### PR TITLE
fix(ui): readable lineage graph with distinct per-entity legend icons

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -922,10 +922,14 @@ function GraphPageInner() {
       preservePinnedPositions: true,
     },
     dagreLr: {
-      nodeWidth: 230,
-      nodeHeight: 84,
-      rankSep: filters.agentName ? 160 : 190,
-      nodeSep: filters.agentName ? 44 : 58,
+      // Bigger node boxes + tighter ranks keep the wide left-to-right DAG from
+      // collapsing into a thin, far-zoomed strip. The extra vertical nodeSep
+      // spreads short graphs so fitView fills the canvas instead of leaving a
+      // tall empty band above and below the topology.
+      nodeWidth: 248,
+      nodeHeight: 96,
+      rankSep: filters.agentName ? 120 : 140,
+      nodeSep: filters.agentName ? 64 : 78,
     },
   });
 

--- a/ui/components/graph-chrome.tsx
+++ b/ui/components/graph-chrome.tsx
@@ -7,7 +7,6 @@
 
 import { useState, useCallback, useEffect } from "react";
 import {
-  Brain,
   Boxes,
   Bug,
   ChevronDown,
@@ -26,6 +25,7 @@ import {
 import { useReactFlow } from "@xyflow/react";
 import { api, type GraphExportFormat } from "@/lib/api";
 import type { LegendItem } from "@/lib/graph-utils";
+import { entityIcon } from "@/components/lineage-nodes";
 
 // ─── Legend Bar ──────────────────────────────────────────────────────────────
 
@@ -155,13 +155,36 @@ function LegendSection({ title, items }: { title: string; items: LegendItem[] })
             className="flex min-w-0 items-center gap-2"
             title={item.description ?? item.label}
           >
-            <LegendMarker item={item} />
-            <LegendIcon item={item} />
+            <LegendGlyph item={item} />
             <span className="min-w-0 truncate" title={item.label}>{item.label}</span>
           </span>
         ))}
       </div>
     </div>
+  );
+}
+
+/**
+ * One glyph per legend row. Edge rows keep the directional line marker; node
+ * rows show the colored entity icon (falling back to the colored shape swatch
+ * only when no icon resolves, e.g. legacy static legends).
+ */
+function LegendGlyph({ item }: { item: LegendItem }) {
+  if (item.kind === "edge") {
+    return (
+      <span className="flex w-5 shrink-0 justify-center">
+        <LegendMarker item={item} />
+      </span>
+    );
+  }
+  const icon = LegendIcon({ item });
+  if (icon) {
+    return <span className="flex w-5 shrink-0 justify-center">{icon}</span>;
+  }
+  return (
+    <span className="flex w-5 shrink-0 justify-center">
+      <LegendMarker item={item} />
+    </span>
   );
 }
 
