### PR TITLE
feat(cloud): Vault key provider + MultiFernet rotation for connection encryption

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -74,12 +74,16 @@ AGENT_BOM_CLICKHOUSE_URL
 AGENT_BOM_CLICKHOUSE_USER
 # Opt-in (default OFF) gate for the estate-wide read-only AWS asset inventory scanner.
 AGENT_BOM_CLOUD_INVENTORY
-# base64 Fernet key for at-rest encryption of cloud-connection secrets (ExternalId); secret, env/KMS-only, never in config.py or ENV_VARS.md. With provider=aws-kms it holds the base64 KMS-wrapped data key instead.
+# base64 Fernet key for at-rest encryption of cloud-connection secrets (ExternalId); secret, env/KMS-only, never in config.py or ENV_VARS.md. With provider=aws-kms it holds the base64 KMS-wrapped data key instead. Accepts a comma-separated list of keys for MultiFernet rotation (first key = primary/encrypt, any key decrypts).
 AGENT_BOM_CONNECTIONS_KEY
-# Selects how the connection encryption key is resolved: env (default) | aws-secrets | aws-kms; read at key-load time in api/connection_crypto.py.
+# Selects how the connection encryption key is resolved: env (default) | aws-secrets | aws-kms | vault; read at key-load time in api/connection_crypto.py.
 AGENT_BOM_CONNECTIONS_KEY_PROVIDER
-# Reference (not a secret value) to the managed connection key: the Secrets Manager secret id/ARN for provider=aws-secrets; resolved read-only at key-load time.
+# Reference (not a secret value) to the managed connection key: the Secrets Manager secret id/ARN for provider=aws-secrets, or the Vault KV v2 'mount/path#field' for provider=vault; resolved read-only at key-load time. The resolved value may be a comma-separated list of Fernet keys for rotation.
 AGENT_BOM_CONNECTIONS_KEY_REF
+# Base URL of the HashiCorp Vault server for provider=vault (e.g. https://vault.internal:8200); read-only KV v2 GET at key-load time in api/connection_crypto.py. Not a secret.
+AGENT_BOM_VAULT_ADDR
+# HashiCorp Vault token for provider=vault, sent as the X-Vault-Token header on the read-only KV v2 GET; secret, env/reference-only, never logged.
+AGENT_BOM_VAULT_TOKEN
 # opt-in flag (default OFF) enabling the background loop that re-scans due cloud connections (Phase B.2); read live in api/connection_scheduler.py
 AGENT_BOM_CONNECTIONS_SCHEDULER
 # CLI profile config path override; read at command invocation time.

--- a/src/agent_bom/api/connection_crypto.py
+++ b/src/agent_bom/api/connection_crypto.py
@@ -32,6 +32,15 @@ Providers (``AGENT_BOM_CONNECTIONS_KEY_PROVIDER``):
     32-byte data key is encoded into a ``Fernet`` key. The plaintext data key
     never touches disk.
 
+``vault``
+    The base64 ``Fernet`` key is fetched from a HashiCorp Vault **KV v2** secret
+    over a read-only ``GET {AGENT_BOM_VAULT_ADDR}/v1/{mount}/data/{path}`` with
+    an ``X-Vault-Token: {AGENT_BOM_VAULT_TOKEN}`` header.
+    ``AGENT_BOM_CONNECTIONS_KEY_REF`` names the location and field as
+    ``mount/path#field`` (the ``#field`` suffix is optional and defaults to
+    ``key``). TLS verification stays on; nothing about the key or token is
+    stored locally or logged.
+
 Planned seam: ``azure-keyvault`` and ``gcp-secret-manager`` follow the same
 resolver contract (return the base64 Fernet key, fail closed on any error) and
 can be added without touching the encrypt/decrypt API below.
@@ -40,6 +49,30 @@ The resolved key is cached in-process; :func:`reset_key_cache` clears it (used
 by tests and by an operator-driven rotation). Any resolution failure — missing
 ref, access denied, malformed material — raises :class:`ConnectionSecretError`;
 the deployment fails closed and never persists plaintext.
