### PR TITLE
feat(cloud): identity/RBAC depth — IAM groups, service principals, role-definition resolution into the graph

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -155,6 +155,31 @@ identity and drift stores onto the inventory so attack paths can traverse
 `agent → managed_identity → access_grant → tool → vulnerable package` and
 `agent ↔ drift_incident → tool`.
 
+`GROUP` and `SERVICE_PRINCIPAL` carry identity/RBAC depth so group- and
+SP-granted access is visible to effective-permissions / privilege-escalation
+analysis:
+
+- **AWS** — IAM groups, user→group memberships, and group attached + inline
+  policies (`iam:ListGroups` / `GetGroup` / `ListGroupsForUser` /
+  `ListGroupPolicies` / `ListAttachedGroupPolicies`, all within the read-only
+  `SecurityAudit` role). Each group becomes a `GROUP` node with `ATTACHED`
+  policies and `MEMBER_OF` edges from its members.
+- **Azure** — Entra service principals + groups and group memberships, discovered
+  via Microsoft Graph. This needs `Directory.Read.All` (NOT in the ARM `Reader`
+  role), so it is **opt-in** behind the existing Entra gate
+  (`AGENT_BOM_ENTRA_DISCOVERY` + `AGENT_BOM_ENTRA_TOKEN`) and degrades to a
+  warning when absent. A role assigned to a group is expanded to its members so
+  the assignment reaches each principal.
+- **GCP** — predefined + custom role definitions are resolved to their permission
+  sets (`iam.roles.get`, within `securityReviewer`/`viewer`) and `group:`
+  bindings are captured as `GROUP` principals. Member expansion via the Workspace
+  Directory API is an optional, gated seam (members stay unresolved otherwise).
+
+The effective-permissions overlay inherits a principal's access through the
+`GROUP`s it is `MEMBER_OF` (transitively, for nested groups). Group-inherited
+access is recorded on `HAS_PERMISSION` as `access="group"` and is not, by itself,
+a privilege escalation (only assume/trust chains are).
+
 ### Relationship types (46)
 
 | Group | Relationships | Direction |

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -115,6 +115,7 @@ AGENT_BOM_DISABLE_DOCS
 AGENT_BOM_DISTRIBUTED_SCANS
 AGENT_BOM_ENABLE_LOCAL_PATH_SCANS
 AGENT_BOM_ENTRA_DISCOVERY  # opt-in flag (default OFF) gating read-only Entra ID (Azure AD) non-human-identity discovery; read in identity/entra_nhi.py
+AGENT_BOM_ENTRA_MAX_GROUPS  # defensive cap (default 500) on Entra groups whose membership is expanded during read-only directory discovery; read in cloud/azure_inventory.py
 AGENT_BOM_ENTRA_TENANT_ID  # Entra tenant id (informational) for read-only NHI discovery; read in identity/entra_nhi.py
 AGENT_BOM_ENTRA_TOKEN  # Microsoft Graph bearer token for read-only Entra NHI discovery (tokens-only, no passwords); never stored, read in identity/entra_nhi.py
 AGENT_BOM_ENV

