### PR TITLE
fix(graph): prune orphan nodes in scoped views

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1352,6 +1352,21 @@ async def get_graph(
             entity_types=et_set,
             min_severity_rank=min_rank,
         )
+        # Overlay the live agent-identity governance control plane (managed
+        # identities, JIT grants, conditional-access policies, drift incidents)
+        # so attack paths can traverse agent → identity → grant → tool and
+        # agent ↔ drift. Applied BEFORE the scoped filter so governance edges
+        # are subject to the relationship filter and governance nodes left
+        # unconnected in a scoped view are pruned with everything else, rather
+        # than reappearing as orphan nodes. Best-effort; never breaks the read.
+        if not et_set:
+            try:
+                from agent_bom.graph.governance_overlay import apply_governance_overlay
+
+                apply_governance_overlay(graph, tenant_id=tenant)
+            except Exception:  # noqa: BLE001
+                logger.warning("governance overlay failed", exc_info=True)
+
         rel_set = _parse_relationship_filter(relationships)
         filters = GraphFilterOptions(
             relationship_types=rel_set,
@@ -1360,18 +1375,6 @@ async def get_graph(
             max_depth=max_depth or 6,
         )
         graph = graph.filtered_view(filters)
-
-        # Overlay the live agent-identity governance control plane (managed
-        # identities, JIT grants, conditional-access policies, drift incidents)
-        # so attack paths can traverse agent → identity → grant → tool and
-        # agent ↔ drift. Best-effort; never breaks the graph read.
-        if not et_set:
-            try:
-                from agent_bom.graph.governance_overlay import apply_governance_overlay
-
-                apply_governance_overlay(graph, tenant_id=tenant)
-            except Exception:  # noqa: BLE001
-                logger.warning("governance overlay failed", exc_info=True)
 
         stats = graph.stats()
         all_nodes = list(graph.nodes.values())

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -718,6 +718,7 @@ class UnifiedGraph:
         """Build a subgraph from user-controlled filter options."""
         entity_set = filters.entity_types if filters.entity_types else None
         rel_set = filters.relationship_types if filters.relationship_types else None
+        edge_scoped = bool(rel_set or filters.static_only or filters.dynamic_only)
 
         def node_filter(n: UnifiedNode) -> bool:
             if entity_set and n.entity_type not in entity_set:
@@ -739,7 +740,24 @@ class UnifiedGraph:
                 return False
             return True
 
-        return self._subgraph(node_filter=node_filter, edge_filter=edge_filter)
+        sub = self._subgraph(node_filter=node_filter, edge_filter=edge_filter)
+        if not edge_scoped:
+            return sub
+
+        keep_ids = set(filters.include_ids)
+        for edge in sub.edges:
+            keep_ids.add(edge.source)
+            keep_ids.add(edge.target)
+
+        pruned = UnifiedGraph(scan_id=sub.scan_id, tenant_id=sub.tenant_id, created_at=sub.created_at)
+        for node_id in keep_ids:
+            node = sub.nodes.get(node_id)
+            if node:
+                pruned.add_node(node)
+        for edge in sub.edges:
+            if edge.source in pruned.nodes and edge.target in pruned.nodes:
+                pruned.add_edge(edge)
+        return pruned
 
     def _subgraph(
         self,

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -2499,17 +2499,45 @@ class TestGraphStoreBackendSelection:
         recording_graph_store.graph.add_edge(
             UnifiedEdge(source="server:s", target="vuln:cve", relationship=RelationshipType.VULNERABLE_TO, traversable=True)
         )
-        client = TestClient(app)
 
-        response = client.get("/v1/graph?relationships=vulnerable_to")
+        # The /v1/graph route overlays the governance control plane (drift /
+        # identity nodes) on top of the scan graph. Seed a drift incident so the
+        # overlay injects a drift node connected only by exhibits_drift — a
+        # vulnerable_to-scoped view must prune it, not surface it as an orphan.
+        from agent_bom.api.drift_incident_store import (
+            DriftIncident,
+            InMemoryDriftIncidentStore,
+            set_drift_incident_store,
+        )
+
+        drift_store = InMemoryDriftIncidentStore()
+        drift_store.upsert(
+            DriftIncident(
+                incident_id="inc-prune",
+                tenant_id="default",
+                blueprint_id="a",
+                status="drift_detected",
+                drift_score=0.8,
+                violation_count=1,
+                warning_count=0,
+                top_violations=[{"tool_name": "read_file", "type": "unauthorized_tool"}],
+                first_detected_at="2026-06-01T00:00:00Z",
+                last_detected_at="2026-06-02T00:00:00Z",
+            )
+        )
+        set_drift_incident_store(drift_store)
+        try:
+            client = TestClient(app)
+
+            response = client.get("/v1/graph?relationships=vulnerable_to")
+        finally:
+            set_drift_incident_store(None)
 
         assert response.status_code == 200
         body = response.json()
         node_ids = {node["id"] for node in body["nodes"]}
-        assert {"server:s", "vuln:cve"} <= node_ids
-        assert "agent:a" not in node_ids
-        assert "agent:orphan" not in node_ids
-        assert ("server:s", "vuln:cve") in {(edge["source"], edge["target"]) for edge in body["edges"]}
+        assert node_ids == {"server:s", "vuln:cve"}
+        assert {(edge["source"], edge["target"]) for edge in body["edges"]} == {("server:s", "vuln:cve")}
 
     def test_graph_query_rejects_unknown_relationship(self, recording_graph_store):
         client = TestClient(app)

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -2505,8 +2505,11 @@ class TestGraphStoreBackendSelection:
 
         assert response.status_code == 200
         body = response.json()
-        assert {node["id"] for node in body["nodes"]} == {"server:s", "vuln:cve"}
-        assert {(edge["source"], edge["target"]) for edge in body["edges"]} == {("server:s", "vuln:cve")}
+        node_ids = {node["id"] for node in body["nodes"]}
+        assert {"server:s", "vuln:cve"} <= node_ids
+        assert "agent:a" not in node_ids
+        assert "agent:orphan" not in node_ids
+        assert ("server:s", "vuln:cve") in {(edge["source"], edge["target"]) for edge in body["edges"]}
 
     def test_graph_query_rejects_unknown_relationship(self, recording_graph_store):
         client = TestClient(app)

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -2479,6 +2479,35 @@ class TestGraphStoreBackendSelection:
         assert response.status_code == 422
         assert "Unsupported graph relationship type" in response.json()["detail"]
 
+    def test_graph_get_relationship_filter_prunes_unconnected_nodes(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="vuln:cve",
+                entity_type=EntityType.VULNERABILITY,
+                label="CVE-2026-1",
+                severity="critical",
+                severity_id=5,
+            )
+        )
+        recording_graph_store.graph.add_node(UnifiedNode(id="agent:orphan", entity_type=EntityType.AGENT, label="orphan"))
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES, traversable=True)
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="server:s", target="vuln:cve", relationship=RelationshipType.VULNERABLE_TO, traversable=True)
+        )
+        client = TestClient(app)
+
+        response = client.get("/v1/graph?relationships=vulnerable_to")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert {node["id"] for node in body["nodes"]} == {"server:s", "vuln:cve"}
+        assert {(edge["source"], edge["target"]) for edge in body["edges"]} == {("server:s", "vuln:cve")}
+
     def test_graph_query_rejects_unknown_relationship(self, recording_graph_store):
         client = TestClient(app)
 

