### PR TITLE
fix(security): sanitize exception text across API, cloud, and runtime paths + regression guard

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -207,6 +207,15 @@ Minimum verification matrix:
   dark themes and avoid dense unreadable canvases as the first view.
 - For auth, tenant, audit, firewall, gateway, and proxy changes, document
   fail-open/fail-closed behavior explicitly.
+- Never surface a raw exception string to an HTTP response body or a log line on
+  API / cloud / runtime paths — raw exceptions carry secrets, ARNs, paths, and
+  connection strings. Route response text through
+  `agent_bom.security.sanitize_error(exc)` (use `generic=True` on
+  auth/secret/encryption/session/broker paths) and log text through
+  `sanitize_text(...)`. The `scripts/check_exception_sanitization.py` guard
+  (pre-commit + CI) fails on new `detail=str(exc)` / `detail=f"...{exc}"` bodies
+  and raw-exception log f-strings; use `# exc-safe: <reason>` only for a vetted
+  exception.
 - For docs, avoid vague capability lists. Prefer "first command -> artifact ->
   next step."
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           if printf '%s\n' "$changed" | grep -Eq '^(pyproject\.toml|uv\.lock|Dockerfile|\.github/actions/setup-python/|\.github/workflows/ci\.yml$)'; then
             alpine_full=true
           fi
-          if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/api/postgres_|src/agent_bom/api/storage_schema\.py|tests/test_postgres_|\.github/workflows/ci\.yml$)'; then
+          if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/api/postgres_|src/agent_bom/api/storage_schema\.py|tests/test_postgres_)'; then
             postgres=true
           fi
           if printf '%s\n' "$changed" | grep -Eq '^(deploy/endpoints/|scripts/(build-[^/]+|render_homebrew_formula\.py)|src/agent_bom/cli/_runtime\.py|tests/test_cli_runtime\.py|pyproject\.toml|uv\.lock|\.github/actions/setup-python/|\.github/workflows/ci\.yml$|site-docs/deployment/aws-company-rollout\.md$)'; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,14 @@ jobs:
         # breadcrumbs must never ship in product source. Pure stdlib, fails fast.
         run: python scripts/check_comment_hygiene.py
 
+      - name: Exception sanitization — no raw exception text in HTTP responses or logs
+        # Source: scripts/check_exception_sanitization.py
+        # Raw exception strings carry secrets, ARNs, paths, and connection
+        # strings. New detail=str(exc) / detail=f"...{exc}" HTTPException bodies
+        # and raw-exception log f-strings on API/cloud/runtime paths must route
+        # through agent_bom.security.sanitize_error / sanitize_text. Pure stdlib.
+        run: python scripts/check_exception_sanitization.py
+
       - name: Trust-contract — provisioning stays read-only
         # Source: scripts/check_provisioning_readonly.py
         # The cloud-connect Terraform modules (deploy/terraform/connect-*)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,16 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      - id: exception-sanitization-guard
+        name: exception sanitization (no raw exception text in HTTP responses or logs)
+        # Rejects new detail=str(exc) / detail=f"...{exc}" HTTPException bodies and
+        # raw-exception log f-strings on API/cloud/runtime paths. Raw exception
+        # strings carry secrets, ARNs, paths, and connection strings; they must go
+        # through agent_bom.security.sanitize_error / sanitize_text. Pure stdlib.
+        entry: python3 scripts/check_exception_sanitization.py
+        language: system
+        pass_filenames: false
+        files: ^(src/agent_bom/(api|cloud|runtime)/.*\.py|src/agent_bom/proxy\.py|scripts/check_exception_sanitization\.py)$
       - id: duplicate-artifact-guard
         name: Finder duplicate artifact guard
         # --working-tree also catches untracked Finder copies (e.g. 'nav 2.tsx')

