### PR TITLE
feat(graph): ASPM correlation layer organizing AppSec findings around applications

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -42,8 +42,8 @@ is wired into the docs site so drift produces a visible regression.
 | `TransportType` | 4 | `stdio`, `sse`, `streamable-http`, `unknown` |
 | `ServerSurface` | 10 | `mcp-server`, `container-image`, `oci-tarball`, `filesystem`, `sbom`, `external-scan`, `os-packages`, `sast`, `ai-inventory`, `other` |
 | `AgentStatus` | 2 | `configured`, `installed-not-configured` |
-| `EntityType` | 37 | `agent`, `server`, `package`, `tool`, `tool_call`, `model`, `dataset`, `container`, `cloud_resource`, `resource`, `source_file`, `code_module`, `config_file`, `external_import`, `ci_job`, `vulnerability`, `misconfiguration`, `credential`, `credential_ref`, `org`, `account`, `user`, `group`, `role`, `policy`, `service_account`, `service_principal`, `federated_identity`, `managed_identity`, `access_grant`, `access_policy`, `drift_incident`, `data_store`, `provider`, `environment`, `fleet`, `cluster` |
-| `RelationshipType` | 45 | `hosts`, `uses`, `depends_on`, `provides_tool`, `exposes_cred`, `reaches_tool`, `serves_model`, `contains`, `imports`, `defines`, `runs`, `configures`, `affects`, `vulnerable_to`, `exploitable_via`, `remediates`, `triggers`, `shares_server`, `shares_cred`, `lateral_path`, `manages`, `owns`, `part_of`, `member_of`, `assumes`, `trusts`, `attached`, `inherits`, `can_access`, `cross_account_trust`, `authenticates_as`, `scoped_to`, `governs`, `exhibits_drift`, `exposed_to`, `stores`, `has_permission`, `acted_as`, `invoked`, `called`, `used_credential`, `accessed`, `delegated_to`, `correlates_with`, `possibly_correlates_with` |
+| `EntityType` | 38 | `agent`, `server`, `package`, `tool`, `tool_call`, `model`, `dataset`, `container`, `cloud_resource`, `resource`, `source_file`, `code_module`, `config_file`, `external_import`, `ci_job`, `vulnerability`, `misconfiguration`, `credential`, `credential_ref`, `org`, `account`, `user`, `group`, `role`, `policy`, `service_account`, `service_principal`, `federated_identity`, `managed_identity`, `access_grant`, `access_policy`, `drift_incident`, `data_store`, `application`, `provider`, `environment`, `fleet`, `cluster` |
+| `RelationshipType` | 46 | `hosts`, `uses`, `depends_on`, `provides_tool`, `exposes_cred`, `reaches_tool`, `serves_model`, `contains`, `imports`, `defines`, `runs`, `configures`, `affects`, `vulnerable_to`, `exploitable_via`, `remediates`, `triggers`, `shares_server`, `shares_cred`, `lateral_path`, `manages`, `owns`, `part_of`, `member_of`, `assumes`, `trusts`, `attached`, `inherits`, `can_access`, `cross_account_trust`, `authenticates_as`, `scoped_to`, `governs`, `exhibits_drift`, `exposed_to`, `stores`, `has_permission`, `acted_as`, `invoked`, `called`, `used_credential`, `accessed`, `delegated_to`, `correlates_with`, `possibly_correlates_with`, `belongs_to` |
 
 ### Live Schema Cross-Checks
 
@@ -127,7 +127,7 @@ Used for unified findings outside the SCA / blast-radius path
 The unified graph projects the canonical model into a node/edge form
 used for blast-radius traversal, dashboards, and OCSF export.
 
-### Entity types (37)
+### Entity types (38)
 
 `AGENT`, `SERVER`, `PACKAGE`, `TOOL`, `TOOL_CALL`, `MODEL`, `DATASET`,
 `CONTAINER`, `CLOUD_RESOURCE`, `RESOURCE`, `SOURCE_FILE`, `CODE_MODULE`,
@@ -135,11 +135,18 @@ used for blast-radius traversal, dashboards, and OCSF export.
 `MISCONFIGURATION`, `CREDENTIAL`, `CREDENTIAL_REF`, `ORG`, `ACCOUNT`,
 `USER`, `GROUP`, `ROLE`, `POLICY`, `SERVICE_ACCOUNT`, `SERVICE_PRINCIPAL`,
 `FEDERATED_IDENTITY`, `MANAGED_IDENTITY`, `ACCESS_GRANT`, `ACCESS_POLICY`,
-`DRIFT_INCIDENT`, `DATA_STORE`, `PROVIDER`, `ENVIRONMENT`, `FLEET`, `CLUSTER`.
+`DRIFT_INCIDENT`, `DATA_STORE`, `APPLICATION`, `PROVIDER`, `ENVIRONMENT`,
+`FLEET`, `CLUSTER`.
 
 `DATA_STORE` is a cloud-CNAPP primitive — a database / bucket / lake / warehouse
 holding data at rest, derived from cloud resources so path-to-sensitive-data is
 traversable.
+
+`APPLICATION` is the ASPM (Application Security Posture Management) correlation
+root — derived per service / repo / manifest-root from finding source paths, it
+groups every AppSec signal (SCA / secrets / IaC / container / CI-CD / AI-BOM)
+around the application it belongs to and carries a per-app severity roll-up and
+risk score.
 
 The agent-identity governance control plane is first-class in the graph:
 `MANAGED_IDENTITY`, `ACCESS_GRANT` (time-bound JIT), `ACCESS_POLICY`
@@ -148,7 +155,7 @@ identity and drift stores onto the inventory so attack paths can traverse
 `agent → managed_identity → access_grant → tool → vulnerable package` and
 `agent ↔ drift_incident → tool`.
 
-### Relationship types (45)
+### Relationship types (46)
 
 | Group | Relationships | Direction |
 |---|---|---|
@@ -161,6 +168,7 @@ identity and drift stores onto the inventory so attack paths can traverse
 | Cloud-CNAPP | `EXPOSED_TO`, `STORES`, `HAS_PERMISSION` | internet exposure; data-at-rest; effective permission |
 | Runtime | `ACTED_AS`, `INVOKED`, `CALLED`, `USED_CREDENTIAL`, `ACCESSED`, `DELEGATED_TO` | source → target, time-stamped |
 | Cross-environment correlation | `CORRELATES_WITH`, `POSSIBLY_CORRELATES_WITH` | local ↔ cloud agent correlation |
+| ASPM | `BELONGS_TO` | finding / component → application |
 
 `EXPLOITABLE_VIA` is a capability-impact edge from a vulnerability to a
 tool when the affected package is connected to the MCP server that provides

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -2717,6 +2717,21 @@ _RELATIONSHIP_SCHEMA_META: dict[str, dict[str, object]] = {
         "target_types": [EntityType.CLOUD_RESOURCE.value, EntityType.DATA_STORE.value, EntityType.RESOURCE.value, EntityType.TOOL.value],
         "traversable": True,
     },
+    RelationshipType.BELONGS_TO.value: {
+        "category": "aspm",
+        "direction": "directed",
+        "source_types": [
+            EntityType.VULNERABILITY.value,
+            EntityType.MISCONFIGURATION.value,
+            EntityType.PACKAGE.value,
+            EntityType.CONTAINER.value,
+            EntityType.CLOUD_RESOURCE.value,
+            EntityType.SERVER.value,
+            EntityType.CREDENTIAL.value,
+        ],
+        "target_types": [EntityType.APPLICATION.value],
+        "traversable": True,
+    },
 }
 
 

