### PR TITLE
feat(output): surface top agent→MCP→CVE→tool exposure path in posture and SARIF

### DIFF
--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -145,6 +145,8 @@ The scanner covers package risk, malicious or suspicious package indicators, con
 
 Blast radius is the product center of gravity. `agent-bom` connects vulnerabilities to packages, MCP servers, agents, credential exposure, and reachable tools. Impact is CWE-aware so the reported consequences match the weakness class instead of inflating every issue into full compromise.
 
+The highest-risk trust chain is surfaced directly in the human and machine surfaces, not only the JSON report. The `--posture` card renders the top exposure path as a one-line spine (`agent → MCP server → package@version → CVE → tool`) with its blast-radius summary (`N cred(s), N tool(s) reachable`), and SARIF results carry the same chain in the result message, an `exposure_chain` property, and `relatedLocations` so it renders in code-scanning viewers.
+
 ### Trust and policy
 
 `agent-bom` scores trust with evidence, not a black-box label. It combines package and registry posture, capability risk, drift, exposed credentials, and related supply-chain signals. Policy and compliance layers can then act on those findings with clearer context.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,6 +9,11 @@ The canonical command reference lives in
 - `agent-bom agents -f <format> -o <path>` validates output suffixes and
   appends the canonical suffix when `<path>` has no extension.
 - JSON reports include `posture_scorecard` and root `posture_grade`.
+- `agent-bom agents --posture` renders a compact card that includes the top
+  exposure path as `agent → MCP server → package@version → CVE → tool` plus its
+  blast-radius summary (`N cred(s), N tool(s) reachable`). The same chain is
+  emitted in SARIF result messages, an `exposure_chain` property, and
+  `relatedLocations`.
 - `agent-bom agents --agent-mode` writes a stable JSON envelope for assistant
   and automation callers.
 - `agent-bom profiles ...` manages named contexts in

--- a/src/agent_bom/cli/agents/_posture.py
+++ b/src/agent_bom/cli/agents/_posture.py
@@ -64,6 +64,17 @@ def render_posture_summary(agents: list[Any], blast_radii: list[Any]) -> None:
         lines.append(f"[bold]Fixes:[/bold]    {fixable} finding(s) have an upgrade path")
         if top_str:
             lines.append(f"[bold]Top:[/bold]      {top_str}")
+            from agent_bom.output.exposure_path import (
+                exposure_path_blast_summary,
+                exposure_path_chain,
+                exposure_path_for_blast_radius,
+            )
+
+            top_path = exposure_path_for_blast_radius(top, rank=1)
+            chain = exposure_path_chain(top_path)
+            if chain:
+                lines.append(f"[bold]Path:[/bold]     {chain}")
+                lines.append(f"             {exposure_path_blast_summary(top_path)}")
     else:
         lines.append("[bold]Risk:[/bold]     No vulnerabilities found")
     lines.append(f"[bold]Trust:[/bold]    {floating} server(s) floating on @latest, {unverified} unverified")

--- a/src/agent_bom/output/exposure_path.py
+++ b/src/agent_bom/output/exposure_path.py
@@ -84,6 +84,47 @@ def exposure_path_for_blast_radius(br: BlastRadius, *, rank: int | None = None) 
     return {key: value for key, value in path.items() if value is not None}
 
 
