### PR TITLE
fix(sbom): preserve packages, relationships, and document metadata across SPDX round-trip

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -545,7 +545,7 @@ represent, but the canonical report keeps everything.
 | JSON | `json_fmt.py` | Full report, lossless | nothing |
 | SARIF 2.1 | `sarif.py` | Findings, locations, fix recommendations | runtime trace, fleet membership |
 | CycloneDX 1.6 (+ ML BOM) | `cyclonedx_fmt.py` | Components, vulnerabilities, services, ML-BOM `model` blocks | dashboard-only attributes |
-| SPDX 3.0 | `spdx_fmt.py` | Packages, relationships, licenses | runtime + agent context |
+| SPDX 3.0 | `spdx_fmt.py` | Packages, relationships, licenses, vulnerability assessments | runtime + agent context |
 | HTML | `html.py` | Interactive dashboard view | suitable for emailed PDF |
 | Graph JSON | `graph_export.py` | `UnifiedGraph` nodes/edges/paths | textual narratives |
 | Graph HTML | `graph.py` | Cytoscape-rendered graph | — |
@@ -561,6 +561,30 @@ represent, but the canonical report keeps everything.
 | Attack Flow | `attack_flow.py` | MITRE Attack Flow JSON | non-attack-path nodes |
 | Plain text | `__init__.py` | Console summary | everything except top-line stats |
 | **OCSF** (event delivery) | `ocsf.py` | Findings as OCSF events for SIEM / security-lake | Used for streaming, not as a `-f ocsf` report option |
+
+### SBOM round-trip fidelity (emit → `agent-bom sbom` ingest)
+
+`agent_bom/sbom.py` ingests CycloneDX and SPDX 2.x/3.0. For SPDX 3.0 — the
+format agent-bom emits — the emit→ingest→emit path is **lossless for the
+package-level fields agent-bom models**:
+
+- **Round-trips:** every package's `name`, `version`, `purl`, `ecosystem`,
+  `license`, `supplier`, `description`, `homepage`, `download_url`,
+  `copyright_text`, plus vulnerability assessments (`AFFECTS`) with `id`,
+  `summary`, `severity`, `cvss_score`, `fixed_version`, KEV/EPSS/CWE
+  enrichments carried as annotations.
+- **Intentionally not round-tripped:** the agent → MCP-server → package
+  dependency tree (`CONTAINS`/server-scoped `DEPENDS_ON`) and per-package
+  `is_direct`/`dependency_depth`. Ingestion deliberately produces a **flat
+  package list** (`list[Package]`) with no agent/server hierarchy, so the
+  tree is not reconstructed; agents and MCP servers are emitted as
+  `APPLICATION`-purpose elements and skipped on ingest rather than being
+  re-imported as packages. Direct-dependency status is recovered only from
+  document → package `DEPENDS_ON` edges present in third-party SPDX.
+
+Ingestion also tolerates third-party SPDX 3.0 emitter variants
+(`software/packageVersion`, `software/packageUrl`, single-object or list
+`externalIdentifier`) and ignores fields agent-bom does not model.
 
 ---
 

--- a/src/agent_bom/sbom.py
+++ b/src/agent_bom/sbom.py
@@ -269,6 +269,161 @@ def parse_cyclonedx(data: dict) -> list[Package]:
 
 # ─── SPDX ────────────────────────────────────────────────────────────────────
 
