### PR TITLE
feat(cloud): Azure, GCP, and Snowflake connection brokers — read-only scan launch for all providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,14 @@ account.
 
 ### API
 - **REST cloud-scanning endpoints** with MCP write-tool role enforcement.
+- **Multi-cloud connection brokers.** A stored read-only cloud connection now
+  launches a read-only scan for every provider — AWS (`sts:AssumeRole` with the
+  decrypted ExternalId), Azure (`ClientSecretCredential`, Reader role), GCP
+  (service-account credentials scoped to `cloud-platform.read-only`), and
+  Snowflake (key-pair connection). Provider-specific non-secret parameters are
+  stored in a new `auth_params` column (the single reversible secret stays in the
+  encrypted `external_id`); the secret is decrypted only at broker time and never
+  logged or returned. The background scan scheduler covers all four providers.
 - **Shared backend contract and selection factory** for control-plane stores.
 
 ### Deploy / Packaging

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -156,6 +156,13 @@
         "additionalProperties": false,
         "description": "Request body for creating a connection. ``external_id`` is write-only.\n\n``scan_interval_minutes`` opts the connection into recurring background scans\n(Phase B.2). Null (the default) means manual-only \u2014 the scheduler ignores it.",
         "properties": {
+          "auth_params": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Auth Params",
+            "type": "object"
+          },
           "display_name": {
             "maxLength": 200,
             "minLength": 1,
@@ -163,7 +170,7 @@
             "type": "string"
           },
           "external_id": {
-            "maxLength": 1024,
+            "maxLength": 8192,
             "minLength": 1,
             "title": "External Id",
             "type": "string"
@@ -6308,7 +6315,7 @@
     },
     "/v1/cloud/connections/{connection_id}/scan": {
       "post": {
-        "description": "Launch a read-only cloud scan for a stored connection via the broker.\n\nResolves the tenant's connection (404 otherwise), uses the credential broker\nto assume a short-lived read-only session, and runs the same inventory + CIS\ndiscovery the sibling cloud routes use. Results persist through the existing\nscan/graph stores; the connection status moves to ``active`` + ``last_scan_at``\non success or ``error`` + ``status_detail`` (no secret) on failure. AWS only\ntoday \u2014 azure / gcp / snowflake return a clear 501 ``planned`` response.",
+        "description": "Launch a read-only cloud scan for a stored connection via the broker.\n\nResolves the tenant's connection (404 otherwise), uses the credential broker\nto obtain a short-lived read-only session / credential / connection, and runs\nthe same inventory + CIS discovery the sibling cloud routes use. Results\npersist through the existing scan/graph stores; the connection status moves to\n``active`` + ``last_scan_at`` on success or ``error`` + ``status_detail`` (no\nsecret) on failure. All four providers (AWS, Azure, GCP, Snowflake) are\nbroker-enabled.",
         "operationId": "scan_connection_v1_cloud_connections__connection_id__scan_post",
         "parameters": [
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -115,13 +115,18 @@ components:
         \ scans\n(Phase B.2). Null (the default) means manual-only \u2014 the scheduler\
         \ ignores it."
       properties:
+        auth_params:
+          additionalProperties:
+            type: string
+          title: Auth Params
+          type: object
         display_name:
           maxLength: 200
           minLength: 1
           title: Display Name
           type: string
         external_id:
-          maxLength: 1024
+          maxLength: 8192
           minLength: 1
           title: External Id
           type: string
@@ -4143,14 +4148,25 @@ paths:
       - cloud-connections
   /v1/cloud/connections/{connection_id}/scan:
     post:
-      description: "Launch a read-only cloud scan for a stored connection via the\
-        \ broker.\n\nResolves the tenant's connection (404 otherwise), uses the credential\
-        \ broker\nto assume a short-lived read-only session, and runs the same inventory\
-        \ + CIS\ndiscovery the sibling cloud routes use. Results persist through the\
-        \ existing\nscan/graph stores; the connection status moves to ``active`` +\
-        \ ``last_scan_at``\non success or ``error`` + ``status_detail`` (no secret)\
-        \ on failure. AWS only\ntoday \u2014 azure / gcp / snowflake return a clear\
-        \ 501 ``planned`` response."
+      description: 'Launch a read-only cloud scan for a stored connection via the
+        broker.
+
+
+        Resolves the tenant''s connection (404 otherwise), uses the credential broker
+
+        to obtain a short-lived read-only session / credential / connection, and runs
+
+        the same inventory + CIS discovery the sibling cloud routes use. Results
+
+        persist through the existing scan/graph stores; the connection status moves
+        to
+
+        ``active`` + ``last_scan_at`` on success or ``error`` + ``status_detail``
+        (no
+
+        secret) on failure. All four providers (AWS, Azure, GCP, Snowflake) are
+
+        broker-enabled.'
       operationId: scan_connection_v1_cloud_connections__connection_id__scan_post
       parameters:
       - in: path

--- a/src/agent_bom/api/connection_scheduler.py
+++ b/src/agent_bom/api/connection_scheduler.py
@@ -20,8 +20,8 @@ Design notes:
   one replica runs a given due scan. Bounded concurrency caps brokered scans.
 * **Safe.** Read-only scans only. A failing connection is marked ``error`` with a
   sanitized, secret-free detail and the loop continues — one bad connection never
-  stops the loop. AWS only today (the broker is AWS-only); other providers are
-  skipped, never claimed.
+  stops the loop. All four providers (AWS, Azure, GCP, Snowflake) are
+  broker-enabled and schedulable.
 """
 
 from __future__ import annotations
@@ -46,9 +46,8 @@ from agent_bom.config import (
 
 logger = logging.getLogger(__name__)
 
-# Only AWS is broker-enabled; other recognized providers are skipped (not claimed)
-# until their credential broker lands.
-_SCHEDULABLE_PROVIDERS: frozenset[str] = frozenset({"aws"})
+# Every supported provider is broker-enabled and therefore schedulable.
+_SCHEDULABLE_PROVIDERS: frozenset[str] = frozenset({"aws", "azure", "gcp", "snowflake"})
 
 
 def connections_scheduler_enabled() -> bool:
@@ -103,12 +102,13 @@ def select_due_connections(store: ConnectionStore, now: datetime) -> list[CloudC
 
 
 def claim_due_connections(store: ConnectionStore, now: datetime) -> list[CloudConnectionRecord]:
-    """Select due AWS connections and atomically claim each for this replica.
+    """Select due connections and atomically claim each for this replica.
 
-    Returns only the connections this replica won. Non-AWS providers are skipped
-    (the broker is AWS-only) and are never claimed. The claim advances
-    ``last_scan_at`` to *now* so a racing replica loses the compare-and-swap and
-    a failed scan is not retried until the next interval.
+    Returns only the connections this replica won. A provider with no broker is
+    skipped and never claimed (defensive — all supported providers are
+    broker-enabled). The claim advances ``last_scan_at`` to *now* so a racing
+    replica loses the compare-and-swap and a failed scan is not retried until the
+    next interval.
     """
     claimed_at = now.isoformat()
     won: list[CloudConnectionRecord] = []
@@ -123,8 +123,8 @@ def claim_due_connections(store: ConnectionStore, now: datetime) -> list[CloudCo
 def execute_connection_scan(record: CloudConnectionRecord) -> bool:
     """Run the broker scan for a claimed connection and persist the outcome.
 
-    Reuses the Phase B scan-launch path (``_run_aws_connection_scan``) and the
-    Phase A lifecycle mutator (``_mark_connection``). On success the connection
+    Reuses the provider-dispatching scan-launch path (``_run_connection_scan``)
+    and the lifecycle mutator (``_mark_connection``). On success the connection
     moves to ``active`` + a fresh ``last_scan_at``; on failure it is marked
     ``error`` with a sanitized, secret-free detail. Never raises — returns
     whether the scan succeeded so one bad connection cannot sink the loop.
@@ -134,12 +134,12 @@ def execute_connection_scan(record: CloudConnectionRecord) -> bool:
     from agent_bom.api.routes.cloud_connections import (
         _mark_connection,
         _now,
-        _run_aws_connection_scan,
+        _run_connection_scan,
     )
     from agent_bom.security import sanitize_error
 
     try:
-        summary = _run_aws_connection_scan(record, record.tenant_id)
+        summary = _run_connection_scan(record, record.tenant_id)
     except Exception as exc:  # noqa: BLE001 - broker / discovery / persistence failure
         detail = sanitize_error(exc)
         _mark_connection(record, status=STATUS_ERROR, status_detail=detail)

--- a/src/agent_bom/api/connection_store.py
+++ b/src/agent_bom/api/connection_store.py
@@ -57,6 +57,12 @@ class CloudConnectionRecord:
     updated_at: str = ""
     last_scan_at: str | None = None
     scan_interval_minutes: int | None = None
+    # Non-secret, provider-specific connection parameters (e.g. Azure
+    # tenant_id/subscription_id, GCP project_id, Snowflake user/role/warehouse).
+    # The single reversible secret per connection lives in
+    # ``external_id_encrypted``; these are deliberately NOT secret and are safe to
+    # return in API responses.
+    auth_params: dict[str, Any] = field(default_factory=dict)
 
     def to_public_dict(self) -> dict[str, Any]:
         """Non-secret representation for API responses.
@@ -64,7 +70,7 @@ class CloudConnectionRecord:
         Deliberately excludes ``external_id_encrypted`` (and never carries the
         plaintext) so no secret material can leak through a response body. Also
         surfaces ``has_external_id`` so a client can tell a secret is configured
-        without ever seeing it.
+        without ever seeing it. ``auth_params`` is non-secret and is included.
         """
         data = asdict(self)
         data.pop("external_id_encrypted", None)
@@ -108,6 +114,7 @@ CONNECTION_STORAGE_SCHEMA = StorageSchema(
                 "updated_at",
                 "last_scan_at",
                 "scan_interval_minutes",
+                "auth_params",
             ),
             ddl_by_backend={
                 "sqlite": (
@@ -116,7 +123,8 @@ CONNECTION_STORAGE_SCHEMA = StorageSchema(
                     "role_ref TEXT NOT NULL, external_id_encrypted TEXT NOT NULL DEFAULT '', "
                     "regions TEXT NOT NULL DEFAULT '[]', status TEXT NOT NULL DEFAULT 'pending', "
                     "status_detail TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL, "
-                    "updated_at TEXT NOT NULL, last_scan_at TEXT, scan_interval_minutes INTEGER)"
+                    "updated_at TEXT NOT NULL, last_scan_at TEXT, scan_interval_minutes INTEGER, "
+                    "auth_params TEXT NOT NULL DEFAULT '{}')"
                 ),
                 "postgres": (
                     "CREATE TABLE IF NOT EXISTS cloud_connections (id TEXT PRIMARY KEY, "
@@ -124,7 +132,8 @@ CONNECTION_STORAGE_SCHEMA = StorageSchema(
                     "role_ref TEXT NOT NULL, external_id_encrypted TEXT NOT NULL DEFAULT '', "
                     "regions TEXT NOT NULL DEFAULT '[]', status TEXT NOT NULL DEFAULT 'pending', "
                     "status_detail TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL, "
-                    "updated_at TEXT NOT NULL, last_scan_at TEXT, scan_interval_minutes INTEGER)"
+                    "updated_at TEXT NOT NULL, last_scan_at TEXT, scan_interval_minutes INTEGER, "
+                    "auth_params TEXT NOT NULL DEFAULT '{}')"
                 ),
             },
         ),
@@ -155,6 +164,23 @@ def _decode_interval(raw: Any) -> int | None:
         return None
 
 
+def _decode_auth_params(raw: Any) -> dict[str, Any]:
+    """Parse a stored ``auth_params`` JSON blob into a dict (tolerant).
+
+    Non-secret provider-specific params. Defaults to an empty dict on any
+    malformed / missing value so a legacy row (pre-migration) reads cleanly.
+    """
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw) if isinstance(raw, (str, bytes)) else raw
+    except (ValueError, TypeError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {str(k): v for k, v in parsed.items()}
+
+
 def _row_to_record(row: Sequence[Any]) -> CloudConnectionRecord:
     """Map a ``cloud_connections`` row tuple to a record (shared by backends)."""
     return CloudConnectionRecord(
@@ -171,6 +197,7 @@ def _row_to_record(row: Sequence[Any]) -> CloudConnectionRecord:
         updated_at=row[10] or "",
         last_scan_at=row[11] if len(row) > 11 else None,
         scan_interval_minutes=_decode_interval(row[12]) if len(row) > 12 else None,
+        auth_params=_decode_auth_params(row[13]) if len(row) > 13 else {},
     )
 
 
@@ -181,7 +208,7 @@ def _copy_record(record: CloudConnectionRecord) -> CloudConnectionRecord:
     Without this the in-memory store would hand out the live reference and the
     compare-and-swap claim could never observe a concurrent change.
     """
-    return replace(record, regions=list(record.regions))
+    return replace(record, regions=list(record.regions), auth_params=dict(record.auth_params))
 
 
 class InMemoryConnectionStore:
@@ -268,6 +295,10 @@ class SQLiteConnectionStore:
         columns = {row[1] for row in self._conn.execute("PRAGMA table_info(cloud_connections)").fetchall()}
         if "scan_interval_minutes" not in columns:
             self._conn.execute("ALTER TABLE cloud_connections ADD COLUMN scan_interval_minutes INTEGER")
+        if "auth_params" not in columns:
+            # Idempotent migration: backfill existing rows with an empty object so
+            # the column stays NOT NULL and legacy connections read as no-params.
+            self._conn.execute("ALTER TABLE cloud_connections ADD COLUMN auth_params TEXT NOT NULL DEFAULT '{}'")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_cloud_connections_tenant ON cloud_connections(tenant_id, created_at)")
         self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_cloud_connections_schedulable ON cloud_connections(scan_interval_minutes, last_scan_at)"
@@ -280,8 +311,8 @@ class SQLiteConnectionStore:
             INSERT OR REPLACE INTO cloud_connections
                 (id, tenant_id, provider, display_name, role_ref, external_id_encrypted,
                  regions, status, status_detail, created_at, updated_at, last_scan_at,
-                 scan_interval_minutes)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 scan_interval_minutes, auth_params)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 record.id,
@@ -297,6 +328,7 @@ class SQLiteConnectionStore:
                 record.updated_at,
                 record.last_scan_at,
                 record.scan_interval_minutes,
+                json.dumps(record.auth_params),
             ),
         )
         self._conn.commit()
@@ -304,7 +336,7 @@ class SQLiteConnectionStore:
     def get(self, tenant_id: str, connection_id: str) -> CloudConnectionRecord | None:
         row = self._conn.execute(
             "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-            "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes "
+            "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params "
             "FROM cloud_connections WHERE tenant_id = ? AND id = ?",
             (tenant_id, connection_id),
         ).fetchone()
@@ -313,7 +345,7 @@ class SQLiteConnectionStore:
     def list_for_tenant(self, tenant_id: str) -> list[CloudConnectionRecord]:
         rows = self._conn.execute(
             "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-            "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes "
+            "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params "
             "FROM cloud_connections WHERE tenant_id = ? ORDER BY created_at, id",
             (tenant_id,),
         ).fetchall()
@@ -330,7 +362,7 @@ class SQLiteConnectionStore:
     def list_schedulable(self) -> list[CloudConnectionRecord]:
         rows = self._conn.execute(
             "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-            "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes "
+            "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params "
             "FROM cloud_connections WHERE scan_interval_minutes IS NOT NULL ORDER BY created_at, id"
         ).fetchall()
         return [_row_to_record(row) for row in rows]

--- a/src/agent_bom/api/postgres_connection.py
+++ b/src/agent_bom/api/postgres_connection.py
@@ -49,10 +49,14 @@ class PostgresConnectionStore:
                     created_at            TEXT NOT NULL,
                     updated_at            TEXT NOT NULL,
                     last_scan_at          TEXT,
-                    scan_interval_minutes INTEGER
+                    scan_interval_minutes INTEGER,
+                    auth_params           TEXT NOT NULL DEFAULT '{}'
                 )
             """)
             conn.execute("ALTER TABLE cloud_connections ADD COLUMN IF NOT EXISTS scan_interval_minutes INTEGER")
+            # Idempotent migration: backfill existing rows with an empty object so
+            # the column stays NOT NULL and legacy connections read as no-params.
+            conn.execute("ALTER TABLE cloud_connections ADD COLUMN IF NOT EXISTS auth_params TEXT NOT NULL DEFAULT '{}'")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_cloud_connections_tenant ON cloud_connections(tenant_id, created_at)")
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_cloud_connections_schedulable ON cloud_connections(scan_interval_minutes, last_scan_at)"
@@ -67,8 +71,8 @@ class PostgresConnectionStore:
                 INSERT INTO cloud_connections
                     (id, tenant_id, provider, display_name, role_ref, external_id_encrypted,
                      regions, status, status_detail, created_at, updated_at, last_scan_at,
-                     scan_interval_minutes)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                     scan_interval_minutes, auth_params)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (id) DO UPDATE SET
                     provider = EXCLUDED.provider,
                     display_name = EXCLUDED.display_name,
@@ -79,7 +83,8 @@ class PostgresConnectionStore:
                     status_detail = EXCLUDED.status_detail,
                     updated_at = EXCLUDED.updated_at,
                     last_scan_at = EXCLUDED.last_scan_at,
-                    scan_interval_minutes = EXCLUDED.scan_interval_minutes
+                    scan_interval_minutes = EXCLUDED.scan_interval_minutes,
+                    auth_params = EXCLUDED.auth_params
                 """,
                 (
                     record.id,
@@ -95,6 +100,7 @@ class PostgresConnectionStore:
                     record.updated_at,
                     record.last_scan_at,
                     record.scan_interval_minutes,
+                    json.dumps(record.auth_params),
                 ),
             )
             conn.commit()
