### PR TITLE
docs(readme): add product workflow diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,44 @@ and exposure scoring all read from the same evidence. That evidence is reachable
 through CLI/CI, a REST API, MCP tools, and a self-hosted dashboard; runtime
 proxy/gateway enforcement is optional and scoped to where it earns its cost.
 
+## How It Works
+
+`agent-bom` is a read-only collection and evidence engine first: it discovers
+assets, matches and enriches risk signals, normalizes everything into one graph,
+then serves the same evidence through CLI, CI, API, UI, MCP, reports, and
+runtime controls.
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-light.svg" alt="agent-bom workflow from read-only intake through scan engine, evidence graph, control plane, and outputs" width="980" />
+  </picture>
+</p>
+
+<details>
+<summary><b>Control-plane architecture — sources, backend, API, MCP, UI, and consumers</b></summary>
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-light.svg" alt="agent-bom architecture showing sources, scan engine, unified model, control plane, and consumers" width="980" />
+  </picture>
+</p>
+
+</details>
+
+<details>
+<summary><b>Scan pipeline — discover, match, enrich, evaluate, normalize, report</b></summary>
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/scan-pipeline-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/scan-pipeline-light.svg" alt="agent-bom scan pipeline from discovery through vulnerability matching, enrichment, analysis, reporting, and enforcement" width="980" />
+  </picture>
+</p>
+
+</details>
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-dark.svg">
@@ -163,7 +201,7 @@ agent-bom cloud aws --cis
 agent-bom cloud scan --fail-on-severity high
 ```
 
-Azure, GCP, and Snowflake setup, the full grant templates, per-cloud permission
+AWS, Azure, GCP, and Snowflake setup, the full grant templates, per-cloud permission
 catalogs, and the "why read-only is enough" rationale live in
 [docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md). agent-bom is a **scanner, not a
 platform** — it reads inventory and posture, normalizes it into one graph, and

--- a/docs/images/how-it-works-dark.svg
+++ b/docs/images/how-it-works-dark.svg
@@ -1,0 +1,152 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1260 620" fill="none" role="img" aria-labelledby="how-title how-desc">
+<title id="how-title">How agent-bom works</title>
+<desc id="how-desc">A concise visual flow from read-only inputs through scan and enrichment, unified evidence graph, control plane, outputs, reports, posture, and enforcement.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
+<style>
+text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif; letter-spacing: 0; }
+.title { font-size: 29px; font-weight: 850; } .subtitle { font-size: 13px; font-weight: 550; } .label { font-size: 11px; font-weight: 850; letter-spacing: .14em; }
+.card-title { font-size: 18px; font-weight: 850; } .chip { font-size: 13px; font-weight: 800; } .badge { font-size: 10px; font-weight: 850; } .tiny { font-size: 10px; font-weight: 700; } .node { font-size: 10px; font-weight: 850; }
+</style></defs>
+<rect x="0" y="0" width="1260" height="620" rx="18" fill="#09090b" stroke="#2a2a30" stroke-width="0"/>
+<text x="48" y="50" class="title" fill="#f4f4f5">From inventory to enforceable evidence</text>
+<text x="48" y="74" class="subtitle" fill="#a1a1aa">Read-only collection, deterministic matching, graph-backed blast radius, and one control plane for humans and agents.</text>
+<rect x="40" y="112" width="220" height="390" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1"/>
+<text x="58" y="142" class="label" fill="#60a5fa">READ-ONLY INTAKE</text>
+<rect x="300" y="112" width="210" height="390" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1"/>
+<text x="318" y="142" class="label" fill="#fbbf24">SCAN ENGINE</text>
+<rect x="550" y="112" width="240" height="390" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1"/>
+<text x="568" y="142" class="label" fill="#a78bfa">EVIDENCE CORE</text>
+<rect x="830" y="112" width="190" height="390" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1"/>
+<text x="848" y="142" class="label" fill="#34d399">CONTROL PLANE</text>
+<rect x="1060" y="112" width="160" height="390" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1"/>
+<text x="1078" y="142" class="label" fill="#67e8f9">OUTPUTS</text>
+<rect x="63" y="160" width="78" height="38" rx="12" fill="#0f1d35" stroke="#2563eb" stroke-width="1.5"/>
+<circle cx="83" cy="179" r="9" fill="#60a5fa" opacity="0.95"/>
+<text x="101" y="183" class="chip" fill="#f4f4f5">REPO</text>
+<rect x="158" y="160" width="78" height="38" rx="12" fill="#0f1d35" stroke="#2563eb" stroke-width="1.5"/>
+<circle cx="178" cy="179" r="9" fill="#60a5fa" opacity="0.95"/>
+<text x="196" y="183" class="chip" fill="#f4f4f5">CI</text>
+<rect x="63" y="221" width="78" height="38" rx="12" fill="#1d1230" stroke="#7c3aed" stroke-width="1.5"/>
+<circle cx="83" cy="240" r="9" fill="#a78bfa" opacity="0.95"/>
+<text x="101" y="244" class="chip" fill="#f4f4f5">MCP</text>
+<rect x="158" y="221" width="78" height="38" rx="12" fill="#072229" stroke="#0891b2" stroke-width="1.5"/>
+<circle cx="178" cy="240" r="9" fill="#67e8f9" opacity="0.95"/>
+<text x="196" y="244" class="chip" fill="#f4f4f5">CLOUD</text>
+<rect x="63" y="282" width="78" height="38" rx="12" fill="#271a05" stroke="#b45309" stroke-width="1.5"/>
+<circle cx="83" cy="301" r="9" fill="#fbbf24" opacity="0.95"/>
+<text x="101" y="305" class="chip" fill="#f4f4f5">IMG</text>
+<rect x="158" y="282" width="78" height="38" rx="12" fill="#261306" stroke="#ea580c" stroke-width="1.5"/>
+<circle cx="178" cy="301" r="9" fill="#fdba74" opacity="0.95"/>
+<text x="196" y="305" class="chip" fill="#f4f4f5">IaC</text>
+<rect x="63" y="343" width="78" height="38" rx="12" fill="#062419" stroke="#059669" stroke-width="1.5"/>
+<circle cx="83" cy="362" r="9" fill="#34d399" opacity="0.95"/>
+<text x="101" y="366" class="chip" fill="#f4f4f5">SBOM</text>
+<rect x="158" y="343" width="78" height="38" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1.5"/>
+<circle cx="178" cy="362" r="9" fill="#fb7185" opacity="0.95"/>
+<text x="196" y="366" class="chip" fill="#f4f4f5">MODEL</text>
+<rect x="62" y="424" width="42" height="24" rx="12" fill="#261306" stroke="#ea580c" stroke-width="1"/>
+<text x="83.0" y="440" class="badge" fill="#fdba74" text-anchor="middle">AWS</text>
+<rect x="109" y="424" width="42" height="24" rx="12" fill="#0f1d35" stroke="#2563eb" stroke-width="1"/>
+<text x="130.0" y="440" class="badge" fill="#60a5fa" text-anchor="middle">AZ</text>
+<rect x="156" y="424" width="42" height="24" rx="12" fill="#062419" stroke="#059669" stroke-width="1"/>
+<text x="177.0" y="440" class="badge" fill="#34d399" text-anchor="middle">GCP</text>
+<rect x="203" y="424" width="42" height="24" rx="12" fill="#072229" stroke="#0891b2" stroke-width="1"/>
+<text x="224.0" y="440" class="badge" fill="#67e8f9" text-anchor="middle">SNOW</text>
+<text x="150" y="468" class="tiny" fill="#71717a" text-anchor="middle">no writes · no secret values</text>
+<circle cx="338" cy="173" r="17" fill="#0f1d35" stroke="#2563eb" stroke-width="2"/>
+<text x="338" y="178" class="badge" fill="#60a5fa" text-anchor="middle">1</text>
+<text x="370" y="178" class="card-title" fill="#f4f4f5">Discover</text>
+<line x1="338" y1="193" x2="338" y2="212" stroke="#52525b" stroke-width="1.8"/>
+<circle cx="338" cy="231" r="17" fill="#271a05" stroke="#b45309" stroke-width="2"/>
+<text x="338" y="236" class="badge" fill="#fbbf24" text-anchor="middle">2</text>
+<text x="370" y="236" class="card-title" fill="#f4f4f5">Match</text>
+<line x1="338" y1="251" x2="338" y2="270" stroke="#52525b" stroke-width="1.8"/>
+<circle cx="338" cy="289" r="17" fill="#2a0d17" stroke="#e11d48" stroke-width="2"/>
+<text x="338" y="294" class="badge" fill="#fb7185" text-anchor="middle">3</text>
+<text x="370" y="294" class="card-title" fill="#f4f4f5">Enrich</text>
+<line x1="338" y1="309" x2="338" y2="328" stroke="#52525b" stroke-width="1.8"/>
+<circle cx="338" cy="347" r="17" fill="#072229" stroke="#0891b2" stroke-width="2"/>
+<text x="338" y="352" class="badge" fill="#67e8f9" text-anchor="middle">4</text>
+<text x="370" y="352" class="card-title" fill="#f4f4f5">Evaluate</text>
+<line x1="338" y1="367" x2="338" y2="386" stroke="#52525b" stroke-width="1.8"/>
+<circle cx="338" cy="405" r="17" fill="#1d1230" stroke="#7c3aed" stroke-width="2"/>
+<text x="338" y="410" class="badge" fill="#a78bfa" text-anchor="middle">5</text>
+<text x="370" y="410" class="card-title" fill="#f4f4f5">Normalize</text>
+<rect x="318" y="440" width="72" height="24" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1"/>
+<text x="354.0" y="456" class="badge" fill="#fb7185" text-anchor="middle">OSV</text>
+<rect x="401" y="440" width="72" height="24" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1"/>
+<text x="437.0" y="456" class="badge" fill="#fb7185" text-anchor="middle">GHSA</text>
+<rect x="318" y="468" width="72" height="24" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1"/>
+<text x="354.0" y="484" class="badge" fill="#fb7185" text-anchor="middle">NVD</text>
+<rect x="401" y="468" width="72" height="24" rx="12" fill="#261306" stroke="#ea580c" stroke-width="1"/>
+<text x="437.0" y="484" class="badge" fill="#fdba74" text-anchor="middle">KEV</text>
+<rect x="318" y="496" width="72" height="24" rx="12" fill="#271a05" stroke="#b45309" stroke-width="1"/>
+<text x="354.0" y="512" class="badge" fill="#fbbf24" text-anchor="middle">EPSS</text>
+<line x1="670" y1="236" x2="602" y2="290" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
+<line x1="670" y1="236" x2="738" y2="290" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
+<line x1="670" y1="236" x2="712" y2="346" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
+<line x1="602" y1="290" x2="636" y2="346" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
+<line x1="602" y1="290" x2="712" y2="346" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
+<line x1="738" y1="290" x2="636" y2="346" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
+<line x1="738" y1="290" x2="712" y2="346" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
+<line x1="636" y1="346" x2="712" y2="346" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
+<circle cx="670" cy="236" r="30" fill="#2a0d17" stroke="#e11d48" stroke-width="2"/>
+<text x="670" y="240" class="node" fill="#fb7185" text-anchor="middle">Finding</text>
+<circle cx="602" cy="290" r="30" fill="#0f1d35" stroke="#2563eb" stroke-width="2"/>
+<text x="602" y="294" class="node" fill="#60a5fa" text-anchor="middle">Asset</text>
+<circle cx="738" cy="290" r="30" fill="#1d1230" stroke="#7c3aed" stroke-width="2"/>
+<text x="738" y="294" class="node" fill="#a78bfa" text-anchor="middle">Agent</text>
+<circle cx="636" cy="346" r="30" fill="#072229" stroke="#0891b2" stroke-width="2"/>
+<text x="636" y="350" class="node" fill="#67e8f9" text-anchor="middle">Tool</text>
+<circle cx="712" cy="346" r="30" fill="#261306" stroke="#ea580c" stroke-width="2"/>
+<text x="712" y="350" class="node" fill="#fdba74" text-anchor="middle">Cred</text>
+<text x="670" y="173" class="card-title" fill="#f4f4f5" text-anchor="middle">Finding + ContextGraph</text>
+<rect x="598" y="386" width="70" height="24" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1"/>
+<text x="633.0" y="402" class="badge" fill="#fb7185" text-anchor="middle">severity</text>
+<rect x="676" y="386" width="86" height="24" rx="12" fill="#1d1230" stroke="#7c3aed" stroke-width="1"/>
+<text x="719.0" y="402" class="badge" fill="#a78bfa" text-anchor="middle">provenance</text>
+<rect x="612" y="418" width="96" height="24" rx="12" fill="#062419" stroke="#059669" stroke-width="1"/>
+<text x="660.0" y="434" class="badge" fill="#34d399" text-anchor="middle">tenant scope</text>
+<text x="670" y="468" class="tiny" fill="#71717a" text-anchor="middle">one model across scans, cloud, runtime, and imports</text>
+<rect x="852" y="158" width="124" height="38" rx="12" fill="#062419" stroke="#059669" stroke-width="1.5"/>
+<circle cx="872" cy="177" r="9" fill="#34d399" opacity="0.95"/>
+<text x="890" y="181" class="chip" fill="#f4f4f5">API</text>
+<rect x="852" y="208" width="124" height="38" rx="12" fill="#1d1230" stroke="#7c3aed" stroke-width="1.5"/>
+<circle cx="872" cy="227" r="9" fill="#a78bfa" opacity="0.95"/>
+<text x="890" y="231" class="chip" fill="#f4f4f5">UI</text>
+<rect x="852" y="258" width="124" height="38" rx="12" fill="#072229" stroke="#0891b2" stroke-width="1.5"/>
+<circle cx="872" cy="277" r="9" fill="#67e8f9" opacity="0.95"/>
+<text x="890" y="281" class="chip" fill="#f4f4f5">MCP</text>
+<rect x="852" y="308" width="124" height="38" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1.5"/>
+<circle cx="872" cy="327" r="9" fill="#fb7185" opacity="0.95"/>
+<text x="890" y="331" class="chip" fill="#f4f4f5">GATE</text>
+<rect x="852" y="358" width="124" height="38" rx="12" fill="#271a05" stroke="#b45309" stroke-width="1.5"/>
+<circle cx="872" cy="377" r="9" fill="#fbbf24" opacity="0.95"/>
+<text x="890" y="381" class="chip" fill="#f4f4f5">WORK</text>
+<rect x="852" y="408" width="124" height="38" rx="12" fill="#261306" stroke="#ea580c" stroke-width="1.5"/>
+<circle cx="872" cy="427" r="9" fill="#fdba74" opacity="0.95"/>
+<text x="890" y="431" class="chip" fill="#f4f4f5">AUDIT</text>
+<text x="925" y="468" class="tiny" fill="#71717a" text-anchor="middle">auth · RBAC · scopes · audit</text>
+<rect x="1082" y="158" width="112" height="24" rx="12" fill="#062419" stroke="#059669" stroke-width="1"/>
+<text x="1138.0" y="174" class="badge" fill="#34d399" text-anchor="middle">SARIF</text>
+<rect x="1082" y="201" width="112" height="24" rx="12" fill="#271a05" stroke="#b45309" stroke-width="1"/>
+<text x="1138.0" y="217" class="badge" fill="#fbbf24" text-anchor="middle">SBOM</text>
+<rect x="1082" y="244" width="112" height="24" rx="12" fill="#0f1d35" stroke="#2563eb" stroke-width="1"/>
+<text x="1138.0" y="260" class="badge" fill="#60a5fa" text-anchor="middle">HTML</text>
+<rect x="1082" y="287" width="112" height="24" rx="12" fill="#072229" stroke="#0891b2" stroke-width="1"/>
+<text x="1138.0" y="303" class="badge" fill="#67e8f9" text-anchor="middle">JSON</text>
+<rect x="1082" y="330" width="112" height="24" rx="12" fill="#1d1230" stroke="#7c3aed" stroke-width="1"/>
+<text x="1138.0" y="346" class="badge" fill="#a78bfa" text-anchor="middle">POSTURE</text>
+<rect x="1082" y="373" width="112" height="24" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1"/>
+<text x="1138.0" y="389" class="badge" fill="#fb7185" text-anchor="middle">FIX</text>
+<text x="1140" y="450" class="tiny" fill="#71717a" text-anchor="middle">reports</text>
+<text x="1140" y="468" class="tiny" fill="#71717a" text-anchor="middle">gates</text>
+<text x="1140" y="486" class="tiny" fill="#71717a" text-anchor="middle">runtime decisions</text>
+<line x1="260" y1="307" x2="300" y2="307" stroke="#52525b" stroke-width="2.5" marker-end="url(#arrow)"/><text x="280.0" y="297" class="tiny" fill="#71717a" text-anchor="middle">collect</text>
+<line x1="510" y1="307" x2="550" y2="307" stroke="#52525b" stroke-width="2.5" marker-end="url(#arrow)"/><text x="530.0" y="297" class="tiny" fill="#71717a" text-anchor="middle">canonicalize</text>
+<line x1="790" y1="307" x2="830" y2="307" stroke="#52525b" stroke-width="2.5" marker-end="url(#arrow)"/><text x="810.0" y="297" class="tiny" fill="#71717a" text-anchor="middle">serve</text>
+<line x1="1020" y1="307" x2="1060" y2="307" stroke="#52525b" stroke-width="2.5" marker-end="url(#arrow)"/><text x="1040.0" y="297" class="tiny" fill="#71717a" text-anchor="middle">export</text>
+<rect x="40" y="532" width="1180" height="42" rx="14" fill="#062419" stroke="#059669" stroke-width="1"/>
+<text x="62" y="558" class="tiny" fill="#34d399">Trust boundary:</text>
+<text x="164" y="558" class="tiny" fill="#a1a1aa">default-off cloud connectors · read-only permissions · secret redaction · signed/auditable evidence · same data model everywhere</text>
+</svg>

--- a/docs/images/how-it-works-dark.svg
+++ b/docs/images/how-it-works-dark.svg
@@ -1,152 +1,159 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1260 620" fill="none" role="img" aria-labelledby="how-title how-desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 650" fill="none" role="img" aria-labelledby="how-title how-desc">
 <title id="how-title">How agent-bom works</title>
 <desc id="how-desc">A concise visual flow from read-only inputs through scan and enrichment, unified evidence graph, control plane, outputs, reports, posture, and enforcement.</desc>
-<defs><marker id="arrow" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
+<defs><marker id="arrow" viewBox="0 0 10 8" refX="8.2" refY="4" markerWidth="7" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#69707d"/></marker>
 <style>
 text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif; letter-spacing: 0; }
-.title { font-size: 29px; font-weight: 850; } .subtitle { font-size: 13px; font-weight: 550; } .label { font-size: 11px; font-weight: 850; letter-spacing: .14em; }
-.card-title { font-size: 18px; font-weight: 850; } .chip { font-size: 13px; font-weight: 800; } .badge { font-size: 10px; font-weight: 850; } .tiny { font-size: 10px; font-weight: 700; } .node { font-size: 10px; font-weight: 850; }
+.title { font-size: 30px; font-weight: 850; } .subtitle { font-size: 13px; font-weight: 550; } .label { font-size: 11px; font-weight: 850; letter-spacing: .14em; }
+.step { font-size: 22px; font-weight: 850; } .chip { font-size: 13px; font-weight: 850; } .badge { font-size: 10.5px; font-weight: 850; } .tiny { font-size: 10px; font-weight: 700; } .node { font-size: 10px; font-weight: 850; }
 </style></defs>
-<rect x="0" y="0" width="1260" height="620" rx="18" fill="#09090b" stroke="#2a2a30" stroke-width="0"/>
-<text x="48" y="50" class="title" fill="#f4f4f5">From inventory to enforceable evidence</text>
-<text x="48" y="74" class="subtitle" fill="#a1a1aa">Read-only collection, deterministic matching, graph-backed blast radius, and one control plane for humans and agents.</text>
-<rect x="40" y="112" width="220" height="390" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1"/>
-<text x="58" y="142" class="label" fill="#60a5fa">READ-ONLY INTAKE</text>
-<rect x="300" y="112" width="210" height="390" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1"/>
-<text x="318" y="142" class="label" fill="#fbbf24">SCAN ENGINE</text>
-<rect x="550" y="112" width="240" height="390" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1"/>
-<text x="568" y="142" class="label" fill="#a78bfa">EVIDENCE CORE</text>
-<rect x="830" y="112" width="190" height="390" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1"/>
-<text x="848" y="142" class="label" fill="#34d399">CONTROL PLANE</text>
-<rect x="1060" y="112" width="160" height="390" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1"/>
-<text x="1078" y="142" class="label" fill="#67e8f9">OUTPUTS</text>
-<rect x="63" y="160" width="78" height="38" rx="12" fill="#0f1d35" stroke="#2563eb" stroke-width="1.5"/>
-<circle cx="83" cy="179" r="9" fill="#60a5fa" opacity="0.95"/>
-<text x="101" y="183" class="chip" fill="#f4f4f5">REPO</text>
-<rect x="158" y="160" width="78" height="38" rx="12" fill="#0f1d35" stroke="#2563eb" stroke-width="1.5"/>
-<circle cx="178" cy="179" r="9" fill="#60a5fa" opacity="0.95"/>
-<text x="196" y="183" class="chip" fill="#f4f4f5">CI</text>
-<rect x="63" y="221" width="78" height="38" rx="12" fill="#1d1230" stroke="#7c3aed" stroke-width="1.5"/>
-<circle cx="83" cy="240" r="9" fill="#a78bfa" opacity="0.95"/>
-<text x="101" y="244" class="chip" fill="#f4f4f5">MCP</text>
-<rect x="158" y="221" width="78" height="38" rx="12" fill="#072229" stroke="#0891b2" stroke-width="1.5"/>
-<circle cx="178" cy="240" r="9" fill="#67e8f9" opacity="0.95"/>
-<text x="196" y="244" class="chip" fill="#f4f4f5">CLOUD</text>
-<rect x="63" y="282" width="78" height="38" rx="12" fill="#271a05" stroke="#b45309" stroke-width="1.5"/>
-<circle cx="83" cy="301" r="9" fill="#fbbf24" opacity="0.95"/>
-<text x="101" y="305" class="chip" fill="#f4f4f5">IMG</text>
-<rect x="158" y="282" width="78" height="38" rx="12" fill="#261306" stroke="#ea580c" stroke-width="1.5"/>
-<circle cx="178" cy="301" r="9" fill="#fdba74" opacity="0.95"/>
-<text x="196" y="305" class="chip" fill="#f4f4f5">IaC</text>
-<rect x="63" y="343" width="78" height="38" rx="12" fill="#062419" stroke="#059669" stroke-width="1.5"/>
-<circle cx="83" cy="362" r="9" fill="#34d399" opacity="0.95"/>
-<text x="101" y="366" class="chip" fill="#f4f4f5">SBOM</text>
-<rect x="158" y="343" width="78" height="38" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1.5"/>
-<circle cx="178" cy="362" r="9" fill="#fb7185" opacity="0.95"/>
-<text x="196" y="366" class="chip" fill="#f4f4f5">MODEL</text>
-<rect x="62" y="424" width="42" height="24" rx="12" fill="#261306" stroke="#ea580c" stroke-width="1"/>
-<text x="83.0" y="440" class="badge" fill="#fdba74" text-anchor="middle">AWS</text>
-<rect x="109" y="424" width="42" height="24" rx="12" fill="#0f1d35" stroke="#2563eb" stroke-width="1"/>
-<text x="130.0" y="440" class="badge" fill="#60a5fa" text-anchor="middle">AZ</text>
-<rect x="156" y="424" width="42" height="24" rx="12" fill="#062419" stroke="#059669" stroke-width="1"/>
-<text x="177.0" y="440" class="badge" fill="#34d399" text-anchor="middle">GCP</text>
-<rect x="203" y="424" width="42" height="24" rx="12" fill="#072229" stroke="#0891b2" stroke-width="1"/>
-<text x="224.0" y="440" class="badge" fill="#67e8f9" text-anchor="middle">SNOW</text>
-<text x="150" y="468" class="tiny" fill="#71717a" text-anchor="middle">no writes · no secret values</text>
-<circle cx="338" cy="173" r="17" fill="#0f1d35" stroke="#2563eb" stroke-width="2"/>
-<text x="338" y="178" class="badge" fill="#60a5fa" text-anchor="middle">1</text>
-<text x="370" y="178" class="card-title" fill="#f4f4f5">Discover</text>
-<line x1="338" y1="193" x2="338" y2="212" stroke="#52525b" stroke-width="1.8"/>
-<circle cx="338" cy="231" r="17" fill="#271a05" stroke="#b45309" stroke-width="2"/>
-<text x="338" y="236" class="badge" fill="#fbbf24" text-anchor="middle">2</text>
-<text x="370" y="236" class="card-title" fill="#f4f4f5">Match</text>
-<line x1="338" y1="251" x2="338" y2="270" stroke="#52525b" stroke-width="1.8"/>
-<circle cx="338" cy="289" r="17" fill="#2a0d17" stroke="#e11d48" stroke-width="2"/>
-<text x="338" y="294" class="badge" fill="#fb7185" text-anchor="middle">3</text>
-<text x="370" y="294" class="card-title" fill="#f4f4f5">Enrich</text>
-<line x1="338" y1="309" x2="338" y2="328" stroke="#52525b" stroke-width="1.8"/>
-<circle cx="338" cy="347" r="17" fill="#072229" stroke="#0891b2" stroke-width="2"/>
-<text x="338" y="352" class="badge" fill="#67e8f9" text-anchor="middle">4</text>
-<text x="370" y="352" class="card-title" fill="#f4f4f5">Evaluate</text>
-<line x1="338" y1="367" x2="338" y2="386" stroke="#52525b" stroke-width="1.8"/>
-<circle cx="338" cy="405" r="17" fill="#1d1230" stroke="#7c3aed" stroke-width="2"/>
-<text x="338" y="410" class="badge" fill="#a78bfa" text-anchor="middle">5</text>
-<text x="370" y="410" class="card-title" fill="#f4f4f5">Normalize</text>
-<rect x="318" y="440" width="72" height="24" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1"/>
-<text x="354.0" y="456" class="badge" fill="#fb7185" text-anchor="middle">OSV</text>
-<rect x="401" y="440" width="72" height="24" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1"/>
-<text x="437.0" y="456" class="badge" fill="#fb7185" text-anchor="middle">GHSA</text>
-<rect x="318" y="468" width="72" height="24" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1"/>
-<text x="354.0" y="484" class="badge" fill="#fb7185" text-anchor="middle">NVD</text>
-<rect x="401" y="468" width="72" height="24" rx="12" fill="#261306" stroke="#ea580c" stroke-width="1"/>
-<text x="437.0" y="484" class="badge" fill="#fdba74" text-anchor="middle">KEV</text>
-<rect x="318" y="496" width="72" height="24" rx="12" fill="#271a05" stroke="#b45309" stroke-width="1"/>
-<text x="354.0" y="512" class="badge" fill="#fbbf24" text-anchor="middle">EPSS</text>
-<line x1="670" y1="236" x2="602" y2="290" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
-<line x1="670" y1="236" x2="738" y2="290" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
-<line x1="670" y1="236" x2="712" y2="346" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
-<line x1="602" y1="290" x2="636" y2="346" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
-<line x1="602" y1="290" x2="712" y2="346" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
-<line x1="738" y1="290" x2="636" y2="346" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
-<line x1="738" y1="290" x2="712" y2="346" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
-<line x1="636" y1="346" x2="712" y2="346" stroke="#52525b" stroke-width="1.4" opacity="0.65"/>
-<circle cx="670" cy="236" r="30" fill="#2a0d17" stroke="#e11d48" stroke-width="2"/>
-<text x="670" y="240" class="node" fill="#fb7185" text-anchor="middle">Finding</text>
-<circle cx="602" cy="290" r="30" fill="#0f1d35" stroke="#2563eb" stroke-width="2"/>
-<text x="602" y="294" class="node" fill="#60a5fa" text-anchor="middle">Asset</text>
-<circle cx="738" cy="290" r="30" fill="#1d1230" stroke="#7c3aed" stroke-width="2"/>
-<text x="738" y="294" class="node" fill="#a78bfa" text-anchor="middle">Agent</text>
-<circle cx="636" cy="346" r="30" fill="#072229" stroke="#0891b2" stroke-width="2"/>
-<text x="636" y="350" class="node" fill="#67e8f9" text-anchor="middle">Tool</text>
-<circle cx="712" cy="346" r="30" fill="#261306" stroke="#ea580c" stroke-width="2"/>
-<text x="712" y="350" class="node" fill="#fdba74" text-anchor="middle">Cred</text>
-<text x="670" y="173" class="card-title" fill="#f4f4f5" text-anchor="middle">Finding + ContextGraph</text>
-<rect x="598" y="386" width="70" height="24" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1"/>
-<text x="633.0" y="402" class="badge" fill="#fb7185" text-anchor="middle">severity</text>
-<rect x="676" y="386" width="86" height="24" rx="12" fill="#1d1230" stroke="#7c3aed" stroke-width="1"/>
-<text x="719.0" y="402" class="badge" fill="#a78bfa" text-anchor="middle">provenance</text>
-<rect x="612" y="418" width="96" height="24" rx="12" fill="#062419" stroke="#059669" stroke-width="1"/>
-<text x="660.0" y="434" class="badge" fill="#34d399" text-anchor="middle">tenant scope</text>
-<text x="670" y="468" class="tiny" fill="#71717a" text-anchor="middle">one model across scans, cloud, runtime, and imports</text>
-<rect x="852" y="158" width="124" height="38" rx="12" fill="#062419" stroke="#059669" stroke-width="1.5"/>
-<circle cx="872" cy="177" r="9" fill="#34d399" opacity="0.95"/>
-<text x="890" y="181" class="chip" fill="#f4f4f5">API</text>
-<rect x="852" y="208" width="124" height="38" rx="12" fill="#1d1230" stroke="#7c3aed" stroke-width="1.5"/>
-<circle cx="872" cy="227" r="9" fill="#a78bfa" opacity="0.95"/>
-<text x="890" y="231" class="chip" fill="#f4f4f5">UI</text>
-<rect x="852" y="258" width="124" height="38" rx="12" fill="#072229" stroke="#0891b2" stroke-width="1.5"/>
-<circle cx="872" cy="277" r="9" fill="#67e8f9" opacity="0.95"/>
-<text x="890" y="281" class="chip" fill="#f4f4f5">MCP</text>
-<rect x="852" y="308" width="124" height="38" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1.5"/>
-<circle cx="872" cy="327" r="9" fill="#fb7185" opacity="0.95"/>
-<text x="890" y="331" class="chip" fill="#f4f4f5">GATE</text>
-<rect x="852" y="358" width="124" height="38" rx="12" fill="#271a05" stroke="#b45309" stroke-width="1.5"/>
-<circle cx="872" cy="377" r="9" fill="#fbbf24" opacity="0.95"/>
-<text x="890" y="381" class="chip" fill="#f4f4f5">WORK</text>
-<rect x="852" y="408" width="124" height="38" rx="12" fill="#261306" stroke="#ea580c" stroke-width="1.5"/>
-<circle cx="872" cy="427" r="9" fill="#fdba74" opacity="0.95"/>
-<text x="890" y="431" class="chip" fill="#f4f4f5">AUDIT</text>
-<text x="925" y="468" class="tiny" fill="#71717a" text-anchor="middle">auth · RBAC · scopes · audit</text>
-<rect x="1082" y="158" width="112" height="24" rx="12" fill="#062419" stroke="#059669" stroke-width="1"/>
-<text x="1138.0" y="174" class="badge" fill="#34d399" text-anchor="middle">SARIF</text>
-<rect x="1082" y="201" width="112" height="24" rx="12" fill="#271a05" stroke="#b45309" stroke-width="1"/>
-<text x="1138.0" y="217" class="badge" fill="#fbbf24" text-anchor="middle">SBOM</text>
-<rect x="1082" y="244" width="112" height="24" rx="12" fill="#0f1d35" stroke="#2563eb" stroke-width="1"/>
-<text x="1138.0" y="260" class="badge" fill="#60a5fa" text-anchor="middle">HTML</text>
-<rect x="1082" y="287" width="112" height="24" rx="12" fill="#072229" stroke="#0891b2" stroke-width="1"/>
-<text x="1138.0" y="303" class="badge" fill="#67e8f9" text-anchor="middle">JSON</text>
-<rect x="1082" y="330" width="112" height="24" rx="12" fill="#1d1230" stroke="#7c3aed" stroke-width="1"/>
-<text x="1138.0" y="346" class="badge" fill="#a78bfa" text-anchor="middle">POSTURE</text>
-<rect x="1082" y="373" width="112" height="24" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1"/>
-<text x="1138.0" y="389" class="badge" fill="#fb7185" text-anchor="middle">FIX</text>
-<text x="1140" y="450" class="tiny" fill="#71717a" text-anchor="middle">reports</text>
-<text x="1140" y="468" class="tiny" fill="#71717a" text-anchor="middle">gates</text>
-<text x="1140" y="486" class="tiny" fill="#71717a" text-anchor="middle">runtime decisions</text>
-<line x1="260" y1="307" x2="300" y2="307" stroke="#52525b" stroke-width="2.5" marker-end="url(#arrow)"/><text x="280.0" y="297" class="tiny" fill="#71717a" text-anchor="middle">collect</text>
-<line x1="510" y1="307" x2="550" y2="307" stroke="#52525b" stroke-width="2.5" marker-end="url(#arrow)"/><text x="530.0" y="297" class="tiny" fill="#71717a" text-anchor="middle">canonicalize</text>
-<line x1="790" y1="307" x2="830" y2="307" stroke="#52525b" stroke-width="2.5" marker-end="url(#arrow)"/><text x="810.0" y="297" class="tiny" fill="#71717a" text-anchor="middle">serve</text>
-<line x1="1020" y1="307" x2="1060" y2="307" stroke="#52525b" stroke-width="2.5" marker-end="url(#arrow)"/><text x="1040.0" y="297" class="tiny" fill="#71717a" text-anchor="middle">export</text>
-<rect x="40" y="532" width="1180" height="42" rx="14" fill="#062419" stroke="#059669" stroke-width="1"/>
-<text x="62" y="558" class="tiny" fill="#34d399">Trust boundary:</text>
-<text x="164" y="558" class="tiny" fill="#a1a1aa">default-off cloud connectors · read-only permissions · secret redaction · signed/auditable evidence · same data model everywhere</text>
+<rect x="0" y="0" width="1320" height="650" rx="18" fill="#09090b" stroke="#2a2a30" stroke-width="0" />
+<text x="48" y="52" class="title" fill="#f4f4f5">From inventory to enforceable evidence</text>
+<text x="48" y="78" class="subtitle" fill="#a1a1aa">Read-only collection becomes deterministic matching, enriched findings, graph-backed blast radius, and operational outputs.</text>
+<rect x="40" y="118" width="240" height="392" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1" />
+<text x="58" y="149" class="label" fill="#60a5fa">READ-ONLY INTAKE</text>
+<rect x="330" y="118" width="230" height="392" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1" />
+<text x="348" y="149" class="label" fill="#fbbf24">SCAN ENGINE</text>
+<rect x="610" y="118" width="270" height="392" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1" />
+<text x="628" y="149" class="label" fill="#a78bfa">EVIDENCE CORE</text>
+<rect x="930" y="118" width="200" height="392" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1" />
+<text x="948" y="149" class="label" fill="#34d399">CONTROL PLANE</text>
+<rect x="1170" y="118" width="120" height="392" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1" />
+<text x="1188" y="149" class="label" fill="#67e8f9">OUTPUTS</text>
+<rect x="62" y="165" width="92" height="42" rx="13" fill="#0f1d35" stroke="#2563eb" stroke-width="1.7" />
+<rect x="73" y="175" width="22" height="22" rx="7" fill="#18181b" stroke="#2563eb" stroke-width="1.2" />
+<path d="M77 178h11l5 5v13h-16z M88 178v5h5" stroke="#60a5fa" stroke-width="1.8" fill="none" stroke-linejoin="round"/>
+<text x="105" y="191" class="chip" fill="#f4f4f5">Repo</text>
+<rect x="166" y="165" width="92" height="42" rx="13" fill="#0f1d35" stroke="#2563eb" stroke-width="1.7" />
+<rect x="177" y="175" width="22" height="22" rx="7" fill="#18181b" stroke="#2563eb" stroke-width="1.2" />
+<path d="M180 186l5 5 11-12" stroke="#60a5fa" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="209" y="191" class="chip" fill="#f4f4f5">CI</text>
+<rect x="62" y="229" width="92" height="42" rx="13" fill="#1d1230" stroke="#7c3aed" stroke-width="1.7" />
+<rect x="73" y="239" width="22" height="22" rx="7" fill="#18181b" stroke="#7c3aed" stroke-width="1.2" />
+<circle cx="84" cy="250" r="3" fill="#a78bfa"/><circle cx="76" cy="257" r="3" fill="#a78bfa"/><circle cx="92" cy="257" r="3" fill="#a78bfa"/><path d="M83 252l-5 4 M85 252l5 4" stroke="#a78bfa" stroke-width="1.6"/>
+<text x="105" y="255" class="chip" fill="#f4f4f5">MCP</text>
+<rect x="166" y="229" width="92" height="42" rx="13" fill="#072229" stroke="#0891b2" stroke-width="1.7" />
+<rect x="177" y="239" width="22" height="22" rx="7" fill="#18181b" stroke="#0891b2" stroke-width="1.2" />
+<path d="M178 255h19a5 5 0 0 0 1-10 8 8 0 0 0-15-3 6 6 0 0 0-5 13z" stroke="#67e8f9" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+<text x="209" y="255" class="chip" fill="#f4f4f5">Cloud</text>
+<rect x="62" y="293" width="92" height="42" rx="13" fill="#271a05" stroke="#b45309" stroke-width="1.7" />
+<rect x="73" y="303" width="22" height="22" rx="7" fill="#18181b" stroke="#b45309" stroke-width="1.2" />
+<rect x="75" y="306" width="18" height="16" rx="3" stroke="#fbbf24" stroke-width="1.8" fill="none"/><path d="M77 319l5-5 4 4 3-3 6 6" stroke="#fbbf24" stroke-width="1.5" fill="none"/>
+<text x="105" y="319" class="chip" fill="#f4f4f5">Image</text>
+<rect x="166" y="293" width="92" height="42" rx="13" fill="#261306" stroke="#ea580c" stroke-width="1.7" />
+<rect x="177" y="303" width="22" height="22" rx="7" fill="#18181b" stroke="#ea580c" stroke-width="1.2" />
+<path d="M182 306c-5 3-5 13 0 16 M194 306c5 3 5 13 0 16" stroke="#fdba74" stroke-width="2" fill="none" stroke-linecap="round"/>
+<text x="209" y="319" class="chip" fill="#f4f4f5">IaC</text>
+<rect x="62" y="357" width="92" height="42" rx="13" fill="#062419" stroke="#059669" stroke-width="1.7" />
+<rect x="73" y="367" width="22" height="22" rx="7" fill="#18181b" stroke="#059669" stroke-width="1.2" />
+<path d="M76 370h16v16h-16z M80 375h8 M80 379h8 M80 383h5" stroke="#34d399" stroke-width="1.6" fill="none" stroke-linecap="round"/>
+<text x="105" y="383" class="chip" fill="#f4f4f5">SBOM</text>
+<rect x="166" y="357" width="92" height="42" rx="13" fill="#2a0d17" stroke="#e11d48" stroke-width="1.7" />
+<rect x="177" y="367" width="22" height="22" rx="7" fill="#18181b" stroke="#e11d48" stroke-width="1.2" />
+<path d="M188 368l9 5v10l-9 5-9-5v-10z M188 368v20 M179 373l18 10" stroke="#fb7185" stroke-width="1.5" fill="none" stroke-linejoin="round"/>
+<text x="209" y="383" class="chip" fill="#f4f4f5">Model</text>
+<rect x="62" y="438" width="46" height="26" rx="13" fill="#261306" stroke="#ea580c" stroke-width="1.4" />
+<text x="85.0" y="455" class="badge" fill="#fdba74" text-anchor="middle">AWS</text>
+<rect x="114" y="438" width="46" height="26" rx="13" fill="#0f1d35" stroke="#2563eb" stroke-width="1.4" />
+<text x="137.0" y="455" class="badge" fill="#60a5fa" text-anchor="middle">AZ</text>
+<rect x="166" y="438" width="46" height="26" rx="13" fill="#062419" stroke="#059669" stroke-width="1.4" />
+<text x="189.0" y="455" class="badge" fill="#34d399" text-anchor="middle">GCP</text>
+<rect x="218" y="438" width="46" height="26" rx="13" fill="#072229" stroke="#0891b2" stroke-width="1.4" />
+<text x="241.0" y="455" class="badge" fill="#67e8f9" text-anchor="middle">SNOW</text>
+<text x="160" y="486" class="tiny" fill="#71717a" text-anchor="middle">no writes · no secret values</text>
+<circle cx="368" cy="183" r="18" fill="#0f1d35" stroke="#2563eb" stroke-width="2"/>
+<text x="368" y="188" class="badge" fill="#60a5fa" text-anchor="middle">1</text>
+<text x="410" y="190" class="step" fill="#f4f4f5">Discover</text>
+<path d="M368 202 C368 211, 368 214, 368 221" stroke="#3f4652" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="241" r="18" fill="#271a05" stroke="#b45309" stroke-width="2"/>
+<text x="368" y="246" class="badge" fill="#fbbf24" text-anchor="middle">2</text>
+<text x="410" y="248" class="step" fill="#f4f4f5">Match</text>
+<path d="M368 260 C368 269, 368 272, 368 279" stroke="#3f4652" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="299" r="18" fill="#2a0d17" stroke="#e11d48" stroke-width="2"/>
+<text x="368" y="304" class="badge" fill="#fb7185" text-anchor="middle">3</text>
+<text x="410" y="306" class="step" fill="#f4f4f5">Enrich</text>
+<path d="M368 318 C368 327, 368 330, 368 337" stroke="#3f4652" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="357" r="18" fill="#072229" stroke="#0891b2" stroke-width="2"/>
+<text x="368" y="362" class="badge" fill="#67e8f9" text-anchor="middle">4</text>
+<text x="410" y="364" class="step" fill="#f4f4f5">Evaluate</text>
+<path d="M368 376 C368 385, 368 388, 368 395" stroke="#3f4652" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="415" r="18" fill="#1d1230" stroke="#7c3aed" stroke-width="2"/>
+<text x="368" y="420" class="badge" fill="#a78bfa" text-anchor="middle">5</text>
+<text x="410" y="422" class="step" fill="#f4f4f5">Normalize</text>
+<rect x="350" y="446" width="76" height="26" rx="13" fill="#2a0d17" stroke="#e11d48" stroke-width="1.4" />
+<text x="388.0" y="463" class="badge" fill="#fb7185" text-anchor="middle">OSV</text>
+<rect x="440" y="446" width="76" height="26" rx="13" fill="#2a0d17" stroke="#e11d48" stroke-width="1.4" />
+<text x="478.0" y="463" class="badge" fill="#fb7185" text-anchor="middle">GHSA</text>
+<rect x="350" y="477" width="76" height="26" rx="13" fill="#2a0d17" stroke="#e11d48" stroke-width="1.4" />
+<text x="388.0" y="494" class="badge" fill="#fb7185" text-anchor="middle">NVD</text>
+<rect x="440" y="477" width="76" height="26" rx="13" fill="#261306" stroke="#ea580c" stroke-width="1.4" />
+<text x="478.0" y="494" class="badge" fill="#fdba74" text-anchor="middle">KEV</text>
+<rect x="350" y="508" width="76" height="26" rx="13" fill="#271a05" stroke="#b45309" stroke-width="1.4" />
+<text x="388.0" y="525" class="badge" fill="#fbbf24" text-anchor="middle">EPSS</text>
+<text x="745" y="175" class="step" fill="#f4f4f5" text-anchor="middle">Finding + ContextGraph</text>
+<line x1="745" y1="256" x2="673" y2="312" stroke="#3f4652" stroke-width="1.6" opacity="0.82"/>
+<line x1="745" y1="256" x2="817" y2="312" stroke="#3f4652" stroke-width="1.6" opacity="0.82"/>
+<line x1="745" y1="256" x2="703" y2="372" stroke="#3f4652" stroke-width="1.6" opacity="0.82"/>
+<line x1="745" y1="256" x2="789" y2="372" stroke="#3f4652" stroke-width="1.6" opacity="0.82"/>
+<line x1="673" y1="312" x2="703" y2="372" stroke="#3f4652" stroke-width="1.6" opacity="0.82"/>
+<line x1="817" y1="312" x2="789" y2="372" stroke="#3f4652" stroke-width="1.6" opacity="0.82"/>
+<line x1="703" y1="372" x2="789" y2="372" stroke="#3f4652" stroke-width="1.6" opacity="0.82"/>
+<circle cx="745" cy="256" r="36" fill="#2a0d17" stroke="#e11d48" stroke-width="2.2"/>
+<text x="745" y="260" class="node" fill="#fb7185" text-anchor="middle">Finding</text>
+<circle cx="673" cy="312" r="34" fill="#0f1d35" stroke="#2563eb" stroke-width="2.2"/>
+<text x="673" y="316" class="node" fill="#60a5fa" text-anchor="middle">Asset</text>
+<circle cx="817" cy="312" r="34" fill="#1d1230" stroke="#7c3aed" stroke-width="2.2"/>
+<text x="817" y="316" class="node" fill="#a78bfa" text-anchor="middle">Agent</text>
+<circle cx="703" cy="372" r="32" fill="#072229" stroke="#0891b2" stroke-width="2.2"/>
+<text x="703" y="376" class="node" fill="#67e8f9" text-anchor="middle">Tool</text>
+<circle cx="789" cy="372" r="32" fill="#261306" stroke="#ea580c" stroke-width="2.2"/>
+<text x="789" y="376" class="node" fill="#fdba74" text-anchor="middle">Cred</text>
+<rect x="650" y="410" width="84" height="26" rx="13" fill="#2a0d17" stroke="#e11d48" stroke-width="1.4" />
+<text x="692.0" y="427" class="badge" fill="#fb7185" text-anchor="middle">severity</text>
+<rect x="746" y="410" width="106" height="26" rx="13" fill="#1d1230" stroke="#7c3aed" stroke-width="1.4" />
+<text x="799.0" y="427" class="badge" fill="#a78bfa" text-anchor="middle">provenance</text>
+<rect x="696" y="446" width="108" height="26" rx="13" fill="#062419" stroke="#059669" stroke-width="1.4" />
+<text x="750.0" y="463" class="badge" fill="#34d399" text-anchor="middle">tenant scope</text>
+<text x="745" y="486" class="tiny" fill="#71717a" text-anchor="middle">one model across scan, cloud, runtime, and imports</text>
+<rect x="958" y="165" width="144" height="38" rx="12" fill="#062419" stroke="#059669" stroke-width="1.7" />
+<circle cx="981" cy="184" r="9" fill="#34d399"/>
+<text x="1004" y="189" class="chip" fill="#f4f4f5">API</text>
+<rect x="958" y="215" width="144" height="38" rx="12" fill="#1d1230" stroke="#7c3aed" stroke-width="1.7" />
+<circle cx="981" cy="234" r="9" fill="#a78bfa"/>
+<text x="1004" y="239" class="chip" fill="#f4f4f5">UI</text>
+<rect x="958" y="265" width="144" height="38" rx="12" fill="#072229" stroke="#0891b2" stroke-width="1.7" />
+<circle cx="981" cy="284" r="9" fill="#67e8f9"/>
+<text x="1004" y="289" class="chip" fill="#f4f4f5">MCP</text>
+<rect x="958" y="315" width="144" height="38" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1.7" />
+<circle cx="981" cy="334" r="9" fill="#fb7185"/>
+<text x="1004" y="339" class="chip" fill="#f4f4f5">Gate</text>
+<rect x="958" y="365" width="144" height="38" rx="12" fill="#271a05" stroke="#b45309" stroke-width="1.7" />
+<circle cx="981" cy="384" r="9" fill="#fbbf24"/>
+<text x="1004" y="389" class="chip" fill="#f4f4f5">Work</text>
+<rect x="958" y="415" width="144" height="38" rx="12" fill="#261306" stroke="#ea580c" stroke-width="1.7" />
+<circle cx="981" cy="434" r="9" fill="#fdba74"/>
+<text x="1004" y="439" class="chip" fill="#f4f4f5">Audit</text>
+<text x="1030" y="486" class="tiny" fill="#71717a" text-anchor="middle">auth · RBAC · scopes · audit</text>
+<rect x="1195" y="165" width="70" height="26" rx="13" fill="#062419" stroke="#059669" stroke-width="1.4" />
+<text x="1230.0" y="182" class="badge" fill="#34d399" text-anchor="middle">SARIF</text>
+<rect x="1195" y="210" width="70" height="26" rx="13" fill="#271a05" stroke="#b45309" stroke-width="1.4" />
+<text x="1230.0" y="227" class="badge" fill="#fbbf24" text-anchor="middle">SBOM</text>
+<rect x="1195" y="255" width="70" height="26" rx="13" fill="#0f1d35" stroke="#2563eb" stroke-width="1.4" />
+<text x="1230.0" y="272" class="badge" fill="#60a5fa" text-anchor="middle">HTML</text>
+<rect x="1195" y="300" width="70" height="26" rx="13" fill="#072229" stroke="#0891b2" stroke-width="1.4" />
+<text x="1230.0" y="317" class="badge" fill="#67e8f9" text-anchor="middle">JSON</text>
+<rect x="1195" y="345" width="70" height="26" rx="13" fill="#1d1230" stroke="#7c3aed" stroke-width="1.4" />
+<text x="1230.0" y="362" class="badge" fill="#a78bfa" text-anchor="middle">POSTURE</text>
+<rect x="1195" y="390" width="70" height="26" rx="13" fill="#2a0d17" stroke="#e11d48" stroke-width="1.4" />
+<text x="1230.0" y="407" class="badge" fill="#fb7185" text-anchor="middle">FIX</text>
+<text x="1230" y="452" class="tiny" fill="#71717a" text-anchor="middle">reports</text>
+<text x="1230" y="474" class="tiny" fill="#71717a" text-anchor="middle">gates</text>
+<text x="1230" y="496" class="tiny" fill="#71717a" text-anchor="middle">runtime</text>
+<path d="M280 314 C302.5 314, 307.5 314, 330 314" stroke="#69707d" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="305.0" y="302" class="tiny" fill="#71717a" text-anchor="middle">collect</text>
+<path d="M560 314 C582.5 314, 587.5 314, 610 314" stroke="#69707d" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="585.0" y="302" class="tiny" fill="#71717a" text-anchor="middle">canonicalize</text>
+<path d="M880 314 C902.5 314, 907.5 314, 930 314" stroke="#69707d" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="905.0" y="302" class="tiny" fill="#71717a" text-anchor="middle">serve</text>
+<path d="M1130 314 C1148.0 314, 1152.0 314, 1170 314" stroke="#69707d" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="1150.0" y="302" class="tiny" fill="#71717a" text-anchor="middle">export</text>
+<rect x="40" y="548" width="1250" height="46" rx="15" fill="#062419" stroke="#059669" stroke-width="1" />
+<text x="66" y="577" class="tiny" fill="#34d399">Trust boundary:</text>
+<text x="172" y="577" class="tiny" fill="#a1a1aa">default-off cloud connectors · read-only permissions · secret redaction · signed evidence · same model everywhere</text>
 </svg>

--- a/docs/images/how-it-works-light.svg
+++ b/docs/images/how-it-works-light.svg
@@ -1,152 +1,159 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1260 620" fill="none" role="img" aria-labelledby="how-title how-desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 650" fill="none" role="img" aria-labelledby="how-title how-desc">
 <title id="how-title">How agent-bom works</title>
 <desc id="how-desc">A concise visual flow from read-only inputs through scan and enrichment, unified evidence graph, control plane, outputs, reports, posture, and enforcement.</desc>
-<defs><marker id="arrow" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#9ca3af"/></marker>
+<defs><marker id="arrow" viewBox="0 0 10 8" refX="8.2" refY="4" markerWidth="7" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#9aa3b2"/></marker>
 <style>
 text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif; letter-spacing: 0; }
-.title { font-size: 29px; font-weight: 850; } .subtitle { font-size: 13px; font-weight: 550; } .label { font-size: 11px; font-weight: 850; letter-spacing: .14em; }
-.card-title { font-size: 18px; font-weight: 850; } .chip { font-size: 13px; font-weight: 800; } .badge { font-size: 10px; font-weight: 850; } .tiny { font-size: 10px; font-weight: 700; } .node { font-size: 10px; font-weight: 850; }
+.title { font-size: 30px; font-weight: 850; } .subtitle { font-size: 13px; font-weight: 550; } .label { font-size: 11px; font-weight: 850; letter-spacing: .14em; }
+.step { font-size: 22px; font-weight: 850; } .chip { font-size: 13px; font-weight: 850; } .badge { font-size: 10.5px; font-weight: 850; } .tiny { font-size: 10px; font-weight: 700; } .node { font-size: 10px; font-weight: 850; }
 </style></defs>
-<rect x="0" y="0" width="1260" height="620" rx="18" fill="#ffffff" stroke="#d7dce5" stroke-width="0"/>
-<text x="48" y="50" class="title" fill="#111827">From inventory to enforceable evidence</text>
-<text x="48" y="74" class="subtitle" fill="#4b5563">Read-only collection, deterministic matching, graph-backed blast radius, and one control plane for humans and agents.</text>
-<rect x="40" y="112" width="220" height="390" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1"/>
-<text x="58" y="142" class="label" fill="#1d4ed8">READ-ONLY INTAKE</text>
-<rect x="300" y="112" width="210" height="390" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1"/>
-<text x="318" y="142" class="label" fill="#b45309">SCAN ENGINE</text>
-<rect x="550" y="112" width="240" height="390" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1"/>
-<text x="568" y="142" class="label" fill="#6d28d9">EVIDENCE CORE</text>
-<rect x="830" y="112" width="190" height="390" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1"/>
-<text x="848" y="142" class="label" fill="#047857">CONTROL PLANE</text>
-<rect x="1060" y="112" width="160" height="390" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1"/>
-<text x="1078" y="142" class="label" fill="#0e7490">OUTPUTS</text>
-<rect x="63" y="160" width="78" height="38" rx="12" fill="#eff6ff" stroke="#60a5fa" stroke-width="1.5"/>
-<circle cx="83" cy="179" r="9" fill="#1d4ed8" opacity="0.95"/>
-<text x="101" y="183" class="chip" fill="#111827">REPO</text>
-<rect x="158" y="160" width="78" height="38" rx="12" fill="#eff6ff" stroke="#60a5fa" stroke-width="1.5"/>
-<circle cx="178" cy="179" r="9" fill="#1d4ed8" opacity="0.95"/>
-<text x="196" y="183" class="chip" fill="#111827">CI</text>
-<rect x="63" y="221" width="78" height="38" rx="12" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1.5"/>
-<circle cx="83" cy="240" r="9" fill="#6d28d9" opacity="0.95"/>
-<text x="101" y="244" class="chip" fill="#111827">MCP</text>
-<rect x="158" y="221" width="78" height="38" rx="12" fill="#ecfeff" stroke="#22d3ee" stroke-width="1.5"/>
-<circle cx="178" cy="240" r="9" fill="#0e7490" opacity="0.95"/>
-<text x="196" y="244" class="chip" fill="#111827">CLOUD</text>
-<rect x="63" y="282" width="78" height="38" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/>
-<circle cx="83" cy="301" r="9" fill="#b45309" opacity="0.95"/>
-<text x="101" y="305" class="chip" fill="#111827">IMG</text>
-<rect x="158" y="282" width="78" height="38" rx="12" fill="#fff7ed" stroke="#fb923c" stroke-width="1.5"/>
-<circle cx="178" cy="301" r="9" fill="#c2410c" opacity="0.95"/>
-<text x="196" y="305" class="chip" fill="#111827">IaC</text>
-<rect x="63" y="343" width="78" height="38" rx="12" fill="#ecfdf5" stroke="#34d399" stroke-width="1.5"/>
-<circle cx="83" cy="362" r="9" fill="#047857" opacity="0.95"/>
-<text x="101" y="366" class="chip" fill="#111827">SBOM</text>
-<rect x="158" y="343" width="78" height="38" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1.5"/>
-<circle cx="178" cy="362" r="9" fill="#be123c" opacity="0.95"/>
-<text x="196" y="366" class="chip" fill="#111827">MODEL</text>
-<rect x="62" y="424" width="42" height="24" rx="12" fill="#fff7ed" stroke="#fb923c" stroke-width="1"/>
-<text x="83.0" y="440" class="badge" fill="#c2410c" text-anchor="middle">AWS</text>
-<rect x="109" y="424" width="42" height="24" rx="12" fill="#eff6ff" stroke="#60a5fa" stroke-width="1"/>
-<text x="130.0" y="440" class="badge" fill="#1d4ed8" text-anchor="middle">AZ</text>
-<rect x="156" y="424" width="42" height="24" rx="12" fill="#ecfdf5" stroke="#34d399" stroke-width="1"/>
-<text x="177.0" y="440" class="badge" fill="#047857" text-anchor="middle">GCP</text>
-<rect x="203" y="424" width="42" height="24" rx="12" fill="#ecfeff" stroke="#22d3ee" stroke-width="1"/>
-<text x="224.0" y="440" class="badge" fill="#0e7490" text-anchor="middle">SNOW</text>
-<text x="150" y="468" class="tiny" fill="#6b7280" text-anchor="middle">no writes · no secret values</text>
-<circle cx="338" cy="173" r="17" fill="#eff6ff" stroke="#60a5fa" stroke-width="2"/>
-<text x="338" y="178" class="badge" fill="#1d4ed8" text-anchor="middle">1</text>
-<text x="370" y="178" class="card-title" fill="#111827">Discover</text>
-<line x1="338" y1="193" x2="338" y2="212" stroke="#9ca3af" stroke-width="1.8"/>
-<circle cx="338" cy="231" r="17" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
-<text x="338" y="236" class="badge" fill="#b45309" text-anchor="middle">2</text>
-<text x="370" y="236" class="card-title" fill="#111827">Match</text>
-<line x1="338" y1="251" x2="338" y2="270" stroke="#9ca3af" stroke-width="1.8"/>
-<circle cx="338" cy="289" r="17" fill="#fff1f2" stroke="#fb7185" stroke-width="2"/>
-<text x="338" y="294" class="badge" fill="#be123c" text-anchor="middle">3</text>
-<text x="370" y="294" class="card-title" fill="#111827">Enrich</text>
-<line x1="338" y1="309" x2="338" y2="328" stroke="#9ca3af" stroke-width="1.8"/>
-<circle cx="338" cy="347" r="17" fill="#ecfeff" stroke="#22d3ee" stroke-width="2"/>
-<text x="338" y="352" class="badge" fill="#0e7490" text-anchor="middle">4</text>
-<text x="370" y="352" class="card-title" fill="#111827">Evaluate</text>
-<line x1="338" y1="367" x2="338" y2="386" stroke="#9ca3af" stroke-width="1.8"/>
-<circle cx="338" cy="405" r="17" fill="#f5f3ff" stroke="#a78bfa" stroke-width="2"/>
-<text x="338" y="410" class="badge" fill="#6d28d9" text-anchor="middle">5</text>
-<text x="370" y="410" class="card-title" fill="#111827">Normalize</text>
-<rect x="318" y="440" width="72" height="24" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1"/>
-<text x="354.0" y="456" class="badge" fill="#be123c" text-anchor="middle">OSV</text>
-<rect x="401" y="440" width="72" height="24" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1"/>
-<text x="437.0" y="456" class="badge" fill="#be123c" text-anchor="middle">GHSA</text>
-<rect x="318" y="468" width="72" height="24" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1"/>
-<text x="354.0" y="484" class="badge" fill="#be123c" text-anchor="middle">NVD</text>
-<rect x="401" y="468" width="72" height="24" rx="12" fill="#fff7ed" stroke="#fb923c" stroke-width="1"/>
-<text x="437.0" y="484" class="badge" fill="#c2410c" text-anchor="middle">KEV</text>
-<rect x="318" y="496" width="72" height="24" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="1"/>
-<text x="354.0" y="512" class="badge" fill="#b45309" text-anchor="middle">EPSS</text>
-<line x1="670" y1="236" x2="602" y2="290" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
-<line x1="670" y1="236" x2="738" y2="290" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
-<line x1="670" y1="236" x2="712" y2="346" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
-<line x1="602" y1="290" x2="636" y2="346" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
-<line x1="602" y1="290" x2="712" y2="346" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
-<line x1="738" y1="290" x2="636" y2="346" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
-<line x1="738" y1="290" x2="712" y2="346" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
-<line x1="636" y1="346" x2="712" y2="346" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
-<circle cx="670" cy="236" r="30" fill="#fff1f2" stroke="#fb7185" stroke-width="2"/>
-<text x="670" y="240" class="node" fill="#be123c" text-anchor="middle">Finding</text>
-<circle cx="602" cy="290" r="30" fill="#eff6ff" stroke="#60a5fa" stroke-width="2"/>
-<text x="602" y="294" class="node" fill="#1d4ed8" text-anchor="middle">Asset</text>
-<circle cx="738" cy="290" r="30" fill="#f5f3ff" stroke="#a78bfa" stroke-width="2"/>
-<text x="738" y="294" class="node" fill="#6d28d9" text-anchor="middle">Agent</text>
-<circle cx="636" cy="346" r="30" fill="#ecfeff" stroke="#22d3ee" stroke-width="2"/>
-<text x="636" y="350" class="node" fill="#0e7490" text-anchor="middle">Tool</text>
-<circle cx="712" cy="346" r="30" fill="#fff7ed" stroke="#fb923c" stroke-width="2"/>
-<text x="712" y="350" class="node" fill="#c2410c" text-anchor="middle">Cred</text>
-<text x="670" y="173" class="card-title" fill="#111827" text-anchor="middle">Finding + ContextGraph</text>
-<rect x="598" y="386" width="70" height="24" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1"/>
-<text x="633.0" y="402" class="badge" fill="#be123c" text-anchor="middle">severity</text>
-<rect x="676" y="386" width="86" height="24" rx="12" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1"/>
-<text x="719.0" y="402" class="badge" fill="#6d28d9" text-anchor="middle">provenance</text>
-<rect x="612" y="418" width="96" height="24" rx="12" fill="#ecfdf5" stroke="#34d399" stroke-width="1"/>
-<text x="660.0" y="434" class="badge" fill="#047857" text-anchor="middle">tenant scope</text>
-<text x="670" y="468" class="tiny" fill="#6b7280" text-anchor="middle">one model across scans, cloud, runtime, and imports</text>
-<rect x="852" y="158" width="124" height="38" rx="12" fill="#ecfdf5" stroke="#34d399" stroke-width="1.5"/>
-<circle cx="872" cy="177" r="9" fill="#047857" opacity="0.95"/>
-<text x="890" y="181" class="chip" fill="#111827">API</text>
-<rect x="852" y="208" width="124" height="38" rx="12" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1.5"/>
-<circle cx="872" cy="227" r="9" fill="#6d28d9" opacity="0.95"/>
-<text x="890" y="231" class="chip" fill="#111827">UI</text>
-<rect x="852" y="258" width="124" height="38" rx="12" fill="#ecfeff" stroke="#22d3ee" stroke-width="1.5"/>
-<circle cx="872" cy="277" r="9" fill="#0e7490" opacity="0.95"/>
-<text x="890" y="281" class="chip" fill="#111827">MCP</text>
-<rect x="852" y="308" width="124" height="38" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1.5"/>
-<circle cx="872" cy="327" r="9" fill="#be123c" opacity="0.95"/>
-<text x="890" y="331" class="chip" fill="#111827">GATE</text>
-<rect x="852" y="358" width="124" height="38" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/>
-<circle cx="872" cy="377" r="9" fill="#b45309" opacity="0.95"/>
-<text x="890" y="381" class="chip" fill="#111827">WORK</text>
-<rect x="852" y="408" width="124" height="38" rx="12" fill="#fff7ed" stroke="#fb923c" stroke-width="1.5"/>
-<circle cx="872" cy="427" r="9" fill="#c2410c" opacity="0.95"/>
-<text x="890" y="431" class="chip" fill="#111827">AUDIT</text>
-<text x="925" y="468" class="tiny" fill="#6b7280" text-anchor="middle">auth · RBAC · scopes · audit</text>
-<rect x="1082" y="158" width="112" height="24" rx="12" fill="#ecfdf5" stroke="#34d399" stroke-width="1"/>
-<text x="1138.0" y="174" class="badge" fill="#047857" text-anchor="middle">SARIF</text>
-<rect x="1082" y="201" width="112" height="24" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="1"/>
-<text x="1138.0" y="217" class="badge" fill="#b45309" text-anchor="middle">SBOM</text>
-<rect x="1082" y="244" width="112" height="24" rx="12" fill="#eff6ff" stroke="#60a5fa" stroke-width="1"/>
-<text x="1138.0" y="260" class="badge" fill="#1d4ed8" text-anchor="middle">HTML</text>
-<rect x="1082" y="287" width="112" height="24" rx="12" fill="#ecfeff" stroke="#22d3ee" stroke-width="1"/>
-<text x="1138.0" y="303" class="badge" fill="#0e7490" text-anchor="middle">JSON</text>
-<rect x="1082" y="330" width="112" height="24" rx="12" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1"/>
-<text x="1138.0" y="346" class="badge" fill="#6d28d9" text-anchor="middle">POSTURE</text>
-<rect x="1082" y="373" width="112" height="24" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1"/>
-<text x="1138.0" y="389" class="badge" fill="#be123c" text-anchor="middle">FIX</text>
-<text x="1140" y="450" class="tiny" fill="#6b7280" text-anchor="middle">reports</text>
-<text x="1140" y="468" class="tiny" fill="#6b7280" text-anchor="middle">gates</text>
-<text x="1140" y="486" class="tiny" fill="#6b7280" text-anchor="middle">runtime decisions</text>
-<line x1="260" y1="307" x2="300" y2="307" stroke="#9ca3af" stroke-width="2.5" marker-end="url(#arrow)"/><text x="280.0" y="297" class="tiny" fill="#6b7280" text-anchor="middle">collect</text>
-<line x1="510" y1="307" x2="550" y2="307" stroke="#9ca3af" stroke-width="2.5" marker-end="url(#arrow)"/><text x="530.0" y="297" class="tiny" fill="#6b7280" text-anchor="middle">canonicalize</text>
-<line x1="790" y1="307" x2="830" y2="307" stroke="#9ca3af" stroke-width="2.5" marker-end="url(#arrow)"/><text x="810.0" y="297" class="tiny" fill="#6b7280" text-anchor="middle">serve</text>
-<line x1="1020" y1="307" x2="1060" y2="307" stroke="#9ca3af" stroke-width="2.5" marker-end="url(#arrow)"/><text x="1040.0" y="297" class="tiny" fill="#6b7280" text-anchor="middle">export</text>
-<rect x="40" y="532" width="1180" height="42" rx="14" fill="#ecfdf5" stroke="#34d399" stroke-width="1"/>
-<text x="62" y="558" class="tiny" fill="#047857">Trust boundary:</text>
-<text x="164" y="558" class="tiny" fill="#4b5563">default-off cloud connectors · read-only permissions · secret redaction · signed/auditable evidence · same data model everywhere</text>
+<rect x="0" y="0" width="1320" height="650" rx="18" fill="#ffffff" stroke="#d7dce5" stroke-width="0" />
+<text x="48" y="52" class="title" fill="#111827">From inventory to enforceable evidence</text>
+<text x="48" y="78" class="subtitle" fill="#4b5563">Read-only collection becomes deterministic matching, enriched findings, graph-backed blast radius, and operational outputs.</text>
+<rect x="40" y="118" width="240" height="392" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1" />
+<text x="58" y="149" class="label" fill="#1d4ed8">READ-ONLY INTAKE</text>
+<rect x="330" y="118" width="230" height="392" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1" />
+<text x="348" y="149" class="label" fill="#b45309">SCAN ENGINE</text>
+<rect x="610" y="118" width="270" height="392" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1" />
+<text x="628" y="149" class="label" fill="#6d28d9">EVIDENCE CORE</text>
+<rect x="930" y="118" width="200" height="392" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1" />
+<text x="948" y="149" class="label" fill="#047857">CONTROL PLANE</text>
+<rect x="1170" y="118" width="120" height="392" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1" />
+<text x="1188" y="149" class="label" fill="#0e7490">OUTPUTS</text>
+<rect x="62" y="165" width="92" height="42" rx="13" fill="#eff6ff" stroke="#60a5fa" stroke-width="1.7" />
+<rect x="73" y="175" width="22" height="22" rx="7" fill="#ffffff" stroke="#60a5fa" stroke-width="1.2" />
+<path d="M77 178h11l5 5v13h-16z M88 178v5h5" stroke="#1d4ed8" stroke-width="1.8" fill="none" stroke-linejoin="round"/>
+<text x="105" y="191" class="chip" fill="#111827">Repo</text>
+<rect x="166" y="165" width="92" height="42" rx="13" fill="#eff6ff" stroke="#60a5fa" stroke-width="1.7" />
+<rect x="177" y="175" width="22" height="22" rx="7" fill="#ffffff" stroke="#60a5fa" stroke-width="1.2" />
+<path d="M180 186l5 5 11-12" stroke="#1d4ed8" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+<text x="209" y="191" class="chip" fill="#111827">CI</text>
+<rect x="62" y="229" width="92" height="42" rx="13" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1.7" />
+<rect x="73" y="239" width="22" height="22" rx="7" fill="#ffffff" stroke="#a78bfa" stroke-width="1.2" />
+<circle cx="84" cy="250" r="3" fill="#6d28d9"/><circle cx="76" cy="257" r="3" fill="#6d28d9"/><circle cx="92" cy="257" r="3" fill="#6d28d9"/><path d="M83 252l-5 4 M85 252l5 4" stroke="#6d28d9" stroke-width="1.6"/>
+<text x="105" y="255" class="chip" fill="#111827">MCP</text>
+<rect x="166" y="229" width="92" height="42" rx="13" fill="#ecfeff" stroke="#22d3ee" stroke-width="1.7" />
+<rect x="177" y="239" width="22" height="22" rx="7" fill="#ffffff" stroke="#22d3ee" stroke-width="1.2" />
+<path d="M178 255h19a5 5 0 0 0 1-10 8 8 0 0 0-15-3 6 6 0 0 0-5 13z" stroke="#0e7490" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+<text x="209" y="255" class="chip" fill="#111827">Cloud</text>
+<rect x="62" y="293" width="92" height="42" rx="13" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.7" />
+<rect x="73" y="303" width="22" height="22" rx="7" fill="#ffffff" stroke="#f59e0b" stroke-width="1.2" />
+<rect x="75" y="306" width="18" height="16" rx="3" stroke="#b45309" stroke-width="1.8" fill="none"/><path d="M77 319l5-5 4 4 3-3 6 6" stroke="#b45309" stroke-width="1.5" fill="none"/>
+<text x="105" y="319" class="chip" fill="#111827">Image</text>
+<rect x="166" y="293" width="92" height="42" rx="13" fill="#fff7ed" stroke="#fb923c" stroke-width="1.7" />
+<rect x="177" y="303" width="22" height="22" rx="7" fill="#ffffff" stroke="#fb923c" stroke-width="1.2" />
+<path d="M182 306c-5 3-5 13 0 16 M194 306c5 3 5 13 0 16" stroke="#c2410c" stroke-width="2" fill="none" stroke-linecap="round"/>
+<text x="209" y="319" class="chip" fill="#111827">IaC</text>
+<rect x="62" y="357" width="92" height="42" rx="13" fill="#ecfdf5" stroke="#34d399" stroke-width="1.7" />
+<rect x="73" y="367" width="22" height="22" rx="7" fill="#ffffff" stroke="#34d399" stroke-width="1.2" />
+<path d="M76 370h16v16h-16z M80 375h8 M80 379h8 M80 383h5" stroke="#047857" stroke-width="1.6" fill="none" stroke-linecap="round"/>
+<text x="105" y="383" class="chip" fill="#111827">SBOM</text>
+<rect x="166" y="357" width="92" height="42" rx="13" fill="#fff1f2" stroke="#fb7185" stroke-width="1.7" />
+<rect x="177" y="367" width="22" height="22" rx="7" fill="#ffffff" stroke="#fb7185" stroke-width="1.2" />
+<path d="M188 368l9 5v10l-9 5-9-5v-10z M188 368v20 M179 373l18 10" stroke="#be123c" stroke-width="1.5" fill="none" stroke-linejoin="round"/>
+<text x="209" y="383" class="chip" fill="#111827">Model</text>
+<rect x="62" y="438" width="46" height="26" rx="13" fill="#fff7ed" stroke="#fb923c" stroke-width="1.4" />
+<text x="85.0" y="455" class="badge" fill="#c2410c" text-anchor="middle">AWS</text>
+<rect x="114" y="438" width="46" height="26" rx="13" fill="#eff6ff" stroke="#60a5fa" stroke-width="1.4" />
+<text x="137.0" y="455" class="badge" fill="#1d4ed8" text-anchor="middle">AZ</text>
+<rect x="166" y="438" width="46" height="26" rx="13" fill="#ecfdf5" stroke="#34d399" stroke-width="1.4" />
+<text x="189.0" y="455" class="badge" fill="#047857" text-anchor="middle">GCP</text>
+<rect x="218" y="438" width="46" height="26" rx="13" fill="#ecfeff" stroke="#22d3ee" stroke-width="1.4" />
+<text x="241.0" y="455" class="badge" fill="#0e7490" text-anchor="middle">SNOW</text>
+<text x="160" y="486" class="tiny" fill="#6b7280" text-anchor="middle">no writes · no secret values</text>
+<circle cx="368" cy="183" r="18" fill="#eff6ff" stroke="#60a5fa" stroke-width="2"/>
+<text x="368" y="188" class="badge" fill="#1d4ed8" text-anchor="middle">1</text>
+<text x="410" y="190" class="step" fill="#111827">Discover</text>
+<path d="M368 202 C368 211, 368 214, 368 221" stroke="#c4cbd6" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="241" r="18" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
+<text x="368" y="246" class="badge" fill="#b45309" text-anchor="middle">2</text>
+<text x="410" y="248" class="step" fill="#111827">Match</text>
+<path d="M368 260 C368 269, 368 272, 368 279" stroke="#c4cbd6" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="299" r="18" fill="#fff1f2" stroke="#fb7185" stroke-width="2"/>
+<text x="368" y="304" class="badge" fill="#be123c" text-anchor="middle">3</text>
+<text x="410" y="306" class="step" fill="#111827">Enrich</text>
+<path d="M368 318 C368 327, 368 330, 368 337" stroke="#c4cbd6" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="357" r="18" fill="#ecfeff" stroke="#22d3ee" stroke-width="2"/>
+<text x="368" y="362" class="badge" fill="#0e7490" text-anchor="middle">4</text>
+<text x="410" y="364" class="step" fill="#111827">Evaluate</text>
+<path d="M368 376 C368 385, 368 388, 368 395" stroke="#c4cbd6" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="415" r="18" fill="#f5f3ff" stroke="#a78bfa" stroke-width="2"/>
+<text x="368" y="420" class="badge" fill="#6d28d9" text-anchor="middle">5</text>
+<text x="410" y="422" class="step" fill="#111827">Normalize</text>
+<rect x="350" y="446" width="76" height="26" rx="13" fill="#fff1f2" stroke="#fb7185" stroke-width="1.4" />
+<text x="388.0" y="463" class="badge" fill="#be123c" text-anchor="middle">OSV</text>
+<rect x="440" y="446" width="76" height="26" rx="13" fill="#fff1f2" stroke="#fb7185" stroke-width="1.4" />
+<text x="478.0" y="463" class="badge" fill="#be123c" text-anchor="middle">GHSA</text>
+<rect x="350" y="477" width="76" height="26" rx="13" fill="#fff1f2" stroke="#fb7185" stroke-width="1.4" />
+<text x="388.0" y="494" class="badge" fill="#be123c" text-anchor="middle">NVD</text>
+<rect x="440" y="477" width="76" height="26" rx="13" fill="#fff7ed" stroke="#fb923c" stroke-width="1.4" />
+<text x="478.0" y="494" class="badge" fill="#c2410c" text-anchor="middle">KEV</text>
+<rect x="350" y="508" width="76" height="26" rx="13" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.4" />
+<text x="388.0" y="525" class="badge" fill="#b45309" text-anchor="middle">EPSS</text>
+<text x="745" y="175" class="step" fill="#111827" text-anchor="middle">Finding + ContextGraph</text>
+<line x1="745" y1="256" x2="673" y2="312" stroke="#c4cbd6" stroke-width="1.6" opacity="0.82"/>
+<line x1="745" y1="256" x2="817" y2="312" stroke="#c4cbd6" stroke-width="1.6" opacity="0.82"/>
+<line x1="745" y1="256" x2="703" y2="372" stroke="#c4cbd6" stroke-width="1.6" opacity="0.82"/>
+<line x1="745" y1="256" x2="789" y2="372" stroke="#c4cbd6" stroke-width="1.6" opacity="0.82"/>
+<line x1="673" y1="312" x2="703" y2="372" stroke="#c4cbd6" stroke-width="1.6" opacity="0.82"/>
+<line x1="817" y1="312" x2="789" y2="372" stroke="#c4cbd6" stroke-width="1.6" opacity="0.82"/>
+<line x1="703" y1="372" x2="789" y2="372" stroke="#c4cbd6" stroke-width="1.6" opacity="0.82"/>
+<circle cx="745" cy="256" r="36" fill="#fff1f2" stroke="#fb7185" stroke-width="2.2"/>
+<text x="745" y="260" class="node" fill="#be123c" text-anchor="middle">Finding</text>
+<circle cx="673" cy="312" r="34" fill="#eff6ff" stroke="#60a5fa" stroke-width="2.2"/>
+<text x="673" y="316" class="node" fill="#1d4ed8" text-anchor="middle">Asset</text>
+<circle cx="817" cy="312" r="34" fill="#f5f3ff" stroke="#a78bfa" stroke-width="2.2"/>
+<text x="817" y="316" class="node" fill="#6d28d9" text-anchor="middle">Agent</text>
+<circle cx="703" cy="372" r="32" fill="#ecfeff" stroke="#22d3ee" stroke-width="2.2"/>
+<text x="703" y="376" class="node" fill="#0e7490" text-anchor="middle">Tool</text>
+<circle cx="789" cy="372" r="32" fill="#fff7ed" stroke="#fb923c" stroke-width="2.2"/>
+<text x="789" y="376" class="node" fill="#c2410c" text-anchor="middle">Cred</text>
+<rect x="650" y="410" width="84" height="26" rx="13" fill="#fff1f2" stroke="#fb7185" stroke-width="1.4" />
+<text x="692.0" y="427" class="badge" fill="#be123c" text-anchor="middle">severity</text>
+<rect x="746" y="410" width="106" height="26" rx="13" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1.4" />
+<text x="799.0" y="427" class="badge" fill="#6d28d9" text-anchor="middle">provenance</text>
+<rect x="696" y="446" width="108" height="26" rx="13" fill="#ecfdf5" stroke="#34d399" stroke-width="1.4" />
+<text x="750.0" y="463" class="badge" fill="#047857" text-anchor="middle">tenant scope</text>
+<text x="745" y="486" class="tiny" fill="#6b7280" text-anchor="middle">one model across scan, cloud, runtime, and imports</text>
+<rect x="958" y="165" width="144" height="38" rx="12" fill="#ecfdf5" stroke="#34d399" stroke-width="1.7" />
+<circle cx="981" cy="184" r="9" fill="#047857"/>
+<text x="1004" y="189" class="chip" fill="#111827">API</text>
+<rect x="958" y="215" width="144" height="38" rx="12" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1.7" />
+<circle cx="981" cy="234" r="9" fill="#6d28d9"/>
+<text x="1004" y="239" class="chip" fill="#111827">UI</text>
+<rect x="958" y="265" width="144" height="38" rx="12" fill="#ecfeff" stroke="#22d3ee" stroke-width="1.7" />
+<circle cx="981" cy="284" r="9" fill="#0e7490"/>
+<text x="1004" y="289" class="chip" fill="#111827">MCP</text>
+<rect x="958" y="315" width="144" height="38" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1.7" />
+<circle cx="981" cy="334" r="9" fill="#be123c"/>
+<text x="1004" y="339" class="chip" fill="#111827">Gate</text>
+<rect x="958" y="365" width="144" height="38" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.7" />
+<circle cx="981" cy="384" r="9" fill="#b45309"/>
+<text x="1004" y="389" class="chip" fill="#111827">Work</text>
+<rect x="958" y="415" width="144" height="38" rx="12" fill="#fff7ed" stroke="#fb923c" stroke-width="1.7" />
+<circle cx="981" cy="434" r="9" fill="#c2410c"/>
+<text x="1004" y="439" class="chip" fill="#111827">Audit</text>
+<text x="1030" y="486" class="tiny" fill="#6b7280" text-anchor="middle">auth · RBAC · scopes · audit</text>
+<rect x="1195" y="165" width="70" height="26" rx="13" fill="#ecfdf5" stroke="#34d399" stroke-width="1.4" />
+<text x="1230.0" y="182" class="badge" fill="#047857" text-anchor="middle">SARIF</text>
+<rect x="1195" y="210" width="70" height="26" rx="13" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.4" />
+<text x="1230.0" y="227" class="badge" fill="#b45309" text-anchor="middle">SBOM</text>
+<rect x="1195" y="255" width="70" height="26" rx="13" fill="#eff6ff" stroke="#60a5fa" stroke-width="1.4" />
+<text x="1230.0" y="272" class="badge" fill="#1d4ed8" text-anchor="middle">HTML</text>
+<rect x="1195" y="300" width="70" height="26" rx="13" fill="#ecfeff" stroke="#22d3ee" stroke-width="1.4" />
+<text x="1230.0" y="317" class="badge" fill="#0e7490" text-anchor="middle">JSON</text>
+<rect x="1195" y="345" width="70" height="26" rx="13" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1.4" />
+<text x="1230.0" y="362" class="badge" fill="#6d28d9" text-anchor="middle">POSTURE</text>
+<rect x="1195" y="390" width="70" height="26" rx="13" fill="#fff1f2" stroke="#fb7185" stroke-width="1.4" />
+<text x="1230.0" y="407" class="badge" fill="#be123c" text-anchor="middle">FIX</text>
+<text x="1230" y="452" class="tiny" fill="#6b7280" text-anchor="middle">reports</text>
+<text x="1230" y="474" class="tiny" fill="#6b7280" text-anchor="middle">gates</text>
+<text x="1230" y="496" class="tiny" fill="#6b7280" text-anchor="middle">runtime</text>
+<path d="M280 314 C302.5 314, 307.5 314, 330 314" stroke="#9aa3b2" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="305.0" y="302" class="tiny" fill="#6b7280" text-anchor="middle">collect</text>
+<path d="M560 314 C582.5 314, 587.5 314, 610 314" stroke="#9aa3b2" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="585.0" y="302" class="tiny" fill="#6b7280" text-anchor="middle">canonicalize</text>
+<path d="M880 314 C902.5 314, 907.5 314, 930 314" stroke="#9aa3b2" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="905.0" y="302" class="tiny" fill="#6b7280" text-anchor="middle">serve</text>
+<path d="M1130 314 C1148.0 314, 1152.0 314, 1170 314" stroke="#9aa3b2" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="1150.0" y="302" class="tiny" fill="#6b7280" text-anchor="middle">export</text>
+<rect x="40" y="548" width="1250" height="46" rx="15" fill="#ecfdf5" stroke="#34d399" stroke-width="1" />
+<text x="66" y="577" class="tiny" fill="#047857">Trust boundary:</text>
+<text x="172" y="577" class="tiny" fill="#4b5563">default-off cloud connectors · read-only permissions · secret redaction · signed evidence · same model everywhere</text>
 </svg>

--- a/docs/images/how-it-works-light.svg
+++ b/docs/images/how-it-works-light.svg
@@ -1,0 +1,152 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1260 620" fill="none" role="img" aria-labelledby="how-title how-desc">
+<title id="how-title">How agent-bom works</title>
+<desc id="how-desc">A concise visual flow from read-only inputs through scan and enrichment, unified evidence graph, control plane, outputs, reports, posture, and enforcement.</desc>
+<defs><marker id="arrow" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#9ca3af"/></marker>
+<style>
+text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif; letter-spacing: 0; }
+.title { font-size: 29px; font-weight: 850; } .subtitle { font-size: 13px; font-weight: 550; } .label { font-size: 11px; font-weight: 850; letter-spacing: .14em; }
+.card-title { font-size: 18px; font-weight: 850; } .chip { font-size: 13px; font-weight: 800; } .badge { font-size: 10px; font-weight: 850; } .tiny { font-size: 10px; font-weight: 700; } .node { font-size: 10px; font-weight: 850; }
+</style></defs>
+<rect x="0" y="0" width="1260" height="620" rx="18" fill="#ffffff" stroke="#d7dce5" stroke-width="0"/>
+<text x="48" y="50" class="title" fill="#111827">From inventory to enforceable evidence</text>
+<text x="48" y="74" class="subtitle" fill="#4b5563">Read-only collection, deterministic matching, graph-backed blast radius, and one control plane for humans and agents.</text>
+<rect x="40" y="112" width="220" height="390" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1"/>
+<text x="58" y="142" class="label" fill="#1d4ed8">READ-ONLY INTAKE</text>
+<rect x="300" y="112" width="210" height="390" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1"/>
+<text x="318" y="142" class="label" fill="#b45309">SCAN ENGINE</text>
+<rect x="550" y="112" width="240" height="390" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1"/>
+<text x="568" y="142" class="label" fill="#6d28d9">EVIDENCE CORE</text>
+<rect x="830" y="112" width="190" height="390" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1"/>
+<text x="848" y="142" class="label" fill="#047857">CONTROL PLANE</text>
+<rect x="1060" y="112" width="160" height="390" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1"/>
+<text x="1078" y="142" class="label" fill="#0e7490">OUTPUTS</text>
+<rect x="63" y="160" width="78" height="38" rx="12" fill="#eff6ff" stroke="#60a5fa" stroke-width="1.5"/>
+<circle cx="83" cy="179" r="9" fill="#1d4ed8" opacity="0.95"/>
+<text x="101" y="183" class="chip" fill="#111827">REPO</text>
+<rect x="158" y="160" width="78" height="38" rx="12" fill="#eff6ff" stroke="#60a5fa" stroke-width="1.5"/>
+<circle cx="178" cy="179" r="9" fill="#1d4ed8" opacity="0.95"/>
+<text x="196" y="183" class="chip" fill="#111827">CI</text>
+<rect x="63" y="221" width="78" height="38" rx="12" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1.5"/>
+<circle cx="83" cy="240" r="9" fill="#6d28d9" opacity="0.95"/>
+<text x="101" y="244" class="chip" fill="#111827">MCP</text>
+<rect x="158" y="221" width="78" height="38" rx="12" fill="#ecfeff" stroke="#22d3ee" stroke-width="1.5"/>
+<circle cx="178" cy="240" r="9" fill="#0e7490" opacity="0.95"/>
+<text x="196" y="244" class="chip" fill="#111827">CLOUD</text>
+<rect x="63" y="282" width="78" height="38" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/>
+<circle cx="83" cy="301" r="9" fill="#b45309" opacity="0.95"/>
+<text x="101" y="305" class="chip" fill="#111827">IMG</text>
+<rect x="158" y="282" width="78" height="38" rx="12" fill="#fff7ed" stroke="#fb923c" stroke-width="1.5"/>
+<circle cx="178" cy="301" r="9" fill="#c2410c" opacity="0.95"/>
+<text x="196" y="305" class="chip" fill="#111827">IaC</text>
+<rect x="63" y="343" width="78" height="38" rx="12" fill="#ecfdf5" stroke="#34d399" stroke-width="1.5"/>
+<circle cx="83" cy="362" r="9" fill="#047857" opacity="0.95"/>
+<text x="101" y="366" class="chip" fill="#111827">SBOM</text>
+<rect x="158" y="343" width="78" height="38" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1.5"/>
+<circle cx="178" cy="362" r="9" fill="#be123c" opacity="0.95"/>
+<text x="196" y="366" class="chip" fill="#111827">MODEL</text>
+<rect x="62" y="424" width="42" height="24" rx="12" fill="#fff7ed" stroke="#fb923c" stroke-width="1"/>
+<text x="83.0" y="440" class="badge" fill="#c2410c" text-anchor="middle">AWS</text>
+<rect x="109" y="424" width="42" height="24" rx="12" fill="#eff6ff" stroke="#60a5fa" stroke-width="1"/>
+<text x="130.0" y="440" class="badge" fill="#1d4ed8" text-anchor="middle">AZ</text>
+<rect x="156" y="424" width="42" height="24" rx="12" fill="#ecfdf5" stroke="#34d399" stroke-width="1"/>
+<text x="177.0" y="440" class="badge" fill="#047857" text-anchor="middle">GCP</text>
+<rect x="203" y="424" width="42" height="24" rx="12" fill="#ecfeff" stroke="#22d3ee" stroke-width="1"/>
+<text x="224.0" y="440" class="badge" fill="#0e7490" text-anchor="middle">SNOW</text>
+<text x="150" y="468" class="tiny" fill="#6b7280" text-anchor="middle">no writes · no secret values</text>
+<circle cx="338" cy="173" r="17" fill="#eff6ff" stroke="#60a5fa" stroke-width="2"/>
+<text x="338" y="178" class="badge" fill="#1d4ed8" text-anchor="middle">1</text>
+<text x="370" y="178" class="card-title" fill="#111827">Discover</text>
+<line x1="338" y1="193" x2="338" y2="212" stroke="#9ca3af" stroke-width="1.8"/>
+<circle cx="338" cy="231" r="17" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
+<text x="338" y="236" class="badge" fill="#b45309" text-anchor="middle">2</text>
+<text x="370" y="236" class="card-title" fill="#111827">Match</text>
+<line x1="338" y1="251" x2="338" y2="270" stroke="#9ca3af" stroke-width="1.8"/>
+<circle cx="338" cy="289" r="17" fill="#fff1f2" stroke="#fb7185" stroke-width="2"/>
+<text x="338" y="294" class="badge" fill="#be123c" text-anchor="middle">3</text>
+<text x="370" y="294" class="card-title" fill="#111827">Enrich</text>
+<line x1="338" y1="309" x2="338" y2="328" stroke="#9ca3af" stroke-width="1.8"/>
+<circle cx="338" cy="347" r="17" fill="#ecfeff" stroke="#22d3ee" stroke-width="2"/>
+<text x="338" y="352" class="badge" fill="#0e7490" text-anchor="middle">4</text>
+<text x="370" y="352" class="card-title" fill="#111827">Evaluate</text>
+<line x1="338" y1="367" x2="338" y2="386" stroke="#9ca3af" stroke-width="1.8"/>
+<circle cx="338" cy="405" r="17" fill="#f5f3ff" stroke="#a78bfa" stroke-width="2"/>
+<text x="338" y="410" class="badge" fill="#6d28d9" text-anchor="middle">5</text>
+<text x="370" y="410" class="card-title" fill="#111827">Normalize</text>
+<rect x="318" y="440" width="72" height="24" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1"/>
+<text x="354.0" y="456" class="badge" fill="#be123c" text-anchor="middle">OSV</text>
+<rect x="401" y="440" width="72" height="24" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1"/>
+<text x="437.0" y="456" class="badge" fill="#be123c" text-anchor="middle">GHSA</text>
+<rect x="318" y="468" width="72" height="24" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1"/>
+<text x="354.0" y="484" class="badge" fill="#be123c" text-anchor="middle">NVD</text>
+<rect x="401" y="468" width="72" height="24" rx="12" fill="#fff7ed" stroke="#fb923c" stroke-width="1"/>
+<text x="437.0" y="484" class="badge" fill="#c2410c" text-anchor="middle">KEV</text>
+<rect x="318" y="496" width="72" height="24" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="1"/>
+<text x="354.0" y="512" class="badge" fill="#b45309" text-anchor="middle">EPSS</text>
+<line x1="670" y1="236" x2="602" y2="290" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
+<line x1="670" y1="236" x2="738" y2="290" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
+<line x1="670" y1="236" x2="712" y2="346" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
+<line x1="602" y1="290" x2="636" y2="346" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
+<line x1="602" y1="290" x2="712" y2="346" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
+<line x1="738" y1="290" x2="636" y2="346" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
+<line x1="738" y1="290" x2="712" y2="346" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
+<line x1="636" y1="346" x2="712" y2="346" stroke="#9ca3af" stroke-width="1.4" opacity="0.65"/>
+<circle cx="670" cy="236" r="30" fill="#fff1f2" stroke="#fb7185" stroke-width="2"/>
+<text x="670" y="240" class="node" fill="#be123c" text-anchor="middle">Finding</text>
+<circle cx="602" cy="290" r="30" fill="#eff6ff" stroke="#60a5fa" stroke-width="2"/>
+<text x="602" y="294" class="node" fill="#1d4ed8" text-anchor="middle">Asset</text>
+<circle cx="738" cy="290" r="30" fill="#f5f3ff" stroke="#a78bfa" stroke-width="2"/>
+<text x="738" y="294" class="node" fill="#6d28d9" text-anchor="middle">Agent</text>
+<circle cx="636" cy="346" r="30" fill="#ecfeff" stroke="#22d3ee" stroke-width="2"/>
+<text x="636" y="350" class="node" fill="#0e7490" text-anchor="middle">Tool</text>
+<circle cx="712" cy="346" r="30" fill="#fff7ed" stroke="#fb923c" stroke-width="2"/>
+<text x="712" y="350" class="node" fill="#c2410c" text-anchor="middle">Cred</text>
+<text x="670" y="173" class="card-title" fill="#111827" text-anchor="middle">Finding + ContextGraph</text>
+<rect x="598" y="386" width="70" height="24" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1"/>
+<text x="633.0" y="402" class="badge" fill="#be123c" text-anchor="middle">severity</text>
+<rect x="676" y="386" width="86" height="24" rx="12" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1"/>
+<text x="719.0" y="402" class="badge" fill="#6d28d9" text-anchor="middle">provenance</text>
+<rect x="612" y="418" width="96" height="24" rx="12" fill="#ecfdf5" stroke="#34d399" stroke-width="1"/>
+<text x="660.0" y="434" class="badge" fill="#047857" text-anchor="middle">tenant scope</text>
+<text x="670" y="468" class="tiny" fill="#6b7280" text-anchor="middle">one model across scans, cloud, runtime, and imports</text>
+<rect x="852" y="158" width="124" height="38" rx="12" fill="#ecfdf5" stroke="#34d399" stroke-width="1.5"/>
+<circle cx="872" cy="177" r="9" fill="#047857" opacity="0.95"/>
+<text x="890" y="181" class="chip" fill="#111827">API</text>
+<rect x="852" y="208" width="124" height="38" rx="12" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1.5"/>
+<circle cx="872" cy="227" r="9" fill="#6d28d9" opacity="0.95"/>
+<text x="890" y="231" class="chip" fill="#111827">UI</text>
+<rect x="852" y="258" width="124" height="38" rx="12" fill="#ecfeff" stroke="#22d3ee" stroke-width="1.5"/>
+<circle cx="872" cy="277" r="9" fill="#0e7490" opacity="0.95"/>
+<text x="890" y="281" class="chip" fill="#111827">MCP</text>
+<rect x="852" y="308" width="124" height="38" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1.5"/>
+<circle cx="872" cy="327" r="9" fill="#be123c" opacity="0.95"/>
+<text x="890" y="331" class="chip" fill="#111827">GATE</text>
+<rect x="852" y="358" width="124" height="38" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.5"/>
+<circle cx="872" cy="377" r="9" fill="#b45309" opacity="0.95"/>
+<text x="890" y="381" class="chip" fill="#111827">WORK</text>
+<rect x="852" y="408" width="124" height="38" rx="12" fill="#fff7ed" stroke="#fb923c" stroke-width="1.5"/>
+<circle cx="872" cy="427" r="9" fill="#c2410c" opacity="0.95"/>
+<text x="890" y="431" class="chip" fill="#111827">AUDIT</text>
+<text x="925" y="468" class="tiny" fill="#6b7280" text-anchor="middle">auth · RBAC · scopes · audit</text>
+<rect x="1082" y="158" width="112" height="24" rx="12" fill="#ecfdf5" stroke="#34d399" stroke-width="1"/>
+<text x="1138.0" y="174" class="badge" fill="#047857" text-anchor="middle">SARIF</text>
+<rect x="1082" y="201" width="112" height="24" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="1"/>
+<text x="1138.0" y="217" class="badge" fill="#b45309" text-anchor="middle">SBOM</text>
+<rect x="1082" y="244" width="112" height="24" rx="12" fill="#eff6ff" stroke="#60a5fa" stroke-width="1"/>
+<text x="1138.0" y="260" class="badge" fill="#1d4ed8" text-anchor="middle">HTML</text>
+<rect x="1082" y="287" width="112" height="24" rx="12" fill="#ecfeff" stroke="#22d3ee" stroke-width="1"/>
+<text x="1138.0" y="303" class="badge" fill="#0e7490" text-anchor="middle">JSON</text>
+<rect x="1082" y="330" width="112" height="24" rx="12" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1"/>
+<text x="1138.0" y="346" class="badge" fill="#6d28d9" text-anchor="middle">POSTURE</text>
+<rect x="1082" y="373" width="112" height="24" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1"/>
+<text x="1138.0" y="389" class="badge" fill="#be123c" text-anchor="middle">FIX</text>
+<text x="1140" y="450" class="tiny" fill="#6b7280" text-anchor="middle">reports</text>
+<text x="1140" y="468" class="tiny" fill="#6b7280" text-anchor="middle">gates</text>
+<text x="1140" y="486" class="tiny" fill="#6b7280" text-anchor="middle">runtime decisions</text>
+<line x1="260" y1="307" x2="300" y2="307" stroke="#9ca3af" stroke-width="2.5" marker-end="url(#arrow)"/><text x="280.0" y="297" class="tiny" fill="#6b7280" text-anchor="middle">collect</text>
+<line x1="510" y1="307" x2="550" y2="307" stroke="#9ca3af" stroke-width="2.5" marker-end="url(#arrow)"/><text x="530.0" y="297" class="tiny" fill="#6b7280" text-anchor="middle">canonicalize</text>
+<line x1="790" y1="307" x2="830" y2="307" stroke="#9ca3af" stroke-width="2.5" marker-end="url(#arrow)"/><text x="810.0" y="297" class="tiny" fill="#6b7280" text-anchor="middle">serve</text>
+<line x1="1020" y1="307" x2="1060" y2="307" stroke="#9ca3af" stroke-width="2.5" marker-end="url(#arrow)"/><text x="1040.0" y="297" class="tiny" fill="#6b7280" text-anchor="middle">export</text>
+<rect x="40" y="532" width="1180" height="42" rx="14" fill="#ecfdf5" stroke="#34d399" stroke-width="1"/>
+<text x="62" y="558" class="tiny" fill="#047857">Trust boundary:</text>
+<text x="164" y="558" class="tiny" fill="#4b5563">default-off cloud connectors · read-only permissions · secret redaction · signed/auditable evidence · same data model everywhere</text>
+</svg>


### PR DESCRIPTION
Summary
- add a concise how-it-works visual for read-only intake, scan/enrichment, unified evidence, control plane, and outputs
- expose existing architecture and scan-pipeline diagrams as collapsible README sections
- fix cloud-connect README wording so AWS is included with the other setup docs

Verification
- rsvg-convert docs/images/how-it-works-dark.svg -o /tmp/how-it-works-dark.png
- rsvg-convert docs/images/how-it-works-light.svg -o /tmp/how-it-works-light.png
- XML parse check for how-it-works, architecture, and scan-pipeline SVGs
- git diff --check

Notes
- docs/image-only change; no runtime code paths changed