--- a/ui/lib/filter-algebra.ts
+++ b/ui/lib/filter-algebra.ts
@@ -412,6 +412,22 @@ function pruneEdgesToNodes(
   return edges.filter((e) => nodeIds.has(e.source) && nodeIds.has(e.target));
 }
 
+function filterNodesToEdgeEndpoints(
+  nodes: UnifiedNode[],
+  edges: UnifiedEdge[],
+): UnifiedNode[] {
+  const endpointIds = new Set<string>();
+  for (const edge of edges) {
+    endpointIds.add(edge.source);
+    endpointIds.add(edge.target);
+  }
+  return nodes.filter((node) => endpointIds.has(node.id));
+}
+
+function hasEdgeScopedFilter(filters: FilterState): boolean {
+  return filters.relationshipScope !== "all" || filters.runtimeMode !== "all";
+}
+
 // ───────────────────────────────────────────────────────────────────────
 // Public entry points
 // ───────────────────────────────────────────────────────────────────────
@@ -445,13 +461,16 @@ export function applyFilters(
   const { nodes: filteredNodes } = passNodes(nodes, filteredEdges, filters, {});
   const keepIds = new Set(filteredNodes.map((n) => n.id));
   const finalEdges = pruneEdgesToNodes(filteredEdges, keepIds);
+  const finalNodes = hasEdgeScopedFilter(filters)
+    ? filterNodesToEdgeEndpoints(filteredNodes, finalEdges)
+    : filteredNodes;
 
   // Compute valid values by running 4 alternative passes — each one
   // skips ONE dimension so we can collect what would still appear.
   const validValues = computeValidValues(nodes, edges, filters);
 
   return {
-    nodes: filteredNodes,
+    nodes: finalNodes,
     edges: finalEdges,
     validValues,
   };

--- a/ui/tests/filter-algebra.test.ts
+++ b/ui/tests/filter-algebra.test.ts
@@ -331,11 +331,14 @@ describe("applyFilters — constraint propagation", () => {
     // attack edges: VULNERABLE_TO ×2, AFFECTS ×2.
     // Surviving nodes are only those connected by attack edges:
     // pkg-A1, pkg-B1, cve-1, cve-2, agent-A, agent-B (via AFFECTS).
-    // Other nodes still PASS the layer + severity + vulnOnly + agent
-    // predicates so they remain in `nodes` — but the algebra prunes
-    // edges to attack-scope only. So node count is unchanged (no
-    // node-level attack predicate).
-    expect(result.nodes).toHaveLength(20);
+    expect(result.nodes.map((node) => node.id).sort()).toEqual([
+      "agent-A",
+      "agent-B",
+      "cve-1",
+      "cve-2",
+      "pkg-A1",
+      "pkg-B1",
+    ]);
     // But every surviving edge must be attack scope.
     const allowed = new Set([
       "affects",


### PR DESCRIPTION
## Summary
- prune relationship/static/runtime-scoped graph API views to the endpoints of surviving edges
- mirror the same behavior in the UI filter algebra so scoped views do not show unrelated orphan nodes
- add API/UI regressions for relationship-scoped attack graphs

Refs #3192

## Tests
- python -m pytest tests/test_graph_api.py tests/test_graph_rollup.py -q
- cd ui && npm test -- --run tests/filter-algebra.test.ts tests/unified-graph-flow.test.ts tests/graph-renderer-switch.test.ts
- ruff check src/agent_bom/graph/container.py tests/test_graph_api.py
- cd ui && npm run lint