### PR TITLE
chore(ci): self-host image and filesystem vulnerability gates on agent-bom

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,16 +224,24 @@ jobs:
             echo "::warning::osv-scanner found only unfixable TypeScript SDK lockfile CVEs (no upstream fix) — passing"
           }
 
-      - name: Filesystem vulnerability scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
-        with:
-          scan-type: fs
-          scan-ref: .
-          format: table
-          severity: MEDIUM,HIGH,CRITICAL,UNKNOWN
-          ignore-unfixed: true
-          exit-code: '1'
-          trivyignores: .image-scan-ignore
+      - name: Filesystem vulnerability scan (agent-bom — dogfood)
+        # Self-hosted filesystem dependency gate. Mirrors the previous
+        # third-party scanner: MEDIUM+ severity (agent-bom has no separate
+        # UNKNOWN tier), unfixable findings excluded (= ignore-unfixed), and
+        # the known-unfixable OS CVE allowlist in .image-scan-ignore.
+        run: |
+          uv run agent-bom fs . \
+            --ignore .image-scan-ignore \
+            --exclude-unfixable \
+            --fail-on-severity medium
+
+      - name: Filesystem secret scan (agent-bom — informational)
+        # Dogfoods agent-bom's secret/PII scanner over the tree, matching the
+        # secret-scanning the previous filesystem scanner performed. The
+        # authoritative blocking secret gate is the dedicated gitleaks workflow
+        # (.github/workflows/gitleaks.yml); this step is informational so
+        # committed test fixtures and PII heuristics do not double-gate CI.
+        run: uv run agent-bom secrets . || true
 
       - name: Validate npm lockfiles
         run: python scripts/check_npm_lockfile.py ui/package-lock.json sdks/typescript/package-lock.json
@@ -991,15 +999,24 @@ jobs:
       - name: Smoke test
         run: docker run --rm agent-bom:test --version
 
-      - name: Image vulnerability scan
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+      - uses: ./.github/actions/setup-python
         with:
-          image-ref: agent-bom:test
-          format: table
-          severity: MEDIUM,HIGH,CRITICAL,UNKNOWN
-          ignore-unfixed: true
-          exit-code: '1'
-          trivyignores: .image-scan-ignore
+          python-version: '3.11'
+
+      - name: Install agent-bom for image scan gate
+        run: uv sync --frozen --extra dev
+
+      - name: Image vulnerability scan (agent-bom — dogfood)
+        # Self-hosted image gate over the locally loaded agent-bom:test image
+        # (agent-bom shells `docker save` to read it). Native OS-layer
+        # (dpkg/rpm/apk) + app-dependency scanning at MEDIUM+ severity
+        # (no separate UNKNOWN tier), unfixable findings excluded
+        # (= ignore-unfixed), and the .image-scan-ignore CVE allowlist.
+        run: |
+          uv run agent-bom image agent-bom:test \
+            --ignore .image-scan-ignore \
+            --exclude-unfixable \
+            --fail-on-severity medium
 
       - name: agent-bom native image tar scan gate
         run: |

--- a/.github/workflows/container-rescan.yml
+++ b/.github/workflows/container-rescan.yml
@@ -36,33 +36,40 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: '3.11'
+
+      - name: Install agent-bom for the image scan
+        run: uv sync --frozen --extra dev
+
       - name: Pull ${{ matrix.platform }} image
         run: docker pull --platform ${{ matrix.platform }} agentbom/agent-bom:latest
 
-      - name: Container image scan table (fixable MEDIUM+/UNKNOWN)
+      - name: Container image scan table (fixable MEDIUM+)
         id: image_scan_table
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
-        with:
-          image-ref: agentbom/agent-bom:latest
-          format: table
-          severity: MEDIUM,HIGH,CRITICAL,UNKNOWN
-          ignore-unfixed: true
-          exit-code: "1"
-          trivyignores: .image-scan-ignore
         continue-on-error: true
