### PR TITLE
feat(graph): repo folder/file structure layer — directory tree, file→dependency→vuln paths, roll-up

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -42,7 +42,7 @@ is wired into the docs site so drift produces a visible regression.
 | `TransportType` | 4 | `stdio`, `sse`, `streamable-http`, `unknown` |
 | `ServerSurface` | 10 | `mcp-server`, `container-image`, `oci-tarball`, `filesystem`, `sbom`, `external-scan`, `os-packages`, `sast`, `ai-inventory`, `other` |
 | `AgentStatus` | 2 | `configured`, `installed-not-configured` |
-| `EntityType` | 39 | `agent`, `server`, `package`, `tool`, `tool_call`, `model`, `dataset`, `container`, `cloud_resource`, `resource`, `source_file`, `code_module`, `config_file`, `external_import`, `ci_job`, `vulnerability`, `misconfiguration`, `credential`, `credential_ref`, `org`, `account`, `user`, `group`, `role`, `policy`, `service_account`, `service_principal`, `federated_identity`, `managed_identity`, `access_grant`, `access_policy`, `drift_incident`, `data_store`, `api_gateway`, `application`, `provider`, `environment`, `fleet`, `cluster` |
+| `EntityType` | 40 | `agent`, `server`, `package`, `tool`, `tool_call`, `model`, `dataset`, `container`, `cloud_resource`, `resource`, `source_file`, `code_module`, `config_file`, `external_import`, `ci_job`, `directory`, `vulnerability`, `misconfiguration`, `credential`, `credential_ref`, `org`, `account`, `user`, `group`, `role`, `policy`, `service_account`, `service_principal`, `federated_identity`, `managed_identity`, `access_grant`, `access_policy`, `drift_incident`, `data_store`, `api_gateway`, `application`, `provider`, `environment`, `fleet`, `cluster` |
 | `RelationshipType` | 47 | `hosts`, `uses`, `depends_on`, `provides_tool`, `exposes_cred`, `reaches_tool`, `serves_model`, `contains`, `imports`, `defines`, `runs`, `configures`, `affects`, `vulnerable_to`, `exploitable_via`, `remediates`, `triggers`, `shares_server`, `shares_cred`, `lateral_path`, `manages`, `owns`, `part_of`, `member_of`, `assumes`, `trusts`, `attached`, `inherits`, `can_access`, `cross_account_trust`, `authenticates_as`, `scoped_to`, `governs`, `exhibits_drift`, `exposed_to`, `stores`, `has_permission`, `protects`, `acted_as`, `invoked`, `called`, `used_credential`, `accessed`, `delegated_to`, `correlates_with`, `possibly_correlates_with`, `belongs_to` |
 
 ### Live Schema Cross-Checks
@@ -127,16 +127,27 @@ Used for unified findings outside the SCA / blast-radius path
 The unified graph projects the canonical model into a node/edge form
 used for blast-radius traversal, dashboards, and OCSF export.
 
-### Entity types (39)
+### Entity types (40)
 
 `AGENT`, `SERVER`, `PACKAGE`, `TOOL`, `TOOL_CALL`, `MODEL`, `DATASET`,
 `CONTAINER`, `CLOUD_RESOURCE`, `RESOURCE`, `SOURCE_FILE`, `CODE_MODULE`,
-`CONFIG_FILE`, `EXTERNAL_IMPORT`, `CI_JOB`, `VULNERABILITY`,
+`CONFIG_FILE`, `EXTERNAL_IMPORT`, `DIRECTORY`, `CI_JOB`, `VULNERABILITY`,
 `MISCONFIGURATION`, `CREDENTIAL`, `CREDENTIAL_REF`, `ORG`, `ACCOUNT`,
 `USER`, `GROUP`, `ROLE`, `POLICY`, `SERVICE_ACCOUNT`, `SERVICE_PRINCIPAL`,
 `FEDERATED_IDENTITY`, `MANAGED_IDENTITY`, `ACCESS_GRANT`, `ACCESS_POLICY`,
 `DRIFT_INCIDENT`, `DATA_STORE`, `API_GATEWAY`, `APPLICATION`, `PROVIDER`,
 `ENVIRONMENT`, `FLEET`, `CLUSTER`.
