### PR TITLE
feat(cloud): KMS / Secrets Manager key resolution for connection encryption

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -74,8 +74,12 @@ AGENT_BOM_CLICKHOUSE_URL
 AGENT_BOM_CLICKHOUSE_USER
 # Opt-in (default OFF) gate for the estate-wide read-only AWS asset inventory scanner.
 AGENT_BOM_CLOUD_INVENTORY
-# base64 Fernet key for at-rest encryption of cloud-connection secrets (ExternalId); secret, env/KMS-only, never in config.py or ENV_VARS.md
+# base64 Fernet key for at-rest encryption of cloud-connection secrets (ExternalId); secret, env/KMS-only, never in config.py or ENV_VARS.md. With provider=aws-kms it holds the base64 KMS-wrapped data key instead.
 AGENT_BOM_CONNECTIONS_KEY
+# Selects how the connection encryption key is resolved: env (default) | aws-secrets | aws-kms; read at key-load time in api/connection_crypto.py.
+AGENT_BOM_CONNECTIONS_KEY_PROVIDER
+# Reference (not a secret value) to the managed connection key: the Secrets Manager secret id/ARN for provider=aws-secrets; resolved read-only at key-load time.
+AGENT_BOM_CONNECTIONS_KEY_REF
 # CLI profile config path override; read at command invocation time.
 AGENT_BOM_CONFIG
 AGENT_BOM_COMPLIANCE_BUNDLE_TTL_SECONDS

--- a/src/agent_bom/api/connection_crypto.py
+++ b/src/agent_bom/api/connection_crypto.py
@@ -5,57 +5,212 @@ provider-appropriate equivalent) that the credential broker presents when it
 assumes the customer's read-only role. That value must never be persisted in
 plaintext, returned in an API response, or written to a log.
 
-Key resolution is environment-only: ``AGENT_BOM_CONNECTIONS_KEY`` carries a
-base64 ``Fernet`` key. When it is unset the module is in a clearly-degraded
-mode that *refuses* to encrypt — callers raise rather than fall back to storing
-plaintext. The plaintext secret and the key itself are never logged.
+Key resolution is pluggable via ``AGENT_BOM_CONNECTIONS_KEY_PROVIDER`` so a
+hosted deployment can resolve the Fernet key from a managed key service instead
+of a process env var. The encrypt/decrypt contract is identical across
+providers; only key resolution differs. When the resolved key cannot be
+obtained the module is in a clearly-degraded mode that *refuses* to encrypt —
+callers raise rather than fall back to storing plaintext. The plaintext secret,
+the key, and any provider error detail are never logged.
 
-Production extension seam: ``AGENT_BOM_CONNECTIONS_KEY`` is the open default. A
-hosted/enterprise deployment should resolve the key (or wrap the ciphertext)
-through a KMS / secrets-manager handle instead of a process env var; replace
-:func:`_load_key` with a provider that fetches the data key from KMS, AWS
-Secrets Manager, Azure Key Vault, or GCP Secret Manager. The encrypt/decrypt
-contract below is unchanged by that swap.
+Providers (``AGENT_BOM_CONNECTIONS_KEY_PROVIDER``):
+
+``env`` (default)
+    ``AGENT_BOM_CONNECTIONS_KEY`` carries a base64 ``Fernet`` key directly. This
+    is the open / self-hosted default and is unchanged from Phase A.
+
+``aws-secrets``
+    The base64 ``Fernet`` key is fetched from AWS Secrets Manager at the secret
+    id/ARN named by ``AGENT_BOM_CONNECTIONS_KEY_REF`` using a read-only
+    ``secretsmanager:GetSecretValue``. Nothing about the key is stored locally.
+
+``aws-kms``
+    Envelope encryption. ``AGENT_BOM_CONNECTIONS_KEY`` holds a KMS-wrapped
+    (base64) data key — the ``CiphertextBlob`` an operator produces once with
+    ``aws kms generate-data-key --key-id <cmk> --number-of-bytes 32`` (the wrap
+    step). At load the blob is decrypted with ``kms:Decrypt`` and the recovered
+    32-byte data key is encoded into a ``Fernet`` key. The plaintext data key
+    never touches disk.
+
+Planned seam: ``azure-keyvault`` and ``gcp-secret-manager`` follow the same
+resolver contract (return the base64 Fernet key, fail closed on any error) and
+can be added without touching the encrypt/decrypt API below.
+
+The resolved key is cached in-process; :func:`reset_key_cache` clears it (used
+by tests and by an operator-driven rotation). Any resolution failure — missing
+ref, access denied, malformed material — raises :class:`ConnectionSecretError`;
+the deployment fails closed and never persists plaintext.
 """
 
 from __future__ import annotations
 
+import base64
 import os
+from collections.abc import Callable
 from typing import Any
 
 CONNECTIONS_KEY_ENV = "AGENT_BOM_CONNECTIONS_KEY"
+CONNECTIONS_KEY_PROVIDER_ENV = "AGENT_BOM_CONNECTIONS_KEY_PROVIDER"
+CONNECTIONS_KEY_REF_ENV = "AGENT_BOM_CONNECTIONS_KEY_REF"
+
+PROVIDER_ENV = "env"
+PROVIDER_AWS_SECRETS = "aws-secrets"
+PROVIDER_AWS_KMS = "aws-kms"
+
+# In-process cache of the resolved base64 Fernet key. ``None`` means "not yet
+# resolved"; cleared by :func:`reset_key_cache`.
+_RESOLVED_KEY: bytes | None = None
 
 
 class ConnectionSecretError(RuntimeError):
     """Raised when a connection secret cannot be encrypted or decrypted.
 
