### PR TITLE
feat(cloud): connections plane Phase B — launch a read-only scan from a stored connection

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 238 |
+| `docs/openapi/v1.json` | paths | 239 |
 | `docs/openapi/v1.json` | component schemas | 62 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -6175,6 +6175,99 @@
         ]
       }
     },
+    "/v1/cloud/connections/{connection_id}/scan": {
+      "post": {
+        "description": "Launch a read-only cloud scan for a stored connection via the broker.\n\nResolves the tenant's connection (404 otherwise), uses the credential broker\nto assume a short-lived read-only session, and runs the same inventory + CIS\ndiscovery the sibling cloud routes use. Results persist through the existing\nscan/graph stores; the connection status moves to ``active`` + ``last_scan_at``\non success or ``error`` + ``status_detail`` (no secret) on failure. AWS only\ntoday \u2014 azure / gcp / snowflake return a clear 501 ``planned`` response.",
+        "operationId": "scan_connection_v1_cloud_connections__connection_id__scan_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connection_id",
+            "required": true,
+            "schema": {
+              "title": "Connection Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Scan Connection V1 Cloud Connections  Connection Id  Scan Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Scan Connection",
+        "tags": [
+          "cloud-connections"
+        ]
+      }
+    },
     "/v1/cloud/{provider}/cis-benchmark": {
       "get": {
         "description": "Run the CIS Foundations benchmark for a cloud provider over REST.\n\nCalls the same provider ``run_benchmark`` functions the CLI and MCP\n``cis_benchmark`` tool use and returns the report's canonical ``to_dict()``\nshape unchanged, so REST / CLI / MCP report the same checks and counts.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -4053,6 +4053,67 @@ paths:
       summary: Get Connection
       tags:
       - cloud-connections
+  /v1/cloud/connections/{connection_id}/scan:
+    post:
+      description: "Launch a read-only cloud scan for a stored connection via the\
+        \ broker.\n\nResolves the tenant's connection (404 otherwise), uses the credential\
+        \ broker\nto assume a short-lived read-only session, and runs the same inventory\
+        \ + CIS\ndiscovery the sibling cloud routes use. Results persist through the\
+        \ existing\nscan/graph stores; the connection status moves to ``active`` +\
+        \ ``last_scan_at``\non success or ``error`` + ``status_detail`` (no secret)\
+        \ on failure. AWS only\ntoday \u2014 azure / gcp / snowflake return a clear\
+        \ 501 ``planned`` response."
+      operationId: scan_connection_v1_cloud_connections__connection_id__scan_post
+      parameters:
+      - in: path
+        name: connection_id
+        required: true
+        schema:
+          title: Connection Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Scan Connection V1 Cloud Connections  Connection Id  Scan
+                  Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Scan Connection
+      tags:
+      - cloud-connections
   /v1/cloud/{provider}/cis-benchmark:
     get:
       description: 'Run the CIS Foundations benchmark for a cloud provider over REST.

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -13,10 +13,20 @@ under-privileged role is rejected with 403. Reads and deletes are tenant-scoped:
 a tenant can only see or remove its own connections.
 
 Endpoints:
-    POST   /v1/cloud/connections        create a connection (encrypts the secret)
-    GET    /v1/cloud/connections        list this tenant's connections
-    GET    /v1/cloud/connections/{id}   one connection (non-secret metadata)
-    DELETE /v1/cloud/connections/{id}   remove a connection
+    POST   /v1/cloud/connections          create a connection (encrypts the secret)
+    GET    /v1/cloud/connections          list this tenant's connections
+    GET    /v1/cloud/connections/{id}     one connection (non-secret metadata)
+    DELETE /v1/cloud/connections/{id}     remove a connection
+    POST   /v1/cloud/connections/{id}/scan  launch a read-only scan via the broker
+
+The ``/scan`` endpoint (Phase B) brokers the stored connection into a short-lived
+read-only cloud session (``sts:AssumeRole`` with the decrypted ExternalId) and
+runs the **same** inventory + CIS discovery the sibling ``cloud`` routes use,
+against that session. Results persist through the existing scan/graph stores —
+no parallel persistence path — and the connection's lifecycle status is updated
+(``active`` + ``last_scan_at`` on success, ``error`` + ``status_detail`` on
+failure, never carrying a secret). AWS is broker-enabled today; azure / gcp /
+snowflake return a clear "planned" 501. A recurring scheduler is Phase B.2.
 """
 
 from __future__ import annotations
@@ -33,6 +43,8 @@ from pydantic import BaseModel, ConfigDict, Field
 from agent_bom.api.audit_log import log_action
 from agent_bom.api.connection_crypto import ConnectionSecretError, connections_key_configured, encrypt_secret
 from agent_bom.api.connection_store import (
+    STATUS_ACTIVE,
+    STATUS_ERROR,
     STATUS_PENDING,
     SUPPORTED_PROVIDERS,
     CloudConnectionRecord,
@@ -40,6 +52,12 @@ from agent_bom.api.connection_store import (
 )
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.rbac import require_authenticated_permission
+from agent_bom.security import sanitize_error
+
+# Providers whose credential broker is not yet implemented (Phase B is AWS-only).
+_PLANNED_SCAN_PROVIDERS: tuple[str, ...] = ("azure", "gcp", "snowflake")
+# Cap the status_detail we persist so a verbose backend error can't bloat the row.
+_MAX_STATUS_DETAIL = 300
 
 router = APIRouter(tags=["cloud-connections"])
 _logger = logging.getLogger(__name__)
@@ -181,3 +199,165 @@ async def delete_connection(request: Request, connection_id: str, _role: Any = _
         tenant_id=record.tenant_id,
         provider=record.provider,
     )
+
+
+def _mark_connection(
+    record: CloudConnectionRecord,
+    *,
+    status: str,
+    status_detail: str = "",
+    last_scan_at: str | None = None,
+) -> None:
+    """Persist a connection lifecycle transition via the Phase A store's upsert.
+
+    Reuses ``put`` (the store's update path) rather than a parallel mutator. The
+    record was already fetched tenant-scoped, so this stays within the tenant.
+    ``status_detail`` is capped and never carries a secret (the broker's error
+    text is secret-free and is additionally sanitized by the caller).
+    """
+    record.status = status
+    record.status_detail = status_detail[:_MAX_STATUS_DETAIL]
+    record.updated_at = _now()
+    if last_scan_at is not None:
+        record.last_scan_at = last_scan_at
+    get_connection_store().put(record)
+
+
+def _run_aws_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> dict[str, Any]:
+    """Broker the connection into a read-only session and run inventory + CIS.
+
+    Calls the **same** ``aws_inventory.discover_inventory`` and AWS CIS
+    ``run_benchmark`` the sibling cloud routes use — passing the brokered session
+    so the read-only code path runs against the assumed role — then persists the
+    result through the existing scan/graph stores (the pipeline's persistence
+    path), not a parallel one. Returns a non-secret scan summary.
+    """
+    import uuid as _uuid
+
+    from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+    from agent_bom.api.pipeline import _persist_graph_snapshot
+    from agent_bom.api.stores import _get_store, _jobs_put
+    from agent_bom.cloud import aws_inventory
+    from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_aws_cis
+    from agent_bom.cloud.connection_broker import broker_session
+    from agent_bom.mcp_tools.posture import _summarize_inventory_payload
+    from agent_bom.models import AIBOMReport
+    from agent_bom.output import to_json
+
+    region = record.regions[0] if record.regions else None
+    session = broker_session(record, session_name=f"agent-bom-scan-{record.id[:8]}")
+
+    # Same read-only discovery the cloud routes run, against the brokered role.
+    inventory_payload = aws_inventory.discover_inventory(region=region, force=True, session=session)
+    cis_report = run_aws_cis(region=region, session=session)
+    cis_dict = cis_report.to_dict()
+
+    scan_id = str(_uuid.uuid4())
+    report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=scan_id)
+    report.cloud_inventory_data = inventory_payload
+    report.cis_benchmark_data = cis_dict
+    report_json = to_json(report)
+
+    now = _now()
+    job = ScanJob(
+        job_id=scan_id,
+        tenant_id=tenant_id,
+        created_at=now,
+        started_at=now,
+        completed_at=now,
+        status=JobStatus.DONE,
+        request=ScanRequest(),
+        result=report_json,
+        triggered_by=f"cloud-connection/{record.id}",
+    )
+    # Existing persistence path: durable scan store + in-memory job map + unified
+    # graph snapshot (same calls the scan pipeline makes on completion).
+    store = _get_store()
+    store.put(job)
+    _jobs_put(job.job_id, job, compact_terminal=True)
+    _persist_graph_snapshot(job, report_json)
+
+    inv_summary = _summarize_inventory_payload("aws", inventory_payload)
+    return {
+        "schema_version": "cloud.connections.scan.v1",
+        "connection_id": record.id,
+        "tenant_id": tenant_id,
+        "provider": "aws",
+        "scan_id": scan_id,
+        "inventory": inv_summary,
+        "cis_benchmark": {
+            "benchmark": cis_dict.get("benchmark"),
+            "benchmark_version": cis_dict.get("benchmark_version"),
+            "passed": cis_dict.get("passed"),
+            "failed": cis_dict.get("failed"),
+            "total": cis_dict.get("total"),
+            "pass_rate": cis_dict.get("pass_rate"),
+        },
+        "audit_metadata": {
+            "read_only": True,
+            "writes_performed": False,
+            "note": (
+                "Scan ran against a short-lived read-only role assumed from the stored connection. "
+                "Inventory + CIS are read-only; no resource is mutated and no secret value is returned."
+            ),
+        },
+    }
+
+
+@router.post("/v1/cloud/connections/{connection_id}/scan")
+async def scan_connection(request: Request, connection_id: str, _role: Any = _SCAN_DEP) -> dict[str, Any]:
+    """Launch a read-only cloud scan for a stored connection via the broker.
+
+    Resolves the tenant's connection (404 otherwise), uses the credential broker
+    to assume a short-lived read-only session, and runs the same inventory + CIS
+    discovery the sibling cloud routes use. Results persist through the existing
+    scan/graph stores; the connection status moves to ``active`` + ``last_scan_at``
+    on success or ``error`` + ``status_detail`` (no secret) on failure. AWS only
+    today — azure / gcp / snowflake return a clear 501 ``planned`` response.
+    """
+    record = _require_connection(request, connection_id)
+    tenant_id = record.tenant_id
+    actor = _actor(request)
+
+    if record.provider in _PLANNED_SCAN_PROVIDERS:
+        # Recognized provider whose broker is not yet implemented — clear, not a crash.
+        raise HTTPException(
+            status_code=501,
+            detail=(
+                f"Cloud scan for provider '{record.provider}' is planned but not yet available (Phase B+). "
+                "AWS read-only AssumeRole scanning is supported today."
+            ),
+        )
+    if record.provider != "aws":
+        raise HTTPException(status_code=400, detail=f"Unsupported provider '{record.provider}'.")
+
+    try:
+        summary = _run_aws_connection_scan(record, tenant_id)
+    except Exception as exc:  # noqa: BLE001 - broker / discovery / persistence failure
+        # Persist an error status with a sanitized, secret-free detail. Full
+        # diagnostics go to the server log only; the client gets a generic message.
+        detail = sanitize_error(exc)
+        _mark_connection(record, status=STATUS_ERROR, status_detail=detail)
+        _logger.exception("Cloud connection scan failed for connection %s", record.id)
+        log_action(
+            "cloud_connection.scan",
+            actor=actor,
+            resource=f"cloud-connection/{record.id}",
+            tenant_id=tenant_id,
+            provider=record.provider,
+            outcome="failure",
+        )
+        raise HTTPException(status_code=502, detail="Cloud connection scan failed; see server logs.") from exc
+
+    _mark_connection(record, status=STATUS_ACTIVE, status_detail="", last_scan_at=_now())
+    log_action(
+        "cloud_connection.scan",
+        actor=actor,
+        resource=f"cloud-connection/{record.id}",
+        tenant_id=tenant_id,
+        provider=record.provider,
+        outcome="success",
+        scan_id=summary["scan_id"],
+    )
+    summary["connection"] = record.to_public_dict()
+    return summary

--- a/src/agent_bom/cloud/aws_cis_benchmark.py
+++ b/src/agent_bom/cloud/aws_cis_benchmark.py
@@ -2594,6 +2594,8 @@ def run_benchmark(
     region: str | None = None,
     profile: str | None = None,
     checks: list[str] | None = None,
+    *,
+    session: Any = None,
 ) -> CISBenchmarkReport:
     """Run CIS AWS Foundations Benchmark v3.0 checks.
 
@@ -2604,6 +2606,10 @@ def run_benchmark(
         profile: AWS credential profile name.
         checks: Optional list of check IDs to run (e.g. ``["1.4", "1.5"]``).
             Runs all checks if *None*.
+        session: Optional pre-built boto3 session (e.g. the read-only session
+            the credential broker assumes from a stored connection). When
+            supplied it is used as-is and ``region`` / ``profile`` are ignored,
+            so the same read-only checks run against the brokered credentials.
 
     Returns:
         CISBenchmarkReport with per-check pass/fail results.
@@ -2614,13 +2620,14 @@ def run_benchmark(
     except ImportError:
         raise CloudDiscoveryError("boto3 is required for CIS AWS Benchmark checks. Install with: pip install 'agent-bom[aws]'")
 
-    session_kwargs: dict[str, Any] = {}
-    if region:
-        session_kwargs["region_name"] = region
-    if profile:
-        session_kwargs["profile_name"] = profile
+    if session is None:
+        session_kwargs: dict[str, Any] = {}
+        if region:
+            session_kwargs["region_name"] = region
+        if profile:
+            session_kwargs["profile_name"] = profile
 
-    session = boto3.Session(**session_kwargs)
+        session = boto3.Session(**session_kwargs)
     resolved_region = session.region_name or os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
 
     # Get account ID for the report

--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -647,6 +647,7 @@ def discover_inventory(
     include_compute: bool = True,
     include_network: bool = True,
     force: bool = False,
+    session: Any = None,
 ) -> dict[str, Any]:
     """Enumerate the general AWS estate (S3, EC2 + security groups, IAM).
 
@@ -660,6 +661,11 @@ def discover_inventory(
     - ``"boto3_missing"``   — boto3 is not installed.
     - ``"no_credentials"``  — no AWS credentials resolved.
     - ``"ok"``              — enumeration ran (possibly with per-service warnings).
+
+    When ``session`` is supplied (e.g. the read-only session the credential
+    broker assumes from a stored connection), it is used as-is and the
+    ``region`` / ``profile`` arguments are ignored — the same read-only code path
+    runs against the brokered credentials instead of the local default chain.
 
     Never raises: boto3 absence, missing credentials, and per-service access
     denials all degrade to an empty (or partial) inventory plus warnings.
@@ -679,16 +685,17 @@ def discover_inventory(
             "warnings": ["boto3 is required for AWS inventory. Install with: pip install 'agent-bom[aws]'"],
         }
 
-    session_kwargs: dict[str, Any] = {}
-    if region:
-        session_kwargs["region_name"] = region
-    if profile:
-        session_kwargs["profile_name"] = profile
+    if session is None:
+        session_kwargs: dict[str, Any] = {}
+        if region:
+            session_kwargs["region_name"] = region
+        if profile:
+            session_kwargs["profile_name"] = profile
 
-    try:
-        session = boto3.Session(**session_kwargs)
-    except Exception as exc:  # noqa: BLE001 — boto profile/config errors must not crash a scan
-        return {**empty, "status": "no_credentials", "warnings": [sanitize_discovery_warning(exc)]}
+        try:
+            session = boto3.Session(**session_kwargs)
+        except Exception as exc:  # noqa: BLE001 — boto profile/config errors must not crash a scan
+            return {**empty, "status": "no_credentials", "warnings": [sanitize_discovery_warning(exc)]}
 
     resolved_region = session.region_name or os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
     account_id = _resolve_account_id(session)

--- a/src/agent_bom/mcp_tools/posture.py
+++ b/src/agent_bom/mcp_tools/posture.py
@@ -125,6 +125,14 @@ async def nhi_discover_impl(
 
 _INVENTORY_RESOURCE_KEYS = ("buckets", "instances", "security_groups")
 _INVENTORY_IDENTITY_KEYS = ("roles", "users")
+_PUBLIC_INVENTORY_STATUSES = {
+    "ok",
+    "unknown",
+    "disabled",
+    "boto3_missing",
+    "no_credentials",
+    "partial",
+}
 
 
 def _summarize_inventory_payload(provider: str, payload: dict[str, Any]) -> dict[str, Any]:
@@ -144,9 +152,11 @@ def _summarize_inventory_payload(provider: str, payload: dict[str, Any]) -> dict
     # exception-free notice instead; full warnings stay in the server log.
     warning_count = len(payload.get("warnings") or [])
     public_warnings = [f"{warning_count} provider discovery warning(s) — see server logs for detail."] if warning_count else []
+    raw_status = str(payload.get("status", "unknown") or "unknown").strip().lower()
+    public_status = raw_status if raw_status in _PUBLIC_INVENTORY_STATUSES else "unknown"
     return {
         "provider": provider,
-        "status": payload.get("status", "unknown"),
+        "status": public_status,
         "account": payload.get("account_id") or payload.get("subscription_id") or payload.get("project_id") or None,
         "region": payload.get("region") or "",
         "resource_count": resource_count,

--- a/src/agent_bom/mcp_tools/posture.py
+++ b/src/agent_bom/mcp_tools/posture.py
@@ -138,6 +138,12 @@ def _summarize_inventory_payload(provider: str, payload: dict[str, Any]) -> dict
     normalized = _normalize_cloud_inventory(payload)
     resource_count = sum(len(normalized.get(key) or []) for key in _INVENTORY_RESOURCE_KEYS)
     identity_count = sum(len(normalized.get(key) or []) for key in _INVENTORY_IDENTITY_KEYS)
+    # Provider discovery warnings are built from caught exceptions
+    # (``sanitize_discovery_warning(exc)``), so they must not be surfaced verbatim
+    # in a summary that flows to REST/MCP responses. Emit a count-derived,
+    # exception-free notice instead; full warnings stay in the server log.
+    warning_count = len(payload.get("warnings") or [])
+    public_warnings = [f"{warning_count} provider discovery warning(s) — see server logs for detail."] if warning_count else []
     return {
         "provider": provider,
         "status": payload.get("status", "unknown"),
@@ -152,7 +158,7 @@ def _summarize_inventory_payload(provider: str, payload: dict[str, Any]) -> dict
             "roles": len(normalized.get("roles") or []),
             "users": len(normalized.get("users") or []),
         },
-        "warnings": list(payload.get("warnings") or []),
+        "warnings": public_warnings,
     }
 
 

--- a/tests/test_cloud_connections.py
+++ b/tests/test_cloud_connections.py
@@ -488,3 +488,22 @@ def test_scan_non_aws_provider_returns_planned(provider: str, monkeypatch: pytes
     # The connection was not touched (still pending, no scan).
     fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
     assert fetched["status"] == STATUS_PENDING
+
+
+def test_summarize_inventory_payload_redacts_raw_warnings() -> None:
+    """Inventory summary must not echo exception-derived warnings (py/stack-trace-exposure)."""
+    from agent_bom.mcp_tools.posture import _summarize_inventory_payload
+
+    payload = {
+        "status": "ok",
+        "account_id": "030225640638",
+        "warnings": [
+            "Could not list roles: Traceback (most recent call last): RuntimeError boom",
+            "AccessDenied: arn:aws:iam::...:user/x — assume failed: <stack>",
+        ],
+    }
+    summary = _summarize_inventory_payload("aws", payload)
+    warnings = summary["warnings"]
+    assert warnings == ["2 provider discovery warning(s) — see server logs for detail."]
+    blob = " ".join(warnings)
+    assert "Traceback" not in blob and "AccessDenied" not in blob and "arn:aws:iam" not in blob

--- a/tests/test_cloud_connections.py
+++ b/tests/test_cloud_connections.py
@@ -323,3 +323,168 @@ def test_broker_secret_failure_does_not_leak(monkeypatch: pytest.MonkeyPatch) ->
     with pytest.raises(connection_broker.ConnectionBrokerError) as exc:
         connection_broker.broker_session(record)
     assert "super-secret-external-id" not in str(exc.value)
+
+
+# --------------------------------------------------------------------------- #
+# Phase B: launch a read-only scan from a stored connection via the broker
+# --------------------------------------------------------------------------- #
+
+
+_BROKER_SESSION_SENTINEL = object()
+
+
+def _install_scan_mocks(monkeypatch: pytest.MonkeyPatch, *, fail: bool = False) -> dict[str, Any]:
+    """Patch the broker + AWS inventory/CIS the scan route reuses.
+
+    Captures the session each discovery call receives so a test can assert the
+    brokered session (not the local default chain) is what runs the scan.
+    """
+    from agent_bom.cloud import aws_cis_benchmark, aws_inventory, connection_broker
+
+    calls: dict[str, Any] = {}
+
+    def _fake_broker(record: CloudConnectionRecord, **kwargs: Any) -> Any:
+        calls["broker_record_id"] = record.id
+        if fail:
+            raise connection_broker.ConnectionBrokerError(f"AssumeRole failed for connection {record.id}.")
+        return _BROKER_SESSION_SENTINEL
+
+    def _fake_inventory(region: str | None = None, force: bool = False, session: Any = None, **kwargs: Any) -> dict[str, Any]:
+        calls["inventory_session"] = session
+        calls["inventory_force"] = force
+        return {
+            "provider": "aws",
+            "status": "ok",
+            "account_id": "123456789012",
+            "region": region or "us-east-1",
+            "buckets": [],
+            "instances": [],
+            "security_groups": [],
+            "roles": [],
+            "users": [],
+            "warnings": [],
+        }
+
+    class _FakeCISReport:
+        def to_dict(self) -> dict[str, Any]:
+            return {
+                "benchmark": "CIS AWS Foundations",
+                "benchmark_version": "3.0.0",
+                "account_id": "123456789012",
+                "region": "us-east-1",
+                "pass_rate": 50.0,
+                "passed": 1,
+                "failed": 1,
+                "total": 2,
+                "checks": [],
+            }
+
+    def _fake_cis(region: str | None = None, session: Any = None, **kwargs: Any) -> Any:
+        calls["cis_session"] = session
+        return _FakeCISReport()
+
+    monkeypatch.setattr(connection_broker, "broker_session", _fake_broker)
+    monkeypatch.setattr(aws_inventory, "discover_inventory", _fake_inventory)
+    monkeypatch.setattr(aws_cis_benchmark, "run_benchmark", _fake_cis)
+    return calls
+
+
+def _seed_connection(tenant: str = "tenant-alpha", *, provider: str = "aws") -> str:
+    """Create a connection through the API and return its id."""
+    client = TestClient(_app())
+    body = _create_body()
+    body["provider"] = provider
+    created = client.post("/v1/cloud/connections", json=body, headers=_proxy_headers(tenant=tenant)).json()
+    return str(created["id"])
+
+
+def test_scan_launch_brokers_runs_persists_and_marks_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _install_scan_mocks(monkeypatch)
+    client = TestClient(_app())
+    cid = _seed_connection("tenant-alpha")
+
+    resp = client.post(f"/v1/cloud/connections/{cid}/scan", headers=_proxy_headers(tenant="tenant-alpha"))
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # The broker was used and the brokered session (not the default chain) ran both scans.
+    assert calls["broker_record_id"] == cid
+    assert calls["inventory_session"] is _BROKER_SESSION_SENTINEL
+    assert calls["cis_session"] is _BROKER_SESSION_SENTINEL
+    assert calls["inventory_force"] is True
+
+    assert body["provider"] == "aws"
+    scan_id = body["scan_id"]
+    assert scan_id
+    assert body["cis_benchmark"]["total"] == 2
+    assert body["inventory"]["status"] == "ok"
+
+    # Results persisted through the existing scan store (no parallel path).
+    from agent_bom.api.stores import _get_store
+
+    job = _get_store().get(scan_id, "tenant-alpha")
+    assert job is not None
+    assert job.result is not None
+    assert job.result.get("cloud_inventory", {}).get("provider") == "aws"
+    assert job.result.get("cis_benchmark", {}).get("total") == 2
+
+    # Connection status flipped to active with last_scan_at set, no error detail.
+    fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
+    assert fetched["status"] == "active"
+    assert fetched["last_scan_at"]
+    assert fetched["status_detail"] == ""
+    # No secret anywhere in the response surface.
+    assert "super-secret-external-id" not in str(body)
+
+
+def test_scan_failure_marks_error_without_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_scan_mocks(monkeypatch, fail=True)
+    client = TestClient(_app())
+    cid = _seed_connection("tenant-alpha")
+
+    resp = client.post(f"/v1/cloud/connections/{cid}/scan", headers=_proxy_headers(tenant="tenant-alpha"))
+    assert resp.status_code == 502
+    assert "super-secret-external-id" not in str(resp.json())
+
+    fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
+    assert fetched["status"] == "error"
+    assert fetched["status_detail"]
+    assert "super-secret-external-id" not in fetched["status_detail"]
+    assert fetched["last_scan_at"] is None
+
+
+def test_scan_requires_scan_permission(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_scan_mocks(monkeypatch)
+    cid = _seed_connection("tenant-alpha")
+    client = TestClient(_app())
+    resp = client.post(f"/v1/cloud/connections/{cid}/scan", headers=_proxy_headers(role="viewer", tenant="tenant-alpha"))
+    assert resp.status_code == 403
+
+
+def test_scan_is_tenant_scoped(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_scan_mocks(monkeypatch)
+    cid = _seed_connection("tenant-alpha")
+    client = TestClient(_app())
+    # Another tenant cannot scan (or even resolve) this connection.
+    resp = client.post(f"/v1/cloud/connections/{cid}/scan", headers=_proxy_headers(tenant="tenant-beta"))
+    assert resp.status_code == 404
+
+
+def test_scan_missing_connection_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_scan_mocks(monkeypatch)
+    client = TestClient(_app())
+    resp = client.post(f"/v1/cloud/connections/{uuid.uuid4()}/scan", headers=_proxy_headers(tenant="tenant-alpha"))
+    assert resp.status_code == 404
+
+
+@pytest.mark.parametrize("provider", ["azure", "gcp", "snowflake"])
+def test_scan_non_aws_provider_returns_planned(provider: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_scan_mocks(monkeypatch)
+    cid = _seed_connection("tenant-alpha", provider=provider)
+    client = TestClient(_app())
+    resp = client.post(f"/v1/cloud/connections/{cid}/scan", headers=_proxy_headers(tenant="tenant-alpha"))
+    assert resp.status_code == 501
+    assert "planned" in resp.json()["detail"].lower()
+    # The connection was not touched (still pending, no scan).
+    fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
+    assert fetched["status"] == STATUS_PENDING


### PR DESCRIPTION
Phase B of #3175: `POST /v1/cloud/connections/{id}/scan` launches a read-only scan from a stored connection via the credential broker. Builds on Phase A (#3191).

- **Brokered, short-lived session:** resolves the tenant's connection (404 if missing/other tenant), `sts:AssumeRole` with the decrypted ExternalId → read-only boto3 session, runs the **same** `aws_inventory.discover_inventory` + `aws_cis_benchmark.run_benchmark` the existing cloud routes use (they gained an optional `session=` kwarg; `None` = unchanged behavior).
- **No parallel persistence:** results flow through the existing pipeline — `AIBOMReport` → `ScanJob` via the scan store + `_persist_graph_snapshot`, exactly as the scan pipeline does on completion.
- **Status:** `active` + `last_scan_at` on success; `error` + sanitized detail (shared `sanitize_error`) on failure → HTTP 502 with a generic body. Secrets never appear in responses/logs/errors (responses use Phase A redaction).
- **AWS-only today:** azure/gcp/snowflake return a clear 501 "planned" without touching the connection. Recurring scheduler = Phase B.2 (deferred).

Full-stack: OpenAPI + DATA_MODEL regenerated, router already registered. 25 tests (broker invocation, session threading into inventory+CIS, persistence, status/last_scan_at, secret-free error path, RBAC 403, tenant isolation, non-AWS 501); `pytest -k connection/broker/cloud` 627 passed; ruff/mypy(strict)/bandit clean.
