### PR TITLE
fix(ci): self-scan SARIF lands under its intended code-scanning category

### DIFF
--- a/.github/workflows/post-merge-self-scan.yml
+++ b/.github/workflows/post-merge-self-scan.yml
@@ -126,34 +126,32 @@ jobs:
               print(f"... {len(findings) - 20} additional findings omitted from log")
           PY
 
-      - name: Upload dep scan SARIF
-        if: always() && hashFiles('sarif/self-dep.sarif') != ''
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
-        with:
-          sarif_file: sarif/self-dep.sarif
-          category: agent-bom-self-dep
-
-      - name: Prepare legacy scheduled SARIF category
+      - name: Align dep scan SARIF category
         if: always() && hashFiles('sarif/self-dep.sarif') != ''
         run: |
           python3 - <<'PY'
           import json
           from pathlib import Path
 
-          source = Path("sarif/self-dep.sarif")
-          target = Path("sarif/self-dep-scheduled.sarif")
-          data = json.loads(source.read_text())
+          # agent-bom's SARIF formatter pre-sets runs[].automationDetails.id to
+          # "agent-bom/<scan_id>". github/codeql-action/upload-sarif only injects
+          # its `category` input when automationDetails is absent, so the pre-set
+          # id wins and GitHub derives the category from it (the part before the
+          # final "/", i.e. "agent-bom") instead of the intended
+          # "agent-bom-self-dep". Drop it so the upload `category` below applies.
+          path = Path("sarif/self-dep.sarif")
+          data = json.loads(path.read_text())
           for run in data.get("runs", []):
-              run.setdefault("automationDetails", {})["id"] = "agent-bom-scheduled"
-          target.write_text(json.dumps(data, indent=2) + "\n")
+              run.pop("automationDetails", None)
+          path.write_text(json.dumps(data, indent=2) + "\n")
           PY
 
-      - name: Refresh legacy scheduled SARIF category
-        if: always() && hashFiles('sarif/self-dep-scheduled.sarif') != ''
+      - name: Upload dep scan SARIF
+        if: always() && hashFiles('sarif/self-dep.sarif') != ''
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
-          sarif_file: sarif/self-dep-scheduled.sarif
-          category: agent-bom-scheduled
+          sarif_file: sarif/self-dep.sarif
+          category: agent-bom-self-dep
 
       - name: Fail on critical (optional, only when explicitly requested)
         if: inputs.fail_on_critical == true

--- a/.github/workflows/pr-security-gate.yml
+++ b/.github/workflows/pr-security-gate.yml
@@ -52,12 +52,6 @@ jobs:
           }
           EOF
 
-      - name: Upload scheduled config placeholder
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
-        with:
-          sarif_file: sarif/empty-agent-bom.sarif
-          category: agent-bom-scheduled
-
       - name: Upload dependency self-scan config placeholder
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
@@ -256,6 +250,26 @@ jobs:
               sys.exit(1)
           if os.environ.get("SCAN_EXIT") not in {"0", None}:
               print("::warning::agent-bom self-scan returned non-zero but SARIF contains no blocking findings")
+          PY
+
+      - name: Align self-scan SARIF category
+        if: always() && hashFiles('self-scan.sarif') != ''
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          # agent-bom's SARIF formatter pre-sets runs[].automationDetails.id to
+          # "agent-bom/<scan_id>". github/codeql-action/upload-sarif only injects
+          # its `category` input when automationDetails is absent, so the pre-set
+          # id wins and GitHub derives the category from it (the part before the
+          # final "/", i.e. "agent-bom") instead of "agent-bom-self-scan". Drop it
+          # so the upload `category` below applies.
+          path = Path("self-scan.sarif")
+          data = json.loads(path.read_text())
+          for run in data.get("runs", []):
+              run.pop("automationDetails", None)
+          path.write_text(json.dumps(data, indent=2) + "\n")
           PY
 
       - name: Upload SARIF to code-scanning

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -851,6 +851,26 @@ jobs:
             exit 2
           fi
 
+      - name: Align release self-scan SARIF category
+        if: always() && hashFiles('sarif/release-self-dep.sarif') != ''
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          # agent-bom's SARIF formatter pre-sets runs[].automationDetails.id to
+          # "agent-bom/<scan_id>". github/codeql-action/upload-sarif only injects
+          # its `category` input when automationDetails is absent, so the pre-set
+          # id wins and GitHub derives the category from it (the part before the
+          # final "/", i.e. "agent-bom") instead of "agent-bom-release-gate". Drop
+          # it so the upload `category` below applies.
+          path = Path("sarif/release-self-dep.sarif")
+          data = json.loads(path.read_text())
+          for run in data.get("runs", []):
+              run.pop("automationDetails", None)
+          path.write_text(json.dumps(data, indent=2) + "\n")
+          PY
+
       - name: Upload release self-scan SARIF
         if: always() && hashFiles('sarif/release-self-dep.sarif') != ''
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4


### PR DESCRIPTION
Fixes the self-scan code-scanning uploads so each SARIF lands under its intended category instead of collapsing to `agent-bom` (which is why the Security tab showed a stale `agent-bom-scheduled` config and a blank-category analysis).

**Root cause:** agent-bom's SARIF formatter (`output/sarif.py`) hardcodes `runs[].automationDetails.id = "agent-bom/{scan_id}"`. `github/codeql-action/upload-sarif` only injects its `category:` input when `automationDetails` is absent, so the pre-set id won and GitHub derived the category as the substring before the final `/` → `agent-bom`. The empty `""` category came from the old legacy step setting a bare `agent-bom-scheduled` id (no slash → empty).

**Fix (workflow-only, all three uploads of formatter-generated SARIF):**
- `post-merge-self-scan.yml` — normalize (strip `automationDetails`) before the `agent-bom-self-dep` upload; removed the two dead legacy `agent-bom-scheduled` steps.
- `pr-security-gate.yml` — normalize before the real `agent-bom-self-scan` upload; removed the legacy `agent-bom-scheduled` placeholder. (The `agent-bom-self-dep`/`-self-sast` placeholders here use an empty SARIF with no `automationDetails`, so their categories already apply — left untouched.)
- `release.yml` — normalize immediately before the `agent-bom-release-gate` upload only; **no other job/needs/ordering changed** (verified; release call-graph linter passes).

`actionlint` clean on all three; pre-commit passes (the `release-workflow-lint` hook errored only on a missing-PyYAML env issue — verified it passes via direct run). After merge, the stale `agent-bom-scheduled` config can be deleted from the Security tab and won't reappear.