+
+`DIRECTORY` is the repository folder/file-structure backbone — materialised by
+the repo-structure overlay from the project inventory, each directory and its
+ancestors become a `DIRECTORY` node linked `CONTAINS` parent → child (repo root
+→ sub-directory → file). Manifest / lockfile files become `CONFIG_FILE` nodes
+the directory `CONTAINS`; the representative manifest is linked `DEPENDS_ON` to
+the direct packages it declares so a vulnerability is traceable back through its
+package to the file and folder that introduced it, and file-scoped findings are
+placed under their folder (`AFFECTS` finding → file). The estate roll-up
+collapses deep source trees along these `CONTAINS` edges the same way it
+collapses the cloud `org → account → resource` hierarchy.
 
 `DATA_STORE` is a cloud-CNAPP primitive — a database / bucket / lake / warehouse
 holding data at rest, derived from cloud resources so path-to-sensitive-data is

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -2208,17 +2208,9 @@ _SHAPE_TO_ICON: dict[str, str] = {
 
 
 _RESERVED_GRAPH_NODE_KINDS: dict[str, tuple[list[str], str]] = {
-    EntityType.SOURCE_FILE.value: (
-        ["code_graph"],
-        "Reserved for source-code topology; static supply-chain scans do not emit file-level nodes yet.",
-    ),
     EntityType.CODE_MODULE.value: (
         ["code_graph"],
         "Reserved for source-code topology; static supply-chain scans do not emit module-level nodes yet.",
-    ),
-    EntityType.CONFIG_FILE.value: (
-        ["code_graph"],
-        "Reserved for configuration topology; static supply-chain scans do not emit config-file nodes yet.",
     ),
     EntityType.EXTERNAL_IMPORT.value: (
         ["code_graph"],
@@ -2266,6 +2258,11 @@ _RESERVED_GRAPH_EDGE_KINDS: dict[str, tuple[list[str], str]] = {
 _EMITTED_GRAPH_NODE_SURFACES: dict[str, list[str]] = {
     EntityType.TOOL_CALL.value: ["runtime_proxy", "gateway_event_projection"],
     EntityType.RESOURCE.value: ["runtime_proxy", "gateway_event_projection", "cnapp_overlay"],
+    # Repository folder/file-structure nodes emitted by the repo-structure
+    # overlay for a code / project scan (directory tree + manifest files).
+    EntityType.DIRECTORY.value: ["repo_structure_overlay"],
+    EntityType.SOURCE_FILE.value: ["repo_structure_overlay"],
+    EntityType.CONFIG_FILE.value: ["repo_structure_overlay"],
 }
 
 
@@ -2327,7 +2324,12 @@ _RELATIONSHIP_SCHEMA_META: dict[str, dict[str, object]] = {
     RelationshipType.DEPENDS_ON.value: {
         "category": "inventory",
         "direction": "directed",
-        "source_types": [EntityType.SERVER.value, EntityType.CONTAINER.value],
+        "source_types": [
+            EntityType.SERVER.value,
+            EntityType.CONTAINER.value,
+            EntityType.CONFIG_FILE.value,
+            EntityType.SOURCE_FILE.value,
+        ],
         "target_types": [EntityType.PACKAGE.value],
         "traversable": True,
     },
@@ -2362,8 +2364,20 @@ _RELATIONSHIP_SCHEMA_META: dict[str, dict[str, object]] = {
     RelationshipType.CONTAINS.value: {
         "category": "inventory",
         "direction": "directed",
-        "source_types": [EntityType.CONTAINER.value, EntityType.CLUSTER.value, EntityType.FLEET.value],
-        "target_types": [EntityType.PACKAGE.value, EntityType.SERVER.value, EntityType.CONTAINER.value],
+        "source_types": [
+            EntityType.CONTAINER.value,
+            EntityType.CLUSTER.value,
+            EntityType.FLEET.value,
+            EntityType.DIRECTORY.value,
+        ],
+        "target_types": [
+            EntityType.PACKAGE.value,
+            EntityType.SERVER.value,
+            EntityType.CONTAINER.value,
+            EntityType.DIRECTORY.value,
+            EntityType.SOURCE_FILE.value,
+            EntityType.CONFIG_FILE.value,
+        ],
         "traversable": True,
     },
     RelationshipType.IMPORTS.value: {
@@ -2398,7 +2412,13 @@ _RELATIONSHIP_SCHEMA_META: dict[str, dict[str, object]] = {
         "category": "vulnerability",
         "direction": "directed",
         "source_types": [EntityType.VULNERABILITY.value, EntityType.MISCONFIGURATION.value],
-        "target_types": [EntityType.PACKAGE.value, EntityType.SERVER.value, EntityType.CONTAINER.value],
+        "target_types": [
+            EntityType.PACKAGE.value,
+            EntityType.SERVER.value,
+            EntityType.CONTAINER.value,
+            EntityType.SOURCE_FILE.value,
+            EntityType.CONFIG_FILE.value,
+        ],
         "traversable": True,
     },
     RelationshipType.VULNERABLE_TO.value: {

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1085,6 +1085,19 @@ def build_unified_graph_from_report(
     except Exception:  # noqa: BLE001
         _logger.warning("ASPM overlay failed", exc_info=True)
 
+    # Repository folder/file structure: materialise the directory tree, manifest
+    # files, file → dependency → vuln paths, and file → finding paths from the
+    # project inventory + file-scoped findings already in the report, so a code
+    # / repo scan visualises its folder layout the way the cloud graph
+    # visualises the cloud hierarchy. Runs after the inventory + ASPM overlays so
+    # the project servers, packages, and misconfiguration nodes it stitches onto
+    # already exist. No-op (graph byte-identical) when no project inventory and
+    # no file-scoped findings are present.
+    try:
+        _apply_repo_structure_overlay(graph, report_json)
+    except Exception:  # noqa: BLE001
+        _logger.warning("repo-structure overlay failed", exc_info=True)
+
     if span is not None:
         span.set_attribute("agent_bom.graph.scan_id", sid)
         span.set_attribute("agent_bom.graph.tenant_id", tenant_id or "default")
@@ -1139,6 +1152,30 @@ def _apply_aspm_overlay(graph: UnifiedGraph, report_json: Mapping[str, Any]) -> 
     from agent_bom.graph.aspm_overlay import apply_aspm_overlay
 
     apply_aspm_overlay(graph, dict(report_json), datetime.now(timezone.utc))
+
+
+def _apply_repo_structure_overlay(graph: UnifiedGraph, report_json: Mapping[str, Any]) -> None:
+    """Materialise the repository folder/file structure into the graph.
+
+    Reads the optional ``project_inventory`` block (the directory tree + per-
+    directory manifest / lockfile / declaration files the project scanner already
+    emits) and hands it to
+    :func:`agent_bom.graph.repo_structure_overlay.apply_repo_structure_overlay`,
+    which builds ``DIRECTORY`` nodes with ``CONTAINS`` edges, attaches manifest
+    ``CONFIG_FILE`` nodes, links each manifest to the direct packages it declares
+    (file → package → vuln), and places file-scoped findings under their folder
+    (finding → file). Gated to a clean no-op when neither a project inventory nor
+    a file-scoped finding is present, so an unrelated scan leaves the graph
+    byte-identical. Mirrors how ``_apply_aspm_overlay`` is invoked above.
+    """
+    has_inventory = isinstance(report_json.get("project_inventory"), Mapping)
+    if not has_inventory and not any(node.entity_type == EntityType.MISCONFIGURATION for node in graph.nodes.values()):
+        return
+    from datetime import datetime, timezone
+
+    from agent_bom.graph.repo_structure_overlay import apply_repo_structure_overlay
+
+    apply_repo_structure_overlay(graph, dict(report_json), datetime.now(timezone.utc))
 
 
 def _iter_agentic_identity_graph_projections(report_json: Mapping[str, Any]) -> list[Mapping[str, Any]]:

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -862,6 +862,7 @@ ENTITY_LEGEND: list[LegendEntry] = [
     LegendEntry(key="container", label="Container", color="#6366f1", shape="square", layer=GraphSemanticLayer.INFRA.value),
     LegendEntry(key="cloud_resource", label="Cloud Resource", color="#0ea5e9", shape="square", layer=GraphSemanticLayer.INFRA.value),
     LegendEntry(key="resource", label="Resource", color="#38bdf8", shape="square", layer=GraphSemanticLayer.ASSET.value),
+    LegendEntry(key="directory", label="Directory", color="#0d9488", shape="square", layer=GraphSemanticLayer.CODE.value),
     LegendEntry(key="source_file", label="Source File", color="#22d3ee", shape="square", layer=GraphSemanticLayer.CODE.value),
     LegendEntry(key="code_module", label="Code Module", color="#06b6d4", shape="circle", layer=GraphSemanticLayer.CODE.value),
     LegendEntry(key="config_file", label="Config File", color="#f97316", shape="square", layer=GraphSemanticLayer.CODE.value),

--- a/src/agent_bom/graph/ocsf.py
+++ b/src/agent_bom/graph/ocsf.py
@@ -30,6 +30,7 @@ ENTITY_OCSF_MAP: dict[str, dict[str, int]] = {
     EntityType.CODE_MODULE: {"category_uid": 5, "class_uid": 4001},
     EntityType.CONFIG_FILE: {"category_uid": 5, "class_uid": 4001},
     EntityType.EXTERNAL_IMPORT: {"category_uid": 5, "class_uid": 4001},
+    EntityType.DIRECTORY: {"category_uid": 5, "class_uid": 4001},
     EntityType.CI_JOB: {"category_uid": 5, "class_uid": 4001},
     EntityType.CREDENTIAL: {"category_uid": 5, "class_uid": 4001},
     EntityType.CREDENTIAL_REF: {"category_uid": 5, "class_uid": 4001},

--- a/src/agent_bom/graph/repo_structure_overlay.py
+++ b/src/agent_bom/graph/repo_structure_overlay.py
@@ -1,0 +1,380 @@
+"""Repository folder/file structure overlay.
+
+A code / project scan (``agent-bom agents -p .`` or ``--repo``) already discovers
+manifests, lockfiles, packages, and file-scoped findings — but the graph stored
+them as a flat ``server → package → vulnerability`` fan-out with no notion of the
+*folder structure* the code actually lives in. The cloud graph, by contrast,
+renders a readable ``org → account → resource`` containment tree. This overlay
+closes that gap for repositories: it materialises the **directory tree** as
+first-class graph nodes so a repository scan visualises its folder/file layout,
+its file → dependency → vulnerability paths, and its file → finding paths the
+same way the cloud graph visualises cloud architecture.
+
+It is a pure, in-place, additive correlation layer over data the report already
+carries — it adds **no scanners** and makes **no network calls**:
+
+- **Directory tree** — from ``project_inventory.directories`` (each carries a
+  repo-relative ``path`` plus its manifest / lockfile / declaration files), every
+  directory and its ancestors become a ``DIRECTORY`` node, linked
+  ``CONTAINS`` parent → child so the existing server-side CONTAINS roll-up
+  collapses deep trees exactly as it does for the cloud hierarchy.
+- **Manifest / config files** — each manifest, lockfile, and declaration file
+  becomes a ``CONFIG_FILE`` node ``CONTAINS``-ed by its directory.
+- **file → dependency → vuln** — the representative manifest of a directory is
+  linked ``DEPENDS_ON`` to the *direct* packages discovered for that directory
+  (resolved via the existing project ``SERVER`` node whose label is the
+  directory path), so a viewer can trace a vulnerability back through its
+  package to the manifest file and folder that introduced it.
+- **file → finding** — every existing ``MISCONFIGURATION`` node that names a
+  source/config file (SAST / IaC / secrets findings carry a file path) gets a
+  ``SOURCE_FILE`` / ``CONFIG_FILE`` node placed in the tree, linked
+  ``AFFECTS`` finding → file, so a finding is locatable by folder.
+
+The overlay is **idempotent** (applying twice yields identical nodes / edges),
+**deterministic** (every iteration is sorted), and a complete **no-op** (graph
+byte-identical) when the report carries no ``project_inventory`` and no
+file-scoped findings.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+from typing import Any
+
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import NodeDimensions, UnifiedNode
+from agent_bom.graph.types import EntityType, GraphSemanticLayer, RelationshipType
+
+_OVERLAY_SOURCE = "repo-structure-overlay"
+
+# Source-code file extensions → SOURCE_FILE; everything else placed in the tree
+# (manifests, lockfiles, yaml/json/toml config) is a CONFIG_FILE. Conservative:
+# anything not recognised as code is treated as config.
+_CODE_EXTENSIONS = frozenset(
+    {
+        "py",
+        "pyi",
+        "js",
+        "jsx",
+        "ts",
+        "tsx",
+        "mjs",
+        "cjs",
+        "go",
+        "rs",
+        "rb",
+        "java",
+        "kt",
+        "kts",
+        "scala",
+        "c",
+        "cc",
+        "cpp",
+        "h",
+        "hpp",
+        "cs",
+        "php",
+        "swift",
+        "m",
+        "sh",
+        "bash",
+    }
+)
+
+# Misconfiguration-node attribute keys that carry the file a finding is about.
+_FILE_PATH_ATTRS = ("file_path", "path", "source_file")
+
+
+def _zero() -> dict[str, int]:
+    return {
+        "directories": 0,
+        "files": 0,
+        "contains_edges": 0,
+        "file_package_edges": 0,
+        "file_finding_edges": 0,
+    }
+
+
+def _norm_path(raw: Any) -> str:
+    """Normalise a repo-relative path: forward slashes, no ``./`` / trailing ``/``.
+
+    The repo root (``""`` or ``"."``) normalises to ``""`` so it is the single
+    tree root regardless of how the inventory or a finding spelled it.
+    """
+    if not isinstance(raw, str):
+        return ""
+    text = raw.strip().replace("\\", "/")
+    while text.startswith("./"):
+        text = text[2:]
+    text = text.strip("/")
+    return "" if text == "." else text
+
+
+def _dir_node_id(dir_path: str) -> str:
+    return "directory:." if dir_path == "" else f"directory:{dir_path}"
+
+
+def _file_node_id(file_path: str, entity_type: EntityType) -> str:
+    return f"{entity_type.value}:{file_path}"
+
+
+def _dir_label(dir_path: str) -> str:
+    return "." if dir_path == "" else dir_path.rsplit("/", 1)[-1]
+
+
+def _parent_dir(dir_path: str) -> str:
+    return dir_path.rsplit("/", 1)[0] if "/" in dir_path else ""
+
+
+def _ancestors(dir_path: str) -> list[str]:
+    """Every ancestor directory of *dir_path*, including itself and the root."""
+    chain: list[str] = [""]
+    if dir_path == "":
+        return chain
+    parts = dir_path.split("/")
+    for i in range(1, len(parts) + 1):
+        chain.append("/".join(parts[:i]))
+    return chain
+
+
+def _file_dir(file_path: str) -> str:
+    return file_path.rsplit("/", 1)[0] if "/" in file_path else ""
+
+
+def _file_entity_type(file_path: str) -> EntityType:
+    name = file_path.rsplit("/", 1)[-1]
+    ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
+    return EntityType.SOURCE_FILE if ext in _CODE_EXTENSIONS else EntityType.CONFIG_FILE
+
+
+def _looks_like_path(value: Any) -> bool:
+    """True when *value* is a concrete repo file path (not a placeholder/blank).
+
+    Rejects the redacted ``project <redacted>`` asset locations and bare names
+    with no extension and no separator so we never invent a tree from noise.
+    """
+    if not isinstance(value, str):
+        return False
+    text = value.strip()
+    if not text or text.startswith("project ") or "<" in text:
+        return False
+    return "/" in text or "." in text
+
+
+def apply_repo_structure_overlay(
+    graph: UnifiedGraph,
+    report_json: dict[str, Any],
+    now: datetime,
+) -> dict[str, int]:
+    """Materialise the repository folder/file structure into the graph, in place.
+
+    Args:
+        graph: the unified graph to enrich (mutated in place). Runs after the
+            inventory builder so the project ``SERVER`` and ``PACKAGE`` nodes a
+            directory's files link to already exist.
+        report_json: the persisted AIBOM report JSON contract. Reads the optional
+            ``project_inventory`` block (directory tree + per-directory manifest
+            files) and consults existing ``MISCONFIGURATION`` nodes for file
+            paths. Never fetched here.
+        now: reference time for the created nodes' timestamps (no inline
+            ``datetime.now`` — determinism / testability).
+
+    Returns counts of directories, files, and the three edge classes created. A
+    complete no-op (all-zero, graph untouched) when neither a project inventory
+    nor a file-scoped finding is present.
+    """
+    counts = _zero()
+    now_iso = now.isoformat()
+
+    project_inventory = report_json.get("project_inventory") if isinstance(report_json, dict) else None
+    directories = project_inventory.get("directories") if isinstance(project_inventory, dict) else None
+    directory_records: dict[str, dict[str, Any]] = {}
+    if isinstance(directories, list):
+        for record in directories:
+            if isinstance(record, dict) and isinstance(record.get("path"), str):
+                directory_records[_norm_path(record.get("path"))] = record
+
+    # ── Index existing graph state we stitch onto ───────────────────────────
+    # Project SERVER nodes are keyed in the graph by their directory-path label
+    # for a local/repo scan (label "" == repo root). Map dir path → packages it
+    # depends on so a manifest file can be linked to the deps it declares.
+    server_by_dir: dict[str, str] = {}
+    for node in graph.nodes.values():
+        if node.entity_type == EntityType.SERVER:
+            server_by_dir.setdefault(_norm_path(node.label), node.id)
+    deps_by_server: dict[str, list[str]] = defaultdict(list)
+    for edge in graph.edges:
+        if edge.relationship == RelationshipType.DEPENDS_ON and edge.source in graph.nodes:
+            deps_by_server[edge.source].append(edge.target)
+
+    # ── Collect every directory that needs a node (records + their ancestors +
+    #    the directories that finding-file paths live in) ─────────────────────
+    needed_dirs: set[str] = set()
+    for dir_path in directory_records:
+        needed_dirs.update(_ancestors(dir_path))
+
+    # File-scoped findings: map an existing misconfiguration node → the file it
+    # names, so we can both create the file node and link finding → file.
+    finding_files: dict[str, str] = {}  # misconfig_node_id -> normalised file path
+    for node in graph.nodes.values():
+        if node.entity_type != EntityType.MISCONFIGURATION:
+            continue
+        attrs = node.attributes or {}
+        raw_path = next((attrs.get(key) for key in _FILE_PATH_ATTRS if _looks_like_path(attrs.get(key))), None)
+        if raw_path is None:
+            continue
+        file_path = _norm_path(raw_path)
+        if not file_path:
+            continue
+        finding_files[node.id] = file_path
+        needed_dirs.update(_ancestors(_file_dir(file_path)))
+
+    if not needed_dirs:
+        return counts
+
+    # ── 1. Directory nodes ──────────────────────────────────────────────────
+    for dir_path in sorted(needed_dirs):
+        node_id = _dir_node_id(dir_path)
+        if node_id not in graph.nodes:
+            counts["directories"] += 1
+        record = directory_records.get(dir_path, {})
+        graph.add_node(
+            UnifiedNode(
+                id=node_id,
+                entity_type=EntityType.DIRECTORY,
+                label=_dir_label(dir_path),
+                first_seen=now_iso,
+                last_seen=now_iso,
+                attributes={
+                    "path": dir_path or ".",
+                    "is_repo_root": dir_path == "",
+                    "package_count": record.get("package_count", 0),
+                    "direct_packages": record.get("direct_packages", 0),
+                    "ecosystems": record.get("ecosystems", {}),
+                    "advisory_evidence": record.get("advisory_evidence", ""),
+                },
+                data_sources=[_OVERLAY_SOURCE],
+                dimensions=NodeDimensions(surface=GraphSemanticLayer.CODE.value),
+            )
+        )
+
+    # ── 2. CONTAINS edges: parent directory → child directory ───────────────
+    for dir_path in sorted(needed_dirs):
+        if dir_path == "":
+            continue
+        graph.add_edge(
+            UnifiedEdge(
+                source=_dir_node_id(_parent_dir(dir_path)),
+                target=_dir_node_id(dir_path),
+                relationship=RelationshipType.CONTAINS,
+                evidence={"source": _OVERLAY_SOURCE},
+            )
+        )
+        counts["contains_edges"] += 1
+
+    # ── 3. Manifest / lockfile / declaration files per directory ─────────────
+    for dir_path in sorted(directory_records):
+        record = directory_records[dir_path]
+        manifest_files = _str_list(record.get("manifest_files"))
+        lockfile_files = _str_list(record.get("lockfile_files"))
+        declaration_files = _str_list(record.get("declaration_files"))
+        all_files = sorted(set(manifest_files) | set(lockfile_files) | set(declaration_files))
+
+        for file_name in all_files:
+            file_path = f"{dir_path}/{file_name}" if dir_path else file_name
+            entity_type = _file_entity_type(file_path)
+            file_id = _file_node_id(file_path, entity_type)
+            if file_id not in graph.nodes:
+                counts["files"] += 1
+            graph.add_node(
+                UnifiedNode(
+                    id=file_id,
+                    entity_type=entity_type,
+                    label=file_name,
+                    first_seen=now_iso,
+                    last_seen=now_iso,
+                    attributes={"path": file_path, "directory": dir_path or "."},
+                    data_sources=[_OVERLAY_SOURCE],
+                    dimensions=NodeDimensions(surface=GraphSemanticLayer.CODE.value),
+                )
+            )
+            graph.add_edge(
+                UnifiedEdge(
+                    source=_dir_node_id(dir_path),
+                    target=file_id,
+                    relationship=RelationshipType.CONTAINS,
+                    evidence={"source": _OVERLAY_SOURCE},
+                )
+            )
+            counts["contains_edges"] += 1
+
+        # file → dependency: link the representative manifest to the DIRECT
+        # packages discovered for this directory (declaration manifest preferred
+        # — it is what literally declares direct deps — then any manifest, then a
+        # lockfile). Transitive packages stay reachable via the package graph.
+        representative = declaration_files or manifest_files or lockfile_files
+        server_id = server_by_dir.get(dir_path)
+        if representative and server_id:
+            rep_name = sorted(representative)[0]
+            rep_path = f"{dir_path}/{rep_name}" if dir_path else rep_name
+            rep_id = _file_node_id(rep_path, _file_entity_type(rep_path))
+            for pkg_id in sorted(set(deps_by_server.get(server_id, []))):
+                pkg_node = graph.nodes.get(pkg_id)
+                if pkg_node is None or not pkg_node.attributes.get("is_direct", True):
+                    continue
+                graph.add_edge(
+                    UnifiedEdge(
+                        source=rep_id,
+                        target=pkg_id,
+                        relationship=RelationshipType.DEPENDS_ON,
+                        evidence={"source": _OVERLAY_SOURCE, "declared_in": rep_path},
+                    )
+                )
+                counts["file_package_edges"] += 1
+
+    # ── 4. file → finding: place each finding's file in the tree + link it ───
+    for misconfig_id, file_path in sorted(finding_files.items()):
+        entity_type = _file_entity_type(file_path)
+        file_id = _file_node_id(file_path, entity_type)
+        if file_id not in graph.nodes:
+            counts["files"] += 1
+            graph.add_node(
+                UnifiedNode(
+                    id=file_id,
+                    entity_type=entity_type,
+                    label=file_path.rsplit("/", 1)[-1],
+                    first_seen=now_iso,
+                    last_seen=now_iso,
+                    attributes={"path": file_path, "directory": _file_dir(file_path) or "."},
+                    data_sources=[_OVERLAY_SOURCE],
+                    dimensions=NodeDimensions(surface=GraphSemanticLayer.CODE.value),
+                )
+            )
+            graph.add_edge(
+                UnifiedEdge(
+                    source=_dir_node_id(_file_dir(file_path)),
+                    target=file_id,
+                    relationship=RelationshipType.CONTAINS,
+                    evidence={"source": _OVERLAY_SOURCE},
+                )
+            )
+            counts["contains_edges"] += 1
+        graph.add_edge(
+            UnifiedEdge(
+                source=misconfig_id,
+                target=file_id,
+                relationship=RelationshipType.AFFECTS,
+                evidence={"source": _OVERLAY_SOURCE},
+            )
+        )
+        counts["file_finding_edges"] += 1
+
+    return counts
+
+
+def _str_list(raw: Any) -> list[str]:
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, str) and item.strip()]

--- a/src/agent_bom/graph/rollup.py
+++ b/src/agent_bom/graph/rollup.py
@@ -45,6 +45,11 @@ _CONTAINER_TYPES: frozenset[str] = frozenset(
         EntityType.SERVER.value,
         EntityType.CONTAINER.value,
         EntityType.CLOUD_RESOURCE.value,
+        # A directory is a CODE-layer container: the repo folder tree collapses
+        # along its CONTAINS edges (repo root → sub-directory → file) exactly the
+        # way the cloud org → account → resource hierarchy does, so a deep
+        # source tree renders as a handful of top-level folders with drill-down.
+        EntityType.DIRECTORY.value,
     }
 )
 

--- a/src/agent_bom/graph/types.py
+++ b/src/agent_bom/graph/types.py
@@ -24,6 +24,14 @@ class EntityType(str, Enum):
     CONFIG_FILE = "config_file"
     EXTERNAL_IMPORT = "external_import"
     CI_JOB = "ci_job"
+    # Repository folder/file structure — a directory node forms the CODE-layer
+    # containment backbone (repo root → sub-directory → file) so a code/project
+    # scan renders folder structure the way the cloud graph renders the
+    # org → account → resource hierarchy. Materialised by the repo-structure
+    # overlay from the project inventory; CONTAINS edges build the tree and the
+    # estate roll-up collapses deep trees the same way it collapses the cloud
+    # CONTAINS hierarchy.
+    DIRECTORY = "directory"
 
     # Finding entities (OCSF Category 2)
     VULNERABILITY = "vulnerability"

--- a/src/agent_bom/output/graph.py
+++ b/src/agent_bom/output/graph.py
@@ -476,7 +476,174 @@ def build_graph_elements(
                             }
                         )
 
+    _append_repo_structure_elements(elements, report, collapse_cves=collapse_cves, vuln_pkg_keys=vuln_pkg_keys)
     return elements
+
+
+def _norm_repo_dir(raw: object) -> str:
+    """Normalise a repo-relative directory path; root (``""``/``"."``) → ``""``."""
+    if not isinstance(raw, str):
+        return ""
+    text = raw.strip().replace("\\", "/")
+    while text.startswith("./"):
+        text = text[2:]
+    text = text.strip("/")
+    return "" if text == "." else text
+
+
+def _append_repo_structure_elements(
+    elements: list[dict],
+    report: "AIBOMReport",
+    *,
+    collapse_cves: bool,
+    vuln_pkg_keys: set[tuple[str, str]],
+) -> None:
+    """Append the repository folder/file structure to a Cytoscape element list.
+
+    Materialises the directory tree (``directory`` nodes linked ``contains``
+    parent → child), the manifest / lockfile files each directory holds
+    (``config_file`` / ``source_file`` nodes the directory ``contains``), and a
+    ``depends_on`` edge from a directory's representative manifest to the
+    vulnerable packages discovered for that directory, so a viewer can trace a
+    finding back to the file and folder that introduced it. A no-op when the
+    report carries no project inventory.
+    """
+    inventory = report.project_inventory_data
+    if not isinstance(inventory, dict):
+        return
+    directories = inventory.get("directories")
+    if not isinstance(directories, list) or not directories:
+        return
+
+    code_ext = {
+        "py",
+        "pyi",
+        "js",
+        "jsx",
+        "ts",
+        "tsx",
+        "mjs",
+        "cjs",
+        "go",
+        "rs",
+        "rb",
+        "java",
+        "kt",
+        "kts",
+        "scala",
+        "c",
+        "cc",
+        "cpp",
+        "h",
+        "hpp",
+        "cs",
+        "php",
+        "swift",
+        "m",
+        "sh",
+        "bash",
+    }
+
+    def file_type(name: str) -> str:
+        ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
+        return "source_file" if ext in code_ext else "config_file"
+
+    def dir_id(path: str) -> str:
+        return "dir:." if path == "" else f"dir:{path}"
+
+    def dir_label(path: str) -> str:
+        return "." if path == "" else path.rsplit("/", 1)[-1]
+
+    # Vulnerable package node ids discovered per directory (the legacy graph only
+    # emits vulnerable packages), keyed by normalised directory path.
+    pkgs_by_dir: dict[str, list[str]] = {}
+    for agent in report.agents:
+        for srv in agent.mcp_servers:
+            dir_path = _norm_repo_dir(srv.name)
+            for pkg in srv.packages:
+                if (pkg.name, pkg.ecosystem) not in vuln_pkg_keys:
+                    continue
+                pid = _package_node_id(pkg.name, pkg.ecosystem, agent_name=agent.name, server_name=srv.name, scoped=collapse_cves)
+                pkgs_by_dir.setdefault(dir_path, []).append(pid)
+
+    records: dict[str, dict] = {}
+    for record in directories:
+        if isinstance(record, dict) and isinstance(record.get("path"), str):
+            records[_norm_repo_dir(record.get("path"))] = record
+
+    # Every directory plus its ancestors needs a node so the tree is connected.
+    needed: set[str] = set()
+    for path in records:
+        parts = path.split("/") if path else []
+        needed.add("")
+        for i in range(1, len(parts) + 1):
+            needed.add("/".join(parts[:i]))
+
+    seen_nodes: set[str] = set()
+    seen_edges: set[tuple[str, str]] = set()
+
+    for path in sorted(needed):
+        node_id = dir_id(path)
+        if node_id in seen_nodes:
+            continue
+        seen_nodes.add(node_id)
+        record = records.get(path, {})
+        elements.append(
+            {
+                "data": {
+                    "id": node_id,
+                    "label": dir_label(path),
+                    "type": "directory",
+                    "tip": f"Directory: {path or '.'}\nPackages: {record.get('package_count', 0)}",
+                    "path": path or ".",
+                    "packageCount": record.get("package_count", 0),
+                }
+            }
+        )
+        if path != "":
+            parent = path.rsplit("/", 1)[0] if "/" in path else ""
+            key = (dir_id(parent), node_id)
+            if key not in seen_edges:
+                seen_edges.add(key)
+                elements.append({"data": {"source": key[0], "target": key[1], "type": "contains"}})
+
+    for path in sorted(records):
+        record = records[path]
+        manifest_files = [f for f in (record.get("manifest_files") or []) if isinstance(f, str)]
+        lockfiles = [f for f in (record.get("lockfile_files") or []) if isinstance(f, str)]
+        declarations = [f for f in (record.get("declaration_files") or []) if isinstance(f, str)]
+        all_files = sorted(set(manifest_files) | set(lockfiles) | set(declarations))
+        for file_name in all_files:
+            file_path = f"{path}/{file_name}" if path else file_name
+            node_id = f"file:{file_path}"
+            if node_id not in seen_nodes:
+                seen_nodes.add(node_id)
+                elements.append(
+                    {
+                        "data": {
+                            "id": node_id,
+                            "label": file_name,
+                            "type": file_type(file_name),
+                            "tip": f"File: {file_path}",
+                            "path": file_path,
+                        }
+                    }
+                )
+            key = (dir_id(path), node_id)
+            if key not in seen_edges:
+                seen_edges.add(key)
+                elements.append({"data": {"source": key[0], "target": key[1], "type": "contains"}})
+
+        # Representative manifest → the vulnerable packages this directory holds.
+        representative = sorted(declarations or manifest_files or lockfiles)
+        if representative and pkgs_by_dir.get(path):
+            rep_path = f"{path}/{representative[0]}" if path else representative[0]
+            rep_id = f"file:{rep_path}"
+            for pid in sorted(set(pkgs_by_dir[path])):
+                key = (rep_id, pid)
+                if key not in seen_edges:
+                    seen_edges.add(key)
+                    elements.append({"data": {"source": rep_id, "target": pid, "type": "depends_on"}})
 
 
 def _provider_label(source: str) -> str:
@@ -922,6 +1089,9 @@ _GRAPH_HTML_TEMPLATE = """<!DOCTYPE html>
   <div><span class="dot" style="background:#6e7681"></span> Server (clean)</div>
   <div><span class="dot" style="background:#f85149"></span> Server (vulnerable)</div>
   <div><span class="dot" style="background:#d29922"></span> Server (credentials)</div>
+  <div><span class="dot" style="background:#0d9488"></span> Directory</div>
+  <div><span class="dot" style="background:#f97316"></span> Config file</div>
+  <div><span class="dot" style="background:#22d3ee"></span> Source file</div>
   <div><span class="dot" style="background:#da3633"></span> CVE critical</div>
   <div><span class="dot" style="background:#db6d28"></span> CVE high</div>
   <div><span class="dot" style="background:#d29922"></span> CVE medium</div>
@@ -994,6 +1164,18 @@ const cy=cytoscape({{
       'background-color':'#3b1a1a','border-color':'#da3633',
       'width':'mapData(vulnCount, 1, 15, 180, 280)','height':58,'text-max-width':220
     }}}},
+    {{selector:'node[type="directory"]',style:{{
+      'background-color':'#0f2e2b','border-color':'#0d9488','border-width':2,
+      'shape':'roundrectangle','width':150,'height':42,'font-size':12
+    }}}},
+    {{selector:'node[type="config_file"]',style:{{
+      'background-color':'#3f2a0b','border-color':'#f97316','color':'#fed7aa',
+      'shape':'cut-rectangle','width':150,'height':40,'font-size':12
+    }}}},
+    {{selector:'node[type="source_file"]',style:{{
+      'background-color':'#0c2b33','border-color':'#22d3ee','color':'#a5f3fc',
+      'shape':'cut-rectangle','width':150,'height':40,'font-size':12
+    }}}},
     {{selector:'node[type="cve"][severity="critical"], node[type^="cve_critical"]',style:{{'background-color':'#ff3b30','color':'#fff',
       'shape':'diamond','width':160,'height':70}}}},
     {{selector:'node[type="cve"][severity="high"], node[type^="cve_high"]',style:{{'background-color':'#ff8a24','color':'#fff',
@@ -1019,6 +1201,7 @@ const cy=cytoscape({{
       'line-color':'#ff5d5d','target-arrow-color':'#ff5d5d','width':2.5
     }}}},
     {{selector:'edge[type="depends_on"][maxSeverity = "high"]',style:{{'line-color':'#ff8a24','target-arrow-color':'#ff8a24','width':2}}}},
+    {{selector:'edge[type="contains"]',style:{{'line-color':'#0d9488','target-arrow-color':'#0d9488','width':1.6}}}},
     {{selector:'edge[type="affects"]',style:{{'line-style':'dashed','line-color':'#ff5d5d','target-arrow-color':'#ff5d5d','width':1.8}}}},
     {{selector:'.faded',style:{{'opacity':0.08}}}},
     {{selector:'.focus',style:{{'opacity':1,'border-width':4,'border-color':'#58a6ff','z-index':9999}}}},

--- a/tests/test_graph_repo_structure.py
+++ b/tests/test_graph_repo_structure.py
@@ -1,0 +1,193 @@
+"""Tests for the repository folder/file structure graph overlay.
+
+Covers the contract that a repo / project scan materialises a CODE-layer
+directory tree (``DIRECTORY`` nodes + ``CONTAINS`` edges), manifest
+(``CONFIG_FILE``) nodes, ``file → package (→ vulnerability)`` paths, and that a
+deep tree collapses via the existing server-side ``CONTAINS`` roll-up.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from agent_bom.graph.builder import build_unified_graph_from_report
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.repo_structure_overlay import apply_repo_structure_overlay
+from agent_bom.graph.rollup import rollup_view
+from agent_bom.graph.types import EntityType, RelationshipType
+
+_NOW = datetime(2026, 6, 27, tzinfo=timezone.utc)
+
+
+def _repo_report() -> dict:
+    """A minimal repo-scan report: two manifest directories + a direct vuln."""
+    return {
+        "scan_id": "repo-scan",
+        "scan_sources": ["local-discovery"],
+        "agents": [
+            {
+                "name": "project",
+                "source": "local",
+                "mcp_servers": [
+                    {
+                        # Server label == repo-root directory path ("").
+                        "name": "",
+                        "packages": [
+                            {
+                                "name": "flask",
+                                "version": "2.0.0",
+                                "ecosystem": "pypi",
+                                "is_direct": True,
+                                "vulnerabilities": [{"id": "CVE-2025-0001", "severity": "high"}],
+                            },
+                            {
+                                "name": "transitive-dep",
+                                "version": "1.0.0",
+                                "ecosystem": "pypi",
+                                "is_direct": False,
+                            },
+                        ],
+                    },
+                    {
+                        # A nested project under ui/.
+                        "name": "ui",
+                        "packages": [
+                            {
+                                "name": "react",
+                                "version": "18.0.0",
+                                "ecosystem": "npm",
+                                "is_direct": True,
+                            }
+                        ],
+                    },
+                ],
+            }
+        ],
+        "blast_radius": [
+            {
+                "vulnerability_id": "CVE-2025-0001",
+                "severity": "high",
+                "package_name": "flask",
+                "package_version": "2.0.0",
+                "ecosystem": "pypi",
+            }
+        ],
+        "project_inventory": {
+            "root": "/repo",
+            "directories": [
+                {
+                    "path": ".",
+                    "package_count": 2,
+                    "direct_packages": 1,
+                    "manifest_files": ["pyproject.toml", "uv.lock"],
+                    "lockfile_files": ["uv.lock"],
+                    "declaration_files": ["pyproject.toml"],
+                    "ecosystems": {"pypi": 2},
+                },
+                {
+                    "path": "ui",
+                    "package_count": 1,
+                    "direct_packages": 1,
+                    "manifest_files": ["package.json"],
+                    "lockfile_files": [],
+                    "declaration_files": ["package.json"],
+                    "ecosystems": {"npm": 1},
+                },
+            ],
+        },
+    }
+
+
+def test_repo_scan_emits_directory_tree_and_file_dependency_vuln_paths() -> None:
+    graph = build_unified_graph_from_report(_repo_report())
+
+    # Directory nodes: repo root + the nested ui/ directory, both CODE layer.
+    dir_ids = {n.id for n in graph.nodes.values() if n.entity_type == EntityType.DIRECTORY}
+    assert "directory:." in dir_ids
+    assert "directory:ui" in dir_ids
+    for nid in dir_ids:
+        assert graph.nodes[nid].dimensions.surface == "code"
+
+    # Manifest files materialised as CONFIG_FILE nodes.
+    assert graph.has_node("config_file:pyproject.toml")
+    assert graph.has_node("config_file:uv.lock")
+    assert graph.has_node("config_file:ui/package.json")
+
+    contains = {(e.source, e.target) for e in graph.edges if e.relationship == RelationshipType.CONTAINS}
+    # Tree: root → ui (parent → child) and root → its manifest file.
+    assert ("directory:.", "directory:ui") in contains
+    assert ("directory:.", "config_file:pyproject.toml") in contains
+    assert ("directory:ui", "config_file:ui/package.json") in contains
+
+    # file → package: the declaration manifest declares the DIRECT package only.
+    depends = {
+        (e.source, e.target)
+        for e in graph.edges
+        if e.relationship == RelationshipType.DEPENDS_ON and e.source.startswith(("config_file:", "source_file:"))
+    }
+    flask_id = next(n.id for n in graph.nodes.values() if n.entity_type == EntityType.PACKAGE and n.label.startswith("flask"))
+    react_id = next(n.id for n in graph.nodes.values() if n.entity_type == EntityType.PACKAGE and n.label.startswith("react"))
+    assert ("config_file:pyproject.toml", flask_id) in depends
+    assert ("config_file:ui/package.json", react_id) in depends
+    # The transitive dependency is NOT linked from the manifest.
+    transitive_id = next(n.id for n in graph.nodes.values() if n.entity_type == EntityType.PACKAGE and n.label.startswith("transitive"))
+    assert all(target != transitive_id for _, target in depends)
+
+    # file → package → vulnerability is a complete, traversable path.
+    vuln_targets = {e.target for e in graph.edges if e.relationship == RelationshipType.VULNERABLE_TO and e.source == flask_id}
+    assert vuln_targets, "flask package should be VULNERABLE_TO a vuln node"
+    assert graph.has_node("vuln:CVE-2025-0001")
+
+
+def test_repo_structure_overlay_is_idempotent() -> None:
+    report = _repo_report()
+    graph = build_unified_graph_from_report(report)
+    nodes_before = set(graph.nodes)
+    edges_before = {(e.source, e.target, e.relationship) for e in graph.edges}
+
+    # Applying the overlay again must not add or change anything.
+    counts = apply_repo_structure_overlay(graph, report, _NOW)
+
+    assert set(graph.nodes) == nodes_before
+    assert {(e.source, e.target, e.relationship) for e in graph.edges} == edges_before
+    assert counts["directories"] == 0
+    assert counts["files"] == 0
+
+
+def test_repo_structure_overlay_noop_without_inventory() -> None:
+    graph = UnifiedGraph(scan_id="empty")
+    counts = apply_repo_structure_overlay(graph, {"agents": []}, _NOW)
+    assert counts == {
+        "directories": 0,
+        "files": 0,
+        "contains_edges": 0,
+        "file_package_edges": 0,
+        "file_finding_edges": 0,
+    }
+    assert not any(n.entity_type == EntityType.DIRECTORY for n in graph.nodes.values())
+
+
+def test_deep_directory_tree_collapses_via_contains_rollup() -> None:
+    """A deep source tree collapses to a single top-level container via the
+    existing CONTAINS roll-up — the same mechanism the cloud hierarchy uses."""
+    directories = [
+        {"path": "/".join(["src"] + ["pkg%d" % i for i in range(depth)]), "manifest_files": ["__init__.py"]} for depth in range(1, 9)
+    ]
+    report = {
+        "scan_id": "deep",
+        "agents": [],
+        "project_inventory": {"root": "/repo", "directories": directories},
+    }
+    graph = build_unified_graph_from_report(report)
+
+    directory_count = sum(1 for n in graph.nodes.values() if n.entity_type == EntityType.DIRECTORY)
+    assert directory_count >= 9, "every nested directory + the root becomes a node"
+
+    view = rollup_view(graph)
+    # The whole directory tree rolls up under the single repo-root container.
+    dir_containers = [c for c in view["top_level"] if c["entity_type"] == EntityType.DIRECTORY.value]
+    assert len(dir_containers) == 1
+    root_container = dir_containers[0]
+    assert root_container["id"] == "directory:."
+    # Its rolled-up aggregate reaches the deepest descendants, not just children.
+    assert root_container["aggregate"]["descendant_count"] >= 8

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -1214,7 +1214,7 @@ class TestGraphSchemaEndpoint:
         node_entries = {entry["key"]: entry for entry in body["node_kinds"]}
         edge_entries = {entry["key"]: entry for entry in body["edge_kinds"]}
 
-        reserved_nodes = {"source_file", "code_module", "config_file", "external_import", "ci_job"}
+        reserved_nodes = {"code_module", "external_import", "ci_job"}
         reserved_edges = {"imports", "defines", "runs", "configures", "owns", "remediates", "acted_as"}
         for key in reserved_nodes:
             assert node_entries[key]["emission_status"] == "reserved"
@@ -1231,6 +1231,13 @@ class TestGraphSchemaEndpoint:
         for key in runtime_edges:
             assert edge_entries[key]["emission_status"] == "emitted"
             assert any("runtime" in surface for surface in edge_entries[key]["emission_surfaces"])
+
+        # Repository folder/file-structure nodes are now emitted by the
+        # repo-structure overlay for a code / project scan.
+        repo_structure_nodes = {"directory", "source_file", "config_file"}
+        for key in repo_structure_nodes:
+            assert node_entries[key]["emission_status"] == "emitted"
+            assert any("repo_structure" in surface for surface in node_entries[key]["emission_surfaces"])
 
     def test_every_entity_type_has_semantic_layer(self):
         from agent_bom.graph import ENTITY_LEGEND, GraphSemanticLayer

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -18,7 +18,11 @@ import { AlertTriangle, Loader2, Route, ShieldAlert } from "lucide-react";
 
 import { AttackPathCard } from "@/components/attack-path-card";
 import { GraphEvaluationSummary } from "@/components/graph-evaluation-summary";
-import { GraphEvidenceExportButton, GraphLegend, FullscreenButton } from "@/components/graph-chrome";
+import {
+  GraphEvidenceExportButton,
+  GraphLegend,
+  FullscreenButton,
+} from "@/components/graph-chrome";
 import { LargeGraphOverview } from "@/components/large-graph-overview";
 import { LineageDetailPanel } from "@/components/lineage-detail";
 import {
@@ -72,7 +76,10 @@ import {
   minimapNodeColor,
   readableGraphEdges,
 } from "@/lib/graph-utils";
-import { graphFitViewOptions, shouldShowGraphMiniMap } from "@/lib/graph-viewport";
+import {
+  graphFitViewOptions,
+  shouldShowGraphMiniMap,
+} from "@/lib/graph-viewport";
 import {
   prettifyReachabilityType,
   summarizeReachability,
@@ -101,7 +108,10 @@ import {
 import { useCaptureMode } from "@/lib/use-capture-mode";
 
 const SigmaGraphOverview = dynamic(
-  () => import("@/components/sigma-graph-overview").then((mod) => mod.SigmaGraphOverview),
+  () =>
+    import("@/components/sigma-graph-overview").then(
+      (mod) => mod.SigmaGraphOverview,
+    ),
   {
     ssr: false,
     loading: () => (
@@ -117,8 +127,13 @@ function PulseStyles() {
   return (
     <style jsx global>{`
       @keyframes pulse-critical {
-        0%, 100% { box-shadow: 0 0 6px rgba(239, 68, 68, 0.35); }
-        50% { box-shadow: 0 0 12px rgba(239, 68, 68, 0.55); }
+        0%,
+        100% {
+          box-shadow: 0 0 6px rgba(239, 68, 68, 0.35);
+        }
+        50% {
+          box-shadow: 0 0 12px rgba(239, 68, 68, 0.55);
+        }
       }
       .node-critical-pulse {
         animation: none;
@@ -128,9 +143,15 @@ function PulseStyles() {
          sync — when ten or twenty nodes pulse together at the same
          phase the page reads as a flickering page-wide flash. The
          animation-delay buckets desync neighbours visually. */
-      .node-critical-pulse:nth-child(3n)   { animation-delay: -0.4s; }
-      .node-critical-pulse:nth-child(3n+1) { animation-delay: -1.2s; }
-      .node-critical-pulse:nth-child(3n+2) { animation-delay: -2.0s; }
+      .node-critical-pulse:nth-child(3n) {
+        animation-delay: -0.4s;
+      }
+      .node-critical-pulse:nth-child(3n + 1) {
+        animation-delay: -1.2s;
+      }
+      .node-critical-pulse:nth-child(3n + 2) {
+        animation-delay: -2s;
+      }
       @media (prefers-reduced-motion: reduce) {
         .node-critical-pulse {
           animation: none;
@@ -156,8 +177,13 @@ function PulseStyles() {
       /* Sibling-aggregation cluster pill pulses subtly to suggest
          "click me to expand". Honors prefers-reduced-motion. */
       @keyframes cluster-pill-pulse {
-        0%, 100% { box-shadow: 0 0 6px rgba(56, 189, 248, 0.35); }
-        50% { box-shadow: 0 0 14px rgba(56, 189, 248, 0.65); }
+        0%,
+        100% {
+          box-shadow: 0 0 6px rgba(56, 189, 248, 0.35);
+        }
+        50% {
+          box-shadow: 0 0 14px rgba(56, 189, 248, 0.65);
+        }
       }
       .cluster-pill-pulse {
         animation: none;
@@ -204,7 +230,11 @@ function getLocalNeighborhoodIds(
   return visited;
 }
 
-function addNeighbor(map: Map<string, Set<string>>, source: string, target: string): void {
+function addNeighbor(
+  map: Map<string, Set<string>>,
+  source: string,
+  target: string,
+): void {
   const existing = map.get(source);
   if (existing) {
     existing.add(target);
@@ -237,9 +267,15 @@ const LAYER_ENTITY_TYPES: Array<[LineageNodeType, EntityType]> = [
   ["accessPolicy", EntityType.ACCESS_POLICY],
   ["driftIncident", EntityType.DRIFT_INCIDENT],
   ["dataStore", EntityType.DATA_STORE],
+  ["directory", EntityType.DIRECTORY],
+  ["sourceFile", EntityType.SOURCE_FILE],
+  ["configFile", EntityType.CONFIG_FILE],
 ];
 
-const RELATIONSHIP_SCOPE_MAP: Record<FilterState["relationshipScope"], RelationshipType[] | undefined> = {
+const RELATIONSHIP_SCOPE_MAP: Record<
+  FilterState["relationshipScope"],
+  RelationshipType[] | undefined
+> = {
   all: undefined,
   inventory: [
     RelationshipType.HOSTS,
@@ -292,7 +328,9 @@ const RELATIONSHIP_SCOPE_MAP: Record<FilterState["relationshipScope"], Relations
 };
 
 function entityTypesForLayers(filters: FilterState): EntityType[] {
-  return LAYER_ENTITY_TYPES.filter(([layer]) => filters.layers[layer]).map(([, entityType]) => entityType);
+  return LAYER_ENTITY_TYPES.filter(([layer]) => filters.layers[layer]).map(
+    ([, entityType]) => entityType,
+  );
 }
 
 function emptyGraphResponse(scanId: string): UnifiedGraphResponse {
@@ -325,17 +363,27 @@ function emptyGraphResponse(scanId: string): UnifiedGraphResponse {
 }
 
 function lineageTypeForEntity(entityType: string): LineageNodeType {
-  return LAYER_ENTITY_TYPES.find(([, current]) => current === entityType)?.[0] ?? "server";
+  return (
+    LAYER_ENTITY_TYPES.find(([, current]) => current === entityType)?.[0] ??
+    "server"
+  );
 }
 
-function stringAttribute(attributes: Record<string, unknown> | undefined, key: string): string | undefined {
+function stringAttribute(
+  attributes: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
   const value = attributes?.[key];
   return typeof value === "string" ? value : undefined;
 }
 
-function versionProvenanceAttribute(attributes: Record<string, unknown> | undefined, key: string): string | undefined {
+function versionProvenanceAttribute(
+  attributes: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
   const value = attributes?.version_provenance;
-  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    return undefined;
   const nested = (value as Record<string, unknown>)[key];
   return typeof nested === "string" ? nested : undefined;
 }
@@ -359,10 +407,16 @@ function buildFallbackNodeData(node: UnifiedNode): LineageNodeData {
       stringAttribute(attributes, "recommendation") ||
       stringAttribute(attributes, "framework") ||
       stringAttribute(attributes, "source"),
-    version: stringAttribute(attributes, "version") || stringAttribute(attributes, "hash"),
+    version:
+      stringAttribute(attributes, "version") ||
+      stringAttribute(attributes, "hash"),
     ecosystem: stringAttribute(attributes, "ecosystem"),
-    versionSource: versionProvenanceAttribute(attributes, "version_source") || stringAttribute(attributes, "version_source"),
-    versionConfidence: versionProvenanceAttribute(attributes, "confidence") || stringAttribute(attributes, "version_confidence"),
+    versionSource:
+      versionProvenanceAttribute(attributes, "version_source") ||
+      stringAttribute(attributes, "version_source"),
+    versionConfidence:
+      versionProvenanceAttribute(attributes, "confidence") ||
+      stringAttribute(attributes, "version_confidence"),
     command:
       stringAttribute(attributes, "command") ||
       stringAttribute(attributes, "transport") ||
@@ -372,7 +426,10 @@ function buildFallbackNodeData(node: UnifiedNode): LineageNodeData {
   };
 }
 
-function mergeNodeDetail(base: LineageNodeData, detail: GraphNodeDetailResponse): LineageNodeData {
+function mergeNodeDetail(
+  base: LineageNodeData,
+  detail: GraphNodeDetailResponse,
+): LineageNodeData {
   const mergedAttributes = {
     ...(base.attributes ?? {}),
     ...(detail.node.attributes ?? {}),
@@ -386,8 +443,12 @@ function mergeNodeDetail(base: LineageNodeData, detail: GraphNodeDetailResponse)
     severity: detail.node.severity || base.severity,
     firstSeen: detail.node.first_seen || base.firstSeen,
     lastSeen: detail.node.last_seen || base.lastSeen,
-    dataSources: detail.node.data_sources?.length ? detail.node.data_sources : base.dataSources,
-    complianceTags: detail.node.compliance_tags?.length ? detail.node.compliance_tags : base.complianceTags,
+    dataSources: detail.node.data_sources?.length
+      ? detail.node.data_sources
+      : base.dataSources,
+    complianceTags: detail.node.compliance_tags?.length
+      ? detail.node.compliance_tags
+      : base.complianceTags,
     attributes: mergedAttributes,
     neighborCount: detail.neighbors.length,
     sourceCount: detail.sources.length,
@@ -402,7 +463,10 @@ function mergeNodeDetail(base: LineageNodeData, detail: GraphNodeDetailResponse)
       stringAttribute(mergedAttributes, "recommendation") ||
       stringAttribute(mergedAttributes, "framework") ||
       stringAttribute(mergedAttributes, "source"),
-    version: base.version || stringAttribute(mergedAttributes, "version") || stringAttribute(mergedAttributes, "hash"),
+    version:
+      base.version ||
+      stringAttribute(mergedAttributes, "version") ||
+      stringAttribute(mergedAttributes, "hash"),
     ecosystem: base.ecosystem || stringAttribute(mergedAttributes, "ecosystem"),
     versionSource:
       base.versionSource ||
@@ -417,8 +481,10 @@ function mergeNodeDetail(base: LineageNodeData, detail: GraphNodeDetailResponse)
       stringAttribute(mergedAttributes, "command") ||
       stringAttribute(mergedAttributes, "transport") ||
       stringAttribute(mergedAttributes, "url"),
-    agentType: base.agentType || stringAttribute(mergedAttributes, "agent_type"),
-    agentStatus: base.agentStatus || stringAttribute(mergedAttributes, "status"),
+    agentType:
+      base.agentType || stringAttribute(mergedAttributes, "agent_type"),
+    agentStatus:
+      base.agentStatus || stringAttribute(mergedAttributes, "status"),
   };
 }
 
@@ -433,9 +499,17 @@ function buildPathEdgeKeys(hops: string[]): Set<string> {
   return keys;
 }
 
-function graphErrorState(message: string): { title: string; detail: string; suggestions: string[] } {
+function graphErrorState(message: string): {
+  title: string;
+  detail: string;
+  suggestions: string[];
+} {
   const lowered = message.toLowerCase();
-  if (lowered.includes("budget") || lowered.includes("limit") || lowered.includes("too large")) {
+  if (
+    lowered.includes("budget") ||
+    lowered.includes("limit") ||
+    lowered.includes("too large")
+  ) {
     return {
       title: "Graph query budget reached",
       detail: message,
@@ -457,7 +531,12 @@ function graphErrorState(message: string): { title: string; detail: string; sugg
       ],
     };
   }
-  if (lowered.includes("permission") || lowered.includes("tenant") || lowered.includes("forbidden") || lowered.includes("unauthorized")) {
+  if (
+    lowered.includes("permission") ||
+    lowered.includes("tenant") ||
+    lowered.includes("forbidden") ||
+    lowered.includes("unauthorized")
+  ) {
     return {
       title: "Graph is unavailable for this tenant or session",
       detail: message,
@@ -487,7 +566,9 @@ type InvestigationMode = {
   edgeCount: number;
 };
 
-function queryResponseToGraphResponse(response: GraphQueryResponse): UnifiedGraphResponse {
+function queryResponseToGraphResponse(
+  response: GraphQueryResponse,
+): UnifiedGraphResponse {
   return {
     scan_id: response.scan_id,
     tenant_id: response.tenant_id,
@@ -532,20 +613,30 @@ function GraphPageInner() {
   const [error, setError] = useState<string | null>(null);
   const [diffError, setDiffError] = useState<string | null>(null);
   const [graphDiff, setGraphDiff] = useState<GraphDiffResponse | null>(null);
-  const [selectedNode, setSelectedNode] = useState<LineageNodeData | null>(null);
+  const [selectedNode, setSelectedNode] = useState<LineageNodeData | null>(
+    null,
+  );
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
-  const [selectedAttackPathKey, setSelectedAttackPathKey] = useState<string | null>(null);
+  const [selectedAttackPathKey, setSelectedAttackPathKey] = useState<
+    string | null
+  >(null);
   const [autoPathDismissed, setAutoPathDismissed] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<UnifiedNode[]>([]);
   const [searching, setSearching] = useState(false);
-  const [investigationMode, setInvestigationMode] = useState<InvestigationMode | null>(null);
-  const [reachabilitySummary, setReachabilitySummary] = useState<ReachabilitySummary | null>(null);
+  const [investigationMode, setInvestigationMode] =
+    useState<InvestigationMode | null>(null);
+  const [reachabilitySummary, setReachabilitySummary] =
+    useState<ReachabilitySummary | null>(null);
   const loadingReachability = false;
-  const [reachabilityError, setReachabilityError] = useState<string | null>(null);
+  const [reachabilityError, setReachabilityError] = useState<string | null>(
+    null,
+  );
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [pinnedFocusId, setPinnedFocusId] = useState<string | null>(null);
-  const [expandedClusterIds, setExpandedClusterIds] = useState<Set<string>>(() => new Set());
+  const [expandedClusterIds, setExpandedClusterIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -562,18 +653,21 @@ function GraphPageInner() {
   // auto-focus effect that picks the first agent doesn't clobber an
   // explicit ?agent= param on initial load.
   const seededFromUrlRef = useRef<boolean>(
-    typeof window !== "undefined" && new URLSearchParams(window.location.search).toString().length > 0,
+    typeof window !== "undefined" &&
+      new URLSearchParams(window.location.search).toString().length > 0,
   );
   const requestedScanIdRef = useRef<string>(
     typeof window !== "undefined"
       ? new URLSearchParams(window.location.search).get("scan") ||
-        new URLSearchParams(window.location.search).get("scan_id") ||
-        ""
+          new URLSearchParams(window.location.search).get("scan_id") ||
+          ""
       : "",
   );
   const requestedInvestigationRef = useRef<GraphInvestigationRequest | null>(
     typeof window !== "undefined"
-      ? decodeGraphInvestigationParams(new URLSearchParams(window.location.search))
+      ? decodeGraphInvestigationParams(
+          new URLSearchParams(window.location.search),
+        )
       : null,
   );
   const firstScanSelectionRef = useRef(true);
@@ -600,7 +694,10 @@ function GraphPageInner() {
       .finally(() => setLoadingSnapshots(false));
   }, []);
 
-  const serverEntityTypes = useMemo(() => entityTypesForLayers(filters), [filters]);
+  const serverEntityTypes = useMemo(
+    () => entityTypesForLayers(filters),
+    [filters],
+  );
 
   const serverRelationships = useMemo(
     () => RELATIONSHIP_SCOPE_MAP[filters.relationshipScope],
@@ -709,11 +806,14 @@ function GraphPageInner() {
   ]);
 
   const activeSnapshot = useMemo(
-    () => snapshots.find((snapshot) => snapshot.scan_id === selectedScanId) ?? null,
+    () =>
+      snapshots.find((snapshot) => snapshot.scan_id === selectedScanId) ?? null,
     [snapshots, selectedScanId],
   );
   const previousSnapshot = useMemo(() => {
-    const index = snapshots.findIndex((snapshot) => snapshot.scan_id === selectedScanId);
+    const index = snapshots.findIndex(
+      (snapshot) => snapshot.scan_id === selectedScanId,
+    );
     if (index < 0 || index + 1 >= snapshots.length) return null;
     return snapshots[index + 1];
   }, [snapshots, selectedScanId]);
@@ -776,7 +876,8 @@ function GraphPageInner() {
     () =>
       [...(graphData?.attack_paths ?? [])].sort(
         (left, right) =>
-          right.composite_risk - left.composite_risk || right.hops.length - left.hops.length,
+          right.composite_risk - left.composite_risk ||
+          right.hops.length - left.hops.length,
       ),
     [graphData?.attack_paths],
   );
@@ -790,21 +891,32 @@ function GraphPageInner() {
   const selectedAttackPath = useMemo(
     () =>
       effectiveSelectedAttackPathKey
-        ? attackPaths.find((path) => attackPathKey(path) === effectiveSelectedAttackPathKey) ?? null
+        ? (attackPaths.find(
+            (path) => attackPathKey(path) === effectiveSelectedAttackPathKey,
+          ) ?? null)
         : null,
     [attackPaths, effectiveSelectedAttackPathKey],
   );
 
   useEffect(() => {
     if (!selectedAttackPathKey) return;
-    if (!attackPaths.some((path) => attackPathKey(path) === selectedAttackPathKey)) {
+    if (
+      !attackPaths.some((path) => attackPathKey(path) === selectedAttackPathKey)
+    ) {
       setSelectedAttackPathKey(null);
     }
   }, [attackPaths, selectedAttackPathKey]);
 
   const flow = useMemo(() => {
     if (!graphData) {
-      return { nodes: [], edges: [], agentNames: [], legend: [], summary: null as null | ReturnType<typeof buildUnifiedFlowGraph>["summary"] };
+      return {
+        nodes: [],
+        edges: [],
+        agentNames: [],
+        legend: [],
+        summary: null as
+          null | ReturnType<typeof buildUnifiedFlowGraph>["summary"],
+      };
     }
     return buildUnifiedFlowGraph(graphData, filters);
   }, [graphData, filters]);
@@ -835,7 +947,8 @@ function GraphPageInner() {
     if (requestedWebgl === "1") {
       nextParams.set("webgl", requestedWebgl);
     }
-    const shareableInvestigation = investigationMode ?? requestedInvestigationRef.current;
+    const shareableInvestigation =
+      investigationMode ?? requestedInvestigationRef.current;
     if (shareableInvestigation) {
       nextParams.set("investigate", "1");
       nextParams.set("root", shareableInvestigation.rootId);
@@ -851,7 +964,14 @@ function GraphPageInner() {
     if (next === current) return;
     const url = next ? `${pathname}?${next}` : pathname;
     router.replace(url, { scroll: false });
-  }, [filters, investigationMode, pathname, router, searchParams, selectedScanId]);
+  }, [
+    filters,
+    investigationMode,
+    pathname,
+    router,
+    searchParams,
+    selectedScanId,
+  ]);
 
   // Constraint propagation — recompute valid values whenever graph or
   // filters change. Cheap on focused snapshots, BFS-bounded on expanded.
@@ -889,14 +1009,19 @@ function GraphPageInner() {
     [flow.nodes, flow.edges, aggregationThreshold, expandedClusterIds],
   );
   const aggregatedClusterNodes = useMemo(
-    () => aggregated.nodes.filter((node) => isClusterPillNode(node as Node<LineageNodeData>)),
+    () =>
+      aggregated.nodes.filter((node) =>
+        isClusterPillNode(node as Node<LineageNodeData>),
+      ),
     [aggregated.nodes],
   );
   const graphIdentityKey = useMemo(
     () =>
       JSON.stringify({
         nodes: flow.nodes.map((node) => node.id),
-        edges: flow.edges.map((edge) => `${edge.source}->${edge.target}:${edge.id}`),
+        edges: flow.edges.map(
+          (edge) => `${edge.source}->${edge.target}:${edge.id}`,
+        ),
       }),
     [flow.nodes, flow.edges],
   );
@@ -915,23 +1040,28 @@ function GraphPageInner() {
   // renderers upstream, so ReactFlow only ever lays out small/medium graphs
   // where dagre is the better fit.
   const graphLayoutKind = "dagre-lr";
-  const { nodes: layoutNodes, edges: layoutEdges } = useGraphLayout(graphLayoutKind, aggregated.nodes, aggregated.edges, {
-    force: {
-      idealEdgeLength: filters.agentName ? 168 : 196,
-      nodeRepulsion: filters.agentName ? 3600 : 4400,
-      preservePinnedPositions: true,
+  const { nodes: layoutNodes, edges: layoutEdges } = useGraphLayout(
+    graphLayoutKind,
+    aggregated.nodes,
+    aggregated.edges,
+    {
+      force: {
+        idealEdgeLength: filters.agentName ? 168 : 196,
+        nodeRepulsion: filters.agentName ? 3600 : 4400,
+        preservePinnedPositions: true,
+      },
+      dagreLr: {
+        // Bigger node boxes + tighter ranks keep the wide left-to-right DAG from
+        // collapsing into a thin, far-zoomed strip. The extra vertical nodeSep
+        // spreads short graphs so fitView fills the canvas instead of leaving a
+        // tall empty band above and below the topology.
+        nodeWidth: 248,
+        nodeHeight: 96,
+        rankSep: filters.agentName ? 120 : 140,
+        nodeSep: filters.agentName ? 64 : 78,
+      },
     },
-    dagreLr: {
-      // Bigger node boxes + tighter ranks keep the wide left-to-right DAG from
-      // collapsing into a thin, far-zoomed strip. The extra vertical nodeSep
-      // spreads short graphs so fitView fills the canvas instead of leaving a
-      // tall empty band above and below the topology.
-      nodeWidth: 248,
-      nodeHeight: 96,
-      rankSep: filters.agentName ? 120 : 140,
-      nodeSep: filters.agentName ? 64 : 78,
-    },
-  });
+  );
 
   // Focus mode (#2257). The "active" focus is whichever the operator
   // pinned (click) — falling back to whatever is hovered. Pinning
@@ -939,7 +1069,10 @@ function GraphPageInner() {
   // node. Hover never overrides a pin.
   const activeFocusId = pinnedFocusId ?? hoveredNodeId;
   const localNeighborhoodIds = useMemo(
-    () => (activeFocusId ? getLocalNeighborhoodIds(activeFocusId, layoutEdges) : null),
+    () =>
+      activeFocusId
+        ? getLocalNeighborhoodIds(activeFocusId, layoutEdges)
+        : null,
     [activeFocusId, layoutEdges],
   );
 
@@ -949,11 +1082,15 @@ function GraphPageInner() {
   );
 
   const attackPathEdgeKeys = useMemo(
-    () => (selectedAttackPath ? buildPathEdgeKeys(selectedAttackPath.hops) : null),
+    () =>
+      selectedAttackPath ? buildPathEdgeKeys(selectedAttackPath.hops) : null,
     [selectedAttackPath],
   );
   const attackPathNodeOrder = useMemo(
-    () => (selectedAttackPath ? new Map(selectedAttackPath.hops.map((hop, index) => [hop, index])) : null),
+    () =>
+      selectedAttackPath
+        ? new Map(selectedAttackPath.hops.map((hop, index) => [hop, index]))
+        : null,
     [selectedAttackPath],
   );
 
@@ -969,7 +1106,11 @@ function GraphPageInner() {
     focused: boolean,
     dimmed: boolean,
   ): string =>
-    [base, focused ? "lineage-node-focus" : "", dimmed ? "lineage-node-dim" : ""]
+    [
+      base,
+      focused ? "lineage-node-focus" : "",
+      dimmed ? "lineage-node-dim" : "",
+    ]
       .filter(Boolean)
       .join(" ") || "";
 
@@ -987,24 +1128,26 @@ function GraphPageInner() {
   const lineageLayoutNodes = layoutNodes as Node<LineageNodeData>[];
   const displayNodes = useMemo<Node<LineageNodeData>[]>(() => {
     if (attackPathNodeIds) {
-      return lineageLayoutNodes.filter((node) => attackPathNodeIds.has(node.id)).map((node) => {
-        const inPath = attackPathNodeIds.has(node.id);
-        const order = attackPathNodeOrder?.get(node.id) ?? 0;
-        return {
-          ...node,
-          position: {
-            x: order * 255,
-            y: order % 2 === 0 ? 0 : 96,
-          },
-          className: composeFocusClass(node.className, inPath, !inPath),
-          data: {
-            ...node.data,
-            renderBand: effectiveLodBand,
-            dimmed: !inPath,
-            highlighted: inPath,
-          },
-        };
-      });
+      return lineageLayoutNodes
+        .filter((node) => attackPathNodeIds.has(node.id))
+        .map((node) => {
+          const inPath = attackPathNodeIds.has(node.id);
+          const order = attackPathNodeOrder?.get(node.id) ?? 0;
+          return {
+            ...node,
+            position: {
+              x: order * 255,
+              y: order % 2 === 0 ? 0 : 96,
+            },
+            className: composeFocusClass(node.className, inPath, !inPath),
+            data: {
+              ...node.data,
+              renderBand: effectiveLodBand,
+              dimmed: !inPath,
+              highlighted: inPath,
+            },
+          };
+        });
     }
     if (reachabilitySummary) {
       return lineageLayoutNodes.map((node) => {
@@ -1046,7 +1189,15 @@ function GraphPageInner() {
         },
       };
     });
-  }, [lineageLayoutNodes, localNeighborhoodIds, attackPathNodeIds, attackPathNodeOrder, reachabilitySummary, activeFocusId, effectiveLodBand]);
+  }, [
+    lineageLayoutNodes,
+    localNeighborhoodIds,
+    attackPathNodeIds,
+    attackPathNodeOrder,
+    reachabilitySummary,
+    activeFocusId,
+    effectiveLodBand,
+  ]);
 
   const compressedGroupCount = aggregatedClusterNodes.length;
   const sourceNodeCount = graphData?.nodes.length ?? flow.nodes.length;
@@ -1054,40 +1205,53 @@ function GraphPageInner() {
 
   const displayEdges = useMemo(() => {
     if (attackPathEdgeKeys) {
-      return layoutEdges.filter((edge) => attackPathEdgeKeys.has(`${edge.source}=>${edge.target}`)).map((edge): Edge => {
-        const inPath = attackPathEdgeKeys.has(`${edge.source}=>${edge.target}`);
-        const relationshipLabel =
-          typeof edge.data?.relationshipLabel === "string"
-            ? edge.data.relationshipLabel
-            : typeof edge.data?.relationship === "string"
-              ? edge.data.relationship.replace(/_/g, " ")
-              : undefined;
-        return {
-          ...edge,
-          label: relationshipLabel,
-          labelShowBg: true,
-          labelBgPadding: [8, 4],
-          labelBgBorderRadius: 6,
-          labelBgStyle: {
-            fill: captureMode ? "#0a0a0a" : "rgba(24,24,27,0.92)",
-            fillOpacity: 0.94,
-          },
-          labelStyle: {
-            fill: "#f4f4f5",
-            fontSize: 11,
-            fontWeight: 600,
-          },
-          animated: captureMode ? false : Boolean(inPath || edge.animated),
-          style: {
-            ...edge.style,
-            opacity: inPath ? 1 : 0.08,
-            strokeWidth: inPath
-              ? Math.max(typeof edge.style?.strokeWidth === "number" ? edge.style.strokeWidth : 2, 3.2)
-              : 1,
-            ...(inPath ? { filter: "drop-shadow(0 0 6px rgba(249,115,22,0.55))" } : {}),
-          },
-        };
-      });
+      return layoutEdges
+        .filter((edge) =>
+          attackPathEdgeKeys.has(`${edge.source}=>${edge.target}`),
+        )
+        .map((edge): Edge => {
+          const inPath = attackPathEdgeKeys.has(
+            `${edge.source}=>${edge.target}`,
+          );
+          const relationshipLabel =
+            typeof edge.data?.relationshipLabel === "string"
+              ? edge.data.relationshipLabel
+              : typeof edge.data?.relationship === "string"
+                ? edge.data.relationship.replace(/_/g, " ")
+                : undefined;
+          return {
+            ...edge,
+            label: relationshipLabel,
+            labelShowBg: true,
+            labelBgPadding: [8, 4],
+            labelBgBorderRadius: 6,
+            labelBgStyle: {
+              fill: captureMode ? "#0a0a0a" : "rgba(24,24,27,0.92)",
+              fillOpacity: 0.94,
+            },
+            labelStyle: {
+              fill: "#f4f4f5",
+              fontSize: 11,
+              fontWeight: 600,
+            },
+            animated: captureMode ? false : Boolean(inPath || edge.animated),
+            style: {
+              ...edge.style,
+              opacity: inPath ? 1 : 0.08,
+              strokeWidth: inPath
+                ? Math.max(
+                    typeof edge.style?.strokeWidth === "number"
+                      ? edge.style.strokeWidth
+                      : 2,
+                    3.2,
+                  )
+                : 1,
+              ...(inPath
+                ? { filter: "drop-shadow(0 0 6px rgba(249,115,22,0.55))" }
+                : {}),
+            },
+          };
+        });
     }
     if (reachabilitySummary) {
       return layoutEdges.map((edge): Edge => {
@@ -1101,9 +1265,16 @@ function GraphPageInner() {
             ...edge.style,
             opacity: inReach ? 0.95 : 0.07,
             strokeWidth: inReach
-              ? Math.max(typeof edge.style?.strokeWidth === "number" ? edge.style.strokeWidth : 2, 3)
+              ? Math.max(
+                  typeof edge.style?.strokeWidth === "number"
+                    ? edge.style.strokeWidth
+                    : 2,
+                  3,
+                )
               : 1,
-            ...(inReach ? { filter: "drop-shadow(0 0 6px rgba(244,63,94,0.5))" } : {}),
+            ...(inReach
+              ? { filter: "drop-shadow(0 0 6px rgba(244,63,94,0.5))" }
+              : {}),
           },
         };
       });
@@ -1114,7 +1285,14 @@ function GraphPageInner() {
       inactiveOpacity: 0.06,
       captureMode,
     });
-  }, [layoutEdges, localNeighborhoodIds, attackPathEdgeKeys, reachabilitySummary, graphLayoutKind, captureMode]);
+  }, [
+    layoutEdges,
+    localNeighborhoodIds,
+    attackPathEdgeKeys,
+    reachabilitySummary,
+    graphLayoutKind,
+    captureMode,
+  ]);
 
   const graphEvaluation = useMemo(
     () => evaluateGraphUx(graphData, displayNodes, displayEdges),
@@ -1138,7 +1316,8 @@ function GraphPageInner() {
   );
   const showMiniMap = useMemo(
     () =>
-      !captureMode && shouldShowGraphMiniMap({
+      !captureMode &&
+      shouldShowGraphMiniMap({
         nodeCount: displayNodes.length,
         edgeCount: displayEdges.length,
         selectedNode: Boolean(selectedNode),
@@ -1148,16 +1327,18 @@ function GraphPageInner() {
   );
 
   const hasContextualGraph = useMemo(
-    () => displayNodes.some((node) => {
-      const nodeType = (node.data as LineageNodeData).nodeType;
-      return nodeType !== "vulnerability" && nodeType !== "misconfiguration";
-    }),
+    () =>
+      displayNodes.some((node) => {
+        const nodeType = (node.data as LineageNodeData).nodeType;
+        return nodeType !== "vulnerability" && nodeType !== "misconfiguration";
+      }),
     [displayNodes],
   );
 
   const graphOnlyFindings = displayNodes.length > 0 && !hasContextualGraph;
   const webglGraphEnabled =
-    searchParams?.get("renderer") === "webgl" || searchParams?.get("webgl") === "1";
+    searchParams?.get("renderer") === "webgl" ||
+    searchParams?.get("webgl") === "1";
   const graphRenderer = decideGraphRenderer({
     nodeCount: sourceNodeCount,
     edgeCount: graphData?.edges.length ?? displayEdges.length,
@@ -1167,13 +1348,16 @@ function GraphPageInner() {
     graphOnlyFindings,
     webglEnabled: webglGraphEnabled,
   });
-  const graphPanelError = error && snapshots.length > 0 ? graphErrorState(error) : null;
+  const graphPanelError =
+    error && snapshots.length > 0 ? graphErrorState(error) : null;
   const findingNodes = useMemo(
     () =>
       displayNodes
         .filter((node) => {
           const nodeType = (node.data as LineageNodeData).nodeType;
-          return nodeType === "vulnerability" || nodeType === "misconfiguration";
+          return (
+            nodeType === "vulnerability" || nodeType === "misconfiguration"
+          );
         })
         .map((node) => ({ id: node.id, data: node.data as LineageNodeData })),
     [displayNodes],
@@ -1210,15 +1394,21 @@ function GraphPageInner() {
     setHoveredNodeId(null);
   }, []);
 
-  const onLargeGraphNodeSelect = useCallback((nodeId: string) => {
-    const node = displayNodes.find((candidate) => candidate.id === nodeId);
-    if (!node) return;
-    onNodeClick({} as React.MouseEvent, node);
-  }, [displayNodes, onNodeClick]);
+  const onLargeGraphNodeSelect = useCallback(
+    (nodeId: string) => {
+      const node = displayNodes.find((candidate) => candidate.id === nodeId);
+      if (!node) return;
+      onNodeClick({} as React.MouseEvent, node);
+    },
+    [displayNodes, onNodeClick],
+  );
 
-  const onNodeMouseEnter = useCallback((_event: React.MouseEvent, node: Node) => {
-    setHoveredNodeId(node.id);
-  }, []);
+  const onNodeMouseEnter = useCallback(
+    (_event: React.MouseEvent, node: Node) => {
+      setHoveredNodeId(node.id);
+    },
+    [],
+  );
 
   const onNodeMouseLeave = useCallback(() => {
     setHoveredNodeId(null);
@@ -1261,11 +1451,14 @@ function GraphPageInner() {
   }, [filters.severity, searchQuery, selectedScanId, serverEntityTypes]);
 
   const loadRootInvestigation = useCallback(
-    async (request: GraphInvestigationRequest & { node?: UnifiedNode | undefined }) => {
+    async (
+      request: GraphInvestigationRequest & { node?: UnifiedNode | undefined },
+    ) => {
       if (!selectedScanId) return;
 
       const fallback = request.node
-        ? flowNodeDataById.get(request.node.id) ?? buildFallbackNodeData(request.node)
+        ? (flowNodeDataById.get(request.node.id) ??
+          buildFallbackNodeData(request.node))
         : null;
       if (fallback) {
         setSelectedNode({
@@ -1286,7 +1479,9 @@ function GraphPageInner() {
       setReachabilitySummary(null);
       setReachabilityError(null);
       setSearchResults([]);
-      setSearchQuery(request.rootLabel ?? request.node?.label ?? request.rootId);
+      setSearchQuery(
+        request.rootLabel ?? request.node?.label ?? request.rootId,
+      );
       setLoadingGraph(true);
       try {
         const response = await api.queryGraph({
@@ -1304,7 +1499,9 @@ function GraphPageInner() {
           include_attack_paths: true,
           relationship_types: serverRelationships,
         });
-        const rootNode = response.nodes.find((node) => node.id === request.rootId) ?? request.node;
+        const rootNode =
+          response.nodes.find((node) => node.id === request.rootId) ??
+          request.node;
         if (rootNode) {
           setSelectedNode(buildFallbackNodeData(rootNode));
         }
@@ -1328,12 +1525,20 @@ function GraphPageInner() {
         );
         setError(null);
       } catch (e) {
-        setError(e instanceof Error ? e.message : "Failed to load root-centered graph");
+        setError(
+          e instanceof Error ? e.message : "Failed to load root-centered graph",
+        );
       } finally {
         setLoadingGraph(false);
       }
     },
-    [filters.runtimeMode, filters.vulnOnly, flowNodeDataById, selectedScanId, serverRelationships],
+    [
+      filters.runtimeMode,
+      filters.vulnOnly,
+      flowNodeDataById,
+      selectedScanId,
+      serverRelationships,
+    ],
   );
 
   useEffect(() => {
@@ -1364,10 +1569,16 @@ function GraphPageInner() {
     setReachabilityError(null);
   }, []);
 
-  const pageStart = graphData && graphData.pagination.total > 0 ? graphData.pagination.offset + 1 : 0;
+  const pageStart =
+    graphData && graphData.pagination.total > 0
+      ? graphData.pagination.offset + 1
+      : 0;
   const pageEnd =
     graphData && graphData.pagination.total > 0
-      ? Math.min(graphData.pagination.offset + graphData.pagination.limit, graphData.pagination.total)
+      ? Math.min(
+          graphData.pagination.offset + graphData.pagination.limit,
+          graphData.pagination.total,
+        )
       : 0;
   const pageNumber =
     graphData && graphData.pagination.limit > 0
@@ -1375,7 +1586,10 @@ function GraphPageInner() {
       : 1;
   const totalPages =
     graphData && graphData.pagination.limit > 0
-      ? Math.max(1, Math.ceil(graphData.pagination.total / graphData.pagination.limit))
+      ? Math.max(
+          1,
+          Math.ceil(graphData.pagination.total / graphData.pagination.limit),
+        )
       : 1;
   if (loadingSnapshots) {
     return (
@@ -1391,7 +1605,9 @@ function GraphPageInner() {
       <div className="flex flex-col items-center justify-center h-[80vh] text-zinc-400 gap-3">
         <AlertTriangle className="w-8 h-8 text-amber-500" />
         <p className="text-sm">Could not load the unified graph</p>
-        <p className="text-xs text-zinc-500">Run a scan first so the API can persist graph snapshots.</p>
+        <p className="text-xs text-zinc-500">
+          Run a scan first so the API can persist graph snapshots.
+        </p>
       </div>
     );
   }
@@ -1401,7 +1617,9 @@ function GraphPageInner() {
       <div className="flex flex-col items-center justify-center h-[80vh] text-zinc-400 gap-3">
         <ShieldAlert className="w-8 h-8 text-zinc-600" />
         <p className="text-sm">No graph snapshots found</p>
-        <p className="text-xs text-zinc-500">Run a scan to persist the unified inventory and security graph.</p>
+        <p className="text-xs text-zinc-500">
+          Run a scan to persist the unified inventory and security graph.
+        </p>
       </div>
     );
   }
@@ -1419,10 +1637,15 @@ function GraphPageInner() {
       <div className="border-b border-zinc-800 bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.10),transparent_24%),linear-gradient(180deg,rgba(24,24,27,0.96),rgba(9,9,11,0.96))] px-4 py-3">
         <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
           <div>
-            <p className="text-[10px] uppercase tracking-[0.24em] text-sky-400">Unified graph</p>
-            <h1 className="mt-1 text-lg font-semibold text-zinc-100">Lineage Graph</h1>
+            <p className="text-[10px] uppercase tracking-[0.24em] text-sky-400">
+              Unified graph
+            </p>
+            <h1 className="mt-1 text-lg font-semibold text-zinc-100">
+              Lineage Graph
+            </h1>
             <p className="text-xs text-zinc-500">
-              Evidence-backed relationships across agents, servers, packages, credentials, tools, and findings.
+              Evidence-backed relationships across agents, servers, packages,
+              credentials, tools, and findings.
             </p>
           </div>
 
@@ -1431,9 +1654,21 @@ function GraphPageInner() {
               <>
                 <MetricCard value={flow.summary.agents} label="agents" />
                 <MetricCard value={flow.summary.servers} label="servers" />
-                <MetricCard value={flow.summary.findings} label="findings" accent="orange" />
-                <MetricCard value={flow.summary.critical} label="critical" accent="red" />
-                <MetricCard value={flow.summary.attackPaths} label="paths" accent="blue" />
+                <MetricCard
+                  value={flow.summary.findings}
+                  label="findings"
+                  accent="orange"
+                />
+                <MetricCard
+                  value={flow.summary.critical}
+                  label="critical"
+                  accent="red"
+                />
+                <MetricCard
+                  value={flow.summary.attackPaths}
+                  label="paths"
+                  accent="blue"
+                />
               </>
             )}
 
@@ -1444,14 +1679,17 @@ function GraphPageInner() {
             >
               {snapshots.map((snapshot) => (
                 <option key={snapshot.scan_id} value={snapshot.scan_id}>
-                  {snapshot.scan_id.slice(0, 12)} · {new Date(snapshot.created_at).toLocaleString()}
+                  {snapshot.scan_id.slice(0, 12)} ·{" "}
+                  {new Date(snapshot.created_at).toLocaleString()}
                 </option>
               ))}
             </select>
 
             <GraphEvidenceExportButton
               scanId={selectedScanId || undefined}
-              filenamePrefix={selectedScanId ? `scan-${selectedScanId}-graph` : undefined}
+              filenamePrefix={
+                selectedScanId ? `scan-${selectedScanId}-graph` : undefined
+              }
             />
             <FullscreenButton />
           </div>
@@ -1481,9 +1719,15 @@ function GraphPageInner() {
           </form>
 
           <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-zinc-400">
-            <ViewPill label="Scope" value={filters.agentName ? filters.agentName : "all agents"} />
+            <ViewPill
+              label="Scope"
+              value={filters.agentName ? filters.agentName : "all agents"}
+            />
             <ViewPill label="View" value={graphScopeLabelForFilters(filters)} />
-            <ViewPill label="Severity" value={filters.severity ? `${filters.severity}+` : "all"} />
+            <ViewPill
+              label="Severity"
+              value={filters.severity ? `${filters.severity}+` : "all"}
+            />
             {sourceNodeCount > 0 && (
               <span
                 data-testid="graph-compression-summary"
@@ -1505,48 +1749,71 @@ function GraphPageInner() {
           <details className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3 group">
             <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-3 [&::-webkit-details-marker]:hidden">
               <div>
-                <span className="text-[10px] uppercase tracking-[0.22em] text-zinc-500">View controls</span>
+                <span className="text-[10px] uppercase tracking-[0.22em] text-zinc-500">
+                  View controls
+                </span>
                 <p className="mt-1 text-xs text-zinc-400">
-                  Change scope, layers, severity, traversal, and page size without changing the persisted graph.
+                  Change scope, layers, severity, traversal, and page size
+                  without changing the persisted graph.
                 </p>
               </div>
-              <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:hidden">show</span>
-              <span className="hidden text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:inline">hide</span>
+              <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:hidden">
+                show
+              </span>
+              <span className="hidden text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:inline">
+                hide
+              </span>
             </summary>
             <div className="mt-3 space-y-3">
               <div className="flex flex-wrap gap-2 text-[11px]">
-              <button
-                type="button"
-                onClick={() => setFilters(createImmediateGraphFilters(filters.agentName ?? flow.agentNames[0] ?? null))}
-                className={scopeButtonClass(activeScopePreset === "immediate")}
-                title="One-hop triage around the selected agent"
-              >
-                Immediate
-              </button>
-              <button
-                type="button"
-                onClick={() => setFilters(createFocusedGraphFilters(filters.agentName ?? flow.agentNames[0] ?? null))}
-                className={scopeButtonClass(activeScopePreset === "relevant")}
-                title="Default fix-first graph with bounded path context"
-              >
-                Relevant paths
-              </button>
-              <button
-                type="button"
-                onClick={() => setFilters(createExpandedGraphFilters(null))}
-                className={scopeButtonClass(activeScopePreset === "expanded")}
-                title="Broader topology review with lower-priority context included"
-              >
-                Expanded topology
-              </button>
-              <button
-                type="button"
-                onClick={() => setFilters({ ...filters, vulnOnly: !filters.vulnOnly })}
-                className={scopeButtonClass(filters.vulnOnly)}
-                title="Limit the graph to vulnerability-bearing paths"
-              >
-                Vulnerable only
-              </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setFilters(
+                      createImmediateGraphFilters(
+                        filters.agentName ?? flow.agentNames[0] ?? null,
+                      ),
+                    )
+                  }
+                  className={scopeButtonClass(
+                    activeScopePreset === "immediate",
+                  )}
+                  title="One-hop triage around the selected agent"
+                >
+                  Immediate
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setFilters(
+                      createFocusedGraphFilters(
+                        filters.agentName ?? flow.agentNames[0] ?? null,
+                      ),
+                    )
+                  }
+                  className={scopeButtonClass(activeScopePreset === "relevant")}
+                  title="Default fix-first graph with bounded path context"
+                >
+                  Relevant paths
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setFilters(createExpandedGraphFilters(null))}
+                  className={scopeButtonClass(activeScopePreset === "expanded")}
+                  title="Broader topology review with lower-priority context included"
+                >
+                  Expanded topology
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    setFilters({ ...filters, vulnOnly: !filters.vulnOnly })
+                  }
+                  className={scopeButtonClass(filters.vulnOnly)}
+                  title="Limit the graph to vulnerability-bearing paths"
+                >
+                  Vulnerable only
+                </button>
               </div>
               <FilterPanel
                 filters={filters}
@@ -1562,8 +1829,11 @@ function GraphPageInner() {
           {investigationMode && (
             <div className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-xs text-sky-100">
               <span>
-                Root-centered investigation: <span className="font-mono">{investigationMode.rootId}</span>
-                {investigationMode.truncated ? " · traversal budget reached" : ""}
+                Root-centered investigation:{" "}
+                <span className="font-mono">{investigationMode.rootId}</span>
+                {investigationMode.truncated
+                  ? " · traversal budget reached"
+                  : ""}
               </span>
               <button
                 type="button"
@@ -1575,7 +1845,9 @@ function GraphPageInner() {
             </div>
           )}
 
-          {(reachabilitySummary || loadingReachability || reachabilityError) && (
+          {(reachabilitySummary ||
+            loadingReachability ||
+            reachabilityError) && (
             <ReachabilityDrillInPanel
               summary={reachabilitySummary}
               loading={loadingReachability}
@@ -1590,7 +1862,8 @@ function GraphPageInner() {
           {searchResults.length > 0 && (
             <div className="mt-2 rounded-2xl border border-zinc-800 bg-zinc-950/90 p-2">
               <div className="mb-2 px-1 text-[10px] uppercase tracking-[0.18em] text-zinc-500">
-                Search respects current entity scope{filters.severity ? ` and ${filters.severity}+ severity` : ""}
+                Search respects current entity scope
+                {filters.severity ? ` and ${filters.severity}+ severity` : ""}
               </div>
               <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
                 {searchResults.map((result) => (
@@ -1600,7 +1873,9 @@ function GraphPageInner() {
                     onClick={() => void focusSearchResult(result)}
                     className="rounded-xl border border-zinc-800 bg-zinc-900/80 px-3 py-2 text-left transition hover:border-zinc-600 hover:bg-zinc-900"
                   >
-                    <p className="truncate text-sm font-medium text-zinc-100">{result.label}</p>
+                    <p className="truncate text-sm font-medium text-zinc-100">
+                      {result.label}
+                    </p>
                     <p className="mt-1 text-[10px] uppercase tracking-[0.18em] text-zinc-500">
                       {String(result.entity_type)}
                     </p>
@@ -1608,7 +1883,8 @@ function GraphPageInner() {
                       {result.severity && <span>{result.severity}</span>}
                       <span>
                         risk{" "}
-                        {typeof result.risk_score === "number" && Number.isFinite(result.risk_score)
+                        {typeof result.risk_score === "number" &&
+                        Number.isFinite(result.risk_score)
                           ? result.risk_score.toFixed(1)
                           : "N/A"}
                       </span>
@@ -1625,12 +1901,15 @@ function GraphPageInner() {
             <>
               <span>{activeSnapshot.node_count} nodes</span>
               <span>{activeSnapshot.edge_count} edges</span>
-              <span>captured {new Date(activeSnapshot.created_at).toLocaleString()}</span>
+              <span>
+                captured {new Date(activeSnapshot.created_at).toLocaleString()}
+              </span>
             </>
           )}
           {graphData && graphData.pagination.total > 0 && (
             <span>
-              showing {pageStart}-{pageEnd} of {graphData.pagination.total} nodes
+              showing {pageStart}-{pageEnd} of {graphData.pagination.total}{" "}
+              nodes
             </span>
           )}
         </div>
@@ -1648,7 +1927,9 @@ function GraphPageInner() {
           <details className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3 group">
             <summary className="flex flex-wrap items-center justify-between gap-3 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
               <div className="flex items-center gap-3">
-                <span className="text-[10px] uppercase tracking-[0.24em] text-sky-400">Snapshot diff</span>
+                <span className="text-[10px] uppercase tracking-[0.24em] text-sky-400">
+                  Snapshot diff
+                </span>
                 <span className="text-xs text-zinc-500">
                   {graphDiff
                     ? `+${graphDiff.nodes_added.length} −${graphDiff.nodes_removed.length} nodes · +${graphDiff.edges_added.length} −${graphDiff.edges_removed.length} edges`
@@ -1664,8 +1945,12 @@ function GraphPageInner() {
                     loading
                   </span>
                 )}
-                <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:hidden">show</span>
-                <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 hidden group-open:inline">hide</span>
+                <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:hidden">
+                  show
+                </span>
+                <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 hidden group-open:inline">
+                  hide
+                </span>
               </div>
             </summary>
             {diffError ? (
@@ -1676,43 +1961,108 @@ function GraphPageInner() {
               <DiffLoadingGrid />
             ) : (
               <div className="mt-3 grid gap-2 md:grid-cols-3 xl:grid-cols-5">
-                <DiffMetric label="nodes added" value={graphDiff?.nodes_added.length ?? 0} tone="green" />
-                <DiffMetric label="nodes removed" value={graphDiff?.nodes_removed.length ?? 0} tone="amber" />
-                <DiffMetric label="nodes changed" value={graphDiff?.nodes_changed.length ?? 0} tone="blue" />
-                <DiffMetric label="edges added" value={graphDiff?.edges_added.length ?? 0} tone="green" />
-                <DiffMetric label="edges removed" value={graphDiff?.edges_removed.length ?? 0} tone="amber" />
+                <DiffMetric
+                  label="nodes added"
+                  value={graphDiff?.nodes_added.length ?? 0}
+                  tone="green"
+                />
+                <DiffMetric
+                  label="nodes removed"
+                  value={graphDiff?.nodes_removed.length ?? 0}
+                  tone="amber"
+                />
+                <DiffMetric
+                  label="nodes changed"
+                  value={graphDiff?.nodes_changed.length ?? 0}
+                  tone="blue"
+                />
+                <DiffMetric
+                  label="edges added"
+                  value={graphDiff?.edges_added.length ?? 0}
+                  tone="green"
+                />
+                <DiffMetric
+                  label="edges removed"
+                  value={graphDiff?.edges_removed.length ?? 0}
+                  tone="amber"
+                />
               </div>
             )}
-            {graphDiff && (graphDiff.nodes_added.length > 0 || graphDiff.nodes_changed.length > 0 || graphDiff.nodes_removed.length > 0) && (
-              <div className="mt-3 grid gap-2 lg:grid-cols-3">
-                <DiffPreview label="Added" items={graphDiff.nodes_added} />
-                <DiffPreview label="Changed" items={graphDiff.nodes_changed} />
-                <DiffPreview label="Removed" items={graphDiff.nodes_removed} />
-              </div>
-            )}
+            {graphDiff &&
+              (graphDiff.nodes_added.length > 0 ||
+                graphDiff.nodes_changed.length > 0 ||
+                graphDiff.nodes_removed.length > 0) && (
+                <div className="mt-3 grid gap-2 lg:grid-cols-3">
+                  <DiffPreview label="Added" items={graphDiff.nodes_added} />
+                  <DiffPreview
+                    label="Changed"
+                    items={graphDiff.nodes_changed}
+                  />
+                  <DiffPreview
+                    label="Removed"
+                    items={graphDiff.nodes_removed}
+                  />
+                </div>
+              )}
           </details>
         )}
 
         <details className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3 text-xs text-zinc-400 group">
           <summary className="flex items-center justify-between cursor-pointer list-none [&::-webkit-details-marker]:hidden">
-            <span className="font-medium text-zinc-200">How to read this graph</span>
-            <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:hidden">show</span>
-            <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 hidden group-open:inline">hide</span>
+            <span className="font-medium text-zinc-200">
+              How to read this graph
+            </span>
+            <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:hidden">
+              show
+            </span>
+            <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 hidden group-open:inline">
+              hide
+            </span>
           </summary>
           <ul className="mt-2 space-y-1.5">
-            <li>Each snapshot is a persisted control-plane view of entities, edges, attack paths, and relationship counts at one capture time.</li>
-            <li>Node IDs are stable identifiers inside the graph model; the detail panel shows the node ID, first seen, last seen, sources, and edge counts.</li>
-            <li>Pagination changes the visible canvas, not the persisted snapshot itself. Narrow the scope when the graph gets large; page when you need broader coverage.</li>
-            <li>Relevant paths is for operator triage. Expanded is for topology review. Attack-path cards are the fix-first shortlist, not the whole graph.</li>
-            <li>Pages at or above {LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD.toLocaleString()} visible nodes or {LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD.toLocaleString()} visible edges use the limited 2D overview. Narrowing, search results, attack-path focus, and reachability drill-ins return to React Flow.</li>
-            <li>Hop depth controls how far traversal can move from the selected agent or root. Entity layers control what kinds of nodes can render, without changing the persisted graph.</li>
+            <li>
+              Each snapshot is a persisted control-plane view of entities,
+              edges, attack paths, and relationship counts at one capture time.
+            </li>
+            <li>
+              Node IDs are stable identifiers inside the graph model; the detail
+              panel shows the node ID, first seen, last seen, sources, and edge
+              counts.
+            </li>
+            <li>
+              Pagination changes the visible canvas, not the persisted snapshot
+              itself. Narrow the scope when the graph gets large; page when you
+              need broader coverage.
+            </li>
+            <li>
+              Relevant paths is for operator triage. Expanded is for topology
+              review. Attack-path cards are the fix-first shortlist, not the
+              whole graph.
+            </li>
+            <li>
+              Pages at or above{" "}
+              {LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD.toLocaleString()} visible
+              nodes or {LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD.toLocaleString()}{" "}
+              visible edges use the limited 2D overview. Narrowing, search
+              results, attack-path focus, and reachability drill-ins return to
+              React Flow.
+            </li>
+            <li>
+              Hop depth controls how far traversal can move from the selected
+              agent or root. Entity layers control what kinds of nodes can
+              render, without changing the persisted graph.
+            </li>
           </ul>
         </details>
 
         <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
           <button
             type="button"
-            onClick={() => setPageOffset((current) => Math.max(0, current - filters.pageSize))}
+            onClick={() =>
+              setPageOffset((current) =>
+                Math.max(0, current - filters.pageSize),
+              )
+            }
             disabled={loadingGraph || pageOffset === 0}
             className="rounded-lg border border-zinc-700 bg-zinc-900/80 px-3 py-1.5 text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-40"
           >
@@ -1720,7 +2070,9 @@ function GraphPageInner() {
           </button>
           <button
             type="button"
-            onClick={() => setPageOffset((current) => current + filters.pageSize)}
+            onClick={() =>
+              setPageOffset((current) => current + filters.pageSize)
+            }
             disabled={loadingGraph || !graphData?.pagination.has_more}
             className="rounded-lg border border-zinc-700 bg-zinc-900/80 px-3 py-1.5 text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-40"
           >
@@ -1730,7 +2082,9 @@ function GraphPageInner() {
             Page {pageNumber} of {totalPages}
           </span>
           {graphData?.pagination.has_more && (
-            <span className="text-amber-400">Large snapshot: narrow the graph or keep paging.</span>
+            <span className="text-amber-400">
+              Large snapshot: narrow the graph or keep paging.
+            </span>
           )}
         </div>
 
@@ -1741,18 +2095,27 @@ function GraphPageInner() {
           >
             <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-2 [&::-webkit-details-marker]:hidden">
               <div>
-                <p className="text-[10px] uppercase tracking-[0.24em] text-orange-400">Attack paths</p>
+                <p className="text-[10px] uppercase tracking-[0.24em] text-orange-400">
+                  Attack paths
+                </p>
                 <p className="mt-1 text-xs text-zinc-500">
-                  {attackPaths.length} ranked path{attackPaths.length === 1 ? "" : "s"} available for focused investigation.
+                  {attackPaths.length} ranked path
+                  {attackPaths.length === 1 ? "" : "s"} available for focused
+                  investigation.
                 </p>
               </div>
-              <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:hidden">show queue</span>
-              <span className="hidden text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:inline">hide queue</span>
+              <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:hidden">
+                show queue
+              </span>
+              <span className="hidden text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:inline">
+                hide queue
+              </span>
             </summary>
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div>
                 <p className="mt-3 text-xs text-zinc-500">
-                  Focus the current graph on a precomputed exploit chain in this filtered snapshot page.
+                  Focus the current graph on a precomputed exploit chain in this
+                  filtered snapshot page.
                 </p>
               </div>
               {selectedAttackPath && (
@@ -1806,27 +2169,58 @@ function GraphPageInner() {
                 />
                 <PathStat
                   label="Hop count"
-                  value={String(Math.max(0, selectedAttackPath.hops.length - 1))}
+                  value={String(
+                    Math.max(0, selectedAttackPath.hops.length - 1),
+                  )}
                 />
                 <PathStat
                   label="Credential exposure"
-                  value={selectedAttackPath.credential_exposure.length > 0 ? selectedAttackPath.credential_exposure.length.toString() : "none"}
-                  tone={selectedAttackPath.credential_exposure.length > 0 ? "amber" : "zinc"}
+                  value={
+                    selectedAttackPath.credential_exposure.length > 0
+                      ? selectedAttackPath.credential_exposure.length.toString()
+                      : "none"
+                  }
+                  tone={
+                    selectedAttackPath.credential_exposure.length > 0
+                      ? "amber"
+                      : "zinc"
+                  }
                 />
                 <PathStat
                   label="Tool exposure"
-                  value={selectedAttackPath.tool_exposure.length > 0 ? selectedAttackPath.tool_exposure.length.toString() : "none"}
-                  tone={selectedAttackPath.tool_exposure.length > 0 ? "blue" : "zinc"}
+                  value={
+                    selectedAttackPath.tool_exposure.length > 0
+                      ? selectedAttackPath.tool_exposure.length.toString()
+                      : "none"
+                  }
+                  tone={
+                    selectedAttackPath.tool_exposure.length > 0
+                      ? "blue"
+                      : "zinc"
+                  }
                 />
-                <PathTagList label="Summary" tags={[selectedAttackPath.summary || "No summary provided"]} wide />
+                <PathTagList
+                  label="Summary"
+                  tags={[selectedAttackPath.summary || "No summary provided"]}
+                  wide
+                />
                 {selectedAttackPath.vuln_ids.length > 0 && (
-                  <PathTagList label="Findings" tags={selectedAttackPath.vuln_ids} />
+                  <PathTagList
+                    label="Findings"
+                    tags={selectedAttackPath.vuln_ids}
+                  />
                 )}
                 {selectedAttackPath.credential_exposure.length > 0 && (
-                  <PathTagList label="Credentials" tags={selectedAttackPath.credential_exposure} />
+                  <PathTagList
+                    label="Credentials"
+                    tags={selectedAttackPath.credential_exposure}
+                  />
                 )}
                 {selectedAttackPath.tool_exposure.length > 0 && (
-                  <PathTagList label="Tools" tags={selectedAttackPath.tool_exposure} />
+                  <PathTagList
+                    label="Tools"
+                    tags={selectedAttackPath.tool_exposure}
+                  />
                 )}
               </div>
             )}
@@ -1864,7 +2258,11 @@ function GraphPageInner() {
               onSelect={selectFindingCard}
               scanId={selectedScanId || undefined}
               onExpandScope={() =>
-                setFilters(createExpandedGraphFilters(filters.agentName ?? flow.agentNames[0] ?? null))
+                setFilters(
+                  createExpandedGraphFilters(
+                    filters.agentName ?? flow.agentNames[0] ?? null,
+                  ),
+                )
               }
             />
           ) : graphRenderer.kind === "large-overview" ? (
@@ -1999,14 +2397,23 @@ function ReachabilityDrillInPanel({
         <div className="flex items-start gap-2">
           <Route className="mt-0.5 h-4 w-4 text-rose-300" />
           <div>
-            <p className="text-[10px] uppercase tracking-[0.24em] text-rose-300">Reachability drill-in</p>
+            <p className="text-[10px] uppercase tracking-[0.24em] text-rose-300">
+              Reachability drill-in
+            </p>
             <p className="mt-1 text-sm font-medium text-rose-50">
-              {summary ? `${summary.rootLabel} can reach ${affectedCount} node${affectedCount === 1 ? "" : "s"}` : "Loading reachable graph"}
+              {summary
+                ? `${summary.rootLabel} can reach ${affectedCount} node${affectedCount === 1 ? "" : "s"}`
+                : "Loading reachable graph"}
             </p>
             {summary?.truncated && (
-              <p className="mt-1 text-[11px] text-amber-200">Traversal budget reached; narrow the graph or inspect a smaller root.</p>
+              <p className="mt-1 text-[11px] text-amber-200">
+                Traversal budget reached; narrow the graph or inspect a smaller
+                root.
+              </p>
             )}
-            {error && <p className="mt-1 text-[11px] text-amber-200">{error}</p>}
+            {error && (
+              <p className="mt-1 text-[11px] text-amber-200">{error}</p>
+            )}
             {loading && (
               <p className="mt-1 flex items-center gap-1 text-[11px] text-rose-200">
                 <Loader2 className="h-3 w-3 animate-spin" />
@@ -2027,9 +2434,13 @@ function ReachabilityDrillInPanel({
       {summary && (
         <div className="mt-3 grid gap-3 xl:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
           <div className="rounded-xl border border-rose-400/20 bg-zinc-950/45 p-2">
-            <p className="text-[10px] uppercase tracking-[0.2em] text-rose-300">Affected by type</p>
+            <p className="text-[10px] uppercase tracking-[0.2em] text-rose-300">
+              Affected by type
+            </p>
             {Object.keys(summary.countsByType).length === 0 ? (
-              <p className="mt-2 text-zinc-400">No downstream nodes returned for this root.</p>
+              <p className="mt-2 text-zinc-400">
+                No downstream nodes returned for this root.
+              </p>
             ) : (
               <div className="mt-2 flex flex-wrap gap-1.5">
                 {Object.entries(summary.countsByType)
@@ -2047,17 +2458,27 @@ function ReachabilityDrillInPanel({
           </div>
 
           <div className="rounded-xl border border-rose-400/20 bg-zinc-950/45 p-2">
-            <p className="text-[10px] uppercase tracking-[0.2em] text-rose-300">Bounded paths</p>
+            <p className="text-[10px] uppercase tracking-[0.2em] text-rose-300">
+              Bounded paths
+            </p>
             {summary.pathPreviews.length === 0 ? (
-              <p className="mt-2 text-zinc-400">No path preview is available for this root.</p>
+              <p className="mt-2 text-zinc-400">
+                No path preview is available for this root.
+              </p>
             ) : (
               <div className="mt-2 grid gap-1.5">
                 {summary.pathPreviews.map((path) => (
-                  <div key={`${path.targetId}:${path.hops.join(">")}`} className="rounded-lg bg-zinc-950/70 px-2 py-1.5">
+                  <div
+                    key={`${path.targetId}:${path.hops.join(">")}`}
+                    className="rounded-lg bg-zinc-950/70 px-2 py-1.5"
+                  >
                     <div className="flex flex-wrap items-center justify-between gap-2">
-                      <span className="font-medium text-rose-50">{path.targetLabel}</span>
+                      <span className="font-medium text-rose-50">
+                        {path.targetLabel}
+                      </span>
                       <span className="text-[10px] uppercase tracking-[0.16em] text-zinc-500">
-                        {prettifyReachabilityType(path.targetType)} · {path.depth} hop{path.depth === 1 ? "" : "s"}
+                        {prettifyReachabilityType(path.targetType)} ·{" "}
+                        {path.depth} hop{path.depth === 1 ? "" : "s"}
                       </span>
                     </div>
                     <p className="mt-1 truncate font-mono text-[10px] text-zinc-400">
@@ -2100,7 +2521,9 @@ function PathStat({
 
   return (
     <div className={`rounded-xl border px-3 py-2 ${toneClass}`}>
-      <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">{label}</p>
+      <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+        {label}
+      </p>
       <p className="mt-1 font-mono text-sm text-zinc-100">{value}</p>
     </div>
   );
@@ -2116,8 +2539,12 @@ function PathTagList({
   wide?: boolean;
 }) {
   return (
-    <div className={`rounded-xl border border-zinc-800 bg-zinc-900/70 p-3 ${wide ? "lg:col-span-4" : ""}`}>
-      <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">{label}</p>
+    <div
+      className={`rounded-xl border border-zinc-800 bg-zinc-900/70 p-3 ${wide ? "lg:col-span-4" : ""}`}
+    >
+      <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+        {label}
+      </p>
       <div className="mt-2 flex flex-wrap gap-1.5">
         {tags.map((tag) => (
           <span
@@ -2150,7 +2577,9 @@ function DiffMetric({
 
   return (
     <div className={`rounded-xl border px-3 py-2 ${toneClass}`}>
-      <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">{label}</p>
+      <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+        {label}
+      </p>
       <p className="mt-1 font-mono text-lg text-zinc-100">{value}</p>
     </div>
   );
@@ -2158,10 +2587,24 @@ function DiffMetric({
 
 function DiffLoadingGrid() {
   return (
-    <div className="mt-3 grid gap-2 md:grid-cols-3 xl:grid-cols-5" data-testid="graph-diff-loading">
-      {["nodes added", "nodes removed", "nodes changed", "edges added", "edges removed"].map((label) => (
-        <div key={label} className="rounded-xl border border-zinc-800 bg-zinc-900/70 px-3 py-2">
-          <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">{label}</p>
+    <div
+      className="mt-3 grid gap-2 md:grid-cols-3 xl:grid-cols-5"
+      data-testid="graph-diff-loading"
+    >
+      {[
+        "nodes added",
+        "nodes removed",
+        "nodes changed",
+        "edges added",
+        "edges removed",
+      ].map((label) => (
+        <div
+          key={label}
+          className="rounded-xl border border-zinc-800 bg-zinc-900/70 px-3 py-2"
+        >
+          <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+            {label}
+          </p>
           <div className="mt-2 h-6 w-12 animate-pulse rounded-full bg-zinc-800" />
         </div>
       ))}
@@ -2174,17 +2617,26 @@ function DiffPreview({ label, items }: { label: string; items: string[] }) {
   return (
     <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-3">
       <div className="flex items-center justify-between gap-2">
-        <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">{label}</p>
-        <span className="font-mono text-[11px] text-zinc-500">{items.length}</span>
+        <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+          {label}
+        </p>
+        <span className="font-mono text-[11px] text-zinc-500">
+          {items.length}
+        </span>
       </div>
       <div className="mt-2 space-y-1">
         {visible.map((item) => (
-          <p key={`${label}-${item}`} className="truncate font-mono text-[11px] text-zinc-300">
+          <p
+            key={`${label}-${item}`}
+            className="truncate font-mono text-[11px] text-zinc-300"
+          >
             {item}
           </p>
         ))}
         {items.length > visible.length && (
-          <p className="text-[11px] text-zinc-500">+{items.length - visible.length} more</p>
+          <p className="text-[11px] text-zinc-500">
+            +{items.length - visible.length} more
+          </p>
         )}
       </div>
     </div>

--- a/ui/components/lineage-detail.tsx
+++ b/ui/components/lineage-detail.tsx
@@ -9,6 +9,9 @@ import {
   Cloud,
   Database,
   ExternalLink,
+  FileCode,
+  FileCog,
+  Folder,
   Hourglass,
   KeyRound,
   Lock,
@@ -61,6 +64,9 @@ const TYPE_ICON = {
   accessPolicy: KeyRound,
   driftIncident: TriangleAlert,
   dataStore: Database,
+  directory: Folder,
+  sourceFile: FileCode,
+  configFile: FileCog,
 } as const;
 
 const TYPE_LABELS: Record<LineageNodeData["nodeType"], string> = {
@@ -94,6 +100,9 @@ const TYPE_LABELS: Record<LineageNodeData["nodeType"], string> = {
   accessPolicy: "Access Policy",
   driftIncident: "Drift Incident",
   dataStore: "Data Store",
+  directory: "Directory",
+  sourceFile: "Source File",
+  configFile: "Config File",
 };
 
 const TYPE_BORDER: Record<LineageNodeData["nodeType"], string> = {
@@ -127,6 +136,9 @@ const TYPE_BORDER: Record<LineageNodeData["nodeType"], string> = {
   accessPolicy: "border-amber-700",
   driftIncident: "border-orange-700",
   dataStore: "border-sky-700",
+  directory: "border-teal-700",
+  sourceFile: "border-cyan-700",
+  configFile: "border-orange-700",
 };
 
 export function LineageDetailPanel({
@@ -137,37 +149,42 @@ export function LineageDetailPanel({
   onClose: () => void;
 }) {
   const Icon = TYPE_ICON[data.nodeType];
-  const osvUrl = data.nodeType === "vulnerability" ? getOsvVulnerabilityUrl(data.label) : null;
-  const extraAttributes = Object.entries(data.attributes ?? {}).filter(([key]) => {
-    return !new Set([
-      "agent_type",
-      "status",
-      "version",
-      "ecosystem",
-      "description",
-      "framework",
-      "source",
-      "hash",
-      "verified",
-      "container_image",
-      "cloud_provider",
-      "resource_id",
-      "source_section",
-      "rule_id",
-      "check_id",
-      "recommendation",
-      "evidence",
-      "path",
-      "file_path",
-      "line",
-      "start_line",
-      "end_line",
-      "cvss_score",
-      "epss_score",
-      "is_kev",
-      "fixed_version",
-    ]).has(key);
-  });
+  const osvUrl =
+    data.nodeType === "vulnerability"
+      ? getOsvVulnerabilityUrl(data.label)
+      : null;
+  const extraAttributes = Object.entries(data.attributes ?? {}).filter(
+    ([key]) => {
+      return !new Set([
+        "agent_type",
+        "status",
+        "version",
+        "ecosystem",
+        "description",
+        "framework",
+        "source",
+        "hash",
+        "verified",
+        "container_image",
+        "cloud_provider",
+        "resource_id",
+        "source_section",
+        "rule_id",
+        "check_id",
+        "recommendation",
+        "evidence",
+        "path",
+        "file_path",
+        "line",
+        "start_line",
+        "end_line",
+        "cvss_score",
+        "epss_score",
+        "is_kev",
+        "fixed_version",
+      ]).has(key);
+    },
+  );
 
   return (
     <div
@@ -181,7 +198,9 @@ export function LineageDetailPanel({
             </span>
             <div className="flex items-center gap-2 mt-0.5">
               <Icon className="w-4 h-4 text-zinc-400" />
-              <h3 className="text-sm font-semibold text-zinc-100">{data.label}</h3>
+              <h3 className="text-sm font-semibold text-zinc-100">
+                {data.label}
+              </h3>
             </div>
           </div>
           <button
@@ -207,13 +226,23 @@ export function LineageDetailPanel({
                     : "border-emerald-800 bg-emerald-950 text-emerald-400"
                 }`}
               >
-                {data.agentStatus === "installed-not-configured" ? "Not Configured" : "Configured"}
+                {data.agentStatus === "installed-not-configured"
+                  ? "Not Configured"
+                  : "Configured"}
               </div>
             )}
-            {data.serverCount !== undefined && <Row label="Servers" value={data.serverCount} />}
-            {data.packageCount !== undefined && <Row label="Packages" value={data.packageCount} />}
+            {data.serverCount !== undefined && (
+              <Row label="Servers" value={data.serverCount} />
+            )}
+            {data.packageCount !== undefined && (
+              <Row label="Packages" value={data.packageCount} />
+            )}
             {(data.vulnCount ?? 0) > 0 && (
-              <Row label="Findings" value={data.vulnCount ?? 0} className="text-red-400" />
+              <Row
+                label="Findings"
+                value={data.vulnCount ?? 0}
+                className="text-red-400"
+              />
             )}
           </div>
         )}
@@ -236,9 +265,15 @@ export function LineageDetailPanel({
             {data.command && (
               <CodeBlock label="Connection" value={data.command} />
             )}
-            {data.toolCount !== undefined && data.toolCount > 0 && <Row label="Tools" value={data.toolCount} />}
+            {data.toolCount !== undefined && data.toolCount > 0 && (
+              <Row label="Tools" value={data.toolCount} />
+            )}
             {data.credentialCount !== undefined && data.credentialCount > 0 && (
-              <Row label="Credentials" value={data.credentialCount} className="text-amber-400" />
+              <Row
+                label="Credentials"
+                value={data.credentialCount}
+                className="text-amber-400"
+              />
             )}
             {data.packageCount !== undefined && data.packageCount > 0 && (
               <Row label="Packages" value={data.packageCount} />
@@ -256,7 +291,9 @@ export function LineageDetailPanel({
             {data.sharedAgents && data.sharedAgents.length > 0 && (
               <TagList label="Connected Agents" tags={data.sharedAgents} />
             )}
-            {data.command && <CodeBlock label="Connection" value={data.command} />}
+            {data.command && (
+              <CodeBlock label="Connection" value={data.command} />
+            )}
           </div>
         )}
 
@@ -264,12 +301,22 @@ export function LineageDetailPanel({
           <div className="space-y-3">
             {data.ecosystem && <Row label="Ecosystem" value={data.ecosystem} />}
             {data.version && <Row label="Version" value={data.version} />}
-            {data.versionSource && <Row label="Version source" value={data.versionSource} />}
-            {data.versionConfidence && <Row label="Version confidence" value={data.versionConfidence} />}
+            {data.versionSource && (
+              <Row label="Version source" value={data.versionSource} />
+            )}
+            {data.versionConfidence && (
+              <Row label="Version confidence" value={data.versionConfidence} />
+            )}
             {(data.vulnCount ?? 0) > 0 ? (
-              <Row label="Findings" value={data.vulnCount ?? 0} className="text-red-400" />
+              <Row
+                label="Findings"
+                value={data.vulnCount ?? 0}
+                className="text-red-400"
+              />
             ) : (
-              <div className="text-xs text-emerald-400">No known findings on this package node</div>
+              <div className="text-xs text-emerald-400">
+                No known findings on this package node
+              </div>
             )}
           </div>
         )}
@@ -283,31 +330,41 @@ export function LineageDetailPanel({
                 {data.severity}
               </span>
             )}
-            {typeof data.cvssScore === "number" && Number.isFinite(data.cvssScore) && (
-              <Row label="CVSS" value={data.cvssScore.toFixed(1)} />
-            )}
+            {typeof data.cvssScore === "number" &&
+              Number.isFinite(data.cvssScore) && (
+                <Row label="CVSS" value={data.cvssScore.toFixed(1)} />
+              )}
             {typeof data.epssScore === "number" && data.epssScore > 0 && (
-              <Row label="EPSS" value={`${(data.epssScore * 100).toFixed(1)}%`} />
+              <Row
+                label="EPSS"
+                value={`${(data.epssScore * 100).toFixed(1)}%`}
+              />
             )}
             {data.isKev && (
               <div className="text-xs px-2 py-1 rounded bg-red-900 text-red-300 border border-red-700 font-mono inline-block">
                 CISA Known Exploited
               </div>
             )}
-            {data.fixedVersion && <Row label="Fix version" value={data.fixedVersion} className="text-emerald-400" />}
+            {data.fixedVersion && (
+              <Row
+                label="Fix version"
+                value={data.fixedVersion}
+                className="text-emerald-400"
+              />
+            )}
             {data.effectiveReach && (
               <div className="space-y-1.5">
                 <Label>Effective reach</Label>
                 <div className="flex items-center gap-2">
                   <span
                     className={`inline-block w-2.5 h-2.5 rounded-full ${reachColorClass(
-                      data.effectiveReach.band
+                      data.effectiveReach.band,
                     )}`}
                     aria-label={`reach band ${data.effectiveReach.band}`}
                   />
                   <span
                     className={`text-xs font-mono ${reachTextClass(
-                      data.effectiveReach.band
+                      data.effectiveReach.band,
                     )}`}
                   >
                     {data.effectiveReach.composite.toFixed(1)} / 100 ·{" "}
@@ -337,8 +394,12 @@ export function LineageDetailPanel({
                   )}
               </div>
             )}
-            {data.owaspTags && data.owaspTags.length > 0 && <TagList label="OWASP" tags={data.owaspTags} />}
-            {data.atlasTags && data.atlasTags.length > 0 && <TagList label="ATLAS" tags={data.atlasTags} />}
+            {data.owaspTags && data.owaspTags.length > 0 && (
+              <TagList label="OWASP" tags={data.owaspTags} />
+            )}
+            {data.atlasTags && data.atlasTags.length > 0 && (
+              <TagList label="ATLAS" tags={data.atlasTags} />
+            )}
             {osvUrl && (
               <a
                 href={osvUrl}
@@ -362,14 +423,21 @@ export function LineageDetailPanel({
                 {data.severity}
               </span>
             )}
-            {data.description && <div className="text-xs text-zinc-400">{data.description}</div>}
+            {data.description && (
+              <div className="text-xs text-zinc-400">{data.description}</div>
+            )}
           </div>
         )}
 
         {data.nodeType === "credential" && (
           <div className="space-y-3">
-            <div className="text-xs text-amber-400">Environment variable or credential-like secret exposed in configuration.</div>
-            {data.serverName && <Row label="Linked server" value={data.serverName} />}
+            <div className="text-xs text-amber-400">
+              Environment variable or credential-like secret exposed in
+              configuration.
+            </div>
+            {data.serverName && (
+              <Row label="Linked server" value={data.serverName} />
+            )}
           </div>
         )}
 
@@ -394,11 +462,17 @@ export function LineageDetailPanel({
         )}
 
         {data.nodeType === "container" && (
-          <GenericAssetSection description={data.description} attributes={data.attributes} />
+          <GenericAssetSection
+            description={data.description}
+            attributes={data.attributes}
+          />
         )}
 
         {data.nodeType === "cloudResource" && (
-          <GenericAssetSection description={data.description} attributes={data.attributes} />
+          <GenericAssetSection
+            description={data.description}
+            attributes={data.attributes}
+          />
         )}
 
         <EvidenceTierBadge
@@ -407,22 +481,35 @@ export function LineageDetailPanel({
           notAfter={data.evidenceNotAfter}
         />
 
-        {(data.status || data.riskScore != null || data.firstSeen || data.lastSeen) && (
+        {(data.status ||
+          data.riskScore != null ||
+          data.firstSeen ||
+          data.lastSeen) && (
           <div className="space-y-2">
             <Label>Lifecycle</Label>
             {data.status && <Row label="Status" value={data.status} />}
-            {data.riskScore != null && <Row label="Risk score" value={data.riskScore.toFixed(1)} />}
-            {data.firstSeen && <Row label="First seen" value={shortDate(data.firstSeen)} />}
-            {data.lastSeen && <Row label="Last seen" value={shortDate(data.lastSeen)} />}
+            {data.riskScore != null && (
+              <Row label="Risk score" value={data.riskScore.toFixed(1)} />
+            )}
+            {data.firstSeen && (
+              <Row label="First seen" value={shortDate(data.firstSeen)} />
+            )}
+            {data.lastSeen && (
+              <Row label="Last seen" value={shortDate(data.lastSeen)} />
+            )}
           </div>
         )}
 
-        {typeof data.attributes?.node_id === "string" && data.attributes.node_id && (
-          <div className="space-y-2">
-            <Label>Identifier</Label>
-            <CodeBlock label="Node ID" value={String(data.attributes.node_id)} />
-          </div>
-        )}
+        {typeof data.attributes?.node_id === "string" &&
+          data.attributes.node_id && (
+            <div className="space-y-2">
+              <Label>Identifier</Label>
+              <CodeBlock
+                label="Node ID"
+                value={String(data.attributes.node_id)}
+              />
+            </div>
+          )}
 
         {(data.neighborCount != null ||
           data.sourceCount != null ||
@@ -431,12 +518,28 @@ export function LineageDetailPanel({
           data.impactCount != null) && (
           <div className="space-y-2">
             <Label>Graph Context</Label>
-            {data.neighborCount != null && <Row label="Neighbors" value={data.neighborCount} />}
-            {data.sourceCount != null && <Row label="Sources" value={data.sourceCount} />}
-            {data.incomingEdgeCount != null && <Row label="Incoming edges" value={data.incomingEdgeCount} />}
-            {data.outgoingEdgeCount != null && <Row label="Outgoing edges" value={data.outgoingEdgeCount} />}
-            {data.impactCount != null && <Row label="Affected nodes" value={data.impactCount} className="text-orange-300" />}
-            {data.maxImpactDepth != null && <Row label="Impact depth" value={data.maxImpactDepth} />}
+            {data.neighborCount != null && (
+              <Row label="Neighbors" value={data.neighborCount} />
+            )}
+            {data.sourceCount != null && (
+              <Row label="Sources" value={data.sourceCount} />
+            )}
+            {data.incomingEdgeCount != null && (
+              <Row label="Incoming edges" value={data.incomingEdgeCount} />
+            )}
+            {data.outgoingEdgeCount != null && (
+              <Row label="Outgoing edges" value={data.outgoingEdgeCount} />
+            )}
+            {data.impactCount != null && (
+              <Row
+                label="Affected nodes"
+                value={data.impactCount}
+                className="text-orange-300"
+              />
+            )}
+            {data.maxImpactDepth != null && (
+              <Row label="Impact depth" value={data.maxImpactDepth} />
+            )}
           </div>
         )}
 
@@ -481,7 +584,11 @@ export function LineageDetailPanel({
             <Label>Attributes</Label>
             <div className="space-y-1.5">
               {extraAttributes.slice(0, 10).map(([key, value]) => (
-                <Row key={key} label={prettifyKey(key)} value={formatValue(value)} />
+                <Row
+                  key={key}
+                  label={prettifyKey(key)}
+                  value={formatValue(value)}
+                />
               ))}
             </div>
           </div>
@@ -502,7 +609,9 @@ function GenericAssetSection({
 }) {
   return (
     <div className="space-y-3">
-      {description && <div className="text-xs text-zinc-400">{description}</div>}
+      {description && (
+        <div className="text-xs text-zinc-400">{description}</div>
+      )}
       {version && <Row label="Version / hash" value={version} />}
       {typeof attributes?.verified === "boolean" && (
         <Row label="Verified" value={attributes.verified ? "yes" : "no"} />
@@ -530,7 +639,7 @@ function TagList({
     <div>
       <Label>{label}</Label>
       <div className="flex flex-wrap gap-1 mt-1">
-        {tags.map((tag) => (
+        {tags.map((tag) =>
           linkBuilder ? (
             <Link
               key={tag}
@@ -540,11 +649,14 @@ function TagList({
               {tag}
             </Link>
           ) : (
-            <span key={tag} className={`text-[10px] px-1.5 py-0.5 rounded border ${toneClass}`}>
+            <span
+              key={tag}
+              className={`text-[10px] px-1.5 py-0.5 rounded border ${toneClass}`}
+            >
               {tag}
             </span>
-          )
-        ))}
+          ),
+        )}
       </div>
     </div>
   );
@@ -562,7 +674,11 @@ function CodeBlock({ label, value }: { label: string; value: string }) {
 }
 
 function Label({ children }: { children: ReactNode }) {
-  return <div className="text-[10px] uppercase tracking-wider text-zinc-500 mb-0.5">{children}</div>;
+  return (
+    <div className="text-[10px] uppercase tracking-wider text-zinc-500 mb-0.5">
+      {children}
+    </div>
+  );
 }
 
 function Row({
@@ -577,7 +693,11 @@ function Row({
   return (
     <div className="flex items-center justify-between gap-4 text-xs">
       <span className="text-zinc-500">{label}</span>
-      <span className={`text-zinc-300 font-mono text-right break-all ${className}`}>{value}</span>
+      <span
+        className={`text-zinc-300 font-mono text-right break-all ${className}`}
+      >
+        {value}
+      </span>
     </div>
   );
 }
@@ -591,8 +711,13 @@ function shortDate(value: string): string {
 function formatValue(value: unknown): string {
   if (value == null) return "—";
   if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean") return String(value);
-  if (Array.isArray(value)) return value.slice(0, 4).map((item) => String(item)).join(", ");
+  if (typeof value === "number" || typeof value === "boolean")
+    return String(value);
+  if (Array.isArray(value))
+    return value
+      .slice(0, 4)
+      .map((item) => String(item))
+      .join(", ");
   return JSON.stringify(value);
 }
 
@@ -643,14 +768,19 @@ function EvidenceTierBadge({
   if (notAfter) {
     const expiry = new Date(notAfter).getTime();
     if (!Number.isNaN(expiry)) {
-      const deltaDays = Math.max(0, Math.floor((expiry - Date.now()) / 86_400_000));
+      const deltaDays = Math.max(
+        0,
+        Math.floor((expiry - Date.now()) / 86_400_000),
+      );
       rotatesIn = deltaDays;
     }
   }
   return (
     <div className="flex items-center gap-1.5 rounded border border-amber-800 bg-amber-950 px-2 py-1 text-[10px] font-mono text-amber-300">
       <Hourglass className="w-3 h-3" />
-      <span>{rotatesIn != null ? `Rotates in ${rotatesIn} days` : "Replay only"}</span>
+      <span>
+        {rotatesIn != null ? `Rotates in ${rotatesIn} days` : "Replay only"}
+      </span>
     </div>
   );
 }

--- a/ui/components/lineage-filter.tsx
+++ b/ui/components/lineage-filter.tsx
@@ -48,6 +48,9 @@ export const FOCUSED_LAYER_DEFAULTS: Record<LineageNodeType, boolean> = {
   accessPolicy: false,
   driftIncident: true,
   dataStore: true,
+  directory: true,
+  sourceFile: true,
+  configFile: true,
 };
 
 export const EXPANDED_LAYER_DEFAULTS: Record<LineageNodeType, boolean> = {
@@ -81,6 +84,9 @@ export const EXPANDED_LAYER_DEFAULTS: Record<LineageNodeType, boolean> = {
   accessPolicy: true,
   driftIncident: true,
   dataStore: true,
+  directory: true,
+  sourceFile: true,
+  configFile: true,
 };
 
 export type GraphScopePreset = "immediate" | "relevant" | "expanded";
@@ -97,7 +103,9 @@ export const GRAPH_SCOPE_DESCRIPTIONS: Record<GraphScopePreset, string> = {
   expanded: "Broader topology review with lower-priority context included.",
 };
 
-export function createImmediateGraphFilters(agentName: string | null = null): FilterState {
+export function createImmediateGraphFilters(
+  agentName: string | null = null,
+): FilterState {
   return {
     layers: { ...FOCUSED_LAYER_DEFAULTS },
     severity: "high",
@@ -110,7 +118,9 @@ export function createImmediateGraphFilters(agentName: string | null = null): Fi
   };
 }
 
-export function createFocusedGraphFilters(agentName: string | null = null): FilterState {
+export function createFocusedGraphFilters(
+  agentName: string | null = null,
+): FilterState {
   return {
     layers: { ...FOCUSED_LAYER_DEFAULTS },
     severity: "high",
@@ -123,7 +133,9 @@ export function createFocusedGraphFilters(agentName: string | null = null): Filt
   };
 }
 
-export function createExpandedGraphFilters(agentName: string | null = null): FilterState {
+export function createExpandedGraphFilters(
+  agentName: string | null = null,
+): FilterState {
   return {
     layers: { ...EXPANDED_LAYER_DEFAULTS },
     severity: null,
@@ -138,9 +150,17 @@ export function createExpandedGraphFilters(agentName: string | null = null): Fil
 
 export const DEFAULT_FILTERS: FilterState = createFocusedGraphFilters();
 
-export function graphScopePresetForFilters(filters: FilterState): GraphScopePreset {
-  if (filters.maxDepth <= 1 && filters.pageSize <= 25 && filters.vulnOnly) return "immediate";
-  if (filters.maxDepth <= 2 && filters.pageSize <= 50 && filters.vulnOnly && filters.severity === "high") {
+export function graphScopePresetForFilters(
+  filters: FilterState,
+): GraphScopePreset {
+  if (filters.maxDepth <= 1 && filters.pageSize <= 25 && filters.vulnOnly)
+    return "immediate";
+  if (
+    filters.maxDepth <= 2 &&
+    filters.pageSize <= 50 &&
+    filters.vulnOnly &&
+    filters.severity === "high"
+  ) {
     return "relevant";
   }
   return "expanded";
@@ -171,7 +191,10 @@ const SEVERITY_OPTIONS: Array<{ value: string; label: string }> = [
   { value: "low", label: "Low + above" },
 ];
 
-const RELATIONSHIP_SCOPE_OPTIONS: Array<{ value: FilterState["relationshipScope"]; label: string }> = [
+const RELATIONSHIP_SCOPE_OPTIONS: Array<{
+  value: FilterState["relationshipScope"];
+  label: string;
+}> = [
   { value: "all", label: "All relationships" },
   { value: "inventory", label: "Inventory only" },
   { value: "attack", label: "Attack / lateral" },
@@ -180,7 +203,10 @@ const RELATIONSHIP_SCOPE_OPTIONS: Array<{ value: FilterState["relationshipScope"
 ];
 
 /** Edge-kind sets used to decide whether a relationship-scope option is reachable. */
-const SCOPE_RELATIONSHIPS: Record<Exclude<FilterState["relationshipScope"], "all">, string[]> = {
+const SCOPE_RELATIONSHIPS: Record<
+  Exclude<FilterState["relationshipScope"], "all">,
+  string[]
+> = {
   inventory: [
     "hosts",
     "uses",
@@ -262,13 +288,23 @@ const LAYER_LABELS: { key: LineageNodeType; label: string; color: string }[] = [
   { key: "accessPolicy", label: "Policies", color: "bg-amber-700" },
   { key: "driftIncident", label: "Drift", color: "bg-orange-400" },
   { key: "dataStore", label: "Data Stores", color: "bg-sky-600" },
+  { key: "directory", label: "Folders", color: "bg-teal-600" },
+  { key: "sourceFile", label: "Source Files", color: "bg-cyan-400" },
+  { key: "configFile", label: "Config Files", color: "bg-orange-500" },
 ];
 
 const AGENT_OPTION_HEIGHT = 32;
 const AGENT_VISIBLE_ROWS = 8;
 const AGENT_OVERSCAN_ROWS = 4;
 
-export function FilterPanel({ filters, onChange, agentNames, validValues, onReset, variant = "rail" }: FilterPanelProps) {
+export function FilterPanel({
+  filters,
+  onChange,
+  agentNames,
+  validValues,
+  onReset,
+  variant = "rail",
+}: FilterPanelProps) {
   const [openSections, setOpenSections] = useState({
     layers: false,
     severity: true,
@@ -278,7 +314,10 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
     pageSize: false,
   });
   const toggle = (key: LineageNodeType) =>
-    onChange({ ...filters, layers: { ...filters.layers, [key]: !filters.layers[key] } });
+    onChange({
+      ...filters,
+      layers: { ...filters.layers, [key]: !filters.layers[key] },
+    });
   const toggleSection = (key: keyof typeof openSections) =>
     setOpenSections((current) => ({ ...current, [key]: !current[key] }));
 
@@ -315,8 +354,16 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
           : "w-48 bg-[var(--surface)] backdrop-blur-sm border-r border-[var(--border-subtle)] p-3 space-y-4 overflow-y-auto text-xs text-[var(--text-secondary)]"
       }
     >
-      <div className={variant === "panel" ? "flex items-center justify-between md:col-span-2 xl:col-span-4" : "flex items-center justify-between -mt-1 -mx-1 mb-1"}>
-        <span className="text-[10px] uppercase tracking-[0.2em] text-[var(--text-tertiary)] px-1">Filters</span>
+      <div
+        className={
+          variant === "panel"
+            ? "flex items-center justify-between md:col-span-2 xl:col-span-4"
+            : "flex items-center justify-between -mt-1 -mx-1 mb-1"
+        }
+      >
+        <span className="text-[10px] uppercase tracking-[0.2em] text-[var(--text-tertiary)] px-1">
+          Filters
+        </span>
         {onReset && (
           <button
             type="button"
@@ -373,7 +420,9 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
       >
         <select
           value={filters.severity ?? ""}
-          onChange={(e) => onChange({ ...filters, severity: e.target.value || null })}
+          onChange={(e) =>
+            onChange({ ...filters, severity: e.target.value || null })
+          }
           className="w-full bg-[var(--surface)] border border-[var(--border-subtle)] rounded px-2 py-1 text-[var(--foreground)] focus:outline-none focus:border-emerald-600"
         >
           {SEVERITY_OPTIONS.map(({ value, label }) => {
@@ -397,14 +446,19 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
         title="Edges"
         open={openSections.edges}
         onToggle={() => toggleSection("edges")}
-        summary={filters.relationshipScope === "all" ? "all" : filters.relationshipScope}
+        summary={
+          filters.relationshipScope === "all"
+            ? "all"
+            : filters.relationshipScope
+        }
       >
         <select
           value={filters.relationshipScope}
           onChange={(e) =>
             onChange({
               ...filters,
-              relationshipScope: e.target.value as FilterState["relationshipScope"],
+              relationshipScope: e.target
+                .value as FilterState["relationshipScope"],
             })
           }
           className="w-full bg-[var(--surface)] border border-[var(--border-subtle)] rounded px-2 py-1 text-[var(--foreground)] focus:outline-none focus:border-emerald-600"
@@ -487,7 +541,9 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
           <input
             type="checkbox"
             checked={filters.vulnOnly}
-            onChange={(e) => onChange({ ...filters, vulnOnly: e.target.checked })}
+            onChange={(e) =>
+              onChange({ ...filters, vulnOnly: e.target.checked })
+            }
             className="accent-emerald-500 w-3 h-3"
           />
           Vulnerable only
@@ -502,7 +558,9 @@ export function FilterPanel({ filters, onChange, agentNames, validValues, onRese
       >
         <select
           value={String(filters.pageSize)}
-          onChange={(e) => onChange({ ...filters, pageSize: Number(e.target.value) })}
+          onChange={(e) =>
+            onChange({ ...filters, pageSize: Number(e.target.value) })
+          }
           className="w-full bg-[var(--surface)] border border-[var(--border-subtle)] rounded px-2 py-1 text-[var(--foreground)] focus:outline-none focus:border-emerald-600"
         >
           <option value="25">25 nodes</option>
@@ -533,16 +591,28 @@ function VirtualizedAgentPicker({
   const filteredAgents = useMemo(
     () =>
       normalizedQuery
-        ? agentNames.filter((agentName) => agentName.toLowerCase().includes(normalizedQuery))
+        ? agentNames.filter((agentName) =>
+            agentName.toLowerCase().includes(normalizedQuery),
+          )
         : agentNames,
     [agentNames, normalizedQuery],
   );
   const listHeight = AGENT_VISIBLE_ROWS * AGENT_OPTION_HEIGHT;
   const visibleCount = AGENT_VISIBLE_ROWS + AGENT_OVERSCAN_ROWS * 2;
-  const startIndex = Math.max(0, Math.floor(scrollTop / AGENT_OPTION_HEIGHT) - AGENT_OVERSCAN_ROWS);
-  const visibleAgents = filteredAgents.slice(startIndex, startIndex + visibleCount);
+  const startIndex = Math.max(
+    0,
+    Math.floor(scrollTop / AGENT_OPTION_HEIGHT) - AGENT_OVERSCAN_ROWS,
+  );
+  const visibleAgents = filteredAgents.slice(
+    startIndex,
+    startIndex + visibleCount,
+  );
   const topPadding = startIndex * AGENT_OPTION_HEIGHT;
-  const bottomPadding = Math.max(0, (filteredAgents.length - startIndex - visibleAgents.length) * AGENT_OPTION_HEIGHT);
+  const bottomPadding = Math.max(
+    0,
+    (filteredAgents.length - startIndex - visibleAgents.length) *
+      AGENT_OPTION_HEIGHT,
+  );
 
   return (
     <div className="space-y-2">
@@ -601,12 +671,15 @@ function VirtualizedAgentPicker({
             );
           })}
           {visibleAgents.length === 0 && (
-            <div className="px-2 py-3 text-[11px] text-[var(--text-tertiary)]">No agents match this filter.</div>
+            <div className="px-2 py-3 text-[11px] text-[var(--text-tertiary)]">
+              No agents match this filter.
+            </div>
           )}
         </div>
       </div>
       <p className="text-[10px] text-[var(--text-tertiary)]">
-        Showing {visibleAgents.length.toLocaleString()} of {filteredAgents.length.toLocaleString()} matches.
+        Showing {visibleAgents.length.toLocaleString()} of{" "}
+        {filteredAgents.length.toLocaleString()} matches.
       </p>
     </div>
   );
@@ -633,12 +706,26 @@ function FilterSection({
         className="flex w-full items-center justify-between px-3 py-2 text-left"
       >
         <div>
-          <h3 className="font-semibold text-[var(--text-secondary)] uppercase tracking-wider text-[10px]">{title}</h3>
-          {summary ? <p className="mt-1 text-[10px] text-[var(--text-tertiary)]">{summary}</p> : null}
+          <h3 className="font-semibold text-[var(--text-secondary)] uppercase tracking-wider text-[10px]">
+            {title}
+          </h3>
+          {summary ? (
+            <p className="mt-1 text-[10px] text-[var(--text-tertiary)]">
+              {summary}
+            </p>
+          ) : null}
         </div>
-        {open ? <ChevronDown className="h-3.5 w-3.5 text-[var(--text-tertiary)]" /> : <ChevronRight className="h-3.5 w-3.5 text-[var(--text-tertiary)]" />}
+        {open ? (
+          <ChevronDown className="h-3.5 w-3.5 text-[var(--text-tertiary)]" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 text-[var(--text-tertiary)]" />
+        )}
       </button>
-      {open ? <div className="border-t border-[var(--border-subtle)] px-3 py-3">{children}</div> : null}
+      {open ? (
+        <div className="border-t border-[var(--border-subtle)] px-3 py-3">
+          {children}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/ui/components/lineage-nodes.tsx
+++ b/ui/components/lineage-nodes.tsx
@@ -14,7 +14,10 @@ import {
   Cloud,
   Container,
   Database,
+  FileCode,
+  FileCog,
   Fingerprint,
+  Folder,
   IdCard,
   KeyRound,
   Landmark,
@@ -68,7 +71,10 @@ export type LineageNodeType =
   | "accessGrant"
   | "accessPolicy"
   | "driftIncident"
-  | "dataStore";
+  | "dataStore"
+  | "directory"
+  | "sourceFile"
+  | "configFile";
 
 export type LineageNodeData = {
   label: string;
@@ -179,12 +185,18 @@ function NodeCard({
       />
       <div className="flex items-center gap-2 mb-1">
         <Icon className={`w-[18px] h-[18px] shrink-0 ${iconClass}`} />
-        <span className="text-[15px] font-semibold leading-5 text-zinc-950 dark:text-zinc-50 truncate">{data.label}</span>
+        <span className="text-[15px] font-semibold leading-5 text-zinc-950 dark:text-zinc-50 truncate">
+          {data.label}
+        </span>
         <span className="ml-auto rounded border border-black/10 bg-white/70 px-1.5 py-0.5 text-[10px] uppercase tracking-[0.1em] text-zinc-600 dark:border-white/15 dark:bg-black/25 dark:text-zinc-200">
           {NODE_TYPE_BADGES[data.nodeType]}
         </span>
       </div>
-      {subtitle && <div className="text-xs leading-4 text-zinc-700 dark:text-zinc-200/90 truncate">{subtitle}</div>}
+      {subtitle && (
+        <div className="text-xs leading-4 text-zinc-700 dark:text-zinc-200/90 truncate">
+          {subtitle}
+        </div>
+      )}
       {footer}
     </div>
   );
@@ -196,7 +208,10 @@ function NodeCard({
  * glyph shown on a node is byte-for-byte the glyph shown in the legend row
  * for the same type. Every type gets a DISTINCT, on-meaning Lucide icon.
  */
-export type EntityIcon = ComponentType<{ className?: string; style?: CSSProperties }>;
+export type EntityIcon = ComponentType<{
+  className?: string;
+  style?: CSSProperties;
+}>;
 
 export const ENTITY_ICONS: Record<LineageNodeType, EntityIcon> = {
   provider: Cloud,
@@ -229,9 +244,14 @@ export const ENTITY_ICONS: Record<LineageNodeType, EntityIcon> = {
   accessPolicy: ShieldCheck,
   driftIncident: Activity,
   dataStore: Warehouse,
+  directory: Folder,
+  sourceFile: FileCode,
+  configFile: FileCog,
 };
 
-export function entityIcon(nodeType: LineageNodeType | string | undefined): EntityIcon {
+export function entityIcon(
+  nodeType: LineageNodeType | string | undefined,
+): EntityIcon {
   if (nodeType && nodeType in ENTITY_ICONS) {
     return ENTITY_ICONS[nodeType as LineageNodeType];
   }
@@ -269,6 +289,9 @@ const NODE_TYPE_BADGES: Record<LineageNodeType, string> = {
   accessPolicy: "Policy",
   driftIncident: "Drift",
   dataStore: "Data",
+  directory: "Folder",
+  sourceFile: "Source",
+  configFile: "Config",
 };
 
 function AgentNode({ data }: { data: LineageNodeData }) {
@@ -276,17 +299,31 @@ function AgentNode({ data }: { data: LineageNodeData }) {
   return (
     <NodeCard
       data={data}
-      borderClass={notConfigured ? "border-yellow-500 border-dashed" : "border-emerald-500 dark:border-emerald-600"}
-      bgClass={notConfigured ? "bg-yellow-50 dark:bg-yellow-950/80" : "bg-emerald-50 dark:bg-emerald-950/80"}
+      borderClass={
+        notConfigured
+          ? "border-yellow-500 border-dashed"
+          : "border-emerald-500 dark:border-emerald-600"
+      }
+      bgClass={
+        notConfigured
+          ? "bg-yellow-50 dark:bg-yellow-950/80"
+          : "bg-emerald-50 dark:bg-emerald-950/80"
+      }
       ringClass="ring-emerald-400"
       iconClass="text-emerald-600 dark:text-emerald-400"
       target={false}
       subtitle={data.agentType}
       footer={
         <div className="flex gap-2 mt-1 text-[10px] text-zinc-600 dark:text-zinc-500">
-          {data.serverCount !== undefined && <span>{data.serverCount} srv</span>}
-          {data.packageCount !== undefined && <span>{data.packageCount} pkg</span>}
-          {(data.vulnCount ?? 0) > 0 && <span className="text-red-400">{data.vulnCount} finding</span>}
+          {data.serverCount !== undefined && (
+            <span>{data.serverCount} srv</span>
+          )}
+          {data.packageCount !== undefined && (
+            <span>{data.packageCount} pkg</span>
+          )}
+          {(data.vulnCount ?? 0) > 0 && (
+            <span className="text-red-400">{data.vulnCount} finding</span>
+          )}
         </div>
       }
     />
@@ -304,7 +341,9 @@ function ProviderNode({ data }: { data: LineageNodeData }) {
       target={false}
       footer={
         data.agentCount !== undefined ? (
-          <div className="mt-1 text-[10px] text-zinc-600 dark:text-zinc-500">{data.agentCount} agents</div>
+          <div className="mt-1 text-[10px] text-zinc-600 dark:text-zinc-500">
+            {data.agentCount} agents
+          </div>
         ) : undefined
       }
     />
@@ -400,8 +439,12 @@ function StructureNode({
       subtitle={data.description}
       footer={
         <div className="flex gap-2 mt-1 text-[10px] text-zinc-600 dark:text-zinc-500">
-          {data.agentCount !== undefined && <span>{data.agentCount} agents</span>}
-          {data.serverCount !== undefined && <span>{data.serverCount} servers</span>}
+          {data.agentCount !== undefined && (
+            <span>{data.agentCount} agents</span>
+          )}
+          {data.serverCount !== undefined && (
+            <span>{data.serverCount} servers</span>
+          )}
         </div>
       }
     />
@@ -484,8 +527,16 @@ function PackageNode({ data }: { data: LineageNodeData }) {
   return (
     <NodeCard
       data={data}
-      borderClass={hasVulns ? "border-red-400 dark:border-red-600/60" : "border-zinc-300 dark:border-zinc-600"}
-      bgClass={hasVulns ? "bg-red-50 dark:bg-red-950/40" : "bg-white dark:bg-zinc-900/80"}
+      borderClass={
+        hasVulns
+          ? "border-red-400 dark:border-red-600/60"
+          : "border-zinc-300 dark:border-zinc-600"
+      }
+      bgClass={
+        hasVulns
+          ? "bg-red-50 dark:bg-red-950/40"
+          : "bg-white dark:bg-zinc-900/80"
+      }
       ringClass="ring-zinc-400"
       iconClass="text-zinc-600 dark:text-zinc-400"
       subtitle={
@@ -522,19 +573,26 @@ function FindingNode({
       borderClass={borderClass}
       bgClass={bgClass}
       ringClass="ring-white/50"
-      shapeClass={data.nodeType === "misconfiguration" ? "rounded-md" : "rounded-lg"}
+      shapeClass={
+        data.nodeType === "misconfiguration" ? "rounded-md" : "rounded-lg"
+      }
       iconClass={accentClass}
       source={false}
       subtitle={data.description}
       footer={
         <div className="flex flex-wrap gap-1 mt-1">
           {data.severity && (
-            <span className={`text-[10px] px-1.5 py-0.5 rounded border font-mono uppercase ${severityColor(data.severity)}`}>
+            <span
+              className={`text-[10px] px-1.5 py-0.5 rounded border font-mono uppercase ${severityColor(data.severity)}`}
+            >
               {data.severity}
             </span>
           )}
-          {typeof data.cvssScore === "number" && Number.isFinite(data.cvssScore) ? (
-            <span className="text-[10px] text-zinc-400">CVSS {data.cvssScore.toFixed(1)}</span>
+          {typeof data.cvssScore === "number" &&
+          Number.isFinite(data.cvssScore) ? (
+            <span className="text-[10px] text-zinc-400">
+              CVSS {data.cvssScore.toFixed(1)}
+            </span>
           ) : null}
           {data.isKev && (
             <span className="text-[10px] px-1.5 py-0.5 rounded bg-red-900 text-red-300 border border-red-700 font-mono">
@@ -550,20 +608,40 @@ function FindingNode({
 function VulnNode({ data }: { data: LineageNodeData }) {
   const sev = data.severity ?? "medium";
   const borderClass =
-    sev === "critical" ? "border-red-500" :
-    sev === "high" ? "border-orange-500" :
-    sev === "medium" ? "border-yellow-500" :
-    "border-blue-500";
+    sev === "critical"
+      ? "border-red-500"
+      : sev === "high"
+        ? "border-orange-500"
+        : sev === "medium"
+          ? "border-yellow-500"
+          : "border-blue-500";
   const bgClass =
-    sev === "critical" ? "bg-red-100 dark:bg-red-950/80" :
-    sev === "high" ? "bg-orange-100 dark:bg-orange-950/80" :
-    sev === "medium" ? "bg-yellow-100 dark:bg-yellow-950/80" :
-    "bg-blue-100 dark:bg-blue-950/80";
-  return <FindingNode data={data} accentClass="text-red-300" borderClass={borderClass} bgClass={bgClass} />;
+    sev === "critical"
+      ? "bg-red-100 dark:bg-red-950/80"
+      : sev === "high"
+        ? "bg-orange-100 dark:bg-orange-950/80"
+        : sev === "medium"
+          ? "bg-yellow-100 dark:bg-yellow-950/80"
+          : "bg-blue-100 dark:bg-blue-950/80";
+  return (
+    <FindingNode
+      data={data}
+      accentClass="text-red-300"
+      borderClass={borderClass}
+      bgClass={bgClass}
+    />
+  );
 }
 
 function MisconfigNode({ data }: { data: LineageNodeData }) {
-  return <FindingNode data={data} accentClass="text-orange-600 dark:text-orange-300" borderClass="border-orange-500" bgClass="bg-orange-100 dark:bg-orange-950/75" />;
+  return (
+    <FindingNode
+      data={data}
+      accentClass="text-orange-600 dark:text-orange-300"
+      borderClass="border-orange-500"
+      bgClass="bg-orange-100 dark:bg-orange-950/75"
+    />
+  );
 }
 
 function CredentialNode({ data }: { data: LineageNodeData }) {
@@ -675,8 +753,16 @@ function ClusterPillNode({ data }: { data: LineageNodeData }) {
       } cluster-pill-pulse cursor-pointer`}
       title="Click to expand"
     >
-      <Handle type="target" position={Position.Left} className="!w-2 !h-2 !bg-sky-300" />
-      <Handle type="source" position={Position.Right} className="!w-2 !h-2 !bg-sky-300" />
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="!w-2 !h-2 !bg-sky-300"
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!w-2 !h-2 !bg-sky-300"
+      />
       <div className="flex items-center gap-1.5">
         <Icon className="w-3.5 h-3.5 text-sky-200" />
         <span className="text-xs font-semibold text-sky-100 whitespace-nowrap">
@@ -743,8 +829,16 @@ function SummaryNode({ data }: { data: LineageNodeData }) {
         data.dimmed ? "opacity-25" : ""
       } ${data.highlighted ? "ring-2 ring-sky-400" : ""}`}
     >
-      <Handle type="target" position={Position.Left} className="!w-1.5 !h-1.5" />
-      <Handle type="source" position={Position.Right} className="!w-1.5 !h-1.5" />
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="!w-1.5 !h-1.5"
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!w-1.5 !h-1.5"
+      />
       <div className="flex items-center gap-1">
         <span className="text-[10px] font-medium truncate">{data.label}</span>
         {vulnCount > 0 && (
@@ -778,8 +872,16 @@ function ClusterBubbleNode({ data }: { data: LineageNodeData }) {
         borderColor: color,
       }}
     >
-      <Handle type="target" position={Position.Left} className="!w-1 !h-1 !bg-transparent !border-0" />
-      <Handle type="source" position={Position.Right} className="!w-1 !h-1 !bg-transparent !border-0" />
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="!w-1 !h-1 !bg-transparent !border-0"
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!w-1 !h-1 !bg-transparent !border-0"
+      />
     </div>
   );
 }
@@ -815,9 +917,15 @@ const CLUSTER_BUBBLE_COLORS: Record<LineageNodeType, string> = {
   accessPolicy: "#a16207",
   driftIncident: "#fb923c",
   dataStore: "#0284c7",
+  directory: "#0d9488",
+  sourceFile: "#22d3ee",
+  configFile: "#f97316",
 };
 
-const DETAIL_RENDERERS: Record<LineageNodeType, ComponentType<{ data: LineageNodeData }>> = {
+const DETAIL_RENDERERS: Record<
+  LineageNodeType,
+  ComponentType<{ data: LineageNodeData }>
+> = {
   provider: ProviderNode,
   agent: AgentNode,
   user: UserNode,
@@ -848,6 +956,9 @@ const DETAIL_RENDERERS: Record<LineageNodeType, ComponentType<{ data: LineageNod
   accessPolicy: CredentialNode,
   driftIncident: MisconfigNode,
   dataStore: CloudResourceNode,
+  directory: ContainerNode,
+  sourceFile: PackageNode,
+  configFile: PackageNode,
 };
 
 function AdaptiveLineageNode({ data }: { data: LineageNodeData }) {

--- a/ui/lib/context-graph.ts
+++ b/ui/lib/context-graph.ts
@@ -4,15 +4,24 @@
  */
 
 import { type Node, type Edge, MarkerType } from "@xyflow/react";
-import type { LineageNodeData, LineageNodeType } from "@/components/lineage-nodes";
-import { readReachBreakdown, readReachScore, reachEdgeWidth, reachStrokeColor } from "@/lib/effective-reach";
+import type {
+  LineageNodeData,
+  LineageNodeType,
+} from "@/components/lineage-nodes";
+import {
+  readReachBreakdown,
+  readReachScore,
+  reachEdgeWidth,
+  reachStrokeColor,
+} from "@/lib/effective-reach";
 import { RELATIONSHIP_COLOR_MAP } from "@/lib/graph-schema";
 
 // ─── Types (mirror Python context_graph.to_serializable) ────────────────────
 
 export interface ContextGraphNode {
   id: string;
-  kind: "agent" | "server" | "credential" | "tool" | "vulnerability" | "iam_role";
+  kind:
+    "agent" | "server" | "credential" | "tool" | "vulnerability" | "iam_role";
   entity_type?: string;
   label: string;
   metadata: Record<string, unknown>;
@@ -116,21 +125,24 @@ const NODE_TYPE_TO_RENDERER: Record<LineageNodeType, string> = {
   accessPolicy: "accessPolicyNode",
   driftIncident: "driftIncidentNode",
   dataStore: "dataStoreNode",
+  directory: "containerNode",
+  sourceFile: "packageNode",
+  configFile: "packageNode",
 };
 
 // ─── Edge colors ─────────────────────────────────────────────────────────────
 
 const EDGE_COLORS: Record<string, string> = {
-  uses: "#10b981",          // emerald  agent→server
-  exposes: "#f59e0b",       // amber    server→credential
-  exposes_cred: "#f59e0b",  // amber    server→credential
-  provides: "#a855f7",      // purple   server→tool
+  uses: "#10b981", // emerald  agent→server
+  exposes: "#f59e0b", // amber    server→credential
+  exposes_cred: "#f59e0b", // amber    server→credential
+  provides: "#a855f7", // purple   server→tool
   provides_tool: "#a855f7", // purple   server→tool
   vulnerable_to: "#ef4444", // red      server→vulnerability
   shares_server: "#22d3ee", // cyan     agent↔agent
   shares_credential: "#f97316", // orange agent↔agent
-  shares_cred: "#f97316",   // orange   agent↔agent
-  member_of: "#60a5fa",     // blue     identity→agent
+  shares_cred: "#f97316", // orange   agent↔agent
+  member_of: "#60a5fa", // blue     identity→agent
 };
 
 // ─── Builder ─────────────────────────────────────────────────────────────────
@@ -142,7 +154,7 @@ const EDGE_COLORS: Record<string, string> = {
  */
 export function buildContextFlowGraph(
   data: ContextGraphData,
-  selectedAgent?: string
+  selectedAgent?: string,
 ): { nodes: Node[]; edges: Edge[] } {
   // Collect IDs on the selected agent's lateral paths
   const pathNodeIds = new Set<string>();
@@ -166,9 +178,10 @@ export function buildContextFlowGraph(
       if (edge.target === seedId) pathNodeIds.add(edge.source);
     }
   }
-  const visibleIds = selectedAgent && pathNodeIds.size > 0
-    ? pathNodeIds
-    : new Set(data.nodes.map((node) => node.id));
+  const visibleIds =
+    selectedAgent && pathNodeIds.size > 0
+      ? pathNodeIds
+      : new Set(data.nodes.map((node) => node.id));
 
   // Shared server IDs
   const sharedServerNames = new Set<string>();
@@ -183,29 +196,31 @@ export function buildContextFlowGraph(
   const nodes: Node[] = data.nodes
     .filter((node) => visibleIds.has(node.id))
     .map((n) => {
-    const graphKind = n.entity_type ?? n.kind;
-    let nodeType = KIND_TO_NODE_TYPE[graphKind] ?? "server";
-    if (n.kind === "server" && sharedServerNames.has(n.label)) {
-      nodeType = "sharedServer";
-    }
+      const graphKind = n.entity_type ?? n.kind;
+      let nodeType = KIND_TO_NODE_TYPE[graphKind] ?? "server";
+      if (n.kind === "server" && sharedServerNames.has(n.label)) {
+        nodeType = "sharedServer";
+      }
 
-    const dimmed = selectedAgent ? !pathNodeIds.has(n.id) && pathNodeIds.size > 0 : false;
-    const highlighted = selectedAgent ? pathNodeIds.has(n.id) : false;
+      const dimmed = selectedAgent
+        ? !pathNodeIds.has(n.id) && pathNodeIds.size > 0
+        : false;
+      const highlighted = selectedAgent ? pathNodeIds.has(n.id) : false;
 
-    const nodeData: LineageNodeData = {
-      nodeType,
-      label: n.label,
-      dimmed,
-      highlighted,
-      severity: (n.metadata?.severity as string) ?? undefined,
-      cvssScore: (n.metadata?.cvss_score as number) ?? undefined,
-      epssScore: (n.metadata?.epss_score as number) ?? undefined,
-      isKev: n.metadata?.is_kev === true,
-      effectiveReach: readReachBreakdown(n.metadata?.effective_reach),
-      description: (n.metadata?.description as string) ?? undefined,
-      serverName: (n.metadata?.agent as string) ?? undefined,
-      serverCount: (n.metadata?.server_count as number) ?? undefined,
-    };
+      const nodeData: LineageNodeData = {
+        nodeType,
+        label: n.label,
+        dimmed,
+        highlighted,
+        severity: (n.metadata?.severity as string) ?? undefined,
+        cvssScore: (n.metadata?.cvss_score as number) ?? undefined,
+        epssScore: (n.metadata?.epss_score as number) ?? undefined,
+        isKev: n.metadata?.is_kev === true,
+        effectiveReach: readReachBreakdown(n.metadata?.effective_reach),
+        description: (n.metadata?.description as string) ?? undefined,
+        serverName: (n.metadata?.agent as string) ?? undefined,
+        serverCount: (n.metadata?.server_count as number) ?? undefined,
+      };
 
       return {
         id: n.id,
@@ -216,14 +231,19 @@ export function buildContextFlowGraph(
     });
 
   const edges: Edge[] = data.edges
-    .filter((edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target))
+    .filter(
+      (edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target),
+    )
     .map((e, i) => {
-    const isOnPath = pathEdgePairs.has(`${e.source}→${e.target}`);
-    const relationship = e.relationship ?? e.kind;
-    const baseColor = RELATIONSHIP_COLOR_MAP[relationship] ?? EDGE_COLORS[relationship] ?? "#52525b";
-    const reachScore = readReachScore(e.metadata?.effective_reach_score);
-    const reachColor = reachStrokeColor(reachScore);
-    const strokeColor = isOnPath ? "#f97316" : reachColor ?? baseColor;
+      const isOnPath = pathEdgePairs.has(`${e.source}→${e.target}`);
+      const relationship = e.relationship ?? e.kind;
+      const baseColor =
+        RELATIONSHIP_COLOR_MAP[relationship] ??
+        EDGE_COLORS[relationship] ??
+        "#52525b";
+      const reachScore = readReachScore(e.metadata?.effective_reach_score);
+      const reachColor = reachStrokeColor(reachScore);
+      const strokeColor = isOnPath ? "#f97316" : (reachColor ?? baseColor);
 
       return {
         id: `ctx-edge-${i}`,
@@ -233,14 +253,21 @@ export function buildContextFlowGraph(
         data: {
           relationship,
           relationshipLabel: relationship.replace(/_/g, " "),
-          evidenceMode: isOnPath ? "selected_path" : relationship.includes("runtime") ? "runtime" : "static",
+          evidenceMode: isOnPath
+            ? "selected_path"
+            : relationship.includes("runtime")
+              ? "runtime"
+              : "static",
         },
         animated: isOnPath,
         style: {
           stroke: strokeColor,
-          strokeWidth: isOnPath ? 2.5 : Math.max(1.5, reachEdgeWidth(reachScore)),
+          strokeWidth: isOnPath
+            ? 2.5
+            : Math.max(1.5, reachEdgeWidth(reachScore)),
           strokeDasharray: isOnPath ? "8 4" : undefined,
-          opacity: selectedAgent && pathNodeIds.size > 0 && !isOnPath ? 0.15 : 1,
+          opacity:
+            selectedAgent && pathNodeIds.size > 0 && !isOnPath ? 0.15 : 1,
         },
         markerEnd: {
           type: MarkerType.ArrowClosed,
@@ -248,11 +275,13 @@ export function buildContextFlowGraph(
           width: 12,
           height: 12,
         },
-        label: relationship === "shares_server"
-          ? `shared: ${(e.metadata?.server as string) ?? ""}`
-          : relationship === "shares_credential" || relationship === "shares_cred"
-          ? `shared: ${(e.metadata?.credential as string) ?? ""}`
-          : undefined,
+        label:
+          relationship === "shares_server"
+            ? `shared: ${(e.metadata?.server as string) ?? ""}`
+            : relationship === "shares_credential" ||
+                relationship === "shares_cred"
+              ? `shared: ${(e.metadata?.credential as string) ?? ""}`
+              : undefined,
         labelStyle: { fontSize: 9, fill: "#71717a" },
       };
     });

--- a/ui/lib/filter-algebra.ts
+++ b/ui/lib/filter-algebra.ts
@@ -88,6 +88,9 @@ const LAYER_TO_ENTITY: Record<LineageNodeType, EntityType | string> = {
   accessPolicy: EntityType.ACCESS_POLICY,
   driftIncident: EntityType.DRIFT_INCIDENT,
   dataStore: EntityType.DATA_STORE,
+  directory: EntityType.DIRECTORY,
+  sourceFile: EntityType.SOURCE_FILE,
+  configFile: EntityType.CONFIG_FILE,
 };
 
 const ENTITY_TO_LAYER: Map<string, LineageNodeType> = new Map();
@@ -99,7 +102,10 @@ for (const [layer, entity] of Object.entries(LAYER_TO_ENTITY)) {
   }
 }
 
-const RELATIONSHIP_SCOPE_MAP: Record<FilterState["relationshipScope"], Set<string> | null> = {
+const RELATIONSHIP_SCOPE_MAP: Record<
+  FilterState["relationshipScope"],
+  Set<string> | null
+> = {
   all: null,
   inventory: new Set<string>([
     RelationshipType.HOSTS,
@@ -164,7 +170,10 @@ const RUNTIME_RELATIONSHIPS: Set<string> = new Set([
 // Predicates — each represents one filter dimension
 // ───────────────────────────────────────────────────────────────────────
 
-function severityPasses(node: UnifiedNode, minSeverity: string | null): boolean {
+function severityPasses(
+  node: UnifiedNode,
+  minSeverity: string | null,
+): boolean {
   if (!minSeverity) return true;
   const minRank = SEVERITY_RANK[minSeverity.toLowerCase()] ?? 0;
   if (minRank === 0) return true;
@@ -179,7 +188,10 @@ function severityPasses(node: UnifiedNode, minSeverity: string | null): boolean 
   return rank >= minRank;
 }
 
-function layerPasses(node: UnifiedNode, layers: Record<LineageNodeType, boolean>): boolean {
+function layerPasses(
+  node: UnifiedNode,
+  layers: Record<LineageNodeType, boolean>,
+): boolean {
   const layer = ENTITY_TO_LAYER.get(String(node.entity_type));
   if (!layer) return true; // unmapped entity types pass through
   return Boolean(layers[layer]);
@@ -214,7 +226,10 @@ function vulnOnlyPasses(
  * misconfiguration over the given edges (undirected). Computed once per
  * filter pass when vuln-only is active.
  */
-function buildVulnReachSet(nodes: UnifiedNode[], edges: UnifiedEdge[]): Set<string> {
+function buildVulnReachSet(
+  nodes: UnifiedNode[],
+  edges: UnifiedEdge[],
+): Set<string> {
   const reach = new Set<string>();
   const seeds = nodes.filter(
     (n) =>
@@ -257,7 +272,10 @@ function relationshipScopePasses(
   return allowed.has(String(edge.relationship));
 }
 
-function runtimeModePasses(edge: UnifiedEdge, mode: FilterState["runtimeMode"]): boolean {
+function runtimeModePasses(
+  edge: UnifiedEdge,
+  mode: FilterState["runtimeMode"],
+): boolean {
   if (mode === "all") return true;
   const isRuntime = RUNTIME_RELATIONSHIPS.has(String(edge.relationship));
   if (mode === "static") return !isRuntime;
@@ -350,7 +368,10 @@ function passEdges(
   opts: FilterPassOptions,
 ): UnifiedEdge[] {
   return edges.filter((e) => {
-    if (!opts.skipRelationship && !relationshipScopePasses(e, filters.relationshipScope)) {
+    if (
+      !opts.skipRelationship &&
+      !relationshipScopePasses(e, filters.relationshipScope)
+    ) {
       return false;
     }
     if (!runtimeModePasses(e, filters.runtimeMode)) return false;
@@ -365,12 +386,18 @@ function passNodes(
   opts: FilterPassOptions,
 ): { nodes: UnifiedNode[]; reachIndex: ReachIndex } {
   const reachIndex = buildAgentReachIndex(nodes, edgeSubset, filters.maxDepth);
-  const vulnReach = filters.vulnOnly ? buildVulnReachSet(nodes, edgeSubset) : null;
+  const vulnReach = filters.vulnOnly
+    ? buildVulnReachSet(nodes, edgeSubset)
+    : null;
   const filtered = nodes.filter((n) => {
     if (!opts.skipLayer && !layerPasses(n, filters.layers)) return false;
-    if (!opts.skipSeverity && !severityPasses(n, filters.severity)) return false;
+    if (!opts.skipSeverity && !severityPasses(n, filters.severity))
+      return false;
     if (!vulnOnlyPasses(n, filters.vulnOnly, vulnReach)) return false;
-    if (!opts.skipAgent && !nodeIsInAgentNeighborhood(n, filters.agentName, reachIndex)) {
+    if (
+      !opts.skipAgent &&
+      !nodeIsInAgentNeighborhood(n, filters.agentName, reachIndex)
+    ) {
       return false;
     }
     return true;
@@ -378,7 +405,10 @@ function passNodes(
   return { nodes: filtered, reachIndex };
 }
 
-function pruneEdgesToNodes(edges: UnifiedEdge[], nodeIds: Set<string>): UnifiedEdge[] {
+function pruneEdgesToNodes(
+  edges: UnifiedEdge[],
+  nodeIds: Set<string>,
+): UnifiedEdge[] {
   return edges.filter((e) => nodeIds.has(e.source) && nodeIds.has(e.target));
 }
 
@@ -438,7 +468,9 @@ export function computeValidValues(
 ): FilterValidValues {
   // Severity — drop severity, keep the rest.
   const sevPassEdges = passEdges(edges, filters, {});
-  const { nodes: sevNodes } = passNodes(nodes, sevPassEdges, filters, { skipSeverity: true });
+  const { nodes: sevNodes } = passNodes(nodes, sevPassEdges, filters, {
+    skipSeverity: true,
+  });
   const severities = new Set<string>();
   for (const n of sevNodes) {
     if (!n.severity) continue;
@@ -613,7 +645,12 @@ export function decodeFiltersFromParams(
 
   const layers = get("layers");
   if (layers !== null) {
-    const enabled = new Set(layers.split(",").map((s) => s.trim()).filter(Boolean));
+    const enabled = new Set(
+      layers
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
     const next = {} as Record<LineageNodeType, boolean>;
     for (const key of URL_LAYER_KEYS) {
       next[key] = enabled.has(key);

--- a/ui/lib/graph-schema.generated.ts
+++ b/ui/lib/graph-schema.generated.ts
@@ -102,6 +102,7 @@ export enum GraphNodeKind {
   CREDENTIAL_REF = "credential_ref",
   DATA_STORE = "data_store",
   DATASET = "dataset",
+  DIRECTORY = "directory",
   DRIFT_INCIDENT = "drift_incident",
   ENVIRONMENT = "environment",
   EXTERNAL_IMPORT = "external_import",
@@ -127,9 +128,9 @@ export enum GraphNodeKind {
   VULNERABILITY = "vulnerability",
 }
 
-export type GraphNodeKindKey = "access_grant" | "access_policy" | "account" | "agent" | "api_gateway" | "application" | "ci_job" | "cloud_resource" | "cluster" | "code_module" | "config_file" | "container" | "credential" | "credential_ref" | "data_store" | "dataset" | "drift_incident" | "environment" | "external_import" | "federated_identity" | "fleet" | "group" | "managed_identity" | "misconfiguration" | "model" | "org" | "package" | "policy" | "provider" | "resource" | "role" | "server" | "service_account" | "service_principal" | "source_file" | "tool" | "tool_call" | "user" | "vulnerability";
+export type GraphNodeKindKey = "access_grant" | "access_policy" | "account" | "agent" | "api_gateway" | "application" | "ci_job" | "cloud_resource" | "cluster" | "code_module" | "config_file" | "container" | "credential" | "credential_ref" | "data_store" | "dataset" | "directory" | "drift_incident" | "environment" | "external_import" | "federated_identity" | "fleet" | "group" | "managed_identity" | "misconfiguration" | "model" | "org" | "package" | "policy" | "provider" | "resource" | "role" | "server" | "service_account" | "service_principal" | "source_file" | "tool" | "tool_call" | "user" | "vulnerability";
 
-export const GRAPH_NODE_KINDS: readonly GraphNodeKindKey[] = ["access_grant", "access_policy", "account", "agent", "api_gateway", "application", "ci_job", "cloud_resource", "cluster", "code_module", "config_file", "container", "credential", "credential_ref", "data_store", "dataset", "drift_incident", "environment", "external_import", "federated_identity", "fleet", "group", "managed_identity", "misconfiguration", "model", "org", "package", "policy", "provider", "resource", "role", "server", "service_account", "service_principal", "source_file", "tool", "tool_call", "user", "vulnerability"] as const;
+export const GRAPH_NODE_KINDS: readonly GraphNodeKindKey[] = ["access_grant", "access_policy", "account", "agent", "api_gateway", "application", "ci_job", "cloud_resource", "cluster", "code_module", "config_file", "container", "credential", "credential_ref", "data_store", "dataset", "directory", "drift_incident", "environment", "external_import", "federated_identity", "fleet", "group", "managed_identity", "misconfiguration", "model", "org", "package", "policy", "provider", "resource", "role", "server", "service_account", "service_principal", "source_file", "tool", "tool_call", "user", "vulnerability"] as const;
 
 export interface GraphNodeKindMeta {
   label: string;
@@ -282,6 +283,15 @@ export const GRAPH_NODE_KIND_META: Record<GraphNodeKindKey, GraphNodeKindMeta> =
     "color": "#06b6d4",
     "shape": "square",
     "layer": "asset",
+    "icon": "square",
+    "category_uid": 5,
+    "class_uid": 4001
+  },
+  "directory": {
+    "label": "Directory",
+    "color": "#0d9488",
+    "shape": "square",
+    "layer": "code",
     "icon": "square",
     "category_uid": 5,
     "class_uid": 4001
@@ -610,7 +620,9 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "target_types": [
       "package",
       "server",
-      "container"
+      "container",
+      "source_file",
+      "config_file"
     ],
     "traversable": true
   },
@@ -742,12 +754,16 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "source_types": [
       "container",
       "cluster",
-      "fleet"
+      "fleet",
+      "directory"
     ],
     "target_types": [
       "package",
       "server",
-      "container"
+      "container",
+      "directory",
+      "source_file",
+      "config_file"
     ],
     "traversable": true
   },
@@ -820,7 +836,9 @@ export const GRAPH_EDGE_KIND_META: Record<GraphEdgeKindKey, GraphEdgeKindMeta> =
     "direction": "directed",
     "source_types": [
       "server",
-      "container"
+      "container",
+      "config_file",
+      "source_file"
     ],
     "target_types": [
       "package"

--- a/ui/lib/graph-schema.ts
+++ b/ui/lib/graph-schema.ts
@@ -57,6 +57,7 @@ export enum EntityType {
   CODE_MODULE = "code_module",
   CONFIG_FILE = "config_file",
   EXTERNAL_IMPORT = "external_import",
+  DIRECTORY = "directory",
   CI_JOB = "ci_job",
   // Finding entities (OCSF Category 2)
   VULNERABILITY = "vulnerability",
@@ -269,6 +270,7 @@ export const ENTITY_OCSF_MAP: Record<
   [EntityType.CODE_MODULE]: { category_uid: 5, class_uid: 4001 },
   [EntityType.CONFIG_FILE]: { category_uid: 5, class_uid: 4001 },
   [EntityType.EXTERNAL_IMPORT]: { category_uid: 5, class_uid: 4001 },
+  [EntityType.DIRECTORY]: { category_uid: 5, class_uid: 4001 },
   [EntityType.CI_JOB]: { category_uid: 5, class_uid: 4001 },
   [EntityType.VULNERABILITY]: { category_uid: 2, class_uid: 2001 },
   // Credentials are INVENTORY — presence of env var is not a finding
@@ -432,43 +434,44 @@ export const EDGE_KIND_TO_RELATIONSHIP: Record<string, RelationshipType> = {
 
 /** Canonical node colors by entity type */
 export const ENTITY_COLOR_MAP: Record<string, string> = {
-  [EntityType.AGENT]: "#10b981",           // emerald
-  [EntityType.SERVER]: "#3b82f6",          // blue
-  [EntityType.PACKAGE]: "#52525b",         // zinc
-  [EntityType.TOOL]: "#a855f7",            // purple
-  [EntityType.TOOL_CALL]: "#9333ea",       // purple
-  [EntityType.MODEL]: "#8b5cf6",           // violet
-  [EntityType.DATASET]: "#06b6d4",         // cyan
-  [EntityType.CONTAINER]: "#6366f1",       // indigo
-  [EntityType.RESOURCE]: "#3b82f6",        // blue
-  [EntityType.CLOUD_RESOURCE]: "#0ea5e9",  // sky
-  [EntityType.SOURCE_FILE]: "#22d3ee",      // cyan
-  [EntityType.CODE_MODULE]: "#06b6d4",      // cyan
-  [EntityType.CONFIG_FILE]: "#f97316",      // orange
-  [EntityType.EXTERNAL_IMPORT]: "#f59e0b",  // amber
-  [EntityType.CI_JOB]: "#a855f7",           // purple
-  [EntityType.VULNERABILITY]: "#ef4444",   // red
-  [EntityType.CREDENTIAL]: "#f59e0b",      // amber
-  [EntityType.CREDENTIAL_REF]: "#facc15",  // yellow
+  [EntityType.AGENT]: "#10b981", // emerald
+  [EntityType.SERVER]: "#3b82f6", // blue
+  [EntityType.PACKAGE]: "#52525b", // zinc
+  [EntityType.TOOL]: "#a855f7", // purple
+  [EntityType.TOOL_CALL]: "#9333ea", // purple
+  [EntityType.MODEL]: "#8b5cf6", // violet
+  [EntityType.DATASET]: "#06b6d4", // cyan
+  [EntityType.CONTAINER]: "#6366f1", // indigo
+  [EntityType.RESOURCE]: "#3b82f6", // blue
+  [EntityType.CLOUD_RESOURCE]: "#0ea5e9", // sky
+  [EntityType.SOURCE_FILE]: "#22d3ee", // cyan
+  [EntityType.CODE_MODULE]: "#06b6d4", // cyan
+  [EntityType.CONFIG_FILE]: "#f97316", // orange
+  [EntityType.EXTERNAL_IMPORT]: "#f59e0b", // amber
+  [EntityType.DIRECTORY]: "#0d9488", // teal
+  [EntityType.CI_JOB]: "#a855f7", // purple
+  [EntityType.VULNERABILITY]: "#ef4444", // red
+  [EntityType.CREDENTIAL]: "#f59e0b", // amber
+  [EntityType.CREDENTIAL_REF]: "#facc15", // yellow
   [EntityType.MISCONFIGURATION]: "#f97316", // orange
-  [EntityType.ORG]: "#115e59",             // teal
-  [EntityType.ACCOUNT]: "#0f766e",         // teal
-  [EntityType.USER]: "#14b8a6",            // teal
-  [EntityType.GROUP]: "#0d9488",           // teal
-  [EntityType.ROLE]: "#ea580c",            // orange
-  [EntityType.POLICY]: "#d97706",          // amber
+  [EntityType.ORG]: "#115e59", // teal
+  [EntityType.ACCOUNT]: "#0f766e", // teal
+  [EntityType.USER]: "#14b8a6", // teal
+  [EntityType.GROUP]: "#0d9488", // teal
+  [EntityType.ROLE]: "#ea580c", // orange
+  [EntityType.POLICY]: "#d97706", // amber
   [EntityType.SERVICE_ACCOUNT]: "#0f766e", // teal
   [EntityType.SERVICE_PRINCIPAL]: "#0f766e", // teal
   [EntityType.FEDERATED_IDENTITY]: "#0e7490", // cyan
   [EntityType.MANAGED_IDENTITY]: "#0891b2", // cyan
-  [EntityType.ACCESS_GRANT]: "#ca8a04",    // amber
-  [EntityType.ACCESS_POLICY]: "#a16207",   // amber
-  [EntityType.DRIFT_INCIDENT]: "#fb923c",  // orange
-  [EntityType.DATA_STORE]: "#0284c7",      // sky
-  [EntityType.API_GATEWAY]: "#2563eb",     // blue
-  [EntityType.APPLICATION]: "#7c3aed",     // violet
-  [EntityType.PROVIDER]: "#6b7280",        // gray
-  [EntityType.ENVIRONMENT]: "#6b7280",     // gray
+  [EntityType.ACCESS_GRANT]: "#ca8a04", // amber
+  [EntityType.ACCESS_POLICY]: "#a16207", // amber
+  [EntityType.DRIFT_INCIDENT]: "#fb923c", // orange
+  [EntityType.DATA_STORE]: "#0284c7", // sky
+  [EntityType.API_GATEWAY]: "#2563eb", // blue
+  [EntityType.APPLICATION]: "#7c3aed", // violet
+  [EntityType.PROVIDER]: "#6b7280", // gray
+  [EntityType.ENVIRONMENT]: "#6b7280", // gray
 };
 
 /** Canonical edge colors by relationship type */
@@ -556,7 +559,8 @@ export function filterNodes(
     if (opts.entityTypes && !opts.entityTypes.has(n.entity_type)) return false;
     if (minRank && severityRank(n.severity) < minRank) return false;
     if (opts.status && n.status !== opts.status) return false;
-    if (opts.dataSource && !n.data_sources.includes(opts.dataSource)) return false;
+    if (opts.dataSource && !n.data_sources.includes(opts.dataSource))
+      return false;
     return true;
   });
 }
@@ -571,7 +575,8 @@ export function filterEdges(
   } = {},
 ): UnifiedEdge[] {
   return edges.filter((e) => {
-    if (opts.relationships && !opts.relationships.has(e.relationship)) return false;
+    if (opts.relationships && !opts.relationships.has(e.relationship))
+      return false;
     if (opts.traversableOnly && !e.traversable) return false;
     if (opts.minWeight != null && e.weight < opts.minWeight) return false;
     return true;
@@ -667,46 +672,141 @@ export const ENTITY_LEGEND: LegendEntry[] = [
   { key: "package", label: "Package", color: "#52525b", shape: "square" },
   { key: "tool", label: "Tool", color: "#a855f7", shape: "diamond" },
   { key: "tool_call", label: "Tool Call", color: "#9333ea", shape: "diamond" },
-  { key: "vulnerability", label: "Vulnerability", color: "#ef4444", shape: "triangle" },
-  { key: "credential", label: "Credential", color: "#f59e0b", shape: "diamond" },
-  { key: "credential_ref", label: "Credential Ref", color: "#facc15", shape: "diamond" },
-  { key: "misconfiguration", label: "Misconfiguration", color: "#f97316", shape: "triangle" },
+  {
+    key: "vulnerability",
+    label: "Vulnerability",
+    color: "#ef4444",
+    shape: "triangle",
+  },
+  {
+    key: "credential",
+    label: "Credential",
+    color: "#f59e0b",
+    shape: "diamond",
+  },
+  {
+    key: "credential_ref",
+    label: "Credential Ref",
+    color: "#facc15",
+    shape: "diamond",
+  },
+  {
+    key: "misconfiguration",
+    label: "Misconfiguration",
+    color: "#f97316",
+    shape: "triangle",
+  },
   { key: "resource", label: "Resource", color: "#3b82f6", shape: "square" },
   { key: "model", label: "Model", color: "#8b5cf6", shape: "square" },
   { key: "container", label: "Container", color: "#6366f1", shape: "square" },
-  { key: "cloud_resource", label: "Cloud Resource", color: "#0ea5e9", shape: "square" },
+  {
+    key: "cloud_resource",
+    label: "Cloud Resource",
+    color: "#0ea5e9",
+    shape: "square",
+  },
   { key: "org", label: "Organization", color: "#115e59", shape: "square" },
   { key: "account", label: "Account", color: "#0f766e", shape: "square" },
   { key: "user", label: "User", color: "#14b8a6", shape: "circle" },
   { key: "group", label: "Group", color: "#0d9488", shape: "circle" },
   { key: "role", label: "Role", color: "#ea580c", shape: "circle" },
   { key: "policy", label: "Policy", color: "#d97706", shape: "diamond" },
-  { key: "service_account", label: "Service Account", color: "#0f766e", shape: "circle" },
-  { key: "service_principal", label: "Service Principal", color: "#0f766e", shape: "circle" },
-  { key: "federated_identity", label: "Federated Identity", color: "#0e7490", shape: "circle" },
+  {
+    key: "service_account",
+    label: "Service Account",
+    color: "#0f766e",
+    shape: "circle",
+  },
+  {
+    key: "service_principal",
+    label: "Service Principal",
+    color: "#0f766e",
+    shape: "circle",
+  },
+  {
+    key: "federated_identity",
+    label: "Federated Identity",
+    color: "#0e7490",
+    shape: "circle",
+  },
 ];
 
 export const RELATIONSHIP_LEGEND: LegendEntry[] = [
   { key: "uses", label: "Uses", color: "#10b981", shape: "circle" },
   { key: "depends_on", label: "Depends On", color: "#52525b", shape: "circle" },
-  { key: "provides_tool", label: "Provides Tool", color: "#a855f7", shape: "circle" },
-  { key: "exposes_cred", label: "Exposes Credential", color: "#f59e0b", shape: "circle" },
-  { key: "reaches_tool", label: "Credential Reaches Tool", color: "#fbbf24", shape: "circle" },
-  { key: "vulnerable_to", label: "Vulnerable To", color: "#ef4444", shape: "circle" },
-  { key: "shares_server", label: "Shares Server", color: "#22d3ee", shape: "circle" },
-  { key: "shares_cred", label: "Shares Credential", color: "#f97316", shape: "circle" },
-  { key: "lateral_path", label: "Lateral Path", color: "#ea580c", shape: "circle" },
+  {
+    key: "provides_tool",
+    label: "Provides Tool",
+    color: "#a855f7",
+    shape: "circle",
+  },
+  {
+    key: "exposes_cred",
+    label: "Exposes Credential",
+    color: "#f59e0b",
+    shape: "circle",
+  },
+  {
+    key: "reaches_tool",
+    label: "Credential Reaches Tool",
+    color: "#fbbf24",
+    shape: "circle",
+  },
+  {
+    key: "vulnerable_to",
+    label: "Vulnerable To",
+    color: "#ef4444",
+    shape: "circle",
+  },
+  {
+    key: "shares_server",
+    label: "Shares Server",
+    color: "#22d3ee",
+    shape: "circle",
+  },
+  {
+    key: "shares_cred",
+    label: "Shares Credential",
+    color: "#f97316",
+    shape: "circle",
+  },
+  {
+    key: "lateral_path",
+    label: "Lateral Path",
+    color: "#ea580c",
+    shape: "circle",
+  },
   { key: "acted_as", label: "Acted As", color: "#14b8a6", shape: "circle" },
-  { key: "invoked", label: "Invoked (runtime)", color: "#10b981", shape: "circle" },
+  {
+    key: "invoked",
+    label: "Invoked (runtime)",
+    color: "#10b981",
+    shape: "circle",
+  },
   { key: "called", label: "Called", color: "#a855f7", shape: "circle" },
-  { key: "accessed", label: "Accessed (runtime)", color: "#3b82f6", shape: "circle" },
-  { key: "used_credential", label: "Used Credential", color: "#facc15", shape: "circle" },
+  {
+    key: "accessed",
+    label: "Accessed (runtime)",
+    color: "#3b82f6",
+    shape: "circle",
+  },
+  {
+    key: "used_credential",
+    label: "Used Credential",
+    color: "#facc15",
+    shape: "circle",
+  },
   { key: "assumes", label: "Assumes", color: "#ea580c", shape: "circle" },
   { key: "trusts", label: "Trusts", color: "#0891b2", shape: "circle" },
   { key: "attached", label: "Attached", color: "#d97706", shape: "circle" },
   { key: "inherits", label: "Inherits", color: "#a16207", shape: "circle" },
   { key: "can_access", label: "Can Access", color: "#dc2626", shape: "circle" },
-  { key: "cross_account_trust", label: "Cross-Account Trust", color: "#be123c", shape: "circle" },
+  {
+    key: "cross_account_trust",
+    label: "Cross-Account Trust",
+    color: "#be123c",
+    shape: "circle",
+  },
 ];
 
 /** Entity types that represent actual security findings (for SIEM export) */

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -3,7 +3,10 @@
  * Background styling used across all graph views (Lineage, Mesh, Context, Attack Flow).
  */
 
-import type { LineageNodeData, LineageNodeType } from "@/components/lineage-nodes";
+import type {
+  LineageNodeData,
+  LineageNodeType,
+} from "@/components/lineage-nodes";
 import type { Edge } from "@xyflow/react";
 import {
   GRAPH_EDGE_KIND_META,
@@ -17,7 +20,8 @@ import {
 export const CONTROLS_CLASS =
   "!bg-zinc-900/90 !border-zinc-700 !rounded-lg !backdrop-blur-sm [&>button]:!bg-zinc-800 [&>button]:!border-zinc-700 [&>button]:!text-zinc-300 [&>button:hover]:!bg-zinc-700";
 
-export const MINIMAP_CLASS = "!bg-zinc-900/90 !border-zinc-700 !rounded-lg !backdrop-blur-sm";
+export const MINIMAP_CLASS =
+  "!bg-zinc-900/90 !border-zinc-700 !rounded-lg !backdrop-blur-sm";
 export const MINIMAP_BG = "#09090b";
 export const MINIMAP_MASK = "rgba(24,24,27,0.82)";
 
@@ -26,7 +30,10 @@ export const BACKGROUND_GAP = 24;
 
 const SHARED_SERVER_COLOR = "#22d3ee";
 
-export const LINEAGE_NODE_GRAPH_KIND: Record<LineageNodeType, GraphNodeKindKey | null> = {
+export const LINEAGE_NODE_GRAPH_KIND: Record<
+  LineageNodeType,
+  GraphNodeKindKey | null
+> = {
   provider: "provider",
   agent: "agent",
   server: "server",
@@ -57,6 +64,9 @@ export const LINEAGE_NODE_GRAPH_KIND: Record<LineageNodeType, GraphNodeKindKey |
   accessPolicy: "access_policy",
   driftIncident: "drift_incident",
   dataStore: "data_store",
+  directory: "directory",
+  sourceFile: "source_file",
+  configFile: "config_file",
 };
 
 function generatedMetaForNodeType(nodeType: LineageNodeType) {
@@ -64,24 +74,37 @@ function generatedMetaForNodeType(nodeType: LineageNodeType) {
   return kind ? GRAPH_NODE_KIND_META[kind] : null;
 }
 
-const UI_NODE_LEGEND_OVERRIDES: Partial<Record<LineageNodeType, Pick<LegendItem, "label" | "color" | "shape">>> = {
-  managedIdentity: { label: "Managed Identity", color: "#0891b2", shape: "dot" },
+const UI_NODE_LEGEND_OVERRIDES: Partial<
+  Record<LineageNodeType, Pick<LegendItem, "label" | "color" | "shape">>
+> = {
+  managedIdentity: {
+    label: "Managed Identity",
+    color: "#0891b2",
+    shape: "dot",
+  },
   accessGrant: { label: "Access Grant", color: "#ca8a04", shape: "diamond" },
   accessPolicy: { label: "Access Policy", color: "#a16207", shape: "diamond" },
-  driftIncident: { label: "Drift Incident", color: "#fb923c", shape: "diamond" },
+  driftIncident: {
+    label: "Drift Incident",
+    color: "#fb923c",
+    shape: "diamond",
+  },
   dataStore: { label: "Data Store", color: "#0284c7", shape: "square" },
 };
 
 // ─── MiniMap Node Color Map ──────────────────────────────────────────────────
 
-export const NODE_COLOR_MAP: Record<LineageNodeType, string> = Object.fromEntries(
-  (Object.keys(LINEAGE_NODE_GRAPH_KIND) as LineageNodeType[]).map((nodeType) => [
-    nodeType,
-    nodeType === "sharedServer"
-      ? SHARED_SERVER_COLOR
-      : generatedMetaForNodeType(nodeType)?.color ?? "#52525b",
-  ]),
-) as Record<LineageNodeType, string>;
+export const NODE_COLOR_MAP: Record<LineageNodeType, string> =
+  Object.fromEntries(
+    (Object.keys(LINEAGE_NODE_GRAPH_KIND) as LineageNodeType[]).map(
+      (nodeType) => [
+        nodeType,
+        nodeType === "sharedServer"
+          ? SHARED_SERVER_COLOR
+          : (generatedMetaForNodeType(nodeType)?.color ?? "#52525b"),
+      ],
+    ),
+  ) as Record<LineageNodeType, string>;
 
 export function minimapNodeColor(n: { data: Record<string, unknown> }): string {
   const d = n.data as LineageNodeData;
@@ -152,6 +175,9 @@ const NODE_TYPE_LEGEND_ORDER: LineageNodeType[] = [
   "sharedServer",
   "server",
   "package",
+  "directory",
+  "configFile",
+  "sourceFile",
   "model",
   "dataset",
   "container",
@@ -198,14 +224,19 @@ export function legendItemForNodeType(nodeType: LineageNodeType): LegendItem {
     color: override?.color ?? meta?.color ?? "#52525b",
     layer: meta?.layer,
     kind: "node",
-    shape: override?.shape ?? (meta ? legendShapeForGraphShape(meta.shape) : "pill"),
+    shape:
+      override?.shape ?? (meta ? legendShapeForGraphShape(meta.shape) : "pill"),
     nodeType,
   };
 }
 
-const NODE_TYPE_LEGEND_ITEMS: Record<LineageNodeType, LegendItem> = Object.fromEntries(
-  NODE_TYPE_LEGEND_ORDER.map((nodeType) => [nodeType, legendItemForNodeType(nodeType)]),
-) as Record<LineageNodeType, LegendItem>;
+const NODE_TYPE_LEGEND_ITEMS: Record<LineageNodeType, LegendItem> =
+  Object.fromEntries(
+    NODE_TYPE_LEGEND_ORDER.map((nodeType) => [
+      nodeType,
+      legendItemForNodeType(nodeType),
+    ]),
+  ) as Record<LineageNodeType, LegendItem>;
 
 const RELATIONSHIP_LEGEND_ORDER = [
   "hosts",
@@ -279,25 +310,36 @@ const RELATIONSHIP_LABEL_OVERRIDES: Record<string, string> = {
 };
 
 const RELATIONSHIP_DESCRIPTION_OVERRIDES: Record<string, string> = {
-  exposes_cred: "Static evidence that a server can surface a credential or secret reference.",
-  reaches_tool: "Credential or identity can reach a tool-capable execution boundary.",
+  exposes_cred:
+    "Static evidence that a server can surface a credential or secret reference.",
+  reaches_tool:
+    "Credential or identity can reach a tool-capable execution boundary.",
   vulnerable_to: "Package or component is linked to a vulnerability finding.",
-  exploitable_via: "Finding has a reachable exploit path through agent, MCP, tool, or identity context.",
-  shares_server: "Multiple agents share an MCP server, creating a lateral movement choke point.",
+  exploitable_via:
+    "Finding has a reachable exploit path through agent, MCP, tool, or identity context.",
+  shares_server:
+    "Multiple agents share an MCP server, creating a lateral movement choke point.",
   shares_cred: "Multiple agents or servers share credential material.",
-  lateral_path: "Ranked traversal chain that connects source, tool/credential, and impacted target.",
-  authenticates_as: "Agent can operate as a managed identity or service principal.",
-  scoped_to: "Access grant is constrained to a resource, tool, or environment scope.",
-  governs: "Policy or control applies to the connected identity, tool, or environment.",
-  exhibits_drift: "Observed behavior or posture differs from expected governance state.",
+  lateral_path:
+    "Ranked traversal chain that connects source, tool/credential, and impacted target.",
+  authenticates_as:
+    "Agent can operate as a managed identity or service principal.",
+  scoped_to:
+    "Access grant is constrained to a resource, tool, or environment scope.",
+  governs:
+    "Policy or control applies to the connected identity, tool, or environment.",
+  exhibits_drift:
+    "Observed behavior or posture differs from expected governance state.",
   exposed_to: "Internet, account, or environment exposure reaches this asset.",
   stores: "Asset stores or indexes data that may be reachable from the path.",
-  has_permission: "Identity has an effective permission on the connected resource.",
+  has_permission:
+    "Identity has an effective permission on the connected resource.",
   invoked: "Runtime evidence that an agent invoked a server or tool.",
   called: "Runtime evidence of a concrete tool call.",
   accessed: "Runtime evidence that a tool or call accessed an asset.",
   used_credential: "Runtime evidence that credential material was used.",
-  delegated_to: "Runtime delegation from one actor or tool boundary to another.",
+  delegated_to:
+    "Runtime delegation from one actor or tool boundary to another.",
 };
 
 function fallbackRelationshipLabel(relationship: string): string {
@@ -312,7 +354,10 @@ export function relationshipLegendItem(relationship: string): LegendItem {
   const meta = GRAPH_EDGE_KIND_META[relationship as GraphEdgeKindKey];
   const dashed = DASHED_LEGEND_RELATIONSHIPS.has(relationship);
   return {
-    label: RELATIONSHIP_LABEL_OVERRIDES[relationship] ?? meta?.label ?? fallbackRelationshipLabel(relationship),
+    label:
+      RELATIONSHIP_LABEL_OVERRIDES[relationship] ??
+      meta?.label ??
+      fallbackRelationshipLabel(relationship),
     color: meta?.color ?? "#52525b",
     layer: meta?.category,
     description: RELATIONSHIP_DESCRIPTION_OVERRIDES[relationship],
@@ -322,8 +367,14 @@ export function relationshipLegendItem(relationship: string): LegendItem {
   };
 }
 
-const RELATIONSHIP_LEGEND_ITEMS: Record<(typeof RELATIONSHIP_LEGEND_ORDER)[number], LegendItem> = Object.fromEntries(
-  RELATIONSHIP_LEGEND_ORDER.map((relationship) => [relationship, relationshipLegendItem(relationship)]),
+const RELATIONSHIP_LEGEND_ITEMS: Record<
+  (typeof RELATIONSHIP_LEGEND_ORDER)[number],
+  LegendItem
+> = Object.fromEntries(
+  RELATIONSHIP_LEGEND_ORDER.map((relationship) => [
+    relationship,
+    relationshipLegendItem(relationship),
+  ]),
 ) as Record<(typeof RELATIONSHIP_LEGEND_ORDER)[number], LegendItem>;
 
 function isLineageNodeType(value: unknown): value is LineageNodeType {
@@ -336,15 +387,16 @@ export function legendItemsForVisibleNodes(
 ): LegendItem[] {
   const visibleTypes = new Set<LineageNodeType>();
   for (const node of nodes) {
-    const nodeType = (node.data as Partial<LineageNodeData> | undefined)?.nodeType;
+    const nodeType = (node.data as Partial<LineageNodeData> | undefined)
+      ?.nodeType;
     if (isLineageNodeType(nodeType)) {
       visibleTypes.add(nodeType);
     }
   }
 
-  const items = NODE_TYPE_LEGEND_ORDER
-    .filter((nodeType) => visibleTypes.has(nodeType))
-    .map((nodeType) => NODE_TYPE_LEGEND_ITEMS[nodeType]);
+  const items = NODE_TYPE_LEGEND_ORDER.filter((nodeType) =>
+    visibleTypes.has(nodeType),
+  ).map((nodeType) => NODE_TYPE_LEGEND_ITEMS[nodeType]);
 
   for (const extra of extras) {
     if (!items.some((item) => item.label === extra.label)) {
@@ -355,18 +407,24 @@ export function legendItemsForVisibleNodes(
   return items;
 }
 
-export function relationshipLegendItemsForVisibleEdges(edges: Array<{ data?: unknown }>): LegendItem[] {
+export function relationshipLegendItemsForVisibleEdges(
+  edges: Array<{ data?: unknown }>,
+): LegendItem[] {
   const visibleRelationships = new Set<string>();
   for (const edge of edges) {
-    const relationship = (edge.data as { relationship?: unknown } | undefined)?.relationship;
-    if (typeof relationship === "string" && relationship in RELATIONSHIP_LEGEND_ITEMS) {
+    const relationship = (edge.data as { relationship?: unknown } | undefined)
+      ?.relationship;
+    if (
+      typeof relationship === "string" &&
+      relationship in RELATIONSHIP_LEGEND_ITEMS
+    ) {
       visibleRelationships.add(relationship);
     }
   }
 
-  return RELATIONSHIP_LEGEND_ORDER
-    .filter((relationship) => visibleRelationships.has(relationship))
-    .map((relationship) => RELATIONSHIP_LEGEND_ITEMS[relationship]);
+  return RELATIONSHIP_LEGEND_ORDER.filter((relationship) =>
+    visibleRelationships.has(relationship),
+  ).map((relationship) => RELATIONSHIP_LEGEND_ITEMS[relationship]);
 }
 
 export function legendItemsForVisibleGraph(
@@ -405,7 +463,8 @@ function numericStrokeWidth(edge: Edge, fallback = 1.4): number {
 }
 
 function edgeRelationship(edge: Edge): string {
-  const relationship = (edge.data as { relationship?: unknown } | undefined)?.relationship;
+  const relationship = (edge.data as { relationship?: unknown } | undefined)
+    ?.relationship;
   return typeof relationship === "string" ? relationship : "";
 }
 
@@ -433,10 +492,18 @@ export function readableGraphEdges(
   return edges.map((edge): Edge => {
     const relationship = edgeRelationship(edge);
     const highSignal = HIGH_SIGNAL_RELATIONSHIPS.has(relationship);
-    const active = activeNodeIds ? activeNodeIds.has(edge.source) && activeNodeIds.has(edge.target) : false;
-    const captureBaseOpacity = captureMode ? Math.max(baseOpacity, 0.42) : baseOpacity;
-    const captureHighSignalOpacity = captureMode ? Math.max(highSignalOpacity, 0.68) : highSignalOpacity;
-    const captureInactiveOpacity = captureMode ? Math.max(inactiveOpacity, 0.18) : inactiveOpacity;
+    const active = activeNodeIds
+      ? activeNodeIds.has(edge.source) && activeNodeIds.has(edge.target)
+      : false;
+    const captureBaseOpacity = captureMode
+      ? Math.max(baseOpacity, 0.42)
+      : baseOpacity;
+    const captureHighSignalOpacity = captureMode
+      ? Math.max(highSignalOpacity, 0.68)
+      : highSignalOpacity;
+    const captureInactiveOpacity = captureMode
+      ? Math.max(inactiveOpacity, 0.18)
+      : inactiveOpacity;
     const opacity = activeNodeIds
       ? active
         ? activeOpacity
@@ -448,7 +515,11 @@ export function readableGraphEdges(
 
     return {
       ...edge,
-      animated: captureMode ? false : quietAnimation ? Boolean(activeNodeIds && active && edge.animated) : Boolean(edge.animated),
+      animated: captureMode
+        ? false
+        : quietAnimation
+          ? Boolean(activeNodeIds && active && edge.animated)
+          : Boolean(edge.animated),
       style: {
         ...edge.style,
         opacity,
@@ -478,5 +549,12 @@ export const CONTEXT_LEGEND: LegendItem[] = [
   { label: "Cred", color: "#f59e0b", kind: "node", shape: "dot" },
   { label: "Tool", color: "#a855f7", kind: "node", shape: "pill" },
   { label: "Vuln", color: "#ef4444", kind: "node", shape: "diamond" },
-  { label: "Lateral", color: "#f97316", kind: "edge", dashed: true, lineStyle: "dashed", shape: "diamond" },
+  {
+    label: "Lateral",
+    color: "#f97316",
+    kind: "edge",
+    dashed: true,
+    lineStyle: "dashed",
+    shape: "diamond",
+  },
 ];

--- a/ui/lib/sibling-aggregator.ts
+++ b/ui/lib/sibling-aggregator.ts
@@ -18,7 +18,10 @@
 
 import type { Edge, Node } from "@xyflow/react";
 
-import type { LineageNodeData, LineageNodeType } from "@/components/lineage-nodes";
+import type {
+  LineageNodeData,
+  LineageNodeType,
+} from "@/components/lineage-nodes";
 
 export const CLUSTER_PILL_NODE_TYPE = "clusterPillNode";
 export const CLUSTER_ID_PREFIX = "cluster:";
@@ -58,7 +61,10 @@ export interface SiblingAggregateResult {
    * "expand pill" callback — pop the id, add the members back to
    * `expandedClusterIds`, and re-run the aggregator.
    */
-  clusters: Map<string, { parentId: string; childType: LineageNodeType; members: string[] }>;
+  clusters: Map<
+    string,
+    { parentId: string; childType: LineageNodeType; members: string[] }
+  >;
 }
 
 /**
@@ -83,7 +89,11 @@ function siblingGroupKey(key: SiblingGroupKey): string {
   return `${key.parentId}::${key.edgeKind}::${key.childType}`;
 }
 
-function clusterId(parentId: string, childType: LineageNodeType, edgeKind: string): string {
+function clusterId(
+  parentId: string,
+  childType: LineageNodeType,
+  edgeKind: string,
+): string {
   return `${CLUSTER_ID_PREFIX}${parentId}:${childType}:${edgeKind}`;
 }
 
@@ -100,7 +110,10 @@ export function aggregateSiblings(
   edges: Edge[],
   options: SiblingAggregateOptions = {},
 ): SiblingAggregateResult {
-  const thresholdN = Math.max(2, options.thresholdN ?? FOCUSED_AGGREGATION_THRESHOLD);
+  const thresholdN = Math.max(
+    2,
+    options.thresholdN ?? FOCUSED_AGGREGATION_THRESHOLD,
+  );
   const expanded = options.expandedClusterIds ?? new Set<string>();
 
   const nodeById = new Map(nodes.map((node) => [node.id, node]));
@@ -149,7 +162,10 @@ export function aggregateSiblings(
   const childParentCount = new Map<string, number>();
   for (const edge of edges) {
     if (!nodeById.has(edge.source) || !nodeById.has(edge.target)) continue;
-    childParentCount.set(edge.target, (childParentCount.get(edge.target) ?? 0) + 1);
+    childParentCount.set(
+      edge.target,
+      (childParentCount.get(edge.target) ?? 0) + 1,
+    );
   }
 
   const dropNodeIds = new Set<string>();
@@ -265,12 +281,17 @@ const CHILD_TYPE_NOUNS: Partial<Record<LineageNodeType, string>> = {
   fleet: "fleet",
   cluster: "cluster",
   sharedServer: "shared server",
+  directory: "folder",
+  sourceFile: "source file",
+  configFile: "config file",
 };
 
 function readEdgeKind(edge: Edge): string {
   const data = edge.data as Record<string, unknown> | undefined;
-  if (data && typeof data["relationship"] === "string") return data["relationship"];
-  if (typeof edge.label === "string" && edge.label.trim().length > 0) return edge.label;
+  if (data && typeof data["relationship"] === "string")
+    return data["relationship"];
+  if (typeof edge.label === "string" && edge.label.trim().length > 0)
+    return edge.label;
   return edge.type ?? "edge";
 }
 
@@ -280,5 +301,7 @@ function readEdgeKind(edge: Edge): string {
  * between regular node selection and "expand cluster" behaviour.
  */
 export function isClusterPillNode(node: Node<LineageNodeData>): boolean {
-  return (node.data as unknown as ClusterPillData | undefined)?.isCluster === true;
+  return (
+    (node.data as unknown as ClusterPillData | undefined)?.isCluster === true
+  );
 }

--- a/ui/lib/sigma-graph-overview.ts
+++ b/ui/lib/sigma-graph-overview.ts
@@ -1,7 +1,10 @@
 import Graph from "graphology";
 import type { Edge, Node } from "@xyflow/react";
 
-import type { LineageNodeData, LineageNodeType } from "@/components/lineage-nodes";
+import type {
+  LineageNodeData,
+  LineageNodeType,
+} from "@/components/lineage-nodes";
 import type { UnifiedGraphData } from "@/lib/graph-schema";
 import {
   buildLargeGraphOverviewModel,
@@ -76,6 +79,9 @@ const SIGMA_DEFAULT_LAYERS: Record<LineageNodeType, boolean> = {
   accessPolicy: true,
   driftIncident: true,
   dataStore: true,
+  directory: true,
+  sourceFile: true,
+  configFile: true,
 };
 
 const SIGMA_DEFAULT_FILTERS: UnifiedGraphFlowFilters = {
@@ -90,7 +96,12 @@ function edgeIsHighlighted(
   source: { highlighted: boolean; forceLabel: boolean } | undefined,
   target: { highlighted: boolean; forceLabel: boolean } | undefined,
 ): boolean {
-  return Boolean(source?.highlighted || target?.highlighted || source?.forceLabel || target?.forceLabel);
+  return Boolean(
+    source?.highlighted ||
+    target?.highlighted ||
+    source?.forceLabel ||
+    target?.forceLabel,
+  );
 }
 
 export function buildSigmaGraphOverviewModel(

--- a/ui/lib/unified-graph-flow.ts
+++ b/ui/lib/unified-graph-flow.ts
@@ -1,7 +1,15 @@
 import { MarkerType, type Edge, type Node } from "@xyflow/react";
 
-import type { LineageNodeData, LineageNodeType } from "@/components/lineage-nodes";
-import { readReachBreakdown, readReachScore, reachEdgeWidth, reachStrokeColor } from "@/lib/effective-reach";
+import type {
+  LineageNodeData,
+  LineageNodeType,
+} from "@/components/lineage-nodes";
+import {
+  readReachBreakdown,
+  readReachScore,
+  reachEdgeWidth,
+  reachStrokeColor,
+} from "@/lib/effective-reach";
 import { relationshipLegendItem, type LegendItem } from "@/lib/graph-utils";
 import {
   EntityType,
@@ -32,9 +40,14 @@ export interface UnifiedGraphFlowSummary {
 function safeGraphConnection(value: string): string {
   try {
     const url = new URL(value);
-    return url.protocol === "https:" || url.protocol === "http:" ? `${url.protocol}//${url.host}${url.pathname}` : value;
+    return url.protocol === "https:" || url.protocol === "http:"
+      ? `${url.protocol}//${url.host}${url.pathname}`
+      : value;
   } catch {
-    return value.replace(/(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}|(?:sk|pk|rk)[-_](?:live|test|prod)[-_]\w{10,}/gi, "<redacted>");
+    return value.replace(
+      /(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}|(?:sk|pk|rk)[-_](?:live|test|prod)[-_]\w{10,}/gi,
+      "<redacted>",
+    );
   }
 }
 
@@ -46,7 +59,9 @@ export interface UnifiedGraphFlowResult {
   summary: UnifiedGraphFlowSummary;
 }
 
-const ENTITY_TO_NODE_TYPE: Partial<Record<EntityType | string, LineageNodeType>> = {
+const ENTITY_TO_NODE_TYPE: Partial<
+  Record<EntityType | string, LineageNodeType>
+> = {
   [EntityType.PROVIDER]: "provider",
   [EntityType.AGENT]: "agent",
   [EntityType.ORG]: "org",
@@ -80,6 +95,12 @@ const ENTITY_TO_NODE_TYPE: Partial<Record<EntityType | string, LineageNodeType>>
   [EntityType.ACCESS_POLICY]: "accessPolicy",
   [EntityType.DRIFT_INCIDENT]: "driftIncident",
   [EntityType.DATA_STORE]: "dataStore",
+  // Repository folder/file-structure nodes (CODE layer) so a repo / project
+  // scan renders its directory tree, manifest files, and file → dependency →
+  // vuln paths.
+  [EntityType.DIRECTORY]: "directory",
+  [EntityType.SOURCE_FILE]: "sourceFile",
+  [EntityType.CONFIG_FILE]: "configFile",
 };
 
 const FLOW_NODE_TYPES: Record<LineageNodeType, string> = {
@@ -113,6 +134,9 @@ const FLOW_NODE_TYPES: Record<LineageNodeType, string> = {
   accessPolicy: "accessPolicyNode",
   driftIncident: "driftIncidentNode",
   dataStore: "dataStoreNode",
+  directory: "containerNode",
+  sourceFile: "packageNode",
+  configFile: "packageNode",
 };
 
 const NODE_LABELS: Record<LineageNodeType, string> = {
@@ -146,6 +170,9 @@ const NODE_LABELS: Record<LineageNodeType, string> = {
   accessPolicy: "Access Policy",
   driftIncident: "Drift Incident",
   dataStore: "Data Store",
+  directory: "Directory",
+  sourceFile: "Source File",
+  configFile: "Config File",
 };
 
 const NODE_COLORS: Record<LineageNodeType, string> = {
@@ -179,6 +206,9 @@ const NODE_COLORS: Record<LineageNodeType, string> = {
   accessPolicy: "#a16207",
   driftIncident: "#fb923c",
   dataStore: "#0284c7",
+  directory: "#0d9488",
+  sourceFile: "#22d3ee",
+  configFile: "#f97316",
 };
 
 const NODE_LAYERS: Record<LineageNodeType, string> = {
@@ -212,9 +242,15 @@ const NODE_LAYERS: Record<LineageNodeType, string> = {
   accessPolicy: "identity",
   driftIncident: "finding",
   dataStore: "asset",
+  directory: "code",
+  sourceFile: "code",
+  configFile: "code",
 };
 
-const FINDING_NODE_TYPES = new Set<LineageNodeType>(["vulnerability", "misconfiguration"]);
+const FINDING_NODE_TYPES = new Set<LineageNodeType>([
+  "vulnerability",
+  "misconfiguration",
+]);
 const RUNTIME_RELATIONSHIPS = new Set<string>([
   RelationshipType.INVOKED,
   RelationshipType.CALLED,
@@ -281,7 +317,10 @@ export function buildUnifiedFlowGraph(
 
   const prePrunedNodeIds = new Set(nodes.map((node) => node.id));
   const prePrunedEdges: Edge[] = graph.edges
-    .filter((edge) => prePrunedNodeIds.has(edge.source) && prePrunedNodeIds.has(edge.target))
+    .filter(
+      (edge) =>
+        prePrunedNodeIds.has(edge.source) && prePrunedNodeIds.has(edge.target),
+    )
     .map((edge) => toFlowEdge(edge));
 
   const connectedNodeIds = new Set<string>();
@@ -291,14 +330,25 @@ export function buildUnifiedFlowGraph(
   }
   const anchorNodeIds = new Set(
     nodes
-      .filter((node) => node.data.nodeType === "agent" || FINDING_NODE_TYPES.has(node.data.nodeType))
+      .filter(
+        (node) =>
+          node.data.nodeType === "agent" ||
+          FINDING_NODE_TYPES.has(node.data.nodeType),
+      )
       .map((node) => node.id),
   );
-  const prunedNodes = nodes.filter((node) => connectedNodeIds.has(node.id) || anchorNodeIds.has(node.id));
+  const prunedNodes = nodes.filter(
+    (node) => connectedNodeIds.has(node.id) || anchorNodeIds.has(node.id),
+  );
   const visibleNodeIds = new Set(prunedNodes.map((node) => node.id));
-  const edges = prePrunedEdges.filter((edge) => visibleNodeIds.has(edge.source) && visibleNodeIds.has(edge.target));
+  const edges = prePrunedEdges.filter(
+    (edge) =>
+      visibleNodeIds.has(edge.source) && visibleNodeIds.has(edge.target),
+  );
 
-  const visibleNodeTypes = new Set(prunedNodes.map((node) => node.data.nodeType));
+  const visibleNodeTypes = new Set(
+    prunedNodes.map((node) => node.data.nodeType),
+  );
   const summary = buildSummary(prunedNodes, graph);
   const legend = legendForNodeTypes(visibleNodeTypes);
 
@@ -314,11 +364,21 @@ function deriveVisibleNodeIds(
 
   if (filters.agentName) {
     const seeds = graph.nodes
-      .filter((node) => node.entity_type === EntityType.AGENT && node.label === filters.agentName)
+      .filter(
+        (node) =>
+          node.entity_type === EntityType.AGENT &&
+          node.label === filters.agentName,
+      )
       .map((node) => node.id);
     if (seeds.length > 0) {
-      const agentDepth = filters.vulnOnly || filters.severity ? Math.max(filters.maxDepth, 3) : Math.max(filters.maxDepth, 2);
-      visible = intersectSets(visible, collectNeighborhood(seeds, undirected, agentDepth));
+      const agentDepth =
+        filters.vulnOnly || filters.severity
+          ? Math.max(filters.maxDepth, 3)
+          : Math.max(filters.maxDepth, 2);
+      visible = intersectSets(
+        visible,
+        collectNeighborhood(seeds, undirected, agentDepth),
+      );
     }
   }
 
@@ -331,7 +391,8 @@ function deriveVisibleNodeIds(
         return meetsSeverityThreshold(node.severity, filters.severity);
       })
       .sort((left, right) => {
-        const severityDiff = severityRank(right.severity) - severityRank(left.severity);
+        const severityDiff =
+          severityRank(right.severity) - severityRank(left.severity);
         if (severityDiff !== 0) return severityDiff;
         return (right.risk_score ?? 0) - (left.risk_score ?? 0);
       })
@@ -341,7 +402,14 @@ function deriveVisibleNodeIds(
     // using a shallow finding-side neighborhood kept only middle nodes
     // (server/package) and dropped the endpoints an operator needs to explain
     // the path: the source agent and the CVE/finding.
-    visible = intersectSets(visible, collectNeighborhood(findingSeeds, undirected, Math.max(3, filters.maxDepth)));
+    visible = intersectSets(
+      visible,
+      collectNeighborhood(
+        findingSeeds,
+        undirected,
+        Math.max(3, filters.maxDepth),
+      ),
+    );
   }
 
   visible = new Set(
@@ -393,13 +461,27 @@ function toLineageData(
 
   switch (nodeType) {
     case "provider":
-      data.agentCount = countOutgoing(node.id, outgoing, RelationshipType.HOSTS);
+      data.agentCount = countOutgoing(
+        node.id,
+        outgoing,
+        RelationshipType.HOSTS,
+      );
       break;
     case "agent":
       data.agentType = stringAttr(node, "agent_type");
       data.agentStatus = stringAttr(node, "status");
-      data.serverCount = countOutgoing(node.id, outgoing, RelationshipType.USES);
-      data.packageCount = countReachableTypes(node.id, outgoing, nodeById, new Set([EntityType.PACKAGE]), 3);
+      data.serverCount = countOutgoing(
+        node.id,
+        outgoing,
+        RelationshipType.USES,
+      );
+      data.packageCount = countReachableTypes(
+        node.id,
+        outgoing,
+        nodeById,
+        new Set([EntityType.PACKAGE]),
+        3,
+      );
       data.vulnCount = countReachableTypes(
         node.id,
         outgoing,
@@ -424,14 +506,42 @@ function toLineageData(
         stringAttr(node, "provider") ||
         stringAttr(node, "cluster_type") ||
         stringAttr(node, "description");
-      data.agentCount = countReachableTypes(node.id, outgoing, nodeById, new Set([EntityType.AGENT]), 4);
-      data.serverCount = countReachableTypes(node.id, outgoing, nodeById, new Set([EntityType.SERVER]), 4);
+      data.agentCount = countReachableTypes(
+        node.id,
+        outgoing,
+        nodeById,
+        new Set([EntityType.AGENT]),
+        4,
+      );
+      data.serverCount = countReachableTypes(
+        node.id,
+        outgoing,
+        nodeById,
+        new Set([EntityType.SERVER]),
+        4,
+      );
       break;
     case "server":
-      data.command = safeGraphConnection(stringAttr(node, "command") || stringAttr(node, "transport") || stringAttr(node, "url"));
-      data.toolCount = countOutgoing(node.id, outgoing, RelationshipType.PROVIDES_TOOL);
-      data.credentialCount = countOutgoing(node.id, outgoing, RelationshipType.EXPOSES_CRED);
-      data.packageCount = countOutgoing(node.id, outgoing, RelationshipType.DEPENDS_ON);
+      data.command = safeGraphConnection(
+        stringAttr(node, "command") ||
+          stringAttr(node, "transport") ||
+          stringAttr(node, "url"),
+      );
+      data.toolCount = countOutgoing(
+        node.id,
+        outgoing,
+        RelationshipType.PROVIDES_TOOL,
+      );
+      data.credentialCount = countOutgoing(
+        node.id,
+        outgoing,
+        RelationshipType.EXPOSES_CRED,
+      );
+      data.packageCount = countOutgoing(
+        node.id,
+        outgoing,
+        RelationshipType.DEPENDS_ON,
+      );
       data.vulnCount = countReachableTypes(
         node.id,
         outgoing,
@@ -443,15 +553,23 @@ function toLineageData(
     case "package":
       data.ecosystem = stringAttr(node, "ecosystem");
       data.version = stringAttr(node, "version");
-      data.versionSource = versionProvenanceString(node, "version_source") || stringAttr(node, "version_source");
+      data.versionSource =
+        versionProvenanceString(node, "version_source") ||
+        stringAttr(node, "version_source");
       data.versionConfidence = versionProvenanceString(node, "confidence");
-      data.vulnCount = countOutgoing(node.id, outgoing, RelationshipType.VULNERABLE_TO);
+      data.vulnCount = countOutgoing(
+        node.id,
+        outgoing,
+        RelationshipType.VULNERABLE_TO,
+      );
       break;
     case "vulnerability":
       data.cvssScore = numberAttr(node, "cvss_score");
       data.epssScore = numberAttr(node, "epss_score");
       data.isKev = booleanAttr(node, "is_kev");
-      data.effectiveReach = readReachBreakdown(node.attributes?.effective_reach);
+      data.effectiveReach = readReachBreakdown(
+        node.attributes?.effective_reach,
+      );
       data.fixedVersion = stringAttr(node, "fixed_version");
       data.owaspTags = complianceSubset(node.compliance_tags, "OWASP");
       data.atlasTags = complianceSubset(node.compliance_tags, "ATLAS");
@@ -464,7 +582,12 @@ function toLineageData(
         stringAttr(node, "check_id");
       break;
     case "credential":
-      data.serverName = firstLinkedLabel(node.id, incoming, nodeById, EntityType.SERVER);
+      data.serverName = firstLinkedLabel(
+        node.id,
+        incoming,
+        nodeById,
+        EntityType.SERVER,
+      );
       break;
     case "managedIdentity":
       data.description =
@@ -505,18 +628,23 @@ function toLineageData(
       data.description = stringAttr(node, "description");
       break;
     case "model":
-      data.description = stringAttr(node, "framework") || stringAttr(node, "source");
+      data.description =
+        stringAttr(node, "framework") || stringAttr(node, "source");
       data.version = stringAttr(node, "hash");
       break;
     case "dataset":
-      data.description = stringAttr(node, "description") || stringAttr(node, "source_url");
+      data.description =
+        stringAttr(node, "description") || stringAttr(node, "source_url");
       data.version = stringAttr(node, "version");
       break;
     case "container":
-      data.description = stringAttr(node, "container_image") || stringAttr(node, "framework");
+      data.description =
+        stringAttr(node, "container_image") || stringAttr(node, "framework");
       break;
     case "cloudResource":
-      data.description = stringAttr(node, "cloud_provider") || stringAttr(node, "source_section");
+      data.description =
+        stringAttr(node, "cloud_provider") ||
+        stringAttr(node, "source_section");
       break;
     default:
       break;
@@ -533,7 +661,10 @@ function toFlowEdge(edge: UnifiedEdge): Edge {
   const reachColor = reachStrokeColor(reachScore);
   const strokeColor = reachColor ?? color;
   const dashed = DASHED_RELATIONSHIPS.has(relationship);
-  const animated = ANIMATED_RELATIONSHIPS.has(relationship) || edge.weight >= 4 || (reachScore ?? 0) >= 90;
+  const animated =
+    ANIMATED_RELATIONSHIPS.has(relationship) ||
+    edge.weight >= 4 ||
+    (reachScore ?? 0) >= 90;
   const runtime = RUNTIME_RELATIONSHIPS.has(relationship);
 
   return {
@@ -550,7 +681,10 @@ function toFlowEdge(edge: UnifiedEdge): Edge {
     animated,
     style: {
       stroke: strokeColor,
-      strokeWidth: Math.max(Math.min(Math.max(edge.weight, 1.2), 4.5), reachEdgeWidth(reachScore)),
+      strokeWidth: Math.max(
+        Math.min(Math.max(edge.weight, 1.2), 4.5),
+        reachEdgeWidth(reachScore),
+      ),
       opacity: animated ? 0.95 : 0.82,
       strokeDasharray: dashed ? "6 3" : undefined,
     },
@@ -567,11 +701,14 @@ function buildSummary(
   nodes: Node<LineageNodeData>[],
   graph: UnifiedGraphData,
 ): UnifiedGraphFlowSummary {
-  const findings = nodes.filter((node) => FINDING_NODE_TYPES.has(node.data.nodeType)).length;
+  const findings = nodes.filter((node) =>
+    FINDING_NODE_TYPES.has(node.data.nodeType),
+  ).length;
   const critical = nodes.filter(
     (node) =>
       FINDING_NODE_TYPES.has(node.data.nodeType) &&
-      (node.data.severity?.toLowerCase() === "critical" || node.data.isCritical),
+      (node.data.severity?.toLowerCase() === "critical" ||
+        node.data.isCritical),
   ).length;
   const visibleNodeIds = new Set(nodes.map((node) => node.id));
   const runtimeEdges = graph.edges.filter(
@@ -623,7 +760,9 @@ function legendForNodeTypes(nodeTypes: Set<LineageNodeType>): LegendItem[] {
     "misconfiguration",
     "driftIncident",
   ]
-    .filter((nodeType): nodeType is LineageNodeType => nodeTypes.has(nodeType as LineageNodeType))
+    .filter((nodeType): nodeType is LineageNodeType =>
+      nodeTypes.has(nodeType as LineageNodeType),
+    )
     .map((nodeType) => ({
       label: NODE_LABELS[nodeType],
       color: NODE_COLORS[nodeType],
@@ -632,7 +771,10 @@ function legendForNodeTypes(nodeTypes: Set<LineageNodeType>): LegendItem[] {
     }));
 }
 
-function buildAdjacency(edges: UnifiedEdge[], side: "source" | "target"): Map<string, UnifiedEdge[]> {
+function buildAdjacency(
+  edges: UnifiedEdge[],
+  side: "source" | "target",
+): Map<string, UnifiedEdge[]> {
   const map = new Map<string, UnifiedEdge[]>();
   for (const edge of edges) {
     const key = side === "source" ? edge.source : edge.target;
@@ -646,7 +788,9 @@ function buildAdjacency(edges: UnifiedEdge[], side: "source" | "target"): Map<st
   return map;
 }
 
-function buildUndirectedAdjacency(edges: UnifiedEdge[]): Map<string, Set<string>> {
+function buildUndirectedAdjacency(
+  edges: UnifiedEdge[],
+): Map<string, Set<string>> {
   const map = new Map<string, Set<string>>();
   for (const edge of edges) {
     addNeighbor(map, edge.source, edge.target);
@@ -683,7 +827,9 @@ function countOutgoing(
   outgoing: Map<string, UnifiedEdge[]>,
   relationship: RelationshipType,
 ): number {
-  return (outgoing.get(nodeId) ?? []).filter((edge) => edge.relationship === relationship).length;
+  return (outgoing.get(nodeId) ?? []).filter(
+    (edge) => edge.relationship === relationship,
+  ).length;
 }
 
 function countReachableTypes(
@@ -756,7 +902,11 @@ function meetsSeverityThreshold(
   return severityRank(severity) >= severityRank(threshold);
 }
 
-function addNeighbor(map: Map<string, Set<string>>, source: string, target: string): void {
+function addNeighbor(
+  map: Map<string, Set<string>>,
+  source: string,
+  target: string,
+): void {
   const existing = map.get(source);
   if (existing) {
     existing.add(target);
@@ -765,8 +915,11 @@ function addNeighbor(map: Map<string, Set<string>>, source: string, target: stri
   }
 }
 
-function legendShapeForNodeType(nodeType: LineageNodeType): LegendItem["shape"] {
-  if (nodeType === "vulnerability" || nodeType === "misconfiguration") return "diamond";
+function legendShapeForNodeType(
+  nodeType: LineageNodeType,
+): LegendItem["shape"] {
+  if (nodeType === "vulnerability" || nodeType === "misconfiguration")
+    return "diamond";
   if (nodeType === "role" || nodeType === "policy") return "diamond";
   if (
     nodeType === "server" ||
@@ -777,7 +930,13 @@ function legendShapeForNodeType(nodeType: LineageNodeType): LegendItem["shape"] 
   ) {
     return "square";
   }
-  if (nodeType === "package" || nodeType === "tool" || nodeType === "model" || nodeType === "dataset") return "pill";
+  if (
+    nodeType === "package" ||
+    nodeType === "tool" ||
+    nodeType === "model" ||
+    nodeType === "dataset"
+  )
+    return "pill";
   return "dot";
 }
 
@@ -806,9 +965,13 @@ function booleanAttr(node: UnifiedNode, key: string): boolean {
   return node.attributes?.[key] === true;
 }
 
-function evidenceTierAttr(attributes: Record<string, unknown>): "safe_to_store" | "replay_only" | undefined {
+function evidenceTierAttr(
+  attributes: Record<string, unknown>,
+): "safe_to_store" | "replay_only" | undefined {
   const value = attributes.evidence_tier ?? attributes.tier;
-  return value === "safe_to_store" || value === "replay_only" ? value : undefined;
+  return value === "safe_to_store" || value === "replay_only"
+    ? value
+    : undefined;
 }
 
 function complianceSubset(tags: string[], prefix: string): string[] {
@@ -817,5 +980,7 @@ function complianceSubset(tags: string[], prefix: string): string[] {
 
 function isCriticalNode(node: UnifiedNode): boolean {
   if (node.severity?.toLowerCase() === "critical") return true;
-  return booleanAttr(node, "is_kev") || (numberAttr(node, "risk_score") ?? 0) >= 8;
+  return (
+    booleanAttr(node, "is_kev") || (numberAttr(node, "risk_score") ?? 0) >= 8
+  );
 }


### PR DESCRIPTION
## What

A repository / code-structure scan now renders its **folder/file architecture** as a
first-class CODE-layer graph view, the way the cloud graph renders the
`org → account → resource` hierarchy. Previously a `agent-bom agents -p .` / `--repo`
scan stored code as a flat `server → package → vulnerability` fan-out with no notion
of the directory structure the code lives in, and the `source_file` / `config_file`
entity types were declared but documented as *reserved* (never emitted).

## Changes

**Graph model**
- New `DIRECTORY` entity type in the CODE semantic layer (OCSF mapping, legend entry,
  roll-up container registration).
- New `repo_structure_overlay` (wired into the unified graph builder) that, from data
  the report already carries (`project_inventory` + existing package/finding nodes):
  - builds the directory tree — every directory and its ancestors become a `DIRECTORY`
    node linked `CONTAINS` parent → child (repo root → sub-directory → file);
  - attaches each manifest / lockfile / declaration file as a `CONFIG_FILE`
    (or `SOURCE_FILE`) node the directory `CONTAINS`;
  - links the representative manifest to the **direct** packages it declares
    (`DEPENDS_ON`), so a vulnerability is traceable back through its package to the
    file and folder that introduced it (`file → package → vulnerability`);
  - places file-scoped findings under their folder (`AFFECTS` finding → file).
  - Idempotent, deterministic, and a byte-identical no-op when no project inventory and
    no file-scoped findings are present.
- Deep source trees collapse via the **existing** server-side `CONTAINS` roll-up
  (`DIRECTORY` added to the roll-up container types) so large repos stay readable.

**Output formats**
- CLI `--format graph` / `graph-html` for a repo scan now emits the directory tree,
  manifest files, and `file → package` edges, with matching Cytoscape styles + legend
  rows (no unstyled/floating nodes).

**Schema**
- `source_file` / `config_file` / `directory` move from *reserved* to *emitted*;
  `CONTAINS` / `DEPENDS_ON` / `AFFECTS` relationship metadata extended for code nodes.

**UI**
- The CODE layer is filterable on the graph page like other layers, with distinct,
  meaningful Lucide icons per code entity (`directory` = Folder, `source_file` =
  FileCode, `config_file` = FileCog). Shared `ENTITY_ICONS` map, node renderers,
  legend ordering, and layer toggles updated; generated graph schema regenerated.

**Docs / tests**
- `DATA_MODEL.md` entity taxonomy + generated atlas updated.
- Tests: directory tree + `file → package(→ vuln)` paths, roll-up collapse of a deep
  tree, overlay idempotency, no-op-without-inventory, and the schema reserved/emitted
  contract.

## Validation

- New + existing graph/schema/rollup/output suites pass (`860 passed` in the graph
  sweep; repo-structure + schema + parity + graph-api suites green).
- `ruff format` / `ruff check` / `mypy` / pre-commit all pass.
- UI `tsc --noEmit`, `eslint`, `vitest` (275 tests), `next build`, and the JS bundle
  budget check all pass (bundle within budget; budget file untouched).

## Honest scope / gaps

- This enriches the existing graph — it is **not** a from-scratch interprocedural
  call/import graph. Internal source-to-source `IMPORTS` / `DEFINES` edges and
  `code_module` nodes remain reserved (out of scope).
- `file → package` uses the per-directory project node (manifest directory) to attach a
  directory's direct packages to its representative manifest; the report does not carry
  per-package manifest attribution, so transitive packages stay reachable via the
  package graph rather than being linked directly to a file.
