### PR TITLE
feat(cli): canonical front-door verbs (connect/scan/graph/report/up)

### DIFF
--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -2,6 +2,17 @@
 
 ## Commands
 
+### Get started
+
+The narrow front door for humans: `connect` → `scan` → `graph` → `report`, plus
+`up` to run the platform locally. Every command below remains available; these
+verbs are additive entry points that delegate to the underlying implementations.
+
+| Command | Description |
+|---------|-------------|
+| `connect` | Read-only onboard a cloud or data source (AWS, Azure, GCP, Snowflake); prints the exact read-only Terraform module and opt-in inventory env var, then reports detected credentials |
+| `up` | Run the platform locally — alias of `serve`; accepts the same flags and points at `deploy/docker-compose.fullstack.yml` for the full stack |
+
 ### Scanning
 
 | Command | Description |

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -208,6 +208,16 @@ main.add_command(serve_cmd, "serve")
 main.add_command(api_cmd, "api")
 # mcp-server is under `mcp server` — no top-level duplicate
 
+# ---------------------------------------------------------------------------
+# Canonical front-door verbs — the narrow human entry point.
+# connect → scan → graph → report (and `up` to run the platform locally).
+# `scan`/`graph`/`report` already exist; `connect` + `up` are additive.
+# ---------------------------------------------------------------------------
+from agent_bom.cli._entry_points import connect_group, make_up_command  # noqa: E402
+
+main.add_command(connect_group, "connect")
+main.add_command(make_up_command(serve_cmd), "up")
+
 from agent_bom.cli._gateway import gateway_group  # noqa: E402
 
 main.add_command(gateway_group, "gateway")

