### PR TITLE
feat(cloud): agentless AWS EBS disk side-scan (CWPP) with guaranteed cleanup

### DIFF
--- a/deploy/terraform/connect-aws-sidescan/README.md
+++ b/deploy/terraform/connect-aws-sidescan/README.md
@@ -1,0 +1,129 @@
+# connect-aws-sidescan
+
+Mints the **separately-scoped snapshot role** the agentless **EBS disk
+side-scan** (CWPP) needs. This is **distinct from `connect-aws`** and exists
+because the side-scan is the **one deliberate, opt-in, non-read-only**
+capability in agent-bom.
+
+| | `connect-aws` | `connect-aws-sidescan` (this module) |
+|---|---|---|
+| Grant | AWS-managed `SecurityAudit` (+ `ViewOnlyAccess`) | a tiny **inline** snapshot-lifecycle policy |
+| Mutations | **none** — `List*`/`Describe*`/`Get*` only | snapshot + temp-volume create/attach/detach/delete |
+| Scope of writes | n/a | conditioned on the **`agent-bom-sidescan` tag** |
+| When used | every cloud scan (default-off env flag) | **only** when `AGENT_BOM_SIDESCAN=1` |
+
+Keep the read-only connect role for everything else. Apply **this** module only
+if you want agentless deep disk inspection (SBOM + CVEs + secret locations
+pulled directly off an EBS snapshot, without an in-guest agent).
+
+## The trust model (why a deliberate non-read-only role is safe here)
+
+The side-scan never copies block data out of your account. The flow is:
+
+1. **Snapshot** the target EBS volume (`ec2:CreateSnapshot`), tagged
+   `agent-bom-sidescan`.
+2. **Create a temp volume** from that snapshot and **attach it to an in-account
+   collector** EC2 instance, mounted **read-only**.
+3. **Parse** the mounted filesystem on the collector → package SBOM, matched
+   CVEs, and secret **type/location** (values are redacted; file contents are
+   never read out).
+4. **Cleanup** — unmount, detach + delete the temp volume, delete the snapshot.
+   The scanner does this in a `try/finally` and best-effort sweeps orphaned
+   `agent-bom-sidescan`-tagged snapshots on the next run.
+
+**Only metadata leaves the boundary** (an SBOM + CVE list + secret
+locations) — never disk images, never block data, never secret values.
+
+## What this module grants (and what it deliberately does not)
+
+The inline policy is the **minimum** the lifecycle above requires:
+
+- **Read (account-wide, unavoidable):** `ec2:DescribeVolumes`,
+  `DescribeSnapshots`, `DescribeInstances`, `DescribeTags`,
+  `DescribeAvailabilityZones`. EC2 `Describe*` cannot be resource-scoped; these
+  are reads, no mutation.
+- **Create (tag-gated):** `ec2:CreateSnapshot`, `ec2:CreateVolume`, and
+  `ec2:CreateTags` — but **only** when the request carries the
+  `agent-bom-sidescan` tag (`aws:RequestTag`). The role **cannot create an
+  untagged (unsweepable) resource**.
+- **Mutate / delete (tag-gated):** `ec2:DeleteSnapshot`, `ec2:DeleteVolume`,
+  `ec2:AttachVolume`, `ec2:DetachVolume` — **only** on resources already tagged
+  `agent-bom-sidescan` (`aws:ResourceTag`). The role **cannot delete or detach a
+  pre-existing customer snapshot/volume**.
+
+It does **not** grant `SecurityAudit`, `ViewOnlyAccess`, any S3/data read, any
+instance start/stop, or any permission outside this lifecycle.
+
+> **Why tag-conditions matter.** Without `aws:ResourceTag`/`aws:RequestTag`
+> conditions, a `DeleteSnapshot`/`DeleteVolume` grant would let the role destroy
+> *any* snapshot or volume in the account. Scoping every mutation to the
+> `agent-bom-sidescan` tag means the blast radius of the role is exactly — and
+> only — the ephemeral resources the side-scan itself creates.
+
+## Secure by default
+
+- **Mandatory ExternalId (confused-deputy defense)** — always applied on
+  cross-account assume-role; auto-generated 32-char high-entropy value when you
+  don't pin one. Read it with `terraform output -raw external_id`.
+- **Unique, unpredictable role name (anti-squatting)** — defaults to
+  `abom-sidescan-<random hex>`. Override `name` only when a stable name is
+  required.
+- **No access keys** — role mode only; the in-account collector (instance role
+  / IRSA) or your scanner assumes it. Keyless.
+
+## Usage
+
+### In-account collector (recommended)
+
+```hcl
+module "agent_bom_sidescan" {
+  source = "github.com/<org>/agent-bom//deploy/terraform/connect-aws-sidescan"
+
+  # The collector instance's role assumes this snapshot role.
+  trusted_principal_arns  = ["arn:aws:iam::123456789012:role/agent-bom-collector"]
+  collector_instance_arns = ["arn:aws:ec2:us-east-1:123456789012:instance/i-0collector"]
+  # external_id omitted → high-entropy value generated and ALWAYS enforced.
+}
+```
+
+### Keyless collector pod (EKS / IRSA)
+
+```hcl
+module "agent_bom_sidescan" {
+  source = "github.com/<org>/agent-bom//deploy/terraform/connect-aws-sidescan"
+
+  trusted_oidc_provider_arn = "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLE"
+  trusted_oidc_subjects     = ["system:serviceaccount:agent-bom:collector"]
+}
+```
+
+## After apply
+
+```bash
+export AGENT_BOM_SIDESCAN=1               # opt-in, default-OFF — required to enable the side-scan
+# Run the side-scan from the in-account collector, which assumes role_arn below
+# using external_id, against a target instance or volume.
+```
+
+With `AGENT_BOM_SIDESCAN` unset, the side-scan does nothing and no snapshot is
+ever created — the capability is fully inert until you opt in.
+
+`terraform output role_arn` gives the ARN to hand to the collector;
+`terraform output sidescan_tag` shows the tag the role is bounded to.
+
+## Inputs (key)
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `name` | `""` | Fixed role-name override. Empty → auto-generated unique name. |
+| `name_prefix` | `abom-sidescan` | Prefix for the auto-generated unique name. |
+| `trusted_principal_arns` | `[]` | Principals (collector role / scanner) allowed to assume the role. |
+| `trusted_oidc_provider_arn` | `""` | IAM OIDC provider ARN for keyless federation. |
+| `collector_instance_arns` | `[]` | Restrict attach/detach to these collector instances (empty = any in account/region). |
+| `external_id` | `""` | BYO `sts:ExternalId`. Empty → high-entropy value auto-generated and always enforced. |
+| `sidescan_tag_key` / `sidescan_tag_value` | `agent-bom-sidescan` / `true` | The tag every mutation is conditioned on. |
+
+## Outputs
+
+`role_arn`, `role_name`, `external_id` (**sensitive** —
+`terraform output -raw external_id`), `sidescan_tag`.

