### PR TITLE
feat(cloud): grouped, readable CIS posture report in cloud scan

### DIFF
--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -105,6 +105,7 @@ def _run_cloud_scan(
     azure_subscription: Optional[str] = None,
     gcp_project: Optional[str] = None,
     cis: bool = True,
+    show_passed: bool = False,
     output_format: str = "console",
     output_path: Optional[str] = None,
     quiet: bool = False,
@@ -157,7 +158,13 @@ def _run_cloud_scan(
             f"\n[bold]Cloud scan[/bold] [dim]· {', '.join(p.upper() for p in providers)} · {'CIS + ' if cis else ''}discovery[/dim]"
         )
 
+    # Pass --show-passed through to the grouped CIS renderer in run_benchmarks
+    # (the scan command itself has no such flag). click.Context.meta is shared
+    # across the whole context stack, so it survives the invoke into `scan`.
+    from agent_bom.cli.agents._cloud import CIS_SHOW_PASSED_META
+
     ctx = click.get_current_context()
+    ctx.meta[CIS_SHOW_PASSED_META] = show_passed
     ctx.invoke(
         scan,
         aws=aws_on,
@@ -242,6 +249,11 @@ def cloud_group(ctx: click.Context) -> None:
 @click.option("--project", default=None, help="GCP project ID (gcp only).")
 @click.option("--cis/--no-cis", default=True, show_default=True, help="Run CIS benchmark for each selected provider.")
 @click.option(
+    "--show-passed",
+    is_flag=True,
+    help="List passed CIS checks in the posture report instead of collapsing them into a count.",
+)
+@click.option(
     "--verify",
     is_flag=True,
     help="Confirm detected credentials authenticate (STS/whoami). Opt-in — makes a network call.",
@@ -260,6 +272,7 @@ def scan_cmd(
     subscription: Optional[str],
     project: Optional[str],
     cis: bool,
+    show_passed: bool,
     verify: bool,
     output_format: str,
     output_path: Optional[str],
@@ -293,6 +306,7 @@ def scan_cmd(
         azure_subscription=subscription,
         gcp_project=project,
         cis=cis,
+        show_passed=show_passed,
         output_format=output_format,
         output_path=output_path,
         quiet=quiet,
@@ -308,6 +322,7 @@ def scan_cmd(
 @click.option("--include-iam", is_flag=True, help="Enrich identity graph with IAM role policies and trust principals")
 @click.option("--cis", is_flag=True, default=True, help="Run CIS benchmark (default: on)")
 @click.option("--no-cis", is_flag=True, help="Skip CIS benchmark")
+@click.option("--show-passed", is_flag=True, help="List passed CIS checks instead of collapsing them into a count.")
 @click.option("-f", "--format", "output_format", default="console", help="Output format")
 @click.option("-o", "--output", "output_path", help="Output file path")
 @click.option("--quiet", "-q", is_flag=True)
@@ -320,6 +335,7 @@ def aws_cmd(
     include_iam: bool,
     cis: bool,
     no_cis: bool,
+    show_passed: bool,
     output_format: str,
     output_path: Optional[str],
     quiet: bool,
@@ -337,6 +353,7 @@ def aws_cmd(
         aws_include_ec2=include_ec2,
         aws_include_iam=include_iam,
         cis=cis and not no_cis,
+        show_passed=show_passed,
         output_format=output_format,
         output_path=output_path,
         quiet=quiet,
@@ -347,6 +364,7 @@ def aws_cmd(
 @click.option("--subscription", default=None, help="Azure subscription ID")
 @click.option("--cis", is_flag=True, default=True, help="Run CIS benchmark (default: on)")
 @click.option("--no-cis", is_flag=True, help="Skip CIS benchmark")
+@click.option("--show-passed", is_flag=True, help="List passed CIS checks instead of collapsing them into a count.")
 @click.option("-f", "--format", "output_format", default="console", help="Output format")
 @click.option("-o", "--output", "output_path", help="Output file path")
 @click.option("--quiet", "-q", is_flag=True)
@@ -354,6 +372,7 @@ def azure_cmd(
     subscription: Optional[str],
     cis: bool,
     no_cis: bool,
+    show_passed: bool,
     output_format: str,
     output_path: Optional[str],
     quiet: bool,
@@ -366,6 +385,7 @@ def azure_cmd(
         ["azure"],
         azure_subscription=subscription,
         cis=cis and not no_cis,
+        show_passed=show_passed,
         output_format=output_format,
         output_path=output_path,
         quiet=quiet,
@@ -376,6 +396,7 @@ def azure_cmd(
 @click.option("--project", default=None, help="GCP project ID")
 @click.option("--cis", is_flag=True, default=True, help="Run CIS benchmark (default: on)")
 @click.option("--no-cis", is_flag=True, help="Skip CIS benchmark")
+@click.option("--show-passed", is_flag=True, help="List passed CIS checks instead of collapsing them into a count.")
 @click.option("-f", "--format", "output_format", default="console", help="Output format")
 @click.option("-o", "--output", "output_path", help="Output file path")
 @click.option("--quiet", "-q", is_flag=True)
@@ -383,6 +404,7 @@ def gcp_cmd(
     project: Optional[str],
     cis: bool,
     no_cis: bool,
+    show_passed: bool,
     output_format: str,
     output_path: Optional[str],
     quiet: bool,
@@ -395,6 +417,7 @@ def gcp_cmd(
         ["gcp"],
         gcp_project=project,
         cis=cis and not no_cis,
+        show_passed=show_passed,
         output_format=output_format,
         output_path=output_path,
         quiet=quiet,

--- a/src/agent_bom/cli/agents/_cloud.py
+++ b/src/agent_bom/cli/agents/_cloud.py
@@ -309,26 +309,6 @@ def run_benchmarks(
             total = ctx.cis_benchmark_report.total
             rate = ctx.cis_benchmark_report.pass_rate
             con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
-            if failed > 0:
-                from rich.table import Table
-
-                tbl = Table(title="CIS AWS Foundations Benchmark v3.0", show_lines=False, padding=(0, 1))
-                tbl.add_column("Check", style="cyan", width=6)
-                tbl.add_column("Title", min_width=30)
-                tbl.add_column("Status", width=_CIS_STATUS_WIDTH)
-                tbl.add_column("Severity", width=8)
-                tbl.add_column("Evidence", max_width=50)
-                _sev_style = {"critical": "[red]critical[/]", "high": "[bright_red]high[/]", "medium": "[yellow]medium[/]"}
-                for c in ctx.cis_benchmark_report.checks:
-                    tbl.add_row(
-                        c.check_id,
-                        c.title,
-                        _cis_status_badge(c.status.value),
-                        _sev_style.get(c.severity, c.severity),
-                        c.evidence,
-                    )
-                con.print()
-                con.print(tbl)
         except CloudDiscoveryError as exc:
             con.print(f"  [red]CIS Benchmark error: {exc}[/red]")
 
@@ -347,26 +327,6 @@ def run_benchmarks(
             total = ctx.sf_cis_benchmark_report.total
             rate = ctx.sf_cis_benchmark_report.pass_rate
             con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
-            if failed > 0:
-                from rich.table import Table
-
-                tbl = Table(title="CIS Snowflake Benchmark v1.0", show_lines=False, padding=(0, 1))
-                tbl.add_column("Check", style="cyan", width=6)
-                tbl.add_column("Title", min_width=30)
-                tbl.add_column("Status", width=_CIS_STATUS_WIDTH)
-                tbl.add_column("Severity", width=8)
-                tbl.add_column("Evidence", max_width=50)
-                _sf_sev_style = {"critical": "[red]critical[/]", "high": "[bright_red]high[/]", "medium": "[yellow]medium[/]"}
-                for c in ctx.sf_cis_benchmark_report.checks:
-                    tbl.add_row(
-                        c.check_id,
-                        c.title,
-                        _cis_status_badge(c.status.value),
-                        _sf_sev_style.get(c.severity, c.severity),
-                        c.evidence,
-                    )
-                con.print()
-                con.print(tbl)
         except _SFCISError as exc:
             con.print(f"  [red]CIS Snowflake Benchmark error: {exc}[/red]")
 
@@ -386,31 +346,6 @@ def run_benchmarks(
             total = ctx.azure_cis_benchmark_report.total
             rate = ctx.azure_cis_benchmark_report.pass_rate
             con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
-            if failed > 0:
-                from rich.table import Table
-
-                tbl = Table(title="CIS Azure Security Benchmark v3.0", show_lines=False, padding=(0, 1))
-                tbl.add_column("Check", style="cyan", width=6)
-                tbl.add_column("Title", min_width=30)
-                tbl.add_column("Status", width=_CIS_STATUS_WIDTH)
-                tbl.add_column("Severity", width=8)
-                tbl.add_column("ATT&CK", width=20)
-                tbl.add_column("Evidence", max_width=40)
-                _az_sev = {"critical": "[red]critical[/]", "high": "[bright_red]high[/]", "medium": "[yellow]medium[/]"}
-                from agent_bom.mitre_attack import tag_cis_check
-
-                for c in ctx.azure_cis_benchmark_report.checks:
-                    attack = ", ".join(tag_cis_check(c)) or "-"
-                    tbl.add_row(
-                        c.check_id,
-                        c.title,
-                        _cis_status_badge(c.status.value),
-                        _az_sev.get(c.severity, c.severity),
-                        attack,
-                        c.evidence,
-                    )
-                con.print()
-                con.print(tbl)
         except _AZCISError as exc:
             con.print(f"  [red]CIS Azure Benchmark error: {exc}[/red]")
 
@@ -428,31 +363,6 @@ def run_benchmarks(
             total = ctx.gcp_cis_benchmark_report.total
             rate = ctx.gcp_cis_benchmark_report.pass_rate
             con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
-            if failed > 0:
-                from rich.table import Table
-
-                tbl = Table(title="CIS GCP Foundation Benchmark v3.0", show_lines=False, padding=(0, 1))
-                tbl.add_column("Check", style="cyan", width=6)
-                tbl.add_column("Title", min_width=30)
-                tbl.add_column("Status", width=_CIS_STATUS_WIDTH)
-                tbl.add_column("Severity", width=8)
-                tbl.add_column("ATT&CK", width=20)
-                tbl.add_column("Evidence", max_width=40)
-                _gcp_sev = {"critical": "[red]critical[/]", "high": "[bright_red]high[/]", "medium": "[yellow]medium[/]"}
-                from agent_bom.mitre_attack import tag_cis_check as _tag_gcp
-
-                for c in ctx.gcp_cis_benchmark_report.checks:
-                    attack = ", ".join(_tag_gcp(c)) or "-"
-                    tbl.add_row(
-                        c.check_id,
-                        c.title,
-                        _cis_status_badge(c.status.value),
-                        _gcp_sev.get(c.severity, c.severity),
-                        attack,
-                        c.evidence,
-                    )
-                con.print()
-                con.print(tbl)
         except _GCPCISError as exc:
             con.print(f"  [red]CIS GCP Benchmark error: {exc}[/red]")
 
@@ -474,32 +384,6 @@ def run_benchmarks(
             total = ctx.databricks_security_report.total
             rate = ctx.databricks_security_report.pass_rate
             con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
-            if failed > 0:
-                from rich.table import Table
-
-                tbl = Table(title="Databricks Security Best Practices", show_lines=False, padding=(0, 1))
-                tbl.add_column("Check", style="cyan", width=6)
-                tbl.add_column("Title", min_width=30)
-                tbl.add_column("Status", width=6)
-                tbl.add_column("Severity", width=8)
-                tbl.add_column("ATT&CK", width=20)
-                tbl.add_column("Evidence", max_width=40)
-                _db_status = {"pass": "[green]PASS[/]", "fail": "[red]FAIL[/]", "error": "[yellow]ERR[/]"}
-                _db_sev = {"critical": "[red]critical[/]", "high": "[bright_red]high[/]", "medium": "[yellow]medium[/]"}
-                from agent_bom.mitre_attack import tag_cis_check as _tag_db
-
-                for c in ctx.databricks_security_report.checks:
-                    attack = ", ".join(_tag_db(c)) or "-"
-                    tbl.add_row(
-                        c.check_id,
-                        c.title,
-                        _db_status.get(c.status.value, c.status.value),
-                        _db_sev.get(c.severity, c.severity),
-                        attack,
-                        c.evidence,
-                    )
-                con.print()
-                con.print(tbl)
         except _DBSecError as exc:
             con.print(f"  [red]Databricks security check error: {exc}[/red]")
 
@@ -645,3 +529,49 @@ def run_benchmarks(
             con.print(tbl)
         except Exception as exc:
             con.print(f"  [red]AISVS benchmark error: {exc}[/red]")
+
+    # Grouped CIS posture: prioritized failed-first plan with evidence + fix
+    # per check and PASS collapsed (the flat per-provider tables above are
+    # unreadable past ~60 checks). Renders once across every benchmarked cloud.
+    _render_cis_findings(ctx)
+
+
+# click.Context.meta key the cloud command writes when --show-passed is set;
+# meta is shared across the whole context stack, so it survives the
+# ``cloud scan`` → ``scan`` invoke without a new flag on the scan command.
+CIS_SHOW_PASSED_META = "cis_show_passed"
+
+
+def _render_cis_findings(ctx: ScanContext) -> None:
+    """Route benchmarked CIS results through the grouped console renderer.
+
+    Builds a lightweight report-shaped view exposing each provider's
+    serialized bundle under the attribute name the renderer reads
+    (``*_cis_benchmark_data``), then defers to ``print_cis_findings``.
+    Honors the cloud command's ``--show-passed`` flag (carried on the click
+    context ``meta``) to list passed checks instead of collapsing them.
+    Emits nothing when no CIS data is present.
+    """
+    from types import SimpleNamespace
+    from typing import cast
+
+    import click
+
+    from agent_bom.models import AIBOMReport
+    from agent_bom.output.console_render import print_cis_findings
+
+    bundle_attrs = (
+        ("cis_benchmark_data", ctx.cis_benchmark_report),
+        ("azure_cis_benchmark_data", ctx.azure_cis_benchmark_report),
+        ("gcp_cis_benchmark_data", ctx.gcp_cis_benchmark_report),
+        ("snowflake_cis_benchmark_data", ctx.sf_cis_benchmark_report),
+        ("databricks_cis_benchmark_data", ctx.databricks_security_report),
+    )
+    # print_cis_findings reads each provider's bundle off the report via
+    # getattr(report, "<provider>_cis_benchmark_data"); a namespace carrying
+    # exactly those attributes is all it touches, so no full report is needed.
+    view = SimpleNamespace(**{attr: (rep.to_dict() if rep is not None else None) for attr, rep in bundle_attrs})
+
+    click_ctx = click.get_current_context(silent=True)
+    show_passed = bool(click_ctx.meta.get(CIS_SHOW_PASSED_META)) if click_ctx is not None else False
+    print_cis_findings(cast("AIBOMReport", view), show_passed=show_passed)

--- a/tests/test_cli_cloud_scan.py
+++ b/tests/test_cli_cloud_scan.py
@@ -251,3 +251,162 @@ class TestCredentialDetection:
         assert r.exit_code == 0
         assert verified == ["aws"]
         assert "verified" in r.output
+
+
+# ── --show-passed wiring to the grouped CIS renderer ─────────────────────────
+
+
+class TestShowPassedWiring:
+    """`--show-passed` is surfaced on every cloud command and the choice rides
+    the click context ``meta`` through the ``cloud scan`` → ``scan`` invoke so
+    the grouped CIS renderer can honor it."""
+
+    def test_flag_present_in_help_for_every_command(self):
+        for command in ("scan", "aws", "azure", "gcp"):
+            r = CliRunner().invoke(cloud_group, [command, "--help"])
+            assert r.exit_code == 0
+            assert "--show-passed" in r.output, command
+
+    @staticmethod
+    def _capture_meta(monkeypatch):
+        """Capture the show-passed meta value visible to the scan callback."""
+        from agent_bom.cli.agents._cloud import CIS_SHOW_PASSED_META
+
+        seen: list[object] = []
+
+        def fake_scan(**kwargs):
+            import click
+
+            seen.append(click.get_current_context().meta.get(CIS_SHOW_PASSED_META))
+
+        monkeypatch.setattr("agent_bom.cli.agents.scan.callback", fake_scan)
+        return seen
+
+    def test_show_passed_rides_context_meta(self, monkeypatch):
+        seen = self._capture_meta(monkeypatch)
+        r = CliRunner().invoke(cloud_group, ["scan", "--provider", "aws", "--show-passed"])
+        assert r.exit_code == 0
+        assert seen == [True]
+
+    def test_default_meta_is_falsey(self, monkeypatch):
+        seen = self._capture_meta(monkeypatch)
+        r = CliRunner().invoke(cloud_group, ["scan", "--provider", "aws"])
+        assert r.exit_code == 0
+        assert seen == [False]
+
+    def test_alias_forwards_show_passed(self, monkeypatch):
+        seen = self._capture_meta(monkeypatch)
+        CliRunner().invoke(cloud_group, ["aws", "--show-passed"])
+        assert seen == [True]
+
+
+# ── grouped CIS renderer routing (run_benchmarks → print_cis_findings) ────────
+
+
+class _FakeBenchmarkReport:
+    """Minimal stand-in for a benchmark report exposing ``to_dict()``."""
+
+    def __init__(self, bundle: dict) -> None:
+        self._bundle = bundle
+
+    def to_dict(self) -> dict:
+        return self._bundle
+
+
+def _cis_bundle() -> dict:
+    """Small AWS-style bundle: 1 critical fail, 1 high fail, 2 passes."""
+    return {
+        "benchmark": "CIS AWS Foundations",
+        "pass_rate": 50.0,
+        "passed": 2,
+        "failed": 2,
+        "total": 4,
+        "checks": [
+            {
+                "check_id": "1.1",
+                "title": "Root account has no access keys",
+                "status": "fail",
+                "severity": "critical",
+                "evidence": "root key present",
+                "resource_ids": ["arn:aws:iam::1:root"],
+                "recommendation": "Delete root access keys.",
+                "remediation": {"fix_cli": "aws iam delete-access-key", "priority": 1},
+                "cis_section": "1 - IAM",
+            },
+            {
+                "check_id": "2.1",
+                "title": "CloudTrail enabled in all regions",
+                "status": "fail",
+                "severity": "high",
+                "evidence": "trail missing",
+                "resource_ids": ["trail-x"],
+                "recommendation": "Enable multi-region CloudTrail.",
+                "remediation": {"priority": 2},
+                "cis_section": "2 - Logging",
+            },
+            {"check_id": "1.2", "title": "MFA on root", "status": "pass", "severity": "high"},
+            {"check_id": "1.3", "title": "Password policy", "status": "pass", "severity": "medium"},
+        ],
+    }
+
+
+def _render_ctx_cis(monkeypatch, *, show_passed: bool) -> str:
+    """Run ``_render_cis_findings`` with one AWS bundle and capture console output."""
+    from io import StringIO
+
+    import click
+    from rich.console import Console
+
+    import agent_bom.output as output_mod
+    from agent_bom.cli.agents._cloud import CIS_SHOW_PASSED_META, _render_cis_findings
+    from agent_bom.cli.agents._context import ScanContext
+
+    buf = StringIO()
+    con = Console(file=buf, force_terminal=False, width=200)
+    monkeypatch.setattr(output_mod, "console", con)
+
+    ctx = ScanContext(con=con)
+    ctx.cis_benchmark_report = _FakeBenchmarkReport(_cis_bundle())
+
+    # --show-passed is carried on the click context meta; render under a click
+    # context that mirrors how the cloud command sets it.
+    with click.Context(click.Command("scan")) as click_ctx:
+        click_ctx.meta[CIS_SHOW_PASSED_META] = show_passed
+        _render_cis_findings(ctx)
+    return buf.getvalue()
+
+
+class TestGroupedCisRendererRouting:
+    def test_failed_first_grouped_and_passes_collapsed(self, monkeypatch):
+        out = _render_ctx_cis(monkeypatch, show_passed=False)
+        # Severity bands present, CRITICAL ahead of HIGH (failed-first ordering).
+        assert "CRITICAL" in out and "HIGH" in out
+        assert out.index("CRITICAL") < out.index("HIGH")
+        # Failed checks carry evidence + fix lines.
+        assert "evidence:" in out and "fix:" in out
+        assert "arn:aws:iam::1:root" in out
+        assert "aws iam delete-access-key" in out
+        # Passes are collapsed into a count, not listed individually.
+        assert "2 passed" in out
+        assert "--show-passed" in out
+        assert "Password policy" not in out
+
+    def test_show_passed_lists_individual_passes(self, monkeypatch):
+        out = _render_ctx_cis(monkeypatch, show_passed=True)
+        assert "Passed (2)" in out
+        assert "Password policy" in out
+
+    def test_no_cis_data_emits_nothing(self, monkeypatch):
+        from io import StringIO
+
+        from rich.console import Console
+
+        import agent_bom.output as output_mod
+        from agent_bom.cli.agents._cloud import _render_cis_findings
+        from agent_bom.cli.agents._context import ScanContext
+
+        buf = StringIO()
+        con = Console(file=buf, force_terminal=False, width=200)
+        monkeypatch.setattr(output_mod, "console", con)
+        _render_cis_findings(ScanContext(con=con))
+        assert buf.getvalue() == ""


### PR DESCRIPTION
## What

The cloud scan rendered each provider's CIS benchmark as one flat table listing every check — unreadable once a benchmark grows past ~60 checks. This routes that console output through the prioritized grouped renderer instead.

For each benchmarked cloud:
- A posture header: pass-rate band, passed/evaluated counts, and a verdict driven by the highest failing severity.
- Failed checks lead, grouped by severity (CRITICAL first) then CIS section, each with a severity badge, check id + title, affected-resource evidence, and a remediation/fix line.
- PASS checks collapse into a single per-cloud count by default.

## Flag

`--show-passed` (added to `cloud scan` and the `aws` / `azure` / `gcp` aliases) lists the passed checks instead of collapsing them into a count. The choice rides the click context `meta` through the `cloud scan` → `scan` invoke, so the underlying scan command needs no new flag.

## Scope

- The grouped renderer runs once across every benchmarked cloud (AWS, Azure, GCP, Snowflake, Databricks).
- It routes through the existing format-aware output console, so `-f json` / `-o file` output is unchanged: on non-console formats the console is already routed to stderr, keeping stdout clean for piping.

## Tests

`tests/test_cli_cloud_scan.py`:
- `TestShowPassedWiring` — flag present in help for every command; `--show-passed` rides context meta into the scan invoke; default is falsey; the `aws` alias forwards it.
- `TestGroupedCisRendererRouting` — failed-first grouped output with evidence + fix and passes collapsed; `--show-passed` lists individual passes; no CIS data emits nothing.

`uv run ruff check`, `uv run ruff format --check`, and `uv run mypy` are clean on the changed files; the `cloud`/`cis`/`render`/`scan` test selection is green.