-    The message intentionally never embeds the plaintext secret or the key —
-    only the failure mode — so it is safe to surface in an error envelope or log.
+    The message intentionally never embeds the plaintext secret, the key, or a
+    provider's error detail — only the failure mode — so it is safe to surface
+    in an error envelope or log.
     """
+
+
+def _provider() -> str:
+    """Return the configured key provider, normalized; defaults to ``env``."""
+    return os.environ.get(CONNECTIONS_KEY_PROVIDER_ENV, PROVIDER_ENV).strip().lower() or PROVIDER_ENV
+
+
+def reset_key_cache() -> None:
+    """Clear the in-process resolved-key cache.
+
+    Forces the next encrypt/decrypt to re-resolve the key through the configured
+    provider. Used by tests and by operator-driven key rotation.
+    """
+    global _RESOLVED_KEY
+    _RESOLVED_KEY = None
 
 
 def connections_key_configured() -> bool:
-    """Return whether an at-rest encryption key is available.
+    """Return whether an at-rest encryption key is *configured* for the provider.
 
-    Used by the API to fail closed *before* accepting a secret when the store
-    would otherwise be unable to encrypt it.
+    Used by the API to fail closed *before* accepting a secret. This checks that
+    the configuration a provider needs is present (env key / secret ref / wrapped
+    key); it does not make a network call. Actual resolution failures still fail
+    closed at encrypt/decrypt time, so a denied/malformed managed key never
+    results in stored plaintext.
     """
-    return bool(os.environ.get(CONNECTIONS_KEY_ENV, "").strip())
+    if _RESOLVED_KEY is not None:
+        return True
+    provider = _provider()
+    if provider == PROVIDER_ENV:
+        return bool(os.environ.get(CONNECTIONS_KEY_ENV, "").strip())
+    if provider == PROVIDER_AWS_SECRETS:
+        return bool(os.environ.get(CONNECTIONS_KEY_REF_ENV, "").strip())
+    if provider == PROVIDER_AWS_KMS:
+        return bool(os.environ.get(CONNECTIONS_KEY_ENV, "").strip())
+    return False
 
 
-def _load_key() -> bytes:
-    """Resolve the Fernet key from the environment.
+def _boto3_client(service: str, provider: str) -> Any:
+    """Return a boto3 client for ``service`` or fail closed.
 
