### PR TITLE
fix(mcp): bind write tools to authenticated operator tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,9 +274,10 @@ References: [Threat model](docs/THREAT_MODEL.md) ·
 | Python / TypeScript clients | services and agent runtimes | typed helpers for stable REST endpoints |
 
 MCP server mode advertises 70 MCP tools, 6 resources, and 6 workflow prompts.
-Most tools are read-only; the three Shield write actions fail closed unless the
-caller supplies `operator_role=admin`, `operator_scopes=shield:write`, and an
-audit reason. CLI scan commands run local scan pipelines today and share lower
+Most tools are read-only; Shield and identity write actions fail closed unless
+the MCP request is authenticated with `AGENT_BOM_MCP_OPERATOR_TOKEN` and the
+tool call includes the matching admin role, write scope, and audit reason. CLI
+scan commands run local scan pipelines today and share lower
 scanner and discovery libraries with the API, but they are not API wrappers yet.
 MCP registry presence is tracked through the committed Smithery manifest and
 other registry metadata; install and liveness checks live in the integration

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -108,6 +108,10 @@ Connect any SSE-capable MCP client to `https://your-server/sse`.
 For non-loopback SSE or Streamable HTTP binds, `agent-bom` now fails closed unless you set
 `--bearer-token` / `AGENT_BOM_MCP_BEARER_TOKEN` or explicitly pass
 `--allow-insecure-no-auth`. Keep TLS at your proxy or ingress for remote deployments.
+The regular bearer token is read-only. To enable audited Shield or identity
+write tools, configure a separate `AGENT_BOM_MCP_OPERATOR_TOKEN`; write calls
+still need `operator_role=admin`, the matching `operator_scopes` value, and an
+audit reason, but those arguments no longer authorize the write by themselves.
 
 ### Enterprise Control-Plane Contract
 
@@ -206,9 +210,8 @@ live runtime traffic rather than static reachability.
 ## Security Model
 
 - **Read-mostly**: scanner, graph, audit, and posture tools are read-only.
-  Shield write tools require `operator_role=admin`, `operator_scopes=shield:write`,
-  plus a reason and are
-  audit-logged.
+  Shield and identity write tools require an authenticated MCP operator token
+  plus admin role, write scope, and audit reason; they are audit-logged.
 - **No credential storage**: Never stores, logs, or transmits your credentials.
 - **No network exfiltration**: Scans local configs, queries public CVE databases.
 - **Agentless**: No agents installed on targets.

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -193,6 +193,9 @@ AGENT_BOM_LOG_JSON
 AGENT_BOM_LOG_LEVEL
 AGENT_BOM_MAX_MANIFEST_BYTES
 AGENT_BOM_MCP_BEARER_TOKEN
+# Separate MCP operator bearer token for write tools; secret reference only,
+# read at server startup to bind Shield/identity writes to authenticated scopes.
+AGENT_BOM_MCP_OPERATOR_TOKEN
 AGENT_BOM_MCP_SANDBOX
 AGENT_BOM_MCP_SANDBOX_CPUS
 AGENT_BOM_MCP_SANDBOX_EGRESS

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -8,6 +8,9 @@ Most tools are read-only. Shield write actions require `operator_role=admin`,
 Identity write actions require `operator_role=admin`, `operator_scopes=identity:write`, and an audit reason —
 the same admin/scope/audit contract for issuing, rotating, and revoking
 identities and granting or revoking just-in-time access.
+For remote SSE/HTTP deployments, those write arguments are audit context only:
+the request must authenticate with `AGENT_BOM_MCP_OPERATOR_TOKEN`. The regular
+`AGENT_BOM_MCP_BEARER_TOKEN` is read-only.
 
 ## Local (stdio)
 

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -8,9 +8,13 @@ Most tools are read-only. Shield write actions require `operator_role=admin`,
 Identity write actions require `operator_role=admin`, `operator_scopes=identity:write`, and an audit reason —
 the same admin/scope/audit contract for issuing, rotating, and revoking
 identities and granting or revoking just-in-time access.
