### PR TITLE
docs: concise, restructured README with cloud-first positioning

### DIFF
--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -1,6 +1,6 @@
 # agent-bom
 
-**Open security scanner and self-hosted control plane for AI/MCP infrastructure.**
+**Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.**
 
 `agent-bom` follows package, agent, MCP, credential-name, cloud estate,
 non-human identity, runtime, and skill evidence into one reachability-backed AI

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -2,7 +2,7 @@
 
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
-**Open security scanner and self-hosted control plane for AI/MCP infrastructure.**
+**Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.**
 
 Start with the demo, then choose the entrypoint that matches your first job:
 repo scan, image scan, cloud posture, fix plan, dashboard, MCP tools, or

--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ Most tools are read-only; the three Shield write actions fail closed unless the
 caller supplies `operator_role=admin`, `operator_scopes=shield:write`, and an
 audit reason. CLI scan commands run local scan pipelines today and share lower
 scanner and discovery libraries with the API, but they are not API wrappers yet.
+MCP registry presence is tracked through the committed Smithery manifest and
+other registry metadata; install and liveness checks live in the integration
+docs, not this front door.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 </p>
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
-<p align="center"><b>Open security scanner and self-hosted control plane for AI/MCP infrastructure.</b></p>
-<p align="center">Headless agent primitives and human cockpit surfaces over the same evidence model.</p>
+<p align="center"><b>Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.</b></p>
+<p align="center">Headless agent primitives and human cockpit surfaces over one shared evidence model.</p>
 
 <p align="center">
   <a href="https://msaad00.github.io/agent-bom/">Docs</a> ·
@@ -28,16 +28,16 @@
   <a href="https://github.com/msaad00/agent-bom/releases">Changelog</a>
 </p>
 
-`agent-bom` scans local and fleet AI infrastructure, builds an AI BOM across
-agents, MCP servers, tools, packages, credential environment names, cloud
-estate, non-human identities, runtime, and skills, then turns that inventory
-into findings, compliance evidence, LLM cost posture, and graph-backed
-multi-hop exposure paths.
+## What It Is
 
-The same evidence is available through CLI/CI, REST API, MCP tools, and a
-self-hosted dashboard. Runtime proxy/gateway controls — including inline
-firewall enforcement and a secure-by-default gateway — are optional and scoped
-to environments where enforcement is worth the operational cost.
+`agent-bom` scans AI infrastructure across local projects, agent fleets, and
+cloud estates (AWS, Azure, GCP, Snowflake), and builds one AI BOM of agents,
+MCP servers, tools, packages, credential references, non-human identities,
+models, datasets, and runtime. Every source converges into a unified `Finding`
+model and a unified `ContextGraph`, so blast radius, multi-hop exposure paths,
+and exposure scoring all read from the same evidence. That evidence is reachable
+through CLI/CI, a REST API, MCP tools, and a self-hosted dashboard; runtime
+proxy/gateway enforcement is optional and scoped to where it earns its cost.
 
 <p align="center">
   <picture>
@@ -47,260 +47,104 @@ to environments where enforcement is worth the operational cost.
 </p>
 
 ```text
-package
-  -> vulnerability finding
-  -> MCP server
-  -> tools + credential refs
-  -> agent
+package -> vulnerability finding -> MCP server -> tools + credential refs -> agent
 ```
 
-Blast radius is the core idea. A vulnerable package is not just a CVE row; it
-is linked to the MCP server that loads it, the tools exposed by that server,
-the credential environment names in reach, and the agents that can call it.
+Blast radius is the core idea: a vulnerable package is not just a CVE row — it
+is linked to the MCP server that loads it, the tools that server exposes, the
+credential environment names in reach, and the agents that can call it.
 
 ## What It Scans
 
 | Domain | Coverage |
 |---|---|
-| Supply chain | 15 package ecosystems (npm, PyPI, Maven, Go, Cargo, NuGet, Composer, RubyGems, conda, Hex, Pub, Swift, plus OS packages apk/deb/rpm) with OSV/GHSA enrichment, transitive resolution, and dependency-confusion detection |
-| Agents + MCP | MCP clients, servers, tools, transports, trust posture, and live introspection across 29 first-class client types |
+| Supply chain | 15 package ecosystems (npm, PyPI, Maven, Go, Cargo, NuGet, Composer, RubyGems, conda, Hex, Pub, Swift, plus apk/deb/rpm) with OSV/GHSA enrichment, transitive resolution, and dependency-confusion detection |
+| Agents + MCP | MCP clients, servers, tools, transports, and trust posture with live introspection across 29 first-class client types |
 | AI models + datasets | Malicious-model detection via safe pickle-opcode disassembly (no deserialization), model/dataset cards, and PII/PHI dataset scanning |