--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -89,12 +89,18 @@ _AWS_EC2_PERMISSIONS: tuple[str, ...] = (
 _AWS_IAM_PERMISSIONS: tuple[str, ...] = (
     "iam:ListRoles",
     "iam:ListUsers",
+    "iam:ListGroups",
+    "iam:GetGroup",
+    "iam:ListGroupsForUser",
     "iam:ListAttachedRolePolicies",
     "iam:ListAttachedUserPolicies",
+    "iam:ListAttachedGroupPolicies",
     "iam:ListRolePolicies",
     "iam:ListUserPolicies",
+    "iam:ListGroupPolicies",
     "iam:GetRolePolicy",
     "iam:GetUserPolicy",
+    "iam:GetGroupPolicy",
     "iam:GetPolicy",
     "iam:GetPolicyVersion",
 )
@@ -346,6 +352,7 @@ def _empty_payload(*, region: str) -> dict[str, Any]:
         "security_groups": [],
         "roles": [],
         "users": [],
+        "groups": [],
         "rds_instances": [],
         "lambda_functions": [],
         "dynamodb_tables": [],
@@ -575,6 +582,7 @@ def discover_inventory_all_regions(
         "buckets": _dedupe(global_payload.get("buckets", []) or [], "arn"),
         "roles": _dedupe(global_payload.get("roles", []) or [], "arn"),
         "users": _dedupe(global_payload.get("users", []) or [], "arn"),
+        "groups": _dedupe(global_payload.get("groups", []) or [], "arn"),
         "cloudfront_distributions": _dedupe(cloudfront_seen, "name"),
     }
 
@@ -618,6 +626,7 @@ def discover_inventory_all_regions(
         "security_groups": merged["security_groups"],
         "roles": deduped_globals.get("roles", []),
         "users": deduped_globals.get("users", []),
+        "groups": deduped_globals.get("groups", []),
         "rds_instances": merged["rds_instances"],
         "lambda_functions": merged["lambda_functions"],
         "dynamodb_tables": merged["dynamodb_tables"],
@@ -700,6 +709,7 @@ def discover_inventory(
     security_groups: list[dict[str, Any]] = []
     roles: list[dict[str, Any]] = []
     users: list[dict[str, Any]] = []
+    groups: list[dict[str, Any]] = []
     rds_instances: list[dict[str, Any]] = []
     lambda_functions: list[dict[str, Any]] = []
     dynamodb_tables: list[dict[str, Any]] = []
@@ -719,7 +729,7 @@ def discover_inventory(
         if include_ec2:
             instances, security_groups = _discover_ec2(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
         if include_iam:
-            roles, users = _discover_iam(session, account_id=account_id, warnings=warnings, missing=missing)
+            roles, users, groups = _discover_iam(session, account_id=account_id, warnings=warnings, missing=missing)
         if include_data:
             rds_instances = _discover_rds(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
             dynamodb_tables = _discover_dynamodb(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
@@ -781,6 +791,7 @@ def discover_inventory(
         "security_groups": security_groups,
         "roles": roles,
         "users": users,
+        "groups": groups,
         "rds_instances": rds_instances,
         "lambda_functions": lambda_functions,
         "dynamodb_tables": dynamodb_tables,
@@ -1026,17 +1037,21 @@ def _discover_iam(
     account_id: str | None,
     warnings: list[str],
     missing: list[dict[str, str]] | None = None,
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """Enumerate all IAM roles and users in the account (read-only).
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Enumerate all IAM roles, users, and groups in the account (read-only).
 
     Each principal carries attached managed-policy metadata classified to a
     privilege level (admin/write/read) so the effective-permissions overlay can
     consume it without an additional fetch. Roles also carry their trust
-    principals from the AssumeRole policy document.
+    principals from the AssumeRole policy document. Groups carry their attached
+    and inline policies plus their member users; each user carries the names of
+    the groups it belongs to so the graph can attribute group-granted access to
+    the member — group-based access is one of the most common privilege paths.
     """
     iam = session.client("iam")
     roles: list[dict[str, Any]] = []
     users: list[dict[str, Any]] = []
+    groups: list[dict[str, Any]] = []
 
     try:
         role_paginator = iam.get_paginator("list_roles")
@@ -1049,6 +1064,16 @@ def _discover_iam(
         )
 
     try:
+        group_paginator = iam.get_paginator("list_groups")
+        for page in group_paginator.paginate():
+            for group in page.get("Groups", []):
+                groups.append(_normalize_group(iam, group, account_id=account_id, warnings=warnings))
+    except Exception as exc:  # noqa: BLE001 — one failed IAM list must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="IAM groups", permission="iam:ListGroups", cloud="aws", warnings=warnings, missing=missing
+        )
+
+    try:
         user_paginator = iam.get_paginator("list_users")
         for page in user_paginator.paginate():
             for user in page.get("Users", []):
@@ -1058,7 +1083,7 @@ def _discover_iam(
             exc=exc, resource_type="IAM users", permission="iam:ListUsers", cloud="aws", warnings=warnings, missing=missing
         )
 
-    return roles, users
+    return roles, users, groups
 
 
 def _normalize_role(iam: Any, role: dict[str, Any], *, account_id: str | None, warnings: list[str]) -> dict[str, Any]:
@@ -1095,17 +1120,91 @@ def _normalize_user(iam: Any, user: dict[str, Any], *, account_id: str | None, w
         "account_id": account_id or _account_id_from_arn(user_arn),
         "path": str(user.get("Path", "") or ""),
         "policies": policies,
+        "groups": _groups_for_user(iam, user_name, warnings=warnings),
         "privilege_level": _highest_privilege(policies),
         "created_at": _iso(user.get("CreateDate")),
     }
+
+
+def _normalize_group(iam: Any, group: dict[str, Any], *, account_id: str | None, warnings: list[str]) -> dict[str, Any]:
+    """Normalize one IAM group with its attached + inline policies and members.
+
+    A group's attached/inline policies grant every member their access, so the
+    group carries the same policy shape as a user/role (classified to a privilege
+    level) plus the list of member users. The graph builder turns the group into
+    a ``GROUP`` node, attaches its policies, and wires ``MEMBER_OF`` edges from
+    each member so the effective-permissions overlay attributes group-granted
+    access to the member.
+    """
+    group_name = str(group.get("GroupName", "") or "")
+    group_arn = str(group.get("Arn", "") or "")
+    policies = _attached_policies(iam, "group", group_name, warnings=warnings)
+    policies += _inline_policies(iam, "group", group_name, warnings=warnings)
+    return {
+        "principal_type": "group",
+        "name": group_name,
+        "arn": group_arn,
+        "account_id": account_id or _account_id_from_arn(group_arn),
+        "path": str(group.get("Path", "") or ""),
+        "policies": policies,
+        "members": _group_members(iam, group_name, warnings=warnings),
+        "privilege_level": _highest_privilege(policies),
+        "created_at": _iso(group.get("CreateDate")),
+    }
+
+
+def _group_members(iam: Any, group_name: str, *, warnings: list[str]) -> list[dict[str, str]]:
+    """Return the member users of an IAM group (read-only ``GetGroup``).
+
+    Each member is recorded by ARN + name + ``user`` type so the builder can wire
+    a ``MEMBER_OF`` edge to the existing user node. Degrades to an empty list plus
+    a warning on error; never blocks enumeration.
+    """
+    if not group_name:
+        return []
+    members: list[dict[str, str]] = []
+    try:
+        paginator = iam.get_paginator("get_group")
+        for page in paginator.paginate(GroupName=group_name):
+            for user in page.get("Users", []) or []:
+                arn = str(user.get("Arn", "") or "")
+                name = str(user.get("UserName", "") or "")
+                ident = arn or name
+                if ident:
+                    members.append({"id": ident, "name": name or ident, "type": "user"})
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"IAM group membership enumeration skipped for {group_name}: {sanitize_discovery_warning(exc)}")
+    return members
+
+
+def _groups_for_user(iam: Any, user_name: str, *, warnings: list[str]) -> list[str]:
+    """Return the names of the IAM groups a user belongs to (read-only).
+
+    Group membership is the link that carries a group's policies to the member,
+    so capturing it lets the graph attribute group-granted access to each user.
+    Degrades to an empty list plus a warning on error; never blocks enumeration.
+    """
+    if not user_name:
+        return []
+    names: list[str] = []
+    try:
+        paginator = iam.get_paginator("list_groups_for_user")
+        for page in paginator.paginate(UserName=user_name):
+            for group in page.get("Groups", []) or []:
+                name = str(group.get("GroupName", "") or "")
+                if name:
+                    names.append(name)
+    except Exception as exc:  # noqa: BLE001
+        warnings.append(f"IAM group-membership lookup skipped for user {user_name}: {sanitize_discovery_warning(exc)}")
+    return names
 
 
 def _attached_policies(iam: Any, principal_kind: str, principal_name: str, *, warnings: list[str]) -> list[dict[str, Any]]:
     """Return attached managed policies with a classified privilege level."""
     if not principal_name:
         return []
-    paginator_name = "list_attached_role_policies" if principal_kind == "role" else "list_attached_user_policies"
-    kwarg = "RoleName" if principal_kind == "role" else "UserName"
+    paginator_name = f"list_attached_{principal_kind}_policies"
+    kwarg = {"role": "RoleName", "user": "UserName", "group": "GroupName"}[principal_kind]
     policies: list[dict[str, Any]] = []
     try:
         paginator = iam.get_paginator(paginator_name)
@@ -1139,11 +1238,11 @@ def _inline_policies(iam: Any, principal_kind: str, principal_name: str, *, warn
     """
     if not principal_name:
         return []
-    list_op = "list_role_policies" if principal_kind == "role" else "list_user_policies"
-    kwarg = "RoleName" if principal_kind == "role" else "UserName"
+    list_op = f"list_{principal_kind}_policies"
+    kwarg = {"role": "RoleName", "user": "UserName", "group": "GroupName"}[principal_kind]
     policies: list[dict[str, Any]] = []
     try:
-        get_doc = iam.get_role_policy if principal_kind == "role" else iam.get_user_policy
+        get_doc = getattr(iam, {"role": "get_role_policy", "user": "get_user_policy", "group": "get_group_policy"}[principal_kind])
         paginator = iam.get_paginator(list_op)
         for page in paginator.paginate(**{kwarg: principal_name}):
             for name in page.get("PolicyNames", []):

--- a/src/agent_bom/cloud/azure_inventory.py
+++ b/src/agent_bom/cloud/azure_inventory.py
@@ -194,6 +194,7 @@ def discover_inventory(
         "managed_identities": [],
         "role_assignments": [],
         "service_principals": [],
+        "entra_groups": [],
         "key_vaults": [],
         "container_registries": [],
         "databases": [],
@@ -343,6 +344,19 @@ def discover_inventory(
         management_groups, mg_warnings = _discover_management_groups(credential)
         warnings.extend(mg_warnings)
 
+    # Entra (Azure AD) directory read — service principals + groups + memberships.
+    # Tenant-scoped and uses a Microsoft Graph token (not the ARM credential), so
+    # it runs once outside the per-subscription pool. Opt-in + degrades to empty:
+    # the ARM scan above is complete regardless of whether this grant is present.
+    service_principals: list[dict[str, Any]] = []
+    entra_groups: list[dict[str, Any]] = []
+    entra_ran = False
+    if include_identity:
+        entra_missing: list[dict[str, str]] = []
+        service_principals, entra_groups = _discover_entra_directory(warnings=warnings, missing=entra_missing)
+        missing.extend(entra_missing)
+        entra_ran = bool(service_principals or entra_groups or entra_missing)
+
     permissions_used: list[str] = []
     if include_storage:
         permissions_used.extend(_AZURE_STORAGE_PERMISSIONS)
@@ -356,6 +370,11 @@ def discover_inventory(
         permissions_used.extend(_AZURE_NETWORK_PERMISSIONS)
     if include_hierarchy:
         permissions_used.append("Microsoft.Management/managementGroups/read")
+    if entra_ran:
+        # Additional read-only Microsoft Graph grant beyond the ARM Reader role.
+        from agent_bom.identity.entra_nhi import ENTRA_READ_PERMISSIONS
+
+        permissions_used.extend(ENTRA_READ_PERMISSIONS)
 
     envelope = DiscoveryEnvelope(
         scan_mode=ScanMode.CLOUD_READ_ONLY,
@@ -376,7 +395,8 @@ def discover_inventory(
         "security_groups": security_groups,
         "managed_identities": managed_identities,
         "role_assignments": role_assignments,
-        "service_principals": [],
+        "service_principals": service_principals,
+        "entra_groups": entra_groups,
         "key_vaults": key_vaults,
         "container_registries": container_registries,
         "databases": databases,
@@ -875,6 +895,162 @@ def _discover_role_assignments(
             missing=missing,
         )
     return assignments
+
+
+# Microsoft Graph directory-read fan-out caps. A hostile/huge tenant must not be
+# able to make group-membership expansion run unbounded.
+_ENTRA_MAX_GROUPS_EXPANDED = int(os.environ.get("AGENT_BOM_ENTRA_MAX_GROUPS", "500") or "500")
+
+# Map a Microsoft Graph ``@odata.type`` to the canonical principal type the graph
+# builder understands, so a group member resolves to the right node entity.
+_ENTRA_MEMBER_TYPE: dict[str, str] = {
+    "#microsoft.graph.user": "user",
+    "#microsoft.graph.serviceprincipal": "service-principal",
+    "#microsoft.graph.group": "group",
+}
+
+
+def entra_directory_enabled() -> bool:
+    """Whether the opt-in Microsoft Graph directory-read path is enabled.
+
+    Reuses the existing Entra NHI discovery gate (``AGENT_BOM_ENTRA_DISCOVERY``)
+    so service-principal + Entra-group discovery shares one opt-in switch. This
+    needs Microsoft Graph ``Directory.Read.All`` — a read-only grant the ARM
+    ``Reader`` role does NOT include — so it stays default OFF and additive.
+    """
+    from agent_bom.identity import entra_nhi
+
+    return entra_nhi._is_truthy(os.environ.get(entra_nhi._DISCOVERY_FLAG_ENV))
+
+
+def _discover_entra_directory(
+    *,
+    client: Any = None,
+    force: bool = False,
+    warnings: list[str],
+    missing: list[dict[str, str]] | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Discover Entra service principals + groups (with members) — opt-in, read-only.
+
+    Returns ``(service_principals, entra_groups)``. A service principal that holds
+    a dangerous role is invisible to RBAC analysis unless it is a node, and a role
+    granted to a group only reaches its members once membership is known — this
+    closes both gaps.
+
+    Permission posture: this calls Microsoft Graph (``servicePrincipals`` /
+    ``groups`` / ``groups/{id}/members``) which requires ``Directory.Read.All``,
+    NOT covered by the ARM ``Reader`` role. It is therefore gated behind the same
+    ``AGENT_BOM_ENTRA_DISCOVERY`` flag (token via ``AGENT_BOM_ENTRA_TOKEN``) as
+    the Entra NHI path and is purely additive. When the gate is off, the token is
+    missing, or the Graph permission is denied, it warns and returns empty so the
+    rest of the ARM scan proceeds unaffected.
+    """
+    from agent_bom.identity import entra_nhi
+
+    gate_on = force or client is not None or entra_directory_enabled()
+    if not gate_on:
+        # Opt-in feature, default OFF: stay silent so a normal ARM-only scan is not
+        # spammed with a note every run. The grant requirement is documented; a
+        # warning is reserved for "enabled but the token/permission is missing".
+        return [], []
+
+    if client is None:
+        token = (os.environ.get(entra_nhi._TOKEN_ENV) or "").strip()
+        if not token:
+            warnings.append(f"Entra directory discovery enabled but {entra_nhi._TOKEN_ENV} is not set; skipping (ARM scan continues).")
+            return [], []
+        try:
+            client = entra_nhi.EntraClient(token)
+        except Exception as exc:  # noqa: BLE001 — client init failure must not sink the scan
+            warnings.append(f"Could not initialise the Microsoft Graph client for directory discovery: {sanitize_discovery_warning(exc)}")
+            return [], []
+
+    service_principals: list[dict[str, Any]] = []
+    entra_groups: list[dict[str, Any]] = []
+
+    try:
+        for sp in client.list_service_principals() or []:
+            if not isinstance(sp, dict):
+                continue
+            sp_id = str(sp.get("id") or "").strip()
+            if not sp_id:
+                continue
+            service_principals.append(
+                {
+                    "principal_type": "service-principal",
+                    "name": str(sp.get("displayName") or sp_id),
+                    "arn": sp_id,
+                    "principal_id": sp_id,
+                    "app_id": str(sp.get("appId") or ""),
+                    "service_principal_type": str(sp.get("servicePrincipalType") or ""),
+                    "policies": [],
+                    "trust_principals": [],
+                    "privilege_level": "unknown",
+                }
+            )
+    except Exception as exc:  # noqa: BLE001 — Graph SP listing failure degrades to a warning
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Entra service principals",
+            permission="Directory.Read.All",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
+
+    try:
+        raw_groups = list(client.list_groups() or [])
+    except Exception as exc:  # noqa: BLE001 — Graph group listing failure degrades to a warning
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Entra groups",
+            permission="Directory.Read.All",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
+        raw_groups = []
+
+    expanded = 0
+    for group in raw_groups:
+        if not isinstance(group, dict):
+            continue
+        group_id = str(group.get("id") or "").strip()
+        if not group_id:
+            continue
+        members: list[dict[str, str]] = []
+        if expanded < _ENTRA_MAX_GROUPS_EXPANDED:
+            expanded += 1
+            try:
+                for member in client.list_group_members(group_id) or []:
+                    if not isinstance(member, dict):
+                        continue
+                    member_id = str(member.get("id") or "").strip()
+                    if not member_id:
+                        continue
+                    odata = str(member.get("@odata.type") or "").strip().lower()
+                    members.append(
+                        {
+                            "id": member_id,
+                            "name": str(member.get("displayName") or member_id),
+                            "type": _ENTRA_MEMBER_TYPE.get(odata, "user"),
+                        }
+                    )
+            except Exception as exc:  # noqa: BLE001 — one group's member read must not sink the rest
+                warnings.append(f"Entra group-member read skipped for {group_id}: {sanitize_discovery_warning(exc)}")
+        entra_groups.append(
+            {
+                "principal_type": "group",
+                "name": str(group.get("displayName") or group_id),
+                "arn": group_id,
+                "principal_id": group_id,
+                "members": members,
+                "policies": [],
+                "privilege_level": "unknown",
+            }
+        )
+
+    return service_principals, entra_groups
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent_bom/cloud/gcp_inventory.py
+++ b/src/agent_bom/cloud/gcp_inventory.py
@@ -67,7 +67,12 @@ _GCP_COMPUTE_PERMISSIONS: tuple[str, ...] = (
 _GCP_IAM_PERMISSIONS: tuple[str, ...] = (
     "iam.serviceAccounts.list",
     "resourcemanager.projects.getIamPolicy",
+    "iam.roles.get",
 )
+
+# Cap on the permission set captured per resolved role definition, so a single
+# broad role (e.g. owner) cannot bloat the inventory payload.
+_MAX_ROLE_PERMISSIONS = 500
 # Estate-breadth read-only permissions exercised by the extended discoverers
 # (GKE / Cloud Run / Cloud Functions / Cloud SQL / VPC / disks / Pub/Sub). Kept
 # explicit so the discovery envelope's `permissions_used` stays honest.
@@ -324,6 +329,7 @@ def discover_inventory(
         "instances": [],
         "firewalls": [],
         "service_accounts": [],
+        "groups": [],
         "gke_clusters": [],
         "cloud_run_services": [],
         "cloud_functions": [],
@@ -373,6 +379,7 @@ def discover_inventory(
     instances: list[dict[str, Any]] = []
     firewalls: list[dict[str, Any]] = []
     service_accounts: list[dict[str, Any]] = []
+    iam_groups: list[dict[str, Any]] = []
     gke_clusters: list[dict[str, Any]] = []
     cloud_run_services: list[dict[str, Any]] = []
     cloud_functions: list[dict[str, Any]] = []
@@ -387,10 +394,19 @@ def discover_inventory(
         instances = _discover_instances(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
         firewalls = _discover_firewalls(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
     if include_iam:
-        iam_bindings = _discover_project_iam_bindings(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
-        service_accounts = _discover_service_accounts(
-            resolved_project, credentials=credentials, warnings=warnings, iam_bindings=iam_bindings, missing=missing
+        iam_bindings, member_kinds = _discover_project_iam_bindings(
+            resolved_project, credentials=credentials, warnings=warnings, missing=missing
         )
+        role_resolver = _make_role_resolver(credentials=credentials, warnings=warnings)
+        service_accounts = _discover_service_accounts(
+            resolved_project,
+            credentials=credentials,
+            warnings=warnings,
+            iam_bindings=iam_bindings,
+            role_resolver=role_resolver,
+            missing=missing,
+        )
+        iam_groups = _build_iam_group_principals(iam_bindings, member_kinds, project_id=resolved_project, role_resolver=role_resolver)
     if include_containers:
         gke_clusters = _discover_gke_clusters(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
     if include_serverless:
@@ -442,6 +458,7 @@ def discover_inventory(
         "instances": instances,
         "firewalls": firewalls,
         "service_accounts": service_accounts,
+        "groups": iam_groups,
         "gke_clusters": gke_clusters,
         "cloud_run_services": cloud_run_services,
         "cloud_functions": cloud_functions,
@@ -715,22 +732,26 @@ def _safe_int(value: str) -> int | None:
 
 def _discover_project_iam_bindings(
     project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
-) -> dict[str, list[str]]:
-    """Read the project IAM policy (read-only) → ``{member: [roles…]}``.
+) -> tuple[dict[str, list[str]], dict[str, str]]:
+    """Read the project IAM policy (read-only) → ``({member: [roles…]}, {member: kind})``.
 
     Calls ``cloudresourcemanager`` ``projects.getIamPolicy`` and inverts the
     role→members bindings into a member→roles map so each principal carries the
     roles bound to it. The member key is the bare identity (e.g.
     ``svc@p.iam.gserviceaccount.com``) with the ``serviceAccount:`` / ``user:`` /
-    ``group:`` prefix stripped, matching the SA email used elsewhere. Degrades to
-    an empty map plus a warning on any error — never raises.
+    ``group:`` prefix stripped, matching the SA email used elsewhere. The second
+    map records each member's kind (``serviceaccount`` / ``user`` / ``group`` /
+    ``domain`` …) so ``group:`` bindings can be represented as group principals
+    rather than silently collapsed into the SA-only view. Degrades to empty maps
+    plus a warning on any error — never raises.
     """
     bindings_by_member: dict[str, list[str]] = {}
+    member_kinds: dict[str, str] = {}
     try:
         from google.cloud import resourcemanager_v3
     except ImportError:
         warnings.append("google-cloud-resource-manager not installed. Skipping project IAM-binding discovery.")
-        return bindings_by_member
+        return bindings_by_member, member_kinds
     try:
         from google.iam.v1 import iam_policy_pb2
 
@@ -742,9 +763,17 @@ def _discover_project_iam_bindings(
             if not role:
                 continue
             for member in binding.get("members", []) or []:
-                key = str(member).split(":", 1)[-1].strip().lower() if ":" in str(member) else str(member).strip().lower()
+                raw = str(member)
+                if ":" in raw:
+                    prefix, _, ident = raw.partition(":")
+                    key = ident.strip().lower()
+                    kind = prefix.strip().lower()
+                else:
+                    key = raw.strip().lower()
+                    kind = ""
                 if not key:
                     continue
+                member_kinds.setdefault(key, kind)
                 roles = bindings_by_member.setdefault(key, [])
                 if role not in roles:
                     roles.append(role)
@@ -757,7 +786,99 @@ def _discover_project_iam_bindings(
             warnings=warnings,
             missing=missing,
         )
-    return bindings_by_member
+    return bindings_by_member, member_kinds
+
+
+def _make_role_resolver(*, credentials: Any, warnings: list[str]) -> Any:
+    """Return a cached ``role_id -> [permission…]`` resolver (read-only ``roles.get``).
+
+    Resolves both predefined (``roles/...``) and custom
+    (``projects|organizations/.../roles/...``) role definitions to their concrete
+    ``includedPermissions`` so a binding's *actual* capabilities are known rather
+    than only its name-classified privilege level — closing the gap with the
+    Azure path, which already resolves role definitions to actions. Each role is
+    resolved at most once (cached) and the permission set is capped. Within
+    ``roles/iam.securityReviewer`` / ``viewer``. Degrades to an empty list plus a
+    warning on any error — never raises.
+    """
+    cache: dict[str, list[str]] = {}
+    client_holder: dict[str, Any] = {}
+
+    def resolve(role: str) -> list[str]:
+        name = str(role or "").strip()
+        if not name:
+            return []
+        if name in cache:
+            return cache[name]
+        permissions: list[str] = []
+        try:
+            from google.cloud import iam_admin_v1
+
+            client = client_holder.get("client")
+            if client is None:
+                client = iam_admin_v1.IAMClient(credentials=credentials)
+                client_holder["client"] = client
+            role_def = client.get_role(request=iam_admin_v1.GetRoleRequest(name=name))
+            permissions = [str(p) for p in (getattr(role_def, "included_permissions", None) or [])][:_MAX_ROLE_PERMISSIONS]
+        except Exception as exc:  # noqa: BLE001 — one failed role lookup must not sink the scan
+            warnings.append(f"GCP role-definition resolution skipped for {name}: {sanitize_discovery_warning(exc)}")
+        cache[name] = permissions
+        return permissions
+
+    return resolve
+
+
+def _role_policy_entry(role: str, *, role_resolver: Any) -> dict[str, Any]:
+    """Build one classified IAM-binding policy entry, resolved to its permissions."""
+    return {
+        "policy_id": role,
+        "policy_name": role,
+        "attachment_type": "iam-binding",
+        "privilege_level": _classify_role_privilege(role),
+        "permissions": role_resolver(role) if role_resolver is not None else [],
+        "source_field": "projects.getIamPolicy.bindings",
+    }
+
+
+def _build_iam_group_principals(
+    bindings_by_member: dict[str, list[str]],
+    member_kinds: dict[str, str],
+    *,
+    project_id: str,
+    role_resolver: Any,
+) -> list[dict[str, Any]]:
+    """Represent ``group:`` IAM-policy bindings as group principals (read-only).
+
+    A role granted to a Google group reaches every member of that group, so the
+    group must be a first-class principal carrying its bound roles (resolved to
+    permissions) — otherwise group-granted access is invisible to the
+    effective-permissions graph. Member expansion (who is in the group) needs the
+    Workspace Directory API (admin-scoped) and is left as an explicit, optional
+    seam: ``members`` stays empty here unless a gated directory connector fills it.
+    """
+    groups: list[dict[str, Any]] = []
+    for member, roles in bindings_by_member.items():
+        if member_kinds.get(member) != "group":
+            continue
+        policies = [_role_policy_entry(role, role_resolver=role_resolver) for role in roles]
+        groups.append(
+            {
+                "principal_type": "group",
+                "name": member,
+                "arn": member,
+                "principal_id": member,
+                "email": member,
+                "account_id": project_id,
+                "roles": roles,
+                "policies": policies,
+                # Seam: Workspace Directory API (admin-scoped) member expansion is
+                # optional + gated; leave empty rather than guess membership.
+                "members": [],
+                "members_expansion": "unresolved",
+                "privilege_level": _highest_privilege(roles),
+            }
+        )
+    return groups
 
 
 def _discover_service_accounts(
@@ -766,6 +887,7 @@ def _discover_service_accounts(
     credentials: Any,
     warnings: list[str],
     iam_bindings: dict[str, list[str]] | None = None,
+    role_resolver: Any = None,
     missing: list[dict[str, str]] | None = None,
 ) -> list[dict[str, Any]]:
     """Enumerate all service accounts in the project (read-only).
@@ -793,16 +915,7 @@ def _discover_service_accounts(
             if not email:
                 continue
             roles = list(bindings.get(email.lower(), []))
-            policies = [
-                {
-                    "policy_id": role,
-                    "policy_name": role,
-                    "attachment_type": "iam-binding",
-                    "privilege_level": _classify_role_privilege(role),
-                    "source_field": "projects.getIamPolicy.bindings",
-                }
-                for role in roles
-            ]
+            policies = [_role_policy_entry(role, role_resolver=role_resolver) for role in roles]
             accounts.append(
                 {
                     "principal_type": "service-account",

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -2315,6 +2315,7 @@ def _normalize_azure_inventory(inventory: dict[str, Any]) -> dict[str, Any]:
         instances.append({**vm, "_service": "compute", "_kind": "azure-vm", "_label": "vm"})
     principals = [p for p in inventory.get("managed_identities", []) or [] if isinstance(p, dict)]
     principals.extend(p for p in inventory.get("service_principals", []) or [] if isinstance(p, dict))
+    identity_groups = [g for g in inventory.get("entra_groups", []) or [] if isinstance(g, dict)]
     return {
         **inventory,
         "buckets": buckets,
@@ -2322,6 +2323,7 @@ def _normalize_azure_inventory(inventory: dict[str, Any]) -> dict[str, Any]:
         "instances": instances,
         "roles": [],
         "users": principals,
+        "groups": identity_groups,
     }
 
 
@@ -2344,6 +2346,7 @@ def _normalize_gcp_inventory(inventory: dict[str, Any]) -> dict[str, Any]:
             continue
         instances.append({**instance, "_service": "compute", "_kind": "gce-instance", "_label": "gce"})
     principals = [p for p in inventory.get("service_accounts", []) or [] if isinstance(p, dict)]
+    identity_groups = [g for g in inventory.get("groups", []) or [] if isinstance(g, dict)]
     return {
         **inventory,
         "buckets": buckets,
@@ -2351,6 +2354,7 @@ def _normalize_gcp_inventory(inventory: dict[str, Any]) -> dict[str, Any]:
         "instances": instances,
         "roles": [],
         "users": principals,
+        "groups": identity_groups,
     }
 
 
@@ -3720,7 +3724,7 @@ _RBAC_PRINCIPAL_ENTITY = {
     "serviceprincipal": EntityType.SERVICE_PRINCIPAL,
     "service_principal": EntityType.SERVICE_PRINCIPAL,
     "user": EntityType.USER,
-    "group": EntityType.SERVICE_ACCOUNT,
+    "group": EntityType.GROUP,
     "managedidentity": EntityType.MANAGED_IDENTITY,
     "managed_identity": EntityType.MANAGED_IDENTITY,
 }
@@ -4036,6 +4040,16 @@ def _add_cloud_role_assignments(graph: UnifiedGraph, inventory: Any, data_source
             if arm:
                 resource_by_arm[arm.lower()] = node.id
 
+    # Index group → member principals from the MEMBER_OF edges the inventory pass
+    # already added (it runs before this one). A role granted to a group reaches
+    # every member, so a group-scoped assignment is expanded to its members.
+    group_members: dict[str, list[str]] = defaultdict(list)
+    for edge in graph.edges:
+        if edge.relationship == RelationshipType.MEMBER_OF:
+            target = graph.nodes.get(edge.target)
+            if target is not None and target.entity_type == EntityType.GROUP:
+                group_members[edge.target].append(edge.source)
+
     def _scope_target(scope: str) -> str:
         s = scope.rstrip("/")
         low = s.lower()
@@ -4109,20 +4123,41 @@ def _add_cloud_role_assignments(graph: UnifiedGraph, inventory: Any, data_source
             )
         )
         roles = entry["roles"]
+        scope_target = _scope_target(scope)
+        privileged = any(r.lower() in _RBAC_PRIVILEGED_ROLES for r in roles)
         graph.add_edge(
             UnifiedEdge(
                 source=principal_node_id,
-                target=_scope_target(scope),
+                target=scope_target,
                 relationship=RelationshipType.HAS_PERMISSION,
                 evidence={
                     "source": "cloud-rbac",
                     "roles": roles,
                     "role": roles[0] if roles else "",
-                    "privileged": any(r.lower() in _RBAC_PRIVILEGED_ROLES for r in roles),
+                    "privileged": privileged,
                     "scope": scope,
                 },
             )
         )
+        # A role granted to a group reaches every member: expand the assignment to
+        # each member principal so group-granted RBAC access is not invisible.
+        if entity == EntityType.GROUP:
+            for member_node_id in group_members.get(principal_node_id, []):
+                graph.add_edge(
+                    UnifiedEdge(
+                        source=member_node_id,
+                        target=scope_target,
+                        relationship=RelationshipType.HAS_PERMISSION,
+                        evidence={
+                            "source": "cloud-rbac",
+                            "roles": roles,
+                            "role": roles[0] if roles else "",
+                            "privileged": privileged,
+                            "scope": scope,
+                            "via_group": principal_id,
+                        },
+                    )
+                )
 
 
 def _gcp_firewall_applies(firewall_attrs: dict[str, Any], instance: dict[str, Any]) -> bool:
@@ -4574,6 +4609,18 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
                 graph, principal, provider=provider, account_node_id=account_node_id, resource_ids=resource_ids, data_sources=data_sources
             )
 
+    # ── IAM / Entra groups → GROUP nodes + MEMBER_OF edges from members ──
+    # A group carries its members' shared access (its attached policies / bound
+    # roles). Wiring the group as a principal with CAN_ACCESS, plus MEMBER_OF
+    # edges from each member, lets the effective-permissions overlay attribute
+    # group-granted access to the member — group-based access is one of the most
+    # common privilege paths and was invisible before.
+    for group in inventory.get("groups", []) or []:
+        if isinstance(group, dict):
+            _add_inventory_group(
+                graph, group, provider=provider, account_node_id=account_node_id, resource_ids=resource_ids, data_sources=data_sources
+            )
+
 
 def _add_management_group_hierarchy(graph: UnifiedGraph, inventory: dict[str, Any], *, provider: str, data_sources: list[str]) -> None:
     """Build the management-group → subscription hierarchy as ORG nodes + CONTAINS edges.
@@ -4871,6 +4918,113 @@ def _add_inventory_principal(
                     evidence={"source": "cloud-inventory", "basis": f"{privilege}_privilege"},
                 )
             )
+
+
+def _add_inventory_group(
+    graph: UnifiedGraph,
+    group: dict[str, Any],
+    *,
+    provider: str,
+    account_node_id: str,
+    resource_ids: list[str],
+    data_sources: list[str],
+) -> None:
+    """Emit one IAM/Entra group as a ``GROUP`` node with policies + membership.
+
+    The group node carries its attached/bound policies (``ATTACHED``) and, when
+    it is admin/write-privileged, a ``CAN_ACCESS`` edge to each inventoried
+    resource — the same baseline the effective-permissions overlay applies to a
+    user/role. ``MEMBER_OF`` edges run from each member principal to the group so
+    the overlay attributes group-granted access to the member. Members are created
+    as thin nodes when a per-principal scan has not already added them.
+    """
+    group_id = _clean_graph_part(group.get("arn")) or _clean_graph_part(group.get("name"))
+    if not group_id:
+        return
+    group_name = _clean_graph_part(group.get("name")) or group_id
+    group_node_id = _identity_node_id(EntityType.GROUP, provider, group_id)
+    privilege = _clean_graph_part(group.get("privilege_level")) or "unknown"
+    graph.add_node(
+        UnifiedNode(
+            id=group_node_id,
+            entity_type=EntityType.GROUP,
+            label=group_name,
+            attributes={
+                "principal_id": group_id,
+                "principal_name": group_name,
+                "principal_type": "group",
+                "cloud_provider": provider,
+                "privilege_level": privilege,
+                "iam_path": _clean_graph_part(group.get("path")),
+                "source": "cloud-inventory",
+            },
+            data_sources=data_sources,
+            dimensions=NodeDimensions(cloud_provider=provider, surface="identity"),
+        )
+    )
+    if account_node_id:
+        _add_rel_edge(
+            graph, group_node_id, account_node_id, RelationshipType.MEMBER_OF, {"source": "cloud-inventory", "principal_type": "group"}
+        )
+
+    # Group-attached policies (privilege already classified by the scanner).
+    for policy in _policy_entries(group):
+        policy_node_id = _add_identity_node(
+            graph,
+            EntityType.POLICY,
+            policy["id"],
+            provider,
+            data_sources,
+            label=policy["name"],
+            policy_id=policy["id"],
+            policy_name=policy["name"],
+            privilege_level=policy.get("privilege_level", "unknown"),
+            cloud_provider=provider,
+        )
+        _add_rel_edge(
+            graph, group_node_id, policy_node_id, RelationshipType.ATTACHED, {"source": "cloud-inventory", "principal_type": "group"}
+        )
+
+    # Admin/write group → baseline same-account CAN_ACCESS, so the overlay can
+    # inherit it to members via MEMBER_OF (mirrors the user/role baseline).
+    if privilege in ("admin", "write"):
+        for resource_id in resource_ids:
+            _add_rel_edge(
+                graph,
+                group_node_id,
+                resource_id,
+                RelationshipType.CAN_ACCESS,
+                {"source": "cloud-inventory", "basis": f"{privilege}_privilege"},
+            )
+
+    # Members → MEMBER_OF the group. Each member may be a user / service principal
+    # / nested group; create a thin node when the member was not separately
+    # inventoried so the membership edge always lands on a real node.
+    for member in group.get("members", []) or []:
+        if not isinstance(member, dict):
+            continue
+        member_id = _clean_graph_part(member.get("id"))
+        if not member_id:
+            continue
+        member_entity = _identity_entity_type(_clean_graph_part(member.get("type")) or "user")
+        member_node_id = _identity_node_id(member_entity, provider, member_id)
+        if member_node_id not in graph.nodes:
+            _add_identity_node(
+                graph,
+                member_entity,
+                member_id,
+                provider,
+                data_sources,
+                label=_clean_graph_part(member.get("name")) or member_id,
+                principal_id=member_id,
+                principal_name=_clean_graph_part(member.get("name")) or member_id,
+                principal_type=_clean_graph_part(member.get("type")) or "user",
+                cloud_provider=provider,
+                source="cloud-inventory",
+            )
+        _add_rel_edge(
+            graph, member_node_id, group_node_id, RelationshipType.MEMBER_OF, {"source": "cloud-inventory", "membership": "group"}
+        )
 
 
 def _add_cross_env_correlation(

--- a/src/agent_bom/graph/effective_permissions.py
+++ b/src/agent_bom/graph/effective_permissions.py
@@ -1,12 +1,14 @@
 """Effective-permission computation and privilege-escalation detection.
 
-The identity graph already records direct access (``CAN_ACCESS``) and
-assume/trust relationships (``TRUSTS`` / ``CROSS_ACCOUNT_TRUST`` / ``ASSUMES``)
-between principals. This overlay resolves them into *effective* access — what a
-principal can reach after assuming the roles it is allowed to assume — and emits
-``HAS_PERMISSION`` edges for the transitive closure. A principal that reaches a
-resource only by assuming another role is flagged as a privilege-escalation
-chain.
+The identity graph already records direct access (``CAN_ACCESS``), assume/trust
+relationships (``TRUSTS`` / ``CROSS_ACCOUNT_TRUST`` / ``ASSUMES``), and group
+membership (``MEMBER_OF`` into a ``GROUP``) between principals. This overlay
+resolves them into *effective* access — what a principal can reach after assuming
+the roles it is allowed to assume and inheriting the access of the groups it
+belongs to — and emits ``HAS_PERMISSION`` edges for the transitive closure. A
+principal that reaches a resource only by assuming another role is flagged as a
+privilege-escalation chain; group-inherited access is recorded as ``group`` and
+is not, by itself, an escalation.
 
 Computed over edges already in the graph; no new scanner input. Bounded for
 scale: principals and chain depth are capped.
@@ -57,6 +59,7 @@ def apply_effective_permissions(graph: UnifiedGraph) -> dict[str, int]:
 
     direct_access: dict[str, set[str]] = defaultdict(set)
     assumes: dict[str, set[str]] = defaultdict(set)
+    member_of_groups: dict[str, set[str]] = defaultdict(set)
     attached_policy_labels: dict[str, list[str]] = defaultdict(list)
     admin_by_policy_actions: set[str] = set()
     for edge in graph.edges:
@@ -67,6 +70,13 @@ def apply_effective_permissions(graph: UnifiedGraph) -> dict[str, int]:
                 direct_access[edge.source].add(edge.target)
         elif rel in _ASSUME_RELS and edge.source in principal_ids and edge.target in principal_ids:
             assumes[edge.source].add(edge.target)
+        elif rel == RelationshipType.MEMBER_OF and edge.source in principal_ids:
+            # A principal inherits the access of every GROUP it belongs to. Group
+            # membership is NOT an assume chain, so it is tracked separately and
+            # never flagged as privilege escalation.
+            target = graph.nodes.get(edge.target)
+            if target is not None and target.entity_type == EntityType.GROUP:
+                member_of_groups[edge.source].add(edge.target)
         elif rel == RelationshipType.ATTACHED and edge.source in principal_ids:
             policy = graph.nodes.get(edge.target)
             if policy is not None and policy.entity_type == EntityType.POLICY:
@@ -86,9 +96,29 @@ def apply_effective_permissions(graph: UnifiedGraph) -> dict[str, int]:
         if any(kw in haystack for kw in _ADMIN_PRIVILEGE_KEYWORDS):
             admin_principals.add(p.id)
 
-    def effective(principal_id: str) -> tuple[set[str], set[str], set[str]]:
-        """Return (all_resources, via_assume_only, assumed_principal_ids)."""
+    def _group_closure(principal_id: str) -> set[str]:
+        """Return the GROUP ids a principal belongs to, transitively (nested groups)."""
+        groups: set[str] = set()
+        frontier = list(member_of_groups.get(principal_id, set()))
+        depth = 0
+        while frontier and depth < _MAX_DEPTH:
+            nxt: list[str] = []
+            for gid in frontier:
+                if gid in groups:
+                    continue
+                groups.add(gid)
+                nxt.extend(member_of_groups.get(gid, set()))
+            frontier = nxt
+            depth += 1
+        return groups
+
+    def effective(principal_id: str) -> tuple[set[str], set[str], set[str], set[str]]:
+        """Return (all_resources, via_assume_only, via_group_only, assumed_principal_ids)."""
         direct = set(direct_access.get(principal_id, set()))
+        # Access inherited from group membership (and the groups a group nests in).
+        via_group: set[str] = set()
+        for gid in _group_closure(principal_id):
+            via_group |= direct_access.get(gid, set())
         via_assume: set[str] = set()
         assumed: set[str] = set()
         visited = {principal_id}
@@ -105,19 +135,25 @@ def apply_effective_permissions(graph: UnifiedGraph) -> dict[str, int]:
                 nxt.extend(assumes.get(pid, set()))
             frontier = nxt
             depth += 1
-        return direct | via_assume, via_assume - direct, assumed
+        all_resources = direct | via_assume | via_group
+        return all_resources, via_assume - direct, via_group - direct - via_assume, assumed
 
     edges_added = 0
     escalations = 0
     seen_perm: set[tuple[str, str]] = set()
     for principal in principals:
-        all_resources, escalated, assumed = effective(principal.id)
+        all_resources, escalated, via_group_only, assumed = effective(principal.id)
         for resource_id in all_resources:
             key = (principal.id, resource_id)
             if key in seen_perm:
                 continue
             seen_perm.add(key)
-            via = "assume_chain" if resource_id in escalated else "direct"
+            if resource_id in escalated:
+                via = "assume_chain"
+            elif resource_id in via_group_only:
+                via = "group"
+            else:
+                via = "direct"
             graph.add_edge(
                 UnifiedEdge(
                     source=principal.id,

--- a/src/agent_bom/identity/entra_nhi.py
+++ b/src/agent_bom/identity/entra_nhi.py
@@ -113,6 +113,22 @@ class EntraClient:
         """List application registrations (carry credential end dates)."""
         return self._get(f"/applications?$top={_PAGE_LIMIT}")
 
+    def list_groups(self) -> list[dict[str, Any]]:
+        """List Entra (Azure AD) groups — directory read, no membership expansion."""
+        return self._get(f"/groups?$top={_PAGE_LIMIT}")
+
+    def list_group_members(self, group_id: str) -> list[dict[str, Any]]:
+        """List the direct members of one Entra group (users / SPs / nested groups).
+
+        Read-only ``GET /groups/{id}/members``. Each member carries its object id
+        and ``@odata.type`` so the caller can resolve the principal kind without a
+        second fetch.
+        """
+        gid = str(group_id or "").strip()
+        if not gid:
+            return []
+        return self._get(f"/groups/{gid}/members?$top={_PAGE_LIMIT}")
+
 
 def _is_truthy(value: str | None) -> bool:
     return value is not None and value.strip().lower() in _TRUTHY

--- a/tests/test_cloud_aws_inventory.py
+++ b/tests/test_cloud_aws_inventory.py
@@ -721,3 +721,108 @@ def test_aws_permission_denied_degrades_with_guidance(monkeypatch: pytest.Monkey
     actionable = [w for w in payload["warnings"] if "role lacks s3:ListAllMyBuckets" in w]
     assert actionable, payload["warnings"]
     assert payload["missing_permissions"] == [{"cloud": "aws", "permission": "s3:ListAllMyBuckets", "resource_type": "S3 buckets"}]
+
+
+# ---------------------------------------------------------------------------
+# IAM groups + group-based access (identity/RBAC depth)
+# ---------------------------------------------------------------------------
+
+
+class _FakeIAMGroups:
+    """IAM client where `alice` is admin ONLY through the `admins` group."""
+
+    def get_paginator(self, op: str) -> _FakePaginator:
+        if op == "list_roles":
+            return _FakePaginator([{"Roles": []}])
+        if op == "list_users":
+            return _FakePaginator([{"Users": [{"UserName": "alice", "Arn": "arn:aws:iam::111122223333:user/alice", "Path": "/"}]}])
+        if op == "list_groups":
+            return _FakePaginator([{"Groups": [{"GroupName": "admins", "Arn": "arn:aws:iam::111122223333:group/admins", "Path": "/"}]}])
+        if op == "get_group":
+            return _FakePaginator([{"Users": [{"UserName": "alice", "Arn": "arn:aws:iam::111122223333:user/alice"}]}])
+        if op == "list_groups_for_user":
+            return _FakePaginator([{"Groups": [{"GroupName": "admins"}]}])
+        if op == "list_attached_group_policies":
+            return _FakePaginator(
+                [{"AttachedPolicies": [{"PolicyArn": "arn:aws:iam::aws:policy/AdministratorAccess", "PolicyName": "AdministratorAccess"}]}]
+            )
+        # All other attached/inline list ops resolve to empty.
+        return _FakePaginator([{"AttachedPolicies": [], "PolicyNames": []}])
+
+
+def test_discover_iam_enumerates_groups_and_memberships() -> None:
+    class _Sess:
+        def client(self, name: str, **_kwargs: Any) -> Any:
+            return _FakeIAMGroups()
+
+    roles, users, groups = aws_inventory._discover_iam(_Sess(), account_id="111122223333", warnings=[])
+    assert roles == []
+    by_name = {g["name"]: g for g in groups}
+    assert "admins" in by_name
+    admins = by_name["admins"]
+    assert admins["privilege_level"] == "admin"
+    assert admins["members"][0]["id"] == "arn:aws:iam::111122223333:user/alice"
+    assert admins["members"][0]["type"] == "user"
+    # The user itself has NO direct privilege but records its group membership.
+    alice = {u["name"]: u for u in users}["alice"]
+    assert alice["privilege_level"] == "unknown"
+    assert alice["groups"] == ["admins"]
+
+
+def test_graph_user_admin_via_group_surfaces_effective_permission() -> None:
+    from agent_bom.graph.types import EntityType, RelationshipType
+
+    payload = {
+        "provider": "aws",
+        "status": "ok",
+        "account_id": "111122223333",
+        "region": "us-east-1",
+        "buckets": [{"name": "prod-bucket", "arn": "arn:bucket", "publicly_accessible": False, "location": "us-east-1"}],
+        "roles": [],
+        "users": [
+            {
+                "principal_type": "user",
+                "name": "alice",
+                "arn": "arn:aws:iam::111122223333:user/alice",
+                "policies": [],
+                "groups": ["admins"],
+                "privilege_level": "unknown",
+            }
+        ],
+        "groups": [
+            {
+                "principal_type": "group",
+                "name": "admins",
+                "arn": "arn:aws:iam::111122223333:group/admins",
+                "policies": [
+                    {
+                        "policy_id": "arn:aws:iam::aws:policy/AdministratorAccess",
+                        "policy_name": "AdministratorAccess",
+                        "privilege_level": "admin",
+                    }
+                ],
+                "members": [{"id": "arn:aws:iam::111122223333:user/alice", "name": "alice", "type": "user"}],
+                "privilege_level": "admin",
+            }
+        ],
+    }
+    graph = _build_graph_from_inventory(payload)
+    nodes = graph.nodes
+
+    group_node = "group:aws:arn:aws:iam::111122223333:group/admins"
+    user_node = "user:aws:arn:aws:iam::111122223333:user/alice"
+    policy_node = "policy:aws:arn:aws:iam::aws:policy/AdministratorAccess"
+    assert nodes[group_node].entity_type == EntityType.GROUP
+    # Group + membership + group policy are all in the graph.
+    assert any(e.relationship == RelationshipType.MEMBER_OF and e.source == user_node and e.target == group_node for e in graph.edges)
+    assert any(e.relationship == RelationshipType.ATTACHED and e.source == group_node and e.target == policy_node for e in graph.edges)
+    # The user is admin ONLY via the group, yet surfaces effective access to the
+    # bucket, marked as group-inherited (not a privilege escalation).
+    bucket_node = "cloud_resource:aws:s3:bucket:prod-bucket"
+    user_perms = {
+        e.target: e.evidence.get("access")
+        for e in graph.edges
+        if e.relationship == RelationshipType.HAS_PERMISSION and e.source == user_node
+    }
+    assert user_perms.get(bucket_node) == "group"
+    assert nodes[user_node].attributes.get("can_escalate_privilege") is None

--- a/tests/test_cloud_azure_inventory.py
+++ b/tests/test_cloud_azure_inventory.py
@@ -449,3 +449,123 @@ def test_azure_missing_permissions_are_sorted_and_deduped(monkeypatch: pytest.Mo
     assert [e["resource_type"] for e in perms] == ["Azure Storage Accounts", "Azure virtual machines"]
     # Idempotent: re-deduping the same list is a no-op.
     assert azure_inventory.dedupe_missing_permissions(perms + perms) == perms
+
+
+# ---------------------------------------------------------------------------
+# Entra directory read (service principals + groups) — gated, read-only
+# ---------------------------------------------------------------------------
+
+
+class _FakeGraphClient:
+    """Stand-in Microsoft Graph client (same surface EntraClient exposes)."""
+
+    def list_service_principals(self) -> list[dict[str, Any]]:
+        return [{"id": "sp-oid", "displayName": "ci-runner", "appId": "app-1", "servicePrincipalType": "Application"}]
+
+    def list_groups(self) -> list[dict[str, Any]]:
+        return [{"id": "grp-oid", "displayName": "platform-admins"}]
+
+    def list_group_members(self, group_id: str) -> list[dict[str, Any]]:
+        assert group_id == "grp-oid"
+        return [{"id": "sp-oid", "displayName": "ci-runner", "@odata.type": "#microsoft.graph.servicePrincipal"}]
+
+
+def test_entra_directory_discovers_sps_and_groups_with_injected_client() -> None:
+    warnings: list[str] = []
+    sps, groups = azure_inventory._discover_entra_directory(client=_FakeGraphClient(), warnings=warnings)
+    assert {sp["principal_id"] for sp in sps} == {"sp-oid"}
+    assert sps[0]["principal_type"] == "service-principal"
+    assert len(groups) == 1
+    grp = groups[0]
+    assert grp["principal_type"] == "group" and grp["principal_id"] == "grp-oid"
+    assert grp["members"] == [{"id": "sp-oid", "name": "ci-runner", "type": "service-principal"}]
+
+
+def test_entra_directory_disabled_is_silent_and_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.identity import entra_nhi
+
+    monkeypatch.delenv(entra_nhi._DISCOVERY_FLAG_ENV, raising=False)
+    warnings: list[str] = []
+    sps, groups = azure_inventory._discover_entra_directory(warnings=warnings)
+    # Opt-in + default OFF: an ARM-only scan is not spammed with a note every run.
+    assert sps == [] and groups == [] and warnings == []
+
+
+def test_entra_directory_gated_on_but_no_token_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.identity import entra_nhi
+
+    monkeypatch.setenv(entra_nhi._DISCOVERY_FLAG_ENV, "1")
+    monkeypatch.delenv(entra_nhi._TOKEN_ENV, raising=False)
+    warnings: list[str] = []
+    sps, groups = azure_inventory._discover_entra_directory(warnings=warnings)
+    assert sps == [] and groups == []
+    assert any(entra_nhi._TOKEN_ENV in w for w in warnings)
+
+
+def test_inventory_includes_entra_directory_when_gated_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(azure_inventory.INVENTORY_ENV_FLAG, "1")
+
+    monkeypatch.setattr(
+        azure_inventory,
+        "_discover_entra_directory",
+        lambda **kw: ([{"principal_id": "sp-oid", "principal_type": "service-principal", "name": "sp", "arn": "sp-oid"}], []),
+    )
+    with _install_fake_azure():
+        payload = azure_inventory.discover_inventory(subscription_id="sub-1", credential=_FakeCredential())
+    assert payload["service_principals"][0]["principal_id"] == "sp-oid"
+    assert "Directory.Read.All" in payload["discovery_envelope"]["permissions_used"]
+
+
+def test_graph_group_scoped_assignment_reaches_members() -> None:
+    from agent_bom.graph.builder import build_unified_graph_from_report
+    from agent_bom.graph.types import EntityType, RelationshipType
+
+    payload = {
+        "provider": "azure",
+        "status": "ok",
+        "subscription_id": "sub-1",
+        "account_id": "sub-1",
+        "service_principals": [
+            {
+                "principal_type": "service-principal",
+                "name": "ci-runner",
+                "arn": "sp-oid",
+                "principal_id": "sp-oid",
+                "privilege_level": "unknown",
+                "policies": [],
+                "trust_principals": [],
+            }
+        ],
+        "entra_groups": [
+            {
+                "principal_type": "group",
+                "name": "platform-admins",
+                "arn": "grp-oid",
+                "principal_id": "grp-oid",
+                "members": [{"id": "sp-oid", "name": "ci-runner", "type": "service-principal"}],
+                "policies": [],
+                "privilege_level": "unknown",
+            }
+        ],
+        "role_assignments": [
+            {
+                "principal_id": "grp-oid",
+                "principal_type": "group",
+                "role_name": "Owner",
+                "scope": "/subscriptions/sub-1",
+                "account_id": "sub-1",
+            }
+        ],
+    }
+    graph = build_unified_graph_from_report({"agents": [], "cloud_inventory": payload})
+
+    group_node = "group:azure:grp-oid"
+    sp_node = "service_principal:azure:sp-oid"
+    account_node = "account:azure:sub-1"
+    assert graph.nodes[group_node].entity_type == EntityType.GROUP
+    assert graph.nodes[sp_node].entity_type == EntityType.SERVICE_PRINCIPAL
+    # The Owner role granted to the group reaches the member service principal.
+    member_perm = [
+        e for e in graph.edges if e.relationship == RelationshipType.HAS_PERMISSION and e.source == sp_node and e.target == account_node
+    ]
+    assert member_perm and member_perm[0].evidence.get("via_group") == "grp-oid"

--- a/tests/test_cloud_gcp_inventory.py
+++ b/tests/test_cloud_gcp_inventory.py
@@ -985,3 +985,91 @@ def test_gcp_missing_permissions_are_sorted_and_deduped(monkeypatch: pytest.Monk
     assert [e["resource_type"] for e in perms] == ["GCS buckets", "GKE clusters"]
     # Idempotent: re-deduping the same list is a no-op.
     assert gcp_inventory.dedupe_missing_permissions(perms + perms) == perms
+
+
+# ---------------------------------------------------------------------------
+# Role-definition resolution + group: bindings (identity/RBAC depth)
+# ---------------------------------------------------------------------------
+
+
+def test_iam_bindings_capture_group_and_member_kind(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _group_policy(self: Any, request: Any) -> Any:
+        return _Obj(
+            bindings=[
+                {"role": "roles/owner", "members": ["group:admins@example.com"]},
+                {"role": "roles/viewer", "members": ["serviceAccount:svc@p.iam.gserviceaccount.com"]},
+            ]
+        )
+
+    with _install_fake_gcp():
+        monkeypatch.setattr(_FakeProjectsClient, "get_iam_policy", _group_policy)
+        by_member, kinds = gcp_inventory._discover_project_iam_bindings("proj-1", credentials=None, warnings=[])
+    assert by_member["admins@example.com"] == ["roles/owner"]
+    assert kinds["admins@example.com"] == "group"
+    assert kinds["svc@p.iam.gserviceaccount.com"] == "serviceaccount"
+
+
+def test_role_resolver_resolves_and_caches_permissions(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def _get_role(self: Any, request: Any) -> Any:
+        calls.append(request.name)
+        return _Obj(included_permissions=["storage.objects.get", "storage.objects.list"])
+
+    with _install_fake_gcp():
+        monkeypatch.setattr(_FakeIAMClient, "get_role", _get_role, raising=False)
+        monkeypatch.setattr(_FakeIAMAdminModule, "GetRoleRequest", _Obj, raising=False)
+        resolve = gcp_inventory._make_role_resolver(credentials=None, warnings=[])
+        first = resolve("roles/viewer")
+        second = resolve("roles/viewer")
+    assert first == ["storage.objects.get", "storage.objects.list"]
+    assert second == first
+    assert calls == ["roles/viewer"]  # cached: resolved once
+
+
+def test_build_group_principals_resolves_role_to_permissions() -> None:
+    groups = gcp_inventory._build_iam_group_principals(
+        {"admins@example.com": ["roles/owner"]},
+        {"admins@example.com": "group"},
+        project_id="proj-1",
+        role_resolver=lambda role: ["resourcemanager.projects.setIamPolicy"],
+    )
+    assert len(groups) == 1
+    grp = groups[0]
+    assert grp["principal_type"] == "group"
+    assert grp["privilege_level"] == "admin"
+    assert grp["policies"][0]["permissions"] == ["resourcemanager.projects.setIamPolicy"]
+    assert grp["members_expansion"] == "unresolved"  # Workspace Directory seam
+
+
+def test_graph_gcp_group_binding_surfaces_effective_permission() -> None:
+    from agent_bom.graph.types import EntityType, RelationshipType
+
+    payload = {
+        "provider": "gcp",
+        "status": "ok",
+        "project_id": "proj-1",
+        "account_id": "proj-1",
+        "buckets": [{"name": "data-lake", "publicly_accessible": False}],
+        "service_accounts": [],
+        "groups": [
+            {
+                "principal_type": "group",
+                "name": "admins@example.com",
+                "arn": "admins@example.com",
+                "principal_id": "admins@example.com",
+                "policies": [{"policy_id": "roles/owner", "policy_name": "roles/owner", "privilege_level": "admin"}],
+                "members": [],
+                "privilege_level": "admin",
+            }
+        ],
+    }
+    graph = _build_graph_from_inventory(payload)
+    group_node = "group:gcp:admins@example.com"
+    assert graph.nodes[group_node].entity_type == EntityType.GROUP
+    # The admin group reaches the project's bucket (effective permission).
+    bucket_node = "cloud_resource:gcp:gcs:bucket:data-lake"
+    group_perms = [
+        e for e in graph.edges if e.relationship == RelationshipType.HAS_PERMISSION and e.source == group_node and e.target == bucket_node
+    ]
+    assert group_perms

--- a/tests/test_graph_effective_permissions.py
+++ b/tests/test_graph_effective_permissions.py
@@ -82,3 +82,35 @@ def test_escalation_to_admin_role_is_higher_risk():
     assert g.nodes["user:dev"].attributes.get("escalates_to_admin") is True
     esc = [r for r in g.interaction_risks if r.pattern == "privilege_escalation"]
     assert esc and esc[0].risk_score == 9.0 and "admin-privileged" in esc[0].description
+
+
+def test_group_membership_inherits_access_without_escalation():
+    # A user with no direct access of its own reaches a resource only because the
+    # GROUP it belongs to can access it. The user must surface that effective
+    # permission, marked "group", and NOT be flagged as privilege escalation.
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="user:alice", entity_type=EntityType.USER, label="alice"))
+    g.add_node(UnifiedNode(id="group:admins", entity_type=EntityType.GROUP, label="admins"))
+    g.add_node(UnifiedNode(id="cloud:bucket", entity_type=EntityType.CLOUD_RESOURCE, label="bucket"))
+    g.add_edge(UnifiedEdge(source="user:alice", target="group:admins", relationship=RelationshipType.MEMBER_OF))
+    g.add_edge(UnifiedEdge(source="group:admins", target="cloud:bucket", relationship=RelationshipType.CAN_ACCESS))
+
+    stats = apply_effective_permissions(g)
+    assert stats["privilege_escalations"] == 0
+    assert _perm(g, "user:alice").get("cloud:bucket") == "group"
+    assert g.nodes["user:alice"].attributes.get("can_escalate_privilege") is None
+
+
+def test_nested_group_membership_is_bounded_and_inherited():
+    # alice → team → org-admins (nested groups); org-admins can access the secret.
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="user:alice", entity_type=EntityType.USER, label="alice"))
+    g.add_node(UnifiedNode(id="group:team", entity_type=EntityType.GROUP, label="team"))
+    g.add_node(UnifiedNode(id="group:org-admins", entity_type=EntityType.GROUP, label="org-admins"))
+    g.add_node(UnifiedNode(id="data:secret", entity_type=EntityType.DATA_STORE, label="secret"))
+    g.add_edge(UnifiedEdge(source="user:alice", target="group:team", relationship=RelationshipType.MEMBER_OF))
+    g.add_edge(UnifiedEdge(source="group:team", target="group:org-admins", relationship=RelationshipType.MEMBER_OF))
+    g.add_edge(UnifiedEdge(source="group:org-admins", target="data:secret", relationship=RelationshipType.CAN_ACCESS))
+
+    apply_effective_permissions(g)
+    assert _perm(g, "user:alice").get("data:secret") == "group"


### PR DESCRIPTION
Resolves #3187 — identity/RBAC depth so group- and service-principal-granted access is visible to the effective-permissions / privilege-escalation graph (it modeled `GROUP`/`SERVICE_PRINCIPAL` but the connectors never populated them).

All read-only, degrade-on-denial:
- **AWS** (`aws_inventory`): IAM groups, user→group memberships, group attached + inline policies. New IAM read actions are all within the existing `SecurityAudit` role — no new grant.
- **Azure** (`azure_inventory` + `identity/entra_nhi`): service principals, Entra groups, and memberships via Microsoft Graph. Needs `Directory.Read.All` (not in ARM `Reader`), so it reuses the existing gated Entra path (`AGENT_BOM_ENTRA_DISCOVERY` + token): silent/empty when off, warn-and-continue when denied.
- **GCP** (`gcp_inventory`): predefined + custom role definitions resolved to permission sets (cached, capped); `group:` bindings captured as group principals. Workspace Directory member expansion left as an explicit gated seam.

Graph wiring: `GROUP` nodes with `ATTACHED` policies + `MEMBER_OF` edges; group-scoped role assignments expand to members (`via_group`); `effective_permissions` inherits access through `MEMBER_OF` (depth-bounded for nested groups), recorded as `access="group"` and — correctly — **not** flagged as privilege escalation (only assume/trust chains are).

Tests: per-cloud + overlay (AWS admin-only-via-group surfaces the effective permission; Azure gated-on discovers SPs+groups and a group-scoped Owner reaches the member SP, gated-off silent, no-token warns; GCP role resolution + group binding; nested-group inheritance). `pytest -k` selection 860 passed; builder/overlay 311 passed; ruff/mypy/bandit clean.