-    Raises :class:`ConnectionSecretError` when the key is missing — the
-    no-plaintext-fallback guarantee — or malformed.
+    boto3 is an optional (``[aws]``) dependency; its absence is a configuration
+    error for the AWS-backed providers, not a reason to fall back to plaintext.
     """
+    try:
+        import boto3
+    except ImportError as exc:
+        raise ConnectionSecretError(
+            f"boto3 is required for the '{provider}' connection key provider. Install with: pip install 'agent-bom[aws]'."
+        ) from exc
+    return boto3.client(service)
+
+
+def _resolve_env() -> bytes:
+    """Resolve the base64 Fernet key from ``AGENT_BOM_CONNECTIONS_KEY``."""
     raw = os.environ.get(CONNECTIONS_KEY_ENV, "").strip()
     if not raw:
         raise ConnectionSecretError(
             f"{CONNECTIONS_KEY_ENV} is not set; refusing to store or read a connection secret in plaintext. "
-            "Provide a base64 Fernet key (or wire a KMS/secrets-manager key provider)."
+            "Provide a base64 Fernet key (or set "
+            f"{CONNECTIONS_KEY_PROVIDER_ENV} to a managed key provider)."
         )
     return raw.encode("ascii")
+
+
+def _resolve_aws_secrets() -> bytes:
+    """Fetch the base64 Fernet key from AWS Secrets Manager (read-only)."""
+    ref = os.environ.get(CONNECTIONS_KEY_REF_ENV, "").strip()
+    if not ref:
+        raise ConnectionSecretError(
+            f"{CONNECTIONS_KEY_PROVIDER_ENV}={PROVIDER_AWS_SECRETS} requires {CONNECTIONS_KEY_REF_ENV} "
+            "(the secret id/ARN of the base64 Fernet key); refusing to fall back to plaintext."
+        )
+    client = _boto3_client("secretsmanager", PROVIDER_AWS_SECRETS)
+    try:
+        response = client.get_secret_value(SecretId=ref)
+    except Exception as exc:  # noqa: BLE001 - botocore ClientError et al.
+        # Never echo the provider error (it can carry the secret ARN/account).
+        raise ConnectionSecretError("Unable to resolve the connection encryption key from AWS Secrets Manager.") from exc
+    raw = (response.get("SecretString") or "").strip()
+    if not raw:
+        raise ConnectionSecretError("AWS Secrets Manager returned an empty connection encryption key.")
+    return raw.encode("ascii")
+
+
+def _resolve_aws_kms() -> bytes:
+    """Unwrap the KMS-wrapped data key in ``AGENT_BOM_CONNECTIONS_KEY``.
+
+    The env var holds the base64 ``CiphertextBlob`` produced by KMS
+    ``GenerateDataKey``; ``kms:Decrypt`` recovers the 32-byte data key, which is
+    encoded into a ``Fernet`` key.
+    """
+    wrapped = os.environ.get(CONNECTIONS_KEY_ENV, "").strip()
+    if not wrapped:
+        raise ConnectionSecretError(
+            f"{CONNECTIONS_KEY_PROVIDER_ENV}={PROVIDER_AWS_KMS} requires {CONNECTIONS_KEY_ENV} "
+            "to hold a KMS-wrapped (base64) data key; refusing to fall back to plaintext."
+        )
+    try:
+        ciphertext_blob = base64.b64decode(wrapped, validate=True)
+    except Exception as exc:  # noqa: BLE001 - malformed base64
+        raise ConnectionSecretError(f"{CONNECTIONS_KEY_ENV} is not a valid base64 KMS-wrapped data key.") from exc
+    client = _boto3_client("kms", PROVIDER_AWS_KMS)
+    try:
+        response = client.decrypt(CiphertextBlob=ciphertext_blob)
+    except Exception as exc:  # noqa: BLE001 - botocore ClientError et al.
+        # Never echo the provider error (it can carry the KMS key ARN/account).
+        raise ConnectionSecretError("Unable to decrypt the connection encryption key with AWS KMS.") from exc
+    plaintext = response.get("Plaintext")
+    if not plaintext:
+        raise ConnectionSecretError("AWS KMS returned an empty data key.")
+    # Encode the raw data key into a urlsafe-base64 Fernet key. A wrong-length
+    # data key yields an invalid Fernet key and fails closed at construction.
+    return base64.urlsafe_b64encode(bytes(plaintext))
+
+
+_RESOLVERS: dict[str, Callable[[], bytes]] = {
+    PROVIDER_ENV: _resolve_env,
+    PROVIDER_AWS_SECRETS: _resolve_aws_secrets,
+    PROVIDER_AWS_KMS: _resolve_aws_kms,
+}
+
+
+def _load_key() -> bytes:
+    """Resolve the base64 Fernet key through the configured provider, cached.
+
+    Raises :class:`ConnectionSecretError` when the key is unresolvable — the
+    no-plaintext-fallback guarantee — or the provider is unknown.
+    """
+    global _RESOLVED_KEY
+    if _RESOLVED_KEY is not None:
+        return _RESOLVED_KEY
+    provider = _provider()
+    resolver = _RESOLVERS.get(provider)
+    if resolver is None:
+        raise ConnectionSecretError(
+            f"{CONNECTIONS_KEY_PROVIDER_ENV}={provider!r} is not a supported key provider; "
+            f"expected one of {PROVIDER_ENV!r}, {PROVIDER_AWS_SECRETS!r}, {PROVIDER_AWS_KMS!r}."
+        )
+    key = resolver()
+    _RESOLVED_KEY = key
+    return key
 
 
 def _fernet() -> Any:
@@ -69,7 +224,7 @@ def _fernet() -> Any:
         raise
     except Exception as exc:  # noqa: BLE001 - malformed key material
         # Never echo the key or its decode error detail; only the failure mode.
-        raise ConnectionSecretError(f"{CONNECTIONS_KEY_ENV} is not a valid base64 Fernet key.") from exc
+        raise ConnectionSecretError("The resolved connection encryption key is not a valid Fernet key.") from exc
 
 
 def encrypt_secret(plaintext: str) -> str:

--- a/tests/test_cloud_connections.py
+++ b/tests/test_cloud_connections.py
@@ -9,6 +9,7 @@ error).
 
 from __future__ import annotations
 
+import base64
 import os
 import sqlite3
 import uuid
@@ -47,10 +48,15 @@ def _connection_env() -> Iterator[None]:
         "AGENT_BOM_TRUST_PROXY_AUTH": os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH"),
         "AGENT_BOM_TRUST_PROXY_AUTH_SECRET": os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH_SECRET"),
         connection_crypto.CONNECTIONS_KEY_ENV: os.environ.get(connection_crypto.CONNECTIONS_KEY_ENV),
+        connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV: os.environ.get(connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV),
+        connection_crypto.CONNECTIONS_KEY_REF_ENV: os.environ.get(connection_crypto.CONNECTIONS_KEY_REF_ENV),
     }
     os.environ["AGENT_BOM_TRUST_PROXY_AUTH"] = "1"
     os.environ["AGENT_BOM_TRUST_PROXY_AUTH_SECRET"] = PROXY_SECRET
     os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = _TEST_KEY
+    os.environ.pop(connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV, None)
+    os.environ.pop(connection_crypto.CONNECTIONS_KEY_REF_ENV, None)
+    connection_crypto.reset_key_cache()
     set_connection_store(InMemoryConnectionStore())
     try:
         yield
@@ -60,6 +66,7 @@ def _connection_env() -> Iterator[None]:
                 os.environ.pop(key, None)
             else:
                 os.environ[key] = value
+        connection_crypto.reset_key_cache()
         set_connection_store(None)
 
 
@@ -164,6 +171,160 @@ def test_invalid_key_raises_clear_error() -> None:
     os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = "not-a-valid-fernet-key"
     with pytest.raises(connection_crypto.ConnectionSecretError):
         connection_crypto.encrypt_secret("x")
+
+
+# --------------------------------------------------------------------------- #
+# Key providers: managed-key resolution (aws-secrets / aws-kms), fail-closed,
+# in-process caching. boto3 is mocked at the _boto3_client seam.
+# --------------------------------------------------------------------------- #
+
+
+class _FakeSecretsClient:
+    """Stand-in for a Secrets Manager client; counts GetSecretValue calls."""
+
+    def __init__(self, *, secret_string: str | None = None, error: Exception | None = None) -> None:
+        self.calls = 0
+        self._secret_string = secret_string
+        self._error = error
+
+    def get_secret_value(self, *, SecretId: str) -> dict[str, Any]:  # noqa: N803 - boto3 kwarg
+        self.calls += 1
+        if self._error is not None:
+            raise self._error
+        return {"SecretString": self._secret_string}
+
+
+class _FakeKmsClient:
+    """Stand-in for a KMS client; counts Decrypt calls."""
+
+    def __init__(self, *, plaintext: bytes | None = None, error: Exception | None = None) -> None:
+        self.calls = 0
+        self._plaintext = plaintext
+        self._error = error
+
+    def decrypt(self, *, CiphertextBlob: bytes) -> dict[str, Any]:  # noqa: N803 - boto3 kwarg
+        self.calls += 1
+        if self._error is not None:
+            raise self._error
+        return {"Plaintext": self._plaintext}
+
+
+def _patch_client(monkeypatch: Any, client: Any) -> None:
+    monkeypatch.setattr(connection_crypto, "_boto3_client", lambda service, provider: client)
+
+
+def test_aws_secrets_provider_round_trip(monkeypatch: Any) -> None:
+    os.environ[connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV] = connection_crypto.PROVIDER_AWS_SECRETS
+    os.environ[connection_crypto.CONNECTIONS_KEY_REF_ENV] = "arn:aws:secretsmanager:us-east-1:123456789012:secret:agent-bom/conn-key"
+    os.environ.pop(connection_crypto.CONNECTIONS_KEY_ENV, None)
+    fake = _FakeSecretsClient(secret_string=_TEST_KEY)
+    _patch_client(monkeypatch, fake)
+    connection_crypto.reset_key_cache()
+
+    assert connection_crypto.connections_key_configured() is True
+    token = connection_crypto.encrypt_secret("ext-id")
+    assert connection_crypto.decrypt_secret(token) == "ext-id"
+    # Resolved once, then served from cache (decrypt did not re-fetch).
+    assert fake.calls == 1
+
+
+def test_aws_secrets_missing_ref_fails_closed(monkeypatch: Any) -> None:
+    os.environ[connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV] = connection_crypto.PROVIDER_AWS_SECRETS
+    os.environ.pop(connection_crypto.CONNECTIONS_KEY_REF_ENV, None)
+    fake = _FakeSecretsClient(secret_string=_TEST_KEY)
+    _patch_client(monkeypatch, fake)
+    connection_crypto.reset_key_cache()
+
+    assert connection_crypto.connections_key_configured() is False
+    with pytest.raises(connection_crypto.ConnectionSecretError):
+        connection_crypto.encrypt_secret("ext-id")
+    # Never attempted a provider call without a ref.
+    assert fake.calls == 0
+
+
+def test_aws_secrets_denial_fails_closed_without_leaking(monkeypatch: Any) -> None:
+    os.environ[connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV] = connection_crypto.PROVIDER_AWS_SECRETS
+    os.environ[connection_crypto.CONNECTIONS_KEY_REF_ENV] = "arn:aws:secretsmanager:us-east-1:123456789012:secret:agent-bom/conn-key"
+    denial = RuntimeError("AccessDeniedException: not authorized to GetSecretValue on agent-bom/conn-key")
+    fake = _FakeSecretsClient(error=denial)
+    _patch_client(monkeypatch, fake)
+    connection_crypto.reset_key_cache()
+
+    with pytest.raises(connection_crypto.ConnectionSecretError) as excinfo:
+        connection_crypto.encrypt_secret("ext-id")
+    message = str(excinfo.value)
+    assert "conn-key" not in message
+    assert "AccessDenied" not in message
+    assert _TEST_KEY not in message
+
+
+def test_aws_kms_provider_unwraps_data_key(monkeypatch: Any) -> None:
+    data_key = os.urandom(32)  # what GenerateDataKey(NumberOfBytes=32) returns
+    wrapped = base64.b64encode(b"kms-wrapped-ciphertext-blob").decode("ascii")
+    os.environ[connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV] = connection_crypto.PROVIDER_AWS_KMS
+    os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = wrapped
+    fake = _FakeKmsClient(plaintext=data_key)
+    _patch_client(monkeypatch, fake)
+    connection_crypto.reset_key_cache()
+
+    assert connection_crypto.connections_key_configured() is True
+    token = connection_crypto.encrypt_secret("ext-id")
+    assert connection_crypto.decrypt_secret(token) == "ext-id"
+    assert fake.calls == 1
+
+
+def test_aws_kms_denial_fails_closed_without_leaking(monkeypatch: Any) -> None:
+    os.environ[connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV] = connection_crypto.PROVIDER_AWS_KMS
+    os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = base64.b64encode(b"blob").decode("ascii")
+    denial = RuntimeError("AccessDeniedException: not authorized to Decrypt with arn:aws:kms:us-east-1:123456789012:key/abc-123")
+    fake = _FakeKmsClient(error=denial)
+    _patch_client(monkeypatch, fake)
+    connection_crypto.reset_key_cache()
+
+    with pytest.raises(connection_crypto.ConnectionSecretError) as excinfo:
+        connection_crypto.encrypt_secret("ext-id")
+    message = str(excinfo.value)
+    assert "arn:aws:kms" not in message
+    assert "AccessDenied" not in message
+
+
+def test_aws_kms_malformed_wrapped_key_fails_closed(monkeypatch: Any) -> None:
+    os.environ[connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV] = connection_crypto.PROVIDER_AWS_KMS
+    os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = "not!valid!base64!!"
+    fake = _FakeKmsClient(plaintext=os.urandom(32))
+    _patch_client(monkeypatch, fake)
+    connection_crypto.reset_key_cache()
+
+    with pytest.raises(connection_crypto.ConnectionSecretError):
+        connection_crypto.encrypt_secret("ext-id")
+    # Malformed base64 is rejected before any KMS call.
+    assert fake.calls == 0
+
+
+def test_resolved_key_cached_until_reset(monkeypatch: Any) -> None:
+    os.environ[connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV] = connection_crypto.PROVIDER_AWS_SECRETS
+    os.environ[connection_crypto.CONNECTIONS_KEY_REF_ENV] = "arn:aws:secretsmanager:us-east-1:123456789012:secret:agent-bom/conn-key"
+    fake = _FakeSecretsClient(secret_string=_TEST_KEY)
+    _patch_client(monkeypatch, fake)
+    connection_crypto.reset_key_cache()
+
+    connection_crypto.encrypt_secret("a")
+    connection_crypto.encrypt_secret("b")
+    connection_crypto.decrypt_secret(connection_crypto.encrypt_secret("c"))
+    assert fake.calls == 1  # one fetch served every operation
+
+    connection_crypto.reset_key_cache()
+    connection_crypto.encrypt_secret("d")
+    assert fake.calls == 2  # reset forces a fresh resolution
+
+
+def test_unknown_provider_fails_closed() -> None:
+    os.environ[connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV] = "azure-keyvault"
+    connection_crypto.reset_key_cache()
+
+    assert connection_crypto.connections_key_configured() is False
+    with pytest.raises(connection_crypto.ConnectionSecretError):
+        connection_crypto.encrypt_secret("ext-id")
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes a control-plane wiring gap for #3175: the cloud-connection at-rest encryption key can now resolve from a managed key service, not just a process env var. The encrypt/decrypt API and the store are unchanged — only `_load_key()` changed, behind the seam Phase A documented.

`AGENT_BOM_CONNECTIONS_KEY_PROVIDER`:
- **env** (default): `AGENT_BOM_CONNECTIONS_KEY` = base64 Fernet key (unchanged OSS path).
- **aws-secrets**: fetch the base64 Fernet key from AWS Secrets Manager at `AGENT_BOM_CONNECTIONS_KEY_REF` (read-only `secretsmanager:GetSecretValue`).
- **aws-kms**: envelope — `AGENT_BOM_CONNECTIONS_KEY` holds a KMS-wrapped data key (`GenerateDataKey`); `kms:Decrypt` recovers it at load.
- azure-keyvault / gcp-secret-manager = documented planned seams (same resolver contract).

Resolved key cached in-process (`reset_key_cache()` for tests/rotation). **Fail-closed on every path** (missing ref, access denied, malformed blob, empty/invalid key, unknown provider, boto3 absent) → `ConnectionSecretError`; the secret, key, and provider error detail are never logged or echoed. `connections_key_configured()` is honest per provider, so the create route still 503s before accepting a secret.

8 new tests (boto3 mocked): aws-secrets round-trip + missing-ref + denial; aws-kms unwrap + denial + malformed; cache-fetches-once + reset; unknown-provider fail-closed; secret/ARN/AccessDenied absent from error messages. `pytest tests/test_cloud_connections.py` 34 passed; ruff/mypy(strict)/bandit clean.