-| Cloud estate | Read-only, gated asset inventory across AWS, Azure, GCP, and Snowflake plus AI/GPU provider posture and CIS benchmarks. One connection model per cloud: a scoped read-only role and keyless/token auth — see [docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md) |
-| Identity (NHI) | Non-human identity discovery (Okta/Entra, gated), credential-expiry posture, and access-review recertification campaigns |
+| Cloud estate | Read-only, gated asset inventory and CIS posture across AWS, Azure, GCP, and Snowflake, plus AI/GPU provider posture |
+| Identity (NHI) | Non-human identity discovery (Okta/Entra, gated), credential-expiry posture, and access-review recertification |
 | LLM cost | Spend forecasting, budget runway, chargeback/allocation, and seasonal-aware spend-anomaly detection |
-| Containers + IaC | Native OCI image parsing plus Dockerfile, Terraform, CloudFormation, Helm, and Kubernetes; registry-wide sweeps across ECR/ACR/GAR (`cloud registry-scan`) and agentless AWS EBS disk side-scan (CWPP, snapshot-based, read-only) |
-| Secrets + runtime | Secret detection, MCP proxy/gateway, A2A and MCP auth-posture checks, inline firewall enforcement, and redaction surfaces |
+| Containers + IaC | OCI images, Dockerfile, Terraform, CloudFormation, Helm, and Kubernetes; registry sweeps across ECR/ACR/GAR and agentless AWS EBS disk side-scan (read-only, snapshot-based) |
+| Secrets + runtime | Secret detection, MCP proxy/gateway, A2A and MCP auth-posture checks, inline firewall enforcement, and redaction |
 | Compliance | Mapped governance frameworks plus ZIP evidence bundles for auditors |
 
-Findings converge on one unified `Finding` model and a unified `ContextGraph`,
-so multi-hop attack-path fusion, blast radius, and exposure scoring all read
-from the same evidence. The graph adds correlation overlays on top of that base:
-an ASPM layer that organizes AppSec findings around the application they belong
-to, LLM cost fused onto the resources that incur it, read-only cloud audit-trail
-activity as behavioral edges, and an estate-scale `CONTAINS` roll-up with
-drill-down so large clouds stay readable instead of one sprawling canvas.
+CIS misconfigurations and graph toxic-combinations converge into the same
+`Finding` stream and exit-code gate as package vulnerabilities, so a real
+exposure can fail a pipeline. The graph adds correlation overlays on the same
+base: AppSec findings organized around their application, LLM cost fused onto the
+resources that incur it, read-only cloud audit-trail activity as behavioral
+edges, and an estate-scale `CONTAINS` roll-up with drill-down so large clouds
+stay readable.
+
+<details>
+<summary><b>Product proof — dashboard, graph, and identity surfaces</b></summary>
+
+Captured from the packaged UI with bundled demo scan data and seeded
+control-plane records — synthetic data where needed, but the real scan, graph,
+fleet, identity, audit, and gateway routes.
 
 <p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/control-loop-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/control-loop-light.svg" alt="agent-bom control loop from discovery to graph evidence to gateway policy and runtime enforcement" width="900" />
-  </picture>
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png" alt="agent-bom risk overview dashboard with posture score, findings, and attack path summary" width="900" />
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-live.png" alt="agent-bom agent mesh graph showing agent, MCP server, package, tool, credential reference, and finding path" width="900" />
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/security-graph-live.png" alt="agent-bom security graph with attack-path queue, graph evidence export, and remediation handoff" width="900" />
 </p>