+def _chain_token(hop: str) -> str:
+    """Render a single hop ref (``server:database-server``) as a display token."""
+
+    return hop.rsplit(":", 1)[-1] if ":" in hop else hop
+
+
+def exposure_path_chain(path: dict[str, Any], *, include_tool: bool = True) -> str:
+    """Render the primary trust spine of an ExposurePath as a one-line chain.
+
+    Produces ``agent → server → package@version → finding → tool`` from the
+    already-computed ``hops``/``target`` projection. The chain is the
+    differentiating wedge (agent → MCP server → package → CVE → tool); the wider
+    reachable-tool/credential set is summarised separately via blast counts.
+    """
+
+    hops = [hop for hop in (path.get("hops") or []) if hop]
+    if not hops:
+        return ""
+
+    def first(prefix: str) -> str | None:
+        return next((hop for hop in hops if hop.startswith(prefix)), None)
+
+    spine: list[str] = [hops[0]]
+    for candidate in (first("server:"), first("pkg:"), path.get("target") or first("finding:")):
+        if candidate and candidate not in spine:
+            spine.append(candidate)
+    if include_tool:
+        tool = first("tool:")
+        if tool and tool not in spine:
+            spine.append(tool)
+    return " → ".join(_chain_token(hop) for hop in spine)
+
+
+def exposure_path_blast_summary(path: dict[str, Any]) -> str:
+    """Render ``N cred(s), N tool(s) reachable`` for a single ExposurePath."""
+
+    creds = len(path.get("exposedCredentials") or [])
+    tools = len(path.get("reachableTools") or [])
+    return f"{creds} cred(s), {tools} tool(s) reachable"
+
+
 def exposure_path_brief(br: BlastRadius, *, rank: int) -> dict[str, str]:
     """Return compact strings for Markdown/HTML investigation summaries."""
 

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -17,7 +17,11 @@ from agent_bom.asset_provenance import (
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.finding import FindingType
 from agent_bom.models import AIBOMReport, Severity
-from agent_bom.output.exposure_path import exposure_path_for_blast_radius
+from agent_bom.output.exposure_path import (
+    exposure_path_blast_summary,
+    exposure_path_chain,
+    exposure_path_for_blast_radius,
+)
 from agent_bom.security import sanitize_sensitive_payload
 
 _SARIF_SEVERITY_MAP = {
@@ -142,6 +146,32 @@ def _sanitize_sarif_text(field_name: str, value: Any, *, fallback: str = "") -> 
     if redacted is None:
         return fallback
     return str(redacted)
+
+
+def _exposure_related_locations(exposure_path: dict[str, Any]) -> list[dict]:
+    """Project an ExposurePath spine into SARIF relatedLocations.
+
+    Each hop becomes a logicalLocation so SARIF viewers can render the
+    agent → server → package → CVE → tool trust chain alongside the result.
+    """
+
+    hops = [hop for hop in (exposure_path.get("hops") or []) if isinstance(hop, str) and hop]
+    related: list[dict] = []
+    for index, hop in enumerate(hops):
+        kind, _, name = hop.partition(":")
+        related.append(
+            {
+                "id": index,
+                "logicalLocations": [
+                    {
+                        "fullyQualifiedName": _sanitize_sarif_text("title", hop, fallback=hop),
+                        "kind": _sanitize_sarif_text("title", kind or "node", fallback="node"),
+                    }
+                ],
+                "message": {"text": _sanitize_sarif_text("title", name or hop, fallback=hop)},
+            }
+        )
+    return related
 
 
 def _trust_assessment_sarif_property(data: dict[str, Any]) -> dict[str, str]:
@@ -335,9 +365,13 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
             rules.append(rule)
 
         affected = ", ".join(a.name for a in br.affected_agents)
+        exposure_path = exposure_path_for_blast_radius(br, rank=rank)
         message_text = f"{vuln.id} ({vuln.severity.value}) in {br.package.name}@{br.package.version}. Affects agents: {affected}."
         if vuln.fixed_version:
             message_text += f" Fix: upgrade to {vuln.fixed_version}."
+        exposure_chain = exposure_path_chain(exposure_path)
+        if exposure_chain:
+            message_text += f" Exposure path: {exposure_chain}. Blast radius: {exposure_path_blast_summary(exposure_path)}."
 
         raw_config_path = br.affected_agents[0].config_path if br.affected_agents else "unknown"
         # SARIF requires relative paths from repo root for GitHub Security tab.
@@ -371,12 +405,19 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
                 }
             ],
         }