+
+Key rotation (MultiFernet)
+--------------------------
+
+Every provider's resolved value may be a **comma-separated list** of base64
+``Fernet`` keys. When more than one key is present the module builds a
+``MultiFernet``: it **encrypts with the first (primary) key and decrypts with
+any** key in the list. A single key stays a plain ``Fernet`` (fully backward
+compatible — existing single-key deployments are unchanged).
+
+This is the standard zero-downtime rotation procedure:
+
+1. **Add** a freshly generated key as the new *primary* (prepend it), keeping
+   the old key in the list, e.g.
+   ``AGENT_BOM_CONNECTIONS_KEY="<new>,<old>"`` (or store the comma-separated
+   list in the managed provider). New writes use ``<new>``; existing ciphertext
+   still decrypts under ``<old>``.
+2. **Re-encrypt** (optional but recommended) existing rows in the background;
+   each decrypt-then-encrypt round-trip rewraps the row under the primary key.
+3. **Remove** the retired key from the list once no ciphertext depends on it,
+   leaving only ``AGENT_BOM_CONNECTIONS_KEY="<new>"``.
+
+``reset_key_cache`` must be called after changing the configured keys so the
+next operation re-resolves the rotated list.
 """
 
 from __future__ import annotations
@@ -52,13 +85,20 @@ from typing import Any
 CONNECTIONS_KEY_ENV = "AGENT_BOM_CONNECTIONS_KEY"
 CONNECTIONS_KEY_PROVIDER_ENV = "AGENT_BOM_CONNECTIONS_KEY_PROVIDER"
 CONNECTIONS_KEY_REF_ENV = "AGENT_BOM_CONNECTIONS_KEY_REF"
+VAULT_ADDR_ENV = "AGENT_BOM_VAULT_ADDR"
+VAULT_TOKEN_ENV = "AGENT_BOM_VAULT_TOKEN"
 
 PROVIDER_ENV = "env"
 PROVIDER_AWS_SECRETS = "aws-secrets"
 PROVIDER_AWS_KMS = "aws-kms"
+PROVIDER_VAULT = "vault"
 
-# In-process cache of the resolved base64 Fernet key. ``None`` means "not yet
-# resolved"; cleared by :func:`reset_key_cache`.
+# Default field name inside a Vault KV v2 secret when ``...#field`` is omitted.
+DEFAULT_VAULT_FIELD = "key"
+
+# In-process cache of the resolved key material. ``None`` means "not yet
+# resolved"; cleared by :func:`reset_key_cache`. The value may carry a
+# comma-separated list of base64 Fernet keys (MultiFernet rotation).
 _RESOLVED_KEY: bytes | None = None
 
 
@@ -104,6 +144,12 @@ def connections_key_configured() -> bool:
         return bool(os.environ.get(CONNECTIONS_KEY_REF_ENV, "").strip())
     if provider == PROVIDER_AWS_KMS:
         return bool(os.environ.get(CONNECTIONS_KEY_ENV, "").strip())
+    if provider == PROVIDER_VAULT:
+        return bool(
+            os.environ.get(VAULT_ADDR_ENV, "").strip()
+            and os.environ.get(VAULT_TOKEN_ENV, "").strip()
+            and os.environ.get(CONNECTIONS_KEY_REF_ENV, "").strip()
+        )
     return False
 
 
@@ -185,10 +231,67 @@ def _resolve_aws_kms() -> bytes:
     return base64.urlsafe_b64encode(bytes(plaintext))
 
 
+def _parse_vault_ref(ref: str) -> tuple[str, str, str]:
+    """Parse ``mount/path#field`` into ``(mount, path, field)``.
+
+    ``#field`` is optional and defaults to :data:`DEFAULT_VAULT_FIELD`. Raises
+    :class:`ConnectionSecretError` when the mount or path is missing.
+    """
+    location, _, field = ref.partition("#")
+    field = field.strip() or DEFAULT_VAULT_FIELD
+    mount, _, path = location.strip().strip("/").partition("/")
+    if not mount or not path:
+        raise ConnectionSecretError(
+            f"{CONNECTIONS_KEY_REF_ENV} for the '{PROVIDER_VAULT}' provider must be "
+            "'mount/path[#field]' (the KV v2 mount and secret path); refusing to fall back to plaintext."
+        )
+    return mount, path, field
+
+
+def _resolve_vault() -> bytes:
+    """Fetch the base64 Fernet key from a HashiCorp Vault KV v2 secret (read-only)."""
+    addr = os.environ.get(VAULT_ADDR_ENV, "").strip().rstrip("/")
+    token = os.environ.get(VAULT_TOKEN_ENV, "").strip()
+    ref = os.environ.get(CONNECTIONS_KEY_REF_ENV, "").strip()
+    if not addr or not token or not ref:
+        raise ConnectionSecretError(
+            f"{CONNECTIONS_KEY_PROVIDER_ENV}={PROVIDER_VAULT} requires {VAULT_ADDR_ENV}, "
+            f"{VAULT_TOKEN_ENV}, and {CONNECTIONS_KEY_REF_ENV} (mount/path#field); "
+            "refusing to fall back to plaintext."
+        )
+    mount, path, field = _parse_vault_ref(ref)
+    url = f"{addr}/v1/{mount}/data/{path}"
+
+    from agent_bom import http_client
+
+    try:
+        # Read-only GET via the shared client (TLS verification on by default).
+        response = http_client.sync_get(url, headers={"X-Vault-Token": token})
+    except Exception as exc:  # noqa: BLE001 - never echo the token or transport detail
+        raise ConnectionSecretError("Unable to reach HashiCorp Vault to resolve the connection encryption key.") from exc
+    if response is None:
+        raise ConnectionSecretError("Unable to reach HashiCorp Vault to resolve the connection encryption key.")
+    if response.status_code != 200:
+        # Status only — never the body (it can carry the token/policy detail).
+        raise ConnectionSecretError(f"HashiCorp Vault returned HTTP {response.status_code} resolving the connection encryption key.")
+    try:
+        body = response.json()
+        value = body["data"]["data"][field]
+    except Exception as exc:  # noqa: BLE001 - malformed body / missing field
+        raise ConnectionSecretError(
+            "HashiCorp Vault response did not contain the connection encryption key at the configured field."
+        ) from exc
+    raw = (value or "").strip() if isinstance(value, str) else ""
+    if not raw:
+        raise ConnectionSecretError("HashiCorp Vault returned an empty connection encryption key.")
+    return raw.encode("ascii")
+
+
 _RESOLVERS: dict[str, Callable[[], bytes]] = {
     PROVIDER_ENV: _resolve_env,
     PROVIDER_AWS_SECRETS: _resolve_aws_secrets,
     PROVIDER_AWS_KMS: _resolve_aws_kms,
+    PROVIDER_VAULT: _resolve_vault,
 }
 
 
@@ -206,20 +309,39 @@ def _load_key() -> bytes:
     if resolver is None:
         raise ConnectionSecretError(
             f"{CONNECTIONS_KEY_PROVIDER_ENV}={provider!r} is not a supported key provider; "
-            f"expected one of {PROVIDER_ENV!r}, {PROVIDER_AWS_SECRETS!r}, {PROVIDER_AWS_KMS!r}."
+            f"expected one of {PROVIDER_ENV!r}, {PROVIDER_AWS_SECRETS!r}, {PROVIDER_AWS_KMS!r}, {PROVIDER_VAULT!r}."
         )
     key = resolver()
     _RESOLVED_KEY = key
     return key
 
 
+def _split_keys(material: bytes) -> list[bytes]:
+    """Split resolved key material into individual base64 Fernet keys.
+
+    Supports a comma-separated list for MultiFernet rotation; surrounding
+    whitespace and empty entries are ignored.
+    """
+    return [chunk.strip() for chunk in material.split(b",") if chunk.strip()]
+
+
 def _fernet() -> Any:
+    """Build a Fernet (single key) or MultiFernet (rotation list).
+
+    A single key stays a plain ``Fernet`` for backward compatibility. With more
+    than one key a ``MultiFernet`` encrypts under the first (primary) key and
+    decrypts under any key in the list.
+    """
     try:
-        from cryptography.fernet import Fernet
+        from cryptography.fernet import Fernet, MultiFernet
     except ImportError as exc:  # pragma: no cover - cryptography is a core dependency
         raise ConnectionSecretError("cryptography is required for connection secret encryption.") from exc
+    keys = _split_keys(_load_key())
+    if not keys:
+        raise ConnectionSecretError("No connection encryption key is configured; refusing to operate on plaintext.")
     try:
-        return Fernet(_load_key())
+        fernets = [Fernet(key) for key in keys]
+        return fernets[0] if len(fernets) == 1 else MultiFernet(fernets)
     except ConnectionSecretError:
         raise
     except Exception as exc:  # noqa: BLE001 - malformed key material

--- a/tests/test_cloud_connections.py
+++ b/tests/test_cloud_connections.py
@@ -328,6 +328,225 @@ def test_unknown_provider_fails_closed() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# Key provider: HashiCorp Vault (KV v2), fail-closed, no token/key leak.
+# The shared HTTP client is mocked at the http_client.sync_get seam.
+# --------------------------------------------------------------------------- #
+
+
+class _FakeVaultResponse:
+    """Stand-in for an httpx.Response from a Vault KV v2 read."""
+
+    def __init__(self, *, status_code: int = 200, payload: Any = None, raise_json: bool = False) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self._raise_json = raise_json
+
+    def json(self) -> Any:
+        if self._raise_json:
+            raise ValueError("not json")
+        return self._payload
+
+
+def _vault_payload(key: str, field: str = "key") -> dict[str, Any]:
+    """A well-formed KV v2 read payload carrying the Fernet key at *field*."""
+    return {"data": {"data": {field: key}, "metadata": {"version": 1}}}
+
+
+def _configure_vault(monkeypatch: Any, *, ref: str = "secret/agent-bom/conn-key") -> None:
+    monkeypatch.setenv(connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV, connection_crypto.PROVIDER_VAULT)
+    monkeypatch.setenv(connection_crypto.VAULT_ADDR_ENV, "https://vault.internal:8200")
+    monkeypatch.setenv(connection_crypto.VAULT_TOKEN_ENV, "s.super-secret-vault-token")
+    monkeypatch.setenv(connection_crypto.CONNECTIONS_KEY_REF_ENV, ref)
+    os.environ.pop(connection_crypto.CONNECTIONS_KEY_ENV, None)
+    connection_crypto.reset_key_cache()
+
+
+def _patch_vault_get(monkeypatch: Any, response: Any) -> dict[str, Any]:
+    """Patch http_client.sync_get; capture the url + headers it was called with."""
+    from agent_bom import http_client
+
+    captured: dict[str, Any] = {"calls": 0}
+
+    def _fake_get(url: str, timeout: Any = None, headers: Any = None) -> Any:
+        captured["calls"] += 1
+        captured["url"] = url
+        captured["headers"] = headers
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    monkeypatch.setattr(http_client, "sync_get", _fake_get)
+    return captured
+
+
+def test_vault_provider_round_trip(monkeypatch: Any) -> None:
+    _configure_vault(monkeypatch)
+    captured = _patch_vault_get(monkeypatch, _FakeVaultResponse(payload=_vault_payload(_TEST_KEY)))
+
+    assert connection_crypto.connections_key_configured() is True
+    token = connection_crypto.encrypt_secret("ext-id")
+    assert connection_crypto.decrypt_secret(token) == "ext-id"
+    # KV v2 data path + token header; resolved once then served from cache.
+    assert captured["url"] == "https://vault.internal:8200/v1/secret/data/agent-bom/conn-key"
+    assert captured["headers"]["X-Vault-Token"] == "s.super-secret-vault-token"
+    assert captured["calls"] == 1
+
+
+def test_vault_custom_field(monkeypatch: Any) -> None:
+    _configure_vault(monkeypatch, ref="secret/agent-bom/conn#fernet")
+    _patch_vault_get(monkeypatch, _FakeVaultResponse(payload=_vault_payload(_TEST_KEY, field="fernet")))
+
+    token = connection_crypto.encrypt_secret("ext-id")
+    assert connection_crypto.decrypt_secret(token) == "ext-id"
+
+
+def test_vault_missing_addr_fails_closed(monkeypatch: Any) -> None:
+    _configure_vault(monkeypatch)
+    monkeypatch.delenv(connection_crypto.VAULT_ADDR_ENV, raising=False)
+    captured = _patch_vault_get(monkeypatch, _FakeVaultResponse(payload=_vault_payload(_TEST_KEY)))
+    connection_crypto.reset_key_cache()
+
+    assert connection_crypto.connections_key_configured() is False
+    with pytest.raises(connection_crypto.ConnectionSecretError):
+        connection_crypto.encrypt_secret("ext-id")
+    assert captured["calls"] == 0  # never reached the network without an address
+
+
+def test_vault_missing_token_fails_closed(monkeypatch: Any) -> None:
+    _configure_vault(monkeypatch)
+    monkeypatch.delenv(connection_crypto.VAULT_TOKEN_ENV, raising=False)
+    captured = _patch_vault_get(monkeypatch, _FakeVaultResponse(payload=_vault_payload(_TEST_KEY)))
+    connection_crypto.reset_key_cache()
+
+    assert connection_crypto.connections_key_configured() is False
+    with pytest.raises(connection_crypto.ConnectionSecretError):
+        connection_crypto.encrypt_secret("ext-id")
+    assert captured["calls"] == 0
+
+
+def test_vault_missing_field_fails_closed(monkeypatch: Any) -> None:
+    _configure_vault(monkeypatch)
+    # Body is well-formed KV v2 but the configured field is absent.
+    _patch_vault_get(monkeypatch, _FakeVaultResponse(payload=_vault_payload(_TEST_KEY, field="other")))
+
+    with pytest.raises(connection_crypto.ConnectionSecretError):
+        connection_crypto.encrypt_secret("ext-id")
+
+
+def test_vault_non_200_fails_closed_without_leaking(monkeypatch: Any) -> None:
+    _configure_vault(monkeypatch)
+    _patch_vault_get(monkeypatch, _FakeVaultResponse(status_code=403, payload={"errors": ["permission denied"]}))
+
+    with pytest.raises(connection_crypto.ConnectionSecretError) as excinfo:
+        connection_crypto.encrypt_secret("ext-id")
+    message = str(excinfo.value)
+    assert "s.super-secret-vault-token" not in message
+    assert _TEST_KEY not in message
+    assert "permission denied" not in message
+
+
+def test_vault_malformed_body_fails_closed(monkeypatch: Any) -> None:
+    _configure_vault(monkeypatch)
+    _patch_vault_get(monkeypatch, _FakeVaultResponse(payload="not-a-dict"))
+
+    with pytest.raises(connection_crypto.ConnectionSecretError) as excinfo:
+        connection_crypto.encrypt_secret("ext-id")
+    assert "s.super-secret-vault-token" not in str(excinfo.value)
+
+
+def test_vault_unreachable_fails_closed_without_leaking(monkeypatch: Any) -> None:
+    _configure_vault(monkeypatch)
+    # sync_get returns None when retries are exhausted.
+    _patch_vault_get(monkeypatch, None)
+
+    with pytest.raises(connection_crypto.ConnectionSecretError) as excinfo:
+        connection_crypto.encrypt_secret("ext-id")
+    assert "s.super-secret-vault-token" not in str(excinfo.value)
+
+
+def test_vault_transport_error_does_not_leak_token(monkeypatch: Any) -> None:
+    _configure_vault(monkeypatch)
+    boom = RuntimeError("connect to https://vault.internal:8200 with token s.super-secret-vault-token failed")
+    _patch_vault_get(monkeypatch, boom)
+
+    with pytest.raises(connection_crypto.ConnectionSecretError) as excinfo:
+        connection_crypto.encrypt_secret("ext-id")
+    assert "s.super-secret-vault-token" not in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------- #
+# MultiFernet key rotation: encrypt with the primary, decrypt with any key.
+# --------------------------------------------------------------------------- #
+
+
+def test_rotation_old_ciphertext_decrypts_after_new_primary() -> None:
+    old_key = _TEST_KEY
+    new_key = Fernet.generate_key().decode("ascii")
+
+    # Encrypt under the original single key.
+    os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = old_key
+    connection_crypto.reset_key_cache()
+    token = connection_crypto.encrypt_secret("ext-id")
+
+    # Rotate: new key becomes primary, old key retained for decrypt.
+    os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = f"{new_key},{old_key}"
+    connection_crypto.reset_key_cache()
+    assert connection_crypto.decrypt_secret(token) == "ext-id"
+
+
+def test_rotation_encrypts_with_primary_key() -> None:
+    new_key = Fernet.generate_key().decode("ascii")
+    old_key = _TEST_KEY
+
+    os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = f"{new_key},{old_key}"
+    connection_crypto.reset_key_cache()
+    token = connection_crypto.encrypt_secret("ext-id")
+
+    # The token must decrypt under the primary (new) key alone...
+    assert Fernet(new_key.encode("ascii")).decrypt(token.encode("ascii")).decode() == "ext-id"
+    # ...and NOT under the retired (old) key alone.
+    os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = old_key
+    connection_crypto.reset_key_cache()
+    with pytest.raises(connection_crypto.ConnectionSecretError):
+        connection_crypto.decrypt_secret(token)
+
+
+def test_rotation_round_trip_with_multiple_keys() -> None:
+    keys = ",".join(Fernet.generate_key().decode("ascii") for _ in range(3))
+    os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = keys
+    connection_crypto.reset_key_cache()
+
+    token = connection_crypto.encrypt_secret("value-123")
+    assert token != "value-123"
+    assert connection_crypto.decrypt_secret(token) == "value-123"
+
+
+def test_single_key_unchanged_is_plain_fernet() -> None:
+    from cryptography.fernet import Fernet as _Fernet
+    from cryptography.fernet import MultiFernet as _MultiFernet
+
+    os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = _TEST_KEY
+    connection_crypto.reset_key_cache()
+    cipher = connection_crypto._fernet()
+    assert isinstance(cipher, _Fernet)
+    assert not isinstance(cipher, _MultiFernet)
+
+
+def test_rotation_via_vault_resolved_list(monkeypatch: Any) -> None:
+    old_key = _TEST_KEY
+    new_key = Fernet.generate_key().decode("ascii")
+
+    # Vault returns a comma-separated rotation list in the single KV field.
+    _configure_vault(monkeypatch)
+    _patch_vault_get(monkeypatch, _FakeVaultResponse(payload=_vault_payload(f"{new_key},{old_key}")))
+
+    token = connection_crypto.encrypt_secret("ext-id")
+    # Primary (new) key encrypts; round-trips through the MultiFernet.
+    assert connection_crypto.decrypt_secret(token) == "ext-id"
+    assert Fernet(new_key.encode("ascii")).decrypt(token.encode("ascii")).decode() == "ext-id"
+
+
+# --------------------------------------------------------------------------- #
 # API: RBAC, no-secret responses, tenant scoping
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
Extends connection at-rest encryption (KMS work, #3197) with a **HashiCorp Vault provider** + **MultiFernet key rotation** — matching the Airflow/Superset convention for secure, rotatable secrets. Encrypt/decrypt API and the store are unchanged; only key resolution + Fernet construction.

- **Vault provider** (`AGENT_BOM_CONNECTIONS_KEY_PROVIDER=vault`): read-only `GET {AGENT_BOM_VAULT_ADDR}/v1/{mount}/data/{path}` with `X-Vault-Token`, key from KV v2 `data.data[field]` (`AGENT_BOM_CONNECTIONS_KEY_REF` = `mount/path#field`, field defaults to `key`). Uses the repo HTTP client (TLS verify on, no new dep). Cached + reset hook.
- **MultiFernet rotation** (all providers): any resolved key value may be a comma-separated list → `MultiFernet` that **encrypts with the primary (first) key, decrypts with any**. Single key stays plain Fernet (backward compatible). Documented zero-downtime procedure: add new key as primary → optional bulk re-encrypt → drop old.
- **Fail-closed / no-leak**: missing addr/token/ref, malformed ref, non-200, malformed body, missing field, transport error all raise `ConnectionSecretError`; errors carry only the failure mode — never the token, key, or Vault body (tests assert their absence).

New env vars (`AGENT_BOM_VAULT_ADDR`, `AGENT_BOM_VAULT_TOKEN`) + multi-key/vault notes in the allowlist. 54 tests (15 new: 9 Vault, 6 rotation); env-var drift OK; ruff/mypy(strict)/bandit clean.
