### PR TITLE
fix(ci): refresh latest image with runtime security overlay

### DIFF
--- a/.github/workflows/refresh-latest-container.yml
+++ b/.github/workflows/refresh-latest-container.yml
@@ -44,6 +44,7 @@ jobs:
         id: release
         run: |
           set -euo pipefail
+          MAIN_SHA=$(git rev-parse HEAD)
           git fetch --tags --force
           TAG=$(git tag -l 'v*.*.*' --sort=-version:refname | head -n1)
           if [ -z "$TAG" ]; then
@@ -53,7 +54,21 @@ jobs:
           VERSION="${TAG#v}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "main_sha=$MAIN_SHA" >> "$GITHUB_OUTPUT"
           git checkout "$TAG"
+
+      - name: Apply current runtime security overlay
+        run: |
+          set -euo pipefail
+          # The application code and version stay pinned to the latest release tag,
+          # but the floating `latest` image is rebuilt daily to absorb base/runtime
+          # security-only refreshes such as patched pip hashes. Without this overlay,
+          # an old release tag can keep rebuilding a known-vulnerable container even
+          # after the default branch has the safe runtime pin.
+          git checkout "${{ steps.release.outputs.main_sha }}" -- \
+            deploy/docker/pip-requirements.txt \
+            .image-scan-ignore \
+            security/image-exceptions.yaml
 
       - name: Verify pyproject version matches release tag
         run: |

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -443,6 +443,20 @@ def test_publish_registries_workflow_validates_smithery_best_effort_and_curated_
     assert '_publish_skill "integrations/openclaw" "agent-bom"' not in workflow
 
 
+def test_refresh_latest_container_keeps_release_code_but_applies_runtime_security_overlay():
+    """Daily latest refresh can patch runtime CVEs without changing app code."""
+    workflow = (ROOT / ".github" / "workflows" / "refresh-latest-container.yml").read_text()
+
+    assert "main_sha=$MAIN_SHA" in workflow
+    assert "git checkout \"$TAG\"" in workflow
+    assert "Apply current runtime security overlay" in workflow
+    assert 'git checkout "${{ steps.release.outputs.main_sha }}" -- \\' in workflow
+    assert "deploy/docker/pip-requirements.txt \\" in workflow
+    assert ".image-scan-ignore \\" in workflow
+    assert "security/image-exceptions.yaml" in workflow
+    assert "The application code and version stay pinned to the latest release tag" in workflow
+
+
 def test_deploy_mcp_sse_workflow_uses_bearer_token_for_health_check():
     """Post-deploy health verification should use the same auth contract as Railway."""
     workflow = (ROOT / ".github" / "workflows" / "deploy-mcp-sse.yml").read_text()


### PR DESCRIPTION
Summary
- Keep the floating latest image refresh pinned to the latest release tag for application code and version checks.
- Reapply current runtime security overlay files from main before building so stale release tags do not rebuild known-vulnerable runtimes.
- Add a regression guard for the release-tag plus overlay workflow contract.

Root cause
- The latest refresh workflow checks out v0.89.2, whose Docker pip requirements still pin pip==26.1. Current main already pins pip==26.1.2, but the daily rebuild never consumed that runtime-only security fix.

Verification
- uv run pytest -q tests/test_deployment.py::test_refresh_latest_container_keeps_release_code_but_applies_runtime_security_overlay
- python scripts/check_workflow_timeouts.py
- python YAML parse for .github/workflows/refresh-latest-container.yml
- git diff --check
- Simulated v0.89.2 overlay: before=pip==26.1, after=pip==26.1.2

Notes
- Refs #3227 and #3228. The automated container rescan should close them after the refreshed latest image publishes cleanly.