### PR TITLE
chore(ui): raise client JS bundle budget for merged UI features

### DIFF
--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -18,7 +18,8 @@ const BUDGETS = {
   // Includes the cloud CIS benchmark drill-down (per-cloud checks + remediation) on the compliance dashboard.
   // Includes the cross-domain overview landing page entrypoint and API client contract.
   // Includes the self-service cloud-connections page + Add Cloud Account wizard.
-  totalClientJsBytes: 3_055_000,
+  // Includes the repo folder/file structure graph layer icons and code-layer filters.
+  totalClientJsBytes: 3_065_000,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };


### PR DESCRIPTION
The UI bundle-budget gate is failing on main (and therefore on every open PR that builds the UI). Measured on a clean production build: **total client JS = 2984.9 KiB vs the checked-in 2983.4 KiB budget — 1.5 KiB over.**

Root cause is legitimate cumulative growth from recently merged UI: the self-service connections page + Add Cloud Account wizard, and the repo folder/file structure graph layer (code-layer icons + filters).

- Raise `totalClientJsBytes` 3,055,000 → 3,065,000 (≈8 KiB headroom).
- Largest chunk (384.4/927.7 KiB) and shared app runtime (416.7/439.5 KiB) remain well within budget.

Unblocks the UI Validate job on open PRs.