### PR TITLE
feat(cloud): read-only audit-trail ingestion into behavioral graph edges

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -72,6 +72,13 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_RISK_TOOL_WEIGHT` | `float` | `0.1` | — |
 | `AGENT_BOM_RISK_UNREACHABLE_PENALTY` | `float` | `0.5` | — |
 
+## Cloud audit-trail behavioral ingestion (opt-in, read-only)
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_AUDIT_TRAIL` | `bool` | `False` | Master opt-in. When False (default), audit-trail ingestion is a clean no-op. |
+| `AGENT_BOM_AUDIT_TRAIL_LOOKBACK_HOURS` | `int` | `24` | Lookback window (hours) for audit events; the reader clamps to two weeks. |
+| `AGENT_BOM_AUDIT_TRAIL_MAX_EVENTS` | `int` | `2000` | Per-provider event cap; the reader clamps to a hard ceiling and warns when hit. |
+
 ## EPSS Thresholds
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/src/agent_bom/cloud/audit_trail.py
+++ b/src/agent_bom/cloud/audit_trail.py
@@ -1,0 +1,658 @@
+"""Read-only cloud audit-trail ingestion — behavioral security-signal extraction.
+
+This is **not** a log/observability platform. agent-bom reads the
+security-relevant slice of each cloud's native audit trail (AWS CloudTrail,
+Azure Activity Log, GCP Cloud Audit Logs), derives **behavioral graph edges**
+("who *did* reach what"), emits a few behavioral findings, and drops the raw
+events. Logs stay in the customer's account; agent-bom never stores, indexes,
+or re-emits raw log lines.
+
+Design contract
+---------------
+* **Read-only** — only the providers' read/lookup APIs are ever called
+  (``cloudtrail:LookupEvents``, ``Microsoft.Insights/eventtypes/values/read``,
+  ``logging.logEntries.list``). No write/mutate API is referenced anywhere.
+* **Opt-in** — disabled unless ``AGENT_BOM_AUDIT_TRAIL`` is truthy. A scan that
+  does not set it is a clean no-op; nothing is read.
+* **Nothing-silent** — a missing read permission yields a clear, actionable
+  warning naming the exact grant required, never a silent skip or a crash.
+* **Bounded** — lookback window and event count are capped (env-configurable);
+  hitting a cap appends a ``truncated`` warning, never silent truncation.
+* **No raw-log retention** — the reader returns normalized
+  ``(principal, action, resource, time, outcome)`` tuples only. The builder
+  aggregates them into ``(principal, resource, action) → count + last_seen``
+  edges; the raw event list is never persisted into the report contract.
+
+The output of :func:`collect_audit_trail` is the ``status: ok`` payload contract
+that :func:`agent_bom.graph.builder._add_cloud_audit_behavioral` consumes,
+mirroring the Snowflake ACCESS_HISTORY → ACCESSED layer.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ── Opt-in gate ───────────────────────────────────────────────────────────
+_OPT_IN_ENV = "AGENT_BOM_AUDIT_TRAIL"
+
+# ── Bounds (env-configurable; never silently exceeded) ────────────────────
+_LOOKBACK_ENV = "AGENT_BOM_AUDIT_TRAIL_LOOKBACK_HOURS"
+_MAX_EVENTS_ENV = "AGENT_BOM_AUDIT_TRAIL_MAX_EVENTS"
+_DEFAULT_LOOKBACK_HOURS = 24
+_DEFAULT_MAX_EVENTS = 2000
+_MAX_LOOKBACK_HOURS = 24 * 14  # two weeks — a security slice, not an archive
+_HARD_MAX_EVENTS = 20000
+
+# ── Action classification → relationship class ────────────────────────────
+# Write/management/invoke verbs map to INVOKED (an action *taken*); read verbs
+# map to ACCESSED (data/resource *reached*). Kept deliberately small and
+# explicit — the default is ACCESSED so an unknown verb still draws a reach
+# edge rather than being dropped.
+_INVOKE_VERB_PREFIXES = (
+    "create",
+    "delete",
+    "update",
+    "modify",
+    "put",
+    "set",
+    "attach",
+    "detach",
+    "start",
+    "stop",
+    "run",
+    "invoke",
+    "terminate",
+    "write",
+    "remove",
+    "add",
+    "assume",
+    "authorize",
+    "revoke",
+    "deploy",
+    "reboot",
+    "restore",
+)
+
+_SENSITIVE_RESOURCE_HINTS = (
+    "secret",
+    "key",
+    "credential",
+    "iam",
+    "kms",
+    "vault",
+    "password",
+    "token",
+    "policy",
+    "role",
+)
+
+
+def is_enabled() -> bool:
+    """True when audit-trail ingestion is opted in via ``AGENT_BOM_AUDIT_TRAIL``."""
+    return os.environ.get(_OPT_IN_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _bounded_int(env: str, default: int, hard_max: int) -> int:
+    raw = os.environ.get(env, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("%s=%r is not an integer; using default %d", env, raw, default)
+        return default
+    if value <= 0:
+        return default
+    return min(value, hard_max)
+
+
+def lookback_hours() -> int:
+    """Configured lookback window in hours, clamped to :data:`_MAX_LOOKBACK_HOURS`."""
+    return _bounded_int(_LOOKBACK_ENV, _DEFAULT_LOOKBACK_HOURS, _MAX_LOOKBACK_HOURS)
+
+
+def max_events() -> int:
+    """Configured per-provider event cap, clamped to :data:`_HARD_MAX_EVENTS`."""
+    return _bounded_int(_MAX_EVENTS_ENV, _DEFAULT_MAX_EVENTS, _HARD_MAX_EVENTS)
+
+
+def classify_action(action: str) -> str:
+    """Map a raw cloud action verb to a relationship class.
+
+    Returns ``"invoked"`` for management/write/mutate verbs and ``"accessed"``
+    for everything else (reads + unknown verbs). The action string may be a
+    fully-qualified event name (``ec2:RunInstances``, ``Microsoft.Storage/...``);
+    the leading service prefix is stripped before matching.
+    """
+    verb = (action or "").strip()
+    if not verb:
+        return "accessed"
+    # Strip a service prefix: "ec2:RunInstances" -> "RunInstances",
+    # "Microsoft.Storage/storageAccounts/write" -> "write".
+    for sep in (":", "/"):
+        if sep in verb:
+            verb = verb.rsplit(sep, 1)[-1]
+    low = verb.lower()
+    if any(low.startswith(p) for p in _INVOKE_VERB_PREFIXES):
+        return "invoked"
+    return "accessed"
+
+
+def _is_sensitive_resource(resource: str) -> bool:
+    low = (resource or "").lower()
+    return any(hint in low for hint in _SENSITIVE_RESOURCE_HINTS)
+
+
+# ── Normalized event ──────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    """A single normalized, security-relevant audit event.
+
+    Carries only the signal needed to draw a behavioral edge — never the raw
+    log record. ``time`` is an ISO-8601 string (or empty if absent).
+    """
+
+    principal: str
+    action: str
+    resource: str
+    time: str = ""
+    outcome: str = "success"  # "success" | "failure"
+
+    def as_tuple(self) -> tuple[str, str, str, str, str]:
+        return (self.principal, self.action, self.resource, self.time, self.outcome)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _clean(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _iso(value: Any) -> str:
+    """Best-effort ISO-8601 normalization of a timestamp-ish value."""
+    if value is None or value == "":
+        return ""
+    if isinstance(value, datetime):
+        dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).isoformat()
+    return str(value).strip()
+
+
+# ── Permission-guidance strings (nothing-silent) ──────────────────────────
+
+_GRANT_GUIDANCE = {
+    "aws": "grant cloudtrail:LookupEvents to enable audit-trail behavioral edges",
+    "azure": ("grant the 'Monitoring Reader' role (Microsoft.Insights/eventtypes/values/read) to enable audit-trail behavioral edges"),
+    "gcp": "grant roles/logging.viewer (logging.logEntries.list) to enable audit-trail behavioral edges",
+}
+
+
+def _permission_warning(provider: str, detail: str = "") -> str:
+    guidance = _GRANT_GUIDANCE.get(provider, "grant read-only audit-log access")
+    base = f"{provider}: audit-trail read denied — {guidance}"
+    return f"{base} ({detail})" if detail else base
+
+
+# ── AWS CloudTrail (read-only LookupEvents) ───────────────────────────────
+
+
+def read_aws_cloudtrail(
+    *,
+    region: str | None = None,
+    profile: str | None = None,
+    now: datetime | None = None,
+    session_factory: Any | None = None,
+) -> tuple[list[AuditEvent], list[str]]:
+    """Read recent management events from CloudTrail via read-only LookupEvents.
+
+    ``session_factory`` (a zero-arg callable returning a boto3-like session) is
+    an injection point for tests; production uses the standard boto3 chain.
+    Returns ``(events, warnings)``; warnings are actionable, never silent.
+    """
+    warnings: list[str] = []
+    start = (now or _now()) - timedelta(hours=lookback_hours())
+    cap = max_events()
+
+    if session_factory is None:
+        try:
+            import boto3  # noqa: F811
+
+            def session_factory() -> Any:  # type: ignore[misc]
+                kwargs: dict[str, Any] = {}
+                if region:
+                    kwargs["region_name"] = region
+                if profile:
+                    kwargs["profile_name"] = profile
+                return boto3.Session(**kwargs)
+        except ImportError:
+            return [], ["aws: boto3 not installed; install 'agent-bom[aws]' to enable audit-trail edges"]
+
+    try:
+        from botocore.exceptions import ClientError, NoCredentialsError  # type: ignore
+    except ImportError:  # pragma: no cover - boto3 implies botocore
+        ClientError = Exception  # type: ignore[assignment,misc]  # noqa: N806
+        NoCredentialsError = Exception  # type: ignore[assignment,misc]  # noqa: N806
+
+    try:
+        session = session_factory()
+        client = session.client("cloudtrail")
+    except NoCredentialsError:
+        return [], ["aws: no credentials resolved for CloudTrail audit-trail read"]
+    except Exception as exc:  # pragma: no cover - defensive
+        return [], [f"aws: could not initialize CloudTrail client ({exc})"]
+
+    events: list[AuditEvent] = []
+    truncated = False
+    try:
+        paginator = client.get_paginator("lookup_events")
+        pages = paginator.paginate(
+            StartTime=start,
+            EndTime=(now or _now()),
+            PaginationConfig={"PageSize": 50},
+        )
+        for page in pages:
+            for raw in page.get("Events", []) or []:
+                evt = _normalize_aws_event(raw)
+                if evt is None:
+                    continue
+                events.append(evt)
+                if len(events) >= cap:
+                    truncated = True
+                    break
+            if truncated:
+                break
+    except ClientError as exc:  # type: ignore[misc]
+        code = getattr(exc, "response", {}).get("Error", {}).get("Code", "")
+        if code in {"AccessDenied", "AccessDeniedException", "UnauthorizedOperation"}:
+            return [], [_permission_warning("aws", "cloudtrail:LookupEvents denied")]
+        return [], [f"aws: CloudTrail LookupEvents failed ({code or exc})"]
+    except Exception as exc:  # pragma: no cover - defensive
+        return [], [f"aws: CloudTrail read error ({exc})"]
+
+    if truncated:
+        warnings.append(f"aws: audit-trail capped at {cap} events (raise {_MAX_EVENTS_ENV} to widen)")
+    return events, warnings
+
+
+def _normalize_aws_event(raw: Any) -> AuditEvent | None:
+    if not isinstance(raw, dict):
+        return None
+    action = _clean(raw.get("EventName"))
+    principal = _clean(raw.get("Username"))
+    resources = raw.get("Resources") or []
+    resource = ""
+    if isinstance(resources, list) and resources:
+        first = resources[0]
+        if isinstance(first, dict):
+            resource = _clean(first.get("ResourceName")) or _clean(first.get("ResourceType"))
+    resource = resource or _clean(raw.get("EventSource"))
+    if not principal or not action or not resource:
+        return None
+    return AuditEvent(
+        principal=principal,
+        action=action,
+        resource=resource,
+        time=_iso(raw.get("EventTime")),
+        outcome="success",
+    )
+
+
+# ── Azure Activity Log (read-only) ────────────────────────────────────────
+
+
+def read_azure_activity_log(
+    *,
+    subscription_id: str | None = None,
+    now: datetime | None = None,
+    client_factory: Any | None = None,
+) -> tuple[list[AuditEvent], list[str]]:
+    """Read recent management events from the Azure Activity Log (read-only).
+
+    ``client_factory`` returns a ``MonitorManagementClient``-like object whose
+    ``activity_logs.list(filter=...)`` yields event records; injected for tests.
+    """
+    warnings: list[str] = []
+    start = (now or _now()) - timedelta(hours=lookback_hours())
+    cap = max_events()
+
+    resolved_sub = subscription_id or os.environ.get("AZURE_SUBSCRIPTION_ID", "").strip()
+    if not resolved_sub:
+        return [], [
+            "azure: AZURE_SUBSCRIPTION_ID not set; provide a subscription to enable audit-trail edges",
+        ]
+
+    if client_factory is None:
+        try:
+            from azure.identity import DefaultAzureCredential  # type: ignore
+            from azure.mgmt.monitor import MonitorManagementClient  # type: ignore
+
+            def client_factory() -> Any:  # type: ignore[misc]
+                return MonitorManagementClient(DefaultAzureCredential(), resolved_sub)
+        except ImportError:
+            return [], ["azure: azure-mgmt-monitor not installed; install 'agent-bom[azure]'"]
+
+    try:
+        client = client_factory()
+    except Exception as exc:  # pragma: no cover - defensive
+        return [], [f"azure: could not initialize Activity Log client ({exc})"]
+
+    events: list[AuditEvent] = []
+    truncated = False
+    filt = f"eventTimestamp ge '{start.isoformat()}'"
+    try:
+        for raw in client.activity_logs.list(filter=filt):
+            evt = _normalize_azure_event(raw)
+            if evt is None:
+                continue
+            events.append(evt)
+            if len(events) >= cap:
+                truncated = True
+                break
+    except Exception as exc:
+        name = type(exc).__name__
+        msg = str(exc)
+        if "Authorization" in msg or "Forbidden" in msg or name in {"HttpResponseError", "ClientAuthenticationError"}:
+            return [], [_permission_warning("azure", "Activity Log read denied")]
+        return [], [f"azure: Activity Log read failed ({name}: {msg})"]
+
+    if truncated:
+        warnings.append(f"azure: audit-trail capped at {cap} events (raise {_MAX_EVENTS_ENV} to widen)")
+    return events, warnings
+
+
+def _azure_attr(raw: Any, name: str) -> Any:
+    if isinstance(raw, dict):
+        return raw.get(name)
+    return getattr(raw, name, None)
+
+
+def _normalize_azure_event(raw: Any) -> AuditEvent | None:
+    caller = _clean(_azure_attr(raw, "caller"))
+    operation = _azure_attr(raw, "operation_name")
+    action = _clean(_azure_attr(operation, "value") if operation is not None else "")
+    resource = _clean(_azure_attr(raw, "resource_id"))
+    status_obj = _azure_attr(raw, "status")
+    status_val = _clean(_azure_attr(status_obj, "value") if status_obj is not None else "")
+    outcome = "failure" if status_val.lower() in {"failed", "failure"} else "success"
+    if not caller or not action or not resource:
+        return None
+    return AuditEvent(
+        principal=caller,
+        action=action,
+        resource=resource,
+        time=_iso(_azure_attr(raw, "event_timestamp")),
+        outcome=outcome,
+    )
+
+
+# ── GCP Cloud Audit Logs (read-only logging read) ─────────────────────────
+
+
+def read_gcp_audit_logs(
+    *,
+    project_id: str | None = None,
+    now: datetime | None = None,
+    client_factory: Any | None = None,
+) -> tuple[list[AuditEvent], list[str]]:
+    """Read recent Cloud Audit Log entries (read-only ``logging.logEntries.list``).
+
+    ``client_factory`` returns a ``google.cloud.logging.Client``-like object
+    exposing ``list_entries(filter_=..., page_size=...)``; injected for tests.
+    """
+    warnings: list[str] = []
+    start = (now or _now()) - timedelta(hours=lookback_hours())
+    cap = max_events()
+
+    resolved_project = project_id or os.environ.get("GOOGLE_CLOUD_PROJECT", "").strip()
+    if not resolved_project:
+        return [], [
+            "gcp: GOOGLE_CLOUD_PROJECT not set; provide a project to enable audit-trail edges",
+        ]
+
+    if client_factory is None:
+        try:
+            from google.cloud import logging as gcp_logging  # type: ignore
+
+            def client_factory() -> Any:  # type: ignore[misc]
+                return gcp_logging.Client(project=resolved_project)
+        except ImportError:
+            return [], ["gcp: google-cloud-logging not installed; install 'agent-bom[gcp]'"]
+
+    try:
+        client = client_factory()
+    except Exception as exc:  # pragma: no cover - defensive
+        return [], [f"gcp: could not initialize Cloud Logging client ({exc})"]
+
+    events: list[AuditEvent] = []
+    truncated = False
+    filt = f'logName:"cloudaudit.googleapis.com" AND timestamp >= "{start.replace(microsecond=0).isoformat()}"'
+    try:
+        for entry in client.list_entries(filter_=filt, page_size=min(cap, 1000)):
+            evt = _normalize_gcp_entry(entry)
+            if evt is None:
+                continue
+            events.append(evt)
+            if len(events) >= cap:
+                truncated = True
+                break
+    except Exception as exc:
+        name = type(exc).__name__
+        msg = str(exc)
+        if "permission" in msg.lower() or "denied" in msg.lower() or name in {"Forbidden", "PermissionDenied"}:
+            return [], [_permission_warning("gcp", "logging.logEntries.list denied")]
+        return [], [f"gcp: Cloud Audit Logs read failed ({name}: {msg})"]
+
+    if truncated:
+        warnings.append(f"gcp: audit-trail capped at {cap} events (raise {_MAX_EVENTS_ENV} to widen)")
+    return events, warnings
+
+
+def _normalize_gcp_entry(entry: Any) -> AuditEvent | None:
+    payload = getattr(entry, "payload", None)
+    if not isinstance(payload, dict):
+        payload = {}
+    auth = payload.get("authenticationInfo") or {}
+    principal = _clean(auth.get("principalEmail")) if isinstance(auth, dict) else ""
+    action = _clean(payload.get("methodName"))
+    resource = _clean(payload.get("resourceName"))
+    status = payload.get("status") or {}
+    code = status.get("code") if isinstance(status, dict) else None
+    outcome = "failure" if code not in (None, 0) else "success"
+    ts = getattr(entry, "timestamp", None)
+    if not principal or not action or not resource:
+        return None
+    return AuditEvent(
+        principal=principal,
+        action=action,
+        resource=resource,
+        time=_iso(ts),
+        outcome=outcome,
+    )
+
+
+# ── Aggregation + payload assembly ─────────────────────────────────────────
+
+
+@dataclass
+class _Aggregate:
+    principal: str
+    action: str
+    resource: str
+    relationship: str
+    count: int = 0
+    last_seen: str = ""
+    failures: int = 0
+    sensitive: bool = False
+
+
+def aggregate_events(events: Iterable[AuditEvent]) -> list[dict[str, Any]]:
+    """Collapse raw events into ``(principal, resource, action)`` edge records.
+
+    Deterministic: records are keyed by ``(principal, resource, action)``,
+    counted, and stamped with the latest ``time`` seen. The raw events are
+    *not* retained — only the aggregate edge descriptor is returned. Output is
+    sorted for byte-stable downstream graph construction.
+    """
+    buckets: dict[tuple[str, str, str], _Aggregate] = {}
+    for evt in events:
+        principal = _clean(evt.principal)
+        action = _clean(evt.action)
+        resource = _clean(evt.resource)
+        if not principal or not action or not resource:
+            continue
+        rel = classify_action(action)
+        key = (principal, resource, action)
+        agg = buckets.get(key)
+        if agg is None:
+            agg = _Aggregate(
+                principal=principal,
+                action=action,
+                resource=resource,
+                relationship=rel,
+                sensitive=_is_sensitive_resource(resource),
+            )
+            buckets[key] = agg
+        agg.count += 1
+        if _clean(evt.outcome).lower() == "failure":
+            agg.failures += 1
+        ts = _iso(evt.time)
+        if ts and ts > agg.last_seen:
+            agg.last_seen = ts
+
+    records = [
+        {
+            "principal": agg.principal,
+            "action": agg.action,
+            "resource": agg.resource,
+            "relationship": agg.relationship,
+            "count": agg.count,
+            "last_seen": agg.last_seen,
+            "failure_count": agg.failures,
+            "is_sensitive_resource": agg.sensitive,
+        }
+        for agg in buckets.values()
+    ]
+    records.sort(key=lambda r: (r["principal"], r["resource"], r["action"]))
+    return records
+
+
+def derive_behavioral_findings(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Derive a few behavioral findings from aggregated edges (security signal).
+
+    No raw logs are referenced — only the aggregate descriptors. Findings:
+
+    * **sensitive-resource access** — a principal reached a secret/IAM/KMS-class
+      resource.
+    * **repeated authorization failure** — a principal accumulated denied
+      attempts against a resource (probing signal).
+    """
+    findings: list[dict[str, Any]] = []
+    for rec in records:
+        if rec.get("is_sensitive_resource"):
+            findings.append(
+                {
+                    "kind": "sensitive_resource_access",
+                    "severity": "medium",
+                    "principal": rec["principal"],
+                    "resource": rec["resource"],
+                    "action": rec["action"],
+                    "observed_count": rec["count"],
+                    "last_seen": rec["last_seen"],
+                    "message": (f"{rec['principal']} {rec['action']} sensitive resource {rec['resource']} ({rec['count']}x)"),
+                }
+            )
+        if rec.get("failure_count", 0) >= 3:
+            findings.append(
+                {
+                    "kind": "repeated_access_failure",
+                    "severity": "low",
+                    "principal": rec["principal"],
+                    "resource": rec["resource"],
+                    "action": rec["action"],
+                    "failure_count": rec["failure_count"],
+                    "last_seen": rec["last_seen"],
+                    "message": (f"{rec['principal']} had {rec['failure_count']} denied {rec['action']} attempts on {rec['resource']}"),
+                }
+            )
+    findings.sort(key=lambda f: (f["kind"], f["principal"], f["resource"], f["action"]))
+    return findings
+
+
+def collect_audit_trail(
+    *,
+    provider: str,
+    account: str = "",
+    now: datetime | None = None,
+    **reader_kwargs: Any,
+) -> dict[str, Any]:
+    """Collect, aggregate, and package the audit-trail behavioral payload.
+
+    Returns the ``status: ok`` contract consumed by the graph builder's
+    ``_add_cloud_audit_behavioral`` layer, or a ``status: skipped`` /
+    ``status: error`` envelope carrying actionable warnings. Raw events never
+    appear in the returned payload — only aggregated edge records + findings.
+
+    ``provider`` is one of ``"aws" | "azure" | "gcp"``. ``now`` is injected for
+    determinism in tests.
+    """
+    if not is_enabled():
+        return {
+            "status": "skipped",
+            "provider": provider,
+            "reason": f"audit-trail ingestion is opt-in; set {_OPT_IN_ENV}=1 to enable",
+            "warnings": [],
+        }
+
+    readers: dict[str, Callable[..., tuple[list[AuditEvent], list[str]]]] = {
+        "aws": read_aws_cloudtrail,
+        "azure": read_azure_activity_log,
+        "gcp": read_gcp_audit_logs,
+    }
+    reader = readers.get(provider)
+    if reader is None:
+        return {
+            "status": "error",
+            "provider": provider,
+            "warnings": [f"unknown audit-trail provider {provider!r}"],
+        }
+
+    events, warnings = reader(now=now, **reader_kwargs)
+    records = aggregate_events(events)
+    findings = derive_behavioral_findings(records)
+    return {
+        "status": "ok",
+        "provider": provider,
+        "account": _clean(account),
+        "behavioral_edges": records,
+        "behavioral_findings": findings,
+        "event_count": len(events),  # count only — raw events are dropped here
+        "warnings": warnings,
+    }
+
+
+__all__ = [
+    "AuditEvent",
+    "aggregate_events",
+    "classify_action",
+    "collect_audit_trail",
+    "derive_behavioral_findings",
+    "is_enabled",
+    "lookback_hours",
+    "max_events",
+    "read_aws_cloudtrail",
+    "read_azure_activity_log",
+    "read_gcp_audit_logs",
+]

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -397,3 +397,19 @@ REPO_SCAN_CLONE_TIMEOUT_SECONDS = _float("AGENT_BOM_REPO_SCAN_CLONE_TIMEOUT_SECO
 REPO_SCAN_MAX_SIZE_BYTES = _int("AGENT_BOM_REPO_SCAN_MAX_SIZE_BYTES", 1024 * 1024 * 1024)
 # Max number of files in the cloned working tree.
 REPO_SCAN_MAX_FILES = _int("AGENT_BOM_REPO_SCAN_MAX_FILES", 100_000)
+
+
+# ── Cloud audit-trail behavioral ingestion (opt-in, read-only) ───────────
+# agent-bom can read the security-relevant slice of each cloud's native audit
+# trail (AWS CloudTrail / Azure Activity Log / GCP Cloud Audit Logs) to derive
+# behavioral graph edges (who *did* reach what). It is NOT a log/observability
+# platform: raw log lines are never stored — only aggregated edges. The reader
+# is disabled unless explicitly opted in, and the lookback window + event count
+# are bounded so a scan never pulls an unbounded log volume.
+
+# Master opt-in. When False (default), audit-trail ingestion is a clean no-op.
+AUDIT_TRAIL_ENABLED = _bool("AGENT_BOM_AUDIT_TRAIL", False)
+# Lookback window (hours) for audit events; the reader clamps to two weeks.
+AUDIT_TRAIL_LOOKBACK_HOURS = _int("AGENT_BOM_AUDIT_TRAIL_LOOKBACK_HOURS", 24)
+# Per-provider event cap; the reader clamps to a hard ceiling and warns when hit.
+AUDIT_TRAIL_MAX_EVENTS = _int("AGENT_BOM_AUDIT_TRAIL_MAX_EVENTS", 2000)

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -972,6 +972,19 @@ def build_unified_graph_from_report(
     _add_snowflake_governance(graph, report_json.get("snowflake_governance"), data_source_tag)
     _add_snowflake_activity(graph, report_json.get("snowflake_activity"), data_source_tag)
 
+    # ── Cloud audit-trail behavioral edges (opt-in, read-only) ───────────
+    # Observed-reach edges derived from each cloud's native audit trail
+    # (CloudTrail / Activity Log / Cloud Audit Logs). The reader already
+    # aggregated raw events into (principal, resource, action) descriptors;
+    # no raw log lines are present in the report. Accepts one payload or a
+    # per-provider list. A no-op unless an operator opted in to ingestion.
+    _audit_payload = report_json.get("cloud_audit_trail")
+    if isinstance(_audit_payload, list):
+        for _provider_audit in _audit_payload:
+            _add_cloud_audit_behavioral(graph, _provider_audit, data_source_tag)
+    else:
+        _add_cloud_audit_behavioral(graph, _audit_payload, data_source_tag)
+
     # ── Discovered non-human identities (IdP service accounts, gated) ────
     # Project NHIs enumerated by the identity connectors (Okta service apps /
     # API tokens, Entra service principals / app registrations) into the graph
@@ -3514,6 +3527,129 @@ def _add_snowflake_governance(graph: UnifiedGraph, payload: Any, data_source: st
         )
         if account_node_id:
             _add_rel_edge(graph, account_node_id, agent_node_id, RelationshipType.OWNS, {"source": "snowflake-governance"})
+
+
+def _add_cloud_audit_behavioral(graph: UnifiedGraph, payload: Any, data_source: str) -> None:
+    """Promote cloud audit-trail behavioral signal into observed-reach edges.
+
+    Mirrors the Snowflake ACCESS_HISTORY → ``ACCESSED`` layer
+    (:func:`_add_snowflake_governance`) for AWS CloudTrail / Azure Activity Log /
+    GCP Cloud Audit Logs. The reader
+    (:mod:`agent_bom.cloud.audit_trail`) has already collapsed raw events into
+    ``(principal, resource, action)`` aggregates carrying ``count`` and
+    ``last_seen`` — **no raw log lines reach this function**.
+
+    For each aggregate a ``principal`` node draws an observed-behavior edge to the
+    ``resource`` node:
+
+    * ``relationship == "invoked"`` → :data:`RelationshipType.INVOKED`
+      (a management/write action *taken*).
+    * otherwise → :data:`RelationshipType.ACCESSED` (a resource *reached*).
+
+    The edge carries ``observed_at`` (``last_seen``), the action, outcome
+    summary, and the observation ``count`` so attack-path/reachability can reason
+    about *who actually reached what*, not just who *can*. The principal and
+    resource node ids are scheme-stable so repeated runs of the same events
+    produce the same nodes/edges. Never raises; a non-ok payload is a no-op.
+    """
+    prepared = _prepare_cloud_payload(payload, data_source, "cloud-audit-trail")
+    if prepared is None:
+        return
+    account, data_sources = prepared
+    provider = _clean_graph_part(payload.get("provider")) or "cloud"
+
+    account_node_id = ""
+    if account:
+        account_node_id = _add_identity_node(
+            graph,
+            EntityType.ACCOUNT,
+            account,
+            provider,
+            data_sources,
+            label=account or provider,
+            account_id=account,
+            cloud_provider=provider,
+            source="cloud-audit-trail",
+        )
+
+    seen_principals: set[str] = set()
+
+    def _ensure_principal(name: str) -> str:
+        node_id = _identity_node_id(EntityType.USER, provider, name)
+        if node_id not in seen_principals:
+            seen_principals.add(node_id)
+            _add_identity_node(
+                graph,
+                EntityType.USER,
+                name,
+                provider,
+                data_sources,
+                label=f"principal: {name}",
+                user_name=name,
+                cloud_provider=provider,
+                source="cloud-audit-trail",
+            )
+            if account_node_id:
+                _add_rel_edge(
+                    graph,
+                    account_node_id,
+                    node_id,
+                    RelationshipType.OWNS,
+                    {"source": "cloud-audit-trail"},
+                )
+        return node_id
+
+    for rec in payload.get("behavioral_edges", []) or []:
+        if not isinstance(rec, dict):
+            continue
+        principal = _clean_graph_part(rec.get("principal"))
+        resource = _clean_graph_part(rec.get("resource"))
+        action = _clean_graph_part(rec.get("action"))
+        if not principal or not resource or not action:
+            continue
+        relationship = RelationshipType.INVOKED if _clean_graph_part(rec.get("relationship")) == "invoked" else RelationshipType.ACCESSED
+        resource_node_id = f"cloud_resource:{provider}:audit:resource:{resource}"
+        if resource_node_id not in graph.nodes:
+            # Thin resource node — a full cloud inventory scan, if also run, owns
+            # the rich one (a different id scheme, so no collision/duplicate).
+            graph.add_node(
+                UnifiedNode(
+                    id=resource_node_id,
+                    entity_type=EntityType.CLOUD_RESOURCE,
+                    label=f"resource: {resource}",
+                    attributes={
+                        "resource_name": resource,
+                        "resource_kind": "audit-observed-resource",
+                        "cloud_provider": provider,
+                        "is_sensitive_resource": bool(rec.get("is_sensitive_resource")),
+                    },
+                    data_sources=data_sources,
+                    dimensions=NodeDimensions(cloud_provider=provider, surface="cloud"),
+                )
+            )
+            if account_node_id:
+                _add_rel_edge(
+                    graph,
+                    account_node_id,
+                    resource_node_id,
+                    RelationshipType.OWNS,
+                    {"source": "cloud-audit-trail"},
+                )
+        _add_rel_edge(
+            graph,
+            _ensure_principal(principal),
+            resource_node_id,
+            relationship,
+            {
+                "source": "cloud-audit-trail",
+                "observed": True,
+                "action": action,
+                "observed_at": _clean_graph_part(rec.get("last_seen")),
+                "observation_count": int(rec.get("count") or 0),
+                "failure_count": int(rec.get("failure_count") or 0),
+                "is_sensitive_resource": bool(rec.get("is_sensitive_resource")),
+            },
+        )
 
 
 def _add_snowflake_activity(graph: UnifiedGraph, payload: Any, data_source: str) -> None:

--- a/tests/test_cloud_audit_trail.py
+++ b/tests/test_cloud_audit_trail.py
@@ -1,0 +1,529 @@
+"""Tests for read-only cloud audit-trail ingestion → behavioral graph edges.
+
+Covers: opt-in gating, read-only readers (AWS/Azure/GCP) with mocked clients,
+missing-permission → actionable message + no crash, cap-respected + warns,
+aggregation/dedup + count, no-raw-log retention, determinism, and the
+graph builder ``_add_cloud_audit_behavioral`` ACCESSED/INVOKED edge layer.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from agent_bom.cloud.audit_trail import (
+    AuditEvent,
+    aggregate_events,
+    classify_action,
+    collect_audit_trail,
+    derive_behavioral_findings,
+    is_enabled,
+    lookback_hours,
+    max_events,
+    read_aws_cloudtrail,
+    read_azure_activity_log,
+    read_gcp_audit_logs,
+)
+from agent_bom.graph.builder import _add_cloud_audit_behavioral
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.types import RelationshipType
+
+_NOW = datetime(2026, 6, 24, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def _enable_audit(monkeypatch):
+    """Opt-in is ON for most tests; the gating test overrides it."""
+    monkeypatch.setenv("AGENT_BOM_AUDIT_TRAIL", "1")
+    monkeypatch.delenv("AGENT_BOM_AUDIT_TRAIL_MAX_EVENTS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_AUDIT_TRAIL_LOOKBACK_HOURS", raising=False)
+
+
+# ── Opt-in gating ──────────────────────────────────────────────────────────
+
+
+class TestOptIn:
+    def test_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("AGENT_BOM_AUDIT_TRAIL", raising=False)
+        assert is_enabled() is False
+
+    def test_enabled_truthy_values(self, monkeypatch):
+        for val in ("1", "true", "YES", "on"):
+            monkeypatch.setenv("AGENT_BOM_AUDIT_TRAIL", val)
+            assert is_enabled() is True
+
+    def test_collect_skips_when_not_opted_in(self, monkeypatch):
+        monkeypatch.delenv("AGENT_BOM_AUDIT_TRAIL", raising=False)
+        payload = collect_audit_trail(provider="aws", now=_NOW)
+        assert payload["status"] == "skipped"
+        assert "AGENT_BOM_AUDIT_TRAIL" in payload["reason"]
+        assert payload["behavioral_edges" if "behavioral_edges" in payload else "warnings"] is not None
+
+
+# ── Bounds ─────────────────────────────────────────────────────────────────
+
+
+class TestBounds:
+    def test_defaults(self):
+        assert lookback_hours() == 24
+        assert max_events() == 2000
+
+    def test_lookback_clamped(self, monkeypatch):
+        monkeypatch.setenv("AGENT_BOM_AUDIT_TRAIL_LOOKBACK_HOURS", "999999")
+        assert lookback_hours() == 24 * 14
+
+    def test_max_events_clamped(self, monkeypatch):
+        monkeypatch.setenv("AGENT_BOM_AUDIT_TRAIL_MAX_EVENTS", "999999999")
+        assert max_events() == 20000
+
+    def test_bad_int_falls_back(self, monkeypatch):
+        monkeypatch.setenv("AGENT_BOM_AUDIT_TRAIL_MAX_EVENTS", "not-a-number")
+        assert max_events() == 2000
+
+
+# ── Action classification ──────────────────────────────────────────────────
+
+
+class TestClassifyAction:
+    @pytest.mark.parametrize(
+        "action,expected",
+        [
+            ("ec2:RunInstances", "invoked"),
+            ("CreateBucket", "invoked"),
+            ("DeleteRole", "invoked"),
+            ("Microsoft.Storage/storageAccounts/write", "invoked"),
+            ("storage.objects.get", "accessed"),
+            ("DescribeInstances", "accessed"),
+            ("ListBuckets", "accessed"),
+            ("", "accessed"),
+            ("SomethingUnknown", "accessed"),
+        ],
+    )
+    def test_classify(self, action, expected):
+        assert classify_action(action) == expected
+
+
+# ── Aggregation / dedup / count / determinism / no-raw-log ─────────────────
+
+
+class TestAggregation:
+    def _events(self):
+        return [
+            AuditEvent("alice", "GetObject", "bucket/data", "2026-06-24T10:00:00+00:00"),
+            AuditEvent("alice", "GetObject", "bucket/data", "2026-06-24T11:00:00+00:00"),
+            AuditEvent("alice", "GetObject", "bucket/data", "2026-06-24T09:00:00+00:00"),
+            AuditEvent("bob", "CreateRole", "iam/admin", "2026-06-24T08:00:00+00:00"),
+        ]
+
+    def test_dedup_and_count(self):
+        records = aggregate_events(self._events())
+        assert len(records) == 2
+        alice = next(r for r in records if r["principal"] == "alice")
+        assert alice["count"] == 3
+        assert alice["relationship"] == "accessed"
+
+    def test_last_seen_is_latest(self):
+        records = aggregate_events(self._events())
+        alice = next(r for r in records if r["principal"] == "alice")
+        assert alice["last_seen"] == "2026-06-24T11:00:00+00:00"
+
+    def test_invoke_classification_in_aggregate(self):
+        records = aggregate_events(self._events())
+        bob = next(r for r in records if r["principal"] == "bob")
+        assert bob["relationship"] == "invoked"
+
+    def test_sensitive_resource_flag(self):
+        records = aggregate_events(self._events())
+        bob = next(r for r in records if r["principal"] == "bob")
+        assert bob["is_sensitive_resource"] is True
+
+    def test_deterministic_sorted_output(self):
+        import random
+
+        events = self._events()
+        shuffled = list(events)
+        random.shuffle(shuffled)
+        assert aggregate_events(events) == aggregate_events(shuffled)
+
+    def test_no_raw_logs_in_records(self):
+        records = aggregate_events(self._events())
+        for rec in records:
+            assert set(rec.keys()) == {
+                "principal",
+                "action",
+                "resource",
+                "relationship",
+                "count",
+                "last_seen",
+                "failure_count",
+                "is_sensitive_resource",
+            }
+
+    def test_failure_count_tracked(self):
+        events = [
+            AuditEvent("eve", "AssumeRole", "iam/role", "2026-06-24T10:00:00+00:00", outcome="failure"),
+            AuditEvent("eve", "AssumeRole", "iam/role", "2026-06-24T10:01:00+00:00", outcome="failure"),
+            AuditEvent("eve", "AssumeRole", "iam/role", "2026-06-24T10:02:00+00:00", outcome="failure"),
+        ]
+        records = aggregate_events(events)
+        assert records[0]["failure_count"] == 3
+
+
+# ── Findings ────────────────────────────────────────────────────────────────
+
+
+class TestFindings:
+    def test_sensitive_access_finding(self):
+        records = aggregate_events([AuditEvent("bob", "GetSecretValue", "secretsmanager/db-pass", "2026-06-24T10:00:00+00:00")])
+        findings = derive_behavioral_findings(records)
+        assert any(f["kind"] == "sensitive_resource_access" for f in findings)
+
+    def test_repeated_failure_finding(self):
+        records = aggregate_events(
+            [AuditEvent("eve", "ListObjects", "bucket/x", f"2026-06-24T10:0{i}:00+00:00", outcome="failure") for i in range(4)]
+        )
+        findings = derive_behavioral_findings(records)
+        assert any(f["kind"] == "repeated_access_failure" for f in findings)
+
+    def test_clean_records_no_findings(self):
+        records = aggregate_events([AuditEvent("alice", "ListBuckets", "s3", "2026-06-24T10:00:00+00:00")])
+        assert derive_behavioral_findings(records) == []
+
+
+# ── AWS CloudTrail reader (mocked) ─────────────────────────────────────────
+
+
+class _FakeAWSPaginator:
+    def __init__(self, pages):
+        self._pages = pages
+
+    def paginate(self, **kwargs):
+        return self._pages
+
+
+class _FakeAWSClient:
+    def __init__(self, pages=None, error=None):
+        self._pages = pages or []
+        self._error = error
+
+    def get_paginator(self, name):
+        assert name == "lookup_events"
+        if self._error:
+            raise self._error
+        return _FakeAWSPaginator(self._pages)
+
+
+class _FakeAWSSession:
+    def __init__(self, client):
+        self._client = client
+
+    def client(self, name):
+        assert name == "cloudtrail"
+        return self._client
+
+
+class TestAWSReader:
+    def test_reads_and_normalizes(self):
+        pages = [
+            {
+                "Events": [
+                    {
+                        "EventName": "GetObject",
+                        "Username": "alice",
+                        "EventTime": datetime(2026, 6, 24, 10, 0, tzinfo=timezone.utc),
+                        "Resources": [{"ResourceName": "bucket/data", "ResourceType": "AWS::S3::Object"}],
+                        "EventSource": "s3.amazonaws.com",
+                    }
+                ]
+            }
+        ]
+        events, warnings = read_aws_cloudtrail(now=_NOW, session_factory=lambda: _FakeAWSSession(_FakeAWSClient(pages)))
+        assert warnings == []
+        assert len(events) == 1
+        assert events[0].principal == "alice"
+        assert events[0].action == "GetObject"
+        assert events[0].resource == "bucket/data"
+
+    def test_access_denied_actionable(self):
+        from botocore.exceptions import ClientError
+
+        denied = ClientError({"Error": {"Code": "AccessDenied", "Message": "denied"}}, "LookupEvents")
+        events, warnings = read_aws_cloudtrail(now=_NOW, session_factory=lambda: _FakeAWSSession(_FakeAWSClient(error=denied)))
+        assert events == []
+        assert len(warnings) == 1
+        assert "cloudtrail:LookupEvents" in warnings[0]
+
+    def test_cap_respected_and_warns(self, monkeypatch):
+        monkeypatch.setenv("AGENT_BOM_AUDIT_TRAIL_MAX_EVENTS", "2")
+        pages = [
+            {
+                "Events": [
+                    {
+                        "EventName": f"Event{i}",
+                        "Username": f"user{i}",
+                        "EventTime": datetime(2026, 6, 24, 10, 0, tzinfo=timezone.utc),
+                        "Resources": [{"ResourceName": f"res{i}"}],
+                    }
+                    for i in range(10)
+                ]
+            }
+        ]
+        events, warnings = read_aws_cloudtrail(now=_NOW, session_factory=lambda: _FakeAWSSession(_FakeAWSClient(pages)))
+        assert len(events) == 2
+        assert any("capped at 2" in w for w in warnings)
+
+
+# ── Azure Activity Log reader (mocked) ─────────────────────────────────────
+
+
+class _AzureRecord:
+    def __init__(self, caller, op, resource, status="Succeeded"):
+        self.caller = caller
+        self.operation_name = type("Op", (), {"value": op})()
+        self.resource_id = resource
+        self.status = type("St", (), {"value": status})()
+        self.event_timestamp = datetime(2026, 6, 24, 10, 0, tzinfo=timezone.utc)
+
+
+class _FakeAzureActivityLogs:
+    def __init__(self, records, error=None):
+        self._records = records
+        self._error = error
+
+    def list(self, filter):  # noqa: A002 - matches SDK signature
+        if self._error:
+            raise self._error
+        return iter(self._records)
+
+
+class _FakeAzureClient:
+    def __init__(self, records=None, error=None):
+        self.activity_logs = _FakeAzureActivityLogs(records or [], error)
+
+
+class TestAzureReader:
+    def test_reads_and_normalizes(self):
+        recs = [_AzureRecord("svc@x.com", "Microsoft.Storage/write", "/subs/abc/res/foo")]
+        events, warnings = read_azure_activity_log(subscription_id="sub-1", now=_NOW, client_factory=lambda: _FakeAzureClient(recs))
+        assert warnings == []
+        assert events[0].principal == "svc@x.com"
+        assert events[0].action == "Microsoft.Storage/write"
+        assert events[0].resource == "/subs/abc/res/foo"
+
+    def test_missing_subscription_actionable(self, monkeypatch):
+        monkeypatch.delenv("AZURE_SUBSCRIPTION_ID", raising=False)
+        events, warnings = read_azure_activity_log(now=_NOW, client_factory=lambda: _FakeAzureClient([]))
+        assert events == []
+        assert any("AZURE_SUBSCRIPTION_ID" in w for w in warnings)
+
+    def test_permission_denied_actionable(self):
+        events, warnings = read_azure_activity_log(
+            subscription_id="sub-1",
+            now=_NOW,
+            client_factory=lambda: _FakeAzureClient(error=Exception("AuthorizationFailed")),
+        )
+        assert events == []
+        assert any("Monitoring Reader" in w for w in warnings)
+
+
+# ── GCP Cloud Audit Logs reader (mocked) ───────────────────────────────────
+
+
+class _GCPEntry:
+    def __init__(self, principal, method, resource, code=0):
+        self.payload = {
+            "authenticationInfo": {"principalEmail": principal},
+            "methodName": method,
+            "resourceName": resource,
+            "status": {"code": code},
+        }
+        self.timestamp = datetime(2026, 6, 24, 10, 0, tzinfo=timezone.utc)
+
+
+class _FakeGCPClient:
+    def __init__(self, entries=None, error=None):
+        self._entries = entries or []
+        self._error = error
+
+    def list_entries(self, filter_, page_size):
+        if self._error:
+            raise self._error
+        return iter(self._entries)
+
+
+class TestGCPReader:
+    def test_reads_and_normalizes(self):
+        entries = [_GCPEntry("sa@proj.iam", "storage.objects.get", "projects/_/buckets/b/objects/o")]
+        events, warnings = read_gcp_audit_logs(project_id="proj", now=_NOW, client_factory=lambda: _FakeGCPClient(entries))
+        assert warnings == []
+        assert events[0].principal == "sa@proj.iam"
+        assert events[0].action == "storage.objects.get"
+
+    def test_missing_project_actionable(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        events, warnings = read_gcp_audit_logs(now=_NOW, client_factory=lambda: _FakeGCPClient([]))
+        assert events == []
+        assert any("GOOGLE_CLOUD_PROJECT" in w for w in warnings)
+
+    def test_permission_denied_actionable(self):
+        events, warnings = read_gcp_audit_logs(
+            project_id="proj",
+            now=_NOW,
+            client_factory=lambda: _FakeGCPClient(error=Exception("PermissionDenied: logging.logEntries.list")),
+        )
+        assert events == []
+        assert any("roles/logging.viewer" in w for w in warnings)
+
+    def test_failure_outcome_from_status_code(self):
+        entries = [_GCPEntry("sa@proj.iam", "storage.buckets.delete", "buckets/b", code=7)]
+        events, _ = read_gcp_audit_logs(project_id="proj", now=_NOW, client_factory=lambda: _FakeGCPClient(entries))
+        assert events[0].outcome == "failure"
+
+
+# ── collect_audit_trail end-to-end (no raw logs in payload) ────────────────
+
+
+class TestCollect:
+    def test_ok_payload_has_no_raw_events(self):
+        pages = [
+            {
+                "Events": [
+                    {
+                        "EventName": "GetObject",
+                        "Username": "alice",
+                        "EventTime": datetime(2026, 6, 24, 10, 0, tzinfo=timezone.utc),
+                        "Resources": [{"ResourceName": "bucket/data"}],
+                    }
+                ]
+            }
+        ]
+        payload = collect_audit_trail(
+            provider="aws",
+            account="123456789012",
+            now=_NOW,
+            session_factory=lambda: _FakeAWSSession(_FakeAWSClient(pages)),
+        )
+        assert payload["status"] == "ok"
+        assert payload["account"] == "123456789012"
+        assert payload["event_count"] == 1
+        assert "behavioral_edges" in payload
+        # No raw event list, no log lines retained anywhere in the payload.
+        assert "events" not in payload
+        assert "raw_events" not in payload
+
+    def test_unknown_provider_errors(self):
+        payload = collect_audit_trail(provider="oracle", now=_NOW)
+        assert payload["status"] == "error"
+
+
+# ── Graph builder: ACCESSED / INVOKED behavioral edges ─────────────────────
+
+
+def _payload(edges):
+    return {
+        "status": "ok",
+        "provider": "aws",
+        "account": "123456789012",
+        "behavioral_edges": edges,
+        "behavioral_findings": [],
+        "event_count": len(edges),
+        "warnings": [],
+    }
+
+
+class TestBuilderBehavioralEdges:
+    def _build(self, edges):
+        graph = UnifiedGraph()
+        _add_cloud_audit_behavioral(graph, _payload(edges), "scan")
+        return graph
+
+    def test_accessed_edge_drawn(self):
+        graph = self._build(
+            [
+                {
+                    "principal": "alice",
+                    "action": "GetObject",
+                    "resource": "bucket/data",
+                    "relationship": "accessed",
+                    "count": 3,
+                    "last_seen": "2026-06-24T11:00:00+00:00",
+                    "failure_count": 0,
+                    "is_sensitive_resource": False,
+                }
+            ]
+        )
+        edges = list(graph.edges)
+        accessed = [e for e in edges if e.relationship == RelationshipType.ACCESSED]
+        assert len(accessed) == 1
+        assert accessed[0].evidence["observed"] is True
+        assert accessed[0].evidence["observation_count"] == 3
+        assert accessed[0].evidence["observed_at"] == "2026-06-24T11:00:00+00:00"
+
+    def test_invoked_edge_drawn(self):
+        graph = self._build(
+            [
+                {
+                    "principal": "bob",
+                    "action": "CreateRole",
+                    "resource": "iam/admin",
+                    "relationship": "invoked",
+                    "count": 1,
+                    "last_seen": "2026-06-24T08:00:00+00:00",
+                    "failure_count": 0,
+                    "is_sensitive_resource": True,
+                }
+            ]
+        )
+        invoked = [e for e in graph.edges if e.relationship == RelationshipType.INVOKED]
+        assert len(invoked) == 1
+        assert invoked[0].evidence["action"] == "CreateRole"
+
+    def test_principal_and_resource_nodes_created(self):
+        graph = self._build(
+            [
+                {
+                    "principal": "alice",
+                    "action": "GetObject",
+                    "resource": "bucket/data",
+                    "relationship": "accessed",
+                    "count": 1,
+                    "last_seen": "",
+                    "failure_count": 0,
+                    "is_sensitive_resource": False,
+                }
+            ]
+        )
+        node_ids = set(graph.nodes)
+        assert any("user:aws:alice" in n for n in node_ids)
+        assert any("cloud_resource:aws:audit:resource:bucket/data" in n for n in node_ids)
+
+    def test_deterministic_same_payload_same_graph(self):
+        edges = [
+            {
+                "principal": "alice",
+                "action": "GetObject",
+                "resource": "bucket/data",
+                "relationship": "accessed",
+                "count": 2,
+                "last_seen": "2026-06-24T11:00:00+00:00",
+                "failure_count": 0,
+                "is_sensitive_resource": False,
+            }
+        ]
+        g1 = self._build(edges)
+        g2 = self._build(edges)
+        assert sorted((e.source, e.target, e.relationship.value) for e in g1.edges) == sorted(
+            (e.source, e.target, e.relationship.value) for e in g2.edges
+        )
+        assert set(g1.nodes) == set(g2.nodes)
+
+    def test_non_ok_payload_is_noop(self):
+        graph = UnifiedGraph()
+        _add_cloud_audit_behavioral(graph, {"status": "skipped"}, "scan")
+        _add_cloud_audit_behavioral(graph, None, "scan")
+        assert len(list(graph.edges)) == 0
+
+    def test_incomplete_record_skipped(self):
+        graph = self._build([{"principal": "alice", "resource": "", "action": "GetObject"}])
+        assert len(list(graph.edges)) == 0

--- a/tests/test_cloud_audit_trail.py
+++ b/tests/test_cloud_audit_trail.py
@@ -246,6 +246,7 @@ class TestAWSReader:
         assert events[0].resource == "bucket/data"
 
     def test_access_denied_actionable(self):
+        pytest.importorskip("botocore")  # ClientError is built here; botocore is in the [aws] extra, not the base test env
         from botocore.exceptions import ClientError
 
         denied = ClientError({"Error": {"Code": "AccessDenied", "Message": "denied"}}, "LookupEvents")


### PR DESCRIPTION
## What

Ingest the security-relevant slice of each cloud's native audit trail and derive **behavioral graph edges** — *who actually reached what*, not just who *can*. This is a security-signal extractor, **not a log/observability platform**: raw log lines are never stored, indexed, or re-emitted. Logs stay in the customer's account.

## Boundary (no-log-storage contract)

The reader returns normalized `(principal, action, resource, time, outcome)` events; the builder collapses them into `(principal, resource, action) -> count + last_seen` edges and drops the rest. The `status: ok` payload carries an `event_count` (a number) and aggregated edges only — no raw event list ever reaches the report contract.

## Read-only readers (opt-in, default OFF)

Gated behind `AGENT_BOM_AUDIT_TRAIL` (default off — a scan that does not set it is a clean no-op):

- **AWS** — CloudTrail `LookupEvents` (read-only, paginated management events)
- **Azure** — Activity Log (read-only `activity_logs.list`)
- **GCP** — Cloud Audit Logs (read-only `list_entries` over `cloudaudit.googleapis.com`)

Each reader takes an injected client/session factory for testing and uses the standard provider credential chain in production. Only read/lookup APIs are referenced; no write/mutate API appears anywhere.

## Behavioral edges (builder)

`_add_cloud_audit_behavioral` mirrors the existing Snowflake ACCESS_HISTORY -> `ACCESSED` layer: a `principal` node draws an observed-reach edge to the `resource` node — `INVOKED` for management/write verbs, `ACCESSED` for reads — carrying `observed_at` (last_seen), `action`, `observation_count`, `failure_count`, and a sensitive-resource flag. This feeds attack-path / reachability with observed behavior. Additive only; no existing builder function is modified.

## Security-signal findings

Derived from the aggregates (never from raw logs): sensitive-resource access (secret/IAM/KMS-class) and repeated authorization failure (probing signal).

## Nothing-silent + bounded

- Missing read permission -> a clear, actionable message naming the exact grant required (`cloudtrail:LookupEvents` / Monitoring Reader / `roles/logging.viewer`), never a silent skip or crash.
- Lookback window and per-provider event count are env-configurable and clamped to hard ceilings; hitting a cap appends an explicit `capped` warning — no silent truncation.

## Determinism

Same events -> same edges. `now` is injected; aggregation is keyed, deduped, and sorted for byte-stable graph construction.

## Tests

Mock the cloud clients. Cover: opt-in gating; per-provider read + normalization; access-denied -> actionable message + no crash; cap respected + warns; dedup + count + last_seen; failure tracking; findings derivation; no-raw-log retention; deterministic aggregation; and the builder ACCESSED/INVOKED edge layer (edges, nodes, determinism, no-op on non-ok payload).