+# Element-level keys that may carry a package version across SPDX 3.0 emitters.
+# agent-bom emits ``versionInfo``; third-party tools emit the expanded
+# ``software/packageVersion`` / ``software_packageVersion`` / ``packageVersion``.
+_SPDX3_VERSION_KEYS = ("versionInfo", "software/packageVersion", "software_packageVersion", "packageVersion")
+# Element-level keys that may carry a flat PackageURL string.
+_SPDX3_PURL_KEYS = ("software/packageUrl", "software_packageUrl", "packageUrl")
+
+
+def _spdx3_version(elem: dict) -> str:
+    """Return the package version from an SPDX 3.0 element, or ``"unknown"``."""
+    for key in _SPDX3_VERSION_KEYS:
+        value = elem.get(key)
+        if value:
+            return str(value)
+    return "unknown"
+
+
+def _spdx3_purl(elem: dict) -> str:
+    """Return the PackageURL for an SPDX 3.0 element.
+
+    Handles every shape agent-bom and third-party tools produce:
+    - a flat ``software/packageUrl`` (or aliases) string, or
+    - an ``externalIdentifier`` that is either a single object or a list of
+      objects, each ``{"type": "PackageURL", "identifier": "pkg:..."}``.
+    """
+    for key in _SPDX3_PURL_KEYS:
+        value = elem.get(key)
+        if isinstance(value, str) and value:
+            return value
+
+    ext = elem.get("externalIdentifier")
+    candidates = ext if isinstance(ext, list) else [ext] if isinstance(ext, dict) else []
+    fallback = ""
+    for entry in candidates:
+        if not isinstance(entry, dict):
+            continue
+        identifier = entry.get("identifier") or ""
+        if not identifier:
+            continue
+        id_type = str(entry.get("type") or "").lower()
+        if id_type in ("packageurl", "purl") or identifier.startswith("pkg:"):
+            return identifier
+        if not fallback:
+            fallback = identifier
+    return fallback
+
+
+def _spdx3_primary_purpose(elem: dict) -> str:
+    """Return the (upper-cased) primaryPurpose for an SPDX 3.0 element."""
+    for key in ("primaryPurpose", "software/primaryPurpose", "software_primaryPurpose"):
+        value = elem.get(key)
+        if isinstance(value, str) and value:
+            return value.upper()
+    return ""
+
+
+def _spdx3_annotation_kv(elem: dict) -> dict[str, str]:
+    """Parse ``agent-bom:key=value`` annotation statements into a dict."""
+    kv: dict[str, str] = {}
+    annotations = elem.get("annotation")
+    if isinstance(annotations, dict):
+        annotations = [annotations]
+    for ann in annotations or []:
+        if not isinstance(ann, dict):
+            continue
+        statement = ann.get("statement") or ""
+        if statement.startswith("agent-bom:") and "=" in statement:
+            key, _, value = statement[len("agent-bom:") :].partition("=")
+            kv[key] = value
+    return kv
+
+
+def _spdx3_vulnerabilities(data: dict, pkg_by_id: dict[str, Package]) -> None:
+    """Attach SPDX 3.0 vulnerability assessments (AFFECTS) to packages in place.
+
+    agent-bom emits each vulnerability as a ``security/Vulnerability`` element and
+    links it to the affected package via a ``security/VulnAssessmentRelationship``
+    (``relationshipType: AFFECTS``) in the top-level ``relationships`` array. The
+    severity/fix/KEV/EPSS/CWE enrichments ride on the relationship and on the
+    vulnerability element's annotations.
+    """
+    elements = data.get("elements", [])
+    vuln_elems: dict[str, dict] = {}
+    for elem in elements:
+        if isinstance(elem, dict) and str(elem.get("type") or "").lower().endswith("vulnerability"):
+            spdx_id = elem.get("spdxId") or elem.get("SPDXID")
+            if spdx_id:
+                vuln_elems[spdx_id] = elem
+
+    # AFFECTS relationships can live in the top-level array or among elements.
+    relationships = list(data.get("relationships", []))
+    relationships += [e for e in elements if isinstance(e, dict) and "Relationship" in str(e.get("type") or "")]
+
+    for rel in relationships:
+        if not isinstance(rel, dict) or rel.get("relationshipType") != "AFFECTS":
+            continue
+        vuln_elem = vuln_elems.get(rel.get("from", ""))
+        if vuln_elem is None:
+            continue
+        targets = rel.get("to", [])
+        if isinstance(targets, str):
+            targets = [targets]
+
+        vuln_id = vuln_elem.get("name") or ""
+        raw_score = vuln_elem.get("score")
+        score_obj: dict = raw_score if isinstance(raw_score, dict) else {}
+        sev_str = rel.get("severity") or score_obj.get("severity") or "unknown"
+        try:
+            severity = Severity(str(sev_str).lower())
+        except ValueError:
+            severity = Severity.UNKNOWN
+        cvss_score: float | None = None
+        if score_obj.get("score") is not None:
+            try:
+                cvss_score = float(score_obj["score"])
+            except (TypeError, ValueError):
+                cvss_score = None
+
+        fixed_version = None
+        remediation = rel.get("remediation") or ""
+        if remediation.startswith("Upgrade to "):
+            fixed_version = remediation[len("Upgrade to ") :].strip() or None
+
+        ann = _spdx3_annotation_kv(vuln_elem)
+        cwe_ids = [v for k, v in ann.items() if k == "cwe"]
+
+        def _as_float(value: str | None) -> float | None:
+            try:
+                return float(value) if value is not None else None
+            except (TypeError, ValueError):
+                return None
+
+        for pkg_id in targets:
+            pkg = pkg_by_id.get(pkg_id)
+            if pkg is None or not vuln_id:
+                continue
+            if any(existing.id == vuln_id for existing in pkg.vulnerabilities):
+                continue
+            pkg.vulnerabilities.append(
+                Vulnerability(
+                    id=vuln_id,
+                    summary=vuln_elem.get("description") or "",
+                    severity=severity,
+                    cvss_score=cvss_score,
+                    fixed_version=fixed_version,
+                    severity_source=ann.get("severity-source"),
+                    epss_score=_as_float(ann.get("epss-score")),
+                    epss_percentile=_as_float(ann.get("epss-percentile")),
+                    is_kev=ann.get("kev") == "true",
+                    kev_date_added=ann.get("kev-date-added"),
+                    kev_due_date=ann.get("kev-due-date"),
+                    cwe_ids=cwe_ids,
+                )
+            )
+
 
 def parse_spdx(data: dict) -> list[Package]:
     """Parse an SPDX 2.x or 3.0 JSON document into Package objects.
@@ -279,28 +434,35 @@ def parse_spdx(data: dict) -> list[Package]:
     """
     packages: list[Package] = []
 
