### PR TITLE
feat(ast): surface dependency symbol reach from tools

### DIFF
--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -41,6 +41,7 @@ from agent_bom.ast_python_analysis import (
     _SKIP_FILE_PATTERNS,
     _analyze_file,
     _build_call_graph,
+    _build_dependency_symbol_reach,
     _build_taint_findings,
 )
 from agent_bom.ast_python_analysis import (
@@ -157,6 +158,7 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
     python_call_edges, interprocedural_findings = _build_call_graph(function_analyses)
     result.call_edges.extend(python_call_edges)
     result.flow_findings.extend(interprocedural_findings)
+    result.dependency_symbol_reach.extend(_build_dependency_symbol_reach(function_analyses))
     result.flow_findings.extend(_build_taint_findings(function_analyses))
     js_ts_call_edges, js_ts_interprocedural_findings = _build_js_ts_flow_findings(
         functions=js_ts_functions,

--- a/src/agent_bom/ast_models.py
+++ b/src/agent_bom/ast_models.py
@@ -82,6 +82,21 @@ class FlowFinding:
 
 
 @dataclass
+class DependencySymbolReach:
+    """Imported dependency symbol reachable from a tool entrypoint."""
+
+    entrypoint: str
+    package: str
+    module: str
+    symbol: str
+    file_path: str
+    line_number: int
+    call_path: list[str] = field(default_factory=list)
+    depth: int = 0
+    confidence: str = "import-symbol"
+
+
+@dataclass
 class ASTAnalysisResult:
     """Complete AST analysis result for a project."""
 
@@ -91,6 +106,7 @@ class ASTAnalysisResult:
     call_edges: list[CallEdge] = field(default_factory=list)
     cfg_edges: list[ControlFlowEdge] = field(default_factory=list)
     flow_findings: list[FlowFinding] = field(default_factory=list)
+    dependency_symbol_reach: list[DependencySymbolReach] = field(default_factory=list)
     frameworks_detected: list[str] = field(default_factory=list)
     files_analyzed: int = 0
     warnings: list[str] = field(default_factory=list)
@@ -166,6 +182,20 @@ class ASTAnalysisResult:
                 }
                 for finding in self.flow_findings
             ],
+            "dependency_symbol_reach": [
+                {
+                    "entrypoint": reach.entrypoint,
+                    "package": reach.package,
+                    "module": reach.module,
+                    "symbol": reach.symbol,
+                    "file": reach.file_path,
+                    "line": reach.line_number,
+                    "call_path": reach.call_path,
+                    "depth": reach.depth,
+                    "confidence": reach.confidence,
+                }
+                for reach in self.dependency_symbol_reach
+            ],
             "frameworks": self.frameworks_detected,
             "files_analyzed": self.files_analyzed,
             "warnings": self.warnings,
@@ -176,6 +206,7 @@ class ASTAnalysisResult:
                 "total_call_edges": len(self.call_edges),
                 "total_cfg_edges": len(self.cfg_edges),
                 "total_flow_findings": len(self.flow_findings),
+                "total_dependency_symbol_reach": len(self.dependency_symbol_reach),
                 "prompts_with_risks": sum(1 for p in self.prompts if p.risk_flags),
             },
         }