@@ -103,7 +109,7 @@ class PostgresConnectionStore:
         with _tenant_connection(self._pool) as conn:
             row = conn.execute(
                 "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes "
+                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params "
                 "FROM cloud_connections WHERE tenant_id = %s AND id = %s",
                 (tenant_id, connection_id),
             ).fetchone()
@@ -113,7 +119,7 @@ class PostgresConnectionStore:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes "
+                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params "
                 "FROM cloud_connections WHERE tenant_id = %s ORDER BY created_at, id",
                 (tenant_id,),
             ).fetchall()
@@ -138,7 +144,7 @@ class PostgresConnectionStore:
         with bypass_tenant_rls(), _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes "
+                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params "
                 "FROM cloud_connections WHERE scan_interval_minutes IS NOT NULL ORDER BY created_at, id"
             ).fetchall()
         return [_row_to_record(row) for row in rows]

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -19,15 +19,16 @@ Endpoints:
     DELETE /v1/cloud/connections/{id}     remove a connection
     POST   /v1/cloud/connections/{id}/scan  launch a read-only scan via the broker
 
-The ``/scan`` endpoint (Phase B) brokers the stored connection into a short-lived
-read-only cloud session (``sts:AssumeRole`` with the decrypted ExternalId) and
-runs the **same** inventory + CIS discovery the sibling ``cloud`` routes use,
-against that session. Results persist through the existing scan/graph stores —
-no parallel persistence path — and the connection's lifecycle status is updated
-(``active`` + ``last_scan_at`` on success, ``error`` + ``status_detail`` on
-failure, never carrying a secret). AWS is broker-enabled today; azure / gcp /
-snowflake return a clear "planned" 501. A connection may also carry a
-``scan_interval_minutes`` so the Phase B.2 background scheduler
+The ``/scan`` endpoint brokers the stored connection into a short-lived read-only
+cloud session / credential / connection (AWS ``sts:AssumeRole`` with the decrypted
+ExternalId; Azure ``ClientSecretCredential``; GCP read-only service-account
+credentials; Snowflake key-pair connection) and runs the **same** inventory + CIS
+discovery the sibling ``cloud`` routes use, against that session. Results persist
+through the existing scan/graph stores — no parallel persistence path — and the
+connection's lifecycle status is updated (``active`` + ``last_scan_at`` on
+success, ``error`` + ``status_detail`` on failure, never carrying a secret). All
+four providers (AWS, Azure, GCP, Snowflake) are broker-enabled. A connection may
+also carry a ``scan_interval_minutes`` so the background scheduler
 (:mod:`agent_bom.api.connection_scheduler`) re-runs this same scan path when due.
 """
 
@@ -36,6 +37,7 @@ from __future__ import annotations
 import logging
 import re
 import uuid
+from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
 
@@ -57,10 +59,12 @@ from agent_bom.config import CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES
 from agent_bom.rbac import require_authenticated_permission
 from agent_bom.security import sanitize_error
 
-# Providers whose credential broker is not yet implemented (Phase B is AWS-only).
-_PLANNED_SCAN_PROVIDERS: tuple[str, ...] = ("azure", "gcp", "snowflake")
 # Cap the status_detail we persist so a verbose backend error can't bloat the row.
 _MAX_STATUS_DETAIL = 300
+# Bounds on the non-secret provider params blob so a caller can't bloat the row.
+_MAX_AUTH_PARAMS = 20
+_MAX_AUTH_PARAM_KEY_LEN = 64
+_MAX_AUTH_PARAM_VALUE_LEN = 1024
 # Upper bound on a recurring scan interval (1 week) so a typo can't park a
 # connection effectively-never-scanning while still claiming to be scheduled.
 _MAX_SCAN_INTERVAL_MINUTES = 7 * 24 * 60
@@ -87,9 +91,13 @@ class CloudConnectionCreate(BaseModel):
     provider: str
     display_name: str = Field(min_length=1, max_length=200)
     role_ref: str = Field(min_length=1, max_length=2048)
-    external_id: str = Field(min_length=1, max_length=1024)
+    external_id: str = Field(min_length=1, max_length=8192)
     regions: list[str] = Field(default_factory=list)
     scan_interval_minutes: int | None = None
+    # Non-secret provider-specific params (Azure tenant/subscription, GCP
+    # project, Snowflake user/role/warehouse). Never a secret — the one secret
+    # is ``external_id``.
+    auth_params: dict[str, str] = Field(default_factory=dict)
 
 
 class CloudConnectionUpdate(BaseModel):
@@ -138,6 +146,32 @@ def _validate_scan_interval(interval: int | None) -> int | None:
     return interval
 
 
+def _validate_auth_params(auth_params: dict[str, str]) -> dict[str, str]:
+    """Validate the non-secret provider params blob (bounds + string coercion).
+
+    Keeps the row small and predictable: caps the number of keys and the key /
+    value lengths. Values are coerced to trimmed strings. These params are never
+    secret (the one secret is ``external_id``), so they are stored and returned
+    as-is.
+    """
+    if not auth_params:
+        return {}
+    if len(auth_params) > _MAX_AUTH_PARAMS:
+        raise HTTPException(status_code=400, detail=f"Too many auth_params (max {_MAX_AUTH_PARAMS}).")
+    cleaned: dict[str, str] = {}
+    for key, value in auth_params.items():
+        key_str = str(key).strip()
+        if not key_str:
+            continue
+        if len(key_str) > _MAX_AUTH_PARAM_KEY_LEN:
+            raise HTTPException(status_code=400, detail=f"auth_params key too long (max {_MAX_AUTH_PARAM_KEY_LEN}).")
+        value_str = str(value).strip()
+        if len(value_str) > _MAX_AUTH_PARAM_VALUE_LEN:
+            raise HTTPException(status_code=400, detail=f"auth_params value too long (max {_MAX_AUTH_PARAM_VALUE_LEN}).")
+        cleaned[key_str] = value_str
+    return cleaned
+
+
 def _validate_regions(regions: list[str]) -> list[str]:
     cleaned = [r.strip() for r in regions if r.strip()]
     if len(cleaned) > _MAX_REGIONS:
@@ -166,6 +200,7 @@ async def create_connection(request: Request, body: CloudConnectionCreate, _role
 
     regions = _validate_regions(body.regions)
     scan_interval_minutes = _validate_scan_interval(body.scan_interval_minutes)
+    auth_params = _validate_auth_params(body.auth_params)
 
     # Fail closed before doing anything if the store cannot encrypt the secret.
     if not connections_key_configured():
@@ -195,6 +230,7 @@ async def create_connection(request: Request, body: CloudConnectionCreate, _role
         updated_at=now,
         last_scan_at=None,
         scan_interval_minutes=scan_interval_minutes,
+        auth_params=auth_params,
     )
     get_connection_store().put(record)
     log_action(
@@ -297,6 +333,55 @@ def _mark_connection(
     get_connection_store().put(record)
 
 
+def _cis_summary(cis_dict: dict[str, Any]) -> dict[str, Any]:
+    """Reduce a CIS report dict to the non-secret counts surfaced in the summary."""
+    return {
+        "benchmark": cis_dict.get("benchmark"),
+        "benchmark_version": cis_dict.get("benchmark_version"),
+        "passed": cis_dict.get("passed"),
+        "failed": cis_dict.get("failed"),
+        "total": cis_dict.get("total"),
+        "pass_rate": cis_dict.get("pass_rate"),
+    }
+
+
+def _persist_connection_report(record: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
+    """Persist a brokered-scan report through the existing scan/graph stores.
+
+    Reuses the pipeline's persistence path (durable scan store + in-memory job
+    map + unified graph snapshot) rather than a parallel one — the same calls the
+    scan pipeline makes on completion. Returns the scan id.
+    """
+    from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+    from agent_bom.api.pipeline import _persist_graph_snapshot
+    from agent_bom.api.stores import _get_store, _jobs_put
+    from agent_bom.output import to_json
+
+    report_json = to_json(report)
+    now = _now()
+    job = ScanJob(
+        job_id=report.scan_id,
+        tenant_id=tenant_id,
+        created_at=now,
+        started_at=now,
+        completed_at=now,
+        status=JobStatus.DONE,
+        request=ScanRequest(),
+        result=report_json,
+        triggered_by=f"cloud-connection/{record.id}",
+    )
+    store = _get_store()
+    store.put(job)
+    _jobs_put(job.job_id, job, compact_terminal=True)
+    _persist_graph_snapshot(job, report_json)
+    return str(report.scan_id)
+
+
+def _scan_audit_metadata(note: str) -> dict[str, Any]:
+    """Read-only audit envelope attached to every connection-scan summary."""
+    return {"read_only": True, "writes_performed": False, "note": note}
+
+
 def _run_aws_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> dict[str, Any]:
     """Broker the connection into a read-only session and run inventory + CIS.
 
@@ -308,15 +393,11 @@ def _run_aws_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> d
     """
     import uuid as _uuid
 
-    from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
-    from agent_bom.api.pipeline import _persist_graph_snapshot
-    from agent_bom.api.stores import _get_store, _jobs_put
     from agent_bom.cloud import aws_inventory
     from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_aws_cis
     from agent_bom.cloud.connection_broker import broker_session
     from agent_bom.mcp_tools.posture import _summarize_inventory_payload
     from agent_bom.models import AIBOMReport
-    from agent_bom.output import to_json
 
     region = record.regions[0] if record.regions else None
     session = broker_session(record, session_name=f"agent-bom-scan-{record.id[:8]}")
@@ -326,56 +407,179 @@ def _run_aws_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> d
     cis_report = run_aws_cis(region=region, session=session)
     cis_dict = cis_report.to_dict()
 
-    scan_id = str(_uuid.uuid4())
-    report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=scan_id)
+    report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=str(_uuid.uuid4()))
     report.cloud_inventory_data = inventory_payload
     report.cis_benchmark_data = cis_dict
-    report_json = to_json(report)
+    scan_id = _persist_connection_report(record, tenant_id, report)
 
-    now = _now()
-    job = ScanJob(
-        job_id=scan_id,
-        tenant_id=tenant_id,
-        created_at=now,
-        started_at=now,
-        completed_at=now,
-        status=JobStatus.DONE,
-        request=ScanRequest(),
-        result=report_json,
-        triggered_by=f"cloud-connection/{record.id}",
-    )
-    # Existing persistence path: durable scan store + in-memory job map + unified
-    # graph snapshot (same calls the scan pipeline makes on completion).
-    store = _get_store()
-    store.put(job)
-    _jobs_put(job.job_id, job, compact_terminal=True)
-    _persist_graph_snapshot(job, report_json)
-
-    inv_summary = _summarize_inventory_payload("aws", inventory_payload)
     return {
         "schema_version": "cloud.connections.scan.v1",
         "connection_id": record.id,
         "tenant_id": tenant_id,
         "provider": "aws",
         "scan_id": scan_id,
-        "inventory": inv_summary,
-        "cis_benchmark": {
-            "benchmark": cis_dict.get("benchmark"),
-            "benchmark_version": cis_dict.get("benchmark_version"),
-            "passed": cis_dict.get("passed"),
-            "failed": cis_dict.get("failed"),
-            "total": cis_dict.get("total"),
-            "pass_rate": cis_dict.get("pass_rate"),
-        },
-        "audit_metadata": {
-            "read_only": True,
-            "writes_performed": False,
-            "note": (
-                "Scan ran against a short-lived read-only role assumed from the stored connection. "
-                "Inventory + CIS are read-only; no resource is mutated and no secret value is returned."
-            ),
-        },
+        "inventory": _summarize_inventory_payload("aws", inventory_payload),
+        "cis_benchmark": _cis_summary(cis_dict),
+        "audit_metadata": _scan_audit_metadata(
+            "Scan ran against a short-lived read-only role assumed from the stored connection. "
+            "Inventory + CIS are read-only; no resource is mutated and no secret value is returned."
+        ),
     }
+
+
+def _run_azure_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> dict[str, Any]:
+    """Broker an Azure read-only credential and run inventory + CIS.
+
+    Uses the brokered ``ClientSecretCredential`` (Reader role) and the
+    ``subscription_id`` from the connection's ``auth_params`` so the same
+    ``azure_inventory.discover_inventory`` and Azure CIS ``run_benchmark`` the
+    sibling cloud routes use run against the customer subscription. Read-only.
+    """
+    import uuid as _uuid
+
+    from agent_bom.cloud import azure_inventory
+    from agent_bom.cloud.azure_cis_benchmark import run_benchmark as run_azure_cis
+    from agent_bom.cloud.connection_broker import broker_session
+    from agent_bom.mcp_tools.posture import _summarize_inventory_payload
+    from agent_bom.models import AIBOMReport
+
+    credential = broker_session(record, session_name=f"agent-bom-scan-{record.id[:8]}")
+    subscription_id = str(record.auth_params.get("subscription_id") or "").strip() or None
+
+    inventory_payload = azure_inventory.discover_inventory(subscription_id=subscription_id, credential=credential, force=True)
+    cis_report = run_azure_cis(subscription_id=subscription_id, credential=credential)
+    cis_dict = cis_report.to_dict()
+
+    report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=str(_uuid.uuid4()))
+    report.cloud_inventory_data = inventory_payload
+    report.azure_cis_benchmark_data = cis_dict
+    scan_id = _persist_connection_report(record, tenant_id, report)
+
+    return {
+        "schema_version": "cloud.connections.scan.v1",
+        "connection_id": record.id,
+        "tenant_id": tenant_id,
+        "provider": "azure",
+        "scan_id": scan_id,
+        "inventory": _summarize_inventory_payload("azure", inventory_payload),
+        "cis_benchmark": _cis_summary(cis_dict),
+        "audit_metadata": _scan_audit_metadata(
+            "Scan ran against a read-only Azure Reader credential brokered from the stored connection. "
+            "Inventory + CIS are read-only; no resource is mutated and no secret value is returned."
+        ),
+    }
+
+
+def _run_gcp_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> dict[str, Any]:
+    """Broker GCP read-only service-account credentials and run inventory + CIS.
+
+    Uses the brokered ``service_account.Credentials`` (cloud-platform.read-only
+    scope) and the ``project_id`` from the connection's ``auth_params`` so the
+    same ``gcp_inventory.discover_inventory`` and GCP CIS ``run_benchmark`` the
+    sibling cloud routes use run against the customer project. Read-only.
+    """
+    import uuid as _uuid
+
+    from agent_bom.cloud import gcp_inventory
+    from agent_bom.cloud.connection_broker import broker_session
+    from agent_bom.cloud.gcp_cis_benchmark import run_benchmark as run_gcp_cis
+    from agent_bom.mcp_tools.posture import _summarize_inventory_payload
+    from agent_bom.models import AIBOMReport
+
+    credentials = broker_session(record, session_name=f"agent-bom-scan-{record.id[:8]}")
+    project_id = str(record.auth_params.get("project_id") or "").strip() or None
+
+    inventory_payload = gcp_inventory.discover_inventory(project_id=project_id, credentials=credentials, force=True)
+    cis_report = run_gcp_cis(project_id=project_id, credentials=credentials)
+    cis_dict = cis_report.to_dict()
+
+    report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=str(_uuid.uuid4()))
+    report.cloud_inventory_data = inventory_payload
+    report.gcp_cis_benchmark_data = cis_dict
+    scan_id = _persist_connection_report(record, tenant_id, report)
+
+    return {
+        "schema_version": "cloud.connections.scan.v1",
+        "connection_id": record.id,
+        "tenant_id": tenant_id,
+        "provider": "gcp",
+        "scan_id": scan_id,
+        "inventory": _summarize_inventory_payload("gcp", inventory_payload),
+        "cis_benchmark": _cis_summary(cis_dict),
+        "audit_metadata": _scan_audit_metadata(
+            "Scan ran against read-only GCP service-account credentials (cloud-platform.read-only) brokered from the "
+            "stored connection. Inventory + CIS are read-only; no resource is mutated and no secret value is returned."
+        ),
+    }
+
+
+def _run_snowflake_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> dict[str, Any]:
+    """Broker a Snowflake read-only connection and run discovery + CIS.
+
+    Opens one brokered key-pair connection and threads it into both
+    ``snowflake.discover`` and Snowflake CIS ``run_benchmark`` so a single
+    read-only session backs the whole scan; the broker's connection is closed
+    here once both have run. Read-only.
+    """
+    import uuid as _uuid
+
+    from agent_bom.cloud import snowflake as snowflake_discovery
+    from agent_bom.cloud.connection_broker import broker_session
+    from agent_bom.cloud.snowflake_cis_benchmark import run_benchmark as run_snowflake_cis
+    from agent_bom.models import AIBOMReport
+
+    conn = broker_session(record, session_name=f"agent-bom-scan-{record.id[:8]}")
+    try:
+        agents, _warnings = snowflake_discovery.discover(conn=conn)
+        cis_report = run_snowflake_cis(conn=conn)
+    finally:
+        # The broker connection is this function's to close (discover / CIS do
+        # not close an injected connection).
+        try:
+            conn.close()
+        except Exception:  # noqa: BLE001 - close best-effort; never mask the scan result
+            _logger.debug("Snowflake broker connection close failed for connection %s", record.id)
+    cis_dict = cis_report.to_dict()
+
+    report = AIBOMReport(agents=agents, blast_radii=[], findings=[], scan_id=str(_uuid.uuid4()))
+    report.snowflake_cis_benchmark_data = cis_dict
+    scan_id = _persist_connection_report(record, tenant_id, report)
+
+    return {
+        "schema_version": "cloud.connections.scan.v1",
+        "connection_id": record.id,
+        "tenant_id": tenant_id,
+        "provider": "snowflake",
+        "scan_id": scan_id,
+        "inventory": {"provider": "snowflake", "status": "ok", "agent_count": len(agents)},
+        "cis_benchmark": _cis_summary(cis_dict),
+        "audit_metadata": _scan_audit_metadata(
+            "Scan ran against a read-only Snowflake key-pair connection brokered from the stored connection. "
+            "Discovery + CIS are read-only; no object is mutated and no secret value is returned."
+        ),
+    }
+
+
+# Per-provider brokered-scan dispatch. Every entry is broker-enabled and runs the
+# same read-only inventory/discovery + CIS the sibling cloud routes use.
+_SCAN_RUNNERS: dict[str, Callable[[CloudConnectionRecord, str], dict[str, Any]]] = {
+    "aws": _run_aws_connection_scan,
+    "azure": _run_azure_connection_scan,
+    "gcp": _run_gcp_connection_scan,
+    "snowflake": _run_snowflake_connection_scan,
+}
+
+
+def _run_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> dict[str, Any]:
+    """Dispatch a brokered read-only scan by provider.
+
+    Raises ``ValueError`` for an unknown provider (the route validates the
+    provider on create, so this is a defensive guard).
+    """
+    runner = _SCAN_RUNNERS.get((record.provider or "").strip().lower())
+    if runner is None:
+        raise ValueError(f"Unsupported provider '{record.provider}'.")
+    return runner(record, tenant_id)
 
 
 @router.post("/v1/cloud/connections/{connection_id}/scan")
@@ -383,30 +587,22 @@ async def scan_connection(request: Request, connection_id: str, _role: Any = _SC
     """Launch a read-only cloud scan for a stored connection via the broker.
 
     Resolves the tenant's connection (404 otherwise), uses the credential broker
