### PR TITLE
fix(action): fail high vulnerabilities by default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,9 +16,9 @@ inputs:
     required: false
     default: ''
   severity-threshold:
-    description: 'Fail if vulnerabilities at or above this severity (critical, high, medium, low). Empty = no gate.'
+    description: 'Fail if vulnerabilities at or above this severity (critical, high, medium, low). Default high; set to empty to disable the gate.'
     required: false
-    default: ''
+    default: 'high'
   warn-on-severity:
     description: 'Warn (non-blocking) if vulnerabilities at or above this severity. Use with severity-threshold for two-tier gates.'
     required: false
@@ -762,7 +762,7 @@ runs:
         fi
 
     - name: Post PR comment with findings summary
-      if: inputs.pr-comment == 'true' && github.event_name == 'pull_request'
+      if: always() && inputs.pr-comment == 'true' && github.event_name == 'pull_request'
       shell: python
       env:
         GH_TOKEN: ${{ github.token }}

--- a/tests/test_pr_gate_sarif_action_contract.py
+++ b/tests/test_pr_gate_sarif_action_contract.py
@@ -83,6 +83,21 @@ def test_action_allows_skills_sarif_upload_contract() -> None:
     assert "github/codeql-action/upload-sarif" in action_text
 
 
+def test_action_defaults_to_repo_scan_with_high_severity_gate_and_failure_comment() -> None:
+    action_text = (ROOT / "action.yml").read_text(encoding="utf-8")
+    action = yaml.safe_load(action_text)
+    scan_step = next(step for step in action["runs"]["steps"] if step.get("id") == "scan")
+    run_script = scan_step["run"]
+    comment_step = next(step for step in action["runs"]["steps"] if step.get("name") == "Post PR comment with findings summary")
+
+    assert action["inputs"]["scan-type"]["default"] == "scan"
+    assert action["inputs"]["severity-threshold"]["default"] == "high"
+    assert 'scan|"")' in run_script
+    assert "ARGS=(scan)" in run_script
+    assert 'ARGS+=(--fail-on-severity "$INPUT_SEVERITY")' in run_script
+    assert "always() && inputs.pr-comment == 'true'" in comment_step["if"]
+
+
 def test_focused_secrets_and_code_reject_sarif_format(tmp_path: Path) -> None:
     runner = CliRunner()
 


### PR DESCRIPTION
Summary
- Make the published composite Action fail on high+ vulnerabilities by default instead of running as a report-only scan.
- Keep the current default scan target as `scan`, which already maps to the repository scan path on current main.
- Run the PR findings comment step with `always()` so blocking gates still leave an explanation on the PR.

Audit validation
- The pasted audit was stale on `scan-type`: current main already defaults to `scan`, not `agent-discovery`.
- The missing default gate was real: `severity-threshold` was empty, so default Action use did not fail on critical/high findings.

Verification
- uv run pytest -q tests/test_pr_gate_sarif_action_contract.py::test_action_defaults_to_repo_scan_with_high_severity_gate_and_failure_comment tests/test_ai_enrich.py::test_action_yml_has_required_inputs tests/test_ai_enrich.py::test_action_yml_validates_severity_inputs
- uv run pytest -q tests/test_pr_gate_sarif_action_contract.py tests/test_ai_enrich.py::test_action_yml_has_required_inputs tests/test_ai_enrich.py::test_action_yml_has_new_inputs tests/test_ai_enrich.py::test_action_yml_has_outputs tests/test_ai_enrich.py::test_action_yml_composite tests/test_ai_enrich.py::test_action_yml_uses_safe_argv_execution_and_step_summary tests/test_ai_enrich.py::test_action_yml_validates_severity_inputs tests/test_ai_enrich.py::test_action_yml_sanitizes_pr_comment_body_and_single_loads_sarif
- python YAML parse for action.yml
- git diff --check