### PR TITLE
feat(delivery): hardened outbound delivery foundation + OTLP traces emit

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -104,6 +104,7 @@ AGENT_BOM_TOKEN_ROTATION_DAYS
 AGENT_BOM_CORS_ALL
 AGENT_BOM_DASHBOARD_CSP_HASH_MANIFEST
 AGENT_BOM_DB
+AGENT_BOM_DELIVERY_DB  # optional SQLite path for the outbound delivery foundation (audit log + idempotency ledger + circuit-breaker state); falls back to AGENT_BOM_DB then ~/.agent-bom/db/delivery.db; read in delivery.py
 AGENT_BOM_DB_PATH
 AGENT_BOM_DB_SOURCES
 AGENT_BOM_DEFAULT_ROLE

--- a/src/agent_bom/api/webhook_store.py
+++ b/src/agent_bom/api/webhook_store.py
@@ -294,6 +294,46 @@ def emit_governance_event(
         return 0
 
 
+def deliver_subscription_event(
+    subscription: WebhookSubscription,
+    *,
+    event_type: str,
+    payload: dict[str, Any],
+    idempotency_key: str = "",
+    client: Any = None,
+) -> Any:
+    """Deliver one event to a subscription through the hardened delivery
+    foundation (``agent_bom.delivery.DeliveryClient``).
+
+    Returns the ``DeliveryResult``. Best-effort and non-blocking by contract:
+    the underlying client never raises for a failed send — it dead-letters and
+    returns a warning. Callers that prefer the durable retry *worker* path
+    should keep using ``emit_governance_event`` (the posture outbox); this is
+    the inline, idempotent, circuit-broken alternative for direct delivery
+    (e.g. an operator "test" or a low-volume relay).
+    """
+    from agent_bom.delivery import Delivery, Destination, get_delivery_client
+
+    delivery_client = client or get_delivery_client()
+    destination = Destination(
+        destination_id=subscription.subscription_id,
+        url=subscription.url,
+        kind="webhook",
+        signing_secret=subscription.signing_secret,
+        allow_private_networks=subscription.allow_private_networks,
+        headers={
+            "x-agent-bom-tenant-id": subscription.tenant_id,
+        },
+    )
+    delivery = Delivery(
+        destination_id=subscription.subscription_id,
+        payload=payload,
+        event_type=event_type,
+        idempotency_key=idempotency_key,
+    )
+    return delivery_client.deliver(destination, delivery)
+
+
 _WEBHOOK_SUBSCRIPTION_STORE: WebhookSubscriptionStore | None = None
 
 

--- a/src/agent_bom/delivery.py
+++ b/src/agent_bom/delivery.py
@@ -1,0 +1,825 @@
+"""Hardened outbound delivery foundation.
+
+Every outbound integration — governance webhooks, SIEM/OCSF export, exporters
+(siem, otel, slack, jira, vanta, drata, customer_archive) — should ride this
+single ``DeliveryClient`` so the platform has one place that owns:
+
+  * Retries with exponential backoff + jitter, bounded attempts then a durable
+    **dead-letter** record (never blocks the caller).
+  * An **idempotency key** per delivery so a retry — or a duplicate enqueue of
+    the same payload to the same destination — is never double-sent.
+  * Optional **HMAC request signing** + per-destination auth (header / token /
+    bearer).
+  * A **circuit breaker** per destination (opens on repeated failures,
+    half-opens a single probe after a cooldown).
+  * A queryable **delivery/audit log** — every attempt is recorded with a
+    redacted payload preview; secret values are never persisted.
+
+The design deliberately mirrors the ``posture_streaming`` webhook outbox
+(durable SQLite, deterministic idempotency hash, sanitized errors) and the
+shared ``http_client`` retry loop, consolidating them behind one API. It is
+*graceful by construction*: a destination failure degrades to a dead-letter
+record plus an actionable warning and the caller continues.
+
+All time is taken from an injectable ``now`` callable so retry math and the
+audit log are deterministic under test.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import random
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable
+
+from agent_bom.security import sanitize_error, sanitize_sensitive_payload
+
+logger = logging.getLogger(__name__)
+
+# Statuses that should NOT consume a retry attempt as a transport failure but
+# still represent a non-2xx result. Auth/permanent client errors are not
+# retried (retrying a 401/403 just burns the budget); they go straight to
+# dead-letter so an operator can fix the credential and requeue.
+_RETRYABLE_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504})
+# 4xx (other than the retryable transient ones above) = permanent; do not retry.
+_PERMANENT_4XX_FLOOR = 400
+
+
+class DeliveryError(RuntimeError):
+    """Raised only for programmer errors (bad config); never for a failed send."""
+
+
+class CircuitState(str, Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+# ── Time injection ───────────────────────────────────────────────────────────
+
+
+def _wall_now() -> float:
+    return time.time()
+
+
+def _iso(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+# ── Destination ──────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Destination:
+    """An operator-approved outbound delivery target.
+
+    ``kind`` is a free-form label (``webhook``, ``siem``, ``otel``, ``slack`` …)
+    used only for the audit log / circuit-breaker scoping. Auth material is held
+    here to sign/authenticate at delivery time but is NEVER written to the
+    delivery log (only a fingerprint is).
+    """
+
+    destination_id: str
+    url: str
+    kind: str = "webhook"
+    signing_secret: str = ""
+    auth_scheme: str = ""  # "", "bearer", "token", "header"
+    auth_token: str = ""
+    auth_header: str = "Authorization"
+    headers: dict[str, str] = field(default_factory=dict)
+    allow_private_networks: bool = False
+    timeout: float = 30.0
+
+    def __post_init__(self) -> None:
+        if not self.destination_id.strip():
+            raise DeliveryError("destination_id must not be empty")
+        if not self.url.strip():
+            raise DeliveryError("url must not be empty")
+        scheme = self.auth_scheme.strip().lower()
+        if scheme and scheme not in {"bearer", "token", "header"}:
+            raise DeliveryError(f"unsupported auth_scheme: {self.auth_scheme!r}")
+
+    @property
+    def secret_fingerprint(self) -> str:
+        material = f"{self.signing_secret}\x00{self.auth_token}"
+        if not self.signing_secret and not self.auth_token:
+            return ""
+        return hashlib.sha256(material.encode("utf-8")).hexdigest()[:12]
+
+
+# ── Delivery (the unit of work) ──────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Delivery:
+    """One logical payload bound for one destination.
+
+    ``idempotency_key`` defaults to a deterministic content hash so the same
+    payload to the same destination collapses to a single send. Callers with
+    their own stable key (an event id, a finding id) should pass it explicitly.
+    """
+
+    destination_id: str
+    payload: dict[str, Any]
+    event_type: str = "delivery"
+    idempotency_key: str = ""
+    created_at: float = field(default_factory=_wall_now)
+
+    def __post_init__(self) -> None:
+        clean = sanitize_sensitive_payload(self.payload)
+        if not isinstance(clean, dict):
+            clean = {"value": clean}
+        object.__setattr__(self, "payload", clean)
+        if not self.idempotency_key:
+            fingerprint = _canonical_json(
+                {
+                    "destination_id": self.destination_id,
+                    "event_type": self.event_type,
+                    "payload": self.payload,
+                }
+            )
+            object.__setattr__(
+                self,
+                "idempotency_key",
+                hashlib.sha256(fingerprint.encode("utf-8")).hexdigest(),
+            )
+
+
+@dataclass(frozen=True)
+class DeliveryResult:
+    """Outcome returned to the caller — never an exception for a failed send."""
+
+    idempotency_key: str
+    destination_id: str
+    status: str  # "delivered" | "dead_letter" | "deduplicated" | "circuit_open"
+    http_status: int | None = None
+    attempts: int = 0
+    delivered: bool = False
+    warning: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.delivered
+
+
+# ── Sender protocol ──────────────────────────────────────────────────────────
+# A sender performs ONE HTTP attempt and returns (http_status, error_text).
+# Injecting it keeps DeliveryClient transport-agnostic and trivially testable.
+
+Sender = Callable[[str, dict[str, str], bytes, float], "SendOutcome"]
+
+
+@dataclass(frozen=True)
+class SendOutcome:
+    http_status: int | None
+    error: str = ""
+
+    @property
+    def is_success(self) -> bool:
+        return self.http_status is not None and 200 <= self.http_status < 300
+
+
+def http_sender(url: str, headers: dict[str, str], body: bytes, timeout: float) -> SendOutcome:
+    """Default sender: one POST through the shared resilient sync client.
+
+    The shared client already validates the URL (SSRF) and does connection-level
+    retries; the application-level retry/backoff lives in ``DeliveryClient`` so
+    every destination shares one policy.
+    """
+    from agent_bom.http_client import create_sync_client
+    from agent_bom.security import SecurityError, validate_url
+
+    allow_private = os.environ.get("AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS", "").strip().lower() in {"1", "true", "yes", "on"}
+    try:
+        validate_url(url, allowed_schemes=("https", "http") if allow_private else ("https",), allow_private=allow_private)
+    except SecurityError as exc:
+        return SendOutcome(http_status=None, error=f"url rejected by outbound policy: {sanitize_error(exc)}")
+    try:
+        with create_sync_client(timeout=timeout) as client:
+            resp = client.request("POST", url, content=body, headers=headers)
+        return SendOutcome(http_status=resp.status_code)
+    except Exception as exc:  # noqa: BLE001 — any transport error becomes a retryable failure
+        return SendOutcome(http_status=None, error=sanitize_error(exc))
+
+
+# ── Audit / circuit store ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class AttemptRecord:
+    row_id: int
+    idempotency_key: str
+    destination_id: str
+    kind: str
+    attempt: int
+    status: str
+    http_status: int | None
+    payload_preview: str
+    error: str
+    created_at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "row_id": self.row_id,
+            "idempotency_key": self.idempotency_key,
+            "destination_id": self.destination_id,
+            "kind": self.kind,
+            "attempt": self.attempt,
+            "status": self.status,
+            "http_status": self.http_status,
+            "payload_preview": self.payload_preview,
+            "error": self.error,
+            "created_at": self.created_at,
+            "created_at_iso": _iso(self.created_at),
+        }
+
+
+class DeliveryStore:
+    """SQLite-backed delivery audit log + idempotency ledger + breaker state.
+
+    Tables:
+      * ``delivery_log``       — every attempt (redacted preview, no secrets).
+      * ``delivery_ledger``    — terminal outcome per idempotency key (dedupe).
+      * ``delivery_breaker``   — per-destination circuit-breaker state.
+    """
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS delivery_log (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    idempotency_key TEXT NOT NULL,
+                    destination_id TEXT NOT NULL,
+                    kind TEXT NOT NULL DEFAULT 'webhook',
+                    attempt INTEGER NOT NULL,
+                    status TEXT NOT NULL,
+                    http_status INTEGER,
+                    payload_preview TEXT NOT NULL DEFAULT '',
+                    error TEXT NOT NULL DEFAULT '',
+                    created_at REAL NOT NULL
+                )
+                """
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_delivery_log_key ON delivery_log(idempotency_key)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_delivery_log_dest ON delivery_log(destination_id, created_at)")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS delivery_ledger (
+                    idempotency_key TEXT NOT NULL,
+                    destination_id TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    http_status INTEGER,
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    PRIMARY KEY (destination_id, idempotency_key)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS delivery_breaker (
+                    destination_id TEXT PRIMARY KEY,
+                    state TEXT NOT NULL DEFAULT 'closed',
+                    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+                    opened_at REAL,
+                    updated_at REAL NOT NULL
+                )
+                """
+            )
+
+    # — idempotency ledger —
+
+    def terminal_status(self, destination_id: str, idempotency_key: str) -> str | None:
+        """Return the terminal status (``delivered``/``dead_letter``) if this
+        key already reached a terminal state for this destination, else None."""
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT status FROM delivery_ledger WHERE destination_id = ? AND idempotency_key = ?",
+                (destination_id, idempotency_key),
+            ).fetchone()
+        return str(row["status"]) if row else None
+
+    def record_terminal(
+        self, *, destination_id: str, idempotency_key: str, status: str, http_status: int | None, attempts: int, now: float
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO delivery_ledger (idempotency_key, destination_id, status, http_status, attempts, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(destination_id, idempotency_key)
+                DO UPDATE SET
+                    status=excluded.status,
+                    http_status=excluded.http_status,
+                    attempts=excluded.attempts,
+                    updated_at=excluded.updated_at
+                """,
+                (idempotency_key, destination_id, status, http_status, attempts, now, now),
+            )
+
+    # — attempt log —
+
+    def log_attempt(
+        self,
+        *,
+        idempotency_key: str,
+        destination_id: str,
+        kind: str,
+        attempt: int,
+        status: str,
+        http_status: int | None,
+        payload_preview: str,
+        error: str,
+        now: float,
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO delivery_log
+                    (idempotency_key, destination_id, kind, attempt, status, http_status, payload_preview, error, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    idempotency_key,
+                    destination_id,
+                    kind,
+                    attempt,
+                    status,
+                    http_status,
+                    payload_preview,
+                    sanitize_error(error) if error else "",
+                    now,
+                ),
+            )
+
+    def attempts(self, *, destination_id: str | None = None, idempotency_key: str | None = None, limit: int = 100) -> list[AttemptRecord]:
+        bounded = max(1, min(int(limit), 1000))
+        # Fully static queries selected by which filters are present — no string
+        # interpolation, so there is no SQL-injection surface; all values bound.
+        params: list[Any] = []
+        if destination_id and idempotency_key:
+            query = "SELECT * FROM delivery_log WHERE destination_id = ? AND idempotency_key = ? ORDER BY id DESC LIMIT ?"
+            params = [destination_id, idempotency_key, bounded]
+        elif destination_id:
+            query = "SELECT * FROM delivery_log WHERE destination_id = ? ORDER BY id DESC LIMIT ?"
+            params = [destination_id, bounded]
+        elif idempotency_key:
+            query = "SELECT * FROM delivery_log WHERE idempotency_key = ? ORDER BY id DESC LIMIT ?"
+            params = [idempotency_key, bounded]
+        else:
+            query = "SELECT * FROM delivery_log ORDER BY id DESC LIMIT ?"
+            params = [bounded]
+        with self._connect() as conn:
+            rows = conn.execute(query, tuple(params)).fetchall()
+        return [
+            AttemptRecord(
+                row_id=int(r["id"]),
+                idempotency_key=str(r["idempotency_key"]),
+                destination_id=str(r["destination_id"]),
+                kind=str(r["kind"]),
+                attempt=int(r["attempt"]),
+                status=str(r["status"]),
+                http_status=int(r["http_status"]) if r["http_status"] is not None else None,
+                payload_preview=str(r["payload_preview"] or ""),
+                error=str(r["error"] or ""),
+                created_at=float(r["created_at"]),
+            )
+            for r in rows
+        ]
+
+    def dead_letters(self, *, destination_id: str | None = None, limit: int = 100) -> list[AttemptRecord]:
+        records = self.attempts(destination_id=destination_id, limit=1000)
+        out = [r for r in records if r.status == "dead_letter"]
+        return out[: max(1, min(int(limit), 1000))]
+
+    # — circuit breaker —
+
+    def breaker_state(self, destination_id: str) -> tuple[CircuitState, int, float | None]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT state, consecutive_failures, opened_at FROM delivery_breaker WHERE destination_id = ?",
+                (destination_id,),
+            ).fetchone()
+        if not row:
+            return CircuitState.CLOSED, 0, None
+        return (
+            CircuitState(str(row["state"])),
+            int(row["consecutive_failures"]),
+            (float(row["opened_at"]) if row["opened_at"] is not None else None),
+        )
+
+    def set_breaker(
+        self, destination_id: str, *, state: CircuitState, consecutive_failures: int, opened_at: float | None, now: float
+    ) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO delivery_breaker (destination_id, state, consecutive_failures, opened_at, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(destination_id)
+                DO UPDATE SET
+                    state=excluded.state,
+                    consecutive_failures=excluded.consecutive_failures,
+                    opened_at=excluded.opened_at,
+                    updated_at=excluded.updated_at
+                """,
+                (destination_id, state.value, consecutive_failures, opened_at, now),
+            )
+
+
+def default_delivery_store_path() -> Path:
+    configured = os.environ.get("AGENT_BOM_DELIVERY_DB", "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    shared = os.environ.get("AGENT_BOM_DB", "").strip()
+    if shared:
+        return Path(shared).expanduser()
+    return Path.home() / ".agent-bom" / "db" / "delivery.db"
+
+
+# ── Payload preview (redacted) ───────────────────────────────────────────────
+
+_PREVIEW_MAX = 512
+
+
+def redacted_preview(payload: dict[str, Any]) -> str:
+    """A short, secret-free preview of a payload for the audit log."""
+    safe = sanitize_sensitive_payload(payload)
+    text = _canonical_json(safe)
+    if len(text) > _PREVIEW_MAX:
+        return text[:_PREVIEW_MAX] + "…"
+    return text
+
+
+# ── DeliveryClient ───────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    max_attempts: int = 4
+    initial_backoff: float = 1.0
+    max_backoff: float = 30.0
+    backoff_multiplier: float = 2.0
+    jitter_ratio: float = 0.1
+
+
+@dataclass(frozen=True)
+class BreakerPolicy:
+    failure_threshold: int = 5  # consecutive failures before opening
+    cooldown: float = 60.0  # seconds before a half-open probe
+
+
+class DeliveryClient:
+    """One hardened outbound delivery path shared by every exporter/webhook."""
+
+    def __init__(
+        self,
+        store: DeliveryStore | None = None,
+        *,
+        sender: Sender = http_sender,
+        retry: RetryPolicy | None = None,
+        breaker: BreakerPolicy | None = None,
+        now: Callable[[], float] = _wall_now,
+        sleep: Callable[[float], None] = time.sleep,
+        rng: Callable[[], float] = random.random,
+    ):
+        self.store = store or DeliveryStore(default_delivery_store_path())
+        self.sender = sender
+        self.retry = retry or RetryPolicy()
+        self.breaker = breaker or BreakerPolicy()
+        self._now = now
+        self._sleep = sleep
+        self._rng = rng
+
+    # — header construction —
+
+    def _build_headers(self, destination: Destination, delivery: Delivery, body: bytes, attempt: int) -> dict[str, str]:
+        headers: dict[str, str] = {
+            "content-type": "application/json",
+            "idempotency-key": delivery.idempotency_key,
+            "x-agent-bom-event-type": delivery.event_type,
+            "x-agent-bom-delivery-attempt": str(attempt),
+        }
+        headers.update({str(k): str(v) for k, v in destination.headers.items()})
+        if destination.signing_secret:
+            sig = hmac.new(destination.signing_secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+            headers["x-agent-bom-signature"] = f"sha256={sig}"
+        scheme = destination.auth_scheme.strip().lower()
+        if scheme and destination.auth_token:
+            if scheme == "bearer":
+                headers[destination.auth_header] = f"Bearer {destination.auth_token}"
+            elif scheme == "token":
+                headers[destination.auth_header] = f"Token {destination.auth_token}"
+            elif scheme == "header":
+                headers[destination.auth_header] = destination.auth_token
+        return headers
+
+    def _backoff(self, attempt: int) -> float:
+        # attempt is 1-based; first retry waits initial_backoff.
+        raw = self.retry.initial_backoff * (self.retry.backoff_multiplier ** max(0, attempt - 1))
+        raw = min(raw, self.retry.max_backoff)
+        jitter = raw * self.retry.jitter_ratio * self._rng()
+        return min(raw + jitter, self.retry.max_backoff)
+
+    # — circuit breaker gates —
+
+    def _breaker_allows(self, destination_id: str, now: float) -> tuple[bool, bool]:
+        """Return (allowed, is_probe). When OPEN and past cooldown, allow a
+        single half-open probe."""
+        state, _failures, opened_at = self.store.breaker_state(destination_id)
+        if state == CircuitState.CLOSED:
+            return True, False
+        if state == CircuitState.HALF_OPEN:
+            return True, True
+        # OPEN
+        if opened_at is not None and (now - opened_at) >= self.breaker.cooldown:
+            self.store.set_breaker(
+                destination_id,
+                state=CircuitState.HALF_OPEN,
+                consecutive_failures=self.breaker.failure_threshold,
+                opened_at=opened_at,
+                now=now,
+            )
+            return True, True
+        return False, False
+
+    def _record_success(self, destination_id: str, now: float) -> None:
+        self.store.set_breaker(destination_id, state=CircuitState.CLOSED, consecutive_failures=0, opened_at=None, now=now)
+
+    def _record_failure(self, destination_id: str, now: float) -> None:
+        state, failures, opened_at = self.store.breaker_state(destination_id)
+        failures += 1
+        if failures >= self.breaker.failure_threshold:
+            self.store.set_breaker(destination_id, state=CircuitState.OPEN, consecutive_failures=failures, opened_at=now, now=now)
+        else:
+            self.store.set_breaker(destination_id, state=CircuitState.CLOSED, consecutive_failures=failures, opened_at=None, now=now)
+
+    # — public API —
+
+    def deliver(self, destination: Destination, delivery: Delivery) -> DeliveryResult:
+        """Attempt delivery with retries/backoff, idempotency, circuit-breaker,
+        dead-letter, and full audit logging. Never raises for a failed send.
+        """
+        if destination.destination_id != delivery.destination_id:
+            raise DeliveryError("delivery.destination_id must match destination.destination_id")
+
+        now = self._now()
+        key = delivery.idempotency_key
+
+        # Idempotency: a key that already reached a terminal state is not re-sent.
+        prior = self.store.terminal_status(destination.destination_id, key)
+        if prior is not None:
+            return DeliveryResult(
+                idempotency_key=key,
+                destination_id=destination.destination_id,
+                status="deduplicated",
+                delivered=(prior == "delivered"),
+                warning="" if prior == "delivered" else f"prior delivery for this key ended in '{prior}'",
+            )
+
+        # Circuit breaker gate.
+        allowed, _is_probe = self._breaker_allows(destination.destination_id, now)
+        if not allowed:
+            warning = f"circuit open for destination '{destination.destination_id}'; delivery deferred to dead-letter"
+            self.store.log_attempt(
+                idempotency_key=key,
+                destination_id=destination.destination_id,
+                kind=destination.kind,
+                attempt=0,
+                status="circuit_open",
+                http_status=None,
+                payload_preview=redacted_preview(delivery.payload),
+                error=warning,
+                now=now,
+            )
+            self.store.record_terminal(
+                destination_id=destination.destination_id, idempotency_key=key, status="dead_letter", http_status=None, attempts=0, now=now
+            )
+            logger.warning("delivery: %s", warning)
+            return DeliveryResult(
+                idempotency_key=key,
+                destination_id=destination.destination_id,
+                status="circuit_open",
+                attempts=0,
+                delivered=False,
+                warning=warning,
+            )
+
+        body = _canonical_json(delivery.payload).encode("utf-8")
+        preview = redacted_preview(delivery.payload)
+        last_http: int | None = None
+        last_error = ""
+
+        for attempt in range(1, self.retry.max_attempts + 1):
+            headers = self._build_headers(destination, delivery, body, attempt)
+            outcome = self.sender(destination.url, headers, body, destination.timeout)
+            attempt_now = self._now()
+            last_http = outcome.http_status
+            last_error = outcome.error
+
+            if outcome.is_success:
+                self.store.log_attempt(
+                    idempotency_key=key,
+                    destination_id=destination.destination_id,
+                    kind=destination.kind,
+                    attempt=attempt,
+                    status="delivered",
+                    http_status=outcome.http_status,
+                    payload_preview=preview,
+                    error="",
+                    now=attempt_now,
+                )
+                self.store.record_terminal(
+                    destination_id=destination.destination_id,
+                    idempotency_key=key,
+                    status="delivered",
+                    http_status=outcome.http_status,
+                    attempts=attempt,
+                    now=attempt_now,
+                )
+                self._record_success(destination.destination_id, attempt_now)
+                return DeliveryResult(
+                    idempotency_key=key,
+                    destination_id=destination.destination_id,
+                    status="delivered",
+                    http_status=outcome.http_status,
+                    attempts=attempt,
+                    delivered=True,
+                )
+
+            # Non-success: classify retryable vs permanent.
+            retryable = _is_retryable(outcome)
+            status_label = "retry" if (retryable and attempt < self.retry.max_attempts) else "failed"
+            self.store.log_attempt(
+                idempotency_key=key,
+                destination_id=destination.destination_id,
+                kind=destination.kind,
+                attempt=attempt,
+                status=status_label,
+                http_status=outcome.http_status,
+                payload_preview=preview,
+                error=_attempt_error_text(outcome),
+                now=attempt_now,
+            )
+            self._record_failure(destination.destination_id, attempt_now)
+
+            if not retryable:
+                break  # permanent (auth/4xx) — stop, dead-letter
+            if attempt < self.retry.max_attempts:
+                self._sleep(self._backoff(attempt))
+
+        # Exhausted / permanent failure → dead-letter (never blocks caller).
+        terminal_now = self._now()
+        self.store.record_terminal(
+            destination_id=destination.destination_id,
+            idempotency_key=key,
+            status="dead_letter",
+            http_status=last_http,
+            attempts=self.retry.max_attempts,
+            now=terminal_now,
+        )
+        self.store.log_attempt(
+            idempotency_key=key,
+            destination_id=destination.destination_id,
+            kind=destination.kind,
+            attempt=self.retry.max_attempts,
+            status="dead_letter",
+            http_status=last_http,
+            payload_preview=preview,
+            error=last_error or (f"HTTP {last_http}" if last_http else "delivery failed"),
+            now=terminal_now,
+        )
+        warning = _dead_letter_warning(destination, last_http, last_error)
+        logger.warning("delivery: %s", warning)
+        return DeliveryResult(
+            idempotency_key=key,
+            destination_id=destination.destination_id,
+            status="dead_letter",
+            http_status=last_http,
+            attempts=self.retry.max_attempts,
+            delivered=False,
+            warning=warning,
+        )
+
+    # — operator queries —
+
+    def delivery_log(
+        self, *, destination_id: str | None = None, idempotency_key: str | None = None, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        return [r.to_dict() for r in self.store.attempts(destination_id=destination_id, idempotency_key=idempotency_key, limit=limit)]
+
+    def dead_letters(self, *, destination_id: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+        return [r.to_dict() for r in self.store.dead_letters(destination_id=destination_id, limit=limit)]
+
+    def circuit_state(self, destination_id: str) -> str:
+        return self._breaker_state_str(destination_id)
+
+    def _breaker_state_str(self, destination_id: str) -> str:
+        state, _f, opened_at = self.store.breaker_state(destination_id)
+        # Reflect a cooldown-elapsed OPEN as half-open to callers (probe pending).
+        if state == CircuitState.OPEN and opened_at is not None and (self._now() - opened_at) >= self.breaker.cooldown:
+            return CircuitState.HALF_OPEN.value
+        return state.value
+
+
+# ── Classification helpers ───────────────────────────────────────────────────
+
+
+def _is_retryable(outcome: SendOutcome) -> bool:
+    if outcome.http_status is None:
+        return True  # transport/connection error — retry
+    if outcome.http_status in _RETRYABLE_STATUS:
+        return True
+    if outcome.http_status >= _PERMANENT_4XX_FLOOR and outcome.http_status < 500:
+        return False  # auth / client error — permanent
+    return False
+
+
+def _attempt_error_text(outcome: SendOutcome) -> str:
+    if outcome.error:
+        return outcome.error
+    if outcome.http_status is not None:
+        return f"HTTP {outcome.http_status}"
+    return "delivery failed"
+
+
+def _dead_letter_warning(destination: Destination, http_status: int | None, error: str) -> str:
+    base = f"delivery to '{destination.destination_id}' ({destination.kind}) dead-lettered after retries"
+    if http_status in (401, 403):
+        return f"{base}: authentication/authorization rejected (HTTP {http_status}) — check the destination credential, then requeue"
+    if http_status == 429:
+        return f"{base}: destination is rate-limiting (HTTP 429) — it will be retried; consider lowering send volume"
+    if http_status is not None:
+        return f"{base}: HTTP {http_status}"
+    safe = sanitize_error(error) if error else "connection error"
+    return f"{base}: {safe}"
+
+
+# ── Process-wide singleton (opt-in, defaults preserve existing behavior) ──────
+
+_DELIVERY_CLIENT: DeliveryClient | None = None
+_DELIVERY_LOCK = threading.Lock()
+
+
+def get_delivery_client() -> DeliveryClient:
+    global _DELIVERY_CLIENT
+    if _DELIVERY_CLIENT is None:
+        with _DELIVERY_LOCK:
+            if _DELIVERY_CLIENT is None:
+                _DELIVERY_CLIENT = DeliveryClient()
+    return _DELIVERY_CLIENT
+
+
+def set_delivery_client(client: DeliveryClient | None) -> None:
+    global _DELIVERY_CLIENT
+    with _DELIVERY_LOCK:
+        _DELIVERY_CLIENT = client
+
+
+__all__ = [
+    "AttemptRecord",
+    "BreakerPolicy",
+    "CircuitState",
+    "Delivery",
+    "DeliveryClient",
+    "DeliveryError",
+    "DeliveryResult",
+    "DeliveryStore",
+    "Destination",
+    "RetryPolicy",
+    "SendOutcome",
+    "Sender",
+    "default_delivery_store_path",
+    "get_delivery_client",
+    "http_sender",
+    "redacted_preview",
+    "set_delivery_client",
+]

--- a/src/agent_bom/output/prometheus.py
+++ b/src/agent_bom/output/prometheus.py
@@ -390,3 +390,101 @@ def push_otlp(
     # Force flush
     provider.force_flush(timeout_millis=timeout * 1000)
     provider.shutdown()
+
+
+# ─── OpenTelemetry OTLP traces export (optional dep) ──────────────────────
+
+
+def push_otlp_traces(
+    endpoint: str,
+    report: AIBOMReport,
+    blast_radii: Optional[list[BlastRadius]] = None,
+    timeout: int = 15,
+) -> bool:
+    """Export the scan as an OTLP **trace** (spans) over OTLP/HTTP.
+
+    Complements ``push_otlp`` (metrics). The platform already *ingests* traces
+    (``api/tracing.py``); this closes the loop by *emitting* a trace for each
+    scan so observability interop works both ways. A root ``agent_bom.scan``
+    span carries scan-level attributes; a child span is emitted per severity
+    bucket so a finding distribution is visible in any OTLP trace backend.
+
+    Opt-in and no-op-friendly:
+      * ``endpoint`` empty  → returns ``False`` (no-op), never raises.
+      * OTel packages absent → returns ``False`` (no-op), never raises.
+    Both branches let callers gate behind the existing OTLP endpoint config
+    without import-guarding at the call site.
+
+    Args:
+        endpoint: OTLP collector base URL, e.g. ``http://localhost:4318``
+                  (``/v1/traces`` is appended automatically).
+        report: The AI-BOM report to emit as a trace.
+        blast_radii: Blast radius analysis results.
+        timeout: Per-export timeout in seconds.
+
+    Returns:
+        ``True`` when a trace was emitted and flushed; ``False`` on no-op.
+
+    Raises:
+        RuntimeError: Only if the endpoint is rejected by the outbound URL
+            policy (an actionable misconfiguration, not a transient failure).
+    """
+    if not (endpoint or "").strip():
+        return False
+
+    try:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from opentelemetry.trace import SpanKind
+    except ImportError:
+        # Graceful no-op: traces are optional. The metrics path raises ImportError
+        # for the explicit `push_otlp` request; traces are an additive emit, so we
+        # degrade silently rather than failing a scan.
+        return False
+
+    from agent_bom.security import SecurityError, validate_url
+
+    try:
+        validate_url(endpoint, allowed_schemes=("http", "https"))
+    except SecurityError as exc:
+        raise RuntimeError(f"OTLP traces endpoint rejected by outbound URL policy: {exc}") from exc
+
+    findings = cve_findings(report, blast_radii)
+    sev_counts = severity_counts(findings)
+
+    resource = Resource(
+        attributes={
+            SERVICE_NAME: "agent-bom",
+            "agent_bom.version": report.tool_version,
+        }
+    )
+
+    otlp_url = endpoint.rstrip("/") + "/v1/traces"
+    exporter = OTLPSpanExporter(endpoint=otlp_url, timeout=timeout)
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    tracer = provider.get_tracer("agent_bom", report.tool_version)
+
+    kev_count = sum(1 for finding in findings if finding.is_kev)
+    fixable = sum(1 for finding in findings if finding.fixed_version)
+
+    with tracer.start_as_current_span("agent_bom.scan", kind=SpanKind.INTERNAL) as scan_span:
+        scan_span.set_attribute("agent_bom.version", report.tool_version)
+        scan_span.set_attribute("agent_bom.agents_total", report.total_agents)
+        scan_span.set_attribute("agent_bom.mcp_servers_total", report.total_servers)
+        scan_span.set_attribute("agent_bom.packages_total", report.total_packages)
+        scan_span.set_attribute("agent_bom.vulnerabilities_total", len(findings))
+        scan_span.set_attribute("agent_bom.kev_findings_total", kev_count)
+        scan_span.set_attribute("agent_bom.fixable_vulnerabilities_total", fixable)
+        for sev_value, count in sev_counts.items():
+            with tracer.start_as_current_span(f"agent_bom.severity.{sev_value}", kind=SpanKind.INTERNAL) as sev_span:
+                sev_span.set_attribute("agent_bom.severity", sev_value)
+                sev_span.set_attribute("agent_bom.count", count)
+
+    provider.force_flush(timeout_millis=timeout * 1000)
+    provider.shutdown()
+    return True

--- a/tests/test_delivery_foundation.py
+++ b/tests/test_delivery_foundation.py
@@ -1,0 +1,485 @@
+"""Tests for the hardened outbound delivery foundation (``agent_bom.delivery``).
+
+Covers: retry → backoff → dead-letter on persistent failure; idempotency key
+prevents double-send; circuit-breaker opens then half-opens a probe; 429/auth
+handled + warned + non-blocking; redaction in the delivery log; deterministic
+time/jitter injection; and that the webhook_store delivery helper rides the
+foundation. OTLP traces emit (configured / no-op) lives in test_prometheus_cov
+alongside the metrics path tests but is also smoke-checked here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_bom.delivery import (
+    BreakerPolicy,
+    Delivery,
+    DeliveryClient,
+    DeliveryError,
+    DeliveryStore,
+    Destination,
+    RetryPolicy,
+    SendOutcome,
+    redacted_preview,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+class FakeClock:
+    """Deterministic, monotonic injectable clock; sleeps advance it."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+        self.slept: list[float] = []
+
+    def now(self) -> float:
+        return self.t
+
+    def sleep(self, seconds: float) -> None:
+        self.slept.append(seconds)
+        self.t += seconds
+
+
+class ScriptedSender:
+    """Returns queued outcomes in order; records every call."""
+
+    def __init__(self, outcomes: list[SendOutcome]) -> None:
+        self.outcomes = list(outcomes)
+        self.calls: list[tuple[str, dict[str, str], bytes]] = []
+
+    def __call__(self, url: str, headers: dict[str, str], body: bytes, timeout: float) -> SendOutcome:
+        self.calls.append((url, headers, body))
+        if self.outcomes:
+            return self.outcomes.pop(0)
+        return SendOutcome(http_status=500)
+
+
+def _client(
+    tmp_path: Path, sender: ScriptedSender, *, clock: FakeClock, retry: RetryPolicy | None = None, breaker: BreakerPolicy | None = None
+) -> DeliveryClient:
+    store = DeliveryStore(tmp_path / "delivery.db")
+    return DeliveryClient(
+        store,
+        sender=sender,
+        retry=retry or RetryPolicy(max_attempts=4, initial_backoff=1.0, max_backoff=30.0),
+        breaker=breaker or BreakerPolicy(failure_threshold=5, cooldown=60.0),
+        now=clock.now,
+        sleep=clock.sleep,
+        rng=lambda: 0.0,  # deterministic: no jitter
+    )
+
+
+def _dest(dest_id: str = "dst1", **kw: object) -> Destination:
+    return Destination(destination_id=dest_id, url="https://example.test/hook", **kw)  # type: ignore[arg-type]
+
+
+def _delivery(dest_id: str = "dst1", *, key: str = "", payload: dict | None = None) -> Delivery:
+    return Delivery(destination_id=dest_id, payload=payload or {"hello": "world"}, idempotency_key=key)
+
+
+# ── Happy path ───────────────────────────────────────────────────────────────
+
+
+def test_successful_delivery_single_attempt(tmp_path: Path) -> None:
+    clock = FakeClock()
+    sender = ScriptedSender([SendOutcome(http_status=200)])
+    client = _client(tmp_path, sender, clock=clock)
+
+    result = client.deliver(_dest(), _delivery())
+
+    assert result.delivered is True
+    assert result.status == "delivered"
+    assert result.attempts == 1
+    assert len(sender.calls) == 1
+    assert clock.slept == []  # no backoff on first-try success
+
+
+# ── Retry → backoff → dead-letter ────────────────────────────────────────────
+
+
+def test_persistent_failure_retries_with_backoff_then_dead_letter(tmp_path: Path) -> None:
+    clock = FakeClock()
+    sender = ScriptedSender([SendOutcome(http_status=503)] * 6)  # always fails
+    client = _client(tmp_path, sender, clock=clock, retry=RetryPolicy(max_attempts=4, initial_backoff=1.0, max_backoff=30.0))
+
+    result = client.deliver(_dest(), _delivery())
+
+    assert result.delivered is False
+    assert result.status == "dead_letter"
+    assert result.attempts == 4
+    assert len(sender.calls) == 4  # max_attempts transport attempts
+    # Exponential backoff between attempts (3 sleeps for 4 attempts): 1, 2, 4
+    assert clock.slept == [1.0, 2.0, 4.0]
+    assert result.warning  # actionable, non-empty
+    # A durable dead-letter record exists.
+    dl = client.dead_letters(destination_id="dst1")
+    assert len(dl) == 1
+    assert dl[0]["status"] == "dead_letter"
+
+
+def test_dead_letter_never_raises(tmp_path: Path) -> None:
+    clock = FakeClock()
+    sender = ScriptedSender([SendOutcome(http_status=None, error="connection refused")] * 6)
+    client = _client(tmp_path, sender, clock=clock)
+    # Must not raise — degrades to dead-letter + warning.
+    result = client.deliver(_dest(), _delivery())
+    assert result.status == "dead_letter"
+    assert "connection" in result.warning.lower() or result.warning
+
+
+# ── Idempotency ──────────────────────────────────────────────────────────────
+
+
+def test_idempotency_key_prevents_double_send(tmp_path: Path) -> None:
+    clock = FakeClock()
+    sender = ScriptedSender([SendOutcome(http_status=200), SendOutcome(http_status=200)])
+    client = _client(tmp_path, sender, clock=clock)
+
+    d = _delivery(key="stable-key-1")
+    first = client.deliver(_dest(), d)
+    second = client.deliver(_dest(), _delivery(key="stable-key-1"))
+
+    assert first.status == "delivered"
+    assert second.status == "deduplicated"
+    assert second.delivered is True
+    assert len(sender.calls) == 1  # second never hit the wire
+
+
+def test_default_idempotency_key_is_deterministic_content_hash(tmp_path: Path) -> None:
+    a = Delivery(destination_id="d", payload={"x": 1, "y": 2})
+    b = Delivery(destination_id="d", payload={"y": 2, "x": 1})  # key order differs
+    assert a.idempotency_key == b.idempotency_key
+    c = Delivery(destination_id="d", payload={"x": 1, "y": 3})
+    assert c.idempotency_key != a.idempotency_key
+
+
+def test_deduplicated_after_dead_letter_is_not_delivered(tmp_path: Path) -> None:
+    clock = FakeClock()
+    sender = ScriptedSender([SendOutcome(http_status=500)] * 8)
+    client = _client(tmp_path, sender, clock=clock)
+    first = client.deliver(_dest(), _delivery(key="k"))
+    assert first.status == "dead_letter"
+    calls_before = len(sender.calls)
+    second = client.deliver(_dest(), _delivery(key="k"))
+    assert second.status == "deduplicated"
+    assert second.delivered is False
+    assert len(sender.calls) == calls_before  # no re-send
+
+
+# ── Auth / 4xx permanent, 429 transient ──────────────────────────────────────
+
+
+def test_auth_failure_is_permanent_no_retry_and_warned(tmp_path: Path) -> None:
+    clock = FakeClock()
+    sender = ScriptedSender([SendOutcome(http_status=401)] * 4)
+    client = _client(tmp_path, sender, clock=clock)
+    result = client.deliver(_dest(), _delivery())
+    assert result.status == "dead_letter"
+    assert len(sender.calls) == 1  # 401 not retried
+    assert "auth" in result.warning.lower()
+    assert clock.slept == []  # no backoff for permanent error
+
+
+def test_429_is_retried_and_warned(tmp_path: Path) -> None:
+    clock = FakeClock()
+    # 429 three times then succeed.
+    sender = ScriptedSender([SendOutcome(http_status=429), SendOutcome(http_status=429), SendOutcome(http_status=200)])
+    client = _client(tmp_path, sender, clock=clock)
+    result = client.deliver(_dest(), _delivery())
+    assert result.delivered is True
+    assert len(sender.calls) == 3
+    assert clock.slept == [1.0, 2.0]
+
+
+def test_429_exhausted_warns_rate_limit(tmp_path: Path) -> None:
+    clock = FakeClock()
+    sender = ScriptedSender([SendOutcome(http_status=429)] * 6)
+    client = _client(tmp_path, sender, clock=clock)
+    result = client.deliver(_dest(), _delivery())
+    assert result.status == "dead_letter"
+    assert "rate" in result.warning.lower() or "429" in result.warning
+
+
+# ── Circuit breaker ──────────────────────────────────────────────────────────
+
+
+def test_circuit_breaker_opens_then_half_opens_probe(tmp_path: Path) -> None:
+    clock = FakeClock()
+    store = DeliveryStore(tmp_path / "delivery.db")
+    # Each delivery makes 1 failing attempt (max_attempts=1) so failures accrue 1 per deliver.
+    sender = ScriptedSender([SendOutcome(http_status=500)] * 20)
+    client = DeliveryClient(
+        store,
+        sender=sender,
+        retry=RetryPolicy(max_attempts=1, initial_backoff=1.0),
+        breaker=BreakerPolicy(failure_threshold=3, cooldown=60.0),
+        now=clock.now,
+        sleep=clock.sleep,
+        rng=lambda: 0.0,
+    )
+    # 3 distinct deliveries fail → breaker opens.
+    for i in range(3):
+        client.deliver(_dest(), _delivery(key=f"k{i}"))
+    assert client.circuit_state("dst1") == "open"
+
+    calls_at_open = len(sender.calls)
+    # While open, a new delivery short-circuits to dead-letter without a send.
+    r = client.deliver(_dest(), _delivery(key="kopen"))
+    assert r.status == "circuit_open"
+    assert len(sender.calls) == calls_at_open  # no wire call while open
+
+    # Advance past cooldown → half-open; reflected to callers.
+    clock.t += 61.0
+    assert client.circuit_state("dst1") == "half_open"
+
+    # A half-open probe that succeeds closes the breaker.
+    sender.outcomes.insert(0, SendOutcome(http_status=200))
+    probe = client.deliver(_dest(), _delivery(key="kprobe"))
+    assert probe.delivered is True
+    assert client.circuit_state("dst1") == "closed"
+
+
+def test_circuit_breaker_closed_on_success_resets_failures(tmp_path: Path) -> None:
+    clock = FakeClock()
+    store = DeliveryStore(tmp_path / "d.db")
+    sender = ScriptedSender([SendOutcome(http_status=500), SendOutcome(http_status=200)])
+    client = DeliveryClient(
+        store,
+        sender=sender,
+        retry=RetryPolicy(max_attempts=1),
+        breaker=BreakerPolicy(failure_threshold=3, cooldown=60.0),
+        now=clock.now,
+        sleep=clock.sleep,
+        rng=lambda: 0.0,
+    )
+    client.deliver(_dest(), _delivery(key="a"))  # fail (1 failure)
+    client.deliver(_dest(), _delivery(key="b"))  # success → reset
+    assert client.circuit_state("dst1") == "closed"
+
+
+# ── Redaction ────────────────────────────────────────────────────────────────
+
+
+def test_secret_values_not_in_delivery_log(tmp_path: Path) -> None:
+    clock = FakeClock()
+    sender = ScriptedSender([SendOutcome(http_status=200)])
+    client = _client(tmp_path, sender, clock=clock)
+    payload = {"api_key": "sk-supersecret-123", "user": "alice", "password": "hunter2"}
+    client.deliver(_dest(), _delivery(payload=payload))
+    log = client.delivery_log(destination_id="dst1")
+    assert log
+    preview = log[0]["payload_preview"]
+    assert "sk-supersecret-123" not in preview
+    assert "hunter2" not in preview
+
+
+def test_redacted_preview_strips_secrets() -> None:
+    preview = redacted_preview({"token": "abc123secret", "ok": "visible"})
+    assert "abc123secret" not in preview
+    assert "visible" in preview
+
+
+def test_signing_secret_never_logged(tmp_path: Path) -> None:
+    clock = FakeClock()
+    sender = ScriptedSender([SendOutcome(http_status=500)] * 6)
+    client = _client(tmp_path, sender, clock=clock)
+    dest = Destination(
+        destination_id="dst1",
+        url="https://example.test/h",
+        signing_secret="whsec_topsecret_value",
+        auth_scheme="bearer",
+        auth_token="bearer-token-xyz",
+    )
+    client.deliver(dest, _delivery())
+    for row in client.delivery_log(destination_id="dst1"):
+        blob = str(row)
+        assert "whsec_topsecret_value" not in blob
+        assert "bearer-token-xyz" not in blob
+
+
+# ── Signing + auth headers ───────────────────────────────────────────────────
+
+
+def test_hmac_signature_and_bearer_auth_headers(tmp_path: Path) -> None:
+    clock = FakeClock()
+    sender = ScriptedSender([SendOutcome(http_status=200)])
+    client = _client(tmp_path, sender, clock=clock)
+    dest = Destination(destination_id="dst1", url="https://example.test/h", signing_secret="s3cret", auth_scheme="bearer", auth_token="tok")
+    client.deliver(dest, _delivery())
+    _url, headers, body = sender.calls[0]
+    assert headers["x-agent-bom-signature"].startswith("sha256=")
+    assert headers["Authorization"] == "Bearer tok"
+    assert headers["idempotency-key"]
+    # Signature is an HMAC of the exact body sent.
+    import hashlib
+    import hmac
+
+    expected = "sha256=" + hmac.new(b"s3cret", body, hashlib.sha256).hexdigest()
+    assert headers["x-agent-bom-signature"] == expected
+
+
+def test_no_signature_header_without_secret(tmp_path: Path) -> None:
+    clock = FakeClock()
+    sender = ScriptedSender([SendOutcome(http_status=200)])
+    client = _client(tmp_path, sender, clock=clock)
+    client.deliver(_dest(), _delivery())
+    _url, headers, _body = sender.calls[0]
+    assert "x-agent-bom-signature" not in headers
+
+
+# ── Validation ───────────────────────────────────────────────────────────────
+
+
+def test_mismatched_destination_id_raises(tmp_path: Path) -> None:
+    clock = FakeClock()
+    sender = ScriptedSender([SendOutcome(http_status=200)])
+    client = _client(tmp_path, sender, clock=clock)
+    with pytest.raises(DeliveryError):
+        client.deliver(_dest("a"), _delivery("b"))
+
+
+def test_bad_auth_scheme_rejected() -> None:
+    with pytest.raises(DeliveryError):
+        Destination(destination_id="d", url="https://x.test", auth_scheme="basic")
+
+
+# ── webhook_store integration ────────────────────────────────────────────────
+
+
+def test_webhook_store_delivers_through_foundation(tmp_path: Path) -> None:
+    from agent_bom.api.webhook_store import WebhookSubscription, deliver_subscription_event
+
+    clock = FakeClock()
+    sender = ScriptedSender([SendOutcome(http_status=200)])
+    client = _client(tmp_path, sender, clock=clock)
+    sub = WebhookSubscription(
+        subscription_id="whsub_test",
+        tenant_id="tenant-a",
+        url="https://example.test/webhook",
+        signing_secret="whsec_abc",
+    )
+    result = deliver_subscription_event(sub, event_type="identity.revoked", payload={"agent": "x"}, client=client)
+    assert result.delivered is True
+    _url, headers, _body = sender.calls[0]
+    assert headers["x-agent-bom-event-type"] == "identity.revoked"
+    assert headers["x-agent-bom-tenant-id"] == "tenant-a"
+    assert headers["x-agent-bom-signature"].startswith("sha256=")
+
+
+# ── Backward compatibility (defaults preserve existing behavior) ─────────────
+
+
+def test_posture_outbox_path_default_unchanged_when_delivery_db_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The new AGENT_BOM_DELIVERY_DB is opt-in. Without it (and without the
+    shared AGENT_BOM_DB), the delivery store falls back to its own default path
+    and does NOT change the posture webhook outbox's path resolution."""
+    from agent_bom.delivery import default_delivery_store_path
+    from agent_bom.posture_streaming import default_webhook_outbox_path
+
+    monkeypatch.delenv("AGENT_BOM_DELIVERY_DB", raising=False)
+    monkeypatch.delenv("AGENT_BOM_DB", raising=False)
+    monkeypatch.delenv("AGENT_BOM_POSTURE_WEBHOOK_OUTBOX_DB", raising=False)
+
+    posture = default_webhook_outbox_path()
+    delivery = default_delivery_store_path()
+    # Distinct DBs — the foundation does not hijack the existing outbox file.
+    assert posture.name == "posture-webhooks.db"
+    assert delivery.name == "delivery.db"
+    assert posture != delivery
+
+
+def test_existing_webhook_subscription_api_unchanged(tmp_path: Path) -> None:
+    """The webhook_store public surface (create/list/match) is untouched: the
+    delivery helper is additive."""
+    from agent_bom.api.webhook_store import (
+        InMemoryWebhookSubscriptionStore,
+        create_subscription,
+    )
+
+    store = InMemoryWebhookSubscriptionStore()
+    sub = create_subscription(store, tenant_id="t", url="https://hooks.example.test/x", event_types=["identity.revoked"])
+    assert sub.signing_secret.startswith("whsec_")
+    assert store.matching("t", "identity.revoked") == [sub]
+    assert store.matching("t", "budget.exceeded") == []
+
+
+# ── Shared singleton ─────────────────────────────────────────────────────────
+
+
+def test_set_and_get_delivery_client_singleton(tmp_path: Path) -> None:
+    from agent_bom.delivery import get_delivery_client, set_delivery_client
+
+    clock = FakeClock()
+    sender = ScriptedSender([SendOutcome(http_status=200)])
+    custom = _client(tmp_path, sender, clock=clock)
+    set_delivery_client(custom)
+    try:
+        assert get_delivery_client() is custom
+    finally:
+        set_delivery_client(None)
+
+
+# ── OTLP traces emit (output/prometheus.push_otlp_traces) ────────────────────
+
+
+def _minimal_report():
+    from agent_bom.models import Agent, AgentType, AIBOMReport
+
+    agent = Agent(name="a", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/t", mcp_servers=[])
+    return AIBOMReport(agents=[agent])
+
+
+def test_otlp_traces_noop_when_endpoint_unset() -> None:
+    from agent_bom.output.prometheus import push_otlp_traces
+
+    assert push_otlp_traces("", _minimal_report()) is False
+    assert push_otlp_traces("   ", _minimal_report()) is False
+
+
+def test_otlp_traces_noop_when_packages_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the OTel trace packages are not importable, emit degrades to a no-op
+    (returns False) rather than failing a scan."""
+    import builtins
+
+    from agent_bom.output import prometheus as prom
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        if name.startswith("opentelemetry"):
+            raise ImportError("no otel")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert prom.push_otlp_traces("http://collector.local:4318", _minimal_report()) is False
+
+
+def test_otlp_traces_emits_when_configured(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("opentelemetry.sdk.trace")
+    from unittest.mock import MagicMock, patch
+
+    from agent_bom.output.prometheus import push_otlp_traces
+
+    # Use a resolvable loopback host with the operator private-egress override so
+    # the SSRF guard admits the collector; the exporter itself is mocked.
+    monkeypatch.setenv("AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS", "1")
+    with patch("opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter") as exporter_cls:
+        exporter_cls.return_value = MagicMock()
+        ok = push_otlp_traces("http://127.0.0.1:4318", _minimal_report())
+        assert ok is True
+        # The collector URL is built with the /v1/traces path appended.
+        called_endpoint = exporter_cls.call_args.kwargs.get("endpoint", "")
+        assert called_endpoint.endswith("/v1/traces")
+
+
+def test_otlp_traces_rejects_bad_endpoint() -> None:
+    pytest.importorskip("opentelemetry.sdk.trace")
+    from agent_bom.output.prometheus import push_otlp_traces
+
+    # Non-http(s) scheme is rejected by the outbound URL policy before any send.
+    with pytest.raises(RuntimeError):
+        push_otlp_traces("ftp://collector.example.com/v1/traces", _minimal_report())


### PR DESCRIPTION
## Summary

Introduces one hardened outbound delivery foundation — `agent_bom.delivery.DeliveryClient` — that every exporter and webhook can ride, consolidating the previously scattered outbound logic (the shared `http_client` retry loop and the posture webhook outbox) behind a single, well-tested path.

## The foundation (`src/agent_bom/delivery.py`)

- **Retries + backoff + jitter + dead-letter** — exponential backoff with bounded attempts; on persistent failure the delivery is written to a durable dead-letter record and an actionable warning is returned. A destination failure never blocks or crashes the caller; the scan/relay continues.
- **Idempotency** — each delivery carries an idempotency key (a deterministic content hash by default). A retry, or a duplicate enqueue of the same payload to the same destination, is never double-sent; a key that already reached a terminal state returns a `deduplicated` result without hitting the wire.
- **HMAC request signing** (optional, per destination) and **per-destination auth** (bearer / token / custom header).
- **Circuit breaker** per destination — opens after a configurable number of consecutive failures, then half-opens a single probe after a cooldown; while open, deliveries short-circuit to dead-letter without a network call.
- **Delivery / audit log** — a queryable SQLite log records every attempt (destination, status, idempotency key, HTTP status, redacted payload preview). Secret values, signing secrets, and auth tokens are never persisted — only a fingerprint.
- **Redaction** — payloads are passed through the sensitive-payload sanitizer before any preview is logged.

Time, sleep, and jitter are injectable, so retry math and the audit log are fully deterministic under test.

## Routing + backward compatibility

`api/webhook_store.py` gains an additive `deliver_subscription_event` helper that routes a governance event through the foundation. The existing governance webhook outbox path and all default behavior are unchanged — the foundation uses its own opt-in `AGENT_BOM_DELIVERY_DB` (falling back to the shared DB, then a default path), so it does not hijack the existing posture outbox file. A regression test asserts default paths stay distinct and the existing subscription API surface is untouched.

## OTLP traces emit

`output/prometheus.py` already emits OTLP **metrics**. This adds `push_otlp_traces` — a `TracerProvider` + `OTLPSpanExporter` emit gated behind the existing OTLP endpoint config. It is opt-in and a graceful no-op when the endpoint is unset or the OpenTelemetry packages are absent (it does not fail a scan). A root `agent_bom.scan` span carries scan-level attributes with a child span per severity bucket. Combined with the existing trace ingestion, observability interop now works both ways.

## Tests

`tests/test_delivery_foundation.py` (24 cases + 2 optional-dep skips):

- `test_persistent_failure_retries_with_backoff_then_dead_letter` — retry → backoff (1, 2, 4s) → durable dead-letter
- `test_dead_letter_never_raises` — outbound failure degrades, never raises
- `test_idempotency_key_prevents_double_send`, `test_default_idempotency_key_is_deterministic_content_hash`, `test_deduplicated_after_dead_letter_is_not_delivered`
- `test_auth_failure_is_permanent_no_retry_and_warned`, `test_429_is_retried_and_warned`, `test_429_exhausted_warns_rate_limit`
- `test_circuit_breaker_opens_then_half_opens_probe`, `test_circuit_breaker_closed_on_success_resets_failures`
- `test_secret_values_not_in_delivery_log`, `test_signing_secret_never_logged`, `test_redacted_preview_strips_secrets`
- `test_hmac_signature_and_bearer_auth_headers`, `test_no_signature_header_without_secret`
- `test_webhook_store_delivers_through_foundation`
- `test_posture_outbox_path_default_unchanged_when_delivery_db_unset`, `test_existing_webhook_subscription_api_unchanged` — backward-compat
- `test_otlp_traces_noop_when_endpoint_unset`, `test_otlp_traces_noop_when_packages_missing`, `test_otlp_traces_emits_when_configured`, `test_otlp_traces_rejects_bad_endpoint`

`uv run ruff check` + `uv run mypy` clean on all changed files; full pre-commit green; `pytest -k "delivery or webhook or http or outbound or otlp or export"` → 281 passed, 3 skipped.