### PR TITLE
docs: align CLI/API/README surfaces with current commands and capabilities

### DIFF
--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -106,13 +106,18 @@ docker run --rm -v "$(pwd):/workspace" agentbom/agent-bom:latest iac /workspace
 - AI/MCP coverage across agents, MCP, skills, AI models/datasets, runtime,
   containers, cloud, IaC, and GPU
 - Supply-chain scanning across 15 package ecosystems with OSV/GHSA enrichment
-- Cloud estate inventory (AWS/Azure/GCP, read-only), non-human identity
-  governance (NHI discovery, credential-expiry, access review), and LLM cost
-  forecasting with chargeback and spend-anomaly detection
+- Read-only, keyless cloud estate inventory (AWS/Azure/GCP/Snowflake) plus CIS
+  benchmarks, registry-wide container image sweeps (ECR/ACR/GAR), and agentless
+  AWS EBS disk side-scan (snapshot-based CWPP, read-only)
+- Non-human identity governance (NHI discovery, credential-expiry, access
+  review) and LLM cost forecasting with chargeback and spend-anomaly detection
 - Malicious-model detection via safe pickle-opcode disassembly (no execution)
 - One unified `Finding` model and `ContextGraph` across CLI, CI, API,
-  dashboard, reports, and MCP tools
-- Multi-hop attack-path fusion for humans and headless agent workflows
+  dashboard, reports, and MCP tools — with ASPM correlation around applications,
+  LLM cost fused onto resources, read-only audit-trail behavioral edges, and an
+  estate-scale `CONTAINS` roll-up with drill-down for large clouds
+- Multi-hop attack-path fusion plus advisory, blast-radius-ordered remediation
+  plans for humans and headless agent workflows
 - Runtime MCP protection — inline firewall enforcement, secure-by-default
   gateway, A2A/MCP auth-posture checks — plus tamper-evident evidence exports
 
@@ -121,7 +126,7 @@ docker run --rm -v "$(pwd):/workspace" agentbom/agent-bom:latest iac /workspace
 The promoted self-hosted rollout is a scoped operator stack, not one forced
 runtime monolith. Teams typically deploy only the surfaces they need:
 
-- **scan**: discovery, inventory, CVE, image, IaC, Kubernetes, cloud estate, AI model/dataset, and supply-chain analysis
+- **scan**: discovery, inventory, CVE, image, IaC, Kubernetes, cloud estate (with registry-wide image sweep and agentless EBS disk side-scan), AI model/dataset, and supply-chain analysis
 - **fleet**: endpoint and collector inventory pushed into the control plane
 - **identity / cost**: non-human identity governance and LLM spend forecasting, chargeback, and anomaly detection
 - **proxy / runtime**: inline MCP firewall enforcement near selected workloads

--- a/README.md
+++ b/README.md
@@ -74,7 +74,11 @@ the credential environment names in reach, and the agents that can call it.
 
 Findings converge on one unified `Finding` model and a unified `ContextGraph`,
 so multi-hop attack-path fusion, blast radius, and exposure scoring all read
-from the same evidence.
+from the same evidence. The graph adds correlation overlays on top of that base:
+an ASPM layer that organizes AppSec findings around the application they belong
+to, LLM cost fused onto the resources that incur it, read-only cloud audit-trail
+activity as behavioral edges, and an estate-scale `CONTAINS` roll-up with
+drill-down so large clouds stay readable instead of one sprawling canvas.
 
 <p align="center">
   <picture>
@@ -217,6 +221,7 @@ Screenshot capture rules and the full manifest live in
 | Goal | Command | Artifact |
 |---|---|---|
 | Local agent and MCP inventory | `agent-bom agents` | findings, AI BOM, graph-ready JSON |
+| Read-only cloud onboarding | `agent-bom connect aws` | exact read-only grant + opt-in env var; no network I/O until you opt in |
 | Guided local onboarding | `agent-bom quickstart --dry-run --offline` | scan, sample-data, and local API/UI next steps |
 | One-command onboarding | `agent-bom quickstart --run --offline` | writes sample, runs a graph-persisting scan, seeds a baseline gateway policy |
 | Repo and lockfile scan | `agent-bom agents -p .` | package findings, SARIF/SBOM/HTML when requested |
