### PR TITLE
feat(cloud): network-edge inventory (WAF/API-GW/LB/NAT/NACL/ENI/IPs) wired into graph exposure

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -42,8 +42,8 @@ is wired into the docs site so drift produces a visible regression.
 | `TransportType` | 4 | `stdio`, `sse`, `streamable-http`, `unknown` |
 | `ServerSurface` | 10 | `mcp-server`, `container-image`, `oci-tarball`, `filesystem`, `sbom`, `external-scan`, `os-packages`, `sast`, `ai-inventory`, `other` |
 | `AgentStatus` | 2 | `configured`, `installed-not-configured` |
-| `EntityType` | 38 | `agent`, `server`, `package`, `tool`, `tool_call`, `model`, `dataset`, `container`, `cloud_resource`, `resource`, `source_file`, `code_module`, `config_file`, `external_import`, `ci_job`, `vulnerability`, `misconfiguration`, `credential`, `credential_ref`, `org`, `account`, `user`, `group`, `role`, `policy`, `service_account`, `service_principal`, `federated_identity`, `managed_identity`, `access_grant`, `access_policy`, `drift_incident`, `data_store`, `application`, `provider`, `environment`, `fleet`, `cluster` |
-| `RelationshipType` | 46 | `hosts`, `uses`, `depends_on`, `provides_tool`, `exposes_cred`, `reaches_tool`, `serves_model`, `contains`, `imports`, `defines`, `runs`, `configures`, `affects`, `vulnerable_to`, `exploitable_via`, `remediates`, `triggers`, `shares_server`, `shares_cred`, `lateral_path`, `manages`, `owns`, `part_of`, `member_of`, `assumes`, `trusts`, `attached`, `inherits`, `can_access`, `cross_account_trust`, `authenticates_as`, `scoped_to`, `governs`, `exhibits_drift`, `exposed_to`, `stores`, `has_permission`, `acted_as`, `invoked`, `called`, `used_credential`, `accessed`, `delegated_to`, `correlates_with`, `possibly_correlates_with`, `belongs_to` |
+| `EntityType` | 39 | `agent`, `server`, `package`, `tool`, `tool_call`, `model`, `dataset`, `container`, `cloud_resource`, `resource`, `source_file`, `code_module`, `config_file`, `external_import`, `ci_job`, `vulnerability`, `misconfiguration`, `credential`, `credential_ref`, `org`, `account`, `user`, `group`, `role`, `policy`, `service_account`, `service_principal`, `federated_identity`, `managed_identity`, `access_grant`, `access_policy`, `drift_incident`, `data_store`, `api_gateway`, `application`, `provider`, `environment`, `fleet`, `cluster` |
+| `RelationshipType` | 47 | `hosts`, `uses`, `depends_on`, `provides_tool`, `exposes_cred`, `reaches_tool`, `serves_model`, `contains`, `imports`, `defines`, `runs`, `configures`, `affects`, `vulnerable_to`, `exploitable_via`, `remediates`, `triggers`, `shares_server`, `shares_cred`, `lateral_path`, `manages`, `owns`, `part_of`, `member_of`, `assumes`, `trusts`, `attached`, `inherits`, `can_access`, `cross_account_trust`, `authenticates_as`, `scoped_to`, `governs`, `exhibits_drift`, `exposed_to`, `stores`, `has_permission`, `protects`, `acted_as`, `invoked`, `called`, `used_credential`, `accessed`, `delegated_to`, `correlates_with`, `possibly_correlates_with`, `belongs_to` |
 
 ### Live Schema Cross-Checks
 
@@ -127,7 +127,7 @@ Used for unified findings outside the SCA / blast-radius path
 The unified graph projects the canonical model into a node/edge form
 used for blast-radius traversal, dashboards, and OCSF export.
 
-### Entity types (38)
+### Entity types (39)
 
 `AGENT`, `SERVER`, `PACKAGE`, `TOOL`, `TOOL_CALL`, `MODEL`, `DATASET`,
 `CONTAINER`, `CLOUD_RESOURCE`, `RESOURCE`, `SOURCE_FILE`, `CODE_MODULE`,
@@ -135,12 +135,19 @@ used for blast-radius traversal, dashboards, and OCSF export.
 `MISCONFIGURATION`, `CREDENTIAL`, `CREDENTIAL_REF`, `ORG`, `ACCOUNT`,
 `USER`, `GROUP`, `ROLE`, `POLICY`, `SERVICE_ACCOUNT`, `SERVICE_PRINCIPAL`,
 `FEDERATED_IDENTITY`, `MANAGED_IDENTITY`, `ACCESS_GRANT`, `ACCESS_POLICY`,
-`DRIFT_INCIDENT`, `DATA_STORE`, `APPLICATION`, `PROVIDER`, `ENVIRONMENT`,
-`FLEET`, `CLUSTER`.
+`DRIFT_INCIDENT`, `DATA_STORE`, `API_GATEWAY`, `APPLICATION`, `PROVIDER`,
+`ENVIRONMENT`, `FLEET`, `CLUSTER`.
 
 `DATA_STORE` is a cloud-CNAPP primitive — a database / bucket / lake / warehouse
 holding data at rest, derived from cloud resources so path-to-sensitive-data is
 traversable.
+
+`API_GATEWAY` is a network-edge primitive in the API_GATEWAY semantic layer —
+an API gateway / managed front-door populated from live cloud inventory (AWS API
+Gateway, GCP API Gateway / Apigee, Azure API Management). Together with WAF /
+Cloud Armor web ACLs (emitted as `CLOUD_RESOURCE`), it carries a `PROTECTS` edge
+to the resource it fronts so the CNAPP overlay refines that resource's internet
+exposure verdict.
 
 `APPLICATION` is the ASPM (Application Security Posture Management) correlation
 root — derived per service / repo / manifest-root from finding source paths, it
@@ -180,7 +187,7 @@ The effective-permissions overlay inherits a principal's access through the
 access is recorded on `HAS_PERMISSION` as `access="group"` and is not, by itself,
 a privilege escalation (only assume/trust chains are).
 
-### Relationship types (46)
+### Relationship types (47)
 
 | Group | Relationships | Direction |
 |---|---|---|
@@ -190,7 +197,7 @@ a privilege escalation (only assume/trust chains are).
 | Lateral movement | `SHARES_SERVER`, `SHARES_CRED`, `LATERAL_PATH` | symmetric |
 | Ownership and identity | `MANAGES`, `OWNS`, `PART_OF`, `MEMBER_OF`, `ASSUMES`, `TRUSTS`, `ATTACHED`, `INHERITS`, `CAN_ACCESS`, `CROSS_ACCOUNT_TRUST` | hierarchical / access path |
 | Agent-identity governance | `AUTHENTICATES_AS`, `SCOPED_TO`, `GOVERNS`, `EXHIBITS_DRIFT` | agent → identity → grant → tool; agent ↔ drift |
-| Cloud-CNAPP | `EXPOSED_TO`, `STORES`, `HAS_PERMISSION` | internet exposure; data-at-rest; effective permission |
+| Cloud-CNAPP | `EXPOSED_TO`, `STORES`, `HAS_PERMISSION`, `PROTECTS` | internet exposure; data-at-rest; effective permission; WAF/gateway fronts a resource |
 | Runtime | `ACTED_AS`, `INVOKED`, `CALLED`, `USED_CREDENTIAL`, `ACCESSED`, `DELEGATED_TO` | source → target, time-stamped |
 | Cross-environment correlation | `CORRELATES_WITH`, `POSSIBLY_CORRELATES_WITH` | local ↔ cloud agent correlation |
 | ASPM | `BELONGS_TO` | finding / component → application |

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -2718,6 +2718,13 @@ _RELATIONSHIP_SCHEMA_META: dict[str, dict[str, object]] = {
         "target_types": [EntityType.CLOUD_RESOURCE.value, EntityType.DATA_STORE.value, EntityType.RESOURCE.value, EntityType.TOOL.value],
         "traversable": True,
     },
