### PR TITLE
docs: consolidate Unreleased changelog and refresh architecture/security/deployment docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,164 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+Deepens the cloud/CNAPP estate from a single-provider inventory into a
+multi-account, multi-region, tenant-scale model that rolls up readably in the
+graph, adds agentless workload (CWPP), audit-trail behavioral, and ASPM
+application views, and lands a read-only-by-default connect path on every cloud.
+All cloud access stays read-only and in-account: nothing leaves the customer's
+account.
+
+### Cloud / CNAPP
+- **Estate inventory deepened across all three clouds**, with every asset wired
+  into the unified graph: AWS (RDS, DynamoDB, Lambda, EKS, ELB, VPC, KMS,
+  Secrets Manager, CloudFront, ECR, Redshift, SNS/SQS) with multi-region
+  aggregation; Azure (Key Vault, Container Registry, SQL/PostgreSQL/MySQL, AKS,
+  network topology, messaging/cache/disks/App Service, and edge/WAF — App
+  Gateway, Front Door, API Management); GCP (GKE, Cloud Run, Functions, Cloud
+  SQL, VPC, disks, Pub/Sub).
+- **Tenant-scale account hierarchy as a navigable `CONTAINS` backbone:** AWS
+  Organizations (org / OUs / accounts / SCPs), Azure management-group tree with
+  multi-subscription fan-out, GCP Org → Folders → Projects fan-out, and a
+  Snowflake organization → accounts roll-up.
+- **Normalized cross-cloud resource model** so AWS, Azure, and GCP assets share
+  one schema and ingest into the graph identically.
+- **Read-only audit-trail ingestion.** CloudTrail, Azure Activity Log, and GCP
+  Cloud Audit Logs are read via read-only APIs and reduced to behavioral
+  `ACCESSED` / `INVOKED` graph edges (principal → resource, counts and
+  last-seen only — raw events never persist). Opt-in via
+  `AGENT_BOM_AUDIT_TRAIL`.
+- **Agentless AWS EBS disk side-scan (CWPP).** Snapshots a volume, attaches it
+  to an in-account collector, and reads package/filesystem metadata. Temp
+  snapshots and volumes are cleaned up in a guaranteed `try/finally`, with an
+  orphan sweep recovering after a hard crash; no block data leaves the account.
+- **Registry-wide container image sweep** across ECR, ACR, and GAR: enumerates
+  repositories and tags via read-only APIs, deduplicates by image digest, scans
+  freshest first, and caps work at `AGENT_BOM_REGISTRY_MAX_IMAGES`.
+- **Effective-permission foundation:** AWS IAM inline-policy enumeration (not
+  just attached managed policies), Azure RBAC role-assignment inventory with
+  `HAS_PERMISSION` edges, and GCP instance internet-exposure plus IAM privilege
+  classification.
+- **Cloud data sensitivity classified from resource tags/labels** across AWS,
+  Azure, and GCP.
+- **Snowflake estate depth:** identity/auth-posture graph with login-anomaly
+  detection (impossible travel, failed-login bursts) and MITRE tagging, object
+  and dependency-lineage graph, exfil graph (shares, external stages, sensitive
+  objects), data-pipeline objects (tasks/streams/pipes), integrations, iceberg
+  and external tables, and governance/activity discovery wired into the scan.
+- **CIS posture converges into the findings stream and the gate.** Cloud CIS
+  failures now flow into the unified findings stream and the severity gate,
+  drive the verbose posture headline, and render as a grouped, readable report
+  in the terminal and HTML at estate scale.
+- **Unified cloud-aware scan runs across every configured provider in one
+  command.** Providers are detected by credential source rather than a CLI on
+  `PATH`, native GCP service-account impersonation and Azure subscription
+  auto-derivation give keyless read-only connection, and inventory tolerates
+  partial permissions instead of failing when a role lacks a single grant.
+
+### Graph
+- **Estate-scale `CONTAINS` roll-up with drill-down.** A 1000+ node estate
+  collapses along its containment tree to a handful of top-level container
+  nodes, each carrying aggregate descendant counts, a by-type breakdown,
+  worst-severity, a per-severity histogram, and internet-exposed /
+  toxic-combination flags propagated from descendants; an attack-path-first
+  view and one-level drill-down are exposed at `GET /v1/graph/rollup`.
+- **ASPM correlation layer.** AppSec findings (SCA, secrets, IaC, container,
+  SBOM, AI-BOM) are organized around `APPLICATION` nodes via `BELONGS_TO`
+  edges, deduplicated across sources, with per-application risk rolled up.
+- **Toxic-combination evaluator emits enforceable findings** rather than only
+  annotating the graph.
+- **New cloud graph edges:** normalized cloud resources ingested as nodes, an
+  internet-exposure edge (public IP → load balancer), and a VM →
+  managed-identity privilege edge (`ASSUMES`).
+
+### Cost / FinOps
+- **LLM spend fused into the unified graph.** Per-node `cost_usd` /
+  `cost_usd_30d` attributes roll up along `CONTAINS` edges into
+  `subtree_cost_usd`, and nodes that are both high-spend and high-risk are
+  flagged `cost_risk_priority` for cost × exposure triage.
+
+### Identity / NHI
+- **Lifecycle enforcement for agent identities** with JIT (time-bound) grants.
+
+### Gateway / Runtime
+- **Policy engine hardened** with fail-closed evaluation, quarantine,
+  conditional access, a plugin surface, and OCSF webhook interop.
+- **Runtime-observed incidents feed back into the unified graph**, and the
+  gateway consumes graph reachability for pre-emptive blocking.
+- **Hardened outbound delivery foundation** with OTLP trace emission.
+
+### Remediation
+- **Advisory remediation foundation with least-privilege-to-apply.** Each fix
+  carries the concrete, minimal IAM actions the operator's own apply role would
+  need, plus optional text-only runbook/Terraform artifacts. Strictly advisory:
+  `applied` and `auto_remediation` are always false — agent-bom recommends,
+  the operator applies.
+
+### AI / MCP security
+- **Adversarial red-team series:** LLM-harnessed adversarial variant
+  generation, bias/toxicity/hallucination detectors, and an adversarial-coverage
+  governance score with live-target firing.
+- **Obfuscation-resistant prompt-injection detection** (raises detection on
+  obfuscated payloads from 24% to 100% on the bundled corpus).
+- **Credentials ranked by exposure even without a CVE**, and
+  **hardware/firmware attestation evidence ingest**.
+- **Deterministic tool/skills surfaces** so agent-side caching stays stable.
+
+### CLI
+- **Canonical front-door verbs** (`connect` / `scan` / `graph` / `report` /
+  `up`) as the primary entry path.
+- **Capability doctor** surfaces every gated feature, its current state, and
+  the unlock path.
+- **`scan` accepts an optional positional `PATH`**, and scans can be grouped
+  into parent-child batches.
+
+### API
+- **REST cloud-scanning endpoints** with MCP write-tool role enforcement.
+- **Shared backend contract and selection factory** for control-plane stores.
+
+### Deploy / Packaging
+- **One-apply EKS platform module** (`deploy/terraform/platform-eks/`) plus a
+  three-tier deploy-anywhere guide ([`docs/DEPLOY_PLATFORM.md`](docs/DEPLOY_PLATFORM.md)).
+- **Connect-a-cloud Terraform modules** provision one read-only role per cloud
+  (AWS `SecurityAudit`, Azure `Reader`, GCP `roles/viewer` +
+  `iam.securityReviewer`), with keyless federated-credential options and no
+  long-lived keys; CI enforces that the connect modules stay read-only.
+- **Keyless read-only collectors for EKS / GKE / AKS** via workload identity
+  (IRSA / Azure workload identity / GCP Workload Identity Federation).
+- **CloudFormation one-click read-only AWS scan** via CodeBuild.
+
+### UI
+- **Cross-domain overview landing page** and **cloud CIS benchmark drill-down**
+  on the compliance dashboard.
+
+### Changed
+- **Vulnerability cache auto-refreshes** and surfaces a freshness indicator.
+- Flat (non-graph) outputs prefer canonical findings for consistency with the
+  graph view.
+
+### Fixed
+- **Offline coverage gaps now warn instead of discarding real findings** (was a
+  silent false-negative).
+- **Go `go.mod` block-`require` parsing** no longer emits a phantom package, and
+  **Cargo manifests parse without a lockfile** including target and workspace
+  dependencies.
+- **Hardcoded-secret findings surface in JSON and SARIF**, not only the console,
+  and **SARIF locates dependency findings at their own ecosystem's manifest**.
+- **MCP `check` tool** parses pip specifiers and flags errors, reads
+  nonexistent explicit versions as not-clean, and raises a clean error (instead
+  of crashing) on an out-of-sandbox scan path.
+- **Legacy context graph reads `credential_env_vars`** so lateral-movement
+  analysis is no longer credential-blind, and the **CLI graph export includes
+  the cloud estate** (was local-only).
+- **Subscription-scoped cloud misconfigurations anchor to their account node**
+  in the graph.
+- **CLI degrades gracefully on low disk** instead of crashing, and the **cloud
+  inventory summary counts every asset collection**.
+- **SQLite/Postgres timestamp alignment, dedup, and cost-table DDL** reconciled
+  across the two store backends.
+- Request models reject unknown fields (`extra=forbid`), and cloud API routes
+  resolve CodeQL info-exposure and log-injection findings.
+
 ---
 
 ## [0.89.2] - 2026-06-22

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -281,6 +281,22 @@ graph LR
 
 The full contract for what the graph promises and what it does not — entity types, edge kinds, scaling tiers, re-baseline procedure, and known coverage gaps — is in [docs/graph/CONTRACT.md](graph/CONTRACT.md).
 