+
+Capture rules and the full manifest live in [docs/CAPTURE.md](docs/CAPTURE.md)
+and [docs/images/product-screenshots.json](docs/images/product-screenshots.json).
+
+</details>
 
 ## First Run
 
 ```bash
 pip install agent-bom
-agent-bom quickstart --dry-run --offline   # print the onboarding plan
-agent-bom quickstart --run --offline        # write sample, scan, seed gateway policy, populate the cockpit
-agent-bom agents --demo --offline
+agent-bom quickstart --run --offline    # write sample, scan, seed gateway policy, populate the cockpit
+agent-bom agents -p . -f html -o agent-bom-report.html   # a real local scan
 ```
 
 The demo uses bundled advisory-backed OSV/GHSA ranges against intentionally
-vulnerable sample packages and produces graph-ready inventory without touching
-your source tree.
-For a real local scan:
-
-```bash
-agent-bom agents -p . -f html -o agent-bom-report.html
-```
-
-Want an inspectable sample stack first?
-
-```bash
-agent-bom samples first-run
-agent-bom agents --inventory agent-bom-first-run/inventory.json -p agent-bom-first-run --enrich
-```
-
-See [docs/FIRST_RUN.md](docs/FIRST_RUN.md) for the guided path from CLI output
-to the dashboard.
-
-To reproduce the dashboard screenshots from a clean local control-plane store:
-
-```bash
-make build-ui
-uv run agent-bom serve --persist /tmp/agent-bom-demo.db --allow-insecure-no-auth
-uv run agent-bom agents --demo --offline --no-auto-update-db -f json -o /tmp/agent-bom-demo.json
-curl -sS -H 'content-type: application/json' --data-binary @/tmp/agent-bom-demo.json \
-  http://127.0.0.1:8422/v1/results/push
-```
+vulnerable sample packages, producing graph-ready inventory without touching
+your source tree. See [docs/FIRST_RUN.md](docs/FIRST_RUN.md) for the guided path
+from CLI output to the dashboard, and [docs/CAPTURE.md](docs/CAPTURE.md) to
+reproduce the dashboard screenshots from a clean local control-plane store.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif" alt="agent-bom terminal demo" width="820" />
 </p>
 
-## Product Proof
-
-The dashboard screenshots below are captured from the packaged UI with bundled
-demo scan data and seeded control-plane records, not static mockups. The data is
-synthetic where needed, but the routes are the real scan, graph, fleet,
-identity, audit, and gateway surfaces. The README keeps the first screen
-focused; expand the gallery when you want to inspect the control-plane surfaces.
-
-<details open>
-<summary><b>Evidence cockpit and agent mesh</b></summary>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png" alt="agent-bom risk overview dashboard with posture score, findings, and attack path summary" width="900" />
-</p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-live.png" alt="agent-bom agent mesh graph showing agent, MCP server, package, tool, credential reference, and finding path" width="900" />
-</p>
-
-</details>
-
-<details open>
-<summary><b>Graph views beyond the agent mesh</b></summary>
-
-The graph proof set is intentionally split across modes: fix-first exposure
-paths, root-centered lineage, lateral context, and package risk distribution.
-That keeps each view readable instead of forcing every relationship into one
-sprawling canvas.
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/security-graph-live.png" alt="agent-bom security graph with attack-path queue, graph evidence export, and remediation handoff" width="900" />
-</p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/lineage-graph-live.png" alt="agent-bom lineage graph centered on an agent with bounded paths, filters, and graph evidence export" width="900" />
-</p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/context-map-live.png" alt="agent-bom context map showing agent-to-server reachability and lateral movement context" width="900" />
-</p>
-
-</details>
-
-<details open>
-<summary><b>Environment state and identity lifecycle</b></summary>
-
-Fleet and identity views use the same control-plane APIs that operators use for
-customer-owned deployments. The sample below seeds environment, owner, lifecycle
-state, and agent identity events so the screenshots show how local scan evidence
-connects to reviewable governance records.
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/fleet-state-live.png" alt="agent-bom fleet state dashboard showing lifecycle distribution, approved and discovered agents, owner metadata, environment labels, and discovery state" width="900" />
-</p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/identity-audit-live.png" alt="agent-bom audit log filtered to identity lifecycle events with HMAC integrity counters and issue, rotate, revoke rows" width="900" />
-</p>
-
-</details>
-
-<details>
-<summary><b>Dependency and remediation views</b></summary>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dependency-map-live.png" alt="agent-bom dependency map with scan pipeline counts, supply-chain treemap, blast-radius chart, and EPSS by CVSS risk map" width="900" />
-</p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/remediation-live.png" alt="agent-bom remediation dashboard with prioritized package fixes and compliance context" width="900" />
-</p>
-
-</details>
-
-<details>
-<summary><b>Runtime policy and audit posture</b></summary>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/gateway-policies-live.png" alt="agent-bom gateway policy dashboard showing advisory runtime posture, enabled policy count, rule counts, and bound agents" width="900" />
-</p>
-
-</details>
-
-Screenshot capture rules and the full manifest live in
-[docs/CAPTURE.md](docs/CAPTURE.md) and
-[docs/images/product-screenshots.json](docs/images/product-screenshots.json).
-
 ## Start Here
 