-    to assume a short-lived read-only session, and runs the same inventory + CIS
-    discovery the sibling cloud routes use. Results persist through the existing
-    scan/graph stores; the connection status moves to ``active`` + ``last_scan_at``
-    on success or ``error`` + ``status_detail`` (no secret) on failure. AWS only
-    today — azure / gcp / snowflake return a clear 501 ``planned`` response.
+    to obtain a short-lived read-only session / credential / connection, and runs
+    the same inventory + CIS discovery the sibling cloud routes use. Results
+    persist through the existing scan/graph stores; the connection status moves to
+    ``active`` + ``last_scan_at`` on success or ``error`` + ``status_detail`` (no
+    secret) on failure. All four providers (AWS, Azure, GCP, Snowflake) are
+    broker-enabled.
     """
     record = _require_connection(request, connection_id)
     tenant_id = record.tenant_id
     actor = _actor(request)
 
-    if record.provider in _PLANNED_SCAN_PROVIDERS:
-        # Recognized provider whose broker is not yet implemented — clear, not a crash.
-        raise HTTPException(
-            status_code=501,
-            detail=(
-                f"Cloud scan for provider '{record.provider}' is planned but not yet available (Phase B+). "
-                "AWS read-only AssumeRole scanning is supported today."
-            ),
-        )
-    if record.provider != "aws":
+    if (record.provider or "").strip().lower() not in _SCAN_RUNNERS:
         raise HTTPException(status_code=400, detail=f"Unsupported provider '{record.provider}'.")
 
     try:
-        summary = _run_aws_connection_scan(record, tenant_id)
+        summary = _run_connection_scan(record, tenant_id)
     except Exception as exc:  # noqa: BLE001 - broker / discovery / persistence failure
         # Persist an error status with a sanitized, secret-free detail. Full
         # diagnostics go to the server log only; the client gets a generic message.

--- a/src/agent_bom/cloud/connection_broker.py
+++ b/src/agent_bom/cloud/connection_broker.py
@@ -2,24 +2,39 @@
 
 The broker is the *only* place a stored connection secret is decrypted. Given a
 :class:`~agent_bom.api.connection_store.CloudConnectionRecord`, it produces a
-short-lived, keyless cloud session by assuming the customer's read-only role
-from the control-plane identity — the control plane never holds long-lived
-customer keys.
+short-lived, read-only cloud session / credential / connection that discovery
+runs against — the control plane never holds long-lived customer keys beyond the
+single encrypted secret per connection, which is decrypted only at broker time.
 
-AWS is implemented in Phase A: ``sts:AssumeRole(RoleArn=role_ref,
-ExternalId=<decrypted external_id>)`` returns a ``boto3.Session`` backed by the
-temporary credentials. The decrypted ``ExternalId`` is presented to STS and
-never logged or returned. Azure / GCP / Snowflake are recognized providers that
-raise a clear "planned" error until their broker lands.
+All four providers are broker-enabled:
 
-Read-only posture: the broker assumes the role the connection points at; it
-performs no write/mutating API calls. Enforcing that the *role* grants only
-read permissions is the customer's IAM responsibility (and is surfaced by the
-read-only role modules and discovery envelope elsewhere in the product).
+- **AWS** — ``sts:AssumeRole(RoleArn=role_ref, ExternalId=<decrypted
+  external_id>)`` returns a ``boto3.Session`` backed by temporary credentials.
+- **Azure** — ``ClientSecretCredential(tenant_id, client_id=role_ref,
+  client_secret=<decrypted secret>)`` (``tenant_id`` from ``auth_params``).
+  The customer grants the app the read-only Reader role.
+- **GCP** — ``service_account.Credentials.from_service_account_info`` built from
+  the decrypted service-account key JSON, scoped to the read-only
+  ``cloud-platform.read-only`` scope.
+- **Snowflake** — ``snowflake.connector.connect`` using the decrypted PEM
+  private key (loaded to DER via ``cryptography``) for key-pair auth, with
+  ``account`` from ``role_ref`` and ``user`` / ``role`` / ``warehouse`` from
+  ``auth_params``.
+
+The decrypted secret is presented to the provider and never logged or returned.
+Each broker fails closed with :class:`ConnectionBrokerError` whose message
+carries only the connection id and failure mode — never the secret.
+
+Read-only posture: the broker assumes the role / uses the identity the
+connection points at; it performs no write/mutating API calls. Enforcing that
+the role / identity grants only read permissions is the customer's IAM
+responsibility (and is surfaced by the read-only role modules and discovery
+envelope elsewhere in the product).
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -33,8 +48,11 @@ logger = logging.getLogger(__name__)
 
 # Default STS session duration (seconds). Short-lived by design.
 _DEFAULT_SESSION_DURATION = 3600
-# Providers whose broker is planned but not yet implemented.
-_PLANNED_PROVIDERS = ("azure", "gcp", "snowflake")
+
+# Read-only OAuth scope for GCP service-account credentials. The cloud-platform
+# read-only scope cannot authorize any mutating API, so the brokered credential
+# is structurally incapable of a write even if a caller asked for one.
+_GCP_READONLY_SCOPE = "https://www.googleapis.com/auth/cloud-platform.read-only"
 
 
 class ConnectionBrokerError(RuntimeError):
@@ -90,29 +108,172 @@ def _broker_aws(record: CloudConnectionRecord, *, session_name: str, duration_se
     )
 
 
+def _decrypt_or_fail(record: CloudConnectionRecord) -> str:
+    """Decrypt the connection's single secret, mapping failures to a safe error.
+
+    The returned plaintext is the secret the provider broker presents (Azure
+    client secret / GCP SA-key JSON / Snowflake PEM private key). Callers must
+    clear the local reference as soon as the provider call returns.
+    """
+    try:
+        return decrypt_secret(record.external_id_encrypted)
+    except ConnectionSecretError as exc:
+        # Surface the failure mode, never the ciphertext or key detail.
+        raise ConnectionBrokerError(f"Unable to access connection secret for {record.id}: {exc}") from exc
+
+
+def _broker_azure(record: CloudConnectionRecord) -> Any:
+    """Build a read-only Azure ``ClientSecretCredential`` for the connection.
+
+    ``role_ref`` is the app/service-principal client id, the decrypted secret is
+    the client secret, and ``auth_params`` carries ``tenant_id`` (required) and
+    ``subscription_id`` (used by the scan route). The customer grants the app the
+    read-only Reader role; the broker never makes a write call.
+    """
+    try:
+        from azure.identity import ClientSecretCredential
+    except ImportError as exc:
+        raise CloudDiscoveryError(
+            "azure-identity is required to broker Azure connections. Install with: pip install 'agent-bom[azure]'"
+        ) from exc
+
+    tenant_id = str(record.auth_params.get("tenant_id") or "").strip()
+    if not tenant_id:
+        raise ConnectionBrokerError(f"Azure connection {record.id} is missing required auth_params.tenant_id.")
+    client_id = (record.role_ref or "").strip()
+    if not client_id:
+        raise ConnectionBrokerError(f"Azure connection {record.id} is missing the client id (role_ref).")
+
+    client_secret = _decrypt_or_fail(record)
+    try:
+        return ClientSecretCredential(tenant_id=tenant_id, client_id=client_id, client_secret=client_secret)
+    except Exception as exc:  # noqa: BLE001 - azure-identity construction error
+        logger.warning("Azure credential construction failed for connection %s", record.id)
+        raise ConnectionBrokerError(f"Azure credential construction failed for connection {record.id}.") from exc
+    finally:
+        # Drop the plaintext reference as soon as the credential is built.
+        client_secret = ""
+
+
+def _broker_gcp(record: CloudConnectionRecord) -> Any:
+    """Build read-only GCP service-account credentials from the stored key JSON.
+
+    ``role_ref`` is the service-account email, the decrypted secret is the
+    service-account key JSON, and ``auth_params`` carries ``project_id`` (used by
+    the scan route). Credentials are scoped to the read-only cloud-platform scope
+    so they cannot authorize any mutating API.
+    """
+    try:
+        from google.oauth2 import service_account
+    except ImportError as exc:
+        raise CloudDiscoveryError("google-auth is required to broker GCP connections. Install with: pip install 'agent-bom[gcp]'") from exc
+
+    key_json = _decrypt_or_fail(record)
+    try:
+        key_info = json.loads(key_json)
+    except (ValueError, TypeError) as exc:
+        # Never echo the key material — only the failure mode.
+        key_json = ""
+        raise ConnectionBrokerError(f"GCP connection {record.id} service-account key is not valid JSON.") from exc
+    try:
+        return service_account.Credentials.from_service_account_info(key_info, scopes=[_GCP_READONLY_SCOPE])
+    except Exception as exc:  # noqa: BLE001 - google-auth construction error
+        logger.warning("GCP credential construction failed for connection %s", record.id)
+        raise ConnectionBrokerError(f"GCP credential construction failed for connection {record.id}.") from exc
+    finally:
+        # Drop the plaintext key material and parsed copy as soon as we are done.
+        key_json = ""
+        key_info = {}
+
+
+def _broker_snowflake(record: CloudConnectionRecord) -> Any:
+    """Open a read-only Snowflake connection via key-pair auth for the connection.
+
+    ``role_ref`` is the ``account`` (or ``account/user``), the decrypted secret is
+    the PEM private key, and ``auth_params`` carries ``user`` / ``role`` /
+    ``warehouse``. The PEM is loaded to DER via ``cryptography`` and presented as
+    ``private_key`` to the connector — key-pair auth, no password.
+    """
+    try:
+        import snowflake.connector
+    except ImportError as exc:
+        raise CloudDiscoveryError(
+            "snowflake-connector-python is required to broker Snowflake connections. Install with: pip install 'agent-bom[snowflake]'"
+        ) from exc
+    try:
+        from cryptography.hazmat.primitives import serialization
+    except ImportError as exc:  # pragma: no cover - cryptography is a core dependency
+        raise CloudDiscoveryError("cryptography is required to broker Snowflake connections.") from exc
+
+    ref = (record.role_ref or "").strip()
+    if not ref:
+        raise ConnectionBrokerError(f"Snowflake connection {record.id} is missing the account (role_ref).")
+    # Support either "account" or "account/user"; auth_params.user takes priority.
+    account, _, ref_user = ref.partition("/")
+    account = account.strip()
+    user = str(record.auth_params.get("user") or ref_user or "").strip()
+    role = str(record.auth_params.get("role") or "").strip()
+    warehouse = str(record.auth_params.get("warehouse") or "").strip()
+    if not account:
+        raise ConnectionBrokerError(f"Snowflake connection {record.id} is missing the account (role_ref).")
+    if not user:
+        raise ConnectionBrokerError(f"Snowflake connection {record.id} is missing required auth_params.user.")
+
+    pem = _decrypt_or_fail(record)
+    try:
+        private_key = serialization.load_pem_private_key(pem.encode("utf-8"), password=None)
+        der = private_key.private_bytes(
+            encoding=serialization.Encoding.DER,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    except Exception as exc:  # noqa: BLE001 - malformed PEM / unsupported key
+        # Never echo the key material — only the failure mode.
+        raise ConnectionBrokerError(f"Snowflake connection {record.id} private key could not be loaded.") from exc
+    finally:
+        pem = ""
+
+    conn_kwargs: dict[str, Any] = {"account": account, "user": user, "private_key": der}
+    if role:
+        conn_kwargs["role"] = role
+    if warehouse:
+        conn_kwargs["warehouse"] = warehouse
+    try:
+        return snowflake.connector.connect(**conn_kwargs)
+    except Exception as exc:  # noqa: BLE001 - connector error (may carry account detail)
+        logger.warning("Snowflake connection failed for connection %s", record.id)
+        raise ConnectionBrokerError(f"Snowflake connection failed for connection {record.id}.") from exc
+    finally:
+        der = b""
+
+
 def broker_session(
     record: CloudConnectionRecord,
     *,
     session_name: str = "agent-bom-readonly-scan",
     duration_seconds: int = _DEFAULT_SESSION_DURATION,
 ) -> Any:
-    """Return a read-only cloud session for a stored connection.
+    """Return a read-only cloud session / credential / connection for a connection.
 
-    AWS is brokered via ``sts:AssumeRole`` with the connection's decrypted
-    ``ExternalId``. Azure / GCP / Snowflake are recognized but raise
-    :class:`NotImplementedError` until their broker ships (Phase B+).
+    Dispatches by provider and returns the provider-appropriate object:
+
+    - ``aws``       → ``boto3.Session`` (temporary AssumeRole credentials)
+    - ``azure``     → ``azure.identity.ClientSecretCredential``
+    - ``gcp``       → ``google.oauth2.service_account.Credentials`` (read-only)
+    - ``snowflake`` → a live ``snowflake.connector`` connection (caller closes it)
 
     Raises:
-        ConnectionBrokerError: AWS brokering failed (secret access or AssumeRole).
-        NotImplementedError: provider is recognized but not yet broker-enabled.
+        ConnectionBrokerError: brokering failed (secret access or provider auth).
+        CloudDiscoveryError: the provider SDK extra is not installed.
         ValueError: provider is unknown.
     """
     provider = (record.provider or "").strip().lower()
     if provider == "aws":
         return _broker_aws(record, session_name=session_name, duration_seconds=duration_seconds)
-    if provider in _PLANNED_PROVIDERS:
-        raise NotImplementedError(
-            f"Connection brokering for provider '{provider}' is planned but not yet implemented (Phase B+). "
-            "AWS read-only AssumeRole is supported today."
-        )
+    if provider == "azure":
+        return _broker_azure(record)
+    if provider == "gcp":
+        return _broker_gcp(record)
+    if provider == "snowflake":
+        return _broker_snowflake(record)
     raise ValueError(f"Unknown connection provider '{record.provider}'.")

