### PR TITLE
fix(gateway): fail closed on policy engine faults

### DIFF
--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -901,7 +901,8 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
     rate_limit_store = _build_gateway_rate_limit_store(settings)
     # Fail-closed posture resolved once at build time. "closed" makes a
     # missing/unloadable policy or an evaluation error DENY instead of silently
-    # degrading to default-allow. Default "open" preserves current behaviour.
+    # degrading to default-allow. Explicit "open" remains available for local
+    # development, but production defaults to closed.
     resolved_fail_mode = resolve_fail_mode(settings.fail_mode)
     fail_closed = resolved_fail_mode == "closed"
     if fail_closed:
@@ -1919,7 +1920,11 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 )
                 try:
                     cond_decision, cond_reason, _cond_rule = evaluate_conditional_rules(current_policy, decision_ctx)
-                    plugin_decision, plugin_reason, _plugin_name = evaluate_policy_plugins(decision_ctx, current_policy)
+                    plugin_decision, plugin_reason, _plugin_name = evaluate_policy_plugins(
+                        decision_ctx,
+                        current_policy,
+                        fail_closed=fail_closed,
+                    )
                     eval_error = False
                 except Exception as exc:  # noqa: BLE001
                     logger.warning("gateway conditional/plugin evaluation error: %s", _sanitize_for_log(exc))

--- a/src/agent_bom/proxy_policy.py
+++ b/src/agent_bom/proxy_policy.py
@@ -385,7 +385,8 @@ class GatewayDecision(str, Enum):
 
 
 # Env knobs (read by the gateway, surfaced here so the contract lives with the
-# engine). Defaults preserve current behaviour: fail-open, no webhook.
+# engine). Gateway policy failure is fail-closed by default; operators can still
+# opt into explicit fail-open for local/dev compatibility.
 GATEWAY_FAIL_MODE_ENV = "AGENT_BOM_GATEWAY_FAIL_MODE"
 POLICY_WEBHOOK_URL_ENV = "AGENT_BOM_POLICY_WEBHOOK_URL"
 POLICY_WEBHOOK_TOKEN_ENV = "AGENT_BOM_POLICY_WEBHOOK_TOKEN"
@@ -397,17 +398,16 @@ def resolve_fail_mode(explicit: str | None = None) -> str:
     """Return ``"open"`` or ``"closed"`` for the missing/unloadable-policy path.
 
     Precedence: an explicit caller value, then ``AGENT_BOM_GATEWAY_FAIL_MODE``,
-    then the secure-compatible default ``"open"`` (unchanged behaviour). Any
-    unrecognised value falls back to ``"open"`` with a warning so a typo never
-    silently fails the whole relay closed.
+    then the secure default ``"closed"``. Any unrecognised value falls back to
+    ``"closed"`` with a warning so a typo never silently disables enforcement.
     """
     raw = (explicit if explicit is not None else os.environ.get(GATEWAY_FAIL_MODE_ENV, "")).strip().lower()
     if not raw:
-        return "open"
+        return "closed"
     if raw in ("open", "closed"):
         return raw
-    logger.warning("Unrecognised gateway fail mode %r; defaulting to 'open'", raw)
-    return "open"
+    logger.warning("Unrecognised gateway fail mode %r; defaulting to 'closed'", raw)
+    return "closed"
 
 
 @dataclass(frozen=True)
@@ -641,12 +641,20 @@ def _load_entrypoint_evaluators() -> None:
         _REGISTERED_EVALUATORS.setdefault(name, evaluator)
 
 