--- a/deploy/terraform/connect-aws-sidescan/main.tf
+++ b/deploy/terraform/connect-aws-sidescan/main.tf
@@ -1,0 +1,228 @@
+# connect-aws-sidescan — mints the SEPARATELY-SCOPED snapshot role the agentless
+# EBS disk side-scan (CWPP) needs.
+#
+# This is DISTINCT from connect-aws. connect-aws grants the read-only scanner
+# (List*/Describe*/Get* only — never a write). The side-scan is the ONE
+# deliberate, opt-in, non-read-only capability in agent-bom: it must create an
+# EBS snapshot, create + attach a temp volume to the in-account collector, then
+# delete everything. Those mutations live HERE, in a separate role, so the
+# read-only posture of everything else is never widened.
+#
+# Trust-model guarantees this module encodes:
+#   * The mutating actions (delete snapshot/volume, attach/detach/delete volume)
+#     are conditioned on the `agent-bom-sidescan` resource tag, so the role can
+#     only act on resources the side-scan itself created — never pre-existing
+#     snapshots/volumes.
+#   * CreateSnapshot/CreateVolume require that same tag in the request, so the
+#     role cannot create UNtagged (and therefore unsweepable) resources.
+#   * ExternalId is always enforced on cross-account assume-role.
+# No data leaves the account: the temp volume is attached to an in-account
+# collector and only SBOM/CVE/secret *metadata* is emitted by the scanner.
+
+locals {
+  common_tags = merge(
+    {
+      "agent-bom.io/managed-by" = "terraform"
+      "agent-bom.io/module"     = "connect-aws-sidescan"
+      "agent-bom.io/access"     = "snapshot-lifecycle"
+    },
+    var.tags,
+  )
+
+  # Unique, non-guessable principal name by default (anti-squatting).
+  principal_name = var.name != "" ? var.name : "${var.name_prefix}-${random_id.name_suffix.hex}"
+
+  # ExternalId is ALWAYS enforced (never silently omitted).
+  effective_external_id = var.external_id != "" ? var.external_id : random_password.external_id.result
+
+  # Scope volume attach/detach to known collectors when provided, else any
+  # instance in the account (the operator is expected to run a dedicated
+  # collector; pass collector_instance_arns to tighten).
+  instance_resources = length(var.collector_instance_arns) > 0 ? var.collector_instance_arns : ["*"]
+
+  # Derive "<host>/<path>" form used in OIDC condition keys from the provider ARN.
+  oidc_issuer_hostpath = var.trusted_oidc_provider_arn != "" ? replace(
+    var.trusted_oidc_provider_arn,
+    "/^arn:aws[^:]*:iam::[0-9]+:oidc-provider\\//",
+    "",
+  ) : ""
+}
+
+# ---------------------------------------------------------------------------
+# Secure-by-default randomness (unique name + high-entropy ExternalId).
+# ---------------------------------------------------------------------------
+resource "random_id" "name_suffix" {
+  byte_length = 4
+}
+
+resource "random_password" "external_id" {
+  length  = 32
+  special = false
+}
+
+# ---------------------------------------------------------------------------
+# Trust policy: who may assume the snapshot role.
+# ---------------------------------------------------------------------------
+data "aws_iam_policy_document" "assume_role" {
+  # Static principals (collector instance role / cross-account scanner).
+  dynamic "statement" {
+    for_each = length(var.trusted_principal_arns) > 0 ? [1] : []
+
+    content {
+      effect  = "Allow"
+      actions = ["sts:AssumeRole"]
+
+      principals {
+        type        = "AWS"
+        identifiers = var.trusted_principal_arns
+      }
+
+      # ExternalId is always required on assume-role — confused-deputy defense
+      # cannot be silently turned off.
+      condition {
+        test     = "StringEquals"
+        variable = "sts:ExternalId"
+        values   = [local.effective_external_id]
+      }
+    }
+  }
+
+  # Keyless federation (OIDC): EKS/IRSA collector pod or CI.
+  dynamic "statement" {
+    for_each = var.trusted_oidc_provider_arn != "" ? [1] : []
+
+    content {
+      effect  = "Allow"
+      actions = ["sts:AssumeRoleWithWebIdentity"]
+
+      principals {
+        type        = "Federated"
+        identifiers = [var.trusted_oidc_provider_arn]
+      }
+
+      condition {
+        test     = "StringEquals"
+        variable = "${local.oidc_issuer_hostpath}:aud"
+        values   = [var.trusted_oidc_audience]
+      }
+
+      condition {
+        test     = "StringLike"
+        variable = "${local.oidc_issuer_hostpath}:sub"
+        values   = var.trusted_oidc_subjects
+      }
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Scoped snapshot-lifecycle policy. ONLY the actions the side-scan needs —
+# no SecurityAudit, no broad read. Mutations are tag-conditioned.
+# ---------------------------------------------------------------------------
+data "aws_iam_policy_document" "sidescan" {
+  # Read-only enumeration of targets and our own resources. Describe* in EC2
+  # is not resource-scopable, so these are account-wide reads (no mutation).
+  statement {
+    sid    = "ReadOnlyEnumerate"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeVolumes",
+      "ec2:DescribeSnapshots",
+      "ec2:DescribeInstances",
+      "ec2:DescribeTags",
+      "ec2:DescribeAvailabilityZones",
+    ]
+    resources = ["*"]
+  }
+
+  # CreateSnapshot / CreateVolume — require the side-scan tag in the request so
+  # the role can never create an untagged (unsweepable) resource. CreateTags is
+  # gated to the create flow via the ec2:CreateAction request condition.
+  statement {
+    sid    = "CreateTaggedSnapshotAndVolume"
+    effect = "Allow"
+    actions = [
+      "ec2:CreateSnapshot",
+      "ec2:CreateVolume",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/${var.sidescan_tag_key}"
+      values   = [var.sidescan_tag_value]
+    }
+  }
+
+  statement {
+    sid       = "TagOnCreateOnly"
+    effect    = "Allow"
+    actions   = ["ec2:CreateTags"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:CreateAction"
+      values   = ["CreateSnapshot", "CreateVolume"]
+    }
+  }
+
+  # Delete snapshot / delete volume — ONLY resources we tagged. This is the core
+  # guarantee: the role cannot delete a customer's pre-existing snapshot/volume.
+  statement {
+    sid    = "DeleteTaggedSnapshotAndVolume"
+    effect = "Allow"
+    actions = [
+      "ec2:DeleteSnapshot",
+      "ec2:DeleteVolume",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/${var.sidescan_tag_key}"
+      values   = [var.sidescan_tag_value]
+    }
+  }
+
+  # Attach/detach the tagged temp volume to/from the in-account collector. The
+  # volume side is tag-scoped; the instance side is scoped to the collector
+  # ARNs when provided.
+  statement {
+    sid    = "AttachDetachTaggedVolume"
+    effect = "Allow"
+    actions = [
+      "ec2:AttachVolume",
+      "ec2:DetachVolume",
+    ]
+    resources = concat(
+      ["arn:aws:ec2:*:*:volume/*"],
+      local.instance_resources == ["*"] ? ["arn:aws:ec2:*:*:instance/*"] : local.instance_resources,
+    )
+
+    # The volume acted on must carry our tag.
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/${var.sidescan_tag_key}"
+      values   = [var.sidescan_tag_value]
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Role (always role mode — keyless assume; the collector or scanner assumes it).
+# ---------------------------------------------------------------------------
+resource "aws_iam_role" "this" {
+  name                 = local.principal_name
+  path                 = var.path
+  description          = "Scoped snapshot-lifecycle role for agent-bom agentless EBS side-scan. NOT the read-only scanner role. Mutations are tag-conditioned to agent-bom-created resources."
+  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
+  permissions_boundary = var.permissions_boundary_arn != "" ? var.permissions_boundary_arn : null
+  tags                 = local.common_tags
+}
+
+resource "aws_iam_role_policy" "sidescan" {
+  name   = "sidescan-snapshot-lifecycle"
+  role   = aws_iam_role.this.id
+  policy = data.aws_iam_policy_document.sidescan.json
+}

--- a/deploy/terraform/connect-aws-sidescan/outputs.tf
+++ b/deploy/terraform/connect-aws-sidescan/outputs.tf
@@ -1,0 +1,20 @@
+output "role_arn" {
+  description = "ARN of the scoped side-scan snapshot role. Hand this to the in-account collector / agent-bom side-scan so it can assume the role. This role is DISTINCT from the read-only connect-aws role."
+  value       = aws_iam_role.this.arn
+}
+
+output "role_name" {
+  description = "Name of the scoped side-scan snapshot role."
+  value       = aws_iam_role.this.name
+}
+
+output "external_id" {
+  description = "The sts:ExternalId required on assume-role. Always set (auto-generated when not supplied). Configure the collector with this value so it can assume the role. Marked sensitive — read it explicitly with `terraform output -raw external_id`."
+  value       = local.effective_external_id
+  sensitive   = true
+}
+
+output "sidescan_tag" {
+  description = "The tag (key=value) the role is permitted to act on. Side-scan-created snapshots/volumes carry this tag; the role cannot touch resources without it."
+  value       = "${var.sidescan_tag_key}=${var.sidescan_tag_value}"
+}

--- a/deploy/terraform/connect-aws-sidescan/variables.tf
+++ b/deploy/terraform/connect-aws-sidescan/variables.tf
@@ -1,0 +1,77 @@
+variable "name" {
+  description = "Explicit, fixed name for the side-scan snapshot role. Leave empty (default) to auto-generate a unique, non-guessable name (\"<name_prefix>-<random hex>\"), which defends against name-squatting and targeting of a predictable principal. Set this only when an external system requires a stable, known name."
+  type        = string
+  default     = ""
+}
+
+variable "name_prefix" {
+  description = "Prefix for the auto-generated unique principal name when \"name\" is empty. A random suffix is appended so the final name is unique and unpredictable."
+  type        = string
+  default     = "abom-sidescan"
+}
+
+variable "trusted_principal_arns" {
+  description = "ARNs allowed to assume the side-scan snapshot role (e.g. the in-account collector instance role, or the agent-bom hosted scanner account/role for BYOC). At least one trust path (this or trusted_oidc_provider_arn) must be set."
+  type        = list(string)
+  default     = []
+}
+
+variable "trusted_oidc_provider_arn" {
+  description = "Optional IAM OIDC provider ARN for keyless federation (e.g. an EKS/IRSA issuer for the collector pod, or GitHub Actions). When set, the role can be assumed via web identity instead of a static principal."
+  type        = string
+  default     = ""
+}
+
+variable "trusted_oidc_subjects" {
+  description = "Allowed sub claims for the OIDC trust (matched against <issuer>:sub). Required when trusted_oidc_provider_arn is set."
+  type        = list(string)
+  default     = []
+}
+
+variable "trusted_oidc_audience" {
+  description = "Expected aud claim for the OIDC trust (matched against <issuer>:aud)."
+  type        = string
+  default     = "sts.amazonaws.com"
+}
+
+variable "external_id" {
+  description = "Bring-your-own sts:ExternalId required on assume-role, to defend against the confused-deputy problem in cross-account trust. Leave empty (default) to auto-generate a high-entropy ExternalId — the confused-deputy condition is ALWAYS applied and can never be silently omitted. Read the generated value from the (sensitive) external_id output and configure the collector with it. Set this only to pin a known value."
+  type        = string
+  default     = ""
+}
+
+variable "collector_instance_arns" {
+  description = "ARNs of the in-account collector EC2 instance(s) the temp volume may be attached to/detached from. Scopes ec2:AttachVolume / ec2:DetachVolume to known collectors instead of every instance in the account. Empty (default) allows any instance in the account/region — set this to tighten the grant to your collector(s)."
+  type        = list(string)
+  default     = []
+}
+
+variable "sidescan_tag_key" {
+  description = "Tag key applied to every snapshot/temp-volume the side-scan creates. The mutating permissions (delete snapshot/volume, attach/detach/delete) are conditioned on this tag via aws:ResourceTag, so the role can only act on resources agent-bom created — never pre-existing snapshots or volumes."
+  type        = string
+  default     = "agent-bom-sidescan"
+}
+
+variable "sidescan_tag_value" {
+  description = "Tag value paired with sidescan_tag_key on side-scan-created resources."
+  type        = string
+  default     = "true"
+}
+
+variable "permissions_boundary_arn" {
+  description = "Optional IAM permissions boundary ARN to cap the role's effective permissions. The scoped snapshot policy stays well within any sane boundary."
+  type        = string
+  default     = ""
+}
+
+variable "path" {
+  description = "IAM path for the created role."
+  type        = string
+  default     = "/"
+}
+
+variable "tags" {
+  description = "Additional tags to apply to created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/deploy/terraform/connect-aws-sidescan/versions.tf
+++ b/deploy/terraform/connect-aws-sidescan/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+  }
+}

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -313,6 +313,7 @@ AGENT_BOM_SHUTDOWN_DRAIN_SECONDS
 AGENT_BOM_SIDECAR_PROXY_IMAGE
 AGENT_BOM_SIDECAR_TOKEN_SECRET_KEY
 AGENT_BOM_SIDECAR_TOKEN_SECRET_NAME
+AGENT_BOM_SIDESCAN  # opt-in flag (default OFF) gating the agentless EBS disk side-scan — the one deliberate non-read-only capability; read at call-time in cloud/side_scan.py
 AGENT_BOM_SIEM_FORMAT
 AGENT_BOM_SIEM_INDEX
 AGENT_BOM_SIEM_TOKEN

--- a/src/agent_bom/cloud/side_scan.py
+++ b/src/agent_bom/cloud/side_scan.py
@@ -1,0 +1,575 @@
+"""Agentless AWS EBS disk side-scan (CWPP) with guaranteed cleanup.
+
+This is the **one deliberate, opt-in, non-read-only** capability in agent-bom.
+Everything else in the product calls only ``List*/Describe*/Get*``. The side-scan
+needs a separately-scoped *snapshot role* (distinct from the read-only scanner
+role) so it can take an EBS snapshot, attach a temp volume to an in-account
+collector, read the filesystem, and tear everything back down.
+
+Trust model (non-negotiable):
+
+- **Opt-in only.** OFF unless ``AGENT_BOM_SIDESCAN`` is truthy (see
+  :func:`is_sidescan_enabled`). No snapshot is ever created implicitly.
+- **In-account collector.** The temp volume is attached to a collector instance
+  *inside the target account*. No disk image or block data leaves the account.
+- **Metadata-only output.** Only the package SBOM, matched CVEs, and secret
+  *type/location* (never secret values, never file contents) are returned.
+- **Mandatory cleanup.** Snapshot → volume → mount are always torn down in a
+  ``try/finally``, even if parsing raises or the process is interrupted. A
+  best-effort orphan sweep deletes any ``agent-bom-sidescan``-tagged snapshots
+  left behind by an earlier crash.
+
+The actual OS-level mount runs on the collector and is abstracted behind a
+:class:`MountController` so the lifecycle is fully mockable in tests with no real
+AWS and no real ``mount`` syscall.
+
+This module deliberately does **not** import boto3 at module load — boto3 is an
+optional extra (``pip install 'agent-bom[aws]'``) and the import is deferred so a
+plain install can import this module (and surface the graceful opt-in message)
+without the dependency present.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import tempfile
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional, Protocol
+
+from agent_bom.filesystem import scan_disk_path_native
+from agent_bom.models import Package
+from agent_bom.secret_scanner import SecretScanResult, scan_secrets
+
+from .base import CloudDiscoveryError
+
+logger = logging.getLogger(__name__)
+
+# Tag applied to every snapshot/volume we create, so the orphan sweep can find
+# and reap resources left behind by a crashed run.
+SIDESCAN_TAG_KEY = "agent-bom-sidescan"
+SIDESCAN_TAG_VALUE = "true"
+
+# Environment flag that gates the entire capability. Default OFF.
+SIDESCAN_ENV_VAR = "AGENT_BOM_SIDESCAN"
+
+
+def is_sidescan_enabled() -> bool:
+    """Return True only when the operator has explicitly opted in.
+
+    The side-scan is the single non-read-only capability in agent-bom, so it is
+    gated behind ``AGENT_BOM_SIDESCAN`` and is OFF by default.
+    """
+    raw = os.environ.get(SIDESCAN_ENV_VAR)
+    if raw is None:
+        return False
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+class SideScanDisabledError(CloudDiscoveryError):
+    """Raised when a side-scan is attempted without the opt-in flag set."""
+
+
+class SideScanConfigError(CloudDiscoveryError):
+    """Raised when required side-scan configuration (collector, role) is missing."""
+
+
+# ---------------------------------------------------------------------------
+# Result model — metadata only. No file contents, no secret values.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SideScanSecret:
+    """A redacted secret finding from the side-scan.
+
+    Records only the *type* and *location* of a secret — never the matched bytes.
+    """
+
+    secret_type: str
+    file_path: str
+    line_number: int
+    severity: str
+    category: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": self.secret_type,
+            "file": self.file_path,
+            "line": self.line_number,
+            "severity": self.severity,
+            "category": self.category,
+        }
+
+
+@dataclass
+class SideScanResult:
+    """Metadata-only result of an EBS side-scan for a single target volume.
+
+    Carries the package SBOM (with CVEs attached to each :class:`Package`) and
+    redacted secret findings. By construction it never holds raw file contents
+    or secret values.
+    """
+
+    instance_id: Optional[str] = None
+    volume_id: Optional[str] = None
+    snapshot_id: Optional[str] = None
+    packages: list[Package] = field(default_factory=list)
+    secrets: list[SideScanSecret] = field(default_factory=list)
+    vulnerability_count: int = 0
+    warnings: list[str] = field(default_factory=list)
+    cleaned_up: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "instance_id": self.instance_id,
+            "volume_id": self.volume_id,
+            "snapshot_id": self.snapshot_id,
+            "package_count": len(self.packages),
+            "vulnerability_count": self.vulnerability_count,
+            "secret_count": len(self.secrets),
+            "secrets": [s.to_dict() for s in self.secrets],
+            "warnings": list(self.warnings),
+            "cleaned_up": self.cleaned_up,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Mount boundary — abstracted so the real syscall runs only on the collector,
+# and tests can substitute a fixture directory with no privileges.
+# ---------------------------------------------------------------------------
+
+
+class MountController(Protocol):
+    """Boundary for the OS-level attach + mount that runs on the collector.
+
+    Implementations attach the temp volume (created from the snapshot) to the
+    in-account collector instance and mount it READ-ONLY, returning the mount
+    point. ``unmount`` reverses it. Abstracting this keeps :class:`AwsEbsSideScanner`
+    fully testable without root or a real block device.
+    """
+
+    def attach_and_mount(self, volume_id: str, device: str) -> Path:
+        """Attach *volume_id* to the collector at *device*, mount read-only, return mount point."""
+        ...
+
+    def unmount(self, mount_point: Path) -> None:
+        """Unmount the read-only mount at *mount_point* (best-effort)."""
+        ...
+
+
+class CollectorMountController:
+    """Real mount controller for the in-account collector instance.
+
+    Runs ``mount -o ro,nosuid,nodev,noexec`` against the device the temp volume
+    was attached to. The actual ``ec2:AttachVolume`` call is performed by the
+    scanner; this controller waits for the kernel to surface the device and then
+    mounts it read-only. Used only on the collector host — never in tests.
+    """
+
+    def __init__(self, mount_base: Path | None = None) -> None:
+        self._mount_base = mount_base or Path(tempfile.gettempdir())
+
+    def attach_and_mount(self, volume_id: str, device: str) -> Path:
+        mount_point = self._mount_base / f"agent-bom-sidescan-{uuid.uuid4().hex[:8]}"
+        mount_point.mkdir(parents=True, exist_ok=True)
+        # Read-only, and refuse setuid/device/exec semantics from untrusted disks.
+        subprocess.run(
+            ["mount", "-o", "ro,nosuid,nodev,noexec", device, str(mount_point)],
+            check=True,
+            capture_output=True,
+            timeout=120,
+        )
+        return mount_point
+
+    def unmount(self, mount_point: Path) -> None:
+        try:
+            subprocess.run(["umount", str(mount_point)], check=True, capture_output=True, timeout=120)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as exc:
+            logger.warning("side-scan: umount %s failed (best-effort): %s", mount_point, exc)
+        try:
+            mount_point.rmdir()
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Scanner — orchestrates the snapshot lifecycle with guaranteed cleanup.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _LifecycleState:
+    """Tracks every AWS resource created so cleanup can reap exactly what we made."""
+
+    snapshot_id: Optional[str] = None
+    volume_id: Optional[str] = None
+    attached_device: Optional[str] = None
+    mount_point: Optional[Path] = None
+
+
+class AwsEbsSideScanner:
+    """Orchestrate the AWS EBS side-scan lifecycle for a single account/region.
+
+    Lifecycle per target volume:
+
+    1. **Snapshot** the target volume (``ec2:CreateSnapshot``), tagged
+       ``agent-bom-sidescan``.
+    2. **Create + attach** a temp volume from the snapshot to the in-account
+       collector, then **mount** it read-only (via :class:`MountController`).
+    3. **Parse** the mounted filesystem with the existing native parsers
+       (:func:`scan_disk_path_native`) → SBOM, then run the existing secret
+       scanner (values redacted).
+    4. **Cleanup** in a ``finally``: unmount, detach + delete the temp volume,
+       delete the snapshot. Always runs.
+
+    All AWS calls go through a boto3 EC2 client; ``ec2_client`` may be injected
+    for testing. The collector instance id and an availability zone are required
+    so the temp volume can be created in the right AZ and attached to the right
+    host.
+    """
+
+    def __init__(
+        self,
+        *,
+        ec2_client: Any | None = None,
+        collector_instance_id: str | None = None,
+        availability_zone: str | None = None,
+        mount_controller: MountController | None = None,
+        region: str | None = None,
+        device: str = "/dev/xvdf",
+    ) -> None:
+        if not is_sidescan_enabled():
+            raise SideScanDisabledError(
+                "Disk side-scan is opt-in and currently OFF. It is the only non-read-only "
+                f"capability in agent-bom. To enable it, set {SIDESCAN_ENV_VAR}=1, apply the "
+                "scoped snapshot role (deploy/terraform/connect-aws-sidescan), and provide an "
+                "in-account collector instance."
+            )
+
+        self._region = region
+        self._collector_instance_id = collector_instance_id
+        self._availability_zone = availability_zone
+        self._device = device
+        self._mount_controller: MountController = mount_controller or CollectorMountController()
+        self._ec2 = ec2_client if ec2_client is not None else self._build_ec2_client(region)
+
+    @staticmethod
+    def _build_ec2_client(region: str | None) -> Any:
+        try:
+            import boto3
+        except ImportError as exc:
+            raise CloudDiscoveryError("boto3 is required for the EBS side-scan. Install with: pip install 'agent-bom[aws]'") from exc
+        return boto3.client("ec2", region_name=region) if region else boto3.client("ec2")
+
+    # ── Enumeration (read-only describe) ──────────────────────────────────
+
+    def enumerate_target_volumes(
+        self,
+        *,
+        instance_id: str | None = None,
+        volume_id: str | None = None,
+    ) -> list[dict[str, str]]:
+        """Resolve the set of EBS volumes to scan (read-only ``Describe*``).
+
+        - A specific ``volume_id`` → that one volume.
+        - An ``instance_id`` → all EBS volumes attached to that instance.
+        - Neither → every in-account EBS volume.
+
+        Returns a list of ``{"volume_id", "instance_id"}`` dicts.
+        """
+        if volume_id:
+            resp = self._ec2.describe_volumes(VolumeIds=[volume_id])
+        elif instance_id:
+            resp = self._ec2.describe_volumes(Filters=[{"Name": "attachment.instance-id", "Values": [instance_id]}])
+        else:
+            resp = self._ec2.describe_volumes()
+
+        targets: list[dict[str, str]] = []
+        for vol in resp.get("Volumes", []):
+            vid = vol.get("VolumeId", "")
+            if not vid:
+                continue
+            attached_instance = ""
+            for att in vol.get("Attachments", []):
+                attached_instance = att.get("InstanceId", "") or attached_instance
+            targets.append({"volume_id": vid, "instance_id": attached_instance or (instance_id or "")})
+        return targets
+
+    # ── Full scan with guaranteed cleanup ─────────────────────────────────
+
+    async def scan_volume(
+        self,
+        volume_id: str,
+        *,
+        instance_id: str | None = None,
+        scan_secrets_enabled: bool = True,
+    ) -> SideScanResult:
+        """Run the full snapshot → mount → parse → cleanup lifecycle for one volume.
+
+        Cleanup is guaranteed via ``try/finally`` — a parse failure or
+        interruption still tears down the snapshot and temp volume. Returns a
+        metadata-only :class:`SideScanResult`.
+        """
+        result = SideScanResult(instance_id=instance_id, volume_id=volume_id)
+        state = _LifecycleState()
+        try:
+            state.snapshot_id = self._create_snapshot(volume_id)
+            result.snapshot_id = state.snapshot_id
+            self._wait_for_snapshot(state.snapshot_id)
+
+            mount_point = self._provision_and_mount(state)
+
+            packages = self._parse_packages(mount_point)
+            result.packages = packages
+            result.vulnerability_count = await self._scan_cves(packages)
+
+            if scan_secrets_enabled:
+                result.secrets = self._scan_secrets_redacted(mount_point)
+        finally:
+            # MANDATORY: always reap what we created, even on failure / interrupt.
+            cleanup_warnings = self._cleanup(state)
+            result.warnings.extend(cleanup_warnings)
+            result.cleaned_up = not cleanup_warnings
+        return result
+
+    # ── Lifecycle steps ───────────────────────────────────────────────────
+
+    def _create_snapshot(self, volume_id: str) -> str:
+        resp = self._ec2.create_snapshot(
+            VolumeId=volume_id,
+            Description="agent-bom agentless side-scan (metadata-only, auto-deleted)",
+            TagSpecifications=[
+                {
+                    "ResourceType": "snapshot",
+                    "Tags": [{"Key": SIDESCAN_TAG_KEY, "Value": SIDESCAN_TAG_VALUE}],
+                }
+            ],
+        )
+        snapshot_id = resp.get("SnapshotId", "")
+        if not snapshot_id:
+            raise CloudDiscoveryError(f"CreateSnapshot returned no SnapshotId for volume {volume_id}")
+        logger.info("side-scan: created snapshot %s from volume %s", snapshot_id, volume_id)
+        return snapshot_id
+
+    def _wait_for_snapshot(self, snapshot_id: str) -> None:
+        waiter = getattr(self._ec2, "get_waiter", None)
+        if callable(waiter):
+            try:
+                self._ec2.get_waiter("snapshot_completed").wait(SnapshotIds=[snapshot_id])
+            except Exception as exc:  # noqa: BLE001 — waiter failure shouldn't abort; describe will catch it
+                logger.debug("side-scan: snapshot waiter failed for %s: %s", snapshot_id, exc)
+
+    def _provision_and_mount(self, state: _LifecycleState) -> Path:
+        if not self._collector_instance_id or not self._availability_zone:
+            raise SideScanConfigError(
+                "Side-scan requires an in-account collector instance id and availability zone "
+                "(the temp volume is attached to the collector — no block data leaves the account)."
+            )
+        assert state.snapshot_id is not None
+        vol_resp = self._ec2.create_volume(
+            SnapshotId=state.snapshot_id,
+            AvailabilityZone=self._availability_zone,
+            TagSpecifications=[
+                {
+                    "ResourceType": "volume",
+                    "Tags": [{"Key": SIDESCAN_TAG_KEY, "Value": SIDESCAN_TAG_VALUE}],
+                }
+            ],
+        )
+        state.volume_id = vol_resp.get("VolumeId", "")
+        if not state.volume_id:
+            raise CloudDiscoveryError("CreateVolume returned no VolumeId")
+        self._wait_for_volume_available(state.volume_id)
+
+        self._ec2.attach_volume(
+            VolumeId=state.volume_id,
+            InstanceId=self._collector_instance_id,
+            Device=self._device,
+        )
+        state.attached_device = self._device
+        logger.info(
+            "side-scan: attached temp volume %s to collector %s at %s",
+            state.volume_id,
+            self._collector_instance_id,
+            self._device,
+        )
+
+        mount_point = self._mount_controller.attach_and_mount(state.volume_id, self._device)
+        state.mount_point = mount_point
+        return mount_point
+
+    def _wait_for_volume_available(self, volume_id: str) -> None:
+        waiter = getattr(self._ec2, "get_waiter", None)
+        if callable(waiter):
+            try:
+                self._ec2.get_waiter("volume_available").wait(VolumeIds=[volume_id])
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("side-scan: volume waiter failed for %s: %s", volume_id, exc)
+
+    # ── Parse (reuse existing native parsers + secret scanner) ────────────
+
+    def _parse_packages(self, mount_point: Path) -> list[Package]:
+        # Reuse the existing native disk parsers (dpkg/rpm/apk/python/node/lock).
+        # Metadata only — these read package databases, never copy file contents out.
+        return scan_disk_path_native(mount_point)
+
+    async def _scan_cves(self, packages: list[Package]) -> int:
+        if not packages:
+            return 0
+        from agent_bom.scanners import scan_packages
+
+        return await scan_packages(packages)
+
+    def _scan_secrets_redacted(self, mount_point: Path) -> list[SideScanSecret]:
+        """Run the existing secret scanner and project to type/location only.
+
+        The upstream :class:`SecretScanResult` already redacts matched bytes
+        (``matched_preview`` is a fixed ``[*_REDACTED]`` label). We additionally
+        drop even that preview field here so the side-scan output carries *only*
+        the secret type and location — never any matched content.
+        """
+        try:
+            scan_result: SecretScanResult = scan_secrets(mount_point)
+        except Exception as exc:  # noqa: BLE001 — secret scan is best-effort enrichment
+            logger.warning("side-scan: secret scan failed (continuing): %s", exc)
+            return []
+        return [
+            SideScanSecret(
+                secret_type=f.secret_type,
+                file_path=f.file_path,
+                line_number=f.line_number,
+                severity=f.severity,
+                category=f.category,
+            )
+            for f in scan_result.findings
+        ]
+
+    # ── Cleanup (MANDATORY) ───────────────────────────────────────────────
+
+    def _cleanup(self, state: _LifecycleState) -> list[str]:
+        """Tear down mount → volume → snapshot. Best-effort; never raises.
+
+        Returns a list of warning strings for any step that could not complete,
+        so the caller can surface a non-clean teardown without aborting.
+        """
+        warnings: list[str] = []
+
+        if state.mount_point is not None:
+            try:
+                self._mount_controller.unmount(state.mount_point)
+            except Exception as exc:  # noqa: BLE001
+                warnings.append(f"unmount failed: {exc}")
+
+        if state.volume_id:
+            if state.attached_device:
+                try:
+                    self._ec2.detach_volume(VolumeId=state.volume_id, Force=True)
+                    waiter = getattr(self._ec2, "get_waiter", None)
+                    if callable(waiter):
+                        try:
+                            self._ec2.get_waiter("volume_available").wait(VolumeIds=[state.volume_id])
+                        except Exception:  # noqa: BLE001
+                            pass
+                except Exception as exc:  # noqa: BLE001
+                    warnings.append(f"detach volume {state.volume_id} failed: {exc}")
+            try:
+                self._ec2.delete_volume(VolumeId=state.volume_id)
+                logger.info("side-scan: deleted temp volume %s", state.volume_id)
+            except Exception as exc:  # noqa: BLE001
+                warnings.append(f"delete volume {state.volume_id} failed: {exc}")
+
+        if state.snapshot_id:
+            try:
+                self._ec2.delete_snapshot(SnapshotId=state.snapshot_id)
+                logger.info("side-scan: deleted snapshot %s", state.snapshot_id)
+            except Exception as exc:  # noqa: BLE001
+                warnings.append(f"delete snapshot {state.snapshot_id} failed: {exc}")
+
+        return warnings
+
+    # ── Orphan sweep (recover from an earlier crash) ──────────────────────
+
+    def sweep_orphan_snapshots(self) -> list[str]:
+        """Delete any ``agent-bom-sidescan``-tagged snapshots left by a crash.
+
+        Best-effort recovery: even though every run cleans up in a ``finally``,
+        a hard kill (OOM, SIGKILL) could strand a snapshot. This sweep is safe to
+        call at the start of every run — it only touches resources we tagged.
+        Returns the list of snapshot ids deleted.
+        """
+        deleted: list[str] = []
+        try:
+            resp = self._ec2.describe_snapshots(
+                Filters=[{"Name": f"tag:{SIDESCAN_TAG_KEY}", "Values": [SIDESCAN_TAG_VALUE]}],
+                OwnerIds=["self"],
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("side-scan: orphan sweep describe failed: %s", exc)
+            return deleted
+
+        for snap in resp.get("Snapshots", []):
+            snap_id = snap.get("SnapshotId", "")
+            if not snap_id:
+                continue
+            try:
+                self._ec2.delete_snapshot(SnapshotId=snap_id)
+                deleted.append(snap_id)
+                logger.info("side-scan: orphan sweep deleted stranded snapshot %s", snap_id)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("side-scan: orphan sweep could not delete %s: %s", snap_id, exc)
+        return deleted
+
+
+# ---------------------------------------------------------------------------
+# Thin opt-in entry point — callable from the cloud scan path.
+# ---------------------------------------------------------------------------
+
+
+async def run_side_scan(
+    *,
+    instance_id: str | None = None,
+    volume_id: str | None = None,
+    collector_instance_id: str | None = None,
+    availability_zone: str | None = None,
+    region: str | None = None,
+    ec2_client: Any | None = None,
+    mount_controller: MountController | None = None,
+    scan_secrets_enabled: bool = True,
+    sweep_orphans: bool = True,
+) -> list[SideScanResult]:
+    """Opt-in agentless EBS side-scan entry point.
+
+    Returns one :class:`SideScanResult` per target volume. Raises
+    :class:`SideScanDisabledError` (a :class:`CloudDiscoveryError`) with an
+    actionable message when ``AGENT_BOM_SIDESCAN`` is not set — callers should
+    surface that message rather than crash.
+
+    Guarantees: each volume's lifecycle cleans up in a ``finally``; when
+    ``sweep_orphans`` is set, any snapshot stranded by an earlier crash is reaped
+    first.
+    """
+    scanner = AwsEbsSideScanner(
+        ec2_client=ec2_client,
+        collector_instance_id=collector_instance_id,
+        availability_zone=availability_zone,
+        mount_controller=mount_controller,
+        region=region,
+    )
+
+    if sweep_orphans:
+        scanner.sweep_orphan_snapshots()
+
+    targets = scanner.enumerate_target_volumes(instance_id=instance_id, volume_id=volume_id)
+    results: list[SideScanResult] = []
+    for target in targets:
+        res = await scanner.scan_volume(
+            target["volume_id"],
+            instance_id=target.get("instance_id") or instance_id,
+            scan_secrets_enabled=scan_secrets_enabled,
+        )
+        results.append(res)
+    return results

--- a/tests/test_side_scan.py
+++ b/tests/test_side_scan.py
@@ -1,0 +1,412 @@
+"""Tests for the agentless AWS EBS disk side-scan (CWPP).
+
+No real AWS, no real mount/umount — boto3 is replaced by a fake EC2 client that
+records every call, and the mount boundary is replaced by a controller that
+hands back a fixture directory. The tests assert:
+
+- full lifecycle (snapshot → volume → attach → mount → parse → cleanup)
+- cleanup runs even when parsing raises (the load-bearing guarantee)
+- orphan-snapshot sweep by tag
+- metadata-only output (no file contents, no secret values)
+- opt-in gating (OFF by default; clear error when disabled)
+- missing collector config → actionable error, no crash, still cleans up
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_bom.cloud.side_scan import (
+    SIDESCAN_TAG_KEY,
+    SIDESCAN_TAG_VALUE,
+    AwsEbsSideScanner,
+    SideScanConfigError,
+    SideScanDisabledError,
+    is_sidescan_enabled,
+    run_side_scan,
+)
+
+# ── Fakes ─────────────────────────────────────────────────────────────────────
+
+
+class FakeEc2Client:
+    """Records every EC2 call so tests can assert the full lifecycle ran."""
+
+    def __init__(self, *, volumes: list[dict] | None = None, orphan_snapshots: list[dict] | None = None) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self._volumes = volumes if volumes is not None else [{"VolumeId": "vol-target", "Attachments": [{"InstanceId": "i-target"}]}]
+        self._orphan_snapshots = orphan_snapshots or []
+        self._snap_counter = 0
+        self._vol_counter = 0
+
+    def _record(self, name: str, **kwargs: object) -> None:
+        self.calls.append((name, dict(kwargs)))
+
+    def names(self) -> list[str]:
+        return [c[0] for c in self.calls]
+
+    # read-only describe
+    def describe_volumes(self, **kwargs: object) -> dict:
+        self._record("describe_volumes", **kwargs)
+        return {"Volumes": self._volumes}
+
+    def describe_snapshots(self, **kwargs: object) -> dict:
+        self._record("describe_snapshots", **kwargs)
+        return {"Snapshots": self._orphan_snapshots}
+
+    # snapshot lifecycle
+    def create_snapshot(self, **kwargs: object) -> dict:
+        self._record("create_snapshot", **kwargs)
+        self._snap_counter += 1
+        return {"SnapshotId": f"snap-{self._snap_counter}"}
+
+    def delete_snapshot(self, **kwargs: object) -> dict:
+        self._record("delete_snapshot", **kwargs)
+        return {}
+
+    # volume lifecycle
+    def create_volume(self, **kwargs: object) -> dict:
+        self._record("create_volume", **kwargs)
+        self._vol_counter += 1
+        return {"VolumeId": f"vol-temp-{self._vol_counter}"}
+
+    def attach_volume(self, **kwargs: object) -> dict:
+        self._record("attach_volume", **kwargs)
+        return {}
+
+    def detach_volume(self, **kwargs: object) -> dict:
+        self._record("detach_volume", **kwargs)
+        return {}
+
+    def delete_volume(self, **kwargs: object) -> dict:
+        self._record("delete_volume", **kwargs)
+        return {}
+
+    # waiters are optional; omit get_waiter so the scanner skips them
+
+
+class FakeMountController:
+    """Mount boundary replacement — returns a fixture dir, records unmounts."""
+
+    def __init__(self, mount_dir: Path) -> None:
+        self._mount_dir = mount_dir
+        self.attach_calls: list[tuple[str, str]] = []
+        self.unmount_calls: list[Path] = []
+
+    def attach_and_mount(self, volume_id: str, device: str) -> Path:
+        self.attach_calls.append((volume_id, device))
+        return self._mount_dir
+
+    def unmount(self, mount_point: Path) -> None:
+        self.unmount_calls.append(mount_point)
+
+
+@pytest.fixture()
+def enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_SIDESCAN", "1")
+
+
+@pytest.fixture()
+def debian_rootfs(tmp_path: Path) -> Path:
+    """A minimal mounted-snapshot fixture: dpkg status + a planted secret file."""
+    root = tmp_path / "mnt"
+    (root / "etc").mkdir(parents=True)
+    (root / "etc" / "os-release").write_text('ID=debian\nVERSION_ID="12"\n')
+    dpkg_dir = root / "var" / "lib" / "dpkg"
+    dpkg_dir.mkdir(parents=True)
+    (dpkg_dir / "status").write_text("Package: libssl3\nStatus: install ok installed\nVersion: 3.0.11-1\nSource: openssl\n\n")
+    # Planted credential so the secret scanner has something to redact.
+    (root / "app.env").write_text("AWS_SECRET_ACCESS_KEY=AKIAIOSFODNN7EXAMPLEDEADBEEFCAFE1234\n")
+    return root
+
+
+# ── Opt-in gating ─────────────────────────────────────────────────────────────
+
+
+class TestOptInGating:
+    def test_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AGENT_BOM_SIDESCAN", raising=False)
+        assert is_sidescan_enabled() is False
+
+    def test_constructor_raises_when_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AGENT_BOM_SIDESCAN", raising=False)
+        with pytest.raises(SideScanDisabledError) as exc:
+            AwsEbsSideScanner(ec2_client=FakeEc2Client())
+        # Actionable, mentions the flag and that it is opt-in.
+        assert "AGENT_BOM_SIDESCAN" in str(exc.value)
+        assert "opt-in" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_run_side_scan_raises_when_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AGENT_BOM_SIDESCAN", raising=False)
+        with pytest.raises(SideScanDisabledError):
+            await run_side_scan(ec2_client=FakeEc2Client(), volume_id="vol-x")
+
+    def test_enabled_truthy_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for val in ("1", "true", "YES", "on"):
+            monkeypatch.setenv("AGENT_BOM_SIDESCAN", val)
+            assert is_sidescan_enabled() is True
+        for val in ("0", "false", "no", ""):
+            monkeypatch.setenv("AGENT_BOM_SIDESCAN", val)
+            assert is_sidescan_enabled() is False
+
+
+# ── Full lifecycle ────────────────────────────────────────────────────────────
+
+
+class TestFullLifecycle:
+    @pytest.mark.asyncio
+    async def test_snapshot_mount_parse_cleanup(self, enabled: None, debian_rootfs: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Avoid any network in CVE scan.
+        async def _no_cves(_self: object, _pkgs: object) -> int:
+            return 0
+
+        monkeypatch.setattr(AwsEbsSideScanner, "_scan_cves", _no_cves)
+
+        ec2 = FakeEc2Client()
+        mount = FakeMountController(debian_rootfs)
+        scanner = AwsEbsSideScanner(
+            ec2_client=ec2,
+            collector_instance_id="i-collector",
+            availability_zone="us-east-1a",
+            mount_controller=mount,
+        )
+
+        result = await scanner.scan_volume("vol-target", instance_id="i-target")
+
+        names = ec2.names()
+        # Full ordered lifecycle present.
+        assert "create_snapshot" in names
+        assert "create_volume" in names
+        assert "attach_volume" in names
+        assert "detach_volume" in names
+        assert "delete_volume" in names
+        assert "delete_snapshot" in names
+        # Snapshot is tagged for the orphan sweep.
+        snap_call = next(c for c in ec2.calls if c[0] == "create_snapshot")
+        tags = snap_call[1]["TagSpecifications"][0]["Tags"]
+        assert {"Key": SIDESCAN_TAG_KEY, "Value": SIDESCAN_TAG_VALUE} in tags
+        # Mounted, parsed, and torn down.
+        assert mount.attach_calls and mount.unmount_calls
+        assert result.cleaned_up is True
+        assert result.snapshot_id == "snap-1"
+        # Native parser found the deb package off the mounted fixture.
+        assert any(p.name == "libssl3" for p in result.packages)
+
+    @pytest.mark.asyncio
+    async def test_delete_snapshot_targets_created_snapshot(
+        self, enabled: None, debian_rootfs: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def _no_cves(_self: object, _pkgs: object) -> int:
+            return 0
+
+        monkeypatch.setattr(AwsEbsSideScanner, "_scan_cves", _no_cves)
+        ec2 = FakeEc2Client()
+        scanner = AwsEbsSideScanner(
+            ec2_client=ec2,
+            collector_instance_id="i-collector",
+            availability_zone="us-east-1a",
+            mount_controller=FakeMountController(debian_rootfs),
+        )
+        await scanner.scan_volume("vol-target")
+        del_snap = next(c for c in ec2.calls if c[0] == "delete_snapshot")
+        assert del_snap[1]["SnapshotId"] == "snap-1"
+
+
+# ── Cleanup guarantee on failure ──────────────────────────────────────────────
+
+
+class TestCleanupOnFailure:
+    @pytest.mark.asyncio
+    async def test_parse_raises_snapshot_still_deleted(self, enabled: None, debian_rootfs: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        ec2 = FakeEc2Client()
+        scanner = AwsEbsSideScanner(
+            ec2_client=ec2,
+            collector_instance_id="i-collector",
+            availability_zone="us-east-1a",
+            mount_controller=FakeMountController(debian_rootfs),
+        )
+
+        # Make parsing blow up after the snapshot + volume + mount exist.
+        def _boom(_self: object, _mp: object) -> list:
+            raise RuntimeError("parser exploded mid-scan")
+
+        monkeypatch.setattr(AwsEbsSideScanner, "_parse_packages", _boom)
+
+        with pytest.raises(RuntimeError, match="parser exploded"):
+            await scanner.scan_volume("vol-target")
+
+        # The load-bearing guarantee: teardown happened despite the raise.
+        names = ec2.names()
+        assert "delete_volume" in names
+        assert "delete_snapshot" in names
+
+    @pytest.mark.asyncio
+    async def test_mount_raises_snapshot_still_deleted(self, enabled: None, monkeypatch: pytest.MonkeyPatch) -> None:
+        ec2 = FakeEc2Client()
+
+        class ExplodingMount:
+            def attach_and_mount(self, volume_id: str, device: str) -> Path:
+                raise OSError("mount failed")
+
+            def unmount(self, mount_point: Path) -> None:  # pragma: no cover - never reached
+                pass
+
+        scanner = AwsEbsSideScanner(
+            ec2_client=ec2,
+            collector_instance_id="i-collector",
+            availability_zone="us-east-1a",
+            mount_controller=ExplodingMount(),
+        )
+        with pytest.raises(OSError):
+            await scanner.scan_volume("vol-target")
+        # Snapshot + temp volume created before the mount failure must be reaped.
+        names = ec2.names()
+        assert "delete_snapshot" in names
+        assert "delete_volume" in names
+
+
+# ── Missing config (graceful) ─────────────────────────────────────────────────
+
+
+class TestMissingConfig:
+    @pytest.mark.asyncio
+    async def test_missing_collector_raises_actionable_and_cleans_snapshot(self, enabled: None, monkeypatch: pytest.MonkeyPatch) -> None:
+        ec2 = FakeEc2Client()
+        # No collector_instance_id / AZ — provisioning the temp volume is impossible.
+        scanner = AwsEbsSideScanner(ec2_client=ec2, mount_controller=FakeMountController(Path("/tmp")))
+        with pytest.raises(SideScanConfigError) as exc:
+            await scanner.scan_volume("vol-target")
+        assert "collector" in str(exc.value).lower()
+        # Snapshot was created before we discovered the missing config — it must
+        # still be cleaned up (no temp volume was ever created).
+        names = ec2.names()
+        assert "create_snapshot" in names
+        assert "delete_snapshot" in names
+        assert "create_volume" not in names
+
+
+# ── Orphan sweep ──────────────────────────────────────────────────────────────
+
+
+class TestOrphanSweep:
+    def test_sweep_deletes_tagged_snapshots(self, enabled: None) -> None:
+        ec2 = FakeEc2Client(orphan_snapshots=[{"SnapshotId": "snap-orphan-1"}, {"SnapshotId": "snap-orphan-2"}])
+        scanner = AwsEbsSideScanner(ec2_client=ec2)
+        deleted = scanner.sweep_orphan_snapshots()
+        assert deleted == ["snap-orphan-1", "snap-orphan-2"]
+        # Filtered by our tag, self-owned only.
+        desc = next(c for c in ec2.calls if c[0] == "describe_snapshots")
+        assert desc[1]["Filters"][0]["Name"] == f"tag:{SIDESCAN_TAG_KEY}"
+        assert desc[1]["OwnerIds"] == ["self"]
+
+    def test_sweep_nothing_to_do(self, enabled: None) -> None:
+        ec2 = FakeEc2Client(orphan_snapshots=[])
+        scanner = AwsEbsSideScanner(ec2_client=ec2)
+        assert scanner.sweep_orphan_snapshots() == []
+
+    @pytest.mark.asyncio
+    async def test_run_side_scan_sweeps_then_scans(self, enabled: None, debian_rootfs: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def _no_cves(_self: object, _pkgs: object) -> int:
+            return 0
+
+        monkeypatch.setattr(AwsEbsSideScanner, "_scan_cves", _no_cves)
+        ec2 = FakeEc2Client(orphan_snapshots=[{"SnapshotId": "snap-orphan-1"}])
+        mount = FakeMountController(debian_rootfs)
+        # Patch the default mount controller construction by injecting via kwargs.
+        results = await run_side_scan(
+            volume_id="vol-target",
+            collector_instance_id="i-collector",
+            availability_zone="us-east-1a",
+            ec2_client=ec2,
+            mount_controller=mount,
+        )
+        names = ec2.names()
+        assert "describe_snapshots" in names  # the sweep
+        assert "create_snapshot" in names  # the actual scan
+        assert len(results) == 1
+        assert results[0].cleaned_up is True
+
+
+# ── Metadata-only output ──────────────────────────────────────────────────────
+
+
+class TestMetadataOnly:
+    @pytest.mark.asyncio
+    async def test_secrets_carry_no_values_or_content(self, enabled: None, debian_rootfs: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def _no_cves(_self: object, _pkgs: object) -> int:
+            return 0
+
+        monkeypatch.setattr(AwsEbsSideScanner, "_scan_cves", _no_cves)
+        ec2 = FakeEc2Client()
+        scanner = AwsEbsSideScanner(
+            ec2_client=ec2,
+            collector_instance_id="i-collector",
+            availability_zone="us-east-1a",
+            mount_controller=FakeMountController(debian_rootfs),
+        )
+        result = await scanner.scan_volume("vol-target")
+
+        # The planted AWS secret value must never appear anywhere in the output.
+        planted_value = "AKIAIOSFODNN7EXAMPLEDEADBEEFCAFE1234"
+        serialized = str(result.to_dict())
+        assert planted_value not in serialized
+        for secret in result.secrets:
+            d = secret.to_dict()
+            # Only type/location/severity/category — never a value/preview/content field.
+            assert set(d.keys()) == {"type", "file", "line", "severity", "category"}
+            assert planted_value not in str(d)
+
+    @pytest.mark.asyncio
+    async def test_result_dict_has_no_file_contents(self, enabled: None, debian_rootfs: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def _no_cves(_self: object, _pkgs: object) -> int:
+            return 0
+
+        monkeypatch.setattr(AwsEbsSideScanner, "_scan_cves", _no_cves)
+        ec2 = FakeEc2Client()
+        scanner = AwsEbsSideScanner(
+            ec2_client=ec2,
+            collector_instance_id="i-collector",
+            availability_zone="us-east-1a",
+            mount_controller=FakeMountController(debian_rootfs),
+        )
+        result = await scanner.scan_volume("vol-target")
+        d = result.to_dict()
+        # Only counts + metadata, no raw blobs.
+        assert set(d.keys()) >= {
+            "package_count",
+            "vulnerability_count",
+            "secret_count",
+            "cleaned_up",
+        }
+        assert "content" not in d
+        assert "raw" not in d
+
+
+# ── Enumeration ───────────────────────────────────────────────────────────────
+
+
+class TestEnumeration:
+    def test_enumerate_specific_volume(self, enabled: None) -> None:
+        ec2 = FakeEc2Client(volumes=[{"VolumeId": "vol-abc", "Attachments": []}])
+        scanner = AwsEbsSideScanner(ec2_client=ec2)
+        targets = scanner.enumerate_target_volumes(volume_id="vol-abc")
+        assert targets == [{"volume_id": "vol-abc", "instance_id": ""}]
+        call = next(c for c in ec2.calls if c[0] == "describe_volumes")
+        assert call[1]["VolumeIds"] == ["vol-abc"]
+
+    def test_enumerate_by_instance(self, enabled: None) -> None:
+        ec2 = FakeEc2Client(volumes=[{"VolumeId": "vol-1", "Attachments": [{"InstanceId": "i-xyz"}]}])
+        scanner = AwsEbsSideScanner(ec2_client=ec2)
+        targets = scanner.enumerate_target_volumes(instance_id="i-xyz")
+        assert targets[0]["instance_id"] == "i-xyz"
+        call = next(c for c in ec2.calls if c[0] == "describe_volumes")
+        assert call[1]["Filters"][0]["Name"] == "attachment.instance-id"
+
+    def test_enumerate_all(self, enabled: None) -> None:
+        ec2 = FakeEc2Client(volumes=[{"VolumeId": "vol-1", "Attachments": []}, {"VolumeId": "vol-2", "Attachments": []}])
+        scanner = AwsEbsSideScanner(ec2_client=ec2)
+        targets = scanner.enumerate_target_volumes()
+        assert {t["volume_id"] for t in targets} == {"vol-1", "vol-2"}


### PR DESCRIPTION
## What

Adds an opt-in, agentless EBS disk side-scan: inspect a host's disk for packages, CVEs, and secret locations **without an in-guest agent**. AWS EBS first.

Lifecycle per target volume:
1. **Enumerate** target volumes (a given instance/volume id, or in-account EBS volumes) via read-only `Describe*`.
2. **Snapshot** the volume (`ec2:CreateSnapshot`), tagged `agent-bom-sidescan`.
3. **Create + attach** a temp volume from the snapshot to an in-account collector, **mount read-only**.
4. **Parse** the mounted filesystem with the existing native package parsers (dpkg/rpm/apk/python/node/lock) → SBOM → existing CVE scan + secret scan.
5. **Cleanup** in `try/finally`: unmount, detach + delete the temp volume, delete the snapshot.

## Trust model

This is the one deliberate, non-read-only capability — gated accordingly:

- **Opt-in only.** OFF unless `AGENT_BOM_SIDESCAN` is set. Fully inert (no snapshot ever created) until then.
- **Separately-scoped snapshot role**, distinct from the read-only scanner role. New Terraform module `deploy/terraform/connect-aws-sidescan` grants only the snapshot/volume lifecycle, with every mutation (delete/attach/detach) conditioned on the `agent-bom-sidescan` tag — the role cannot touch a pre-existing customer snapshot or volume, and cannot create an untagged (unsweepable) resource.
- **In-account collector.** The temp volume is attached to a collector inside the target account. No disk image or block data leaves the account — only SBOM/CVE/secret-location metadata is emitted (secret values redacted, file contents never copied out).
- **Mandatory cleanup.** Teardown runs in `try/finally` even if parsing raises or the process is interrupted, plus a best-effort tag-based orphan-snapshot sweep on the next run, so a crash never strands snapshots/volumes.

## Design notes

- The OS-level attach + mount is abstracted behind a `MountController` so the real mount runs only on the collector and the full lifecycle is testable with no real AWS and no real `mount` syscall.
- boto3 import is deferred (optional `[aws]` extra); a plain install can import the module and surface the graceful opt-in message without the dependency present.
- Reuses existing native disk parsers and the existing secret scanner (values already redacted; the side-scan additionally drops even the redacted preview so output carries only secret type + location).

## Tests

`tests/test_side_scan.py` (fake EC2 client + mock mount boundary, no real AWS):
- `TestFullLifecycle` — snapshot → volume → attach → mount → parse → cleanup, snapshot tag, native parse off the mounted fixture.
- `TestCleanupOnFailure` — parse raises / mount raises → snapshot + temp volume still deleted.
- `TestMissingConfig` — missing collector → actionable error, snapshot still cleaned up, no temp volume created.
- `TestOrphanSweep` — tag-filtered, self-owned snapshot sweep + run-time integration.
- `TestMetadataOnly` — planted secret value never appears in output; only type/location/severity/category fields.
- `TestOptInGating` — OFF by default; clear error when disabled.
- `TestEnumeration` — specific volume / by-instance / all.

## Validation

- `ruff check` + `mypy` clean on the new module.
- `pytest tests/ -k "side_scan or sidescan or snapshot or disk"` → 101 passed.
- Terraform `fmt -check` (exit 0) + `validate -backend=false` (success) on the new module.
- LIVE validation requires the scoped snapshot role applied and an in-account collector.