@@ -207,9 +230,19 @@ function LegendMarker({ item }: { item: LegendItem }) {
 }
 
 function LegendIcon({ item }: { item: LegendItem }) {
-  const label = item.label.toLowerCase();
   const className = "h-3.5 w-3.5 shrink-0";
 
+  // Primary path: the same entity-type → icon map the nodes render with, so a
+  // legend row and its node always carry the identical glyph.
+  if (item.kind !== "edge" && item.nodeType) {
+    const Icon = entityIcon(item.nodeType);
+    return <Icon className={className} style={{ color: item.color }} />;
+  }
+
+  // Fallback for items without a nodeType (e.g. the static STANDARD/MESH
+  // legends and relationship rows): keyword-match the label to a glyph.
+  if (item.kind === "edge") return null;
+  const label = item.label.toLowerCase();
   if (label.includes("agent")) return <Shield className={className} style={{ color: item.color }} />;
   if (label.includes("identity") || label.includes("grant") || label.includes("policy") || label.includes("permission")) {
     return <KeyRound className={className} style={{ color: item.color }} />;
@@ -219,7 +252,7 @@ function LegendIcon({ item }: { item: LegendItem }) {
   if (label.includes("cred")) return <KeyRound className={className} style={{ color: item.color }} />;
   if (label.includes("tool")) return <Wrench className={className} style={{ color: item.color }} />;
   if (label.includes("vuln") || label.includes("cve")) return <Bug className={className} style={{ color: item.color }} />;
-  if (label.includes("model")) return <Brain className={className} style={{ color: item.color }} />;
+  if (label.includes("model")) return <Database className={className} style={{ color: item.color }} />;
   if (label.includes("dataset")) return <Database className={className} style={{ color: item.color }} />;
   if (label.includes("cloud")) return <Cloud className={className} style={{ color: item.color }} />;
   if (label.includes("provider") || label.includes("fleet") || label.includes("cluster")) {

--- a/ui/components/lineage-nodes.tsx
+++ b/ui/components/lineage-nodes.tsx
@@ -1,19 +1,37 @@
 "use client";
 
-import type { ComponentType, ReactNode } from "react";
+import type { ComponentType, CSSProperties, ReactNode } from "react";
 import { Handle, Position } from "@xyflow/react";
 import {
-  Brain,
+  Activity,
+  BadgeCheck,
+  Bot,
   Box,
+  Boxes,
+  BrainCircuit,
   Bug,
   Building2,
   Cloud,
+  Container,
   Database,
+  Fingerprint,
+  IdCard,
   KeyRound,
+  Landmark,
+  Layers,
+  Link2,
+  Network,
   Package,
+  ScrollText,
   Server,
-  ShieldAlert,
+  Share2,
+  ShieldCheck,
+  Ticket,
   TriangleAlert,
+  User,
+  UserCog,
+  Users,
+  Warehouse,
   Wrench,
 } from "lucide-react";
 
@@ -119,7 +137,6 @@ type CardProps = {
   bgClass: string;
   ringClass: string;
   shapeClass?: string;
-  icon: ComponentType<{ className?: string }>;
   iconClass: string;
   source?: boolean;
   target?: boolean;
@@ -133,17 +150,20 @@ function NodeCard({
   bgClass,
   ringClass,
   shapeClass = "rounded-xl",
-  icon: Icon,
   iconClass,
   source = true,
   target = true,
   subtitle,
   footer,
 }: CardProps) {
+  // The glyph is keyed by entity type from the shared ENTITY_ICONS map, so the
+  // node and its legend row are always the same icon — even for the renderers
+  // shared across several types (e.g. CredentialNode serves role/policy/grants).
+  const Icon = entityIcon(data.nodeType);
   return (
     <div
       title={data.label}
-      className={`${shapeClass} border-2 px-3.5 py-2.5 min-w-[188px] max-w-[280px] shadow-xl backdrop-blur transition-opacity ${borderClass} ${bgClass} ${
+      className={`${shapeClass} border-2 px-4 py-3 min-w-[208px] max-w-[300px] shadow-xl backdrop-blur transition-opacity ${borderClass} ${bgClass} ${
         data.dimmed ? "opacity-25" : ""
       } ${data.highlighted ? `ring-2 ${ringClass}` : ""}`}
     >
@@ -158,8 +178,8 @@ function NodeCard({
         className={`!w-2 !h-2 !bg-current ${source ? "" : "!opacity-0"}`}
       />
       <div className="flex items-center gap-2 mb-1">
-        <Icon className={`w-4 h-4 shrink-0 ${iconClass}`} />
-        <span className="text-sm font-semibold leading-5 text-zinc-950 dark:text-zinc-50 truncate">{data.label}</span>
+        <Icon className={`w-[18px] h-[18px] shrink-0 ${iconClass}`} />
+        <span className="text-[15px] font-semibold leading-5 text-zinc-950 dark:text-zinc-50 truncate">{data.label}</span>
         <span className="ml-auto rounded border border-black/10 bg-white/70 px-1.5 py-0.5 text-[10px] uppercase tracking-[0.1em] text-zinc-600 dark:border-white/15 dark:bg-black/25 dark:text-zinc-200">
           {NODE_TYPE_BADGES[data.nodeType]}
         </span>
@@ -168,6 +188,54 @@ function NodeCard({
       {footer}
     </div>
   );
+}
+
+/**
+ * Single source of truth for entity-type → icon. The lineage node renderers,
+ * the cluster pills, and the on-canvas legend all read from this map so the
+ * glyph shown on a node is byte-for-byte the glyph shown in the legend row
+ * for the same type. Every type gets a DISTINCT, on-meaning Lucide icon.
+ */
+export type EntityIcon = ComponentType<{ className?: string; style?: CSSProperties }>;
+
+export const ENTITY_ICONS: Record<LineageNodeType, EntityIcon> = {
+  provider: Cloud,
+  agent: Bot,
+  server: Server,
+  sharedServer: Share2,
+  package: Package,
+  vulnerability: Bug,
+  misconfiguration: TriangleAlert,
+  credential: KeyRound,
+  tool: Wrench,
+  model: BrainCircuit,
+  dataset: Database,
+  container: Container,
+  cloudResource: Box,
+  org: Building2,
+  account: Landmark,
+  user: User,
+  group: Users,
+  role: IdCard,
+  policy: ScrollText,
+  serviceAccount: UserCog,
+  servicePrincipal: Fingerprint,
+  federatedIdentity: Link2,
+  environment: Layers,
+  fleet: Boxes,
+  cluster: Network,
+  managedIdentity: BadgeCheck,
+  accessGrant: Ticket,
+  accessPolicy: ShieldCheck,
+  driftIncident: Activity,
+  dataStore: Warehouse,
+};
+
+export function entityIcon(nodeType: LineageNodeType | string | undefined): EntityIcon {
+  if (nodeType && nodeType in ENTITY_ICONS) {
+    return ENTITY_ICONS[nodeType as LineageNodeType];
+  }
+  return Box;
 }
 
 const NODE_TYPE_BADGES: Record<LineageNodeType, string> = {
@@ -211,7 +279,6 @@ function AgentNode({ data }: { data: LineageNodeData }) {
       borderClass={notConfigured ? "border-yellow-500 border-dashed" : "border-emerald-500 dark:border-emerald-600"}
       bgClass={notConfigured ? "bg-yellow-50 dark:bg-yellow-950/80" : "bg-emerald-50 dark:bg-emerald-950/80"}
       ringClass="ring-emerald-400"
-      icon={ShieldAlert}
       iconClass="text-emerald-600 dark:text-emerald-400"
       target={false}
       subtitle={data.agentType}
@@ -233,7 +300,6 @@ function ProviderNode({ data }: { data: LineageNodeData }) {
       borderClass="border-zinc-300 dark:border-zinc-600"
       bgClass="bg-white dark:bg-zinc-900/90"
       ringClass="ring-zinc-400"
-      icon={Building2}
       iconClass="text-zinc-600 dark:text-zinc-400"
       target={false}
       footer={
@@ -250,7 +316,6 @@ function IdentityNode({
   borderClass,
   bgClass,
   ringClass,
-  icon,
   iconClass,
   subtitle,
 }: {
@@ -258,7 +323,6 @@ function IdentityNode({
   borderClass: string;
   bgClass: string;
   ringClass: string;
-  icon: ComponentType<{ className?: string }>;
   iconClass: string;
   subtitle?: ReactNode;
 }) {
@@ -268,7 +332,6 @@ function IdentityNode({
       borderClass={borderClass}
       bgClass={bgClass}
       ringClass={ringClass}
-      icon={icon}
       iconClass={iconClass}
       subtitle={subtitle}
     />
@@ -282,7 +345,6 @@ function UserNode({ data }: { data: LineageNodeData }) {
       borderClass="border-emerald-400 dark:border-emerald-700"
       bgClass="bg-emerald-50 dark:bg-emerald-950/60"
       ringClass="ring-emerald-400"
-      icon={ShieldAlert}
       iconClass="text-emerald-600 dark:text-emerald-300"
       subtitle={data.description}
     />
@@ -296,7 +358,6 @@ function GroupNode({ data }: { data: LineageNodeData }) {
       borderClass="border-fuchsia-400 dark:border-fuchsia-700"
       bgClass="bg-fuchsia-50 dark:bg-fuchsia-950/55"
       ringClass="ring-fuchsia-400"
-      icon={Building2}
       iconClass="text-fuchsia-600 dark:text-fuchsia-300"
       subtitle={data.description}
     />
@@ -310,7 +371,6 @@ function ServiceAccountNode({ data }: { data: LineageNodeData }) {
       borderClass="border-amber-400 dark:border-amber-700"
       bgClass="bg-amber-50 dark:bg-amber-950/55"
       ringClass="ring-amber-400"
-      icon={KeyRound}
       iconClass="text-amber-600 dark:text-amber-300"
       subtitle={data.description}
     />
@@ -322,14 +382,12 @@ function StructureNode({
   borderClass,
   bgClass,
   ringClass,
-  icon,
   iconClass,
 }: {
   data: LineageNodeData;
   borderClass: string;
   bgClass: string;
   ringClass: string;
-  icon: ComponentType<{ className?: string }>;
   iconClass: string;
 }) {
   return (
@@ -338,7 +396,6 @@ function StructureNode({
       borderClass={borderClass}
       bgClass={bgClass}
       ringClass={ringClass}
-      icon={icon}
       iconClass={iconClass}
       subtitle={data.description}
       footer={
@@ -358,7 +415,6 @@ function EnvironmentNode({ data }: { data: LineageNodeData }) {
       borderClass="border-teal-400 dark:border-teal-700"
       bgClass="bg-teal-50 dark:bg-teal-950/55"
       ringClass="ring-teal-400"
-      icon={Cloud}
       iconClass="text-teal-600 dark:text-teal-300"
     />
   );
@@ -371,7 +427,6 @@ function FleetNode({ data }: { data: LineageNodeData }) {
       borderClass="border-cyan-400 dark:border-cyan-700"
       bgClass="bg-cyan-50 dark:bg-cyan-950/55"
       ringClass="ring-cyan-400"
-      icon={Building2}
       iconClass="text-cyan-600 dark:text-cyan-300"
     />
   );
@@ -384,7 +439,6 @@ function ClusterNode({ data }: { data: LineageNodeData }) {
       borderClass="border-sky-400 dark:border-sky-700"
       bgClass="bg-sky-50 dark:bg-sky-950/55"
       ringClass="ring-sky-400"
-      icon={Server}
       iconClass="text-sky-600 dark:text-sky-300"
     />
   );
@@ -397,7 +451,6 @@ function ServerNode({ data }: { data: LineageNodeData }) {
       borderClass="border-blue-500 dark:border-blue-600"
       bgClass="bg-blue-50 dark:bg-blue-950/80"
       ringClass="ring-blue-400"
-      icon={Server}
       iconClass="text-blue-600 dark:text-blue-400"
       subtitle={data.command}
       footer={
@@ -434,7 +487,6 @@ function PackageNode({ data }: { data: LineageNodeData }) {
       borderClass={hasVulns ? "border-red-400 dark:border-red-600/60" : "border-zinc-300 dark:border-zinc-600"}
       bgClass={hasVulns ? "bg-red-50 dark:bg-red-950/40" : "bg-white dark:bg-zinc-900/80"}
       ringClass="ring-zinc-400"
-      icon={Package}
       iconClass="text-zinc-600 dark:text-zinc-400"
       subtitle={
         data.version
@@ -471,7 +523,6 @@ function FindingNode({
       bgClass={bgClass}
       ringClass="ring-white/50"
       shapeClass={data.nodeType === "misconfiguration" ? "rounded-md" : "rounded-lg"}
-      icon={data.nodeType === "misconfiguration" ? TriangleAlert : Bug}
       iconClass={accentClass}
       source={false}
       subtitle={data.description}
@@ -523,7 +574,6 @@ function CredentialNode({ data }: { data: LineageNodeData }) {
       bgClass="bg-amber-50 dark:bg-amber-950/60"
       ringClass="ring-amber-400"
       shapeClass="rounded-2xl"
-      icon={KeyRound}
       iconClass="text-amber-600 dark:text-amber-400"
       source={false}
       subtitle={data.serverName}
@@ -539,7 +589,6 @@ function ToolNode({ data }: { data: LineageNodeData }) {
       bgClass="bg-purple-50 dark:bg-purple-950/60"
       ringClass="ring-purple-400"
       shapeClass="rounded-2xl"
-      icon={Wrench}
       iconClass="text-purple-600 dark:text-purple-400"
       source={false}
       subtitle={data.description}
@@ -554,7 +603,6 @@ function ModelNode({ data }: { data: LineageNodeData }) {
       borderClass="border-violet-500 dark:border-violet-600"
       bgClass="bg-violet-50 dark:bg-violet-950/70"
       ringClass="ring-violet-400"
-      icon={Brain}
       iconClass="text-violet-600 dark:text-violet-300"
       subtitle={data.description}
     />
@@ -568,7 +616,6 @@ function DatasetNode({ data }: { data: LineageNodeData }) {
       borderClass="border-cyan-500 dark:border-cyan-600"
       bgClass="bg-cyan-50 dark:bg-cyan-950/70"
       ringClass="ring-cyan-400"
-      icon={Database}
       iconClass="text-cyan-600 dark:text-cyan-300"
       subtitle={data.description}
     />
@@ -582,7 +629,6 @@ function ContainerNode({ data }: { data: LineageNodeData }) {
       borderClass="border-indigo-500 dark:border-indigo-600"
       bgClass="bg-indigo-50 dark:bg-indigo-950/70"
       ringClass="ring-indigo-400"
-      icon={Box}
       iconClass="text-indigo-600 dark:text-indigo-300"
       subtitle={data.description}
     />
@@ -596,7 +642,6 @@ function CloudResourceNode({ data }: { data: LineageNodeData }) {
       borderClass="border-sky-500 dark:border-sky-600"
       bgClass="bg-sky-50 dark:bg-sky-950/70"
       ringClass="ring-sky-400"
-      icon={Cloud}
       iconClass="text-sky-600 dark:text-sky-300"
       subtitle={data.description}
     />
@@ -620,7 +665,7 @@ function ClusterPillNode({ data }: { data: LineageNodeData }) {
   };
   const count = cluster.count ?? 0;
   const childType = (cluster.childType ?? cluster.nodeType) as LineageNodeType;
-  const Icon = CLUSTER_PILL_ICONS[childType] ?? Box;
+  const Icon = entityIcon(childType);
   return (
     <div
       data-testid="cluster-pill"
@@ -645,25 +690,6 @@ function ClusterPillNode({ data }: { data: LineageNodeData }) {
   );
 }
 
-const CLUSTER_PILL_ICONS: Partial<Record<LineageNodeType, ComponentType<{ className?: string }>>> = {
-  agent: ShieldAlert,
-  server: Server,
-  sharedServer: Server,
-  package: Package,
-  vulnerability: Bug,
-  misconfiguration: TriangleAlert,
-  credential: KeyRound,
-  tool: Wrench,
-  model: Brain,
-  dataset: Database,
-  container: Box,
-  cloudResource: Cloud,
-  provider: Building2,
-  environment: Cloud,
-  fleet: Building2,
-  cluster: Server,
-};
-
 function SharedServerNode({ data }: { data: LineageNodeData }) {
   return (
     <NodeCard
@@ -672,7 +698,6 @@ function SharedServerNode({ data }: { data: LineageNodeData }) {
       bgClass="bg-cyan-50 dark:bg-cyan-950/80"
       ringClass="ring-cyan-300"
       shapeClass="rounded-[18px]"
-      icon={Server}
       iconClass="text-cyan-600 dark:text-cyan-300"
       subtitle={data.command}
       footer={

--- a/ui/e2e/lineage-graph-readability.spec.ts
+++ b/ui/e2e/lineage-graph-readability.spec.ts
@@ -227,6 +227,21 @@ async function captureGraphScreenshot(page: Page, testInfo: TestInfo, theme: "da
     await expect(canvas.getByText("Desktop Agent").first()).toBeVisible();
     await expect(canvas.getByText("CVE-2026-103").first()).toBeVisible();
     await expect(page.getByText("Legend").first()).toBeVisible();
+    const application = page.getByRole("application").first();
+    // Topology with the legend collapsed — proves the nodes fill the canvas
+    // and read clearly at default zoom.
+    await application.screenshot({
+      path: testInfo.outputPath(`lineage-graph-canvas-${theme}.png`),
+    });
+    // Open the on-canvas legend so the per-entity-type icons are captured.
+    const legendToggle = page.getByRole("button", { name: /show legend/i });
+    if (await legendToggle.isVisible()) {
+      await legendToggle.click();
+    }
+    await expect(page.getByRole("button", { name: /hide legend/i })).toBeVisible();
+    await application.screenshot({
+      path: testInfo.outputPath(`lineage-graph-legend-${theme}.png`),
+    });
   }
   await page.screenshot({
     path: testInfo.outputPath(`lineage-graph-dense-${theme}.png`),

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -127,6 +127,9 @@ export interface LegendItem {
   kind?: "node" | "edge" | undefined;
   lineStyle?: "solid" | "dashed" | undefined;
   shape?: "dot" | "square" | "diamond" | "pill" | undefined;
+  // Entity type drives the legend glyph from the same ENTITY_ICONS map the
+  // node renderers use, so a legend row and its node always show one icon.
+  nodeType?: LineageNodeType | undefined;
 }
 
 function legendShapeForGraphShape(shape: string): LegendItem["shape"] {
@@ -184,6 +187,7 @@ export function legendItemForNodeType(nodeType: LineageNodeType): LegendItem {
       layer: GRAPH_NODE_KIND_META.server.layer,
       kind: "node",
       shape: "square",
+      nodeType: "sharedServer",
     };
   }
 
@@ -195,6 +199,7 @@ export function legendItemForNodeType(nodeType: LineageNodeType): LegendItem {
     layer: meta?.layer,
     kind: "node",
     shape: override?.shape ?? (meta ? legendShapeForGraphShape(meta.shape) : "pill"),
+    nodeType,
   };
 }
 

--- a/ui/lib/graph-viewport.ts
+++ b/ui/lib/graph-viewport.ts
@@ -30,24 +30,28 @@ export function graphFitViewOptions(input: GraphViewportInput): GraphFitViewOpti
   let padding = 0.16;
   let maxZoom = 1.05;
 
+  // maxZoom is the readability ceiling: when a small/medium topology is wide
+  // and short, fitView is width-bound and would otherwise zoom far out and
+  // leave the nodes tiny. A higher ceiling lets fitView scale the nodes up to
+  // a legible size before it stops.
   if (nodeCount <= 0) {
     padding = 0.18;
     maxZoom = 1;
   } else if (nodeCount <= 6) {
-    padding = 0.08;
-    maxZoom = 1.72;
+    padding = 0.06;
+    maxZoom = 2;
   } else if (nodeCount <= 16) {
-    padding = 0.1;
-    maxZoom = 1.48;
+    padding = 0.08;
+    maxZoom = 1.75;
   } else if (nodeCount <= 32) {
-    padding = 0.12;
-    maxZoom = 1.28;
+    padding = 0.1;
+    maxZoom = 1.5;
   } else if (nodeCount <= 80) {
-    padding = 0.16;
-    maxZoom = 1.08;
+    padding = 0.14;
+    maxZoom = 1.2;
   } else {
-    padding = 0.2;
-    maxZoom = 0.92;
+    padding = 0.18;
+    maxZoom = 1;
   }
 
   const density = nodeCount > 0 ? edgeCount / nodeCount : 0;

--- a/ui/tests/graph-utils.test.ts
+++ b/ui/tests/graph-utils.test.ts
@@ -46,6 +46,7 @@ describe("graph utility metadata", () => {
         layer: GRAPH_NODE_KIND_META[GraphNodeKind.SERVER].layer,
         kind: "node",
         shape: "square",
+        nodeType: "sharedServer",
       },
     ]);
   });


### PR DESCRIPTION
The lineage graph rendered tiny nodes in a vast empty canvas, and the legend showed generic colored dots because `LegendIcon` returned `null` for most types. The graph was not readable and the legend icons did not map to what each object is.

- **Distinct icons per entity type** — a single `ENTITY_ICONS` map (30 types) is the source of truth, used by both the node cards and the legend, so a type's glyph is identical in canvas and legend (agent→Bot, server→Server, package→Package, vulnerability→Bug, credential→KeyRound, tool→Wrench, policy→ScrollText, serviceAccount→UserCog, account→Landmark, dataset→Database, model→BrainCircuit, …). The legend groups rows by layer and shows only the types present.\n- **Readable nodes + layout** — larger node cards, tuned dagre spacing, and higher fitView zoom ceilings so the topology fills the canvas instead of sitting tiny. Labels truncate cleanly; no overflow.\n\ntypecheck + lint clean; 271 vitest pass; lineage/security-graph/large-graph e2e specs pass.\n\nFollow-up: re-capture the graph proof images against this improved component before they re-enter the README gallery.