--- a/src/agent_bom/cli/_entry_points.py
+++ b/src/agent_bom/cli/_entry_points.py
@@ -1,0 +1,247 @@
+"""Canonical front-door verbs for the human CLI.
+
+agent-bom exposes a deep command catalog (scanning, runtime, MCP, reporting,
+governance, plus every cloud/identity/cost surface). For a first-time human the
+breadth is the problem, not the depth. This module adds a *narrow front door* —
+five canonical verbs that read like a story:
+
+    connect → scan → graph → report     (and `up` to run the platform locally)
+
+Nothing here removes or rewrites an existing command. ``scan``, ``graph`` and
+``report`` already exist and are simply surfaced as the primary verbs in
+``--help``. This module contributes the two genuinely new verbs:
+
+* ``connect`` — read-only onboarding guidance for a cloud/source. It points at
+  the per-cloud read-only Terraform module under ``deploy/terraform/connect-*``
+  and the opt-in inventory env var, then reports whether local credentials are
+  already detectable so the next ``scan`` will have something to read.
+* ``up`` (alias of ``serve``) — run the platform locally. It delegates to the
+  existing ``serve`` command and points at the full-stack docker compose file.
+
+Every flag/behavior of the underlying commands is preserved; these verbs are
+additive aliases and guidance, not a restructure.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import click
+
+# ---------------------------------------------------------------------------
+# `connect` — read-only onboarding guidance + credential detection
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ConnectSource:
+    """Static description of one connectable cloud/source.
+
+    All values are documentation pointers — ``connect`` never mutates anything
+    and never calls a cloud API. ``cred_env_vars`` are the standard provider
+    credential variables we look for to report whether a local scan will have
+    something to read.
+    """
+
+    name: str
+    title: str
+    terraform_module: str
+    inventory_env: str
+    inventory_value: str
+    cred_env_vars: tuple[str, ...]
+    scan_command: str
+    role_summary: str
+
+
+# Ordered to match the documented onboarding story (cloud → data platforms).
+_CONNECT_SOURCES: dict[str, _ConnectSource] = {
+    "aws": _ConnectSource(
+        name="aws",
+        title="Amazon Web Services",
+        terraform_module="deploy/terraform/connect-aws",
+        inventory_env="AGENT_BOM_AWS_INVENTORY",
+        inventory_value="1",
+        cred_env_vars=("AWS_PROFILE", "AWS_ACCESS_KEY_ID", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE"),
+        scan_command="agent-bom scan --aws",
+        role_summary="IAM principal with AWS-managed SecurityAudit (+ ViewOnlyAccess). List/Describe/Get only.",
+    ),
+    "azure": _ConnectSource(
+        name="azure",
+        title="Microsoft Azure",
+        terraform_module="deploy/terraform/connect-azure",
+        inventory_env="AGENT_BOM_AZURE_INVENTORY",
+        inventory_value="1",
+        cred_env_vars=("AZURE_CLIENT_ID", "AZURE_TENANT_ID", "AZURE_SUBSCRIPTION_ID"),
+        scan_command="agent-bom scan --azure",
+        role_summary="Service principal with the built-in Reader role. Read-only; no write/delete grants.",
+    ),
+    "gcp": _ConnectSource(
+        name="gcp",
+        title="Google Cloud Platform",
+        terraform_module="deploy/terraform/connect-gcp",
+        inventory_env="AGENT_BOM_GCP_INVENTORY",
+        inventory_value="1",
+        cred_env_vars=("GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT"),
+        scan_command="agent-bom scan --gcp",
+        role_summary="Service account with roles/viewer (+ roles/iam.securityReviewer). Read-only.",
+    ),
+    "snowflake": _ConnectSource(
+        name="snowflake",
+        title="Snowflake",
+        terraform_module="deploy/terraform/connect-snowflake",
+        inventory_env="SNOWFLAKE_ACCOUNT",
+        inventory_value="<your-account-locator>",
+        cred_env_vars=("SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PRIVATE_KEY_PATH"),
+        scan_command="agent-bom cloud snowflake",
+        role_summary="Read-only role (warehouse USAGE + governance views). No DML/DDL grants.",
+    ),
+}
+
+
+def _detected_cred_vars(source: _ConnectSource) -> list[str]:
+    """Return the subset of the source's credential env vars currently set."""
+    return [name for name in source.cred_env_vars if os.environ.get(name)]
+
+
+def _render_connect_guidance(con: object, source: _ConnectSource) -> None:
+    """Print the deterministic read-only setup for one source.
+
+    Output is fixed for a given environment (only the credential-detection line
+    reflects the current env), so it is safe to snapshot in tests.
+    """
+    printer = con.print  # type: ignore[attr-defined]
+    printer()
+    printer(f"  [bold]Connect {source.title}[/bold] [dim](read-only)[/dim]")
+    printer(f"  [dim]{source.role_summary}[/dim]")
+    printer()
+    printer("  [bold]1. Provision the read-only grant[/bold]")
+    printer(f"     [cyan]terraform -chdir={source.terraform_module} init && terraform -chdir={source.terraform_module} apply[/cyan]")
+    printer("     [dim]Module mints exactly the read-only role agent-bom needs — nothing is created or modified in your account.[/dim]")
+    printer()
+    printer("  [bold]2. Opt in to inventory[/bold] [dim](default-off; agent-bom does zero network I/O until set)[/dim]")
+    printer(f"     [cyan]export {source.inventory_env}={source.inventory_value}[/cyan]")
+    printer()
+    printer("  [bold]3. Scan[/bold]")
+    printer(f"     [cyan]{source.scan_command}[/cyan]")
+    printer()
+
+    detected = _detected_cred_vars(source)
+    if detected:
+        printer(f"  [green]Credentials detected:[/green] {', '.join(detected)}")
+    else:
+        expected = ", ".join(source.cred_env_vars)
+        printer(f"  [yellow]No credentials detected.[/yellow] Set one of: [dim]{expected}[/dim]")
+    printer()
+
+
+def _list_connect_sources() -> None:
+    """Print the supported `connect` sources (shown when no source is given)."""
+    from rich.console import Console
+
+    con = Console()
+    con.print()
+    con.print("  [bold]agent-bom connect[/bold] [dim]— read-only onboarding[/dim]")
+    con.print("  [dim]Pick a source; agent-bom prints the exact read-only setup and verifies detection.[/dim]")
+    con.print()
+    for source in _CONNECT_SOURCES.values():
+        con.print(f"    [cyan]>[/cyan] [bold]agent-bom connect {source.name}[/bold]   {source.title}")
+    con.print()
+
+
+@click.group(
+    "connect",
+    invoke_without_command=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.pass_context
+def connect_group(ctx: click.Context) -> None:
+    """Read-only onboard a cloud or data source.
+
+    \b
+    Prints the exact read-only setup for a source (Terraform module + opt-in
+    inventory env var), then reports whether local credentials are already
+    detectable. agent-bom never mutates the target and does no network I/O
+    until you opt in.
+
+    \b
+    Sources:
+      agent-bom connect aws         IAM SecurityAudit/ViewOnly role (read-only)
+      agent-bom connect azure       Reader-role service principal (read-only)
+      agent-bom connect gcp         roles/viewer service account (read-only)
+      agent-bom connect snowflake   read-only governance role
+
+    \b
+    Then:  agent-bom scan   ->   agent-bom graph   ->   agent-bom report
+    """
+    if ctx.invoked_subcommand is None:
+        _list_connect_sources()
+
+
+def _make_connect_subcommand(source: _ConnectSource) -> click.Command:
+    @click.command(
+        source.name,
+        help=(
+            f"Read-only onboarding for {source.title}.\n\n"
+            f"Prints the read-only Terraform module ({source.terraform_module}), the "
+            f"opt-in inventory env var ({source.inventory_env}), and the scan command, "
+            f"then reports whether local credentials are detectable. Read-only — nothing "
+            f"is created or modified in your account."
+        ),
+    )
+    def _cmd() -> None:
+        from rich.console import Console
+
+        _render_connect_guidance(Console(), source)
+
+    return _cmd
+
+
+for _source in _CONNECT_SOURCES.values():
+    connect_group.add_command(_make_connect_subcommand(_source))
+
+
+# ---------------------------------------------------------------------------
+# `up` — run the platform locally (alias of `serve`)
+# ---------------------------------------------------------------------------
+
+_FULLSTACK_COMPOSE = "deploy/docker-compose.fullstack.yml"
+
+
+def make_up_command(serve_cmd: click.Command) -> click.Command:
+    """Build the ``up`` verb as a thin pass-through to the existing ``serve``.
+
+    ``up`` keeps every flag ``serve`` accepts (host/port/persist/…) by reusing
+    ``serve``'s parameters and forwarding to its callback. The only addition is
+    an epilog pointing at the full-stack docker compose file for users who want
+    the complete UI + API + datastores rather than the single-process server.
+    """
+
+    @click.command(
+        "up",
+        context_settings={"help_option_names": ["-h", "--help"]},
+        params=list(serve_cmd.params),
+        short_help="Run the platform locally (alias of `serve`).",
+    )
+    @click.pass_context
+    def up_cmd(ctx: click.Context, **kwargs: object) -> None:
+        """Run the agent-bom platform locally (API + dashboard).
+
+        \b
+        Alias of `agent-bom serve` — accepts the same flags (--host, --port,
+        --persist, ...). Starts the single-process server with the bundled UI.
+
+        \b
+        For the full stack (UI + API + Postgres + graph store), use docker:
+          docker compose -f deploy/docker-compose.fullstack.yml up
+
+        \b
+        Needs: an open port (default 8422). No cloud credentials required to boot.
+        """
+        ctx.invoke(serve_cmd, **kwargs)
+
+    up_cmd.epilog = f"Full stack (UI + API + datastores):  docker compose -f {_FULLSTACK_COMPOSE} up"
+    return up_cmd
+
+
+__all__ = ["connect_group", "make_up_command"]

--- a/src/agent_bom/cli/_grouped_help.py
+++ b/src/agent_bom/cli/_grouped_help.py
@@ -12,8 +12,12 @@ import click
 COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
     [
         (
+            "Get started",
+            ["connect", "agents", "graph", "report", "up"],
+        ),
+        (
             "Scanning",
-            ["agents", "skills", "image", "fs", "iac", "sbom", "ingest", "cloud", "check", "verify", "secrets", "code"],
+            ["skills", "image", "fs", "iac", "sbom", "ingest", "cloud", "check", "verify", "secrets", "code"],
         ),
         (
             "Runtime",
@@ -43,6 +47,7 @@ COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
 )
 
 CATEGORY_DESCRIPTIONS: dict[str, str] = {
+    "Get started": "The front door: connect a source (read-only) → scan → graph → report. `up` runs the platform locally.",
     "Scanning": "Inventory, package, image, IaC, cloud, and skills scanning entry points.",
     "Runtime": "Live MCP enforcement, replay, and runtime monitoring surfaces.",
     "MCP": "Discovery, inventory, introspection, and MCP server operations.",
@@ -140,7 +145,7 @@ class GroupedGroup(SuggestingGroup):
     def format_epilog(self, ctx: click.Context, formatter: click.HelpFormatter) -> None:
         formatter.write_paragraph()
         formatter.write_text(
-            "Navigation tips: start with `agent-bom doctor` for readiness, "
-            "`agent-bom agents --demo` for a reproducible local run, and "
-            "`agent-bom COMMAND --help` for command-specific flags."
+            "Navigation tips: get started with connect → scan → graph → report. "
+            "Run `agent-bom doctor` for readiness, `agent-bom agents --demo` for a "
+            "reproducible local run, and `agent-bom COMMAND --help` for command-specific flags."
         )

--- a/tests/test_cli_canonical_verbs.py
+++ b/tests/test_cli_canonical_verbs.py
@@ -1,0 +1,192 @@
+"""Tests for the 5 canonical front-door verbs.
+
+The CLI exposes a narrow human front door — connect → scan → graph → report,
+plus `up` to run the platform locally — layered additively on top of the full
+command catalog. These tests verify:
+
+* All 5 verbs exist and delegate to the right implementation.
+* `--help` leads with the front door ("Get started").
+* Nothing was removed: existing commands/aliases still resolve and work.
+"""
+
+from __future__ import annotations
+
+import click
+from click.testing import CliRunner
+
+
+def _runner() -> CliRunner:
+    return CliRunner()
+
+
+# ── The 5 verbs exist + are the front door ───────────────────────────────────
+
+
+class TestFrontDoorExists:
+    def test_top_level_help_leads_with_get_started(self):
+        from agent_bom.cli import main
+
+        r = _runner().invoke(main, ["--help"])
+        assert r.exit_code == 0
+        assert "Get started" in r.output
+        # The Get started section precedes the Scanning section.
+        assert r.output.index("Get started") < r.output.index("Scanning")
+        assert "connect → scan → graph → report" in r.output
+
+    def test_five_verbs_resolve(self):
+        from agent_bom.cli import main
+
+        for verb in ("connect", "scan", "graph", "report", "up"):
+            cmd = main.get_command(None, verb)
+            assert cmd is not None, f"missing front-door verb: {verb}"
+
+    def test_visible_verbs_appear_in_help(self):
+        from agent_bom.cli import main
+
+        r = _runner().invoke(main, ["--help"])
+        for verb in ("connect", "graph", "report", "up"):
+            assert verb in r.output, f"{verb} not shown in --help"
+
+
+# ── connect ──────────────────────────────────────────────────────────────────
+
+
+class TestConnect:
+    def test_connect_lists_sources(self):
+        from agent_bom.cli import main
+
+        r = _runner().invoke(main, ["connect"])
+        assert r.exit_code == 0
+        for source in ("aws", "azure", "gcp", "snowflake"):
+            assert source in r.output
+
+    def test_connect_help_states_read_only_and_needs(self):
+        from agent_bom.cli import main
+
+        r = _runner().invoke(main, ["connect", "--help"])
+        assert r.exit_code == 0
+        assert "read-only" in r.output.lower()
+        # Each subcommand listed in help.
+        for source in ("aws", "azure", "gcp", "snowflake"):
+            assert source in r.output
+
+    def test_connect_aws_prints_terraform_module_and_env(self):
+        from agent_bom.cli import main
+
+        r = _runner().invoke(main, ["connect", "aws"])
+        assert r.exit_code == 0
+        assert "deploy/terraform/connect-aws" in r.output
+        assert "AGENT_BOM_AWS_INVENTORY" in r.output
+        assert "agent-bom scan --aws" in r.output
+
+    def test_connect_snowflake_prints_module(self):
+        from agent_bom.cli import main
+
+        r = _runner().invoke(main, ["connect", "snowflake"])
+        assert r.exit_code == 0
+        assert "deploy/terraform/connect-snowflake" in r.output
+
+    def test_connect_reports_no_credentials_when_unset(self, monkeypatch):
+        from agent_bom.cli import main
+
+        for var in ("AWS_PROFILE", "AWS_ACCESS_KEY_ID", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE"):
+            monkeypatch.delenv(var, raising=False)
+        r = _runner().invoke(main, ["connect", "aws"])
+        assert r.exit_code == 0
+        assert "No credentials detected" in r.output
+
+    def test_connect_detects_present_credentials(self, monkeypatch):
+        from agent_bom.cli import main
+
+        monkeypatch.setenv("AWS_PROFILE", "abom-readonly")
+        r = _runner().invoke(main, ["connect", "aws"])
+        assert r.exit_code == 0
+        assert "Credentials detected" in r.output
+        assert "AWS_PROFILE" in r.output
+
+
+# ── up (alias of serve) ──────────────────────────────────────────────────────
+
+
+class TestUp:
+    def test_up_help_points_at_serve_and_fullstack_compose(self):
+        from agent_bom.cli import main
+
+        r = _runner().invoke(main, ["up", "--help"])
+        assert r.exit_code == 0
+        assert "serve" in r.output
+        assert "deploy/docker-compose.fullstack.yml" in r.output
+
+    def test_up_inherits_serve_flags(self):
+        from agent_bom.cli import main
+        from agent_bom.cli._server import serve_cmd
+
+        up_cmd = main.get_command(None, "up")
+        serve_params = {p.name for p in serve_cmd.params}
+        up_params = {p.name for p in up_cmd.params}
+        assert serve_params <= up_params, "up dropped serve flags"
+
+    def test_up_delegates_to_serve(self, monkeypatch):
+        from agent_bom.cli._entry_points import make_up_command
+        from agent_bom.cli._server import serve_cmd
+
+        seen: dict[str, object] = {}
+
+        def fake_serve(**kwargs: object) -> None:
+            seen.update(kwargs)
+
+        monkeypatch.setattr(serve_cmd, "callback", fake_serve)
+        up_cmd = make_up_command(serve_cmd)
+        r = _runner().invoke(up_cmd, ["--port", "9911"])
+        assert r.exit_code == 0, r.output
+        assert seen.get("port") == 9911
+
+
+# ── Nothing removed: existing commands/aliases still work ─────────────────────
+
+
+class TestNothingRemoved:
+    def test_scan_alias_still_works(self):
+        from agent_bom.cli import main
+
+        r = _runner().invoke(main, ["scan", "--help"])
+        assert r.exit_code == 0
+
+    def test_agents_primary_command_still_works(self):
+        from agent_bom.cli import main
+
+        r = _runner().invoke(main, ["agents", "--help"])
+        assert r.exit_code == 0
+
+    def test_graph_command_unchanged(self):
+        from agent_bom.cli import main
+        from agent_bom.cli._analysis import graph_cmd
+
+        assert main.get_command(None, "graph") is graph_cmd
+
+    def test_report_group_unchanged(self):
+        from agent_bom.cli import main
+        from agent_bom.cli._report_group import report_group
+
+        assert main.get_command(None, "report") is report_group
+
+    def test_serve_command_still_registered(self):
+        from agent_bom.cli import main
+        from agent_bom.cli._server import serve_cmd
+
+        assert main.get_command(None, "serve") is serve_cmd
+
+    def test_existing_groups_intact(self):
+        from agent_bom.cli import main
+
+        for group in ("cloud", "mcp", "policy", "runtime", "identity", "cost", "report"):
+            assert main.get_command(None, group) is not None, f"{group} removed"
+
+    def test_up_is_distinct_object_from_serve(self):
+        """`up` wraps serve but is its own command (so hiding/renaming serve is unaffected)."""
+        from agent_bom.cli import main
+        from agent_bom.cli._server import serve_cmd
+
+        up_cmd = main.get_command(None, "up")
+        assert isinstance(up_cmd, click.Command)
+        assert up_cmd is not serve_cmd


### PR DESCRIPTION
## Summary

Adds a narrow, obvious front door for the human CLI — five canonical verbs layered additively over the full command catalog. The top-level `--help` now leads with a **Get started** group so a first-time user sees the workflow (`connect → scan → graph → report`) before the depth.

This is the front-door **foundation**. It removes nothing: every existing command, alias, flag, MCP tool, and API surface is unchanged. The agent surface (MCP) stays granular; this narrows only the human CLI.

## The 5 verbs

| Verb | What it does | Delegates to |
|------|--------------|--------------|
| `connect` | Read-only onboard a cloud/data source (`aws`/`azure`/`gcp`/`snowflake`). Prints the read-only Terraform module under `deploy/terraform/connect-*`, the opt-in inventory env var, and the scan command — then reports whether local credentials are detectable. Never mutates the target; no network I/O. | New guidance group (read-only Terraform modules + credential detection) |
| `scan` | Universal scan verb (cloud + code + image + AI/MCP, auto-detect). | Existing `agents`/`scan` (surfaced as primary) |
| `graph` | Emit the unified dependency/topology graph. | Existing top-level `graph` |
| `report` | Shareable artifact (history/diff/analytics/dashboard/narrative). | Existing `report` group |
| `up` | Run the platform locally; alias of `serve`, inherits every flag. Points at `deploy/docker-compose.fullstack.yml` for the full stack. | Existing `serve` command |

## Non-breaking guarantees

- `scan`, `graph`, `report`, `serve` resolve to the same command objects as before.
- `up` is a distinct command that forwards to `serve` (renaming/hiding `serve` later stays safe).
- All existing groups (`cloud`, `mcp`, `policy`, `runtime`, `identity`, `cost`, `report`, …) still resolve.
- Tests cover: the 5 verbs exist + delegate correctly, credential detection (set vs unset), `--help` leads with the front door, and existing commands/aliases still work.

## Scope

Touches only the top-level CLI registration (`cli/__init__.py`), a new `cli/_entry_points.py`, the grouped-help categories/epilog (`cli/_grouped_help.py`), the CLI reference doc, and a new test module. Does not touch `graph/`, `output/`, `cloud/`, advisor/intel, or stores.

Follow-up: deeper surface-narrowing (one-pane fusion) builds on this foundation.
