### PR TITLE
feat(cloud): connections scan scheduler (Phase B.2) — cluster-safe recurring re-scans

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -54,7 +54,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
 | `docs/openapi/v1.json` | paths | 239 |
-| `docs/openapi/v1.json` | component schemas | 62 |
+| `docs/openapi/v1.json` | component schemas | 63 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -154,7 +154,7 @@
       },
       "CloudConnectionCreate": {
         "additionalProperties": false,
-        "description": "Request body for creating a connection. ``external_id`` is write-only.",
+        "description": "Request body for creating a connection. ``external_id`` is write-only.\n\n``scan_interval_minutes`` opts the connection into recurring background scans\n(Phase B.2). Null (the default) means manual-only \u2014 the scheduler ignores it.",
         "properties": {
           "display_name": {
             "maxLength": 200,
@@ -184,6 +184,17 @@
             "minLength": 1,
             "title": "Role Ref",
             "type": "string"
+          },
+          "scan_interval_minutes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scan Interval Minutes"
           }
         },
         "required": [
@@ -193,6 +204,25 @@
           "external_id"
         ],
         "title": "CloudConnectionCreate",
+        "type": "object"
+      },
+      "CloudConnectionUpdate": {
+        "additionalProperties": false,
+        "description": "Request body for updating a connection's recurring scan schedule.\n\n``scan_interval_minutes`` is set to the supplied value; null disables the\nrecurring scan (back to manual-only).",
+        "properties": {
+          "scan_interval_minutes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scan Interval Minutes"
+          }
+        },
+        "title": "CloudConnectionUpdate",
         "type": "object"
       },
       "ComplianceAuditIntegrity": {
@@ -6170,6 +6200,107 @@
           }
         },
         "summary": "Get Connection",