@@ -228,6 +233,8 @@ Screenshot capture rules and the full manifest live in
 | Snowflake AI BOM + CIS | `agent-bom agents --snowflake` | Cortex agents, Snowpark apps, and CIS posture (read-only, key-pair) |
 | LLM cost forecast | `agent-bom cost forecast` | spend burn-rate, budget runway, and chargeback posture |
 | Non-human identity posture | `agent-bom identity credential-expiry` | expiring/overdue NHI credentials and access reviews |
+| Advisory remediation plan | `agent-bom remediate -p .` | prioritized, blast-radius-ordered fixes (optional `--apply` / `--open-pr`) |
+| Gated-capability readiness | `agent-bom capabilities` | every gated feature: state, why, and how to unlock |
 | CI gate | `uses: msaad00/agent-bom@v0.89.2` | SARIF, PR summary, optional code-scanning upload |
 | MCP tools | `pip install 'agent-bom[mcp-server]' && agent-bom mcp server` | strict-args security tools for MCP clients |
 | Local API/UI | `pip install 'agent-bom[ui]' && agent-bom serve` | API plus bundled dashboard |
@@ -289,6 +296,11 @@ role — because each platform's grant primitive is different. Everything else i
 identical: enable with `AGENT_BOM_<PROVIDER>_INVENTORY=1`, authenticate with the
 cloud's own identity (never a secret handed to agent-bom), get the same graph
 and findings out.
+
+`agent-bom connect aws | azure | gcp | snowflake` prints the exact read-only
+setup for each source — the Terraform module, the opt-in inventory env var, and
+whether local credentials are already detectable — without doing any network
+I/O until you opt in.
 
 | Cloud | Read-only grant | Keyless / token auth | Enable | Scan |
 |---|---|---|---|---|

--- a/docs/CLI_MAP.md
+++ b/docs/CLI_MAP.md
@@ -1,15 +1,29 @@
 # CLI Command Map
 
-`agent-bom` ships 48 top-level commands (plus an inline `upgrade`) under a
-single Click entry point. The CLI groups them into 7 help categories — run
+`agent-bom` exposes 50 visible top-level commands (plus hidden aliases such as
+`scan`, `up`, `guard`, `run`, `runtime`, and `registry`) under a single Click
+entry point. The CLI groups the visible commands into help categories — run
 `agent-bom --help` to see this layout live. Grouping is defined in
 [`../src/agent_bom/cli/_grouped_help.py`](../src/agent_bom/cli/_grouped_help.py).
 
-Many commands are themselves groups with subcommands (e.g. `cloud`, `identity`,
-`runtime`, `mcp`). This map covers the top-level surface; run `<command> --help`
-for subcommands.
+Many commands are themselves groups with subcommands (e.g. `cloud`, `connect`,
+`identity`, `runtime`, `mcp`). This map covers the top-level surface; run
+`<command> --help` for subcommands.
 
 ---
+
+## Front door (canonical verbs)
+
+The onboarding path is `connect` → `scan` → `graph` → `report`, with `up` to run
+the platform locally. These verbs front the same evidence model.
+
+| Command | What it does |
+|---|---|
+| `connect` | Read-only onboard a cloud or data source (`aws`/`azure`/`gcp`/`snowflake`). Prints the exact read-only grant + opt-in env var; performs no network I/O until you opt in. |
+| `scan` | Discover agents, extract dependencies, scan for vulnerabilities. Accepts an optional positional `PATH`. Front-door equivalent of `agents`. |
+| `graph` | Export the transitive dependency / context graph from a saved JSON scan report. |
+| `report` | Reporting group — history, diff, analytics, narrative, dashboard. |
+| `up` | Run the platform locally (API + bundled dashboard). Alias of `serve`. |
 
 ## Scanning
 
@@ -22,8 +36,9 @@ Inventory, package, image, IaC, cloud, and skills scanning entry points.
 | `image` | Scan a container image. |
 | `fs` | Scan a filesystem / disk image. |
 | `iac` | Scan IaC: Dockerfile, Terraform, CloudFormation, Helm, Kubernetes. |