--- a/scripts/check_exception_sanitization.py
+++ b/scripts/check_exception_sanitization.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Exception-sanitization guard: keep raw exception text out of HTTP responses and logs.
+
+Raw exception strings routinely carry secrets, ARNs, file paths, connection
+strings, and stack detail. Surfacing them to an HTTP response body or a log line
+leaks that data to API consumers and log sinks. The fix is the central
+``agent_bom.security`` sanitizers (``sanitize_error`` for API responses,
+``sanitize_text`` for logs) — see ``src/agent_bom/security.py``.
+
+This guard fails CI/pre-commit when a *new* unsanitized pattern lands on the
+API / cloud / runtime paths, so the release bar is enforced systemically rather
+than relying on each exception source being safe.
+
+Forbidden patterns (on the scanned trees):
+
+  1. ``HTTPException(... detail=str(exc) ...)`` — raw exception in a response
+     body. Use ``detail=sanitize_error(exc)`` (or ``sanitize_error(exc,
+     generic=True)`` on auth/secret/encryption/session/broker paths).
+  2. ``HTTPException(... detail=f"...{exc}..." ...)`` — same leak via f-string.
+     Wrap the exception: ``detail=f"...{sanitize_error(exc)}..."``.
+  3. ``logger.<level>(f"...{exc}...")`` — raw exception interpolated into a log
+     f-string. Use lazy ``%s`` formatting with a sanitized value:
+     ``logger.warning("...: %s", sanitize_text(exc))``.
+
+Only the bare exception token (``{exc}``, ``{e}``, ``{err}``, ``{error}``,
+``{ex}`` and their ``{exc!r}`` / ``{exc:...}`` forms) is flagged. Attribute
+access such as ``{exc.status.value}`` (a safe enum) and structured payloads such
+as ``graph.py``'s ``exc.to_dict()`` rate-limit body are intentionally NOT
+matched, so the few safe call sites need no allowlist.
+
+A genuine false positive can be silenced with a trailing ``# exc-safe: <why>``
+pragma on the offending line.
+
+Exit 0 = clean. Exit 1 = a violation. Pure stdlib so it runs anywhere in CI.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Subtrees the guard scans. Narrow and explicit: the paths where an exception
+# can reach an external HTTP consumer or a shared log sink.
+INCLUDE_DIRS: tuple[str, ...] = (
+    "src/agent_bom/api",
+    "src/agent_bom/cloud",
+    "src/agent_bom/runtime",
+)
+INCLUDE_FILES: tuple[str, ...] = ("src/agent_bom/proxy.py",)
+
+EXCLUDE_FRAGMENTS: tuple[str, ...] = (
+    "/test",
+    "test_",
+    "_test.",
+    "/tests/",
+    "/fixtures/",
+    "conftest.py",
+)
+
+# This guard names the patterns it forbids, so it must exempt itself.
+SELF = "scripts/check_exception_sanitization.py"
+
+PRAGMA = "exc-safe:"
+
+# Common caught-exception variable names.
+_EXC_VARS = r"(?:exc|e|err|error|ex)"
+
+# Bare exception token inside an f-string field: {exc}, {exc!r}, {exc:...}.
+# A leading attribute/index ({exc.status.value}) is deliberately excluded.
+_EXC_FIELD = re.compile(r"\{" + _EXC_VARS + r"(?:![rsa])?(?::[^}]*)?\}")
+
+# detail=str(exc) / detail=str(e) ...
+_DETAIL_STR = re.compile(r"detail\s*=\s*str\(\s*" + _EXC_VARS + r"\s*\)")
+
+# detail=f"...": flagged only if the f-string carries a bare exc field.
+_DETAIL_FSTRING = re.compile(r"""detail\s*=\s*f["']""")
+
+# logger.<level>(f"...": flagged only if the f-string carries a bare exc field.
+# Matches log / logger / _log / _logger / self.logger and similar names.
+_LOGGER_FSTRING = re.compile(
+    r"""\b\w*log\w*\.(?:debug|info|warning|error|exception|critical)\(\s*f["']""",
+)
+
+
+def _iter_files() -> list[Path]:
+    files: list[Path] = []
+    for rel in INCLUDE_DIRS:
+        base = REPO_ROOT / rel
+        if base.is_dir():
+            files.extend(sorted(base.rglob("*.py")))
+    for rel in INCLUDE_FILES:
+        path = REPO_ROOT / rel
+        if path.is_file():
+            files.append(path)
+    out: list[Path] = []
+    for path in files:
+        posix = path.as_posix()
+        if any(frag in posix for frag in EXCLUDE_FRAGMENTS):
+            continue
+        out.append(path)
+    return out
+
+
+def _scan_line(line: str) -> str | None:
+    """Return a human reason if *line* violates the bar, else None."""
+    if _DETAIL_STR.search(line):
+        return "raw exception in HTTPException detail — use sanitize_error(exc)"
+    if _DETAIL_FSTRING.search(line) and _EXC_FIELD.search(line):
+        return "raw exception interpolated into HTTPException detail f-string — wrap with sanitize_error(exc)"
+    if _LOGGER_FSTRING.search(line) and _EXC_FIELD.search(line):
+        return "raw exception interpolated into a log f-string — use lazy %s with sanitize_text(exc)"
+    return None
+
+
+def scan_text(text: str, label: str) -> list[str]:
+    """Scan a blob of source. Used by the test-suite to feed deliberate samples."""
+    violations: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if PRAGMA in line:
+            continue
+        reason = _scan_line(line)
+        if reason:
+            violations.append(f"{label}:{lineno}: {reason}")
+    return violations
+
+
+def main() -> int:
+    violations: list[str] = []
+    for path in _iter_files():
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        if rel == SELF:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        violations.extend(scan_text(text, rel))
+
+    if violations:
+        sys.stderr.write("Exception-sanitization guard found unsanitized exception text:\n\n")
+        for item in violations:
+            sys.stderr.write(f"  {item}\n")
+        sys.stderr.write(
+            "\nRoute raw exception text through agent_bom.security.sanitize_error "
+            "(HTTP responses) or sanitize_text (logs). See scripts/check_exception_sanitization.py "
+            "for the rule, or append '# exc-safe: <reason>' for a vetted exception.\n"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -40,6 +40,7 @@ from starlette.responses import JSONResponse
 from starlette.types import ASGIApp
 
 from agent_bom.api.dashboard_csp import dashboard_csp_header, describe_dashboard_csp_posture
+from agent_bom.security import sanitize_text
 
 _logger = logging.getLogger(__name__)
 _RATE_LIMIT_FINGERPRINT_FALLBACK = secrets.token_bytes(32)
@@ -1111,7 +1112,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 )
             except OIDCError as exc:
                 record_oidc_decode_failure()
