### PR TITLE
fix(scanners): preserve Alpine source package matching

### DIFF
--- a/src/agent_bom/cli/_focused_commands.py
+++ b/src/agent_bom/cli/_focused_commands.py
@@ -115,6 +115,7 @@ def image_cmd(
         images=(image_ref,) if image_ref else (),
         image_tars=(image_tar,) if image_tar else (),
         _image_only=True,
+        no_skill=True,
         image_platform=platform,
         output_format=output_format,
         output=output_path,

--- a/src/agent_bom/filesystem.py
+++ b/src/agent_bom/filesystem.py
@@ -260,12 +260,14 @@ def parse_apk_installed(installed_file: Path) -> list[Package]:
             if current.get("P") and current.get("V"):
                 name = current["P"]
                 version = current["V"]
+                source_package = current.get("o") or current.get("O")
                 packages.append(
                     Package(
                         name=name,
                         version=version,
                         ecosystem="apk",
                         purl=f"pkg:apk/alpine/{name}@{version}",
+                        source_package=source_package,
                         is_direct=True,
                     )
                 )
@@ -279,12 +281,14 @@ def parse_apk_installed(installed_file: Path) -> list[Package]:
     if current.get("P") and current.get("V"):
         name = current["P"]
         version = current["V"]
+        source_package = current.get("o") or current.get("O")
         packages.append(
             Package(
                 name=name,
                 version=version,
                 ecosystem="apk",
                 purl=f"pkg:apk/alpine/{name}@{version}",
+                source_package=source_package,
                 is_direct=True,
             )
         )

--- a/src/agent_bom/image.py
+++ b/src/agent_bom/image.py
@@ -539,17 +539,33 @@ def _packages_from_tar(tar_path: Path) -> list[Package]:
                     if f:
                         content = f.read().decode("utf-8", errors="ignore")
                         pkg_name = pkg_version = ""
+                        source_package: str | None = None
                         for line in content.splitlines():
                             if line.startswith("P:"):
                                 pkg_name = line[2:].strip()
                             elif line.startswith("V:"):
                                 pkg_version = line[2:].strip()
+                            elif line.startswith("o:") or line.startswith("O:"):
+                                source_package = line[2:].strip() or None
                             elif line == "" and pkg_name and pkg_version:
-                                _add(pkg_name, pkg_version, "apk", f"pkg:apk/alpine/{pkg_name}@{pkg_version}")
+                                _add(
+                                    pkg_name,
+                                    pkg_version,
+                                    "apk",
+                                    f"pkg:apk/alpine/{pkg_name}@{pkg_version}",
+                                    source_package=source_package,
+                                )
                                 pkg_name = pkg_version = ""
+                                source_package = None
                         # Handle last entry if file doesn't end with blank line
                         if pkg_name and pkg_version:
-                            _add(pkg_name, pkg_version, "apk", f"pkg:apk/alpine/{pkg_name}@{pkg_version}")
+                            _add(
+                                pkg_name,
+                                pkg_version,
+                                "apk",
+                                f"pkg:apk/alpine/{pkg_name}@{pkg_version}",
+                                source_package=source_package,
+                            )
                 except Exception:
                     _logger.debug("Failed to parse Alpine apk db from container")
 

--- a/src/agent_bom/oci_parser.py
+++ b/src/agent_bom/oci_parser.py
@@ -744,11 +744,14 @@ def _extract_packages_from_layer(
             if f:
                 content = f.read().decode("utf-8", errors="ignore")
                 pkg_name = pkg_version = ""
+                apk_source_package: str | None = None
                 for line in content.splitlines():
                     if line.startswith("P:"):
                         pkg_name = line[2:].strip()
                     elif line.startswith("V:"):
                         pkg_version = line[2:].strip()
+                    elif line.startswith("o:") or line.startswith("O:"):
+                        apk_source_package = line[2:].strip() or None
                     elif line == "" and pkg_name and pkg_version:
                         _add_package(
                             packages_by_key,
@@ -757,10 +760,12 @@ def _extract_packages_from_layer(
                             pkg_version,
                             "apk",
                             f"pkg:apk/alpine/{pkg_name}@{pkg_version}",
+                            source_package=apk_source_package,
                             layer=layer,
                             package_path=apk_path,
                         )
                         pkg_name = pkg_version = ""
+                        apk_source_package = None
                 if pkg_name and pkg_version:
                     _add_package(
                         packages_by_key,
@@ -769,6 +774,7 @@ def _extract_packages_from_layer(
                         pkg_version,
                         "apk",
                         f"pkg:apk/alpine/{pkg_name}@{pkg_version}",
+                        source_package=apk_source_package,
                         layer=layer,
                         package_path=apk_path,
                     )

--- a/src/agent_bom/parsers/os_parsers.py
+++ b/src/agent_bom/parsers/os_parsers.py
@@ -250,12 +250,17 @@ def parse_apk_packages(root: Path = Path("/")) -> list[Package]:
             for line in result.stdout.splitlines():
                 m = re.match(r"^([a-z0-9._+-]+)-(\d[^\s{}]*)\s", line)
                 if m:
+                    name = m.group(1)
+                    version = m.group(2)
+                    origin_match = re.search(r"\{([^}]+)\}", line)
+                    source_package = origin_match.group(1).strip() if origin_match else None
                     packages.append(
                         Package(
-                            name=m.group(1),
-                            version=m.group(2),
+                            name=name,
+                            version=version,
                             ecosystem="apk",
-                            purl=f"pkg:apk/alpine/{m.group(1)}@{m.group(2)}",
+                            purl=f"pkg:apk/alpine/{name}@{version}",
+                            source_package=source_package,
                         )
                     )
             if packages:
@@ -269,11 +274,14 @@ def parse_apk_packages(root: Path = Path("/")) -> list[Package]:
         try:
             content = installed_db.read_text(errors="ignore")
             pkg_name = pkg_version = ""
+            source_package = None
             for line in content.splitlines():
                 if line.startswith("P:"):
                     pkg_name = line[2:].strip()
                 elif line.startswith("V:"):
                     pkg_version = line[2:].strip()
+                elif line.startswith("o:") or line.startswith("O:"):
+                    source_package = line[2:].strip() or None
                 elif line == "" and pkg_name and pkg_version:
                     packages.append(
                         Package(
@@ -281,9 +289,11 @@ def parse_apk_packages(root: Path = Path("/")) -> list[Package]:
                             version=pkg_version,
                             ecosystem="apk",
                             purl=f"pkg:apk/alpine/{pkg_name}@{pkg_version}",
+                            source_package=source_package,
                         )
                     )
                     pkg_name = pkg_version = ""
+                    source_package = None
             # Handle last stanza without trailing blank line
             if pkg_name and pkg_version:
                 packages.append(
@@ -292,6 +302,7 @@ def parse_apk_packages(root: Path = Path("/")) -> list[Package]:
                         version=pkg_version,
                         ecosystem="apk",
                         purl=f"pkg:apk/alpine/{pkg_name}@{pkg_version}",
+                        source_package=source_package,
                     )
                 )
         except OSError:
@@ -323,7 +334,7 @@ def detect_os_type(root: Path = Path("/")) -> str | None:
                 os_id = line.split("=", 1)[1].strip().strip('"').lower()
                 if os_id in ("debian", "ubuntu", "linuxmint", "pop"):
                     return "deb"
-                if os_id in ("fedora", "rhel", "centos", "rocky", "alma", "ol"):
+                if os_id in ("fedora", "rhel", "centos", "rocky", "alma", "almalinux", "ol"):
                     return "rpm"
                 if os_id == "alpine":
                     return "apk"

--- a/tests/test_alpine_release_keying.py
+++ b/tests/test_alpine_release_keying.py
@@ -20,7 +20,7 @@ from agent_bom.db.lookup import lookup_packages_batch
 from agent_bom.db.schema import init_db
 from agent_bom.models import Package
 from agent_bom.package_utils import alpine_release_branch
-from agent_bom.scanners import _db_ecosystems_for_package, _osv_ecosystems_for_package
+from agent_bom.scanners import _db_ecosystems_for_package, _osv_ecosystems_for_package, _scan_packages_db_conn
 
 
 @pytest.mark.parametrize(
@@ -130,5 +130,84 @@ def test_three_part_version_resolves_branch_advisory():
         # And the older, buggy full-VERSION_ID key resolves nothing.
         empty = lookup_packages_batch(conn, [("alpine:v3.16.9", "busybox", "1.35.0-r17")])
         assert empty[("alpine:v3.16.9", "busybox", "1.35.0-r17")] == []
+    finally:
+        conn.close()
+
+
+def test_alpine_subpackage_matches_source_package_advisory_individual_path():
+    """Alpine secdb advisories are keyed by origin/source package.
+
+    Installed apk packages such as ``musl-utils`` and ``ssl_client`` are
+    subpackages. Their advisories live under ``musl`` and ``busybox`` in secdb,
+    so source-package candidates must be used for exact local DB lookup.
+    """
+    conn = init_db(Path(":memory:"))
+    try:
+        conn.execute(
+            "INSERT INTO vulns(id, summary, severity, source) VALUES (?, ?, ?, ?)",
+            ("CVE-2025-26519", "musl issue", "high", "alpine-secdb"),
+        )
+        conn.execute(
+            "INSERT INTO affected(vuln_id, ecosystem, package_name, introduced, fixed) VALUES (?, ?, ?, ?, ?)",
+            ("CVE-2025-26519", "alpine:v3.16", "musl", "0", "1.2.3-r4"),
+        )
+        conn.commit()
+
+        pkg = Package(
+            name="musl-utils",
+            version="1.2.3-r3",
+            ecosystem="apk",
+            source_package="musl",
+            distro_name="alpine",
+            distro_version="3.16.9",
+        )
+        covered: set[str] = set()
+
+        assert _scan_packages_db_conn(conn, [pkg], covered) == 1
+        assert [v.id for v in pkg.vulnerabilities] == ["CVE-2025-26519"]
+        assert "apk:musl-utils@1.2.3-r3" in covered
+    finally:
+        conn.close()
+
+
+def test_alpine_subpackage_matches_source_package_advisory_batch_path():
+    """Batch local DB lookup must use the same source-package candidates."""
+    conn = init_db(Path(":memory:"))
+    try:
+        conn.execute(
+            "INSERT INTO vulns(id, summary, severity, source) VALUES (?, ?, ?, ?)",
+            ("CVE-2023-42366", "busybox issue", "medium", "alpine-secdb"),
+        )
+        conn.execute(
+            "INSERT INTO affected(vuln_id, ecosystem, package_name, introduced, fixed) VALUES (?, ?, ?, ?, ?)",
+            ("CVE-2023-42366", "alpine:v3.16", "busybox", "0", "1.35.0-r18"),
+        )
+        conn.commit()
+
+        packages = [
+            Package(
+                name="ssl_client",
+                version="1.35.0-r17",
+                ecosystem="apk",
+                source_package="busybox",
+                distro_name="alpine",
+                distro_version="3.16.9",
+            )
+        ]
+        packages.extend(
+            Package(
+                name=f"filler-{idx}",
+                version="1.0.0-r0",
+                ecosystem="apk",
+                distro_name="alpine",
+                distro_version="3.16.9",
+            )
+            for idx in range(55)
+        )
+        covered: set[str] = set()
+
+        assert _scan_packages_db_conn(conn, packages, covered) == 1
+        assert [v.id for v in packages[0].vulnerabilities] == ["CVE-2023-42366"]
+        assert "apk:ssl_client@1.35.0-r17" in covered
     finally:
         conn.close()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1303,6 +1303,7 @@ def test_cli_image_accepts_tarball_without_image_ref(monkeypatch):
     assert seen[0]["images"] == ()
     assert seen[0]["image_tars"] == ("image.tar",)
     assert seen[0]["_image_only"] is True
+    assert seen[0]["no_skill"] is True
 
 
 def test_cli_image_rejects_reference_and_tarball_together(monkeypatch):

--- a/tests/test_native_disk_scan.py
+++ b/tests/test_native_disk_scan.py
@@ -340,11 +340,13 @@ APK_INSTALLED = """\
 P:busybox
 V:1.36.1-r6
 A:x86_64
+o:busybox
 T:Size optimized toolbox of many common UNIX utilities
 
-P:musl
+P:musl-utils
 V:1.2.4_git20230717-r4
 A:x86_64
+o:musl
 T:the musl c library (libc) implementation
 
 P:zlib
@@ -361,7 +363,7 @@ class TestParseApkInstalled:
         pkgs = parse_apk_installed(f)
         assert len(pkgs) == 3
         names = {p.name for p in pkgs}
-        assert names == {"busybox", "musl", "zlib"}
+        assert names == {"busybox", "musl-utils", "zlib"}
 
     def test_ecosystem_is_apk(self, tmp_path):
         f = tmp_path / "installed"
@@ -375,6 +377,8 @@ class TestParseApkInstalled:
         pkgs = parse_apk_installed(f)
         bb = next(p for p in pkgs if p.name == "busybox")
         assert bb.purl == "pkg:apk/alpine/busybox@1.36.1-r6"
+        musl_utils = next(p for p in pkgs if p.name == "musl-utils")
+        assert musl_utils.source_package == "musl"
 
     def test_missing_file_returns_empty(self, tmp_path):
         assert parse_apk_installed(tmp_path / "nonexistent") == []

--- a/tests/test_oci_parser.py
+++ b/tests/test_oci_parser.py
@@ -204,11 +204,18 @@ Architecture: amd64
 
 _APK_INSTALLED = b"""P:busybox
 V:1.36.1-r0
+o:busybox
 T:Size optimized toolbox of many common UNIX utilities
 
 P:musl
 V:1.2.4-r2
+o:musl
 T:the musl c library (libc) implementation
+
+P:ssl_client
+V:1.36.1-r0
+o:busybox
+T:SSL client for busybox
 
 """
 
@@ -329,6 +336,8 @@ def test_docker_save_alpine_packages():
     names = {p.name for p in result.packages}
     assert "busybox" in names
     assert "musl" in names
+    ssl_client = next(p for p in result.packages if p.name == "ssl_client")
+    assert ssl_client.source_package == "busybox"
 
 
 def test_docker_save_multi_layer_dedup():

--- a/tests/test_os_parsers.py
+++ b/tests/test_os_parsers.py
@@ -49,6 +49,7 @@ T:the musl c library
 
 P:busybox
 V:1.36.1-r19
+o:busybox
 T:size optimized toolbox of many common UNIX utilities
 
 """
@@ -263,14 +264,15 @@ def test_parse_rpm_packages_purl_format(tmp_path: Path) -> None:
 
 def test_parse_apk_packages_uses_command(tmp_path: Path) -> None:
     """When apk list --installed succeeds, packages are returned."""
-    mock_stdout = "musl-1.2.4-r2 {musl} (MIT) [installed]\nbusybox-1.36.1-r19 {busybox} (GPL-2.0-only) [installed]\n"
+    mock_stdout = "musl-utils-1.2.4-r2 {musl} (MIT) [installed]\nbusybox-1.36.1-r19 {busybox} (GPL-2.0-only) [installed]\n"
     mock_result = type("R", (), {"returncode": 0, "stdout": mock_stdout})()
     with patch("subprocess.run", return_value=mock_result):
         packages = parse_apk_packages(tmp_path)
     assert len(packages) == 2
-    assert packages[0].name == "musl"
+    assert packages[0].name == "musl-utils"
     assert packages[0].version == "1.2.4-r2"
     assert packages[0].ecosystem == "apk"
+    assert packages[0].source_package == "musl"
 
 
 def test_parse_apk_packages_from_db(tmp_path: Path) -> None:
@@ -283,6 +285,7 @@ def test_parse_apk_packages_from_db(tmp_path: Path) -> None:
     assert packages[0].name == "musl"
     assert packages[0].version == "1.2.4-r2"
     assert packages[1].name == "busybox"
+    assert packages[1].source_package == "busybox"
 
 
 def test_parse_apk_packages_from_db_no_trailing_blank(tmp_path: Path) -> None:
@@ -333,6 +336,12 @@ def test_scan_os_packages_alpine(tmp_path: Path) -> None:
         packages = scan_os_packages(tmp_path)
     assert len(packages) == 2
     assert all(p.ecosystem == "apk" for p in packages)
+
+
+def test_scan_os_packages_almalinux(tmp_path: Path) -> None:
+    (tmp_path / "etc").mkdir()
+    (tmp_path / "etc/os-release").write_text("ID=almalinux\nVERSION_ID=9.3\n")
+    assert detect_os_type(tmp_path) == "rpm"
 
 
 def test_scan_os_packages_unknown_os_no_data(tmp_path: Path) -> None:


### PR DESCRIPTION
Summary
- Preserve Alpine apk origin/source package metadata across filesystem, OCI, and legacy image parsers so subpackages such as `musl-utils` and `ssl_client` match Alpine secdb advisories keyed by `musl` and `busybox`.
- Keep `agent-bom image ...` image-only by disabling ambient skill/instruction scanning in the focused image command.
- Recognize `ID=almalinux` as RPM-family in OS parser detection.

Verification
- `UV_PROJECT_ENVIRONMENT=.venv-fresh-audit uv run pytest -q tests/test_alpine_release_keying.py tests/test_oci_parser.py tests/test_native_disk_scan.py tests/test_os_parsers.py tests/test_core.py::test_cli_image_accepts_tarball_without_image_ref tests/test_core.py::test_cli_image_output_json_extension_writes_report`
- `UV_PROJECT_ENVIRONMENT=.venv-fresh-audit uv run pytest -q tests/test_alpine_release_keying.py tests/test_debian_release_matching.py tests/test_coverage_warning.py tests/test_scanner_ecosystems.py tests/test_os_package_scanning.py tests/test_local_vuln_db.py tests/test_version_utils.py tests/test_oci_parser.py tests/test_native_disk_scan.py tests/test_os_parsers.py tests/test_core.py::test_cli_image_accepts_tarball_without_image_ref tests/test_core.py::test_cli_image_output_json_extension_writes_report`
- `UV_PROJECT_ENVIRONMENT=.venv-fresh-audit uv run ruff check src/agent_bom/filesystem.py src/agent_bom/parsers/os_parsers.py src/agent_bom/oci_parser.py src/agent_bom/image.py src/agent_bom/cli/_focused_commands.py tests/test_alpine_release_keying.py tests/test_oci_parser.py tests/test_native_disk_scan.py tests/test_os_parsers.py tests/test_core.py`
- `UV_PROJECT_ENVIRONMENT=.venv-fresh-audit uv run mypy src/agent_bom/filesystem.py src/agent_bom/parsers/os_parsers.py src/agent_bom/oci_parser.py src/agent_bom/image.py src/agent_bom/cli/_focused_commands.py`
- `UV_PROJECT_ENVIRONMENT=.venv-fresh-audit uv run agent-bom image alpine:3.16 --offline -f json -o /tmp/agent-bom-alpine316-sourcefix-v2.json --quiet`
- `UV_PROJECT_ENVIRONMENT=.venv-fresh-audit uv run agent-bom image alpine:3.20.10 --offline -f json -o /tmp/agent-bom-alpine320-sourcefix-v2.json --quiet`
- `UV_PROJECT_ENVIRONMENT=.venv-fresh-audit uv run agent-bom agents --demo --offline --format json --output /tmp/agent-bom-demo-sourcefix.json --no-color --quiet`

Real image evidence
- `alpine:3.16`: 4 image-only findings, no coverage warnings: `musl@1.2.3-r3 -> 1.2.3-r4`, `musl-utils@1.2.3-r3 -> 1.2.3-r4`, `busybox@1.35.0-r17 -> 1.35.0-r18`, `ssl_client@1.35.0-r17 -> 1.35.0-r18`.
- `alpine:3.20.10`: 0 findings, no coverage warnings.
- Both reports have `scan_sources: ["image"]`, confirming the focused image command no longer mixes current-directory skill/package findings into image output.

Notes
- Removed local Finder duplicate artifacts (`* 2` files) that were blocking the repository duplicate-artifact pre-commit guard; they were untracked/generated and not part of this PR.
