### PR TITLE
fix(agent-mode): redact credentials at the envelope source (#1760)

### DIFF
--- a/src/agent_bom/cli/_agent_mode.py
+++ b/src/agent_bom/cli/_agent_mode.py
@@ -344,7 +344,11 @@ def success_envelope(
     automation caller's context window. Pass ``full=True`` to inline the
     complete report (the legacy shape); ``data_mode`` records which shape was
     emitted.
+
+    Credential-keyed values are stripped from the report up front so no secret
+    can reach the serialized envelope, which automation callers routinely log.
     """
+    report_json = _redact_sensitive(report_json)
     if full:
         data, truncation = _truncate_report(report_json, token_budget)
         data_mode = "full"


### PR DESCRIPTION
Strengthens the fix for CodeQL alert #1760 (`py/clear-text-logging-sensitive-data`, High).

The initial fix redacted inside `dumps_envelope`, after the report had already flowed into the payload at the call site (`src/agent_bom/cli/agents/_output.py:294`). This moves the redaction to the top of `success_envelope`, so the report is sanitized **before** it reaches the summary, truncation, and `data` fields — no credential-keyed value enters the envelope structure at all. The `dumps_envelope` barrier is kept as defense in depth.

Verified that credential-keyed values (password, registry_pass, DB_PASSWORD, etc.) are masked while reference labels and non-secret fields are preserved. 200 agent-mode/redaction tests pass.

Note: the custom redactor is not part of CodeQL's modeled sanitizer set, so the alert may require a justified dismissal even with this barrier in place; the code path is mitigated regardless of which provider payload supplies the value.