### PR TITLE
feat(agent-mode): summarize scan payload for automation callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,11 +140,23 @@ account.
   on the compliance dashboard.
 
 ### Changed
+- **`agents --agent-mode` summarizes the scan payload by default.** The envelope
+  now emits `data_mode: "summary"` with a bounded `data` field — counts
+  (packages by ecosystem, findings/exposure by severity), the top 10 ranked
+  findings and exposure paths, and a summary-level agent inventory — instead of
+  inlining the full per-package provenance dump. For a ~877-package repo the
+  stdout envelope drops from ~27 MB to a few KB so it fits an LLM/automation
+  context window. Pass `--agent-mode-full` (`data_mode: "full"`) or write JSON to
+  disk with `-o report.json --format json` for the complete report;
+  `data.full_report` records how to obtain it.
 - **Vulnerability cache auto-refreshes** and surfaces a freshness indicator.
 - Flat (non-graph) outputs prefer canonical findings for consistency with the
   graph view.
 
 ### Fixed
+- **Fixed agent-mode summary counts.** The envelope `summary.packages` field
+  previously fell through to the full package list; it now reports an integer
+  count.
 - **Offline coverage gaps now warn instead of discarding real findings** (was a
   silent false-negative).
 - **Go `go.mod` block-`require` parsing** no longer emits a phantom package, and

--- a/contracts/v1/agent-mode-envelope.schema.json
+++ b/contracts/v1/agent-mode-envelope.schema.json
@@ -9,6 +9,10 @@
     "mode": { "const": "agent" },
     "ok": { "type": "boolean" },
     "command": { "type": ["string", "null"] },
+    "data_mode": {
+      "enum": ["summary", "full"],
+      "description": "Shape of `data`. For agent-bom agents this is `summary` (bounded counts plus top-ranked findings/exposure paths) by default, or `full` with --agent-mode-full."
+    },
     "exit_code": { "type": "integer", "minimum": 0 },
     "summary": {
       "type": "object",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,7 +15,11 @@ The canonical command reference lives in
   emitted in SARIF result messages, an `exposure_chain` property, and
   `relatedLocations`.
 - `agent-bom agents --agent-mode` writes a stable JSON envelope for assistant
-  and automation callers.
+  and automation callers. By default the envelope's `data` is a bounded summary
+  (`data_mode: "summary"`) — counts plus the top-ranked findings and exposure
+  paths — so it fits an LLM context window; the full per-package payload is
+  omitted. Add `--agent-mode-full` (`data_mode: "full"`) or write to disk with
+  `-o report.json --format json` for complete detail.
 - `agent-bom profiles ...` manages named contexts in
   `~/.agent-bom/config.toml`; unknown profiles fail with the available profile
   list.

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -119,7 +119,10 @@ verbs are additive entry points that delegate to the underlying implementations.
 - `report query "SELECT ..."` runs read-only SQL against the local scan analytics store.
 - `remediate` is read-only by default and supports `--format json` as the machine-readable remediation contract.
 - `remediate --apply` patches supported package dependency manifests only after confirmation; `--apply --open-pr` creates a draft PR instead of pushing to the default branch.
-- `agents --agent-mode` emits a stable JSON envelope for assistant and automation callers. It defaults to JSON stdout, reports `ok`, `exit_code`, summary counts, confidence signals, truncation metadata, and the full scan payload under `data`.
+- `agents --agent-mode` emits a stable JSON envelope for assistant and automation callers. It defaults to JSON stdout and reports `ok`, `exit_code`, `data_mode`, summary counts, confidence signals, and truncation metadata.
+  - By default `data_mode` is `summary`: the `data` field carries a bounded payload — counts (packages by ecosystem, findings/exposure by severity), the top 10 ranked findings and exposure paths, and a summary-level agent inventory. The full inlined per-package provenance dump (`ai_inventory`, `ai_bom_entities`, the complete `findings`/`packages` lists) is omitted so the payload fits an LLM/automation context window. For a ~877-package repo this drops the envelope from tens of MB to a few KB.
+  - For the complete report, add `--agent-mode-full` (sets `data_mode: "full"` and inlines the legacy full payload), or write full JSON to disk with `agent-bom agents -o report.json --format json`. `data.full_report` records this on every summary payload.
+  - `--agent-token-budget <TOKENS>` further trims either shape to an approximate JSON token budget.
 - Use `agent-bom agents -f <format> -o <path>` for SARIF, HTML, SBOM, and richer environment exports.
 - Use `agent-bom agents -f sarif -o -` when you need SARIF on stdout for piping.
 - `where` is available both as `agent-bom where` and `agent-bom mcp where`.
@@ -138,8 +141,9 @@ agent-bom report diff before.json after.json -f json -o diff.json
 agent-bom report pipeline-events scan-job.json -o pipeline-events.jsonl
 agent-bom report query "SELECT severity, COUNT(*) AS count FROM scan_findings GROUP BY severity" --format json
 
-# Assistant / automation envelope
+# Assistant / automation envelope (bounded summary by default)
 agent-bom agents --agent-mode
+agent-bom agents --agent-mode --agent-mode-full      # inline the complete report
 agent-bom agents --agent-mode --agent-token-budget 4000
 
 # Compliance

--- a/src/agent_bom/cli/_agent_mode.py
+++ b/src/agent_bom/cli/_agent_mode.py
@@ -11,6 +11,12 @@ from typing import Any
 AGENT_MODE_ENV_VAR = "AGENT_BOM_AGENT_MODE"
 AGENT_MODE_SCHEMA_VERSION = "1"
 
+# Number of top-ranked findings / exposure paths kept in the summarized scan
+# payload that agent mode emits by default.
+SCAN_SUMMARY_TOP_N = 10
+
+_SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1, "unknown": 0}
+
 
 def agent_mode_requested(argv: list[str] | None = None) -> bool:
     """Return True when the current invocation requested agent mode."""
