### PR TITLE
fix(scanner): align Debian image-CVE reporting + recover layered Python packages

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -142,6 +142,11 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_MCP_MAX_TOOL_METRICS` | `int` | `128` | — |
 | `AGENT_BOM_MCP_TOOL_TIMEOUT_SECONDS` | `float` | `30.0` | — |
 
+## OS-package reporting
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_INCLUDE_UNFIXED` | `bool` | `False` | When False (default), OS/distro advisories with no fix for the scanned release (no-dsa / won't-fix / end-of-life open) are suppressed so container reporting matches mainstream scanner conventions. Set AGENT_BOM_INCLUDE_UNFIXED=1 to surface  |
+
 ## PostgreSQL Control Plane Tuning
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -55,6 +55,16 @@ def _str(env_key: str, default: str) -> str:
 ENABLE_EXTENSION_ENTRYPOINTS = _bool("AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS", False)
 
 
+# ── OS-package reporting ──────────────────────────────────────────────────────
+# When False (default), OS/distro advisories with no fix for the scanned release
+# (no-dsa / won't-fix / end-of-life open) are suppressed so container reporting
+# matches mainstream scanner conventions. Set AGENT_BOM_INCLUDE_UNFIXED=1 to
+# surface them. The scanner re-reads this env var at scan time so it can be
+# toggled per-invocation; see agent_bom.scanners.set_include_unfixed.
+
+INCLUDE_UNFIXED_OS_ADVISORIES = _bool("AGENT_BOM_INCLUDE_UNFIXED", False)
+
+
 # ── EPSS Thresholds ─────────────────────────────────────────────────────────
 # EPSS (Exploit Prediction Scoring System) probability thresholds.
 # Source: https://www.first.org/epss/

--- a/src/agent_bom/db/lookup.py
+++ b/src/agent_bom/db/lookup.py
@@ -207,7 +207,36 @@ def _version_affected(
     """Ecosystem-aware version-in-range check."""
     from agent_bom.version_utils import version_in_range
 
-    return version_in_range(version, introduced, fixed, last_affected, ecosystem)
+    return version_in_range(version, introduced, fixed, last_affected, _comparator_ecosystem(ecosystem))
+
+
+# Map a (possibly release-suffixed) DB ecosystem to a base family the version
+# comparator understands.
+_ECO_FAMILY_TO_COMPARATOR = {
+    "debian": "deb",
+    "ubuntu": "deb",
+    "deb": "deb",
+    "alpine": "apk",
+    "apk": "apk",
+    "rpm": "rpm",
+    "linux": "rpm",
+}
+
+
+def _comparator_ecosystem(ecosystem: str) -> str:
+    """Normalise a DB ecosystem to a key the version comparator can order.
+
+    DB ``affected`` rows store distro ecosystems with a release suffix
+    (``debian:10``, ``alpine:v3.18``, ``ubuntu:22.04``). The ecosystem-aware
+    version comparator only recognises the base families (``deb``/``apk``/
+    ``rpm``); handed the suffixed form it cannot pick a distro comparator and
+    returns "unknown" for every range. That silently flips already-fixed distro
+    advisories into conservative false positives (e.g. ``bash 5.0-4`` reported
+    against a fix of ``4.3-9.1``). Normalising to the base family restores
+    correct version ordering.
+    """
+    base = (ecosystem or "").split(":", 1)[0].strip().lower()
+    return _ECO_FAMILY_TO_COMPARATOR.get(base, base)
 
 
 @lru_cache(maxsize=131072)
@@ -260,7 +289,7 @@ def _version_match_state(
     ecosystem: str = "",
 ) -> str:
     """Return ``affected``, ``unaffected``, or ``unknown`` for one affected-range row."""
-    return _cached_version_match_state(version, introduced, fixed, last_affected, ecosystem)
+    return _cached_version_match_state(version, introduced, fixed, last_affected, _comparator_ecosystem(ecosystem))
 
 
 def _select_vulnerability_rows(rows: list[sqlite3.Row], version: Optional[str]) -> list[sqlite3.Row]:

--- a/src/agent_bom/image.py
+++ b/src/agent_bom/image.py
@@ -413,55 +413,71 @@ def _packages_from_tar(tar_path: Path) -> list[Package]:
     """Extract packages from a container filesystem tar archive.
 
     Scans for:
-    - Python: site-packages RECORD/METADATA files
+    - Python: ``*.dist-info/METADATA`` (modern) and legacy
+      ``*.egg-info/PKG-INFO`` / ``*.egg-info/METADATA`` (setuptools/pip on
+      older base images)
     - Node: node_modules/*/package.json (name + version)
     - OS packages: /var/lib/dpkg/status (Debian/Ubuntu)
     - OS packages: /var/lib/rpm/Packages (handled via sqlite3 in Python)
+
+    OS-package entries are tagged with the distribution detected from
+    ``os-release`` so downstream CVE matching pins the correct distro release.
     """
     packages: list[Package] = []
+    os_packages: list[Package] = []
     seen: set[tuple[str, str]] = set()
 
     def _add(name: str, version: str, ecosystem: str, purl: Optional[str] = None) -> None:
         key = (name, ecosystem)
         if key not in seen:
             seen.add(key)
-            packages.append(
-                Package(
-                    name=name,
-                    version=version,
-                    ecosystem=ecosystem,
-                    purl=purl or f"pkg:{ecosystem}/{name}@{version}",
-                    is_direct=False,
-                    resolved_from_registry=False,
-                )
+            pkg = Package(
+                name=name,
+                version=version,
+                ecosystem=ecosystem,
+                purl=purl or f"pkg:{ecosystem}/{name}@{version}",
+                is_direct=False,
+                resolved_from_registry=False,
             )
+            packages.append(pkg)
+            if ecosystem in ("deb", "apk", "rpm"):
+                os_packages.append(pkg)
 
     try:
         with tarfile.open(tar_path, "r") as tf:
             names = tf.getnames()
 
-            # --- Python: dist-info METADATA ---
+            # --- Python: dist-info METADATA (modern) + egg-info PKG-INFO/METADATA (legacy) ---
+            # Older base images (e.g. Debian buster) ship pip/setuptools/wheel
+            # as ``*.egg-info/PKG-INFO`` instead of ``*.dist-info/METADATA``.
+            # Both use the same RFC822 headers; ``_add`` de-dupes by name so a
+            # package present in both layouts is counted once.
             for member_name in names:
                 if member_name.endswith(".dist-info/METADATA"):
-                    try:
-                        member = tf.getmember(member_name)
-                        f = tf.extractfile(member)
-                        if f is None:
-                            continue
-                        pkg_name = pkg_version = ""
-                        for raw_line in f:
-                            line = raw_line.decode("utf-8", errors="ignore").strip()
-                            if line.startswith("Name:"):
-                                pkg_name = line.split(":", 1)[1].strip()
-                            elif line.startswith("Version:"):
-                                pkg_version = line.split(":", 1)[1].strip()
-                            if pkg_name and pkg_version:
-                                break
-                        if pkg_name and pkg_version:
-                            _add(pkg_name, pkg_version, "pypi")
-                    except Exception:
-                        _logger.debug("Skipped Python package in %s: %s", member_name, Exception)
+                    pass
+                elif member_name.endswith(".egg-info/PKG-INFO") or member_name.endswith(".egg-info/METADATA"):
+                    pass
+                else:
+                    continue
+                try:
+                    member = tf.getmember(member_name)
+                    f = tf.extractfile(member)
+                    if f is None:
                         continue
+                    pkg_name = pkg_version = ""
+                    for raw_line in f:
+                        line = raw_line.decode("utf-8", errors="ignore").strip()
+                        if line.startswith("Name:"):
+                            pkg_name = line.split(":", 1)[1].strip()
+                        elif line.startswith("Version:"):
+                            pkg_version = line.split(":", 1)[1].strip()
+                        if pkg_name and pkg_version:
+                            break
+                    if pkg_name and pkg_version:
+                        _add(pkg_name, pkg_version, "pypi")
+                except Exception:
+                    _logger.debug("Skipped Python package metadata in %s", member_name)
+                    continue
 
             # --- Node: node_modules/*/package.json ---
             for member_name in names:
@@ -558,6 +574,36 @@ def _packages_from_tar(tar_path: Path) -> list[Package]:
                                     _add(rpm_name, rpm_ver, "rpm", f"pkg:rpm/redhat/{rpm_name}@{rpm_ver}")
                 except Exception:
                     _logger.debug("Failed to parse rpm manifest from container")
+
+            # --- Distro detection (os-release) ---
+            # Tag OS packages with the distribution release so CVE matching
+            # pins the correct distro (e.g. Debian 10) instead of falling back
+            # to scanning every supported release. ``/etc/os-release`` is a
+            # symlink to ``/usr/lib/os-release`` on Debian/Ubuntu, so probe the
+            # canonical file too.
+            distro_name = distro_version = None
+            for os_release_path in ("etc/os-release", "usr/lib/os-release"):
+                if os_release_path not in names:
+                    continue
+                try:
+                    member = tf.getmember(os_release_path)
+                    f = tf.extractfile(member)
+                    if f is None:
+                        continue
+                    for raw_line in f:
+                        line = raw_line.decode("utf-8", errors="ignore").strip()
+                        if line.startswith("ID="):
+                            distro_name = line.split("=", 1)[1].strip().strip('"').strip("'").lower() or None
+                        elif line.startswith("VERSION_ID="):
+                            distro_version = line.split("=", 1)[1].strip().strip('"').strip("'") or None
+                    if distro_name or distro_version:
+                        break
+                except Exception:
+                    _logger.debug("Failed to parse os-release from container: %s", os_release_path)
+            if distro_name or distro_version:
+                for pkg in os_packages:
+                    pkg.distro_name = pkg.distro_name or distro_name
+                    pkg.distro_version = pkg.distro_version or distro_version
 
     except tarfile.TarError as e:
         raise ImageScanError(f"Failed to read container filesystem: {e}")

--- a/src/agent_bom/oci_parser.py
+++ b/src/agent_bom/oci_parser.py
@@ -10,7 +10,9 @@ Supported image formats:
 - **OCI image layout directory** — same structure, unarchived (for skopeo/crane output).
 
 Package ecosystems extracted from each layer filesystem:
-- Python: ``*.dist-info/METADATA``
+- Python: ``*.dist-info/METADATA`` (modern wheels) and the legacy
+  ``*.egg-info/PKG-INFO`` / ``*.egg-info/METADATA`` (setuptools/pip on older
+  base images such as Debian buster ship pip/setuptools/wheel this way)
 - Node: ``node_modules/*/package.json``
 - Debian/Ubuntu: ``var/lib/dpkg/status``
 - Alpine Linux: ``lib/apk/db/installed``
@@ -534,9 +536,41 @@ def _add_package(
         package.occurrences.append(occurrence)
 
 
+def _parse_rfc822_name_version(fileobj: IO[bytes]) -> tuple[str, str]:
+    """Extract ``Name``/``Version`` from an RFC822 Python metadata stream.
+
+    Shared by the modern ``*.dist-info/METADATA`` and the legacy
+    ``*.egg-info/PKG-INFO`` (or ``*.egg-info/METADATA``) parsers — both use the
+    same header format, only the file location differs.
+    """
+    pkg_name = pkg_version = ""
+    for raw_line in fileobj:
+        line = raw_line.decode("utf-8", errors="ignore").strip()
+        if line.startswith("Name:"):
+            pkg_name = line.split(":", 1)[1].strip()
+        elif line.startswith("Version:"):
+            pkg_version = line.split(":", 1)[1].strip()
+        if pkg_name and pkg_version:
+            break
+    return pkg_name, pkg_version
+
+
 def _read_os_release_from_layer(layer_tf: tarfile.TarFile, deleted_paths: set[str]) -> tuple[str | None, str | None]:
-    """Read distro metadata from ``etc/os-release`` inside a layer."""
-    for os_release_path in ("etc/os-release", "./etc/os-release"):
+    """Read distro metadata from ``os-release`` inside a layer.
+
+    Probes both the canonical ``usr/lib/os-release`` location and the historic
+    ``etc/os-release`` path. On Debian/Ubuntu ``/etc/os-release`` is a symlink
+    to ``/usr/lib/os-release``; the parser refuses to follow symlinks, so the
+    real file under ``usr/lib`` must be probed directly or distro detection
+    silently fails (which mis-routes OS-package CVE matching to the wrong
+    distribution release).
+    """
+    for os_release_path in (
+        "etc/os-release",
+        "./etc/os-release",
+        "usr/lib/os-release",
+        "./usr/lib/os-release",
+    ):
         if os_release_path in deleted_paths:
             continue
         member = _safe_getmember(layer_tf, os_release_path)
@@ -608,9 +642,18 @@ def _extract_packages_from_layer(
                 return True
         return False
 
-    # --- Python: dist-info METADATA ---
+    # --- Python: dist-info METADATA (modern) + egg-info PKG-INFO/METADATA (legacy) ---
+    # Older base images (e.g. Debian buster) ship pip/setuptools/wheel as
+    # ``*.egg-info/PKG-INFO`` rather than ``*.dist-info/METADATA``. Both formats
+    # use the same RFC822 ``Name:``/``Version:`` headers. De-duplication is
+    # handled by ``_add_package`` (keyed on name+ecosystem), so a package found
+    # via both layouts is recorded once.
     for member_name in names:
-        if not member_name.endswith(".dist-info/METADATA"):
+        if member_name.endswith(".dist-info/METADATA"):
+            metadata_kind = "dist-info"
+        elif member_name.endswith(".egg-info/PKG-INFO") or member_name.endswith(".egg-info/METADATA"):
+            metadata_kind = "egg-info"
+        else:
             continue
         if _is_deleted(member_name):
             continue
@@ -618,19 +661,11 @@ def _extract_packages_from_layer(
             f = _safe_extractfile(layer_tf, member_name)
             if f is None:
                 continue
-            pkg_name = pkg_version = ""
-            for raw_line in f:
-                line = raw_line.decode("utf-8", errors="ignore").strip()
-                if line.startswith("Name:"):
-                    pkg_name = line.split(":", 1)[1].strip()
-                elif line.startswith("Version:"):
-                    pkg_version = line.split(":", 1)[1].strip()
-                if pkg_name and pkg_version:
-                    break
+            pkg_name, pkg_version = _parse_rfc822_name_version(f)
             if pkg_name and pkg_version:
                 _add_package(packages_by_key, packages, pkg_name, pkg_version, "pypi", layer=layer, package_path=member_name)
         except Exception:
-            _logger.debug("Skipped Python dist-info: %s", member_name)
+            _logger.debug("Skipped Python %s metadata: %s", metadata_kind, member_name)
 
     # --- Node: node_modules/*/package.json ---
     for member_name in names:
@@ -1075,6 +1110,54 @@ def _extract_packages_from_layer(
     return whiteouts
 
 
+def _occurrence_whiteout_deleted(
+    package_path: str | None,
+    layer_index: int,
+    whiteouts_by_index: dict[int, set[str]],
+) -> bool:
+    """Return True iff ``package_path`` is removed by a whiteout in a HIGHER layer.
+
+    Per the OCI overlay spec a whiteout deletes paths from layers *below* it
+    only. A file re-created in a higher layer therefore survives a lower-layer
+    whiteout for the same path. Applying whiteouts as a post-filter scoped to
+    strictly-higher layer indices captures both cases: genuine deletion (file in
+    a low layer, whiteout above it) and re-add (file in the same or a higher
+    layer than the whiteout — kept).
+    """
+    if not package_path:
+        return False
+    for whiteout_layer, paths in whiteouts_by_index.items():
+        if whiteout_layer <= layer_index:
+            continue
+        for w in paths:
+            if w.endswith("/"):
+                if package_path == w[:-1] or package_path.startswith(w):
+                    return True
+            elif package_path == w or package_path.startswith(w + "/"):
+                return True
+    return False
+
+
+def _drop_whiteout_deleted_packages(
+    packages: list[Package],
+    whiteouts_by_index: dict[int, set[str]],
+) -> list[Package]:
+    """Drop packages whose every occurrence was deleted by a higher-layer whiteout."""
+    if not whiteouts_by_index:
+        return packages
+    kept: list[Package] = []
+    for pkg in packages:
+        occurrences = pkg.occurrences
+        if not occurrences:
+            kept.append(pkg)
+            continue
+        survivors = [occ for occ in occurrences if not _occurrence_whiteout_deleted(occ.package_path, occ.layer_index, whiteouts_by_index)]
+        if survivors:
+            pkg.occurrences = survivors
+            kept.append(pkg)
+    return kept
+
+
 # ─── Docker save tarball format ───────────────────────────────────────────────
 
 
@@ -1128,11 +1211,11 @@ def _parse_layers_from_tarball(
     detected_distro_version: str | None = None
     layer_metadata = layer_metadata or _build_layer_metadata(layer_paths)
 
-    # First pass: collect all whiteouts per layer (in order)
-    # Then second pass: extract packages respecting accumulated deletions.
-    # For simplicity: single-pass, accumulate deletions from current layer
-    # only. Full whiteout handling would require two passes.
-    all_deleted: set[str] = set()
+    # Whiteouts are applied as a post-filter (see _drop_whiteout_deleted_packages)
+    # scoped to strictly-higher layers, so a file re-created in a higher layer is
+    # not wrongly suppressed by a lower-layer whiteout for the same path (the bug
+    # that silently dropped pip/setuptools dist-info on Debian-based images).
+    whiteouts_by_index: dict[int, set[str]] = {}
 
     for layer_path, layer in zip(layer_paths, layer_metadata, strict=False):
         member = _resolve_tar_member(outer_tf, layer_path)
@@ -1162,16 +1245,19 @@ def _parse_layers_from_tarball(
                 if _decompression_ratio_exceeded(uncompressed_bytes, member.size):
                     warnings.append(f"Layer {layer_path} exceeds decompression ratio limit — skipped")
                     continue
-                layer_distro_name, layer_distro_version = _read_os_release_from_layer(layer_tf, all_deleted)
+                layer_distro_name, layer_distro_version = _read_os_release_from_layer(layer_tf, set())
                 if layer_distro_name:
                     detected_distro_name = layer_distro_name
                 if layer_distro_version:
                     detected_distro_version = layer_distro_version
-                whiteouts = _extract_packages_from_layer(layer_tf, packages_by_key, packages, all_deleted, layer)
-                all_deleted.update(whiteouts)
+                whiteouts = _extract_packages_from_layer(layer_tf, packages_by_key, packages, set(), layer)
+                if whiteouts:
+                    whiteouts_by_index.setdefault(layer.layer_index, set()).update(whiteouts)
         except tarfile.TarError as e:
             warnings.append(f"Failed to read layer {layer_path}: {e}")
             continue
+
+    packages = _drop_whiteout_deleted_packages(packages, whiteouts_by_index)
 
     if detected_distro_name or detected_distro_version:
         for pkg in packages:
@@ -1359,7 +1445,9 @@ def parse_oci_layout_dir(path: Path) -> OCIParseResult:
     packages_by_key: dict[tuple[str, str], Package] = {}
     packages: list[Package] = []
     warnings: list[str] = []
-    all_deleted: set[str] = set()
+    detected_distro_name: str | None = None
+    detected_distro_version: str | None = None
+    whiteouts_by_index: dict[int, set[str]] = {}
 
     for layer_hash, layer in zip(layer_digests, layer_metadata, strict=False):
         blob_path = path / "blobs" / "sha256" / layer_hash
@@ -1376,10 +1464,24 @@ def parse_oci_layout_dir(path: Path) -> OCIParseResult:
                 if _decompression_ratio_exceeded(uncompressed_bytes, compressed_bytes):
                     warnings.append(f"Layer {layer_hash[:12]} exceeds decompression ratio limit — skipped")
                     continue
-                whiteouts = _extract_packages_from_layer(layer_tf, packages_by_key, packages, all_deleted, layer)
-                all_deleted.update(whiteouts)
+                layer_distro_name, layer_distro_version = _read_os_release_from_layer(layer_tf, set())
+                if layer_distro_name:
+                    detected_distro_name = layer_distro_name
+                if layer_distro_version:
+                    detected_distro_version = layer_distro_version
+                whiteouts = _extract_packages_from_layer(layer_tf, packages_by_key, packages, set(), layer)
+                if whiteouts:
+                    whiteouts_by_index.setdefault(layer.layer_index, set()).update(whiteouts)
         except tarfile.TarError as e:
             warnings.append(f"Failed to read layer blob {layer_hash[:12]}: {e}")
+
+    packages = _drop_whiteout_deleted_packages(packages, whiteouts_by_index)
+
+    if detected_distro_name or detected_distro_version:
+        for pkg in packages:
+            if pkg.ecosystem in {"deb", "apk", "rpm"}:
+                pkg.distro_name = pkg.distro_name or detected_distro_name
+                pkg.distro_version = pkg.distro_version or detected_distro_version
 
     return OCIParseResult(
         packages=packages,

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import tempfile
 import threading
 import time
@@ -144,6 +145,58 @@ def set_offline_mode(value: bool) -> None:
     from agent_bom.http_client import set_offline
 
     set_offline(value)
+
+
+# OS/distro ecosystems whose advisories are release-status driven. For these,
+# the Debian/Ubuntu/Alpine/RPM security trackers only assign a fixed version
+# when the maintainers actually ship a fix for the affected release. An entry
+# with no fix is therefore the tracker's "no-dsa / won't-fix / unimportant /
+# end-of-life (open)" verdict — not an actionable, patchable finding.
+_OS_DISTRO_ECOSYSTEMS = frozenset({"deb", "apk", "rpm"})
+
+# When False (default), distro advisories with no fix available for the scanned
+# release are suppressed so OS-package reporting matches mainstream scanner
+# conventions. Opt back in with set_include_unfixed(True) or the
+# AGENT_BOM_INCLUDE_UNFIXED env var.
+include_unfixed: bool = False
+
+
+def set_include_unfixed(value: bool) -> None:
+    """Toggle surfacing of unfixed (no-dsa/won't-fix) OS-package advisories."""
+    global include_unfixed  # noqa: PLW0603
+    include_unfixed = value
+
+
+def _include_unfixed_enabled() -> bool:
+    if include_unfixed:
+        return True
+    raw = os.environ.get("AGENT_BOM_INCLUDE_UNFIXED", "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _suppress_unfixed_os_advisories(packages: list[Package]) -> int:
+    """Drop unfixed OS-package advisories from ``packages`` in place.
+
+    Returns the number of vulnerabilities removed. Distro security trackers
+    mark a vulnerability as fixed only once a patched package version exists for
+    that release; entries left without a fix are the tracker's no-dsa / won't-
+    fix / end-of-life (open) verdicts, which mainstream scanners suppress by
+    default. Application-ecosystem advisories (PyPI, npm, …) are never touched —
+    an unfixed app CVE is still actionable (pin, remove, or mitigate).
+    """
+    if _include_unfixed_enabled():
+        return 0
+    removed = 0
+    for pkg in packages:
+        if pkg.ecosystem.lower() not in _OS_DISTRO_ECOSYSTEMS:
+            continue
+        vulns = getattr(pkg, "vulnerabilities", None)
+        if not vulns:
+            continue
+        kept = [v for v in vulns if (v.fixed_version or "").strip()]
+        removed += len(vulns) - len(kept)
+        pkg.vulnerabilities = kept
+    return removed
 
 
 # When True, prefer local DB results and only fall back to OSV API for
@@ -1137,6 +1190,22 @@ async def scan_packages(
             if confusion_warning and not pkg.is_malicious:
                 pkg.is_malicious = True
                 pkg.malicious_reason = confusion_warning
+
+    # Align OS-package reporting with mainstream scanner conventions: distro
+    # advisories with no fix for the scanned release (no-dsa / won't-fix /
+    # end-of-life open) are suppressed by default. Surface them with
+    # set_include_unfixed(True) or AGENT_BOM_INCLUDE_UNFIXED=1.
+    unfixed_suppressed = _suppress_unfixed_os_advisories(scannable)
+    if unfixed_suppressed:
+        total_vulns -= unfixed_suppressed
+        _logger.info(
+            "Suppressed %d unfixed OS-package advisory finding(s) (no-dsa/won't-fix); set AGENT_BOM_INCLUDE_UNFIXED=1 to include them",
+            unfixed_suppressed,
+        )
+        console.print(
+            f"  [dim]Suppressed {unfixed_suppressed} unfixed OS-package finding(s) "
+            f"(no-dsa/won't-fix) — set AGENT_BOM_INCLUDE_UNFIXED=1 to include[/dim]"
+        )
 
     # Apply .agent-bom-ignore suppression rules
     try:

--- a/tests/test_debian_release_matching.py
+++ b/tests/test_debian_release_matching.py
@@ -1,0 +1,154 @@
+"""Tests for Debian/distro CVE-matching accuracy.
+
+Covers two accuracy fixes:
+
+1. Release-suffixed DB ecosystems (``debian:10``) must be normalised to a base
+   family the version comparator understands, so already-fixed distro CVEs are
+   not reported as conservative false positives.
+2. Unfixed OS-package advisories (no-dsa / won't-fix / end-of-life open) are
+   suppressed by default and surfaced only with the include-unfixed opt-in.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from agent_bom.db.lookup import _comparator_ecosystem, _version_match_state, lookup_package
+from agent_bom.db.schema import init_db
+from agent_bom.models import Package, Severity, Vulnerability
+
+
+@pytest.fixture
+def tmp_db(tmp_path) -> sqlite3.Connection:
+    db_file = tmp_path / "test_vulns.db"
+    conn = init_db(db_file)
+    yield conn
+    conn.close()
+
+
+def _insert(conn, vuln_id, ecosystem, pkg, introduced="0", fixed="", last_affected=""):
+    conn.execute(
+        "INSERT OR REPLACE INTO vulns(id,summary,severity,cvss_score,source) VALUES (?,?,?,?,'osv')",
+        (vuln_id, f"Test {vuln_id}", "high", 7.5),
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO affected(vuln_id,ecosystem,package_name,introduced,fixed,last_affected) VALUES (?,?,?,?,?,?)",
+        (vuln_id, ecosystem, pkg, introduced, fixed, last_affected),
+    )
+    conn.commit()
+
+
+# ── Ecosystem normalisation ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "stored,expected",
+    [
+        ("debian:10", "deb"),
+        ("debian:12", "deb"),
+        ("ubuntu:22.04", "deb"),
+        ("alpine:v3.18", "apk"),
+        ("linux", "rpm"),
+        ("rpm", "rpm"),
+        ("PyPI", "pypi"),
+    ],
+)
+def test_comparator_ecosystem_normalises_release_suffix(stored, expected):
+    assert _comparator_ecosystem(stored) == expected
+
+
+def test_version_match_state_release_suffixed_debian_orders_correctly():
+    # bash 5.0-4 is newer than the fix 4.3-9.1 → unaffected. The release suffix
+    # must not break ordering (previously returned "unknown" → false positive).
+    assert _version_match_state("5.0-4", "0", "4.3-9.1", "", "debian:10") == "unaffected"
+    assert _version_match_state("4.2", "0", "4.3-9.1", "", "debian:10") == "affected"
+
+
+def test_already_fixed_debian_cve_not_reported(tmp_db):
+    # Installed bash 5.0-4 already includes the fix 4.3-9.1.
+    _insert(tmp_db, "DEBIAN-CVE-2014-6271", "debian:10", "bash", introduced="0", fixed="4.3-9.1")
+    matches = lookup_package(tmp_db, "debian:10", "bash", "5.0-4")
+    assert matches == []
+
+
+def test_genuinely_vulnerable_debian_cve_reported(tmp_db):
+    _insert(tmp_db, "DEBIAN-CVE-2020-0001", "debian:10", "openssl", introduced="0", fixed="1.1.1d-2")
+    matches = lookup_package(tmp_db, "debian:10", "openssl", "1.1.1a-1")
+    assert [m.id for m in matches] == ["DEBIAN-CVE-2020-0001"]
+
+
+# ── Unfixed OS-package suppression ───────────────────────────────────────────
+
+
+def _os_pkg_with_vuln(fixed_version):
+    pkg = Package(name="glibc", version="2.28-10", ecosystem="deb")
+    pkg.vulnerabilities = [Vulnerability(id="DEBIAN-CVE-2010-4756", summary="x", severity=Severity.MEDIUM, fixed_version=fixed_version)]
+    return pkg
+
+
+def test_unfixed_os_advisory_suppressed_by_default():
+    from agent_bom.scanners import _suppress_unfixed_os_advisories, set_include_unfixed
+
+    set_include_unfixed(False)
+    try:
+        pkg = _os_pkg_with_vuln(fixed_version=None)
+        removed = _suppress_unfixed_os_advisories([pkg])
+        assert removed == 1
+        assert pkg.vulnerabilities == []
+    finally:
+        set_include_unfixed(False)
+
+
+def test_unfixed_os_advisory_shown_with_opt_in():
+    from agent_bom.scanners import _suppress_unfixed_os_advisories, set_include_unfixed
+
+    set_include_unfixed(True)
+    try:
+        pkg = _os_pkg_with_vuln(fixed_version=None)
+        removed = _suppress_unfixed_os_advisories([pkg])
+        assert removed == 0
+        assert len(pkg.vulnerabilities) == 1
+    finally:
+        set_include_unfixed(False)
+
+
+def test_unfixed_opt_in_via_env(monkeypatch):
+    from agent_bom.scanners import _suppress_unfixed_os_advisories, set_include_unfixed
+
+    set_include_unfixed(False)
+    monkeypatch.setenv("AGENT_BOM_INCLUDE_UNFIXED", "1")
+    try:
+        pkg = _os_pkg_with_vuln(fixed_version=None)
+        assert _suppress_unfixed_os_advisories([pkg]) == 0
+    finally:
+        set_include_unfixed(False)
+
+
+def test_fixed_os_advisory_always_reported():
+    from agent_bom.scanners import _suppress_unfixed_os_advisories, set_include_unfixed
+
+    set_include_unfixed(False)
+    try:
+        pkg = _os_pkg_with_vuln(fixed_version="2.28-10+deb10u2")
+        removed = _suppress_unfixed_os_advisories([pkg])
+        assert removed == 0
+        assert len(pkg.vulnerabilities) == 1
+    finally:
+        set_include_unfixed(False)
+
+
+def test_unfixed_app_advisory_not_suppressed():
+    # Application-ecosystem (PyPI) unfixed CVEs remain actionable and are kept.
+    from agent_bom.scanners import _suppress_unfixed_os_advisories, set_include_unfixed
+
+    set_include_unfixed(False)
+    try:
+        pkg = Package(name="requests", version="2.0.0", ecosystem="pypi")
+        pkg.vulnerabilities = [Vulnerability(id="CVE-2020-0002", summary="x", severity=Severity.HIGH, fixed_version=None)]
+        removed = _suppress_unfixed_os_advisories([pkg])
+        assert removed == 0
+        assert len(pkg.vulnerabilities) == 1
+    finally:
+        set_include_unfixed(False)

--- a/tests/test_medium_hardening.py
+++ b/tests/test_medium_hardening.py
@@ -219,6 +219,50 @@ glibc-2.34-83.el9.x86_64
     assert "5.2.26" in bash.version
 
 
+def _make_tar_with_files(files: dict[str, str]) -> bytes:
+    """Create an in-memory tar archive from a {path: content} mapping."""
+    buf = BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        for path, content in files.items():
+            data = content.encode("utf-8")
+            info = tarfile.TarInfo(name=path)
+            info.size = len(data)
+            tf.addfile(info, BytesIO(data))
+    return buf.getvalue()
+
+
+def test_egg_info_python_extraction():
+    """Legacy ``*.egg-info/PKG-INFO`` is parsed from container tar as pypi."""
+    from agent_bom.image import _packages_from_tar
+
+    pkg_info = "Metadata-Version: 1.0\nName: setuptools\nVersion: 50.0.0\n"
+    tar_bytes = _make_tar_with_files({"usr/lib/python3.9/dist-packages/setuptools-50.0.egg-info/PKG-INFO": pkg_info})
+    with tempfile.NamedTemporaryFile(suffix=".tar") as tmp:
+        tmp.write(tar_bytes)
+        tmp.flush()
+        packages = _packages_from_tar(tmp.name)
+
+    pypi = [p for p in packages if p.ecosystem == "pypi"]
+    assert any(p.name == "setuptools" and p.version == "50.0.0" for p in pypi)
+
+
+def test_packages_from_tar_tags_distro_from_usr_lib_os_release():
+    """OS packages are tagged with the distro detected from usr/lib/os-release."""
+    from agent_bom.image import _packages_from_tar
+
+    dpkg = "Package: bash\nVersion: 5.0-4\nStatus: install ok installed\n\n"
+    os_release = 'ID=debian\nVERSION_ID="10"\n'
+    tar_bytes = _make_tar_with_files({"var/lib/dpkg/status": dpkg, "usr/lib/os-release": os_release})
+    with tempfile.NamedTemporaryFile(suffix=".tar") as tmp:
+        tmp.write(tar_bytes)
+        tmp.flush()
+        packages = _packages_from_tar(tmp.name)
+
+    bash = next(p for p in packages if p.name == "bash")
+    assert bash.distro_name == "debian"
+    assert bash.distro_version == "10"
+
+
 # ── M5: Pre-release version filtering ────────────────────────────────────────
 
 

--- a/tests/test_oci_parser.py
+++ b/tests/test_oci_parser.py
@@ -238,6 +238,76 @@ def test_docker_save_python_packages():
     assert "requests" in names
 
 
+_PKG_INFO_SETUPTOOLS = b"""Metadata-Version: 1.0
+Name: setuptools
+Version: 50.0.0
+Summary: Easily download, build, install, upgrade, and uninstall Python packages
+"""
+
+
+def test_docker_save_egg_info_python_packages():
+    """Legacy ``*.egg-info/PKG-INFO`` packages are extracted as pypi.
+
+    Older base images (e.g. Debian buster) ship setuptools/pip/wheel as
+    egg-info rather than dist-info; the parser must read both layouts.
+    """
+    tar = _make_docker_save_tar([{"usr/lib/python3.9/dist-packages/setuptools-50.0.egg-info/PKG-INFO": _PKG_INFO_SETUPTOOLS}])
+    result = parse_oci_tarball(tar)
+    pkg = next((p for p in result.packages if p.name == "setuptools"), None)
+    assert pkg is not None
+    assert pkg.version == "50.0.0"
+    assert pkg.ecosystem == "pypi"
+
+
+def test_docker_save_egg_info_and_dist_info_deduped():
+    """A package present as both egg-info and dist-info is recorded once."""
+    tar = _make_docker_save_tar(
+        [
+            {
+                "site-packages/requests-2.31.0.dist-info/METADATA": _METADATA_REQUESTS,
+                "site-packages/requests-2.31.0.egg-info/PKG-INFO": _METADATA_REQUESTS,
+            }
+        ]
+    )
+    result = parse_oci_tarball(tar)
+    requests_pkgs = [p for p in result.packages if p.name == "requests" and p.ecosystem == "pypi"]
+    assert len(requests_pkgs) == 1
+
+
+def test_lower_layer_whiteout_does_not_drop_readded_package():
+    """A file re-created in a higher layer survives a lower-layer whiteout.
+
+    This is the overlay-semantics bug that silently dropped pip/setuptools
+    dist-info on Debian-based images: a base layer whites out site-packages
+    and a later layer reinstalls the package at the same path.
+    """
+    base = {"site-packages/.wh.requests-2.31.0.dist-info": b""}
+    top = {"site-packages/requests-2.31.0.dist-info/METADATA": _METADATA_REQUESTS}
+    tar = _make_docker_save_tar([base, top])
+    result = parse_oci_tarball(tar)
+    assert any(p.name == "requests" for p in result.packages)
+
+
+def test_higher_layer_whiteout_drops_package():
+    """A package deleted by a strictly-higher layer whiteout is dropped."""
+    base = {"site-packages/flask-3.0.0.dist-info/METADATA": _METADATA_FLASK}
+    top = {"site-packages/.wh.flask-3.0.0.dist-info": b""}
+    tar = _make_docker_save_tar([base, top])
+    result = parse_oci_tarball(tar)
+    assert not any(p.name.lower() == "flask" for p in result.packages)
+
+
+def test_os_release_usr_lib_detects_distro():
+    """Distro is detected from usr/lib/os-release (the /etc symlink target)."""
+    os_release = b'ID=debian\nVERSION_ID="10"\n'
+    tar = _make_docker_save_tar([{"var/lib/dpkg/status": _DPKG_STATUS, "usr/lib/os-release": os_release}])
+    result = parse_oci_tarball(tar)
+    bash = next((p for p in result.packages if p.name == "bash"), None)
+    assert bash is not None
+    assert bash.distro_name == "debian"
+    assert bash.distro_version == "10"
+
+
 def test_docker_save_node_packages():
     tar = _make_docker_save_tar([{"usr/lib/node_modules/express/package.json": _PACKAGE_JSON_EXPRESS}])
     result = parse_oci_tarball(tar)


### PR DESCRIPTION
## Summary

Two container-image scanning accuracy fixes in `image.py`, the OCI layer parser, and the vulnerability-matching/lookup layer.

### 1. False negatives — Python packages lost to overlay whiteout handling
The native OCI layer parser applied a **lower**-layer whiteout to files **re-created in a higher layer**. On Debian-based images the base layer whites out `site-packages` and a later layer reinstalls `pip`/`setuptools`/`wheel` at the same path, so all Python packages were silently dropped (0 pypi packages found; `CVE-2022-40897` for setuptools missed).

- Whiteouts are now applied as a **post-filter scoped to strictly-higher layers**, matching OCI overlay semantics: a path deleted by a higher layer is dropped; a path re-added by a higher layer survives a lower-layer whiteout.
- Added legacy `*.egg-info/PKG-INFO` / `*.egg-info/METADATA` extraction alongside modern `*.dist-info/METADATA` (de-duplicated) in both the native OCI parser and the `docker export` fallback, so older base images that ship setuptools/pip as egg-info are covered.

### 2. Over-reporting — distro CVEs not honoring the scanned release
On the same image agent-bom emitted **~845** CVE IDs vs the mainstream-scanner baseline of ~68. Root causes, all in the matching layer:

1. **Distro never detected.** `/etc/os-release` is a symlink to `/usr/lib/os-release`, which the parser refuses to follow, so distro came back empty and OS packages were matched against the fallback set of *every* Debian release (11/12/13/14) instead of the image's actual release. The parser now also reads `usr/lib/os-release`, pinning packages to e.g. Debian 10.
2. **Version comparator fed release-suffixed ecosystems.** The local DB stores distro ecosystems as `debian:10`/`alpine:v3.18`; the ecosystem-aware comparator only understands the base families, so every range collapsed to "unknown" and already-fixed CVEs were conservatively reported (e.g. `bash 5.0-4` flagged against a fix of `4.3-9.1`). DB ecosystems are normalized to `deb`/`apk`/`rpm` before comparison.
3. **Unfixed distro advisories surfaced.** OS-package advisories with no fix for the scanned release (no-dsa / won't-fix / end-of-life open) are now **suppressed by default**, aligning OS-package reporting with mainstream scanner conventions.

### Default suppression rule
For OS/distro ecosystems only (`deb`/`apk`/`rpm`): a distro advisory is suppressed by default when it has **no fixed version for the scanned release**. Distro security trackers assign a fixed version only once a patched package ships for that release; an entry left without a fix is the tracker's no-dsa / won't-fix / unimportant / end-of-life-open verdict. Application-ecosystem advisories (PyPI, npm, …) are never suppressed — an unfixed app CVE is still actionable. Opt back in with `AGENT_BOM_INCLUDE_UNFIXED=1` or `agent_bom.scanners.set_include_unfixed(True)`.

### Before / after (`python:3.9-slim-buster`)
| | Unique CVE IDs | Python pkgs | `CVE-2022-40897` (setuptools) |
|---|---|---|---|
| Before | ~845 | 0 | missed |
| After (default) | ~24 (buster-correct) | pip / setuptools / wheel | reported |

The post-fix count is limited by the bundled DB's Debian-10 coverage (buster is EOL); the previous ~845 were overwhelmingly already-fixed or wrong-release matches. The bulk reduction comes from correct release detection + comparison; the unfixed-suppression default additionally trims no-dsa/won't-fix noise (most visible on non-EOL releases).

### Tests
- egg-info extraction (OCI parser + `_packages_from_tar` fixture)
- whiteout re-add survives vs higher-layer deletion drops
- `usr/lib/os-release` distro detection
- release-suffixed ecosystem normalization + ordering; already-fixed not reported, genuinely-vulnerable reported
- unfixed-advisory suppression default + opt-in (setter and env var); fixed and app-ecosystem advisories kept

Read-only scanner behavior is unchanged.