+        "tags": [
+          "cloud-connections"
+        ]
+      },
+      "patch": {
+        "description": "Update a connection's recurring scan schedule (tenant-scoped).\n\nSets ``scan_interval_minutes`` (null disables recurring scans). The encrypted\nsecret is untouched and never returned.",
+        "operationId": "update_connection_v1_cloud_connections__connection_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connection_id",
+            "required": true,
+            "schema": {
+              "title": "Connection Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CloudConnectionUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Update Connection V1 Cloud Connections  Connection Id  Patch",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Connection",
         "tags": [
           "cloud-connections"
         ]

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -110,7 +110,10 @@ components:
       type: object
     CloudConnectionCreate:
       additionalProperties: false
-      description: Request body for creating a connection. ``external_id`` is write-only.
+      description: "Request body for creating a connection. ``external_id`` is write-only.\n\
+        \n``scan_interval_minutes`` opts the connection into recurring background\
+        \ scans\n(Phase B.2). Null (the default) means manual-only \u2014 the scheduler\
+        \ ignores it."
       properties:
         display_name:
           maxLength: 200
@@ -135,12 +138,33 @@ components:
           minLength: 1
           title: Role Ref
           type: string
+        scan_interval_minutes:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Scan Interval Minutes
       required:
       - provider
       - display_name
       - role_ref
       - external_id
       title: CloudConnectionCreate
+      type: object
+    CloudConnectionUpdate:
+      additionalProperties: false
+      description: 'Request body for updating a connection''s recurring scan schedule.
+
+
+        ``scan_interval_minutes`` is set to the supplied value; null disables the
+
+        recurring scan (back to manual-only).'
+      properties:
+        scan_interval_minutes:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Scan Interval Minutes
+      title: CloudConnectionUpdate
       type: object
     ComplianceAuditIntegrity:
       properties:
@@ -4051,6 +4075,70 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Get Connection
+      tags:
+      - cloud-connections
+    patch:
+      description: 'Update a connection''s recurring scan schedule (tenant-scoped).
+
+
+        Sets ``scan_interval_minutes`` (null disables recurring scans). The encrypted
+
+        secret is untouched and never returned.'
+      operationId: update_connection_v1_cloud_connections__connection_id__patch
+      parameters:
+      - in: path
+        name: connection_id
+        required: true
+        schema:
+          title: Connection Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CloudConnectionUpdate'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Update Connection V1 Cloud Connections  Connection
+                  Id  Patch
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Update Connection
       tags:
       - cloud-connections
   /v1/cloud/connections/{connection_id}/scan:

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -38,6 +38,9 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_API_SCAN_WORKERS` | `int` | `min(4, os.cpu_count() or 2)` | — |
 | `AGENT_BOM_API_SCAN_WORKER_RECYCLE_JOBS` | `int` | `10` | — |
 | `AGENT_BOM_BODY_MIN_BPS` | `int` | `256` | Slowloris throughput floor (audit-5 PR-C): minimum sustained body bytes/second once a request body crosses the warmup threshold inside MaxBodySizeMiddleware. 0 disables the floor entirely (escape hatch for legitimate slow clients in restric |
+| `AGENT_BOM_CONNECTIONS_SCHEDULER_MAX_CONCURRENCY` | `int` | `4` | — |
+| `AGENT_BOM_CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES` | `int` | `15` | — |
+| `AGENT_BOM_CONNECTIONS_SCHEDULER_POLL_SECONDS` | `int` | `60` | Cloud-connection scan scheduler (Phase B.2). The background loop re-scans cloud connections that carry an interval, so "connect once, keeps evaluating" is automatic. Disabled by default (AGENT_BOM_CONNECTIONS_SCHEDULER, read live) so it nev |
 
 ## Agent-to-Agent (A2A) auth posture
 | Env var | Type | Default | Description |

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -80,6 +80,8 @@ AGENT_BOM_CONNECTIONS_KEY
 AGENT_BOM_CONNECTIONS_KEY_PROVIDER
 # Reference (not a secret value) to the managed connection key: the Secrets Manager secret id/ARN for provider=aws-secrets; resolved read-only at key-load time.
 AGENT_BOM_CONNECTIONS_KEY_REF
+# opt-in flag (default OFF) enabling the background loop that re-scans due cloud connections (Phase B.2); read live in api/connection_scheduler.py
+AGENT_BOM_CONNECTIONS_SCHEDULER
 # CLI profile config path override; read at command invocation time.
 AGENT_BOM_CONFIG
 AGENT_BOM_COMPLIANCE_BUNDLE_TTL_SECONDS

--- a/src/agent_bom/api/connection_scheduler.py
+++ b/src/agent_bom/api/connection_scheduler.py
@@ -1,0 +1,231 @@
+"""Background scheduler that re-scans due cloud connections (Phase B.2).
+
+Phase B added an on-demand ``POST /v1/cloud/connections/{id}/scan`` path that
+brokers a stored connection into a short-lived read-only role and runs the same
+inventory + CIS discovery the sibling cloud routes use. This module turns that
+into "connect once, keeps evaluating": a control-plane background loop that
+periodically finds connections carrying a ``scan_interval_minutes`` and re-runs
+the **same** broker scan path when one is due.
+
+Design notes:
+
+* **Opt-in, off by default.** The loop only starts when
+  ``AGENT_BOM_CONNECTIONS_SCHEDULER`` is truthy (read live), so it never runs in
+  CLI/dev. A connection is only eligible when it carries an interval; the field
+  is null (manual-only) by default.
+* **Cluster-safe.** Multiple control-plane replicas may run this loop. Each due
+  connection is claimed via an atomic compare-and-swap on ``last_scan_at``
+  (``ConnectionStore.claim_due_scan``): the first replica to advance the stored
+  timestamp wins, every racing replica's conditional UPDATE then no-ops. Exactly
+  one replica runs a given due scan. Bounded concurrency caps brokered scans.
+* **Safe.** Read-only scans only. A failing connection is marked ``error`` with a
+  sanitized, secret-free detail and the loop continues — one bad connection never
+  stops the loop. AWS only today (the broker is AWS-only); other providers are
+  skipped, never claimed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+from agent_bom.api.connection_store import (
+    STATUS_ACTIVE,
+    STATUS_ERROR,
+    CloudConnectionRecord,
+    ConnectionStore,
+    get_connection_store,
+)
+from agent_bom.config import (
+    CONNECTIONS_SCHEDULER_MAX_CONCURRENCY,
+    CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES,
+    CONNECTIONS_SCHEDULER_POLL_SECONDS,
+)
+
+logger = logging.getLogger(__name__)
+
+# Only AWS is broker-enabled; other recognized providers are skipped (not claimed)
+# until their credential broker lands.
+_SCHEDULABLE_PROVIDERS: frozenset[str] = frozenset({"aws"})
+
+
+def connections_scheduler_enabled() -> bool:
+    """Return whether the cloud-connection scan scheduler loop is enabled.
+
+    Read live (not import-time) so tests and operators can toggle it. Default OFF
+    so the loop never runs in CLI/dev — only when an operator opts in on the
+    control plane.
+    """
+    raw = os.environ.get("AGENT_BOM_CONNECTIONS_SCHEDULER", "")
+    return raw.strip().lower() in {"1", "true", "yes", "on", "enabled"}
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    """Parse a stored ISO timestamp into an aware UTC datetime (tolerant)."""
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _effective_interval_minutes(record: CloudConnectionRecord) -> int | None:
+    """Effective interval, clamped to the configured minimum (defensive floor)."""
+    if record.scan_interval_minutes is None:
+        return None
+    return max(int(record.scan_interval_minutes), CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES)
+
+
+def is_due(record: CloudConnectionRecord, now: datetime) -> bool:
+    """Return whether a connection's recurring scan is due at *now*.
+
+    Due when an interval is set and either the connection has never scanned or
+    at least the (clamped) interval has elapsed since ``last_scan_at``.
+    """
+    interval = _effective_interval_minutes(record)
+    if interval is None:
+        return False
+    last = _parse_iso(record.last_scan_at)
+    if last is None:
+        return True
+    return now - last >= timedelta(minutes=interval)
+
+
+def select_due_connections(store: ConnectionStore, now: datetime) -> list[CloudConnectionRecord]:
+    """Return schedulable connections whose recurring scan is due at *now*."""
+    return [record for record in store.list_schedulable() if is_due(record, now)]
+
+
+def claim_due_connections(store: ConnectionStore, now: datetime) -> list[CloudConnectionRecord]:
+    """Select due AWS connections and atomically claim each for this replica.
+
+    Returns only the connections this replica won. Non-AWS providers are skipped
+    (the broker is AWS-only) and are never claimed. The claim advances
+    ``last_scan_at`` to *now* so a racing replica loses the compare-and-swap and
+    a failed scan is not retried until the next interval.
+    """
+    claimed_at = now.isoformat()
+    won: list[CloudConnectionRecord] = []
+    for record in select_due_connections(store, now):
+        if record.provider not in _SCHEDULABLE_PROVIDERS:
+            continue
+        if store.claim_due_scan(record, claimed_at):
+            won.append(record)
+    return won
+
+
+def execute_connection_scan(record: CloudConnectionRecord) -> bool:
+    """Run the broker scan for a claimed connection and persist the outcome.
+
+    Reuses the Phase B scan-launch path (``_run_aws_connection_scan``) and the
+    Phase A lifecycle mutator (``_mark_connection``). On success the connection
+    moves to ``active`` + a fresh ``last_scan_at``; on failure it is marked
+    ``error`` with a sanitized, secret-free detail. Never raises — returns
+    whether the scan succeeded so one bad connection cannot sink the loop.
+    """
+    # Imported lazily to avoid a route-module import at server startup time.
+    from agent_bom.api.audit_log import log_action
+    from agent_bom.api.routes.cloud_connections import (
+        _mark_connection,
+        _now,
+        _run_aws_connection_scan,
+    )
+    from agent_bom.security import sanitize_error
+
+    try:
+        summary = _run_aws_connection_scan(record, record.tenant_id)
+    except Exception as exc:  # noqa: BLE001 - broker / discovery / persistence failure
+        detail = sanitize_error(exc)
+        _mark_connection(record, status=STATUS_ERROR, status_detail=detail)
+        logger.exception("Scheduled cloud connection scan failed for connection %s", record.id)
+        log_action(
+            "cloud_connection.scheduled_scan",
+            actor="scheduler",
+            resource=f"cloud-connection/{record.id}",
+            tenant_id=record.tenant_id,
+            provider=record.provider,
+            outcome="failure",
+        )
+        return False
+
+    _mark_connection(record, status=STATUS_ACTIVE, status_detail="", last_scan_at=_now())
+    log_action(
+        "cloud_connection.scheduled_scan",
+        actor="scheduler",
+        resource=f"cloud-connection/{record.id}",
+        tenant_id=record.tenant_id,
+        provider=record.provider,
+        outcome="success",
+        scan_id=summary.get("scan_id"),
+    )
+    return True
+
+
+async def run_due_scans_once(
+    store: ConnectionStore,
+    now: datetime,
+    *,
+    max_concurrency: int = CONNECTIONS_SCHEDULER_MAX_CONCURRENCY,
+) -> int:
+    """Claim and run every due connection scan once, with bounded concurrency.
+
+    Returns the number of connections this replica claimed and attempted. Each
+    brokered scan runs in a worker thread (boto3 is blocking) under a semaphore
+    so at most *max_concurrency* scans run at a time.
+    """
+    claimed = claim_due_connections(store, now)
+    if not claimed:
+        return 0
+
+    semaphore = asyncio.Semaphore(max(1, max_concurrency))
+
+    async def _guarded(record: CloudConnectionRecord) -> None:
+        async with semaphore:
+            await asyncio.to_thread(execute_connection_scan, record)
+
+    await asyncio.gather(*(_guarded(record) for record in claimed))
+    return len(claimed)
+
+
+async def connection_scheduler_loop(
+    store: ConnectionStore | None = None,
+    *,
+    poll_seconds: int = CONNECTIONS_SCHEDULER_POLL_SECONDS,
+    max_backoff: int = 900,
+) -> None:
+    """Background loop that re-scans due cloud connections.
+
+    Runs as an asyncio task during API server lifespan. Uses exponential backoff
+    on consecutive failures (up to *max_backoff* seconds) so a broken store does
+    not get hammered. A failure scanning one connection is isolated inside
+    :func:`execute_connection_scan` and never breaks the loop.
+    """
+    interval = max(1, poll_seconds)
+    consecutive_failures = 0
+    while True:
+        try:
+            active_store = store or get_connection_store()
+            now = datetime.now(timezone.utc)
+            count = await run_due_scans_once(active_store, now)
+            if count:
+                logger.info("Connection scheduler ran %d due cloud-connection scan(s)", count)
+            consecutive_failures = 0
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            consecutive_failures += 1
+            backoff = min(interval * (2**consecutive_failures), max_backoff)
+            logger.exception(
+                "Connection scheduler loop error (attempt %d, next retry in %ds)",
+                consecutive_failures,
+                backoff,
+            )
+            await asyncio.sleep(backoff)
+            continue
+        await asyncio.sleep(interval)

--- a/src/agent_bom/api/connection_store.py
+++ b/src/agent_bom/api/connection_store.py
@@ -18,7 +18,7 @@ import json
 import sqlite3
 import threading
 from collections.abc import Sequence
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from typing import Any, Protocol
 
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
@@ -56,6 +56,7 @@ class CloudConnectionRecord:
     created_at: str = ""
     updated_at: str = ""
     last_scan_at: str | None = None
+    scan_interval_minutes: int | None = None
 
     def to_public_dict(self) -> dict[str, Any]:
         """Non-secret representation for API responses.
@@ -79,6 +80,8 @@ class ConnectionStore(Protocol):
     def get(self, tenant_id: str, connection_id: str) -> CloudConnectionRecord | None: ...
     def list_for_tenant(self, tenant_id: str) -> list[CloudConnectionRecord]: ...
     def delete(self, tenant_id: str, connection_id: str) -> bool: ...
+    def list_schedulable(self) -> list[CloudConnectionRecord]: ...
+    def claim_due_scan(self, record: CloudConnectionRecord, claimed_at: str) -> bool: ...
 
 
 # ── Portable schema seam ──────────────────────────────────────────────────────
@@ -104,6 +107,7 @@ CONNECTION_STORAGE_SCHEMA = StorageSchema(
                 "created_at",
                 "updated_at",
                 "last_scan_at",
+                "scan_interval_minutes",
             ),
             ddl_by_backend={
                 "sqlite": (
@@ -112,7 +116,7 @@ CONNECTION_STORAGE_SCHEMA = StorageSchema(
                     "role_ref TEXT NOT NULL, external_id_encrypted TEXT NOT NULL DEFAULT '', "
                     "regions TEXT NOT NULL DEFAULT '[]', status TEXT NOT NULL DEFAULT 'pending', "
                     "status_detail TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL, "
-                    "updated_at TEXT NOT NULL, last_scan_at TEXT)"
+                    "updated_at TEXT NOT NULL, last_scan_at TEXT, scan_interval_minutes INTEGER)"
                 ),
                 "postgres": (
                     "CREATE TABLE IF NOT EXISTS cloud_connections (id TEXT PRIMARY KEY, "
@@ -120,7 +124,7 @@ CONNECTION_STORAGE_SCHEMA = StorageSchema(
                     "role_ref TEXT NOT NULL, external_id_encrypted TEXT NOT NULL DEFAULT '', "
                     "regions TEXT NOT NULL DEFAULT '[]', status TEXT NOT NULL DEFAULT 'pending', "
                     "status_detail TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL, "
-                    "updated_at TEXT NOT NULL, last_scan_at TEXT)"
+                    "updated_at TEXT NOT NULL, last_scan_at TEXT, scan_interval_minutes INTEGER)"
                 ),
             },
         ),
@@ -141,6 +145,16 @@ def _decode_regions(raw: Any) -> list[str]:
     return [str(item) for item in parsed]
 
 
+def _decode_interval(raw: Any) -> int | None:
+    """Parse a stored ``scan_interval_minutes`` value into an int (tolerant)."""
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return None
+
+
 def _row_to_record(row: Sequence[Any]) -> CloudConnectionRecord:
     """Map a ``cloud_connections`` row tuple to a record (shared by backends)."""
     return CloudConnectionRecord(
@@ -156,7 +170,18 @@ def _row_to_record(row: Sequence[Any]) -> CloudConnectionRecord:
         created_at=row[9] or "",
         updated_at=row[10] or "",
         last_scan_at=row[11] if len(row) > 11 else None,
+        scan_interval_minutes=_decode_interval(row[12]) if len(row) > 12 else None,
     )
+
+
+def _copy_record(record: CloudConnectionRecord) -> CloudConnectionRecord:
+    """Return an independent copy so callers cannot mutate stored state in place.
+
+    Mirrors the durable backends, which deserialize a fresh object on every read.
+    Without this the in-memory store would hand out the live reference and the
+    compare-and-swap claim could never observe a concurrent change.
+    """
+    return replace(record, regions=list(record.regions))
 
 
 class InMemoryConnectionStore:
@@ -171,18 +196,18 @@ class InMemoryConnectionStore:
 
     def put(self, record: CloudConnectionRecord) -> None:
         with self._lock:
-            self._rows[record.id] = record
+            self._rows[record.id] = _copy_record(record)
 
     def get(self, tenant_id: str, connection_id: str) -> CloudConnectionRecord | None:
         with self._lock:
             record = self._rows.get(connection_id)
-        if record is None or record.tenant_id != tenant_id:
-            return None
-        return record
+            if record is None or record.tenant_id != tenant_id:
+                return None
+            return _copy_record(record)
 
     def list_for_tenant(self, tenant_id: str) -> list[CloudConnectionRecord]:
         with self._lock:
-            records = [r for r in self._rows.values() if r.tenant_id == tenant_id]
+            records = [_copy_record(r) for r in self._rows.values() if r.tenant_id == tenant_id]
         return sorted(records, key=lambda r: (r.created_at, r.id))
 
     def delete(self, tenant_id: str, connection_id: str) -> bool:
@@ -192,6 +217,28 @@ class InMemoryConnectionStore:
                 return False
             del self._rows[connection_id]
             return True
+
+    def list_schedulable(self) -> list[CloudConnectionRecord]:
+        with self._lock:
+            return [_copy_record(r) for r in self._rows.values() if r.scan_interval_minutes is not None]
+
+    def claim_due_scan(self, record: CloudConnectionRecord, claimed_at: str) -> bool:
+        """Atomically claim a due scan, gated on the last-seen ``last_scan_at``.
+
+        Returns True only if the stored row still carries the ``last_scan_at``
+        the caller observed — a compare-and-swap so exactly one replica wins a
+        given due scan even when several poll the same connection concurrently.
+        """
+        with self._lock:
+            current = self._rows.get(record.id)
+            if current is None or current.tenant_id != record.tenant_id:
+                return False
+            if current.last_scan_at != record.last_scan_at:
+                return False
+            current.last_scan_at = claimed_at
+            current.updated_at = claimed_at
+        record.last_scan_at = claimed_at
+        return True
 
 
 class SQLiteConnectionStore:
@@ -218,7 +265,13 @@ class SQLiteConnectionStore:
         ddl = CONNECTION_STORAGE_SCHEMA.tables[0].ddl_for("sqlite")
         if ddl:
             self._conn.execute(ddl)
+        columns = {row[1] for row in self._conn.execute("PRAGMA table_info(cloud_connections)").fetchall()}
+        if "scan_interval_minutes" not in columns:
+            self._conn.execute("ALTER TABLE cloud_connections ADD COLUMN scan_interval_minutes INTEGER")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_cloud_connections_tenant ON cloud_connections(tenant_id, created_at)")
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_cloud_connections_schedulable ON cloud_connections(scan_interval_minutes, last_scan_at)"
+        )
         self._conn.commit()
 
     def put(self, record: CloudConnectionRecord) -> None:
@@ -226,8 +279,9 @@ class SQLiteConnectionStore:
             """
             INSERT OR REPLACE INTO cloud_connections
                 (id, tenant_id, provider, display_name, role_ref, external_id_encrypted,
-                 regions, status, status_detail, created_at, updated_at, last_scan_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 regions, status, status_detail, created_at, updated_at, last_scan_at,
+                 scan_interval_minutes)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 record.id,
@@ -242,6 +296,7 @@ class SQLiteConnectionStore:
                 record.created_at,
                 record.updated_at,
                 record.last_scan_at,
+                record.scan_interval_minutes,
             ),
         )
         self._conn.commit()
@@ -249,7 +304,7 @@ class SQLiteConnectionStore:
     def get(self, tenant_id: str, connection_id: str) -> CloudConnectionRecord | None:
         row = self._conn.execute(
             "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-            "regions, status, status_detail, created_at, updated_at, last_scan_at "
+            "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes "
             "FROM cloud_connections WHERE tenant_id = ? AND id = ?",
             (tenant_id, connection_id),
         ).fetchone()
@@ -258,7 +313,7 @@ class SQLiteConnectionStore:
     def list_for_tenant(self, tenant_id: str) -> list[CloudConnectionRecord]:
         rows = self._conn.execute(
             "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-            "regions, status, status_detail, created_at, updated_at, last_scan_at "
+            "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes "
             "FROM cloud_connections WHERE tenant_id = ? ORDER BY created_at, id",
             (tenant_id,),
         ).fetchall()
@@ -271,6 +326,38 @@ class SQLiteConnectionStore:
         )
         self._conn.commit()
         return cursor.rowcount > 0
+
+    def list_schedulable(self) -> list[CloudConnectionRecord]:
+        rows = self._conn.execute(
+            "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
+            "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes "
+            "FROM cloud_connections WHERE scan_interval_minutes IS NOT NULL ORDER BY created_at, id"
+        ).fetchall()
+        return [_row_to_record(row) for row in rows]
+
+    def claim_due_scan(self, record: CloudConnectionRecord, claimed_at: str) -> bool:
+        """Atomically claim a due scan via a compare-and-swap on ``last_scan_at``.
+
+        The conditional UPDATE only matches while the stored ``last_scan_at``
+        equals the value the caller observed, so two replicas racing the same
+        due connection cannot both win — the loser's WHERE no longer matches
+        after the winner commits the new claim timestamp.
+        """
+        if record.last_scan_at is None:
+            cursor = self._conn.execute(
+                "UPDATE cloud_connections SET last_scan_at = ?, updated_at = ? WHERE id = ? AND tenant_id = ? AND last_scan_at IS NULL",
+                (claimed_at, claimed_at, record.id, record.tenant_id),
+            )
+        else:
+            cursor = self._conn.execute(
+                "UPDATE cloud_connections SET last_scan_at = ?, updated_at = ? WHERE id = ? AND tenant_id = ? AND last_scan_at = ?",
+                (claimed_at, claimed_at, record.id, record.tenant_id, record.last_scan_at),
+            )
+        self._conn.commit()
+        won = cursor.rowcount == 1
+        if won:
+            record.last_scan_at = claimed_at
+        return won
 
 
 _CONNECTION_STORE: ConnectionStore | None = None

--- a/src/agent_bom/api/postgres_connection.py
+++ b/src/agent_bom/api/postgres_connection.py
@@ -12,7 +12,13 @@ from __future__ import annotations
 import json
 
 from agent_bom.api.connection_store import CloudConnectionRecord, _row_to_record
-from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
+from agent_bom.api.postgres_common import (
+    ConnectionPool,
+    _ensure_tenant_rls,
+    _get_pool,
+    _tenant_connection,
+    bypass_tenant_rls,
+)
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
 
@@ -42,10 +48,15 @@ class PostgresConnectionStore:
                     status_detail         TEXT NOT NULL DEFAULT '',
                     created_at            TEXT NOT NULL,
                     updated_at            TEXT NOT NULL,
-                    last_scan_at          TEXT
+                    last_scan_at          TEXT,
+                    scan_interval_minutes INTEGER
                 )
             """)
+            conn.execute("ALTER TABLE cloud_connections ADD COLUMN IF NOT EXISTS scan_interval_minutes INTEGER")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_cloud_connections_tenant ON cloud_connections(tenant_id, created_at)")
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_cloud_connections_schedulable ON cloud_connections(scan_interval_minutes, last_scan_at)"
+            )
             _ensure_tenant_rls(conn, "cloud_connections", "tenant_id")
             conn.commit()
 
@@ -55,8 +66,9 @@ class PostgresConnectionStore:
                 """
                 INSERT INTO cloud_connections
                     (id, tenant_id, provider, display_name, role_ref, external_id_encrypted,
-                     regions, status, status_detail, created_at, updated_at, last_scan_at)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                     regions, status, status_detail, created_at, updated_at, last_scan_at,
+                     scan_interval_minutes)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (id) DO UPDATE SET
                     provider = EXCLUDED.provider,
                     display_name = EXCLUDED.display_name,
@@ -66,7 +78,8 @@ class PostgresConnectionStore:
                     status = EXCLUDED.status,
                     status_detail = EXCLUDED.status_detail,
                     updated_at = EXCLUDED.updated_at,
-                    last_scan_at = EXCLUDED.last_scan_at
+                    last_scan_at = EXCLUDED.last_scan_at,
+                    scan_interval_minutes = EXCLUDED.scan_interval_minutes
                 """,
                 (
                     record.id,
@@ -81,6 +94,7 @@ class PostgresConnectionStore:
                     record.created_at,
                     record.updated_at,
                     record.last_scan_at,
+                    record.scan_interval_minutes,
                 ),
             )
             conn.commit()
@@ -89,7 +103,7 @@ class PostgresConnectionStore:
         with _tenant_connection(self._pool) as conn:
             row = conn.execute(
                 "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-                "regions, status, status_detail, created_at, updated_at, last_scan_at "
+                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes "
                 "FROM cloud_connections WHERE tenant_id = %s AND id = %s",
                 (tenant_id, connection_id),
             ).fetchone()
@@ -99,7 +113,7 @@ class PostgresConnectionStore:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-                "regions, status, status_detail, created_at, updated_at, last_scan_at "
+                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes "
                 "FROM cloud_connections WHERE tenant_id = %s ORDER BY created_at, id",
                 (tenant_id,),
             ).fetchall()
@@ -113,3 +127,47 @@ class PostgresConnectionStore:
             )
             conn.commit()
             return bool(cursor.rowcount > 0)
+
+    def list_schedulable(self) -> list[CloudConnectionRecord]:
+        """Cross-tenant fetch of connections with an interval set (scheduler use).
+
+        Runs with tenant RLS bypassed because the background scheduler is a
+        trusted internal task that must see every tenant's schedulable
+        connections; tenant identity is preserved on each returned record.
+        """
+        with bypass_tenant_rls(), _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
+                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes "
+                "FROM cloud_connections WHERE scan_interval_minutes IS NOT NULL ORDER BY created_at, id"
+            ).fetchall()
+        return [_row_to_record(row) for row in rows]
+
+    def claim_due_scan(self, record: CloudConnectionRecord, claimed_at: str) -> bool:
+        """Atomically claim a due scan via a compare-and-swap on ``last_scan_at``.
+
+        The conditional UPDATE only matches while the stored ``last_scan_at``
+        equals the value the caller observed. Postgres row locking serializes
+        two replicas racing the same due connection: the first to commit
+        advances ``last_scan_at`` so the second's WHERE no longer matches and it
+        loses the claim. Runs RLS-bypassed (trusted scheduler) with the explicit
+        tenant id retained in the predicate.
+        """
+        with bypass_tenant_rls(), _tenant_connection(self._pool) as conn:
+            if record.last_scan_at is None:
+                cursor = conn.execute(
+                    "UPDATE cloud_connections SET last_scan_at = %s, updated_at = %s "
+                    "WHERE id = %s AND tenant_id = %s AND last_scan_at IS NULL",
+                    (claimed_at, claimed_at, record.id, record.tenant_id),
+                )
+            else:
+                cursor = conn.execute(
+                    "UPDATE cloud_connections SET last_scan_at = %s, updated_at = %s "
+                    "WHERE id = %s AND tenant_id = %s AND last_scan_at = %s",
+                    (claimed_at, claimed_at, record.id, record.tenant_id, record.last_scan_at),
+                )
+            conn.commit()
+        won = bool(cursor.rowcount == 1)
+        if won:
+            record.last_scan_at = claimed_at
+        return won

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -26,7 +26,9 @@ against that session. Results persist through the existing scan/graph stores —
 no parallel persistence path — and the connection's lifecycle status is updated
 (``active`` + ``last_scan_at`` on success, ``error`` + ``status_detail`` on
 failure, never carrying a secret). AWS is broker-enabled today; azure / gcp /
-snowflake return a clear "planned" 501. A recurring scheduler is Phase B.2.
+snowflake return a clear "planned" 501. A connection may also carry a
+``scan_interval_minutes`` so the Phase B.2 background scheduler
+(:mod:`agent_bom.api.connection_scheduler`) re-runs this same scan path when due.
 """
 
 from __future__ import annotations
@@ -51,6 +53,7 @@ from agent_bom.api.connection_store import (
     get_connection_store,
 )
 from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.config import CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES
 from agent_bom.rbac import require_authenticated_permission
 from agent_bom.security import sanitize_error
 
@@ -58,6 +61,9 @@ from agent_bom.security import sanitize_error
 _PLANNED_SCAN_PROVIDERS: tuple[str, ...] = ("azure", "gcp", "snowflake")
 # Cap the status_detail we persist so a verbose backend error can't bloat the row.
 _MAX_STATUS_DETAIL = 300
+# Upper bound on a recurring scan interval (1 week) so a typo can't park a
+# connection effectively-never-scanning while still claiming to be scheduled.
+_MAX_SCAN_INTERVAL_MINUTES = 7 * 24 * 60
 
 router = APIRouter(tags=["cloud-connections"])
 _logger = logging.getLogger(__name__)
@@ -70,7 +76,11 @@ _MAX_REGIONS = 50
 
 
 class CloudConnectionCreate(BaseModel):
-    """Request body for creating a connection. ``external_id`` is write-only."""
+    """Request body for creating a connection. ``external_id`` is write-only.
+
+    ``scan_interval_minutes`` opts the connection into recurring background scans
+    (Phase B.2). Null (the default) means manual-only — the scheduler ignores it.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
@@ -79,6 +89,19 @@ class CloudConnectionCreate(BaseModel):
     role_ref: str = Field(min_length=1, max_length=2048)
     external_id: str = Field(min_length=1, max_length=1024)
     regions: list[str] = Field(default_factory=list)
+    scan_interval_minutes: int | None = None
+
+
+class CloudConnectionUpdate(BaseModel):
+    """Request body for updating a connection's recurring scan schedule.
+
+    ``scan_interval_minutes`` is set to the supplied value; null disables the
+    recurring scan (back to manual-only).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    scan_interval_minutes: int | None = None
 
 
 def _now() -> str:
@@ -91,6 +114,28 @@ def _tenant(request: Request) -> str:
 
 def _actor(request: Request) -> str:
     return getattr(request.state, "api_key_name", "") or getattr(request.state, "auth_method", "") or "system"
+
+
+def _validate_scan_interval(interval: int | None) -> int | None:
+    """Validate a recurring scan interval (minutes).
+
+    Null is allowed (manual-only). A set value must be at least the configured
+    minimum so the scheduler never hammers a customer account, and at most one
+    week so a typo cannot silently park a connection.
+    """
+    if interval is None:
+        return None
+    if interval < CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"scan_interval_minutes must be at least {CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES} minutes.",
+        )
+    if interval > _MAX_SCAN_INTERVAL_MINUTES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"scan_interval_minutes must be at most {_MAX_SCAN_INTERVAL_MINUTES} minutes.",
+        )
+    return interval
 
 
 def _validate_regions(regions: list[str]) -> list[str]:
@@ -120,6 +165,7 @@ async def create_connection(request: Request, body: CloudConnectionCreate, _role
         )
 
     regions = _validate_regions(body.regions)
+    scan_interval_minutes = _validate_scan_interval(body.scan_interval_minutes)
 
     # Fail closed before doing anything if the store cannot encrypt the secret.
     if not connections_key_configured():
@@ -148,6 +194,7 @@ async def create_connection(request: Request, body: CloudConnectionCreate, _role
         created_at=now,
         updated_at=now,
         last_scan_at=None,
+        scan_interval_minutes=scan_interval_minutes,
     )
     get_connection_store().put(record)
     log_action(
@@ -185,6 +232,33 @@ def _require_connection(request: Request, connection_id: str) -> CloudConnection
 async def get_connection(request: Request, connection_id: str, _role: Any = _SCAN_DEP) -> dict[str, Any]:
     """Return one connection's non-secret metadata (tenant-scoped)."""
     return _require_connection(request, connection_id).to_public_dict()
+
+
+@router.patch("/v1/cloud/connections/{connection_id}")
+async def update_connection(
+    request: Request,
+    connection_id: str,
+    body: CloudConnectionUpdate,
+    _role: Any = _SCAN_DEP,
+) -> dict[str, Any]:
+    """Update a connection's recurring scan schedule (tenant-scoped).
+
+    Sets ``scan_interval_minutes`` (null disables recurring scans). The encrypted
+    secret is untouched and never returned.
+    """
+    record = _require_connection(request, connection_id)
+    scan_interval_minutes = _validate_scan_interval(body.scan_interval_minutes)
+    record.scan_interval_minutes = scan_interval_minutes
+    record.updated_at = _now()
+    get_connection_store().put(record)
+    log_action(
+        "cloud_connection.update",
+        actor=_actor(request),
+        resource=f"cloud-connection/{record.id}",
+        tenant_id=record.tenant_id,
+        provider=record.provider,
+    )
+    return record.to_public_dict()
 
 
 @router.delete("/v1/cloud/connections/{connection_id}", status_code=204)

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -471,6 +471,17 @@ async def _lifespan(app_instance: FastAPI):
 
     _scheduler_task = asyncio.create_task(scheduler_loop(_get_schedule_store(), _schedule_scan))
 
+    # ── Cloud-connection scan scheduler (Phase B.2) ──
+    # Opt-in background loop that re-scans due cloud connections so a connection
+    # with an interval keeps evaluating without a manual /scan call. Off unless
+    # AGENT_BOM_CONNECTIONS_SCHEDULER is set, so it never runs in CLI/dev.
+    global _connection_scheduler_task
+    from agent_bom.api.connection_scheduler import connection_scheduler_loop, connections_scheduler_enabled
+
+    if connections_scheduler_enabled():
+        _connection_scheduler_task = asyncio.create_task(connection_scheduler_loop())
+        _logger.info("Cloud-connection scan scheduler enabled")
+
     # ── Distributed scan dispatch ──
     # Start a per-replica claim-loop so queued scans are stolen across the
     # cluster. No-op on single-node / non-Postgres deployments.
@@ -506,6 +517,8 @@ async def _lifespan(app_instance: FastAPI):
             _logger.debug("scan worker stop skipped", exc_info=True)
     if _scheduler_task:
         _scheduler_task.cancel()
+    if _connection_scheduler_task:
+        _connection_scheduler_task.cancel()
     if _cleanup_task:
         _cleanup_task.cancel()
     # Drain in-flight scans. Honor the operator-configured drain budget so the
@@ -853,6 +866,7 @@ from agent_bom.api.routes.scan import _dataclass_to_dict, _sanitize_api_path  # 
 
 _cleanup_task: asyncio.Task | None = None
 _scheduler_task: asyncio.Task | None = None
+_connection_scheduler_task: asyncio.Task | None = None
 # Flipped to True during graceful shutdown so the /readyz probe goes red
 # and upstream load balancers stop sending new traffic while in-flight
 # requests complete under the drain budget.

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -260,6 +260,15 @@ API_SCAN_WORKER_RECYCLE_JOBS = _int("AGENT_BOM_API_SCAN_WORKER_RECYCLE_JOBS", 10
 # reclaim it (the owning node renews the lease each poll while the job runs).
 API_SCAN_LEASE_SECONDS = _int("AGENT_BOM_API_SCAN_LEASE_SECONDS", 600)
 API_SCAN_CLAIM_POLL_SECONDS = _int("AGENT_BOM_API_SCAN_CLAIM_POLL_SECONDS", 3)
+# Cloud-connection scan scheduler (Phase B.2). The background loop re-scans
+# cloud connections that carry an interval, so "connect once, keeps evaluating"
+# is automatic. Disabled by default (AGENT_BOM_CONNECTIONS_SCHEDULER, read live)
+# so it never runs in CLI/dev. The minimum per-connection interval guards
+# against hammering a customer account; concurrency bounds how many brokered
+# scans run at once; poll seconds is how often the loop re-checks for due work.
+CONNECTIONS_SCHEDULER_POLL_SECONDS = _int("AGENT_BOM_CONNECTIONS_SCHEDULER_POLL_SECONDS", 60)
+CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES = _int("AGENT_BOM_CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES", 15)
+CONNECTIONS_SCHEDULER_MAX_CONCURRENCY = _int("AGENT_BOM_CONNECTIONS_SCHEDULER_MAX_CONCURRENCY", 4)
 API_JOB_TTL_SECONDS = _int("AGENT_BOM_API_JOB_TTL", 3_600)
 API_MAX_IN_MEMORY_JOBS = _int("AGENT_BOM_API_MAX_MEMORY_JOBS", 200)
 API_MAX_JOB_PROGRESS_EVENTS = _int("AGENT_BOM_API_MAX_JOB_PROGRESS_EVENTS", 500)

--- a/tests/test_cloud_connections.py
+++ b/tests/test_cloud_connections.py
@@ -413,6 +413,72 @@ def test_api_missing_key_fails_closed_503() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# API: recurring scan schedule (scan_interval_minutes) — Phase B.2
+# --------------------------------------------------------------------------- #
+
+
+def test_api_create_default_interval_is_manual_only() -> None:
+    client = TestClient(_app())
+    created = client.post("/v1/cloud/connections", json=_create_body(), headers=_proxy_headers()).json()
+    assert created["scan_interval_minutes"] is None
+
+
+def test_api_create_with_interval_persists() -> None:
+    client = TestClient(_app())
+    body = _create_body()
+    body["scan_interval_minutes"] = 60
+    created = client.post("/v1/cloud/connections", json=body, headers=_proxy_headers()).json()
+    assert created["scan_interval_minutes"] == 60
+
+
+def test_api_create_rejects_interval_below_minimum() -> None:
+    client = TestClient(_app())
+    body = _create_body()
+    body["scan_interval_minutes"] = 5
+    resp = client.post("/v1/cloud/connections", json=body, headers=_proxy_headers())
+    assert resp.status_code == 400
+
+
+def test_api_patch_sets_and_clears_interval() -> None:
+    client = TestClient(_app())
+    cid = client.post("/v1/cloud/connections", json=_create_body(), headers=_proxy_headers()).json()["id"]
+
+    set_resp = client.patch(
+        f"/v1/cloud/connections/{cid}",
+        json={"scan_interval_minutes": 120},
+        headers=_proxy_headers(),
+    )
+    assert set_resp.status_code == 200
+    assert set_resp.json()["scan_interval_minutes"] == 120
+
+    clear_resp = client.patch(
+        f"/v1/cloud/connections/{cid}",
+        json={"scan_interval_minutes": None},
+        headers=_proxy_headers(),
+    )
+    assert clear_resp.status_code == 200
+    assert clear_resp.json()["scan_interval_minutes"] is None
+
+
+def test_api_patch_rejects_interval_below_minimum() -> None:
+    client = TestClient(_app())
+    cid = client.post("/v1/cloud/connections", json=_create_body(), headers=_proxy_headers()).json()["id"]
+    resp = client.patch(f"/v1/cloud/connections/{cid}", json={"scan_interval_minutes": 1}, headers=_proxy_headers())
+    assert resp.status_code == 400
+
+
+def test_api_patch_requires_scan_permission() -> None:
+    client = TestClient(_app())
+    cid = client.post("/v1/cloud/connections", json=_create_body(), headers=_proxy_headers()).json()["id"]
+    resp = client.patch(
+        f"/v1/cloud/connections/{cid}",
+        json={"scan_interval_minutes": 60},
+        headers=_proxy_headers(role="viewer"),
+    )
+    assert resp.status_code == 403
+
+
+# --------------------------------------------------------------------------- #
 # Broker: AWS AssumeRole with the decrypted ExternalId; non-AWS planned
 # --------------------------------------------------------------------------- #
 

--- a/tests/test_connection_scheduler.py
+++ b/tests/test_connection_scheduler.py
@@ -1,0 +1,330 @@
+"""Tests for the cloud-connection scan scheduler (Phase B.2).
+
+Covers due-detection (interval elapsed vs not, never-scanned, no-interval),
+the cluster-safe compare-and-swap claim (a second replica cannot double-run a
+claimed scan), the run-once orchestration (scan triggered + ``last_scan_at``
+advanced + status ``active``), failure isolation (a failing connection is marked
+``error`` and the loop continues), non-AWS skip (the broker is AWS-only), and the
+env toggle that keeps the loop off in CLI/dev.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from cryptography.fernet import Fernet
+
+from agent_bom.api import connection_crypto
+from agent_bom.api.connection_scheduler import (
+    claim_due_connections,
+    connections_scheduler_enabled,
+    is_due,
+    run_due_scans_once,
+    select_due_connections,
+)
+from agent_bom.api.connection_store import (
+    STATUS_ACTIVE,
+    STATUS_ERROR,
+    STATUS_PENDING,
+    CloudConnectionRecord,
+    InMemoryConnectionStore,
+    SQLiteConnectionStore,
+    set_connection_store,
+)
+
+_TEST_KEY = Fernet.generate_key().decode("ascii")
+
+
+@pytest.fixture(autouse=True)
+def _scheduler_env() -> Iterator[None]:
+    """Provide an encryption key and an isolated in-memory store per test."""
+    prior_key = os.environ.get(connection_crypto.CONNECTIONS_KEY_ENV)
+    prior_flag = os.environ.get("AGENT_BOM_CONNECTIONS_SCHEDULER")
+    os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = _TEST_KEY
+    os.environ.pop("AGENT_BOM_CONNECTIONS_SCHEDULER", None)
+    try:
+        yield
+    finally:
+        for key, value in (
+            (connection_crypto.CONNECTIONS_KEY_ENV, prior_key),
+            ("AGENT_BOM_CONNECTIONS_SCHEDULER", prior_flag),
+        ):
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        set_connection_store(None)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _record(
+    tenant_id: str = "tenant-a",
+    *,
+    provider: str = "aws",
+    scan_interval_minutes: int | None = 60,
+    last_scan_at: str | None = None,
+    status: str = STATUS_PENDING,
+) -> CloudConnectionRecord:
+    return CloudConnectionRecord(
+        id=str(uuid.uuid4()),
+        tenant_id=tenant_id,
+        provider=provider,
+        display_name="prod-readonly",
+        role_ref="arn:aws:iam::123456789012:role/agent-bom-readonly",
+        external_id_encrypted=connection_crypto.encrypt_secret("super-secret-external-id"),
+        regions=["us-east-1"],
+        status=status,
+        created_at="2026-06-26T00:00:00+00:00",
+        updated_at="2026-06-26T00:00:00+00:00",
+        last_scan_at=last_scan_at,
+        scan_interval_minutes=scan_interval_minutes,
+    )
+
+
+_BROKER_SESSION_SENTINEL = object()
+
+
+def _install_scan_mocks(monkeypatch: pytest.MonkeyPatch, *, fail: bool = False) -> dict[str, Any]:
+    """Patch the broker + AWS inventory/CIS the scheduler's scan path reuses."""
+    from agent_bom.cloud import aws_cis_benchmark, aws_inventory, connection_broker
+
+    calls: dict[str, Any] = {"scanned_ids": []}
+
+    def _fake_broker(record: CloudConnectionRecord, **kwargs: Any) -> Any:
+        calls["scanned_ids"].append(record.id)
+        if fail:
+            raise connection_broker.ConnectionBrokerError(f"AssumeRole failed for connection {record.id}.")
+        return _BROKER_SESSION_SENTINEL
+
+    def _fake_inventory(region: str | None = None, force: bool = False, session: Any = None, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "provider": "aws",
+            "status": "ok",
+            "account_id": "123456789012",
+            "region": region or "us-east-1",
+            "buckets": [],
+            "instances": [],
+            "security_groups": [],
+            "roles": [],
+            "users": [],
+            "warnings": [],
+        }
+
+    class _FakeCISReport:
+        def to_dict(self) -> dict[str, Any]:
+            return {
+                "benchmark": "CIS AWS Foundations",
+                "benchmark_version": "3.0.0",
+                "account_id": "123456789012",
+                "region": "us-east-1",
+                "pass_rate": 50.0,
+                "passed": 1,
+                "failed": 1,
+                "total": 2,
+                "checks": [],
+            }
+
+    def _fake_cis(region: str | None = None, session: Any = None, **kwargs: Any) -> Any:
+        return _FakeCISReport()
+
+    monkeypatch.setattr(connection_broker, "broker_session", _fake_broker)
+    monkeypatch.setattr(aws_inventory, "discover_inventory", _fake_inventory)
+    monkeypatch.setattr(aws_cis_benchmark, "run_benchmark", _fake_cis)
+    return calls
+
+
+# --------------------------------------------------------------------------- #
+# Due-detection
+# --------------------------------------------------------------------------- #
+
+
+def test_is_due_never_scanned() -> None:
+    assert is_due(_record(last_scan_at=None), _now()) is True
+
+
+def test_is_due_interval_elapsed() -> None:
+    now = _now()
+    stale = (now - timedelta(minutes=61)).isoformat()
+    assert is_due(_record(scan_interval_minutes=60, last_scan_at=stale), now) is True
+
+
+def test_is_due_interval_not_elapsed() -> None:
+    now = _now()
+    recent = (now - timedelta(minutes=5)).isoformat()
+    assert is_due(_record(scan_interval_minutes=60, last_scan_at=recent), now) is False
+
+
+def test_is_due_no_interval_is_manual_only() -> None:
+    assert is_due(_record(scan_interval_minutes=None, last_scan_at=None), _now()) is False
+
+
+def test_select_due_only_returns_due_with_interval() -> None:
+    now = _now()
+    store = InMemoryConnectionStore()
+    due = _record(scan_interval_minutes=60, last_scan_at=(now - timedelta(hours=2)).isoformat())
+    not_due = _record(scan_interval_minutes=60, last_scan_at=(now - timedelta(minutes=1)).isoformat())
+    manual = _record(scan_interval_minutes=None)
+    for record in (due, not_due, manual):
+        store.put(record)
+
+    selected_ids = {r.id for r in select_due_connections(store, now)}
+    assert selected_ids == {due.id}
+
+
+# --------------------------------------------------------------------------- #
+# Cluster-safe claim (compare-and-swap)
+# --------------------------------------------------------------------------- #
+
+
+def test_claim_prevents_double_run_in_memory() -> None:
+    store = InMemoryConnectionStore()
+    record = _record(last_scan_at=None)
+    store.put(record)
+    claimed_at = _now().isoformat()
+
+    # Two replicas each read the same connection (last_scan_at=None) and race.
+    replica_a = store.get(record.tenant_id, record.id)
+    replica_b = store.get(record.tenant_id, record.id)
+    assert replica_a is not None and replica_b is not None
+
+    assert store.claim_due_scan(replica_a, claimed_at) is True
+    assert store.claim_due_scan(replica_b, claimed_at) is False
+
+
+def test_claim_prevents_double_run_sqlite(tmp_path: Any) -> None:
+    store = SQLiteConnectionStore(str(tmp_path / "connections.db"))
+    record = _record(last_scan_at=None)
+    store.put(record)
+    claimed_at = _now().isoformat()
+
+    replica_a = store.get(record.tenant_id, record.id)
+    replica_b = store.get(record.tenant_id, record.id)
+    assert replica_a is not None and replica_b is not None
+
+    assert store.claim_due_scan(replica_a, claimed_at) is True
+    assert store.claim_due_scan(replica_b, claimed_at) is False
+    # The stored row carries the winner's claim timestamp.
+    assert store.get(record.tenant_id, record.id).last_scan_at == claimed_at  # type: ignore[union-attr]
+
+
+def test_claim_due_connections_skips_non_aws() -> None:
+    store = InMemoryConnectionStore()
+    now = _now()
+    aws = _record(provider="aws", last_scan_at=None)
+    azure = _record(provider="azure", last_scan_at=None)
+    store.put(aws)
+    store.put(azure)
+
+    claimed = claim_due_connections(store, now)
+    assert [r.id for r in claimed] == [aws.id]
+    # The non-AWS connection was never claimed (last_scan_at untouched).
+    assert store.get(azure.tenant_id, azure.id).last_scan_at is None  # type: ignore[union-attr]
+
+
+# --------------------------------------------------------------------------- #
+# Run-once orchestration
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_run_once_triggers_scan_and_updates_last_scan_at(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _install_scan_mocks(monkeypatch)
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    record = _record(scan_interval_minutes=60, last_scan_at=None)
+    store.put(record)
+
+    count = await run_due_scans_once(store, _now())
+    assert count == 1
+    assert calls["scanned_ids"] == [record.id]
+
+    fetched = store.get(record.tenant_id, record.id)
+    assert fetched is not None
+    assert fetched.status == STATUS_ACTIVE
+    assert fetched.status_detail == ""
+    assert fetched.last_scan_at is not None
+
+
+@pytest.mark.asyncio
+async def test_run_once_no_due_connections_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _install_scan_mocks(monkeypatch)
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    now = _now()
+    # Manual-only + a recently scanned connection: neither is due.
+    store.put(_record(scan_interval_minutes=None))
+    store.put(_record(scan_interval_minutes=60, last_scan_at=(now - timedelta(minutes=1)).isoformat()))
+
+    count = await run_due_scans_once(store, now)
+    assert count == 0
+    assert calls["scanned_ids"] == []
+
+
+@pytest.mark.asyncio
+async def test_run_once_failing_connection_marked_error_and_loop_continues(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Broker always fails: every claimed scan errors, but the run still completes
+    # for both connections (one bad connection never sinks the loop).
+    _install_scan_mocks(monkeypatch, fail=True)
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    first = _record(scan_interval_minutes=60, last_scan_at=None)
+    second = _record(scan_interval_minutes=60, last_scan_at=None)
+    store.put(first)
+    store.put(second)
+
+    count = await run_due_scans_once(store, _now())
+    assert count == 2
+    for record in (first, second):
+        fetched = store.get(record.tenant_id, record.id)
+        assert fetched is not None
+        assert fetched.status == STATUS_ERROR
+        assert fetched.status_detail
+        assert "super-secret-external-id" not in fetched.status_detail
+
+
+@pytest.mark.asyncio
+async def test_run_once_skips_non_aws(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = _install_scan_mocks(monkeypatch)
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    azure = _record(provider="azure", scan_interval_minutes=60, last_scan_at=None)
+    store.put(azure)
+
+    count = await run_due_scans_once(store, _now())
+    assert count == 0
+    assert calls["scanned_ids"] == []
+    # Untouched: not claimed, status unchanged, never scanned.
+    fetched = store.get(azure.tenant_id, azure.id)
+    assert fetched is not None
+    assert fetched.last_scan_at is None
+    assert fetched.status == STATUS_PENDING
+
+
+# --------------------------------------------------------------------------- #
+# Env toggle
+# --------------------------------------------------------------------------- #
+
+
+def test_scheduler_disabled_by_default() -> None:
+    os.environ.pop("AGENT_BOM_CONNECTIONS_SCHEDULER", None)
+    assert connections_scheduler_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "on", "yes", "enabled", "TRUE"])
+def test_scheduler_enabled_when_flag_truthy(value: str) -> None:
+    os.environ["AGENT_BOM_CONNECTIONS_SCHEDULER"] = value
+    assert connections_scheduler_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "off", "", "no"])
+def test_scheduler_disabled_when_flag_falsy(value: str) -> None:
+    os.environ["AGENT_BOM_CONNECTIONS_SCHEDULER"] = value
+    assert connections_scheduler_enabled() is False


### PR DESCRIPTION
Phase B.2 of #3175: a cluster-safe background scheduler that re-scans due cloud connections, so "connect once, keeps evaluating" is automatic. Closes the second control-plane wiring gap (with #3197 KMS).

- **Schedule field**: `scan_interval_minutes` (nullable; null = manual-only) on the connection + `to_public_dict` + both backends' DDL (idempotent ADD COLUMN). `POST` accepts it; new `PATCH /v1/cloud/connections/{id}` sets/clears it (same `scan` RBAC gate; validated 15 min ≤ interval ≤ 1 week).
- **Scheduler loop** (`connection_scheduler.py`): asyncio loop mirroring the existing `scheduler.py`, finds due connections, claims each, runs the existing `_run_aws_connection_scan` under a bounded semaphore, persists via `_mark_connection`. Registered in `server.py` lifespan, cancelled on shutdown. Gated by `AGENT_BOM_CONNECTIONS_SCHEDULER` (default OFF — never runs in CLI/dev).
- **Cluster-safe claim**: `claim_due_scan` is a compare-and-swap on `last_scan_at` (atomic conditional `UPDATE ... WHERE last_scan_at=<observed>`); the first replica to advance it wins, racers no-op — exactly one replica runs a given due scan. A failed scan keeps the claim, so a broken connection waits a full interval before retry.
- **Safe/opt-in**: read-only; AWS only (non-AWS skipped, never claimed — broker boundary); a failing connection is marked `error` (secret-free) without sinking the loop.

Full-stack: DDL (SQLite+Postgres) + API + OpenAPI/DATA_MODEL/ENV_VARS regenerated + env-var allowlist. New `test_connection_scheduler.py` + additions: due-detection, CAS double-run prevention (in-memory + SQLite), trigger + last_scan_at advance, failure isolation, non-AWS skip, env toggle, PATCH/RBAC. `pytest -k connection/scheduler/broker/cloud` 704 passed; ruff/mypy(strict)/bandit clean.