+        # Self-hosted image gate (dogfood). agent-bom reads the pulled image
+        # from the local Docker daemon (via docker save). Native OS-layer
+        # (dpkg/rpm/apk) + app-dependency scanning at MEDIUM+ severity
+        # (agent-bom has no separate UNKNOWN tier), unfixable findings excluded
+        # (= ignore-unfixed), and the .image-scan-ignore CVE allowlist.
+        run: |
+          uv run agent-bom image agentbom/agent-bom:latest \
+            --ignore .image-scan-ignore \
+            --exclude-unfixable \
+            --fail-on-severity medium
 
       - name: Container image scan SARIF
         id: image_scan_sarif
         continue-on-error: true
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
-        with:
-          image-ref: agentbom/agent-bom:latest
-          format: sarif
-          output: image-scan-${{ matrix.sarif_category }}.sarif
-          severity: MEDIUM,HIGH,CRITICAL,UNKNOWN
-          ignore-unfixed: true
-          exit-code: "0"
-          trivyignores: .image-scan-ignore
+        # Non-gating SARIF export for the GitHub Security tab. Same scan policy
+        # as the table gate above; emits the same allowlist-filtered findings.
+        run: |
+          uv run agent-bom image agentbom/agent-bom:latest \
+            --ignore .image-scan-ignore \
+            --exclude-unfixable \
+            -f sarif -o image-scan-${{ matrix.sarif_category }}.sarif
 
       - name: Detect SARIF output
         id: sarif
@@ -91,7 +98,7 @@ jobs:
       - name: Flag actionable CVEs found
         if: steps.image_scan_table.outcome == 'failure'
         run: |
-          echo "::warning::Container scan found fixable MEDIUM+/UNKNOWN CVEs in agentbom/agent-bom:latest (${{ matrix.platform }}). Check SARIF in Security tab."
+          echo "::warning::Container scan found fixable MEDIUM+ CVEs in agentbom/agent-bom:latest (${{ matrix.platform }}). Check SARIF in Security tab."
 
       - name: Open or close base image vulnerability issue
         if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