--- a/src/agent_bom/graph/aspm_overlay.py
+++ b/src/agent_bom/graph/aspm_overlay.py
@@ -1,0 +1,531 @@
+"""ASPM (Application Security Posture Management) correlation overlay.
+
+agent-bom already produces SCA, secrets, IaC, container, CI/CD, SBOM, and
+AI-BOM findings — but they live next to one another, not *around an application*.
+This overlay closes that gap by organising the AppSec signals already in the
+graph around the **application** they belong to. It is a pure correlation layer
+over the existing findings + graph; it adds **no scanners**.
+
+For each unified finding the report already carries (``report_json["findings"]``,
+one ``Finding.to_dict()`` per issue), the overlay:
+
+- **Derives an application identity** per service / repo / manifest-root from the
+  finding's source path (``asset.location``) or asset name — each manifest
+  directory / repo root becomes one ``APPLICATION`` node, with a best-effort
+  owner pulled from the report's CODEOWNERS / manifest metadata when present.
+- **Aggregates** every finding (SCA / secrets / IaC / container / CI-CD / AI-BOM)
+  to its application via a ``BELONGS_TO`` edge from the finding's existing graph
+  node, and computes a deterministic per-app risk roll-up (counts by severity +
+  a per-app risk score).
+- **Deduplicates cross-finding**: within an application, findings that name the
+  same CVE / rule on the same component across multiple sources are merged so
+  they are counted once, while every reporting source is kept as provenance.
+- **Flags reachability**: where the graph already carries reachability /
+  attack-path signal for a finding's component, the finding is marked
+  ``reachable`` vs ``not_reachable``; ``unknown`` otherwise. No new reachability
+  engine is built — only existing attack-path data is consulted.
+
+The overlay is a pure in-place graph mutation: **idempotent** (applying twice
+yields identical nodes / edges / attributes), **deterministic** (every iteration
+is sorted; dedup is keyed on a stable ``(app, component, rule/cve)`` tuple), and
+a complete **no-op** when the report carries no findings / no derivable apps —
+the graph stays byte-identical to today. Additive only: it never changes the
+meaning of existing nodes or edges; it only adds ``APPLICATION`` nodes,
+``BELONGS_TO`` edges, and per-app attributes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import NodeDimensions, UnifiedNode
+from agent_bom.graph.severity import SEVERITY_RANK, SEVERITY_RISK_SCORE
+from agent_bom.graph.types import EntityType, GraphSemanticLayer, RelationshipType
+
+_OVERLAY_SOURCE = "aspm-overlay"
+
+# Severity buckets we roll up per application, worst-first for deterministic
+# ordering of the rolled-up counts attribute.
+_SEVERITY_ORDER = ("critical", "high", "medium", "low", "info", "unknown")
+
+# Reachability verdicts a finding can carry after correlation. ``unknown`` is the
+# honest default when no attack-path / exposure signal exists for the component —
+# we never fabricate reachability.
+_REACHABLE = "reachable"
+_NOT_REACHABLE = "not_reachable"
+_UNKNOWN = "unknown"
+
+# Finding ``reachability`` strings the upstream scanners already emit that mean
+# "the vulnerable code path is reachable". Kept conservative; anything else is
+# treated as no-signal (→ unknown) rather than asserted not-reachable.
+_REACHABLE_HINTS = frozenset({"reachable", "direct", "runtime", "exploitable", "confirmed"})
+_NOT_REACHABLE_HINTS = frozenset({"unreachable", "not_reachable", "no_path"})
+
+# Manifest / project-root markers. When a finding's source path contains one of
+# these as a path segment, the directory *holding* it is treated as the
+# application root, so sibling findings under the same project collapse to one
+# app. Matched on the basename of each path segment.
+_MANIFEST_FILES = frozenset(
+    {
+        "package.json",
+        "requirements.txt",
+        "pyproject.toml",
+        "setup.py",
+        "setup.cfg",
+        "go.mod",
+        "cargo.toml",
+        "pom.xml",
+        "build.gradle",
+        "build.gradle.kts",
+        "gemfile",
+        "composer.json",
+        "dockerfile",
+        "pipfile",
+        "poetry.lock",
+        "package-lock.json",
+        "yarn.lock",
+    }
+)
+
+
+def _finding_field(finding: Any, name: str) -> Any:
+    """Read a field from a ``Finding.to_dict()`` payload or a dataclass."""
+    if isinstance(finding, dict):
+        return finding.get(name)
+    return getattr(finding, name, None)
+
+
+def _finding_asset(finding: Any) -> dict[str, Any]:
+    asset = _finding_field(finding, "asset")
+    if isinstance(asset, dict):
+        return asset
+    return {}
+
+
+def _norm_path(raw: Any) -> str:
+    """Normalise a source path to forward slashes with no leading ``./``."""
+    if not isinstance(raw, str):
+        return ""
+    text = raw.strip().replace("\\", "/")
+    while text.startswith("./"):
+        text = text[2:]
+    return text.strip("/")
+
+
+def _manifest_roots(findings: list[Any]) -> list[str]:
+    """Collect the directories that hold a manifest file across all findings.
+
+    These are the project / service roots an application is anchored on. Returned
+    longest-first so the most-specific (deepest) root wins when one project nests
+    under another. Deterministic: sorted by depth then lexically.
+    """
+    roots: set[str] = set()
+    for finding in findings:
+        location = _norm_path(_finding_asset(finding).get("location"))
+        if not location:
+            continue
+        segments = location.split("/")
+        if segments[-1].lower() in _MANIFEST_FILES:
+            roots.add("/".join(segments[:-1]))  # "" for a top-level manifest = repo root
+    # Deepest (most path segments) first; the empty repo root sorts last.
+    return sorted(roots, key=lambda r: (-(r.count("/") + 1) if r else 0, r))
+
+
+def _app_identity(finding: Any, manifest_roots: list[str]) -> tuple[str, str]:
+    """Derive ``(app_key, app_label)`` for a finding, deterministically.
+
+    Resolution order (best-effort, all string-only — no filesystem access):
+
+    1. The longest discovered manifest-root directory the finding's source path
+       falls under, so *every* finding beneath a project root (deeply nested
+       source files included) collapses to one application.
+    2. Else the immediate directory of the source path (a standalone service /
+       manifest root with no sibling manifest observed).
+    3. Else the asset name (a server / image / repo name) when no path exists.
+
+    ``app_key`` is a stable lower-cased identity; ``app_label`` is the
+    human-facing name. Returns ``("", "")`` when nothing identifies an app.
+    """
+    asset = _finding_asset(finding)
+    location = _norm_path(asset.get("location"))
+    if location:
+        segments = location.split("/")
+        is_manifest = segments[-1].lower() in _MANIFEST_FILES
+        # 1. Longest manifest root this path lives under (manifest_roots is
+        #    pre-sorted deepest-first, so the first match is the most specific).
+        for root in manifest_roots:
+            if root == "" or location == root or location.startswith(root + "/"):
+                return (root.lower(), root) if root else _repo_root(segments)
+        # 2. No manifest root in play: the file's own directory is the root,
+        #    or the repo root for a bare top-level file.
+        if is_manifest or len(segments) > 1:
+            root = "/".join(segments[:-1])
+            if root:
+                return root.lower(), root
+        return _repo_root(segments)
+
+    asset_name = asset.get("name")
+    if isinstance(asset_name, str) and asset_name.strip():
+        clean = asset_name.strip()
+        return clean.lower(), clean
+    return "", ""
+
+
+def _repo_root(segments: list[str]) -> tuple[str, str]:
+    """Top-level path segment as the repo-root application identity."""
+    top = segments[0] if segments else ""
+    return (top.lower(), top) if top else ("", "")
+
+
+def _app_node_id(app_key: str) -> str:
+    return f"application:{app_key}"
+
+
+def _component_key(finding: Any) -> str:
+    """Stable identity for the *component* a finding is about (within an app).
+
+    Prefers the asset's canonical/stable id, then its identifier (purl / ARN /
+    digest), then name + location. Used as part of the dedup tuple so the same
+    package reported by two scanners dedupes, while two different packages do not.
+    """
+    asset = _finding_asset(finding)
+    for field_name in ("stable_id", "canonical_id", "identifier"):
+        val = asset.get(field_name)
+        if isinstance(val, str) and val.strip():
+            return val.strip().lower()
+    name = str(asset.get("name") or "").strip().lower()
+    location = _norm_path(asset.get("location")).lower()
+    return f"{name}@{location}" if location else name
+
+
+def _rule_key(finding: Any) -> str:
+    """Stable identity for the *rule/vuln* a finding asserts.
+
+    A CVE id when present (so the same CVE from SCA + container dedupes), else
+    the finding's title (so the same rule dedupes across sources).
+    """
+    cve = _finding_field(finding, "cve_id")
+    if isinstance(cve, str) and cve.strip():
+        return cve.strip().lower()
+    title = _finding_field(finding, "title")
+    if isinstance(title, str) and title.strip():
+        return title.strip().lower()
+    ftype = _finding_field(finding, "finding_type")
+    return str(ftype or "finding").lower()
+
+
+def _finding_severity(finding: Any) -> str:
+    """Normalised severity string for roll-up bucketing."""
+    for field_name in ("effective_severity", "severity"):
+        val = _finding_field(finding, field_name)
+        if isinstance(val, str) and val.strip():
+            low = val.strip().lower()
+            if low in SEVERITY_RANK:
+                return "info" if low == "informational" else low
+    return _UNKNOWN
+
+
+def _finding_node_id(graph: UnifiedGraph, finding: Any) -> str | None:
+    """Resolve the existing graph node a finding's component maps to.
+
+    Tries the vuln node id (``vuln:<CVE>``) and the asset's stable/canonical id
+    against the graph. Returns the first id present in the graph, else ``None`` —
+    the finding is still counted in the per-app roll-up, but no BELONGS_TO edge
+    is drawn from a node that doesn't exist (the overlay never invents nodes).
+    """
+    cve = _finding_field(finding, "cve_id")
+    candidates: list[str] = []
+    if isinstance(cve, str) and cve.strip():
+        candidates.append(f"vuln:{cve.strip()}")
+    asset = _finding_asset(finding)
+    for field_name in ("stable_id", "canonical_id"):
+        val = asset.get(field_name)
+        if isinstance(val, str) and val.strip():
+            candidates.append(val.strip())
+    for candidate in candidates:
+        if graph.has_node(candidate):
+            return candidate
+    return None
+
+
+def _attack_path_node_ids(graph: UnifiedGraph) -> set[str]:
+    """Every node id that participates in a materialised attack path.
+
+    Reuses the existing ``graph.attack_paths`` (written by attack-path fusion);
+    a component on any chain is treated as reachable. No new traversal here.
+    """
+    reachable: set[str] = set()
+    for path in graph.attack_paths:
+        for hop in path.hops:
+            if isinstance(hop, str) and hop:
+                reachable.add(hop)
+    return reachable
+
+
+def _node_is_exposed(node: UnifiedNode | None) -> bool:
+    if node is None:
+        return False
+    attrs = node.attributes
+    return bool(
+        attrs.get("internet_exposed")
+        or attrs.get("toxic_exposed_vulnerable")
+        or attrs.get("toxic_exposed_sensitive")
+        or attrs.get("on_attack_path")
+    )
+
+
+def _reachability_verdict(
+    finding: Any,
+    node_id: str | None,
+    graph: UnifiedGraph,
+    attack_path_nodes: set[str],
+) -> str:
+    """Reachable / not-reachable / unknown for a finding, from existing signal.
+
+    Reachable when: the finding's component node is on a materialised attack
+    path, OR carries an exposure flag (internet-exposed / toxic combo), OR the
+    finding itself reports a reachable code path. Not-reachable only when an
+    upstream reachability analysis explicitly said so. Unknown otherwise — the
+    overlay does not assert reachability it cannot back with existing data.
+    """
+    if node_id and node_id in attack_path_nodes:
+        return _REACHABLE
+    if node_id and _node_is_exposed(graph.get_node(node_id)):
+        return _REACHABLE
+    if _finding_field(finding, "is_actionable") is True:
+        return _REACHABLE
+    hint = _finding_field(finding, "reachability")
+    if isinstance(hint, str) and hint.strip():
+        low = hint.strip().lower()
+        if low in _REACHABLE_HINTS:
+            return _REACHABLE
+        if low in _NOT_REACHABLE_HINTS:
+            return _NOT_REACHABLE
+    return _UNKNOWN
+
+
+def _owner_for_app(app_key: str, owners_by_path: dict[str, str]) -> str:
+    """Best-effort CODEOWNERS owner for an application root.
+
+    ``owners_by_path`` maps a normalised path prefix → owner. The longest prefix
+    that the app root starts under wins (CODEOWNERS most-specific-match
+    semantics). Returns ``""`` when no rule matches.
+    """
+    if not owners_by_path:
+        return ""
+    best_prefix = ""
+    best_owner = ""
+    for prefix in sorted(owners_by_path):
+        if app_key == prefix or app_key.startswith(prefix + "/") or prefix == "":
+            if len(prefix) >= len(best_prefix):
+                best_prefix = prefix
+                best_owner = owners_by_path[prefix]
+    return best_owner
+
+
+def _load_owners(report_json: Any) -> dict[str, str]:
+    """Parse an optional CODEOWNERS map carried on the report.
+
+    Accepts ``report_json["codeowners"]`` as either a ``{path_prefix: owner}``
+    dict or a list of ``{"path"/"pattern": ..., "owner"/"owners": ...}`` records.
+    Absent ⇒ empty map ⇒ apps simply carry no owner. Never reads the filesystem.
+    """
+    raw = report_json.get("codeowners") if isinstance(report_json, dict) else None
+    owners: dict[str, str] = {}
+    if isinstance(raw, dict):
+        for path, owner in raw.items():
+            prefix = _norm_path(path).lower()
+            if isinstance(owner, str) and owner.strip():
+                owners[prefix] = owner.strip()
+            elif isinstance(owner, (list, tuple)) and owner:
+                owners[prefix] = ", ".join(str(o).strip() for o in owner if str(o).strip())
+    elif isinstance(raw, list):
+        for entry in raw:
+            if not isinstance(entry, dict):
+                continue
+            prefix = _norm_path(entry.get("path") or entry.get("pattern")).lower()
+            owner_val = entry.get("owner") or entry.get("owners")
+            if isinstance(owner_val, (list, tuple)):
+                owner_str = ", ".join(str(o).strip() for o in owner_val if str(o).strip())
+            else:
+                owner_str = str(owner_val or "").strip()
+            if owner_str:
+                owners[prefix] = owner_str
+    return owners
+
+
+def apply_aspm_overlay(
+    graph: UnifiedGraph,
+    report_json: dict[str, Any],
+    now: datetime,
+) -> dict[str, int]:
+    """Correlate AppSec findings around applications, in place.
+
+    Args:
+        graph: the unified graph to enrich (mutated in place). Runs after the
+            other overlays so it sees attack-path / exposure signals.
+        report_json: the persisted AIBOM report JSON contract. Reads the
+            optional ``findings`` block (a list of ``Finding.to_dict()`` dicts)
+            and optional ``codeowners`` map. Never fetched here.
+        now: reference time for the application nodes' timestamps (no inline
+            ``datetime.now`` — determinism / testability).
+
+    Returns counts of applications created, findings correlated, duplicates
+    merged, and reachable findings flagged. A complete no-op (returns all-zero,
+    graph untouched) when the report carries no findings or none derive an app.
+    """
+    zero = {"applications": 0, "correlated_findings": 0, "deduplicated": 0, "reachable": 0}
+    raw_findings = report_json.get("findings") if isinstance(report_json, dict) else None
+    if not isinstance(raw_findings, list) or not raw_findings:
+        return zero
+    findings = [f for f in raw_findings if isinstance(f, dict)]
+    if not findings:
+        return zero
+
+    owners_by_path = _load_owners(report_json)
+    attack_path_nodes = _attack_path_node_ids(graph)
+    # Discover project/service roots once so deeply-nested source-file findings
+    # collapse onto the manifest root that owns them, not their own sub-directory.
+    manifest_roots = _manifest_roots(findings)
+
+    # ── 1. Bucket findings per application, deduping within each app ─────────
+    # dedup_key = (component_key, rule_key). Within one app, the first finding
+    # for a dedup_key is the canonical occurrence; later ones only contribute
+    # their reporting source to that occurrence's provenance.
+    apps: dict[str, dict[str, Any]] = {}
+    total_correlated = 0
+    total_deduped = 0
+    total_reachable = 0
+
+    for finding in findings:
+        app_key, app_label = _app_identity(finding, manifest_roots)
+        if not app_key:
+            continue
+        total_correlated += 1
+        app = apps.get(app_key)
+        if app is None:
+            app = {
+                "label": app_label,
+                "occurrences": {},  # dedup_key -> occurrence dict
+                "node_ids": set(),  # graph node ids to attach via BELONGS_TO
+            }
+            apps[app_key] = app
+
+        component = _component_key(finding)
+        rule = _rule_key(finding)
+        dedup_key = (component, rule)
+        severity = _finding_severity(finding)
+        source = str(_finding_field(finding, "source") or "unknown").lower()
+        node_id = _finding_node_id(graph, finding)
+        verdict = _reachability_verdict(finding, node_id, graph, attack_path_nodes)
+
+        occurrences: dict[tuple[str, str], dict[str, Any]] = app["occurrences"]
+        occ = occurrences.get(dedup_key)
+        if occ is None:
+            occ = {
+                "component": component,
+                "rule": rule,
+                "severity": severity,
+                "sources": {source} if source else set(),
+                "reachability": verdict,
+                "node_id": node_id,
+            }
+            occurrences[dedup_key] = occ
+        else:
+            total_deduped += 1
+            if source:
+                occ["sources"].add(source)
+            # Worst severity across sources wins; keep the strongest reach signal.
+            if SEVERITY_RANK.get(severity, 0) > SEVERITY_RANK.get(occ["severity"], 0):
+                occ["severity"] = severity
+            if verdict == _REACHABLE:
+                occ["reachability"] = _REACHABLE
+            elif verdict == _NOT_REACHABLE and occ["reachability"] == _UNKNOWN:
+                occ["reachability"] = _NOT_REACHABLE
+            if node_id and not occ["node_id"]:
+                occ["node_id"] = node_id
+
+        if node_id:
+            app["node_ids"].add(node_id)
+
+    if not apps:
+        return zero
+
+    # ── 2. Materialise APPLICATION nodes + per-app roll-up + BELONGS_TO ──────
+    now_iso = now.isoformat()
+    applications_created = 0
+    for app_key in sorted(apps):
+        app = apps[app_key]
+        occurrences = app["occurrences"]
+
+        severity_counts: dict[str, int] = {bucket: 0 for bucket in _SEVERITY_ORDER}
+        risk_score = 0.0
+        reachable_count = 0
+        for occ in occurrences.values():
+            bucket = occ["severity"] if occ["severity"] in severity_counts else _UNKNOWN
+            severity_counts[bucket] += 1
+            risk_score += SEVERITY_RISK_SCORE.get(occ["severity"], 0.0)
+            if occ["reachability"] == _REACHABLE:
+                reachable_count += 1
+        total_reachable += reachable_count
+
+        app_severity = _UNKNOWN
+        for bucket in _SEVERITY_ORDER:
+            if severity_counts.get(bucket):
+                app_severity = bucket
+                break
+
+        owner = _owner_for_app(app_key, owners_by_path)
+        app_node_id = _app_node_id(app_key)
+        # Deterministic, sorted provenance list per app (which sources reported).
+        all_sources: set[str] = set()
+        for occ in occurrences.values():
+            all_sources |= occ["sources"]
+
+        node = UnifiedNode(
+            id=app_node_id,
+            entity_type=EntityType.APPLICATION,
+            label=app["label"] or app_key,
+            severity=app_severity if app_severity != _UNKNOWN else "",
+            risk_score=round(risk_score, 6),
+            first_seen=now_iso,
+            last_seen=now_iso,
+            attributes={
+                "app_key": app_key,
+                "owner": owner,
+                "finding_count": len(occurrences),
+                "severity_counts": {b: severity_counts[b] for b in _SEVERITY_ORDER},
+                "aspm_risk_score": round(risk_score, 6),
+                "reachable_finding_count": reachable_count,
+                "finding_sources": sorted(all_sources),
+                "component_count": len({occ["component"] for occ in occurrences.values()}),
+            },
+            data_sources=[_OVERLAY_SOURCE],
+            dimensions=NodeDimensions(surface=GraphSemanticLayer.APP.value),
+        )
+        if app_node_id not in graph.nodes:
+            applications_created += 1
+        graph.add_node(node)
+
+        # BELONGS_TO from each existing finding/component node → application.
+        # Sorted for determinism; add_edge dedupes so applying twice is identical.
+        belongs_node_ids: list[str] = sorted(str(nid) for nid in app["node_ids"])
+        for belongs_source in belongs_node_ids:
+            graph.add_edge(
+                UnifiedEdge(
+                    source=belongs_source,
+                    target=app_node_id,
+                    relationship=RelationshipType.BELONGS_TO,
+                    evidence={"source": _OVERLAY_SOURCE, "app": app_key},
+                )
+            )
+
+    return {
+        "applications": applications_created,
+        "correlated_findings": total_correlated,
+        "deduplicated": total_deduped,
+        "reachable": total_reachable,
+    }

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1059,6 +1059,19 @@ def build_unified_graph_from_report(
     except Exception:  # noqa: BLE001
         _logger.warning("cost overlay failed", exc_info=True)
 
+    # ASPM (Application Security Posture Management) correlation: organise the
+    # AppSec findings already in the graph AROUND the application they belong to
+    # — derive APPLICATION roots from finding source paths, attach findings via
+    # BELONGS_TO, roll up per-app risk, dedupe duplicate CVE/rule across sources,
+    # and flag reachability from existing attack-path data. Runs LAST so it sees
+    # every attack-path / exposure signal the overlays above wrote. No scanners,
+    # no network: a pure correlation layer that no-ops byte-identically when the
+    # report carries no ``findings`` block.
+    try:
+        _apply_aspm_overlay(graph, report_json)
+    except Exception:  # noqa: BLE001
+        _logger.warning("ASPM overlay failed", exc_info=True)
+
     if span is not None:
         span.set_attribute("agent_bom.graph.scan_id", sid)
         span.set_attribute("agent_bom.graph.tenant_id", tenant_id or "default")
@@ -1091,6 +1104,28 @@ def _apply_cost_overlay(graph: UnifiedGraph, report_json: Mapping[str, Any]) -> 
     from agent_bom.graph.cost_overlay import apply_cost_overlay
 
     apply_cost_overlay(graph, records, datetime.now(timezone.utc))
+
+
+def _apply_aspm_overlay(graph: UnifiedGraph, report_json: Mapping[str, Any]) -> None:
+    """Correlate AppSec findings around applications from the report's findings.
+
+    Reads the optional unified ``findings`` block (a list of ``Finding.to_dict()``
+    dicts the report already carries) and hands it to
+    :func:`agent_bom.graph.aspm_overlay.apply_aspm_overlay`, which derives
+    APPLICATION roots, attaches each finding via ``BELONGS_TO``, rolls up per-app
+    risk, dedupes duplicate CVE/rule across sources, and flags reachability from
+    existing attack-path data. Gated to a clean no-op when the block is absent or
+    empty, so a scan with no findings leaves the graph byte-identical. Mirrors how
+    ``_apply_cost_overlay`` is invoked above.
+    """
+    raw = report_json.get("findings")
+    if not isinstance(raw, list) or not raw:
+        return
+    from datetime import datetime, timezone
+
+    from agent_bom.graph.aspm_overlay import apply_aspm_overlay
+
+    apply_aspm_overlay(graph, dict(report_json), datetime.now(timezone.utc))
 
 
 def _iter_agentic_identity_graph_projections(report_json: Mapping[str, Any]) -> list[Mapping[str, Any]]:

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -894,6 +894,7 @@ ENTITY_LEGEND: list[LegendEntry] = [
     LegendEntry(key="access_policy", label="Access Policy", color="#a16207", shape="diamond", layer=GraphSemanticLayer.IDENTITY.value),
     LegendEntry(key="drift_incident", label="Drift Incident", color="#fb923c", shape="triangle", layer=GraphSemanticLayer.FINDING.value),
     LegendEntry(key="data_store", label="Data Store", color="#0284c7", shape="square", layer=GraphSemanticLayer.ASSET.value),
+    LegendEntry(key="application", label="Application", color="#7c3aed", shape="circle", layer=GraphSemanticLayer.APP.value),
 ]
 
 RELATIONSHIP_LEGEND: list[LegendEntry] = [
@@ -950,4 +951,6 @@ RELATIONSHIP_LEGEND: list[LegendEntry] = [
     LegendEntry(key="exposed_to", label="Exposed To", color="#e11d48"),
     LegendEntry(key="stores", label="Stores", color="#0284c7"),
     LegendEntry(key="has_permission", label="Has Permission", color="#dc2626"),
+    # ASPM
+    LegendEntry(key="belongs_to", label="Belongs To (application)", color="#7c3aed"),
 ]

--- a/src/agent_bom/graph/ocsf.py
+++ b/src/agent_bom/graph/ocsf.py
@@ -53,6 +53,8 @@ ENTITY_OCSF_MAP: dict[str, dict[str, int]] = {
     EntityType.DRIFT_INCIDENT: {"category_uid": 2, "class_uid": 2004},
     # Cloud-CNAPP data primitive (Category 5 — inventory)
     EntityType.DATA_STORE: {"category_uid": 5, "class_uid": 4001},
+    # ASPM application root (Category 5 — inventory)
+    EntityType.APPLICATION: {"category_uid": 5, "class_uid": 4001},
     # Organizational (virtual)
     EntityType.PROVIDER: {"category_uid": 0, "class_uid": 0},
     EntityType.ENVIRONMENT: {"category_uid": 0, "class_uid": 0},

--- a/src/agent_bom/graph/types.py
+++ b/src/agent_bom/graph/types.py
@@ -58,6 +58,12 @@ class EntityType(str, Enum):
     # and path-to-sensitive-data first-class for attack-path traversal.
     DATA_STORE = "data_store"  # database / bucket / data lake holding data at rest
 
+    # Application Security Posture Management (ASPM) — an application is the
+    # correlation root that AppSec findings (SCA / secrets / IaC / container /
+    # CI-CD / AI-BOM) are grouped and rolled up around. Derived per
+    # service/repo/manifest-root by the ASPM overlay (OCSF Category 5 inventory).
+    APPLICATION = "application"
+
     # Organizational hierarchy
     PROVIDER = "provider"
     ENVIRONMENT = "environment"
@@ -151,6 +157,11 @@ class RelationshipType(str, Enum):
     # they stay visible without being conflated with the strict path.
     CORRELATES_WITH = "correlates_with"  # local agent ↔ cloud agent (high)
     POSSIBLY_CORRELATES_WITH = "possibly_correlates_with"  # local ↔ cloud (low)
+
+    # ── Application Security Posture Management (ASPM) ──
+    # Finding/component → application correlation. The ASPM overlay groups every
+    # AppSec signal already in the graph around the application it belongs to.
+    BELONGS_TO = "belongs_to"  # finding/component/asset → application
 
 
 class NodeStatus(str, Enum):

--- a/tests/test_graph_aspm_overlay.py
+++ b/tests/test_graph_aspm_overlay.py
@@ -1,0 +1,401 @@
+"""Tests for the ASPM (Application Security Posture Management) overlay.
+
+The overlay organises the AppSec findings already in the graph AROUND the
+application they belong to: it derives APPLICATION roots from finding source
+paths, attaches findings via BELONGS_TO, rolls up per-app risk, dedupes the same
+CVE/rule across sources, and flags reachability from existing attack-path data.
+It is a pure correlation layer (no scanners) — deterministic, idempotent, and a
+no-op when the report carries no findings.
+"""
+
+from __future__ import annotations
+
+import copy
+from datetime import datetime, timezone
+
+import pytest
+
+from agent_bom.graph.aspm_overlay import apply_aspm_overlay
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+NOW = datetime(2026, 6, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _finding(
+    *,
+    source: str,
+    severity: str = "high",
+    cve_id: str | None = None,
+    title: str = "",
+    location: str = "",
+    name: str = "pkg",
+    identifier: str | None = None,
+    asset_type: str = "package",
+    reachability: str = "",
+    is_actionable: bool = False,
+) -> dict:
+    """Build a minimal ``Finding.to_dict()``-shaped payload."""
+    return {
+        "source": source,
+        "severity": severity,
+        "effective_severity": severity,
+        "cve_id": cve_id,
+        "title": title or (cve_id or "finding"),
+        "finding_type": "CVE" if cve_id else "SAST",
+        "reachability": reachability,
+        "is_actionable": is_actionable,
+        "asset": {
+            "name": name,
+            "asset_type": asset_type,
+            "identifier": identifier,
+            "location": location,
+            "stable_id": identifier or f"stable:{name}:{location}",
+            "canonical_id": identifier or f"stable:{name}:{location}",
+        },
+    }
+
+
+def _app_node(graph: UnifiedGraph, app_key: str) -> UnifiedNode:
+    node = graph.get_node(f"application:{app_key}")
+    assert node is not None, f"no application node for {app_key} (have {sorted(graph.nodes)})"
+    return node
+
+
+# ── No-op safety ─────────────────────────────────────────────────────────
+
+
+def test_empty_findings_is_byte_identical_noop():
+    graph = UnifiedGraph(scan_id="s1")
+    graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="a"))
+    before = copy.deepcopy(graph.to_dict())
+
+    for report in ({}, {"findings": []}, {"findings": [123, "x"]}):
+        result = apply_aspm_overlay(graph, report, NOW)
+        assert result == {"applications": 0, "correlated_findings": 0, "deduplicated": 0, "reachable": 0}
+        assert graph.to_dict() == before
+
+
+def test_findings_without_derivable_app_are_skipped():
+    graph = UnifiedGraph(scan_id="s1")
+    # No location and no asset name → no app derivable.
+    report = {"findings": [_finding(source="SAST", location="", name="")]}
+    result = apply_aspm_overlay(graph, report, NOW)
+    assert result["applications"] == 0
+    assert not [n for n in graph.nodes if n.startswith("application:")]
+
+
+# ── Application derivation + aggregation ───────────────────────────────────
+
+
+def test_findings_group_into_the_right_apps():
+    graph = UnifiedGraph(scan_id="s1")
+    report = {
+        "findings": [
+            _finding(source="SBOM", location="services/billing/requirements.txt", name="requests", cve_id="CVE-2024-1"),
+            _finding(source="SAST", location="services/billing/app/main.py", name="main.py", title="sql-injection"),
+            _finding(source="SECRET_SCAN", location="services/checkout/config.yaml", name="config", title="aws-key"),
+        ]
+    }
+    result = apply_aspm_overlay(graph, report, NOW)
+
+    assert result["correlated_findings"] == 3
+    app_ids = sorted(n for n in graph.nodes if n.startswith("application:"))
+    assert app_ids == ["application:services/billing", "application:services/checkout"]
+
+    billing = _app_node(graph, "services/billing")
+    checkout = _app_node(graph, "services/checkout")
+    assert billing.attributes["finding_count"] == 2
+    assert checkout.attributes["finding_count"] == 1
+
+
+def test_manifest_file_collapses_to_its_directory_root():
+    graph = UnifiedGraph(scan_id="s1")
+    report = {
+        "findings": [
+            _finding(source="SBOM", location="apps/web/package.json", name="lodash", cve_id="CVE-2024-2"),
+            _finding(source="SBOM", location="apps/web/package-lock.json", name="lodash", cve_id="CVE-2024-2"),
+        ]
+    }
+    apply_aspm_overlay(graph, report, NOW)
+    assert _app_node(graph, "apps/web").attributes["app_key"] == "apps/web"
+
+
+def test_per_app_risk_rollup_counts_and_score():
+    graph = UnifiedGraph(scan_id="s1")
+    report = {
+        "findings": [
+            _finding(source="SBOM", location="svc/api/go.mod", name="a", cve_id="CVE-1", severity="critical"),
+            _finding(source="SBOM", location="svc/api/go.mod", name="b", cve_id="CVE-2", severity="high"),
+            _finding(source="SAST", location="svc/api/h.go", name="h.go", title="xss", severity="medium"),
+        ]
+    }
+    apply_aspm_overlay(graph, report, NOW)
+    app = _app_node(graph, "svc/api")
+    counts = app.attributes["severity_counts"]
+    assert counts["critical"] == 1
+    assert counts["high"] == 1
+    assert counts["medium"] == 1
+    assert counts["low"] == 0
+    # 8.0 (crit) + 6.0 (high) + 4.0 (med) = 18.0
+    assert app.attributes["aspm_risk_score"] == pytest.approx(18.0)
+    # App severity = worst bucket present.
+    assert app.severity == "critical"
+
+
+def test_belongs_to_edges_attach_existing_finding_nodes():
+    graph = UnifiedGraph(scan_id="s1")
+    # The vuln node must already exist for a BELONGS_TO edge to be drawn.
+    graph.add_node(UnifiedNode(id="vuln:CVE-2024-9", entity_type=EntityType.VULNERABILITY, label="CVE-2024-9", severity="high"))
+    report = {"findings": [_finding(source="SBOM", location="svc/pay/pom.xml", name="log4j", cve_id="CVE-2024-9")]}
+    apply_aspm_overlay(graph, report, NOW)
+
+    belongs = [
+        e
+        for e in graph.edges
+        if e.relationship == RelationshipType.BELONGS_TO and e.source == "vuln:CVE-2024-9" and e.target == "application:svc/pay"
+    ]
+    assert len(belongs) == 1
+
+
+def test_finding_without_existing_node_is_counted_but_no_dangling_edge():
+    graph = UnifiedGraph(scan_id="s1")
+    # No vuln node added → finding counted in roll-up, but no BELONGS_TO edge.
+    report = {"findings": [_finding(source="SBOM", location="svc/x/go.mod", name="z", cve_id="CVE-X")]}
+    apply_aspm_overlay(graph, report, NOW)
+    assert _app_node(graph, "svc/x").attributes["finding_count"] == 1
+    assert not [e for e in graph.edges if e.relationship == RelationshipType.BELONGS_TO]
+
+
+# ── Cross-finding dedup ────────────────────────────────────────────────────
+
+
+def test_same_cve_across_two_sources_counted_once_with_both_in_provenance():
+    graph = UnifiedGraph(scan_id="s1")
+    report = {
+        "findings": [
+            _finding(source="SBOM", location="svc/api/go.mod", name="openssl", identifier="pkg:generic/openssl@1.0", cve_id="CVE-7"),
+            _finding(source="CONTAINER", location="svc/api/go.mod", name="openssl", identifier="pkg:generic/openssl@1.0", cve_id="CVE-7"),
+        ]
+    }
+    result = apply_aspm_overlay(graph, report, NOW)
+
+    assert result["correlated_findings"] == 2
+    assert result["deduplicated"] == 1
+    app = _app_node(graph, "svc/api")
+    # Two source reports of the same (component, CVE) collapse to one finding.
+    assert app.attributes["finding_count"] == 1
+    # Both reporting sources retained as provenance.
+    assert app.attributes["finding_sources"] == ["container", "sbom"]
+
+
+def test_different_components_same_cve_not_deduped():
+    graph = UnifiedGraph(scan_id="s1")
+    report = {
+        "findings": [
+            _finding(source="SBOM", location="svc/api/go.mod", name="a", identifier="pkg:a@1", cve_id="CVE-9"),
+            _finding(source="SBOM", location="svc/api/go.mod", name="b", identifier="pkg:b@1", cve_id="CVE-9"),
+        ]
+    }
+    result = apply_aspm_overlay(graph, report, NOW)
+    assert result["deduplicated"] == 0
+    assert _app_node(graph, "svc/api").attributes["finding_count"] == 2
+
+
+def test_dedup_keeps_worst_severity():
+    graph = UnifiedGraph(scan_id="s1")
+    report = {
+        "findings": [
+            _finding(source="SBOM", location="svc/api/go.mod", name="x", identifier="pkg:x@1", cve_id="CVE-5", severity="low"),
+            _finding(source="CONTAINER", location="svc/api/go.mod", name="x", identifier="pkg:x@1", cve_id="CVE-5", severity="critical"),
+        ]
+    }
+    apply_aspm_overlay(graph, report, NOW)
+    app = _app_node(graph, "svc/api")
+    assert app.attributes["finding_count"] == 1
+    assert app.attributes["severity_counts"]["critical"] == 1
+    assert app.attributes["severity_counts"]["low"] == 0
+
+
+# ── Reachability hook ──────────────────────────────────────────────────────
+
+
+def test_reachable_flag_set_when_attack_path_data_present():
+    from agent_bom.graph.container import AttackPath
+
+    graph = UnifiedGraph(scan_id="s1")
+    graph.add_node(UnifiedNode(id="vuln:CVE-R", entity_type=EntityType.VULNERABILITY, label="CVE-R", severity="high"))
+    graph.attack_paths.append(
+        AttackPath(
+            source="agent:a",
+            target="vuln:CVE-R",
+            hops=["agent:a", "server:s", "vuln:CVE-R"],
+            edges=["uses", "vulnerable_to"],
+            composite_risk=9.0,
+            summary="chain",
+        )
+    )
+    report = {"findings": [_finding(source="SBOM", location="svc/api/go.mod", name="p", cve_id="CVE-R")]}
+    result = apply_aspm_overlay(graph, report, NOW)
+    assert result["reachable"] == 1
+    assert _app_node(graph, "svc/api").attributes["reachable_finding_count"] == 1
+
+
+def test_exposed_node_marks_finding_reachable():
+    graph = UnifiedGraph(scan_id="s1")
+    graph.add_node(
+        UnifiedNode(
+            id="vuln:CVE-E",
+            entity_type=EntityType.VULNERABILITY,
+            label="CVE-E",
+            severity="high",
+            attributes={"internet_exposed": True},
+        )
+    )
+    report = {"findings": [_finding(source="SBOM", location="svc/api/go.mod", name="p", cve_id="CVE-E")]}
+    result = apply_aspm_overlay(graph, report, NOW)
+    assert result["reachable"] == 1
+
+
+def test_no_reachability_signal_defaults_unknown():
+    graph = UnifiedGraph(scan_id="s1")
+    report = {"findings": [_finding(source="SAST", location="svc/api/main.py", name="main.py", title="bug")]}
+    result = apply_aspm_overlay(graph, report, NOW)
+    assert result["reachable"] == 0
+    assert _app_node(graph, "svc/api").attributes["reachable_finding_count"] == 0
+
+
+def test_finding_reachability_hint_marks_reachable():
+    graph = UnifiedGraph(scan_id="s1")
+    report = {"findings": [_finding(source="SBOM", location="svc/api/go.mod", name="p", cve_id="CVE-H", reachability="reachable")]}
+    result = apply_aspm_overlay(graph, report, NOW)
+    assert result["reachable"] == 1
+
+
+# ── Owner derivation ───────────────────────────────────────────────────────
+
+
+def test_owner_from_codeowners_longest_prefix_match():
+    graph = UnifiedGraph(scan_id="s1")
+    report = {
+        "codeowners": {"services": "@platform", "services/billing": "@payments"},
+        "findings": [
+            _finding(source="SBOM", location="services/billing/go.mod", name="p", cve_id="CVE-1"),
+            _finding(source="SBOM", location="services/search/go.mod", name="q", cve_id="CVE-2"),
+        ],
+    }
+    apply_aspm_overlay(graph, report, NOW)
+    assert _app_node(graph, "services/billing").attributes["owner"] == "@payments"
+    assert _app_node(graph, "services/search").attributes["owner"] == "@platform"
+
+
+def test_owner_from_codeowners_list_form():
+    graph = UnifiedGraph(scan_id="s1")
+    report = {
+        "codeowners": [{"path": "svc/api", "owners": ["@a", "@b"]}],
+        "findings": [_finding(source="SBOM", location="svc/api/go.mod", name="p", cve_id="CVE-1")],
+    }
+    apply_aspm_overlay(graph, report, NOW)
+    assert _app_node(graph, "svc/api").attributes["owner"] == "@a, @b"
+
+
+# ── Determinism + idempotency ──────────────────────────────────────────────
+
+
+def _report():
+    return {
+        "codeowners": {"services/billing": "@payments"},
+        "findings": [
+            _finding(source="SBOM", location="services/billing/go.mod", name="a", identifier="pkg:a@1", cve_id="CVE-1", severity="high"),
+            _finding(
+                source="CONTAINER",
+                location="services/billing/go.mod",
+                name="a",
+                identifier="pkg:a@1",
+                cve_id="CVE-1",
+                severity="critical",
+            ),
+            _finding(source="SAST", location="services/billing/main.go", name="main.go", title="xss", severity="medium"),
+            _finding(source="SECRET_SCAN", location="services/checkout/config.yaml", name="cfg", title="key", severity="high"),
+        ],
+    }
+
+
+def test_applying_twice_is_idempotent():
+    graph = UnifiedGraph(scan_id="s1")
+    graph.add_node(UnifiedNode(id="vuln:CVE-1", entity_type=EntityType.VULNERABILITY, label="CVE-1", severity="critical"))
+
+    first = apply_aspm_overlay(graph, _report(), NOW)
+    snapshot = copy.deepcopy(graph.to_dict())
+    second = apply_aspm_overlay(graph, _report(), NOW)
+
+    assert graph.to_dict() == snapshot
+    # Second application creates no new application nodes.
+    assert second["applications"] == 0
+    assert first["correlated_findings"] == second["correlated_findings"]
+
+
+def test_deterministic_across_input_order():
+    report_a = _report()
+    report_b = _report()
+    report_b["findings"].reverse()
+
+    g1 = UnifiedGraph(scan_id="s1")
+    g1.add_node(UnifiedNode(id="vuln:CVE-1", entity_type=EntityType.VULNERABILITY, label="CVE-1"))
+    g2 = UnifiedGraph(scan_id="s1")
+    g2.add_node(UnifiedNode(id="vuln:CVE-1", entity_type=EntityType.VULNERABILITY, label="CVE-1"))
+
+    apply_aspm_overlay(g1, report_a, NOW)
+    apply_aspm_overlay(g2, report_b, NOW)
+
+    def app_attrs(g: UnifiedGraph) -> dict:
+        return {nid: n.attributes for nid, n in sorted(g.nodes.items()) if nid.startswith("application:")}
+
+    assert app_attrs(g1) == app_attrs(g2)
+
+
+def test_belongs_to_edges_deduped_across_applies():
+    graph = UnifiedGraph(scan_id="s1")
+    graph.add_node(UnifiedNode(id="vuln:CVE-1", entity_type=EntityType.VULNERABILITY, label="CVE-1"))
+    report = {"findings": [_finding(source="SBOM", location="svc/api/go.mod", name="p", cve_id="CVE-1")]}
+    apply_aspm_overlay(graph, report, NOW)
+    apply_aspm_overlay(graph, report, NOW)
+    belongs = [e for e in graph.edges if e.relationship == RelationshipType.BELONGS_TO]
+    assert len(belongs) == 1
+
+
+# ── Builder integration ────────────────────────────────────────────────────
+
+
+def test_builder_invokes_aspm_overlay():
+    from agent_bom.graph.builder import build_unified_graph_from_report
+
+    report = {
+        "scan_id": "build-1",
+        "agents": [],
+        "findings": [
+            _finding(source="SBOM", location="services/billing/go.mod", name="p", cve_id="CVE-1", severity="high"),
+        ],
+    }
+    graph = build_unified_graph_from_report(report)
+    assert graph.get_node("application:services/billing") is not None
+
+
+def test_builder_no_findings_emits_no_application_nodes():
+    from agent_bom.graph.builder import build_unified_graph_from_report
+
+    graph = build_unified_graph_from_report({"scan_id": "build-2", "agents": []})
+    assert not [n for n in graph.nodes if n.startswith("application:")]
+
+
+def test_belongs_to_edge_dedup_helper_path():
+    """A duplicate BELONGS_TO edge from add_edge is merged, not appended."""
+    graph = UnifiedGraph(scan_id="s1")
+    graph.add_node(UnifiedNode(id="vuln:CVE-1", entity_type=EntityType.VULNERABILITY, label="CVE-1"))
+    graph.add_node(UnifiedNode(id="application:svc", entity_type=EntityType.APPLICATION, label="svc"))
+    edge = UnifiedEdge(source="vuln:CVE-1", target="application:svc", relationship=RelationshipType.BELONGS_TO)
+    graph.add_edge(edge)
+    graph.add_edge(edge)
+    assert len([e for e in graph.edges if e.relationship == RelationshipType.BELONGS_TO]) == 1

--- a/ui/lib/graph-schema.generated.ts
+++ b/ui/lib/graph-schema.generated.ts
@@ -90,6 +90,7 @@ export enum GraphNodeKind {
   ACCESS_POLICY = "access_policy",
   ACCOUNT = "account",
   AGENT = "agent",
+  APPLICATION = "application",
   CI_JOB = "ci_job",
   CLOUD_RESOURCE = "cloud_resource",
   CLUSTER = "cluster",
@@ -125,9 +126,9 @@ export enum GraphNodeKind {
   VULNERABILITY = "vulnerability",
 }
 
-export type GraphNodeKindKey = "access_grant" | "access_policy" | "account" | "agent" | "ci_job" | "cloud_resource" | "cluster" | "code_module" | "config_file" | "container" | "credential" | "credential_ref" | "data_store" | "dataset" | "drift_incident" | "environment" | "external_import" | "federated_identity" | "fleet" | "group" | "managed_identity" | "misconfiguration" | "model" | "org" | "package" | "policy" | "provider" | "resource" | "role" | "server" | "service_account" | "service_principal" | "source_file" | "tool" | "tool_call" | "user" | "vulnerability";
+export type GraphNodeKindKey = "access_grant" | "access_policy" | "account" | "agent" | "application" | "ci_job" | "cloud_resource" | "cluster" | "code_module" | "config_file" | "container" | "credential" | "credential_ref" | "data_store" | "dataset" | "drift_incident" | "environment" | "external_import" | "federated_identity" | "fleet" | "group" | "managed_identity" | "misconfiguration" | "model" | "org" | "package" | "policy" | "provider" | "resource" | "role" | "server" | "service_account" | "service_principal" | "source_file" | "tool" | "tool_call" | "user" | "vulnerability";
 
-export const GRAPH_NODE_KINDS: readonly GraphNodeKindKey[] = ["access_grant", "access_policy", "account", "agent", "ci_job", "cloud_resource", "cluster", "code_module", "config_file", "container", "credential", "credential_ref", "data_store", "dataset", "drift_incident", "environment", "external_import", "federated_identity", "fleet", "group", "managed_identity", "misconfiguration", "model", "org", "package", "policy", "provider", "resource", "role", "server", "service_account", "service_principal", "source_file", "tool", "tool_call", "user", "vulnerability"] as const;
+export const GRAPH_NODE_KINDS: readonly GraphNodeKindKey[] = ["access_grant", "access_policy", "account", "agent", "application", "ci_job", "cloud_resource", "cluster", "code_module", "config_file", "container", "credential", "credential_ref", "data_store", "dataset", "drift_incident", "environment", "external_import", "federated_identity", "fleet", "group", "managed_identity", "misconfiguration", "model", "org", "package", "policy", "provider", "resource", "role", "server", "service_account", "service_principal", "source_file", "tool", "tool_call", "user", "vulnerability"] as const;
 
 export interface GraphNodeKindMeta {
   label: string;
@@ -172,6 +173,15 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "color": "#10b981",
     "shape": "circle",
     "layer": "orchestration",
+    "icon": "circle",
+    "category_uid": 5,
+    "class_uid": 4001
+  },
+  "application": {
+    "label": "Application",
+    "color": "#7c3aed",
+    "shape": "circle",
+    "layer": "app",
     "icon": "circle",
     "category_uid": 5,
     "class_uid": 4001
@@ -486,6 +496,7 @@ export enum GraphEdgeKind {
   ASSUMES = "assumes",
   ATTACHED = "attached",
   AUTHENTICATES_AS = "authenticates_as",
+  BELONGS_TO = "belongs_to",
   CALLED = "called",
   CAN_ACCESS = "can_access",
   CONFIGURES = "configures",
@@ -527,9 +538,9 @@ export enum GraphEdgeKind {
   VULNERABLE_TO = "vulnerable_to",
 }
 
-export type GraphEdgeKindKey = "accessed" | "acted_as" | "affects" | "assumes" | "attached" | "authenticates_as" | "called" | "can_access" | "configures" | "contains" | "correlates_with" | "cross_account_trust" | "defines" | "delegated_to" | "depends_on" | "exhibits_drift" | "exploitable_via" | "exposed_to" | "exposes_cred" | "governs" | "has_permission" | "hosts" | "imports" | "inherits" | "invoked" | "lateral_path" | "manages" | "member_of" | "owns" | "part_of" | "possibly_correlates_with" | "provides_tool" | "reaches_tool" | "remediates" | "runs" | "scoped_to" | "serves_model" | "shares_cred" | "shares_server" | "stores" | "triggers" | "trusts" | "used_credential" | "uses" | "vulnerable_to";
+export type GraphEdgeKindKey = "accessed" | "acted_as" | "affects" | "assumes" | "attached" | "authenticates_as" | "belongs_to" | "called" | "can_access" | "configures" | "contains" | "correlates_with" | "cross_account_trust" | "defines" | "delegated_to" | "depends_on" | "exhibits_drift" | "exploitable_via" | "exposed_to" | "exposes_cred" | "governs" | "has_permission" | "hosts" | "imports" | "inherits" | "invoked" | "lateral_path" | "manages" | "member_of" | "owns" | "part_of" | "possibly_correlates_with" | "provides_tool" | "reaches_tool" | "remediates" | "runs" | "scoped_to" | "serves_model" | "shares_cred" | "shares_server" | "stores" | "triggers" | "trusts" | "used_credential" | "uses" | "vulnerable_to";
 
-export const GRAPH_EDGE_KINDS: readonly GraphEdgeKindKey[] = ["accessed", "acted_as", "affects", "assumes", "attached", "authenticates_as", "called", "can_access", "configures", "contains", "correlates_with", "cross_account_trust", "defines", "delegated_to", "depends_on", "exhibits_drift", "exploitable_via", "exposed_to", "exposes_cred", "governs", "has_permission", "hosts", "imports", "inherits", "invoked", "lateral_path", "manages", "member_of", "owns", "part_of", "possibly_correlates_with", "provides_tool", "reaches_tool", "remediates", "runs", "scoped_to", "serves_model", "shares_cred", "shares_server", "stores", "triggers", "trusts", "used_credential", "uses", "vulnerable_to"] as const;
+export const GRAPH_EDGE_KINDS: readonly GraphEdgeKindKey[] = ["accessed", "acted_as", "affects", "assumes", "attached", "authenticates_as", "belongs_to", "called", "can_access", "configures", "contains", "correlates_with", "cross_account_trust", "defines", "delegated_to", "depends_on", "exhibits_drift", "exploitable_via", "exposed_to", "exposes_cred", "governs", "has_permission", "hosts", "imports", "inherits", "invoked", "lateral_path", "manages", "member_of", "owns", "part_of", "possibly_correlates_with", "provides_tool", "reaches_tool", "remediates", "runs", "scoped_to", "serves_model", "shares_cred", "shares_server", "stores", "triggers", "trusts", "used_credential", "uses", "vulnerable_to"] as const;
 
 export interface GraphEdgeKindMeta {
   label: string;
@@ -637,6 +648,25 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     ],
     "target_types": [
       "managed_identity"
+    ],
+    "traversable": true
+  },
+  "belongs_to": {
+    "label": "Belongs To (application)",
+    "color": "#7c3aed",
+    "category": "aspm",
+    "direction": "directed",
+    "source_types": [
+      "vulnerability",
+      "misconfiguration",
+      "package",
+      "container",
+      "cloud_resource",
+      "server",
+      "credential"
+    ],
+    "target_types": [
+      "application"
     ],
     "traversable": true
   },

--- a/ui/lib/graph-schema.ts
+++ b/ui/lib/graph-schema.ts
@@ -82,6 +82,8 @@ export enum EntityType {
   DRIFT_INCIDENT = "drift_incident",
   // Cloud-CNAPP primitives
   DATA_STORE = "data_store",
+  // Application Security Posture Management (ASPM)
+  APPLICATION = "application",
   // Organizational hierarchy
   PROVIDER = "provider",
   ENVIRONMENT = "environment",
@@ -145,6 +147,9 @@ export enum RelationshipType {
   EXPOSED_TO = "exposed_to",
   STORES = "stores",
   HAS_PERMISSION = "has_permission",
+
+  // Application Security Posture Management (ASPM)
+  BELONGS_TO = "belongs_to",
 }
 
 export enum NodeStatus {
@@ -458,6 +463,7 @@ export const ENTITY_COLOR_MAP: Record<string, string> = {
   [EntityType.ACCESS_POLICY]: "#a16207",   // amber
   [EntityType.DRIFT_INCIDENT]: "#fb923c",  // orange
   [EntityType.DATA_STORE]: "#0284c7",      // sky
+  [EntityType.APPLICATION]: "#7c3aed",     // violet
   [EntityType.PROVIDER]: "#6b7280",        // gray
   [EntityType.ENVIRONMENT]: "#6b7280",     // gray
 };
@@ -513,6 +519,8 @@ export const RELATIONSHIP_COLOR_MAP: Record<string, string> = {
   [RelationshipType.EXPOSED_TO]: "#e11d48",
   [RelationshipType.STORES]: "#0284c7",
   [RelationshipType.HAS_PERMISSION]: "#dc2626",
+  // ASPM relations.
+  [RelationshipType.BELONGS_TO]: "#7c3aed",
 };
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What

Adds an **Application Security Posture Management (ASPM)** overlay that organizes the AppSec signals agent-bom already produces — SCA, secrets, IaC, container, CI/CD, SBOM, and AI-BOM findings — **around the application they belong to**. It is a pure correlation layer over the existing graph and unified findings: **no new scanners**.

## How

`graph/aspm_overlay.py::apply_aspm_overlay(graph, report_json, now)` mirrors the cost-overlay pattern and is invoked once from `build_unified_graph_from_report` (a thin `_apply_aspm_overlay` call alongside the other overlay calls, running last so it sees attack-path and exposure signal):

- **Application inventory** — derives an `APPLICATION` root per service / repo / manifest-root from each finding's source path (`asset.location`). Manifest roots (package.json, go.mod, pyproject.toml, Dockerfile, …) are discovered first so deeply-nested source-file findings collapse onto the project root that owns them, not their own sub-directory. Falls back to the asset name when no path exists. Best-effort owner pulled from a `codeowners` map (longest-prefix match) when the report carries one.
- **Per-app aggregation** — attaches every finding's existing graph node to its application via a `BELONGS_TO` edge and computes a deterministic per-app roll-up (counts by severity + an `aspm_risk_score`, plus the worst-severity bucket as the app severity).
- **Cross-finding dedup** — within an application, the same CVE/rule on the same component across multiple sources is merged so it is counted once, keyed on a stable `(component, rule/cve)` tuple. Every reporting source is retained in `finding_sources` as provenance; the worst severity and strongest reachability signal win.
- **Reachability hook** — a finding is flagged `reachable` when its component node sits on a materialised attack path, carries an exposure flag (internet-exposed / toxic combo), or the finding itself reports a reachable code path; `unknown` otherwise. No new reachability engine — only existing attack-path data is consulted.
- **No-op safety** — zero findings / no derivable application ⇒ the graph stays byte-identical.

The overlay is **idempotent** (applying twice yields identical nodes/edges/attributes), **deterministic** (all iteration sorted; `now` is injected, no inline `datetime.now`), and **additive** (only `APPLICATION` nodes, `BELONGS_TO` edges, and per-app attributes are added — no existing node/edge meaning changes).

The new `APPLICATION` entity type and `BELONGS_TO` relationship type are wired through the OCSF map, graph legends, `/v1/graph/schema` relationship metadata, the UI graph schema (hand-rolled + regenerated generated file), and the data-model taxonomy doc.

Broader external SARIF ingestion (Semgrep / CodeQL) is deferred to a separate task; this PR is the app-centric correlation over the findings that already exist.

## Tests

`tests/test_graph_aspm_overlay.py` (22 tests): findings group into the right apps, manifest-root collapse, per-app risk roll-up correctness, BELONGS_TO attaches existing nodes (and no dangling edge when the node is absent), duplicate CVE across two sources counted once with both sources in provenance, different components not deduped, worst-severity-on-dedup, reachable flag set from attack-path / exposure / finding hint, unknown default, CODEOWNERS owner (dict + list forms), idempotency, order-independence, edge dedup across applies, and builder integration (with/without findings).

`uv run ruff check` + `uv run ruff format --check` + `uv run mypy` clean; `pytest -k "aspm or application or graph or overlay or dedup"` green; UI `tsc --noEmit` and graph-schema invariant vitest tests green; `/v1/graph/schema` codegen `--check` confirms the generated TS matches.