-| Goal | Command | Artifact |
-|---|---|---|
-| Local agent and MCP inventory | `agent-bom agents` | findings, AI BOM, graph-ready JSON |
-| Read-only cloud onboarding | `agent-bom connect aws` | exact read-only grant + opt-in env var; no network I/O until you opt in |
-| Guided local onboarding | `agent-bom quickstart --dry-run --offline` | scan, sample-data, and local API/UI next steps |
-| One-command onboarding | `agent-bom quickstart --run --offline` | writes sample, runs a graph-persisting scan, seeds a baseline gateway policy |
-| Repo and lockfile scan | `agent-bom agents -p .` | package findings, SARIF/SBOM/HTML when requested |
-| Pre-install guard | `agent-bom check flask@2.0.0 --ecosystem pypi` | deterministic allow/warn/block result |
-| Container image scan | `agent-bom image nginx:latest` | image findings and remediation |
-| IaC scan | `agent-bom iac Dockerfile k8s/ infra/main.tf` | IaC findings and policy context |
-| Cloud posture check | `agent-bom cloud aws --cis` | runtime CIS posture evidence |
-| Cloud estate inventory | `agent-bom cloud inventory --provider aws` | read-only, gated asset inventory (AWS/Azure/GCP) |
-| Snowflake AI BOM + CIS | `agent-bom agents --snowflake` | Cortex agents, Snowpark apps, and CIS posture (read-only, key-pair) |
-| LLM cost forecast | `agent-bom cost forecast` | spend burn-rate, budget runway, and chargeback posture |
-| Non-human identity posture | `agent-bom identity credential-expiry` | expiring/overdue NHI credentials and access reviews |
-| Advisory remediation plan | `agent-bom remediate -p .` | prioritized, blast-radius-ordered fixes (optional `--apply` / `--open-pr`) |
-| Gated-capability readiness | `agent-bom capabilities` | every gated feature: state, why, and how to unlock |
-| CI gate | `uses: msaad00/agent-bom@v0.89.2` | SARIF, PR summary, optional code-scanning upload |
-| MCP tools | `pip install 'agent-bom[mcp-server]' && agent-bom mcp server` | strict-args security tools for MCP clients |
-| Local API/UI | `pip install 'agent-bom[ui]' && agent-bom serve` | API plus bundled dashboard |
-| First-run extras | `pip install 'agent-bom[all]'` | supported onboarding extras; MLflow remains separately installed |
-| Self-hosted pilot | `docker compose -f docker-compose.pilot.yml up -d` | API and dashboard in your environment |
+| Goal | Command |
+|---|---|
+| Local agent and MCP inventory | `agent-bom agents` |
+| Repo and lockfile scan | `agent-bom agents -p .` |
+| Connect a cloud (read-only) | `agent-bom connect aws` |
+| Cloud estate scan | `agent-bom cloud scan` |
+| Multi-hop exposure paths | `agent-bom graph` |
+| Report (HTML/SARIF/SBOM) | `agent-bom agents -p . -f html -o report.html` |
+| LLM cost forecast | `agent-bom cost forecast` |
+| Non-human identity posture | `agent-bom identity credential-expiry` |
+| Advisory remediation plan | `agent-bom remediate -p .` |
+| Gated-capability readiness | `agent-bom capabilities` |
+| CI gate | `uses: msaad00/agent-bom@v0.89.2` |
+| Local API and dashboard | `pip install 'agent-bom[ui]' && agent-bom serve` |
 
-The base wheel is the scanner and CLI path. Optional runtime surfaces fail fast
+The base wheel is the scanner and CLI path; optional runtime surfaces fail fast
 with install hints when their extras are missing.
