### PR TITLE
feat(cli): capability doctor surface — every gated feature, state, and unlock path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -360,6 +360,7 @@ module = [
     "agent_bom.models",
     "agent_bom.backpressure",
     "agent_bom.proxy_sandbox",
+    "agent_bom.capabilities",
 ]
 disallow_untyped_defs = true
 disallow_incomplete_defs = true

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -100,6 +100,7 @@ verbs are additive entry points that delegate to the underlying implementations.
 | `db freshness` | Show the structured vuln-data freshness indicator (sources, age, staleness) surfaced on every scan, API, and MCP tool |
 | `db framework-status` | Show bundled framework catalog freshness |
 | `doctor` | Check environment readiness for scanning |
+| `capabilities` | Show every gated capability, current state, and exact unlock path without printing secret values |
 | `gateway` | Multi-MCP gateway commands |
 | `interactive` | Start an interactive command shell for repeated CLI workflows |
 | `plugins` | Inspect extension plugin registry status without loading third-party plugin code |

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -1557,13 +1557,11 @@ class PostgresGraphStore:
         where_sql = " AND ".join(node_where)
 
         with _tenant_connection(self._pool) as conn:
-            total_nodes = int(
-                conn.execute(
-                    f"SELECT COUNT(*) FROM graph_nodes WHERE {where_sql}",  # nosec B608 - where_sql is built from static clause fragments
-                    params,
-                ).fetchone()[0]
-                or 0
-            )
+            total_nodes_row = conn.execute(
+                f"SELECT COUNT(*) FROM graph_nodes WHERE {where_sql}",  # nosec B608 - where_sql is built from static clause fragments
+                params,
+            ).fetchone()
+            total_nodes = int((total_nodes_row[0] if total_nodes_row else 0) or 0)
             node_type_rows = conn.execute(
                 f"SELECT entity_type, COUNT(*) FROM graph_nodes WHERE {where_sql} GROUP BY entity_type",  # nosec B608 - where_sql is built from static clause fragments
                 params,
@@ -1572,19 +1570,17 @@ class PostgresGraphStore:
                 f"SELECT severity, COUNT(*) FROM graph_nodes WHERE {where_sql} AND severity <> '' GROUP BY severity",  # nosec B608 - where_sql is built from static clause fragments
                 params,
             ).fetchall()
