### PR TITLE
fix(scanner): normalize Alpine apk release key to major.minor so advisories resolve

### DIFF
--- a/src/agent_bom/coverage.py
+++ b/src/agent_bom/coverage.py
@@ -78,8 +78,11 @@ def _release_key(pkg: "Package") -> Optional[tuple[str, str]]:
             return ("ubuntu", f"ubuntu:{distro_version}")
         return None
     if eco == "apk":
-        normalized = distro_version if distro_version.startswith("v") else f"v{distro_version}"
-        return ("alpine", f"alpine:{normalized}")
+        # Alpine advisories are stored per minor branch (``alpine:v3.16``); truncate
+        # the point release so coverage counts rows instead of a false absence.
+        from agent_bom.package_utils import alpine_release_branch
+
+        return ("alpine", f"alpine:{alpine_release_branch(distro_version)}")
     return None
 
 

--- a/src/agent_bom/package_utils.py
+++ b/src/agent_bom/package_utils.py
@@ -117,6 +117,33 @@ def canonical_package_key(name: str, version: str, ecosystem: str, purl: str | N
     return f"{normalized_ecosystem}:{normalized_name}{suffix}"
 
 
+@lru_cache(maxsize=4096)
+def alpine_release_branch(distro_version: str) -> str:
+    """Normalize an Alpine ``VERSION_ID`` to its secdb branch key (``v{major}.{minor}``).
+
+    Alpine security advisories are published per *minor branch* (``v3.16``), not
+    per point release. A full ``VERSION_ID`` such as ``3.16.9`` must be truncated
+    to ``v3.16`` so apk advisory lookups resolve against the branch's advisory
+    rows instead of zero rows under the (never-stored) point-release key. This
+    aligns apk release keying with mainstream advisory scanners.
+
+    Behaviour:
+    - ``3.16.9`` / ``v3.16.9`` -> ``v3.16``
+    - ``3.20.10`` -> ``v3.20``
+    - ``3.16`` / ``v3.16`` -> ``v3.16`` (already a branch)
+    - non-numeric / single-component streams (``edge``) keep prior ``v``-prefix
+      behaviour so no real branch key changes meaning.
+    """
+    raw = (distro_version or "").strip()
+    if not raw:
+        return raw
+    body = raw[1:] if raw.startswith("v") else raw
+    parts = body.split(".")
+    if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
+        return f"v{parts[0]}.{parts[1]}"
+    return raw if raw.startswith("v") else f"v{raw}"
+
+
 @lru_cache(maxsize=16384)
 def parse_debian_source_name(source_field: str) -> Optional[str]:
     """Extract the Debian source package name from a ``Source:`` field."""
@@ -129,6 +156,7 @@ def parse_debian_source_name(source_field: str) -> Optional[str]:
 
 
 __all__ = [
+    "alpine_release_branch",
     "canonical_package_identity",
     "canonical_package_key",
     "host_matches_domain",

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -46,7 +46,12 @@ from agent_bom.nist_csf import tag_blast_radius as tag_nist_csf
 from agent_bom.owasp import tag_blast_radius
 from agent_bom.owasp_agentic import tag_blast_radius as tag_owasp_agentic
 from agent_bom.owasp_mcp import tag_blast_radius as tag_owasp_mcp
-from agent_bom.package_utils import canonical_package_identity, canonical_package_key, normalize_package_name
+from agent_bom.package_utils import (
+    alpine_release_branch,
+    canonical_package_identity,
+    canonical_package_key,
+    normalize_package_name,
+)
 from agent_bom.scanners.blast_radius import _HOP_RISK_FACTORS, expand_blast_radius_hops
 from agent_bom.scanners.osv import candidate_package_names as _candidate_package_names
 from agent_bom.scanners.osv import enrich_results_if_needed as _enrich_results_if_needed_impl
@@ -280,8 +285,9 @@ def _osv_ecosystems_for_package(pkg: Package) -> list[str]:
     if eco_key == "apk":
         distro_version = (pkg.distro_version or "").strip()
         if distro_version:
-            normalized = distro_version if distro_version.startswith("v") else f"v{distro_version}"
-            return [f"Alpine:{normalized}"]
+            # Alpine advisories are keyed by minor branch (``v3.16``), so a full
+            # VERSION_ID (``3.16.9``) must be truncated or every lookup returns 0 rows.
+            return [f"Alpine:{alpine_release_branch(distro_version)}"]
         return list(_ALPINE_OSV_FALLBACKS)
 
     osv_ecosystem = ECOSYSTEM_MAP.get(eco_key)

--- a/tests/test_alpine_release_keying.py
+++ b/tests/test_alpine_release_keying.py
@@ -1,0 +1,134 @@
+"""Regressions for Alpine apk advisory release keying.
+
+Alpine security advisories are published and stored per *minor branch*
+(``alpine:v3.16``), never per point release. The scanner historically built the
+apk lookup key from the full ``VERSION_ID`` (``3.16.9`` -> ``Alpine:v3.16.9``),
+which matched zero advisory rows and silently reported 0 CVEs on every Alpine
+image. These tests lock the truncation to ``v{major}.{minor}`` in both the
+scanner ecosystem mapping and the coverage release key, and prove a 3-part
+``VERSION_ID`` resolves advisories stored under the branch key.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_bom.coverage import _release_key
+from agent_bom.db.lookup import lookup_packages_batch
+from agent_bom.db.schema import init_db
+from agent_bom.models import Package
+from agent_bom.package_utils import alpine_release_branch
+from agent_bom.scanners import _db_ecosystems_for_package, _osv_ecosystems_for_package
+
+
+@pytest.mark.parametrize(
+    "version_id, expected",
+    [
+        ("3.16.9", "v3.16"),
+        ("v3.16.9", "v3.16"),
+        ("3.20.10", "v3.20"),
+        ("3.16", "v3.16"),
+        ("v3.16", "v3.16"),
+        ("3.21.0", "v3.21"),
+        # Non major.minor / odd inputs keep prior v-prefix behaviour.
+        ("edge", "vedge"),
+        ("3", "v3"),
+        ("", ""),
+    ],
+)
+def test_alpine_release_branch_normalization(version_id: str, expected: str):
+    assert alpine_release_branch(version_id) == expected
+
+
+def _apk_pkg(version_id: str) -> Package:
+    return Package(
+        name="busybox",
+        version="1.35.0-r17",
+        ecosystem="apk",
+        distro_name="alpine",
+        distro_version=version_id,
+    )
+
+
+@pytest.mark.parametrize(
+    "version_id, expected_osv",
+    [
+        ("3.16.9", "Alpine:v3.16"),
+        ("3.20.10", "Alpine:v3.20"),
+        ("3.16", "Alpine:v3.16"),
+        ("v3.16.9", "Alpine:v3.16"),
+    ],
+)
+def test_osv_ecosystems_truncate_apk_to_branch(version_id: str, expected_osv: str):
+    assert _osv_ecosystems_for_package(_apk_pkg(version_id)) == [expected_osv]
+    assert _db_ecosystems_for_package(_apk_pkg(version_id)) == [expected_osv.lower()]
+
+
+@pytest.mark.parametrize(
+    "version_id, expected_key",
+    [
+        ("3.16.9", "alpine:v3.16"),
+        ("3.20.10", "alpine:v3.20"),
+        ("3.16", "alpine:v3.16"),
+    ],
+)
+def test_coverage_release_key_truncates_apk(version_id: str, expected_key: str):
+    assert _release_key(_apk_pkg(version_id)) == ("alpine", expected_key)
+
+
+def test_debian_and_ubuntu_keys_unchanged():
+    """The apk fix must not perturb Debian/Ubuntu release keying."""
+    deb = Package(
+        name="bash",
+        version="5.1-2",
+        ecosystem="deb",
+        distro_name="debian",
+        distro_version="12.5",
+    )
+    ubuntu = Package(
+        name="bash",
+        version="5.1-6ubuntu1",
+        ecosystem="deb",
+        distro_name="ubuntu",
+        distro_version="22.04",
+    )
+    assert _osv_ecosystems_for_package(deb) == ["Debian:12"]
+    assert _release_key(deb) == ("debian", "debian:12")
+    assert _osv_ecosystems_for_package(ubuntu) == ["Ubuntu:22.04:LTS", "Ubuntu:22.04"]
+    assert _release_key(ubuntu) == ("ubuntu", "ubuntu:22.04")
+
+
+def test_three_part_version_resolves_branch_advisory():
+    """A 3-part Alpine VERSION_ID must match advisories stored under the branch key.
+
+    Mirrors the real DB layout: advisories are ingested as ``alpine:v3.16`` but
+    the scanned image reports ``VERSION_ID=3.16.9``. The lookup key built from
+    the package must collapse to ``alpine:v3.16`` so the row is found.
+    """
+    conn = init_db(Path(":memory:"))
+    try:
+        conn.execute(
+            "INSERT INTO vulns(id, summary, severity, source) VALUES (?, ?, ?, ?)",
+            ("CVE-2023-42366", "busybox issue", "high", "alpine-secdb"),
+        )
+        conn.execute(
+            "INSERT INTO affected(vuln_id, ecosystem, package_name, introduced, fixed) VALUES (?, ?, ?, ?, ?)",
+            ("CVE-2023-42366", "alpine:v3.16", "busybox", "0", "1.35.0-r18"),
+        )
+        conn.commit()
+
+        pkg = _apk_pkg("3.16.9")
+        (db_eco,) = _db_ecosystems_for_package(pkg)
+        assert db_eco == "alpine:v3.16"
+
+        results = lookup_packages_batch(conn, [(db_eco, "busybox", "1.35.0-r17")])
+        vulns = results[(db_eco, "busybox", "1.35.0-r17")]
+        assert [v.id for v in vulns] == ["CVE-2023-42366"]
+
+        # And the older, buggy full-VERSION_ID key resolves nothing.
+        empty = lookup_packages_batch(conn, [("alpine:v3.16.9", "busybox", "1.35.0-r17")])
+        assert empty[("alpine:v3.16.9", "busybox", "1.35.0-r17")] == []
+    finally:
+        conn.close()


### PR DESCRIPTION
## Problem

Alpine security advisories are published and stored per **minor branch** (`alpine:v3.16`), never per point release. The scanner (`scanners/__init__.py:_osv_ecosystems_for_package`) and the coverage checker (`coverage.py:_release_key`) built the apk lookup key from the full `VERSION_ID`, only prepending `v`. A 3-part version such as `3.16.9` produced `Alpine:v3.16.9` — which matches **0** advisory rows — instead of `alpine:v3.16`, the populated branch key (2,292 rows locally).

Consequences:
- Every Alpine image reported **0 CVEs**, on EOL and supported releases alike.
- A false `release_advisories_absent` coverage warning fired on supported Alpine images.

The Debian branch directly above already truncates correctly (`Debian:{major}`); Alpine needs **major.minor**.

## Fix

Added a shared `alpine_release_branch()` helper in `package_utils.py` that truncates a `VERSION_ID` to `v{major}.{minor}`:
- `3.16.9` / `v3.16.9` → `v3.16`
- `3.20.10` → `v3.20`
- `3.16` / `v3.16` → `v3.16` (already a branch)
- non-numeric / single-component streams (`edge`) keep prior `v`-prefix behaviour

Wired it into both `_osv_ecosystems_for_package` and `coverage._release_key`. Debian/Ubuntu/rpm keying is untouched. This aligns apk release keying with mainstream advisory scanners.

## Validation (offline scan, isolated cwd)

Built from this branch and scanned both images against the local advisory DB.

| Image | Before | After |
|---|---|---|
| `alpine:3.16` (`sha256:452e7292…2ae4`) | 0 findings + **false** `release_advisories_absent` warning | **2 findings**, no coverage warning |
| `alpine:3.20.10` | 0 findings + **false** `release_advisories_absent` warning | 0 findings (genuinely clean), no coverage warning |

`alpine:3.16` after-fix findings match the mainstream-scanner fixed-only baseline exactly (**2/2 parity, 0 false positives**):
- `CVE-2025-26519` — musl `1.2.3-r3` → `1.2.3-r4` (high)
- `CVE-2023-42366` — busybox `1.35.0-r17` → `1.35.0-r18` (medium)

Both `installed < fixed` confirmed via apk version ordering. `alpine:3.20.10` now resolves against the populated `alpine:v3.20` branch (no rows missed) and is genuinely clean.

## Tests

- Unit tests for the release-key normalization in both code paths (`3.16.9`→`v3.16`, `3.20.10`→`v3.20`, `3.16`→`v3.16`, plus edge cases).
- Regression test: an advisory stored under `alpine:v3.16` resolves for a package whose `VERSION_ID` is `3.16.9`, while the old full-version key resolves nothing.
- Guard test that Debian/Ubuntu keys are unchanged.

ruff / ruff-format / mypy / pre-commit clean; related OS-package, coverage, and ecosystem suites pass.