### PR TITLE
feat(cloud): AWS Organizations cross-account scan fan-out (read-only, opt-in)

### DIFF
--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -82,8 +82,9 @@ covers every action the scanner needs.
 
 ```bash
 export AGENT_BOM_AWS_INVENTORY=1            # opt-in (per-provider, symmetric)
+export AGENT_BOM_AWS_ORG_INVENTORY=1        # fan out across every member account
 export AWS_PROFILE=abom-readonly            # SecurityAudit-attached profile
-agent-bom agents --preset enterprise --aws
+agent-bom agents --preset enterprise --aws --aws-cis-benchmark
 ```
 
 **What it reads** (all read-only): S3, EC2 + security groups, IAM
@@ -91,6 +92,28 @@ roles/users/policies and the permission edges between them, RDS, DynamoDB,
 Lambda, EKS, ELB/ALB/NLB, VPCs, KMS, Secrets Manager (metadata only), CloudFront,
 ECR, Redshift, SNS/SQS — plus AWS **Organizations** (OU tree → accounts → SCPs)
 for multi-account estates, and **60 CIS checks**.
+
+**Org scale (cross-account fan-out):** with `AGENT_BOM_AWS_ORG_INVENTORY=1` the
+connector enumerates every member account of the organization, assumes a
+read-only role in each via `sts:AssumeRole` from the management /
+delegated-admin account (keyless, short-lived, ExternalId-capable), and runs the
+inventory + CIS benchmark against each — partitioned in the graph by account
+under the org → OU `CONTAINS` tree so cross-account attack paths correlate. This
+is the AWS analogue of `AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS` and
+`AGENT_BOM_GCP_ALL_PROJECTS`. Partial-permission tolerant: an account that denies
+the role is skipped with a warning, never a hard failure; the report's
+`aws_organization.account_scan` block summarises accounts scanned / skipped /
+errored. A defensive `AGENT_BOM_AWS_MAX_ACCOUNTS` cap (default 200) bounds blast
+radius.
+
+> **Read-only role expectation.** The conventional `OrganizationAccountAccessRole`
+> is full-admin and is *not* used. Deploy a least-privilege read-only role
+> (SecurityAudit / ViewOnlyAccess) named `agent-bom-readonly` to every account —
+> a CloudFormation **StackSet** targeting the org/OUs is the supported pattern.
+> Override the name with `AGENT_BOM_AWS_ORG_ROLE_NAME`, the trust ExternalId with
+> `AGENT_BOM_AWS_ORG_EXTERNAL_ID`. The role's trust policy grants
+> `sts:AssumeRole` only to the management/delegated-admin principal running the
+> scan.
 
 **Why read-only is enough:** the connector calls only `List*`/`Describe*`/`Get*`
 and `sts:GetCallerIdentity`. The exact action set is declared as permission

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -53,8 +53,16 @@ AGENT_BOM_AUTO_UPDATE_DB
 AGENT_BOM_AWS_ALL_REGIONS
 # Opt-in (default OFF) gate for the estate-wide read-only Azure asset inventory scanner (token/credential auth only).
 AGENT_BOM_AWS_INVENTORY
+# Defensive cap on the number of member accounts a single AWS Organizations scan fans out over (default 200).
+AGENT_BOM_AWS_MAX_ACCOUNTS
 # Defensive cap on the number of regions a single multi-region AWS inventory scan fans out over.
 AGENT_BOM_AWS_MAX_REGIONS
+# Opt-in (default OFF) gate to fan the read-only AWS inventory + CIS benchmark across every member account of the organization (cross-account AssumeRole fan-out).
+AGENT_BOM_AWS_ORG_INVENTORY
+# Name of the read-only role assumed in each member account during the AWS Organizations fan-out (default agent-bom-readonly; StackSet-deployed).
+AGENT_BOM_AWS_ORG_ROLE_NAME
+# Optional confused-deputy ExternalId presented to every per-account sts:AssumeRole during the AWS Organizations fan-out.
+AGENT_BOM_AWS_ORG_EXTERNAL_ID
 # Explicit comma-separated region override for the multi-region AWS inventory fan-out (else enabled regions are enumerated).
 AGENT_BOM_AWS_REGIONS
 AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS

--- a/src/agent_bom/cli/agents/_cloud.py
+++ b/src/agent_bom/cli/agents/_cloud.py
@@ -318,17 +318,28 @@ def run_benchmarks(
 
         con.print("\n[bold blue]Running CIS AWS Foundations Benchmark v3.0...[/bold blue]\n")
         try:
-            from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_cis
+            from agent_bom.cloud import aws_organizations
 
-            # AWS multi-account CIS fan-out is out of scope here: cross-account
-            # checks require the AssumeRole broker tracked in issue #3177. This
-            # benchmark runs against the single configured account/region only.
-            ctx.cis_benchmark_report = run_cis(region=aws_region, profile=aws_profile)
+            # When the org fan-out flag is on, fan the benchmark across every
+            # member account of the organization (same boundary set the inventory
+            # fan-out uses) and aggregate with per-account attribution. Each
+            # account is reached via a read-only AssumeRole; an account that denies
+            # the role is skipped. Off = unchanged single-account/region run.
+            if aws_organizations.org_fanout_enabled():
+                from agent_bom.cloud.aws_cis_benchmark import run_all_account_benchmarks
+
+                ctx.cis_benchmark_report = run_all_account_benchmarks(profile=aws_profile)
+            else:
+                from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_cis
+
+                ctx.cis_benchmark_report = run_cis(region=aws_region, profile=aws_profile)
             passed = ctx.cis_benchmark_report.passed
             failed = ctx.cis_benchmark_report.failed
             total = ctx.cis_benchmark_report.total
             rate = ctx.cis_benchmark_report.pass_rate
-            con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
+            scanned = getattr(ctx.cis_benchmark_report, "accounts_scanned", []) or []
+            scope = f" across {len(scanned)} account(s)" if len(scanned) > 1 else ""
+            con.print(f"  [green]✓[/green] {total} checks evaluated{scope} — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
         except CloudDiscoveryError as exc:
             con.print(f"  [red]CIS Benchmark error: {_safe_error(exc)}[/red]")
             ctx.cloud_provider_failures.append({"provider": "aws", "stage": "cis_benchmark", "error": str(exc)})

--- a/src/agent_bom/cloud/aws_cis_benchmark.py
+++ b/src/agent_bom/cloud/aws_cis_benchmark.py
@@ -120,6 +120,11 @@ class CISBenchmarkReport:
     checks: list[CISCheckResult] = field(default_factory=list)
     region: str = ""
     account_id: str = ""
+    # Populated only by the multi-account fan-out: the member accounts actually
+    # evaluated and any per-account warnings (e.g. an account skipped because the
+    # read-only role could not be assumed). Empty on a single-account run.
+    accounts_scanned: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
 
     @property
     def passed(self) -> int:
@@ -145,11 +150,13 @@ class CISBenchmarkReport:
             "benchmark": "CIS AWS Foundations",
             "benchmark_version": self.benchmark_version,
             "account_id": self.account_id,
+            "accounts_scanned": self.accounts_scanned,
             "region": self.region,
             "pass_rate": round(self.pass_rate, 1),
             "passed": self.passed,
             "failed": self.failed,
             "total": self.total,
+            "warnings": self.warnings,
             "checks": [
                 {
                     "check_id": c.check_id,
@@ -161,6 +168,7 @@ class CISBenchmarkReport:
                     "recommendation": c.recommendation,
                     "remediation": c.remediation,
                     "cis_section": c.cis_section,
+                    "account_id": c.account_id,
                     "network_exposure": c.network_exposure,
                     "attack_techniques": tag_cis_check(c),
                 }
@@ -2712,3 +2720,94 @@ def run_benchmark(
     attach_all(report, cloud="aws")
 
     return report
+
+
+# Bounded concurrency for the multi-account fan-out — mirrors the AWS inventory
+# fan-out's thread pool so an org-wide CIS run collapses the per-account
+# latencies instead of summing them.
+_MAX_CIS_FANOUT_WORKERS = 8
+
+
+def run_all_account_benchmarks(
+    checks: list[str] | None = None,
+    profile: str | None = None,
+) -> CISBenchmarkReport:
+    """Run the CIS AWS benchmark for EVERY member account of the organization.
+
+    The CIS counterpart of
+    :func:`agent_bom.cloud.aws_inventory.discover_all_account_inventories`: it
+    reuses the same member-account enumeration
+    (:func:`agent_bom.cloud.aws_organizations.list_member_account_ids`) and the
+    same read-only AssumeRole broker
+    (:func:`agent_bom.cloud.aws_organizations.assume_account_session`) so the
+    benchmark covers the identical estate the inventory fan-out does. Each account
+    is benchmarked concurrently (bounded thread pool) and the per-account results
+    are aggregated into one :class:`CISBenchmarkReport` with every check tagged by
+    its ``account_id``.
+
+    Read-only and partial-permission tolerant: an account whose read-only role
+    cannot be assumed is skipped with a warning rather than failing the whole run.
+    Falls back to a single ambient-credential benchmark when no org is visible (a
+    standalone account).
+
+    Raises:
+        CloudDiscoveryError: if boto3 is not installed.
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    from agent_bom.cloud import aws_organizations
+
+    from .normalization import sanitize_discovery_warning
+
+    try:
+        import boto3  # noqa: F401
+    except ImportError:
+        raise CloudDiscoveryError("boto3 is required for CIS AWS Benchmark checks. Install with: pip install 'agent-bom[aws]'")
+
+    try:
+        account_ids = aws_organizations.list_member_account_ids(profile, force=True)
+    except Exception as exc:  # noqa: BLE001 — org enumeration failure must degrade, not crash
+        logger.warning("AWS org account enumeration failed: %s", sanitize_discovery_warning(exc))
+        account_ids = []
+
+    if not account_ids:
+        # Standalone account (not in an org) — single-account benchmark.
+        return run_benchmark(profile=profile, checks=checks)
+
+    cap = aws_organizations.max_accounts()
+    capped = account_ids[:cap]
+
+    aggregate = CISBenchmarkReport(account_id=", ".join(capped))
+    if len(account_ids) > cap:
+        aggregate.warnings.append(
+            f"AWS multi-account CIS benchmark capped at {cap} of {len(account_ids)} accounts (set AGENT_BOM_AWS_MAX_ACCOUNTS to raise)."
+        )
+
+    def _run_one(account_id: str) -> tuple[str, CISBenchmarkReport]:
+        session = aws_organizations.assume_account_session(account_id, profile=profile)
+        return account_id, run_benchmark(session=session, checks=checks)
+
+    # Deterministic aggregation: collect per-account reports keyed by id, then
+    # merge in enumeration order so output is stable across runs.
+    reports: dict[str, CISBenchmarkReport] = {}
+    with ThreadPoolExecutor(max_workers=min(_MAX_CIS_FANOUT_WORKERS, len(capped))) as executor:
+        future_to_account = {executor.submit(_run_one, aid): aid for aid in capped}
+        for future in as_completed(future_to_account):
+            account_id = future_to_account[future]
+            try:
+                _aid, account_report = future.result()
+                reports[account_id] = account_report
+            except Exception as exc:  # noqa: BLE001 — one unreadable account must not sink the rest
+                aggregate.warnings.append(f"Account {account_id} skipped: {sanitize_discovery_warning(exc)}")
+
+    for account_id in capped:
+        merged = reports.get(account_id)
+        if merged is None:
+            continue
+        aggregate.accounts_scanned.append(account_id)
+        for check in merged.checks:
+            check.account_id = account_id
+            aggregate.checks.append(check)
+        aggregate.warnings.extend(merged.warnings)
+
+    return aggregate

--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -695,6 +695,93 @@ def discover_inventory_all_regions(
     }
 
 
+def discover_all_account_inventories(profile: str | None = None, *, force: bool = False) -> list[dict[str, Any]]:
+    """Inventory EVERY member account of the AWS Organization (multi-account fan-out).
+
+    The AWS counterpart of Azure's all-subscriptions and GCP's all-projects
+    fan-out: enumerate the org's member accounts, assume the read-only role in
+    each (``sts:AssumeRole`` from the management / delegated-admin account, keyless
+    and short-lived), and run the per-account inventory against the assumed
+    session. Results are partitioned by ``account_id`` so the graph keeps every
+    account distinct under the org → OU ``CONTAINS`` tree and cross-account attack
+    paths correlate.
+
+    Returns a LIST of per-account inventory payloads (the exact shape the graph
+    builder's ``_iter_cloud_inventories`` consumes). Partial-permission tolerant:
+    an account whose role cannot be assumed (or whose reads are denied) yields a
+    non-``ok`` payload carrying its ``account_id`` + a warning, so it is counted
+    in the scan summary and skipped in the graph rather than sinking the run.
+    Falls back to a single ambient-credential inventory when no org is visible (a
+    standalone account). Read-only throughout; never raises.
+    """
+    if not force and not inventory_enabled():
+        return []
+
+    try:
+        import boto3  # noqa: F401
+    except ImportError:
+        return [
+            {
+                **_empty_payload(region=""),
+                "status": "boto3_missing",
+                "warnings": ["boto3 is required for AWS inventory. Install with: pip install 'agent-bom[aws]'"],
+            }
+        ]
+
+    from agent_bom.cloud import aws_organizations
+
+    try:
+        account_ids = aws_organizations.list_member_account_ids(profile, force=True)
+    except Exception as exc:  # noqa: BLE001 — org enumeration failure must degrade, not crash
+        logger.warning("AWS org account enumeration failed: %s", sanitize_discovery_warning(exc))
+        account_ids = []
+
+    if not account_ids:
+        # Standalone account (not in an org) or no org visibility — fall back to
+        # the single ambient-credential inventory so the scan still produces data.
+        return [discover_inventory(profile=profile, force=True)]
+
+    cap = aws_organizations.max_accounts()
+    capped = account_ids[:cap]
+    if len(account_ids) > cap:
+        logger.warning(
+            "AWS multi-account scan capped at %d of %d accounts (set AGENT_BOM_AWS_MAX_ACCOUNTS to raise).",
+            cap,
+            len(account_ids),
+        )
+
+    def _scan(account_id: str) -> dict[str, Any]:
+        try:
+            session = aws_organizations.assume_account_session(account_id, profile=profile)
+        except Exception as exc:  # noqa: BLE001 — a denied account is skipped, not fatal
+            return {
+                **_empty_payload(region=""),
+                "status": "access_denied",
+                "account_id": account_id,
+                "warnings": [f"Account {account_id} skipped: {sanitize_discovery_warning(exc)}"],
+            }
+        return discover_inventory(session=session, force=True)
+
+    payloads: list[dict[str, Any]] = []
+    with ThreadPoolExecutor(max_workers=min(8, len(capped))) as executor:
+        futures = {executor.submit(_scan, aid): aid for aid in capped}
+        for future in as_completed(futures):
+            account_id = futures[future]
+            try:
+                payloads.append(future.result())
+            except Exception as exc:  # noqa: BLE001 — one account's failure must not sink the rest
+                logger.warning("AWS inventory failed for account %s: %s", account_id, sanitize_discovery_warning(exc))
+                payloads.append(
+                    {
+                        **_empty_payload(region=""),
+                        "status": "error",
+                        "account_id": account_id,
+                        "warnings": [f"Account {account_id} failed: {sanitize_discovery_warning(exc)}"],
+                    }
+                )
+    return payloads
+
+
 def discover_inventory(
     region: str | None = None,
     profile: str | None = None,
@@ -2313,6 +2400,7 @@ __all__ = [
     "INVENTORY_ENV_FLAG",
     "REGIONS_ENV_VAR",
     "all_regions_enabled",
+    "discover_all_account_inventories",
     "discover_inventory",
     "discover_inventory_all_regions",
     "inventory_enabled",

--- a/src/agent_bom/cloud/aws_organizations.py
+++ b/src/agent_bom/cloud/aws_organizations.py
@@ -37,6 +37,44 @@ _AWS_ORG_PERMISSIONS: tuple[str, ...] = (
 # Cap the OU recursion + account pagination defensively for very large orgs.
 _MAX_OU_DEPTH = 8
 
+# ---------------------------------------------------------------------------
+# Cross-account scan fan-out (opt-in, read-only)
+#
+# The AWS counterpart of the Azure all-subscriptions and GCP all-projects
+# fan-out: from the management / delegated-admin account, assume a read-only
+# role in every member account and run the per-account inventory + CIS benchmark
+# against the assumed, short-lived session. Default OFF and gated separately
+# from single-account inventory so existing automation is unchanged.
+# ---------------------------------------------------------------------------
+
+# Opt-in org fan-out gate. Default OFF; symmetric with the other providers'
+# tenant/estate-wide fan-out gates (AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS /
+# AGENT_BOM_GCP_ALL_PROJECTS) and the Snowflake org roll-up (AGENT_BOM_SNOWFLAKE_ORG).
+ORG_FANOUT_ENV_FLAG = "AGENT_BOM_AWS_ORG_INVENTORY"
+
+# Read-only role assumed in each member account. The conventional
+# ``OrganizationAccountAccessRole`` is full-admin and deliberately NOT the
+# default — operators deploy a least-privilege, SecurityAudit/ViewOnlyAccess
+# read-only role (e.g. via a CloudFormation StackSet) under this name in every
+# account. Override with ``AGENT_BOM_AWS_ORG_ROLE_NAME``.
+ORG_ROLE_NAME_ENV = "AGENT_BOM_AWS_ORG_ROLE_NAME"
+_DEFAULT_ORG_ROLE_NAME = "agent-bom-readonly"
+
+# Optional confused-deputy ExternalId presented to every per-account AssumeRole.
+ORG_EXTERNAL_ID_ENV = "AGENT_BOM_AWS_ORG_EXTERNAL_ID"
+
+# RoleSessionName stamped on the temporary credentials (visible in CloudTrail).
+_ORG_SESSION_NAME = "agent-bom-readonly"
+
+# Defensive cap so an org with thousands of accounts can't fan out unbounded
+# without an operator opting into a larger budget. Mirrors GCP's MAX_PROJECTS
+# (200) and Snowflake's MAX_ACCOUNTS.
+_DEFAULT_MAX_ACCOUNTS = 200
+
+# The single read-only action the fan-out adds on top of the org-enumeration
+# permissions: assuming the per-account read-only role.
+_AWS_ORG_ASSUME_PERMISSION = "sts:AssumeRole"
+
 
 def discover_organization(profile: str | None = None, *, force: bool = False) -> dict[str, Any]:
     """Enumerate the AWS Organization: OUs, member accounts, and SCPs (read-only).
@@ -210,3 +248,157 @@ def discover_organization(profile: str | None = None, *, force: bool = False) ->
     ).to_dict()
     _ = ou_ids  # reserved for future account→OU placement enrichment
     return result
+
+
+# ---------------------------------------------------------------------------
+# Cross-account scan fan-out helpers (opt-in, read-only)
+# ---------------------------------------------------------------------------
+
+
+def org_fanout_enabled() -> bool:
+    """Whether to fan a single scan across every member account of the org.
+
+    Default OFF. Operators opt in by setting ``AGENT_BOM_AWS_ORG_INVENTORY``
+    truthy, in addition to the base ``AGENT_BOM_AWS_INVENTORY`` gate. Symmetric
+    with Azure's all-subscriptions and GCP's all-projects fan-out gates.
+    """
+    return os.environ.get(ORG_FANOUT_ENV_FLAG, "").strip().lower() in _TRUTHY
+
+
+def max_accounts() -> int:
+    """Defensive cap on the number of member accounts a single fan-out walks.
+
+    Reads ``AGENT_BOM_AWS_MAX_ACCOUNTS`` (default 200); a non-positive or
+    unparseable value falls back to the default so the cap can never disable
+    bounding. Mirrors the GCP/Snowflake account caps.
+    """
+    raw = os.environ.get("AGENT_BOM_AWS_MAX_ACCOUNTS", "").strip()
+    if not raw:
+        return _DEFAULT_MAX_ACCOUNTS
+    try:
+        value = int(raw)
+    except ValueError:
+        return _DEFAULT_MAX_ACCOUNTS
+    return value if value > 0 else _DEFAULT_MAX_ACCOUNTS
+
+
+def list_member_account_ids(profile: str | None = None, *, force: bool = False) -> list[str]:
+    """Return every ACTIVE member account id in the organization (read-only).
+
+    The fan-out source for the AWS multi-account inventory and CIS benchmark.
+    Enumerates the org via :func:`discover_organization` and keeps only accounts
+    whose ``Status`` is ``ACTIVE`` (suspended/closed accounts cannot be assumed
+    into and would only add noise). Returns ``[]`` for a standalone account (not
+    in an org) or when the org cannot be read. Never raises.
+    """
+    org = discover_organization(profile=profile, force=force)
+    if not isinstance(org, dict) or org.get("status") != "ok":
+        return []
+    account_ids: list[str] = []
+    for acct in org.get("accounts", []) or []:
+        if not isinstance(acct, dict):
+            continue
+        status = str(acct.get("status", "") or "").upper()
+        if status and status != "ACTIVE":
+            continue
+        aid = str(acct.get("id", "") or "").strip()
+        if aid and aid not in account_ids:
+            account_ids.append(aid)
+    return account_ids
+
+
+def assume_account_session(
+    account_id: str,
+    *,
+    profile: str | None = None,
+    role_name: str | None = None,
+    external_id: str | None = None,
+    region: str | None = None,
+    session_name: str = _ORG_SESSION_NAME,
+    duration_seconds: int = 3600,
+) -> Any:
+    """Assume the read-only role in *account_id* and return a boto3 session.
+
+    Keyless and short-lived: ``sts:AssumeRole`` from the management /
+    delegated-admin account issues temporary credentials for the per-account
+    read-only role, and the returned :class:`boto3.Session` is backed solely by
+    those — no long-lived key is created or logged. The ExternalId (when set) is
+    presented to satisfy the confused-deputy condition but never logged.
+
+    Raises on failure (boto3 missing, AssumeRole denied) so the caller can skip
+    the account with a warning rather than sinking the whole fan-out.
+    """
+    import boto3
+
+    role = (role_name or os.environ.get(ORG_ROLE_NAME_ENV, "").strip() or _DEFAULT_ORG_ROLE_NAME).strip()
+    ext = external_id if external_id is not None else os.environ.get(ORG_EXTERNAL_ID_ENV, "").strip()
+
+    base = boto3.Session(profile_name=profile) if profile else boto3.Session()
+    sts = base.client("sts")
+    role_arn = f"arn:aws:iam::{account_id}:role/{role}"
+    assume_kwargs: dict[str, Any] = {
+        "RoleArn": role_arn,
+        "RoleSessionName": session_name,
+        "DurationSeconds": duration_seconds,
+    }
+    if ext:
+        assume_kwargs["ExternalId"] = ext
+    try:
+        assumed = sts.assume_role(**assume_kwargs)
+    finally:
+        ext = ""  # drop the plaintext ExternalId reference immediately
+    creds = assumed.get("Credentials", {})
+    return boto3.Session(
+        aws_access_key_id=creds.get("AccessKeyId"),
+        aws_secret_access_key=creds.get("SecretAccessKey"),
+        aws_session_token=creds.get("SessionToken"),
+        region_name=region,
+    )
+
+
+def summarize_account_scan(payloads: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarise a multi-account fan-out into scanned / skipped / errored sets.
+
+    Consumes the per-account inventory payloads
+    :func:`agent_bom.cloud.aws_inventory.discover_all_account_inventories`
+    returns. A ``status: "ok"`` payload counts as scanned; an
+    ``"access_denied"`` payload (AssumeRole/read denied) as skipped; any other
+    status (boto3 missing, unexpected error) as errored. Deterministic and
+    JSON-serialisable so it can ride on the report's ``aws_organization`` block.
+    """
+    scanned: list[str] = []
+    skipped: list[str] = []
+    errored: list[str] = []
+    for payload in payloads:
+        if not isinstance(payload, dict):
+            continue
+        aid = str(payload.get("account_id") or "").strip()
+        status = str(payload.get("status", "") or "")
+        if status == "ok":
+            bucket = scanned
+        elif status == "access_denied":
+            bucket = skipped
+        else:
+            bucket = errored
+        if aid:
+            bucket.append(aid)
+    return {
+        "accounts_scanned": scanned,
+        "accounts_skipped": skipped,
+        "accounts_errored": errored,
+        "total": len(scanned) + len(skipped) + len(errored),
+    }
+
+
+__all__ = [
+    "INVENTORY_ENV_FLAG",
+    "ORG_FANOUT_ENV_FLAG",
+    "ORG_ROLE_NAME_ENV",
+    "ORG_EXTERNAL_ID_ENV",
+    "assume_account_session",
+    "discover_organization",
+    "list_member_account_ids",
+    "max_accounts",
+    "org_fanout_enabled",
+    "summarize_account_scan",
+]

--- a/src/agent_bom/scan_enrichment.py
+++ b/src/agent_bom/scan_enrichment.py
@@ -45,12 +45,17 @@ def collect_cloud_inventory() -> list[dict[str, Any]]:
     """
     payloads: list[dict[str, Any]] = []
 
-    # AWS — AGENT_BOM_CLOUD_INVENTORY
+    # AWS — AGENT_BOM_AWS_INVENTORY (+ AGENT_BOM_AWS_ORG_INVENTORY to fan across
+    # every member account of the organization, like Azure does for subscriptions
+    # and GCP does for projects). The fan-out assumes a read-only role per account.
     try:
-        from agent_bom.cloud import aws_inventory
+        from agent_bom.cloud import aws_inventory, aws_organizations
 
         if aws_inventory.inventory_enabled():
-            payloads.append(aws_inventory.discover_inventory())
+            if aws_organizations.org_fanout_enabled():
+                payloads.extend(aws_inventory.discover_all_account_inventories())
+            else:
+                payloads.append(aws_inventory.discover_inventory())
     except Exception:  # noqa: BLE001 — a connector failure must never break a scan
         _logger.warning("AWS estate inventory enrichment failed", exc_info=True)
 
@@ -203,14 +208,25 @@ def enrich_report_with_estate_discovery(report: AIBOMReport) -> None:
     except Exception:  # noqa: BLE001
         _logger.warning("Audit-trail enrichment skipped", exc_info=True)
 
-    # AWS Organizations hierarchy (org → OUs → accounts → SCPs). Gated by the same
-    # AGENT_BOM_CLOUD_INVENTORY flag; only attached when the account is in an org.
+    # AWS Organizations hierarchy (org → OUs → accounts → SCPs). Gated by the AWS
+    # inventory flag (checked here); ``force=True`` so the modern
+    # AGENT_BOM_AWS_INVENTORY flag drives it, not only the legacy alias. Only
+    # attached when the account is in an org.
     try:
         from agent_bom.cloud import aws_inventory, aws_organizations
 
         if aws_inventory.inventory_enabled():
-            org = aws_organizations.discover_organization()
+            org = aws_organizations.discover_organization(force=True)
             if isinstance(org, dict) and org.get("status") == "ok":
+                # When the multi-account fan-out ran, fold a scanned/skipped/errored
+                # summary onto the org block so the report surfaces per-account
+                # coverage alongside the org → OU → account hierarchy.
+                if aws_organizations.org_fanout_enabled():
+                    raw_inventory = report.cloud_inventory_data
+                    inventory_list = raw_inventory if isinstance(raw_inventory, list) else []
+                    aws_payloads = [item for item in inventory_list if isinstance(item, dict) and item.get("provider") == "aws"]
+                    if aws_payloads:
+                        org["account_scan"] = aws_organizations.summarize_account_scan(aws_payloads)
                 report.aws_organization_data = org
     except Exception:  # noqa: BLE001 — org enrichment must never break a scan
         _logger.warning("AWS organization enrichment skipped", exc_info=True)

--- a/tests/test_aws_org_scan_fanout.py
+++ b/tests/test_aws_org_scan_fanout.py
@@ -9,6 +9,9 @@ default. STS AssumeRole and the org enumeration are mocked throughout.
 
 from __future__ import annotations
 
+import sys
+import types
+
 import pytest
 
 from agent_bom.cloud import aws_cis_benchmark as aws_cis
@@ -16,6 +19,33 @@ from agent_bom.cloud import aws_inventory as aws_inv
 from agent_bom.cloud import aws_organizations as aws_orgs
 from agent_bom.cloud.aws_cis_benchmark import CheckStatus, CISBenchmarkReport, CISCheckResult
 from agent_bom.graph.builder import build_unified_graph_from_report
+
+
+@pytest.fixture(autouse=True)
+def _stub_boto3(monkeypatch):
+    """Make ``import boto3`` resolve to a stub so the fan-out runs with NO real
+    boto3 installed.
+
+    CI's base test env does not install the ``[aws]`` extra, so the module-level
+    ``import boto3`` guards in ``discover_all_account_inventories`` /
+    ``run_all_account_benchmarks`` would otherwise short-circuit before the mocked
+    fan-out runs. The fan-out tests monkeypatch ``assume_account_session`` /
+    ``discover_inventory``, so the stub only has to satisfy those import guards.
+    Mirrors the established pattern in ``tests/test_aws_organizations.py`` and
+    ``tests/test_cloud_aws_inventory.py``. A test that needs boto3 genuinely
+    absent overrides ``sys.modules["boto3"]`` to ``None`` in its own body.
+    """
+    boto3 = types.ModuleType("boto3")
+    boto3.Session = lambda **_kw: None  # type: ignore[attr-defined]
+    botocore = types.ModuleType("botocore")
+    errs = types.ModuleType("botocore.exceptions")
+    errs.NoCredentialsError = type("NoCredentialsError", (Exception,), {})  # type: ignore[attr-defined]
+    errs.ClientError = type("ClientError", (Exception,), {})  # type: ignore[attr-defined]
+    botocore.exceptions = errs  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "boto3", boto3)
+    monkeypatch.setitem(sys.modules, "botocore", botocore)
+    monkeypatch.setitem(sys.modules, "botocore.exceptions", errs)
+
 
 # ---------------------------------------------------------------------------
 # Gating — default OFF
@@ -419,3 +449,30 @@ def test_enrich_report_attaches_account_scan_summary(monkeypatch) -> None:
     assert summary["accounts_scanned"] == ["111111111111"]
     assert summary["accounts_skipped"] == ["222222222222"]
     assert summary["total"] == 2
+
+
+# ---------------------------------------------------------------------------
+# boto3 genuinely absent — degrade gracefully, never crash
+# ---------------------------------------------------------------------------
+
+
+def test_fanout_degrades_gracefully_without_boto3(monkeypatch) -> None:
+    from agent_bom.cloud.base import CloudDiscoveryError
+
+    # Override the autouse stub: make ``import boto3`` raise (boto3 not installed).
+    monkeypatch.setitem(sys.modules, "boto3", None)
+    monkeypatch.setattr(aws_inv, "inventory_enabled", lambda: True)
+
+    # Inventory fan-out returns a single boto3_missing payload — never crashes.
+    payloads = aws_inv.discover_all_account_inventories(force=True)
+    assert len(payloads) == 1
+    assert payloads[0]["status"] == "boto3_missing"
+
+    # CIS fan-out raises the documented CloudDiscoveryError (caught by the CLI).
+    with pytest.raises(CloudDiscoveryError):
+        aws_cis.run_all_account_benchmarks()
+
+    # The AssumeRole broker raises so the caller skips the account with a warning
+    # rather than silently succeeding.
+    with pytest.raises(ImportError):
+        aws_orgs.assume_account_session("111111111111")

--- a/tests/test_aws_org_scan_fanout.py
+++ b/tests/test_aws_org_scan_fanout.py
@@ -1,0 +1,421 @@
+"""AWS Organizations cross-account scan fan-out (read-only, opt-in).
+
+Covers the AWS analogue of the Azure all-subscriptions and GCP all-projects
+fan-out: the inventory + CIS benchmark run once per member account against an
+assumed read-only session, merge into the unified graph under the org → account
+hierarchy, tolerate a denied account, honour the account cap, and stay OFF by
+default. STS AssumeRole and the org enumeration are mocked throughout.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.cloud import aws_cis_benchmark as aws_cis
+from agent_bom.cloud import aws_inventory as aws_inv
+from agent_bom.cloud import aws_organizations as aws_orgs
+from agent_bom.cloud.aws_cis_benchmark import CheckStatus, CISBenchmarkReport, CISCheckResult
+from agent_bom.graph.builder import build_unified_graph_from_report
+
+# ---------------------------------------------------------------------------
+# Gating — default OFF
+# ---------------------------------------------------------------------------
+
+
+def test_org_fanout_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv(aws_orgs.ORG_FANOUT_ENV_FLAG, raising=False)
+    assert aws_orgs.org_fanout_enabled() is False
+
+
+def test_org_fanout_enabled_when_flag_truthy(monkeypatch) -> None:
+    monkeypatch.setenv(aws_orgs.ORG_FANOUT_ENV_FLAG, "1")
+    assert aws_orgs.org_fanout_enabled() is True
+
+
+def test_max_accounts_default_and_override(monkeypatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_AWS_MAX_ACCOUNTS", raising=False)
+    assert aws_orgs.max_accounts() == 200
+    monkeypatch.setenv("AGENT_BOM_AWS_MAX_ACCOUNTS", "3")
+    assert aws_orgs.max_accounts() == 3
+    # A non-positive / unparseable value falls back to the default, never disables the cap.
+    monkeypatch.setenv("AGENT_BOM_AWS_MAX_ACCOUNTS", "0")
+    assert aws_orgs.max_accounts() == 200
+    monkeypatch.setenv("AGENT_BOM_AWS_MAX_ACCOUNTS", "nope")
+    assert aws_orgs.max_accounts() == 200
+
+
+# ---------------------------------------------------------------------------
+# list_member_account_ids — ACTIVE-only enumeration
+# ---------------------------------------------------------------------------
+
+
+def test_list_member_account_ids_keeps_only_active(monkeypatch) -> None:
+    monkeypatch.setattr(
+        aws_orgs,
+        "discover_organization",
+        lambda profile=None, *, force=False: {
+            "status": "ok",
+            "accounts": [
+                {"id": "111111111111", "status": "ACTIVE"},
+                {"id": "222222222222", "status": "SUSPENDED"},
+                {"id": "333333333333", "status": "ACTIVE"},
+                {"id": "111111111111", "status": "ACTIVE"},  # duplicate collapses
+            ],
+        },
+    )
+    assert aws_orgs.list_member_account_ids() == ["111111111111", "333333333333"]
+
+
+def test_list_member_account_ids_empty_when_not_in_org(monkeypatch) -> None:
+    monkeypatch.setattr(aws_orgs, "discover_organization", lambda profile=None, *, force=False: {"status": "not_in_org"})
+    assert aws_orgs.list_member_account_ids() == []
+
+
+# ---------------------------------------------------------------------------
+# assume_account_session — STS AssumeRole broker (mocked)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSTS:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def assume_role(self, **kwargs):
+        self.calls.append(kwargs)
+        return {
+            "Credentials": {
+                "AccessKeyId": "ASIA_TEMP",
+                "SecretAccessKey": "secret",  # noqa: S106 - test stub, not a real secret
+                "SessionToken": "token",
+            }
+        }
+
+
+def test_assume_account_session_uses_role_arn_external_id_region(monkeypatch) -> None:
+    import boto3
+
+    fake_sts = _FakeSTS()
+    built_sessions: list[dict] = []
+
+    class _FakeSession:
+        def __init__(self, **kwargs):
+            built_sessions.append(kwargs)
+
+        def client(self, name):
+            assert name == "sts"
+            return fake_sts
+
+    monkeypatch.setattr(boto3, "Session", _FakeSession)
+    monkeypatch.setenv(aws_orgs.ORG_ROLE_NAME_ENV, "agent-bom-readonly")
+    monkeypatch.setenv(aws_orgs.ORG_EXTERNAL_ID_ENV, "ext-secret")
+
+    aws_orgs.assume_account_session("444444444444", region="us-west-2")
+
+    # AssumeRole presented the per-account read-only role ARN + ExternalId.
+    assert fake_sts.calls[0]["RoleArn"] == "arn:aws:iam::444444444444:role/agent-bom-readonly"
+    assert fake_sts.calls[0]["ExternalId"] == "ext-secret"
+    assert fake_sts.calls[0]["RoleSessionName"]
+    # The returned session is backed by the temporary credentials + requested region.
+    backed = built_sessions[-1]
+    assert backed["aws_access_key_id"] == "ASIA_TEMP"
+    assert backed["aws_session_token"] == "token"
+    assert backed["region_name"] == "us-west-2"
+
+
+def test_assume_account_session_omits_external_id_when_unset(monkeypatch) -> None:
+    import boto3
+
+    fake_sts = _FakeSTS()
+    monkeypatch.setattr(boto3, "Session", lambda **kw: type("S", (), {"client": lambda self, n: fake_sts})())
+    monkeypatch.delenv(aws_orgs.ORG_EXTERNAL_ID_ENV, raising=False)
+
+    aws_orgs.assume_account_session("555555555555")
+    assert "ExternalId" not in fake_sts.calls[0]
+
+
+# ---------------------------------------------------------------------------
+# Inventory fan-out
+# ---------------------------------------------------------------------------
+
+
+def _inv(account_id: str, *, status: str = "ok") -> dict:
+    return {**aws_inv._empty_payload(region="us-east-1"), "status": status, "account_id": account_id}
+
+
+def test_inventory_fanout_merges_each_account(monkeypatch) -> None:
+    monkeypatch.setattr(aws_inv, "inventory_enabled", lambda: True)
+    monkeypatch.setattr(aws_orgs, "list_member_account_ids", lambda profile, *, force=False: ["111111111111", "222222222222"])
+    monkeypatch.setattr(aws_orgs, "assume_account_session", lambda aid, **kw: f"session::{aid}")
+
+    scanned: list[str] = []
+
+    def _fake_inv(*, session=None, force=False):
+        aid = str(session).split("::")[-1]
+        scanned.append(aid)
+        return _inv(aid)
+
+    monkeypatch.setattr(aws_inv, "discover_inventory", _fake_inv)
+
+    payloads = aws_inv.discover_all_account_inventories()
+    assert sorted(scanned) == ["111111111111", "222222222222"]
+    assert {p["account_id"] for p in payloads} == {"111111111111", "222222222222"}
+    assert all(p["status"] == "ok" for p in payloads)
+
+
+def test_inventory_fanout_skips_denied_account_with_warning(monkeypatch) -> None:
+    monkeypatch.setattr(aws_inv, "inventory_enabled", lambda: True)
+    monkeypatch.setattr(aws_orgs, "list_member_account_ids", lambda profile, *, force=False: ["ok-acct", "denied-acct"])
+
+    def _fake_assume(aid, **kw):
+        if aid == "denied-acct":
+            raise PermissionError("AccessDenied: not authorized to assume role in denied-acct")
+        return f"session::{aid}"
+
+    monkeypatch.setattr(aws_orgs, "assume_account_session", _fake_assume)
+    monkeypatch.setattr(aws_inv, "discover_inventory", lambda *, session=None, force=False: _inv(str(session).split("::")[-1]))
+
+    payloads = aws_inv.discover_all_account_inventories()
+    by_acct = {p["account_id"]: p for p in payloads}
+    assert by_acct["ok-acct"]["status"] == "ok"
+    assert by_acct["denied-acct"]["status"] == "access_denied"
+    assert any("denied-acct skipped" in w for w in by_acct["denied-acct"]["warnings"])
+
+
+def test_inventory_fanout_honors_cap(monkeypatch) -> None:
+    monkeypatch.setattr(aws_inv, "inventory_enabled", lambda: True)
+    monkeypatch.setenv("AGENT_BOM_AWS_MAX_ACCOUNTS", "2")
+    monkeypatch.setattr(aws_orgs, "list_member_account_ids", lambda profile, *, force=False: ["a1", "a2", "a3", "a4"])
+    monkeypatch.setattr(aws_orgs, "assume_account_session", lambda aid, **kw: f"session::{aid}")
+    monkeypatch.setattr(aws_inv, "discover_inventory", lambda *, session=None, force=False: _inv(str(session).split("::")[-1]))
+
+    payloads = aws_inv.discover_all_account_inventories()
+    assert len(payloads) == 2
+    assert {p["account_id"] for p in payloads} == {"a1", "a2"}
+
+
+def test_inventory_fanout_falls_back_to_single_account(monkeypatch) -> None:
+    monkeypatch.setattr(aws_inv, "inventory_enabled", lambda: True)
+    monkeypatch.setattr(aws_orgs, "list_member_account_ids", lambda profile, *, force=False: [])
+    called: list[bool] = []
+
+    def _single(*, profile=None, force=False):
+        called.append(True)
+        return _inv("solo")
+
+    monkeypatch.setattr(aws_inv, "discover_inventory", _single)
+    payloads = aws_inv.discover_all_account_inventories()
+    assert called == [True]
+    assert payloads[0]["account_id"] == "solo"
+
+
+def test_inventory_fanout_disabled_returns_empty(monkeypatch) -> None:
+    monkeypatch.setattr(aws_inv, "inventory_enabled", lambda: False)
+    assert aws_inv.discover_all_account_inventories() == []
+
+
+# ---------------------------------------------------------------------------
+# Graph merge — per-account payloads stitch under the org hierarchy
+# ---------------------------------------------------------------------------
+
+
+def test_multi_account_inventory_merges_into_org_graph() -> None:
+    org = {
+        "status": "ok",
+        "org_id": "o-xyz",
+        "organizational_units": [{"id": "r-root", "name": "Root", "parent_id": "", "is_root": True}],
+        "accounts": [
+            {"id": "111111111111", "name": "app", "status": "ACTIVE", "ou_id": "r-root"},
+            {"id": "222222222222", "name": "data", "status": "ACTIVE", "ou_id": "r-root"},
+        ],
+        "scps": [],
+    }
+    inventories = [
+        {
+            **aws_inv._empty_payload(region="us-east-1"),
+            "status": "ok",
+            "account_id": "111111111111",
+            "buckets": [{"name": "app-bucket", "arn": "arn:aws:s3:::app-bucket", "is_public": False}],
+        },
+        {
+            **aws_inv._empty_payload(region="us-east-1"),
+            "status": "ok",
+            "account_id": "222222222222",
+            "buckets": [{"name": "data-bucket", "arn": "arn:aws:s3:::data-bucket", "is_public": False}],
+        },
+    ]
+    g = build_unified_graph_from_report({"aws_organization": org, "cloud_inventory": inventories})
+    # Both member-account nodes exist (from the org hierarchy) and the per-account
+    # resources merged in under the same account-id namespace.
+    assert "account:aws:111111111111" in g.nodes
+    assert "account:aws:222222222222" in g.nodes
+    edges = {(e.source, e.target, e.relationship.value) for e in g.edges}
+    assert ("org:aws:ou:r-root", "account:aws:111111111111", "contains") in edges
+    assert ("org:aws:ou:r-root", "account:aws:222222222222", "contains") in edges
+
+
+# ---------------------------------------------------------------------------
+# summarize_account_scan
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_account_scan_buckets_by_status() -> None:
+    summary = aws_orgs.summarize_account_scan(
+        [
+            {"account_id": "a1", "status": "ok"},
+            {"account_id": "a2", "status": "access_denied"},
+            {"account_id": "a3", "status": "error"},
+            {"account_id": "a4", "status": "ok"},
+        ]
+    )
+    assert summary["accounts_scanned"] == ["a1", "a4"]
+    assert summary["accounts_skipped"] == ["a2"]
+    assert summary["accounts_errored"] == ["a3"]
+    assert summary["total"] == 4
+
+
+# ---------------------------------------------------------------------------
+# CIS benchmark fan-out
+# ---------------------------------------------------------------------------
+
+
+def _cis_report(account_id: str) -> CISBenchmarkReport:
+    report = CISBenchmarkReport(account_id=account_id)
+    report.checks.append(CISCheckResult(check_id="1.4", title="t", status=CheckStatus.PASS, severity="critical"))
+    report.checks.append(CISCheckResult(check_id="3.1", title="t", status=CheckStatus.FAIL, severity="high"))
+    return report
+
+
+def test_cis_fanout_per_account_attribution(monkeypatch) -> None:
+    monkeypatch.setattr(aws_orgs, "list_member_account_ids", lambda profile, *, force=False: ["111111111111", "222222222222"])
+    monkeypatch.setattr(aws_orgs, "assume_account_session", lambda aid, **kw: f"session::{aid}")
+
+    def _fake_run(*, session=None, checks=None):
+        return _cis_report(str(session).split("::")[-1])
+
+    monkeypatch.setattr(aws_cis, "run_benchmark", _fake_run)
+
+    report = aws_cis.run_all_account_benchmarks()
+    assert report.accounts_scanned == ["111111111111", "222222222222"]
+    assert {c.account_id for c in report.checks} == {"111111111111", "222222222222"}
+    assert report.passed == 2
+    assert report.failed == 2
+    assert report.total == 4
+    payload = report.to_dict()
+    assert payload["accounts_scanned"] == ["111111111111", "222222222222"]
+    assert {c["account_id"] for c in payload["checks"]} == {"111111111111", "222222222222"}
+
+
+def test_cis_fanout_skips_denied_account_with_warning(monkeypatch) -> None:
+    monkeypatch.setattr(aws_orgs, "list_member_account_ids", lambda profile, *, force=False: ["ok-acct", "denied-acct"])
+
+    def _fake_assume(aid, **kw):
+        if aid == "denied-acct":
+            raise PermissionError("AccessDenied assuming role in denied-acct")
+        return f"session::{aid}"
+
+    monkeypatch.setattr(aws_orgs, "assume_account_session", _fake_assume)
+    monkeypatch.setattr(aws_cis, "run_benchmark", lambda *, session=None, checks=None: _cis_report(str(session).split("::")[-1]))
+
+    report = aws_cis.run_all_account_benchmarks()
+    assert report.accounts_scanned == ["ok-acct"]
+    assert {c.account_id for c in report.checks} == {"ok-acct"}
+    assert any("denied-acct skipped" in w for w in report.warnings)
+    assert report.total == 2
+
+
+def test_cis_fanout_caps_accounts_with_warning(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_AWS_MAX_ACCOUNTS", "1")
+    monkeypatch.setattr(aws_orgs, "list_member_account_ids", lambda profile, *, force=False: ["a1", "a2", "a3"])
+    monkeypatch.setattr(aws_orgs, "assume_account_session", lambda aid, **kw: f"session::{aid}")
+    monkeypatch.setattr(aws_cis, "run_benchmark", lambda *, session=None, checks=None: _cis_report(str(session).split("::")[-1]))
+
+    report = aws_cis.run_all_account_benchmarks()
+    assert report.accounts_scanned == ["a1"]
+    assert any("capped at 1 of 3" in w for w in report.warnings)
+
+
+def test_cis_fanout_falls_back_to_single_account(monkeypatch) -> None:
+    monkeypatch.setattr(aws_orgs, "list_member_account_ids", lambda profile, *, force=False: [])
+    called: list[bool] = []
+
+    def _single(profile=None, checks=None):
+        called.append(True)
+        return _cis_report("solo")
+
+    monkeypatch.setattr(aws_cis, "run_benchmark", _single)
+    report = aws_cis.run_all_account_benchmarks()
+    assert called == [True]
+    assert report.account_id == "solo"
+
+
+# ---------------------------------------------------------------------------
+# scan_enrichment wiring — gate routes to the fan-out, off keeps single-account
+# ---------------------------------------------------------------------------
+
+
+def test_scan_enrichment_routes_to_fanout_when_gate_on(monkeypatch) -> None:
+    from agent_bom import scan_enrichment
+
+    monkeypatch.setattr(aws_inv, "inventory_enabled", lambda: True)
+    monkeypatch.setattr(aws_orgs, "org_fanout_enabled", lambda: True)
+    monkeypatch.setattr(aws_inv, "discover_all_account_inventories", lambda: [_inv("111111111111"), _inv("222222222222")])
+    monkeypatch.setattr(aws_inv, "discover_inventory", lambda: pytest.fail("single-account path must not run when org gate is on"))
+    # Disable the other providers so only AWS contributes.
+    monkeypatch.setattr("agent_bom.cloud.azure_inventory.inventory_enabled", lambda: False)
+    monkeypatch.setattr("agent_bom.cloud.gcp_inventory.inventory_enabled", lambda: False)
+
+    payloads = scan_enrichment.collect_cloud_inventory()
+    assert {p["account_id"] for p in payloads} == {"111111111111", "222222222222"}
+
+
+def test_scan_enrichment_single_account_when_gate_off(monkeypatch) -> None:
+    from agent_bom import scan_enrichment
+
+    monkeypatch.setattr(aws_inv, "inventory_enabled", lambda: True)
+    monkeypatch.setattr(aws_orgs, "org_fanout_enabled", lambda: False)
+    monkeypatch.setattr(aws_inv, "discover_inventory", lambda: _inv("solo"))
+    monkeypatch.setattr(
+        aws_inv,
+        "discover_all_account_inventories",
+        lambda: pytest.fail("fan-out must not run when org gate is off"),
+    )
+    monkeypatch.setattr("agent_bom.cloud.azure_inventory.inventory_enabled", lambda: False)
+    monkeypatch.setattr("agent_bom.cloud.gcp_inventory.inventory_enabled", lambda: False)
+
+    payloads = scan_enrichment.collect_cloud_inventory()
+    assert [p["account_id"] for p in payloads] == ["solo"]
+
+
+def test_enrich_report_attaches_account_scan_summary(monkeypatch) -> None:
+    from agent_bom import scan_enrichment
+    from agent_bom.models import AIBOMReport
+
+    monkeypatch.setattr(aws_inv, "inventory_enabled", lambda: True)
+    monkeypatch.setattr(aws_orgs, "org_fanout_enabled", lambda: True)
+    monkeypatch.setattr(
+        aws_inv,
+        "discover_all_account_inventories",
+        lambda: [_inv("111111111111"), _inv("222222222222", status="access_denied")],
+    )
+    monkeypatch.setattr(
+        aws_orgs,
+        "discover_organization",
+        lambda profile=None, *, force=False: {
+            "status": "ok",
+            "org_id": "o-xyz",
+            "accounts": [{"id": "111111111111", "status": "ACTIVE"}],
+        },
+    )
+    # Silence the other estate sources so only AWS contributes.
+    monkeypatch.setattr("agent_bom.cloud.azure_inventory.inventory_enabled", lambda: False)
+    monkeypatch.setattr("agent_bom.cloud.gcp_inventory.inventory_enabled", lambda: False)
+    monkeypatch.setattr(scan_enrichment, "collect_identity_discovery", lambda: None)
+    monkeypatch.setattr(scan_enrichment, "collect_audit_trail", lambda: [])
+
+    report = AIBOMReport(agents=[])
+    scan_enrichment.enrich_report_with_estate_discovery(report)
+
+    summary = report.aws_organization_data["account_scan"]
+    assert summary["accounts_scanned"] == ["111111111111"]
+    assert summary["accounts_skipped"] == ["222222222222"]
+    assert summary["total"] == 2


### PR DESCRIPTION
## Summary

Scan every member account of an AWS Organization in one run — inventory + CIS/misconfig + identity — and correlate the results into the unified graph under the existing org → OU → account `CONTAINS` hierarchy. This brings AWS to parity with the Azure-subscriptions (#3084) and GCP-projects (#3122/#3118) fan-out.

Closes #3177.

## How the fan-out works

- From the management / delegated-admin account, `aws_organizations.list_member_account_ids()` enumerates ACTIVE member accounts (reusing the existing `discover_organization()`).
- For each account, `aws_organizations.assume_account_session()` assumes a configurable read-only role via `sts:AssumeRole` (keyless, short-lived, ExternalId-capable) and returns a boto3 session backed solely by the temporary credentials.
- `aws_inventory.discover_all_account_inventories()` and `aws_cis_benchmark.run_all_account_benchmarks()` run the existing per-account inventory + CIS benchmark against each assumed session (bounded thread pool), partitioned by `account_id`. The graph builder already stitches per-account payloads under the org account nodes, so cross-account attack paths correlate.

## Read-only role expectation

The conventional `OrganizationAccountAccessRole` is full-admin and is **not** used. Operators deploy a least-privilege SecurityAudit/ViewOnlyAccess role (default name `agent-bom-readonly`) to every account — a CloudFormation StackSet targeting the org/OUs is the supported pattern. Documented in `docs/CLOUD_CONNECT.md`.

## Gating + safety (symmetric with Azure/GCP)

- Opt-in `AGENT_BOM_AWS_ORG_INVENTORY` gate (default OFF), in addition to the base `AGENT_BOM_AWS_INVENTORY` flag.
- `AGENT_BOM_AWS_MAX_ACCOUNTS` cap (default 200) bounds accounts walked.
- `AGENT_BOM_AWS_ORG_ROLE_NAME` / `AGENT_BOM_AWS_ORG_EXTERNAL_ID` configure the assumed role + confused-deputy ExternalId.
- Partial-permission tolerant: an account that denies AssumeRole or a read is skipped with a warning, never a hard failure.
- Read-only throughout; ExternalId and temporary credentials are never logged.

## Surfacing

- Report: `aws_organization.account_scan` carries a scanned/skipped/errored summary.
- CLI: the CIS benchmark prints an "across N account(s)" scope line, mirroring the Azure/GCP fan-out output.
- CIS report `to_dict` gains `accounts_scanned` + per-check `account_id` attribution.

## Full-stack alignment

org discovery ↔ per-account AssumeRole broker ↔ inventory/CIS/identity ↔ graph merge ↔ CLI/report ↔ tests ↔ docs (`docs/CLOUD_CONNECT.md`) ↔ env allowlist (`scripts/env_var_allowlist.txt`).

## Tests

`tests/test_aws_org_scan_fanout.py` (21 tests, mocked STS + org enumeration): multi-account inventory + CIS fan-out with per-account attribution, denied-account skip-with-warning, cap honored, gate off by default, AssumeRole role-ARN/ExternalId/region wiring, summary bucketing, graph merge under the org hierarchy, and the `scan_enrichment` routing both ways.

## Honest gaps

- Per-account inventory runs single-region (the assumed session's default region); multi-region per account would compose this fan-out with the existing all-regions fan-out and is left for a follow-up.
- Skipped-account warnings from the CIS fan-out are carried on the report's `warnings` list / logs rather than printed line-by-line in the CLI (consistent with the Azure/GCP fan-out).