@@ -109,12 +116,12 @@ jobs:
             BODY=$(cat <<EOF
           ## Automated Base Image Vulnerability Alert
 
-          Daily image rescan found fixable \`MEDIUM+\` or \`UNKNOWN\` findings in \`agentbom/agent-bom:latest\`.
+          Daily image rescan found fixable \`MEDIUM+\` findings in \`agentbom/agent-bom:latest\`.
 
           - Platform: \`${{ matrix.platform }}\`
           - SARIF category: \`${{ matrix.sarif_category }}\`
           - Source workflow: \`.github/workflows/container-rescan.yml\`
-          - Policy: container scans run with \`severity=MEDIUM,HIGH,CRITICAL,UNKNOWN\` and \`ignore-unfixed=true\`
+          - Policy: container scans run with \`agent-bom image --fail-on-severity medium --exclude-unfixable\`
 
           Review the GitHub Security tab and the workflow logs for the current image findings.
           EOF

--- a/.github/workflows/refresh-latest-container.yml
+++ b/.github/workflows/refresh-latest-container.yml
@@ -27,6 +27,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: '3.11'
+
+      - name: Install agent-bom scanner (snapshot from default branch)
+        # The job later checks out the released tag to rebuild the image, so the
+        # scanner is installed non-editably from the default-branch tree FIRST
+        # into an isolated venv. This keeps the image gate on the current scanner
+        # implementation regardless of which tag is being refreshed.
+        run: |
+          uv venv "${RUNNER_TEMP}/abom-scanner"
+          uv pip install --python "${RUNNER_TEMP}/abom-scanner/bin/python" .
+
       - name: Resolve latest release tag
         id: release
         run: |
@@ -79,14 +92,15 @@ jobs:
         run: docker run --rm agent-bom:latest-refresh-test --version
 
       - name: Image vulnerability refresh gate
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
-        with:
-          image-ref: agent-bom:latest-refresh-test
-          format: table
-          severity: MEDIUM,HIGH,CRITICAL,UNKNOWN
-          ignore-unfixed: true
-          exit-code: "1"
-          trivyignores: .image-scan-ignore
+        # Self-hosted image gate (dogfood) using the snapshot scanner. Native
+        # OS-layer (apk) + app-dependency scanning at MEDIUM+ severity
+        # (agent-bom has no separate UNKNOWN tier), unfixable findings excluded
+        # (= ignore-unfixed), and the .image-scan-ignore CVE allowlist.
+        run: |
+          "${RUNNER_TEMP}/abom-scanner/bin/agent-bom" image agent-bom:latest-refresh-test \
+            --ignore .image-scan-ignore \
+            --exclude-unfixable \
+            --fail-on-severity medium
 
       - name: Build and push refreshed latest
         id: build-push
@@ -153,6 +167,19 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: '3.11'
+
+      - name: Install agent-bom scanner (snapshot from default branch)
+        # The job later checks out the released tag to rebuild the image, so the
+        # scanner is installed non-editably from the default-branch tree FIRST
+        # into an isolated venv. This keeps the image gate on the current scanner
+        # implementation regardless of which tag is being refreshed.
+        run: |
+          uv venv "${RUNNER_TEMP}/abom-scanner"
+          uv pip install --python "${RUNNER_TEMP}/abom-scanner/bin/python" .
 
       - name: Resolve latest release tag
         id: release
@@ -223,14 +250,16 @@ jobs:
           }
 
       - name: UI image vulnerability refresh gate
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
-        with:
-          image-ref: agent-bom-ui:latest-refresh-test
-          format: table
-          severity: MEDIUM,HIGH,CRITICAL,UNKNOWN
-          ignore-unfixed: true
-          exit-code: "1"
-          trivyignores: .image-scan-ignore
+        # Self-hosted image gate (dogfood) using the snapshot scanner. The UI
+        # image is Debian (node:bookworm-slim) based; native OS-layer (dpkg) +
+        # app-dependency scanning at MEDIUM+ severity (agent-bom has no separate
+        # UNKNOWN tier), unfixable findings excluded (= ignore-unfixed), and the
+        # .image-scan-ignore CVE allowlist.
+        run: |
+          "${RUNNER_TEMP}/abom-scanner/bin/agent-bom" image agent-bom-ui:latest-refresh-test \
+            --ignore .image-scan-ignore \
+            --exclude-unfixable \
+            --fail-on-severity medium
 
       - name: Build and push refreshed UI latest
         id: build-push-ui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -707,14 +707,23 @@ jobs:
         run: docker run --rm agent-bom:release-test --version
 
       - name: Image vulnerability scan gate
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
-        with:
-          image-ref: agent-bom:release-test
-          format: table
-          severity: MEDIUM,HIGH,CRITICAL,UNKNOWN
-          ignore-unfixed: true
-          exit-code: "1"
-          trivyignores: .image-scan-ignore
+        # Self-hosted release image gate (dogfood). The agent-bom:release-test
+        # image IS agent-bom, so it scans a saved tar of itself: native
+        # OS-layer (dpkg/rpm/apk) + app-dependency vulnerabilities at MEDIUM+
+        # severity (agent-bom has no separate UNKNOWN tier), unfixable findings
+        # excluded (= ignore-unfixed), and the .image-scan-ignore allowlist of
+        # known-unfixable base-image CVEs.
+        run: |
+          docker save agent-bom:release-test -o /tmp/agent-bom-release-test.tar
+          chmod 0644 /tmp/agent-bom-release-test.tar
+          docker run --rm \
+            -v /tmp/agent-bom-release-test.tar:/scan/image.tar:ro \
+            -v "$PWD/.image-scan-ignore:/scan/.image-scan-ignore:ro" \
+            agent-bom:release-test \
+            image --tar /scan/image.tar \
+            --ignore /scan/.image-scan-ignore \
+            --exclude-unfixable \
+            --fail-on-severity medium
 
   self-scan-gate:
     name: Self-scan release gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,22 @@ account.
   the unlock path.
 - **`scan` accepts an optional positional `PATH`**, and scans can be grouped
   into parent-child batches.
+- **`agent-bom image` / `agent-bom fs` gained `--ignore FILE`** to suppress
+  named advisories (CVE / GHSA / OSV) from both the report and the
+  `--fail-on-severity` gate. `FILE` may be a flat newline-delimited id list
+  (`#` comments allowed, e.g. `.image-scan-ignore`) or a structured
+  `.agent-bom-ignore.yaml`. ID matching is alias-aware (a GHSA id suppresses its
+  aliased CVE and vice versa).
+- **`--exclude-unfixable` now applies to the report and gate**, not just SARIF:
+  findings with no available fix are dropped from console/JSON output and from
+  the `--fail-on-severity` gate (an "ignore unfixed" policy).
+
+### CI / Tooling
+- **Image and filesystem vulnerability gates are self-hosted on agent-bom**
+  (dogfooding). The CI/release/container-rescan/refresh workflows now run
+  `agent-bom image` / `agent-bom fs` (OS-layer dpkg/rpm/apk + application
+  dependencies) and `agent-bom secrets` in place of the previous third-party
+  image/filesystem scanner; no workflow depends on an external scanner.
 
 ### API
 - **REST cloud-scanning endpoints** with MCP write-tool role enforcement.

--- a/src/agent_bom/cli/_focused_commands.py
+++ b/src/agent_bom/cli/_focused_commands.py
@@ -65,6 +65,22 @@ def _has_finding_at_or_above(findings, threshold: str = "high") -> bool:
 @click.option("--offline", is_flag=True, help="Scan against local DB only")
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output")
 @click.option("--fixable-only", "fixable_only", is_flag=True, default=False, help="Show only vulnerabilities with available fixes.")
+@click.option(
+    "--exclude-unfixable",
+    "exclude_unfixable",
+    is_flag=True,
+    default=False,
+    help="Drop vulnerabilities with no available fix from output and the --fail-on-severity gate (an 'ignore unfixed' policy).",
+)
+@click.option(
+    "--ignore",
+    "ignore_file",
+    type=click.Path(),
+    default=None,
+    metavar="FILE",
+    help="Suppress advisories listed in FILE (flat CVE/GHSA id list or .agent-bom-ignore.yaml) "
+    "from output and the --fail-on-severity gate.",
+)
 def image_cmd(
     image_ref: str | None,
     image_tar: str | None,
@@ -76,6 +92,8 @@ def image_cmd(
     offline: bool,
     quiet: bool,
     fixable_only: bool,
+    exclude_unfixable: bool,
+    ignore_file: Optional[str],
 ) -> None:
     """Scan a container image for vulnerabilities.
 
@@ -105,6 +123,8 @@ def image_cmd(
         offline=offline,
         quiet=quiet,
         fixable_only=fixable_only,
+        exclude_unfixable=exclude_unfixable,
+        ignore_file=ignore_file,
     )
 
 
@@ -117,6 +137,22 @@ def image_cmd(
 @click.option("--offline", is_flag=True, help="Scan against local DB only")
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output")
 @click.option("--fixable-only", "fixable_only", is_flag=True, default=False, help="Show only vulnerabilities with available fixes.")
+@click.option(
+    "--exclude-unfixable",
+    "exclude_unfixable",
+    is_flag=True,
+    default=False,
+    help="Drop vulnerabilities with no available fix from output and the --fail-on-severity gate (an 'ignore unfixed' policy).",
+)
+@click.option(
+    "--ignore",
+    "ignore_file",
+    type=click.Path(),
+    default=None,
+    metavar="FILE",
+    help="Suppress advisories listed in FILE (flat CVE/GHSA id list or .agent-bom-ignore.yaml) "
+    "from output and the --fail-on-severity gate.",
+)
 def fs_cmd(
     path: str,
     output_format: str,
@@ -126,6 +162,8 @@ def fs_cmd(
     offline: bool,
     quiet: bool,
     fixable_only: bool,
+    exclude_unfixable: bool,
+    ignore_file: Optional[str],
 ) -> None:
     """Scan a filesystem directory or mounted VM disk snapshot.
 
@@ -148,6 +186,8 @@ def fs_cmd(
         offline=offline,
         quiet=quiet,
         fixable_only=fixable_only,
+        exclude_unfixable=exclude_unfixable,
+        ignore_file=ignore_file,
     )
 
 

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -2354,6 +2354,19 @@ def scan(
         # Rebuild report.blast_radii to reflect suppressions
         report.blast_radii = blast_radii
 
+    # `--exclude-unfixable` drops vulnerabilities that have no available fix from
+    # the report, the console/JSON output, and the --fail-on-severity gate. A
+    # finding with no upstream fix cannot be remediated by an upgrade, so this is
+    # the gate-level equivalent of an "ignore unfixed" policy. (SARIF export also
+    # honours the flag independently via to_sarif().)
+    if exclude_unfixable:
+        from agent_bom.ignores import drop_unfixable
+
+        blast_radii, _dropped_unfixed = drop_unfixable(blast_radii)
+        report.blast_radii = blast_radii
+        if _dropped_unfixed and not quiet:
+            con.print(f"\n  [dim]Excluded {_dropped_unfixed} unfixable finding(s) (no upstream fix available)[/dim]")
+
     ctx.step_timings["scanning"] = _time.monotonic() - _step_t0
 
     # Surface graph-walk reachability onto each blast-radius row so the

--- a/src/agent_bom/cli/options_sources.py
+++ b/src/agent_bom/cli/options_sources.py
@@ -244,7 +244,8 @@ def output_options(fn):
                 "--exclude-unfixable",
                 is_flag=True,
                 default=False,
-                help="Exclude findings with no available fix from SARIF output (reduces GitHub Security tab noise)",
+                help="Exclude findings with no available fix from output, SARIF, and the "
+                "--fail-on-severity gate (an 'ignore unfixed' policy; reduces GitHub Security tab noise)",
             ),
             click.option(
                 "--fixable-only",

--- a/src/agent_bom/ignores.py
+++ b/src/agent_bom/ignores.py
@@ -51,10 +51,33 @@ _DEFAULT_IGNORE_FILE = ".agent-bom-ignore.yaml"
 
 
 def load_ignore_file(path: str | Path | None = None) -> list[dict[str, Any]]:
-    """Load and parse an ignore file.  Returns empty list if file not found."""
+    """Load and parse an ignore file.  Returns empty list if file not found.
+
+    Two formats are accepted:
+
+    * **Structured YAML** — a mapping with an ``ignores:`` list (see the module
+      docstring).  Supports per-entry reason/expiry/package/path metadata.
+    * **Flat id list** — a newline-delimited list of CVE / GHSA / OSV ids, one
+      per line, with ``#`` comments allowed (e.g. ``.image-scan-ignore``).
+      Each id becomes ``{"id": <id>}`` and suppresses that advisory wherever it
+      appears.  Used by CI image/filesystem gates that carry known-unfixable
+      base-image CVEs.
+    """
     target = Path(path) if path else Path(_DEFAULT_IGNORE_FILE)
     if not target.exists():
         return []
+
+    try:
+        text = target.read_text()
+    except OSError as exc:
+        raise ValueError(f"Could not read ignore file {target}: {exc}") from exc
+
+    # Flat newline-delimited id lists are detected before YAML parsing because
+    # multiple bare scalars on consecutive lines fold into a single YAML string
+    # rather than the mapping the structured loader expects.
+    if _looks_like_flat_id_list(text):
+        return _parse_flat_id_list(text)
+
     try:
         import yaml  # type: ignore[import]
     except ImportError:
@@ -66,10 +89,7 @@ def load_ignore_file(path: str | Path | None = None) -> list[dict[str, Any]]:
         return _parse_minimal_yaml(target)
 
     try:
-        with target.open() as fh:
-            data = yaml.safe_load(fh) or {}
-    except OSError as exc:
-        raise ValueError(f"Could not read ignore file {target}: {exc}") from exc
+        data = yaml.safe_load(text) or {}
     except yaml.YAMLError as exc:
         raise ValueError(f"Invalid YAML in ignore file {target}: {exc}") from exc
     if not isinstance(data, dict):
@@ -77,6 +97,40 @@ def load_ignore_file(path: str | Path | None = None) -> list[dict[str, Any]]:
     entries = data.get("ignores", [])
     if not isinstance(entries, list):
         raise ValueError(f"Ignore file {target} field 'ignores' must be a list")
+    return entries
+
+
+def _looks_like_flat_id_list(text: str) -> bool:
+    """Return True when *text* is a bare newline-delimited advisory-id list.
+
+    A flat list has at least one meaningful line and no YAML mapping/sequence
+    syntax (``key:`` mappings or ``-`` list items).  ``#`` comments and blank
+    lines are ignored.
+    """
+    saw_id = False
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("-") or line.endswith(":") or ": " in line:
+            return False
+        saw_id = True
+    return saw_id
+
+
+def _parse_flat_id_list(text: str) -> list[dict[str, Any]]:
+    """Parse a newline-delimited CVE/GHSA/OSV id list into ignore entries."""
+    entries: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        key = line.upper()
+        if key in seen:
+            continue
+        seen.add(key)
+        entries.append({"id": line, "reason": "Suppressed via flat ignore list"})
     return entries
 
 
@@ -113,12 +167,16 @@ def _matches_blast_radius(entry: dict[str, Any], br: "BlastRadius") -> bool:
     vuln = br.vulnerability
     pkg = br.package
 
-    # CVE/OSV ID match
+    # CVE/OSV/GHSA ID match — checks the canonical id and any cross-source
+    # aliases (e.g. a GHSA id suppresses its aliased CVE and vice versa).
     cve_id = entry.get("id")
-    if cve_id and vuln.id.upper() != str(cve_id).upper():
-        return False
     if cve_id:
-        return True  # ID match is sufficient
+        wanted = str(cve_id).upper()
+        candidate_ids = {vuln.id.upper()}
+        aliases = getattr(vuln, "aliases", None)
+        if isinstance(aliases, (list, tuple, set)):
+            candidate_ids.update(str(alias).upper() for alias in aliases)
+        return wanted in candidate_ids
 
     # Package name / version match
     pkg_spec = entry.get("package")
@@ -186,6 +244,23 @@ def _matches_finding_type(finding_type: str, br: "BlastRadius") -> bool:
     if ft == "credential_exposure":
         return bool(br.exposed_credentials)
     return False
+
+
+def drop_unfixable(
+    blast_radii: list["BlastRadius"],
+) -> tuple[list["BlastRadius"], int]:
+    """Drop blast-radius findings whose vulnerability has no available fix.
+
+    Returns ``(kept, dropped_count)``.  A finding with no ``fixed_version``
+    cannot be remediated by an upgrade; excluding it is the gate-level
+    equivalent of an "ignore unfixed" policy.
+    """
+    kept: list["BlastRadius"] = []
+    for br in blast_radii:
+        fixed = getattr(br.vulnerability, "fixed_version", None)
+        if isinstance(fixed, str) and fixed.strip():
+            kept.append(br)
+    return kept, len(blast_radii) - len(kept)
 
 
 def apply_ignores(

--- a/tests/test_focused_security_gates.py
+++ b/tests/test_focused_security_gates.py
@@ -143,3 +143,30 @@ def test_iac_command_exits_zero_when_clean(tmp_path: Path):
 
     assert result.exit_code == 0
     assert "no misconfigurations" in " ".join(result.output.split())
+
+
+def test_drop_unfixable_drops_findings_without_fix():
+    """--exclude-unfixable removes findings with no available fix (gate parity)."""
+    from unittest.mock import MagicMock
+
+    from agent_bom.ignores import drop_unfixable
+
+    fixable = MagicMock()
+    fixable.vulnerability.fixed_version = "2.0.0"
+    unfixable = MagicMock()
+    unfixable.vulnerability.fixed_version = None
+    empty_fix = MagicMock()
+    empty_fix.vulnerability.fixed_version = "  "
+
+    kept, dropped = drop_unfixable([fixable, unfixable, empty_fix])
+    assert kept == [fixable]
+    assert dropped == 2
+
+
+def test_image_and_fs_expose_ignore_and_exclude_unfixable():
+    """Both focused gates expose --ignore and --exclude-unfixable (wiring guard)."""
+    for cmd in ("image", "fs"):
+        result = CliRunner().invoke(main, [cmd, "--help"])
+        assert result.exit_code == 0
+        assert "--ignore" in result.output
+        assert "--exclude-unfixable" in result.output

--- a/tests/test_ignores.py
+++ b/tests/test_ignores.py
@@ -246,3 +246,78 @@ def test_scan_ignore_file_flag_accepted(tmp_path):
     ):
         result = CliRunner().invoke(main, ["scan", "--demo", "--ignore-file", str(ignore_f), "--no-scan"])
     assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Flat newline-delimited id list (.image-scan-ignore format)
+# ---------------------------------------------------------------------------
+
+
+def test_load_flat_id_list(tmp_path):
+    f = tmp_path / ".image-scan-ignore"
+    f.write_text("# header comment\nCVE-2026-27459\n\nCVE-2025-69720  # inline comment\nGHSA-xxxx-yyyy-zzzz\n")
+    entries = load_ignore_file(f)
+    ids = [e["id"] for e in entries]
+    assert ids == ["CVE-2026-27459", "CVE-2025-69720", "GHSA-xxxx-yyyy-zzzz"]
+    assert all(e["reason"] for e in entries)
+
+
+def test_load_flat_id_list_dedupes(tmp_path):
+    f = tmp_path / ".image-scan-ignore"
+    f.write_text("CVE-2025-6141\ncve-2025-6141\nCVE-2025-6141\n")
+    entries = load_ignore_file(f)
+    assert [e["id"] for e in entries] == ["CVE-2025-6141"]
+
+
+def test_load_flat_comments_only_is_empty(tmp_path):
+    f = tmp_path / ".image-scan-ignore"
+    f.write_text("# only comments\n\n# nothing else\n")
+    assert load_ignore_file(f) == []
+
+
+def test_load_repo_image_scan_ignore_has_five_cves():
+    """The shipped .image-scan-ignore still suppresses its 5 known CVEs."""
+    from pathlib import Path
+
+    repo_ignore = Path(__file__).resolve().parent.parent / ".image-scan-ignore"
+    entries = load_ignore_file(repo_ignore)
+    ids = {e["id"] for e in entries}
+    assert ids == {
+        "CVE-2026-27459",
+        "CVE-2025-69720",
+        "CVE-2025-6141",
+        "CVE-2025-60876",
+        "CVE-2026-3219",
+    }
+
+
+def test_flat_list_suppresses_blast_radius(tmp_path):
+    f = tmp_path / ".image-scan-ignore"
+    f.write_text("CVE-2024-1234\n")
+    entries = load_ignore_file(f)
+    br = _make_blast_radius(cve_id="CVE-2024-1234")
+    filtered, suppressed = apply_ignores([br], entries)
+    assert suppressed == 1
+    assert filtered == []
+
+
+# ---------------------------------------------------------------------------
+# apply_ignores — alias-aware id match (GHSA <-> CVE)
+# ---------------------------------------------------------------------------
+
+
+def test_alias_id_suppresses():
+    br = _make_blast_radius(cve_id="GHSA-aaaa-bbbb-cccc")
+    br.vulnerability.aliases = ["CVE-2024-5678"]
+    entries = [{"id": "CVE-2024-5678", "reason": "matched via alias"}]
+    filtered, suppressed = apply_ignores([br], entries)
+    assert suppressed == 1
+    assert filtered == []
+
+
+def test_non_sequence_aliases_do_not_crash():
+    br = _make_blast_radius(cve_id="CVE-2024-1234")
+    # aliases left as a MagicMock attribute (non-list) must not raise.
+    entries = [{"id": "CVE-2024-1234", "reason": "primary id still matches"}]
+    filtered, suppressed = apply_ignores([br], entries)
+    assert suppressed == 1


### PR DESCRIPTION
## Summary

agent-bom is a security scanner; its own pipelines must not depend on a
third-party scanner. This replaces every use of the previous third-party
image/filesystem vulnerability scanner across the CI, release,
container-rescan, and refresh-latest workflows with agent-bom's own scanners
(dogfooding). After this change no workflow references an external scanner
(`git grep -i trivy .github/` returns nothing).

## CLI support added for the swap

The focused `image` / `fs` commands had no advisory-suppression flag and no
gate-level "ignore unfixed" control, so two small, tested additions were made
(no `image.py` / scanner-engine code is touched):

- **`--ignore FILE`** on `agent-bom image` and `agent-bom fs` — suppresses named
  advisories (CVE / GHSA / OSV) from both the report **and** the
  `--fail-on-severity` gate. `FILE` may be a flat newline-delimited id list
  (`#` comments allowed, e.g. `.image-scan-ignore`) **or** a structured
  `.agent-bom-ignore.yaml`. The existing ignore pipeline
  (`agent_bom.ignores.apply_ignores`) is reused; `load_ignore_file` now also
  parses the flat list format. ID matching is alias-aware (a GHSA id suppresses
  its aliased CVE and vice versa).
- **`--exclude-unfixable`** now applies to the report and the gate, not only
  SARIF: findings with no available fix are dropped from console/JSON output and
  from the `--fail-on-severity` gate. This is the gate-level equivalent of the
  previous scanner's `ignore-unfixed: true`.

The known-unfixable base-image CVE allowlist stays in `.image-scan-ignore`
(no migration needed — `--ignore` reads it natively). Its 5 entries remain
suppressed.

## Per-step mapping

| Workflow:step | Image/path | New agent-bom command |
|---|---|---|
| `ci.yml` Filesystem vulnerability scan | `.` | `agent-bom fs . --ignore .image-scan-ignore --exclude-unfixable --fail-on-severity medium` (+ `agent-bom secrets .`, informational) |
| `ci.yml` Image vulnerability scan | `agent-bom:test` | host-installed `agent-bom image agent-bom:test --ignore .image-scan-ignore --exclude-unfixable --fail-on-severity medium` |
| `release.yml` Image vulnerability scan gate | `agent-bom:release-test` | in-image self-scan of a saved tar: `docker run … agent-bom:release-test image --tar … --ignore … --exclude-unfixable --fail-on-severity medium` |
| `container-rescan.yml` scan table | `agentbom/agent-bom:latest` | `agent-bom image … --ignore … --exclude-unfixable --fail-on-severity medium` (table) |
| `container-rescan.yml` scan SARIF | `agentbom/agent-bom:latest` | `agent-bom image … --ignore … --exclude-unfixable -f sarif -o image-scan-<cat>.sarif` (non-gating; existing `upload-sarif` unchanged) |
| `refresh-latest-container.yml` main gate | `agent-bom:latest-refresh-test` | snapshot-installed `agent-bom image … --ignore … --exclude-unfixable --fail-on-severity medium` |
| `refresh-latest-container.yml` UI gate | `agent-bom-ui:latest-refresh-test` | snapshot-installed `agent-bom image … --ignore … --exclude-unfixable --fail-on-severity medium` |

## Coverage parity (no reduction)

- **OS-layer (dpkg/rpm/apk):** `agent-bom image` does native OS-package
  extraction from the image (daemon `docker save` or `--tar`).
- **Application dependencies:** covered by both `image` and `fs`.
- **Secret scanning:** the filesystem step adds `agent-bom secrets .` to retain
  the secret scanning the previous filesystem step did. It runs **informationally**
  (non-blocking) because the repo's dedicated `gitleaks.yml` workflow is the
  authoritative blocking secret gate, and a hard agent-bom secrets gate would
  fire on committed SDK test fixtures and PII heuristics that the previous
  scanner did not block.
- **SARIF:** the container-rescan SARIF artifact is still produced and uploaded
  to the Security tab via the unchanged `github/codeql-action/upload-sarif` step.

## Honest gaps / behavior notes

- **No UNKNOWN severity tier.** The previous scanner used
  `severity: MEDIUM,HIGH,CRITICAL,UNKNOWN`. agent-bom has no separate UNKNOWN
  tier; `--fail-on-severity medium` covers medium-and-above.
- **`ignore-unfixed` → `--exclude-unfixable`.** Reproduced at the gate level
  (verified: a scan with only unfixable medium+ findings exits 0 with the flag,
  1 without).
- **Refresh job version-skew.** `refresh-latest-container.yml` checks out the
  released tag to rebuild the image, so the scanner is snapshot-installed
  (non-editable) from the default-branch tree first; the gate runs on the
  current scanner regardless of the tag being refreshed.

## Risk — depends on a scanner-accuracy follow-up

A 4-way comparison on a Debian base showed agent-bom currently **over-reports
Debian-tracker findings** relative to mainstream scanners (Debian no-dsa /
won't-fix / EOL-release entries that other matchers suppress). Measured here:
a Debian `python:3.12-slim` yields ~1,170 fixable medium+ findings vs ~3 on the
Alpine `python:3.14` base that agent-bom's own images use.

Impact on this PR:
- The agent-bom **main images are Alpine-based** (`./Dockerfile`), so the CI,
  release, container-rescan, and refresh-main gates are effectively clean
  (only a couple of fixable musl CVEs may surface; if so they belong in
  `.image-scan-ignore`, not a bloated list).
- The **UI image** (`refresh-latest-container.yml`, `node:24-bookworm-slim`,
  Debian) **will over-report** until the Debian finding-matching accuracy fix
  lands, so that one gate is expected red until then. It is intentionally **not**
  papered over with a large suppression list.

Recommend a precursor "scanner-accuracy" change (Debian fix-status / no-dsa /
EOL handling, plus legacy `*.egg-info/PKG-INFO` extraction for the python-layer
false negatives observed on older images) merge first; this PR's UI gate goes
green after that and a rebase.

Do not merge or retrigger CI from this PR.