-def evaluate_policy_plugins(ctx: DecisionContext, policy: dict) -> tuple[GatewayDecision, str, str | None]:
+def evaluate_policy_plugins(
+    ctx: DecisionContext,
+    policy: dict,
+    *,
+    fail_closed: bool = False,
+) -> tuple[GatewayDecision, str, str | None]:
     """Compose all registered policy-evaluator plugins into one verdict.
 
-    Each plugin is isolated: a raising plugin is logged and skipped (fail-safe),
-    never fatal. DENY outranks QUARANTINE outranks ALLOW; the strictest verdict
-    across plugins wins, with the first plugin producing that verdict named.
+    Each plugin is isolated. In explicit fail-open mode a raising plugin is
+    logged and skipped for local/dev compatibility. In fail-closed mode a
+    raising plugin produces a DENY so a broken evaluator cannot silently disable
+    gateway enforcement. DENY outranks QUARANTINE outranks ALLOW; the strictest
+    verdict across plugins wins, with the first plugin producing that verdict
+    named.
     """
     _load_entrypoint_evaluators()
     if not _REGISTERED_EVALUATORS:
@@ -660,7 +668,9 @@ def evaluate_policy_plugins(ctx: DecisionContext, policy: dict) -> tuple[Gateway
         try:
             verdict = evaluator(ctx, policy)
         except Exception as exc:  # noqa: BLE001 — isolate a misbehaving plugin
-            logger.warning("policy evaluator plugin %r raised and was skipped: %s", name, exc)
+            logger.warning("policy evaluator plugin %r raised: %s", name, exc)
+            if fail_closed:
+                return GatewayDecision.DENY, "policy evaluator unavailable; fail-closed mode denies", name
             continue
         if verdict is None:
             continue

--- a/tests/test_gateway_policy_hardening.py
+++ b/tests/test_gateway_policy_hardening.py
@@ -2,8 +2,8 @@
 
 Covers the five shipped capabilities and the cross-cutting acceptance criteria:
 
-1. Fail-closed mode — missing/unloadable policy DENIES in ``closed`` mode and
-   still ALLOWS (legacy) in the default ``open`` mode.
+1. Fail-closed mode — missing/unloadable policy DENIES by default and still
+   ALLOWS only under explicit ``open`` mode.
 2. Quarantine decision tier — a conditional ``quarantine`` rule blocks the tool
    with a distinct, client-safe reason while flagging + auditing the agent.
 3. Conditional access — declarative time-window / risk-score / required-attribute
@@ -15,7 +15,7 @@ Covers the five shipped capabilities and the cross-cutting acceptance criteria:
    relay is never blocked by a webhook failure.
 
 Plus determinism (same request → identical decision + identical event id) and
-the default-behaviour-unchanged guarantee.
+the non-enforcement default-allow guarantee.
 """
 
 from __future__ import annotations
@@ -89,11 +89,12 @@ def _clean_plugin_registry():
 # ─── Fail-closed mode ──────────────────────────────────────────────────────
 
 
-def test_resolve_fail_mode_default_open(monkeypatch):
+def test_resolve_fail_mode_default_closed(monkeypatch):
     monkeypatch.delenv("AGENT_BOM_GATEWAY_FAIL_MODE", raising=False)
-    assert resolve_fail_mode(None) == "open"
+    assert resolve_fail_mode(None) == "closed"
     assert resolve_fail_mode("closed") == "closed"
-    assert resolve_fail_mode("garbage") == "open"
+    assert resolve_fail_mode("open") == "open"
+    assert resolve_fail_mode("garbage") == "closed"
 
 
 def test_fail_closed_denies_when_policy_file_unloadable(tmp_path):
@@ -107,12 +108,23 @@ def test_fail_closed_denies_when_policy_file_unloadable(tmp_path):
     assert any(e["action"] == "gateway.policy_fail_closed" for e in audit)
 
 
-def test_fail_open_default_allows_when_policy_file_unloadable(tmp_path):
+def test_fail_closed_default_denies_when_policy_file_unloadable(tmp_path):
     missing = tmp_path / "does-not-exist.json"
-    settings = _settings(policy_path=missing)  # fail_mode defaults to open
+    audit: list[dict[str, Any]] = []
+    settings = _settings(audit=audit, policy_path=missing)
     client = TestClient(create_gateway_app(settings))
     resp = client.post("/mcp/filesystem", json=_call())
-    # Legacy behaviour: missing policy degrades to default-allow, call forwards.
+    assert _is_blocked(resp)
+    assert resp.json()["error"]["data"]["policy_source"] == "fail_closed"
+    assert any(e["action"] == "gateway.policy_fail_closed" for e in audit)
+
+
+def test_explicit_fail_open_allows_when_policy_file_unloadable(tmp_path):
+    missing = tmp_path / "does-not-exist.json"
+    settings = _settings(policy_path=missing, fail_mode="open")
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_call())
+    # Local/dev compatibility: explicit fail-open still forwards.
     assert resp.status_code == 200
     assert resp.json().get("result") == {"ok": True}
 
@@ -202,15 +214,35 @@ def test_plugin_evaluator_can_deny_in_relay():
     assert resp.json()["error"]["data"]["policy_source"] == "policy_plugin"
 
 
-def test_raising_plugin_is_isolated_decision_still_returned():
+def test_raising_plugin_fails_closed_by_default():
     def _boom(ctx: DecisionContext, policy: dict) -> PluginDecision | None:
         raise RuntimeError("plugin exploded")
 
     register_policy_evaluator("boom", _boom)
-    settings = _settings()  # fail-open: a raising plugin must not break the relay
+    audit: list[dict[str, Any]] = []
+    settings = _settings(audit=audit)
     client = TestClient(create_gateway_app(settings))
     resp = client.post("/mcp/filesystem", json=_call())
-    # Decision still returned — the call forwards (no plugin opinion survived).
+    assert _is_blocked(resp)
+    body = resp.json()
+    assert body["error"]["data"]["policy_source"] == "policy_plugin"
+    assert body["error"]["data"]["reason"] == "A gateway policy plugin blocked this request"
+    assert any(
+        event["policy_source"] == "policy_plugin"
+        and event["reason"] == "policy evaluator unavailable; fail-closed mode denies"
+        for event in audit
+    )
+
+
+def test_raising_plugin_is_isolated_in_explicit_fail_open_mode():
+    def _boom(ctx: DecisionContext, policy: dict) -> PluginDecision | None:
+        raise RuntimeError("plugin exploded")
+
+    register_policy_evaluator("boom", _boom)
+    settings = _settings(fail_mode="open")
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_call())
+    # Decision still returned — the call forwards only under explicit fail-open.
     assert resp.status_code == 200
     assert resp.json().get("result") == {"ok": True}
 
@@ -321,12 +353,12 @@ def test_webhook_failure_does_not_block_relay():
     assert _is_blocked(resp)  # relay still denies even though the webhook would fail
 
 
-# ─── Default behaviour unchanged ───────────────────────────────────────────
+# ─── Non-enforcement default behaviour unchanged ───────────────────────────
 
 
 def test_defaults_preserve_existing_allow_behaviour():
-    # No fail_mode, no webhook, no conditional rules, no plugins → identical to
-    # legacy: an unmatched policy allows and the call forwards.
+    # No policy_path, no webhook, no conditional rules, no plugins: an unmatched
+    # inline policy is still non-enforcement and forwards.
     settings = _settings(policy={"rules": []})
     client = TestClient(create_gateway_app(settings))
     resp = client.post("/mcp/filesystem", json=_call())


### PR DESCRIPTION
## Why
The release audit correctly flagged the gateway policy engine as fail-open by default. A configured but unavailable policy, typoed fail mode, or broken plugin evaluator could silently forward traffic while enforcement appeared enabled.

## What
- Default fail-mode resolution to closed.
- Keep explicit fail_mode=open / AGENT_BOM_GATEWAY_FAIL_MODE=open for local/dev compatibility.
- Treat invalid fail-mode values as closed instead of open.
- Pass resolved fail-closed posture into plugin evaluation so broken policy plugins deny instead of silently skipping.
- Preserve non-enforcement behavior: no configured policy path and no matching inline rules still forwards.

## Tests
- uv run pytest tests/test_gateway_policy_hardening.py tests/test_gateway_server.py -q
- uv run ruff check src/agent_bom/proxy_policy.py src/agent_bom/gateway_server.py tests/test_gateway_policy_hardening.py
- uv run mypy src/agent_bom/proxy_policy.py src/agent_bom/gateway_server.py