-    # SPDX 3.0: build direct dependency set from relationship elements
+    # SPDX 3.0: build direct dependency set from DEPENDS_ON relationships. These
+    # may sit among the elements (third-party emitters) or in the top-level
+    # ``relationships`` array (agent-bom). Root → package edges mark direct deps.
     _spdx3_direct_ids: set[str] = set()
-    for elem in data.get("elements", []):
-        if isinstance(elem, dict) and elem.get("type") in ("Relationship", "relationship"):
-            if elem.get("relationshipType") == "DEPENDS_ON":
-                from_id = elem.get("from", "")
-                # Root element's DEPENDS_ON targets are direct deps
-                if from_id and from_id == data.get("SPDXID", ""):
-                    _spdx3_direct_ids.update(elem.get("to", []) if isinstance(elem.get("to"), list) else [elem.get("to", "")])
+    _doc_id = data.get("SPDXID", "")
+    for rel in [*data.get("elements", []), *data.get("relationships", [])]:
+        if not isinstance(rel, dict) or rel.get("relationshipType") != "DEPENDS_ON":
+            continue
+        if rel.get("from", "") == _doc_id and _doc_id:
+            to = rel.get("to", [])
+            _spdx3_direct_ids.update(to if isinstance(to, list) else [to])
 
     # SPDX 3.0 format
     if "spdxVersion" in data and data.get("spdxVersion", "").startswith("SPDX-3"):
+        pkg_by_id: dict[str, Package] = {}
         for elem in data.get("elements", []):
             if not isinstance(elem, dict):
                 continue
             if elem.get("type") not in ("software/Package", "SOFTWARE_PACKAGE"):
                 continue
+            # Skip non-library elements (agent-bom emits agents and MCP servers as
+            # SOFTWARE_PACKAGE/APPLICATION; only LIBRARY-purpose elements are deps).
+            if _spdx3_primary_purpose(elem) == "APPLICATION":
+                continue
             name = elem.get("name", "")