+        # Represent the agent → server → package → CVE → tool spine as SARIF
+        # relatedLocations (logicalLocations) so viewers can render the trust
+        # chain that the JSON exposure_path encodes.
+        related_locations = _exposure_related_locations(exposure_path)
+        if related_locations:
+            result["relatedLocations"] = related_locations
         # Always emit structured properties so downstream consumers get
         # the exploit_likelihood (#486) + blast metrics without needing
         # a compliance tag to trigger enrichment.
         result_properties: dict = {
             "blast_score": br.risk_score,
-            "exposure_path": exposure_path_for_blast_radius(br, rank=rank),
+            "exposure_path": exposure_path,
+            "exposure_chain": exposure_chain or None,
             "epss_score": vuln.epss_score,
             "is_kev": vuln.is_kev,
             "exploit_likelihood": vuln.exploit_likelihood,

--- a/tests/test_posture_exposure_path.py
+++ b/tests/test_posture_exposure_path.py
@@ -1,0 +1,79 @@
+"""Posture card surfaces the top agent → MCP → CVE → tool exposure path."""
+
+from __future__ import annotations
+
+from agent_bom.cli.agents._posture import render_posture_summary
+from agent_bom.models import (
+    Agent,
+    AgentType,
+    BlastRadius,
+    MCPServer,
+    MCPTool,
+    Package,
+    Severity,
+    Vulnerability,
+)
+
+
+def _chain_blast_radius() -> tuple[list[Agent], list[BlastRadius]]:
+    vuln = Vulnerability(
+        id="GHSA-8vj2-vxx3-667w",
+        summary="Code execution in pillow",
+        severity=Severity.CRITICAL,
+        cvss_score=9.8,
+        fixed_version="9.0.1",
+    )
+    pkg = Package(
+        name="pillow",
+        version="9.0.0",
+        ecosystem="pypi",
+        vulnerabilities=[vuln],
+        is_direct=True,
+    )
+    server = MCPServer(
+        name="database-server",
+        tools=[MCPTool(name="run_query", description="Run a SQL query")],
+        packages=[pkg],
+    )
+    agent = Agent(
+        name="cursor",
+        agent_type=AgentType.CURSOR,
+        config_path="/tmp/cursor.json",
+        mcp_servers=[server],
+        version="1.0",
+    )
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=[server],
+        affected_agents=[agent],
+        exposed_credentials=["DATABASE_URL", "ANTHROPIC_API_KEY"],
+        exposed_tools=[MCPTool(name="run_query", description="Run a SQL query")],
+    )
+    br.calculate_risk_score()
+    return [agent], [br]
+
+
+def test_posture_renders_top_exposure_chain(capsys) -> None:
+    agents, blast_radii = _chain_blast_radius()
+    render_posture_summary(agents, blast_radii)
+    out = capsys.readouterr().out
+    # Rich wraps the panel, so normalise whitespace before asserting the chain.
+    flat = " ".join(out.split())
+    assert "Path:" in flat
+    assert "cursor → database-server → pillow@9.0.0 → GHSA-8vj2-vxx3-667w → run_query" in flat
+    assert "2 cred(s), 1 tool(s) reachable" in flat
+
+
+def test_posture_omits_exposure_chain_when_no_findings(capsys) -> None:
+    agent = Agent(
+        name="cursor",
+        agent_type=AgentType.CURSOR,
+        config_path="/tmp/cursor.json",
+        mcp_servers=[],
+        version="1.0",
+    )
+    render_posture_summary([agent], [])
+    flat = " ".join(capsys.readouterr().out.split())
+    assert "Path:" not in flat
+    assert "No vulnerabilities found" in flat