--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -285,8 +285,16 @@ def discover(
     authenticator: str | None = None,
     database: str | None = None,
     schema: str | None = None,
+    conn: Any = None,
 ) -> tuple[list[Agent], list[str]]:
     """Discover Cortex agents, MCP servers, and Snowpark packages from Snowflake.
+
+    Args:
+        conn: Optional already-open Snowflake connection (e.g. brokered from a
+            stored read-only connection). When supplied it is used directly
+            instead of building one from env/args, and it is **not** closed here
+            — the caller owns its lifecycle. When ``None`` (the default) a
+            connection is built from env/args and closed before returning.
 
     Returns:
         (agents, warnings) — discovered agents and non-fatal warnings.
@@ -308,28 +316,34 @@ def discover(
     resolved_account = _env_or_value(account, "SNOWFLAKE_ACCOUNT")
     resolved_user = _env_or_value(user, "SNOWFLAKE_USER")
 
-    if not resolved_account:
+    # An injected connection (the broker path) does not require SNOWFLAKE_ACCOUNT
+    # in env; fall back to a placeholder scope label only for graph/envelope use.
+    owns_conn = conn is None
+    if owns_conn and not resolved_account:
         warnings.append("SNOWFLAKE_ACCOUNT not set. Provide --snowflake-account or set the SNOWFLAKE_ACCOUNT env var.")
         return agents, warnings
+    if not resolved_account:
+        resolved_account = "connection"
 
-    conn_kwargs: dict[str, Any] = {
-        "account": resolved_account,
-        "user": resolved_user,
-    }
-    if authenticator:
-        conn_kwargs["authenticator"] = authenticator
-    if database:
-        conn_kwargs["database"] = database
-    if schema:
-        conn_kwargs["schema"] = schema
+    if conn is None:
+        conn_kwargs: dict[str, Any] = {
+            "account": resolved_account,
+            "user": resolved_user,
+        }
+        if authenticator:
+            conn_kwargs["authenticator"] = authenticator
+        if database:
+            conn_kwargs["database"] = database
+        if schema:
+            conn_kwargs["schema"] = schema
 
-    _resolve_snowflake_auth(conn_kwargs, authenticator)
+        _resolve_snowflake_auth(conn_kwargs, authenticator)
 
-    try:
-        conn = snowflake.connector.connect(**conn_kwargs)
-    except (DatabaseError, Exception) as exc:
-        warnings.append(f"Could not connect to Snowflake: {sanitize_error(exc)}")
-        return agents, warnings
+        try:
+            conn = snowflake.connector.connect(**conn_kwargs)
+        except (DatabaseError, Exception) as exc:
+            warnings.append(f"Could not connect to Snowflake: {sanitize_error(exc)}")
+            return agents, warnings
 
     try:
         # ── Cortex Search Services ────────────────────────────────────────
@@ -426,7 +440,10 @@ def discover(
         warnings.extend(nb_warns)
 
     finally:
-        conn.close()
+        # Only close a connection we opened; an injected (brokered) connection is
+        # the caller's to close.
+        if owns_conn:
+            conn.close()
 
     # Per-run discovery envelope (#2083 PR B). Snowflake reads through the
     # SQL surface using the user's role. We expose the role as a scope

--- a/src/agent_bom/cloud/snowflake_cis_benchmark.py
+++ b/src/agent_bom/cloud/snowflake_cis_benchmark.py
@@ -570,6 +570,7 @@ def run_benchmark(
     user: str | None = None,
     authenticator: str | None = None,
     checks: list[str] | None = None,
+    conn: Any = None,
 ) -> SnowflakeCISReport:
     """Run CIS Snowflake Benchmark v1.0 checks.
 