-
-New to the repo? [PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md) is the repo map,
-[docs/START_HERE.md](docs/START_HERE.md) routes you by role, and
+[PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md) is the repo map,
+[docs/START_HERE.md](docs/START_HERE.md) routes by role, and
 [docs/CLI_MAP.md](docs/CLI_MAP.md) groups every command by domain.
 
-MCP registry publishing is tracked through the committed Smithery manifest and
-other registry metadata; install and liveness checks stay in the linked
-integration docs instead of this front door.
-
-## Shipped Surfaces
-
-| Surface | Primary user | Current boundary |
-|---|---|---|
-| CLI / CI | developers and release gates | local scans, SARIF/SBOM/HTML/JSON, deterministic exit codes |
-| REST API | control-plane integrations | scans, bulk findings, dataset versions, evaluation runs, graph evidence, audit, runtime summaries |
-| MCP tools | agents and assistants | strict arguments, read-mostly security queries, exposure paths, deploy decisions, audited Shield actions |
-| Dashboard | security teams and operators | inventory, findings, graph cockpit, compliance, evidence, runtime posture |
-| Runtime proxy/gateway | runtime operators | scoped MCP traffic inspection, policy decisions, redacted audit evidence |
-| Python client | services, notebooks, and automation | typed helper for stable REST endpoints in the packaged wheel |
-| TypeScript client | services and agent runtimes | typed helper for stable REST endpoints |
-
-MCP server mode advertises 70 MCP tools, 6 resources, and 6 workflow prompts.
-Most tools are read-only. The three Shield write actions fail closed unless
-the caller supplies `operator_role=admin`, `operator_scopes=shield:write`, and
-an audit reason.
-
-CLI scan commands run local scan pipelines today. They share lower scanner and
-discovery libraries with the API, but they are not API wrappers yet.
-
-Runtime enforcement is explicit. Proxy mode either wraps a target MCP server
-for audit and policy decisions, or runs that server through Docker/Podman
-isolation when a sandbox image is supplied:
-
-```bash
-agent-bom proxy --no-isolate --policy policy.json --detect-credentials --block-undeclared -- npx @mcp/server-github
-agent-bom proxy --sandbox-image ghcr.io/acme/mcp-runtime@sha256:<digest> \
-  --sandbox-image-pin-policy enforce --block-undeclared -- npx @mcp/server-postgres
-```
-
-## Connect a Cloud (Read-Only)
+## Connect a Cloud (Read-Only Auth)
 
 `agent-bom` reads four clouds — **AWS, Azure, GCP, and Snowflake** — through one
 connection model. Every connector is **read-only, agentless, and keyless** by
 default: only control-plane `list`/`get` (or `SHOW`/`SELECT`) APIs, no writes, no
-secret values, no data leaves your account. Each connector is **opt-in and
-default-off**, gated by a per-provider env flag; with the flag unset, agent-bom
-does zero cloud network I/O.
-
-The *only* thing that differs per cloud is the line that mints the read-only
-role — because each platform's grant primitive is different. Everything else is
-identical: enable with `AGENT_BOM_<PROVIDER>_INVENTORY=1`, authenticate with the
-cloud's own identity (never a secret handed to agent-bom), get the same graph
-and findings out.
-
-`agent-bom connect aws | azure | gcp | snowflake` prints the exact read-only
-setup for each source — the Terraform module, the opt-in inventory env var, and
-whether local credentials are already detectable — without doing any network
-I/O until you opt in.
+secret values, and no data leaves your account. Each connector is opt-in and
+default-off behind a per-provider env flag; with the flag unset, agent-bom does
+zero cloud network I/O. `agent-bom connect aws | azure | gcp | snowflake` prints
+the exact read-only grant, the opt-in env var, and whether local credentials are
+detectable — without any network I/O until you opt in.
 
 | Cloud | Read-only grant | Keyless / token auth | Enable | Scan |
 |---|---|---|---|---|
@@ -315,68 +159,21 @@ export AGENT_BOM_AWS_INVENTORY=1
 export AWS_PROFILE=<readonly-profile>
 agent-bom cloud aws --cis
 