-            version = str(elem.get("software/packageVersion", elem.get("packageVersion", "unknown")) or "unknown")
-            purl = elem.get("software/packageUrl", elem.get("externalIdentifier", {}).get("identifier", ""))
             if not name:
                 continue
+            version = _spdx3_version(elem)
+            purl = _spdx3_purl(elem)
             ecosystem = _ecosystem_from_purl(purl) if purl else "unknown"
 
             # Extract SPDX 3.0 metadata
@@ -310,23 +472,30 @@ def parse_spdx(data: dict) -> list[Package]:
                 supplier_3 = supplier_3.get("name")
             desc_3 = elem.get("description") or elem.get("software/description") or None
             copyright_3 = elem.get("copyrightText") or None
+            homepage_3 = elem.get("homepage") or None
+            download_3 = elem.get("downloadLocation") or None
 
             elem_spdxid = elem.get("spdxId", elem.get("SPDXID", ""))
             _is_direct_3 = elem_spdxid in _spdx3_direct_ids if _spdx3_direct_ids else True
 
-            packages.append(
-                Package(
-                    name=name,
-                    version=version,
-                    ecosystem=ecosystem,
-                    purl=purl or None,
-                    is_direct=_is_direct_3,
-                    license=lic_3 if isinstance(lic_3, str) else None,
-                    supplier=supplier_3 if isinstance(supplier_3, str) else None,
-                    description=desc_3[:300] if desc_3 else None,
-                    copyright_text=copyright_3 if isinstance(copyright_3, str) else None,
-                )
+            pkg = Package(
+                name=name,
+                version=version,
+                ecosystem=ecosystem,
+                purl=purl or None,
+                is_direct=_is_direct_3,
+                license=lic_3 if isinstance(lic_3, str) else None,
+                supplier=supplier_3 if isinstance(supplier_3, str) else None,
+                description=desc_3[:300] if desc_3 else None,
+                homepage=homepage_3 if isinstance(homepage_3, str) else None,
+                download_url=download_3 if isinstance(download_3, str) else None,
+                copyright_text=copyright_3 if isinstance(copyright_3, str) else None,
             )
+            packages.append(pkg)
+            if elem_spdxid:
+                pkg_by_id[elem_spdxid] = pkg
+
+        _spdx3_vulnerabilities(data, pkg_by_id)
         return packages
 
     # SPDX 2.x: build direct dependency set from relationships

--- a/tests/test_sbom_ingestion.py
+++ b/tests/test_sbom_ingestion.py
@@ -270,3 +270,169 @@ def test_parse_sbom_document_autodetects_spdx_2():
 def test_load_sbom_file_not_found():
     with pytest.raises(FileNotFoundError):
         load_sbom("/nonexistent/path/sbom.json")
+
+
+# ─── SPDX 3.0 round-trip (emit → ingest) ──────────────────────────────────────
+
+
+def _round_trip_report():
+    from datetime import datetime, timezone
+
+    from agent_bom.models import (
+        Agent,
+        AgentStatus,
+        AgentType,
+        AIBOMReport,
+        MCPServer,
+        Package,
+        Severity,
+        TransportType,
+        Vulnerability,
+    )
+
+    pkg = Package(
+        name="requests",
+        version="2.28.0",
+        ecosystem="pypi",
+        purl="pkg:pypi/requests@2.28.0",
+        license="Apache-2.0",
+        supplier="PSF",
+        description="HTTP for humans",
+        homepage="https://requests.dev",
+        is_direct=True,
+    )
+    pkg2 = Package(
+        name="urllib3",
+        version="1.26.0",
+        ecosystem="pypi",
+        purl="pkg:pypi/urllib3@1.26.0",
+        is_direct=False,
+    )
+    pkg.vulnerabilities.append(
+        Vulnerability(
+            id="CVE-2023-1234",
+            summary="boom",
+            severity=Severity.HIGH,
+            cvss_score=7.5,
+            fixed_version="2.31.0",
+            is_kev=True,
+            epss_score=0.42,
+            cwe_ids=["CWE-79"],
+        )
+    )
+    server = MCPServer(name="srv1", command="x", transport=TransportType.STDIO, packages=[pkg, pkg2])
+    agent = Agent(
+        name="agent1",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/c.json",
+        status=AgentStatus.CONFIGURED,
+        mcp_servers=[server],
+    )
+    return AIBOMReport(
+        agents=[agent],
+        blast_radii=[],
+        generated_at=datetime.now(timezone.utc),
+        scan_id="rt",
+        tool_version="0.0.0-test",
+    )
+
+
+def test_spdx_round_trip_preserves_packages():
+    from agent_bom.output.spdx_fmt import to_spdx
+
+    report = _round_trip_report()
+    spdx = to_spdx(report)
+    packages = parse_spdx(spdx)
+
+    # Agents and MCP servers (APPLICATION purpose) must NOT be ingested as packages.
+    by_name = {p.name: p for p in packages}
+    assert set(by_name) == {"requests", "urllib3"}
+
+    # name + version + purl + ecosystem survive for every package (set equality).
+    emitted = {
+        ("requests", "2.28.0", "pkg:pypi/requests@2.28.0", "pypi"),
+        ("urllib3", "1.26.0", "pkg:pypi/urllib3@1.26.0", "pypi"),
+    }
+    assert {(p.name, p.version, p.purl, p.ecosystem) for p in packages} == emitted
+
+    # Supply-chain metadata survives.
+    requests_pkg = by_name["requests"]
+    assert requests_pkg.license == "Apache-2.0"
+    assert requests_pkg.supplier == "PSF"
+    assert requests_pkg.homepage == "https://requests.dev"
+
+
+def test_spdx_round_trip_preserves_vulnerability_assessments():
+    from agent_bom.models import Severity
+    from agent_bom.output.spdx_fmt import to_spdx
+
+    report = _round_trip_report()
+    packages = parse_spdx(to_spdx(report))
+    requests_pkg = next(p for p in packages if p.name == "requests")
+
+    assert len(requests_pkg.vulnerabilities) == 1
+    vuln = requests_pkg.vulnerabilities[0]
+    assert vuln.id == "CVE-2023-1234"
+    assert vuln.severity == Severity.HIGH
+    assert vuln.cvss_score == 7.5
+    assert vuln.fixed_version == "2.31.0"
+    assert vuln.is_kev is True
+    assert vuln.epss_score == 0.42
+    assert vuln.cwe_ids == ["CWE-79"]
+
+
+def test_spdx_round_trip_via_parse_sbom_document():
+    from agent_bom.output.spdx_fmt import to_spdx
+
+    report = _round_trip_report()
+    packages, fmt, _name = parse_sbom_document(to_spdx(report))
+    assert fmt == "spdx-3"
+    assert {p.name for p in packages} == {"requests", "urllib3"}
+
+
+def test_parse_spdx3_external_identifier_list():
+    """agent-bom emits externalIdentifier as a list — must not crash."""
+    data = {
+        "spdxVersion": "SPDX-3.0",
+        "elements": [
+            {
+                "type": "SOFTWARE_PACKAGE",
+                "spdxId": "SPDXRef-Pkg-1",
+                "name": "lodash",
+                "versionInfo": "4.17.21",
+                "primaryPurpose": "LIBRARY",
+                "externalIdentifier": [{"type": "PackageURL", "identifier": "pkg:npm/lodash@4.17.21"}],
+            }
+        ],
+    }
+    packages = parse_spdx(data)
+    assert len(packages) == 1
+    assert packages[0].name == "lodash"
+    assert packages[0].version == "4.17.21"
+    assert packages[0].purl == "pkg:npm/lodash@4.17.21"
+    assert packages[0].ecosystem == "npm"
+
+
+def test_parse_spdx3_minimal_external_document_no_crash():
+    """A minimal hand-written third-party SPDX 3.0 doc extracts packages and does not crash."""
+    data = {
+        "spdxVersion": "SPDX-3.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "elements": [
+            {
+                "type": "software/Package",
+                "spdxId": "SPDXRef-a",
+                "name": "openssl",
+                "software/packageVersion": "3.0.0",
+                "software/packageUrl": "pkg:generic/openssl@3.0.0",
+                # Fields agent-bom never emits — must be tolerated.
+                "verifiedUsing": [{"algorithm": "sha256", "hashValue": "deadbeef"}],
+                "builtTime": "2024-01-01T00:00:00Z",
+            },
+            {"type": "Person", "spdxId": "SPDXRef-author", "name": "Some Maintainer"},
+        ],
+    }
+    packages = parse_spdx(data)
+    assert len(packages) == 1
+    assert packages[0].name == "openssl"
+    assert packages[0].version == "3.0.0"


