### PR TITLE
feat(graph): estate-scale CONTAINS roll-up with drill-down and attack-path view

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 235 |
+| `docs/openapi/v1.json` | paths | 236 |
 | `docs/openapi/v1.json` | component schemas | 61 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -12752,6 +12752,136 @@
         ]
       }
     },
+    "/v1/graph/rollup": {
+      "get": {
+        "description": "Collapse the estate along ``CONTAINS`` into a small, readable view.\n\nPast a few hundred nodes the raw topology is an unreadable hairball. This\nendpoint rolls the graph up along the containment hierarchy\n(org -> account/project -> app -> resource) so a 1000+ node estate renders\nas a handful of top-level containers, each carrying aggregate descendant\ncounts, worst-severity, a per-severity histogram, and exposure / toxic\nflags. ``?node=<id>`` returns one level of direct children for on-demand\ndrill-down; ``?mode=attack_path`` returns the nodes/edges on materialised\nattack paths first with the rest collapsed.\n\nBackend for the UI graph-navigation surface. Read-only: never mutates the\nsource graph.",
+        "operationId": "get_graph_rollup_v1_graph_rollup_get",
+        "parameters": [
+          {
+            "description": "Scan snapshot ID; latest if omitted",
+            "in": "query",
+            "name": "scan_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scan snapshot ID; latest if omitted",
+              "title": "Scan Id"
+            }
+          },
+          {
+            "description": "Drill down into a container node's direct children",
+            "in": "query",
+            "name": "node",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Drill down into a container node's direct children",
+              "title": "Node"
+            }
+          },
+          {
+            "description": "Only roll up descendants at/above this severity",
+            "in": "query",
+            "name": "min_severity",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only roll up descendants at/above this severity",
+              "title": "Min Severity"
+            }
+          },
+          {
+            "description": "Only roll up internet-exposed descendants",
+            "in": "query",
+            "name": "exposed",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Only roll up internet-exposed descendants",
+              "title": "Exposed",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Only roll up toxic-combination descendants",
+            "in": "query",
+            "name": "toxic",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Only roll up toxic-combination descendants",
+              "title": "Toxic",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "rollup (default) or attack_path-first view",
+            "in": "query",
+            "name": "mode",
+            "required": false,
+            "schema": {
+              "default": "rollup",
+              "description": "rollup (default) or attack_path-first view",
+              "enum": [
+                "rollup",
+                "attack_path"
+              ],
+              "title": "Mode",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Graph Rollup V1 Graph Rollup Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Graph Rollup",
+        "tags": [
+          "graph"
+        ]
+      }
+    },
     "/v1/graph/schema": {
       "get": {
         "description": "Canonical graph entity/edge taxonomy \u2014 single source of truth.\n\nDrives the TypeScript codegen at ``ui/scripts/codegen-graph-schema.mjs``,\nwhich materialises ``ui/lib/graph-schema.generated.ts``.  CI fails the\nbuild when the checked-in generated file drifts from what this endpoint\nwould emit, so adding a new ``EntityType`` or ``RelationshipType`` in\nPython automatically forces a regen + commit on the UI side.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -8341,6 +8341,112 @@ paths:
       summary: Query Graph
       tags:
       - graph
+  /v1/graph/rollup:
+    get:
+      description: 'Collapse the estate along ``CONTAINS`` into a small, readable
+        view.
+
+
+        Past a few hundred nodes the raw topology is an unreadable hairball. This
+
+        endpoint rolls the graph up along the containment hierarchy
+
+        (org -> account/project -> app -> resource) so a 1000+ node estate renders
+
+        as a handful of top-level containers, each carrying aggregate descendant
+
+        counts, worst-severity, a per-severity histogram, and exposure / toxic
+
+        flags. ``?node=<id>`` returns one level of direct children for on-demand
+
+        drill-down; ``?mode=attack_path`` returns the nodes/edges on materialised
+
+        attack paths first with the rest collapsed.
+
+
+        Backend for the UI graph-navigation surface. Read-only: never mutates the
+
+        source graph.'
+      operationId: get_graph_rollup_v1_graph_rollup_get
+      parameters:
+      - description: Scan snapshot ID; latest if omitted
+        in: query
+        name: scan_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Scan snapshot ID; latest if omitted
+          title: Scan Id
+      - description: Drill down into a container node's direct children
+        in: query
+        name: node
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Drill down into a container node's direct children
+          title: Node
+      - description: Only roll up descendants at/above this severity
+        in: query
+        name: min_severity
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Only roll up descendants at/above this severity
+          title: Min Severity
+      - description: Only roll up internet-exposed descendants
+        in: query
+        name: exposed
+        required: false
+        schema:
+          default: false
+          description: Only roll up internet-exposed descendants
+          title: Exposed
+          type: boolean
+      - description: Only roll up toxic-combination descendants
+        in: query
+        name: toxic
+        required: false
+        schema:
+          default: false
+          description: Only roll up toxic-combination descendants
+          title: Toxic
+          type: boolean
+      - description: rollup (default) or attack_path-first view
+        in: query
+        name: mode
+        required: false
+        schema:
+          default: rollup
+          description: rollup (default) or attack_path-first view
+          enum:
+          - rollup
+          - attack_path
+          title: Mode
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Graph Rollup V1 Graph Rollup Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Graph Rollup
+      tags:
+      - graph
   /v1/graph/schema:
     get:
       description: "Canonical graph entity/edge taxonomy \u2014 single source of truth.\n\

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -10,6 +10,7 @@ Endpoints:
   POST /v1/graph/should-i-deploy — agent-native deploy decision
   GET  /v1/graph/paths          — attack paths from a source node
   GET  /v1/graph/impact         — blast radius of a node (reverse BFS)
+  GET  /v1/graph/rollup         — estate-scale CONTAINS roll-up + drill-down
   GET  /v1/graph/search         — full-text graph search
   GET  /v1/graph/agents         — paginated agent node selector
   GET  /v1/graph/clusters       — semantic cluster rollups
@@ -2851,3 +2852,73 @@ async def delete_preset(request: Request, name: str) -> dict:
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Preset '{name}' not found")
     return {"name": name, "status": "deleted"}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Estate-scale roll-up (CONTAINS) — backend for the UI graph-nav drill-down
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@router.get("/v1/graph/rollup", tags=["graph"])
+async def get_graph_rollup(
+    request: Request,
+    scan_id: Optional[str] = Query(None, description="Scan snapshot ID; latest if omitted"),
+    node: Optional[str] = Query(None, description="Drill down into a container node's direct children"),
+    min_severity: Optional[str] = Query(None, description="Only roll up descendants at/above this severity"),
+    exposed: bool = Query(False, description="Only roll up internet-exposed descendants"),
+    toxic: bool = Query(False, description="Only roll up toxic-combination descendants"),
+    mode: Literal["rollup", "attack_path"] = Query("rollup", description="rollup (default) or attack_path-first view"),
+) -> dict:
+    """Collapse the estate along ``CONTAINS`` into a small, readable view.
+
+    Past a few hundred nodes the raw topology is an unreadable hairball. This
+    endpoint rolls the graph up along the containment hierarchy
+    (org -> account/project -> app -> resource) so a 1000+ node estate renders
+    as a handful of top-level containers, each carrying aggregate descendant
+    counts, worst-severity, a per-severity histogram, and exposure / toxic
+    flags. ``?node=<id>`` returns one level of direct children for on-demand
+    drill-down; ``?mode=attack_path`` returns the nodes/edges on materialised
+    attack paths first with the rest collapsed.
+
+    Backend for the UI graph-navigation surface. Read-only: never mutates the
+    source graph.
+    """
+    from agent_bom.graph.rollup import RollupFilters, attack_path_view, drill_down, rollup_view
+
+    tenant = _tenant(request)
+    graph_store = _get_graph_store_or_503()
+    requested_scan_id = scan_id or ""
+
+    if not requested_scan_id and not await _graph_store_call(graph_store.latest_snapshot_id, tenant_id=tenant):
+        raise HTTPException(status_code=503, detail="Graph snapshots not found. Run a scan first.")
+
+    if min_severity and min_severity.lower() not in SEVERITY_RANK:
+        raise HTTPException(status_code=422, detail=f"Unsupported severity: {min_severity}")
+
+    try:
+        graph = await _graph_store_call(
+            graph_store.load_graph,
+            scan_id=requested_scan_id,
+            tenant_id=tenant,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
+
+    filters = RollupFilters(
+        min_severity=(min_severity or "").lower(),
+        exposed_only=exposed,
+        toxic_only=toxic,
+    )
+
+    try:
+        if node:
+            return drill_down(graph, node, filters=filters)
+        if mode == "attack_path":
+            return attack_path_view(graph, _derived_attack_paths(graph), filters=filters)
+        return rollup_view(graph, filters=filters)
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        # Never leak internal exception detail in the response (CodeQL lesson).
+        logger.warning("graph rollup failed", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to compute graph roll-up") from exc

--- a/src/agent_bom/graph/rollup.py
+++ b/src/agent_bom/graph/rollup.py
@@ -1,0 +1,528 @@
+"""Estate-scale graph roll-up — collapse the CONTAINS hierarchy into a small,
+readable top-level view with on-demand drill-down.
+
+Past a few hundred nodes the raw topology graph is an unreadable hairball. The
+estate is, however, organised as a containment tree (``CONTAINS`` edges:
+org → account/folder/project → app → resource). This module rolls the graph up
+along that tree so a 1000+ node estate renders as a handful of top-level
+container nodes, each carrying aggregate child counts, worst-severity, a
+per-severity histogram, and exposure / toxic-combination flags propagated from
+every descendant. The UI then drills down one level at a time
+(:func:`drill_down`) instead of loading everything at once.
+
+Everything here is a *pure read* over an existing :class:`UnifiedGraph`:
+deterministic (sorted, stable ordering), bounded, and side-effect free — the
+source graph is never mutated. This is the backend that the UI graph-navigation
+follow-up consumes.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.severity import OCSF_SEVERITY_NAMES, SEVERITY_RANK
+from agent_bom.graph.types import EntityType, RelationshipType
+
+# Severity buckets reported in every roll-up histogram, worst → least.
+_SEVERITY_ORDER: tuple[str, ...] = ("critical", "high", "medium", "low", "info", "none")
+
+# Container entity types form the readable top-level scaffold of the estate.
+# A node of one of these types is a candidate roll-up container; everything else
+# is a leaf that aggregates into its nearest container ancestor.
+_CONTAINER_TYPES: frozenset[str] = frozenset(
+    {
+        EntityType.ORG.value,
+        EntityType.ACCOUNT.value,
+        EntityType.PROVIDER.value,
+        EntityType.ENVIRONMENT.value,
+        EntityType.FLEET.value,
+        EntityType.CLUSTER.value,
+        EntityType.APPLICATION.value,
+        EntityType.SERVER.value,
+        EntityType.CONTAINER.value,
+        EntityType.CLOUD_RESOURCE.value,
+    }
+)
+
+# Attributes that mark a node (or a descendant rolled up into a container) as
+# internet-exposed. Any one being truthy flags the container as exposed.
+_EXPOSED_ATTRS: tuple[str, ...] = (
+    "internet_exposed",
+    "toxic_exposed_vulnerable",
+    "toxic_exposed_sensitive",
+)
+
+# Attributes that mark a node as part of a toxic combination (stacked risk).
+_TOXIC_ATTRS: tuple[str, ...] = (
+    "toxic_exposed_vulnerable",
+    "toxic_exposed_sensitive",
+)
+
+
+def _node_type_value(node: UnifiedNode) -> str:
+    return node.entity_type.value if isinstance(node.entity_type, EntityType) else str(node.entity_type)
+
+
+def _severity_bucket(node: UnifiedNode) -> str:
+    sev = (node.severity or "").lower()
+    if sev in {"informational"}:
+        return "info"
+    if sev in _SEVERITY_ORDER:
+        return sev
+    return "none"
+
+
+def _is_exposed(node: UnifiedNode) -> bool:
+    attrs = node.attributes or {}
+    return any(bool(attrs.get(key)) for key in _EXPOSED_ATTRS)
+
+
+def _is_toxic(node: UnifiedNode) -> bool:
+    attrs = node.attributes or {}
+    return any(bool(attrs.get(key)) for key in _TOXIC_ATTRS)
+
+
+@dataclass(slots=True)
+class RollupAggregate:
+    """Aggregate risk facts rolled up from a container's descendants."""
+
+    descendant_count: int = 0
+    by_type: dict[str, int] = field(default_factory=dict)
+    severity_counts: dict[str, int] = field(default_factory=dict)
+    worst_severity: str = "none"
+    worst_severity_rank: int = 0
+    internet_exposed: bool = False
+    toxic_combo: bool = False
+    exposed_count: int = 0
+    toxic_count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "descendant_count": self.descendant_count,
+            "by_type": dict(sorted(self.by_type.items())),
+            "severity_counts": {sev: self.severity_counts.get(sev, 0) for sev in _SEVERITY_ORDER},
+            "worst_severity": self.worst_severity,
+            "worst_severity_rank": self.worst_severity_rank,
+            "internet_exposed": self.internet_exposed,
+            "toxic_combo": self.toxic_combo,
+            "exposed_count": self.exposed_count,
+            "toxic_count": self.toxic_count,
+        }
+
+
+@dataclass(slots=True)
+class RollupContainer:
+    """A top-level (or drilled-into) container node carrying its roll-up."""
+
+    id: str
+    label: str
+    entity_type: str
+    severity: str
+    is_container: bool
+    has_children: bool
+    direct_child_count: int
+    aggregate: RollupAggregate
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "label": self.label,
+            "entity_type": self.entity_type,
+            "severity": self.severity,
+            "is_container": self.is_container,
+            "has_children": self.has_children,
+            "direct_child_count": self.direct_child_count,
+            "aggregate": self.aggregate.to_dict(),
+        }
+
+
+@dataclass(slots=True)
+class RollupFilters:
+    """Optional pre-roll-up filters that focus the view on risk.
+
+    Filters are applied to *descendants* before aggregation: a container is kept
+    if any descendant survives the filter (so risk is never hidden behind an
+    empty container), and its aggregates count only the surviving descendants.
+    """
+
+    min_severity: str = ""
+    exposed_only: bool = False
+    toxic_only: bool = False
+
+    def active(self) -> bool:
+        return bool(self.min_severity) or self.exposed_only or self.toxic_only
+
+    def matches(self, node: UnifiedNode) -> bool:
+        if self.min_severity:
+            min_rank = SEVERITY_RANK.get(self.min_severity.lower(), 0)
+            if SEVERITY_RANK.get((node.severity or "").lower(), 0) < min_rank:
+                return False
+        if self.exposed_only and not _is_exposed(node):
+            return False
+        if self.toxic_only and not _is_toxic(node):
+            return False
+        return True
+
+
+def _contains_children(graph: UnifiedGraph) -> dict[str, list[str]]:
+    """Map container_id -> sorted direct CONTAINS children (deterministic).
+
+    Self-loops are ignored. Children are de-duplicated and sorted by id so the
+    output is stable across runs regardless of edge insertion order.
+    """
+    children: dict[str, set[str]] = defaultdict(set)
+    for edge in graph.edges:
+        rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
+        if rel != RelationshipType.CONTAINS.value:
+            continue
+        if edge.source == edge.target:
+            continue
+        if edge.source not in graph.nodes or edge.target not in graph.nodes:
+            continue
+        children[edge.source].add(edge.target)
+    return {parent: sorted(kids) for parent, kids in children.items()}
+
+
+def _contains_parents(children: dict[str, list[str]]) -> dict[str, set[str]]:
+    parents: dict[str, set[str]] = defaultdict(set)
+    for parent, kids in children.items():
+        for kid in kids:
+            parents[kid].add(parent)
+    return parents
+
+
+def _roots(graph: UnifiedGraph, children: dict[str, list[str]], parents: dict[str, set[str]]) -> list[str]:
+    """Top-level CONTAINS roots: nodes with children but no CONTAINS parent.
+
+    Cycle-safe: if every node in a CONTAINS cycle has a parent (so there is no
+    natural root), the lowest-id member is promoted to a root so the component
+    still renders rather than vanishing.
+    """
+    roots = [nid for nid in children if not parents.get(nid)]
+    if roots:
+        return sorted(roots)
+    # Degenerate: containment forms cycles with no acyclic root. Promote the
+    # lowest-id container so the estate still has a stable entry point.
+    if children:
+        return [min(children)]
+    return []
+
+
+def _descendants(root: str, children: dict[str, list[str]]) -> list[str]:
+    """All transitive CONTAINS descendants of *root* (excludes root). Bounded by
+    a visited set so cycles terminate; returned sorted for determinism."""
+    seen: set[str] = set()
+    queue: deque[str] = deque(children.get(root, []))
+    while queue:
+        current = queue.popleft()
+        if current in seen or current == root:
+            continue
+        seen.add(current)
+        for kid in children.get(current, []):
+            if kid not in seen:
+                queue.append(kid)
+    return sorted(seen)
+
+
+def _aggregate(
+    descendant_ids: list[str],
+    graph: UnifiedGraph,
+    *,
+    filters: Optional[RollupFilters] = None,
+) -> RollupAggregate:
+    agg = RollupAggregate()
+    severity_counts: dict[str, int] = defaultdict(int)
+    by_type: dict[str, int] = defaultdict(int)
+    for nid in descendant_ids:
+        node = graph.nodes.get(nid)
+        if node is None:
+            continue
+        if filters is not None and filters.active() and not filters.matches(node):
+            continue
+        agg.descendant_count += 1
+        by_type[_node_type_value(node)] += 1
+        bucket = _severity_bucket(node)
+        severity_counts[bucket] += 1
+        rank = SEVERITY_RANK.get((node.severity or "").lower(), 0)
+        if rank > agg.worst_severity_rank:
+            agg.worst_severity_rank = rank
+            agg.worst_severity = bucket
+        if _is_exposed(node):
+            agg.internet_exposed = True
+            agg.exposed_count += 1
+        if _is_toxic(node):
+            agg.toxic_combo = True
+            agg.toxic_count += 1
+    agg.by_type = dict(by_type)
+    agg.severity_counts = dict(severity_counts)
+    return agg
+
+
+def _container_for(node: UnifiedNode, child_map: dict[str, list[str]]) -> bool:
+    return _node_type_value(node) in _CONTAINER_TYPES or bool(child_map.get(node.id))
+
+
+def rollup_view(
+    graph: UnifiedGraph,
+    *,
+    filters: Optional[RollupFilters] = None,
+) -> dict[str, Any]:
+    """Collapse the graph along CONTAINS into a small top-level container view.
+
+    Returns top-level container roots, each carrying aggregate descendant
+    counts, worst-severity, a per-severity histogram, and exposure / toxic
+    flags rolled up from every descendant. An estate of thousands of nodes
+    renders as a handful of account / app containers.
+
+    Deterministic and bounded; the source graph is never mutated.
+    """
+    children = _contains_children(graph)
+    parents = _contains_parents(children)
+    root_ids = _roots(graph, children, parents)
+
+    containers: list[RollupContainer] = []
+    rolled_up_ids: set[str] = set()
+    for root_id in root_ids:
+        node = graph.nodes.get(root_id)
+        if node is None:
+            continue
+        descendants = _descendants(root_id, children)
+        agg = _aggregate(descendants, graph, filters=filters)
+        # When filters are active, drop containers whose descendants were all
+        # filtered out — they carry no risk worth surfacing.
+        if filters is not None and filters.active() and agg.descendant_count == 0 and not (filters.matches(node)):
+            continue
+        direct = children.get(root_id, [])
+        containers.append(
+            RollupContainer(
+                id=node.id,
+                label=node.label,
+                entity_type=_node_type_value(node),
+                severity=node.severity or "",
+                is_container=True,
+                has_children=bool(direct),
+                direct_child_count=len(direct),
+                aggregate=agg,
+            )
+        )
+        rolled_up_ids.add(root_id)
+        rolled_up_ids.update(descendants)
+
+    # Nodes outside any CONTAINS tree (orphans / flat estates) are surfaced as
+    # their own single-node entries so nothing silently disappears from the view.
+    orphans: list[RollupContainer] = []
+    for nid in sorted(graph.nodes):
+        if nid in rolled_up_ids:
+            continue
+        node = graph.nodes[nid]
+        if filters is not None and filters.active() and not filters.matches(node):
+            continue
+        orphans.append(
+            RollupContainer(
+                id=node.id,
+                label=node.label,
+                entity_type=_node_type_value(node),
+                severity=node.severity or "",
+                is_container=_container_for(node, children),
+                has_children=bool(children.get(nid)),
+                direct_child_count=len(children.get(nid, [])),
+                aggregate=_aggregate(_descendants(nid, children), graph, filters=filters),
+            )
+        )
+
+    top_level = containers + orphans
+    top_level.sort(key=lambda c: (-c.aggregate.worst_severity_rank, -c.aggregate.descendant_count, c.id))
+
+    return {
+        "scan_id": graph.scan_id,
+        "tenant_id": graph.tenant_id,
+        "created_at": graph.created_at,
+        "mode": "rollup",
+        "filters": _filters_dict(filters),
+        "top_level": [c.to_dict() for c in top_level],
+        "summary": {
+            "total_nodes": len(graph.nodes),
+            "total_edges": len(graph.edges),
+            "top_level_count": len(top_level),
+            "container_count": len(containers),
+            "orphan_count": len(orphans),
+        },
+    }
+
+
+def drill_down(
+    graph: UnifiedGraph,
+    node_id: str,
+    *,
+    filters: Optional[RollupFilters] = None,
+) -> dict[str, Any]:
+    """Return one level of direct CONTAINS children of *node_id*.
+
+    Each child carries its own roll-up so the UI can keep expanding on demand.
+    O(direct children); never loads the whole graph.
+    """
+    if node_id not in graph.nodes:
+        return {
+            "scan_id": graph.scan_id,
+            "tenant_id": graph.tenant_id,
+            "created_at": graph.created_at,
+            "mode": "drilldown",
+            "node": None,
+            "filters": _filters_dict(filters),
+            "children": [],
+            "summary": {"direct_child_count": 0, "returned_child_count": 0},
+        }
+
+    children = _contains_children(graph)
+    direct = children.get(node_id, [])
+    parent = graph.nodes[node_id]
+
+    child_entries: list[RollupContainer] = []
+    for child_id in direct:
+        child = graph.nodes.get(child_id)
+        if child is None:
+            continue
+        descendants = _descendants(child_id, children)
+        agg = _aggregate(descendants, graph, filters=filters)
+        if filters is not None and filters.active() and agg.descendant_count == 0 and not filters.matches(child):
+            continue
+        child_entries.append(
+            RollupContainer(
+                id=child.id,
+                label=child.label,
+                entity_type=_node_type_value(child),
+                severity=child.severity or "",
+                is_container=_container_for(child, children),
+                has_children=bool(children.get(child_id)),
+                direct_child_count=len(children.get(child_id, [])),
+                aggregate=agg,
+            )
+        )
+
+    child_entries.sort(key=lambda c: (-c.aggregate.worst_severity_rank, -c.aggregate.descendant_count, c.id))
+
+    return {
+        "scan_id": graph.scan_id,
+        "tenant_id": graph.tenant_id,
+        "created_at": graph.created_at,
+        "mode": "drilldown",
+        "node": {
+            "id": parent.id,
+            "label": parent.label,
+            "entity_type": _node_type_value(parent),
+            "severity": parent.severity or "",
+        },
+        "filters": _filters_dict(filters),
+        "children": [c.to_dict() for c in child_entries],
+        "summary": {
+            "direct_child_count": len(direct),
+            "returned_child_count": len(child_entries),
+        },
+    }
+
+
+def attack_path_view(
+    graph: UnifiedGraph,
+    attack_paths: list[Any],
+    *,
+    filters: Optional[RollupFilters] = None,
+    max_paths: int = 50,
+) -> dict[str, Any]:
+    """Attack-path-first readable view: the nodes/edges on materialised attack
+    paths up front (the "what matters" view), with everything else collapsed
+    into a small CONTAINS roll-up.
+
+    *attack_paths* is the list of path-like objects (each exposing ``hops`` and
+    ``edges``) the caller already materialised — this function does not derive
+    paths, it only assembles the readable view around them.
+    """
+    ranked = sorted(
+        attack_paths,
+        key=lambda p: (getattr(p, "composite_risk", 0.0), len(getattr(p, "hops", []))),
+        reverse=True,
+    )[: max(0, max_paths)]
+
+    path_node_ids: list[str] = []
+    seen_nodes: set[str] = set()
+    for path in ranked:
+        for hop in getattr(path, "hops", []):
+            if hop in graph.nodes and hop not in seen_nodes:
+                seen_nodes.add(hop)
+                path_node_ids.append(hop)
+
+    # Edges between any two on-path nodes (the readable subgraph the paths walk).
+    path_edges: list[dict[str, Any]] = []
+    seen_edge_keys: set[tuple[str, str, str]] = set()
+    for edge in graph.edges:
+        if edge.source in seen_nodes and edge.target in seen_nodes:
+            rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
+            key = (edge.source, edge.target, rel)
+            if key in seen_edge_keys:
+                continue
+            seen_edge_keys.add(key)
+            path_edges.append(edge.to_dict())
+    path_edges.sort(key=lambda e: (e["source"], e["target"], e["relationship"]))
+
+    path_nodes = [graph.nodes[nid].to_dict() for nid in path_node_ids]
+
+    # Everything not on a path is collapsed into the standard CONTAINS roll-up so
+    # the operator still has the estate context, just not the hairball.
+    collapsed = rollup_view(graph, filters=filters)["top_level"]
+    collapsed_off_path = [c for c in collapsed if c["id"] not in seen_nodes]
+
+    paths_payload = [_attack_path_summary(path) for path in ranked]
+
+    return {
+        "scan_id": graph.scan_id,
+        "tenant_id": graph.tenant_id,
+        "created_at": graph.created_at,
+        "mode": "attack_path",
+        "filters": _filters_dict(filters),
+        "attack_paths": paths_payload,
+        "path_nodes": path_nodes,
+        "path_edges": path_edges,
+        "collapsed": collapsed_off_path,
+        "summary": {
+            "total_nodes": len(graph.nodes),
+            "path_count": len(paths_payload),
+            "path_node_count": len(path_nodes),
+            "path_edge_count": len(path_edges),
+            "collapsed_count": len(collapsed_off_path),
+        },
+    }
+
+
+def _attack_path_summary(path: Any) -> dict[str, Any]:
+    return {
+        "source": getattr(path, "source", ""),
+        "target": getattr(path, "target", ""),
+        "hops": list(getattr(path, "hops", [])),
+        "composite_risk": getattr(path, "composite_risk", 0.0),
+        "summary": getattr(path, "summary", ""),
+    }
+
+
+def _filters_dict(filters: Optional[RollupFilters]) -> dict[str, Any]:
+    if filters is None:
+        return {"min_severity": "", "exposed_only": False, "toxic_only": False}
+    return {
+        "min_severity": filters.min_severity,
+        "exposed_only": filters.exposed_only,
+        "toxic_only": filters.toxic_only,
+    }
+
+
+# Re-exported for callers that want the OCSF display name of a rolled-up bucket.
+__all__ = [
+    "RollupAggregate",
+    "RollupContainer",
+    "RollupFilters",
+    "attack_path_view",
+    "drill_down",
+    "rollup_view",
+    "OCSF_SEVERITY_NAMES",
+]

--- a/tests/test_graph_rollup.py
+++ b/tests/test_graph_rollup.py
@@ -1,0 +1,269 @@
+"""Tests for estate-scale graph roll-up (CONTAINS) + drill-down + endpoint."""
+
+from __future__ import annotations
+
+import copy
+
+from starlette.testclient import TestClient
+
+from agent_bom.api import server as api_server
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.api.server import app
+from agent_bom.api.stores import set_graph_store
+from agent_bom.graph import UnifiedEdge, UnifiedGraph, UnifiedNode
+from agent_bom.graph.container import AttackPath
+from agent_bom.graph.rollup import (
+    RollupFilters,
+    attack_path_view,
+    drill_down,
+    rollup_view,
+)
+from agent_bom.graph.types import EntityType, RelationshipType
+
+# ── Synthetic graph builders ─────────────────────────────────────────────
+
+
+def _contains(graph: UnifiedGraph, parent: str, child: str) -> None:
+    graph.add_edge(UnifiedEdge(source=parent, target=child, relationship=RelationshipType.CONTAINS))
+
+
+def _deep_estate() -> UnifiedGraph:
+    """org -> account -> app -> {server, server} -> {package(crit), package(low)}."""
+    g = UnifiedGraph(scan_id="estate-scan", tenant_id="default")
+    g.add_node(UnifiedNode(id="org:acme", entity_type=EntityType.ORG, label="Acme"))
+    g.add_node(UnifiedNode(id="account:prod", entity_type=EntityType.ACCOUNT, label="prod"))
+    g.add_node(UnifiedNode(id="app:web", entity_type=EntityType.APPLICATION, label="web"))
+    g.add_node(
+        UnifiedNode(
+            id="server:s1",
+            entity_type=EntityType.SERVER,
+            label="s1",
+            attributes={"internet_exposed": True},
+        )
+    )
+    g.add_node(UnifiedNode(id="server:s2", entity_type=EntityType.SERVER, label="s2"))
+    g.add_node(
+        UnifiedNode(
+            id="pkg:crit",
+            entity_type=EntityType.PACKAGE,
+            label="crit-pkg",
+            severity="critical",
+            attributes={"toxic_exposed_vulnerable": True},
+        )
+    )
+    g.add_node(UnifiedNode(id="pkg:low", entity_type=EntityType.PACKAGE, label="low-pkg", severity="low"))
+
+    _contains(g, "org:acme", "account:prod")
+    _contains(g, "account:prod", "app:web")
+    _contains(g, "app:web", "server:s1")
+    _contains(g, "app:web", "server:s2")
+    _contains(g, "server:s1", "pkg:crit")
+    _contains(g, "server:s2", "pkg:low")
+    return g
+
+
+def _large_estate(accounts: int = 10, apps: int = 10, pkgs: int = 12) -> UnifiedGraph:
+    """One org over many accounts/apps/packages — >1000 nodes, one CONTAINS root."""
+    g = UnifiedGraph(scan_id="large-scan", tenant_id="default")
+    g.add_node(UnifiedNode(id="org:root", entity_type=EntityType.ORG, label="root"))
+    for a in range(accounts):
+        acc = f"account:{a}"
+        g.add_node(UnifiedNode(id=acc, entity_type=EntityType.ACCOUNT, label=f"acct-{a}"))
+        _contains(g, "org:root", acc)
+        for p in range(apps):
+            app_id = f"app:{a}-{p}"
+            g.add_node(UnifiedNode(id=app_id, entity_type=EntityType.APPLICATION, label=f"app-{a}-{p}"))
+            _contains(g, acc, app_id)
+            for k in range(pkgs):
+                pkg = f"pkg:{a}-{p}-{k}"
+                sev = "critical" if k == 0 else "low"
+                g.add_node(UnifiedNode(id=pkg, entity_type=EntityType.PACKAGE, label=pkg, severity=sev))
+                _contains(g, app_id, pkg)
+    return g
+
+
+# ── Roll-up ──────────────────────────────────────────────────────────────
+
+
+def test_rollup_collapses_deep_contains_tree_with_aggregate_counts() -> None:
+    view = rollup_view(_deep_estate())
+    assert view["mode"] == "rollup"
+    # A 7-node estate collapses to a single top-level container (the org root).
+    assert view["summary"]["top_level_count"] == 1
+    top = view["top_level"][0]
+    assert top["id"] == "org:acme"
+    agg = top["aggregate"]
+    # 6 descendants under the org (account, app, 2 servers, 2 packages).
+    assert agg["descendant_count"] == 6
+    assert agg["by_type"]["package"] == 2
+    assert agg["by_type"]["server"] == 2
+    assert agg["worst_severity"] == "critical"
+    assert agg["severity_counts"]["critical"] == 1
+    assert agg["severity_counts"]["low"] == 1
+    # Exposure + toxic flags roll up from descendants.
+    assert agg["internet_exposed"] is True
+    assert agg["toxic_combo"] is True
+
+
+def test_rollup_is_deterministic() -> None:
+    g = _deep_estate()
+    assert rollup_view(g) == rollup_view(g)
+
+
+def test_rollup_does_not_mutate_source_graph() -> None:
+    g = _deep_estate()
+    before_nodes = copy.deepcopy(g.nodes)
+    before_edges = [e.to_dict() for e in g.edges]
+    rollup_view(g)
+    drill_down(g, "app:web")
+    attack_path_view(g, [])
+    assert g.nodes == before_nodes
+    assert [e.to_dict() for e in g.edges] == before_edges
+
+
+# ── Large-graph scale ──────────────────────────────────────────────────────
+
+
+def test_large_graph_rolls_up_to_small_top_level() -> None:
+    g = _large_estate(accounts=10, apps=10, pkgs=12)
+    # 1 org + 10 accounts + 100 apps + 1200 packages = 1311 nodes.
+    assert len(g.nodes) > 1000
+    view = rollup_view(g)
+    # The whole estate collapses to exactly one readable top-level container.
+    assert view["summary"]["top_level_count"] == 1
+    top = view["top_level"][0]
+    assert top["id"] == "org:root"
+    assert top["aggregate"]["descendant_count"] == len(g.nodes) - 1
+    # 10 accounts * 10 apps = 100 critical packages roll up.
+    assert top["aggregate"]["severity_counts"]["critical"] == 100
+
+
+def test_drill_down_is_one_level() -> None:
+    g = _large_estate(accounts=10, apps=10, pkgs=12)
+    res = drill_down(g, "org:root")
+    assert res["mode"] == "drilldown"
+    assert res["summary"]["direct_child_count"] == 10
+    assert {c["id"] for c in res["children"]} == {f"account:{a}" for a in range(10)}
+    # Each child still carries its own rolled-up aggregate (1 app-level + ...).
+    for child in res["children"]:
+        assert child["has_children"] is True
+        assert child["aggregate"]["descendant_count"] == 10 + 10 * 12
+
+
+def test_drill_down_unknown_node_returns_empty() -> None:
+    res = drill_down(_deep_estate(), "does-not-exist")
+    assert res["node"] is None
+    assert res["children"] == []
+
+
+# ── Filters ────────────────────────────────────────────────────────────────
+
+
+def test_min_severity_filter_restricts_aggregates() -> None:
+    view = rollup_view(_deep_estate(), filters=RollupFilters(min_severity="high"))
+    top = view["top_level"][0]
+    # Only the one critical package survives a high-severity floor.
+    assert top["aggregate"]["descendant_count"] == 1
+    assert top["aggregate"]["severity_counts"]["critical"] == 1
+    assert top["aggregate"]["severity_counts"]["low"] == 0
+
+
+def test_exposed_only_filter() -> None:
+    view = rollup_view(_deep_estate(), filters=RollupFilters(exposed_only=True))
+    top = view["top_level"][0]
+    # server:s1 (internet_exposed) + pkg:crit (toxic_exposed_vulnerable).
+    assert top["aggregate"]["descendant_count"] == 2
+    assert top["aggregate"]["internet_exposed"] is True
+
+
+def test_toxic_only_filter() -> None:
+    view = rollup_view(_deep_estate(), filters=RollupFilters(toxic_only=True))
+    top = view["top_level"][0]
+    assert top["aggregate"]["descendant_count"] == 1
+    assert top["aggregate"]["toxic_combo"] is True
+
+
+# ── Attack-path-first mode ─────────────────────────────────────────────────
+
+
+def test_attack_path_view_surfaces_path_nodes_first() -> None:
+    g = _deep_estate()
+    path = AttackPath(
+        source="server:s1",
+        target="pkg:crit",
+        hops=["server:s1", "pkg:crit"],
+        edges=["contains"],
+        composite_risk=92.0,
+        summary="exposed server reaches critical package",
+    )
+    view = attack_path_view(g, [path])
+    assert view["mode"] == "attack_path"
+    assert view["summary"]["path_count"] == 1
+    assert {n["id"] for n in view["path_nodes"]} == {"server:s1", "pkg:crit"}
+    assert view["summary"]["path_edge_count"] == 1
+    # The org root is collapsed (off-path), not expanded into the path view.
+    assert any(c["id"] == "org:acme" for c in view["collapsed"])
+    assert "server:s1" not in {c["id"] for c in view["collapsed"]}
+
+
+def test_attack_path_view_with_no_paths_collapses_everything() -> None:
+    view = attack_path_view(_deep_estate(), [])
+    assert view["summary"]["path_count"] == 0
+    assert view["path_nodes"] == []
+    assert view["summary"]["collapsed_count"] >= 1
+
+
+# ── Endpoint ───────────────────────────────────────────────────────────────
+
+
+def test_rollup_endpoint_returns_top_level(tmp_path) -> None:
+    store = SQLiteGraphStore(tmp_path / "graph.db")
+    store.save_graph(_deep_estate())
+    from agent_bom.api import stores as api_stores
+
+    original = api_stores._graph_store
+    try:
+        set_graph_store(store)
+        client = TestClient(app)
+        resp = client.get("/v1/graph/rollup?scan_id=estate-scan")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["mode"] == "rollup"
+        assert body["summary"]["top_level_count"] == 1
+        assert body["top_level"][0]["id"] == "org:acme"
+
+        drill = client.get("/v1/graph/rollup?scan_id=estate-scan&node=app:web")
+        assert drill.status_code == 200
+        assert {c["id"] for c in drill.json()["children"]} == {"server:s1", "server:s2"}
+    finally:
+        set_graph_store(original)
+
+
+def test_rollup_endpoint_rejects_bad_severity(tmp_path) -> None:
+    store = SQLiteGraphStore(tmp_path / "graph.db")
+    store.save_graph(_deep_estate())
+    from agent_bom.api import stores as api_stores
+
+    original = api_stores._graph_store
+    try:
+        set_graph_store(store)
+        client = TestClient(app)
+        resp = client.get("/v1/graph/rollup?scan_id=estate-scan&min_severity=bogus")
+        assert resp.status_code == 422
+    finally:
+        set_graph_store(original)
+
+
+def test_rollup_endpoint_requires_auth_when_key_configured(monkeypatch) -> None:
+    # With an API key configured, an unauthenticated request must be rejected
+    # by the same middleware that guards the sibling graph routes.
+    api_server.configure_api(api_key="rollup-secret-key")
+    try:
+        client = TestClient(app)
+        resp = client.get("/v1/graph/rollup", headers={"X-Agent-Bom-Tenant-ID": "tenant-alpha"})
+        assert resp.status_code == 401
+        # No exception detail or stack leaks into the body.
+        assert "Traceback" not in resp.text
+    finally:
+        api_server.configure_api(api_key=None)
+        api_server._runtime_api_key_seeded = False


### PR DESCRIPTION
## Summary

Past a few hundred nodes the topology graph is an unreadable hairball — the single biggest readability gap at estate scale. The estate is organised as a `CONTAINS` containment tree (org → account/folder/project → app → resource). This PR rolls the graph up along that tree so a 1000+ node estate renders as a handful of top-level container nodes, each carrying aggregate child counts, worst-severity, a per-severity histogram, and exposure / toxic-combination flags propagated from every descendant. The UI then drills down one level at a time instead of loading everything at once.

This is the backend roll-up. The UI graph-navigation surface that consumes it lands in a follow-up.

## What's in it

`src/agent_bom/graph/rollup.py` — pure read over the existing `UnifiedGraph`:

- **Roll-up by CONTAINS** (`rollup_view`) — collapse the graph along the containment hierarchy to top-level roots; each container carries aggregate descendant counts, by-type breakdown, worst-severity, per-severity histogram, and internet-exposed / toxic-combo flags rolled up from descendants. Orphan / flat-estate nodes are surfaced so nothing disappears.
- **Drill-down** (`drill_down`) — given a container id, return its direct children (one level), each with its own roll-up. O(direct children); the UI expands on demand.
- **Filtering** (`RollupFilters`) — optional min-severity, internet-exposed-only, toxic-combo-only, applied to descendants before aggregation so the view focuses on risk.
- **Attack-path-first mode** (`attack_path_view`) — return the nodes/edges on materialised attack paths first (the readable "what matters" view), with the rest collapsed into the standard roll-up.

Deterministic (sorted, stable ordering), bounded, cycle-safe, and never mutates the source graph.

## API

`GET /v1/graph/rollup` (additive route on `api/routes/graph.py`):

- `?node=<id>` — drill down into a container's direct children
- `?min_severity=`, `?exposed=true`, `?toxic=true` — risk filters
- `?mode=attack_path` — attack-path-first view

Reuses the same tenant / RBAC dependency as the sibling graph routes. Returns generic error messages — no exception detail leaks into responses.

## Scale

A test builds a 1311-node estate (1 org → 10 accounts → 100 apps → 1200 packages) and asserts the top-level view collapses to a single container with descendant counts and the per-severity histogram rolling up correctly. Drill-down returns exactly one level.

## Tests

Roll-up aggregates over a deep CONTAINS tree; 1000+ node estate stays small; one-level drill-down; each filter; attack-path mode; source graph unmutated after roll-up / drill-down / attack-path; deterministic output; endpoint returns top-level + drills down; rejects bad severity (422); and requires auth (401) when an API key is configured.

`ruff check` + `ruff format` + `mypy` clean on the changed files; pre-commit green; targeted graph test suites pass.