--- a/tests/test_sarif_schema_2_1_0.py
+++ b/tests/test_sarif_schema_2_1_0.py
@@ -25,6 +25,8 @@ from agent_bom.models import (
     AgentType,
     AIBOMReport,
     BlastRadius,
+    MCPServer,
+    MCPTool,
     Package,
     Severity,
     Vulnerability,
@@ -219,3 +221,86 @@ def test_sarif_spans_multiple_finding_families(sarif_doc: dict) -> None:
     assert any(rid.startswith("iac/") for rid in rule_ids)  # IaC
     assert any(rid.startswith("cis/") for rid in rule_ids)  # cloud CIS
     assert any(rid.startswith("ai-inventory/") for rid in rule_ids)  # AI inventory
+
+
+def _full_chain_report() -> AIBOMReport:
+    """A report whose blast radius spans agent → server → package → CVE → tool."""
+    vuln = Vulnerability(
+        id="GHSA-test-chain",
+        summary="Code execution in pillow",
+        severity=Severity.CRITICAL,
+        cvss_score=9.8,
+        fixed_version="9.0.1",
+    )
+    pkg = Package(
+        name="pillow",
+        version="9.0.0",
+        ecosystem="pypi",
+        purl="pkg:pypi/pillow@9.0.0",
+        vulnerabilities=[vuln],
+        is_direct=True,
+    )
+    server = MCPServer(
+        name="database-server",
+        tools=[MCPTool(name="run_query", description="Run a SQL query")],
+        packages=[pkg],
+    )
+    agent = Agent(
+        name="cursor",
+        agent_type=AgentType.CURSOR,
+        config_path="/tmp/cursor.json",
+        mcp_servers=[server],
+        version="1.0",
+    )
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=[server],
+        affected_agents=[agent],
+        exposed_credentials=["DATABASE_URL", "ANTHROPIC_API_KEY"],
+        exposed_tools=[MCPTool(name="run_query", description="Run a SQL query")],
+    )
+    br.calculate_risk_score()
+    return AIBOMReport(
+        agents=[agent],
+        blast_radii=[br],
+        scan_sources=["agent_discovery"],
+        scan_id="chain-test-001",
+    )
+
+
+def test_sarif_exposure_chain_in_message_and_related_locations() -> None:
+    """The agent → server → package → CVE → tool spine is human/machine visible."""
+    from agent_bom.output.sarif import to_sarif
+
+    doc = to_sarif(_full_chain_report())
+    result = next(r for r in doc["runs"][0]["results"] if r["ruleId"] == "GHSA-test-chain")
+
+    # Human-visible: the chain + blast radius land in the SARIF message text.
+    message = result["message"]["text"]
+    assert "Exposure path:" in message
+    expected_chain = "cursor → database-server → pillow@9.0.0 → GHSA-test-chain → run_query"
+    assert expected_chain in message
+    assert "Blast radius: 2 cred(s), 1 tool(s) reachable" in message
+
+    # Machine-readable: condensed chain + full exposure_path in the properties bag.
+    assert result["properties"]["exposure_chain"] == expected_chain
+    assert result["properties"]["exposure_path"]["hops"]
+
+    # Idiomatic SARIF: each hop is a relatedLocation logicalLocation.
+    related = result["relatedLocations"]
+    fq_names = [loc["logicalLocations"][0]["fullyQualifiedName"] for loc in related]
+    assert "agent:cursor" in fq_names
+    assert "server:database-server" in fq_names
+    assert "tool:run_query" in fq_names
+
+
+def test_sarif_exposure_chain_document_is_schema_valid(sarif_validator: Draft7Validator) -> None:
+    """The exposure-path enrichment keeps the document schema-valid SARIF 2.1.0."""
+    from agent_bom.output.sarif import to_sarif
+
+    doc = to_sarif(_full_chain_report())
+    errors = sorted(sarif_validator.iter_errors(doc), key=lambda e: list(e.path))
+    if errors:
+        rendered = "\n".join(f"  - {'/'.join(str(p) for p in e.path)}: {e.message}" for e in errors[:20])
+        pytest.fail(f"SARIF document is not schema-valid ({len(errors)} error(s)):\n{rendered}")


### PR DESCRIPTION
## Problem

agent-bom computes a full trust/exposure chain `agent → MCP server → package → CVE → tool/credential` with a blast-radius summary, but it was only present in the JSON report (`exposure_paths.paths[]`). Users never saw the differentiator unless they parsed JSON: the human `--posture` card and SARIF output did not surface it.

## Change

Surface the single highest-risk exposure path in two additional surfaces, reusing the already-computed exposure-path projection (blast radius is not recomputed).

**Posture card (`--posture`)** now renders the top exposure path as a one-line spine plus its per-path blast-radius summary:

```
  Top:      pillow@9.0.0 (GHSA-8vj2-vxx3-667w)
  Path:     cursor → database-server → pillow@9.0.0 → GHSA-8vj2-vxx3-667w → run_query
              2 cred(s), 3 tool(s) reachable
```

It is gracefully absent when there are no findings.

**SARIF** results now carry the chain in three valid SARIF 2.1.0 mechanisms:
- the result `message.text` (`... Exposure path: cursor → database-server → pillow@9.0.0 → GHSA-... → run_query. Blast radius: 2 cred(s), 3 tool(s) reachable.`)
- an `exposure_chain` property (alongside the existing full `exposure_path` object)
- `relatedLocations` (one `logicalLocations` entry per hop) so code-scanning viewers render the trust chain.

A shared `exposure_path_chain` / `exposure_path_blast_summary` helper in `output/exposure_path.py` is reused by both surfaces.

## Tests

- `tests/test_posture_exposure_path.py`: `test_posture_renders_top_exposure_chain`, `test_posture_omits_exposure_chain_when_no_findings`.
- `tests/test_sarif_schema_2_1_0.py`: `test_sarif_exposure_chain_in_message_and_related_locations`, `test_sarif_exposure_chain_document_is_schema_valid` (asserts the enriched document still validates against the vendored SARIF 2.1.0 schema).

## Docs

`docs/PRODUCT_BRIEF.md` (blast-radius section) and `docs/cli.md` updated to describe the surfaced chain.