--- a/src/agent_bom/ast_python_analysis.py
+++ b/src/agent_bom/ast_python_analysis.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from agent_bom.ast_models import (
     CallEdge,
     ControlFlowEdge,
+    DependencySymbolReach,
     DetectedGuardrail,
     ExtractedPrompt,
     FlowFinding,
@@ -1127,6 +1128,41 @@ def _resolve_called_function(
     return None
 
 
+def _resolve_external_dependency_symbol(caller: _FunctionAnalysis, raw_name: str) -> tuple[str, str, str] | None:
+    """Resolve an imported dependency call to ``(package, module, symbol)``.
+
+    This is intentionally conservative: it reports only explicit imports
+    visible in the scanned source file. It does not infer dynamic imports,
+    package metadata, or type-dispatched calls.
+    """
+    if not raw_name:
+        return None
+    if raw_name in caller.imported_functions:
+        module_name, symbol = caller.imported_functions[raw_name]
+        package = module_name.split(".", 1)[0]
+        return package, module_name, symbol
+
+    head, _, tail = raw_name.partition(".")
+    imported_target = caller.imported_functions.get(head)
+    if imported_target and tail:
+        module_name, symbol = imported_target
+        package = module_name.split(".", 1)[0]
+        return package, module_name, f"{symbol}.{tail}"
+
+    for alias, module_name in sorted(caller.imported_modules.items(), key=lambda item: len(item[0]), reverse=True):
+        if raw_name == alias:
+            package = module_name.split(".", 1)[0]
+            return package, module_name, module_name.rsplit(".", 1)[-1]
+        if not raw_name.startswith(f"{alias}."):
+            continue
+        symbol = raw_name[len(alias) + 1 :]
+        if not symbol:
+            continue
+        package = module_name.split(".", 1)[0]
+        return package, module_name, symbol
+    return None
+
+
 def _build_taint_findings(functions: list[_FunctionAnalysis]) -> list[FlowFinding]:
     """Build taint/data-flow findings from tool entrypoints into sinks and LLM calls."""
     by_name: dict[str, list[_FunctionAnalysis]] = {}
@@ -1641,6 +1677,65 @@ def _build_taint_findings(functions: list[_FunctionAnalysis]) -> list[FlowFindin
             aggregated_findings.append(finding)
 
     return aggregated_findings
+
+
+def _build_dependency_symbol_reach(functions: list[_FunctionAnalysis]) -> list[DependencySymbolReach]:
+    """Build bounded tool-entrypoint → imported dependency symbol reach evidence."""
+    by_name: dict[str, list[_FunctionAnalysis]] = {}
+    by_module_and_name: dict[tuple[str, str], _FunctionAnalysis] = {}
+    for func in functions:
+        by_name.setdefault(func.simple_name, []).append(func)
+        if func.module_name:
+            by_module_and_name[(func.module_name, func.simple_name)] = func
+
+    adjacency: dict[str, list[_FunctionAnalysis]] = {func.qualified_name: [] for func in functions}
+    for func in functions:
+        for raw_name, _line_num in func.called_names:
+            callee = _resolve_called_function(func, raw_name, by_name, by_module_and_name)
+            if callee is not None:
+                adjacency[func.qualified_name].append(callee)
+
+    function_by_id = {func.qualified_name: func for func in functions}
+    max_depth = _max_taint_depth()
+    reached: list[DependencySymbolReach] = []
+    seen: set[tuple[str, str, str, str, int]] = set()
+    for tool in functions:
+        if not tool.is_tool:
+            continue
+        queue: list[tuple[str, list[str]]] = [(tool.qualified_name, [tool.simple_name])]
+        visited: set[str] = set()
+        while queue:
+            current_id, path = queue.pop(0)
+            if len(path) > max_depth:
+                continue
+            if current_id in visited:
+                continue
+            visited.add(current_id)
+            current = function_by_id[current_id]
+            for raw_name, line_num in current.called_names:
+                external = _resolve_external_dependency_symbol(current, raw_name)
+                if external is None:
+                    continue
+                package, module_name, symbol = external
+                dedup_key = (tool.simple_name, module_name, symbol, current.file_path, line_num)
+                if dedup_key in seen:
+                    continue
+                seen.add(dedup_key)
+                reached.append(
+                    DependencySymbolReach(
+                        entrypoint=tool.simple_name,
+                        package=package,
+                        module=module_name,
+                        symbol=symbol,
+                        file_path=current.file_path,
+                        line_number=line_num,
+                        call_path=[*path, f"{module_name}.{symbol}"],
+                        depth=max(0, len(path) - 1),
+                    )
+                )
+            for child in adjacency.get(current_id, []):
+                queue.append((child.qualified_name, [*path, child.simple_name]))
+    return reached
 
 
 def _build_call_graph(functions: list[_FunctionAnalysis]) -> tuple[list[CallEdge], list[FlowFinding]]:

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -375,6 +375,62 @@ def test_analyze_project_builds_interprocedural_dangerous_flow(tmp_path: Path):
     assert "bounded helper-call chain" in finding.detail
 
 
+def test_analyze_project_surfaces_dependency_symbol_reach_from_tool(tmp_path: Path):
+    (tmp_path / "agent.py").write_text(
+        "import requests\n\n"
+        "@tool\n"
+        "def fetch(url):\n"
+        "    return requests.get(url)\n"
+    )
+
+    result = analyze_project(tmp_path)
+    payload = result.to_dict()
+
+    assert payload["stats"]["total_dependency_symbol_reach"] == 1
+    assert payload["dependency_symbol_reach"] == [
+        {
+            "entrypoint": "fetch",
+            "package": "requests",
+            "module": "requests",
+            "symbol": "get",
+            "file": "agent.py",
+            "line": 5,
+            "call_path": ["fetch", "requests.get"],
+            "depth": 0,
+            "confidence": "import-symbol",
+        }
+    ]
+
+
+def test_analyze_project_surfaces_dependency_symbol_reach_through_helper(tmp_path: Path):
+    (tmp_path / "agent.py").write_text(
+        "from openai import OpenAI\n\n"
+        "def ask_model(prompt):\n"
+        "    client = OpenAI()\n"
+        "    return client.responses.create(input=prompt, model='gpt-test')\n\n"
+        "@tool\n"
+        "def answer(prompt):\n"
+        "    return ask_model(prompt)\n"
+    )
+
+    result = analyze_project(tmp_path)
+    reaches = result.to_dict()["dependency_symbol_reach"]
+
+    assert reaches == [
+        {
+            "entrypoint": "answer",
+            "package": "openai",
+            "module": "openai",
+            "symbol": "OpenAI",
+            "file": "agent.py",
+            "line": 4,
+            "call_path": ["answer", "ask_model", "openai.OpenAI"],
+            "depth": 1,
+            "confidence": "import-symbol",
+        }
+    ]
+
+
 def test_analyze_project_treats_validation_branch_as_guard(tmp_path: Path):
     (tmp_path / "agent.py").write_text(
         "import subprocess\n\n"


### PR DESCRIPTION
Summary:
- Add bounded dependency-symbol reach evidence from Python tool entrypoints to explicitly imported package symbols.
- Serialize the reach list in AST analysis output with entrypoint, package, module, symbol, call path, depth, and confidence.
- Cover direct module calls and helper-chain calls with regression tests.

Verification:
- uv run pytest tests/test_ast_analyzer.py -q
- uv run ruff check src/agent_bom/ast_models.py src/agent_bom/ast_python_analysis.py src/agent_bom/ast_analyzer.py tests/test_ast_analyzer.py
- uv run mypy src/agent_bom/ast_models.py src/agent_bom/ast_python_analysis.py src/agent_bom/ast_analyzer.py

Notes:
- This is deterministic import-symbol reach evidence, not a claim of whole-program proprietary function reachability.