### PR TITLE
docs: contain hero diagram labels within node borders

### DIFF
--- a/docs/images/blast-radius-dark.svg
+++ b/docs/images/blast-radius-dark.svg
@@ -7,11 +7,6 @@
 <rect x="16" y="16" width="928" height="528" rx="18" fill="#0a0a0b" stroke="#26262a" stroke-width="1"/>
 <text x="480" y="48" text-anchor="middle" font-size="17" font-weight="700" fill="#f4f4f5">Attack-path blast radius from one vulnerable package</text>
 <text x="480" y="68" text-anchor="middle" font-size="11" fill="#a1a1aa">package &#8594; finding &#8594; MCP server &#8594; AI agent &#8594; exposed credentials &amp; reachable tools</text>
-<text x="106" y="100" text-anchor="middle" font-size="8.5" font-weight="700" letter-spacing="0.11em" fill="#52525b">PACKAGE</text>
-<text x="282" y="100" text-anchor="middle" font-size="8.5" font-weight="700" letter-spacing="0.11em" fill="#52525b">FINDING</text>
-<text x="470" y="100" text-anchor="middle" font-size="8.5" font-weight="700" letter-spacing="0.11em" fill="#52525b">MCP SERVERS</text>
-<text x="660" y="100" text-anchor="middle" font-size="8.5" font-weight="700" letter-spacing="0.11em" fill="#52525b">AI AGENTS</text>
-<text x="849" y="100" text-anchor="middle" font-size="8.5" font-weight="700" letter-spacing="0.11em" fill="#52525b">BLAST RADIUS</text>
 <path d="M176 270 C194.0 270 194.0 270 212 270" stroke="#5c5c66" stroke-width="1.8" fill="none" marker-end="url(#ar)"/>
 <path d="M352 270 C374.0 270 374.0 186 396 186" stroke="#3a3a40" stroke-width="1.6" fill="none" marker-end="url(#ar)"/>
 <path d="M352 270 C374.0 270 374.0 354 396 354" stroke="#3a3a40" stroke-width="1.6" fill="none" marker-end="url(#ar)"/>

--- a/docs/images/blast-radius-light.svg
+++ b/docs/images/blast-radius-light.svg
@@ -7,11 +7,6 @@
 <rect x="16" y="16" width="928" height="528" rx="18" fill="#ffffff" stroke="#e4e4e7" stroke-width="1"/>
 <text x="480" y="48" text-anchor="middle" font-size="17" font-weight="700" fill="#18181b">Attack-path blast radius from one vulnerable package</text>
 <text x="480" y="68" text-anchor="middle" font-size="11" fill="#71717a">package &#8594; finding &#8594; MCP server &#8594; AI agent &#8594; exposed credentials &amp; reachable tools</text>
-<text x="106" y="100" text-anchor="middle" font-size="8.5" font-weight="700" letter-spacing="0.11em" fill="#a1a1aa">PACKAGE</text>
-<text x="282" y="100" text-anchor="middle" font-size="8.5" font-weight="700" letter-spacing="0.11em" fill="#a1a1aa">FINDING</text>
-<text x="470" y="100" text-anchor="middle" font-size="8.5" font-weight="700" letter-spacing="0.11em" fill="#a1a1aa">MCP SERVERS</text>
-<text x="660" y="100" text-anchor="middle" font-size="8.5" font-weight="700" letter-spacing="0.11em" fill="#a1a1aa">AI AGENTS</text>
-<text x="849" y="100" text-anchor="middle" font-size="8.5" font-weight="700" letter-spacing="0.11em" fill="#a1a1aa">BLAST RADIUS</text>
 <path d="M176 270 C194.0 270 194.0 270 212 270" stroke="#9ca3af" stroke-width="1.8" fill="none" marker-end="url(#ar)"/>
 <path d="M352 270 C374.0 270 374.0 186 396 186" stroke="#cbced4" stroke-width="1.6" fill="none" marker-end="url(#ar)"/>
 <path d="M352 270 C374.0 270 374.0 354 396 354" stroke="#cbced4" stroke-width="1.6" fill="none" marker-end="url(#ar)"/>


### PR DESCRIPTION
Addresses floating, disconnected column headers above the blast-radius flow.

The top header row (PACKAGE / FINDING / MCP SERVERS / AI AGENTS / BLAST RADIUS) sat as free-floating text above the cards and read as disconnected from the flow — most visibly the single-card PACKAGE and FINDING columns. Every card already labels its own type inside its border, and the blast-radius column keeps its in-box title, so the header row was redundant.

- Remove the floating header row from `blast-radius-dark.svg` and `blast-radius-light.svg`.
- All labels now live within a node border or container; the left→right flow and connectors are unchanged.

Both SVGs validated well-formed; dark render eyeballed.