-                _logger.debug("OIDC verification failed: %s", exc)
+                _logger.debug("OIDC verification failed: %s", sanitize_text(exc))
                 # Fall through to API key check — OIDC failure is non-fatal if keys also configured
 
         # RBAC mode: check against KeyStore

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -213,7 +213,7 @@ async def create_connection(request: Request, body: CloudConnectionCreate, _role
     except ConnectionSecretError as exc:
         # Never echo the secret or key detail — only the failure mode.
         _logger.warning("Connection secret encryption unavailable")
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        raise HTTPException(status_code=503, detail=sanitize_error(exc, generic=True)) from exc
 
     now = _now()
     record = CloudConnectionRecord(

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -38,6 +38,7 @@ from agent_bom.api.stores import (
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.rbac import require_authenticated_permission
+from agent_bom.security import sanitize_text
 
 if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport
@@ -577,7 +578,7 @@ async def cis_benchmark_trends(
                     "days": days_clamped,
                 }
         except Exception as exc:  # noqa: BLE001
-            _logger.warning("Postgres CIS aggregation failed; trying analytics store: %s", exc)
+            _logger.warning("Postgres CIS aggregation failed; trying analytics store: %s", sanitize_text(exc))
 
     analytics_store = _get_analytics_store()
     analytics_aggregate = getattr(analytics_store, "aggregate_cis_benchmark_checks", None)
@@ -601,7 +602,7 @@ async def cis_benchmark_trends(
                     "days": days_clamped,
                 }
         except Exception as exc:  # noqa: BLE001
-            _logger.warning("ClickHouse CIS aggregation failed: %s", exc)
+            _logger.warning("ClickHouse CIS aggregation failed: %s", sanitize_text(exc))
 
     # In-memory fallback: aggregate the tenant's recent scan results
     # locally so even single-node and SQLite-only deployments answer.

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -357,7 +357,7 @@ def _set_browser_session_cookie(
             max_age_seconds=max_age,
         )
     except BrowserSessionError as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        raise HTTPException(status_code=503, detail=sanitize_error(exc, generic=True)) from exc
     secure = _session_cookie_secure(request)
     response.set_cookie(
         SESSION_COOKIE_NAME,

--- a/src/agent_bom/api/routes/evaluations.py
+++ b/src/agent_bom/api/routes/evaluations.py
@@ -14,6 +14,7 @@ from agent_bom.api.audit_log import log_action
 from agent_bom.api.dataset_version_store import get_dataset_version_store
 from agent_bom.api.evaluation_store import EvaluationRunRecord, get_evaluation_run_store
 from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.security import sanitize_error
 
 router = APIRouter()
 
@@ -110,7 +111,7 @@ def _validate_path_id(value: str, field_name: str) -> str:
     try:
         return _validate_stable_label(value, field_name)
     except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise HTTPException(status_code=422, detail=sanitize_error(exc)) from exc
 
 
 def _validate_dataset_link(tenant_id: str, body: EvaluationRunCreate) -> None:

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -24,7 +24,7 @@ from agent_bom.api.stores import _get_fleet_store, _get_idempotency_store, _get_
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.api.tenant_quota import enforce_fleet_agents_quota, tenant_quota_guard
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
-from agent_bom.security import sanitize_command_args, sanitize_security_warnings, sanitize_text, sanitize_url
+from agent_bom.security import sanitize_command_args, sanitize_error, sanitize_security_warnings, sanitize_text, sanitize_url
 
 router = APIRouter()
 
@@ -283,7 +283,7 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
                 request_hash=request_hash,
             )
         except IdempotencyConflictError as exc:
-            raise HTTPException(status_code=409, detail=str(exc)) from exc
+            raise HTTPException(status_code=409, detail=sanitize_error(exc)) from exc
         if cached is not None:
             cached["idempotent_replay"] = True
             return cached

--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -31,6 +31,7 @@ from agent_bom.api.stores import _get_firewall_decision_store, _get_policy_store
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.gateway_upstreams import is_gateway_compatible_upstream_transport
 from agent_bom.rbac import require_authenticated_permission
+from agent_bom.security import sanitize_error
 
 if TYPE_CHECKING:
     from agent_bom.api.policy_store import GatewayPolicy
@@ -125,7 +126,7 @@ def _load_control_plane_firewall_policy() -> tuple[Any, dict[str, Any]]:
             try:
                 policy = load_firewall_policy_file(policy_path)
             except FirewallPolicyError as exc:
-                raise HTTPException(status_code=503, detail=f"Firewall policy invalid: {exc}") from exc
+                raise HTTPException(status_code=503, detail=f"Firewall policy invalid: {sanitize_error(exc)}") from exc
             loaded_at = datetime.now(timezone.utc).isoformat()
             _FIREWALL_POLICY_CACHE.update(
                 {

--- a/src/agent_bom/api/routes/intel.py
+++ b/src/agent_bom/api/routes/intel.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, Field
 
 from agent_bom.intel_lookup import build_daily_brief, list_intel_sources, lookup_advisory, match_packages
+from agent_bom.security import sanitize_error
 
 router = APIRouter()
 
@@ -46,7 +47,7 @@ async def get_intel_advisory(advisory_id: str) -> dict[str, Any]:
     try:
         return lookup_advisory(advisory_id)
     except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise HTTPException(status_code=422, detail=sanitize_error(exc)) from exc
 
 
 @router.post("/v1/intel/match", tags=["intel"])
@@ -59,7 +60,7 @@ async def post_intel_match(
     try:
         result = match_packages(body.packages, limit=body.limit)
     except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise HTTPException(status_code=422, detail=sanitize_error(exc)) from exc
     if not include_unmatched:
         result["matches"] = [item for item in result["matches"] if item["match_count"] > 0]
     return result
@@ -81,4 +82,4 @@ async def post_intel_daily_brief(body: IntelDailyBriefRequest) -> dict[str, Any]
             limit=body.limit,
         )
     except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise HTTPException(status_code=422, detail=sanitize_error(exc)) from exc

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -523,7 +523,7 @@ async def receive_push(request: Request, body: PushPayload) -> dict:
     try:
         _persist_graph_snapshot(job, job_result)
     except Exception as exc:  # noqa: BLE001
-        _logger.warning("Pushed-result graph persistence failed: %s", exc)
+        _logger.warning("Pushed-result graph persistence failed: %s", sanitize_text(exc))
         job.progress.append(f"Graph persistence skipped: {sanitize_error(exc)}")
     # Per-tenant quota lock keeps (check + insert) atomic (audit-4 P1).
     with tenant_quota_guard(tenant_id, lambda: enforce_retained_jobs_quota(tenant_id)):
@@ -551,7 +551,7 @@ async def ingest_ocsf(request: Request, body: dict | list[dict]) -> dict:
         if normalized_events:
             _get_analytics_store().record_events(normalized_events, tenant_id=tenant_id)
     except Exception as exc:  # noqa: BLE001
-        _logger.warning("OCSF analytics ingest skipped: %s", exc)
+        _logger.warning("OCSF analytics ingest skipped: %s", sanitize_text(exc))
     _persist_runtime_observations(normalized_events, tenant_id=tenant_id, source="ocsf")
 
     source_ids = sorted({str(event.get("source_id", "")).strip() for event in normalized_events if str(event.get("source_id", "")).strip()})

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 from agent_bom.api.models import ProxyAuditIngestRequest
 from agent_bom.api.stores import _get_idempotency_store
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
-from agent_bom.security import sanitize_sensitive_payload
+from agent_bom.security import sanitize_error, sanitize_sensitive_payload
 
 router = APIRouter()
 
@@ -152,7 +152,7 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
                 request_hash=request_hash,
             )
         except IdempotencyConflictError as exc:
-            raise HTTPException(status_code=409, detail=str(exc)) from exc
+            raise HTTPException(status_code=409, detail=sanitize_error(exc)) from exc
         if cached is not None:
             cached["idempotent_replay"] = True
             return cached

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -193,12 +193,12 @@ def _sanitize_api_path(user_path: str) -> str:
 
 
 def _api_scan_path_or_400(user_path: str) -> str:
-    from agent_bom.security import SecurityError
+    from agent_bom.security import SecurityError, sanitize_text
 
     try:
         return _sanitize_api_path(user_path)
     except SecurityError as exc:
-        _logger.warning("blocked local API scan path: %s", exc)
+        _logger.warning("blocked local API scan path: %s", sanitize_text(exc))
         raise HTTPException(status_code=400, detail="Invalid scan path") from exc
 
 

--- a/src/agent_bom/api/routes/webhooks.py
+++ b/src/agent_bom/api/routes/webhooks.py
@@ -21,6 +21,7 @@ from agent_bom.api.webhook_store import (
     set_subscription_status,
 )
 from agent_bom.rbac import require_authenticated_permission
+from agent_bom.security import sanitize_error
 
 router = APIRouter(tags=["webhooks"])
 
@@ -68,7 +69,7 @@ async def create_webhook_subscription(request: Request, body: dict) -> dict[str,
             allow_private_networks=bool(body.get("allow_private_networks", False)),
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=f"invalid webhook URL: {exc}") from exc
+        raise HTTPException(status_code=400, detail=f"invalid webhook URL: {sanitize_error(exc)}") from exc
     log_action(
         "webhook.subscription_created",
         actor=_actor(request),

--- a/src/agent_bom/api/tenant_quota.py
+++ b/src/agent_bom/api/tenant_quota.py
@@ -22,6 +22,7 @@ from agent_bom.config import (
     API_MAX_RETAINED_JOBS_PER_TENANT,
     API_MAX_SCHEDULES_PER_TENANT,
 )
+from agent_bom.security import sanitize_text
 
 _logger = logging.getLogger(__name__)
 
@@ -134,7 +135,7 @@ def _maybe_postgres_advisory_lock(tenant_id: str) -> Iterator[None]:
             with conn.cursor() as cur:
                 cur.execute("SELECT pg_advisory_unlock(%s)", (key,))
         except Exception as exc:  # noqa: BLE001
-            _logger.warning("pg_advisory_unlock failed for tenant=%s: %s", tenant_id, exc)
+            _logger.warning("pg_advisory_unlock failed for tenant=%s: %s", tenant_id, sanitize_text(exc))
         try:
             pool.putconn(conn)
         except Exception:  # noqa: BLE001

--- a/src/agent_bom/cloud/side_scan.py
+++ b/src/agent_bom/cloud/side_scan.py
@@ -43,6 +43,7 @@ from typing import Any, Optional, Protocol
 from agent_bom.filesystem import scan_disk_path_native
 from agent_bom.models import Package
 from agent_bom.secret_scanner import SecretScanResult, scan_secrets
+from agent_bom.security import sanitize_text
 
 from .base import CloudDiscoveryError
 
@@ -189,7 +190,7 @@ class CollectorMountController:
         try:
             subprocess.run(["umount", str(mount_point)], check=True, capture_output=True, timeout=120)
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as exc:
-            logger.warning("side-scan: umount %s failed (best-effort): %s", mount_point, exc)
+            logger.warning("side-scan: umount %s failed (best-effort): %s", mount_point, sanitize_text(exc))
         try:
             mount_point.rmdir()
         except OSError:
@@ -361,7 +362,7 @@ class AwsEbsSideScanner:
             try:
                 self._ec2.get_waiter("snapshot_completed").wait(SnapshotIds=[snapshot_id])
             except Exception as exc:  # noqa: BLE001 — waiter failure shouldn't abort; describe will catch it
-                logger.debug("side-scan: snapshot waiter failed for %s: %s", snapshot_id, exc)
+                logger.debug("side-scan: snapshot waiter failed for %s: %s", snapshot_id, sanitize_text(exc))
 
     def _provision_and_mount(self, state: _LifecycleState) -> Path:
         if not self._collector_instance_id or not self._availability_zone:
@@ -408,7 +409,7 @@ class AwsEbsSideScanner:
             try:
                 self._ec2.get_waiter("volume_available").wait(VolumeIds=[volume_id])
             except Exception as exc:  # noqa: BLE001
-                logger.debug("side-scan: volume waiter failed for %s: %s", volume_id, exc)
+                logger.debug("side-scan: volume waiter failed for %s: %s", volume_id, sanitize_text(exc))
 
     # ── Parse (reuse existing native parsers + secret scanner) ────────────
 
@@ -435,7 +436,7 @@ class AwsEbsSideScanner:
         try:
             scan_result: SecretScanResult = scan_secrets(mount_point)
         except Exception as exc:  # noqa: BLE001 — secret scan is best-effort enrichment
-            logger.warning("side-scan: secret scan failed (continuing): %s", exc)
+            logger.warning("side-scan: secret scan failed (continuing): %s", sanitize_text(exc))
             return []
         return [
             SideScanSecret(
@@ -508,7 +509,7 @@ class AwsEbsSideScanner:
                 OwnerIds=["self"],
             )
         except Exception as exc:  # noqa: BLE001
-            logger.warning("side-scan: orphan sweep describe failed: %s", exc)
+            logger.warning("side-scan: orphan sweep describe failed: %s", sanitize_text(exc))
             return deleted
 
         for snap in resp.get("Snapshots", []):
@@ -520,7 +521,7 @@ class AwsEbsSideScanner:
                 deleted.append(snap_id)
                 logger.info("side-scan: orphan sweep deleted stranded snapshot %s", snap_id)
             except Exception as exc:  # noqa: BLE001
-                logger.warning("side-scan: orphan sweep could not delete %s: %s", snap_id, exc)
+                logger.warning("side-scan: orphan sweep could not delete %s: %s", snap_id, sanitize_text(exc))
         return deleted
 
 

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -44,7 +44,7 @@ from agent_bom.async_stdin import create_async_stdin_reader, read_async_stdin_li
 from agent_bom.langfuse_otel import set_langfuse_runtime_attributes
 from agent_bom.proxy_sandbox import SandboxConfig, build_sandboxed_command
 from agent_bom.proxy_scanner import ScanConfig, load_scan_config, scan_tool_call, scan_tool_response
-from agent_bom.security import validate_arguments, validate_command
+from agent_bom.security import sanitize_text, validate_arguments, validate_command
 
 logger = logging.getLogger(__name__)
 
@@ -527,7 +527,7 @@ def _load_gateway_policy_cache_signer() -> _GatewayPolicyCacheSigner | None:
         return _gateway_policy_cache_signer
     except Exception as exc:  # noqa: BLE001
         _gateway_policy_cache_signer_error = str(exc)
-        logger.error("%s could not be parsed: %s", _PROXY_POLICY_CACHE_SIGNING_ENV_VAR, exc)
+        logger.error("%s could not be parsed: %s", _PROXY_POLICY_CACHE_SIGNING_ENV_VAR, sanitize_text(exc))
         return None
 
 
@@ -552,7 +552,7 @@ def _load_cached_gateway_policies(
     except FileNotFoundError:
         return None, None
     except (json.JSONDecodeError, OSError) as exc:
-        logger.warning("Ignoring unreadable gateway policy cache %s: %s", cache_path, exc)
+        logger.warning("Ignoring unreadable gateway policy cache %s: %s", cache_path, sanitize_text(exc))
         return None, None
 
     fetched_at = payload.get("fetched_at")
@@ -583,7 +583,7 @@ def _load_cached_gateway_policies(
             logger.warning("Ignoring unsigned gateway policy cache %s because signing is required", cache_path)
             return None, None
         except (KeyError, TypeError, json.JSONDecodeError, OSError) as exc:
-            logger.warning("Ignoring unreadable gateway policy cache signature %s: %s", signature_path, exc)
+            logger.warning("Ignoring unreadable gateway policy cache signature %s: %s", signature_path, sanitize_text(exc))
             return None, None
         if key_id != signer.key_id:
             logger.warning(
@@ -596,13 +596,13 @@ def _load_cached_gateway_policies(
         try:
             signer.verify(_canonicalize_gateway_policy_cache(payload), signature_hex)
         except Exception as exc:  # noqa: BLE001
-            logger.warning("Ignoring gateway policy cache %s with invalid signature: %s", cache_path, exc)
+            logger.warning("Ignoring gateway policy cache %s with invalid signature: %s", cache_path, sanitize_text(exc))
             return None, None
 
     try:
         policies = [GatewayPolicy(**item) for item in payload.get("policies", [])]
     except Exception as exc:  # noqa: BLE001
-        logger.warning("Ignoring invalid gateway policy cache %s: %s", cache_path, exc)
+        logger.warning("Ignoring invalid gateway policy cache %s: %s", cache_path, sanitize_text(exc))
         return None, None
     return policies, payload.get("etag")
 
@@ -654,7 +654,7 @@ def _persist_gateway_policies_cache(
                 temp_sig_path = Path(handle.name)
             temp_sig_path.replace(signature_path)
     except OSError as exc:
-        logger.warning("Failed to persist gateway policy cache %s: %s", cache_path, exc)
+        logger.warning("Failed to persist gateway policy cache %s: %s", cache_path, sanitize_text(exc))
 
 
 async def _fetch_enabled_gateway_policies(
@@ -751,7 +751,7 @@ async def _send_webhook(url: str, payload: dict) -> None:
     try:
         validate_url(url)
     except SecurityError as e:
-        logger.warning("Webhook URL rejected: %s", e)
+        logger.warning("Webhook URL rejected: %s", sanitize_text(e))
         return
 
     try:
@@ -802,7 +802,7 @@ async def _proxy_sse_server(
 
             policy = validate_json_file(Path(policy_path))
         except (json.JSONDecodeError, OSError, SecurityError) as exc:
-            logger.error("Failed to load policy from %s: %s", policy_path, exc)
+            logger.error("Failed to load policy from %s: %s", policy_path, sanitize_text(exc))
             return 1
 
     # Open audit log
@@ -853,7 +853,7 @@ async def _proxy_sse_server(
                             span.set_attribute("agent_bom.proxy.declared_tool_count", len(declared_tools))
                         logger.info("SSE proxy: discovered %d declared tools", len(declared_tools))
             except Exception as exc:  # noqa: BLE001
-                logger.warning("SSE proxy: could not fetch tools/list from %s: %s", url, exc)
+                logger.warning("SSE proxy: could not fetch tools/list from %s: %s", url, sanitize_text(exc))
 
             # Read JSON-RPC from stdin and forward through protection engine
             reader = await create_async_stdin_reader()
@@ -888,7 +888,7 @@ async def _proxy_sse_server(
                         sys.stdout.buffer.write((json.dumps(fwd.json()) + "\n").encode())
                         sys.stdout.buffer.flush()
                     except Exception as exc:  # noqa: BLE001
-                        logger.debug("SSE proxy: pass-through failed: %s", exc)
+                        logger.debug("SSE proxy: pass-through failed: %s", sanitize_text(exc))
                     continue
 
                 tool_name, arguments = policy_subject
@@ -1093,13 +1093,13 @@ async def _proxy_sse_server(
                     resp.raise_for_status()
                     response_data = resp.json()
                 except httpx.HTTPStatusError as exc:
-                    logger.warning("SSE proxy: server returned %d for %s: %s", exc.response.status_code, tool_name, exc)
+                    logger.warning("SSE proxy: server returned %d for %s: %s", exc.response.status_code, tool_name, sanitize_text(exc))
                     error_resp = make_error_response(msg_id, -32603, f"Upstream server error: {exc.response.status_code}")
                     sys.stdout.buffer.write((json.dumps(error_resp) + "\n").encode())
                     sys.stdout.buffer.flush()
                     continue
                 except Exception as exc:  # noqa: BLE001
-                    logger.warning("SSE proxy: connection error for %s: %s", tool_name, exc)
+                    logger.warning("SSE proxy: connection error for %s: %s", tool_name, sanitize_text(exc))
                     error_resp = make_error_response(msg_id, -32603, f"Upstream connection error: {exc}")
                     sys.stdout.buffer.write((json.dumps(error_resp) + "\n").encode())
                     sys.stdout.buffer.flush()
@@ -1182,7 +1182,7 @@ async def run_proxy(
 
             policy = validate_json_file(Path(policy_path))
         except (json.JSONDecodeError, OSError, SecurityError) as exc:
-            logger.error("Failed to load policy from %s: %s", policy_path, exc)
+            logger.error("Failed to load policy from %s: %s", policy_path, sanitize_text(exc))
             raise SystemExit(1) from exc
 
     # Open audit log with restricted permissions (0o600)
@@ -1340,10 +1340,10 @@ async def run_proxy(
                         exc,
                     )
                 else:
-                    logger.error("Failed to load enabled gateway policies from %s: %s", control_plane_url, exc)
+                    logger.error("Failed to load enabled gateway policies from %s: %s", control_plane_url, sanitize_text(exc))
                     raise SystemExit(1) from exc
             else:
-                logger.warning("Gateway policy refresh failed: %s", exc)
+                logger.warning("Gateway policy refresh failed: %s", sanitize_text(exc))
                 return
         if policies is not None:
             control_plane_policies = policies
@@ -1383,7 +1383,7 @@ async def run_proxy(
             )
         except Exception as exc:  # noqa: BLE001
             metrics.record_audit_push_failure()
-            logger.warning("Proxy audit push failed: %s", exc)
+            logger.warning("Proxy audit push failed: %s", sanitize_text(exc))
             async with audit_lock:
                 audit_buffer[:0] = alerts
                 audit_buffer_bytes += in_memory_bytes
@@ -1417,7 +1417,7 @@ async def run_proxy(
             try:
                 firewall_local_policy = load_firewall_policy_file(Path(firewall_local_policy_path))
             except FirewallPolicyError as exc:
-                logger.error("invalid firewall policy at %s: %s", firewall_local_policy_path, exc)
+                logger.error("invalid firewall policy at %s: %s", firewall_local_policy_path, sanitize_text(exc))
                 raise SystemExit(1) from exc
         try:
             fw_fail_mode = FirewallFailMode(firewall_fail_mode)
@@ -2046,7 +2046,7 @@ async def run_proxy(
         for result in results:
             if isinstance(result, Exception) and not isinstance(result, (BrokenPipeError, ConnectionResetError, asyncio.CancelledError)):
                 metrics.relay_errors += 1
-                logger.warning("Relay task exited with unexpected error: %s", result)
+                logger.warning("Relay task exited with unexpected error: %s", sanitize_text(result))
                 if log_file:
                     err_entry = {
                         "ts": datetime.now(timezone.utc).isoformat(),

--- a/tests/test_cloud_connections.py
+++ b/tests/test_cloud_connections.py
@@ -1356,3 +1356,32 @@ def test_summarize_inventory_payload_redacts_raw_warnings() -> None:
     assert warnings == ["2 provider discovery warning(s) — see server logs for detail."]
     blob = " ".join(warnings)
     assert "Traceback" not in blob and "AccessDenied" not in blob and "arn:aws:iam" not in blob
+
+
+# Sensitive raw exception text (KMS broker / encryption path) must never reach the
+# HTTP 503 body. The encryption failure mode is HIGH sensitivity, so the route
+# uses sanitize_error(exc, generic=True): a fixed, non-diagnostic message.
+_LEAKY_SECRET = "kms-key-id=arn:aws:kms:us-east-1:123456789012:key/abcd token=AKIASECRETVALUE at /etc/agent-bom/master.pem"
+
+
+def test_create_503_on_encryption_failure_never_leaks_exception(monkeypatch: Any) -> None:
+    from agent_bom.api.connection_crypto import ConnectionSecretError
+    from agent_bom.api.routes import cloud_connections as routes
+
+    def _boom(_value: str) -> str:
+        raise ConnectionSecretError(_LEAKY_SECRET)
+
+    monkeypatch.setattr(routes, "encrypt_secret", _boom)
+
+    client = TestClient(_app())
+    resp = client.post("/v1/cloud/connections", json=_create_body(), headers=_proxy_headers())
+
+    assert resp.status_code == 503
+    detail = resp.json()["detail"]
+    # Generic, non-diagnostic message — and none of the leaky fragments survive.
+    assert detail == "An internal error occurred. Please contact support."
+    blob = str(resp.json())
+    assert "arn:aws:kms" not in blob
+    assert "AKIASECRETVALUE" not in blob
+    assert "master.pem" not in blob
+    assert "kms-key-id" not in blob

--- a/tests/test_exception_sanitization_guard.py
+++ b/tests/test_exception_sanitization_guard.py
@@ -1,0 +1,119 @@
+"""Tests for scripts/check_exception_sanitization.py — the release-bar guard that
+keeps raw exception text out of HTTP response bodies and log lines on the
+API / cloud / runtime paths.
+
+Also asserts the sanitizer contracts the guard steers callers toward:
+``sanitize_error`` (HTTP responses) and ``sanitize_text`` (logs) strip secrets,
+paths, and credential-bearing URLs while ``generic=True`` collapses to a fixed
+non-diagnostic message.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_exception_sanitization.py"
+
+
+def _load_guard():
+    spec = importlib.util.spec_from_file_location("check_exception_sanitization", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["check_exception_sanitization"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+GUARD = _load_guard()
+
+
+# ---------------------------------------------------------------------------
+# The live tree must be clean end-to-end.
+# ---------------------------------------------------------------------------
+def test_current_tree_passes() -> None:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# Forbidden patterns are flagged.
+# ---------------------------------------------------------------------------
+def test_flags_detail_str_exc() -> None:
+    out = GUARD.scan_text("    raise HTTPException(status_code=422, detail=str(exc)) from exc\n", "sample.py")
+    assert len(out) == 1
+    assert "sanitize_error" in out[0]
+
+
+def test_flags_detail_fstring_exc() -> None:
+    out = GUARD.scan_text('    raise HTTPException(status_code=400, detail=f"bad: {exc}") from exc\n', "sample.py")
+    assert len(out) == 1
+    assert "f-string" in out[0]
+
+
+def test_flags_logger_fstring_exc() -> None:
+    for line in (
+        '    logger.warning(f"failed: {exc}")\n',
+        '    _logger.error(f"oops {e}")\n',
+        '    logger.debug(f"x {err!r}")\n',
+    ):
+        out = GUARD.scan_text(line, "sample.py")
+        assert len(out) == 1, line
+        assert "log f-string" in out[0]
+
+
+# ---------------------------------------------------------------------------
+# Safe patterns are NOT flagged.
+# ---------------------------------------------------------------------------
+def test_allows_sanitized_and_structured_forms() -> None:
+    safe = """
+    raise HTTPException(status_code=422, detail=sanitize_error(exc)) from exc
+    raise HTTPException(status_code=400, detail=f"bad: {sanitize_error(exc)}") from exc
+    raise HTTPException(status_code=503, detail=sanitize_error(exc, generic=True)) from exc
+    logger.warning("failed: %s", sanitize_text(exc))
+    raise HTTPException(status_code=409, detail=f"Cannot approve exception in {exc.status.value} state")
+    return JSONResponse(status_code=429, content=exc.to_dict())
+    """
+    assert GUARD.scan_text(safe, "sample.py") == []
+
+
+def test_pragma_silences_a_vetted_line() -> None:
+    line = "    raise HTTPException(status_code=422, detail=str(exc))  # exc-safe: value is a fixed enum\n"
+    assert GUARD.scan_text(line, "sample.py") == []
+
+
+# ---------------------------------------------------------------------------
+# Sanitizer contracts the guard points callers to.
+# ---------------------------------------------------------------------------
+def test_sanitize_error_generic_is_fixed_message() -> None:
+    from agent_bom.security import sanitize_error
+
+    leaky = Exception("token=AKIASECRET arn:aws:kms:key /etc/agent-bom/master.pem")
+    out = sanitize_error(leaky, generic=True)
+    assert out == "An internal error occurred. Please contact support."
+    assert "AKIASECRET" not in out and "master.pem" not in out
+
+
+def test_sanitize_error_redacts_secret_but_keeps_safe_hint() -> None:
+    from agent_bom.security import sanitize_error
+
+    out = sanitize_error(ValueError("invalid region token=SECRET123 at /etc/conf https://h/p"))
+    assert "invalid region" in out  # safe, user-facing validation hint survives
+    assert "SECRET123" not in out
+    assert "/etc/conf" not in out
+    assert "https://h/p" not in out
+
+
+def test_sanitize_text_redacts_credential_bearing_url_for_logs() -> None:
+    from agent_bom.security import sanitize_text
+
+    out = sanitize_text(Exception("connect failed: postgres://user:supersecretpw@db.internal/app"))
+    assert "supersecretpw" not in out


### PR DESCRIPTION
## Summary

Raw exception strings routinely carry secrets, ARNs, file paths, connection strings, and stack detail. Surfacing them to an HTTP response body or a log line leaks that data to API consumers and log sinks. This change routes every surfaced and hot-path-logged exception through the central `agent_bom.security` sanitizers and adds a regression guard so new leaks cannot land — the systemic release-bar fix, not per-source patching.

## HTTP response bodies (`HTTPException` detail)

High sensitivity -> `sanitize_error(exc, generic=True)` (fixed, non-diagnostic message):
- `api/routes/cloud_connections.py` (connection-secret encryption / broker, 503)
- `api/routes/enterprise.py` (browser-session token, 503)

Validation / idempotency-conflict -> `sanitize_error(exc)` (redacts secrets/paths/URLs, preserves the safe user-facing hint):
- `api/routes/intel.py` (422 x3)
- `api/routes/evaluations.py` (422)
- `api/routes/fleet.py` (409)
- `api/routes/proxy.py` (409)
- `api/routes/gateway.py` (firewall-policy-invalid, 503)
- `api/routes/webhooks.py` (invalid webhook URL, 400)

`graph.py`'s rate-limit `exc.to_dict()` is a structured, already-safe payload and is intentionally left unchanged.

## Hot-path logs

Raw exception passed to lazy `%s` formatting, now wrapped in `sanitize_text(...)`:
- `cloud/side_scan.py` (6)
- `proxy.py` (18)
- `api/middleware.py` (OIDC verify)
- `api/tenant_quota.py` (advisory-unlock)
- `api/routes/compliance.py` (2, CIS aggregation)
- `api/routes/observability.py` (2, graph persist / OCSF ingest)
- `api/routes/scan.py` (blocked local path)

`raise ... from exc` chaining is preserved (server-side tracebacks keep the original); only the surfaced/logged text changes. `runtime/` only uses `exc_info=True` server-side traces and needed no change.

## Regression guard

`scripts/check_exception_sanitization.py` (wired into `.pre-commit-config.yaml` and CI `ci.yml`) fails when a new `detail=str(exc)` / `detail=f"...{exc}"` response body or a raw-exception log f-string lands on the `api/`, `cloud/`, `runtime/`, or `proxy.py` paths. It matches only the bare exception token (`{exc}`, `{exc!r}`, `{exc:...}`, and the `e`/`err`/`error`/`ex` aliases); attribute access such as `{exc.status.value}` (a safe enum) and structured payloads such as `exc.to_dict()` are not matched, so the safe call sites need no allowlist. A vetted line can carry a trailing `# exc-safe: <reason>` pragma. The rule is documented in `AGENTS.md`.

## Tests

- `tests/test_cloud_connections.py`: the encryption-failure path injects an exception whose message carries a fake KMS ARN, access key, and `.pem` path; asserts the 503 body is the generic message and contains none of the leaky fragments.
- `tests/test_exception_sanitization_guard.py`: the guard flags each forbidden pattern, passes the sanitized/structured/pragma forms, the live tree is clean end-to-end, and the `sanitize_error` / `sanitize_text` contracts (generic message, secret/path/URL redaction with safe hint preserved) hold.

## Left for follow-up

To keep this PR reviewable and avoid collisions with the in-flight cloud-inventory work, the broad CIS-benchmark debug-log surface (`cloud/azure_cis_benchmark.py`, `cloud/gcp_cis_benchmark.py`, `cloud/snowflake_cis_benchmark.py`, plus provider debug logs in `cloud/azure.py`, `cloud/aws.py`, `cloud/mlflow_provider.py`, etc.) that interpolates exceptions via lazy `%s` is not converted here. `cloud/aws_cis_benchmark.py` is owned by an open PR and is deliberately untouched. These are server-side `logger.debug` enumeration logs; a follow-up will sanitize them and the guard can then be extended to enforce the lazy-`%s` exception form repo-wide.

## Validation

`ruff check`, `ruff format --check`, `mypy`, `bandit`, comment-hygiene, the new guard, and the full pre-commit suite pass; touched route/proxy/guard test areas pass (300+ tests).