### PR TITLE
docs: align CLI/README references with cloud scan, registry sweep, and freshness surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ the credential environment names in reach, and the agents that can call it.
 | Cloud estate | Read-only, gated asset inventory across AWS, Azure, GCP, and Snowflake plus AI/GPU provider posture and CIS benchmarks. One connection model per cloud: a scoped read-only role and keyless/token auth — see [docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md) |
 | Identity (NHI) | Non-human identity discovery (Okta/Entra, gated), credential-expiry posture, and access-review recertification campaigns |
 | LLM cost | Spend forecasting, budget runway, chargeback/allocation, and seasonal-aware spend-anomaly detection |
-| Containers + IaC | Native OCI image parsing plus Dockerfile, Terraform, CloudFormation, Helm, and Kubernetes |
+| Containers + IaC | Native OCI image parsing plus Dockerfile, Terraform, CloudFormation, Helm, and Kubernetes; registry-wide sweeps across ECR/ACR/GAR (`cloud registry-scan`) and agentless AWS EBS disk side-scan (CWPP, snapshot-based, read-only) |
 | Secrets + runtime | Secret detection, MCP proxy/gateway, A2A and MCP auth-posture checks, inline firewall enforcement, and redaction surfaces |
 | Compliance | Mapped governance frameworks plus ZIP evidence bundles for auditors |
 
@@ -329,6 +329,16 @@ findings):
 agent-bom cloud inventory --provider all        # or aws | azure | gcp
 ```
 
+Or run one cloud-aware scan across every configured provider at once —
+`--provider all` (the default) auto-detects which clouds are connected and
+skips the rest:
+
+```bash
+agent-bom cloud scan                            # all configured clouds, read-only
+agent-bom cloud scan --provider aws --cis --show-passed
+agent-bom cloud registry-scan --provider ecr --region us-east-1   # sweep an ECR/ACR/GAR registry
+```
+
 CIS misconfigurations and graph toxic-combinations converge into the same
 `Finding` stream and exit-code gate as package vulnerabilities, so a real
 exposure can fail a pipeline:
@@ -337,6 +347,7 @@ exposure can fail a pipeline:
 agent-bom agents --aws --azure --gcp --snowflake --fail-on-severity high
 agent-bom graph                                 # multi-hop exposure paths
 agent-bom identity credential-expiry            # non-human identity posture
+agent-bom db freshness                          # confirm vuln data is current before gating
 ```
 
 The full grant templates, per-cloud permission catalogs, and the
@@ -363,10 +374,17 @@ docker compose -f docker-compose.pilot.yml up -d
 
 Production self-hosting starts with the deployment chooser:
 
+- [Deploy anywhere guide](docs/DEPLOY_PLATFORM.md) — one product, three tiers (laptop, your Kubernetes, hosted control plane)
 - [Deployment overview](site-docs/deployment/overview.md)
 - [Helm chart](deploy/helm/agent-bom)
