### PR TITLE
fix(ci): give latest refresh publish jobs cache and budget

### DIFF
--- a/.github/workflows/refresh-latest-container.yml
+++ b/.github/workflows/refresh-latest-container.yml
@@ -15,7 +15,7 @@ jobs:
   refresh-latest:
     name: Rebuild and publish latest from latest release tag
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
@@ -125,6 +125,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: VERSION=${{ steps.release.outputs.version }}
+          cache-from: type=gha,scope=refresh-api-latest
+          cache-to: type=gha,mode=max,scope=refresh-api-latest
           provenance: true
           sbom: true
           tags: |
@@ -171,7 +173,7 @@ jobs:
   refresh-ui-latest:
     name: Rebuild and publish UI latest from latest release tag
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
@@ -286,6 +288,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             NEXT_PUBLIC_API_URL=
+          cache-from: type=gha,scope=refresh-ui-latest
+          cache-to: type=gha,mode=max,scope=refresh-ui-latest
           provenance: true
           sbom: true
           tags: |

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -457,6 +457,17 @@ def test_refresh_latest_container_keeps_release_code_but_applies_runtime_securit
     assert "The application code and version stay pinned to the latest release tag" in workflow
 
 
+def test_refresh_latest_container_has_publish_budget_and_buildkit_cache():
+    """Daily latest refresh should not rebuild multi-arch images from cold every run."""
+    workflow = (ROOT / ".github" / "workflows" / "refresh-latest-container.yml").read_text()
+
+    assert workflow.count("timeout-minutes: 30") >= 2
+    assert "cache-from: type=gha,scope=refresh-api-latest" in workflow
+    assert "cache-to: type=gha,mode=max,scope=refresh-api-latest" in workflow
+    assert "cache-from: type=gha,scope=refresh-ui-latest" in workflow
+    assert "cache-to: type=gha,mode=max,scope=refresh-ui-latest" in workflow
+
+
 def test_deploy_mcp_sse_workflow_uses_bearer_token_for_health_check():
     """Post-deploy health verification should use the same auth contract as Railway."""
     workflow = (ROOT / ".github" / "workflows" / "deploy-mcp-sse.yml").read_text()


### PR DESCRIPTION
Summary
- Increase the latest Docker refresh publish jobs to a realistic 30-minute budget.
- Add scoped BuildKit GHA cache for API and UI multi-arch pushes so daily rebuilds are not cold every time.
- Add a regression test that keeps the publish budget and cache settings in place.

Root cause
- The refreshed API image candidate passed its vulnerability gate, but the multi-arch Docker Hub push was canceled by the 15-minute job timeout. The UI job already took about 19 minutes and had a larger budget, so the API timeout was too tight for the current publish path.

Verification
- uv run pytest -q tests/test_deployment.py::test_refresh_latest_container_keeps_release_code_but_applies_runtime_security_overlay tests/test_deployment.py::test_refresh_latest_container_has_publish_budget_and_buildkit_cache
- python scripts/check_workflow_timeouts.py
- python YAML parse for .github/workflows/refresh-latest-container.yml
- git diff --check

Notes
- Follow-up to #3229. The vulnerability gate passed in run 28332184356; this addresses the publish timeout that remained after the scanner fix.