-For remote SSE/HTTP deployments, those write arguments are audit context only:
-the request must authenticate with `AGENT_BOM_MCP_OPERATOR_TOKEN`. The regular
-`AGENT_BOM_MCP_BEARER_TOKEN` is read-only.
+Those write arguments are audit context only — they no longer authorize the
+write by themselves. The request must authenticate with a separate
+`AGENT_BOM_MCP_OPERATOR_TOKEN` (the regular `AGENT_BOM_MCP_BEARER_TOKEN` is
+read-only). Because the local stdio transport has no token channel, Shield and
+identity **write** tools are unavailable over stdio — run those actions from the
+CLI or the authenticated REST control plane instead. Read-only tools work over
+stdio as before.
 
 ## Local (stdio)
 

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -252,25 +252,28 @@ shield_status(session_id="default")
 ```
 
 ### shield_start
-Start Shield enforcement for a session. Requires `operator_role="admin"`,
-`operator_scopes="shield:write"`, and an audit reason of at least eight
-characters.
+Start Shield enforcement for a session. Remote MCP requests must authenticate
+with `AGENT_BOM_MCP_OPERATOR_TOKEN`; the call also requires
+`operator_role="admin"`, `operator_scopes="shield:write"`, and an audit reason
+of at least eight characters.
 ```
 shield_start(session_id="default", operator_role="admin", operator_scopes="shield:write", reason="incident response")
 ```
 
 ### shield_unblock
-Unblock Shield enforcement for a session. Requires `operator_role="admin"`,
-`operator_scopes="shield:write"`, and an audit reason of at least eight
-characters.
+Unblock Shield enforcement for a session. Remote MCP requests must authenticate
+with `AGENT_BOM_MCP_OPERATOR_TOKEN`; the call also requires
+`operator_role="admin"`, `operator_scopes="shield:write"`, and an audit reason
+of at least eight characters.
 ```
 shield_unblock(session_id="default", operator_role="admin", operator_scopes="shield:write", reason="validated unblock")
 ```
 
 ### shield_break_glass
-Activate the Shield emergency override. Requires `operator_role="admin"`,
-`operator_scopes="shield:write"`, and an audit reason of at least eight
-characters. The action is audit logged.
+Activate the Shield emergency override. Remote MCP requests must authenticate
+with `AGENT_BOM_MCP_OPERATOR_TOKEN`; the call also requires
+`operator_role="admin"`, `operator_scopes="shield:write"`, and an audit reason
+of at least eight characters. The action is audit logged.
 ```
 shield_break_glass(session_id="default", operator_role="admin", operator_scopes="shield:write", reason="approved emergency override")
 ```

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -85,6 +85,7 @@ from __future__ import annotations
 import asyncio
 import hmac
 import logging
+import os
 import re
 import time
 from collections import OrderedDict, deque
@@ -151,16 +152,29 @@ _GHSA_RE = re.compile(r"^GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$", re.IGNORECA
 
 
 class _StaticBearerTokenVerifier:
-    """FastMCP token verifier backed by a single configured bearer token."""
+    """FastMCP token verifier backed by configured bearer tokens.
 
-    def __init__(self, token: str):
+    The primary MCP bearer token authenticates read-only callers. A separate
+    operator token can be configured for write tools so a tool argument cannot
+    self-assert administrative authority.
+    """
+
+    def __init__(self, token: str, operator_token: str | None = None):
         self._token = token
+        self._operator_token = operator_token
 
     async def verify_token(self, token: str):
         from mcp.server.auth.provider import AccessToken
 
+        if self._operator_token and token and hmac.compare_digest(token, self._operator_token):
+            return AccessToken(
+                token=token,
+                client_id="agent-bom-operator-token",
+                scopes=["admin", "shield:write", "identity:write"],
+                resource=None,
+            )
         if token and hmac.compare_digest(token, self._token):
-            return AccessToken(token=token, client_id="agent-bom-static-token", scopes=[], resource=None)
+            return AccessToken(token=token, client_id="agent-bom-static-token", scopes=["read"], resource=None)
         return None
 
 
@@ -406,7 +420,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
         port=port,
         bearer_token=bearer_token,
         version=__version__,
-        token_verifier_factory=_StaticBearerTokenVerifier,
+        token_verifier_factory=lambda token: _StaticBearerTokenVerifier(token, os.environ.get("AGENT_BOM_MCP_OPERATOR_TOKEN")),
     )
 
     # Import tool implementations

--- a/src/agent_bom/mcp_server_factory.py
+++ b/src/agent_bom/mcp_server_factory.py
@@ -15,7 +15,8 @@ def _server_instructions(version: str) -> str:
         "checks security policies, and maps to 14 compliance frameworks"
         "(OWASP LLM/MCP/Agentic, MITRE ATLAS, NIST AI RMF/CSF/800-53, FedRAMP, EU AI Act, ISO 27001, SOC 2). "
         "Discovers 29 first-class MCP client types plus dynamic/project surfaces. "
-        "Scanner and posture tools are read-only; Shield write actions require admin role, shield:write scope, and an audit reason."
+        "Scanner and posture tools are read-only; Shield and identity write actions require an authenticated operator token, "
+        "admin role, write scope, and an audit reason."
     )
 
 

--- a/src/agent_bom/mcp_server_factory.py
+++ b/src/agent_bom/mcp_server_factory.py
@@ -16,7 +16,7 @@ def _server_instructions(version: str) -> str:
         "(OWASP LLM/MCP/Agentic, MITRE ATLAS, NIST AI RMF/CSF/800-53, FedRAMP, EU AI Act, ISO 27001, SOC 2). "
         "Discovers 29 first-class MCP client types plus dynamic/project surfaces. "
         "Scanner and posture tools are read-only; Shield and identity write actions require an authenticated operator token, "
-        "admin role, write scope, and an audit reason."
+        "admin role, write scope, and an audit reason; operator_role is audit metadata, not authentication."
     )
 
 

--- a/src/agent_bom/mcp_server_runtime.py
+++ b/src/agent_bom/mcp_server_runtime.py
@@ -190,16 +190,29 @@ def current_tool_request(request_ctx_getter: Callable[[], Any]) -> dict[str, str
     try:
         current_request = request_ctx_getter()
     except LookupError:
-        return {"caller": "local", "client_id": None, "request_id": None}
+        return {"caller": "local", "client_id": None, "request_id": None, "auth_scopes": ""}
 
     meta = getattr(current_request, "meta", None)
     client_id = getattr(meta, "client_id", None) if meta else None
     session = getattr(current_request, "session", None)
     session_label = f"session-{id(session) % 1_000_000}" if session is not None else "local"
+    auth_scopes: set[str] = set()
+    for holder_name in ("access_token", "auth", "token"):
+        holder = getattr(current_request, holder_name, None)
+        scopes = getattr(holder, "scopes", None)
+        if isinstance(scopes, list | tuple | set):
+            auth_scopes.update(str(scope).strip().lower() for scope in scopes if str(scope).strip())
+    experimental = getattr(current_request, "experimental", None)
+    for holder_name in ("access_token", "auth", "token"):
+        holder = getattr(experimental, holder_name, None) if experimental is not None else None
+        scopes = getattr(holder, "scopes", None)
+        if isinstance(scopes, list | tuple | set):
+            auth_scopes.update(str(scope).strip().lower() for scope in scopes if str(scope).strip())
     return {
         "caller": client_id or session_label,
         "client_id": client_id,
         "request_id": str(getattr(current_request, "request_id", "")) or None,
+        "auth_scopes": ",".join(sorted(auth_scopes)),
     }
 
 
@@ -263,13 +276,10 @@ def record_tool_request(
 
 
 # Write / destructive MCP tools (``destructiveHint: true`` / ``readOnlyHint:
-# false``) accept ``operator_role`` + ``operator_scopes`` parameters. Today each
-# write impl enforces those, but the metadata only *hints* at the dispatch layer.
-# ``authorize_destructive_tool`` makes the dispatch fail closed: a destructive
-# tool invoked without an admin operator role (or with an insufficient scope) is
-# rejected before the handler runs, regardless of whether the impl re-checks.
-# Read-only tools are never gated here.
-_WRITE_SCOPE_WILDCARDS = ("*", "admin", "admin:*", "write", "*:write")
+# false``) accept ``operator_role`` + ``operator_scopes`` as audit/request
+# context, but dispatch authorization is bound to the authenticated MCP request
+# scopes. A tool argument can no longer self-assert admin authority.
+_WRITE_SCOPE_WILDCARDS = ("*", "admin:*", "write", "*:write")
 
 
 def _scope_set(operator_scopes: str) -> set[str]:
@@ -281,16 +291,28 @@ def authorize_destructive_tool(
     *,
     operator_role: str,
     operator_scopes: str,
+    auth_scopes: str = "",
     required_scope: str | None = None,
 ) -> dict[str, Any] | None:
     """Authorize a destructive MCP tool. Return an error payload, or None if allowed.
 
-    Fails closed: a destructive tool requires an ``admin`` operator role. When a
-    ``required_scope`` is supplied, the operator scopes must include it (or a
-    recognized wildcard). Mirrors the per-impl write-tool gate so the dispatch
-    layer enforces the ``destructiveHint`` metadata instead of merely hinting it.
+    Fails closed: a destructive tool requires an authenticated admin/operator
+    token. ``operator_role`` and ``operator_scopes`` are retained for audit
+    context and handler compatibility, but cannot authorize a write by
+    themselves. When ``required_scope`` is supplied, the authenticated scopes
+    must include it (or a recognized wildcard).
     """
     normalized_role = (operator_role or "").strip().lower()
+    trusted_scopes = _scope_set(auth_scopes)
+    has_authenticated_admin = bool(trusted_scopes & {"admin", "operator", "admin:*", "*"})
+    if not has_authenticated_admin:
+        return {
+            "error": f"tool '{tool_name}' is a write action and requires an authenticated operator token",
+            "tool": tool_name,
+            "status": "blocked",
+            "required_role": "admin",
+            "provided_role": normalized_role or "unset",
+        }
     if normalized_role != "admin":
         return {
             "error": f"tool '{tool_name}' is a write action and requires admin operator role",
@@ -300,10 +322,9 @@ def authorize_destructive_tool(
             "provided_role": normalized_role or "unset",
         }
     if required_scope:
-        scopes = _scope_set(operator_scopes)
         wanted = required_scope.strip().lower()
         family = wanted.split(":", 1)[0]
-        allowed = scopes & ({wanted, f"{family}:*", *(_WRITE_SCOPE_WILDCARDS)})
+        allowed = trusted_scopes & ({wanted, f"{family}:*", *(_WRITE_SCOPE_WILDCARDS)})
         if not allowed:
             return {
                 "error": f"tool '{tool_name}' requires the '{wanted}' scope",
@@ -333,15 +354,16 @@ async def execute_tool_async(
     required_scope: str | None = None,
     **kwargs,
 ) -> _ToolReturn | str:
+    request_meta = request_meta_factory()
     if destructive:
         denial = authorize_destructive_tool(
             tool_name,
             operator_role=str(kwargs.get("operator_role", "") or ""),
             operator_scopes=str(kwargs.get("operator_scopes", "") or ""),
+            auth_scopes=str(request_meta.get("auth_scopes", "") or ""),
             required_scope=required_scope,
         )
         if denial is not None:
-            request_meta = request_meta_factory()
             log_caller = _log_value(request_meta["caller"])
             log_role = _log_value(str(kwargs.get("operator_role", "") or "unset"))
             record_tool_metric_fn(tool_name, elapsed_ms=0, success=False, error="forbidden")
@@ -361,7 +383,6 @@ async def execute_tool_async(
                 log_role,
             )
             return truncate_response_fn(json.dumps(denial))
-    request_meta = request_meta_factory()
     log_caller = _log_value(request_meta["caller"])
     log_request_id = _log_value(request_meta["request_id"])
     retry_after = check_caller_rate_limit_fn(request_meta["caller"] or "local")

--- a/tests/test_api_cloud_surface_parity.py
+++ b/tests/test_api_cloud_surface_parity.py
@@ -199,9 +199,30 @@ def test_authorize_destructive_blocks_non_admin() -> None:
 def test_authorize_destructive_blocks_missing_scope() -> None:
     from agent_bom.mcp_server_runtime import authorize_destructive_tool
 
-    denial = authorize_destructive_tool("identity_issue", operator_role="admin", operator_scopes="", required_scope="identity:write")
+    denial = authorize_destructive_tool(
+        "identity_issue",
+        operator_role="admin",
+        operator_scopes="identity:write",
+        auth_scopes="admin",
+        required_scope="identity:write",
+    )
     assert denial is not None
     assert denial["required_scope"] == "identity:write"
+
+
+def test_authorize_destructive_blocks_self_asserted_admin_without_operator_token() -> None:
+    from agent_bom.mcp_server_runtime import authorize_destructive_tool
+
+    denial = authorize_destructive_tool(
+        "identity_issue",
+        operator_role="admin",
+        operator_scopes="identity:write",
+        auth_scopes="",
+        required_scope="identity:write",
+    )
+    assert denial is not None
+    assert denial["status"] == "blocked"
+    assert "authenticated operator token" in denial["error"]
 
 
 def test_authorize_destructive_allows_admin_with_scope() -> None:
@@ -209,12 +230,25 @@ def test_authorize_destructive_allows_admin_with_scope() -> None:
 
     assert (
         authorize_destructive_tool(
-            "identity_issue", operator_role="admin", operator_scopes="identity:write", required_scope="identity:write"
+            "identity_issue",
+            operator_role="admin",
+            operator_scopes="identity:write",
+            auth_scopes="admin,identity:write",
+            required_scope="identity:write",
         )
         is None
     )
     # Wildcard scope is accepted.
-    assert authorize_destructive_tool("identity_issue", operator_role="admin", operator_scopes="*", required_scope="identity:write") is None
+    assert (
+        authorize_destructive_tool(
+            "identity_issue",
+            operator_role="admin",
+            operator_scopes="",
+            auth_scopes="admin,*",
+            required_scope="identity:write",
+        )
+        is None
+    )
 
 
 def test_dispatch_blocks_destructive_tool_for_low_role() -> None:
@@ -237,11 +271,42 @@ def test_dispatch_blocks_destructive_tool_for_low_role() -> None:
     assert json.loads(out)["status"] == "blocked"
 
 
-def test_dispatch_allows_destructive_tool_for_admin() -> None:
+def test_dispatch_blocks_self_asserted_admin_without_operator_token() -> None:
     from agent_bom import mcp_server
 
     async def handler(**_kwargs: object) -> str:
         return "HANDLER_RAN"
+
+    out = asyncio.run(
+        mcp_server._execute_tool_async(
+            "shield_start",
+            handler,
+            destructive=True,
+            required_scope="shield:write",
+            operator_role="admin",
+            operator_scopes="shield:write",
+        )
+    )
+    assert "HANDLER_RAN" not in out
+    assert "authenticated operator token" in json.loads(out)["error"]
+
+
+def test_dispatch_allows_destructive_tool_for_authenticated_operator(monkeypatch) -> None:
+    from agent_bom import mcp_server
+
+    async def handler(**_kwargs: object) -> str:
+        return "HANDLER_RAN"
+
+    monkeypatch.setattr(
+        mcp_server,
+        "_current_tool_request",
+        lambda: {
+            "caller": "operator",
+            "client_id": "agent-bom-operator-token",
+            "request_id": "req-1",
+            "auth_scopes": "admin,shield:write",
+        },
+    )
 
     out = asyncio.run(
         mcp_server._execute_tool_async(

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -256,6 +256,7 @@ def test_mcp_docs_match_resource_and_prompt_catalog():
     assert "35 security tools" not in docs
     assert f"{len(card['tools'])} MCP tools" in docs
     assert "Most tools are read-only" in docs
+    assert "AGENT_BOM_MCP_OPERATOR_TOKEN" in docs
     assert "Shield write actions require `operator_role=admin`" in docs
     assert "operator_scopes=shield:write" in docs
     assert "Identity write actions require `operator_role=admin`" in docs

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -88,6 +88,22 @@ def test_create_mcp_server_enables_static_bearer_auth():
     assert server.settings.auth.required_scopes == []
 
 
+def test_static_bearer_verifier_keeps_read_and_operator_tokens_separate():
+    """Read bearer tokens must not authorize MCP write tools."""
+    from agent_bom.mcp_server import _StaticBearerTokenVerifier
+
+    verifier = _StaticBearerTokenVerifier("read-token", operator_token="operator-token")
+    read_access = _run(verifier.verify_token("read-token"))
+    operator_access = _run(verifier.verify_token("operator-token"))
+
+    assert read_access is not None
+    assert read_access.client_id == "agent-bom-static-token"
+    assert read_access.scopes == ["read"]
+    assert operator_access is not None
+    assert operator_access.client_id == "agent-bom-operator-token"
+    assert set(operator_access.scopes) == {"admin", "shield:write", "identity:write"}
+
+
 # ---------------------------------------------------------------------------
 # Tool: registry_lookup (no mocking needed — reads local JSON)
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server_cov.py
+++ b/tests/test_mcp_server_cov.py
@@ -269,7 +269,7 @@ class TestToolMetrics:
         assert all("req-1\r\nforged=true" not in message for message in messages)
 
     def test_current_tool_request_defaults_to_local_without_context(self):
-        assert _current_tool_request() == {"caller": "local", "client_id": None, "request_id": None}
+        assert _current_tool_request() == {"caller": "local", "client_id": None, "request_id": None, "auth_scopes": ""}
 
     def test_check_caller_rate_limit_enforces_window(self, monkeypatch):
         import agent_bom.mcp_server as mod

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -91,4 +91,5 @@ def test_mcp_server_instructions_do_not_overclaim_read_only_surface() -> None:
 
     assert "Read-only, agentless, no credentials required." not in factory
     assert "Scanner and posture tools are read-only" in factory
-    assert "Shield write actions require admin role, shield:write scope, and an audit reason" in factory
+    assert "write actions require an authenticated operator token" in factory
+    assert "operator_role is audit metadata" in factory


### PR DESCRIPTION
## Summary
- split MCP read bearer auth from operator-token auth for write tools
- make destructive MCP dispatch authorize from authenticated request scopes, not self-asserted tool args
- keep operator_role/operator_scopes as audit context while requiring AGENT_BOM_MCP_OPERATOR_TOKEN for Shield and identity writes
- update MCP docs and server instructions so agents do not learn the old self-assertion model

## Validation
- uv run --extra mcp-server pytest -q tests/test_api_cloud_surface_parity.py::test_authorize_destructive_blocks_non_admin tests/test_api_cloud_surface_parity.py::test_authorize_destructive_blocks_missing_scope tests/test_api_cloud_surface_parity.py::test_authorize_destructive_blocks_self_asserted_admin_without_operator_token tests/test_api_cloud_surface_parity.py::test_authorize_destructive_allows_admin_with_scope tests/test_api_cloud_surface_parity.py::test_dispatch_blocks_destructive_tool_for_low_role tests/test_api_cloud_surface_parity.py::test_dispatch_blocks_self_asserted_admin_without_operator_token tests/test_api_cloud_surface_parity.py::test_dispatch_allows_destructive_tool_for_authenticated_operator tests/test_mcp_server.py::test_create_mcp_server_enables_static_bearer_auth tests/test_mcp_server.py::test_static_bearer_verifier_keeps_read_and_operator_tokens_separate tests/test_deployment.py::test_mcp_docs_match_resource_and_prompt_catalog
- uv run --extra mcp-server pytest -q tests/test_mcp_tool_output_contract.py -k 'shield or identity' tests/test_shield_write_audit.py tests/test_agent_identity_lifecycle.py::test_mcp_identity_issue_requires_admin_and_scope tests/test_agent_identity_lifecycle.py::test_mcp_identity_issue_then_grant_and_revoke_jit
- uv run ruff check src/agent_bom/mcp_server.py src/agent_bom/mcp_server_runtime.py src/agent_bom/mcp_server_factory.py tests/test_api_cloud_surface_parity.py tests/test_mcp_server.py tests/test_deployment.py
- git diff --check

Note: the full MCP tool-output sweep was interrupted after several minutes because an unrelated tool path hung; the write-tool subset that covers this change passed.