### PR TITLE
feat(ui): gateway live-feed card on the activity page

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -14,6 +14,7 @@
 /coverage
 /playwright-report
 /test-results
+/screenshots
 
 # next.js
 /.next/

--- a/ui/app/activity/page.tsx
+++ b/ui/app/activity/page.tsx
@@ -13,6 +13,7 @@ import {
 import { api, formatDate } from "@/lib/api";
 import type { ActivityTimeline } from "@/lib/api";
 import { IntegrationRequiredState } from "@/components/integration-required-state";
+import { GatewayLiveFeedCard } from "@/components/gateway-live-feed-card";
 import {
   ResponsiveContainer,
   BarChart,
@@ -50,16 +51,21 @@ export default function ActivityPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-20 text-zinc-400">
-        <Loader2 className="h-6 w-6 animate-spin mr-2" />
-        Loading activity timeline...
+      <div className="space-y-6">
+        <GatewayLiveFeedCard />
+        <div className="flex items-center justify-center py-20 text-zinc-400">
+          <Loader2 className="h-6 w-6 animate-spin mr-2" />
+          Loading activity timeline...
+        </div>
       </div>
     );
   }
 
   if (error) {
     return (
-      <IntegrationRequiredState
+      <div className="space-y-6">
+        <GatewayLiveFeedCard />
+        <IntegrationRequiredState
         title="Activity timeline integration is not configured"
         summary="This page reconstructs agent and tool activity from query history and AI observability events. Core scanning and graph workflows work without it. The current cloud integration for this page uses Snowflake."
         requirement="Cloud telemetry integration on the API host"
@@ -69,13 +75,19 @@ export default function ActivityPage() {
           "Tool-call and model-usage activity over time",
           "Latency, status, and event volume from observability traces",
         ]}
-        detail={error}
-        onRetry={load}
-      />
+          detail={error}
+          onRetry={load}
+        />
+      </div>
     );
   }
 
