### PR TITLE
feat(core): Router + component registries + orchestrator read-model (foundation)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -361,6 +361,11 @@ module = [
     "agent_bom.backpressure",
     "agent_bom.proxy_sandbox",
     "agent_bom.capabilities",
+    "agent_bom.routing",
+    "agent_bom.orchestration",
+    "agent_bom.components.base",
+    "agent_bom.components.enricher_registry",
+    "agent_bom.components.matcher_registry",
 ]
 disallow_untyped_defs = true
 disallow_incomplete_defs = true

--- a/src/agent_bom/components/__init__.py
+++ b/src/agent_bom/components/__init__.py
@@ -1,0 +1,55 @@
+"""Component-model registries for enrichers and matchers/correlators.
+
+This package mirrors :mod:`agent_bom.scanners.registry` for the two pipeline
+component roles that have no registry today: **enrichers** (CVSS/EPSS/KEV/GHSA,
+AI, registry reputation, estate context) and **matchers/correlators**
+(`correlate.py`, `cross_env_correlation.py`, `runtime_correlation.py`).
+
+The registrations here are metadata-first and descriptive. Existing enrichment
+and correlation execution stays wired through the current CLI/API pipeline;
+these entries give product/API/UI surfaces a capability contract before any
+component is migrated behind a common run interface. No execution path is
+changed by importing or reading these registries.
+"""
+
+from __future__ import annotations
+
+from agent_bom.components.base import (
+    ComponentRole,
+    EnricherRegistration,
+    MatcherRegistration,
+)
+from agent_bom.components.enricher_registry import (
+    builtin_enricher_registrations,
+    enricher_registry_summary,
+    enricher_registry_warnings,
+    get_enricher_registration,
+    list_registered_enrichers,
+    register_enricher,
+)
+from agent_bom.components.matcher_registry import (
+    builtin_matcher_registrations,
+    get_matcher_registration,
+    list_registered_matchers,
+    matcher_registry_summary,
+    matcher_registry_warnings,
+    register_matcher,
+)
+
+__all__ = [
+    "ComponentRole",
+    "EnricherRegistration",
+    "MatcherRegistration",
+    "builtin_enricher_registrations",
+    "builtin_matcher_registrations",
+    "enricher_registry_summary",
+    "enricher_registry_warnings",
+    "get_enricher_registration",
+    "get_matcher_registration",
+    "list_registered_enrichers",
+    "list_registered_matchers",
+    "matcher_registry_summary",
+    "matcher_registry_warnings",
+    "register_enricher",
+    "register_matcher",
+]