-# Azure — assign Reader (+ Security Reader), then:
-export AGENT_BOM_AZURE_INVENTORY=1
-az login
-agent-bom cloud azure --cis
-
-# GCP — grant a read-only SA and impersonate it (no key file):
-export AGENT_BOM_GCP_INVENTORY=1
-export AGENT_BOM_GCP_IMPERSONATE_SA=<sa-email>      # e.g. abom-readonly@<project-id>.iam.gserviceaccount.com
-gcloud auth application-default login
-agent-bom cloud gcp --project <project-id> --cis
-
-# Snowflake — create ABOM_READONLY + a key-pair user (see CLOUD_CONNECT.md), then:
-export SNOWFLAKE_ACCOUNT=<org-account>
-export SNOWFLAKE_USER=ABOM_SCANNER
-export SNOWFLAKE_AUTHENTICATOR=snowflake_jwt
-export SNOWFLAKE_PRIVATE_KEY_PATH=/path/to/abom_key.p8
-agent-bom agents --snowflake
+# Run every configured cloud at once (read-only, auto-detects what is connected):
+agent-bom cloud scan --fail-on-severity high
 ```
 
-A read-only **estate inventory** across the enabled clouds (reference only, no
-findings):
-
-```bash
-agent-bom cloud inventory --provider all        # or aws | azure | gcp
-```
-
-Or run one cloud-aware scan across every configured provider at once —
-`--provider all` (the default) auto-detects which clouds are connected and
-skips the rest:
-
-```bash
-agent-bom cloud scan                            # all configured clouds, read-only
-agent-bom cloud scan --provider aws --cis --show-passed
-agent-bom cloud registry-scan --provider ecr --region us-east-1   # sweep an ECR/ACR/GAR registry
-```
-
-CIS misconfigurations and graph toxic-combinations converge into the same
-`Finding` stream and exit-code gate as package vulnerabilities, so a real
-exposure can fail a pipeline:
-
-```bash
-agent-bom agents --aws --azure --gcp --snowflake --fail-on-severity high
-agent-bom graph                                 # multi-hop exposure paths
-agent-bom identity credential-expiry            # non-human identity posture
-agent-bom db freshness                          # confirm vuln data is current before gating
-```
-
-The full grant templates, per-cloud permission catalogs, and the
-"why read-only is enough" rationale live in
+Azure, GCP, and Snowflake setup, the full grant templates, per-cloud permission
+catalogs, and the "why read-only is enough" rationale live in
 [docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md). agent-bom is a **scanner, not a
 platform** — it reads inventory and posture, normalizes it into one graph, and
 emits findings; it never writes, never reads secret contents, and never moves
 data out of your account.
 
-<!-- TODO: capture real (redacted) screenshot: cross-cloud security graph with AWS + Azure + GCP + Snowflake nodes and a multi-hop exposure path -->
-<!-- TODO: capture real (redacted) screenshot: findings table filtered to cloud CIS misconfigurations across the four providers -->
-<!-- TODO: capture real (redacted) screenshot: identity/CIEM path from a cloud principal to a sensitive data store -->
-
 ## Deploy In Your Boundary
 
-`agent-bom` is designed for customer-controlled deployment: local CLI, Docker,
-GitHub Action, Helm, EKS, Postgres, and optional runtime proxy/gateway.
+`agent-bom` is built for customer-controlled deployment across three tiers of one
+product: a laptop CLI, your own Kubernetes, or a hosted control plane you run.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
@@ -384,50 +181,13 @@ docker compose -f docker-compose.pilot.yml up -d
 # Dashboard -> http://localhost:3000
 ```
 
