### PR TITLE
feat(cloud): CIS benchmark fan-out across Azure subscriptions and GCP projects

### DIFF
--- a/src/agent_bom/cli/agents/_cloud.py
+++ b/src/agent_bom/cli/agents/_cloud.py
@@ -320,6 +320,9 @@ def run_benchmarks(
         try:
             from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_cis
 
+            # AWS multi-account CIS fan-out is out of scope here: cross-account
+            # checks require the AssumeRole broker tracked in issue #3177. This
+            # benchmark runs against the single configured account/region only.
             ctx.cis_benchmark_report = run_cis(region=aws_region, profile=aws_profile)
             passed = ctx.cis_benchmark_report.passed
             failed = ctx.cis_benchmark_report.failed
@@ -355,16 +358,29 @@ def run_benchmarks(
 
         con.print("\n[bold blue]Running CIS Azure Security Benchmark v3.0...[/bold blue]\n")
         try:
-            from agent_bom.cloud.azure_cis_benchmark import run_benchmark as run_az_cis
+            from agent_bom.cloud import azure_inventory
 
-            # Forward the --subscription value; run_benchmark falls back to
-            # AZURE_SUBSCRIPTION_ID only when this is None.
-            ctx.azure_cis_benchmark_report = run_az_cis(subscription_id=azure_subscription or None)
+            # When the multi-subscription flag is on, fan the benchmark across
+            # every subscription in the tenant (same boundary set the inventory
+            # fan-out uses) and aggregate with per-subscription attribution.
+            # Off = unchanged single-subscription run.
+            if azure_inventory.all_subscriptions_enabled():
+                from agent_bom.cloud.azure_cis_benchmark import run_all_subscription_benchmarks
+
+                ctx.azure_cis_benchmark_report = run_all_subscription_benchmarks()
+            else:
+                from agent_bom.cloud.azure_cis_benchmark import run_benchmark as run_az_cis
+
+                # Forward the --subscription value; run_benchmark falls back to
+                # AZURE_SUBSCRIPTION_ID only when this is None.
+                ctx.azure_cis_benchmark_report = run_az_cis(subscription_id=azure_subscription or None)
             passed = ctx.azure_cis_benchmark_report.passed
             failed = ctx.azure_cis_benchmark_report.failed
             total = ctx.azure_cis_benchmark_report.total
             rate = ctx.azure_cis_benchmark_report.pass_rate
-            con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
+            scanned = getattr(ctx.azure_cis_benchmark_report, "subscriptions_scanned", []) or []
+            scope = f" across {len(scanned)} subscription(s)" if len(scanned) > 1 else ""
+            con.print(f"  [green]✓[/green] {total} checks evaluated{scope} — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
         except _AZCISError as exc:
             con.print(f"  [red]CIS Azure Benchmark error: {_safe_error(exc)}[/red]")
             ctx.cloud_provider_failures.append({"provider": "azure", "stage": "cis_benchmark", "error": str(exc)})
@@ -375,14 +391,27 @@ def run_benchmarks(
 
         con.print("\n[bold blue]Running CIS GCP Foundation Benchmark v3.0...[/bold blue]\n")
         try:
-            from agent_bom.cloud.gcp_cis_benchmark import run_benchmark as run_gcp_cis
+            from agent_bom.cloud import gcp_inventory
 
-            ctx.gcp_cis_benchmark_report = run_gcp_cis()
+            # When the multi-project flag is on, fan the benchmark across every
+            # project in the org/folder tree (same boundary set the inventory
+            # fan-out uses) and aggregate with per-project attribution.
+            # Off = unchanged single-project run.
+            if gcp_inventory.all_projects_enabled():
+                from agent_bom.cloud.gcp_cis_benchmark import run_all_project_benchmarks
+
+                ctx.gcp_cis_benchmark_report = run_all_project_benchmarks()
+            else:
+                from agent_bom.cloud.gcp_cis_benchmark import run_benchmark as run_gcp_cis
+
+                ctx.gcp_cis_benchmark_report = run_gcp_cis()
             passed = ctx.gcp_cis_benchmark_report.passed
             failed = ctx.gcp_cis_benchmark_report.failed
             total = ctx.gcp_cis_benchmark_report.total
             rate = ctx.gcp_cis_benchmark_report.pass_rate
-            con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
+            scanned = getattr(ctx.gcp_cis_benchmark_report, "projects_scanned", []) or []
+            scope = f" across {len(scanned)} project(s)" if len(scanned) > 1 else ""
+            con.print(f"  [green]✓[/green] {total} checks evaluated{scope} — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
         except _GCPCISError as exc:
             con.print(f"  [red]CIS GCP Benchmark error: {_safe_error(exc)}[/red]")
             ctx.cloud_provider_failures.append({"provider": "gcp", "stage": "cis_benchmark", "error": str(exc)})

--- a/src/agent_bom/cloud/aws_cis_benchmark.py
+++ b/src/agent_bom/cloud/aws_cis_benchmark.py
@@ -96,6 +96,11 @@ class CISCheckResult:
     resource_ids: list[str] = field(default_factory=list)
     recommendation: str = ""
     cis_section: str = ""
+    # Boundary attribution for multi-account / multi-subscription / multi-project
+    # fan-out. Holds the AWS account id, Azure subscription id, or GCP project id
+    # the check ran against. Empty for a single-boundary run. Lets an aggregated
+    # report keep per-boundary provenance on every finding.
+    account_id: str = ""
     # Structured network exposure (open ports/CIDR to the internet) so the graph
     # can model port-level reachability instead of keyword-matching evidence text.
     # Each entry: {"resource": str, "from_port": int, "to_port": int,

--- a/src/agent_bom/cloud/azure_cis_benchmark.py
+++ b/src/agent_bom/cloud/azure_cis_benchmark.py
@@ -68,6 +68,11 @@ class AzureCISReport:
     benchmark_version: str = "3.0"
     checks: list[CISCheckResult] = field(default_factory=list)
     subscription_id: str = ""
+    # Populated only by the multi-subscription fan-out: the subscriptions actually
+    # evaluated and any per-subscription warnings (e.g. a subscription skipped
+    # because the credential could not read it). Empty for a single-sub run.
+    subscriptions_scanned: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
 
     @property
     def passed(self) -> int:
@@ -104,6 +109,8 @@ class AzureCISReport:
             "benchmark": "CIS Microsoft Azure Foundations",
             "benchmark_version": self.benchmark_version,
             "subscription_id": self.subscription_id,
+            "subscriptions_scanned": self.subscriptions_scanned,
+            "warnings": self.warnings,
             "pass_rate": round(self.pass_rate, 1),
             "passed": self.passed,
             "failed": self.failed,
@@ -122,6 +129,9 @@ class AzureCISReport:
                     "recommendation": c.recommendation,
                     "remediation": c.remediation,
                     "cis_section": c.cis_section,
+                    # Per-check subscription attribution for the multi-subscription
+                    # fan-out; empty string on a single-subscription run.
+                    "subscription_id": c.account_id,
                     "attack_techniques": tag_cis_check(c),
                 }
                 for c in self.checks
@@ -3141,6 +3151,7 @@ def _check_9_6(webapp_client: Any) -> CISCheckResult:
 def run_benchmark(
     subscription_id: str | None = None,
     checks: list[str] | None = None,
+    credential: Any = None,
 ) -> AzureCISReport:
     """Run CIS Azure Security Benchmark v3.0 checks.
 
@@ -3149,6 +3160,10 @@ def run_benchmark(
             AZURE_SUBSCRIPTION_ID env var.
         checks: Optional list of check IDs to run (e.g. ['1.1', '6.1']).
             Runs all checks if omitted.
+        credential: Optional Azure credential threaded into every check's
+            management client. When ``None`` a ``DefaultAzureCredential`` is
+            constructed (the prior behaviour). Passing a shared credential lets
+            the multi-subscription fan-out resolve auth once and reuse it.
 
     Returns:
         AzureCISReport with pass/fail results for each check.
@@ -3165,7 +3180,8 @@ def run_benchmark(
     if not resolved_sub:
         raise CloudDiscoveryError("Azure subscription ID required. Set AZURE_SUBSCRIPTION_ID env var or pass subscription_id.")
 
-    credential = DefaultAzureCredential()
+    if credential is None:
+        credential = DefaultAzureCredential()
     report = AzureCISReport(subscription_id=resolved_sub)
 
     # Build client map (lazy — only import what's needed)
@@ -3354,3 +3370,82 @@ def run_benchmark(
     attach_all(report, cloud="azure")
 
     return report
+
+
+# Bounded concurrency for the multi-subscription fan-out — mirrors the Azure
+# inventory fan-out's thread pool so a tenant-wide CIS run collapses the
+# per-subscription latencies instead of summing them.
+_MAX_CIS_FANOUT_WORKERS = 8
+
+
+def run_all_subscription_benchmarks(
+    checks: list[str] | None = None,
+    credential: Any = None,
+) -> AzureCISReport:
+    """Run the CIS Azure benchmark for EVERY subscription in the tenant.
+
+    The CIS counterpart of :func:`agent_bom.cloud.azure_inventory.discover_all_subscription_inventories`:
+    it reuses the exact same subscription enumeration
+    (:func:`agent_bom.cloud.azure_inventory.enumerate_subscription_ids`, which
+    walks the management-group tree) so the benchmark covers the identical
+    estate the inventory fan-out does. Each subscription is benchmarked
+    concurrently (bounded thread pool) and the per-subscription results are
+    aggregated into one :class:`AzureCISReport` with every check tagged by its
+    ``subscription_id``.
+
+    Read-only and partial-permission tolerant: a subscription the credential
+    cannot read is skipped with a warning rather than failing the whole run.
+
+    Raises:
+        CloudDiscoveryError: if azure-identity is not installed.
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    from agent_bom.cloud import azure_inventory
+
+    if credential is None:
+        try:
+            from azure.identity import DefaultAzureCredential
+        except ImportError:
+            raise CloudDiscoveryError("azure-identity is required for Azure CIS benchmark. Install with: pip install 'agent-bom[azure]'")
+        credential = DefaultAzureCredential()
+
+    sub_ids, warnings = azure_inventory.enumerate_subscription_ids(credential)
+    if not sub_ids:
+        raise CloudDiscoveryError(
+            "No Azure subscriptions resolved for the multi-subscription CIS benchmark. "
+            "Grant Management Group Reader or set AZURE_SUBSCRIPTION_ID."
+        )
+
+    aggregate = AzureCISReport(subscription_id=", ".join(sub_ids))
+    aggregate.warnings.extend(warnings)
+
+    def _run_one(sub_id: str) -> tuple[str, AzureCISReport]:
+        return sub_id, run_benchmark(subscription_id=sub_id, checks=checks, credential=credential)
+
+    # Deterministic aggregation: collect per-subscription reports keyed by id,
+    # then merge in the enumeration order so output is stable across runs.
+    reports: dict[str, AzureCISReport] = {}
+    with ThreadPoolExecutor(max_workers=min(_MAX_CIS_FANOUT_WORKERS, len(sub_ids))) as executor:
+        future_to_sub = {executor.submit(_run_one, sub_id): sub_id for sub_id in sub_ids}
+        for future in as_completed(future_to_sub):
+            sub_id = future_to_sub[future]
+            try:
+                _sid, sub_report = future.result()
+                reports[sub_id] = sub_report
+            except Exception as exc:  # noqa: BLE001 — one unreadable subscription must not sink the rest
+                from .normalization import sanitize_discovery_warning
+
+                aggregate.warnings.append(f"Subscription {sub_id} skipped: {sanitize_discovery_warning(exc)}")
+
+    for sub_id in sub_ids:
+        merged = reports.get(sub_id)
+        if merged is None:
+            continue
+        aggregate.subscriptions_scanned.append(sub_id)
+        for check in merged.checks:
+            check.account_id = sub_id
+            aggregate.checks.append(check)
+        aggregate.warnings.extend(merged.warnings)
+
+    return aggregate

--- a/src/agent_bom/cloud/azure_inventory.py
+++ b/src/agent_bom/cloud/azure_inventory.py
@@ -424,6 +424,33 @@ def _subscription_ids_from_mg_tree(management_groups: list[dict[str, Any]]) -> l
     return sub_ids
 
 
+def enumerate_subscription_ids(credential: Any) -> tuple[list[str], list[str]]:
+    """Resolve every subscription id to fan a single scan across (read-only).
+
+    The single source of truth for the multi-subscription boundary set: discover
+    the management-group hierarchy, extract every subscription id from it, and
+    fall back to the configured ``AZURE_SUBSCRIPTION_ID`` when the tenant root is
+    not visible (e.g. the credential lacks Management Group Reader). Returns
+    ``(subscription_ids, warnings)``; never raises. Shared by both the inventory
+    fan-out and the CIS-benchmark fan-out so the boundary set stays identical.
+    """
+    warnings: list[str] = []
+    try:
+        management_groups, mg_warnings = _discover_management_groups(credential)
+        warnings.extend(mg_warnings)
+    except Exception as exc:  # noqa: BLE001 — MG enumeration failure must degrade, not crash
+        management_groups = []
+        warnings.append(sanitize_discovery_warning(exc))
+
+    sub_ids = _subscription_ids_from_mg_tree(management_groups)
+    if not sub_ids:
+        # No tenant-root visibility — fall back to the single configured sub.
+        single = os.environ.get("AZURE_SUBSCRIPTION_ID", "").strip()
+        if single:
+            sub_ids = [single]
+    return sub_ids, warnings
+
+
 def discover_all_subscription_inventories(credential: Any = None, *, force: bool = False) -> list[dict[str, Any]]:
     """Inventory EVERY subscription in the tenant (multi-subscription fan-out).
 
@@ -450,20 +477,7 @@ def discover_all_subscription_inventories(credential: Any = None, *, force: bool
         except Exception:  # noqa: BLE001
             return []
 
-    warnings: list[str] = []
-    try:
-        management_groups, mg_warnings = _discover_management_groups(credential)
-        warnings.extend(mg_warnings)
-    except Exception as exc:  # noqa: BLE001
-        management_groups, _ = [], None
-        warnings.append(sanitize_discovery_warning(exc))
-
-    sub_ids = _subscription_ids_from_mg_tree(management_groups)
-    if not sub_ids:
-        # No tenant-root visibility — fall back to the single configured sub.
-        single = os.environ.get("AZURE_SUBSCRIPTION_ID", "").strip()
-        if single:
-            sub_ids = [single]
+    sub_ids, _warnings = enumerate_subscription_ids(credential)
 
     payloads: list[dict[str, Any]] = []
     for sub_id in sub_ids[:_MAX_SUBSCRIPTIONS]:
@@ -1745,7 +1759,11 @@ def _clean_tags(tags: Any) -> dict[str, str]:
 
 
 __all__ = [
+    "ALL_SUBSCRIPTIONS_ENV_FLAG",
     "INVENTORY_ENV_FLAG",
+    "all_subscriptions_enabled",
+    "discover_all_subscription_inventories",
     "discover_inventory",
+    "enumerate_subscription_ids",
     "inventory_enabled",
 ]

--- a/src/agent_bom/cloud/gcp_cis_benchmark.py
+++ b/src/agent_bom/cloud/gcp_cis_benchmark.py
@@ -127,6 +127,11 @@ class GCPCISReport:
     benchmark_version: str = "3.0"
     checks: list[CISCheckResult] = field(default_factory=list)
     project_id: str = ""
+    # Populated only by the multi-project fan-out: the projects actually
+    # evaluated and any per-project warnings (e.g. a project skipped because the
+    # credential could not read it). Empty for a single-project run.
+    projects_scanned: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
 
     @property
     def passed(self) -> int:
@@ -152,6 +157,8 @@ class GCPCISReport:
             "benchmark": "CIS Google Cloud Platform Foundation",
             "benchmark_version": self.benchmark_version,
             "project_id": self.project_id,
+            "projects_scanned": self.projects_scanned,
+            "warnings": self.warnings,
             "pass_rate": round(self.pass_rate, 1),
             "passed": self.passed,
             "failed": self.failed,
@@ -167,6 +174,9 @@ class GCPCISReport:
                     "recommendation": c.recommendation,
                     "remediation": c.remediation,
                     "cis_section": c.cis_section,
+                    # Per-check project attribution for the multi-project fan-out;
+                    # empty string on a single-project run.
+                    "project_id": c.account_id,
                     "attack_techniques": tag_cis_check(c),
                 }
                 for c in self.checks
@@ -2779,3 +2789,86 @@ def run_benchmark(
     attach_all(report, cloud="gcp")
 
     return report
+
+
+# Bounded concurrency for the multi-project fan-out — mirrors the GCP inventory
+# fan-out's thread pool. Each thread sets its own credential context (the context
+# is thread-local), so concurrent per-project runs do not contaminate one another.
+_MAX_CIS_FANOUT_WORKERS = 8
+
+
+def run_all_project_benchmarks(
+    credentials: Any = None,
+    checks: list[str] | None = None,
+) -> GCPCISReport:
+    """Run the CIS GCP benchmark for EVERY project in the org/folder tree.
+
+    The CIS counterpart of :func:`agent_bom.cloud.gcp_inventory.discover_all_project_inventories`:
+    it reuses the same project enumeration
+    (:func:`agent_bom.cloud.gcp_organizations.list_project_ids`) and the same
+    read-only impersonation resolution
+    (:func:`agent_bom.cloud.gcp_inventory._resolve_impersonation`) so the
+    benchmark covers the identical estate the inventory fan-out does. Each
+    project is benchmarked concurrently (bounded thread pool) and the
+    per-project results are aggregated into one :class:`GCPCISReport` with every
+    check tagged by its ``project_id``.
+
+    Read-only and partial-permission tolerant: a project the credential cannot
+    read is skipped with a warning rather than failing the whole run.
+
+    Raises:
+        CloudDiscoveryError: if no GCP SDK packages are installed and a project
+            set cannot be resolved.
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    from agent_bom.cloud import gcp_inventory, gcp_organizations
+
+    warnings: list[str] = []
+    resolved = gcp_inventory._resolve_impersonation(credentials, warnings)
+
+    try:
+        project_ids = gcp_organizations.list_project_ids(resolved, force=True)
+    except Exception as exc:  # noqa: BLE001 — org enumeration failure must degrade, not crash
+        logger.warning("GCP org project enumeration failed: %s", sanitize_discovery_warning(exc))
+        warnings.append(sanitize_discovery_warning(exc))
+        project_ids = []
+
+    if not project_ids:
+        single = os.environ.get("GOOGLE_CLOUD_PROJECT", "").strip()
+        project_ids = [single] if single else []
+    if not project_ids:
+        raise CloudDiscoveryError(
+            "No GCP projects resolved for the multi-project CIS benchmark. Grant org/folder browse access or set GOOGLE_CLOUD_PROJECT."
+        )
+
+    aggregate = GCPCISReport(project_id=", ".join(project_ids))
+    aggregate.warnings.extend(warnings)
+
+    def _run_one(project_id: str) -> tuple[str, GCPCISReport]:
+        return project_id, run_benchmark(project_id=project_id, credentials=resolved, checks=checks)
+
+    # Deterministic aggregation: collect per-project reports keyed by id, then
+    # merge in enumeration order so output is stable across runs.
+    reports: dict[str, GCPCISReport] = {}
+    with ThreadPoolExecutor(max_workers=min(_MAX_CIS_FANOUT_WORKERS, len(project_ids))) as executor:
+        future_to_project = {executor.submit(_run_one, pid): pid for pid in project_ids}
+        for future in as_completed(future_to_project):
+            pid = future_to_project[future]
+            try:
+                _pid, project_report = future.result()
+                reports[pid] = project_report
+            except Exception as exc:  # noqa: BLE001 — one unreadable project must not sink the rest
+                aggregate.warnings.append(f"Project {pid} skipped: {sanitize_discovery_warning(exc)}")
+
+    for pid in project_ids:
+        merged = reports.get(pid)
+        if merged is None:
+            continue
+        aggregate.projects_scanned.append(pid)
+        for check in merged.checks:
+            check.account_id = pid
+            aggregate.checks.append(check)
+        aggregate.warnings.extend(merged.warnings)
+
+    return aggregate

--- a/tests/test_cis_multi_boundary_fanout.py
+++ b/tests/test_cis_multi_boundary_fanout.py
@@ -1,0 +1,161 @@
+"""CIS benchmark multi-boundary fan-out — Azure subscriptions and GCP projects.
+
+Mirrors the inventory fan-out tests (test_azure_multi_subscription.py): assert the
+CIS benchmark runs once per boundary and aggregates with per-boundary attribution,
+and that a boundary the credential cannot read is skipped with a warning rather
+than failing the whole run.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.cloud import azure_cis_benchmark as az_cis
+from agent_bom.cloud import azure_inventory as az_inv
+from agent_bom.cloud import gcp_cis_benchmark as gcp_cis
+from agent_bom.cloud import gcp_inventory as gcp_inv
+from agent_bom.cloud import gcp_organizations as gcp_orgs
+from agent_bom.cloud.aws_cis_benchmark import CheckStatus, CISCheckResult
+from agent_bom.cloud.base import CloudDiscoveryError
+
+
+def _report_azure(sub_id: str) -> az_cis.AzureCISReport:
+    report = az_cis.AzureCISReport(subscription_id=sub_id)
+    report.checks.append(CISCheckResult(check_id="1.1", title="t", status=CheckStatus.PASS, severity="high"))
+    report.checks.append(CISCheckResult(check_id="3.1", title="t", status=CheckStatus.FAIL, severity="high"))
+    return report
+
+
+def _report_gcp(project_id: str) -> gcp_cis.GCPCISReport:
+    report = gcp_cis.GCPCISReport(project_id=project_id)
+    report.checks.append(CISCheckResult(check_id="1.1", title="t", status=CheckStatus.PASS, severity="high"))
+    report.checks.append(CISCheckResult(check_id="3.1", title="t", status=CheckStatus.FAIL, severity="high"))
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Azure
+# ---------------------------------------------------------------------------
+
+
+def test_azure_fanout_runs_cis_per_subscription_with_attribution(monkeypatch) -> None:
+    monkeypatch.setattr(
+        az_inv,
+        "enumerate_subscription_ids",
+        lambda cred: (["sub-a", "sub-b"], []),
+    )
+    scanned: list[str] = []
+
+    def _fake_run(subscription_id=None, checks=None, credential=None):
+        scanned.append(subscription_id)
+        return _report_azure(subscription_id)
+
+    monkeypatch.setattr(az_cis, "run_benchmark", _fake_run)
+
+    report = az_cis.run_all_subscription_benchmarks(credential=object())
+
+    assert sorted(scanned) == ["sub-a", "sub-b"]
+    assert report.subscriptions_scanned == ["sub-a", "sub-b"]
+    # Each check is attributed to its originating subscription.
+    attributions = {c.account_id for c in report.checks}
+    assert attributions == {"sub-a", "sub-b"}
+    # Counts reflect BOTH boundaries (2 checks each => 2 passed, 2 failed).
+    assert report.passed == 2
+    assert report.failed == 2
+    assert report.total == 4
+    # to_dict surfaces per-check subscription attribution and the scanned set.
+    payload = report.to_dict()
+    assert payload["subscriptions_scanned"] == ["sub-a", "sub-b"]
+    assert {c["subscription_id"] for c in payload["checks"]} == {"sub-a", "sub-b"}
+
+
+def test_azure_fanout_skips_unreadable_subscription_with_warning(monkeypatch) -> None:
+    monkeypatch.setattr(
+        az_inv,
+        "enumerate_subscription_ids",
+        lambda cred: (["sub-ok", "sub-denied"], []),
+    )
+
+    def _fake_run(subscription_id=None, checks=None, credential=None):
+        if subscription_id == "sub-denied":
+            raise PermissionError("AuthorizationFailed: caller lacks read on sub-denied")
+        return _report_azure(subscription_id)
+
+    monkeypatch.setattr(az_cis, "run_benchmark", _fake_run)
+
+    report = az_cis.run_all_subscription_benchmarks(credential=object())
+
+    # Only the readable subscription contributes checks; the denied one is skipped.
+    assert report.subscriptions_scanned == ["sub-ok"]
+    assert {c.account_id for c in report.checks} == {"sub-ok"}
+    assert any("sub-denied skipped" in w for w in report.warnings)
+    # The whole run did NOT fail because one subscription was unreadable.
+    assert report.total == 2
+
+
+def test_azure_fanout_raises_when_no_subscriptions(monkeypatch) -> None:
+    monkeypatch.setattr(az_inv, "enumerate_subscription_ids", lambda cred: ([], []))
+    with pytest.raises(CloudDiscoveryError):
+        az_cis.run_all_subscription_benchmarks(credential=object())
+
+
+# ---------------------------------------------------------------------------
+# GCP
+# ---------------------------------------------------------------------------
+
+
+def test_gcp_fanout_runs_cis_per_project_with_attribution(monkeypatch) -> None:
+    monkeypatch.setattr(gcp_inv, "_resolve_impersonation", lambda creds, warnings: creds)
+    monkeypatch.setattr(gcp_orgs, "list_project_ids", lambda creds, force=False: ["proj-a", "proj-b"])
+    scanned: list[str] = []
+
+    def _fake_run(project_id=None, credentials=None, checks=None):
+        scanned.append(project_id)
+        return _report_gcp(project_id)
+
+    monkeypatch.setattr(gcp_cis, "run_benchmark", _fake_run)
+
+    report = gcp_cis.run_all_project_benchmarks(credentials=object())
+
+    assert sorted(scanned) == ["proj-a", "proj-b"]
+    assert report.projects_scanned == ["proj-a", "proj-b"]
+    assert {c.account_id for c in report.checks} == {"proj-a", "proj-b"}
+    assert report.passed == 2
+    assert report.failed == 2
+    assert report.total == 4
+    payload = report.to_dict()
+    assert payload["projects_scanned"] == ["proj-a", "proj-b"]
+    assert {c["project_id"] for c in payload["checks"]} == {"proj-a", "proj-b"}
+
+
+def test_gcp_fanout_skips_unreadable_project_with_warning(monkeypatch) -> None:
+    monkeypatch.setattr(gcp_inv, "_resolve_impersonation", lambda creds, warnings: creds)
+    monkeypatch.setattr(gcp_orgs, "list_project_ids", lambda creds, force=False: ["proj-ok", "proj-denied"])
+
+    def _fake_run(project_id=None, credentials=None, checks=None):
+        if project_id == "proj-denied":
+            raise PermissionError("403 caller lacks read on proj-denied")
+        return _report_gcp(project_id)
+
+    monkeypatch.setattr(gcp_cis, "run_benchmark", _fake_run)
+
+    report = gcp_cis.run_all_project_benchmarks(credentials=object())
+
+    assert report.projects_scanned == ["proj-ok"]
+    assert {c.account_id for c in report.checks} == {"proj-ok"}
+    assert any("proj-denied skipped" in w for w in report.warnings)
+    assert report.total == 2
+
+
+def test_gcp_fanout_falls_back_to_ambient_project(monkeypatch) -> None:
+    monkeypatch.setattr(gcp_inv, "_resolve_impersonation", lambda creds, warnings: creds)
+    monkeypatch.setattr(gcp_orgs, "list_project_ids", lambda creds, force=False: [])
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "solo-project")
+
+    def _fake_run(project_id=None, credentials=None, checks=None):
+        return _report_gcp(project_id)
+
+    monkeypatch.setattr(gcp_cis, "run_benchmark", _fake_run)
+
+    report = gcp_cis.run_all_project_benchmarks(credentials=object())
+    assert report.projects_scanned == ["solo-project"]


### PR DESCRIPTION
Makes the CIS benchmark run per boundary on Azure and GCP, matching how inventory already fans out — closing the gap where misconfig coverage was single-boundary even though inventory was estate-wide.

- Azure: `run_all_subscription_benchmarks()` runs CIS for each subscription discovered from the management-group tree, reusing the same enumeration as the inventory fan-out (extracted into a shared `enumerate_subscription_ids()` helper — no duplication). Gated by the existing `AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS`.
- GCP: `run_all_project_benchmarks()` runs CIS for each project in the org/folder tree, reusing `gcp_organizations.list_project_ids()` + the inventory fan-out's read-only impersonation. Gated by the existing `AGENT_BOM_GCP_ALL_PROJECTS`.\n- Aggregation with per-boundary attribution: each `CISCheckResult` is stamped with its originating `subscription_id`/`project_id`; reports carry `subscriptions_scanned`/`projects_scanned` + warnings. Bounded concurrency (≤8 workers), mirroring inventory. A boundary the credential can't read is skipped with a warning, never failing the whole run.\n- Counts and the posture headline now reflect every scanned boundary.\n- AWS multi-account CIS is intentionally out of scope (it needs the AssumeRole broker tracked in #3177) — noted in a code comment.\n\nFlag off = identical single-boundary behavior. 6 new tests; `pytest -k cis/azure/gcp` 796 passed; ruff/mypy/bandit clean.