-  if (!timeline) return null;
+  if (!timeline)
+    return (
+      <div className="space-y-6">
+        <GatewayLiveFeedCard />
+      </div>
+    );
 
   const filteredQueries = timeline.query_history.filter(
     (q) =>
@@ -103,6 +115,9 @@ export default function ActivityPage() {
 
   return (
     <div className="space-y-6">
+      {/* Gateway live feed (#54) */}
+      <GatewayLiveFeedCard />
+
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>

--- a/ui/components/gateway-live-feed-card.tsx
+++ b/ui/components/gateway-live-feed-card.tsx
@@ -20,7 +20,6 @@
  */
 
 import { useEffect, useState } from "react";
-import { Activity } from "lucide-react";
 import {
   api,
   formatDate,
@@ -52,26 +51,6 @@ const SAMPLE_FEED_EVENTS: GatewayFeedEvent[] = [
     source: "proxy",
   },
   {
-    ts: "2026-06-26T14:30:41Z",
-    agent: "support-copilot",
-    action_type: "tool_call_authorized",
-    target: "zendesk.update_ticket",
-    detail: "authorized",
-    tenant: "support",
-    shadow: false,
-    source: "proxy",
-  },
-  {
-    ts: "2026-06-26T14:30:18Z",
-    agent: "finance-reconciliation-agent",
-    action_type: "tool_call_blocked",
-    target: "stripe.create_refund",
-    detail: "Amount exceeds policy ceiling",
-    tenant: "finance",
-    shadow: false,
-    source: "proxy",
-  },
-  {
     ts: "2026-06-26T14:29:55Z",
     agent: "data-analyst-agent",
     action_type: "llm_call",
@@ -81,30 +60,7 @@ const SAMPLE_FEED_EVENTS: GatewayFeedEvent[] = [
     shadow: false,
     source: "observability",
   },
-  {
-    ts: "2026-06-26T14:29:30Z",
-    agent: "recruiting-agent",
-    action_type: "data_filter_applied",
-    target: "workday.search_candidates",
-    detail: "PII redacted",
-    tenant: "people-ops",
-    shadow: false,
-    source: "proxy",
-  },
 ];
-
-const SAMPLE_KPIS: GatewayFeedKpis = {
-  schema_version: "1.0",
-  tenant_id: "sample",
-  generated_at: "2026-06-26T14:31:07Z",
-  calls_today: 4485,
-  blocked_today: 312,
-  shadow_ai_blocked: 247,
-  data_filters_applied: 1893,
-  tool_calls_authorized: 4173,
-  llm_calls: 1204,
-  uptime_seconds: 18732,
-};
 
 // ── Presentation helpers ─────────────────────────────────────────────────────
 
@@ -208,7 +164,7 @@ export function GatewayLiveFeedCard({
         // No live traffic (or API unreachable): show a labelled sample so the
         // card always renders something meaningful.
         setEvents(SAMPLE_FEED_EVENTS);
-        setKpis(liveKpis ?? SAMPLE_KPIS);
+        setKpis(liveKpis);
         setIsSample(true);
       }
       setLoading(false);
@@ -235,7 +191,7 @@ export function GatewayLiveFeedCard({
       {/* Header */}
       <div className="flex items-center justify-between gap-3 border-b border-zinc-800 px-4 py-3">
         <h3 className="flex min-w-0 items-center gap-2 text-sm font-semibold text-zinc-200">
-          <Activity className="h-4 w-4 shrink-0 text-emerald-400" />
+          <span className="h-2 w-2 shrink-0 rounded-full bg-emerald-400" />
           <span className="truncate">Gateway Live Feed</span>
         </h3>
         {isSample ? (

--- a/ui/components/gateway-live-feed-card.tsx
+++ b/ui/components/gateway-live-feed-card.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+/**
+ * Gateway Live Feed card (#54).
+ *
+ * One self-contained card that renders the most recent gateway decisions as a
+ * compact, glanceable stream. Each row is:
+ *   • a status dot — green = allowed, red = blocked/denied
+ *   • a decision title (e.g. "Tool call authorized", "Shadow AI detected")
+ *   • the agent → tool.action path in monospace
+ *   • a muted sub-label — the calling profile (tenant) or the decision note
+ * with an aggregate footer summarising the day.
+ *
+ * Data source: the live gateway feed (`/v1/gateway/feed` + `/v1/gateway/feed/kpis`)
+ * already exposed by `api.getGatewayFeed` / `api.getGatewayFeedKpis`. When the
+ * API is unreachable or returns no events (e.g. a fresh install with no proxy
+ * traffic), the card falls back to a clearly-labelled sample so the surface is
+ * never blank; the fallback is marked "sample data" so it is never mistaken for
+ * live fleet activity.
+ */
+
+import { useEffect, useState } from "react";
+import { Activity } from "lucide-react";
+import {
+  api,
+  formatDate,
+  type GatewayFeedEvent,
+  type GatewayFeedKpis,
+} from "@/lib/api";
+
+// ── Sample fallback (illustrative only — never live data) ────────────────────
+
+const SAMPLE_FEED_EVENTS: GatewayFeedEvent[] = [
+  {
+    ts: "2026-06-26T14:31:07Z",
+    agent: "payroll-agent",
+    action_type: "data_filter_applied",
+    target: "snowflake.query",
+    detail: "Resume data masked",
+    tenant: "eng-team",
+    shadow: false,
+    source: "proxy",
+  },
+  {
+    ts: "2026-06-26T14:30:52Z",
+    agent: "unknown-mcp-client",
+    action_type: "tool_call_blocked",
+    target: "github.create_pull_request",
+    detail: "Shadow AI detected",
+    tenant: "platform",
+    shadow: true,
+    source: "proxy",
+  },
+  {
+    ts: "2026-06-26T14:30:41Z",
+    agent: "support-copilot",
+    action_type: "tool_call_authorized",
+    target: "zendesk.update_ticket",
+    detail: "authorized",
+    tenant: "support",
+    shadow: false,
+    source: "proxy",
+  },
+  {
+    ts: "2026-06-26T14:30:18Z",
+    agent: "finance-reconciliation-agent",
+    action_type: "tool_call_blocked",
+    target: "stripe.create_refund",
+    detail: "Amount exceeds policy ceiling",
+    tenant: "finance",
+    shadow: false,
+    source: "proxy",
+  },
+  {
+    ts: "2026-06-26T14:29:55Z",
+    agent: "data-analyst-agent",
+    action_type: "llm_call",
+    target: "anthropic/claude-opus-4",
+    detail: "$0.0142 · 3,210 tokens",
+    tenant: "analytics",
+    shadow: false,
+    source: "observability",
+  },
+  {
+    ts: "2026-06-26T14:29:30Z",
+    agent: "recruiting-agent",
+    action_type: "data_filter_applied",
+    target: "workday.search_candidates",
+    detail: "PII redacted",
+    tenant: "people-ops",
+    shadow: false,
+    source: "proxy",
+  },
+];
+
+const SAMPLE_KPIS: GatewayFeedKpis = {
+  schema_version: "1.0",
+  tenant_id: "sample",
+  generated_at: "2026-06-26T14:31:07Z",
+  calls_today: 4485,
+  blocked_today: 312,
+  shadow_ai_blocked: 247,
+  data_filters_applied: 1893,
+  tool_calls_authorized: 4173,
+  llm_calls: 1204,
+  uptime_seconds: 18732,
+};
+
+// ── Presentation helpers ─────────────────────────────────────────────────────
+
+function isBlocked(event: GatewayFeedEvent): boolean {
+  return event.action_type === "tool_call_blocked";
+}
+
+function decisionTitle(event: GatewayFeedEvent): string {
+  if (event.shadow) return "Shadow AI detected";
+  switch (event.action_type) {
+    case "tool_call_authorized":
+      return "Tool call authorized";
+    case "tool_call_blocked":
+      return event.detail && event.detail !== "blocked by gateway policy"
+        ? capitalize(event.detail)
+        : "Tool call blocked";
+    case "data_filter_applied":
+      return event.detail ? capitalize(event.detail) : "Sensitive data masked";
+    case "llm_call":
+      return "LLM call routed";
+    default:
+      return "Gateway decision";
+  }
+}
+
+function subLabel(event: GatewayFeedEvent): string {
+  const tenant = event.tenant?.trim();
+  if (tenant && tenant !== "unknown" && tenant !== "default") {
+    return `${tenant} profile`;
+  }
+  return event.detail?.trim() || "—";
+}
+
+function capitalize(value: string): string {
+  if (!value) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function formatUptime(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.round((seconds % 3600) / 60);
+  return m > 0 ? `${h}h ${m}m` : `${h}h`;
+}
+
+function eventTime(ts: string): string {
+  if (!ts) return "—";
+  try {
+    return formatDate(ts);
+  } catch {
+    return ts;
+  }
+}
+
+function footerText(kpis: GatewayFeedKpis | null): string {
+  if (!kpis) return "Awaiting gateway telemetry";
+  const parts = [`${kpis.calls_today.toLocaleString()} calls today`];
+  if (kpis.uptime_seconds != null) {
+    parts.push(`${formatUptime(kpis.uptime_seconds)} uptime`);
+  }
+  parts.push(`${kpis.shadow_ai_blocked.toLocaleString()} shadow AIs blocked`);
+  return parts.join(" · ");
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+interface GatewayLiveFeedCardProps {
+  maxItems?: number;
+  className?: string;
+}
+
+export function GatewayLiveFeedCard({
+  maxItems = 8,
+  className,
+}: GatewayLiveFeedCardProps) {
+  const [events, setEvents] = useState<GatewayFeedEvent[]>([]);
+  const [kpis, setKpis] = useState<GatewayFeedKpis | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [isSample, setIsSample] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      const [feedResult, kpiResult] = await Promise.allSettled([
+        api.getGatewayFeed(maxItems),
+        api.getGatewayFeedKpis(),
+      ]);
+      if (cancelled) return;
+
+      const liveEvents =
+        feedResult.status === "fulfilled" ? feedResult.value.events : [];
+      const liveKpis = kpiResult.status === "fulfilled" ? kpiResult.value : null;
+
+      if (liveEvents.length > 0) {
+        setEvents(liveEvents);
+        setKpis(liveKpis);
+        setIsSample(false);
+      } else {
+        // No live traffic (or API unreachable): show a labelled sample so the
+        // card always renders something meaningful.
+        setEvents(SAMPLE_FEED_EVENTS);
+        setKpis(liveKpis ?? SAMPLE_KPIS);
+        setIsSample(true);
+      }
+      setLoading(false);
+    };
+
+    const timer = window.setTimeout(() => void load(), 0);
+    const interval = window.setInterval(() => void load(), 15000);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+      window.clearInterval(interval);
+    };
+  }, [maxItems]);
+
+  const rows = events.slice(0, maxItems);
+
+  return (
+    <div
+      data-testid="gateway-live-feed"
+      className={`flex flex-col overflow-hidden rounded-xl border border-zinc-800 bg-zinc-900 ${
+        className ?? ""
+      }`}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3 border-b border-zinc-800 px-4 py-3">
+        <h3 className="flex min-w-0 items-center gap-2 text-sm font-semibold text-zinc-200">
+          <Activity className="h-4 w-4 shrink-0 text-emerald-400" />
+          <span className="truncate">Gateway Live Feed</span>
+        </h3>
+        {isSample ? (
+          <span className="shrink-0 rounded-full border border-zinc-700 bg-zinc-800 px-2 py-0.5 text-[10px] font-medium text-zinc-400">
+            sample data
+          </span>
+        ) : (
+          <span className="flex shrink-0 items-center gap-1.5 text-[10px] font-medium text-emerald-400">
+            <span className="relative flex h-1.5 w-1.5">
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+              <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-400" />
+            </span>
+            live
+          </span>
+        )}
+      </div>
+
+      {/* Rows */}
+      {loading ? (
+        <div className="px-4 py-8 text-center text-xs text-zinc-600">
+          Loading gateway activity…
+        </div>
+      ) : rows.length === 0 ? (
+        <div className="px-4 py-8 text-center text-xs text-zinc-600">
+          No gateway activity yet.
+        </div>
+      ) : (
+        <ul className="divide-y divide-zinc-800">
+          {rows.map((event, i) => {
+            const blocked = isBlocked(event);
+            return (
+              <li
+                key={`${event.ts}-${event.agent}-${i}`}
+                className="flex items-start gap-3 px-4 py-3 transition-colors hover:bg-zinc-800/40"
+              >
+                {/* Status dot */}
+                <span
+                  className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${
+                    blocked ? "bg-red-500" : "bg-emerald-500"
+                  }`}
+                  aria-label={blocked ? "blocked" : "allowed"}
+                />
+
+                {/* Text column — min-w-0 lets children truncate instead of overflow */}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="truncate text-sm font-medium text-zinc-100">
+                      {decisionTitle(event)}
+                    </span>
+                    <time className="shrink-0 text-[10px] tabular-nums text-zinc-600">
+                      {eventTime(event.ts)}
+                    </time>
+                  </div>
+                  <code
+                    className="mt-0.5 block truncate font-mono text-xs text-zinc-400"
+                    title={`${event.agent} → ${event.target}`}
+                  >
+                    {event.agent} → {event.target}
+                  </code>
+                  <p className="mt-0.5 truncate text-xs text-zinc-500">
+                    {subLabel(event)}
+                  </p>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {/* Aggregate footer */}
+      <div className="mt-auto border-t border-zinc-800 px-4 py-2.5">
+        <p className="truncate text-center text-[11px] tabular-nums text-zinc-500">
+          {footerText(kpis)}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/ui/e2e/gateway-live-feed-card.spec.ts
+++ b/ui/e2e/gateway-live-feed-card.spec.ts
@@ -1,0 +1,143 @@
+import { expect, test } from "@playwright/test";
+
+// Renders the gateway live-feed card (#54) against mocked live data — including
+// a deliberately overlong agent/target path — and captures it at a narrow
+// (390px) and wide (1280px) viewport to prove text stays contained.
+
+const SHOTS = `${process.env.LIVE_FEED_SHOT_DIR ?? "screenshots"}`;
+
+const feedEvents = [
+  {
+    ts: "2026-06-26T14:31:07Z",
+    agent: "payroll-agent",
+    action_type: "data_filter_applied",
+    target: "snowflake.query",
+    detail: "Resume data masked",
+    tenant: "eng-team",
+    shadow: false,
+    source: "proxy",
+  },
+  {
+    ts: "2026-06-26T14:30:52Z",
+    agent: "extremely-long-undeclared-shadow-mcp-client-instance-name-0xdeadbeef",
+    action_type: "tool_call_blocked",
+    target: "github.create_pull_request_with_a_very_long_action_identifier_overflow_probe",
+    detail: "Shadow AI detected",
+    tenant: "platform",
+    shadow: true,
+    source: "proxy",
+  },
+  {
+    ts: "2026-06-26T14:30:41Z",
+    agent: "support-copilot",
+    action_type: "tool_call_authorized",
+    target: "zendesk.update_ticket",
+    detail: "authorized",
+    tenant: "support",
+    shadow: false,
+    source: "proxy",
+  },
+  {
+    ts: "2026-06-26T14:30:18Z",
+    agent: "finance-reconciliation-agent",
+    action_type: "tool_call_blocked",
+    target: "stripe.create_refund",
+    detail: "Amount exceeds policy ceiling",
+    tenant: "finance",
+    shadow: false,
+    source: "proxy",
+  },
+  {
+    ts: "2026-06-26T14:29:55Z",
+    agent: "data-analyst-agent",
+    action_type: "llm_call",
+    target: "anthropic/claude-opus-4",
+    detail: "$0.0142 · 3,210 tokens",
+    tenant: "analytics",
+    shadow: false,
+    source: "observability",
+  },
+];
+
+const kpis = {
+  schema_version: "1.0",
+  tenant_id: "default",
+  generated_at: "2026-06-26T14:31:07Z",
+  calls_today: 4485,
+  blocked_today: 312,
+  shadow_ai_blocked: 247,
+  data_filters_applied: 1893,
+  tool_calls_authorized: 4173,
+  llm_calls: 1204,
+  uptime_seconds: 18732,
+};
+
+test("gateway live feed card renders without overflow at both widths", async ({
+  page,
+}) => {
+  await page.route("**/health", (route) =>
+    route.fulfill({ contentType: "application/json", body: JSON.stringify({ status: "ok" }) }),
+  );
+  await page.route("**/v1/auth/me", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        authenticated: true,
+        auth_required: false,
+        configured_modes: [],
+        recommended_ui_mode: "no_auth",
+        auth_method: null,
+        subject: null,
+        role: null,
+        role_summary: null,
+        tenant_id: "default",
+        memberships: [],
+        request_id: "req-feed-e2e",
+        trace_id: "trace-feed-e2e",
+        span_id: "span-feed-e2e",
+      }),
+    }),
+  );
+  await page.route("**/v1/gateway/feed/kpis", (route) =>
+    route.fulfill({ contentType: "application/json", body: JSON.stringify(kpis) }),
+  );
+  await page.route("**/v1/gateway/feed*", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        schema_version: "1.0",
+        tenant_id: "default",
+        generated_at: "2026-06-26T14:31:07Z",
+        count: feedEvents.length,
+        events: feedEvents,
+      }),
+    }),
+  );
+
+  const card = page.getByTestId("gateway-live-feed");
+
+  // Narrow (mobile) viewport.
+  await page.setViewportSize({ width: 390, height: 900 });
+  await page.goto("/activity");
+  await expect(card).toBeVisible();
+  await expect(card.getByText("Gateway Live Feed")).toBeVisible();
+  await expect(card.getByText(/4,485 calls today/)).toBeVisible();
+
+  // No row's content extends past the card's right edge.
+  const cardBox = await card.boundingBox();
+  const codeEls = card.locator("code");
+  const codeCount = await codeEls.count();
+  expect(codeCount).toBeGreaterThan(0);
+  for (let i = 0; i < codeCount; i++) {
+    const box = await codeEls.nth(i).boundingBox();
+    if (box && cardBox) {
+      expect(box.x + box.width).toBeLessThanOrEqual(cardBox.x + cardBox.width + 1);
+    }
+  }
+  await card.screenshot({ path: `${SHOTS}/live-feed-card-390.png` });
+
+  // Wide (desktop) viewport.
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await expect(card).toBeVisible();
+  await card.screenshot({ path: `${SHOTS}/live-feed-card-1280.png` });
+});


### PR DESCRIPTION
Closes #54.

Adds a single, self-contained gateway live-feed card to the activity page. Each row shows a status dot (red = blocked tool call, green otherwise), the decision title, the `agent → tool.action` in monospace, a muted profile/decision sub-label, and an aggregate footer.

- Wired to the existing real feed API (`/v1/gateway/feed` + `/v1/gateway/feed/kpis`) with a 15s refresh; falls back to a clearly-labelled sample set only when the API is unreachable or returns zero events, so the card is never blank.
- Footer uptime is derived from real `uptime_seconds`, not a fabricated percentage.
- Long agent/target strings ellipsis-truncate at narrow widths and render in full when wide; a Playwright spec asserts no row overflows the card at 390px and 1280px.
- Reuses existing dashboard tokens/components. typecheck + lint clean.