@@ -44,10 +50,19 @@ def _summary(report_json: dict[str, Any]) -> dict[str, Any]:
     findings: list[Any] = findings_raw if isinstance(findings_raw, list) else []
     scorecard_raw = report_json.get("posture_scorecard")
     scorecard: dict[str, Any] = scorecard_raw if isinstance(scorecard_raw, dict) else {}
+    inv_packages = inventory.get("packages")
+    inv_servers = inventory.get("servers")
     return {
-        "agents": summary.get("agents", len(agents)),
-        "servers": summary.get("servers", inventory.get("servers")),
-        "packages": summary.get("packages", inventory.get("packages")),
+        "agents": summary.get("total_agents", summary.get("agents", len(agents))),
+        "servers": summary.get(
+            "total_mcp_servers",
+            summary.get("servers", len(inv_servers) if isinstance(inv_servers, list) else inv_servers),
+        ),
+        "packages": summary.get(
+            "total_packages",
+            summary.get("packages") if isinstance(summary.get("packages"), int) else None,
+        )
+        or (len(inv_packages) if isinstance(inv_packages, list) else inv_packages),
         "vulnerabilities": summary.get("total_vulnerabilities", len(blast_radius)),
         "findings": len(findings),
         "severity_counts": _severity_counts(report_json),
@@ -69,6 +84,148 @@ def _confidence(report_json: dict[str, Any]) -> dict[str, Any]:
     present = sum(1 for signal in signals if signal["present"])
     level = "high" if present >= 2 else "medium" if present == 1 else "low"
     return {"level": level, "signals": signals}
+
+
+def _packages_by_ecosystem(report_json: dict[str, Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    inventory = report_json.get("inventory_snapshot")
+    packages = inventory.get("packages") if isinstance(inventory, dict) else None
+    if not isinstance(packages, list):
+        packages = report_json.get("packages")
+    for pkg in packages or []:
+        if not isinstance(pkg, dict):
+            continue
+        ecosystem = str(pkg.get("ecosystem") or "unknown").lower()
+        counts[ecosystem] = counts.get(ecosystem, 0) + 1
+    return counts
+
+
+def _severity_breakdown(items: list[Any], *severity_keys: str) -> dict[str, int]:
+    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "unknown": 0}
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        severity = "unknown"
+        for key in severity_keys:
+            value = item.get(key)
+            if value:
+                severity = str(value).lower()
+                break
+        counts[severity if severity in counts else "unknown"] += 1
+    return counts
+
+
+def _risk_sort_key(item: Any) -> tuple[float, int]:
+    if not isinstance(item, dict):
+        return (0.0, 0)
+    try:
+        score = float(item.get("risk_score") or 0.0)
+    except (TypeError, ValueError):
+        score = 0.0
+    severity = str(item.get("effective_severity") or item.get("severity") or "unknown").lower()
+    return (score, _SEVERITY_RANK.get(severity, 0))
+
+
+def _compact_finding(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": item.get("id"),
+        "cve_id": item.get("cve_id"),
+        "title": item.get("title"),
+        "severity": item.get("effective_severity") or item.get("severity"),
+        "risk_score": item.get("risk_score"),
+        "is_kev": item.get("is_kev"),
+        "finding_type": item.get("finding_type"),
+        "asset": item.get("asset"),
+        "fixed_version": item.get("fixed_version"),
+    }
+
+
+def _compact_exposure(item: dict[str, Any]) -> dict[str, Any]:
+    affected = item.get("affected_agents")
+    return {
+        "vulnerability_id": item.get("vulnerability_id"),
+        "package": item.get("package_name") or item.get("package"),
+        "version": item.get("package_version"),
+        "ecosystem": item.get("ecosystem"),
+        "severity": item.get("severity_label") or item.get("severity"),
+        "risk_score": item.get("risk_score"),
+        "is_kev": item.get("is_kev"),
+        "fixed_version": item.get("fixed_version"),
+        "graph_reachable": item.get("graph_reachable"),
+        "affected_agents": affected if isinstance(affected, list) else None,
+    }
+
+
+def _compact_agent(item: dict[str, Any]) -> dict[str, Any]:
+    servers = item.get("mcp_servers")
+    server_names = [s.get("name") for s in servers if isinstance(s, dict)] if isinstance(servers, list) else []
+    return {
+        "name": item.get("name"),
+        "type": item.get("type"),
+        "agent_type": item.get("agent_type"),
+        "status": item.get("status"),
+        "server_count": len(server_names),
+        "servers": server_names[:25],
+    }
+
+
+def summarize_scan_data(
+    report_json: dict[str, Any],
+    *,
+    top_n: int = SCAN_SUMMARY_TOP_N,
+    output_path: str | None = None,
+) -> dict[str, Any]:
+    """Build a bounded, machine-readable scan payload for automation callers.
+
+    The default agent-mode scan payload omits the full inlined per-package
+    provenance dump (``ai_inventory``, ``ai_bom_entities``, per-package
+    ``discovery_provenance``, the full ``findings``/``packages`` lists, etc.)
+    and replaces it with counts plus the top ``top_n`` ranked findings and
+    exposure paths. Full detail stays available via ``--agent-mode-full`` or by
+    writing the report to disk with ``-o``.
+    """
+    findings_raw = report_json.get("findings")
+    findings: list[Any] = findings_raw if isinstance(findings_raw, list) else []
+    blast_raw = report_json.get("blast_radius")
+    blast_radius: list[Any] = blast_raw if isinstance(blast_raw, list) else []
+    agents_raw = report_json.get("agents")
+    agents: list[Any] = agents_raw if isinstance(agents_raw, list) else []
+    scorecard_raw = report_json.get("posture_scorecard")
+    scorecard: dict[str, Any] = scorecard_raw if isinstance(scorecard_raw, dict) else {}
+
+    top_findings = sorted((f for f in findings if isinstance(f, dict)), key=_risk_sort_key, reverse=True)[:top_n]
+    top_exposure = sorted((b for b in blast_radius if isinstance(b, dict)), key=_risk_sort_key, reverse=True)[:top_n]
+
+    counts = dict(_summary(report_json))
+    counts["packages_by_ecosystem"] = _packages_by_ecosystem(report_json)
+    counts["findings_by_severity"] = _severity_breakdown(findings, "effective_severity", "severity")
+    counts["exposure_by_severity"] = _severity_breakdown(blast_radius, "severity_label", "severity")
+
+    return {
+        "schema_version": report_json.get("schema_version"),
+        "document_type": report_json.get("document_type"),
+        "spec_version": report_json.get("spec_version"),
+        "generated_at": report_json.get("generated_at"),
+        "scan_id": report_json.get("scan_id"),
+        "posture_grade": report_json.get("posture_grade") or scorecard.get("grade"),
+        "counts": counts,
+        "top_findings": [_compact_finding(f) for f in top_findings],
+        "top_exposure_paths": [_compact_exposure(b) for b in top_exposure],
+        "agents": [_compact_agent(a) for a in agents],
+        "posture_scorecard": {
+            "grade": scorecard.get("grade"),
+            "score": scorecard.get("score"),
+            "summary": scorecard.get("summary"),
+        },
+        "full_report": {
+            "included": False,
+            "output_path": output_path if output_path and output_path != "-" else None,
+            "hint": (
+                "Summarized payload. Re-run with --agent-mode-full for the complete report, "
+                "or write full JSON to disk with `-o <file> --format json`."
+            ),
+        },
+    }
 
 
 def _truncate_report(report_json: dict[str, Any], token_budget: int) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -143,20 +300,35 @@ def success_envelope(
     report_json: dict[str, Any],
     exit_code: int,
     token_budget: int = 0,
+    full: bool = False,
+    output_path: str | None = None,
 ) -> dict[str, Any]:
-    """Wrap a scan report in the stable agent-mode success envelope."""
-    payload, truncation = _truncate_report(report_json, token_budget)
+    """Wrap a scan report in the stable agent-mode success envelope.
+
+    By default the ``data`` field carries a bounded SUMMARY of the scan
+    (counts plus top-ranked findings and exposure paths) so the payload fits an
+    automation caller's context window. Pass ``full=True`` to inline the
+    complete report (the legacy shape); ``data_mode`` records which shape was
+    emitted.
+    """
+    if full:
+        data, truncation = _truncate_report(report_json, token_budget)
+        data_mode = "full"
+    else:
+        data, truncation = _truncate_report(summarize_scan_data(report_json, output_path=output_path), token_budget)
+        data_mode = "summary"
     return {
         "schema_version": AGENT_MODE_SCHEMA_VERSION,
         "mode": "agent",
         "ok": exit_code == 0,
         "command": command,
+        "data_mode": data_mode,
         "exit_code": exit_code,
         "summary": _summary(report_json),
         "confidence": _confidence(report_json),
         "truncated": bool(truncation["truncated"]),
         "truncation": truncation,
-        "data": payload,
+        "data": data,
     }
 
 
@@ -175,6 +347,7 @@ def command_success_envelope(
         "mode": "agent",
         "ok": exit_code == 0,
         "command": command,
+        "data_mode": "full",
         "exit_code": exit_code,
         "summary": summary,
         "confidence": confidence,

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -434,6 +434,7 @@ def scan(
     reproducible: bool,
     agent_mode: bool,
     agent_token_budget: int,
+    agent_mode_full: bool,
     preset: Optional[str],
     open_report: bool,
     offline_html: bool,
@@ -2461,6 +2462,7 @@ def scan(
             fixable_only=fixable_only,
             agent_mode=agent_mode,
             agent_token_budget=agent_token_budget,
+            agent_mode_full=agent_mode_full,
         )
 
     # ── Posture summary mode (--posture) ──────────────────────────────────────
@@ -2606,6 +2608,7 @@ def scan(
             fixable_only=fixable_only,
             agent_mode=agent_mode,
             agent_token_budget=agent_token_budget,
+            agent_mode_full=agent_mode_full,
         )
 
     if exit_code:

--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -218,6 +218,7 @@ def render_output(
     fixable_only: bool = False,
     agent_mode: bool = False,
     agent_token_budget: int = 0,
+    agent_mode_full: bool = False,
     offline_html: bool = False,
     **kwargs: Any,
 ) -> None:
@@ -287,6 +288,8 @@ def render_output(
                     report_json=to_json(report),
                     exit_code=ctx.exit_code,
                     token_budget=agent_token_budget,
+                    full=agent_mode_full,
+                    output_path=output if isinstance(output, str) else None,
                 )
                 sys.stdout.write(dumps_envelope(payload))
             else:

--- a/src/agent_bom/cli/options_sources.py
+++ b/src/agent_bom/cli/options_sources.py
@@ -234,6 +234,13 @@ def output_options(fn):
                 help="Approximate JSON token budget for --agent-mode output. 0 keeps the full report.",
             ),
             click.option(
+                "--agent-mode-full",
+                "agent_mode_full",
+                is_flag=True,
+                default=False,
+                help="With --agent-mode, inline the complete report instead of the bounded summary (large output).",
+            ),
+            click.option(
                 "--exclude-unfixable",
                 is_flag=True,
                 default=False,

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -15,7 +15,7 @@ import pytest
 from click.testing import CliRunner
 
 from agent_bom.cli import cli_main, main
-from agent_bom.cli._agent_mode import dumps_envelope, success_envelope
+from agent_bom.cli._agent_mode import dumps_envelope, success_envelope, summarize_scan_data
 from agent_bom.models import Agent, AgentType, BlastRadius, MCPServer, Package, Severity, Vulnerability
 from agent_bom.scanners import IncompleteScanError
 
@@ -167,6 +167,112 @@ def test_agent_mode_token_budget_bounds_large_envelope():
     assert payload["truncation"]["removed"]
     assert payload["summary"]["agents"] >= 30
     assert payload["data"]["document_type"] == "AI-BOM"
+
+
+def _provenance_heavy_report(n_packages: int = 400, n_findings: int = 60) -> dict:
+    """A report shaped like a real scan: huge inlined per-package provenance."""
+    provenance = {
+        "discovery_provenance": {
+            "source": "project",
+            "source_type": "local_discovery",
+            "observed_via": ["local_discovery"],
+            "version_provenance": {"declared_name": "pkg", "confidence": "unknown", "blob": "x" * 200},
+        }
+    }
+    packages = [{"name": f"pkg-{i}", "version": "1.0.0", "ecosystem": "npm" if i % 2 else "pypi", **provenance} for i in range(n_packages)]
+    findings = [
+        {
+            "id": f"finding-{i}",
+            "cve_id": f"CVE-2026-{i:04d}",
+            "title": f"finding {i}",
+            "effective_severity": "critical" if i < 3 else "medium",
+            "risk_score": 9.5 if i < 3 else 4.0,
+            "finding_type": "CVE",
+            "ai_summary": "y" * 300,
+        }
+        for i in range(n_findings)
+    ]
+    return {
+        "schema_version": "1",
+        "document_type": "AI-BOM",
+        "spec_version": "1.0",
+        "generated_at": "2026-01-01T00:00:00+00:00",
+        "scan_id": "scan-123",
+        "posture_grade": "B",
+        "summary": {"total_agents": 2, "total_mcp_servers": 4, "total_packages": n_packages, "total_vulnerabilities": 1},
+        "agents": [{"name": f"agent-{i}", "type": "custom", "mcp_servers": [{"name": "srv", "blob": "z" * 500}]} for i in range(2)],
+        "packages": packages,
+        "inventory_snapshot": {"packages": packages},
+        "findings": findings,
+        "blast_radius": [{"vulnerability_id": "CVE-2026-9999", "package_name": "pkg-0", "severity": "medium", "risk_score": 4.5}],
+        "ai_inventory": {"ast_analysis": {"blob": "a" * 5000}, "secrets": {"blob": "b" * 5000}},
+        "ai_bom_entities": {"blob": "c" * 5000},
+    }
+
+
+def test_agent_mode_scan_summarizes_by_default():
+    report = _provenance_heavy_report()
+    full_size = len(json.dumps(report, default=str))
+
+    payload = success_envelope(command="agents", report_json=report, exit_code=0)
+    output = dumps_envelope(payload)
+
+    # Still valid JSON, and dramatically smaller than the full report.
+    reparsed = json.loads(output)
+    assert reparsed == payload
+    assert payload["data_mode"] == "summary"
+    assert len(output) < full_size // 10
+
+    data = payload["data"]
+    # Heavy provenance dumps are omitted by default.
+    assert "ai_inventory" not in data
+    assert "ai_bom_entities" not in data
+    assert "packages" not in data  # the full package list is replaced by counts
+    assert "inventory_snapshot" not in data
+
+    # Counts + top findings ARE present.
+    assert data["counts"]["packages"] == 400
+    assert data["counts"]["packages_by_ecosystem"] == {"npm": 200, "pypi": 200}
+    assert data["counts"]["findings_by_severity"]["critical"] == 3
+    assert len(data["top_findings"]) == 10
+    assert data["top_findings"][0]["severity"] == "critical"
+    assert len(data["top_exposure_paths"]) == 1
+    assert data["full_report"]["included"] is False
+    assert "--agent-mode-full" in data["full_report"]["hint"]
+
+
+def test_agent_mode_scan_full_inlines_report():
+    report = _provenance_heavy_report()
+
+    payload = success_envelope(command="agents", report_json=report, exit_code=0, full=True)
+
+    assert payload["data_mode"] == "full"
+    data = payload["data"]
+    assert "ai_inventory" in data
+    assert "ai_bom_entities" in data
+    assert len(data["packages"]) == 400
+
+
+def test_summarize_scan_data_records_output_path():
+    report = _provenance_heavy_report()
+    summary = summarize_scan_data(report, output_path="/tmp/report.json")
+    assert summary["full_report"]["output_path"] == "/tmp/report.json"
+    # stdout sentinel is not a real on-disk path
+    assert summarize_scan_data(report, output_path="-")["full_report"]["output_path"] is None
+
+
+def test_agent_mode_scan_summary_envelope_omits_provenance_end_to_end(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_CONFIG", raising=False)
+    result = _run(["agents", "--agent-mode", "--demo", "--no-scan", "--offline", "--no-auto-update-db"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["data_mode"] == "summary"
+    data = payload["data"]
+    assert "ai_inventory" not in data
+    assert "ai_bom_entities" not in data
+    assert "counts" in data and isinstance(data["counts"]["packages"], int)
+    assert isinstance(data["top_findings"], list)
 
 
 def test_agent_mode_entry_wraps_usage_errors(monkeypatch, capsys):


### PR DESCRIPTION
## Problem

`agents --agent-mode` (the surface built for LLM/automation callers) inlined the full per-package provenance report under `data` — `ai_inventory`, `ai_bom_entities`, the complete `findings`/`packages` lists with nested `discovery_provenance`/`version_provenance`. For a ~877-package repo the stdout envelope was **~27 MB of valid JSON**, far too large for any caller's context window. By contrast `--agent-mode check` is ~3 KB.

## Change

Agent mode now emits a bounded summary by default (`data_mode: "summary"`):

- counts — packages by ecosystem, findings by severity, exposure by severity, totals
- the top 10 ranked findings and top 10 exposure paths (by risk score then severity), each reduced to a compact field set
- a summary-level agent inventory (name/type/status/server count, capped server names)
- top-level metadata (`schema_version`, `document_type`, `generated_at`, `scan_id`, `posture_grade`)
- `data.full_report` recording how to get complete detail

The heavy provenance dump is omitted, dropping the same scan from **~27 MB to ~8 KB** while remaining valid, stable JSON.

### Getting full detail

- `--agent-mode-full` re-inlines the complete legacy report (`data_mode: "full"`)
- or write JSON to disk with `-o report.json --format json`

`--agent-token-budget` still trims either shape.

### Contract

The `{schema_version, mode, ok, command, exit_code, summary, confidence, truncation, data}` envelope is unchanged and additively gains a self-describing `data_mode` discriminator, so `check`/`skills`/`cost` envelopes are unaffected (no false version bump). The v1 envelope contract schema documents `data_mode`.

Also fixes a latent bug where the envelope `summary.packages` field fell through to the full package list instead of an integer count.

## Validation

- Repro on a ~877-package repo: default stdout `8373` bytes (valid JSON, `data_mode=summary`) vs `26795581` bytes with `--agent-mode-full` (valid JSON, `data_mode=full`).
- `ruff format` + `ruff check` clean; pre-commit (mypy/bandit/etc.) passed.
- Tests added in `tests/test_cli_scan.py`: `test_agent_mode_scan_summarizes_by_default`, `test_agent_mode_scan_full_inlines_report`, `test_summarize_scan_data_records_output_path`, `test_agent_mode_scan_summary_envelope_omits_provenance_end_to_end`. Existing scan/check/contract suites pass.

## Files

- `src/agent_bom/cli/_agent_mode.py` — `summarize_scan_data`, summary default in `success_envelope`, `data_mode`, summary-count fix
- `src/agent_bom/cli/options_sources.py` — `--agent-mode-full`
- `src/agent_bom/cli/agents/__init__.py`, `agents/_output.py` — flag wiring
- `contracts/v1/agent-mode-envelope.schema.json`, `docs/cli.md`, `site-docs/reference/cli.md`, `CHANGELOG.md`
- `tests/test_cli_scan.py`