### PR TITLE
fix(cloud): exit non-zero when a requested provider SDK or creds are missing

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,13 @@ The canonical command reference lives in
   configured, and `cloud aws` / `cloud azure` / `cloud gcp` are aliases for the
   provider-scoped form. CIS misconfigurations converge into the same `Finding`
   stream and `--fail-on-severity` exit-code gate as package vulnerabilities.
+  An explicitly requested provider that hard-fails discovery or its CIS
+  benchmark (missing SDK or absent/invalid credentials) makes the command exit
+  non-zero, while a genuinely empty-but-successful scan and skipped
+  auto-detected clouds still exit 0; one provider failing never aborts the
+  others.
+- `agent-bom secrets <dir>` accepts `--offline` as a no-op (secret scanning is
+  always local) for parity with `agents`/`scan` so shared CI invocations work.
 - `agent-bom cloud registry-scan --provider <ecr|acr|gar>` sweeps an entire
   container registry read-only, deduping by content digest and capping the work
   list with `AGENT_BOM_REGISTRY_MAX_IMAGES` / `AGENT_BOM_REGISTRY_MAX_TAGS_PER_REPO`.

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -124,6 +124,8 @@ verbs are additive entry points that delegate to the underlying implementations.
 - Use `agent-bom agents -f sarif -o -` when you need SARIF on stdout for piping.
 - `where` is available both as `agent-bom where` and `agent-bom mcp where`.
 - `agent-bom verify` and `agent-bom verify agent-bom` both self-verify the installed package.
+- `cloud aws` / `cloud azure` / `cloud gcp` (and `cloud scan --provider <name>`) exit non-zero when an explicitly requested provider hard-fails discovery or its CIS benchmark because the provider SDK is not installed or credentials are absent/invalid. The helpful `pip install 'agent-bom[<provider>]'` / credential-setup message is still printed. A genuinely empty-but-successful scan (credentials present, no AI resources) still exits 0, and one provider failing never aborts the others — every requested provider is still attempted, the exit code only reflects that one hard-failed. `cloud scan --provider all` only scans auto-detected configured clouds, so unconfigured clouds are skipped (not failed) and the run stays at exit 0.
+- `secrets` accepts `--offline` as a no-op for parity with `agents`/`scan`; secret scanning is always local and never makes network calls, so shared CI invocations that pass `--offline` work unchanged.
 
 ## Common flags
 

--- a/src/agent_bom/cli/_focused_commands.py
+++ b/src/agent_bom/cli/_focused_commands.py
@@ -271,6 +271,11 @@ def sbom_cmd(
     default=False,
     help="Also flag high-entropy values assigned to secret-named keys (catches novel secrets; higher recall, some false positives).",
 )