+### Estate-scale roll-up
+
+Past a few hundred nodes a flat topology graph is unreadable. The estate is
+organized as a `CONTAINS` containment tree (org → account/folder/project → app
+→ resource), and `src/agent_bom/graph/rollup.py` collapses the graph along that
+tree to a handful of top-level container nodes — each carrying aggregate
+descendant counts, a by-type breakdown, worst-severity, a per-severity
+histogram, and internet-exposed / toxic-combination flags propagated from every
+descendant. The UI (and `GET /v1/graph/rollup`) drills down one level at a time
+instead of loading the whole estate, with an attack-path-first view that returns
+the nodes on materialized attack paths first. The roll-up is a pure read over
+the existing `UnifiedGraph` — no new collection. Two further overlays enrich the
+same graph: an ASPM layer (`aspm_overlay.py`) that organizes AppSec findings
+around `APPLICATION` nodes, and a FinOps layer (`cost_overlay.py`) that fuses
+LLM spend onto nodes and rolls it up along `CONTAINS` into `subtree_cost_usd`.
+
 ---
 
 ## 4. Compliance Tagging
@@ -392,7 +408,12 @@ graph TB
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine (17 conditions) |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
 | MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (70 tools across core, operator, runtime-catalog, and specialized modules) |
-| Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse |
+| Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse estate inventory + CIS posture |
+| Cloud side-scan | `src/agent_bom/cloud/side_scan.py` | Agentless AWS EBS disk scan (CWPP) — in-account snapshot/volume, guaranteed `try/finally` cleanup + orphan sweep |
+| Registry sweep | `src/agent_bom/cloud/registry_sweep.py` | Registry-wide image enumeration + scan (ECR/ACR/GAR), digest-deduped, capped |
+| Audit trail | `src/agent_bom/cloud/audit_trail.py` | Read-only CloudTrail/Activity Log/Cloud Audit ingest → behavioral `ACCESSED`/`INVOKED` graph edges (counts only) |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |
 | Context Graph | `src/agent_bom/context_graph.py` | Lateral movement analysis — see [Graph Contract](graph/CONTRACT.md) for entity/edge coverage, accuracy guarantees, and scaling boundaries |
