### PR TITLE
fix(agent-mode): redact credential values from the machine-readable envelope (#1760)

### DIFF
--- a/src/agent_bom/cli/_agent_mode.py
+++ b/src/agent_bom/cli/_agent_mode.py
@@ -4,9 +4,43 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from copy import deepcopy
 from typing import Any
+
+# Keys whose value is credential material and must never appear in the
+# machine-readable envelope, which automation callers routinely capture and log.
+# Matched on the key name only, as a whole token, so reference labels and entity
+# types (e.g. a credential node's ``label`` or ``entity_type``) — which name what
+# was found without exposing its value — are preserved. Bare ``token``/``key`` are
+# intentionally excluded to avoid masking fields like ``token_budget``.
+_SENSITIVE_KEY_RE = re.compile(
+    r"(?:^|[_-])(?:password|passwd|pwd|secret|secrets|api[_-]?key|access[_-]?key|"
+    r"secret[_-]?key|private[_-]?key|client[_-]?secret|auth[_-]?token|"
+    r"session[_-]?token|bearer|registry[_-]?pass)(?:$|[_-])",
+    re.IGNORECASE,
+)
+_REDACTED = "[REDACTED]"
+
+
+def _redact_sensitive(value: Any, *, key_is_sensitive: bool = False) -> Any:
+    """Return a copy of ``value`` with credential-keyed string values masked.
+
+    Recurses through dicts and lists. A string is masked only when its own key
+    matched :data:`_SENSITIVE_KEY_RE`; structural values (lists/dicts) under a
+    sensitive key are still walked so nested non-secret fields survive. This is
+    the single sanitization barrier for every agent-mode envelope, so no provider
+    payload can leak a secret value into stdout regardless of its source.
+    """
+    if isinstance(value, dict):
+        return {key: _redact_sensitive(item, key_is_sensitive=bool(_SENSITIVE_KEY_RE.search(str(key)))) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_sensitive(item) for item in value]
+    if key_is_sensitive and isinstance(value, str) and value and value != _REDACTED:
+        return _REDACTED
+    return value
+
 
 AGENT_MODE_ENV_VAR = "AGENT_BOM_AGENT_MODE"
 AGENT_MODE_SCHEMA_VERSION = "1"
@@ -390,4 +424,4 @@ def error_envelope(*, command: str | None, message: str, exit_code: int, error_t
 
 
 def dumps_envelope(payload: dict[str, Any]) -> str:
-    return json.dumps(payload, separators=(",", ":"), sort_keys=True, default=str)
+    return json.dumps(_redact_sensitive(payload), separators=(",", ":"), sort_keys=True, default=str)

--- a/tests/test_agent_mode_redaction.py
+++ b/tests/test_agent_mode_redaction.py
@@ -1,0 +1,53 @@
+"""Agent-mode envelope must never emit credential values as clear text.
+
+The machine-readable envelope is routinely captured and logged by automation
+callers, so any value under a credential-named key is masked at the single
+serialization choke point (``dumps_envelope``), while reference labels, entity
+types, and non-secret fields like ``token_budget`` are preserved.
+"""
+
+from __future__ import annotations
+
+import json
+
+from agent_bom.cli._agent_mode import dumps_envelope
+
+
+def test_envelope_redacts_secret_keyed_values_but_keeps_references() -> None:
+    payload = {
+        "data": {
+            "password": "hunter2-real-secret",
+            "registry_pass": "dckr_pat_abc123",
+            "api_key": "sk-live-xyz",
+            "client_secret": "cs-987",
+            "token_budget": 4000,
+            "safe_to_store": False,
+            "nodes": [
+                {"entity_type": "credential", "label": "GITHUB_FINE_GRAINED_TOKEN"},
+                {"matched_preview": "[SECRET_REDACTED]"},
+            ],
+            "mcp": {"env": {"DB_PASSWORD": "pgpass", "HOST": "db.local"}},
+        }
+    }
+
+    out = json.loads(dumps_envelope(payload))["data"]
+
+    # secret-keyed string values are masked
+    assert out["password"] == "[REDACTED]"
+    assert out["registry_pass"] == "[REDACTED]"
+    assert out["api_key"] == "[REDACTED]"
+    assert out["client_secret"] == "[REDACTED]"
+    assert out["mcp"]["env"]["DB_PASSWORD"] == "[REDACTED]"
+
+    # non-secret fields and reference labels survive
+    assert out["token_budget"] == 4000
+    assert out["safe_to_store"] is False
+    assert out["mcp"]["env"]["HOST"] == "db.local"
+    assert out["nodes"][0]["label"] == "GITHUB_FINE_GRAINED_TOKEN"
+    assert out["nodes"][0]["entity_type"] == "credential"
+
+
+def test_redaction_is_idempotent() -> None:
+    once = dumps_envelope({"password": "x"})
+    twice = dumps_envelope(json.loads(once))
+    assert json.loads(twice)["password"] == "[REDACTED]"


### PR DESCRIPTION
Resolves CodeQL alert #1760 (`py/clear-text-logging-sensitive-data`, High) at `src/agent_bom/cli/agents/_output.py`.

The agent-mode envelope serializes the scan report (or its summary) to stdout, which automation callers routinely capture and log. Any value carried under a credential-named key in an aggregated provider payload could therefore be written as clear text.

Fix: a single recursive redaction barrier in `dumps_envelope` — the one serialization choke point for every agent-mode envelope — masks string values whose key matches a credential-name allowlist (password, registry_pass, api_key, client_secret, private_key, etc.). Reference labels, entity types, and non-secret fields such as `token_budget` are preserved; bare `token`/`key` are intentionally excluded. This closes the exposure regardless of which provider payload supplies the value, and is the recognized sanitizer at the sink.

Secret-scanner findings were already redacted (`matched_preview` never includes matched bytes); this hardens the envelope against any other collector. Adds a regression test; existing agent-mode tests (125) pass.