### PR TITLE
fix(scanner): centralize distro release key normalization

### DIFF
--- a/src/agent_bom/coverage.py
+++ b/src/agent_bom/coverage.py
@@ -73,9 +73,13 @@ def _release_key(pkg: "Package") -> Optional[tuple[str, str]]:
         return None
     if eco == "deb":
         if distro_name == "debian":
-            return ("debian", f"debian:{distro_version.split('.', 1)[0]}")
+            from agent_bom.package_utils import debian_release_branch
+
+            return ("debian", f"debian:{debian_release_branch(distro_version)}")
         if distro_name == "ubuntu":
-            return ("ubuntu", f"ubuntu:{distro_version}")
+            from agent_bom.package_utils import ubuntu_release_branch
+
+            return ("ubuntu", f"ubuntu:{ubuntu_release_branch(distro_version)}")
         return None
     if eco == "apk":
         # Alpine advisories are stored per minor branch (``alpine:v3.16``); truncate

--- a/src/agent_bom/package_utils.py
+++ b/src/agent_bom/package_utils.py
@@ -118,6 +118,38 @@ def canonical_package_key(name: str, version: str, ecosystem: str, purl: str | N
 
 
 @lru_cache(maxsize=4096)
+def debian_release_branch(distro_version: str) -> str:
+    """Normalize Debian ``VERSION_ID`` to the advisory release key.
+
+    Debian security data is release-major scoped (``debian:12``), while
+    container metadata may carry point releases such as ``12.5``. The scanner
+    must collapse those to the major release before querying OSV/local DB rows.
+    """
+    raw = (distro_version or "").strip()
+    if not raw:
+        return raw
+    return raw.split(".", 1)[0]
+
+
+@lru_cache(maxsize=4096)
+def ubuntu_release_branch(distro_version: str) -> str:
+    """Normalize Ubuntu ``VERSION_ID`` to the advisory release key.
+
+    Ubuntu advisory ecosystems are keyed by major.minor branch
+    (``Ubuntu:22.04``), not point releases. Official images usually expose
+    ``22.04``, but derivative metadata can include ``22.04.4``; truncate that
+    to ``22.04`` so release-scoped lookups do not silently miss advisory rows.
+    """
+    raw = (distro_version or "").strip()
+    if not raw:
+        return raw
+    parts = raw.split(".")
+    if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
+        return f"{parts[0]}.{parts[1]}"
+    return raw
+
+
+@lru_cache(maxsize=4096)
 def alpine_release_branch(distro_version: str) -> str:
     """Normalize an Alpine ``VERSION_ID`` to its secdb branch key (``v{major}.{minor}``).
 
@@ -159,9 +191,11 @@ __all__ = [
     "alpine_release_branch",
     "canonical_package_identity",
     "canonical_package_key",
+    "debian_release_branch",
     "host_matches_domain",
     "normalize_package_ecosystem",
     "normalize_package_name",
     "parse_debian_source_name",
     "reference_host_and_path",
+    "ubuntu_release_branch",
 ]

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -50,7 +50,9 @@ from agent_bom.package_utils import (
     alpine_release_branch,
     canonical_package_identity,
     canonical_package_key,
+    debian_release_branch,
     normalize_package_name,
+    ubuntu_release_branch,
 )
 from agent_bom.scanners.blast_radius import _HOP_RISK_FACTORS, expand_blast_radius_hops
 from agent_bom.scanners.osv import candidate_package_names as _candidate_package_names
@@ -274,9 +276,9 @@ def _osv_ecosystems_for_package(pkg: Package) -> list[str]:
         distro_name = (pkg.distro_name or "").lower()
         distro_version = (pkg.distro_version or "").strip()
         if distro_name == "debian" and distro_version:
-            return [f"Debian:{distro_version.split('.', 1)[0]}"]
+            return [f"Debian:{debian_release_branch(distro_version)}"]
         if distro_name == "ubuntu" and distro_version:
-            normalized = distro_version
+            normalized = ubuntu_release_branch(distro_version)
             if normalized.count(".") == 1:
                 return [f"Ubuntu:{normalized}:LTS", f"Ubuntu:{normalized}"]
             return [f"Ubuntu:{normalized}"]

--- a/tests/test_alpine_release_keying.py
+++ b/tests/test_alpine_release_keying.py
@@ -19,7 +19,7 @@ from agent_bom.coverage import _release_key
 from agent_bom.db.lookup import lookup_packages_batch
 from agent_bom.db.schema import init_db
 from agent_bom.models import Package
-from agent_bom.package_utils import alpine_release_branch
+from agent_bom.package_utils import alpine_release_branch, debian_release_branch, ubuntu_release_branch
 from agent_bom.scanners import _db_ecosystems_for_package, _osv_ecosystems_for_package, _scan_packages_db_conn
 
 
@@ -40,6 +40,34 @@ from agent_bom.scanners import _db_ecosystems_for_package, _osv_ecosystems_for_p
 )
 def test_alpine_release_branch_normalization(version_id: str, expected: str):
     assert alpine_release_branch(version_id) == expected
+
+
+@pytest.mark.parametrize(
+    "version_id, expected",
+    [
+        ("12", "12"),
+        ("12.5", "12"),
+        ("10.13", "10"),
+        ("bookworm", "bookworm"),
+        ("", ""),
+    ],
+)
+def test_debian_release_branch_normalization(version_id: str, expected: str):
+    assert debian_release_branch(version_id) == expected
+
+
+@pytest.mark.parametrize(
+    "version_id, expected",
+    [
+        ("22.04", "22.04"),
+        ("22.04.4", "22.04"),
+        ("20.04.6", "20.04"),
+        ("noble", "noble"),
+        ("", ""),
+    ],
+)
+def test_ubuntu_release_branch_normalization(version_id: str, expected: str):
+    assert ubuntu_release_branch(version_id) == expected
 
 
 def _apk_pkg(version_id: str) -> Package:
@@ -97,6 +125,29 @@ def test_debian_and_ubuntu_keys_unchanged():
     assert _osv_ecosystems_for_package(deb) == ["Debian:12"]
     assert _release_key(deb) == ("debian", "debian:12")
     assert _osv_ecosystems_for_package(ubuntu) == ["Ubuntu:22.04:LTS", "Ubuntu:22.04"]
+    assert _release_key(ubuntu) == ("ubuntu", "ubuntu:22.04")
+
+
+def test_debian_and_ubuntu_point_releases_collapse_to_advisory_branch():
+    deb = Package(
+        name="bash",
+        version="5.1-2",
+        ecosystem="deb",
+        distro_name="debian",
+        distro_version="12.5",
+    )
+    ubuntu = Package(
+        name="bash",
+        version="5.1-6ubuntu1",
+        ecosystem="deb",
+        distro_name="ubuntu",
+        distro_version="22.04.4",
+    )
+    assert _osv_ecosystems_for_package(deb) == ["Debian:12"]
+    assert _db_ecosystems_for_package(deb) == ["debian:12"]
+    assert _release_key(deb) == ("debian", "debian:12")
+    assert _osv_ecosystems_for_package(ubuntu) == ["Ubuntu:22.04:LTS", "Ubuntu:22.04"]
+    assert _db_ecosystems_for_package(ubuntu) == ["ubuntu:22.04:lts", "ubuntu:22.04"]
     assert _release_key(ubuntu) == ("ubuntu", "ubuntu:22.04")
 
 


### PR DESCRIPTION
Summary:
- Move Debian, Ubuntu, and Alpine advisory release-branch normalization into shared package utilities.
- Reuse those helpers from scanner OSV/local DB lookup and release coverage warnings so the two paths cannot drift.
- Add regression coverage for Debian point releases, Ubuntu point releases, and existing Alpine branch keying.

Verification:
- uv run pytest tests/test_alpine_release_keying.py tests/test_debian_release_matching.py tests/test_coverage_warning.py -q
- uv run ruff check src/agent_bom/package_utils.py src/agent_bom/scanners/__init__.py src/agent_bom/coverage.py tests/test_alpine_release_keying.py
- uv run mypy src/agent_bom/package_utils.py src/agent_bom/coverage.py

Notes:
- This closes the Alpine-class release audit risk where distro point-release metadata can miss branch-scoped advisory rows.