+| Graph overlays | `src/agent_bom/graph/` | `rollup.py` (estate-scale `CONTAINS` roll-up + drill-down), `aspm_overlay.py` (application correlation), `cost_overlay.py` (LLM-spend fusion) |
+| Remediation | `src/agent_bom/remediation.py` | Advisory-only fixes with least-privilege-to-apply (`applied`/`auto_remediation` always false) |
 | Guard | `src/agent_bom/guard.py` | Pre-install CVE scan for pip/npm packages |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -242,6 +242,30 @@ sequenceDiagram
     Reporter-->>User: Console / JSON / SARIF / HTML / SBOM
 ```
 
+### Component model and extensibility direction
+
+The pipeline is built from four component roles: **scanners** (discover and
+produce raw findings), **enrichers** (add CVSS/EPSS/KEV/GHSA, compliance, cloud
+and cost context), **matchers/correlators** (`correlate.py`,
+`cross_env_correlation.py`, graph overlays), and a **reporter**. Scanner drivers
+are already registered through `scanners/registry.py` with capability metadata
+(surfaced by `agent-bom capabilities`), and `api/pipeline.py` (`ScanPipeline`,
+`_run_scan_sync`) runs the stages and emits per-step DAG events.
+
+Two seams are being formalized so new sources and detections plug in without
+editing core orchestration:
+
+- a **router** that resolves an input or connected source (path, image ref,
+  cloud credential, MCP config, ingested SARIF) to the scanner and provider
+  drivers that handle it, consolidating selection logic currently split across
+  the CLI, the pipeline, and `scanners/__init__.py`; and
+- an **orchestrator** that runs registered `scan → enrich → correlate → graph →
+  findings` stages, with enrichers and matchers registered through the same
+  capability-metadata pattern scanners already use.
+
+This keeps detection-as-code rule packs and additional providers additive at the
+registry boundary rather than as edits to the scan path.
+
 ---
 
 ## 3. Blast Radius Propagation

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -397,6 +397,28 @@ agent-bom agents --azure-subscription-id xxx \
 3. Extract package dependencies
 4. Scan for vulnerabilities
 
+### Read-only cloud connect (Terraform onboarding)
+
+The maintained connect modules under `deploy/terraform/connect-{aws,azure,gcp}/`
+provision exactly **one read-only role per cloud** for onboarding — AWS
+`SecurityAudit`, Azure built-in `Reader`, GCP `roles/viewer` +
+`roles/iam.securityReviewer`. No write actions are granted, AWS enforces an
+`ExternalId`, and CI gates the modules so they cannot drift away from
+read-only. Each module can issue a **keyless federated credential** (OIDC for
+Azure, Workload Identity Federation for GCP, IRSA for AWS) so no long-lived
+key is created.
+
+In-cluster collectors authenticate the same keyless way: the EKS / GKE / AKS
+collectors use workload identity and call only `List*` / `Describe*` / `get`
+APIs. Nothing leaves the account — see
+[`SECURITY_ARCHITECTURE.md` § Cloud connect — read-only by design](SECURITY_ARCHITECTURE.md#cloud-connect--read-only-by-design).
+
+For a one-`terraform apply` control plane (VPC, EKS, RDS Postgres, IRSA, and
+the Helm release wired together), use the EKS platform module at
+`deploy/terraform/platform-eks/` — walked through in
+[`DEPLOY_PLATFORM.md`](DEPLOY_PLATFORM.md). A CloudFormation one-click read-only
+AWS scan via CodeBuild is also available for a no-infrastructure trial.
+
 ---
 
 ## 📊 Scalability Patterns

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -31,6 +31,31 @@ agent-bom agents --offline
 
 In offline mode, **zero external API calls** are made. All scanning uses the pre-synced local database only.
 
+### Cloud connect — read-only by design
+
+Cloud scanning never moves customer data out of the account. The contract:
+
+- **One read-only role per cloud.** The connect Terraform modules grant exactly
+  one identity per provider — AWS `SecurityAudit` (optionally `ViewOnlyAccess`),
+  Azure built-in `Reader` (optionally `Security Reader`), GCP `roles/viewer`
+  plus `roles/iam.securityReviewer`. No write actions are granted, and CI
+  enforces that the connect modules stay read-only.
+- **Keyless where possible.** Collectors authenticate via workload identity
+  (IRSA, Azure workload identity, GCP Workload Identity Federation) and
+  short-lived federated credentials — no long-lived keys are created by default.
+  Providers are detected by credential source, not by a CLI on `PATH`.
+- **Metadata only leaves the collector.** Inventory emits asset metadata, CVE
+  counts, CIS results, and secret *type/location* — never file contents, secret
+  values, or raw block data. Audit-trail ingestion reduces CloudTrail / Activity
+  Log / Cloud Audit events to `(principal, resource, action)` counts and
+  last-seen timestamps; raw events never persist.
+- **Agentless workload scanning stays in-account.** The AWS EBS side-scan
+  (`src/agent_bom/cloud/side_scan.py`) snapshots a volume, attaches it to an
+  in-account collector, reads package/filesystem metadata, and deletes the temp
+  snapshot and volume in a guaranteed `try/finally`. An orphan sweep recovers
+  any leftover temp resources (tagged by the scanner) after a hard crash, so a
+  failed run leaves nothing behind. No volume bytes leave the account.
+
 ### Network Enforcement
 
 - All external calls use HTTPS with full TLS certificate verification (`verify=True`)


### PR DESCRIPTION
Consolidates the `[Unreleased]` changelog for the full post-0.89.2 range into themed sections (Cloud/CNAPP, Graph, Cost, Identity/NHI, Gateway/Runtime, Remediation, AI/MCP, CLI, API, Deploy, UI, Changed, Fixed), mirroring the existing release-note style. Stays unreleased.

Architecture docs refreshed against source:
- ARCHITECTURE.md — module rows for cloud side-scan, registry sweep, audit-trail, graph overlays, remediation; new estate-scale roll-up subsection (graph/rollup.py, GET /v1/graph/rollup) plus ASPM and cost overlays.
- SECURITY_ARCHITECTURE.md — read-only-by-design cloud-connect subsection: one read-only role per cloud, keyless workload identity, metadata-only egress, count-reduced audit-trail, in-account side-scan with guaranteed cleanup.
- DEPLOYMENT.md — Terraform read-only onboarding (connect-aws/azure/gcp), keyless federation, in-cluster collectors, one-apply EKS module, CloudFormation one-click.

Docs-only; no source or test changes.