--- a/src/agent_bom/components/base.py
+++ b/src/agent_bom/components/base.py
@@ -1,0 +1,157 @@
+"""Shared registry types for enricher and matcher components.
+
+Mirrors :mod:`agent_bom.scanners.base`. Like the scanner-driver registry, this
+layer is metadata-first: each enricher/matcher declares its inputs, outputs,
+phase, and execution state so surfaces have a stable contract, while the actual
+enrichment/correlation execution remains wired through the existing pipeline.
+
+Phase and execution-state vocabularies are reused from the scanner registry so
+all three component roles share one capability model.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+from agent_bom.extensions import ExtensionCapabilities, RegistryEntry
+from agent_bom.scanners.base import ScannerExecutionState, ScannerPhase
+
+
+class ComponentRole(str, Enum):
+    """Pipeline component role a registration describes."""
+
+    ENRICHER = "enricher"
+    MATCHER = "matcher"
+
+
+def local_analysis_capabilities(
+    *,
+    scan_modes: tuple[str, ...] = ("analysis",),
+    guarantees: tuple[str, ...] = ("read_only",),
+) -> ExtensionCapabilities:
+    """In-memory, no-network component capabilities."""
+
+    return ExtensionCapabilities(
+        scan_modes=scan_modes,
+        required_scopes=("local_analysis_read",),
+        outbound_destinations=(),
+        data_boundary="local_in_memory_analysis",
+        network_access=False,
+        guarantees=guarantees,
+    )
+
+
+def network_lookup_capabilities(
+    *,
+    destinations: tuple[str, ...],
+    scan_modes: tuple[str, ...] = ("online",),
+    required_scopes: tuple[str, ...] = ("network_egress",),
+) -> ExtensionCapabilities:
+    """Read-only metadata lookup capabilities with bounded egress."""
+
+    return ExtensionCapabilities(
+        scan_modes=scan_modes,
+        required_scopes=required_scopes,
+        outbound_destinations=destinations,
+        data_boundary="read_only_metadata_lookup",
+        network_access=True,
+        guarantees=("read_only", "bounded_egress"),
+    )
+
+
+def _capabilities_dict(capabilities: ExtensionCapabilities) -> dict[str, Any]:
+    return {
+        "scan_modes": list(capabilities.scan_modes),
+        "required_scopes": list(capabilities.required_scopes),
+        "permissions_used": list(capabilities.permissions_used),
+        "outbound_destinations": list(capabilities.outbound_destinations),
+        "data_boundary": capabilities.data_boundary,
+        "writes": capabilities.writes,
+        "network_access": capabilities.network_access,
+        "guarantees": list(capabilities.guarantees),
+    }
+
+
+@dataclass(frozen=True)
+class EnricherRegistration(RegistryEntry):
+    """Registry metadata for an enricher component implementation."""
+
+    phase: ScannerPhase = ScannerPhase.ENRICHMENT
+    execution_state: ScannerExecutionState = ScannerExecutionState.ACTIVE
+    enabled_by_default: bool = True
+    run_attr: str = ""
+    input_types: tuple[str, ...] = ()
+    output_types: tuple[str, ...] = ()
+    enriches: tuple[str, ...] = ()
+    summary: str = ""
+
+    @property
+    def role(self) -> ComponentRole:
+        return ComponentRole.ENRICHER
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable API/CLI-safe representation."""
+
+        return {
+            "name": self.name,
+            "role": ComponentRole.ENRICHER.value,
+            "module": self.module,
+            "source": self.source,
+            "phase": self.phase.value,
+            "execution_state": self.execution_state.value,
+            "enabled_by_default": self.enabled_by_default,
+            "run_attr": self.run_attr,
+            "input_types": list(self.input_types),
+            "output_types": list(self.output_types),
+            "enriches": list(self.enriches),
+            "summary": self.summary,
+            "capabilities": _capabilities_dict(self.capabilities),
+        }
+
+
+@dataclass(frozen=True)
+class MatcherRegistration(RegistryEntry):
+    """Registry metadata for a matcher/correlator component implementation."""
+
+    phase: ScannerPhase = ScannerPhase.ANALYSIS
+    execution_state: ScannerExecutionState = ScannerExecutionState.ACTIVE
+    enabled_by_default: bool = True
+    run_attr: str = ""
+    input_types: tuple[str, ...] = ()
+    output_types: tuple[str, ...] = ()
+    correlation_types: tuple[str, ...] = ()
+    summary: str = ""
+
+    @property
+    def role(self) -> ComponentRole:
+        return ComponentRole.MATCHER
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable API/CLI-safe representation."""
+
+        return {
+            "name": self.name,
+            "role": ComponentRole.MATCHER.value,
+            "module": self.module,
+            "source": self.source,
+            "phase": self.phase.value,
+            "execution_state": self.execution_state.value,
+            "enabled_by_default": self.enabled_by_default,
+            "run_attr": self.run_attr,
+            "input_types": list(self.input_types),
+            "output_types": list(self.output_types),
+            "correlation_types": list(self.correlation_types),
+            "summary": self.summary,
+            "capabilities": _capabilities_dict(self.capabilities),
+        }
+
+
+__all__ = [
+    "ComponentRole",
+    "EnricherRegistration",
+    "MatcherRegistration",
+    "local_analysis_capabilities",
+    "network_lookup_capabilities",
+]

--- a/src/agent_bom/components/enricher_registry.py
+++ b/src/agent_bom/components/enricher_registry.py
@@ -1,0 +1,222 @@
+"""Enricher component registry.
+
+Mirrors :mod:`agent_bom.scanners.registry`. Registers the built-in enrichers as
+descriptive capability metadata so they are discoverable on the same surface as
+scanner drivers. These registrations do NOT change how enrichment runs today —
+the existing pipeline still calls each enricher directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_bom.components.base import (
+    EnricherRegistration,
+    local_analysis_capabilities,
+    network_lookup_capabilities,
+)
+from agent_bom.extensions import ExtensionCapabilities, iter_entry_point_registrations
+from agent_bom.scanners.base import ScannerExecutionState, ScannerPhase
+
+_ENTRY_POINT_GROUP = "agent_bom.enricher_drivers"
+
+_ENRICHER_REGISTRY: dict[str, EnricherRegistration] = {}
+_ENRICHER_REGISTRY_WARNINGS: list[str] = []
+_ENRICHER_REGISTRY_LOADED = False
+
+
+def builtin_enricher_registrations() -> list[EnricherRegistration]:
+    """Return built-in enricher registrations with capability metadata."""
+
+    return [
+        EnricherRegistration(
+            name="vulnerability-intel",
+            module="agent_bom.enrichment",
+            phase=ScannerPhase.ENRICHMENT,
+            run_attr="enrich_vulnerabilities",
+            input_types=("vulnerabilities", "cve_ids"),
+            output_types=("enriched_vulnerabilities",),
+            enriches=("cvss", "epss", "kev", "ghsa", "exploitability"),
+            summary="NVD CVSS, FIRST EPSS, CISA KEV, and GHSA enrichment with caching and circuit breaking.",
+            capabilities=network_lookup_capabilities(
+                destinations=("nvd.nist.gov", "first.org_epss", "cisa_kev_catalog", "github_advisory_database")
+            ),
+        ),
+        EnricherRegistration(
+            name="enrichment-posture",
+            module="agent_bom.enrichment_posture",
+            phase=ScannerPhase.ENRICHMENT,
+            run_attr="describe_enrichment_posture",
+            input_types=("enrichment_source_events",),
+            output_types=("enrichment_posture",),
+            enriches=("source_slo", "circuit_state", "freshness"),
+            summary="Per-source enrichment SLO, failure-threshold, and circuit-breaker posture tracking.",
+            capabilities=local_analysis_capabilities(scan_modes=("posture",)),
+            execution_state=ScannerExecutionState.PASSIVE,
+        ),
+        EnricherRegistration(
+            name="registry-reputation",
+            module="agent_bom.registry_enrichment",
+            phase=ScannerPhase.ENRICHMENT,
+            run_attr="enrich_registry",
+            input_types=("mcp_servers", "registry_entries"),
+            output_types=("registry_reputation",),
+            enriches=("registry_metadata", "risk_flags", "popularity"),
+            summary="MCP server registry reputation enrichment across Smithery, Docker Hub, and GitHub.",
+            capabilities=network_lookup_capabilities(
+                destinations=("smithery_registry", "docker_hub_registry", "github_api"),
+            ),
+        ),
+        EnricherRegistration(
+            name="estate-discovery",
+            module="agent_bom.scan_enrichment",
+            phase=ScannerPhase.ENRICHMENT,
+            run_attr="enrich_report_with_estate_discovery",
+            input_types=("report", "cloud_scope"),
+            output_types=("estate_inventory", "audit_trail", "identity_discovery"),
+            enriches=("cloud_inventory", "audit_trail", "identity"),
+            summary="Read-only cloud estate, audit-trail, and identity discovery fused onto the report.",
+            capabilities=network_lookup_capabilities(
+                destinations=("aws_apis", "azure_apis", "gcp_apis", "snowflake_apis"),
+                scan_modes=("cloud",),
+            ),
+            enabled_by_default=False,
+        ),
+        EnricherRegistration(
+            name="ai-enrichment",
+            module="agent_bom.ai_enrich",
+            phase=ScannerPhase.ENRICHMENT,
+            run_attr="run_ai_enrichment",
+            input_types=("blast_radii", "report"),
+            output_types=("ai_summaries", "threat_chains"),
+            enriches=("executive_summary", "blast_radius_narrative", "threat_chain"),
+            summary="Optional LLM-assisted blast-radius, executive-summary, and threat-chain narration.",
+            capabilities=ExtensionCapabilities(
+                scan_modes=("ai", "online"),
+                required_scopes=("llm_inference",),
+                outbound_destinations=("litellm_provider", "ollama_local", "huggingface_inference"),
+                data_boundary="findings_metadata_to_configured_model",
+                network_access=True,
+                guarantees=("read_only", "opt_in"),
+            ),
+            enabled_by_default=False,
+        ),
+    ]
+
+
+def _coerce_enricher_registration(value: Any, entry_point_name: str) -> EnricherRegistration:
+    if isinstance(value, EnricherRegistration):
+        return value
+    name = str(getattr(value, "name", entry_point_name)).strip()
+    module = str(getattr(value, "module", "")).strip()
+    if not name or not module:
+        raise ValueError("enricher registration must declare name and module")
+    capabilities = getattr(value, "capabilities", ExtensionCapabilities())
+    if not isinstance(capabilities, ExtensionCapabilities):
+        capabilities = ExtensionCapabilities()
+    phase = getattr(value, "phase", ScannerPhase.ENRICHMENT)
+    if not isinstance(phase, ScannerPhase):
+        phase = ScannerPhase(str(phase))
+    execution_state = getattr(value, "execution_state", ScannerExecutionState.ACTIVE)
+    if not isinstance(execution_state, ScannerExecutionState):
+        execution_state = ScannerExecutionState(str(execution_state))
+    return EnricherRegistration(
+        name=name,
+        module=module,
+        capabilities=capabilities,
+        source=str(getattr(value, "source", "entry_point")),
+        phase=phase,
+        execution_state=execution_state,
+        enabled_by_default=bool(getattr(value, "enabled_by_default", True)),
+        run_attr=str(getattr(value, "run_attr", "run")),
+        input_types=tuple(str(item) for item in getattr(value, "input_types", ())),
+        output_types=tuple(str(item) for item in getattr(value, "output_types", ())),
+        enriches=tuple(str(item) for item in getattr(value, "enriches", ())),
+        summary=str(getattr(value, "summary", "")),
+    )
+
+
+def register_enricher(registration: EnricherRegistration) -> None:
+    """Register an enricher component with capability metadata."""
+
+    if not registration.name:
+        raise ValueError("enricher registration must declare a name")
+    if registration.name in _ENRICHER_REGISTRY:
+        raise ValueError(f"duplicate enricher registration: {registration.name}")
+    _ENRICHER_REGISTRY[registration.name] = registration
+
+
+def _ensure_enricher_registry_loaded() -> None:
+    global _ENRICHER_REGISTRY_LOADED
+    if _ENRICHER_REGISTRY_LOADED:
+        return
+    for registration in builtin_enricher_registrations():
+        register_enricher(registration)
+    for registration in iter_entry_point_registrations(
+        group=_ENTRY_POINT_GROUP,
+        coerce=_coerce_enricher_registration,
+        warnings=_ENRICHER_REGISTRY_WARNINGS,
+    ):
+        register_enricher(registration)
+    _ENRICHER_REGISTRY_LOADED = True
+
+
+def list_registered_enrichers(*, include_planned: bool = True) -> list[EnricherRegistration]:
+    """Return registered enricher components sorted by name."""
+
+    _ensure_enricher_registry_loaded()
+    registrations = [_ENRICHER_REGISTRY[name] for name in sorted(_ENRICHER_REGISTRY)]
+    if include_planned:
+        return registrations
+    return [registration for registration in registrations if registration.execution_state != ScannerExecutionState.PLANNED]
+
+
+def get_enricher_registration(name: str) -> EnricherRegistration:
+    """Return one enricher registration or raise ``KeyError``."""
+
+    _ensure_enricher_registry_loaded()
+    return _ENRICHER_REGISTRY[name]
+
+
+def enricher_registry_warnings() -> list[str]:
+    """Return sanitized non-fatal registry loading warnings."""
+
+    _ensure_enricher_registry_loaded()
+    return list(_ENRICHER_REGISTRY_WARNINGS)
+
+
+def enricher_registry_summary() -> dict[str, object]:
+    """Return a compact enricher registry summary for API/UI surfaces."""
+
+    registrations = list_registered_enrichers(include_planned=True)
+    by_phase: dict[str, int] = {}
+    by_state: dict[str, int] = {}
+    for registration in registrations:
+        by_phase[registration.phase.value] = by_phase.get(registration.phase.value, 0) + 1
+        by_state[registration.execution_state.value] = by_state.get(registration.execution_state.value, 0) + 1
+    return {
+        "total": len(registrations),
+        "active": by_state.get(ScannerExecutionState.ACTIVE.value, 0),
+        "passive": by_state.get(ScannerExecutionState.PASSIVE.value, 0),
+        "planned": by_state.get(ScannerExecutionState.PLANNED.value, 0),
+        "by_phase": by_phase,
+        "by_state": by_state,
+    }
+
+
+def _reset_enricher_registry_for_tests() -> None:
+    _ENRICHER_REGISTRY.clear()
+    _ENRICHER_REGISTRY_WARNINGS.clear()
+    global _ENRICHER_REGISTRY_LOADED
+    _ENRICHER_REGISTRY_LOADED = False
+
+
+__all__ = [
+    "EnricherRegistration",
+    "builtin_enricher_registrations",
+    "enricher_registry_summary",
+    "enricher_registry_warnings",
+    "get_enricher_registration",
+    "list_registered_enrichers",
+    "register_enricher",
+]