-| `sbom` | Generate or scan an SBOM (CycloneDX / SPDX). |
-| `cloud` | Cloud posture + estate inventory (AWS/Azure/GCP), CIS benchmarks. |
+| `sbom` | Ingest an existing SBOM (CycloneDX / SPDX) and scan its components. |
+| `ingest` | Ingest operator-provided evidence (e.g. `ingest hardware` firmware attestation) into the graph. |
+| `cloud` | Cloud posture + estate inventory (AWS/Azure/GCP), CIS benchmarks. Group: `scan` (all configured clouds), `aws`/`azure`/`gcp` aliases, `inventory`, `registry-scan` (ECR/ACR/GAR sweep), `resilience`. |
 | `check` | Pre-install check for one package: allow / warn / block. |
 | `verify` | Package integrity + SLSA provenance verification. |
 | `secrets` | Secret detection. |
@@ -76,7 +91,9 @@ Policy, trust, fleet, FinOps, identity, API, scheduling, and control-plane ops.
 | `serve` | Run the local API + bundled dashboard. |
 | `api` | API control-plane command. |
 | `schedule` | Scheduled scans. |
-| `remediate` | Generate / apply remediation plans. |
+| `remediate` | Generate (and optionally `--apply` / `--open-pr`) a prioritized advisory remediation plan. |
+| `capabilities` | Show every gated capability: state (ENABLED/OFF/DEGRADED/UNKNOWN), why, and how to unlock. |
+| `graph-evidence` | Export retained graph history or an evidence manifest. |
 | `teardown` | Deployment teardown. |
 | `run` | Run a configured operation. |
 | `manifest` | Agent manifest operations. |
@@ -114,6 +131,8 @@ object is registered in two places so both the flat and grouped form work:
 
 | Flat (top-level) | Grouped | Notes |
 |---|---|---|
+| `agent-bom up` | `agent-bom serve` | `up` is a hidden alias of `serve` (same flags) — the canonical front-door verb for running the platform locally. |
+| `agent-bom scan` | `agent-bom agents` | `scan` is the canonical front-door verb; `agents` remains the discoverable visible command. Both discover + scan. |
 | `agent-bom proxy …` | `agent-bom runtime proxy …` | Same `proxy_cmd`. Top-level for discoverability; grouped form keeps runtime commands together. |
 | `agent-bom proxy-bootstrap` | `agent-bom runtime bootstrap` | Same command, flat + grouped. |
 | `agent-bom audit` | `agent-bom runtime audit` | Same `audit_replay_cmd` (proxy audit-log replay). |

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ material. The index below groups the canonical docs by audience.
 - [`START_HERE.md`](START_HERE.md) — role-based entry paths (security engineer / platform-SRE / AI-agent developer)
 - [`../PROJECT_STRUCTURE.md`](../PROJECT_STRUCTURE.md) — repo map: where everything lives, which trees are canonical
 - [`ARCHITECTURE.md`](ARCHITECTURE.md) — layered stack, data flow, scan pipeline, blast radius, compliance tagging (mermaid)
-- [`CLI_MAP.md`](CLI_MAP.md) — all 48 top-level commands grouped by domain + intentional aliases
+- [`CLI_MAP.md`](CLI_MAP.md) — all 50 top-level commands grouped by domain + intentional aliases
 
 ## Security engineers (scan · gate · export)
 


### PR DESCRIPTION
Reconciles the documented surface with the actual CLI/API after the post-0.89.2 changes.

- CLI_MAP.md — corrected command count, documented the canonical front-door verbs (connect/scan/graph/report/up), added missing commands (ingest, capabilities, graph-evidence), expanded the cloud subcommand list, fixed the sbom description, and listed intentional hidden aliases.
- README.md — graph-convergence section now reflects ASPM correlation, LLM-cost fusion, audit-trail behavioral edges, and estate-scale CONTAINS roll-up; "Connect a Cloud" documents the `agent-bom connect <cloud>` front door; Start-Here rows added for read-only cloud onboarding, advisory remediation, and capability readiness.
- DOCKER_HUB_README.md — kept as source of truth and synced: registry-wide image sweep, agentless EBS side-scan, ASPM, cost fusion, audit-trail edges, roll-up, advisory remediation.
- docs/README.md index count corrected.

All claims verified against source and live `--help`. Docs-only.