### PR DESCRIPTION
## Problem

agent-bom's SPDX 3.0 emitter (`output/spdx_fmt.py`) and its SBOM ingest path (`sbom.py::parse_spdx`) did not agree on the wire format, so the emit -> ingest -> emit round-trip was not self-consistent. Reproducing it (`to_spdx(report)` -> `parse_spdx(...)`) **raised `AttributeError`** and, where it did not crash, silently dropped data.

Root causes in the SPDX 3.0 ingest branch:
- Package version read only from `software/packageVersion`/`packageVersion`; the emitter writes `versionInfo` -> version became `unknown`.
- purl read via `externalIdentifier.get("identifier")`, assuming a dict; the emitter writes a **list** of identifier objects -> `AttributeError` on every package.
- With no purl, ecosystem fell back to `unknown`.
- The top-level `relationships` array was never read (only relationship *elements* were), so dependency edges were ignored.
- No vulnerability parsing at all -> every `security/Vulnerability` / `AFFECTS` assessment was lost.
- Agents and MCP servers (emitted as `SOFTWARE_PACKAGE`/`APPLICATION`) were re-imported as bogus packages.

## Fix (SPDX 3.0 ingest only — CycloneDX and SPDX 2.x untouched)

- Version from `versionInfo` (+ `software/packageVersion`, `software_packageVersion`, `packageVersion`).
- purl from a flat `software/packageUrl` **or** an `externalIdentifier` that is a single object or a list.
- Recover `homepage` and `downloadLocation` alongside license/supplier/description/copyright.
- Parse `security/Vulnerability` elements and `AFFECTS` relationships (from the top-level `relationships` array **and** inline elements), reattaching `id`, `summary`, `severity`, `cvss_score`, `fixed_version`, plus KEV/EPSS/CWE enrichments carried as annotations.
- Skip `APPLICATION`-purpose elements so agents/MCP servers are not ingested as packages.
- Tolerate unknown third-party fields without crashing.