+- [One-apply EKS platform module](deploy/terraform/platform-eks) — `terraform apply` the full control plane (cluster, Postgres, secrets, ingress)
 - [EKS reference installer](scripts/deploy/install-eks-reference.sh)
 - [Docker Hub image](https://hub.docker.com/r/agentbom/agent-bom)
+
+For a zero-install AWS scan, deploy the
+[CloudFormation one-click template](deploy/cloudformation) — it runs a
+read-only `agent-bom cloud aws` scan in your account via CodeBuild, no local
+credentials handed to agent-bom.
 
 There is no managed cloud offering in this repository today. Product lane
 boundaries are documented in [docs/PRODUCT_BOUNDARIES.md](docs/PRODUCT_BOUNDARIES.md).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,3 +14,14 @@ The canonical command reference lives in
 - `agent-bom profiles ...` manages named contexts in
   `~/.agent-bom/config.toml`; unknown profiles fail with the available profile
   list.
+- `agent-bom cloud scan` runs one cloud-aware scan across every configured
+  provider; `--provider all` (the default) auto-detects which clouds are
+  configured, and `cloud aws` / `cloud azure` / `cloud gcp` are aliases for the
+  provider-scoped form. CIS misconfigurations converge into the same `Finding`
+  stream and `--fail-on-severity` exit-code gate as package vulnerabilities.
+- `agent-bom cloud registry-scan --provider <ecr|acr|gar>` sweeps an entire
+  container registry read-only, deduping by content digest and capping the work
+  list with `AGENT_BOM_REGISTRY_MAX_IMAGES` / `AGENT_BOM_REGISTRY_MAX_TAGS_PER_REPO`.
+- `agent-bom db freshness` emits the structured vuln-data freshness indicator
+  (sources, age, staleness) — the same snapshot surfaced on every scan and
+  returned by the API and MCP tool.

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -17,6 +17,10 @@
 | `ingest` | Ingest operator-provided evidence (e.g. hardware/firmware attestation) into the unified graph |
 | `ingest hardware` | Map a hardware/firmware attestation evidence file onto host / GPU / firmware / advisory graph nodes |
 | `cloud` | Scan AWS, Azure, or GCP infrastructure posture |
+| `cloud scan` | One cloud-aware scan across every configured provider (`--provider all` auto-detects; `--show-passed` lists passed CIS checks) |
+| `cloud aws` / `cloud azure` / `cloud gcp` | Provider-scoped aliases — `cloud scan --provider <aws\|azure\|gcp>` |
+| `cloud registry-scan` | Sweep an entire cloud container registry (ECR/ACR/GAR) — enumerate every repo+tag and scan each, read-only |
+| `cloud resilience` | Show provider pagination, retry, and partial-failure tolerance evidence |
 | `check` | Check one package before install or approval |
 | `verify` | Verify package integrity / provenance or self-verify `agent-bom` |
 | `secrets` | Scan a directory for hardcoded secrets and PII |
@@ -82,6 +86,8 @@
 | Command | Description |
 |---------|-------------|
 | `db` | Manage the local vulnerability database |
+| `db freshness` | Show the structured vuln-data freshness indicator (sources, age, staleness) surfaced on every scan, API, and MCP tool |
+| `db framework-status` | Show bundled framework catalog freshness |
 | `doctor` | Check environment readiness for scanning |
 | `gateway` | Multi-MCP gateway commands |
 | `interactive` | Start an interactive command shell for repeated CLI workflows |
@@ -155,6 +161,15 @@ agent-bom agents --config-dir /path/to/configs
 
 # Self-scan (scan agent-bom's own installed dependencies)
 agent-bom agents --self-scan
+
+# Cloud — one cloud-aware scan across every configured provider (read-only)
+agent-bom cloud scan                            # --provider all, auto-detects configured clouds
+agent-bom cloud scan --provider aws --cis --show-passed
+agent-bom cloud aws                             # alias for cloud scan --provider aws
+agent-bom cloud registry-scan --provider ecr --region us-east-1   # sweep an ECR/ACR/GAR registry, read-only
+
+# Vulnerability data freshness (same indicator surfaced on every scan, API, and MCP tool)
+agent-bom db freshness
 ```
 
 The `--self-scan` flag is on the `agents` subcommand (not top-level). It walks the active Python environment via `importlib.metadata.distributions()` and emits a CVE report against agent-bom's own runtime so you can audit the tool with the tool.
@@ -185,7 +200,9 @@ Contract](remediate-output.md).
 | `NVD_API_KEY` | Increase NVD rate limit | No |
 | `SNYK_TOKEN` | Optional commercial vuln-API enrichment | No |
 | `AGENT_BOM_CLICKHOUSE_URL` | Analytics storage | No |
-| `AWS_PROFILE` | AWS CIS benchmark | Only for `cis-benchmark --provider aws` |
-| `SNOWFLAKE_ACCOUNT` | Snowflake CIS benchmark | Only for `cis-benchmark --provider snowflake` |
+| `AWS_PROFILE` | AWS CIS benchmark | Only for `cloud aws --cis` / `cloud scan --provider aws` |
+| `SNOWFLAKE_ACCOUNT` | Snowflake CIS benchmark | Only for `agents --snowflake` CIS posture |
 | `AGENT_BOM_OKTA_DISCOVERY` / `AGENT_BOM_ENTRA_DISCOVERY` | Gate `identity discover` and discovered-NHI credential expiry | Only for NHI discovery |
-| `AGENT_BOM_CLOUD_INVENTORY` / `AGENT_BOM_AZURE_INVENTORY` / `AGENT_BOM_GCP_INVENTORY` | Gate `cloud inventory` per provider | Only for estate inventory |
+| `AGENT_BOM_AWS_INVENTORY` / `AGENT_BOM_AZURE_INVENTORY` / `AGENT_BOM_GCP_INVENTORY` | Gate `cloud inventory` and `cloud scan` per provider | Only for cloud connect / estate inventory |
+| `AGENT_BOM_VULN_DB_MAX_AGE_HOURS` / `AGENT_BOM_VULN_DB_OFFLINE` | Staleness threshold and offline override behind the `db freshness` indicator | No |
+| `AGENT_BOM_REGISTRY_MAX_IMAGES` / `AGENT_BOM_REGISTRY_MAX_TAGS_PER_REPO` | Cap the `cloud registry-scan` work list | Only for registry sweeps |


### PR DESCRIPTION
Brings the public CLI reference, README, and release-contract docs into line with the cloud-aware scanning, registry, and vuln-freshness surfaces that shipped this release. Generated artifacts (OpenAPI, env-var reference, data-model atlas) were already in sync and are unchanged.

## What changed

**site-docs/reference/cli.md**
- New command rows: `cloud scan` (documents `--provider all` and `--show-passed`), the `cloud aws` / `cloud azure` / `cloud gcp` aliases, `cloud registry-scan`, `cloud resilience`, `db freshness`, `db framework-status`.
- New cloud + freshness examples block under Common flags.
- Corrected stale `cis-benchmark` env-var references (that verb no longer exists) to the current `cloud aws --cis` / `cloud scan` / `agents --snowflake` forms.
- Added `AGENT_BOM_AWS_INVENTORY`/`AZURE`/`GCP`, `AGENT_BOM_VULN_DB_MAX_AGE_HOURS` / `AGENT_BOM_VULN_DB_OFFLINE`, and `AGENT_BOM_REGISTRY_MAX_IMAGES` / `AGENT_BOM_REGISTRY_MAX_TAGS_PER_REPO` to the env-var table (verified against config.py + the allowlist).

**docs/cli.md**
- Added release-contract lines for `cloud scan` (unified provider-detect + Finding/exit-code convergence), `cloud registry-scan`, and `db freshness`.

**README.md**
- Surfaced the unified `cloud scan --provider all` verb, `cloud registry-scan`, and `db freshness` in the Connect-a-Cloud examples.
- Added registry-wide ECR/ACR/GAR sweeps and agentless AWS EBS disk side-scan (CWPP, snapshot-based, read-only) to the capability matrix.
- Added the CloudFormation one-click read-only AWS scan, the one-apply EKS platform module, and the deploy-anywhere guide to the deployment chooser.

## Validation

All green:
- `check_release_consistency.py`, `check_product_surface_contract.py`, `check_cli_reference_alignment.py` — pass
- `generate_env_var_reference.py --check` — `OK: 97 declared, 269 allowlisted`
- `export_openapi.py --check` — `OK: docs/openapi/ matches`
- `pytest -k "docs or openapi or surface or consistency or cli_doc"` — 122 passed, 1 skipped
- pre-commit clean on all three files

Versions remain `0.89.2` across pyproject, Chart.yaml (version + appVersion), and ui/package.json — no bump. Diff is docs-only (README.md, docs/cli.md, site-docs/reference/cli.md).