+    RelationshipType.PROTECTS.value: {
+        "category": "exposure",
+        "direction": "directed",
+        "source_types": [EntityType.API_GATEWAY.value, EntityType.CLOUD_RESOURCE.value],
+        "target_types": [EntityType.CLOUD_RESOURCE.value, EntityType.DATA_STORE.value, EntityType.RESOURCE.value],
+        "traversable": True,
+    },
     RelationshipType.BELONGS_TO.value: {
         "category": "aspm",
         "direction": "directed",

--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -129,6 +129,25 @@ _AWS_SECURITY_PERMISSIONS: tuple[str, ...] = (
     "kms:GetKeyRotationStatus",
     "secretsmanager:ListSecrets",
 )
+# Network-edge read-only actions: WAF, API Gateway, and the VPC plumbing
+# (ENIs, NAT/internet gateways, subnets, route tables, network ACLs, VPC
+# endpoints) plus IP enumeration (Elastic IPs). All inside SecurityAudit /
+# ViewOnlyAccess; no new grant.
+_AWS_EDGE_PERMISSIONS: tuple[str, ...] = (
+    "wafv2:ListWebACLs",
+    "wafv2:ListResourcesForWebACL",
+    "wafv2:GetWebACLForResource",
+    "apigateway:GET",
+    "ec2:DescribeNetworkInterfaces",
+    "ec2:DescribeNatGateways",
+    "ec2:DescribeInternetGateways",
+    "ec2:DescribeEgressOnlyInternetGateways",
+    "ec2:DescribeVpcEndpoints",
+    "ec2:DescribeSubnets",
+    "ec2:DescribeRouteTables",
+    "ec2:DescribeNetworkAcls",
+    "ec2:DescribeAddresses",
+)
 _AWS_BASELINE_PERMISSIONS: tuple[str, ...] = ("sts:GetCallerIdentity",)
 
 # Open-to-the-world CIDR / ipv6 ranges that mark a security-group ingress rule
@@ -365,6 +384,16 @@ def _empty_payload(*, region: str) -> dict[str, Any]:
         "ecr_repositories": [],
         "redshift_clusters": [],
         "messaging": [],
+        "web_acls": [],
+        "api_gateways": [],
+        "network_interfaces": [],
+        "subnets": [],
+        "nat_gateways": [],
+        "internet_gateways": [],
+        "vpc_endpoints": [],
+        "route_tables": [],
+        "network_acls": [],
+        "ip_addresses": [],
         "warnings": [],
         "missing_permissions": [],
         "discovery_envelope": None,
@@ -388,6 +417,16 @@ _REGION_SCOPED_KEYS: tuple[str, ...] = (
     "ecr_repositories",
     "redshift_clusters",
     "messaging",
+    "web_acls",
+    "api_gateways",
+    "network_interfaces",
+    "subnets",
+    "nat_gateways",
+    "internet_gateways",
+    "vpc_endpoints",
+    "route_tables",
+    "network_acls",
+    "ip_addresses",
 )
 
 
@@ -607,6 +646,7 @@ def discover_inventory_all_regions(
         permissions_used.extend(_AWS_COMPUTE_PERMISSIONS)
     if include_network:
         permissions_used.extend(_AWS_NETWORK_PERMISSIONS)
+        permissions_used.extend(_AWS_EDGE_PERMISSIONS)
 
     envelope = DiscoveryEnvelope(
         scan_mode=ScanMode.CLOUD_READ_ONLY,
@@ -639,6 +679,16 @@ def discover_inventory_all_regions(
         "ecr_repositories": merged["ecr_repositories"],
         "redshift_clusters": merged["redshift_clusters"],
         "messaging": merged["messaging"],
+        "web_acls": merged["web_acls"],
+        "api_gateways": merged["api_gateways"],
+        "network_interfaces": merged["network_interfaces"],
+        "subnets": merged["subnets"],
+        "nat_gateways": merged["nat_gateways"],
+        "internet_gateways": merged["internet_gateways"],
+        "vpc_endpoints": merged["vpc_endpoints"],
+        "route_tables": merged["route_tables"],
+        "network_acls": merged["network_acls"],
+        "ip_addresses": merged["ip_addresses"],
         "warnings": warnings,
         "missing_permissions": dedupe_missing_permissions(missing),
         "discovery_envelope": envelope.to_dict(),
@@ -729,6 +779,16 @@ def discover_inventory(
     ecr_repositories: list[dict[str, Any]] = []
     redshift_clusters: list[dict[str, Any]] = []
     messaging: list[dict[str, Any]] = []
+    web_acls: list[dict[str, Any]] = []
+    api_gateways: list[dict[str, Any]] = []
+    network_interfaces: list[dict[str, Any]] = []
+    subnets: list[dict[str, Any]] = []
+    nat_gateways: list[dict[str, Any]] = []
+    internet_gateways: list[dict[str, Any]] = []
+    vpc_endpoints: list[dict[str, Any]] = []
+    route_tables: list[dict[str, Any]] = []
+    network_acls: list[dict[str, Any]] = []
+    ip_addresses: list[dict[str, Any]] = []
 
     try:
         if include_s3:
@@ -752,6 +812,19 @@ def discover_inventory(
             vpcs = _discover_vpcs(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
             cloudfront_distributions = _discover_cloudfront(session, account_id=account_id, warnings=warnings, missing=missing)
             messaging = _discover_messaging(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
+            web_acls = _discover_waf(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
+            api_gateways = _discover_api_gateways(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
+            edge = _discover_network_edge(session, resolved_region, account_id=account_id, warnings=warnings, missing=missing)
+            network_interfaces = edge["network_interfaces"]
+            subnets = edge["subnets"]
+            nat_gateways = edge["nat_gateways"]
+            internet_gateways = edge["internet_gateways"]
+            vpc_endpoints = edge["vpc_endpoints"]
+            route_tables = edge["route_tables"]
+            network_acls = edge["network_acls"]
+            ip_addresses = _discover_ip_addresses(
+                session, resolved_region, account_id=account_id, network_interfaces=network_interfaces, warnings=warnings, missing=missing
+            )
     except NoCredentialsError:
         return {
             **empty,
@@ -774,6 +847,7 @@ def discover_inventory(
         permissions_used.extend(_AWS_SECURITY_PERMISSIONS)
     if include_network:
         permissions_used.extend(_AWS_NETWORK_PERMISSIONS)
+        permissions_used.extend(_AWS_EDGE_PERMISSIONS)
 
     discovery_scope: list[str] = []
     if account_id:
@@ -811,6 +885,16 @@ def discover_inventory(
         "ecr_repositories": ecr_repositories,
         "redshift_clusters": redshift_clusters,
         "messaging": messaging,
+        "web_acls": web_acls,
+        "api_gateways": api_gateways,
+        "network_interfaces": network_interfaces,
+        "subnets": subnets,
+        "nat_gateways": nat_gateways,
+        "internet_gateways": internet_gateways,
+        "vpc_endpoints": vpc_endpoints,
+        "route_tables": route_tables,
+        "network_acls": network_acls,
+        "ip_addresses": ip_addresses,
         "warnings": warnings,
         "missing_permissions": dedupe_missing_permissions(missing),
         "discovery_envelope": envelope.to_dict(),
@@ -1765,6 +1849,451 @@ def _discover_messaging(
     except Exception as exc:  # noqa: BLE001 — one failed SQS list must not sink the scan
         record_discovery_failure(
             exc=exc, resource_type="SQS queues", permission="sqs:ListQueues", cloud="aws", warnings=warnings, missing=missing
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Network edge: WAF, API Gateway, ENIs, NAT/IGW, subnets, route tables, IPs
+# ---------------------------------------------------------------------------
+
+
+def _discover_waf(
+    session: Any, region: str, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
+    """Enumerate WAFv2 web ACLs and the resources they front (read-only).
+
+    Both scopes are covered: ``REGIONAL`` (ALB / API Gateway / AppSync in the
+    region) and ``CLOUDFRONT`` (global edge, enumerated only from us-east-1 so a
+    multi-region scan does not duplicate it). ``protected_targets`` carries the
+    ARNs of the resources each web ACL is associated with, which the graph turns
+    into ``PROTECTS`` edges that refine the fronted resource's exposure verdict.
+    """
+    out: list[dict[str, Any]] = []
+    scopes = ["REGIONAL"]
+    if region == "us-east-1":
+        scopes.append("CLOUDFRONT")
+    for scope in scopes:
+        try:
+            client = session.client("wafv2", region_name="us-east-1" if scope == "CLOUDFRONT" else region)
+            resp = client.list_web_acls(Scope=scope)
+        except Exception as exc:  # noqa: BLE001 — one failed WAF list must not sink the scan
+            record_discovery_failure(
+                exc=exc,
+                resource_type=f"WAF web ACLs ({scope})",
+                permission="wafv2:ListWebACLs",
+                cloud="aws",
+                warnings=warnings,
+                missing=missing,
+            )
+            continue
+        for acl in resp.get("WebACLs", []) or []:
+            name = str(acl.get("Name", "") or "")
+            arn = str(acl.get("ARN", "") or "")
+            if not (name or arn):
+                continue
+            targets: list[str] = []
+            # Regional web ACLs expose their associated resources directly;
+            # CloudFront associations are read from the distribution side and are
+            # left empty here to avoid a per-distribution describe storm.
+            if scope == "REGIONAL" and arn:
+                try:
+                    assoc = client.list_resources_for_web_acl(WebACLArn=arn)
+                    targets = [str(r) for r in assoc.get("ResourceArns", []) or [] if r]
+                except Exception as exc:  # noqa: BLE001 — association read is best-effort
+                    warnings.append(f"Could not list resources for WAF {name}: {sanitize_discovery_warning(exc)}")
+            out.append(
+                {
+                    "name": name or arn.rsplit("/", 1)[-1],
+                    "id": str(acl.get("Id", "") or ""),
+                    "arn": arn,
+                    "scope": scope.lower(),
+                    "protected_targets": targets,
+                    "location": "global" if scope == "CLOUDFRONT" else region,
+                    "account_id": account_id or "",
+                }
+            )
+    return out
+
+
+def _discover_api_gateways(
+    session: Any, region: str, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
+    """Enumerate REST (apigateway) and HTTP/WebSocket (apigatewayv2) APIs (read-only).
+
+    Each API is internet-facing by default, so it becomes an ``API_GATEWAY``
+    graph node in the API_GATEWAY semantic layer; ``stages`` carries the deployed
+    stage names (non-secret) for context.
+    """
+    out: list[dict[str, Any]] = []
+    try:
+        rest = session.client("apigateway", region_name=region)
+        paginator = rest.get_paginator("get_rest_apis")
+        for page in paginator.paginate():
+            for api in page.get("items", []) or []:
+                api_id = str(api.get("id", "") or "")
+                if not api_id:
+                    continue
+                stages: list[str] = []
+                try:
+                    for stage in rest.get_stages(restApiId=api_id).get("item", []) or []:
+                        stage_name = str(stage.get("stageName", "") or "")
+                        if stage_name:
+                            stages.append(stage_name)
+                except Exception:  # noqa: BLE001 — stage read is best-effort
+                    stages = []
+                endpoint_types = [str(t) for t in ((api.get("endpointConfiguration") or {}).get("types") or [])]
+                out.append(
+                    {
+                        "name": str(api.get("name", "") or api_id),
+                        "id": api_id,
+                        "arn": "",
+                        "protocol": "REST",
+                        "endpoint": ",".join(endpoint_types),
+                        "internet_exposed": "PRIVATE" not in endpoint_types,
+                        "stages": stages,
+                        "protected_targets": [],
+                        "location": region,
+                        "account_id": account_id or "",
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001 — one failed API Gateway list must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="API Gateway REST APIs", permission="apigateway:GET", cloud="aws", warnings=warnings, missing=missing
+        )
+
+    try:
+        v2 = session.client("apigatewayv2", region_name=region)
+        next_token: str | None = None
+        while True:
+            resp = v2.get_apis(NextToken=next_token) if next_token else v2.get_apis()
+            for api in resp.get("Items", []) or []:
+                api_id = str(api.get("ApiId", "") or "")
+                if not api_id:
+                    continue
+                out.append(
+                    {
+                        "name": str(api.get("Name", "") or api_id),
+                        "id": api_id,
+                        "arn": "",
+                        "protocol": str(api.get("ProtocolType", "") or "HTTP"),
+                        "endpoint": str(api.get("ApiEndpoint", "") or ""),
+                        "internet_exposed": True,
+                        "stages": [],
+                        "protected_targets": [],
+                        "location": region,
+                        "account_id": account_id or "",
+                    }
+                )
+            next_token = resp.get("NextToken")
+            if not next_token:
+                break
+    except Exception as exc:  # noqa: BLE001 — one failed API Gateway v2 list must not sink the scan
+        record_discovery_failure(
+            exc=exc, resource_type="API Gateway HTTP/WS APIs", permission="apigateway:GET", cloud="aws", warnings=warnings, missing=missing
+        )
+    return out
+
+
+def _discover_network_edge(
+    session: Any, region: str, *, account_id: str | None, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> dict[str, list[dict[str, Any]]]:
+    """Enumerate VPC plumbing (read-only): ENIs, NAT/internet gateways, VPC
+    endpoints, subnets, route tables, and network ACLs.
+
+    A subnet is marked ``is_public`` when a route table associated with it routes
+    ``0.0.0.0/0`` to an internet gateway — the same internet-reachability
+    classifier the GCP firewall path uses, applied to the AWS network fabric.
+    """
+    out: dict[str, list[dict[str, Any]]] = {
+        "network_interfaces": [],
+        "subnets": [],
+        "nat_gateways": [],
+        "internet_gateways": [],
+        "vpc_endpoints": [],
+        "route_tables": [],
+        "network_acls": [],
+    }
+    ec2 = session.client("ec2", region_name=region)
+
+    # Route tables first so subnet public/private classification can use them.
+    public_subnet_ids: set[str] = set()
+    vpc_default_public: set[str] = set()
+    try:
+        paginator = ec2.get_paginator("describe_route_tables")
+        for page in paginator.paginate():
+            for rt in page.get("RouteTables", []) or []:
+                rt_id = str(rt.get("RouteTableId", "") or "")
+                if not rt_id:
+                    continue
+                vpc_id = str(rt.get("VpcId", "") or "")
+                has_igw_route = any(
+                    str(r.get("GatewayId", "") or "").startswith("igw-") and str(r.get("DestinationCidrBlock", "")) in _INTERNET_CIDRS
+                    for r in rt.get("Routes", []) or []
+                    if isinstance(r, dict)
+                )
+                assocs = rt.get("Associations", []) or []
+                main = any(bool(a.get("Main")) for a in assocs if isinstance(a, dict))
+                if has_igw_route:
+                    if main and vpc_id:
+                        vpc_default_public.add(vpc_id)
+                    for a in assocs:
+                        sid = str(a.get("SubnetId", "") or "") if isinstance(a, dict) else ""
+                        if sid:
+                            public_subnet_ids.add(sid)
+                out["route_tables"].append(
+                    {
+                        "id": rt_id,
+                        "name": rt_id,
+                        "vpc_id": vpc_id,
+                        "has_internet_route": has_igw_route,
+                        "location": region,
+                        "account_id": account_id or "",
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        record_discovery_failure(
+            exc=exc, resource_type="route tables", permission="ec2:DescribeRouteTables", cloud="aws", warnings=warnings, missing=missing
+        )
+
+    try:
+        paginator = ec2.get_paginator("describe_subnets")
+        for page in paginator.paginate():
+            for sn in page.get("Subnets", []) or []:
+                sn_id = str(sn.get("SubnetId", "") or "")
+                if not sn_id:
+                    continue
+                vpc_id = str(sn.get("VpcId", "") or "")
+                tags = {str(t.get("Key", "")): str(t.get("Value", "")) for t in sn.get("Tags", []) if t.get("Key")}
+                # Explicit public route-table association wins; otherwise a subnet
+                # that auto-assigns public IPs in an internet-routed VPC is public.
+                is_public = sn_id in public_subnet_ids or (bool(sn.get("MapPublicIpOnLaunch")) and vpc_id in vpc_default_public)
+                out["subnets"].append(
+                    {
+                        "id": sn_id,
+                        "name": tags.get("Name", sn_id),
+                        "vpc_id": vpc_id,
+                        "cidr": str(sn.get("CidrBlock", "") or ""),
+                        "is_public": is_public,
+                        "location": str(sn.get("AvailabilityZone", "") or region),
+                        "account_id": account_id or "",
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        record_discovery_failure(
+            exc=exc, resource_type="subnets", permission="ec2:DescribeSubnets", cloud="aws", warnings=warnings, missing=missing
+        )
+
+    try:
+        paginator = ec2.get_paginator("describe_network_interfaces")
+        for page in paginator.paginate():
+            for eni in page.get("NetworkInterfaces", []) or []:
+                eni_id = str(eni.get("NetworkInterfaceId", "") or "")
+                if not eni_id:
+                    continue
+                sg_ids = [str(g.get("GroupId", "")) for g in eni.get("Groups", []) or [] if isinstance(g, dict) and g.get("GroupId")]
+                attachment = eni.get("Attachment") or {}
+                association = eni.get("Association") or {}
+                out["network_interfaces"].append(
+                    {
+                        "id": eni_id,
+                        "name": eni_id,
+                        "instance_id": str(attachment.get("InstanceId", "") or ""),
+                        "subnet_id": str(eni.get("SubnetId", "") or ""),
+                        "vpc_id": str(eni.get("VpcId", "") or ""),
+                        "security_group_ids": sg_ids,
+                        "private_ip": str(eni.get("PrivateIpAddress", "") or ""),
+                        "public_ip": str(association.get("PublicIp", "") or ""),
+                        "location": region,
+                        "account_id": account_id or "",
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        record_discovery_failure(
+            exc=exc,
+            resource_type="network interfaces",
+            permission="ec2:DescribeNetworkInterfaces",
+            cloud="aws",
+            warnings=warnings,
+            missing=missing,
+        )
+
+    try:
+        paginator = ec2.get_paginator("describe_nat_gateways")
+        for page in paginator.paginate():
+            for nat in page.get("NatGateways", []) or []:
+                nat_id = str(nat.get("NatGatewayId", "") or "")
+                if not nat_id:
+                    continue
+                out["nat_gateways"].append(
+                    {
+                        "id": nat_id,
+                        "name": nat_id,
+                        "vpc_id": str(nat.get("VpcId", "") or ""),
+                        "subnet_id": str(nat.get("SubnetId", "") or ""),
+                        "connectivity": str(nat.get("ConnectivityType", "") or "public"),
+                        "location": region,
+                        "account_id": account_id or "",
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        record_discovery_failure(
+            exc=exc, resource_type="NAT gateways", permission="ec2:DescribeNatGateways", cloud="aws", warnings=warnings, missing=missing
+        )
+
+    try:
+        for igw in ec2.describe_internet_gateways().get("InternetGateways", []) or []:
+            igw_id = str(igw.get("InternetGatewayId", "") or "")
+            if not igw_id:
+                continue
+            vpc_ids = [str(a.get("VpcId", "")) for a in igw.get("Attachments", []) or [] if isinstance(a, dict) and a.get("VpcId")]
+            out["internet_gateways"].append(
+                {
+                    "id": igw_id,
+                    "name": igw_id,
+                    "vpc_id": vpc_ids[0] if vpc_ids else "",
+                    "kind": "internet-gateway",
+                    "location": region,
+                    "account_id": account_id or "",
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        record_discovery_failure(
+            exc=exc,
+            resource_type="internet gateways",
+            permission="ec2:DescribeInternetGateways",
+            cloud="aws",
+            warnings=warnings,
+            missing=missing,
+        )
+
+    try:
+        for eigw in ec2.describe_egress_only_internet_gateways().get("EgressOnlyInternetGateways", []) or []:
+            eigw_id = str(eigw.get("EgressOnlyInternetGatewayId", "") or "")
+            if not eigw_id:
+                continue
+            vpc_ids = [str(a.get("VpcId", "")) for a in eigw.get("Attachments", []) or [] if isinstance(a, dict) and a.get("VpcId")]
+            out["internet_gateways"].append(
+                {
+                    "id": eigw_id,
+                    "name": eigw_id,
+                    "vpc_id": vpc_ids[0] if vpc_ids else "",
+                    "kind": "egress-only-internet-gateway",
+                    "location": region,
+                    "account_id": account_id or "",
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        record_discovery_failure(
+            exc=exc,
+            resource_type="egress-only internet gateways",
+            permission="ec2:DescribeEgressOnlyInternetGateways",
+            cloud="aws",
+            warnings=warnings,
+            missing=missing,
+        )
+
+    try:
+        paginator = ec2.get_paginator("describe_vpc_endpoints")
+        for page in paginator.paginate():
+            for vpe in page.get("VpcEndpoints", []) or []:
+                vpe_id = str(vpe.get("VpcEndpointId", "") or "")
+                if not vpe_id:
+                    continue
+                out["vpc_endpoints"].append(
+                    {
+                        "id": vpe_id,
+                        "name": str(vpe.get("ServiceName", "") or vpe_id),
+                        "vpc_id": str(vpe.get("VpcId", "") or ""),
+                        "endpoint_type": str(vpe.get("VpcEndpointType", "") or ""),
+                        "location": region,
+                        "account_id": account_id or "",
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        record_discovery_failure(
+            exc=exc, resource_type="VPC endpoints", permission="ec2:DescribeVpcEndpoints", cloud="aws", warnings=warnings, missing=missing
+        )
+
+    try:
+        paginator = ec2.get_paginator("describe_network_acls")
+        for page in paginator.paginate():
+            for acl in page.get("NetworkAcls", []) or []:
+                acl_id = str(acl.get("NetworkAclId", "") or "")
+                if not acl_id:
+                    continue
+                out["network_acls"].append(
+                    {
+                        "id": acl_id,
+                        "name": acl_id,
+                        "vpc_id": str(acl.get("VpcId", "") or ""),
+                        "is_default": bool(acl.get("IsDefault")),
+                        "location": region,
+                        "account_id": account_id or "",
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001
+        record_discovery_failure(
+            exc=exc, resource_type="network ACLs", permission="ec2:DescribeNetworkAcls", cloud="aws", warnings=warnings, missing=missing
+        )
+
+    return out
+
+
+def _discover_ip_addresses(
+    session: Any,
+    region: str,
+    *,
+    account_id: str | None,
+    network_interfaces: list[dict[str, Any]],
+    warnings: list[str],
+    missing: list[dict[str, str]] | None = None,
+) -> list[dict[str, Any]]:
+    """Enumerate Elastic IPs plus the public IPs bound to ENIs (read-only).
+
+    Every internet-facing address is inventoried and attributable so an exposed
+    address can be tied back to the resource it fronts. Elastic IPs come from
+    ``describe_addresses``; ephemeral public IPs are read from the already-
+    discovered ENIs (no extra call).
+    """
+    out: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    try:
+        ec2 = session.client("ec2", region_name=region)
+        for addr in ec2.describe_addresses().get("Addresses", []) or []:
+            ip = str(addr.get("PublicIp", "") or "")
+            if not ip or ip in seen:
+                continue
+            seen.add(ip)
+            attached = str(addr.get("InstanceId", "") or addr.get("NetworkInterfaceId", "") or "")
+            out.append(
+                {
+                    "address": ip,
+                    "kind": "elastic",
+                    "attached_to": attached,
+                    "allocation_id": str(addr.get("AllocationId", "") or ""),
+                    "location": region,
+                    "account_id": account_id or "",
+                }
+            )
+    except Exception as exc:  # noqa: BLE001
+        record_discovery_failure(
+            exc=exc, resource_type="Elastic IPs", permission="ec2:DescribeAddresses", cloud="aws", warnings=warnings, missing=missing
+        )
+
+    for eni in network_interfaces:
+        ip = str(eni.get("public_ip", "") or "")
+        if not ip or ip in seen:
+            continue
+        seen.add(ip)
+        out.append(
+            {
+                "address": ip,
+                "kind": "public",
+                "attached_to": str(eni.get("instance_id", "") or eni.get("id", "") or ""),
+                "location": region,
+                "account_id": account_id or "",
+            }
         )
     return out
 

--- a/src/agent_bom/cloud/azure_inventory.py
+++ b/src/agent_bom/cloud/azure_inventory.py
@@ -82,10 +82,16 @@ _AZURE_DATA_PERMISSIONS: tuple[str, ...] = (
 )
 _AZURE_NETWORK_PERMISSIONS: tuple[str, ...] = (
     "Microsoft.Network/virtualNetworks/read",
+    "Microsoft.Network/virtualNetworks/subnets/read",
     "Microsoft.Network/publicIPAddresses/read",
     "Microsoft.Network/loadBalancers/read",
     "Microsoft.Network/applicationGateways/read",
     "Microsoft.Network/frontDoors/read",
+    "Microsoft.Network/azureFirewalls/read",
+    "Microsoft.Network/natGateways/read",
+    "Microsoft.Network/routeTables/read",
+    "Microsoft.Network/networkInterfaces/read",
+    "Microsoft.Network/privateEndpoints/read",
     "Microsoft.ApiManagement/service/read",
 )
 
@@ -199,10 +205,17 @@ def discover_inventory(
         "container_registries": [],
         "databases": [],
         "virtual_networks": [],
+        "subnets": [],
         "public_ips": [],
+        "ip_addresses": [],
+        "network_interfaces": [],
         "load_balancers": [],
         "application_gateways": [],
         "front_doors": [],
+        "azure_firewalls": [],
+        "nat_gateways": [],
+        "route_tables": [],
+        "private_endpoints": [],
         "api_management": [],
         "event_hubs": [],
         "service_bus_namespaces": [],
@@ -277,10 +290,17 @@ def discover_inventory(
         discovery_tasks.append(("redis_caches", _discover_redis_caches))
     if include_network:
         discovery_tasks.append(("virtual_networks", _discover_virtual_networks))
+        discovery_tasks.append(("subnets", _discover_subnets))
         discovery_tasks.append(("public_ips", _discover_public_ips))
+        discovery_tasks.append(("ip_addresses", _discover_ip_addresses))
+        discovery_tasks.append(("network_interfaces", _discover_network_interfaces))
         discovery_tasks.append(("load_balancers", _discover_load_balancers))
         discovery_tasks.append(("application_gateways", _discover_application_gateways))
         discovery_tasks.append(("front_doors", _discover_front_doors))
+        discovery_tasks.append(("azure_firewalls", _discover_azure_firewalls))
+        discovery_tasks.append(("nat_gateways", _discover_nat_gateways))
+        discovery_tasks.append(("route_tables", _discover_route_tables))
+        discovery_tasks.append(("private_endpoints", _discover_private_endpoints))
         discovery_tasks.append(("api_management", _discover_api_management))
 
     collected: dict[str, list[dict[str, Any]]] = {}
@@ -326,10 +346,17 @@ def discover_inventory(
     container_registries = collected.get("container_registries", [])
     databases = collected.get("databases", [])
     virtual_networks = collected.get("virtual_networks", [])
+    subnets = collected.get("subnets", [])
     public_ips = collected.get("public_ips", [])
+    ip_addresses = collected.get("ip_addresses", [])
+    network_interfaces = collected.get("network_interfaces", [])
     load_balancers = collected.get("load_balancers", [])
     application_gateways = collected.get("application_gateways", [])
     front_doors = collected.get("front_doors", [])
+    azure_firewalls = collected.get("azure_firewalls", [])
+    nat_gateways = collected.get("nat_gateways", [])
+    route_tables = collected.get("route_tables", [])
+    private_endpoints = collected.get("private_endpoints", [])
     api_management = collected.get("api_management", [])
     event_hubs = collected.get("event_hubs", [])
     service_bus_namespaces = collected.get("service_bus_namespaces", [])
@@ -401,10 +428,17 @@ def discover_inventory(
         "container_registries": container_registries,
         "databases": databases,
         "virtual_networks": virtual_networks,
+        "subnets": subnets,
         "public_ips": public_ips,
+        "ip_addresses": ip_addresses,
+        "network_interfaces": network_interfaces,
         "load_balancers": load_balancers,
         "application_gateways": application_gateways,
         "front_doors": front_doors,
+        "azure_firewalls": azure_firewalls,
+        "nat_gateways": nat_gateways,
+        "route_tables": route_tables,
+        "private_endpoints": private_endpoints,
         "api_management": api_management,
         "event_hubs": event_hubs,
         "service_bus_namespaces": service_bus_namespaces,
@@ -1374,6 +1408,387 @@ def _discover_public_ips(
     return public_ips
 
 
+def _discover_ip_addresses(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
+    """Surface allocated public IP *addresses* and the resource each is bound to.
+
+    The symmetric counterpart of the NIC ``public_ip`` capture: from the
+    public-IP resource side, record the address value and the ARM id of the IP
+    configuration it is attached to (a NIC / load-balancer / gateway frontend),
+    so the graph can wire the address to its bearer from either direction.
+    """
+    try:
+        from azure.mgmt.network import NetworkManagementClient
+    except ImportError:
+        warnings.append("azure-mgmt-network not installed. Skipping IP-address inventory.")
+        return []
+
+    addresses: list[dict[str, Any]] = []
+    try:
+        client = NetworkManagementClient(credential, subscription_id)
+        for pip in client.public_ip_addresses.list_all():
+            address = str(getattr(pip, "ip_address", "") or "")
+            ip_config = getattr(pip, "ip_configuration", None)
+            attached_to = str(getattr(ip_config, "id", "") or "") if ip_config else ""
+            addresses.append(
+                {
+                    "address": address,
+                    "kind": "public",
+                    "attached_to": attached_to,
+                    "location": str(getattr(pip, "location", "") or ""),
+                    "account_id": subscription_id,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001 — one failed Azure public IPs list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure IP addresses",
+            permission="Microsoft.Network/publicIPAddresses/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
+    return addresses
+
+
+def _discover_subnets(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
+    """Enumerate every subnet across the subscription's VNets (read-only).
+
+    Subnets are not listable subscription-wide directly, so they are read from
+    each VNet's expanded ``subnets`` collection. ``is_public`` is a conservative,
+    provable signal: a subnet with an attached NAT gateway has an explicit
+    internet egress path. The shared builder can refine exposure by joining a
+    subnet's route table against ``route_tables`` (``has_internet_route``).
+    """
+    try:
+        from azure.mgmt.network import NetworkManagementClient
+    except ImportError:
+        warnings.append("azure-mgmt-network not installed. Skipping subnet inventory.")
+        return []
+
+    subnets: list[dict[str, Any]] = []
+    try:
+        client = NetworkManagementClient(credential, subscription_id)
+        for vnet in client.virtual_networks.list_all():
+            vnet_id = str(getattr(vnet, "id", "") or "")
+            for subnet in getattr(vnet, "subnets", None) or []:
+                subnet_id = str(getattr(subnet, "id", "") or "")
+                name = str(getattr(subnet, "name", "") or "").strip()
+                if not name:
+                    continue
+                cidr = str(getattr(subnet, "address_prefix", "") or "")
+                if not cidr:
+                    prefixes = list(getattr(subnet, "address_prefixes", None) or [])
+                    cidr = str(prefixes[0]) if prefixes else ""
+                nat_gateway = getattr(subnet, "nat_gateway", None)
+                subnets.append(
+                    {
+                        "id": subnet_id,
+                        "name": name,
+                        "vpc_id": vnet_id,
+                        "cidr": cidr,
+                        "is_public": nat_gateway is not None,
+                        "location": str(getattr(vnet, "location", "") or ""),
+                        "account_id": subscription_id,
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001 — one failed Azure subnets list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure subnets",
+            permission="Microsoft.Network/virtualNetworks/subnets/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
+    return subnets
+
+
+def _discover_network_interfaces(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
+    """Enumerate every NIC in the subscription with its IP-config topology (read-only).
+
+    Each NIC binds a VM to a subnet (hence a VNet) and may carry an NSG plus a
+    private and/or public IP — the edge data the graph needs to attach a VM to
+    its network position and exposure. Control-plane only; never any secrets.
+    """
+    try:
+        from azure.mgmt.network import NetworkManagementClient
+    except ImportError:
+        warnings.append("azure-mgmt-network not installed. Skipping network-interface inventory.")
+        return []
+
+    nics: list[dict[str, Any]] = []
+    try:
+        client = NetworkManagementClient(credential, subscription_id)
+        for nic in client.network_interfaces.list_all():
+            nic_id = str(getattr(nic, "id", "") or "")
+            name = str(getattr(nic, "name", "") or "").strip()
+            if not name:
+                continue
+            nics.append(_normalize_network_interface(nic, nic_id=nic_id, name=name, subscription_id=subscription_id))
+    except Exception as exc:  # noqa: BLE001 — one failed Azure network interfaces list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure network interfaces",
+            permission="Microsoft.Network/networkInterfaces/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
+    return nics
+
+
+def _normalize_network_interface(nic: Any, *, nic_id: str, name: str, subscription_id: str) -> dict[str, Any]:
+    vm_ref = getattr(nic, "virtual_machine", None)
+    instance_id = str(getattr(vm_ref, "id", "") or "") if vm_ref else ""
+    nsg_ref = getattr(nic, "network_security_group", None)
+    nsg_id = str(getattr(nsg_ref, "id", "") or "") if nsg_ref else ""
+    subnet_id = ""
+    private_ip = ""
+    public_ip = ""
+    for ip_config in getattr(nic, "ip_configurations", None) or []:
+        if not private_ip:
+            private_ip = str(getattr(ip_config, "private_ip_address", "") or "")
+        if not subnet_id:
+            subnet_ref = getattr(ip_config, "subnet", None)
+            subnet_id = str(getattr(subnet_ref, "id", "") or "") if subnet_ref else ""
+        if not public_ip:
+            public_ip = _public_ip_ref_value(getattr(ip_config, "public_ip_address", None))
+    return {
+        "id": nic_id,
+        "name": name,
+        "instance_id": instance_id,
+        "subnet_id": subnet_id,
+        "vpc_id": _vnet_id_from_subnet_id(subnet_id),
+        "security_group_ids": [nsg_id] if nsg_id else [],
+        "private_ip": private_ip,
+        "public_ip": public_ip,
+        "location": str(getattr(nic, "location", "") or ""),
+        "account_id": subscription_id,
+    }
+
+
+def _discover_azure_firewalls(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
+    """Enumerate Azure Firewalls in the subscription (read-only).
+
+    Captures the firewall's private IP and the public IPs it fronts — the
+    network-edge choke point for north/south traffic. Control-plane only.
+    """
+    try:
+        from azure.mgmt.network import NetworkManagementClient
+    except ImportError:
+        warnings.append("azure-mgmt-network not installed. Skipping Azure Firewall inventory.")
+        return []
+
+    firewalls: list[dict[str, Any]] = []
+    try:
+        client = NetworkManagementClient(credential, subscription_id)
+        for fw in client.azure_firewalls.list_all():
+            fw_id = str(getattr(fw, "id", "") or "")
+            name = str(getattr(fw, "name", "") or "").strip()
+            if not name:
+                continue
+            private_ip = ""
+            public_ips: list[str] = []
+            for ip_config in getattr(fw, "ip_configurations", None) or []:
+                if not private_ip:
+                    private_ip = str(getattr(ip_config, "private_ip_address", "") or "")
+                value = _public_ip_ref_value(getattr(ip_config, "public_ip_address", None))
+                if value:
+                    public_ips.append(value)
+            firewalls.append(
+                {
+                    "id": fw_id,
+                    "name": name,
+                    "location": str(getattr(fw, "location", "") or ""),
+                    "account_id": subscription_id,
+                    "private_ip": private_ip,
+                    "public_ips": public_ips,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001 — one failed Azure Firewalls list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure Firewalls",
+            permission="Microsoft.Network/azureFirewalls/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
+    return firewalls
+
+
+def _discover_nat_gateways(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
+    """Enumerate NAT gateways in the subscription (read-only).
+
+    A NAT gateway gives its associated subnet(s) an explicit outbound internet
+    path; the first associated subnet (and its VNet) is recorded so the graph can
+    attach the egress edge. Control-plane only.
+    """
+    try:
+        from azure.mgmt.network import NetworkManagementClient
+    except ImportError:
+        warnings.append("azure-mgmt-network not installed. Skipping NAT-gateway inventory.")
+        return []
+
+    gateways: list[dict[str, Any]] = []
+    try:
+        client = NetworkManagementClient(credential, subscription_id)
+        for nat in client.nat_gateways.list_all():
+            nat_id = str(getattr(nat, "id", "") or "")
+            name = str(getattr(nat, "name", "") or "").strip()
+            if not name:
+                continue
+            subnet_id = ""
+            for subnet_ref in getattr(nat, "subnets", None) or []:
+                subnet_id = str(getattr(subnet_ref, "id", "") or "")
+                if subnet_id:
+                    break
+            gateways.append(
+                {
+                    "id": nat_id,
+                    "name": name,
+                    "vpc_id": _vnet_id_from_subnet_id(subnet_id),
+                    "subnet_id": subnet_id,
+                    "location": str(getattr(nat, "location", "") or ""),
+                    "account_id": subscription_id,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001 — one failed Azure NAT gateways list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure NAT gateways",
+            permission="Microsoft.Network/natGateways/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
+    return gateways
+
+
+def _discover_route_tables(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
+    """Enumerate route tables in the subscription (read-only).
+
+    ``has_internet_route`` is the exposure-relevant signal: any user-defined
+    route whose next hop is the Internet (a default ``0.0.0.0/0`` route to the
+    internet). Control-plane only.
+    """
+    try:
+        from azure.mgmt.network import NetworkManagementClient
+    except ImportError:
+        warnings.append("azure-mgmt-network not installed. Skipping route-table inventory.")
+        return []
+
+    tables: list[dict[str, Any]] = []
+    try:
+        client = NetworkManagementClient(credential, subscription_id)
+        for rt in client.route_tables.list_all():
+            rt_id = str(getattr(rt, "id", "") or "")
+            name = str(getattr(rt, "name", "") or "").strip()
+            if not name:
+                continue
+            vpc_id = ""
+            for subnet_ref in getattr(rt, "subnets", None) or []:
+                vpc_id = _vnet_id_from_subnet_id(str(getattr(subnet_ref, "id", "") or ""))
+                if vpc_id:
+                    break
+            tables.append(
+                {
+                    "id": rt_id,
+                    "name": name,
+                    "vpc_id": vpc_id,
+                    "has_internet_route": _route_table_has_internet_route(getattr(rt, "routes", None)),
+                    "location": str(getattr(rt, "location", "") or ""),
+                    "account_id": subscription_id,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001 — one failed Azure route tables list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure route tables",
+            permission="Microsoft.Network/routeTables/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
+    return tables
+
+
+def _route_table_has_internet_route(routes: Any) -> bool:
+    """True if any route sends traffic straight to the internet (next hop Internet)."""
+    for route in routes or []:
+        next_hop = str(getattr(route, "next_hop_type", "") or "").lower()
+        prefix = str(getattr(route, "address_prefix", "") or "").strip()
+        if next_hop == "internet":
+            return True
+        if prefix == "0.0.0.0/0" and next_hop == "internet":
+            return True
+    return False
+
+
+def _discover_private_endpoints(
+    credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
+    """Enumerate private endpoints in the subscription (read-only).
+
+    A private endpoint places a private IP for a target PaaS resource inside a
+    subnet (the private-link inbound path). The subnet and the target resource id
+    are recorded so the graph can wire the private connection. Control-plane only.
+    """
+    try:
+        from azure.mgmt.network import NetworkManagementClient
+    except ImportError:
+        warnings.append("azure-mgmt-network not installed. Skipping private-endpoint inventory.")
+        return []
+
+    endpoints: list[dict[str, Any]] = []
+    try:
+        client = NetworkManagementClient(credential, subscription_id)
+        for pe in client.private_endpoints.list_all():
+            pe_id = str(getattr(pe, "id", "") or "")
+            name = str(getattr(pe, "name", "") or "").strip()
+            if not name:
+                continue
+            subnet_ref = getattr(pe, "subnet", None)
+            subnet_id = str(getattr(subnet_ref, "id", "") or "") if subnet_ref else ""
+            target_resource = ""
+            for conn in getattr(pe, "private_link_service_connections", None) or []:
+                target_resource = str(getattr(conn, "private_link_service_id", "") or "")
+                if target_resource:
+                    break
+            endpoints.append(
+                {
+                    "id": pe_id,
+                    "name": name,
+                    "location": str(getattr(pe, "location", "") or ""),
+                    "account_id": subscription_id,
+                    "subnet_id": subnet_id,
+                    "target_resource": target_resource,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001 — one failed Azure private endpoints list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Azure private endpoints",
+            permission="Microsoft.Network/privateEndpoints/read",
+            cloud="azure",
+            warnings=warnings,
+            missing=missing,
+        )
+    return endpoints
+
+
 def _discover_load_balancers(
     credential: Any, subscription_id: str, *, warnings: list[str], missing: list[dict[str, str]] | None = None
 ) -> list[dict[str, Any]]:
@@ -1917,6 +2332,29 @@ def _vm_user_assigned_identity_ids(vm: Any) -> list[str]:
     if not isinstance(user_assigned, dict):
         return []
     return [str(arm_id) for arm_id in user_assigned if arm_id]
+
+
+def _vnet_id_from_subnet_id(subnet_id: str) -> str:
+    """Derive the parent VNet ARM id from a subnet ARM id, else ''.
+
+    A subnet id is ``.../virtualNetworks/<vnet>/subnets/<subnet>``; the VNet id is
+    everything up to and including the ``virtualNetworks/<vnet>`` segment.
+    """
+    text = str(subnet_id or "")
+    marker = "/subnets/"
+    index = text.lower().find(marker)
+    return text[:index] if index != -1 else ""
+
+
+def _public_ip_ref_value(ref: Any) -> str:
+    """Resolve a public-IP sub-resource reference to its address, else its ARM id.
+
+    A NIC / firewall IP configuration usually carries only the public IP's ``id``
+    in a list response; the actual address is preferred when present.
+    """
+    if ref is None:
+        return ""
+    return str(getattr(ref, "ip_address", "") or getattr(ref, "id", "") or "")
 
 
 def _resource_group_from_id(resource_id: str) -> str:

--- a/src/agent_bom/cloud/gcp_inventory.py
+++ b/src/agent_bom/cloud/gcp_inventory.py
@@ -335,6 +335,13 @@ def discover_inventory(
         "cloud_functions": [],
         "cloud_sql_instances": [],
         "vpc_networks": [],
+        "subnets": [],
+        "load_balancers": [],
+        "web_acls": [],
+        "api_gateways": [],
+        "nat_gateways": [],
+        "route_tables": [],
+        "ip_addresses": [],
         "disks": [],
         "pubsub_topics": [],
         "warnings": [],
@@ -385,6 +392,13 @@ def discover_inventory(
     cloud_functions: list[dict[str, Any]] = []
     cloud_sql_instances: list[dict[str, Any]] = []
     vpc_networks: list[dict[str, Any]] = []
+    subnets: list[dict[str, Any]] = []
+    load_balancers: list[dict[str, Any]] = []
+    web_acls: list[dict[str, Any]] = []
+    api_gateways: list[dict[str, Any]] = []
+    nat_gateways: list[dict[str, Any]] = []
+    route_tables: list[dict[str, Any]] = []
+    ip_addresses: list[dict[str, Any]] = []
     disks: list[dict[str, Any]] = []
     pubsub_topics: list[dict[str, Any]] = []
 
@@ -415,7 +429,22 @@ def discover_inventory(
     if include_databases:
         cloud_sql_instances = _discover_cloud_sql_instances(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
     if include_networks:
-        vpc_networks = _discover_vpc_networks(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
+        subnets_by_network = _discover_subnets_by_network(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
+        vpc_networks = _discover_vpc_networks(
+            resolved_project, credentials=credentials, warnings=warnings, missing=missing, subnets_by_network=subnets_by_network
+        )
+        subnets = _discover_subnets(subnets_by_network, project_id=resolved_project)
+        load_balancers, backends_by_policy = _discover_load_balancers(
+            resolved_project, credentials=credentials, warnings=warnings, missing=missing
+        )
+        web_acls = _discover_security_policies(
+            resolved_project, credentials=credentials, warnings=warnings, missing=missing, backends_by_policy=backends_by_policy
+        )
+        api_gateways = _discover_api_gateways(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
+        nat_gateways, route_tables = _discover_routers(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
+        ip_addresses = _discover_ip_addresses(
+            resolved_project, credentials=credentials, warnings=warnings, missing=missing, instances=instances
+        )
     if include_disks:
         disks = _discover_disks(resolved_project, credentials=credentials, warnings=warnings, missing=missing)
     if include_messaging:
@@ -435,7 +464,21 @@ def discover_inventory(
     if include_databases:
         permissions_used.append("cloudsql.instances.list")
     if include_networks:
-        permissions_used.extend(("compute.networks.list", "compute.subnetworks.list"))
+        permissions_used.extend(
+            (
+                "compute.networks.list",
+                "compute.subnetworks.list",
+                "compute.securityPolicies.list",
+                "compute.backendServices.list",
+                "compute.urlMaps.list",
+                "compute.forwardingRules.list",
+                "compute.targetHttpProxies.list",
+                "compute.targetHttpsProxies.list",
+                "compute.routers.list",
+                "compute.addresses.list",
+                "apigateway.gateways.list",
+            )
+        )
     if include_disks:
         permissions_used.append("compute.disks.list")
     if include_messaging:
@@ -464,6 +507,13 @@ def discover_inventory(
         "cloud_functions": cloud_functions,
         "cloud_sql_instances": cloud_sql_instances,
         "vpc_networks": vpc_networks,
+        "subnets": subnets,
+        "load_balancers": load_balancers,
+        "web_acls": web_acls,
+        "api_gateways": api_gateways,
+        "nat_gateways": nat_gateways,
+        "route_tables": route_tables,
+        "ip_addresses": ip_addresses,
         "disks": disks,
         "pubsub_topics": pubsub_topics,
         "warnings": warnings,
@@ -1177,16 +1227,27 @@ def _discover_cloud_sql_instances(
 
 
 def _discover_vpc_networks(
-    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+    project_id: str,
+    *,
+    credentials: Any,
+    warnings: list[str],
+    missing: list[dict[str, str]] | None = None,
+    subnets_by_network: dict[str, list[dict[str, Any]]] | None = None,
 ) -> list[dict[str, Any]]:
-    """Enumerate every VPC network + its subnets in the project (read-only)."""
+    """Enumerate every VPC network + its subnets in the project (read-only).
+
+    ``subnets_by_network`` may be supplied by the caller to reuse a single
+    aggregated subnet query (the flat ``subnets`` list shares the same data);
+    when ``None`` the subnets are queried here.
+    """
     try:
         from google.cloud import compute_v1
     except ImportError:
         warnings.append("google-cloud-compute not installed. Skipping VPC network inventory.")
         return []
 
-    subnets_by_network = _discover_subnets_by_network(project_id, credentials=credentials, warnings=warnings, missing=missing)
+    if subnets_by_network is None:
+        subnets_by_network = _discover_subnets_by_network(project_id, credentials=credentials, warnings=warnings, missing=missing)
     networks: list[dict[str, Any]] = []
     try:
         client = compute_v1.NetworksClient(credentials=credentials)
@@ -1234,8 +1295,11 @@ def _discover_subnets_by_network(
             for subnet in getattr(scoped_list, "subnetworks", None) or []:
                 network_link = str(getattr(subnet, "network", "") or "")
                 flow_logs = getattr(subnet, "enable_flow_logs", None)
+                subnet_name = str(getattr(subnet, "name", "") or "")
                 entry = {
-                    "name": str(getattr(subnet, "name", "") or ""),
+                    "id": str(getattr(subnet, "self_link", "") or "") or str(getattr(subnet, "id", "") or "") or subnet_name,
+                    "name": subnet_name,
+                    "network": network_link,
                     "region": _leaf(getattr(subnet, "region", "")),
                     "cidr": str(getattr(subnet, "ip_cidr_range", "") or ""),
                     "flow_logs": bool(flow_logs) if flow_logs is not None else False,
@@ -1252,6 +1316,480 @@ def _discover_subnets_by_network(
             missing=missing,
         )
     return by_network
+
+
+# ---------------------------------------------------------------------------
+# Subnets (flat list, reusing the aggregated subnet query)
+# ---------------------------------------------------------------------------
+
+
+def _discover_subnets(subnets_by_network: dict[str, list[dict[str, Any]]], *, project_id: str) -> list[dict[str, Any]]:
+    """Flatten the aggregated subnet map into a top-level ``subnets`` list.
+
+    Reuses the data already produced by ``_discover_subnets_by_network`` (which
+    keys each subnet under both its network self-link and the network leaf name),
+    so each subnet object is deduplicated by identity rather than re-queried.
+    """
+    seen: set[int] = set()
+    subnets: list[dict[str, Any]] = []
+    for entries in subnets_by_network.values():
+        for entry in entries:
+            marker = id(entry)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            name = str(entry.get("name", "") or "")
+            subnets.append(
+                {
+                    "id": str(entry.get("id", "") or "") or name,
+                    "name": name,
+                    "vpc_id": str(entry.get("network", "") or ""),
+                    "cidr": str(entry.get("cidr", "") or ""),
+                    "is_public": False,
+                    "location": str(entry.get("region", "") or ""),
+                    "account_id": project_id,
+                }
+            )
+    return subnets
+
+
+# ---------------------------------------------------------------------------
+# Load balancers (compute_v1: backend services / URL maps / forwarding rules /
+# target proxies) — normalized into one list, distinguished by ``lb_type``.
+# ---------------------------------------------------------------------------
+
+
+def _discover_load_balancers(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> tuple[list[dict[str, Any]], dict[str, list[str]]]:
+    """Enumerate the load-balancing data plane (read-only).
+
+    Backend services, URL maps, forwarding rules, and target HTTP(S) proxies are
+    normalized into a single list, each tagged with ``lb_type``. Also returns a
+    ``{security_policy_leaf: [backend_id…]}`` map so a Cloud Armor policy can list
+    the backend services it protects. Each resource class is queried in its own
+    try/except so one missing permission degrades only that class.
+    """
+    try:
+        from google.cloud import compute_v1
+    except ImportError:
+        warnings.append("google-cloud-compute not installed. Skipping load-balancer inventory.")
+        return [], {}
+
+    load_balancers: list[dict[str, Any]] = []
+    backends_by_policy: dict[str, list[str]] = {}
+
+    try:
+        client = compute_v1.BackendServicesClient(credentials=credentials)
+        for _scope, scoped_list in client.aggregated_list(project=project_id):
+            for backend in getattr(scoped_list, "backend_services", None) or []:
+                name = str(getattr(backend, "name", "") or "").strip()
+                if not name:
+                    continue
+                scheme = str(getattr(backend, "load_balancing_scheme", "") or "").upper()
+                backend_id = str(getattr(backend, "id", "") or "") or name
+                load_balancers.append(
+                    {
+                        "name": name,
+                        "id": backend_id,
+                        "lb_type": "backend-service",
+                        "scheme": scheme,
+                        "internet_exposed": "EXTERNAL" in scheme,
+                        "location": _leaf(getattr(backend, "region", "")) or "global",
+                        "account_id": project_id,
+                    }
+                )
+                policy_leaf = _leaf(getattr(backend, "security_policy", ""))
+                if policy_leaf:
+                    backends_by_policy.setdefault(policy_leaf, []).append(backend_id)
+    except Exception as exc:  # noqa: BLE001 — one failed backend-services list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="backend services",
+            permission="compute.backendServices.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
+
+    try:
+        client = compute_v1.UrlMapsClient(credentials=credentials)
+        for url_map in client.list(project=project_id):
+            name = str(getattr(url_map, "name", "") or "").strip()
+            if not name:
+                continue
+            load_balancers.append(
+                {
+                    "name": name,
+                    "id": str(getattr(url_map, "id", "") or "") or name,
+                    "lb_type": "url-map",
+                    "scheme": "",
+                    "internet_exposed": False,
+                    "location": _leaf(getattr(url_map, "region", "")) or "global",
+                    "account_id": project_id,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001 — one failed URL-maps list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="URL maps",
+            permission="compute.urlMaps.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
+
+    try:
+        client = compute_v1.ForwardingRulesClient(credentials=credentials)
+        for _scope, scoped_list in client.aggregated_list(project=project_id):
+            for rule in getattr(scoped_list, "forwarding_rules", None) or []:
+                name = str(getattr(rule, "name", "") or "").strip()
+                if not name:
+                    continue
+                scheme = str(getattr(rule, "load_balancing_scheme", "") or "").upper()
+                load_balancers.append(
+                    {
+                        "name": name,
+                        "id": str(getattr(rule, "id", "") or "") or name,
+                        "lb_type": "forwarding-rule",
+                        "scheme": scheme,
+                        "internet_exposed": "EXTERNAL" in scheme,
+                        "location": _leaf(getattr(rule, "region", "")) or "global",
+                        "account_id": project_id,
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001 — one failed forwarding-rules list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="forwarding rules",
+            permission="compute.forwardingRules.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
+
+    load_balancers.extend(_discover_target_proxies(project_id, credentials=credentials, warnings=warnings, missing=missing))
+    return load_balancers, backends_by_policy
+
+
+def _discover_target_proxies(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
+    """Enumerate target HTTP + HTTPS proxies (read-only), normalized as LBs."""
+    try:
+        from google.cloud import compute_v1
+    except ImportError:
+        return []
+
+    proxies: list[dict[str, Any]] = []
+    try:
+        client = compute_v1.TargetHttpProxiesClient(credentials=credentials)
+        for proxy in client.list(project=project_id):
+            name = str(getattr(proxy, "name", "") or "").strip()
+            if not name:
+                continue
+            proxies.append(
+                {
+                    "name": name,
+                    "id": str(getattr(proxy, "id", "") or "") or name,
+                    "lb_type": "target-proxy",
+                    "scheme": "",
+                    "internet_exposed": False,
+                    "location": "global",
+                    "account_id": project_id,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001 — one failed target-HTTP-proxies list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="target HTTP proxies",
+            permission="compute.targetHttpProxies.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
+
+    try:
+        client = compute_v1.TargetHttpsProxiesClient(credentials=credentials)
+        for proxy in client.list(project=project_id):
+            name = str(getattr(proxy, "name", "") or "").strip()
+            if not name:
+                continue
+            proxies.append(
+                {
+                    "name": name,
+                    "id": str(getattr(proxy, "id", "") or "") or name,
+                    "lb_type": "target-proxy",
+                    "scheme": "",
+                    "internet_exposed": False,
+                    "location": "global",
+                    "account_id": project_id,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001 — one failed target-HTTPS-proxies list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="target HTTPS proxies",
+            permission="compute.targetHttpsProxies.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
+    return proxies
+
+
+# ---------------------------------------------------------------------------
+# Cloud Armor security policies (compute_v1) — GCP's WAF → web_acls
+# ---------------------------------------------------------------------------
+
+
+def _discover_security_policies(
+    project_id: str,
+    *,
+    credentials: Any,
+    warnings: list[str],
+    missing: list[dict[str, str]] | None = None,
+    backends_by_policy: dict[str, list[str]] | None = None,
+) -> list[dict[str, Any]]:
+    """Enumerate Cloud Armor security policies (read-only) → ``web_acls`` shape.
+
+    ``protected_targets`` is resolved from the backend services that reference
+    each policy (passed in via ``backends_by_policy``) so the graph can link a
+    policy to the resources it shields.
+    """
+    try:
+        from google.cloud import compute_v1
+    except ImportError:
+        warnings.append("google-cloud-compute not installed. Skipping Cloud Armor inventory.")
+        return []
+
+    by_policy = backends_by_policy or {}
+    policies: list[dict[str, Any]] = []
+    try:
+        client = compute_v1.SecurityPoliciesClient(credentials=credentials)
+        for policy in client.list(project=project_id):
+            name = str(getattr(policy, "name", "") or "").strip()
+            if not name:
+                continue
+            policies.append(
+                {
+                    "name": name,
+                    "id": str(getattr(policy, "id", "") or "") or name,
+                    "arn": "",
+                    "scope": "cloud-armor",
+                    "protected_targets": list(by_policy.get(name, [])),
+                    "location": "global",
+                    "account_id": project_id,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001 — one failed Cloud Armor policies list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="Cloud Armor policies",
+            permission="compute.securityPolicies.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
+    return policies
+
+
+# ---------------------------------------------------------------------------
+# API Gateway (apigateway_v1) — GCP managed API front door → api_gateways
+# ---------------------------------------------------------------------------
+
+
+def _discover_api_gateways(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> list[dict[str, Any]]:
+    """Enumerate API Gateway gateways in the project (read-only).
+
+    Gateways front backend services with a public default hostname, so each is
+    marked ``internet_exposed``. Degrades to ``[]`` plus a warning when the
+    apigateway SDK is absent.
+    """
+    try:
+        from google.cloud import apigateway_v1
+    except ImportError:
+        warnings.append("google-cloud-api-gateway not installed. Skipping API Gateway inventory.")
+        return []
+
+    gateways: list[dict[str, Any]] = []
+    try:
+        client = apigateway_v1.ApiGatewayServiceClient(credentials=credentials)
+        request = apigateway_v1.ListGatewaysRequest(parent=f"projects/{project_id}/locations/-")
+        for gateway in client.list_gateways(request=request):
+            full_name = str(getattr(gateway, "name", "") or "").strip()
+            name = _leaf(full_name)
+            if not name:
+                continue
+            api_config = _leaf(getattr(gateway, "api_config", ""))
+            gateways.append(
+                {
+                    "name": name,
+                    "id": full_name or name,
+                    "arn": "",
+                    "protocol": "apigateway",
+                    "endpoint": str(getattr(gateway, "default_hostname", "") or ""),
+                    "internet_exposed": True,
+                    "stages": [],
+                    "protected_targets": [api_config] if api_config else [],
+                    "location": _segment(full_name, "locations"),
+                    "account_id": project_id,
+                }
+            )
+    except Exception as exc:  # noqa: BLE001 — one failed API Gateway list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="API gateways",
+            permission="apigateway.gateways.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
+    return gateways
+
+
+# ---------------------------------------------------------------------------
+# Cloud routers + Cloud NAT (compute_v1 RoutersClient.aggregated_list)
+# ---------------------------------------------------------------------------
+
+
+def _discover_routers(
+    project_id: str, *, credentials: Any, warnings: list[str], missing: list[dict[str, str]] | None = None
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Enumerate Cloud routers + their NAT configs (read-only).
+
+    Returns ``(nat_gateways, route_tables)``: each router becomes a route-table
+    entry (``has_internet_route`` True when it carries a NAT egress config), and
+    each NAT config on a router becomes a NAT-gateway entry.
+    """
+    try:
+        from google.cloud import compute_v1
+    except ImportError:
+        warnings.append("google-cloud-compute not installed. Skipping router/NAT inventory.")
+        return [], []
+
+    nat_gateways: list[dict[str, Any]] = []
+    route_tables: list[dict[str, Any]] = []
+    try:
+        client = compute_v1.RoutersClient(credentials=credentials)
+        for _scope, scoped_list in client.aggregated_list(project=project_id):
+            for router in getattr(scoped_list, "routers", None) or []:
+                name = str(getattr(router, "name", "") or "").strip()
+                if not name:
+                    continue
+                network = _leaf(getattr(router, "network", ""))
+                region = _leaf(getattr(router, "region", ""))
+                router_id = str(getattr(router, "id", "") or "") or name
+                nats = list(getattr(router, "nats", None) or [])
+                route_tables.append(
+                    {
+                        "id": router_id,
+                        "name": name,
+                        "vpc_id": network,
+                        "has_internet_route": bool(nats),
+                        "location": region,
+                        "account_id": project_id,
+                    }
+                )
+                for nat in nats:
+                    nat_name = str(getattr(nat, "name", "") or "").strip()
+                    if not nat_name:
+                        continue
+                    nat_gateways.append(
+                        {
+                            "id": f"{name}/{nat_name}",
+                            "name": nat_name,
+                            "vpc_id": network,
+                            "subnet_id": "",
+                            "location": region,
+                            "account_id": project_id,
+                        }
+                    )
+    except Exception as exc:  # noqa: BLE001 — one failed routers list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="routers",
+            permission="compute.routers.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
+    return nat_gateways, route_tables
+
+
+# ---------------------------------------------------------------------------
+# External IP addresses (reserved via AddressesClient + ephemeral from instances)
+# ---------------------------------------------------------------------------
+
+
+def _discover_ip_addresses(
+    project_id: str,
+    *,
+    credentials: Any,
+    warnings: list[str],
+    missing: list[dict[str, str]] | None = None,
+    instances: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    """Enumerate reserved external IPs + ephemeral external IPs (read-only).
+
+    Reserved addresses come from ``AddressesClient.aggregated_list``; ephemeral
+    external IPs are read from the already-discovered instances' access configs
+    (their ``public_ip``) and de-duplicated against the reserved set so a static
+    IP attached to a VM is not double-counted.
+    """
+    try:
+        from google.cloud import compute_v1
+    except ImportError:
+        warnings.append("google-cloud-compute not installed. Skipping IP-address inventory.")
+        return []
+
+    ip_addresses: list[dict[str, Any]] = []
+    reserved_values: set[str] = set()
+    try:
+        client = compute_v1.AddressesClient(credentials=credentials)
+        for _scope, scoped_list in client.aggregated_list(project=project_id):
+            for address in getattr(scoped_list, "addresses", None) or []:
+                value = str(getattr(address, "address", "") or "").strip()
+                if not value:
+                    continue
+                reserved_values.add(value)
+                users = [_leaf(u) for u in (getattr(address, "users", None) or []) if u]
+                ip_addresses.append(
+                    {
+                        "address": value,
+                        "kind": "reserved",
+                        "attached_to": users[0] if users else "",
+                        "location": _leaf(getattr(address, "region", "")) or "global",
+                        "account_id": project_id,
+                    }
+                )
+    except Exception as exc:  # noqa: BLE001 — one failed addresses list must not sink the scan
+        record_discovery_failure(
+            exc=exc,
+            resource_type="reserved IP addresses",
+            permission="compute.addresses.list",
+            cloud="gcp",
+            warnings=warnings,
+            missing=missing,
+        )
+
+    for instance in instances or []:
+        public_ip = str(instance.get("public_ip", "") or "").strip()
+        if not public_ip or public_ip in reserved_values:
+            continue
+        reserved_values.add(public_ip)
+        ip_addresses.append(
+            {
+                "address": public_ip,
+                "kind": "ephemeral",
+                "attached_to": str(instance.get("name", "") or instance.get("instance_id", "") or ""),
+                "location": str(instance.get("zone", "") or ""),
+                "account_id": project_id,
+            }
+        )
+    return ip_addresses
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -4473,6 +4473,12 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
     if provider == "gcp":
         _apply_gcp_firewall_exposure(graph, sg_node_by_id, instance_nodes)
 
+    instance_node_by_id: dict[str, str] = {}
+    for inst_node_id, instance in instance_nodes:
+        iid = _clean_graph_part(instance.get("instance_id")) or _clean_graph_part(instance.get("id"))
+        if iid:
+            instance_node_by_id[iid] = inst_node_id
+
     # ── AWS data + compute services (RDS / DynamoDB / Lambda / EKS) ──────
     # (key, service, resource_type, kind, label, is_data_store)
     for coll_key, svc, rtype, kind, label, is_data in (
@@ -4597,6 +4603,20 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
         region=region,
         data_sources=data_sources,
         resource_ids=resource_ids,
+    )
+
+    # ── Network edge: WAF, API gateways, ENIs/NICs, subnets, NAT/IGW, IPs ──
+    _add_network_edge_inventory(
+        graph,
+        inventory,
+        provider=provider,
+        account_id=account_id,
+        account_node_id=account_node_id,
+        region=region,
+        data_sources=data_sources,
+        resource_ids=resource_ids,
+        sg_node_by_id=sg_node_by_id,
+        instance_node_by_id=instance_node_by_id,
     )
 
     # ── Management-group hierarchy (org → subscription CONTAINS tree) ──
@@ -4791,6 +4811,320 @@ def _add_normalized_cloud_resources(
                         evidence={"source": "cloud-inventory", "reason": "public_ip_frontend"},
                     )
                 )
+
+
+# Generic network-edge collections promoted as CLOUD_RESOURCE inventory nodes.
+# (payload key, cloud service, resource_type, resource_kind, label, id field)
+# Load balancers are intentionally NOT here: AWS uses ``elb_load_balancers`` and
+# Azure routes them through the normalized-resource path; only GCP's new
+# ``load_balancers`` key is ingested here, gated to GCP below.
+_NETWORK_EDGE_COLLECTIONS: tuple[tuple[str, str, str, str, str, str], ...] = (
+    ("nat_gateways", "network", "nat_gateway", "nat-gateway", "nat gateway", "id"),
+    ("internet_gateways", "network", "internet_gateway", "internet-gateway", "internet gateway", "id"),
+    ("vpc_endpoints", "network", "vpc_endpoint", "vpc-endpoint", "vpc endpoint", "id"),
+    ("route_tables", "network", "route_table", "route-table", "route table", "id"),
+    ("network_acls", "network", "network_acl", "network-acl", "network acl", "id"),
+)
+_GCP_LB_COLLECTION: tuple[str, str, str, str, str, str] = (
+    "load_balancers",
+    "network",
+    "load_balancer",
+    "load-balancer",
+    "load balancer",
+    "id",
+)
+
+
+def _add_network_edge_inventory(
+    graph: UnifiedGraph,
+    inventory: dict[str, Any],
+    *,
+    provider: str,
+    account_id: str,
+    account_node_id: str,
+    region: str,
+    data_sources: list[str],
+    resource_ids: list[str],
+    sg_node_by_id: dict[str, str],
+    instance_node_by_id: dict[str, str],
+) -> None:
+    """Promote network-edge inventory into nodes + exposure-relevant edges.
+
+    Emits, from the live inventory payload (all three clouds):
+
+    - **API gateways** (AWS API Gateway, GCP API Gateway/Apigee, Azure API
+      Management) → ``API_GATEWAY`` nodes in the API_GATEWAY semantic layer.
+    - **WAF / Cloud Armor** web ACLs → ``CLOUD_RESOURCE`` nodes.
+    - A ``PROTECTS`` edge from each WAF / API gateway to the resource it fronts,
+      so the CNAPP overlay can refine the fronted resource's exposure verdict.
+    - **Subnets** → ``CLOUD_RESOURCE``; a public subnet is ``internet_exposed``.
+    - **ENIs / NICs** → ``CLOUD_RESOURCE`` wired ``PART_OF`` their instance,
+      subnet, and security group(s) so the network path is traversable; an ENI
+      carrying a public IP marks its instance internet-reachable.
+    - NAT/internet gateways, route tables, network ACLs, VPC endpoints, load
+      balancers, and IP addresses → ``CLOUD_RESOURCE`` inventory nodes.
+
+    Never raises into the builder; missing/empty collections are a no-op.
+    """
+    # Index existing resource nodes by their native id/arn/name so a WAF / API
+    # gateway's protected-target reference resolves to the real node.
+    ref_to_node: dict[str, str] = {}
+    for nid in resource_ids:
+        node = graph.nodes.get(nid)
+        if node is None:
+            continue
+        for key in ("resource_id", "resource_name"):
+            ref = _clean_graph_part(node.attributes.get(key))
+            if ref:
+                ref_to_node.setdefault(ref, nid)
+
+    def _emit_resource(*, node_id: str, service: str, rtype: str, kind: str, label: str, name: str, attrs: dict[str, Any]) -> None:
+        graph.add_node(
+            UnifiedNode(
+                id=node_id,
+                entity_type=EntityType.CLOUD_RESOURCE,
+                label=f"{label}: {name}",
+                attributes={
+                    "resource_name": name,
+                    "resource_type": rtype,
+                    "resource_kind": kind,
+                    "cloud_provider": provider,
+                    "cloud_service": service,
+                    "location": _clean_graph_part(attrs.get("location")) or region,
+                    "account_id": account_id,
+                    **attrs,
+                },
+                data_sources=data_sources,
+                dimensions=NodeDimensions(cloud_provider=provider, surface="network"),
+            )
+        )
+        resource_ids.append(node_id)
+        if account_node_id:
+            graph.add_edge(
+                UnifiedEdge(
+                    source=account_node_id, target=node_id, relationship=RelationshipType.OWNS, evidence={"source": "cloud-inventory"}
+                )
+            )
+
+    def _protect(source_node_id: str, targets: list[Any], reason: str) -> None:
+        for target_ref in targets or []:
+            ref = _clean_graph_part(target_ref)
+            target_node_id = ref_to_node.get(ref)
+            if not target_node_id:
+                continue
+            graph.add_edge(
+                UnifiedEdge(
+                    source=source_node_id,
+                    target=target_node_id,
+                    relationship=RelationshipType.PROTECTS,
+                    weight=4.0,
+                    evidence={"source": "cloud-inventory", "reason": reason},
+                )
+            )
+
+    # ── Subnets (public subnet = internet-reachable) ──
+    subnet_node_by_id: dict[str, str] = {}
+    for sn in inventory.get("subnets", []) or []:
+        if not isinstance(sn, dict):
+            continue
+        sn_id = _clean_graph_part(sn.get("id"))
+        if not sn_id:
+            continue
+        node_id = f"cloud_resource:{provider}:network:subnet:{sn_id}"
+        subnet_node_by_id[sn_id] = node_id
+        _emit_resource(
+            node_id=node_id,
+            service="network",
+            rtype="subnet",
+            kind="subnet",
+            label="subnet",
+            name=_clean_graph_part(sn.get("name")) or sn_id,
+            attrs={
+                "resource_id": sn_id,
+                "vpc_id": _clean_graph_part(sn.get("vpc_id")),
+                "cidr": _clean_graph_part(sn.get("cidr")),
+                "is_public": bool(sn.get("is_public")),
+                "internet_exposed": bool(sn.get("is_public")),
+            },
+        )
+
+    # ── Generic edge resources (NAT/IGW/route-table/NACL/VPCe + GCP LB) ──
+    collections = list(_NETWORK_EDGE_COLLECTIONS)
+    if provider == "gcp":
+        collections.append(_GCP_LB_COLLECTION)
+    for coll_key, svc, rtype, kind, label, id_field in collections:
+        for item in inventory.get(coll_key, []) or []:
+            if not isinstance(item, dict):
+                continue
+            ident = _clean_graph_part(item.get(id_field)) or _clean_graph_part(item.get("name"))
+            if not ident:
+                continue
+            node_id = f"cloud_resource:{provider}:{svc}:{rtype}:{ident}"
+            _emit_resource(
+                node_id=node_id,
+                service=svc,
+                rtype=rtype,
+                kind=kind,
+                label=label,
+                name=_clean_graph_part(item.get("name")) or ident,
+                attrs={
+                    "resource_id": ident,
+                    "vpc_id": _clean_graph_part(item.get("vpc_id")),
+                    "internet_exposed": bool(item.get("internet_exposed")),
+                    "has_internet_route": bool(item.get("has_internet_route")),
+                },
+            )
+
+    # ── IP addresses (Elastic/reserved/public) ──
+    for ip in inventory.get("ip_addresses", []) or []:
+        if not isinstance(ip, dict):
+            continue
+        address = _clean_graph_part(ip.get("address"))
+        if not address:
+            continue
+        node_id = f"cloud_resource:{provider}:network:ip_address:{address}"
+        _emit_resource(
+            node_id=node_id,
+            service="network",
+            rtype="ip_address",
+            kind="ip-address",
+            label="ip address",
+            name=address,
+            attrs={
+                "resource_id": address,
+                "ip_kind": _clean_graph_part(ip.get("kind")),
+                "attached_to": _clean_graph_part(ip.get("attached_to")),
+                "internet_exposed": True,
+            },
+        )
+
+    # ── ENIs / NICs → PART_OF instance + subnet + security group(s) ──
+    for eni in inventory.get("network_interfaces", []) or []:
+        if not isinstance(eni, dict):
+            continue
+        eni_id = _clean_graph_part(eni.get("id"))
+        if not eni_id:
+            continue
+        node_id = f"cloud_resource:{provider}:network:network_interface:{eni_id}"
+        public_ip = _clean_graph_part(eni.get("public_ip"))
+        _emit_resource(
+            node_id=node_id,
+            service="network",
+            rtype="network_interface",
+            kind="network-interface",
+            label="network interface",
+            name=_clean_graph_part(eni.get("name")) or eni_id,
+            attrs={
+                "resource_id": eni_id,
+                "vpc_id": _clean_graph_part(eni.get("vpc_id")),
+                "subnet_id": _clean_graph_part(eni.get("subnet_id")),
+                "private_ip": _clean_graph_part(eni.get("private_ip")),
+                "public_ip": public_ip,
+                "internet_exposed": bool(public_ip),
+            },
+        )
+        instance_node_id = instance_node_by_id.get(_clean_graph_part(eni.get("instance_id")))
+        if instance_node_id:
+            graph.add_edge(
+                UnifiedEdge(
+                    source=node_id, target=instance_node_id, relationship=RelationshipType.PART_OF, evidence={"source": "cloud-inventory"}
+                )
+            )
+            # A public IP on the ENI makes the attached instance internet-reachable.
+            if public_ip:
+                inst_node = graph.nodes.get(instance_node_id)
+                if inst_node is not None:
+                    inst_node.attributes["internet_exposed"] = True
+        subnet_node_id = subnet_node_by_id.get(_clean_graph_part(eni.get("subnet_id")))
+        if subnet_node_id:
+            graph.add_edge(
+                UnifiedEdge(
+                    source=node_id, target=subnet_node_id, relationship=RelationshipType.PART_OF, evidence={"source": "cloud-inventory"}
+                )
+            )
+        for sg_id in eni.get("security_group_ids", []) or []:
+            sg_node_id = sg_node_by_id.get(_clean_graph_part(sg_id))
+            if sg_node_id:
+                graph.add_edge(
+                    UnifiedEdge(
+                        source=node_id, target=sg_node_id, relationship=RelationshipType.PART_OF, evidence={"source": "cloud-inventory"}
+                    )
+                )
+
+    # ── WAF / Cloud Armor web ACLs → CLOUD_RESOURCE + PROTECTS ──
+    for acl in inventory.get("web_acls", []) or []:
+        if not isinstance(acl, dict):
+            continue
+        acl_id = _clean_graph_part(acl.get("id")) or _clean_graph_part(acl.get("arn")) or _clean_graph_part(acl.get("name"))
+        if not acl_id:
+            continue
+        name = _clean_graph_part(acl.get("name")) or acl_id
+        node_id = f"cloud_resource:{provider}:waf:web_acl:{acl_id}"
+        _emit_resource(
+            node_id=node_id,
+            service="waf",
+            rtype="waf",
+            kind="web-acl",
+            label="waf",
+            name=name,
+            attrs={"resource_id": _clean_graph_part(acl.get("arn")) or acl_id, "scope": _clean_graph_part(acl.get("scope"))},
+        )
+        _protect(node_id, acl.get("protected_targets", []), "waf_web_acl_association")
+
+    # ── API gateways → API_GATEWAY nodes (+ Azure API Management) + PROTECTS ──
+    api_gateway_items = list(inventory.get("api_gateways", []) or [])
+    for apim in inventory.get("api_management", []) or []:
+        if isinstance(apim, dict):
+            api_gateway_items.append(
+                {
+                    "name": apim.get("name"),
+                    "id": apim.get("id") or apim.get("name"),
+                    "protocol": "apim",
+                    "endpoint": apim.get("gateway_url") or apim.get("endpoint") or "",
+                    "internet_exposed": True,
+                    "stages": [],
+                    "protected_targets": apim.get("protected_targets", []),
+                    "location": apim.get("location"),
+                }
+            )
+    for api in api_gateway_items:
+        if not isinstance(api, dict):
+            continue
+        api_id = _clean_graph_part(api.get("id")) or _clean_graph_part(api.get("arn")) or _clean_graph_part(api.get("name"))
+        if not api_id:
+            continue
+        name = _clean_graph_part(api.get("name")) or api_id
+        node_id = f"api_gateway:{provider}:{api_id}"
+        graph.add_node(
+            UnifiedNode(
+                id=node_id,
+                entity_type=EntityType.API_GATEWAY,
+                label=f"api gateway: {name}",
+                attributes={
+                    "resource_id": _clean_graph_part(api.get("arn")) or api_id,
+                    "resource_name": name,
+                    "resource_type": "api_gateway",
+                    "cloud_provider": provider,
+                    "protocol": _clean_graph_part(api.get("protocol")),
+                    "endpoint": _clean_graph_part(api.get("endpoint")),
+                    "stages": list(api.get("stages", []) or []),
+                    "internet_exposed": bool(api.get("internet_exposed")),
+                    "location": _clean_graph_part(api.get("location")) or region,
+                    "account_id": account_id,
+                    "semantic_layer": "api_gateway",
+                },
+                data_sources=data_sources,
+                dimensions=NodeDimensions(cloud_provider=provider, surface="api_gateway"),
+            )
+        )
+        resource_ids.append(node_id)
+        if account_node_id:
+            graph.add_edge(
+                UnifiedEdge(
+                    source=account_node_id, target=node_id, relationship=RelationshipType.OWNS, evidence={"source": "cloud-inventory"}
+                )
+            )
+        _protect(node_id, api.get("protected_targets", []), "api_gateway_frontend")
 
 
 def _add_inventory_principal(

--- a/src/agent_bom/graph/cnapp_overlay.py
+++ b/src/agent_bom/graph/cnapp_overlay.py
@@ -188,6 +188,15 @@ def apply_cnapp_overlay(graph: UnifiedGraph) -> dict[str, int]:
         if edge.relationship == RelationshipType.VULNERABLE_TO:
             vulnerable_resources.add(edge.source)
 
+    # Resources fronted by a WAF / API gateway (a PROTECTS edge). A protected
+    # resource's internet exposure is mitigated — its exposure verdict is
+    # downgraded below an unprotected peer's so the graph does not score a
+    # WAF-fronted asset identically to a bare one.
+    protected_ids: set[str] = set()
+    for edge in graph.edges:
+        if edge.relationship == RelationshipType.PROTECTS:
+            protected_ids.add(edge.target)
+
     # Map a misconfiguration to the resources it AFFECTS so exposure can attach
     # to the real asset rather than the finding node.
     affected_by_misconfig: dict[str, list[str]] = {}
@@ -215,6 +224,17 @@ def apply_cnapp_overlay(graph: UnifiedGraph) -> dict[str, int]:
         if node.attributes.get("internet_exposed") or _matches(_text_of(node), _EXPOSURE_KEYWORDS):
             node.attributes["internet_exposed"] = True
             exposed_ids.add(node.id)
+
+    # Record exposure mitigation on every protected + exposed resource so its
+    # verdict differs from an unprotected peer, whether or not it is vulnerable.
+    mitigated = 0
+    for resource_id in exposed_ids & protected_ids:
+        node = graph.nodes.get(resource_id)
+        if node is None:
+            continue
+        node.attributes["exposure_mitigated"] = True
+        node.attributes["protected_by_waf"] = True
+        mitigated += 1
 
     # Classify data stores and attach a DATA_STORE companion node.
     data_stores_added = 0
@@ -262,11 +282,32 @@ def apply_cnapp_overlay(graph: UnifiedGraph) -> dict[str, int]:
                 )
             )
 
-    # Toxic combinations: internet-exposed AND vulnerable.
+    # Toxic combinations: internet-exposed AND vulnerable. A WAF/API-gateway in
+    # front of the resource mitigates the exposure, so the verdict is downgraded
+    # (lower risk, distinct pattern) instead of the full toxic escalation.
     toxic = 0
+    toxic_mitigated = 0
     for resource_id in sorted(exposed_ids & vulnerable_resources):
         node = graph.nodes.get(resource_id)
         if node is None:
+            continue
+        if resource_id in protected_ids:
+            node.attributes["toxic_exposed_vulnerable_mitigated"] = True
+            if node.risk_score < 6.5:
+                node.risk_score = 6.5
+            graph.interaction_risks.append(
+                InteractionRisk(
+                    pattern="internet_exposed_vulnerable_mitigated",
+                    agents=[node.label],
+                    risk_score=6.5,
+                    description=(
+                        f"{node.label} carries a known vulnerability and is internet-exposed but fronted by a WAF/API gateway "
+                        "(exposure mitigated)."
+                    ),
+                    owasp_agentic_tag=None,
+                )
+            )
+            toxic_mitigated += 1
             continue
         node.attributes["toxic_exposed_vulnerable"] = True
         if node.risk_score < 9.0:
@@ -335,6 +376,8 @@ def apply_cnapp_overlay(graph: UnifiedGraph) -> dict[str, int]:
         "exposed_nodes": len(exposed_ids),
         "data_stores_added": data_stores_added,
         "toxic_combinations": toxic,
+        "toxic_combinations_mitigated": toxic_mitigated,
+        "exposure_mitigated_nodes": mitigated,
         "sensitive_data_nodes": len(sensitive_ids),
         "exposed_sensitive_data": exposed_sensitive,
     }

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -895,6 +895,7 @@ ENTITY_LEGEND: list[LegendEntry] = [
     LegendEntry(key="drift_incident", label="Drift Incident", color="#fb923c", shape="triangle", layer=GraphSemanticLayer.FINDING.value),
     LegendEntry(key="data_store", label="Data Store", color="#0284c7", shape="square", layer=GraphSemanticLayer.ASSET.value),
     LegendEntry(key="application", label="Application", color="#7c3aed", shape="circle", layer=GraphSemanticLayer.APP.value),
+    LegendEntry(key="api_gateway", label="API Gateway", color="#2563eb", shape="diamond", layer=GraphSemanticLayer.API_GATEWAY.value),
 ]
 
 RELATIONSHIP_LEGEND: list[LegendEntry] = [
@@ -951,6 +952,7 @@ RELATIONSHIP_LEGEND: list[LegendEntry] = [
     LegendEntry(key="exposed_to", label="Exposed To", color="#e11d48"),
     LegendEntry(key="stores", label="Stores", color="#0284c7"),
     LegendEntry(key="has_permission", label="Has Permission", color="#dc2626"),
+    LegendEntry(key="protects", label="Protects (WAF/gateway)", color="#2563eb"),
     # ASPM
     LegendEntry(key="belongs_to", label="Belongs To (application)", color="#7c3aed"),
 ]

--- a/src/agent_bom/graph/ocsf.py
+++ b/src/agent_bom/graph/ocsf.py
@@ -53,6 +53,8 @@ ENTITY_OCSF_MAP: dict[str, dict[str, int]] = {
     EntityType.DRIFT_INCIDENT: {"category_uid": 2, "class_uid": 2004},
     # Cloud-CNAPP data primitive (Category 5 — inventory)
     EntityType.DATA_STORE: {"category_uid": 5, "class_uid": 4001},
+    # Network-edge primitive (Category 5 — inventory)
+    EntityType.API_GATEWAY: {"category_uid": 5, "class_uid": 4001},
     # ASPM application root (Category 5 — inventory)
     EntityType.APPLICATION: {"category_uid": 5, "class_uid": 4001},
     # Organizational (virtual)

--- a/src/agent_bom/graph/types.py
+++ b/src/agent_bom/graph/types.py
@@ -58,6 +58,13 @@ class EntityType(str, Enum):
     # and path-to-sensitive-data first-class for attack-path traversal.
     DATA_STORE = "data_store"  # database / bucket / data lake holding data at rest
 
+    # Network-edge primitive — an API gateway / managed front-door that fronts an
+    # exposed resource. Populated from live cloud inventory (AWS API Gateway, GCP
+    # API Gateway/Apigee, Azure API Management) so the API_GATEWAY semantic layer
+    # carries real nodes and a WAF/gateway in front of a resource refines its
+    # exposure verdict via the PROTECTS edge.
+    API_GATEWAY = "api_gateway"
+
     # Application Security Posture Management (ASPM) — an application is the
     # correlation root that AppSec findings (SCA / secrets / IaC / container /
     # CI-CD / AI-BOM) are grouped and rolled up around. Derived per
@@ -141,6 +148,7 @@ class RelationshipType(str, Enum):
     EXPOSED_TO = "exposed_to"  # resource/server/agent → network/resource (public/internet reach)
     STORES = "stores"  # cloud_resource/data_store/server → dataset/data_store (data at rest)
     HAS_PERMISSION = "has_permission"  # principal/managed_identity → resource/data_store/tool (effective)
+    PROTECTS = "protects"  # waf/api_gateway → resource it fronts (mitigates internet exposure)
 
     # ── Runtime events (dynamic) ──
     ACTED_AS = "acted_as"  # user/service principal → agent (runtime identity)

--- a/tests/test_azure_parallel_discovery.py
+++ b/tests/test_azure_parallel_discovery.py
@@ -25,26 +25,35 @@ def _stub_azure_sdk(monkeypatch):
     monkeypatch.setitem(sys.modules, "azure.identity", identity_mod)
 
 
+# Every per-subscription discoverer registered in azure_inventory's discovery_tasks,
+# in registration order (the order warnings come out). Keep in sync with that list.
 _SERVICES = [
     "_discover_storage_accounts",
     "_discover_vms",
     "_discover_aks_clusters",
+    "_discover_managed_disks",
+    "_discover_app_services",
     "_discover_nsgs",
     "_discover_managed_identities",
     "_discover_role_assignments",
     "_discover_key_vaults",
     "_discover_container_registries",
     "_discover_databases",
-    "_discover_virtual_networks",
-    "_discover_public_ips",
-    "_discover_load_balancers",
-    "_discover_managed_disks",
-    "_discover_app_services",
     "_discover_event_hubs",
     "_discover_service_bus",
     "_discover_redis_caches",
+    "_discover_virtual_networks",
+    "_discover_subnets",
+    "_discover_public_ips",
+    "_discover_ip_addresses",
+    "_discover_network_interfaces",
+    "_discover_load_balancers",
     "_discover_application_gateways",
     "_discover_front_doors",
+    "_discover_azure_firewalls",
+    "_discover_nat_gateways",
+    "_discover_route_tables",
+    "_discover_private_endpoints",
     "_discover_api_management",
 ]
 

--- a/tests/test_cloud_azure_inventory.py
+++ b/tests/test_cloud_azure_inventory.py
@@ -116,9 +116,162 @@ class _FakeNSGOps:
         ]
 
 
+_VNET_ID = "/subscriptions/sub-1/resourceGroups/rg-net/providers/Microsoft.Network/virtualNetworks/vnet-1"
+_WEB_SUBNET_ID = f"{_VNET_ID}/subnets/web-subnet"
+_DB_SUBNET_ID = f"{_VNET_ID}/subnets/db-subnet"
+_NIC_IPCONFIG_ID = (
+    "/subscriptions/sub-1/resourceGroups/rg-web/providers/Microsoft.Network/networkInterfaces/nic-1/ipConfigurations/ipconfig1"
+)
+
+
+class _FakeVNetOps:
+    def list_all(self) -> list[Any]:
+        return [
+            _Obj(
+                name="vnet-1",
+                id=_VNET_ID,
+                location="eastus",
+                address_space=_Obj(address_prefixes=["10.0.0.0/16"]),
+                subnets=[
+                    _Obj(name="web-subnet", id=_WEB_SUBNET_ID, address_prefix="10.0.1.0/24", nat_gateway=_Obj(id="nat-1")),
+                    _Obj(name="db-subnet", id=_DB_SUBNET_ID, address_prefix="10.0.2.0/24", nat_gateway=None),
+                ],
+            )
+        ]
+
+
+class _FakePublicIPOps:
+    def list_all(self) -> list[Any]:
+        return [
+            _Obj(
+                name="pip-1",
+                id="/subscriptions/sub-1/resourceGroups/rg-web/providers/Microsoft.Network/publicIPAddresses/pip-1",
+                location="eastus",
+                ip_address="52.1.2.3",
+                public_ip_allocation_method="Static",
+                ip_configuration=_Obj(id=_NIC_IPCONFIG_ID),
+            ),
+            _Obj(
+                name="pip-unassigned",
+                id="/subscriptions/sub-1/resourceGroups/rg-web/providers/Microsoft.Network/publicIPAddresses/pip-unassigned",
+                location="westus",
+                ip_address="",
+                public_ip_allocation_method="Dynamic",
+                ip_configuration=None,
+            ),
+        ]
+
+
+class _FakeNICOps:
+    def list_all(self) -> list[Any]:
+        return [
+            _Obj(
+                name="nic-1",
+                id="/subscriptions/sub-1/resourceGroups/rg-web/providers/Microsoft.Network/networkInterfaces/nic-1",
+                location="eastus",
+                virtual_machine=_Obj(id="/subscriptions/sub-1/resourceGroups/rg-web/providers/Microsoft.Compute/virtualMachines/web-1"),
+                network_security_group=_Obj(
+                    id="/subscriptions/sub-1/resourceGroups/rg-web/providers/Microsoft.Network/networkSecurityGroups/web-nsg"
+                ),
+                ip_configurations=[
+                    _Obj(
+                        private_ip_address="10.0.1.5",
+                        subnet=_Obj(id=_WEB_SUBNET_ID),
+                        public_ip_address=_Obj(
+                            ip_address="52.1.2.3",
+                            id="/subscriptions/sub-1/resourceGroups/rg-web/providers/Microsoft.Network/publicIPAddresses/pip-1",
+                        ),
+                    )
+                ],
+            ),
+            _Obj(
+                name="nic-internal",
+                id="/subscriptions/sub-1/resourceGroups/rg-web/providers/Microsoft.Network/networkInterfaces/nic-internal",
+                location="eastus",
+                virtual_machine=None,
+                network_security_group=None,
+                ip_configurations=[_Obj(private_ip_address="10.0.2.9", subnet=_Obj(id=_DB_SUBNET_ID), public_ip_address=None)],
+            ),
+        ]
+
+
+class _FakeFirewallOps:
+    def list_all(self) -> list[Any]:
+        return [
+            _Obj(
+                name="fw-1",
+                id="/subscriptions/sub-1/resourceGroups/rg-net/providers/Microsoft.Network/azureFirewalls/fw-1",
+                location="eastus",
+                ip_configurations=[
+                    _Obj(
+                        private_ip_address="10.0.0.4",
+                        public_ip_address=_Obj(
+                            ip_address="52.9.9.9",
+                            id="/subscriptions/sub-1/resourceGroups/rg-net/providers/Microsoft.Network/publicIPAddresses/fw-pip",
+                        ),
+                    )
+                ],
+            )
+        ]
+
+
+class _FakeNatGatewayOps:
+    def list_all(self) -> list[Any]:
+        return [
+            _Obj(
+                name="nat-1",
+                id="/subscriptions/sub-1/resourceGroups/rg-net/providers/Microsoft.Network/natGateways/nat-1",
+                location="eastus",
+                subnets=[_Obj(id=_WEB_SUBNET_ID)],
+            )
+        ]
+
+
+class _FakeRouteTableOps:
+    def list_all(self) -> list[Any]:
+        return [
+            _Obj(
+                name="rt-public",
+                id="/subscriptions/sub-1/resourceGroups/rg-net/providers/Microsoft.Network/routeTables/rt-public",
+                location="eastus",
+                subnets=[_Obj(id=_WEB_SUBNET_ID)],
+                routes=[_Obj(next_hop_type="Internet", address_prefix="0.0.0.0/0")],
+            ),
+            _Obj(
+                name="rt-private",
+                id="/subscriptions/sub-1/resourceGroups/rg-net/providers/Microsoft.Network/routeTables/rt-private",
+                location="eastus",
+                subnets=[],
+                routes=[_Obj(next_hop_type="VirtualAppliance", address_prefix="0.0.0.0/0")],
+            ),
+        ]
+
+
+class _FakePrivateEndpointOps:
+    def list_all(self) -> list[Any]:
+        return [
+            _Obj(
+                name="pe-sql",
+                id="/subscriptions/sub-1/resourceGroups/rg-net/providers/Microsoft.Network/privateEndpoints/pe-sql",
+                location="eastus",
+                subnet=_Obj(id=_DB_SUBNET_ID),
+                private_link_service_connections=[
+                    _Obj(private_link_service_id="/subscriptions/sub-1/resourceGroups/rg-data/providers/Microsoft.Sql/servers/sql-1")
+                ],
+            )
+        ]
+
+
 class _FakeNetworkClient:
     def __init__(self, _credential: Any, _subscription_id: str) -> None:
         self.network_security_groups = _FakeNSGOps()
+        self.virtual_networks = _FakeVNetOps()
+        self.public_ip_addresses = _FakePublicIPOps()
+        self.network_interfaces = _FakeNICOps()
+        self.azure_firewalls = _FakeFirewallOps()
+        self.nat_gateways = _FakeNatGatewayOps()
+        self.route_tables = _FakeRouteTableOps()
+        self.private_endpoints = _FakePrivateEndpointOps()
 
 
 class _FakeMSIOps:
@@ -569,3 +722,173 @@ def test_graph_group_scoped_assignment_reaches_members() -> None:
         e for e in graph.edges if e.relationship == RelationshipType.HAS_PERMISSION and e.source == sp_node and e.target == account_node
     ]
     assert member_perm and member_perm[0].evidence.get("via_group") == "grp-oid"
+
+
+# ---------------------------------------------------------------------------
+# Network-edge inventory: NICs, subnets, public IPs, NAT/route tables,
+# Azure Firewall, private endpoints.
+# ---------------------------------------------------------------------------
+
+
+def _network_payload(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    monkeypatch.setenv(azure_inventory.INVENTORY_ENV_FLAG, "1")
+    with _install_fake_azure():
+        return azure_inventory.discover_inventory(subscription_id="sub-1", credential=_FakeCredential())
+
+
+def test_inventory_enumerates_network_interfaces(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _network_payload(monkeypatch)
+    nics = {n["name"]: n for n in payload["network_interfaces"]}
+    assert set(nics) == {"nic-1", "nic-internal"}
+
+    primary = nics["nic-1"]
+    assert primary["instance_id"].endswith("/virtualMachines/web-1")
+    assert primary["subnet_id"] == _WEB_SUBNET_ID
+    assert primary["vpc_id"] == _VNET_ID
+    assert primary["security_group_ids"] == [
+        "/subscriptions/sub-1/resourceGroups/rg-web/providers/Microsoft.Network/networkSecurityGroups/web-nsg"
+    ]
+    assert primary["private_ip"] == "10.0.1.5"
+    assert primary["public_ip"] == "52.1.2.3"
+    assert primary["account_id"] == "sub-1"
+
+    # A NIC with no VM / NSG / public IP degrades to empty fields, not a crash.
+    internal = nics["nic-internal"]
+    assert internal["instance_id"] == ""
+    assert internal["security_group_ids"] == []
+    assert internal["public_ip"] == ""
+    assert internal["subnet_id"] == _DB_SUBNET_ID
+
+
+def test_inventory_enumerates_subnets(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _network_payload(monkeypatch)
+    subnets = {s["name"]: s for s in payload["subnets"]}
+    assert set(subnets) == {"web-subnet", "db-subnet"}
+    web = subnets["web-subnet"]
+    assert web["vpc_id"] == _VNET_ID
+    assert web["cidr"] == "10.0.1.0/24"
+    # A NAT gateway is an explicit internet egress path → public.
+    assert web["is_public"] is True
+    assert subnets["db-subnet"]["is_public"] is False
+
+
+def test_inventory_enumerates_ip_addresses(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _network_payload(monkeypatch)
+    addrs = payload["ip_addresses"]
+    assert len(addrs) == 2
+    by_addr = {a["address"]: a for a in addrs}
+    assert by_addr["52.1.2.3"]["kind"] == "public"
+    assert by_addr["52.1.2.3"]["attached_to"] == _NIC_IPCONFIG_ID
+    assert by_addr["52.1.2.3"]["account_id"] == "sub-1"
+    # An unassigned (dynamic) public IP carries no address and no binding.
+    assert by_addr[""]["attached_to"] == ""
+
+
+def test_inventory_enumerates_nat_gateways(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _network_payload(monkeypatch)
+    assert len(payload["nat_gateways"]) == 1
+    nat = payload["nat_gateways"][0]
+    assert nat["name"] == "nat-1"
+    assert nat["subnet_id"] == _WEB_SUBNET_ID
+    assert nat["vpc_id"] == _VNET_ID
+    assert nat["account_id"] == "sub-1"
+
+
+def test_inventory_enumerates_route_tables(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _network_payload(monkeypatch)
+    tables = {t["name"]: t for t in payload["route_tables"]}
+    assert set(tables) == {"rt-public", "rt-private"}
+    assert tables["rt-public"]["has_internet_route"] is True
+    assert tables["rt-public"]["vpc_id"] == _VNET_ID
+    # A 0.0.0.0/0 route to a virtual appliance is NOT a direct internet route.
+    assert tables["rt-private"]["has_internet_route"] is False
+
+
+def test_inventory_enumerates_azure_firewalls(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _network_payload(monkeypatch)
+    assert len(payload["azure_firewalls"]) == 1
+    fw = payload["azure_firewalls"][0]
+    assert fw["name"] == "fw-1"
+    assert fw["private_ip"] == "10.0.0.4"
+    assert fw["public_ips"] == ["52.9.9.9"]
+    assert fw["account_id"] == "sub-1"
+
+
+def test_inventory_enumerates_private_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _network_payload(monkeypatch)
+    assert len(payload["private_endpoints"]) == 1
+    pe = payload["private_endpoints"][0]
+    assert pe["name"] == "pe-sql"
+    assert pe["subnet_id"] == _DB_SUBNET_ID
+    assert pe["target_resource"].endswith("/Microsoft.Sql/servers/sql-1")
+    assert pe["account_id"] == "sub-1"
+
+
+def test_inventory_network_permissions_in_envelope(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _network_payload(monkeypatch)
+    perms = payload["discovery_envelope"]["permissions_used"]
+    for perm in (
+        "Microsoft.Network/azureFirewalls/read",
+        "Microsoft.Network/natGateways/read",
+        "Microsoft.Network/routeTables/read",
+        "Microsoft.Network/networkInterfaces/read",
+        "Microsoft.Network/privateEndpoints/read",
+        "Microsoft.Network/virtualNetworks/subnets/read",
+        "Microsoft.Network/publicIPAddresses/read",
+    ):
+        assert perm in perms, perm
+
+
+def test_inventory_payload_carries_all_network_edge_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = _network_payload(monkeypatch)
+    for key in (
+        "network_interfaces",
+        "subnets",
+        "ip_addresses",
+        "nat_gateways",
+        "route_tables",
+        "azure_firewalls",
+        "private_endpoints",
+    ):
+        assert key in payload, key
+        assert isinstance(payload[key], list)
+
+
+def test_network_edge_keys_present_on_disabled_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(azure_inventory.INVENTORY_ENV_FLAG, raising=False)
+    payload = azure_inventory.discover_inventory()
+    assert payload["status"] == "disabled"
+    for key in (
+        "network_interfaces",
+        "subnets",
+        "ip_addresses",
+        "nat_gateways",
+        "route_tables",
+        "azure_firewalls",
+        "private_endpoints",
+    ):
+        assert payload[key] == []
+
+
+def test_network_edge_discoverer_permission_denied_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(azure_inventory.INVENTORY_ENV_FLAG, "1")
+
+    def _denied(self: Any) -> list[Any]:
+        raise _AzureAuthError()
+
+    # Deny only the Azure Firewall list; the rest of the scan must still succeed.
+    monkeypatch.setattr(_FakeFirewallOps, "list_all", _denied)
+    with _install_fake_azure():
+        payload = azure_inventory.discover_inventory(subscription_id="sub-1", credential=_FakeCredential())
+
+    assert payload["status"] == "ok"
+    assert payload["azure_firewalls"] == []
+    # Other network-edge types are unaffected.
+    assert payload["network_interfaces"]
+    assert payload["nat_gateways"]
+    # An actionable warning + a structured missing_permissions entry are recorded.
+    actionable = [w for w in payload["warnings"] if "role lacks" in w and "Azure Firewalls" in w]
+    assert actionable, payload["warnings"]
+    assert "Microsoft.Network/azureFirewalls/read" in actionable[0]
+    entries = [e for e in payload["missing_permissions"] if e["resource_type"] == "Azure Firewalls"]
+    assert entries == [{"cloud": "azure", "permission": "Microsoft.Network/azureFirewalls/read", "resource_type": "Azure Firewalls"}]

--- a/tests/test_cloud_gcp_inventory.py
+++ b/tests/test_cloud_gcp_inventory.py
@@ -154,12 +154,142 @@ class _FakeDisksClient:
         return [("zones/us-central1-a", _Obj(disks=[disk]))]
 
 
+class _FakeBackendServicesClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def aggregated_list(self, project: str) -> list[Any]:
+        ext = _Obj(
+            name="ext-backend",
+            id="be-1",
+            load_balancing_scheme="EXTERNAL_MANAGED",
+            region="",
+            security_policy="https://www.googleapis.com/compute/v1/projects/p/global/securityPolicies/armor-policy",
+        )
+        internal = _Obj(
+            name="int-backend",
+            id="be-2",
+            load_balancing_scheme="INTERNAL_MANAGED",
+            region="https://www.googleapis.com/compute/v1/projects/p/regions/us-central1",
+            security_policy="",
+        )
+        return [("global", _Obj(backend_services=[ext, internal]))]
+
+
+class _FakeUrlMapsClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def list(self, project: str) -> list[Any]:
+        return [_Obj(name="web-urlmap", id="um-1", region="")]
+
+
+class _FakeForwardingRulesClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def aggregated_list(self, project: str) -> list[Any]:
+        rule = _Obj(
+            name="ext-fr",
+            id="fr-1",
+            load_balancing_scheme="EXTERNAL",
+            region="https://www.googleapis.com/compute/v1/projects/p/regions/us-central1",
+        )
+        return [("regions/us-central1", _Obj(forwarding_rules=[rule]))]
+
+
+class _FakeTargetHttpProxiesClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def list(self, project: str) -> list[Any]:
+        return [_Obj(name="http-proxy", id="tp-1")]
+
+
+class _FakeTargetHttpsProxiesClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def list(self, project: str) -> list[Any]:
+        return [_Obj(name="https-proxy", id="tps-1")]
+
+
+class _FakeSecurityPoliciesClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def list(self, project: str) -> list[Any]:
+        return [_Obj(name="armor-policy", id="sp-1")]
+
+
+class _FakeRoutersClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def aggregated_list(self, project: str) -> list[Any]:
+        router = _Obj(
+            name="nat-router",
+            id="rt-1",
+            network="https://www.googleapis.com/compute/v1/projects/p/global/networks/default",
+            region="https://www.googleapis.com/compute/v1/projects/p/regions/us-central1",
+            nats=[_Obj(name="nat-gw-1")],
+        )
+        return [("regions/us-central1", _Obj(routers=[router]))]
+
+
+class _FakeAddressesClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def aggregated_list(self, project: str) -> list[Any]:
+        addr = _Obj(
+            address="34.120.0.1",
+            name="reserved-ip",
+            region="https://www.googleapis.com/compute/v1/projects/p/regions/us-central1",
+            users=["https://www.googleapis.com/compute/v1/projects/p/regions/us-central1/forwardingRules/ext-fr"],
+        )
+        return [("regions/us-central1", _Obj(addresses=[addr]))]
+
+
 class _FakeComputeModule(types.ModuleType):
     InstancesClient = _FakeInstancesClient
     FirewallsClient = _FakeFirewallsClient
     NetworksClient = _FakeNetworksClient
     SubnetworksClient = _FakeSubnetworksClient
     DisksClient = _FakeDisksClient
+    BackendServicesClient = _FakeBackendServicesClient
+    UrlMapsClient = _FakeUrlMapsClient
+    ForwardingRulesClient = _FakeForwardingRulesClient
+    TargetHttpProxiesClient = _FakeTargetHttpProxiesClient
+    TargetHttpsProxiesClient = _FakeTargetHttpsProxiesClient
+    SecurityPoliciesClient = _FakeSecurityPoliciesClient
+    RoutersClient = _FakeRoutersClient
+    AddressesClient = _FakeAddressesClient
+
+
+# --- API Gateway ------------------------------------------------------------
+class _FakeApiGatewayServiceClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+    def list_gateways(self, request: Any) -> list[Any]:
+        return [
+            _Obj(
+                name="projects/proj-1/locations/us-central1/gateways/public-gw",
+                default_hostname="public-gw-abc.uc.gateway.dev",
+                api_config="projects/proj-1/locations/global/apis/api1/configs/cfg1",
+            ),
+        ]
+
+
+class _FakeListGatewaysRequest:
+    def __init__(self, parent: str) -> None:
+        self.parent = parent
+
+
+class _FakeApiGatewayModule(types.ModuleType):
+    ApiGatewayServiceClient = _FakeApiGatewayServiceClient
+    ListGatewaysRequest = _FakeListGatewaysRequest
 
 
 class _FakeServiceAccount:
@@ -385,6 +515,7 @@ def _install_fake_gcp() -> Any:
     run_mod = _FakeRunModule("google.cloud.run_v2")
     functions_mod = _FakeFunctionsModule("google.cloud.functions_v2")
     pubsub_mod = _FakePubsubModule("google.cloud.pubsub_v1")
+    apigateway_mod = _FakeApiGatewayModule("google.cloud.apigateway_v1")
     apiclient_mod = types.ModuleType("googleapiclient")
     discovery_mod = types.ModuleType("googleapiclient.discovery")
     discovery_mod.build = _fake_discovery_build  # type: ignore[attr-defined]
@@ -404,6 +535,7 @@ def _install_fake_gcp() -> Any:
             "google.cloud.run_v2": run_mod,
             "google.cloud.functions_v2": functions_mod,
             "google.cloud.pubsub_v1": pubsub_mod,
+            "google.cloud.apigateway_v1": apigateway_mod,
             "googleapiclient": apiclient_mod,
             "googleapiclient.discovery": discovery_mod,
         },
@@ -1073,3 +1205,176 @@ def test_graph_gcp_group_binding_surfaces_effective_permission() -> None:
         e for e in graph.edges if e.relationship == RelationshipType.HAS_PERMISSION and e.source == group_node and e.target == bucket_node
     ]
     assert group_perms
+
+
+# ---------------------------------------------------------------------------
+# Network-edge breadth: Cloud Armor / API Gateway / load balancers / NAT /
+# routers / subnets / IP addresses
+# ---------------------------------------------------------------------------
+
+
+def test_inventory_enumerates_network_edge(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+    with _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+
+    assert payload["status"] == "ok"
+
+    # Cloud Armor → web_acls, scoped cloud-armor, fronting the backend that refs it.
+    acls = {a["name"]: a for a in payload["web_acls"]}
+    assert set(acls) == {"armor-policy"}
+    assert acls["armor-policy"]["scope"] == "cloud-armor"
+    assert acls["armor-policy"]["protected_targets"] == ["be-1"]
+
+    # API Gateway: public default hostname → internet_exposed.
+    gws = {g["name"]: g for g in payload["api_gateways"]}
+    assert set(gws) == {"public-gw"}
+    assert gws["public-gw"]["protocol"] == "apigateway"
+    assert gws["public-gw"]["internet_exposed"] is True
+    assert gws["public-gw"]["endpoint"] == "public-gw-abc.uc.gateway.dev"
+    assert gws["public-gw"]["location"] == "us-central1"
+
+    # Load balancers: backend services / url map / forwarding rule / target proxies.
+    lbs = payload["load_balancers"]
+    by_type: dict[str, list[dict[str, Any]]] = {}
+    for lb in lbs:
+        by_type.setdefault(lb["lb_type"], []).append(lb)
+    assert len(by_type["backend-service"]) == 2
+    assert len(by_type["url-map"]) == 1
+    assert len(by_type["forwarding-rule"]) == 1
+    assert len(by_type["target-proxy"]) == 2
+    backends = {b["name"]: b for b in by_type["backend-service"]}
+    assert backends["ext-backend"]["internet_exposed"] is True
+    assert backends["int-backend"]["internet_exposed"] is False
+    assert by_type["forwarding-rule"][0]["internet_exposed"] is True
+
+    # Subnets: flat list, reusing the aggregated subnet query (no double-count).
+    subnets = payload["subnets"]
+    assert len(subnets) == 1
+    assert subnets[0]["name"] == "default-sub"
+    assert subnets[0]["cidr"] == "10.0.0.0/20"
+    assert subnets[0]["location"] == "us-central1"
+    assert subnets[0]["account_id"] == "proj-1"
+
+    # Cloud NAT + routers.
+    nats = {n["name"]: n for n in payload["nat_gateways"]}
+    assert nats["nat-gw-1"]["vpc_id"] == "default"
+    assert nats["nat-gw-1"]["location"] == "us-central1"
+    routers = {r["name"]: r for r in payload["route_tables"]}
+    assert routers["nat-router"]["has_internet_route"] is True
+    assert routers["nat-router"]["vpc_id"] == "default"
+
+    # IP addresses: reserved (with attachment) + ephemeral (from instance).
+    ips = {i["address"]: i for i in payload["ip_addresses"]}
+    assert ips["34.120.0.1"]["kind"] == "reserved"
+    assert ips["34.120.0.1"]["attached_to"] == "ext-fr"
+    assert ips["203.0.113.7"]["kind"] == "ephemeral"
+    assert ips["203.0.113.7"]["attached_to"] == "web-1"
+
+    # Per-run trust contract picks up the network-edge permissions.
+    env = payload["discovery_envelope"]
+    for perm in (
+        "compute.securityPolicies.list",
+        "compute.backendServices.list",
+        "compute.urlMaps.list",
+        "compute.forwardingRules.list",
+        "compute.targetHttpProxies.list",
+        "compute.targetHttpsProxies.list",
+        "compute.routers.list",
+        "compute.addresses.list",
+        "apigateway.gateways.list",
+    ):
+        assert perm in env["permissions_used"]
+
+
+def test_inventory_payload_has_network_edge_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+    with _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+    for key in ("subnets", "load_balancers", "web_acls", "api_gateways", "nat_gateways", "route_tables", "ip_addresses"):
+        assert key in payload
+        assert isinstance(payload[key], list)
+
+
+def test_network_edge_gated_off_with_include_networks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+    with _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(project_id="proj-1", include_networks=False)
+    assert payload["web_acls"] == []
+    assert payload["load_balancers"] == []
+    assert payload["api_gateways"] == []
+    assert payload["nat_gateways"] == []
+    assert payload["route_tables"] == []
+    assert payload["ip_addresses"] == []
+    assert payload["subnets"] == []
+    env = payload["discovery_envelope"]
+    assert "compute.securityPolicies.list" not in env["permissions_used"]
+    assert "apigateway.gateways.list" not in env["permissions_used"]
+
+
+def test_api_gateway_sdk_missing_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An absent apigateway SDK degrades to [] + a warning, never a crash."""
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+    import builtins
+
+    original = builtins.__import__
+
+    def _no_apigw(name: str, *args: Any, **kwargs: Any) -> Any:
+        fromlist = kwargs.get("fromlist") or (args[2] if len(args) > 2 and args[2] else ())
+        if name == "google.cloud" and "apigateway_v1" in (fromlist or ()):
+            raise ImportError("mocked")
+        return original(name, *args, **kwargs)
+
+    with _install_fake_gcp(), patch("builtins.__import__", side_effect=_no_apigw):
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+    assert payload["status"] == "ok"
+    assert payload["api_gateways"] == []
+    assert any("API Gateway" in w for w in payload["warnings"])
+    # Other network-edge types still enumerate.
+    assert payload["web_acls"]
+    assert payload["load_balancers"]
+
+
+def test_cloud_armor_permission_denied_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+
+    def _denied(self: Any, project: str) -> Any:
+        raise PermissionDenied()
+
+    monkeypatch.setattr(_FakeSecurityPoliciesClient, "list", _denied)
+    with _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+
+    assert payload["status"] == "ok"
+    # The denied discoverer degrades to empty…
+    assert payload["web_acls"] == []
+    # …while the rest of the scan survives.
+    assert {b["name"] for b in payload["buckets"]} == {"public-lake", "private-logs"}
+    assert payload["load_balancers"]
+    # Actionable warning naming the missing permission.
+    actionable = [w for w in payload["warnings"] if "role lacks" in w and "Cloud Armor policies" in w]
+    assert actionable, payload["warnings"]
+    assert "compute.securityPolicies.list" in actionable[0]
+    # Structured missing_permissions entry.
+    entries = [e for e in payload["missing_permissions"] if e["resource_type"] == "Cloud Armor policies"]
+    assert entries == [{"cloud": "gcp", "permission": "compute.securityPolicies.list", "resource_type": "Cloud Armor policies"}]
+
+
+def test_load_balancer_partial_permission_denied(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One denied LB sub-resource degrades only that class, others survive."""
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+
+    def _denied(self: Any, project: str) -> Any:
+        raise PermissionDenied()
+
+    monkeypatch.setattr(_FakeForwardingRulesClient, "aggregated_list", _denied)
+    with _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+
+    assert payload["status"] == "ok"
+    types_present = {lb["lb_type"] for lb in payload["load_balancers"]}
+    # Forwarding rules denied, but backend services / url maps / target proxies remain.
+    assert "forwarding-rule" not in types_present
+    assert {"backend-service", "url-map", "target-proxy"} <= types_present
+    entries = [e for e in payload["missing_permissions"] if e["resource_type"] == "forwarding rules"]
+    assert entries == [{"cloud": "gcp", "permission": "compute.forwardingRules.list", "resource_type": "forwarding rules"}]

--- a/tests/test_cloud_network_edge.py
+++ b/tests/test_cloud_network_edge.py
@@ -1,0 +1,315 @@
+"""Network-edge inventory (WAF, API Gateway, ENIs, NAT/IGW, subnets, IPs).
+
+Covers AWS live discovery (mocked boto3) and the shared graph wiring: the
+API_GATEWAY node populated from live inventory, the WAF ``PROTECTS`` edge that
+mitigates a fronted resource's exposure verdict, and the ENI mapping that makes
+instance ↔ subnet ↔ security-group traversable.
+"""
+
+from __future__ import annotations
+
+from agent_bom.graph.builder import build_unified_graph_from_report
+from agent_bom.graph.cnapp_overlay import apply_cnapp_overlay
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+
+# ── AWS discovery (mocked boto3) ─────────────────────────────────────────
+class _Paginator:
+    def __init__(self, pages):
+        self._pages = pages
+
+    def paginate(self, **_kw):
+        return self._pages
+
+
+class _AccessDeniedError(Exception):
+    """Mimics a botocore access-denied error (matched by message text)."""
+
+    def __init__(self):
+        super().__init__("AccessDeniedException: not authorized")
+
+
+class _Ec2Client:
+    def __init__(self, *, deny: bool = False):
+        self.deny = deny
+
+    def get_paginator(self, op):
+        if self.deny:
+            raise _AccessDeniedError()
+        pages = {
+            "describe_route_tables": [
+                {
+                    "RouteTables": [
+                        {
+                            "RouteTableId": "rtb-1",
+                            "VpcId": "vpc-1",
+                            "Routes": [{"DestinationCidrBlock": "0.0.0.0/0", "GatewayId": "igw-1"}],
+                            "Associations": [{"SubnetId": "subnet-pub", "Main": False}],
+                        }
+                    ]
+                }
+            ],
+            "describe_subnets": [
+                {
+                    "Subnets": [
+                        {"SubnetId": "subnet-pub", "VpcId": "vpc-1", "CidrBlock": "10.0.1.0/24", "AvailabilityZone": "us-east-1a"},
+                        {"SubnetId": "subnet-priv", "VpcId": "vpc-1", "CidrBlock": "10.0.2.0/24", "AvailabilityZone": "us-east-1b"},
+                    ]
+                }
+            ],
+            "describe_network_interfaces": [
+                {
+                    "NetworkInterfaces": [
+                        {
+                            "NetworkInterfaceId": "eni-1",
+                            "SubnetId": "subnet-pub",
+                            "VpcId": "vpc-1",
+                            "PrivateIpAddress": "10.0.1.5",
+                            "Groups": [{"GroupId": "sg-1"}],
+                            "Attachment": {"InstanceId": "i-1"},
+                            "Association": {"PublicIp": "54.1.2.3"},
+                        }
+                    ]
+                }
+            ],
+            "describe_nat_gateways": [{"NatGateways": [{"NatGatewayId": "nat-1", "VpcId": "vpc-1", "SubnetId": "subnet-pub"}]}],
+            "describe_vpc_endpoints": [
+                {"VpcEndpoints": [{"VpcEndpointId": "vpce-1", "ServiceName": "com.amazonaws.s3", "VpcId": "vpc-1"}]}
+            ],
+            "describe_network_acls": [{"NetworkAcls": [{"NetworkAclId": "acl-1", "VpcId": "vpc-1", "IsDefault": True}]}],
+        }
+        return _Paginator(pages.get(op, []))
+
+    def describe_internet_gateways(self):
+        if self.deny:
+            raise _AccessDeniedError()
+        return {"InternetGateways": [{"InternetGatewayId": "igw-1", "Attachments": [{"VpcId": "vpc-1"}]}]}
+
+    def describe_egress_only_internet_gateways(self):
+        return {"EgressOnlyInternetGateways": []}
+
+    def describe_addresses(self):
+        if self.deny:
+            raise _AccessDeniedError()
+        return {"Addresses": [{"PublicIp": "52.9.9.9", "AllocationId": "eipalloc-1", "InstanceId": "i-1"}]}
+
+
+class _WafClient:
+    def __init__(self, *, deny: bool = False):
+        self.deny = deny
+
+    def list_web_acls(self, Scope):  # noqa: N803 — boto3 API param
+        if self.deny:
+            raise _AccessDeniedError()
+        if Scope == "REGIONAL":
+            return {"WebACLs": [{"Name": "web-acl", "Id": "acl-id", "ARN": "arn:waf:regional"}]}
+        return {"WebACLs": [{"Name": "cf-acl", "Id": "cf-id", "ARN": "arn:waf:cloudfront"}]}
+
+    def list_resources_for_web_acl(self, WebACLArn):  # noqa: N803
+        return {"ResourceArns": ["arn:alb:web"]}
+
+
+class _ApiGwClient:
+    def get_paginator(self, _op):
+        return _Paginator([{"items": [{"id": "rest1", "name": "rest-api", "endpointConfiguration": {"types": ["REGIONAL"]}}]}])
+
+    def get_stages(self, restApiId):  # noqa: N803
+        return {"item": [{"stageName": "prod"}]}
+
+
+class _ApiGwV2Client:
+    def get_apis(self, **_kw):
+        return {"Items": [{"ApiId": "http1", "Name": "http-api", "ProtocolType": "HTTP", "ApiEndpoint": "https://x.execute-api"}]}
+
+
+class _Session:
+    def __init__(self, *, deny: bool = False):
+        self.deny = deny
+
+    def client(self, svc, **_kw):
+        if svc == "ec2":
+            return _Ec2Client(deny=self.deny)
+        if svc == "wafv2":
+            return _WafClient(deny=self.deny)
+        if svc == "apigateway":
+            return _ApiGwClient()
+        if svc == "apigatewayv2":
+            return _ApiGwV2Client()
+        raise AssertionError(f"unexpected client {svc}")
+
+
+def test_discover_waf_enumerates_acls_and_associations() -> None:
+    from agent_bom.cloud import aws_inventory as aws
+
+    warnings: list[str] = []
+    acls = aws._discover_waf(_Session(), "us-east-1", account_id="111122223333", warnings=warnings, missing=[])
+    by_scope = {a["scope"]: a for a in acls}
+    assert "regional" in by_scope and "cloudfront" in by_scope  # both scopes from us-east-1
+    assert by_scope["regional"]["protected_targets"] == ["arn:alb:web"]
+    assert warnings == []
+
+
+def test_discover_api_gateways_rest_and_v2() -> None:
+    from agent_bom.cloud import aws_inventory as aws
+
+    gws = aws._discover_api_gateways(_Session(), "us-east-1", account_id="111122223333", warnings=[], missing=[])
+    protocols = {g["protocol"] for g in gws}
+    assert protocols == {"REST", "HTTP"}
+    rest = next(g for g in gws if g["protocol"] == "REST")
+    assert rest["stages"] == ["prod"] and rest["internet_exposed"] is True
+
+
+def test_discover_network_edge_enumerates_plumbing() -> None:
+    from agent_bom.cloud import aws_inventory as aws
+
+    edge = aws._discover_network_edge(_Session(), "us-east-1", account_id="111122223333", warnings=[], missing=[])
+    assert len(edge["network_interfaces"]) == 1
+    eni = edge["network_interfaces"][0]
+    assert eni["instance_id"] == "i-1" and eni["subnet_id"] == "subnet-pub" and eni["security_group_ids"] == ["sg-1"]
+    subnets = {s["id"]: s for s in edge["subnets"]}
+    assert subnets["subnet-pub"]["is_public"] is True  # 0.0.0.0/0 → igw route
+    assert subnets["subnet-priv"]["is_public"] is False
+    assert len(edge["nat_gateways"]) == 1 and len(edge["internet_gateways"]) == 1
+    assert len(edge["vpc_endpoints"]) == 1 and len(edge["route_tables"]) == 1 and len(edge["network_acls"]) == 1
+
+
+def test_discover_ip_addresses_elastic_and_eni() -> None:
+    from agent_bom.cloud import aws_inventory as aws
+
+    enis = [{"id": "eni-1", "public_ip": "54.1.2.3", "instance_id": "i-1"}]
+    ips = aws._discover_ip_addresses(_Session(), "us-east-1", account_id="x", network_interfaces=enis, warnings=[], missing=[])
+    by_addr = {i["address"]: i for i in ips}
+    assert by_addr["52.9.9.9"]["kind"] == "elastic"
+    assert by_addr["54.1.2.3"]["kind"] == "public" and by_addr["54.1.2.3"]["attached_to"] == "i-1"
+
+
+def test_missing_permission_warns_and_continues() -> None:
+    from agent_bom.cloud import aws_inventory as aws
+
+    warnings: list[str] = []
+    missing: list[dict[str, str]] = []
+    acls = aws._discover_waf(_Session(deny=True), "us-east-1", account_id="x", warnings=warnings, missing=missing)
+    assert acls == []  # degraded, not crashed
+    assert warnings and any("wafv2:ListWebACLs" in w for w in warnings)
+    assert any(m["permission"] == "wafv2:ListWebACLs" for m in missing)
+
+
+def test_discover_inventory_payload_has_network_edge_keys() -> None:
+    from agent_bom.cloud import aws_inventory as aws
+
+    out = aws.discover_inventory(force=False)
+    for key in (
+        "web_acls",
+        "api_gateways",
+        "network_interfaces",
+        "subnets",
+        "nat_gateways",
+        "internet_gateways",
+        "vpc_endpoints",
+        "route_tables",
+        "network_acls",
+        "ip_addresses",
+    ):
+        assert key in out, f"{key} missing from discover_inventory payload"
+
+
+# ── Graph wiring ─────────────────────────────────────────────────────────
+def _aws_inventory() -> dict:
+    return {
+        "provider": "aws",
+        "status": "ok",
+        "account_id": "111122223333",
+        "region": "us-east-1",
+        "instances": [{"instance_id": "i-1", "name": "web", "vpc_id": "vpc-1", "subnet_id": "subnet-pub", "security_group_ids": ["sg-1"]}],
+        "security_groups": [{"group_id": "sg-1", "name": "open", "vpc_id": "vpc-1", "internet_exposed": True, "network_exposure": []}],
+        "subnets": [{"id": "subnet-pub", "name": "pub", "vpc_id": "vpc-1", "cidr": "10.0.1.0/24", "is_public": True}],
+        "network_interfaces": [
+            {
+                "id": "eni-1",
+                "name": "eni-1",
+                "instance_id": "i-1",
+                "subnet_id": "subnet-pub",
+                "vpc_id": "vpc-1",
+                "security_group_ids": ["sg-1"],
+                "private_ip": "10.0.1.5",
+                "public_ip": "54.1.2.3",
+            }
+        ],
+        "elb_load_balancers": [
+            {"name": "web-alb", "arn": "arn:alb:web", "scheme": "internet-facing", "internet_exposed": True, "location": "us-east-1"}
+        ],
+        "web_acls": [
+            {"name": "web-acl", "id": "acl-id", "arn": "arn:waf:regional", "scope": "regional", "protected_targets": ["arn:alb:web"]}
+        ],
+        "api_gateways": [
+            {"name": "rest-api", "id": "rest1", "protocol": "REST", "endpoint": "REGIONAL", "internet_exposed": True, "stages": ["prod"]}
+        ],
+    }
+
+
+def test_api_gateway_node_populated_from_live_inventory() -> None:
+    g = build_unified_graph_from_report({"cloud_inventory": _aws_inventory()})
+    api_nodes = [n for n in g.nodes.values() if n.entity_type == EntityType.API_GATEWAY]
+    assert len(api_nodes) == 1
+    node = api_nodes[0]
+    assert node.attributes["protocol"] == "REST"
+    assert node.attributes["semantic_layer"] == "api_gateway"
+
+
+def test_waf_node_and_protects_edge() -> None:
+    g = build_unified_graph_from_report({"cloud_inventory": _aws_inventory()})
+    edges = {(e.source, e.target, e.relationship.value) for e in g.edges}
+    waf_id = "cloud_resource:aws:waf:web_acl:acl-id"
+    alb_id = "cloud_resource:aws:elbv2:load_balancer:web-alb"
+    assert waf_id in g.nodes
+    assert (waf_id, alb_id, "protects") in edges
+
+
+def test_eni_maps_instance_subnet_and_security_group() -> None:
+    g = build_unified_graph_from_report({"cloud_inventory": _aws_inventory()})
+    edges = {(e.source, e.target, e.relationship.value) for e in g.edges}
+    eni_id = "cloud_resource:aws:network:network_interface:eni-1"
+    assert eni_id in g.nodes
+    assert (eni_id, "cloud_resource:aws:ec2:instance:i-1", "part_of") in edges
+    assert (eni_id, "cloud_resource:aws:network:subnet:subnet-pub", "part_of") in edges
+    assert (eni_id, "cloud_resource:aws:ec2:security-group:sg-1", "part_of") in edges
+
+
+def _exposed_vuln_graph(*, protected: bool) -> UnifiedGraph:
+    g = UnifiedGraph()
+    g.add_node(
+        UnifiedNode(
+            id="res",
+            entity_type=EntityType.CLOUD_RESOURCE,
+            label="api backend",
+            attributes={"internet_exposed": True, "resource_type": "instance"},
+        )
+    )
+    g.add_node(UnifiedNode(id="vuln", entity_type=EntityType.VULNERABILITY, label="CVE-x", severity="high"))
+    g.add_edge(UnifiedEdge(source="res", target="vuln", relationship=RelationshipType.VULNERABLE_TO))
+    if protected:
+        g.add_node(UnifiedNode(id="gw", entity_type=EntityType.API_GATEWAY, label="gateway"))
+        g.add_edge(UnifiedEdge(source="gw", target="res", relationship=RelationshipType.PROTECTS))
+    return g
+
+
+def test_waf_fronted_exposure_verdict_differs_from_unprotected() -> None:
+    unprotected = _exposed_vuln_graph(protected=False)
+    protected = _exposed_vuln_graph(protected=True)
+
+    apply_cnapp_overlay(unprotected)
+    apply_cnapp_overlay(protected)
+
+    bare = unprotected.nodes["res"]
+    fronted = protected.nodes["res"]
+
+    # Unprotected: full toxic escalation. Protected: mitigated, lower risk.
+    assert bare.attributes.get("toxic_exposed_vulnerable") is True
+    assert bare.risk_score >= 9.0
+    assert fronted.attributes.get("exposure_mitigated") is True
+    assert fronted.attributes.get("toxic_exposed_vulnerable_mitigated") is True
+    assert fronted.attributes.get("toxic_exposed_vulnerable") is None
+    assert fronted.risk_score < bare.risk_score

--- a/ui/lib/graph-schema.generated.ts
+++ b/ui/lib/graph-schema.generated.ts
@@ -90,6 +90,7 @@ export enum GraphNodeKind {
   ACCESS_POLICY = "access_policy",
   ACCOUNT = "account",
   AGENT = "agent",
+  API_GATEWAY = "api_gateway",
   APPLICATION = "application",
   CI_JOB = "ci_job",
   CLOUD_RESOURCE = "cloud_resource",
@@ -126,9 +127,9 @@ export enum GraphNodeKind {
   VULNERABILITY = "vulnerability",
 }
 
-export type GraphNodeKindKey = "access_grant" | "access_policy" | "account" | "agent" | "application" | "ci_job" | "cloud_resource" | "cluster" | "code_module" | "config_file" | "container" | "credential" | "credential_ref" | "data_store" | "dataset" | "drift_incident" | "environment" | "external_import" | "federated_identity" | "fleet" | "group" | "managed_identity" | "misconfiguration" | "model" | "org" | "package" | "policy" | "provider" | "resource" | "role" | "server" | "service_account" | "service_principal" | "source_file" | "tool" | "tool_call" | "user" | "vulnerability";
+export type GraphNodeKindKey = "access_grant" | "access_policy" | "account" | "agent" | "api_gateway" | "application" | "ci_job" | "cloud_resource" | "cluster" | "code_module" | "config_file" | "container" | "credential" | "credential_ref" | "data_store" | "dataset" | "drift_incident" | "environment" | "external_import" | "federated_identity" | "fleet" | "group" | "managed_identity" | "misconfiguration" | "model" | "org" | "package" | "policy" | "provider" | "resource" | "role" | "server" | "service_account" | "service_principal" | "source_file" | "tool" | "tool_call" | "user" | "vulnerability";
 
-export const GRAPH_NODE_KINDS: readonly GraphNodeKindKey[] = ["access_grant", "access_policy", "account", "agent", "application", "ci_job", "cloud_resource", "cluster", "code_module", "config_file", "container", "credential", "credential_ref", "data_store", "dataset", "drift_incident", "environment", "external_import", "federated_identity", "fleet", "group", "managed_identity", "misconfiguration", "model", "org", "package", "policy", "provider", "resource", "role", "server", "service_account", "service_principal", "source_file", "tool", "tool_call", "user", "vulnerability"] as const;
+export const GRAPH_NODE_KINDS: readonly GraphNodeKindKey[] = ["access_grant", "access_policy", "account", "agent", "api_gateway", "application", "ci_job", "cloud_resource", "cluster", "code_module", "config_file", "container", "credential", "credential_ref", "data_store", "dataset", "drift_incident", "environment", "external_import", "federated_identity", "fleet", "group", "managed_identity", "misconfiguration", "model", "org", "package", "policy", "provider", "resource", "role", "server", "service_account", "service_principal", "source_file", "tool", "tool_call", "user", "vulnerability"] as const;
 
 export interface GraphNodeKindMeta {
   label: string;
@@ -174,6 +175,15 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "shape": "circle",
     "layer": "orchestration",
     "icon": "circle",
+    "category_uid": 5,
+    "class_uid": 4001
+  },
+  "api_gateway": {
+    "label": "API Gateway",
+    "color": "#2563eb",
+    "shape": "diamond",
+    "layer": "api_gateway",
+    "icon": "diamond",
     "category_uid": 5,
     "class_uid": 4001
   },
@@ -522,6 +532,7 @@ export enum GraphEdgeKind {
   OWNS = "owns",
   PART_OF = "part_of",
   POSSIBLY_CORRELATES_WITH = "possibly_correlates_with",
+  PROTECTS = "protects",
   PROVIDES_TOOL = "provides_tool",
   REACHES_TOOL = "reaches_tool",
   REMEDIATES = "remediates",
@@ -538,9 +549,9 @@ export enum GraphEdgeKind {
   VULNERABLE_TO = "vulnerable_to",
 }
 
-export type GraphEdgeKindKey = "accessed" | "acted_as" | "affects" | "assumes" | "attached" | "authenticates_as" | "belongs_to" | "called" | "can_access" | "configures" | "contains" | "correlates_with" | "cross_account_trust" | "defines" | "delegated_to" | "depends_on" | "exhibits_drift" | "exploitable_via" | "exposed_to" | "exposes_cred" | "governs" | "has_permission" | "hosts" | "imports" | "inherits" | "invoked" | "lateral_path" | "manages" | "member_of" | "owns" | "part_of" | "possibly_correlates_with" | "provides_tool" | "reaches_tool" | "remediates" | "runs" | "scoped_to" | "serves_model" | "shares_cred" | "shares_server" | "stores" | "triggers" | "trusts" | "used_credential" | "uses" | "vulnerable_to";
+export type GraphEdgeKindKey = "accessed" | "acted_as" | "affects" | "assumes" | "attached" | "authenticates_as" | "belongs_to" | "called" | "can_access" | "configures" | "contains" | "correlates_with" | "cross_account_trust" | "defines" | "delegated_to" | "depends_on" | "exhibits_drift" | "exploitable_via" | "exposed_to" | "exposes_cred" | "governs" | "has_permission" | "hosts" | "imports" | "inherits" | "invoked" | "lateral_path" | "manages" | "member_of" | "owns" | "part_of" | "possibly_correlates_with" | "protects" | "provides_tool" | "reaches_tool" | "remediates" | "runs" | "scoped_to" | "serves_model" | "shares_cred" | "shares_server" | "stores" | "triggers" | "trusts" | "used_credential" | "uses" | "vulnerable_to";
 
-export const GRAPH_EDGE_KINDS: readonly GraphEdgeKindKey[] = ["accessed", "acted_as", "affects", "assumes", "attached", "authenticates_as", "belongs_to", "called", "can_access", "configures", "contains", "correlates_with", "cross_account_trust", "defines", "delegated_to", "depends_on", "exhibits_drift", "exploitable_via", "exposed_to", "exposes_cred", "governs", "has_permission", "hosts", "imports", "inherits", "invoked", "lateral_path", "manages", "member_of", "owns", "part_of", "possibly_correlates_with", "provides_tool", "reaches_tool", "remediates", "runs", "scoped_to", "serves_model", "shares_cred", "shares_server", "stores", "triggers", "trusts", "used_credential", "uses", "vulnerable_to"] as const;
+export const GRAPH_EDGE_KINDS: readonly GraphEdgeKindKey[] = ["accessed", "acted_as", "affects", "assumes", "attached", "authenticates_as", "belongs_to", "called", "can_access", "configures", "contains", "correlates_with", "cross_account_trust", "defines", "delegated_to", "depends_on", "exhibits_drift", "exploitable_via", "exposed_to", "exposes_cred", "governs", "has_permission", "hosts", "imports", "inherits", "invoked", "lateral_path", "manages", "member_of", "owns", "part_of", "possibly_correlates_with", "protects", "provides_tool", "reaches_tool", "remediates", "runs", "scoped_to", "serves_model", "shares_cred", "shares_server", "stores", "triggers", "trusts", "used_credential", "uses", "vulnerable_to"] as const;
 
 export interface GraphEdgeKindMeta {
   label: string;
@@ -1091,6 +1102,22 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
       "server"
     ],
     "traversable": false
+  },
+  "protects": {
+    "label": "Protects (WAF/gateway)",
+    "color": "#2563eb",
+    "category": "exposure",
+    "direction": "directed",
+    "source_types": [
+      "api_gateway",
+      "cloud_resource"
+    ],
+    "target_types": [
+      "cloud_resource",
+      "data_store",
+      "resource"
+    ],
+    "traversable": true
   },
   "provides_tool": {
     "label": "Provides Tool",

--- a/ui/lib/graph-schema.ts
+++ b/ui/lib/graph-schema.ts
@@ -82,6 +82,7 @@ export enum EntityType {
   DRIFT_INCIDENT = "drift_incident",
   // Cloud-CNAPP primitives
   DATA_STORE = "data_store",
+  API_GATEWAY = "api_gateway",
   // Application Security Posture Management (ASPM)
   APPLICATION = "application",
   // Organizational hierarchy
@@ -147,6 +148,7 @@ export enum RelationshipType {
   EXPOSED_TO = "exposed_to",
   STORES = "stores",
   HAS_PERMISSION = "has_permission",
+  PROTECTS = "protects",
 
   // Application Security Posture Management (ASPM)
   BELONGS_TO = "belongs_to",
@@ -463,6 +465,7 @@ export const ENTITY_COLOR_MAP: Record<string, string> = {
   [EntityType.ACCESS_POLICY]: "#a16207",   // amber
   [EntityType.DRIFT_INCIDENT]: "#fb923c",  // orange
   [EntityType.DATA_STORE]: "#0284c7",      // sky
+  [EntityType.API_GATEWAY]: "#2563eb",     // blue
   [EntityType.APPLICATION]: "#7c3aed",     // violet
   [EntityType.PROVIDER]: "#6b7280",        // gray
   [EntityType.ENVIRONMENT]: "#6b7280",     // gray
@@ -519,6 +522,7 @@ export const RELATIONSHIP_COLOR_MAP: Record<string, string> = {
   [RelationshipType.EXPOSED_TO]: "#e11d48",
   [RelationshipType.STORES]: "#0284c7",
   [RelationshipType.HAS_PERMISSION]: "#dc2626",
+  [RelationshipType.PROTECTS]: "#2563eb",
   // ASPM relations.
   [RelationshipType.BELONGS_TO]: "#7c3aed",
 };


### PR DESCRIPTION
Resolves #3176 — live network-edge inventory across AWS/Azure/GCP, wired into the graph so exposure scoring accounts for what fronts a resource. All read-only, within existing roles (no new grant).

**Inventory added** (shared payload contract: `api_gateways`, `web_acls`, `network_interfaces`, `subnets`, `nat_gateways`, `route_tables`, `ip_addresses`, …):
- **AWS**: WAFv2 web ACLs + associations (regional + CloudFront), API Gateway REST + HTTP/WS + stages, ENIs, NAT/internet/egress-only gateways, VPC endpoints, subnets (public/private classified by IGW route), route tables, network ACLs, Elastic + ENI public IPs.
- **Azure**: Azure Firewall, NAT gateways, route tables, NICs (+ IP config), private endpoints, symmetric public-IP view.
- **GCP**: Cloud Armor (WAF), API Gateway/Apigee, load balancing (backend services/URL maps/forwarding rules/target proxies), Cloud NAT + routers, subnets, external IPs.

**Graph / exposure (the point):**
- `API_GATEWAY` node populated from live AWS/GCP inventory + Azure API Management.
- New `PROTECTS` relationship from a WAF / API gateway to the resource it fronts.
- `cnapp_overlay`: a WAF-fronted, internet-exposed+vulnerable resource is downgraded (`toxic_exposed_vulnerable_mitigated`, ~6.5) instead of the full toxic 9.0/9.5 — its verdict now differs from an unprotected peer.
- ENIs/NICs wired `PART_OF` instance/subnet/security-group; public IP on an ENI marks the instance internet-reachable; public subnets carry exposure.

Full-stack: graph types/OCSF/legend/schema-meta, regenerated DATA_MODEL + `ui/lib/graph-schema.generated.ts` (39 node / 47 edge kinds). New `tests/test_cloud_network_edge.py` (10) + Azure (30) + GCP (44); `pytest -k cloud/inventory/graph/exposure/builder/cnapp` 1520 passed. (One unrelated local failure: `test_gcp_sdk_coverage` needs the `gcp` extra not installed in the dev venv; passes in CI.)
