### PR TITLE
fix(ui): remove no-op auto-quarantine toggle; lock in legend-toggle regression test

### DIFF
--- a/ui/app/fleet/page.tsx
+++ b/ui/app/fleet/page.tsx
@@ -102,7 +102,6 @@ export default function FleetPage() {
   const [fleetOffset, setFleetOffset] = useState(0);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [trustThreshold, setTrustThreshold] = useState(50);
-  const [autoQuarantine, setAutoQuarantine] = useState(false);
   const { counts } = useDeploymentContext();
 
   const belowThresholdCount = useMemo(
@@ -253,26 +252,6 @@ export default function FleetPage() {
             <span className="text-xs text-zinc-400">
               <span className="font-mono text-yellow-400">{belowThresholdCount}</span> agents below threshold
             </span>
-            <label className="flex items-center gap-2 cursor-pointer">
-              <span className="text-xs text-zinc-500">Auto-quarantine</span>
-              <button
-                type="button"
-                aria-label={autoQuarantine ? "Disable auto-quarantine" : "Enable auto-quarantine"}
-                onClick={() => {
-                  if (!autoQuarantine && !confirm('This will quarantine agents below the trust threshold. Continue?')) return;
-                  setAutoQuarantine((v) => !v);
-                }}
-                className={`relative w-8 h-4 rounded-full transition-colors ${
-                  autoQuarantine ? "bg-emerald-600" : "bg-zinc-700"
-                }`}
-              >
-                <span
-                  className={`absolute top-0.5 left-0.5 w-3 h-3 rounded-full bg-white transition-transform ${
-                    autoQuarantine ? "translate-x-4" : "translate-x-0"
-                  }`}
-                />
-              </button>
-            </label>
           </div>
         </div>
       </div>

--- a/ui/tests/graph-chrome.test.tsx
+++ b/ui/tests/graph-chrome.test.tsx
@@ -46,6 +46,26 @@ describe("GraphLegend", () => {
     expect(screen.getByText("Orchestration")).toBeInTheDocument();
     expect(screen.getByText("Relationships")).toBeInTheDocument();
   });
+
+  it("lets the toggle collapse a defaultOpen legend (defaultOpen only seeds initial state)", () => {
+    render(
+      <GraphLegend
+        defaultOpen
+        items={[
+          { label: "Agent", color: "#10b981", layer: "orchestration", kind: "node", shape: "dot" },
+          { label: "Uses", color: "#10b981", kind: "edge", lineStyle: "solid" },
+        ]}
+      />,
+    );
+
+    const toggle = screen.getByRole("button", { name: /hide legend/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(toggle);
+
+    expect(screen.getByRole("button", { name: /show legend/i })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("Orchestration")).not.toBeInTheDocument();
+  });
 });
 
 describe("GraphEvidenceExportButton", () => {


### PR DESCRIPTION
From the dead-control audit (the inert-legend bug class).

- **Removed the fleet Auto-quarantine toggle** — it flipped local state behind a `confirm()` but called no API and its state was read nowhere, so it promised to "quarantine agents below the trust threshold" while doing nothing. The real "N agents below threshold" indicator stays. A backed auto-quarantine policy (identify sub-threshold agents → lifecycle-transition → enforce) is a separate tracked feature.
- **Added a regression test** (`tests/graph-chrome.test.tsx`) asserting the graph legend collapses on click, so the just-fixed inert-toggle bug cannot return.

Audit result otherwise: no other inert/dead controls found across graph views, filters, and the fleet/gateway/findings tables. typecheck + lint clean; 5 legend tests pass.