--- a/src/agent_bom/components/matcher_registry.py
+++ b/src/agent_bom/components/matcher_registry.py
@@ -1,0 +1,180 @@
+"""Matcher/correlator component registry.
+
+Mirrors :mod:`agent_bom.scanners.registry`. Registers the built-in
+matchers/correlators (`correlate.py`, `cross_env_correlation.py`,
+`runtime_correlation.py`) as descriptive capability metadata. These
+registrations do NOT change how correlation runs today — the existing pipeline
+still calls each correlator directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_bom.components.base import MatcherRegistration, local_analysis_capabilities
+from agent_bom.extensions import ExtensionCapabilities, iter_entry_point_registrations
+from agent_bom.scanners.base import ScannerExecutionState, ScannerPhase
+
+_ENTRY_POINT_GROUP = "agent_bom.matcher_drivers"
+
+_MATCHER_REGISTRY: dict[str, MatcherRegistration] = {}
+_MATCHER_REGISTRY_WARNINGS: list[str] = []
+_MATCHER_REGISTRY_LOADED = False
+
+
+def builtin_matcher_registrations() -> list[MatcherRegistration]:
+    """Return built-in matcher/correlator registrations with capability metadata."""
+
+    return [
+        MatcherRegistration(
+            name="agent-dedup",
+            module="agent_bom.correlate",
+            phase=ScannerPhase.ANALYSIS,
+            run_attr="correlate_agents",
+            input_types=("agents",),
+            output_types=("agents", "correlation_result"),
+            correlation_types=("agent-merge", "package-dedup", "source-provenance"),
+            summary="Cross-source agent deduplication and package merge with provenance tracking.",
+            capabilities=local_analysis_capabilities(),
+        ),
+        MatcherRegistration(
+            name="cross-environment",
+            module="agent_bom.cross_env_correlation",
+            phase=ScannerPhase.ANALYSIS,
+            run_attr="correlate_cross_environment",
+            input_types=("agents", "cloud_inventory"),
+            output_types=("cross_environment_result",),
+            correlation_types=("bedrock", "azure-openai", "gcp-vertex", "local-to-cloud"),
+            summary="Local-to-cloud agent correlation across Bedrock, Azure OpenAI, and GCP Vertex evidence.",
+            capabilities=local_analysis_capabilities(scan_modes=("analysis", "cloud")),
+        ),
+        MatcherRegistration(
+            name="runtime-correlation",
+            module="agent_bom.runtime_correlation",
+            phase=ScannerPhase.ANALYSIS,
+            run_attr="correlate",
+            input_types=("runtime_audit_log", "findings"),
+            output_types=("correlation_report",),
+            correlation_types=("tool-call-amplifier", "runtime-to-finding"),
+            summary="Runtime proxy audit-log correlation linking tool-call activity to findings.",
+            capabilities=local_analysis_capabilities(scan_modes=("runtime",)),
+        ),
+    ]
+
+
+def _coerce_matcher_registration(value: Any, entry_point_name: str) -> MatcherRegistration:
+    if isinstance(value, MatcherRegistration):
+        return value
+    name = str(getattr(value, "name", entry_point_name)).strip()
+    module = str(getattr(value, "module", "")).strip()
+    if not name or not module:
+        raise ValueError("matcher registration must declare name and module")
+    capabilities = getattr(value, "capabilities", ExtensionCapabilities())
+    if not isinstance(capabilities, ExtensionCapabilities):
+        capabilities = ExtensionCapabilities()
+    phase = getattr(value, "phase", ScannerPhase.ANALYSIS)
+    if not isinstance(phase, ScannerPhase):
+        phase = ScannerPhase(str(phase))
+    execution_state = getattr(value, "execution_state", ScannerExecutionState.ACTIVE)
+    if not isinstance(execution_state, ScannerExecutionState):
+        execution_state = ScannerExecutionState(str(execution_state))
+    return MatcherRegistration(
+        name=name,
+        module=module,
+        capabilities=capabilities,
+        source=str(getattr(value, "source", "entry_point")),
+        phase=phase,
+        execution_state=execution_state,
+        enabled_by_default=bool(getattr(value, "enabled_by_default", True)),
+        run_attr=str(getattr(value, "run_attr", "run")),
+        input_types=tuple(str(item) for item in getattr(value, "input_types", ())),
+        output_types=tuple(str(item) for item in getattr(value, "output_types", ())),
+        correlation_types=tuple(str(item) for item in getattr(value, "correlation_types", ())),
+        summary=str(getattr(value, "summary", "")),
+    )
+
+
+def register_matcher(registration: MatcherRegistration) -> None:
+    """Register a matcher/correlator component with capability metadata."""
+
+    if not registration.name:
+        raise ValueError("matcher registration must declare a name")
+    if registration.name in _MATCHER_REGISTRY:
+        raise ValueError(f"duplicate matcher registration: {registration.name}")
+    _MATCHER_REGISTRY[registration.name] = registration
+
+
+def _ensure_matcher_registry_loaded() -> None:
+    global _MATCHER_REGISTRY_LOADED
+    if _MATCHER_REGISTRY_LOADED:
+        return
+    for registration in builtin_matcher_registrations():
+        register_matcher(registration)
+    for registration in iter_entry_point_registrations(
+        group=_ENTRY_POINT_GROUP,
+        coerce=_coerce_matcher_registration,
+        warnings=_MATCHER_REGISTRY_WARNINGS,
+    ):
+        register_matcher(registration)
+    _MATCHER_REGISTRY_LOADED = True
+
+
+def list_registered_matchers(*, include_planned: bool = True) -> list[MatcherRegistration]:
+    """Return registered matcher/correlator components sorted by name."""
+
+    _ensure_matcher_registry_loaded()
+    registrations = [_MATCHER_REGISTRY[name] for name in sorted(_MATCHER_REGISTRY)]
+    if include_planned:
+        return registrations
+    return [registration for registration in registrations if registration.execution_state != ScannerExecutionState.PLANNED]
+
+
+def get_matcher_registration(name: str) -> MatcherRegistration:
+    """Return one matcher registration or raise ``KeyError``."""
+
+    _ensure_matcher_registry_loaded()
+    return _MATCHER_REGISTRY[name]
+
+
+def matcher_registry_warnings() -> list[str]:
+    """Return sanitized non-fatal registry loading warnings."""
+
+    _ensure_matcher_registry_loaded()
+    return list(_MATCHER_REGISTRY_WARNINGS)
+
+
+def matcher_registry_summary() -> dict[str, object]:
+    """Return a compact matcher registry summary for API/UI surfaces."""
+
+    registrations = list_registered_matchers(include_planned=True)
+    by_phase: dict[str, int] = {}
+    by_state: dict[str, int] = {}
+    for registration in registrations:
+        by_phase[registration.phase.value] = by_phase.get(registration.phase.value, 0) + 1
+        by_state[registration.execution_state.value] = by_state.get(registration.execution_state.value, 0) + 1
+    return {
+        "total": len(registrations),
+        "active": by_state.get(ScannerExecutionState.ACTIVE.value, 0),
+        "passive": by_state.get(ScannerExecutionState.PASSIVE.value, 0),
+        "planned": by_state.get(ScannerExecutionState.PLANNED.value, 0),
+        "by_phase": by_phase,
+        "by_state": by_state,
+    }
+
+
+def _reset_matcher_registry_for_tests() -> None:
+    _MATCHER_REGISTRY.clear()
+    _MATCHER_REGISTRY_WARNINGS.clear()
+    global _MATCHER_REGISTRY_LOADED
+    _MATCHER_REGISTRY_LOADED = False
+
+
+__all__ = [
+    "MatcherRegistration",
+    "builtin_matcher_registrations",
+    "get_matcher_registration",
+    "list_registered_matchers",
+    "matcher_registry_summary",
+    "matcher_registry_warnings",
+    "register_matcher",
+]

--- a/src/agent_bom/orchestration.py
+++ b/src/agent_bom/orchestration.py
@@ -1,0 +1,124 @@
+"""Orchestrator read model (façade).
+
+Exposes the registered pipeline stage order as data — ``scan → enrich →
+correlate → graph → findings`` — with the registered component drivers for each
+stage pulled from the scanner, enricher, and matcher registries.
+
+This is a READ MODEL only. It does NOT execute anything and does NOT replace the
+existing execution path (`ScanPipeline` / `_run_scan_sync` in
+``agent_bom.api.pipeline``), which remains the de-facto orchestrator. A later PR
+in this series will execute against this model; importing it changes no behavior.
+
+The ``graph`` and ``findings`` stages exist in the real pipeline but have no
+component registry yet, so they are surfaced as ordered, non-registry-backed
+stages with an empty driver list.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from agent_bom.components.enricher_registry import list_registered_enrichers
+from agent_bom.components.matcher_registry import list_registered_matchers
+from agent_bom.scanners.registry import list_registered_scanners
+
+
+class PipelineStage(str, Enum):
+    """High-level orchestration stage, in execution order."""
+
+    SCAN = "scan"
+    ENRICH = "enrich"
+    CORRELATE = "correlate"
+    GRAPH = "graph"
+    FINDINGS = "findings"
+
+
+STAGE_ORDER: tuple[PipelineStage, ...] = (
+    PipelineStage.SCAN,
+    PipelineStage.ENRICH,
+    PipelineStage.CORRELATE,
+    PipelineStage.GRAPH,
+    PipelineStage.FINDINGS,
+)
+
+_STAGE_SUMMARIES: dict[PipelineStage, str] = {
+    PipelineStage.SCAN: "Discover targets and produce raw findings via scanner drivers.",
+    PipelineStage.ENRICH: "Augment findings with CVSS/EPSS/KEV/GHSA, registry, AI, and estate context.",
+    PipelineStage.CORRELATE: "Deduplicate and correlate evidence across sources and environments.",
+    PipelineStage.GRAPH: "Fuse findings into the ContextGraph and score blast radius (not registry-backed yet).",
+    PipelineStage.FINDINGS: "Normalize, dedupe, and emit the unified Finding set (not registry-backed yet).",
+}
+
+
+@dataclass(frozen=True)
+class StageView:
+    """Read-only view of one orchestration stage and its registered drivers."""
+
+    stage: PipelineStage
+    drivers: tuple[str, ...]
+    registry_backed: bool
+    summary: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "stage": self.stage.value,
+            "drivers": list(self.drivers),
+            "registry_backed": self.registry_backed,
+            "summary": self.summary,
+        }
+
+
+def _stage_drivers(stage: PipelineStage, *, include_planned: bool) -> tuple[bool, tuple[str, ...]]:
+    if stage is PipelineStage.SCAN:
+        return True, tuple(r.name for r in list_registered_scanners(include_planned=include_planned))
+    if stage is PipelineStage.ENRICH:
+        return True, tuple(r.name for r in list_registered_enrichers(include_planned=include_planned))
+    if stage is PipelineStage.CORRELATE:
+        return True, tuple(r.name for r in list_registered_matchers(include_planned=include_planned))
+    # graph and findings stages run in the pipeline but have no component registry yet.
+    return False, ()
+
+
+def ordered_stages(*, include_planned: bool = True) -> list[StageView]:
+    """Return the registered stages in execution order with their drivers."""
+
+    views: list[StageView] = []
+    for stage in STAGE_ORDER:
+        registry_backed, drivers = _stage_drivers(stage, include_planned=include_planned)
+        views.append(
+            StageView(
+                stage=stage,
+                drivers=drivers,
+                registry_backed=registry_backed,
+                summary=_STAGE_SUMMARIES[stage],
+            )
+        )
+    return views
+
+
+def stage_names() -> list[str]:
+    """Return the stage names in execution order."""
+
+    return [stage.value for stage in STAGE_ORDER]
+
+
+def orchestration_summary(*, include_planned: bool = True) -> dict[str, object]:
+    """Return a compact orchestration summary for API/UI surfaces."""
+
+    stages = ordered_stages(include_planned=include_planned)
+    return {
+        "stage_order": stage_names(),
+        "stages": [view.to_dict() for view in stages],
+        "registry_backed_stages": [view.stage.value for view in stages if view.registry_backed],
+    }
+
+
+__all__ = [
+    "STAGE_ORDER",
+    "PipelineStage",
+    "StageView",
+    "orchestration_summary",
+    "ordered_stages",
+    "stage_names",
+]

