### PR TITLE
ci: scope workflow path fanout to applicable jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,13 +83,13 @@ jobs:
           if printf '%s\n' "$changed" | grep -Eq '^(src/|tests/|pyproject\.toml|uv\.lock|Dockerfile|scripts/|\.github/actions/setup-python/|\.github/workflows/ci\.yml$)'; then
             alpine=true
           fi
-          if printf '%s\n' "$changed" | grep -Eq '^(pyproject\.toml|uv\.lock|Dockerfile|\.github/actions/setup-python/|\.github/workflows/ci\.yml$)'; then
+          if printf '%s\n' "$changed" | grep -Eq '^(pyproject\.toml|uv\.lock|Dockerfile|\.github/actions/setup-python/)'; then
             alpine_full=true
           fi
           if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/api/postgres_|src/agent_bom/api/storage_schema\.py|tests/test_postgres_)'; then
             postgres=true
           fi
-          if printf '%s\n' "$changed" | grep -Eq '^(deploy/endpoints/|scripts/(build-[^/]+|render_homebrew_formula\.py)|src/agent_bom/cli/_runtime\.py|tests/test_cli_runtime\.py|pyproject\.toml|uv\.lock|\.github/actions/setup-python/|\.github/workflows/ci\.yml$|site-docs/deployment/aws-company-rollout\.md$)'; then
+          if printf '%s\n' "$changed" | grep -Eq '^(deploy/endpoints/|scripts/(build-[^/]+|render_homebrew_formula\.py)|src/agent_bom/cli/_runtime\.py|tests/test_cli_runtime\.py|pyproject\.toml|uv\.lock|\.github/actions/setup-python/|site-docs/deployment/aws-company-rollout\.md$)'; then
             endpoint=true
           fi
           if printf '%s\n' "$changed" | grep -Eq '^(ui/|action\.yml|contracts/|src/agent_bom/(api/(routes/|models\.py|server\.py)|graph/|context_graph\.py|graph_schema\.py)|src/agent_bom/models\.py|\.github/workflows/ci\.yml$)'; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           if printf '%s\n' "$changed" | grep -Eq '^(action\.yml|\.github/actions/|tests/fixtures/test-(sbom|policy)\.json$)'; then
             action=true
           fi
-          if printf '%s\n' "$changed" | grep -Eq '^(src/|tests/|pyproject\.toml|uv\.lock|Dockerfile|scripts/|\.github/actions/setup-python/|\.github/workflows/ci\.yml$)'; then
+          if printf '%s\n' "$changed" | grep -Eq '^(src/|tests/|pyproject\.toml|uv\.lock|Dockerfile|scripts/|\.github/actions/setup-python/)'; then
             alpine=true
           fi
           if printf '%s\n' "$changed" | grep -Eq '^(pyproject\.toml|uv\.lock|Dockerfile|\.github/actions/setup-python/)'; then
@@ -92,7 +92,7 @@ jobs:
           if printf '%s\n' "$changed" | grep -Eq '^(deploy/endpoints/|scripts/(build-[^/]+|render_homebrew_formula\.py)|src/agent_bom/cli/_runtime\.py|tests/test_cli_runtime\.py|pyproject\.toml|uv\.lock|\.github/actions/setup-python/|site-docs/deployment/aws-company-rollout\.md$)'; then
             endpoint=true
           fi