+@click.option(
+    "--offline",
+    is_flag=True,
+    help="No-op — secret scanning is always local and never makes network calls. Accepted for parity with `scan`.",
+)
 @click.option("--quiet", "-q", is_flag=True)
 def secrets_cmd(
     path: str,
@@ -280,6 +285,7 @@ def secrets_cmd(
     log_json: bool,
     log_file: Optional[str],
     detect_entropy: bool,
+    offline: bool,
     quiet: bool,
 ) -> None:
     """Scan a directory for hardcoded secrets and PII.
@@ -293,7 +299,12 @@ def secrets_cmd(
       agent-bom secrets .                   # scan current directory
       agent-bom secrets /path/to/project    # scan specific project
       agent-bom secrets . --format json     # JSON output
+      agent-bom secrets . --offline         # --offline is a no-op (always local)
     """
+    # --offline is accepted for parity with `scan` (shared CI invocations) but is
+    # inherently a no-op: secret scanning reads local files and never touches the
+    # network. Referenced here so its acceptance is explicit.
+    _ = offline
     import json as _json
 
     from rich.console import Console

--- a/src/agent_bom/cli/agents/_cloud.py
+++ b/src/agent_bom/cli/agents/_cloud.py
@@ -27,6 +27,18 @@ def _cis_status_badge(status_value: str) -> str:
     return _CIS_STATUS_STYLE.get(status_value, status_value)
 
 
+def _safe_error(exc: object) -> str:
+    """Escape an error message for Rich so bracketed install hints survive.
+
+    Provider errors carry hints like ``pip install 'agent-bom[aws]'``; without
+    escaping, Rich parses ``[aws]`` as a markup tag and drops it, mangling the
+    one piece of guidance the operator needs.
+    """
+    from rich.markup import escape
+
+    return escape(str(exc))
+
+
 def run_cloud_discovery(
     ctx: ScanContext,
     *,
@@ -139,7 +151,12 @@ def run_cloud_discovery(
             else:
                 con.print(f"  [dim]  No AI agents found in {provider_name.upper()}[/dim]")
         except CloudDiscoveryError as exc:
-            con.print(f"\n  [red]{provider_name.upper()} discovery error: {exc}[/red]")
+            con.print(f"\n  [red]{provider_name.upper()} discovery error: {_safe_error(exc)}[/red]")
+            # A requested provider whose SDK or credentials are missing/invalid is a
+            # hard failure, not a clean empty result. Record it so the final exit code
+            # is non-zero (silent CI passes are the bug). The loop continues, so the
+            # other requested providers are still scanned.
+            ctx.cloud_provider_failures.append({"provider": provider_name, "stage": "discovery", "error": str(exc)})
 
     # Step 1h2: Auto-scan container images discovered from cloud providers (Azure, GCP, etc.)
     # Cloud providers discover container refs but cannot scan them — bridge that gap here.
@@ -310,7 +327,8 @@ def run_benchmarks(
             rate = ctx.cis_benchmark_report.pass_rate
             con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
         except CloudDiscoveryError as exc:
-            con.print(f"  [red]CIS Benchmark error: {exc}[/red]")
+            con.print(f"  [red]CIS Benchmark error: {_safe_error(exc)}[/red]")
+            ctx.cloud_provider_failures.append({"provider": "aws", "stage": "cis_benchmark", "error": str(exc)})
 
     # Step 1x-sf: CIS Snowflake Benchmark
     if snowflake_cis_benchmark:
@@ -328,7 +346,8 @@ def run_benchmarks(
             rate = ctx.sf_cis_benchmark_report.pass_rate
             con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
         except _SFCISError as exc:
-            con.print(f"  [red]CIS Snowflake Benchmark error: {exc}[/red]")
+            con.print(f"  [red]CIS Snowflake Benchmark error: {_safe_error(exc)}[/red]")
+            ctx.cloud_provider_failures.append({"provider": "snowflake", "stage": "cis_benchmark", "error": str(exc)})
 
     # Step 1x-az: CIS Azure Benchmark
     if azure_cis_benchmark:
@@ -347,7 +366,8 @@ def run_benchmarks(
             rate = ctx.azure_cis_benchmark_report.pass_rate
             con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
         except _AZCISError as exc:
-            con.print(f"  [red]CIS Azure Benchmark error: {exc}[/red]")
+            con.print(f"  [red]CIS Azure Benchmark error: {_safe_error(exc)}[/red]")
+            ctx.cloud_provider_failures.append({"provider": "azure", "stage": "cis_benchmark", "error": str(exc)})
 
     # Step 1x-gcp: CIS GCP Benchmark
     if gcp_cis_benchmark:
@@ -364,7 +384,8 @@ def run_benchmarks(
             rate = ctx.gcp_cis_benchmark_report.pass_rate
             con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
         except _GCPCISError as exc:
-            con.print(f"  [red]CIS GCP Benchmark error: {exc}[/red]")
+            con.print(f"  [red]CIS GCP Benchmark error: {_safe_error(exc)}[/red]")
+            ctx.cloud_provider_failures.append({"provider": "gcp", "stage": "cis_benchmark", "error": str(exc)})
 
     # Step 1x-db: Databricks Security Best Practices
     if databricks_security:
@@ -385,7 +406,8 @@ def run_benchmarks(
             rate = ctx.databricks_security_report.pass_rate
             con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
         except _DBSecError as exc:
-            con.print(f"  [red]Databricks security check error: {exc}[/red]")
+            con.print(f"  [red]Databricks security check error: {_safe_error(exc)}[/red]")
+            ctx.cloud_provider_failures.append({"provider": "databricks", "stage": "security_checks", "error": str(exc)})
 
     # Step 1x-b: Vector DB scan
     if vector_db_scan:

--- a/src/agent_bom/cli/agents/_context.py
+++ b/src/agent_bom/cli/agents/_context.py
@@ -37,6 +37,12 @@ class ScanContext:
     delta_result: Any = None
     policy_passed: bool = True
     exit_code: int = 0
+    # Cloud providers that were explicitly requested but hard-failed discovery or
+    # benchmarking (missing SDK / absent / invalid credentials → CloudDiscoveryError).
+    # Recorded per provider+stage; a non-empty list forces a non-zero exit so a
+    # requested cloud silently passing in CI is impossible. One provider failing
+    # never aborts the others — every requested provider is still attempted.
+    cloud_provider_failures: list = field(default_factory=list)
     # per-step timing breakdown (step_name → seconds)
     step_timings: dict = field(default_factory=dict)
     # internal references used for AI enrichment

--- a/src/agent_bom/cli/agents/_post.py
+++ b/src/agent_bom/cli/agents/_post.py
@@ -365,6 +365,16 @@ def compute_exit_code(
     if not ctx.policy_passed:
         exit_code = 1
 
+    # A requested cloud provider that hard-failed discovery or benchmarking
+    # (missing SDK / absent / invalid credentials) must surface as a non-zero
+    # exit so a silent pass in CI is impossible. A genuinely empty-but-successful
+    # scan records no failure and still exits 0.
+    if ctx.cloud_provider_failures:
+        if not quiet:
+            providers = ", ".join(sorted({str(f.get("provider", "?")) for f in ctx.cloud_provider_failures}))
+            con.print(f"\n  [red]Exiting with code 1: cloud provider discovery failed for {providers} (missing SDK or credentials)[/red]")
+        exit_code = 1
+
     # Push results to central dashboard
     if push_url and report:
         try:

--- a/tests/test_cli_cloud_scan.py
+++ b/tests/test_cli_cloud_scan.py
@@ -410,3 +410,134 @@ class TestGroupedCisRendererRouting:
         monkeypatch.setattr(output_mod, "console", con)
         _render_cis_findings(ScanContext(con=con))
         assert buf.getvalue() == ""
+
+
+# ── requested-provider hard failure → non-zero exit (no silent CI pass) ───────
+
+
+class TestRequestedProviderHardFailExits:
+    """A provider that is explicitly requested but whose SDK or credentials are
+    missing/invalid (CloudDiscoveryError) must make the scan exit non-zero. A
+    genuinely empty-but-successful scan still exits 0, and one provider failing
+    never aborts the others."""
+
+    def test_discovery_sdk_missing_exits_nonzero(self, monkeypatch):
+        from agent_bom.cli import main
+        from agent_bom.cloud import CloudDiscoveryError
+
+        def _raise(provider, **kwargs):
+            raise CloudDiscoveryError("boto3 is required for AWS scanning. Install with pip install 'agent-bom[aws]'")
+
+        monkeypatch.setattr("agent_bom.cloud.discover_from_provider", _raise)
+
+        r = CliRunner().invoke(main, ["scan", "--aws", "--no-discover", "--offline"])
+        assert r.exit_code == 1
+        # The helpful install hint is preserved (brackets survive Rich markup),
+        # and the gate message is shown. Normalize wrapping inserted by the
+        # console at narrow widths before matching.
+        normalized = " ".join(r.output.split())
+        assert "pip install 'agent-bom[aws]'" in normalized
+        assert "cloud provider discovery failed for aws" in normalized
+
+    def test_cis_benchmark_sdk_missing_exits_nonzero(self, monkeypatch):
+        from agent_bom.cli import main
+        from agent_bom.cloud import CloudDiscoveryError
+
+        # Discovery succeeds-but-empty; the CIS benchmark is the hard failure.
+        monkeypatch.setattr("agent_bom.cloud.discover_from_provider", lambda provider, **kwargs: ([], []))
+
+        def _raise_cis(**kwargs):
+            raise CloudDiscoveryError("boto3 is required for AWS scanning.")
+
+        monkeypatch.setattr("agent_bom.cloud.aws_cis_benchmark.run_benchmark", _raise_cis)
+
+        r = CliRunner().invoke(main, ["scan", "--aws", "--aws-cis-benchmark", "--no-discover", "--offline"])
+        assert r.exit_code == 1
+        assert "cloud provider discovery failed for aws" in r.output
+
+    def test_empty_but_successful_scan_still_exits_zero(self, monkeypatch):
+        from agent_bom.cli import main
+
+        # Credentials present, provider reachable, simply no AI resources found.
+        monkeypatch.setattr("agent_bom.cloud.discover_from_provider", lambda provider, **kwargs: ([], []))
+
+        r = CliRunner().invoke(main, ["scan", "--aws", "--no-discover", "--offline"])
+        assert r.exit_code == 0
+        assert "cloud provider discovery failed" not in r.output
+
+    def test_one_provider_failing_does_not_skip_the_others(self, monkeypatch):
+        """Both requested providers are attempted even when the first hard-fails;
+        the failure is recorded once per provider and the exit code is non-zero."""
+        from rich.console import Console
+
+        from agent_bom.cli.agents._cloud import run_cloud_discovery
+        from agent_bom.cli.agents._context import ScanContext
+        from agent_bom.cli.agents._post import compute_exit_code
+        from agent_bom.cloud import CloudDiscoveryError
+
+        attempted: list[str] = []
+
+        def _raise(provider, **kwargs):
+            attempted.append(provider)
+            raise CloudDiscoveryError(f"{provider} SDK missing")
+
+        monkeypatch.setattr("agent_bom.cloud.discover_from_provider", _raise)
+
+        ctx = ScanContext(con=Console(quiet=True))
+        run_cloud_discovery(
+            ctx,
+            skill_only=False,
+            aws=True,
+            aws_region=None,
+            aws_profile=None,
+            aws_include_lambda=False,
+            aws_include_eks=False,
+            aws_include_step_functions=False,
+            aws_include_ec2=False,
+            aws_include_iam=False,
+            aws_ec2_tag=None,
+            azure_flag=True,
+            azure_subscription=None,
+            gcp_flag=False,
+            gcp_project=None,
+            coreweave_flag=False,
+            coreweave_context=None,
+            coreweave_namespace=None,
+            databricks_flag=False,
+            snowflake_flag=False,
+            snowflake_authenticator=None,
+            nebius_flag=False,
+            nebius_api_key=None,
+            nebius_project_id=None,
+            hf_flag=False,
+            hf_token=None,
+            hf_username=None,
+            hf_organization=None,
+            wandb_flag=False,
+            wandb_api_key=None,
+            wandb_entity=None,
+            wandb_project=None,
+            mlflow_flag=False,
+            mlflow_tracking_uri=None,
+            openai_flag=False,
+            openai_api_key=None,
+            openai_org_id=None,
+            ollama_flag=False,
+            ollama_host=None,
+        )
+
+        # Both requested providers were attempted (no early abort).
+        assert attempted == ["aws", "azure"]
+        failed = {f["provider"] for f in ctx.cloud_provider_failures}
+        assert failed == {"aws", "azure"}
+        code = compute_exit_code(
+            ctx,
+            fail_on_severity=None,
+            warn_on_severity=None,
+            fail_on_kev=False,
+            fail_if_ai_risk=False,
+            push_url=None,
+            push_api_key=None,
+            quiet=True,
+        )
+        assert code == 1

--- a/tests/test_focused_security_gates.py
+++ b/tests/test_focused_security_gates.py
@@ -65,6 +65,24 @@ def test_secrets_command_exits_zero_when_clean(tmp_path: Path):
     assert "No secrets or PII found" in result.output
 
 
+def test_secrets_command_accepts_offline_flag_as_noop(tmp_path: Path):
+    # `--offline` is accepted for parity with scan; secret scanning is always
+    # local so it neither errors (exit 2 usage error) nor changes the result.
+    (tmp_path / "README.md").write_text("No credentials here.\n", encoding="utf-8")
+
+    result = CliRunner().invoke(main, ["secrets", str(tmp_path), "--offline"])
+
+    assert result.exit_code == 0
+    assert "No secrets or PII found" in result.output
+
+
+def test_secrets_offline_flag_listed_in_help():
+    result = CliRunner().invoke(main, ["secrets", "--help"])
+
+    assert result.exit_code == 0
+    assert "--offline" in result.output
+
+
 def test_iac_command_exits_one_for_high_findings_by_default(tmp_path: Path):
     finding = IaCFinding(
         rule_id="TF-TEST",


### PR DESCRIPTION
## Summary

Two CLI exit-code/parity fixes.

### FIX A — `cloud aws`/`azure`/`gcp` silently passed when the SDK or credentials were missing

`cloud aws` (and `cloud scan --provider <name>`) exited `0` even when the requested provider could not be scanned because the provider SDK was not installed or credentials were absent/invalid. The `CloudDiscoveryError` raised by per-provider discovery and the CIS benchmarks was caught and downgraded to a console warning that never affected the exit code, so the failure passed silently in CI.

Now each requested provider that hard-fails discovery or benchmarking is recorded on the scan context, and the final exit code is `1` when any are present.

- Every requested provider is still attempted — one failing never aborts the others.
- A genuinely empty-but-successful scan (creds present, no AI resources) still exits `0`.
- `cloud scan --provider all` still skips unconfigured clouds (auto-detect) without failing.
- The bracketed install hint `pip install 'agent-bom[aws]'` is now Rich-escaped, so `[aws]` survives markup parsing instead of being dropped from the message.

### FIX B — `secrets` rejected `--offline`

`agent-bom secrets <dir> --offline` exited `2` with a usage error while `scan` accepts `--offline`. Secret scanning is inherently local, so `--offline` is now accepted as a documented no-op for parity, letting shared CI invocations work unchanged.

## Behavior

| Scenario | Before | After |
| --- | --- | --- |
| `cloud aws` with no boto3 / no creds | exit 0 | exit 1 |
| `cloud scan --provider all` (some clouds unconfigured) | exit 0 | exit 0 (unchanged) |
| Provider reachable, no AI resources found | exit 0 | exit 0 (unchanged) |
| `secrets <dir> --offline` | exit 2 (usage error) | exit 0 |

## Files changed

- `src/agent_bom/cli/agents/_context.py` — `cloud_provider_failures` field on `ScanContext`.
- `src/agent_bom/cli/agents/_cloud.py` — record discovery + CIS/Databricks benchmark `CloudDiscoveryError` failures; Rich-escape provider error messages.
- `src/agent_bom/cli/agents/_post.py` — flip exit code to 1 in `compute_exit_code` when failures are present.
- `src/agent_bom/cli/_focused_commands.py` — `--offline` no-op flag on `secrets`.
- `docs/cli.md`, `site-docs/reference/cli.md` — document the exit-code semantics and `secrets --offline`.
- `tests/test_cli_cloud_scan.py`, `tests/test_focused_security_gates.py` — coverage for both fixes.

## Tests

- `TestRequestedProviderHardFailExits::test_discovery_sdk_missing_exits_nonzero`
- `TestRequestedProviderHardFailExits::test_cis_benchmark_sdk_missing_exits_nonzero`
- `TestRequestedProviderHardFailExits::test_empty_but_successful_scan_still_exits_zero`
- `TestRequestedProviderHardFailExits::test_one_provider_failing_does_not_skip_the_others`
- `test_secrets_command_accepts_offline_flag_as_noop`
- `test_secrets_offline_flag_listed_in_help`

`action.yml` has no `cloud` scan-type and does not pass `--offline`, so its exit-code gating is unaffected.