--- a/src/agent_bom/routing.py
+++ b/src/agent_bom/routing.py
@@ -1,0 +1,89 @@
+"""Input → scanner-driver router.
+
+A pure resolver: given an input descriptor (type and optional source — path,
+image ref, cloud credential, MCP config, ingested SARIF, ...), return the
+registered scanner drivers that declare they accept it, by consulting the
+``input_types`` metadata in :mod:`agent_bom.scanners.registry`.
+
+Scope of this PR: this module centralizes the input→driver *mapping* conceptually
+and is the seam a later PR will route callers through. Selection logic currently
+split across the CLI, ``api/pipeline.py``, and ``scanners/__init__.py`` is NOT
+changed here — nothing in the scan path imports this module yet.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agent_bom.scanners.base import ScannerRegistration
+from agent_bom.scanners.registry import list_registered_scanners
+
+
+@dataclass(frozen=True)
+class InputDescriptor:
+    """A unit of work to route: an input type plus an optional opaque source."""
+
+    input_type: str
+    source: str | None = None
+
+
+def _normalize(input_type: str) -> str:
+    return input_type.strip().lower()
+
+
+def resolve_scanners(input_type: str, *, include_planned: bool = False) -> list[ScannerRegistration]:
+    """Return scanner drivers whose ``input_types`` declare ``input_type``.
+
+    Matching is case-insensitive and order-stable (registry sort order, by name).
+    Planned (roadmap-slot) drivers are excluded unless ``include_planned`` is set.
+    """
+
+    normalized = _normalize(input_type)
+    if not normalized:
+        return []
+    return [
+        registration
+        for registration in list_registered_scanners(include_planned=include_planned)
+        if normalized in {value.lower() for value in registration.input_types}
+    ]
+
+
+def resolve_input(descriptor: InputDescriptor, *, include_planned: bool = False) -> list[ScannerRegistration]:
+    """Resolve an :class:`InputDescriptor` to its scanner drivers."""
+
+    return resolve_scanners(descriptor.input_type, include_planned=include_planned)
+
+
+def known_input_types(*, include_planned: bool = True) -> set[str]:
+    """Return the set of input types any registered scanner driver accepts."""
+
+    types: set[str] = set()
+    for registration in list_registered_scanners(include_planned=include_planned):
+        types.update(value.lower() for value in registration.input_types)
+    return types
+
+
+def can_route(input_type: str, *, include_planned: bool = False) -> bool:
+    """Return True when at least one driver handles ``input_type``."""
+
+    return bool(resolve_scanners(input_type, include_planned=include_planned))
+
+
+def route_table(*, include_planned: bool = True) -> dict[str, list[str]]:
+    """Return an ``input_type -> [driver name, ...]`` map for read surfaces."""
+
+    table: dict[str, list[str]] = {}
+    for registration in list_registered_scanners(include_planned=include_planned):
+        for value in registration.input_types:
+            table.setdefault(value.lower(), []).append(registration.name)
+    return {key: sorted(set(value)) for key, value in sorted(table.items())}
+
+
+__all__ = [
+    "InputDescriptor",
+    "can_route",
+    "known_input_types",
+    "resolve_input",
+    "resolve_scanners",
+    "route_table",
+]

--- a/tests/test_component_registry.py
+++ b/tests/test_component_registry.py
@@ -1,0 +1,142 @@
+"""Tests for the enricher and matcher component registries."""
+
+from __future__ import annotations
+
+import sys
+import types
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from agent_bom.components.base import EnricherRegistration, MatcherRegistration
+from agent_bom.extensions import ENTRYPOINTS_ENABLED_ENV, ExtensionCapabilities
+from agent_bom.scanners.base import ScannerExecutionState, ScannerPhase
+
+
+class FakeEntryPoint:
+    def __init__(self, name: str, loader: Callable[[], Any]) -> None:
+        self.name = name
+        self._loader = loader
+
+    def load(self) -> Any:
+        return self._loader()
+
+
+class FakeEntryPoints(list):
+    def select(self, *, group: str) -> list[FakeEntryPoint]:
+        return [entry_point for entry_point in self if getattr(entry_point, "group", group) == group]
+
+
+def _patch_entry_points(monkeypatch, entries_by_group: dict[str, list[FakeEntryPoint]]) -> None:
+    entries = FakeEntryPoints()
+    for group, group_entries in entries_by_group.items():
+        for entry_point in group_entries:
+            entry_point.group = group
+            entries.append(entry_point)
+    monkeypatch.setattr("agent_bom.extensions.metadata.entry_points", lambda: entries)
+
+
+@pytest.fixture(autouse=True)
+def reset_component_registries(monkeypatch):
+    import agent_bom.components.enricher_registry as enricher_registry
+    import agent_bom.components.matcher_registry as matcher_registry
+
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    enricher_registry._reset_enricher_registry_for_tests()
+    matcher_registry._reset_matcher_registry_for_tests()
+    yield
+    enricher_registry._reset_enricher_registry_for_tests()
+    matcher_registry._reset_matcher_registry_for_tests()
+
+
+def test_enricher_registry_loads_builtins() -> None:
+    from agent_bom.components.enricher_registry import enricher_registry_summary, list_registered_enrichers
+
+    enrichers = {registration.name: registration for registration in list_registered_enrichers()}
+
+    expected = {"vulnerability-intel", "enrichment-posture", "registry-reputation", "estate-discovery", "ai-enrichment"}
+    assert expected <= set(enrichers)
+    assert enrichers["vulnerability-intel"].capabilities.network_access is True
+    assert enrichers["vulnerability-intel"].phase is ScannerPhase.ENRICHMENT
+    assert enrichers["enrichment-posture"].execution_state is ScannerExecutionState.PASSIVE
+    assert enrichers["ai-enrichment"].enabled_by_default is False
+
+    summary = enricher_registry_summary()
+    assert summary["total"] == len(enrichers)
+    assert summary["passive"] == 1
+
+
+def test_matcher_registry_loads_builtins() -> None:
+    from agent_bom.components.matcher_registry import list_registered_matchers, matcher_registry_summary
+
+    matchers = {registration.name: registration for registration in list_registered_matchers()}
+
+    expected = {"agent-dedup", "cross-environment", "runtime-correlation"}
+    assert expected <= set(matchers)
+    assert matchers["agent-dedup"].run_attr == "correlate_agents"
+    assert matchers["cross-environment"].phase is ScannerPhase.ANALYSIS
+    assert matchers["runtime-correlation"].capabilities.network_access is False
+
+    summary = matcher_registry_summary()
+    assert summary["total"] == len(matchers)
+
+
+def test_duplicate_enricher_registration_is_rejected() -> None:
+    from agent_bom.components.enricher_registry import register_enricher
+
+    registration = EnricherRegistration(name="dup-enricher", module="agent_bom.tests.fake")
+    register_enricher(registration)
+    with pytest.raises(ValueError, match="duplicate enricher registration"):
+        register_enricher(registration)
+
+
+def test_duplicate_matcher_registration_is_rejected() -> None:
+    from agent_bom.components.matcher_registry import register_matcher
+
+    registration = MatcherRegistration(name="dup-matcher", module="agent_bom.tests.fake")
+    register_matcher(registration)
+    with pytest.raises(ValueError, match="duplicate matcher registration"):
+        register_matcher(registration)
+
+
+def test_enricher_to_dict_is_api_safe() -> None:
+    from agent_bom.components.enricher_registry import get_enricher_registration
+
+    payload = get_enricher_registration("vulnerability-intel").to_dict()
+    assert payload["role"] == "enricher"
+    assert payload["capabilities"]["network_access"] is True
+    assert "cvss" in payload["enriches"]
+
+
+def test_entry_point_enricher_registration_loads_only_when_enabled(monkeypatch) -> None:
+    import agent_bom.components.enricher_registry as enricher_registry
+
+    module_name = "agent_bom.tests.fake_enricher_driver"
+    fake_module = types.ModuleType(module_name)
+    fake_module.run = lambda **_: {"ok": True}
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+
+    registration = EnricherRegistration(
+        name="acme-enricher",
+        module=module_name,
+        source="entry_point",
+        phase=ScannerPhase.ENRICHMENT,
+        run_attr="run",
+        input_types=("vulnerabilities",),
+        output_types=("enriched_vulnerabilities",),
+        capabilities=ExtensionCapabilities(scan_modes=("analysis",)),
+    )
+    _patch_entry_points(
+        monkeypatch,
+        {"agent_bom.enricher_drivers": [FakeEntryPoint("acme-enricher", lambda: registration)]},
+    )
+
+    enricher_registry._reset_enricher_registry_for_tests()
+    assert "acme-enricher" not in {item.name for item in enricher_registry.list_registered_enrichers()}
+
+    monkeypatch.setenv(ENTRYPOINTS_ENABLED_ENV, "true")
+    enricher_registry._reset_enricher_registry_for_tests()
+    enrichers = {item.name: item for item in enricher_registry.list_registered_enrichers()}
+    assert enrichers["acme-enricher"].source == "entry_point"
+    assert enrichers["acme-enricher"].input_types == ("vulnerabilities",)

--- a/tests/test_input_router.py
+++ b/tests/test_input_router.py
@@ -1,0 +1,72 @@
+"""Tests for the input → scanner-driver router."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.routing import (
+    InputDescriptor,
+    can_route,
+    known_input_types,
+    resolve_input,
+    resolve_scanners,
+    route_table,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_scanner_registry(monkeypatch):
+    import agent_bom.scanners.registry as scanner_registry
+    from agent_bom.extensions import ENTRYPOINTS_ENABLED_ENV
+
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    scanner_registry._reset_scanner_registry_for_tests()
+    yield
+    scanner_registry._reset_scanner_registry_for_tests()
+    scanner_registry.list_registered_scanners()
+
+
+def test_resolve_known_input_types_map_to_expected_drivers() -> None:
+    cases = {
+        "image_ref": "container-image",
+        "cyclonedx": "sbom-ingest",
+        "terraform_dir": "iac-terraform",
+        "github_actions_path": "cicd-github-actions",
+        "prompt_file": "prompt-injection",
+        "code_path": "sast-semgrep",
+    }
+    for input_type, expected_driver in cases.items():
+        names = {registration.name for registration in resolve_scanners(input_type)}
+        assert expected_driver in names, f"{input_type} should route to {expected_driver}"
+
+
+def test_resolution_is_case_insensitive_and_descriptor_aware() -> None:
+    direct = {r.name for r in resolve_scanners("IMAGE_REF")}
+    via_descriptor = {r.name for r in resolve_input(InputDescriptor(input_type="image_ref", source="docker.io/lib/x"))}
+    assert direct == via_descriptor
+    assert "container-image" in direct
+
+
+def test_unknown_input_type_resolves_to_nothing() -> None:
+    assert resolve_scanners("not_a_real_input_type") == []
+    assert resolve_scanners("") == []
+    assert can_route("not_a_real_input_type") is False
+    assert can_route("image_ref") is True
+
+
+def test_planned_drivers_excluded_by_default() -> None:
+    # yara-signature (planned) declares 'model_file'; excluded unless requested.
+    default_names = {r.name for r in resolve_scanners("model_file")}
+    planned_names = {r.name for r in resolve_scanners("model_file", include_planned=True)}
+    assert "yara-signature" not in default_names
+    assert "yara-signature" in planned_names
+
+
+def test_route_table_and_known_input_types_are_consistent() -> None:
+    table = route_table(include_planned=True)
+    types = known_input_types(include_planned=True)
+    assert set(table) == types
+    assert "image_ref" in table
+    assert "container-image" in table["image_ref"]
+    # An input shared by multiple drivers lists them sorted and deduped.
+    assert table["packages"] == sorted(set(table["packages"]))

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -1,0 +1,75 @@
+"""Tests for the orchestrator read model."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.orchestration import (
+    STAGE_ORDER,
+    PipelineStage,
+    orchestration_summary,
+    ordered_stages,
+    stage_names,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_registries(monkeypatch):
+    import agent_bom.components.enricher_registry as enricher_registry
+    import agent_bom.components.matcher_registry as matcher_registry
+    import agent_bom.scanners.registry as scanner_registry
+    from agent_bom.extensions import ENTRYPOINTS_ENABLED_ENV
+
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    scanner_registry._reset_scanner_registry_for_tests()
+    enricher_registry._reset_enricher_registry_for_tests()
+    matcher_registry._reset_matcher_registry_for_tests()
+    yield
+    scanner_registry._reset_scanner_registry_for_tests()
+    enricher_registry._reset_enricher_registry_for_tests()
+    matcher_registry._reset_matcher_registry_for_tests()
+    scanner_registry.list_registered_scanners()
+
+
+def test_stage_order_is_scan_enrich_correlate_graph_findings() -> None:
+    assert stage_names() == ["scan", "enrich", "correlate", "graph", "findings"]
+    assert STAGE_ORDER == (
+        PipelineStage.SCAN,
+        PipelineStage.ENRICH,
+        PipelineStage.CORRELATE,
+        PipelineStage.GRAPH,
+        PipelineStage.FINDINGS,
+    )
+
+
+def test_ordered_stages_carry_registered_drivers_per_phase() -> None:
+    from agent_bom.components.enricher_registry import list_registered_enrichers
+    from agent_bom.components.matcher_registry import list_registered_matchers
+    from agent_bom.scanners.registry import list_registered_scanners
+
+    stages = {view.stage: view for view in ordered_stages()}
+
+    assert [view.stage for view in ordered_stages()] == list(STAGE_ORDER)
+    assert set(stages[PipelineStage.SCAN].drivers) == {r.name for r in list_registered_scanners()}
+    assert set(stages[PipelineStage.ENRICH].drivers) == {r.name for r in list_registered_enrichers()}
+    assert set(stages[PipelineStage.CORRELATE].drivers) == {r.name for r in list_registered_matchers()}
+
+
+def test_graph_and_findings_stages_are_present_but_not_registry_backed() -> None:
+    stages = {view.stage: view for view in ordered_stages()}
+
+    assert stages[PipelineStage.GRAPH].registry_backed is False
+    assert stages[PipelineStage.GRAPH].drivers == ()
+    assert stages[PipelineStage.FINDINGS].registry_backed is False
+    assert stages[PipelineStage.FINDINGS].drivers == ()
+
+    assert stages[PipelineStage.SCAN].registry_backed is True
+    assert stages[PipelineStage.ENRICH].registry_backed is True
+    assert stages[PipelineStage.CORRELATE].registry_backed is True
+
+
+def test_orchestration_summary_shape() -> None:
+    summary = orchestration_summary()
+    assert summary["stage_order"] == ["scan", "enrich", "correlate", "graph", "findings"]
+    assert summary["registry_backed_stages"] == ["scan", "enrich", "correlate"]
+    assert len(summary["stages"]) == 5


### PR DESCRIPTION
Foundation (PR-1 of a staged series) for a Router + Orchestrator component model. Strictly additive — no behavior change; the existing scan pipeline runs identically.

- `routing.py` — pure input→scanner-driver resolver over the existing `scanners/registry.py` (`resolve_scanners`, `resolve_input`, `route_table`, `known_input_types`).
- `components/` — `EnricherRegistration`/`MatcherRegistration` registries mirroring the scanner registry (register/list/summary, entry-point groups `agent_bom.enricher_drivers` / `agent_bom.matcher_drivers`, duplicate rejection). Existing built-in enrichers (`enrichment`, `enrichment_posture`, `registry_enrichment`, `scan_enrichment`, `ai_enrich`) and matchers (`correlate`, `cross_env_correlation`, `runtime_correlation`) are registered as descriptive metadata only.
- `orchestration.py` — read-model façade exposing the `scan → enrich → correlate → graph → findings` stage order with per-stage registered drivers. It does NOT execute and does NOT replace `ScanPipeline`.

No CLI/API/pipeline module imports the new code (verified). 15 new tests + 614 in the registry/routing/enrich regression sweep pass; ruff/mypy(strict)/bandit clean.

Next in the series: route existing caller selection through the Router (mechanical), then surface the registries on CLI/API, then make the orchestrator the execution model.