### PR TITLE
fix(api): close stack-trace exposure in cloud audit-metadata (#1753)

### DIFF
--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -44,6 +44,35 @@ _INVENTORY_PROVIDERS = ("aws", "azure", "gcp")
 _CIS_PROVIDERS = ("aws", "azure", "gcp")
 _REGION_RE = re.compile(r"[a-z]{2}(-gov)?-[a-z]+-\d{1,2}")
 _PROFILE_RE = re.compile(r"[a-zA-Z0-9._-]{1,100}")
+# Audit-field allowlists. IAM action identifiers (AWS ``svc:Action``, GCP
+# ``svc.resource.verb``, Azure ``Provider/type/op``), discovery scopes (account
+# IDs, regions, project IDs, ARNs), and the discovery-mode/redaction enums are
+# all structured tokens with no whitespace or punctuation that could carry a
+# stack trace or CRLF. Matching against these patterns is the sanitizer barrier
+# that keeps any exception-derived text in a provider payload out of the REST
+# response, independent of where the value originated.
+_PERMISSION_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/*-]{0,200}")
+_SCOPE_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/*-]{0,300}")
+_AUDIT_ENUM_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]{0,40}")
+
+
+def _clean_tokens(values: Any, pattern: re.Pattern[str], *, cap: int = 500) -> list[str]:
+    """Keep only well-formed, structured tokens — the sanitizer barrier.
+
+    Each value is coerced, stripped, and admitted only if it fully matches the
+    allowlist ``pattern``. Anything carrying whitespace, control characters, or
+    free-form prose (i.e. an exception/stack fragment) is dropped, so no
+    exception-derived text can reach the response even if it appears in a
+    provider payload field.
+    """
+    cleaned: list[str] = []
+    for value in values or []:
+        token = str(value).strip()
+        if token and pattern.fullmatch(token):
+            cleaned.append(token)
+        if len(cleaned) >= cap:
+            break
+    return cleaned
 
 
 def _tenant(request: Request) -> str:
@@ -80,12 +109,10 @@ def _audit_metadata(payloads: list[dict[str, Any]]) -> dict[str, Any]:
         envelope = payload.get("discovery_envelope")
         if not isinstance(envelope, dict):
             continue
-        permissions.extend(str(p) for p in envelope.get("permissions_used", []) or [])
-        scopes.extend(str(s) for s in envelope.get("discovery_scope", []) or [])
-        if envelope.get("redaction_status"):
-            redaction.append(str(envelope["redaction_status"]))
-        if envelope.get("scan_mode"):
-            scan_modes.append(str(envelope["scan_mode"]))
+        permissions.extend(_clean_tokens(envelope.get("permissions_used"), _PERMISSION_RE))
+        scopes.extend(_clean_tokens(envelope.get("discovery_scope"), _SCOPE_RE))
+        redaction.extend(_clean_tokens([envelope.get("redaction_status")], _AUDIT_ENUM_RE))
+        scan_modes.extend(_clean_tokens([envelope.get("scan_mode")], _AUDIT_ENUM_RE))
     return {
         "read_only": True,
         "writes_performed": False,

--- a/tests/test_api_cloud_surface_parity.py
+++ b/tests/test_api_cloud_surface_parity.py
@@ -264,3 +264,48 @@ def test_dispatch_never_gates_read_only_tools() -> None:
 
     out = asyncio.run(mcp_server._execute_tool_async("scan", handler, destructive=False))
     assert out == "HANDLER_RAN"
+
+
+# --------------------------------------------------------------------------- #
+# Audit metadata must never surface exception-derived text (py/stack-trace).
+# --------------------------------------------------------------------------- #
+
+
+def test_audit_metadata_drops_exception_derived_text() -> None:
+    from agent_bom.api.routes.cloud import _audit_metadata
+
+    out = _audit_metadata(
+        [
+            {
+                "discovery_envelope": {
+                    "permissions_used": [
+                        "ec2:DescribeInstances",
+                        "compute.instances.list",
+                        "Traceback (most recent call last): boom",
+                        "token with spaces",
+                    ],
+                    "discovery_scope": [
+                        "us-east-1",
+                        "arn:aws:s3:::bucket",
+                        "line 154\n  raise RuntimeError('x')",
+                    ],
+                    "redaction_status": "redacted",
+                    "scan_mode": "read_only",
+                },
+                "warnings": ["AccessDenied: arn:... could not assume role: <stack>"],
+            }
+        ]
+    )
+
+    # well-formed IAM identifiers survive
+    assert "ec2:DescribeInstances" in out["permissions_used"]
+    assert "compute.instances.list" in out["permissions_used"]
+    assert "arn:aws:s3:::bucket" in out["discovery_scope"]
+    assert "us-east-1" in out["discovery_scope"]
+    assert out["redaction_status"] == ["redacted"]
+    assert out["scan_modes"] == ["read_only"]
+
+    # any value carrying whitespace / a stack fragment is dropped
+    flat = out["permissions_used"] + out["discovery_scope"]
+    assert all(" " not in tok and "\n" not in tok for tok in flat)
+    assert not any("Traceback" in tok or "raise" in tok for tok in flat)


### PR DESCRIPTION
Resolves CodeQL alert #1753 (`py/stack-trace-exposure`) at `src/agent_bom/api/routes/cloud.py`.

The `/v1/cloud/{provider}/inventory` response rolls each provider's read-only discovery envelope into an `audit_metadata` block. Provider payloads also carry exception-derived `warnings` as a sibling field, so the envelope values flowing into the response were tainted and could in principle surface backend exception detail.

Fix: `_audit_metadata` now admits `permissions_used`, `discovery_scope`, and the redaction/scan-mode enums only when each token fully matches a strict structured-identifier allowlist (IAM action / scope / enum shape — no whitespace or control characters). Well-formed read-only IAM identifiers pass; any free-form or stack-trace-like value is dropped. This is the recognized sanitizer barrier and is also genuine hardening: only well-formed audit identifiers are ever surfaced.

Adds a regression test asserting valid IAM tokens survive while whitespace/stack-fragment values are dropped. Existing cloud surface-parity tests (21) pass; ruff/mypy/bandit clean.