### PR TITLE
docs(changelog): clarify demo-mode offline scans use the bundled advisory DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,14 @@ account.
 - **Vulnerability cache auto-refreshes** and surfaces a freshness indicator.
 - Flat (non-graph) outputs prefer canonical findings for consistency with the
   graph view.
+- **Demo-mode offline scans resolve a curated bundled advisory set, not the full
+  local DB.** In demo mode an offline scan reports against the bundled demo
+  advisory DB (deterministic, every demo package maps to at least one advisory),
+  which surfaces fewer, curated findings than a real offline scan against the
+  full local vulnerability DB. The active source is labeled in scan output
+  (`bundled demo advisory DB` vs `local vulnerability DB`). Demo screenshots and
+  finding counts therefore differ from real-scan numbers by design — compare
+  like-for-like (real scans use the local/synced DB).
 
 ### Fixed
 - **Fixed agent-mode summary counts.** The envelope `summary.packages` field


### PR DESCRIPTION
Audit follow-up (release-note framing). Demo-mode offline scans resolve the **curated bundled demo advisory DB** (deterministic — every demo package maps to ≥1 advisory) rather than the full local vulnerability DB, so demo finding counts and screenshots differ from real-scan numbers **by design**. The active source is already labeled in scan output (`bundled demo advisory DB` vs `local vulnerability DB`); this just documents the distinction so the changed demo numbers aren't read as a regression at release.

No code/behavior change — CHANGELOG only.