-Production self-hosting starts with the deployment chooser:
-
-- [Deploy anywhere guide](docs/DEPLOY_PLATFORM.md) — one product, three tiers (laptop, your Kubernetes, hosted control plane)
-- [Deployment overview](site-docs/deployment/overview.md)
-- [Helm chart](deploy/helm/agent-bom)
-- [One-apply EKS platform module](deploy/terraform/platform-eks) — `terraform apply` the full control plane (cluster, Postgres, secrets, ingress)
-- [EKS reference installer](scripts/deploy/install-eks-reference.sh)
+- [Deploy anywhere guide](docs/DEPLOY_PLATFORM.md) — laptop, your Kubernetes, or hosted control plane
+- [Helm chart](deploy/helm/agent-bom) and [one-apply EKS platform module](deploy/terraform/platform-eks)
 - [Docker Hub image](https://hub.docker.com/r/agentbom/agent-bom)
+- [CloudFormation one-click](deploy/cloudformation) — a read-only `cloud aws` scan via CodeBuild, no local credentials handed to agent-bom
 
-For a zero-install AWS scan, deploy the
-[CloudFormation one-click template](deploy/cloudformation) — it runs a
-read-only `agent-bom cloud aws` scan in your account via CodeBuild, no local
-credentials handed to agent-bom.
-
-There is no managed cloud offering in this repository today. Product lane
-boundaries are documented in [docs/PRODUCT_BOUNDARIES.md](docs/PRODUCT_BOUNDARIES.md).
-
-## Pre-commit Hook
-
-Block secrets, PII, and vulnerable dependencies before they are committed.
-agent-bom ships consumer-facing [pre-commit](https://pre-commit.com) hooks; add
-them to your repository's `.pre-commit-config.yaml`:
-
-```yaml
-repos:
-  - repo: https://github.com/msaad00/agent-bom
-    rev: v0.89.2
-    hooks:
-      - id: agent-bom-secrets
-      - id: agent-bom-scan
-```
-
-```bash
-pip install pre-commit && pre-commit install
-```
-
-| Hook id | Command | Purpose |
-| --- | --- | --- |
-| `agent-bom-secrets` | `agent-bom secrets .` | Scan the working tree for hardcoded secrets and PII. |
-| `agent-bom-scan` | `agent-bom scan --fail-on-severity high` | Scan dependencies, agents, and MCP servers; fail on high-or-above findings. |
-
-pre-commit installs the `agent-bom` package into an isolated environment, so no
-separate install step is needed. See
-[docs/DEPLOYMENT.md](docs/DEPLOYMENT.md#pre-commit-hook) for details.
+There is no managed cloud offering in this repository; lane boundaries are
+documented in [docs/PRODUCT_BOUNDARIES.md](docs/PRODUCT_BOUNDARIES.md).
 
 ## Trust Model
 
@@ -435,37 +195,37 @@ separate install step is needed. See
 - No mandatory telemetry.
 - Credential values are redacted; credential environment names are preserved as
   evidence so exposure paths stay explainable.
-- Findings can export as JSON, SARIF, CycloneDX, SPDX, OCSF, Markdown, HTML, and
+- Findings export as JSON, SARIF, CycloneDX, SPDX, OCSF, Markdown, HTML, and
   compliance evidence bundles.
 - API and runtime paths are designed for tenant scope, auth boundaries, and
-  audit evidence.
-- OpenAPI artifacts are committed for SDK and client contract checks.
+  audit evidence; OpenAPI artifacts are committed for client contract checks.
 
-Security and release references:
+References: [Threat model](docs/THREAT_MODEL.md) ·
+[Pentest readiness](docs/PENTEST_READINESS.md) ·
+[Python client](docs/PYTHON_API.md) · [Go client](sdks/go/README.md) ·
+[Release verification](docs/RELEASE_VERIFICATION.md)
 
-- [Threat model](docs/THREAT_MODEL.md)
-- [Pentest readiness](docs/PENTEST_READINESS.md)
-- [Python API and control-plane client](docs/PYTHON_API.md)
-- [Go control-plane client](sdks/go/README.md)
-- [Product metrics](docs/PRODUCT_METRICS.md)
-- [Release verification](docs/RELEASE_VERIFICATION.md)
-- [GitHub Action](https://github.com/marketplace/actions/agent-bom)
+## Surfaces
 
-## Product Views
+| Surface | Primary user | Current boundary |
+|---|---|---|
+| CLI / CI | developers and release gates | local scans, SARIF/SBOM/HTML/JSON, deterministic exit codes |
+| REST API | control-plane integrations | scans, bulk findings, dataset versions, evaluation runs, graph evidence, audit, runtime summaries |
+| MCP tools | agents and assistants | strict arguments, read-mostly security queries, exposure paths, deploy decisions, audited Shield actions |
+| Dashboard | security teams and operators | inventory, findings, graph cockpit, compliance, evidence, runtime posture |
+| Runtime proxy/gateway | runtime operators | scoped MCP traffic inspection, policy decisions, redacted audit evidence |
+| Python / TypeScript clients | services and agent runtimes | typed helpers for stable REST endpoints |
 
-The docs site carries the deployment-oriented walkthroughs behind those
-screenshots:
-
-- [Dashboard and graph capture protocol](docs/CAPTURE.md)
-- [Documentation site](https://msaad00.github.io/agent-bom/)
-- [Deployment overview](site-docs/deployment/overview.md)
+MCP server mode advertises 70 MCP tools, 6 resources, and 6 workflow prompts.
+Most tools are read-only; the three Shield write actions fail closed unless the
+caller supplies `operator_role=admin`, `operator_scopes=shield:write`, and an
+audit reason. CLI scan commands run local scan pipelines today and share lower
+scanner and discovery libraries with the API, but they are not API wrappers yet.
 
 ## Contributing
 
-Contributions are welcome. Start with:
-
-- [CONTRIBUTING.md](CONTRIBUTING.md)
-- [.agents/AGENTS.md](.agents/AGENTS.md)
-- [Open issues](https://github.com/msaad00/agent-bom/issues)
+Contributions are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md),
+[.agents/AGENTS.md](.agents/AGENTS.md), and the
+[open issues](https://github.com/msaad00/agent-bom/issues).
 
 License: Apache-2.0.

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -226,7 +226,7 @@ This is the right path because it improves product trust without diluting the MC
 
 Good external phrasing:
 
-- Open security scanner and self-hosted control plane for AI/MCP infrastructure.
+- Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.
 - Generate a reachability-backed AI BOM across agents, MCP, packages, credentials, cloud, runtime, and skills.
 - Context-aware security for humans and AI agents across MCP, runtime, and AI supply chain infrastructure.
 - Blast radius from package risk to agents, credentials, tools, and runtime

--- a/glama.json
+++ b/glama.json
@@ -5,7 +5,7 @@
   ],
   "name": "agent-bom",
   "title": "agent-bom",
-  "description": "Open security scanner and self-hosted control plane for AI/MCP infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 69 read-first MCP tools for headless security agents.",
+  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 70 read-first MCP tools for headless security agents.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-bom"
 version = "0.89.2"
-description = "Open security scanner and self-hosted control plane for AI/MCP infrastructure."
+description = "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure."
 readme = "PYPI_README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -24,7 +24,7 @@ SITE_INDEX = ROOT / "site-docs" / "index.md"
 TOP_DOCKERFILE = ROOT / "Dockerfile"
 PYPROJECT = ROOT / "pyproject.toml"
 MCP_REGISTRY = ROOT / "src" / "agent_bom" / "mcp_registry.json"
-CANONICAL_TAGLINE = "Open security scanner and self-hosted control plane for AI/MCP infrastructure."
+CANONICAL_TAGLINE = "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure."
 CANONICAL_TAGLINE_SURFACES: list[Path] = [
     README,
     PYPI_README,

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -8,7 +8,7 @@
     When a topic appears in both, this site is canonical for onboarding and
     `docs/` is canonical for the reference detail.
 
-**Open security scanner and self-hosted control plane for AI/MCP infrastructure.**
+**Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.**
 
 Headless agent primitives and human cockpit surfaces use the same evidence
 model.


### PR DESCRIPTION
Rewrites the root README to be concise, current, and clearly structured (471 -> 231 lines, ~51% shorter) without losing accuracy.

- **Structure:** tagline -> what it is -> what it scans (9-domain table) -> First Run -> Start Here (12 rows) -> Connect a Cloud (read-only auth) -> Deploy in your boundary -> Trust model -> Surfaces -> Contributing.
- **Cloud elevated:** the canonical tagline now reads "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure," and the intro leads with local + fleet + cloud estate (AWS/Azure/GCP/Snowflake). The tagline is updated across every enforced surface (README, PYPI_README, DOCKER_HUB_README, site-docs/index, docs/PRODUCT_BRIEF, pyproject description, glama.json, and the `CANONICAL_TAGLINE` constant) so the consistency gate passes.
- **Trimmed:** the long screenshot-gallery prose collapses to a short proof set (the weak lineage shot is dropped); duplicated cloud command blocks reduced to one compact set; blast-radius/overlay explanation stated once.
- **Verified version-pinned claims** against code (15 ecosystems, 29 client types, 70 MCP tools, `@v0.89.2`); corrected a stale "69 read-first MCP tools" -> 70 in glama.json.

Consistency check passes; pre-commit clean. No competitor names.

Follow-up: re-capture the graph proof images against the readability fix (#3185) before refreshing the gallery shots.