@@ -581,6 +582,10 @@ def run_benchmark(
         user: Snowflake user name.
         authenticator: Authentication method (externalbrowser, snowflake, etc.).
         checks: Optional list of check IDs to run (e.g. ``["1.1", "2.1"]``).
+        conn: Optional already-open Snowflake connection (e.g. brokered from a
+            stored read-only connection). When supplied it is used directly and
+            is **not** closed here — the caller owns its lifecycle. When ``None``
+            a connection is built from env/args and closed before returning.
 
     Returns:
         SnowflakeCISReport with per-check pass/fail results.
@@ -596,21 +601,25 @@ def run_benchmark(
     resolved_account = account or os.environ.get("SNOWFLAKE_ACCOUNT", "")
     resolved_user = user or os.environ.get("SNOWFLAKE_USER") or ""
 
-    if not resolved_account:
+    owns_conn = conn is None
+    if owns_conn and not resolved_account:
         raise CloudDiscoveryError("SNOWFLAKE_ACCOUNT not set. Provide --snowflake-account or set the env var.")
+    if not resolved_account:
+        resolved_account = "connection"
 
-    conn_kwargs: dict[str, str] = {
-        "account": resolved_account,
-        "user": resolved_user,
-    }
-    from .snowflake import _resolve_snowflake_auth
+    if conn is None:
+        conn_kwargs: dict[str, str] = {
+            "account": resolved_account,
+            "user": resolved_user,
+        }
+        from .snowflake import _resolve_snowflake_auth
 
-    _resolve_snowflake_auth(conn_kwargs, authenticator)
+        _resolve_snowflake_auth(conn_kwargs, authenticator)
 
-    try:
-        conn = snowflake.connector.connect(**conn_kwargs)
-    except (DatabaseError, Exception) as exc:
-        raise CloudDiscoveryError(f"Could not connect to Snowflake: {exc}")
+        try:
+            conn = snowflake.connector.connect(**conn_kwargs)
+        except (DatabaseError, Exception) as exc:
+            raise CloudDiscoveryError(f"Could not connect to Snowflake: {exc}")
 
     report = SnowflakeCISReport(account=resolved_account)
 
@@ -651,7 +660,10 @@ def run_benchmark(
                     )
                 )
     finally:
-        conn.close()
+        # Only close a connection we opened; an injected (brokered) one is the
+        # caller's to close.
+        if owns_conn:
+            conn.close()
 
     # Structured remediation per #665.
     from agent_bom.cloud.cis_remediation import attach_all

--- a/tests/test_cloud_connections.py
+++ b/tests/test_cloud_connections.py
@@ -1,10 +1,11 @@
 """Tests for the per-tenant cloud connections plane (Phase A).
 
-Covers the store (CRUD + tenant isolation), at-rest encryption (ciphertext in
-the DB column, decrypt round-trip, missing-key refuses to persist), the CRUD API
-(RBAC, no-secret responses, tenant scoping), and the credential broker (AWS
-AssumeRole with the decrypted ExternalId; non-AWS providers raise the planned
-error).
+Covers the store (CRUD + tenant isolation, ``auth_params`` migration), at-rest
+encryption (ciphertext in the DB column, decrypt round-trip, missing-key refuses
+to persist), the CRUD API (RBAC, no-secret responses, tenant scoping), and the
+credential broker for all four providers (AWS AssumeRole, Azure
+ClientSecretCredential, GCP read-only service-account credentials, Snowflake
+key-pair connection) plus the per-provider read-only scan-launch route.
 """
 
 from __future__ import annotations
@@ -12,6 +13,8 @@ from __future__ import annotations
 import base64
 import os
 import sqlite3
+import sys
+import types
 import uuid
 from collections.abc import Iterator
 from typing import Any
@@ -133,6 +136,54 @@ def test_sqlite_store_crud_and_isolation(tmp_path: Any) -> None:
     assert [r.id for r in store.list_for_tenant("tenant-b")] == [b.id]
     assert store.delete("tenant-b", b.id) is True
     assert store.get("tenant-b", b.id) is None
+
+
+def test_sqlite_auth_params_column_present_defaults_and_round_trips(tmp_path: Any) -> None:
+    db_path = str(tmp_path / "connections.db")
+    store = SQLiteConnectionStore(db_path)
+
+    # The migrated column exists.
+    columns = {row[1] for row in sqlite3.connect(db_path).execute("PRAGMA table_info(cloud_connections)").fetchall()}
+    assert "auth_params" in columns
+
+    # A record with no auth_params defaults to an empty dict on read-back.
+    plain = _record("tenant-a")
+    store.put(plain)
+    assert store.get("tenant-a", plain.id).auth_params == {}
+
+    # A record with auth_params round-trips the JSON unchanged.
+    with_params = _record("tenant-a", provider="azure")
+    with_params.auth_params = {"tenant_id": "t-guid", "subscription_id": "s-guid"}
+    store.put(with_params)
+    assert store.get("tenant-a", with_params.id).auth_params == {"tenant_id": "t-guid", "subscription_id": "s-guid"}
+
+
+def test_sqlite_auth_params_migration_is_idempotent_on_legacy_table(tmp_path: Any) -> None:
+    """A pre-migration table (no auth_params column) is migrated and backfilled."""
+    db_path = str(tmp_path / "legacy.db")
+    raw = sqlite3.connect(db_path)
+    # Recreate the pre-auth_params schema with one legacy row.
+    raw.execute(
+        "CREATE TABLE cloud_connections (id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, provider TEXT NOT NULL, "
+        "display_name TEXT NOT NULL, role_ref TEXT NOT NULL, external_id_encrypted TEXT NOT NULL DEFAULT '', "
+        "regions TEXT NOT NULL DEFAULT '[]', status TEXT NOT NULL DEFAULT 'pending', status_detail TEXT NOT NULL DEFAULT '', "
+        "created_at TEXT NOT NULL, updated_at TEXT NOT NULL, last_scan_at TEXT, scan_interval_minutes INTEGER)"
+    )
+    raw.execute(
+        "INSERT INTO cloud_connections (id, tenant_id, provider, display_name, role_ref, created_at, updated_at) "
+        "VALUES ('legacy-1', 'tenant-a', 'aws', 'legacy', 'arn:role', '2026-06-01T00:00:00+00:00', '2026-06-01T00:00:00+00:00')"
+    )
+    raw.commit()
+    raw.close()
+
+    store = SQLiteConnectionStore(db_path)  # runs the idempotent migration
+    legacy = store.get("tenant-a", "legacy-1")
+    assert legacy is not None
+    assert legacy.auth_params == {}
+    # Re-init is a no-op (idempotent) and the backfilled column stays NOT NULL.
+    store.init_schema()
+    columns = {row[1] for row in sqlite3.connect(db_path).execute("PRAGMA table_info(cloud_connections)").fetchall()}
+    assert "auth_params" in columns
 
 
 # --------------------------------------------------------------------------- #
@@ -742,13 +793,202 @@ def test_broker_aws_assume_role_uses_decrypted_external_id(monkeypatch: pytest.M
     assert sessions["region_name"] == "us-east-1"
 
 
-def test_broker_non_aws_provider_planned_error() -> None:
+def _install_fake_module(monkeypatch: pytest.MonkeyPatch, dotted: str, leaf: types.ModuleType) -> None:
+    """Inject a fake module (and any missing parent packages) into sys.modules.
+
+    Lets the broker's lazy ``from x.y import z`` resolve a fake SDK whether or not
+    the real SDK is installed; monkeypatch restores sys.modules afterwards.
+    """
+    parts = dotted.split(".")
+    for i in range(1, len(parts) + 1):
+        name = ".".join(parts[:i])
+        module = leaf if name == dotted else sys.modules.get(name) or types.ModuleType(name)
+        monkeypatch.setitem(sys.modules, name, module)
+    for i in range(1, len(parts)):
+        parent = sys.modules[".".join(parts[:i])]
+        monkeypatch.setattr(parent, parts[i], sys.modules[".".join(parts[: i + 1])], raising=False)
+
+
+def _azure_record() -> CloudConnectionRecord:
+    record = _record("tenant-a", provider="azure")
+    record.role_ref = "app-client-id-123"
+    record.external_id_encrypted = connection_crypto.encrypt_secret("super-secret-client-secret")
+    record.auth_params = {"tenant_id": "tenant-guid", "subscription_id": "sub-guid"}
+    return record
+
+
+def _gcp_record() -> CloudConnectionRecord:
+    record = _record("tenant-a", provider="gcp")
+    record.role_ref = "sa@project.iam.gserviceaccount.com"
+    record.external_id_encrypted = connection_crypto.encrypt_secret('{"type": "service_account", "project_id": "proj"}')
+    record.auth_params = {"project_id": "proj"}
+    return record
+
+
+def _snowflake_record(pem: str) -> CloudConnectionRecord:
+    record = _record("tenant-a", provider="snowflake")
+    record.role_ref = "ACME-ACCT"
+    record.external_id_encrypted = connection_crypto.encrypt_secret(pem)
+    record.auth_params = {"user": "ABOM_SVC", "role": "ABOM_READONLY", "warehouse": "ABOM_WH"}
+    return record
+
+
+def test_broker_azure_uses_decrypted_client_secret(monkeypatch: pytest.MonkeyPatch) -> None:
     from agent_bom.cloud import connection_broker
 
-    for provider in ("azure", "gcp", "snowflake"):
-        record = _record("tenant-a", provider=provider)
-        with pytest.raises(NotImplementedError):
-            connection_broker.broker_session(record)
+    captured: dict[str, Any] = {}
+    sentinel = object()
+
+    class _FakeClientSecretCredential:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    def _factory(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return sentinel
+
+    fake = types.ModuleType("azure.identity")
+    fake.ClientSecretCredential = _factory  # type: ignore[attr-defined]
+    _install_fake_module(monkeypatch, "azure.identity", fake)
+
+    result = connection_broker.broker_session(_azure_record())
+    assert result is sentinel
+    assert captured["tenant_id"] == "tenant-guid"
+    assert captured["client_id"] == "app-client-id-123"
+    assert captured["client_secret"] == "super-secret-client-secret"
+
+
+def test_broker_azure_missing_tenant_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.cloud import connection_broker
+
+    fake = types.ModuleType("azure.identity")
+    fake.ClientSecretCredential = lambda **kwargs: object()  # type: ignore[attr-defined]
+    _install_fake_module(monkeypatch, "azure.identity", fake)
+
+    record = _azure_record()
+    record.auth_params = {}
+    with pytest.raises(connection_broker.ConnectionBrokerError):
+        connection_broker.broker_session(record)
+
+
+def test_broker_gcp_builds_readonly_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.cloud import connection_broker
+
+    captured: dict[str, Any] = {}
+    sentinel = object()
+
+    class _FakeCreds:
+        @classmethod
+        def from_service_account_info(cls, info: Any, scopes: Any = None) -> Any:
+            captured["info"] = info
+            captured["scopes"] = scopes
+            return sentinel
+
+    sa_mod = types.ModuleType("google.oauth2.service_account")
+    sa_mod.Credentials = _FakeCreds  # type: ignore[attr-defined]
+    _install_fake_module(monkeypatch, "google.oauth2.service_account", sa_mod)
+    oauth2 = sys.modules["google.oauth2"]
+    monkeypatch.setattr(oauth2, "service_account", sa_mod, raising=False)
+
+    result = connection_broker.broker_session(_gcp_record())
+    assert result is sentinel
+    assert captured["info"]["project_id"] == "proj"
+    # Scoped to the read-only cloud-platform scope so it cannot authorize a write.
+    assert captured["scopes"] == [connection_broker._GCP_READONLY_SCOPE]
+
+
+def test_broker_gcp_bad_key_json_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.cloud import connection_broker
+
+    sa_mod = types.ModuleType("google.oauth2.service_account")
+    sa_mod.Credentials = type("C", (), {"from_service_account_info": staticmethod(lambda *a, **k: object())})  # type: ignore[attr-defined]
+    _install_fake_module(monkeypatch, "google.oauth2.service_account", sa_mod)
+    monkeypatch.setattr(sys.modules["google.oauth2"], "service_account", sa_mod, raising=False)
+
+    record = _gcp_record()
+    record.external_id_encrypted = connection_crypto.encrypt_secret("not-json-at-all")
+    with pytest.raises(connection_broker.ConnectionBrokerError) as exc:
+        connection_broker.broker_session(record)
+    assert "not-json-at-all" not in str(exc.value)
+
+
+def _generate_test_pem() -> str:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+
+
+def test_broker_snowflake_keypair_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.cloud import connection_broker
+
+    captured: dict[str, Any] = {}
+    sentinel = object()
+
+    def _fake_connect(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return sentinel
+
+    connector = types.ModuleType("snowflake.connector")
+    connector.connect = _fake_connect  # type: ignore[attr-defined]
+    _install_fake_module(monkeypatch, "snowflake.connector", connector)
+
+    result = connection_broker.broker_session(_snowflake_record(_generate_test_pem()))
+    assert result is sentinel
+    assert captured["account"] == "ACME-ACCT"
+    assert captured["user"] == "ABOM_SVC"
+    assert captured["role"] == "ABOM_READONLY"
+    assert captured["warehouse"] == "ABOM_WH"
+    # Key-pair auth: the private key is presented as DER bytes, never a password.
+    assert isinstance(captured["private_key"], bytes)
+    assert "password" not in captured
+
+
+def test_broker_snowflake_bad_pem_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.cloud import connection_broker
+
+    connector = types.ModuleType("snowflake.connector")
+    connector.connect = lambda **kwargs: object()  # type: ignore[attr-defined]
+    _install_fake_module(monkeypatch, "snowflake.connector", connector)
+
+    record = _snowflake_record("-----BEGIN PRIVATE KEY-----\nnot-a-real-key\n-----END PRIVATE KEY-----")
+    with pytest.raises(connection_broker.ConnectionBrokerError) as exc:
+        connection_broker.broker_session(record)
+    assert "not-a-real-key" not in str(exc.value)
+
+
+@pytest.mark.parametrize("provider", ["azure", "gcp", "snowflake"])
+def test_broker_secret_decrypt_failure_never_leaks(provider: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A decrypt failure fails closed with no plaintext, for every provider.
+
+    SDKs are faked so the broker reaches the decrypt step regardless of which
+    extras are installed.
+    """
+    from agent_bom.cloud import connection_broker
+
+    azure_mod = types.ModuleType("azure.identity")
+    azure_mod.ClientSecretCredential = lambda **kwargs: object()  # type: ignore[attr-defined]
+    _install_fake_module(monkeypatch, "azure.identity", azure_mod)
+    sa_mod = types.ModuleType("google.oauth2.service_account")
+    sa_mod.Credentials = type("C", (), {"from_service_account_info": staticmethod(lambda *a, **k: object())})  # type: ignore[attr-defined]
+    _install_fake_module(monkeypatch, "google.oauth2.service_account", sa_mod)
+    monkeypatch.setattr(sys.modules["google.oauth2"], "service_account", sa_mod, raising=False)
+    connector = types.ModuleType("snowflake.connector")
+    connector.connect = lambda **kwargs: object()  # type: ignore[attr-defined]
+    _install_fake_module(monkeypatch, "snowflake.connector", connector)
+
+    builders = {"azure": _azure_record, "gcp": _gcp_record, "snowflake": lambda: _snowflake_record(_generate_test_pem())}
+    record = builders[provider]()
+    # Corrupt the ciphertext so decryption fails closed.
+    record.external_id_encrypted = "garbage-token"
+    with pytest.raises(connection_broker.ConnectionBrokerError) as exc:
+        connection_broker.broker_session(record)
+    assert "garbage-token" not in str(exc.value)
 
 
 def test_broker_unknown_provider_value_error() -> None:
@@ -923,17 +1163,180 @@ def test_scan_missing_connection_404(monkeypatch: pytest.MonkeyPatch) -> None:
     assert resp.status_code == 404
 
 
-@pytest.mark.parametrize("provider", ["azure", "gcp", "snowflake"])
-def test_scan_non_aws_provider_returns_planned(provider: str, monkeypatch: pytest.MonkeyPatch) -> None:
-    _install_scan_mocks(monkeypatch)
-    cid = _seed_connection("tenant-alpha", provider=provider)
+class _FakeProviderCIS:
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "benchmark": "CIS Provider",
+            "benchmark_version": "1.0",
+            "pass_rate": 50.0,
+            "passed": 1,
+            "failed": 1,
+            "total": 2,
+            "checks": [],
+        }
+
+
+def _fake_inventory_payload(provider: str) -> dict[str, Any]:
+    return {
+        "provider": provider,
+        "status": "ok",
+        "account_id": "acct",
+        "subscription_id": "acct",
+        "project_id": "acct",
+        "region": "",
+        "buckets": [],
+        "instances": [],
+        "security_groups": [],
+        "roles": [],
+        "users": [],
+        "warnings": [],
+    }
+
+
+class _FakeSnowflakeConn:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_scan_azure_brokers_runs_persists_and_marks_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.cloud import azure_cis_benchmark, azure_inventory, connection_broker
+
+    calls: dict[str, Any] = {}
+    monkeypatch.setattr(connection_broker, "broker_session", lambda record, **k: _BROKER_SESSION_SENTINEL)
+
+    def _inv(subscription_id: Any = None, credential: Any = None, force: bool = False, **k: Any) -> dict[str, Any]:
+        calls["inv_cred"] = credential
+        calls["inv_force"] = force
+        return _fake_inventory_payload("azure")
+
+    def _cis(subscription_id: Any = None, credential: Any = None, **k: Any) -> Any:
+        calls["cis_cred"] = credential
+        return _FakeProviderCIS()
+
+    monkeypatch.setattr(azure_inventory, "discover_inventory", _inv)
+    monkeypatch.setattr(azure_cis_benchmark, "run_benchmark", _cis)
+
+    cid = _seed_connection("tenant-alpha", provider="azure")
     client = TestClient(_app())
     resp = client.post(f"/v1/cloud/connections/{cid}/scan", headers=_proxy_headers(tenant="tenant-alpha"))
-    assert resp.status_code == 501
-    assert "planned" in resp.json()["detail"].lower()
-    # The connection was not touched (still pending, no scan).
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["provider"] == "azure"
+    assert calls["inv_cred"] is _BROKER_SESSION_SENTINEL
+    assert calls["cis_cred"] is _BROKER_SESSION_SENTINEL
+    assert calls["inv_force"] is True
+    assert body["inventory"]["status"] == "ok"
+    assert body["cis_benchmark"]["total"] == 2
+
+    from agent_bom.api.stores import _get_store
+
+    assert _get_store().get(body["scan_id"], "tenant-alpha") is not None
     fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
-    assert fetched["status"] == STATUS_PENDING
+    assert fetched["status"] == "active"
+    assert fetched["last_scan_at"]
+
+
+def test_scan_gcp_brokers_runs_persists_and_marks_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.cloud import connection_broker, gcp_cis_benchmark, gcp_inventory
+
+    calls: dict[str, Any] = {}
+    monkeypatch.setattr(connection_broker, "broker_session", lambda record, **k: _BROKER_SESSION_SENTINEL)
+
+    def _inv(project_id: Any = None, credentials: Any = None, force: bool = False, **k: Any) -> dict[str, Any]:
+        calls["inv_creds"] = credentials
+        calls["inv_force"] = force
+        return _fake_inventory_payload("gcp")
+
+    def _cis(project_id: Any = None, credentials: Any = None, **k: Any) -> Any:
+        calls["cis_creds"] = credentials
+        return _FakeProviderCIS()
+
+    monkeypatch.setattr(gcp_inventory, "discover_inventory", _inv)
+    monkeypatch.setattr(gcp_cis_benchmark, "run_benchmark", _cis)
+
+    cid = _seed_connection("tenant-alpha", provider="gcp")
+    client = TestClient(_app())
+    resp = client.post(f"/v1/cloud/connections/{cid}/scan", headers=_proxy_headers(tenant="tenant-alpha"))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["provider"] == "gcp"
+    assert calls["inv_creds"] is _BROKER_SESSION_SENTINEL
+    assert calls["cis_creds"] is _BROKER_SESSION_SENTINEL
+    assert calls["inv_force"] is True
+    assert body["cis_benchmark"]["total"] == 2
+    fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
+    assert fetched["status"] == "active"
+
+
+def test_scan_snowflake_brokers_runs_persists_and_marks_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.cloud import connection_broker, snowflake_cis_benchmark
+    from agent_bom.cloud import snowflake as snowflake_discovery
+
+    calls: dict[str, Any] = {}
+    conn = _FakeSnowflakeConn()
+    monkeypatch.setattr(connection_broker, "broker_session", lambda record, **k: conn)
+
+    def _disc(conn: Any = None, **k: Any) -> Any:
+        calls["disc_conn"] = conn
+        return ([], [])
+
+    def _cis(conn: Any = None, **k: Any) -> Any:
+        calls["cis_conn"] = conn
+        return _FakeProviderCIS()
+
+    monkeypatch.setattr(snowflake_discovery, "discover", _disc)
+    monkeypatch.setattr(snowflake_cis_benchmark, "run_benchmark", _cis)
+
+    cid = _seed_connection("tenant-alpha", provider="snowflake")
+    client = TestClient(_app())
+    resp = client.post(f"/v1/cloud/connections/{cid}/scan", headers=_proxy_headers(tenant="tenant-alpha"))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["provider"] == "snowflake"
+    # The single brokered connection backs both discovery and CIS, and the route
+    # closes it afterwards (discover/CIS do not close an injected connection).
+    assert calls["disc_conn"] is conn
+    assert calls["cis_conn"] is conn
+    assert conn.closed is True
+    assert body["inventory"]["agent_count"] == 0
+    assert body["cis_benchmark"]["total"] == 2
+    fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
+    assert fetched["status"] == "active"
+
+
+def test_scan_sdk_missing_returns_clean_error_without_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A provider whose SDK extra is not installed surfaces a clean error, no secret."""
+    from agent_bom.cloud import connection_broker
+    from agent_bom.cloud.base import CloudDiscoveryError
+
+    def _broker(record: CloudConnectionRecord, **k: Any) -> Any:
+        raise CloudDiscoveryError("azure-identity is required to broker Azure connections. Install with: pip install 'agent-bom[azure]'")
+
+    monkeypatch.setattr(connection_broker, "broker_session", _broker)
+
+    cid = _seed_connection("tenant-alpha", provider="azure")
+    client = TestClient(_app())
+    resp = client.post(f"/v1/cloud/connections/{cid}/scan", headers=_proxy_headers(tenant="tenant-alpha"))
+    assert resp.status_code == 502
+    assert "super-secret-external-id" not in str(resp.json())
+    fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
+    assert fetched["status"] == "error"
+
+
+def test_api_auth_params_round_trip_non_secret() -> None:
+    client = TestClient(_app())
+    body = _create_body()
+    body["provider"] = "azure"
+    body["auth_params"] = {"tenant_id": "t-guid", "subscription_id": "s-guid"}
+    created = client.post("/v1/cloud/connections", json=body, headers=_proxy_headers()).json()
+    assert created["auth_params"] == {"tenant_id": "t-guid", "subscription_id": "s-guid"}
+    # Round-trips through GET unchanged and never carries the secret.
+    fetched = client.get(f"/v1/cloud/connections/{created['id']}", headers=_proxy_headers()).json()
+    assert fetched["auth_params"] == {"tenant_id": "t-guid", "subscription_id": "s-guid"}
+    assert "external_id" not in fetched
 
 
 def test_summarize_inventory_payload_redacts_raw_warnings() -> None:

--- a/tests/test_connection_scheduler.py
+++ b/tests/test_connection_scheduler.py
@@ -215,18 +215,16 @@ def test_claim_prevents_double_run_sqlite(tmp_path: Any) -> None:
     assert store.get(record.tenant_id, record.id).last_scan_at == claimed_at  # type: ignore[union-attr]
 
 
-def test_claim_due_connections_skips_non_aws() -> None:
+def test_claim_due_connections_claims_all_providers() -> None:
     store = InMemoryConnectionStore()
     now = _now()
-    aws = _record(provider="aws", last_scan_at=None)
-    azure = _record(provider="azure", last_scan_at=None)
-    store.put(aws)
-    store.put(azure)
+    records = [_record(provider=p, last_scan_at=None) for p in ("aws", "azure", "gcp", "snowflake")]
+    for record in records:
+        store.put(record)
 
     claimed = claim_due_connections(store, now)
-    assert [r.id for r in claimed] == [aws.id]
-    # The non-AWS connection was never claimed (last_scan_at untouched).
-    assert store.get(azure.tenant_id, azure.id).last_scan_at is None  # type: ignore[union-attr]
+    # Every supported provider is broker-enabled and therefore claimed.
+    assert {r.provider for r in claimed} == {"aws", "azure", "gcp", "snowflake"}
 
 
 # --------------------------------------------------------------------------- #
@@ -291,21 +289,45 @@ async def test_run_once_failing_connection_marked_error_and_loop_continues(monke
 
 
 @pytest.mark.asyncio
-async def test_run_once_skips_non_aws(monkeypatch: pytest.MonkeyPatch) -> None:
-    calls = _install_scan_mocks(monkeypatch)
+async def test_run_once_scans_non_aws_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-AWS provider is now broker-enabled and is scanned by the scheduler."""
+    from agent_bom.cloud import connection_broker, gcp_cis_benchmark, gcp_inventory
+
+    scanned: list[str] = []
+    monkeypatch.setattr(
+        connection_broker,
+        "broker_session",
+        lambda record, **k: scanned.append(record.id) or _BROKER_SESSION_SENTINEL,
+    )
+    monkeypatch.setattr(
+        gcp_inventory,
+        "discover_inventory",
+        lambda project_id=None, credentials=None, force=False, **k: {
+            "provider": "gcp",
+            "status": "ok",
+            "project_id": "proj",
+            "warnings": [],
+        },
+    )
+
+    class _FakeCIS:
+        def to_dict(self) -> dict[str, Any]:
+            return {"benchmark": "CIS GCP", "benchmark_version": "3.0", "pass_rate": 100.0, "passed": 2, "failed": 0, "total": 2}
+
+    monkeypatch.setattr(gcp_cis_benchmark, "run_benchmark", lambda project_id=None, credentials=None, **k: _FakeCIS())
+
     store = InMemoryConnectionStore()
     set_connection_store(store)
-    azure = _record(provider="azure", scan_interval_minutes=60, last_scan_at=None)
-    store.put(azure)
+    gcp = _record(provider="gcp", scan_interval_minutes=60, last_scan_at=None)
+    store.put(gcp)
 
     count = await run_due_scans_once(store, _now())
-    assert count == 0
-    assert calls["scanned_ids"] == []
-    # Untouched: not claimed, status unchanged, never scanned.
-    fetched = store.get(azure.tenant_id, azure.id)
+    assert count == 1
+    assert scanned == [gcp.id]
+    fetched = store.get(gcp.tenant_id, gcp.id)
     assert fetched is not None
-    assert fetched.last_scan_at is None
-    assert fetched.status == STATUS_PENDING
+    assert fetched.status == STATUS_ACTIVE
+    assert fetched.last_scan_at is not None
 
 
 # --------------------------------------------------------------------------- #

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -140,7 +140,7 @@ const PROVIDER_OPTIONS: ProviderOption[] = [
     secretField: {
       key: "external_id",
       label: "Service account key (JSON)",
-      placeholder: '{ "type": "service_account", ... }',
+      placeholder: "Paste the service-account key JSON",
       multiline: true,
       hint: "The service-account key JSON. Brokered with the cloud-platform.read-only scope. Stored encrypted, never shown again.",
     },

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -29,62 +29,176 @@ import { useAuthState } from "@/components/auth-provider";
 import { EmptyState, ErrorBanner } from "@/components/empty-state";
 
 // ── Provider catalog ──────────────────────────────────────────────────────────
-// AWS is broker-enabled today (read-only AssumeRole). Azure / GCP / Snowflake are
-// accepted by the store but the credential broker raises a clear "planned" 501,
-// so they are surfaced as "coming soon" and disabled in the wizard.
+// All four providers are broker-enabled (read-only). Each maps its wizard fields
+// onto the connection's role_ref (plaintext principal ref), external_id (the one
+// write-only secret), and auth_params (non-secret provider params).
+
+interface ProviderField {
+  key: string;
+  label: string;
+  placeholder: string;
+  mono?: boolean;
+}
 
 interface ProviderOption {
   value: string;
   label: string;
-  enabled: boolean;
-  roleLabel: string;
-  rolePlaceholder: string;
-  secretLabel: string;
-  secretHint: string;
+  tagline: string;
+  /** Maps to role_ref (plaintext principal/account reference). */
+  roleField: ProviderField;
+  /** Map to auth_params (non-secret provider params). */
+  authFields: ProviderField[];
+  /** Maps to external_id (the single write-only secret). */
+  secretField: ProviderField & { multiline?: boolean; hint: string };
+  /** Whether regions apply (AWS only). */
+  usesRegions: boolean;
+  setupSteps: string[];
 }
 
 const PROVIDER_OPTIONS: ProviderOption[] = [
   {
     value: "aws",
     label: "Amazon Web Services",
-    enabled: true,
-    roleLabel: "Read-only role ARN",
-    rolePlaceholder: "arn:aws:iam::123456789012:role/agent-bom-readonly",
-    secretLabel: "External ID",
-    secretHint: "The ExternalId from the role's trust policy. Stored encrypted, never shown again.",
+    tagline: "Read-only AssumeRole",
+    roleField: {
+      key: "role_ref",
+      label: "Read-only role ARN",
+      placeholder: "arn:aws:iam::123456789012:role/agent-bom-readonly",
+      mono: true,
+    },
+    authFields: [],
+    secretField: {
+      key: "external_id",
+      label: "External ID",
+      placeholder: "••••••••••••",
+      hint: "The ExternalId from the role's trust policy. Stored encrypted, never shown again.",
+    },
+    usesRegions: true,
+    setupSteps: [
+      "Create an IAM role with a trust policy that allows the agent-bom control plane to assume it.",
+      "Require an ExternalId on the trust policy and keep it secret.",
+      "Attach AWS-managed ReadOnlyAccess (or SecurityAudit).",
+      "Copy the role ARN and the ExternalId into the next step.",
+    ],
   },
   {
     value: "azure",
     label: "Microsoft Azure",
-    enabled: false,
-    roleLabel: "Service principal reference",
-    rolePlaceholder: "subscription / app registration",
-    secretLabel: "Client secret reference",
-    secretHint: "Broker support is planned.",
+    tagline: "Read-only Reader credential",
+    roleField: {
+      key: "role_ref",
+      label: "Client ID (app registration)",
+      placeholder: "00000000-0000-0000-0000-000000000000",
+      mono: true,
+    },
+    authFields: [
+      {
+        key: "tenant_id",
+        label: "Tenant ID",
+        placeholder: "00000000-0000-0000-0000-000000000000",
+        mono: true,
+      },
+      {
+        key: "subscription_id",
+        label: "Subscription ID",
+        placeholder: "00000000-0000-0000-0000-000000000000",
+        mono: true,
+      },
+    ],
+    secretField: {
+      key: "external_id",
+      label: "Client secret",
+      placeholder: "••••••••••••",
+      hint: "The app registration's client secret. Stored encrypted, never shown again.",
+    },
+    usesRegions: false,
+    setupSteps: [
+      "Register an app (service principal) in Microsoft Entra ID and create a client secret.",
+      "Grant the app the built-in Reader role on the subscription (read-only).",
+      "Copy the Tenant ID, Subscription ID, and Client ID into the next step.",
+      "Paste the client secret — it is stored encrypted and never displayed again.",
+    ],
   },
   {
     value: "gcp",
     label: "Google Cloud",
-    enabled: false,
-    roleLabel: "Service account",
-    rolePlaceholder: "agent-bom@project.iam.gserviceaccount.com",
-    secretLabel: "Workload identity reference",
-    secretHint: "Broker support is planned.",
+    tagline: "Read-only service account",
+    roleField: {
+      key: "role_ref",
+      label: "Service account email",
+      placeholder: "agent-bom@project.iam.gserviceaccount.com",
+      mono: true,
+    },
+    authFields: [
+      {
+        key: "project_id",
+        label: "Project ID",
+        placeholder: "my-project-123",
+        mono: true,
+      },
+    ],
+    secretField: {
+      key: "external_id",
+      label: "Service account key (JSON)",
+      placeholder: '{ "type": "service_account", ... }',
+      multiline: true,
+      hint: "The service-account key JSON. Brokered with the cloud-platform.read-only scope. Stored encrypted, never shown again.",
+    },
+    usesRegions: false,
+    setupSteps: [
+      "Create a service account in the target project and grant it the read-only Viewer role.",
+      "Create a JSON key for the service account.",
+      "Copy the Project ID and the service-account email into the next step.",
+      "Paste the key JSON — it is stored encrypted and never displayed again.",
+    ],
   },
   {
     value: "snowflake",
     label: "Snowflake",
-    enabled: false,
-    roleLabel: "Account / role",
-    rolePlaceholder: "org-account / READONLY_ROLE",
-    secretLabel: "Key-pair reference",
-    secretHint: "Broker support is planned.",
+    tagline: "Read-only key-pair connection",
+    roleField: {
+      key: "role_ref",
+      label: "Account",
+      placeholder: "ORG-ACCOUNT",
+      mono: true,
+    },
+    authFields: [
+      { key: "user", label: "User", placeholder: "ABOM_SVC", mono: true },
+      { key: "role", label: "Role", placeholder: "ABOM_READONLY", mono: true },
+      {
+        key: "warehouse",
+        label: "Warehouse",
+        placeholder: "ABOM_WH",
+        mono: true,
+      },
+    ],
+    secretField: {
+      key: "external_id",
+      label: "Private key (PEM)",
+      placeholder: "Paste the PKCS#8 PEM private key…",
+      multiline: true,
+      hint: "The RSA private key (PEM) for key-pair auth. Stored encrypted, never shown again.",
+    },
+    usesRegions: false,
+    setupSteps: [
+      "Create a read-only role and a service user with key-pair authentication.",
+      "Assign the read-only role and a warehouse the user can use.",
+      "Copy the Account, User, Role, and Warehouse into the next step.",
+      "Paste the private key (PEM) — it is stored encrypted and never displayed again.",
+    ],
   },
 ];
 
 function providerLabel(value: string): string {
-  return PROVIDER_OPTIONS.find((option) => option.value === value)?.label ?? value.toUpperCase();
+  return (
+    PROVIDER_OPTIONS.find((option) => option.value === value)?.label ??
+    value.toUpperCase()
+  );
 }
+
+const SCANNABLE_PROVIDERS = new Set(
+  PROVIDER_OPTIONS.map((option) => option.value),
+);
 
 function formatWhen(value: string | null): string {
   if (!value) return "Never";
@@ -104,10 +218,18 @@ function statusTone(status: string): string {
 }
 
 function StatusPill({ status }: { status: string }) {
-  const Icon = status === "active" ? CheckCircle2 : status === "error" ? AlertTriangle : Clock;
-  const label = status === "active" ? "Active" : status === "error" ? "Error" : "Pending";
+  const Icon =
+    status === "active"
+      ? CheckCircle2
+      : status === "error"
+        ? AlertTriangle
+        : Clock;
+  const label =
+    status === "active" ? "Active" : status === "error" ? "Error" : "Pending";
   return (
-    <span className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${statusTone(status)}`}>
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[11px] font-medium ${statusTone(status)}`}
+    >
       <Icon className="h-3 w-3" />
       {label}
     </span>
@@ -131,7 +253,9 @@ export default function ConnectionsPage() {
   const [message, setMessage] = useState<string | null>(null);
   const [wizardOpen, setWizardOpen] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
-  const [scanResults, setScanResults] = useState<Record<string, CloudConnectionScanResponse>>({});
+  const [scanResults, setScanResults] = useState<
+    Record<string, CloudConnectionScanResponse>
+  >({});
   const [scanErrors, setScanErrors] = useState<Record<string, string>>({});
 
   const refresh = useCallback(async () => {
@@ -141,7 +265,11 @@ export default function ConnectionsPage() {
       const result = await api.listCloudConnections();
       setConnections(result.connections);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load cloud connections.");
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Failed to load cloud connections.",
+      );
       setConnections([]);
     } finally {
       setLoading(false);
@@ -195,13 +323,18 @@ export default function ConnectionsPage() {
       setMessage(`Removed ${connection.display_name}.`);
       await refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to delete connection.");
+      setError(
+        err instanceof Error ? err.message : "Failed to delete connection.",
+      );
     } finally {
       setBusyId(null);
     }
   }
 
-  const activeCount = useMemo(() => connections.filter((c) => c.status === "active").length, [connections]);
+  const activeCount = useMemo(
+    () => connections.filter((c) => c.status === "active").length,
+    [connections],
+  );
 
   return (
     <div className="space-y-6">
@@ -209,12 +342,17 @@ export default function ConnectionsPage() {
       <section className="rounded-3xl border border-[color:var(--border-subtle)] bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] p-6 shadow-2xl shadow-black/10">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="min-w-0">
-            <p className="text-[11px] uppercase tracking-[0.22em] text-emerald-400">Connections plane</p>
-            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-[var(--foreground)]">Cloud accounts</h1>
+            <p className="text-[11px] uppercase tracking-[0.22em] text-emerald-400">
+              Connections plane
+            </p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-[var(--foreground)]">
+              Cloud accounts
+            </h1>
             <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--text-secondary)]">
-              Connect a customer cloud account in read-only mode, then launch inventory and CIS
-              discovery against a short-lived assumed role. The connection secret is encrypted at
-              rest and is never returned to the browser.
+              Connect a customer cloud account (AWS, Azure, GCP, or Snowflake)
+              in read-only mode, then launch inventory and CIS discovery against
+              a short-lived brokered credential. The connection secret is
+              encrypted at rest and is never returned to the browser.
             </p>
           </div>
           <div className="flex flex-wrap gap-3">
@@ -237,15 +375,31 @@ export default function ConnectionsPage() {
         </div>
 
         <div className="mt-5 grid gap-3 sm:grid-cols-3">
-          <MetricCard icon={Cloud} label="Connections" value={loading ? "…" : String(connections.length)} />
-          <MetricCard icon={CheckCircle2} label="Active" value={loading ? "…" : String(activeCount)} />
-          <MetricCard icon={Lock} label="Secret storage" value="Encrypted" detail="Write-only external IDs" />
+          <MetricCard
+            icon={Cloud}
+            label="Connections"
+            value={loading ? "…" : String(connections.length)}
+          />
+          <MetricCard
+            icon={CheckCircle2}
+            label="Active"
+            value={loading ? "…" : String(activeCount)}
+          />
+          <MetricCard
+            icon={Lock}
+            label="Secret storage"
+            value="Encrypted"
+            detail="Write-only external IDs"
+          />
         </div>
 
-        {message ? <p className="mt-4 text-sm text-emerald-400">{message}</p> : null}
+        {message ? (
+          <p className="mt-4 text-sm text-emerald-400">{message}</p>
+        ) : null}
         {!canManage ? (
           <p className="mt-3 text-sm text-amber-300">
-            Your role can review connections but cannot create, scan, or delete them.
+            Your role can review connections but cannot create, scan, or delete
+            them.
           </p>
         ) : null}
       </section>
@@ -257,10 +411,12 @@ export default function ConnectionsPage() {
             <ShieldCheck className="h-5 w-5 text-emerald-400" />
           </span>
           <div>
-            <h2 className="text-base font-semibold text-[var(--foreground)]">Connected accounts</h2>
+            <h2 className="text-base font-semibold text-[var(--foreground)]">
+              Connected accounts
+            </h2>
             <p className="mt-1 text-sm text-[var(--text-secondary)]">
-              Each row is a tenant-scoped, encrypted connection. Run a read-only scan to see live
-              inventory counts and CIS pass rate.
+              Each row is a tenant-scoped, encrypted connection. Run a read-only
+              scan to see live inventory counts and CIS pass rate.
             </p>
           </div>
         </div>
@@ -271,14 +427,17 @@ export default function ConnectionsPage() {
           ) : loading ? (
             <div className="space-y-2" aria-busy="true">
               {[0, 1, 2].map((i) => (
-                <div key={i} className="h-14 animate-pulse rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)]" />
+                <div
+                  key={i}
+                  className="h-14 animate-pulse rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)]"
+                />
               ))}
             </div>
           ) : connections.length === 0 ? (
             <EmptyState
               icon={Cloud}
               title="No cloud accounts connected"
-              description="Add a read-only AWS account to launch inventory and CIS discovery from the control plane."
+              description="Add a read-only AWS, Azure, GCP, or Snowflake account to launch inventory and CIS discovery from the control plane."
             />
           ) : (
             <div className="overflow-x-auto rounded-xl border border-[color:var(--border-subtle)]">
@@ -289,7 +448,9 @@ export default function ConnectionsPage() {
                     <th className="px-4 py-3 font-medium">Provider</th>
                     <th className="px-4 py-3 font-medium">Status</th>
                     <th className="px-4 py-3 font-medium">Last scan</th>
-                    <th className="px-4 py-3 text-right font-medium">Actions</th>
+                    <th className="px-4 py-3 text-right font-medium">
+                      Actions
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
@@ -297,7 +458,9 @@ export default function ConnectionsPage() {
                     const isBusy = busyId === connection.id;
                     const result = scanResults[connection.id];
                     const scanError = scanErrors[connection.id];
-                    const scannable = connection.provider === "aws";
+                    const scannable = SCANNABLE_PROVIDERS.has(
+                      connection.provider,
+                    );
                     return (
                       <FragmentRow
                         key={connection.id}
@@ -307,7 +470,11 @@ export default function ConnectionsPage() {
                         scannable={scannable}
                         result={result}
                         scanError={scanError}
-                        statusDetail={connection.status === "error" ? connection.status_detail : ""}
+                        statusDetail={
+                          connection.status === "error"
+                            ? connection.status_detail
+                            : ""
+                        }
                         onScan={() => void handleScan(connection)}
                         onDelete={() => void handleDelete(connection)}
                       />
@@ -321,7 +488,10 @@ export default function ConnectionsPage() {
       </section>
 
       {wizardOpen ? (
-        <AddConnectionWizard onClose={() => setWizardOpen(false)} onCreated={handleCreated} />
+        <AddConnectionWizard
+          onClose={() => setWizardOpen(false)}
+          onCreated={handleCreated}
+        />
       ) : null}
     </div>
   );
@@ -355,8 +525,12 @@ function FragmentRow({
     <>
       <tr className="border-b border-[color:var(--border-subtle)] last:border-b-0 align-top">
         <td className="px-4 py-3">
-          <p className="font-medium text-[var(--foreground)]">{connection.display_name}</p>
-          <p className="mt-0.5 break-all font-mono text-[11px] text-[var(--text-tertiary)]">{connection.role_ref}</p>
+          <p className="font-medium text-[var(--foreground)]">
+            {connection.display_name}
+          </p>
+          <p className="mt-0.5 break-all font-mono text-[11px] text-[var(--text-tertiary)]">
+            {connection.role_ref}
+          </p>
           <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
             {connection.has_external_id ? (
               <span className="inline-flex items-center gap-1 rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-1.5 py-0.5 text-[10px] text-[var(--text-secondary)]">
@@ -364,24 +538,39 @@ function FragmentRow({
               </span>
             ) : null}
             {connection.regions.slice(0, 3).map((region) => (
-              <span key={region} className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--text-secondary)]">
+              <span
+                key={region}
+                className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--text-secondary)]"
+              >
                 {region}
               </span>
             ))}
             {connection.regions.length > 3 ? (
-              <span className="text-[10px] text-[var(--text-tertiary)]">+{connection.regions.length - 3}</span>
+              <span className="text-[10px] text-[var(--text-tertiary)]">
+                +{connection.regions.length - 3}
+              </span>
             ) : null}
           </div>
         </td>
-        <td className="px-4 py-3 text-[var(--text-secondary)]">{providerLabel(connection.provider)}</td>
-        <td className="px-4 py-3"><StatusPill status={connection.status} /></td>
-        <td className="px-4 py-3 text-[var(--text-secondary)]">{formatWhen(connection.last_scan_at)}</td>
+        <td className="px-4 py-3 text-[var(--text-secondary)]">
+          {providerLabel(connection.provider)}
+        </td>
+        <td className="px-4 py-3">
+          <StatusPill status={connection.status} />
+        </td>
+        <td className="px-4 py-3 text-[var(--text-secondary)]">
+          {formatWhen(connection.last_scan_at)}
+        </td>
         <td className="px-4 py-3">
           <div className="flex justify-end gap-2">
             <button
               onClick={onScan}
               disabled={isBusy || !canManage || !scannable}
-              title={scannable ? "Run a read-only scan" : "Scanning for this provider is planned"}
+              title={
+                scannable
+                  ? "Run a read-only scan"
+                  : "Scanning for this provider is unavailable"
+              }
               className="rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {isBusy ? "Scanning…" : "Scan now"}
@@ -421,6 +610,10 @@ function FragmentRow({
 
 function ScanResultPanel({ result }: { result: CloudConnectionScanResponse }) {
   const { inventory, cis_benchmark: cis } = result;
+  // Snowflake reports a discovered-agent count; AWS/Azure/GCP report estate
+  // resource + identity counts. Render whichever the provider returned.
+  const isSnowflake = inventory.agent_count != null;
+  const warnings = inventory.warnings ?? [];
   return (
     <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -428,22 +621,50 @@ function ScanResultPanel({ result }: { result: CloudConnectionScanResponse }) {
           <ShieldCheck className="h-4 w-4 text-emerald-400" />
           Read-only scan complete
         </p>
-        <span className="font-mono text-[10px] text-[var(--text-tertiary)]">scan {result.scan_id.slice(0, 8)}</span>
+        <span className="font-mono text-[10px] text-[var(--text-tertiary)]">
+          scan {result.scan_id.slice(0, 8)}
+        </span>
       </div>
       <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <StatTile icon={Boxes} label="Resources" value={String(inventory.resource_count)} />
-        <StatTile icon={Fingerprint} label="Identities" value={String(inventory.identity_count)} />
+        {isSnowflake ? (
+          <StatTile
+            icon={Boxes}
+            label="Agents"
+            value={String(inventory.agent_count ?? 0)}
+          />
+        ) : (
+          <>
+            <StatTile
+              icon={Boxes}
+              label="Resources"
+              value={String(inventory.resource_count ?? 0)}
+            />
+            <StatTile
+              icon={Fingerprint}
+              label="Identities"
+              value={String(inventory.identity_count ?? 0)}
+            />
+          </>
+        )}
         <StatTile
           icon={CheckCircle2}
           label="CIS passed"
           value={cis.passed == null ? "—" : `${cis.passed}/${cis.total ?? "—"}`}
         />
-        <StatTile icon={KeyRound} label="CIS pass rate" value={formatPassRate(cis.pass_rate)} />
+        <StatTile
+          icon={KeyRound}
+          label="CIS pass rate"
+          value={formatPassRate(cis.pass_rate)}
+        />
       </div>
-      {inventory.warnings.length > 0 ? (
-        <p className="mt-3 text-[11px] leading-5 text-amber-300">{inventory.warnings.join(" · ")}</p>
+      {warnings.length > 0 ? (
+        <p className="mt-3 text-[11px] leading-5 text-amber-300">
+          {warnings.join(" · ")}
+        </p>
       ) : null}
-      <p className="mt-3 text-[11px] leading-5 text-[var(--text-tertiary)]">{result.audit_metadata.note}</p>
+      <p className="mt-3 text-[11px] leading-5 text-[var(--text-tertiary)]">
+        {result.audit_metadata.note}
+      </p>
     </div>
   );
 }
@@ -463,7 +684,9 @@ function StatTile({
         <Icon className="h-3.5 w-3.5 text-emerald-400" />
         {label}
       </div>
-      <p className="mt-1.5 text-lg font-semibold text-[var(--foreground)]">{value}</p>
+      <p className="mt-1.5 text-lg font-semibold text-[var(--foreground)]">
+        {value}
+      </p>
     </div>
   );
 }
@@ -486,11 +709,19 @@ function MetricCard({
           <Icon className="h-4 w-4 text-emerald-400" />
         </span>
         <div className="min-w-0">
-          <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">{label}</p>
-          <p className="mt-1 text-lg font-semibold text-[var(--foreground)]">{value}</p>
+          <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+            {label}
+          </p>
+          <p className="mt-1 text-lg font-semibold text-[var(--foreground)]">
+            {value}
+          </p>
         </div>
       </div>
-      {detail ? <p className="mt-2 text-xs leading-5 text-[var(--text-secondary)]">{detail}</p> : null}
+      {detail ? (
+        <p className="mt-2 text-xs leading-5 text-[var(--text-secondary)]">
+          {detail}
+        </p>
+      ) : null}
     </div>
   );
 }
@@ -503,6 +734,8 @@ interface WizardForm {
   role_ref: string;
   external_id: string;
   regions: string;
+  /** Non-secret provider params keyed by field key (tenant_id, project_id, user, …). */
+  auth: Record<string, string>;
 }
 
 const DEFAULT_WIZARD_FORM: WizardForm = {
@@ -511,6 +744,7 @@ const DEFAULT_WIZARD_FORM: WizardForm = {
   role_ref: "",
   external_id: "",
   regions: "",
+  auth: {},
 };
 
 function AddConnectionWizard({
@@ -526,12 +760,33 @@ function AddConnectionWizard({
   const [formError, setFormError] = useState<string | null>(null);
 
   const provider = useMemo(
-    () => PROVIDER_OPTIONS.find((option) => option.value === form.provider) ?? PROVIDER_OPTIONS[0]!,
+    () =>
+      PROVIDER_OPTIONS.find((option) => option.value === form.provider) ??
+      PROVIDER_OPTIONS[0]!,
     [form.provider],
   );
 
   function update<K extends keyof WizardForm>(field: K, value: WizardForm[K]) {
     setForm((current) => ({ ...current, [field]: value }));
+  }
+
+  function updateAuth(key: string, value: string) {
+    setForm((current) => ({
+      ...current,
+      auth: { ...current.auth, [key]: value },
+    }));
+  }
+
+  function selectProvider(value: string) {
+    // Reset provider-specific fields so a previous provider's params don't leak.
+    setForm((current) => ({
+      ...current,
+      provider: value,
+      role_ref: "",
+      external_id: "",
+      regions: "",
+      auth: {},
+    }));
   }
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -541,21 +796,32 @@ function AddConnectionWizard({
     const displayName = form.display_name.trim();
     const roleRef = form.role_ref.trim();
     const externalId = form.external_id;
-    const regions = form.regions
-      .split(/[\s,]+/)
-      .map((region) => region.trim())
-      .filter(Boolean);
+    const regions = provider.usesRegions
+      ? form.regions
+          .split(/[\s,]+/)
+          .map((region) => region.trim())
+          .filter(Boolean)
+      : [];
 
     if (!displayName) {
       setFormError("A display name is required.");
       return;
     }
     if (!roleRef) {
-      setFormError(`${provider.roleLabel} is required.`);
+      setFormError(`${provider.roleField.label} is required.`);
       return;
     }
+    const authParams: Record<string, string> = {};
+    for (const field of provider.authFields) {
+      const value = (form.auth[field.key] ?? "").trim();
+      if (!value) {
+        setFormError(`${field.label} is required.`);
+        return;
+      }
+      authParams[field.key] = value;
+    }
     if (!externalId.trim()) {
-      setFormError(`${provider.secretLabel} is required.`);
+      setFormError(`${provider.secretField.label} is required.`);
       return;
     }
 
@@ -565,6 +831,7 @@ function AddConnectionWizard({
       role_ref: roleRef,
       external_id: externalId,
       regions,
+      auth_params: authParams,
     };
 
     setSubmitting(true);
@@ -574,7 +841,9 @@ function AddConnectionWizard({
       setForm((current) => ({ ...current, external_id: "" }));
       onCreated(created);
     } catch (err) {
-      setFormError(err instanceof Error ? err.message : "Failed to create connection.");
+      setFormError(
+        err instanceof Error ? err.message : "Failed to create connection.",
+      );
     } finally {
       setSubmitting(false);
     }
@@ -598,8 +867,12 @@ function AddConnectionWizard({
               <Cloud className="h-5 w-5 text-emerald-400" />
             </span>
             <div>
-              <h2 className="text-base font-semibold text-[var(--foreground)]">Add cloud account</h2>
-              <p className="text-xs text-[var(--text-secondary)]">Read-only connection · step {step + 1} of 3</p>
+              <h2 className="text-base font-semibold text-[var(--foreground)]">
+                Add cloud account
+              </h2>
+              <p className="text-xs text-[var(--text-secondary)]">
+                Read-only connection · step {step + 1} of 3
+              </p>
             </div>
           </div>
           <button
@@ -617,7 +890,9 @@ function AddConnectionWizard({
 
             {step === 0 ? (
               <fieldset className="space-y-3">
-                <legend className="text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Choose a provider</legend>
+                <legend className="text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                  Choose a provider
+                </legend>
                 <div className="grid gap-2 sm:grid-cols-2">
                   {PROVIDER_OPTIONS.map((option) => {
                     const selected = form.provider === option.value;
@@ -625,18 +900,19 @@ function AddConnectionWizard({
                       <button
                         type="button"
                         key={option.value}
-                        disabled={!option.enabled}
-                        onClick={() => update("provider", option.value)}
+                        onClick={() => selectProvider(option.value)}
                         aria-pressed={selected}
                         className={`rounded-xl border p-3 text-left transition ${
                           selected
                             ? "border-emerald-500 bg-emerald-950/20"
                             : "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] hover:border-[color:var(--border-strong)]"
-                        } ${option.enabled ? "" : "cursor-not-allowed opacity-60"}`}
+                        }`}
                       >
-                        <p className="text-sm font-medium text-[var(--foreground)]">{option.label}</p>
+                        <p className="text-sm font-medium text-[var(--foreground)]">
+                          {option.label}
+                        </p>
                         <p className="mt-1 text-[11px] text-[var(--text-secondary)]">
-                          {option.enabled ? "Read-only AssumeRole" : "Coming soon"}
+                          {option.tagline}
                         </p>
                       </button>
                     );
@@ -647,17 +923,22 @@ function AddConnectionWizard({
 
             {step === 1 ? (
               <div className="space-y-3">
-                <p className="text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Read-only setup</p>
+                <p className="text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                  Read-only setup
+                </p>
                 <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-xs leading-6 text-[var(--text-secondary)]">
-                  <p className="text-[var(--foreground)]">Create a read-only role agent-bom can assume:</p>
+                  <p className="text-[var(--foreground)]">
+                    Set up a read-only {provider.label} connection:
+                  </p>
                   <ol className="mt-2 list-decimal space-y-1.5 pl-4">
-                    <li>Create an IAM role with a trust policy that allows the agent-bom control plane to assume it.</li>
-                    <li>Require an <code className="rounded bg-[color:var(--surface)] px-1">ExternalId</code> on the trust policy and keep it secret.</li>
-                    <li>Attach AWS-managed <code className="rounded bg-[color:var(--surface)] px-1">ReadOnlyAccess</code> (or <code className="rounded bg-[color:var(--surface)] px-1">SecurityAudit</code>).</li>
-                    <li>Copy the role ARN and the ExternalId into the next step.</li>
+                    {provider.setupSteps.map((stepText) => (
+                      <li key={stepText}>{stepText}</li>
+                    ))}
                   </ol>
                   <p className="mt-3 inline-flex items-center gap-1.5 text-emerald-300">
-                    <Lock className="h-3.5 w-3.5" /> The ExternalId is stored encrypted and never displayed again.
+                    <Lock className="h-3.5 w-3.5" /> The{" "}
+                    {provider.secretField.label.toLowerCase()} is stored
+                    encrypted and never displayed again.
                   </p>
                 </div>
               </div>
@@ -666,59 +947,113 @@ function AddConnectionWizard({
             {step === 2 ? (
               <div className="space-y-4">
                 <label className="block">
-                  <span className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Display name</span>
+                  <span className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                    Display name
+                  </span>
                   <input
                     value={form.display_name}
-                    onChange={(event) => update("display_name", event.target.value)}
+                    onChange={(event) =>
+                      update("display_name", event.target.value)
+                    }
                     placeholder="Production account"
                     className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
                   />
                 </label>
                 <label className="block">
-                  <span className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">{provider.roleLabel}</span>
+                  <span className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                    {provider.roleField.label}
+                  </span>
                   <input
                     value={form.role_ref}
                     onChange={(event) => update("role_ref", event.target.value)}
-                    placeholder={provider.rolePlaceholder}
-                    className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 font-mono text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
+                    placeholder={provider.roleField.placeholder}
+                    className={`w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500 ${provider.roleField.mono ? "font-mono" : ""}`}
                   />
                 </label>
+                {provider.authFields.map((field) => (
+                  <label key={field.key} className="block">
+                    <span className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                      {field.label}
+                    </span>
+                    <input
+                      value={form.auth[field.key] ?? ""}
+                      onChange={(event) =>
+                        updateAuth(field.key, event.target.value)
+                      }
+                      placeholder={field.placeholder}
+                      className={`w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500 ${field.mono ? "font-mono" : ""}`}
+                    />
+                  </label>
+                ))}
                 <label className="block">
-                  <span className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">{provider.secretLabel}</span>
-                  <input
-                    type="password"
-                    autoComplete="off"
-                    value={form.external_id}
-                    onChange={(event) => update("external_id", event.target.value)}
-                    placeholder="••••••••••••"
-                    className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
-                  />
+                  <span className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                    {provider.secretField.label}
+                  </span>
+                  {provider.secretField.multiline ? (
+                    <textarea
+                      autoComplete="off"
+                      rows={5}
+                      value={form.external_id}
+                      onChange={(event) =>
+                        update("external_id", event.target.value)
+                      }
+                      placeholder={provider.secretField.placeholder}
+                      className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 font-mono text-xs text-[var(--foreground)] outline-none transition focus:border-emerald-500"
+                    />
+                  ) : (
+                    <input
+                      type="password"
+                      autoComplete="off"
+                      value={form.external_id}
+                      onChange={(event) =>
+                        update("external_id", event.target.value)
+                      }
+                      placeholder={provider.secretField.placeholder}
+                      className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
+                    />
+                  )}
                   <span className="mt-1.5 inline-flex items-center gap-1.5 text-[11px] text-[var(--text-tertiary)]">
-                    <Lock className="h-3 w-3" /> {provider.secretHint}
+                    <Lock className="h-3 w-3" /> {provider.secretField.hint}
                   </span>
                 </label>
-                <label className="block">
-                  <span className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Regions (optional)</span>
-                  <input
-                    value={form.regions}
-                    onChange={(event) => update("regions", event.target.value)}
-                    placeholder="us-east-1, us-west-2"
-                    className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 font-mono text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
-                  />
-                </label>
+                {provider.usesRegions ? (
+                  <label className="block">
+                    <span className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                      Regions (optional)
+                    </span>
+                    <input
+                      value={form.regions}
+                      onChange={(event) =>
+                        update("regions", event.target.value)
+                      }
+                      placeholder="us-east-1, us-west-2"
+                      className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 font-mono text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
+                    />
+                  </label>
+                ) : null}
               </div>
             ) : null}
 
-            {formError ? <p className="text-sm text-red-400">{formError}</p> : null}
+            {formError ? (
+              <p className="text-sm text-red-400">{formError}</p>
+            ) : null}
           </div>
 
           <div className="flex items-center justify-between gap-3 border-t border-[color:var(--border-subtle)] px-5 py-4">
             <button
               type="button"
-              onClick={() => (step === 0 ? onClose() : setStep((s) => (s - 1) as 0 | 1 | 2))}
+              onClick={() =>
+                step === 0 ? onClose() : setStep((s) => (s - 1) as 0 | 1 | 2)
+              }
               className="inline-flex items-center gap-1.5 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-4 py-2 text-sm text-[var(--foreground)] transition hover:border-[color:var(--border-strong)]"
             >
-              {step === 0 ? "Cancel" : <><ArrowLeft className="h-4 w-4" /> Back</>}
+              {step === 0 ? (
+                "Cancel"
+              ) : (
+                <>
+                  <ArrowLeft className="h-4 w-4" /> Back
+                </>
+              )}
             </button>
             {step < 2 ? (
               <button
@@ -762,8 +1097,14 @@ function StepIndicator({ step }: { step: number }) {
           >
             {index + 1}
           </span>
-          <span className={`text-xs ${index <= step ? "text-[var(--foreground)]" : "text-[var(--text-tertiary)]"}`}>{label}</span>
-          {index < labels.length - 1 ? <span className="h-px flex-1 bg-[color:var(--border-subtle)]" /> : null}
+          <span
+            className={`text-xs ${index <= step ? "text-[var(--foreground)]" : "text-[var(--text-tertiary)]"}`}
+          >
+            {label}
+          </span>
+          {index < labels.length - 1 ? (
+            <span className="h-px flex-1 bg-[color:var(--border-subtle)]" />
+          ) : null}
         </div>
       ))}
     </div>

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1,6 +1,11 @@
 /** Shared API response and request contracts. */
 
-import type { AttackPath, UnifiedEdge, UnifiedGraphData, UnifiedNode } from "./graph-schema";
+import type {
+  AttackPath,
+  UnifiedEdge,
+  UnifiedGraphData,
+  UnifiedNode,
+} from "./graph-schema";
 import type { ExposurePath } from "./exposure-path";
 
 export type JobStatus = "pending" | "running" | "done" | "failed" | "cancelled";
@@ -103,7 +108,10 @@ export interface GraphAttackPath extends AttackPath {
   exposure_path?: ExposurePath | undefined;
 }
 
-export interface UnifiedGraphResponse extends Omit<UnifiedGraphData, "attack_paths"> {
+export interface UnifiedGraphResponse extends Omit<
+  UnifiedGraphData,
+  "attack_paths"
+> {
   attack_paths: GraphAttackPath[];
   pagination: GraphPagination;
 }
@@ -358,7 +366,8 @@ export interface GraphDiffResponse {
   edges_removed: [string, string, string][];
 }
 
-export type GraphExportFormat = "json" | "dot" | "mermaid" | "graphml" | "cypher";
+export type GraphExportFormat =
+  "json" | "dot" | "mermaid" | "graphml" | "cypher";
 
 export type DeploymentMode = "local" | "fleet" | "cluster" | "hybrid";
 
@@ -421,8 +430,10 @@ export interface RemediationItem {
   risk_narrative: string;
 }
 
-export type FindingTriageQueueState = "open" | "assigned" | "reviewing" | "decided";
-export type FindingTriageDecision = "not_affected" | "affected" | "under_investigation";
+export type FindingTriageQueueState =
+  "open" | "assigned" | "reviewing" | "decided";
+export type FindingTriageDecision =
+  "not_affected" | "affected" | "under_investigation";
 export type FindingTriageJustification =
   | "component_not_present"
   | "vulnerable_code_not_present"
@@ -1106,7 +1117,15 @@ export interface AuthPolicyResponse {
     active_override: boolean;
     override_endpoint: string;
     message: string;
-    overrides: Partial<Record<"active_scan_jobs" | "retained_scan_jobs" | "fleet_agents" | "schedules", number>>;
+    overrides: Partial<
+      Record<
+        | "active_scan_jobs"
+        | "retained_scan_jobs"
+        | "fleet_agents"
+        | "schedules",
+        number
+      >
+    >;
     usage: Record<
       "active_scan_jobs" | "retained_scan_jobs" | "fleet_agents" | "schedules",
       {
@@ -1188,7 +1207,8 @@ export interface AuthPolicyResponse {
   data_access_boundaries: DataAccessBoundaries;
 }
 
-export type ApiKeyLifecycleState = "active" | "rotation_overlap" | "rotated" | "revoked" | "expired";
+export type ApiKeyLifecycleState =
+  "active" | "rotation_overlap" | "rotated" | "revoked" | "expired";
 
 export interface ApiKeyRecord {
   key_id: string;
@@ -1598,21 +1618,52 @@ export interface ComplianceResponse {
   pci_dss: ComplianceControl[];
   aisvs_benchmark: AISVSComplianceResponse;
   summary: {
-    owasp_pass: number; owasp_warn: number; owasp_fail: number;
-    owasp_mcp_pass: number; owasp_mcp_warn: number; owasp_mcp_fail: number;
-    atlas_pass: number; atlas_warn: number; atlas_fail: number;
-    nist_pass: number;  nist_warn: number;  nist_fail: number;
-    owasp_agentic_pass: number; owasp_agentic_warn: number; owasp_agentic_fail: number;
-    eu_ai_act_pass: number; eu_ai_act_warn: number; eu_ai_act_fail: number;
-    nist_csf_pass: number; nist_csf_warn: number; nist_csf_fail: number;
-    iso_27001_pass: number; iso_27001_warn: number; iso_27001_fail: number;
-    soc2_pass: number; soc2_warn: number; soc2_fail: number;
-    cis_pass: number; cis_warn: number; cis_fail: number;
-    cmmc_pass: number; cmmc_warn: number; cmmc_fail: number;
-    nist_800_53_pass: number; nist_800_53_warn: number; nist_800_53_fail: number;
-    fedramp_pass: number; fedramp_warn: number; fedramp_fail: number;
-    pci_dss_pass: number; pci_dss_warn: number; pci_dss_fail: number;
-    aisvs_pass: number; aisvs_fail: number; aisvs_error: number; aisvs_not_applicable: number;
+    owasp_pass: number;
+    owasp_warn: number;
+    owasp_fail: number;
+    owasp_mcp_pass: number;
+    owasp_mcp_warn: number;
+    owasp_mcp_fail: number;
+    atlas_pass: number;
+    atlas_warn: number;
+    atlas_fail: number;
+    nist_pass: number;
+    nist_warn: number;
+    nist_fail: number;
+    owasp_agentic_pass: number;
+    owasp_agentic_warn: number;
+    owasp_agentic_fail: number;
+    eu_ai_act_pass: number;
+    eu_ai_act_warn: number;
+    eu_ai_act_fail: number;
+    nist_csf_pass: number;
+    nist_csf_warn: number;
+    nist_csf_fail: number;
+    iso_27001_pass: number;
+    iso_27001_warn: number;
+    iso_27001_fail: number;
+    soc2_pass: number;
+    soc2_warn: number;
+    soc2_fail: number;
+    cis_pass: number;
+    cis_warn: number;
+    cis_fail: number;
+    cmmc_pass: number;
+    cmmc_warn: number;
+    cmmc_fail: number;
+    nist_800_53_pass: number;
+    nist_800_53_warn: number;
+    nist_800_53_fail: number;
+    fedramp_pass: number;
+    fedramp_warn: number;
+    fedramp_fail: number;
+    pci_dss_pass: number;
+    pci_dss_warn: number;
+    pci_dss_fail: number;
+    aisvs_pass: number;
+    aisvs_fail: number;
+    aisvs_error: number;
+    aisvs_not_applicable: number;
   };
 }
 
@@ -1675,7 +1726,12 @@ export interface AgentLifecycleResponse {
   stats: Record<string, number>;
 }
 
-export type FleetLifecycleState = "discovered" | "pending_review" | "approved" | "quarantined" | "decommissioned";
+export type FleetLifecycleState =
+  | "discovered"
+  | "pending_review"
+  | "approved"
+  | "quarantined"
+  | "decommissioned";
 
 export interface FleetAgent {
   agent_id: string;
@@ -1887,7 +1943,8 @@ export interface GatewayPolicyRuntimeSummary {
   source: string;
   source_kind: string;
   enabled_policies: number;
-  rollout_mode: "disabled" | "advisory_only" | "mixed" | "default_deny" | "blocking";
+  rollout_mode:
+    "disabled" | "advisory_only" | "mixed" | "default_deny" | "blocking";
   summary: string;
   total_rules: number;
   blocking_rules: number;
@@ -1916,7 +1973,10 @@ export interface PostureResponse {
   grade: string;
   score: number;
   summary: string;
-  dimensions: Record<string, { score: number; label: string; details?: string }>;
+  dimensions: Record<
+    string,
+    { score: number; label: string; details?: string }
+  >;
 }
 
 // ─── Cross-domain overview (landing page) ────────────────────────────────────
@@ -2196,11 +2256,7 @@ export interface CostBreakdownRow {
  * forecast never blocks a call. Every projection field is nullable: a sparse or
  * empty history yields a clear `status` and `null` projections. */
 export type CostForecastStatus =
-  | "insufficient_history"
-  | "budget_exceeded"
-  | "no_budget"
-  | "stale"
-  | "ok";
+  "insufficient_history" | "budget_exceeded" | "no_budget" | "stale" | "ok";
 
 export interface CostForecast {
   schema_version: string;
@@ -2385,12 +2441,7 @@ export interface DriftIncidentsResponse {
 // All three are reference-only and never carry secret values.
 
 export type CredentialExpiryState =
-  | "overdue"
-  | "expired"
-  | "rotation_due"
-  | "near_expiry"
-  | "unknown_age"
-  | "ok";
+  "overdue" | "expired" | "rotation_due" | "near_expiry" | "unknown_age" | "ok";
 
 export interface CredentialExpiryItem {
   id: string | null;
@@ -2431,10 +2482,7 @@ export interface CredentialExpiryReport {
 }
 
 export type AccessReviewStatus =
-  | "open"
-  | "in_progress"
-  | "completed"
-  | "overdue";
+  "open" | "in_progress" | "completed" | "overdue";
 
 export interface AccessReviewCampaign {
   campaign_id: string;
@@ -2513,6 +2561,8 @@ export interface CloudConnectionRecord {
   created_at: string;
   updated_at: string;
   last_scan_at: string | null;
+  /** Non-secret provider-specific params (Azure tenant/subscription, GCP project, Snowflake user/role/warehouse). */
+  auth_params?: Record<string, string>;
 }
 
 export interface CloudConnectionsResponse {
@@ -2529,22 +2579,29 @@ export interface CloudConnectionCreateRequest {
   role_ref: string;
   external_id: string;
   regions: string[];
+  /** Non-secret provider-specific params. Never carries a secret (that is `external_id`). */
+  auth_params?: Record<string, string>;
 }
 
 export interface CloudConnectionScanInventory {
   provider: string;
-  account: string | null;
-  region: string;
-  resource_count: number;
-  identity_count: number;
-  node_summary: {
+  /** Present for AWS/Azure/GCP; "ok" for Snowflake. */
+  status?: string;
+  account?: string | null;
+  region?: string;
+  /** AWS/Azure/GCP estate-inventory counts. */
+  resource_count?: number;
+  identity_count?: number;
+  node_summary?: {
     buckets: number;
     instances: number;
     security_groups: number;
     roles: number;
     users: number;
   };
-  warnings: string[];
+  /** Snowflake discovery count (Cortex/MCP agents). */
+  agent_count?: number;
+  warnings?: string[];
 }
 
 export interface CloudConnectionScanCis {
@@ -2556,7 +2613,7 @@ export interface CloudConnectionScanCis {
   pass_rate: number | null;
 }
 
-/** Response from `POST /v1/cloud/connections/{id}/scan` (AWS today). */
+/** Response from `POST /v1/cloud/connections/{id}/scan` (AWS, Azure, GCP, Snowflake). */
 export interface CloudConnectionScanResponse {
   schema_version: string;
   connection_id: string;

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -14,16 +14,28 @@ const { apiMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("next/link", () => ({
-  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+  default: ({
+    href,
+    children,
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => <a href={href}>{children}</a>,
 }));
 
 vi.mock("@/components/auth-provider", () => ({
   useAuthState: () => ({
-    session: { authenticated: true, auth_required: true, tenant_id: "tenant-acme", role: "analyst" },
+    session: {
+      authenticated: true,
+      auth_required: true,
+      tenant_id: "tenant-acme",
+      role: "analyst",
+    },
     loading: false,
     error: null,
     refresh: vi.fn(),
-    hasCapability: (capability: string) => ["inventory.read", "scan.run"].includes(capability),
+    hasCapability: (capability: string) =>
+      ["inventory.read", "scan.run"].includes(capability),
   }),
 }));
 
@@ -65,12 +77,26 @@ describe("ConnectionsPage", () => {
     apiMock.createCloudConnection.mockResolvedValue(CREATED_RECORD);
     // After create, the list refresh returns the new connection.
     apiMock.listCloudConnections
-      .mockResolvedValueOnce({ schema_version: "cloud.connections.v1", tenant_id: "tenant-acme", connections: [], count: 0 })
-      .mockResolvedValue({ schema_version: "cloud.connections.v1", tenant_id: "tenant-acme", connections: [CREATED_RECORD], count: 1 });
+      .mockResolvedValueOnce({
+        schema_version: "cloud.connections.v1",
+        tenant_id: "tenant-acme",
+        connections: [],
+        count: 0,
+      })
+      .mockResolvedValue({
+        schema_version: "cloud.connections.v1",
+        tenant_id: "tenant-acme",
+        connections: [CREATED_RECORD],
+        count: 1,
+      });
 
     render(<ConnectionsPage />);
 
-    await waitFor(() => expect(screen.getByText("No cloud accounts connected")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(
+        screen.getByText("No cloud accounts connected"),
+      ).toBeInTheDocument(),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Add cloud account" }));
     // Step 0 -> 1 -> 2. Advancing must NOT trigger a premature form submit.
@@ -79,14 +105,20 @@ describe("ConnectionsPage", () => {
     expect(screen.queryByText("A display name is required.")).toBeNull();
     expect(apiMock.createCloudConnection).not.toHaveBeenCalled();
 
-    fireEvent.change(screen.getByPlaceholderText("Production account"), { target: { value: "Production account" } });
+    fireEvent.change(screen.getByPlaceholderText("Production account"), {
+      target: { value: "Production account" },
+    });
     fireEvent.change(screen.getByPlaceholderText(/arn:aws:iam/), {
       target: { value: "arn:aws:iam::123456789012:role/agent-bom-readonly" },
     });
-    const secretInput = screen.getByPlaceholderText("••••••••••••") as HTMLInputElement;
+    const secretInput = screen.getByPlaceholderText(
+      "••••••••••••",
+    ) as HTMLInputElement;
     expect(secretInput.type).toBe("password");
     fireEvent.change(secretInput, { target: { value: SECRET } });
-    fireEvent.change(screen.getByPlaceholderText("us-east-1, us-west-2"), { target: { value: "us-east-1" } });
+    fireEvent.change(screen.getByPlaceholderText("us-east-1, us-west-2"), {
+      target: { value: "us-east-1" },
+    });
 
     fireEvent.click(screen.getByRole("button", { name: "Create connection" }));
 
@@ -97,16 +129,68 @@ describe("ConnectionsPage", () => {
         role_ref: "arn:aws:iam::123456789012:role/agent-bom-readonly",
         external_id: SECRET,
         regions: ["us-east-1"],
+        // AWS has no provider-specific params, so auth_params is an empty map.
+        auth_params: {},
       }),
     );
 
     // New connection shows up in the list with the "secret configured" affordance.
-    await waitFor(() => expect(screen.getByText("Production account")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText("Production account")).toBeInTheDocument(),
+    );
     expect(screen.getByText("Secret configured")).toBeInTheDocument();
 
     // The plaintext secret must not be present anywhere in the rendered DOM.
     expect(document.body.textContent).not.toContain(SECRET);
     expect(document.querySelector(`input[value="${SECRET}"]`)).toBeNull();
+  });
+
+  it("maps provider-specific GCP fields to role_ref / external_id / auth_params", async () => {
+    apiMock.createCloudConnection.mockResolvedValue({
+      ...CREATED_RECORD,
+      provider: "gcp",
+    });
+
+    render(<ConnectionsPage />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("No cloud accounts connected"),
+      ).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Add cloud account" }));
+    // Step 0: choose GCP, then advance to the details step.
+    fireEvent.click(screen.getByRole("button", { name: /Google Cloud/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Next/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Next/ }));
+
+    fireEvent.change(screen.getByPlaceholderText("Production account"), {
+      target: { value: "GCP prod" },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/gserviceaccount\.com/), {
+      target: { value: "agent-bom@proj.iam.gserviceaccount.com" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("my-project-123"), {
+      target: { value: "proj-123" },
+    });
+    const keyInput = screen.getByPlaceholderText(
+      "Paste the service-account key JSON",
+    ) as HTMLTextAreaElement;
+    fireEvent.change(keyInput, { target: { value: SECRET } });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create connection" }));
+
+    await waitFor(() =>
+      expect(apiMock.createCloudConnection).toHaveBeenCalledWith({
+        provider: "gcp",
+        display_name: "GCP prod",
+        role_ref: "agent-bom@proj.iam.gserviceaccount.com",
+        external_id: SECRET,
+        regions: [],
+        auth_params: { project_id: "proj-123" },
+      }),
+    );
   });
 
   it("runs a read-only scan and shows inventory counts + CIS pass rate", async () => {
@@ -128,22 +212,49 @@ describe("ConnectionsPage", () => {
         region: "us-east-1",
         resource_count: 42,
         identity_count: 7,
-        node_summary: { buckets: 3, instances: 5, security_groups: 4, roles: 6, users: 1 },
+        node_summary: {
+          buckets: 3,
+          instances: 5,
+          security_groups: 4,
+          roles: 6,
+          users: 1,
+        },
         warnings: [],
       },
-      cis_benchmark: { benchmark: "CIS AWS", benchmark_version: "1.5", passed: 30, failed: 10, total: 40, pass_rate: 0.75 },
-      audit_metadata: { read_only: true, writes_performed: false, note: "Read-only scan." },
-      connection: { ...CREATED_RECORD, status: "active", last_scan_at: "2026-06-27T01:00:00Z" },
+      cis_benchmark: {
+        benchmark: "CIS AWS",
+        benchmark_version: "1.5",
+        passed: 30,
+        failed: 10,
+        total: 40,
+        pass_rate: 0.75,
+      },
+      audit_metadata: {
+        read_only: true,
+        writes_performed: false,
+        note: "Read-only scan.",
+      },
+      connection: {
+        ...CREATED_RECORD,
+        status: "active",
+        last_scan_at: "2026-06-27T01:00:00Z",
+      },
     });
 
     render(<ConnectionsPage />);
 
-    await waitFor(() => expect(screen.getByText("Production account")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText("Production account")).toBeInTheDocument(),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Scan now" }));
 
-    await waitFor(() => expect(apiMock.scanCloudConnection).toHaveBeenCalledWith("conn-1"));
-    await waitFor(() => expect(screen.getByText("Read-only scan complete")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(apiMock.scanCloudConnection).toHaveBeenCalledWith("conn-1"),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Read-only scan complete")).toBeInTheDocument(),
+    );
 
     expect(screen.getByText("42")).toBeInTheDocument(); // resources
     expect(screen.getByText("7")).toBeInTheDocument(); // identities
@@ -153,16 +264,36 @@ describe("ConnectionsPage", () => {
 
   it("deletes a connection through the API", async () => {
     apiMock.listCloudConnections
-      .mockResolvedValueOnce({ schema_version: "cloud.connections.v1", tenant_id: "tenant-acme", connections: [CREATED_RECORD], count: 1 })
-      .mockResolvedValue({ schema_version: "cloud.connections.v1", tenant_id: "tenant-acme", connections: [], count: 0 });
+      .mockResolvedValueOnce({
+        schema_version: "cloud.connections.v1",
+        tenant_id: "tenant-acme",
+        connections: [CREATED_RECORD],
+        count: 1,
+      })
+      .mockResolvedValue({
+        schema_version: "cloud.connections.v1",
+        tenant_id: "tenant-acme",
+        connections: [],
+        count: 0,
+      });
     apiMock.deleteCloudConnection.mockResolvedValue(undefined);
 
     render(<ConnectionsPage />);
 
-    await waitFor(() => expect(screen.getByText("Production account")).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText("Production account")).toBeInTheDocument(),
+    );
 
-    fireEvent.click(screen.getByRole("button", { name: /Delete Production account/ }));
-    await waitFor(() => expect(apiMock.deleteCloudConnection).toHaveBeenCalledWith("conn-1"));
-    await waitFor(() => expect(screen.getByText("No cloud accounts connected")).toBeInTheDocument());
+    fireEvent.click(
+      screen.getByRole("button", { name: /Delete Production account/ }),
+    );
+    await waitFor(() =>
+      expect(apiMock.deleteCloudConnection).toHaveBeenCalledWith("conn-1"),
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByText("No cloud accounts connected"),
+      ).toBeInTheDocument(),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Extends the cloud Connections plane so a stored connection can launch a read-only scan for all four providers. AWS already shipped; this adds Azure, GCP, and Snowflake credential brokers and wires them end-to-end (model → SQLite/Postgres DDL → broker → discover injection → route → scheduler → UI → tests → docs).

## Credential model

A new non-secret `auth_params` JSON column on `cloud_connections` carries provider-specific parameters. The single reversible secret per connection stays in the encrypted `external_id`; it is decrypted only at broker time, cleared after use, and never logged or returned.

- **AWS** (unchanged): `role_ref`=role ARN, secret=ExternalId, `auth_params`={}.
- **Azure**: `role_ref`=client id, secret=client secret, `auth_params`={tenant_id, subscription_id} → `ClientSecretCredential` (Reader).
- **GCP**: `role_ref`=service-account email, secret=SA key JSON, `auth_params`={project_id} → `service_account.Credentials` scoped to `cloud-platform.read-only`.
- **Snowflake**: `role_ref`=account, secret=PEM private key, `auth_params`={user, role, warehouse} → key-pair `snowflake.connector` connection.

## Changes

- **Broker** (`connection_broker.py`): `_broker_azure` / `_broker_gcp` / `_broker_snowflake` with lazy SDK imports and clear `install agent-bom[<extra>]` messages; fail-closed `ConnectionBrokerError` carrying only the connection id + failure mode.
- **Store**: idempotent `auth_params` migration in both `connection_store.py` (SQLite) and `postgres_connection.py` (check-if-exists, default `'{}'`, legacy rows backfilled); `to_public_dict()` surfaces `auth_params`, still excludes the secret.
- **Discover injection**: brokered credential threaded into `azure_inventory` + Azure CIS, `gcp_inventory` + GCP CIS (`credentials=`), and a new injected-`conn=` path on `snowflake.discover` + Snowflake CIS (env path preserved as the default; an injected connection is not closed by the callee).
- **Route**: per-provider scan runners dispatched by provider; persist through the existing scan/graph stores; status detail capped and secret-free. The 501 "planned" path is removed.
- **Scheduler**: all four providers are now schedulable and run via the provider dispatcher.
- **UI** (`connections/page.tsx`): the Add Cloud Account wizard renders provider-specific fields mapped to `role_ref` / `external_id` (write-only) / `auth_params`; all providers scannable. `npm run build` + `bundle:check` pass within budget (no bump needed).
- **Docs**: broker + route docstrings updated; OpenAPI spec regenerated; CHANGELOG entry added.

## Tests

Per-provider broker success + fail-closed (asserting the secret never appears in the error), per-provider route scan success + persistence, SDK-missing clean error, and the `auth_params` migration/round-trip. `tests/test_cloud_connections.py` + `tests/test_connection_scheduler.py`: 90 passed. Pre-commit (ruff format/check, mypy, bandit, prettier) clean.

## Decisions / risks

- Brokered GCP credentials use the read-only `cloud-platform.read-only` scope so they are structurally incapable of a write.
- The Snowflake scan opens one brokered key-pair connection, threads it into both discovery and CIS, and closes it in the route's `finally`.
- `external_id` max length raised 1024 → 8192 to fit a GCP service-account key JSON.
- Read-only posture throughout; no write/mutating cloud calls; no secret in any response, log, or error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)