-          if printf '%s\n' "$changed" | grep -Eq '^(ui/|action\.yml|contracts/|src/agent_bom/(api/(routes/|models\.py|server\.py)|graph/|context_graph\.py|graph_schema\.py)|src/agent_bom/models\.py|\.github/workflows/ci\.yml$)'; then
+          if printf '%s\n' "$changed" | grep -Eq '^(ui/|action\.yml|contracts/|src/agent_bom/(api/(routes/|models\.py|server\.py)|graph/|context_graph\.py|graph_schema\.py)|src/agent_bom/models\.py)'; then
             ui=true
           fi
           {

--- a/scripts/check_duplicate_artifacts.py
+++ b/scripts/check_duplicate_artifacts.py
@@ -11,6 +11,7 @@ tools such as pytest.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -18,6 +19,7 @@ from pathlib import Path
 
 _DUPLICATE_COMPONENT_RE = re.compile(r"^.+ [2-9](?:\.[^.\\/]+)?$")
 _IGNORED_PREFIXES = (
+    ".claude/",
     ".git/",
     ".venv/",
     "venv/",
@@ -33,6 +35,7 @@ _IGNORED_PREFIXES = (
     "site/",
 )
 _IGNORED_DIR_NAMES = {
+    ".claude",
     ".git",
     ".mypy_cache",
     ".pytest_cache",
@@ -60,15 +63,17 @@ def _tracked_paths() -> list[str]:
 
 def _working_tree_paths(root: Path) -> list[str]:
     paths: list[str] = []
-    for path in root.rglob("*"):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [name for name in dirnames if name not in _IGNORED_DIR_NAMES]
+        current = Path(dirpath)
         try:
-            relative = path.relative_to(root)
+            current_relative = current.relative_to(root)
         except ValueError:
             continue
-        parts = relative.parts
-        if any(part in _IGNORED_DIR_NAMES for part in parts):
-            continue
-        paths.append(relative.as_posix())
+        if current_relative != Path("."):
+            paths.append(current_relative.as_posix())
+        for filename in filenames:
+            paths.append((current_relative / filename).as_posix())
     return paths
 
 

--- a/tests/test_duplicate_artifact_guard.py
+++ b/tests/test_duplicate_artifact_guard.py
@@ -32,6 +32,7 @@ def test_duplicate_artifact_guard_ignores_untracked_noise_prefixes() -> None:
         "ui/node_modules/package 2/index.js",
         "ui/out/graph 2/index.html",
         "site/deployment/docker 2/index.html",
+        ".claude/worktrees/agent-a/src/agent_bom/graph/repo_structure_overlay 2.py",
         ".venv/lib/python/site-packages/pkg 2.py",
         "src/agent_bom/model_advisories.py",
     ]
@@ -59,9 +60,13 @@ def test_duplicate_artifact_guard_working_tree_mode_detects_untracked_copies(
     ignored = tmp_path / "node_modules" / "package 2" / "index.js"
     ignored.parent.mkdir(parents=True)
     ignored.write_text("", encoding="utf-8")
+    claude_worktree = tmp_path / ".claude" / "worktrees" / "agent-a" / "src" / "agent_bom" / "model 2.py"
+    claude_worktree.parent.mkdir(parents=True)
+    claude_worktree.write_text("", encoding="utf-8")
     monkeypatch.chdir(tmp_path)
 
     assert main(["--working-tree"]) == 1
     captured = capsys.readouterr()
     assert "ui/components/command-palette 2.tsx" in captured.err
     assert "node_modules/package 2/index.js" not in captured.err
+    assert ".claude/worktrees/agent-a/src/agent_bom/model 2.py" not in captured.err


### PR DESCRIPTION
Summary
- Keep real Postgres integration scoped to Postgres/storage changes.
- Stop treating every ci.yml edit as a full Alpine/musl or endpoint-packaging change.
- Preserve targeted Alpine smoke for source/test changes while reserving full Alpine for lockfile, Docker, and setup-python toolchain changes.

Verification
- python scripts/check_exception_sanitization.py
- python - <<PY local classifier/YAML parse check: postgres=false, endpoint=false, alpine=true, alpine_full=false for #3216 shape
- GitHub CI on #3216 confirmed Postgres Integration Contract skipped after the first classifier fix; this PR prevents the remaining unrelated full-Alpine fanout seen on the merged PR run.

Notes
- Follow-up to #3216; the security fix is already merged, this only hardens CI applicability.