### PR TITLE
feat(ci): add consumer pre-commit hooks (.pre-commit-hooks.yaml)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,33 @@
+# Consumer-facing pre-commit hooks for agent-bom.
+#
+# Downstream repos reference these from their own .pre-commit-config.yaml:
+#
+#   repos:
+#     - repo: https://github.com/msaad00/agent-bom
+#       rev: v0.89.2
+#       hooks:
+#         - id: agent-bom-secrets
+#
+# (This file is distinct from .pre-commit-config.yaml, which configures
+#  agent-bom's own development hooks.)
+- id: agent-bom-secrets
+  name: agent-bom secrets/PII scan
+  description: Scan the repository for hardcoded secrets and PII before commit.
+  entry: agent-bom secrets
+  language: python
+  args: ["."]
+  pass_filenames: false
+  always_run: true
+  minimum_pre_commit_version: "2.9.0"
+
+- id: agent-bom-scan
+  name: agent-bom dependency + AI/MCP scan
+  description: >-
+    Scan project dependencies, agents, and MCP servers for known
+    vulnerabilities; fail the commit on high-or-above severity findings.
+  entry: agent-bom scan
+  language: python
+  args: ["--fail-on-severity", "high"]
+  pass_filenames: false
+  always_run: true
+  minimum_pre_commit_version: "2.9.0"

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -235,3 +235,4 @@ names for local builds from this repo, not a second published product line.
 - PyPI: https://pypi.org/project/agent-bom/
 - Docs: https://msaad00.github.io/agent-bom/
 - GitHub Action: https://github.com/marketplace/actions/agent-bom
+- Pre-commit hooks: https://github.com/msaad00/agent-bom/blob/main/.pre-commit-hooks.yaml

--- a/README.md
+++ b/README.md
@@ -401,6 +401,34 @@ credentials handed to agent-bom.
 There is no managed cloud offering in this repository today. Product lane
 boundaries are documented in [docs/PRODUCT_BOUNDARIES.md](docs/PRODUCT_BOUNDARIES.md).
 
+## Pre-commit Hook
+
+Block secrets, PII, and vulnerable dependencies before they are committed.
+agent-bom ships consumer-facing [pre-commit](https://pre-commit.com) hooks; add
+them to your repository's `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/msaad00/agent-bom
+    rev: v0.89.2
+    hooks:
+      - id: agent-bom-secrets
+      - id: agent-bom-scan
+```
+
+```bash
+pip install pre-commit && pre-commit install
+```
+
+| Hook id | Command | Purpose |
+| --- | --- | --- |
+| `agent-bom-secrets` | `agent-bom secrets .` | Scan the working tree for hardcoded secrets and PII. |
+| `agent-bom-scan` | `agent-bom scan --fail-on-severity high` | Scan dependencies, agents, and MCP servers; fail on high-or-above findings. |
+
+pre-commit installs the `agent-bom` package into an isolated environment, so no
+separate install step is needed. See
+[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md#pre-commit-hook) for details.
+
 ## Trust Model
 
 - Read-only discovery by default for cloud and local inventory.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -213,6 +213,41 @@ pipeline {
 }
 ```
 
+#### Pre-commit hook
+
+**Use case**: Block secrets, PII, and vulnerable dependencies before they are
+committed, on the developer's machine.
+
+agent-bom publishes consumer-facing hooks in `.pre-commit-hooks.yaml`. Add them
+to your repository's `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/msaad00/agent-bom
+    rev: v0.89.2
+    hooks:
+      - id: agent-bom-secrets
+      - id: agent-bom-scan
+```
+
+Then enable the hooks:
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files   # optional: run immediately
+```
+
+Available hook ids:
+
+| Hook id | Command | Purpose |
+| --- | --- | --- |
+| `agent-bom-secrets` | `agent-bom secrets .` | Scan the working tree for hardcoded secrets and PII. |
+| `agent-bom-scan` | `agent-bom scan --fail-on-severity high` | Scan dependencies, agents, and MCP servers; fail on high-or-above findings. |
+
+pre-commit installs the `agent-bom` package itself into an isolated environment,
+so no separate install step is required for the hooks.
+
 **Pros**: Automated, fail builds on critical issues
 **Cons**: Requires CI/CD platform access
 


### PR DESCRIPTION
## Summary

agent-bom ships a GitHub Action but had no consumer-facing pre-commit hook. Downstream repos could not add agent-bom via `repo: https://github.com/msaad00/agent-bom`.

This adds a repo-root `.pre-commit-hooks.yaml` — the manifest pre-commit reads from a hook repository, distinct from the existing `.pre-commit-config.yaml` that drives agent-bom's own development hooks.

## Hooks defined

| Hook id | Entry | Purpose |
| --- | --- | --- |
| `agent-bom-secrets` | `agent-bom secrets` (args `["."]`) | Scan the working tree for hardcoded secrets and PII. |
| `agent-bom-scan` | `agent-bom scan` (args `["--fail-on-severity", "high"]`) | Scan dependencies, agents, and MCP servers; fail on high-or-above findings. |

Both use `language: python` so pre-commit installs the published `agent-bom` package (console script `agent-bom`, verified against `[project.scripts]` and the installed CLI) into an isolated environment. `pass_filenames: false` and `always_run: true` since both hooks take a path argument rather than per-file lists.

Consumer usage:

```yaml
repos:
  - repo: https://github.com/msaad00/agent-bom
    rev: v0.89.2
    hooks:
      - id: agent-bom-secrets
      - id: agent-bom-scan
```

## Documentation

- `README.md` — new "Pre-commit Hook" section.
- `docs/DEPLOYMENT.md` — new pre-commit subsection under CI/CD Integration, alongside GitHub Actions / GitLab CI / Jenkins.
- `DOCKER_HUB_README.md` — reference link in Links.

## Validation

- `pre-commit validate-manifest .pre-commit-hooks.yaml` -> exit 0.
- YAML parses via `yaml.safe_load`.
- Flags verified against the installed CLI: `agent-bom secrets PATH`, `agent-bom scan --fail-on-severity [critical|high|medium|low]`.
- Repo dev hooks (check-yaml, release-surface-consistency, etc.) pass.