-            total_edges = int(
-                conn.execute(
-                    f"""
-                    SELECT COUNT(*)
-                    FROM graph_edges
-                    WHERE tenant_id = %s AND scan_id = %s
-                      AND source_id IN (SELECT id FROM graph_nodes WHERE {where_sql})
-                      AND target_id IN (SELECT id FROM graph_nodes WHERE {where_sql})
-                    """,  # nosec B608 - where_sql is built from static clause fragments
-                    [tenant_id, effective_scan_id, *params, *params],
-                ).fetchone()[0]
-                or 0
-            )
+            total_edges_row = conn.execute(
+                f"""
+                SELECT COUNT(*)
+                FROM graph_edges
+                WHERE tenant_id = %s AND scan_id = %s
+                  AND source_id IN (SELECT id FROM graph_nodes WHERE {where_sql})
+                  AND target_id IN (SELECT id FROM graph_nodes WHERE {where_sql})
+                """,  # nosec B608 - where_sql is built from static clause fragments
+                [tenant_id, effective_scan_id, *params, *params],
+            ).fetchone()
+            total_edges = int((total_edges_row[0] if total_edges_row else 0) or 0)
             rel_rows = conn.execute(
                 f"""
                 SELECT relationship, COUNT(*)
@@ -1647,13 +1643,11 @@ class PostgresGraphStore:
                 where.append("severity_id >= %s")
                 params.append(min_severity_rank)
             where_sql = " AND ".join(where)
-            total = int(
-                conn.execute(
-                    f"SELECT COUNT(*) FROM graph_nodes WHERE {where_sql}",  # nosec B608 - where_sql is built from static clause fragments
-                    params,
-                ).fetchone()[0]
-                or 0
-            )
+            total_row = conn.execute(
+                f"SELECT COUNT(*) FROM graph_nodes WHERE {where_sql}",  # nosec B608 - where_sql is built from static clause fragments
+                params,
+            ).fetchone()
+            total = int((total_row[0] if total_row else 0) or 0)
             row_params = list(params)
             cursor_clause = ""
             if cursor:
@@ -1796,7 +1790,8 @@ class PostgresGraphStore:
                  AND gn.tenant_id = gns.tenant_id
             """
             where_sql = " AND ".join(search_where)
-            total = int(conn.execute("SELECT COUNT(*) " + from_clause + " WHERE " + where_sql, params).fetchone()[0] or 0)
+            total_row = conn.execute("SELECT COUNT(*) " + from_clause + " WHERE " + where_sql, params).fetchone()
+            total = int((total_row[0] if total_row else 0) or 0)
             if total == 0:
                 return [], 0, None
             row_params = list(params)

--- a/src/agent_bom/capabilities.py
+++ b/src/agent_bom/capabilities.py
@@ -1,0 +1,472 @@
+"""Capability registry — the nothing-silent surface for gated features.
+
+agent-bom unlocks deeper coverage on *stated* conditions: an opt-in env var, a
+credential, a scoped cloud role, a prior scan, or data already present locally.
+For a security tool, a silently-skipped capability is the worst failure mode: a
+gap that looks like coverage. A disabled or degraded capability must therefore
+**announce itself** and say exactly how to turn it on.
+
+This module is that announcement. It declares every gated capability once, with:
+
+* what it does,
+* the unlock CONDITION (env var / credential / scoped role / prior scan / data),
+* the current STATE — ``on`` / ``off`` / ``degraded`` — *computed* from the
+  environment, never assumed, and
+* a one-line HOW-TO-UNLOCK string.
+
+The ``agent-bom doctor`` / ``agent-bom capabilities`` command renders this list.
+:func:`scan_status_line` exposes a single line the scan path can print at start
+("running with X enabled; Y available — set Z").
+
+Hard rules this module keeps:
+
+* **Nothing-silent.** Every gated feature lives here. A test asserts each known
+  gate appears with a state and an unlock path.
+* **No secrets.** Probing only ever reports *presence/absence* of a variable and
+  the variable *name* — never the value. ``GOOGLE_APPLICATION_CREDENTIALS`` is a
+  path, but even that is not printed; only "set / not set".
+* **Deterministic + graceful.** Probing reads the environment and the local
+  filesystem only, never the network, and is wrapped so a probe can never crash
+  the command — a failed probe degrades to ``unknown`` rather than raising.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Literal
+
+# Shared truthy vocabulary — matches every gate in the codebase (side-scan,
+# audit-trail, the inventory flags, registry airgap). Kept here so the registry
+# probes a gate the same way the gated module does.
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def env_truthy(name: str) -> bool:
+    """True when ``name`` is set to a recognized truthy value.
+
+    Mirrors the parsing used by the gated modules (``is_sidescan_enabled``,
+    ``config._bool``, the inventory gates) so ``doctor`` never disagrees with the
+    feature it describes.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return False
+    return raw.strip().lower() in _TRUTHY
+
+
+def env_present(name: str) -> bool:
+    """True when ``name`` is set to any non-empty value (presence only).
+
+    Used for credential-style variables where the *value* gates behavior but must
+    never be inspected or printed — only its presence is reported.
+    """
+    return bool(os.environ.get(name, "").strip())
+
+
+class State(str, Enum):
+    """Computed state of a capability in the current environment."""
+
+    ON = "on"
+    """Unlock condition met — the capability runs."""
+
+    OFF = "off"
+    """Available but not unlocked — the unlock path tells the operator how."""
+
+    DEGRADED = "degraded"
+    """Partially active: it runs, but with reduced coverage or a caveat."""
+
+    UNKNOWN = "unknown"
+    """A probe failed to evaluate cleanly — never silent, surfaced as unknown."""
+
+
+# Group buckets used by ``doctor`` to order the output as a coverage story.
+Group = Literal["cloud", "scan", "runtime", "data"]
+
+
+@dataclass(frozen=True)
+class CapabilityStatus:
+    """The resolved status of one capability for the current environment."""
+
+    state: State
+    detail: str
+    """Why the capability is in this state — never contains a secret value."""
+
+
+# A probe returns the live status. It must be pure w.r.t. the process env +
+# local filesystem, must not hit the network, and must not raise (the registry
+# wraps it defensively, but probes are expected to handle their own errors).
+Probe = Callable[[], CapabilityStatus]
+
+
+@dataclass(frozen=True)
+class Capability:
+    """A declaratively-gated capability and how to unlock it.
+
+    Attributes:
+        key: Stable identifier (used in tests and machine output).
+        name: Human title.
+        group: Coverage bucket for grouped rendering.
+        does: One sentence on what the capability adds.
+        condition: Human description of the unlock CONDITION (env var, credential,
+            scoped role, prior scan, or data present).
+        unlock: Copy-pasteable one-liner that flips the capability on.
+        env_vars: Variable names this capability reads. Only *names* are ever
+            shown; values are never read for display.
+        probe: Computes the live :class:`CapabilityStatus` from the environment.
+    """
+
+    key: str
+    name: str
+    group: Group
+    does: str
+    condition: str
+    unlock: str
+    env_vars: tuple[str, ...]
+    probe: Probe = field(repr=False)
+
+    def status(self) -> CapabilityStatus:
+        """Evaluate the live state, degrading to ``unknown`` if the probe fails.
+
+        Graceful by contract: a buggy or environment-sensitive probe surfaces as
+        ``UNKNOWN`` (still visible, still with an unlock path) rather than
+        crashing ``doctor`` — a silent capability is never acceptable.
+        """
+        try:
+            return self.probe()
+        except Exception as exc:  # noqa: BLE001 — never let a probe crash doctor
+            return CapabilityStatus(State.UNKNOWN, f"probe error: {type(exc).__name__}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Probe builders for the common gate shapes
+# ---------------------------------------------------------------------------
+
+
+def _env_flag_probe(env_var: str, on_detail: str, off_detail: str) -> Probe:
+    """Probe a simple truthy env-flag gate (side-scan, audit-trail, inventory)."""
+
+    def probe() -> CapabilityStatus:
+        if env_truthy(env_var):
+            return CapabilityStatus(State.ON, on_detail)
+        return CapabilityStatus(State.OFF, off_detail)
+
+    return probe
+
+
+def _inventory_probe(inventory_var: str, cred_vars: tuple[str, ...], provider: str) -> Probe:
+    """Probe a cloud-inventory gate: opt-in flag plus credential presence.
+
+    Three honest states:
+      * flag off            → OFF (nothing is collected; this is the default).
+      * flag on, no creds   → DEGRADED (opted in, but the next scan reads nothing).
+      * flag on, creds set  → ON.
+    """
+
+    def probe() -> CapabilityStatus:
+        if not env_truthy(inventory_var):
+            return CapabilityStatus(State.OFF, f"{inventory_var} not set — {provider} inventory off (default)")
+        detected = [name for name in cred_vars if env_present(name)]
+        if detected:
+            return CapabilityStatus(State.ON, f"{inventory_var} set; credentials detected ({', '.join(detected)})")
+        expected = ", ".join(cred_vars)
+        return CapabilityStatus(
+            State.DEGRADED,
+            f"{inventory_var} set but no credentials detected — set one of: {expected}",
+        )
+
+    return probe
+
+
+def _scan_cache_db_path() -> Path:
+    """Resolve the local vuln-cache path the same way ``ScanCache`` does."""
+    override = os.environ.get("AGENT_BOM_SCAN_CACHE")
+    if override and override.strip():
+        return Path(override)
+    return Path.home() / ".agent-bom" / "scan_cache.db"
+
+
+def _vuln_cache_probe() -> CapabilityStatus:
+    """Probe the local vuln-DB cache: data-present + freshness gate.
+
+    States:
+      * no cache file               → OFF (live OSV/GHSA/NVD; first scan creates it).
+      * cache present but stale     → DEGRADED (recent CVEs may be missed).
+      * cache present and fresh     → ON.
+    Offline mode is surfaced as a caveat so an airgapped run is never silent.
+    """
+    offline = env_truthy("AGENT_BOM_VULN_DB_OFFLINE")
+    db_path = _scan_cache_db_path()
+    if not db_path.exists():
+        base = "no local cache yet — scanning runs live (OSV/GHSA/NVD); first scan populates it"
+        if offline:
+            return CapabilityStatus(State.DEGRADED, "offline forced but no local cache — coverage will be empty")
+        return CapabilityStatus(State.OFF, base)
+
+    try:
+        from agent_bom.vuln_freshness import max_age_hours
+
+        threshold = max_age_hours()
+    except Exception:
+        threshold = 24
+
+    age_hours: float | None = None
+    try:
+        import time
+
+        age_hours = max(0.0, (time.time() - db_path.stat().st_mtime) / 3600.0)
+    except OSError:
+        age_hours = None
+
+    suffix = " (offline mode)" if offline else ""
+    if age_hours is None:
+        return CapabilityStatus(State.ON, f"local cache present at {db_path.name}{suffix}")
+    if age_hours > threshold:
+        return CapabilityStatus(
+            State.DEGRADED,
+            f"local cache is ~{age_hours:.0f}h old (> {threshold}h) — recent CVEs may be missed; "
+            f"refresh with `agent-bom db update`{suffix}",
+        )
+    return CapabilityStatus(State.ON, f"local cache fresh (~{age_hours:.0f}h old, threshold {threshold}h){suffix}")
+
+
+def _registry_sweep_probe() -> CapabilityStatus:
+    """Probe the container-registry sweep: credentials gate + airgap caveat."""
+    airgapped = env_truthy("AGENT_BOM_REGISTRY_AIRGAPPED")
+    has_creds = env_present("AGENT_BOM_REGISTRY_USER") and env_present("AGENT_BOM_REGISTRY_PASS")
+    if airgapped:
+        return CapabilityStatus(
+            State.DEGRADED,
+            "AGENT_BOM_REGISTRY_AIRGAPPED set — sweep stays within the airgap (no external registry pulls)",
+        )
+    if has_creds:
+        return CapabilityStatus(State.ON, "registry credentials detected (AGENT_BOM_REGISTRY_USER/PASS)")
+    return CapabilityStatus(
+        State.OFF,
+        "no registry credentials — anonymous/public pulls only; set AGENT_BOM_REGISTRY_USER + AGENT_BOM_REGISTRY_PASS for private images",
+    )
+
+
+# ---------------------------------------------------------------------------
+# The registry
+# ---------------------------------------------------------------------------
+
+# Per-cloud inventory credential vars (mirrors cli/_entry_points.py connect map).
+_AWS_CRED_VARS = ("AWS_PROFILE", "AWS_ACCESS_KEY_ID", "AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE")
+_AZURE_CRED_VARS = ("AZURE_CLIENT_ID", "AZURE_TENANT_ID", "AZURE_SUBSCRIPTION_ID")
+_GCP_CRED_VARS = ("GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT", "CLOUDSDK_CORE_PROJECT")
+_SNOWFLAKE_CRED_VARS = ("SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PRIVATE_KEY_PATH")
+
+
+def _build_registry() -> tuple[Capability, ...]:
+    """Construct the immutable capability list.
+
+    A function (not a module-level literal) so the probe closures are built once
+    and the result can be wrapped in a tuple for immutability.
+    """
+    caps: list[Capability] = [
+        # ---- Cloud inventory (opt-in flag + scoped read-only role) ------------
+        Capability(
+            key="aws_inventory",
+            name="AWS cloud inventory",
+            group="cloud",
+            does="Folds the AWS estate (resources, IAM, exposure) into the graph.",
+            condition="opt-in env var AGENT_BOM_AWS_INVENTORY + AWS read-only credentials",
+            unlock="export AGENT_BOM_AWS_INVENTORY=1  (role: SecurityAudit + ViewOnlyAccess)",
+            env_vars=("AGENT_BOM_AWS_INVENTORY", *_AWS_CRED_VARS),
+            probe=_inventory_probe("AGENT_BOM_AWS_INVENTORY", _AWS_CRED_VARS, "AWS"),
+        ),
+        Capability(
+            key="azure_inventory",
+            name="Azure cloud inventory",
+            group="cloud",
+            does="Folds the Azure estate into the graph (read-only Reader role).",
+            condition="opt-in env var AGENT_BOM_AZURE_INVENTORY + Azure credentials",
+            unlock="export AGENT_BOM_AZURE_INVENTORY=1  (role: built-in Reader)",
+            env_vars=("AGENT_BOM_AZURE_INVENTORY", *_AZURE_CRED_VARS),
+            probe=_inventory_probe("AGENT_BOM_AZURE_INVENTORY", _AZURE_CRED_VARS, "Azure"),
+        ),
+        Capability(
+            key="gcp_inventory",
+            name="GCP cloud inventory",
+            group="cloud",
+            does="Folds the GCP estate into the graph (read-only viewer role).",
+            condition="opt-in env var AGENT_BOM_GCP_INVENTORY + GCP credentials",
+            unlock="export AGENT_BOM_GCP_INVENTORY=1  (role: roles/viewer + securityReviewer)",
+            env_vars=("AGENT_BOM_GCP_INVENTORY", *_GCP_CRED_VARS),
+            probe=_inventory_probe("AGENT_BOM_GCP_INVENTORY", _GCP_CRED_VARS, "GCP"),
+        ),
+        Capability(
+            key="snowflake_inventory",
+            name="Snowflake inventory",
+            group="cloud",
+            does="Folds the Snowflake estate (data stores, grants) into the graph.",
+            condition="opt-in env var AGENT_BOM_SNOWFLAKE_INVENTORY + Snowflake credentials",
+            unlock="export AGENT_BOM_SNOWFLAKE_INVENTORY=1  (read-only governance role)",
+            env_vars=("AGENT_BOM_SNOWFLAKE_INVENTORY", *_SNOWFLAKE_CRED_VARS),
+            probe=_inventory_probe("AGENT_BOM_SNOWFLAKE_INVENTORY", _SNOWFLAKE_CRED_VARS, "Snowflake"),
+        ),
+        # ---- Cloud organization roll-up ---------------------------------------
+        Capability(
+            key="org_rollup",
+            name="Cloud organization roll-up",
+            group="cloud",
+            does="Enumerates the whole org (AWS OUs/SCPs, GCP/Snowflake org accounts).",
+            condition="opt-in env var AGENT_BOM_CLOUD_INVENTORY + org-level read role",
+            unlock="export AGENT_BOM_CLOUD_INVENTORY=1  (needs org-admin read scope, e.g. ORGADMIN)",
+            env_vars=("AGENT_BOM_CLOUD_INVENTORY",),
+            probe=_env_flag_probe(
+                "AGENT_BOM_CLOUD_INVENTORY",
+                "AGENT_BOM_CLOUD_INVENTORY set — organization roll-up enabled",
+                "AGENT_BOM_CLOUD_INVENTORY not set — single account only (org roll-up off)",
+            ),
+        ),
+        # ---- Side-scan (the one opt-in non-read-only capability) --------------
+        Capability(
+            key="side_scan",
+            name="AWS agentless side-scan (CWPP)",
+            group="cloud",
+            does="Snapshots EBS volumes in-account to read the filesystem SBOM + secret types.",
+            condition="opt-in env var AGENT_BOM_SIDESCAN (the one non-read-only capability)",
+            unlock="export AGENT_BOM_SIDESCAN=1  (needs a separately-scoped snapshot role)",
+            env_vars=("AGENT_BOM_SIDESCAN",),
+            probe=_env_flag_probe(
+                "AGENT_BOM_SIDESCAN",
+                "AGENT_BOM_SIDESCAN set — agentless side-scan enabled (in-account, metadata-only)",
+                "AGENT_BOM_SIDESCAN not set — side-scan off (default; everything else is read-only)",
+            ),
+        ),
+        # ---- Cloud audit-trail ------------------------------------------------
+        Capability(
+            key="audit_trail",
+            name="Cloud audit-trail correlation",
+            group="cloud",
+            does="Pulls a bounded slice of cloud audit logs to draw who-did-what reach edges.",
+            condition="opt-in env var AGENT_BOM_AUDIT_TRAIL + cloud read credentials",
+            unlock="export AGENT_BOM_AUDIT_TRAIL=1",
+            env_vars=("AGENT_BOM_AUDIT_TRAIL",),
+            probe=_env_flag_probe(
+                "AGENT_BOM_AUDIT_TRAIL",
+                "AGENT_BOM_AUDIT_TRAIL set — audit-trail correlation enabled",
+                "AGENT_BOM_AUDIT_TRAIL not set — audit-trail correlation off (default)",
+            ),
+        ),
+        # ---- Registry sweep ---------------------------------------------------
+        Capability(
+            key="registry_sweep",
+            name="Container-registry sweep",
+            group="scan",
+            does="Sweeps a container registry's images/tags for vulnerable packages.",
+            condition="registry credentials present (private images); airgap flag respected",
+            unlock="export AGENT_BOM_REGISTRY_USER=... AGENT_BOM_REGISTRY_PASS=...",
+            env_vars=("AGENT_BOM_REGISTRY_USER", "AGENT_BOM_REGISTRY_PASS", "AGENT_BOM_REGISTRY_AIRGAPPED"),
+            probe=_registry_sweep_probe,
+        ),
+        # ---- Vuln-DB cache + freshness (data present) ------------------------
+        Capability(
+            key="vuln_db_cache",
+            name="Local vuln-DB cache",
+            group="data",
+            does="Serves CVE matches from a local cache for fast, offline-capable scans.",
+            condition="data present: a populated local cache; freshness within threshold",
+            unlock="run a scan to populate it, or `agent-bom db update` to refresh",
+            env_vars=("AGENT_BOM_SCAN_CACHE", "AGENT_BOM_VULN_DB_MAX_AGE_HOURS", "AGENT_BOM_VULN_DB_OFFLINE"),
+            probe=_vuln_cache_probe,
+        ),
+    ]
+    return tuple(caps)
+
+
+CAPABILITIES: tuple[Capability, ...] = _build_registry()
+
+# Stable group order for rendering — a coverage story, cloud-first.
+GROUP_ORDER: tuple[Group, ...] = ("cloud", "scan", "runtime", "data")
+GROUP_TITLES: dict[Group, str] = {
+    "cloud": "Cloud coverage",
+    "scan": "Scan coverage",
+    "runtime": "Runtime coverage",
+    "data": "Vulnerability data",
+}
+
+
+def capability_by_key(key: str) -> Capability | None:
+    """Return the capability with ``key``, or ``None``."""
+    for cap in CAPABILITIES:
+        if cap.key == key:
+            return cap
+    return None
+
+
+def resolved_capabilities() -> list[tuple[Capability, CapabilityStatus]]:
+    """Evaluate every capability against the current environment.
+
+    Deterministic for a fixed environment + filesystem; never hits the network;
+    never raises (each probe is wrapped). The ordering matches ``CAPABILITIES``.
+    """
+    return [(cap, cap.status()) for cap in CAPABILITIES]
+
+
+def coverage_summary() -> dict[State, int]:
+    """Count capabilities by state for the one-line coverage summary."""
+    counts: dict[State, int] = {state: 0 for state in State}
+    for _cap, status in resolved_capabilities():
+        counts[status.state] += 1
+    return counts
+
+
+def coverage_line() -> str:
+    """A single deterministic coverage sentence safe to print anywhere."""
+    counts = coverage_summary()
+    total = len(CAPABILITIES)
+    parts = [f"{counts[State.ON]} enabled", f"{counts[State.OFF]} available to unlock"]
+    if counts[State.DEGRADED]:
+        parts.append(f"{counts[State.DEGRADED]} degraded")
+    if counts[State.UNKNOWN]:
+        parts.append(f"{counts[State.UNKNOWN]} unknown")
+    return f"Coverage: {', '.join(parts)} (of {total} gated capabilities)."
+
+
+def scan_status_line() -> str:
+    """One line for the scan path: what's running, and the top thing to unlock.
+
+    Names no secret values. Reusable by the scan start so a skipped capability is
+    announced rather than silently absent. Example::
+
+        Running with 2 capabilities enabled; 6 available — e.g. set
+        AGENT_BOM_AWS_INVENTORY (AWS cloud inventory). Run `agent-bom doctor`.
+    """
+    resolved = resolved_capabilities()
+    enabled = [cap for cap, st in resolved if st.state is State.ON]
+    degraded = [cap for cap, st in resolved if st.state is State.DEGRADED]
+    off = [cap for cap, st in resolved if st.state is State.OFF]
+
+    head = f"Running with {len(enabled)} capabilit{'y' if len(enabled) == 1 else 'ies'} enabled"
+    bits = [head]
+    if degraded:
+        bits.append(f"{len(degraded)} degraded ({degraded[0].name})")
+    if off:
+        first = off[0]
+        primary_var = first.env_vars[0] if first.env_vars else ""
+        hint = f" — e.g. set {primary_var} ({first.name})" if primary_var else ""
+        bits.append(f"{len(off)} available{hint}")
+    return "; ".join(bits) + ". Run `agent-bom doctor` for the full list."
+
+
+__all__ = [
+    "CAPABILITIES",
+    "GROUP_ORDER",
+    "GROUP_TITLES",
+    "Capability",
+    "CapabilityStatus",
+    "Group",
+    "State",
+    "capability_by_key",
+    "coverage_line",
+    "coverage_summary",
+    "env_present",
+    "env_truthy",
+    "resolved_capabilities",
+    "scan_status_line",
+]

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -412,9 +412,11 @@ main.commands["run"].hidden = True  # Use `proxy` instead
 # ---------------------------------------------------------------------------
 # Doctor / preflight command
 # ---------------------------------------------------------------------------
+from agent_bom.cli._capabilities import capabilities_cmd  # noqa: E402
 from agent_bom.cli._doctor import doctor_cmd  # noqa: E402
 
 main.add_command(doctor_cmd, "doctor")
+main.add_command(capabilities_cmd, "capabilities")
 
 # ---------------------------------------------------------------------------
 # Deployment lifecycle command

--- a/src/agent_bom/cli/_capabilities.py
+++ b/src/agent_bom/cli/_capabilities.py
@@ -1,0 +1,94 @@
+"""`agent-bom capabilities` — the nothing-silent capability view.
+
+Renders the declarative registry in :mod:`agent_bom.capabilities`: every gated
+feature, its current state (enabled / available-to-unlock / degraded), *why*,
+and the exact one-line unlock path. A silent coverage gap is, for a security
+tool, false safety — so this view exists to make every gate self-explanatory.
+
+Print contract:
+  * never prints a secret value — only the presence/absence of a variable name,
+  * deterministic for a fixed environment,
+  * groups output as a coverage story and ends with a one-line summary.
+"""
+
+from __future__ import annotations
+
+import click
+from rich.console import Console
+
+from agent_bom.capabilities import (
+    GROUP_ORDER,
+    GROUP_TITLES,
+    Capability,
+    CapabilityStatus,
+    State,
+    coverage_line,
+    resolved_capabilities,
+)
+
+_STATE_ICON: dict[State, str] = {
+    State.ON: "[green]✓[/green]",
+    State.OFF: "[dim]○[/dim]",
+    State.DEGRADED: "[yellow]◐[/yellow]",
+    State.UNKNOWN: "[red]?[/red]",
+}
+_STATE_LABEL: dict[State, str] = {
+    State.ON: "[green]ENABLED[/green]",
+    State.OFF: "[dim]OFF[/dim]",
+    State.DEGRADED: "[yellow]DEGRADED[/yellow]",
+    State.UNKNOWN: "[red]UNKNOWN[/red]",
+}
+
+
+def _render_capability(console: Console, cap: Capability, status: CapabilityStatus) -> None:
+    icon = _STATE_ICON[status.state]
+    label = _STATE_LABEL[status.state]
+    console.print(f"    {icon}  [bold]{cap.name}[/bold]  {label}")
+    console.print(f"       [dim]{cap.does}[/dim]")
+    console.print(f"       why: {status.detail}")
+    if status.state is not State.ON:
+        console.print(f"       [cyan]unlock:[/cyan] {cap.unlock}")
+    console.print()
+
+
+def render_capabilities(console: Console) -> None:
+    """Render the full grouped capability view to ``console``.
+
+    Reused by ``capabilities`` and by ``doctor`` so both surfaces stay identical.
+    """
+    resolved = resolved_capabilities()
+    by_group: dict[str, list[tuple[Capability, CapabilityStatus]]] = {}
+    for cap, status in resolved:
+        by_group.setdefault(cap.group, []).append((cap, status))
+
+    console.print()
+    console.print("  [bold]agent-bom capabilities[/bold] [dim]— nothing silent[/dim]")
+    console.print("  [dim]Every gated feature, its state, why, and how to unlock it.[/dim]")
+    console.print()
+
+    for group in GROUP_ORDER:
+        items = by_group.get(group)
+        if not items:
+            continue
+        console.print(f"  [bold]{GROUP_TITLES[group]}[/bold]")
+        for cap, status in items:
+            _render_capability(console, cap, status)
+
+    console.print(f"  {coverage_line()}")
+    console.print()
+
+
+@click.command("capabilities")
+def capabilities_cmd() -> None:
+    """Show every gated capability: state, why, and how to unlock.
+
+    \b
+    States:  ENABLED   unlock condition met, the capability runs
+             OFF       available but not unlocked (the unlock line says how)
+             DEGRADED  active with reduced coverage or a caveat
+             UNKNOWN   a probe could not evaluate (surfaced, never silent)
+
+    \b
+    No secret values are ever printed — only whether a variable is set.
+    """
+    render_capabilities(Console())

--- a/src/agent_bom/cli/_doctor.py
+++ b/src/agent_bom/cli/_doctor.py
@@ -130,6 +130,23 @@ def doctor_cmd() -> None:
     _print_section(console, "Runtime surfaces", runtime_checks)
     _print_section(console, "Platform integrations", platform_checks)
 
+    # Nothing-silent capability view — every gated feature with its state and
+    # unlock path, so a skipped/degraded capability is never silent.
+    try:
+        from agent_bom.capabilities import coverage_line, resolved_capabilities
+
+        console.print("  [bold]Capabilities[/bold] [dim](run `agent-bom capabilities` for unlock paths)[/dim]")
+        _state_icon = {"on": "[green]✓[/green]", "off": "[dim]○[/dim]", "degraded": "[yellow]◐[/yellow]", "unknown": "[red]?[/red]"}
+        for cap, status in resolved_capabilities():
+            icon = _state_icon.get(status.state.value, "[dim]○[/dim]")
+            console.print(f"    {icon}  {cap.name + ':':<34s} {status.detail}")
+        console.print()
+        console.print(f"  [dim]{coverage_line()}[/dim]")
+        console.print()
+    except Exception:
+        # Never let the capability view break the core preflight output.
+        pass
+
     console.print()
 
     checks = [*core_checks, *runtime_checks, *platform_checks]

--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -285,8 +285,7 @@ def record_discovery_failure(
     detail = sanitize_discovery_warning(exc)
     if is_access_denied_error(exc):
         warnings.append(
-            f"Skipped {resource_type}: role lacks {permission} — "
-            f"add it to the read-only policy to cover this resource type. ({detail})"
+            f"Skipped {resource_type}: role lacks {permission} — add it to the read-only policy to cover this resource type. ({detail})"
         )
         if missing is not None:
             missing.append(build_missing_permission(cloud=cloud, permission=permission, resource_type=resource_type))
@@ -718,9 +717,7 @@ def discover_inventory(
         if include_s3:
             buckets = _discover_s3_buckets(session, account_id=account_id, warnings=warnings, missing=missing)
         if include_ec2:
-            instances, security_groups = _discover_ec2(
-                session, resolved_region, account_id=account_id, warnings=warnings, missing=missing
-            )
+            instances, security_groups = _discover_ec2(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
         if include_iam:
             roles, users = _discover_iam(session, account_id=account_id, warnings=warnings, missing=missing)
         if include_data:
@@ -728,9 +725,7 @@ def discover_inventory(
             dynamodb_tables = _discover_dynamodb(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
             kms_keys = _discover_kms(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
             secrets = _discover_secrets(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
-            redshift_clusters = _discover_redshift(
-                session, resolved_region, account_id=account_id, warnings=warnings, missing=missing
-            )
+            redshift_clusters = _discover_redshift(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
         if include_compute:
             lambda_functions = _discover_lambda(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
             eks_clusters = _discover_eks(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,284 @@
+"""Tests for the nothing-silent capability registry + doctor/capabilities CLI.
+
+Asserts the core contract:
+  * every known gate appears in the registry and in `capabilities`/`doctor`
+    output with a state and an unlock path (nothing silent),
+  * an unset feature shows OFF + how-to-unlock,
+  * a set env flag shows ENABLED,
+  * no secret values are ever printed,
+  * the output is deterministic for a fixed environment.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from click.testing import CliRunner
+
+from agent_bom import capabilities as cap_mod
+from agent_bom.capabilities import (
+    CAPABILITIES,
+    State,
+    coverage_line,
+    env_truthy,
+    resolved_capabilities,
+    scan_status_line,
+)
+from agent_bom.cli._capabilities import capabilities_cmd
+
+# Every gate this session shipped must be represented. If a new gate lands and
+# this list is updated but the registry isn't (or vice versa), the test fails —
+# that is the nothing-silent guarantee, enforced.
+KNOWN_GATE_KEYS = {
+    "aws_inventory",
+    "azure_inventory",
+    "gcp_inventory",
+    "snowflake_inventory",
+    "org_rollup",
+    "side_scan",
+    "audit_trail",
+    "registry_sweep",
+    "vuln_db_cache",
+}
+
+# Env vars whose *values* must never be printed (credentials / secrets).
+SECRET_VALUE_ENV_VARS = (
+    "AWS_ACCESS_KEY_ID",
+    "AWS_ROLE_ARN",
+    "AZURE_CLIENT_ID",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "SNOWFLAKE_PRIVATE_KEY_PATH",
+    "AGENT_BOM_REGISTRY_PASS",
+)
+
+# All gate flags — cleared before each test so probing is deterministic.
+_ALL_GATE_ENV = {
+    "AGENT_BOM_AWS_INVENTORY",
+    "AGENT_BOM_AZURE_INVENTORY",
+    "AGENT_BOM_GCP_INVENTORY",
+    "AGENT_BOM_SNOWFLAKE_INVENTORY",
+    "AGENT_BOM_CLOUD_INVENTORY",
+    "AGENT_BOM_SIDESCAN",
+    "AGENT_BOM_AUDIT_TRAIL",
+    "AGENT_BOM_REGISTRY_USER",
+    "AGENT_BOM_REGISTRY_PASS",
+    "AGENT_BOM_REGISTRY_AIRGAPPED",
+    "AGENT_BOM_VULN_DB_OFFLINE",
+    "AGENT_BOM_VULN_DB_MAX_AGE_HOURS",
+    "AGENT_BOM_SCAN_CACHE",
+    *SECRET_VALUE_ENV_VARS,
+}
+
+
+@pytest.fixture
+def clean_env(monkeypatch, tmp_path):
+    """Clear every gate var and point the vuln cache at a non-existent path."""
+    for name in _ALL_GATE_ENV:
+        monkeypatch.delenv(name, raising=False)
+    # Point cache override at a missing file so vuln_db_cache is deterministic OFF.
+    monkeypatch.setenv("AGENT_BOM_SCAN_CACHE", str(tmp_path / "no-such-cache.db"))
+    return monkeypatch
+
+
+# ---------------------------------------------------------------------------
+# Registry shape + nothing-silent coverage
+# ---------------------------------------------------------------------------
+
+
+def test_registry_covers_every_known_gate():
+    keys = {cap.key for cap in CAPABILITIES}
+    assert KNOWN_GATE_KEYS <= keys, f"missing gates: {KNOWN_GATE_KEYS - keys}"
+
+
+def test_capability_keys_are_unique():
+    keys = [cap.key for cap in CAPABILITIES]
+    assert len(keys) == len(set(keys))
+
+
+def test_every_capability_has_unlock_and_condition():
+    for cap in CAPABILITIES:
+        assert cap.unlock.strip(), f"{cap.key} has no unlock path"
+        assert cap.condition.strip(), f"{cap.key} has no condition"
+        assert cap.does.strip()
+        assert cap.env_vars, f"{cap.key} declares no env vars"
+
+
+def test_resolved_capabilities_have_state_and_detail(clean_env):
+    resolved = resolved_capabilities()
+    assert len(resolved) == len(CAPABILITIES)
+    for cap, status in resolved:
+        assert isinstance(status.state, State)
+        assert status.detail.strip(), f"{cap.key} has empty detail"
+
+
+# ---------------------------------------------------------------------------
+# State computation: unset → OFF, set → ENABLED, degraded
+# ---------------------------------------------------------------------------
+
+
+def test_unset_flag_capability_is_off_with_unlock(clean_env):
+    statuses = {cap.key: (cap, st) for cap, st in resolved_capabilities()}
+    cap, status = statuses["side_scan"]
+    assert status.state is State.OFF
+    assert "AGENT_BOM_SIDESCAN" in cap.unlock
+
+
+def test_set_flag_capability_is_enabled(clean_env):
+    clean_env.setenv("AGENT_BOM_AUDIT_TRAIL", "1")
+    statuses = {cap.key: st for cap, st in resolved_capabilities()}
+    assert statuses["audit_trail"].state is State.ON
+
+
+def test_inventory_opted_in_without_creds_is_degraded(clean_env):
+    clean_env.setenv("AGENT_BOM_AWS_INVENTORY", "true")
+    statuses = {cap.key: st for cap, st in resolved_capabilities()}
+    assert statuses["aws_inventory"].state is State.DEGRADED
+    assert "no credentials" in statuses["aws_inventory"].detail.lower()
+
+
+def test_inventory_opted_in_with_creds_is_enabled(clean_env):
+    clean_env.setenv("AGENT_BOM_AWS_INVENTORY", "1")
+    clean_env.setenv("AWS_PROFILE", "readonly")
+    statuses = {cap.key: st for cap, st in resolved_capabilities()}
+    assert statuses["aws_inventory"].state is State.ON
+
+
+def test_vuln_cache_off_when_no_local_cache(clean_env):
+    statuses = {cap.key: st for cap, st in resolved_capabilities()}
+    assert statuses["vuln_db_cache"].state is State.OFF
+
+
+def test_vuln_cache_fresh_is_enabled(clean_env, tmp_path):
+    db = tmp_path / "scan_cache.db"
+    db.write_text("x")
+    clean_env.setenv("AGENT_BOM_SCAN_CACHE", str(db))
+    statuses = {cap.key: st for cap, st in resolved_capabilities()}
+    assert statuses["vuln_db_cache"].state is State.ON
+
+
+def test_env_truthy_matches_gate_vocabulary(clean_env):
+    for value in ("1", "true", "YES", "On"):
+        clean_env.setenv("AGENT_BOM_AUDIT_TRAIL", value)
+        assert env_truthy("AGENT_BOM_AUDIT_TRAIL")
+    for value in ("0", "false", "", "nope"):
+        clean_env.setenv("AGENT_BOM_AUDIT_TRAIL", value)
+        assert not env_truthy("AGENT_BOM_AUDIT_TRAIL")
+
+
+def test_probe_never_raises(monkeypatch):
+    """A broken probe degrades to UNKNOWN — never crashes."""
+
+    def boom() -> cap_mod.CapabilityStatus:
+        raise RuntimeError("kaboom")
+
+    bad = cap_mod.Capability(
+        key="bad",
+        name="Bad",
+        group="scan",
+        does="x",
+        condition="c",
+        unlock="u",
+        env_vars=("X",),
+        probe=boom,
+    )
+    status = bad.status()
+    assert status.state is State.UNKNOWN
+    assert "kaboom" in status.detail
+
+
+# ---------------------------------------------------------------------------
+# Determinism + no-secrets
+# ---------------------------------------------------------------------------
+
+
+def test_resolution_is_deterministic(clean_env):
+    a = [(c.key, s.state, s.detail) for c, s in resolved_capabilities()]
+    b = [(c.key, s.state, s.detail) for c, s in resolved_capabilities()]
+    assert a == b
+
+
+def test_no_secret_values_printed(clean_env):
+    sentinel = "SUPERSECRETVALUE12345"
+    for name in SECRET_VALUE_ENV_VARS:
+        clean_env.setenv(name, sentinel)
+    # Also opt in so credential-detection paths run.
+    clean_env.setenv("AGENT_BOM_AWS_INVENTORY", "1")
+    clean_env.setenv("AGENT_BOM_REGISTRY_USER", sentinel)
+
+    result = CliRunner().invoke(capabilities_cmd, [])
+    assert result.exit_code == 0, result.output
+    assert sentinel not in result.output
+
+
+def test_coverage_line_is_a_sentence(clean_env):
+    line = coverage_line()
+    assert line.startswith("Coverage:")
+    assert "gated capabilities" in line
+
+
+def test_scan_status_line_names_unlock_var(clean_env):
+    line = scan_status_line()
+    assert "enabled" in line
+    assert "doctor" in line
+    # With everything off, at least one OFF capability surfaces its env var.
+    assert "AGENT_BOM_" in line
+
+
+# ---------------------------------------------------------------------------
+# CLI: capabilities command lists everything with state + unlock
+# ---------------------------------------------------------------------------
+
+
+def test_capabilities_cmd_lists_all_with_state_and_unlock(clean_env):
+    result = CliRunner().invoke(capabilities_cmd, [])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    for cap in CAPABILITIES:
+        assert cap.name in out, f"{cap.name} missing from capabilities output"
+    # Every state label legend present, and OFF entries show an unlock line.
+    assert "OFF" in out
+    assert "unlock:" in out
+    assert "Coverage:" in out
+
+
+def test_capabilities_cmd_shows_unlock_for_off_capability(clean_env):
+    result = CliRunner().invoke(capabilities_cmd, [])
+    # side-scan is off by default; its unlock var must appear.
+    assert "AGENT_BOM_SIDESCAN" in result.output
+
+
+def test_capabilities_cmd_marks_enabled(clean_env):
+    clean_env.setenv("AGENT_BOM_AUDIT_TRAIL", "1")
+    result = CliRunner().invoke(capabilities_cmd, [])
+    assert "ENABLED" in result.output
+
+
+def test_doctor_includes_capability_section(clean_env):
+    from agent_bom.cli._doctor import doctor_cmd
+
+    result = CliRunner().invoke(doctor_cmd, [])
+    assert result.exit_code == 0, result.output
+    assert "Capabilities" in result.output
+    # The doctor capability section names each gated capability.
+    for cap in CAPABILITIES:
+        assert cap.name in result.output
+
+
+def test_capabilities_registered_on_main_cli():
+    from agent_bom.cli import main
+
+    assert "capabilities" in main.commands
+    assert "doctor" in main.commands
+
+
+def test_output_contains_no_ansi_secret_leak(clean_env):
+    """Sanity: strip rich markup, confirm only var names (not values) surface."""
+    clean_env.setenv("AGENT_BOM_AWS_INVENTORY", "1")
+    clean_env.setenv("AWS_PROFILE", "my-ro-profile")
+    result = CliRunner().invoke(capabilities_cmd, [])
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    # The detected-credential line names the variable, by design, but never a
+    # value that looks like a secret token. AWS_PROFILE is a low-sensitivity
+    # selector and is intentionally surfaced as "detected".
+    assert "AGENT_BOM_AWS_INVENTORY" in plain

--- a/tests/test_cloud_aws_inventory.py
+++ b/tests/test_cloud_aws_inventory.py
@@ -720,6 +720,4 @@ def test_aws_permission_denied_degrades_with_guidance(monkeypatch: pytest.Monkey
     assert payload["instances"]  # EC2 still discovered
     actionable = [w for w in payload["warnings"] if "role lacks s3:ListAllMyBuckets" in w]
     assert actionable, payload["warnings"]
-    assert payload["missing_permissions"] == [
-        {"cloud": "aws", "permission": "s3:ListAllMyBuckets", "resource_type": "S3 buckets"}
-    ]
+    assert payload["missing_permissions"] == [{"cloud": "aws", "permission": "s3:ListAllMyBuckets", "resource_type": "S3 buckets"}]

--- a/tests/test_db_persistence_consistency.py
+++ b/tests/test_db_persistence_consistency.py
@@ -116,9 +116,7 @@ class _FakeReplayConnection:
             tenant = params[0]
             matched = [r for r in rows.values() if r["tenant_id"] == tenant]
             matched.sort(key=lambda r: r["captured_at"], reverse=True)
-            return _FakeCursor(
-                [(r["row_id"], r["tenant_id"], r["captured_at"], r["not_after"], r["record"]) for r in matched]
-            )
+            return _FakeCursor([(r["row_id"], r["tenant_id"], r["captured_at"], r["not_after"], r["record"]) for r in matched])
         return _FakeCursor()
 
     def commit(self):
@@ -173,9 +171,7 @@ def _pg_replay_store(monkeypatch):
         lambda p: pool.connection(),
         raising=False,
     )
-    monkeypatch.setattr(
-        prs.PostgresProxyReplayStore, "_init_tables", lambda self: None, raising=True
-    )
+    monkeypatch.setattr(prs.PostgresProxyReplayStore, "_init_tables", lambda self: None, raising=True)
     return prs.PostgresProxyReplayStore(pool=pool), pool
 
 


### PR DESCRIPTION
## Why

agent-bom unlocks deeper coverage on stated conditions — an opt-in env var, a credential, a scoped cloud role, a prior scan, or data already present. For a security tool, a silently-skipped capability is the worst failure mode: a gap that looks like coverage. This adds a nothing-silent surface so every disabled, skipped, or degraded feature announces itself plus the exact path to turn it on.

## What

- **`src/agent_bom/capabilities.py`** — a declarative registry of gated capabilities. Each entry carries what it does, the unlock condition (env var / credential / scoped role / prior scan / data present), the env var names it reads (names only), and a probe that computes the live state — `on` / `off` / `degraded` / `unknown` — from the environment. Covers: per-provider cloud inventory (AWS/Azure/GCP/Snowflake), organization roll-up, agentless side-scan, audit-trail correlation, container-registry sweep, and the local vuln-DB cache + freshness.
- **`agent-bom capabilities`** — a grouped view (cloud / scan / runtime / data) showing each capability's state, why it is in that state, and a copy-pasteable unlock line for anything not enabled, ending with a one-line coverage summary.
- **`doctor`** — gains a capability section plus the one-line coverage summary, alongside the existing preflight checks.
- **`scan_status_line()`** — a reusable one-liner exposed for the scan path: "running with X enabled; Y available — set Z".

## Guarantees

- **Nothing-silent**: every gated feature lives in the registry; a test asserts each known gate appears with a state and an unlock path.
- **No secrets**: only the presence/absence of a variable name is ever reported — never a value. A test sets sentinel secret values and asserts they never appear in output.
- **Deterministic + graceful**: probes read only the environment and the local filesystem, never the network, and are wrapped so a failed probe degrades to `unknown` rather than crashing the command.

## Tests

22 tests in `tests/test_capabilities.py`: registry covers every known gate, unset flag → OFF + how-to, set flag → ENABLED, inventory opted-in-without-creds → DEGRADED, vuln-cache present/fresh logic, probe-never-raises, determinism, no-secret-values, and the CLI listing all capabilities with state + unlock. `ruff check`, `ruff format --check`, and `mypy` (new module added to the strict list) are clean.