## What now round-trips

| Field | Status |
|---|---|
| package name / version / purl / ecosystem | preserved (set equality) |
| license, supplier, description, homepage, download_url, copyright_text | preserved |
| vulnerability assessments (`AFFECTS`): id, summary, severity, cvss_score, fixed_version, KEV/EPSS/CWE | preserved |
| `spdxVersion`, `SPDXID`, `creationInfo`, `@context` | emitted valid + stable (unchanged) |

## Intentionally not round-tripped (documented)

The agent -> MCP-server -> package **dependency tree** (`CONTAINS` / server-scoped `DEPENDS_ON`) and per-package `is_direct` / `dependency_depth`. Ingestion produces a **flat `list[Package]`** by design and does not reconstruct the hierarchy; agents/servers are skipped rather than re-imported. Direct-dependency status is recovered only from document -> package `DEPENDS_ON` edges that appear in third-party SPDX.

## Tests

- Round-trip: build an `AIBOMReport` -> `to_spdx` -> `parse_spdx`; assert package set equality on name/version/purl/ecosystem, metadata preservation, and full vulnerability-assessment preservation.
- External-SPDX ingest: list-valued `externalIdentifier` does not crash; a minimal hand-written third-party SPDX 3.0 doc (with fields agent-bom never emits) extracts packages.
- CycloneDX and SPDX 2.x behavior unchanged (existing suite green).

Local: `ruff format`/`ruff check`/`mypy`/`pre-commit` clean; `tests/test_sbom_ingestion.py`, `test_sbom.py`, `test_output_formats.py`, `test_sbom_metadata_enrichment.py` all pass.