### PR TITLE
docs(diagrams): redesign architecture and how-it-works for clarity

### DIFF
--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -1,244 +1,174 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 660" fill="none" role="img" aria-labelledby="abom-arch-title abom-arch-desc">
   <title id="abom-arch-title">agent-bom architecture and data flow</title>
-  <desc id="abom-arch-desc">Left-to-right flow: evidence sources are scanned and ingested into one unified Finding and ContextGraph, served through the control plane (API, Gateway, MCP server) to human and headless-agent consumers, emitting SARIF, CycloneDX, SPDX, and OCSF artifacts.</desc>
+  <desc id="abom-arch-desc">Left-to-right flow: read-only sources are scanned and enriched into one unified Finding and ContextGraph, served through the control plane (API, Gateway, MCP server) to human and headless-agent consumers, emitting SARIF, CycloneDX, SPDX, and OCSF artifacts.</desc>
   <defs>
     <linearGradient id="abom-accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#60a5fa"/>
-      <stop offset="100%" stop-color="#a78bfa"/>
+      <stop offset="0%" stop-color="#a78bfa"/>
+      <stop offset="100%" stop-color="#818cf8"/>
     </linearGradient>
-    <marker id="abom-arrow" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto">
-      <path d="M0 0 L10 4 L0 8 Z" fill="#5b6472"/>
-    </marker>
-    <marker id="abom-arrow-accent" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto">
-      <path d="M0 0 L10 4 L0 8 Z" fill="#818cf8"/>
-    </marker>
+    <marker id="abom-arrow" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
+    <marker id="abom-arrow-accent" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
     <style>
-      text { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
-      .title { font-size: 21px; font-weight: 800; fill: #f4f4f5; }
-      .subtitle { font-size: 11.5px; font-weight: 400; fill: #71717a; }
-      .lane-label { font-size: 10px; font-weight: 700; letter-spacing: 0.14em; }
-      .node-title { font-size: 12.5px; font-weight: 700; fill: #e4e4e7; }
-      .node-sub { font-size: 9px; font-weight: 400; fill: #71717a; }
-      .pill { font-size: 9px; font-weight: 600; fill: #a1a1aa; }
-      .flow-label { font-size: 8.5px; font-weight: 700; letter-spacing: 0.08em; fill: #52525b; }
-      .footer { font-size: 9px; font-weight: 600; letter-spacing: 0.05em; fill: #52525b; }
+      text { font-family: Inter, system-ui, -apple-system, 'Segoe UI', sans-serif; }
+      .title { font-size: 22px; font-weight: 800; fill: #f4f4f5; }
+      .subtitle { font-size: 11.5px; font-weight: 400; fill: #8a8a93; }
+      .lane-label { font-size: 10px; font-weight: 800; letter-spacing: 0.16em; fill: #a78bfa; }
+      .lane-sub { font-size: 9px; font-weight: 500; fill: #6b6b75; }
+      .node-title { font-size: 12.5px; font-weight: 700; fill: #e9e9ec; }
+      .node-sub { font-size: 9px; font-weight: 400; fill: #82828c; }
+      .pill { font-size: 9px; font-weight: 600; fill: #a78bfa; }
+      .flow-label { font-size: 8.5px; font-weight: 800; letter-spacing: 0.1em; fill: #6b6b75; }
+      .chip { font-size: 9px; font-weight: 700; fill: #a1a1aa; }
+      .footer { font-size: 9.5px; font-weight: 600; letter-spacing: 0.04em; fill: #4ade80; }
+      .ic { fill: none; stroke: #9a9aa4; stroke-width: 1.55; stroke-linecap: round; stroke-linejoin: round; }
+      .ic-a { fill: none; stroke: #a78bfa; stroke-width: 1.55; stroke-linecap: round; stroke-linejoin: round; }
     </style>
   </defs>
 
-  <rect width="1200" height="660" rx="14" fill="#09090b"/>
-
-  <!-- Header -->
+  <rect width="1200" height="660" rx="14" fill="#0a0a0c"/>
   <text x="40" y="42" class="title">agent-bom <tspan fill="url(#abom-accent)">architecture</tspan></text>
-  <text x="40" y="63" class="subtitle">One evidence model, left to right: collect from every AI-supply-chain surface, normalize into one Finding and ContextGraph, serve through the control plane, deliver to humans and headless agents.</text>
+  <text x="40" y="63" class="subtitle">One evidence model, left to right — collect read-only, normalize into one Finding + ContextGraph, serve through the control plane, deliver to people and agents.</text>
 
-  <!-- Lane connector arrows (between lanes, vertically centered ~y=360) -->
-  <line x1="246" y1="360" x2="270" y2="360" stroke="#5b6472" stroke-width="2" marker-end="url(#abom-arrow)"/>
-  <text x="258" y="350" text-anchor="middle" class="flow-label">SCAN</text>
-  <line x1="486" y1="360" x2="510" y2="360" stroke="#5b6472" stroke-width="2" marker-end="url(#abom-arrow)"/>
-  <text x="498" y="350" text-anchor="middle" class="flow-label">NORMALIZE</text>
-  <line x1="726" y1="360" x2="750" y2="360" stroke="#818cf8" stroke-width="2" marker-end="url(#abom-arrow-accent)"/>
-  <text x="738" y="350" text-anchor="middle" class="flow-label" fill="#818cf8">SERVE</text>
-  <line x1="966" y1="360" x2="990" y2="360" stroke="#5b6472" stroke-width="2" marker-end="url(#abom-arrow)"/>
-  <text x="978" y="350" text-anchor="middle" class="flow-label">DELIVER</text>
+  <!-- ===== LANE 1 SOURCES ===== -->
+  <rect x="40" y="92" width="206" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
+  <text x="56" y="118" class="lane-label">SOURCES</text>
+  <text x="56" y="134" class="lane-sub">Read-only · no writes · no secret values</text>
 
-  <!-- ════════ LANE 1 — SOURCES ════════ -->
-  <rect x="40" y="92" width="206" height="500" rx="12" fill="#0e1420" stroke="#1e293b" stroke-width="1"/>
-  <text x="52" y="116" class="lane-label" fill="#60a5fa">SOURCES</text>
-  <text x="52" y="132" class="node-sub">Read-only · no writes · no secrets stored</text>
+  <g><rect x="52" y="148" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="62" y="161" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M69 168h7l3 3v9h-13z M76 168v3h3"/>
+    <text x="98" y="170" class="node-title">Supply chain</text><text x="98" y="185" class="node-sub">15 ecosystems + OS packages</text></g>
+  <g><rect x="52" y="206" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="62" y="219" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="75" cy="227" r="3"/><circle class="ic" cx="70" cy="238" r="2.4"/><circle class="ic" cx="80" cy="238" r="2.4"/><path class="ic" d="M73 230l-2 6 M77 230l2 6"/>
+    <text x="98" y="228" class="node-title">Agents &amp; MCP</text><text x="98" y="243" class="node-sub">29 clients · servers · tools</text></g>
+  <g><rect x="52" y="264" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="62" y="277" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M68 293h12a4 4 0 0 0 .6-7.9 6 6 0 0 0-11.3-1.6A4.2 4.2 0 0 0 68 293z"/>
+    <text x="98" y="286" class="node-title">Cloud inventory</text><text x="98" y="301" class="node-sub">AWS · Azure · GCP · Snowflake</text></g>
+  <g><rect x="52" y="322" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="62" y="335" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M75 333l7 3.5-7 3.5-7-3.5z M68 341l7 3.5 7-3.5 M68 345l7 3.5 7-3.5"/>
+    <text x="98" y="344" class="node-title">IaC &amp; containers</text><text x="98" y="359" class="node-sub">Terraform · K8s · OCI images</text></g>
+  <g><rect x="52" y="380" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="62" y="393" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="72" cy="403" r="3.4"/><path class="ic" d="M74.4 405.4l7 7 M79 410l2.5-2.5 M81.5 412.5l2.5-2.5"/>
+    <text x="98" y="402" class="node-title">Secrets</text><text x="98" y="417" class="node-sub">credential refs · token patterns</text></g>
+  <g><rect x="52" y="438" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="62" y="451" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M75 458l7 3.5v7l-7 3.5-7-3.5v-7z M75 458v14 M68 461.5l14 7"/>
+    <text x="98" y="460" class="node-title">Models &amp; data</text><text x="98" y="475" class="node-sub">weights · cards · PII/PHI</text></g>
+  <g><rect x="52" y="496" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="62" y="509" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M70 515h10v14h-10z M73 520h7 M73 524h7 M73 528h4"/>
+    <text x="98" y="518" class="node-title">SBOM ingest</text><text x="98" y="533" class="node-sub">CycloneDX · SPDX import</text></g>
 
-  <g>
-    <rect x="52" y="146" width="182" height="50" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="66" y="168" class="node-title">Supply chain</text>
-    <text x="66" y="184" class="node-sub">15 ecosystem parsers · npm/pip/go/maven + OS pkgs</text>
-  </g>
-  <g>
-    <rect x="52" y="204" width="182" height="50" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="66" y="226" class="node-title">AI agents &amp; MCP</text>
-    <text x="66" y="242" class="node-sub">29 client configs · servers · tools · registry</text>
-  </g>
-  <g>
-    <rect x="52" y="262" width="182" height="50" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="66" y="284" class="node-title">Cloud inventory</text>
-    <text x="66" y="300" class="node-sub">AWS · Azure · GCP + 13 AI/data providers</text>
-  </g>
-  <g>
-    <rect x="52" y="320" width="182" height="50" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="66" y="342" class="node-title">IaC &amp; containers</text>
-    <text x="66" y="358" class="node-sub">Terraform · CFN · Helm · K8s · OCI images</text>
-  </g>
-  <g>
-    <rect x="52" y="378" width="182" height="50" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="66" y="400" class="node-title">Secrets</text>
-    <text x="66" y="416" class="node-sub">credential refs · env names · token leak patterns</text>
-  </g>
-  <g>
-    <rect x="52" y="436" width="182" height="50" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="66" y="458" class="node-title">Models &amp; datasets</text>
-    <text x="66" y="474" class="node-sub">weight formats · dataset cards · PII/PHI scan</text>
-  </g>
-  <g>
-    <rect x="52" y="494" width="182" height="50" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="66" y="516" class="node-title">SBOM ingest</text>
-    <text x="66" y="532" class="node-sub">CycloneDX + SPDX import · re-scan inventory</text>
-  </g>
+  <!-- ===== LANE 2 SCAN / INGEST ===== -->
+  <rect x="280" y="92" width="206" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
+  <text x="296" y="118" class="lane-label">SCAN &amp; ENRICH</text>
+  <text x="296" y="134" class="lane-sub">Parallel · local-only</text>
 
-  <!-- ════════ LANE 2 — SCAN / INGEST ════════ -->
-  <rect x="280" y="92" width="206" height="500" rx="12" fill="#1c1408" stroke="#3f2d0a" stroke-width="1"/>
-  <text x="292" y="116" class="lane-label" fill="#fbbf24">SCAN / INGEST</text>
-  <text x="292" y="132" class="node-sub">Parallel enrichment, local-only</text>
+  <g><rect x="292" y="148" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="302" y="164" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="313" cy="175" r="4.2"/><path class="ic" d="M316 178l4 4"/>
+    <text x="338" y="172" class="node-title">Vulnerability scan</text><text x="338" y="188" class="node-sub">OSV batch across all packages</text></g>
+  <g><rect x="292" y="214" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="302" y="230" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M313 233l1.6 3.4 3.4 1.6-3.4 1.6L313 245l-1.6-3.4-3.4-1.6 3.4-1.6z"/>
+    <text x="338" y="238" class="node-title">Threat enrichment</text><text x="338" y="254" class="node-sub">NVD · EPSS · KEV · GHSA</text></g>
+  <g><rect x="292" y="280" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="302" y="296" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M313 300l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M310 308l2 2 4-4.5"/>
+    <text x="338" y="304" class="node-title">Posture checks</text><text x="338" y="320" class="node-sub">MCP/A2A auth · CIS · NHI</text></g>
+  <g><rect x="292" y="346" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="302" y="362" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M307 384v-8 M313 384v-12 M319 384v-6 M306 384h15"/>
+    <text x="338" y="370" class="node-title">Cost / FinOps</text><text x="338" y="386" class="node-sub">model + cloud spend signals</text></g>
+  <g><rect x="292" y="412" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="302" y="428" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M308 434h12 M308 440h12 M308 446h8"/><path class="ic-a" d="M305 434l1.4 1.4 2-2.4"/>
+    <text x="338" y="436" class="node-title">Policy engine</text><text x="338" y="452" class="node-sub">policy-as-code · frameworks</text></g>
+  <g><rect x="292" y="478" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="302" y="494" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="315" cy="507" r="8"/><circle class="ic" cx="315" cy="507" r="4"/><circle class="ic-a" cx="315" cy="507" r="1.4"/>
+    <text x="338" y="502" class="node-title">Blast-radius</text><text x="338" y="518" class="node-sub">pkg → finding → agent fusion</text></g>
 
-  <g>
-    <rect x="292" y="146" width="182" height="58" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="306" y="168" class="node-title">Vulnerability scan</text>
-    <text x="306" y="184" class="node-sub">OSV.dev batch lookup across</text>
-    <text x="306" y="197" class="node-sub">all discovered packages</text>
-  </g>
-  <g>
-    <rect x="292" y="212" width="182" height="72" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="306" y="234" class="node-title">Threat enrichment</text>
-    <text x="306" y="250" class="node-sub">NVD CVSS v3.1/v4.0 · EPSS</text>
-    <text x="306" y="263" class="node-sub">CISA KEV · GHSA · CSAF</text>
-    <text x="306" y="276" class="node-sub">exploit + known-exploited signals</text>
-  </g>
-  <g>
-    <rect x="292" y="292" width="182" height="58" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="306" y="314" class="node-title">Posture checks</text>
-    <text x="306" y="330" class="node-sub">MCP / A2A auth posture · NHI</text>
-    <text x="306" y="343" class="node-sub">identity · IaC misconfig · CIS</text>
-  </g>
-  <g>
-    <rect x="292" y="358" width="182" height="58" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="306" y="380" class="node-title">Cost / FinOps</text>
-    <text x="306" y="396" class="node-sub">model + cloud spend signals</text>
-    <text x="306" y="409" class="node-sub">budget context per workload</text>
-  </g>
-  <g>
-    <rect x="292" y="424" width="182" height="58" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="306" y="446" class="node-title">Policy engine</text>
-    <text x="306" y="462" class="node-sub">policy-as-code conditions</text>
-    <text x="306" y="475" class="node-sub">compliance + framework tagging</text>
-  </g>
-  <g>
-    <rect x="292" y="490" width="182" height="54" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="306" y="512" class="node-title">Blast-radius scoring</text>
-    <text x="306" y="528" class="node-sub">pkg → finding → server →</text>
-    <text x="306" y="541" class="node-sub">agent → creds → tools fusion</text>
-  </g>
+  <!-- ===== LANE 3 CORE MODEL ===== -->
+  <rect x="520" y="92" width="206" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
+  <text x="536" y="118" class="lane-label">EVIDENCE CORE</text>
+  <text x="536" y="134" class="lane-sub">One normalized truth</text>
 
-  <!-- ════════ LANE 3 — UNIFIED FINDING + CONTEXTGRAPH ════════ -->
-  <rect x="520" y="92" width="206" height="500" rx="12" fill="#1a0a14" stroke="#3f1126" stroke-width="1"/>
-  <text x="532" y="116" class="lane-label" fill="#fb7185">CORE MODEL</text>
-  <text x="532" y="132" class="node-sub">One normalized truth</text>
+  <g><rect x="532" y="150" width="182" height="86" rx="9" fill="#15121f" stroke="#5b4bbd"/>
+    <rect x="542" y="164" width="26" height="26" rx="7" fill="#1a1530" stroke="#4c3f9e"/><path class="ic-a" d="M549 170h7l3 3v9h-13z M556 170v3h3 M551 182l1.6 1.6 3-3.4"/>
+    <text x="578" y="172" class="node-title" fill="#f4f4f5">Unified Finding</text><text x="578" y="188" class="node-sub">CVE · misconfig · secret · auth</text>
+    <text x="578" y="205" class="node-sub">+ severity · CVSS · EPSS · KEV</text>
+    <text x="546" y="225" class="pill">one schema for every modality</text></g>
+  <g><rect x="532" y="244" width="182" height="86" rx="9" fill="#15121f" stroke="#5b4bbd"/>
+    <rect x="542" y="258" width="26" height="26" rx="7" fill="#1a1530" stroke="#4c3f9e"/><circle class="ic-a" cx="551" cy="265" r="2.6"/><circle class="ic-a" cx="561" cy="263" r="2.6"/><circle class="ic-a" cx="556" cy="278" r="2.6"/><path class="ic-a" d="M553 266l2 9 M559 265l-2 10"/>
+    <text x="578" y="266" class="node-title" fill="#f4f4f5">ContextGraph</text><text x="578" y="282" class="node-sub">entities + edges across</text>
+    <text x="578" y="299" class="node-sub">env · identity · MCP · model</text>
+    <text x="546" y="319" class="pill">multi-hop attack-path fusion</text></g>
+  <g><rect x="532" y="338" width="182" height="56" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="542" y="353" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="555" cy="366" r="7.5"/><path class="ic" d="M555 362v4.5l3 2"/>
+    <text x="578" y="362" class="node-title">Asset tracker</text><text x="578" y="378" class="node-sub">first_seen · MTTR · drift</text></g>
+  <g><rect x="532" y="402" width="182" height="56" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="542" y="417" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M555 424l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M552 432l2 2 4-4.5"/>
+    <text x="578" y="426" class="node-title">Audit &amp; provenance</text><text x="578" y="442" class="node-sub">signed · hash chain · tenant</text></g>
+  <g><rect x="532" y="466" width="182" height="40" rx="9" fill="#121016" stroke="#2a2733"/>
+    <rect x="542" y="475" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M547 481c0-1.7 2.7-3 6-3s6 1.3 6 3-2.7 3-6 3-6-1.3-6-3z M547 481v8c0 1.7 2.7 3 6 3s6-1.3 6-3v-8"/>
+    <text x="574" y="491" class="node-sub" fill="#a1a1aa">Postgres / SQLite · tenant-isolated</text></g>
 
-  <g>
-    <rect x="532" y="150" width="182" height="92" rx="8" fill="#18181b" stroke="#3f1126"/>
-    <text x="546" y="174" class="node-title">Unified Finding</text>
-    <text x="546" y="191" class="node-sub">one schema for every modality:</text>
-    <text x="546" y="204" class="node-sub">CVE · misconfig · secret · auth</text>
-    <text x="546" y="217" class="node-sub">+ severity, CVSS, EPSS, KEV,</text>
-    <text x="546" y="230" class="node-sub">compliance controls, provenance</text>
-  </g>
-  <g>
-    <rect x="532" y="252" width="182" height="98" rx="8" fill="#18181b" stroke="#3f1126"/>
-    <text x="546" y="276" class="node-title">ContextGraph</text>
-    <text x="546" y="293" class="node-sub">entities + edges across env,</text>
-    <text x="546" y="306" class="node-sub">identity, MCP, package, cred,</text>
-    <text x="546" y="319" class="node-sub">model, dataset, finding</text>
-    <text x="546" y="337" class="pill" fill="#fb7185">multi-hop attack-path fusion</text>
-  </g>
-  <g>
-    <rect x="532" y="360" width="182" height="62" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="546" y="382" class="node-title">Asset tracker</text>
-    <text x="546" y="398" class="node-sub">first_seen · resolved · MTTR</text>
-    <text x="546" y="411" class="node-sub">drift over time per asset</text>
-  </g>
-  <g>
-    <rect x="532" y="432" width="182" height="62" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="546" y="454" class="node-title">Audit &amp; provenance</text>
-    <text x="546" y="470" class="node-sub">signed evidence · hash chain</text>
-    <text x="546" y="483" class="node-sub">tenant scope · replay</text>
-  </g>
-  <g>
-    <rect x="532" y="504" width="182" height="40" rx="8" fill="#0f0a16" stroke="#3f1126"/>
-    <text x="546" y="527" class="node-sub" fill="#a1a1aa">Postgres / SQLite store · tenant-isolated, cluster-safe</text>
-  </g>
+  <!-- ===== LANE 4 CONTROL PLANE ===== -->
+  <rect x="760" y="92" width="206" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
+  <text x="776" y="118" class="lane-label">CONTROL PLANE</text>
+  <text x="776" y="134" class="lane-sub">Self-hosted · tenant-scoped auth</text>
 
-  <!-- ════════ LANE 4 — CONTROL PLANE ════════ -->
-  <rect x="760" y="92" width="206" height="500" rx="12" fill="#0c1418" stroke="#134e4a" stroke-width="1.5"/>
-  <text x="772" y="116" class="lane-label" fill="#2dd4bf">CONTROL PLANE</text>
-  <text x="772" y="132" class="node-sub">Self-hosted · tenant-scoped auth</text>
+  <g><rect x="772" y="150" width="182" height="86" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="782" y="164" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M792 170l-4 7 4 7 M798 170l4 7-4 7"/>
+    <text x="818" y="172" class="node-title">REST API</text><text x="818" y="188" class="node-sub">scans · findings · graph</text>
+    <text x="818" y="205" class="node-sub">compliance · identity · cost</text>
+    <text x="786" y="225" class="pill">OIDC · SAML · SCIM · RBAC</text></g>
+  <g><rect x="772" y="244" width="182" height="86" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="782" y="258" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M795 264l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M791 272l3 3 5-5.5"/>
+    <text x="818" y="266" class="node-title">Gateway / Proxy</text><text x="818" y="282" class="node-sub">inline firewall + identity</text>
+    <text x="818" y="299" class="node-sub">inspect · block · sign · audit</text>
+    <text x="786" y="319" class="pill">runtime MCP enforcement</text></g>
+  <g><rect x="772" y="338" width="182" height="76" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="782" y="356" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><rect class="ic" x="788" y="361" width="14" height="6" rx="2"/><rect class="ic" x="788" y="371" width="14" height="6" rx="2"/><path class="ic" d="M792 364h.01 M792 374h.01"/>
+    <text x="818" y="362" class="node-title">MCP server</text><text x="818" y="378" class="node-sub">70 tools · scan · graph · shield</text>
+    <text x="786" y="400" class="pill">stdio · SSE · streamable-HTTP</text></g>
+  <g><rect x="772" y="422" width="182" height="66" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="782" y="438" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><rect class="ic" x="788" y="444" width="6" height="6" rx="1.5"/><rect class="ic" x="796" y="444" width="6" height="6" rx="1.5"/><rect class="ic" x="788" y="452" width="6" height="6" rx="1.5"/><rect class="ic" x="796" y="452" width="6" height="6" rx="1.5"/>
+    <text x="818" y="446" class="node-title">Fleet &amp; scheduling</text><text x="818" y="462" class="node-sub">multi-replica dispatch</text>
+    <text x="818" y="478" class="node-sub">Helm / EKS deployable</text></g>
+  <g><rect x="772" y="496" width="182" height="40" rx="9" fill="#121016" stroke="#2a2733"/>
+    <text x="863" y="520" text-anchor="middle" class="node-sub" fill="#a1a1aa">fail-closed auth · RBAC · scopes · audit</text></g>
 
-  <g>
-    <rect x="772" y="150" width="182" height="100" rx="8" fill="#0f172a" stroke="#1e3a36"/>
-    <text x="786" y="174" class="node-title" fill="#5eead4">REST API</text>
-    <text x="786" y="191" class="node-sub">272 routes · scans, findings,</text>
-    <text x="786" y="204" class="node-sub">graph, fleet, compliance,</text>
-    <text x="786" y="217" class="node-sub">identity, cost, audit</text>
-    <text x="786" y="237" class="pill" fill="#5eead4">OIDC / SAML / SCIM · RBAC · keys</text>
-  </g>
-  <g>
-    <rect x="772" y="260" width="182" height="98" rx="8" fill="#0f172a" stroke="#1e3a36"/>
-    <text x="786" y="284" class="node-title" fill="#5eead4">Gateway / Proxy</text>
-    <text x="786" y="301" class="node-sub">enforce firewall + budget +</text>
-    <text x="786" y="314" class="node-sub">identity inline in the relay</text>
-    <text x="786" y="327" class="node-sub">inspect · block · sign · audit</text>
-    <text x="786" y="346" class="pill" fill="#5eead4">runtime MCP traffic enforcement</text>
-  </g>
-  <g>
-    <rect x="772" y="368" width="182" height="88" rx="8" fill="#0f172a" stroke="#1e3a36"/>
-    <text x="786" y="392" class="node-title" fill="#5eead4">MCP server</text>
-    <text x="786" y="409" class="node-sub">70 tools · scan, intel, graph,</text>
-    <text x="786" y="422" class="node-sub">remediate, identity, shield</text>
-    <text x="786" y="441" class="pill" fill="#5eead4">stdio · SSE · streamable-HTTP</text>
-  </g>
-  <g>
-    <rect x="772" y="466" width="182" height="78" rx="8" fill="#0f172a" stroke="#1e3a36"/>
-    <text x="786" y="490" class="node-title" fill="#5eead4">Fleet &amp; scheduling</text>
-    <text x="786" y="507" class="node-sub">multi-replica scan dispatch</text>
-    <text x="786" y="520" class="node-sub">lifecycle review · quarantine</text>
-    <text x="786" y="536" class="node-sub">Helm / EKS deployable</text>
-  </g>
+  <!-- ===== LANE 5 CONSUMERS ===== -->
+  <rect x="1000" y="92" width="160" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
+  <text x="1016" y="118" class="lane-label">CONSUMERS</text>
+  <text x="1016" y="134" class="lane-sub">People + agents</text>
 
-  <!-- ════════ LANE 5 — CONSUMERS ════════ -->
-  <rect x="1000" y="92" width="160" height="500" rx="12" fill="#130c1c" stroke="#3b2a52" stroke-width="1"/>
-  <text x="1012" y="116" class="lane-label" fill="#c4b5fd">CONSUMERS</text>
-  <text x="1012" y="132" class="node-sub">Humans + agents</text>
+  <text x="1016" y="162" class="chip" fill="#a78bfa" letter-spacing="0.1em">PEOPLE</text>
+  <g><rect x="1012" y="170" width="136" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="1022" y="182" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M1028 190l4 4-4 4 M1034 198h5"/>
+    <text x="1056" y="190" class="node-title">CLI</text><text x="1056" y="205" class="node-sub">terminal · CI gate</text></g>
+  <g><rect x="1012" y="224" width="136" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="1022" y="236" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><rect class="ic" x="1027" y="241" width="14" height="11" rx="2"/><path class="ic" d="M1027 245h14"/>
+    <text x="1056" y="244" class="node-title">Web UI</text><text x="1056" y="259" class="node-sub">dashboard · graph</text></g>
 
-  <text x="1012" y="160" class="pill" fill="#c4b5fd" letter-spacing="0.1em">HUMANS</text>
-  <g>
-    <rect x="1012" y="168" width="136" height="48" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="1026" y="189" class="node-title">CLI</text>
-    <text x="1026" y="205" class="node-sub">terminal · CI gate · Docker</text>
-  </g>
-  <g>
-    <rect x="1012" y="222" width="136" height="48" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="1026" y="243" class="node-title">Web UI</text>
-    <text x="1026" y="259" class="node-sub">dashboard · graph · fleet</text>
-  </g>
+  <text x="1016" y="298" class="chip" fill="#a78bfa" letter-spacing="0.1em">AGENTS</text>
+  <g><rect x="1012" y="306" width="136" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="1022" y="318" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="1031" cy="325" r="2.4"/><circle class="ic" cx="1027" cy="335" r="2"/><circle class="ic" cx="1036" cy="335" r="2"/><path class="ic" d="M1030 327l-2 6 M1033 327l2 6"/>
+    <text x="1056" y="326" class="node-title">MCP clients</text><text x="1056" y="341" class="node-sub">tool calls over MCP</text></g>
+  <g><rect x="1012" y="360" width="136" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+    <rect x="1022" y="372" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M1031 378l-4 6 4 6 M1037 378l4 6-4 6"/>
+    <text x="1056" y="380" class="node-title">API / SDK</text><text x="1056" y="395" class="node-sub">programmatic</text></g>
 
-  <text x="1012" y="296" class="pill" fill="#c4b5fd" letter-spacing="0.1em">HEADLESS AGENTS</text>
-  <g>
-    <rect x="1012" y="304" width="136" height="48" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="1026" y="325" class="node-title">MCP clients</text>
-    <text x="1026" y="341" class="node-sub">tool calls over MCP</text>
-  </g>
-  <g>
-    <rect x="1012" y="358" width="136" height="48" rx="8" fill="#18181b" stroke="#27272a"/>
-    <text x="1026" y="379" class="node-title">API / SDK</text>
-    <text x="1026" y="395" class="node-sub">programmatic automation</text>
-  </g>
+  <text x="1016" y="434" class="chip" fill="#a78bfa" letter-spacing="0.1em">ARTIFACTS</text>
+  <g><rect x="1012" y="442" width="136" height="102" rx="9" fill="#121016" stroke="#2a2733"/>
+    <rect x="1024" y="454" width="50" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1049" y="466" text-anchor="middle" class="chip">SARIF</text>
+    <rect x="1080" y="454" width="56" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1108" y="466" text-anchor="middle" class="chip">CycloneDX</text>
+    <rect x="1024" y="478" width="44" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1046" y="490" text-anchor="middle" class="chip">SPDX</text>
+    <rect x="1074" y="478" width="44" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1096" y="490" text-anchor="middle" class="chip">OCSF</text>
+    <rect x="1024" y="502" width="44" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1046" y="514" text-anchor="middle" class="chip">HTML</text>
+    <rect x="1074" y="502" width="44" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1096" y="514" text-anchor="middle" class="chip">JSON</text>
+    <text x="1080" y="535" text-anchor="middle" class="node-sub">→ SIEM · webhooks</text></g>
 
-  <text x="1012" y="432" class="pill" fill="#c4b5fd" letter-spacing="0.1em">ARTIFACTS</text>
-  <g>
-    <rect x="1012" y="440" width="136" height="104" rx="8" fill="#0f0a16" stroke="#3b2a52"/>
-    <text x="1026" y="461" class="node-sub" fill="#a1a1aa">SARIF · GitHub Security</text>
-    <text x="1026" y="479" class="node-sub" fill="#a1a1aa">CycloneDX SBOM</text>
-    <text x="1026" y="497" class="node-sub" fill="#a1a1aa">SPDX SBOM</text>
-    <text x="1026" y="515" class="node-sub" fill="#a1a1aa">OCSF events → SIEM</text>
-    <text x="1026" y="533" class="node-sub" fill="#a1a1aa">HTML · JSON · webhooks</text>
-  </g>
+  <!-- flow arrows (drawn on top so labels are never clipped by lane panels) -->
+  <line x1="246" y1="360" x2="278" y2="360" stroke="#52525b" stroke-width="2" marker-end="url(#abom-arrow)"/><text x="262" y="350" text-anchor="middle" class="flow-label">SCAN</text>
+  <line x1="486" y1="360" x2="518" y2="360" stroke="#52525b" stroke-width="2" marker-end="url(#abom-arrow)"/><text x="502" y="350" text-anchor="middle" class="flow-label">NORMALIZE</text>
+  <line x1="726" y1="360" x2="758" y2="360" stroke="#8b5cf6" stroke-width="2.2" marker-end="url(#abom-arrow-accent)"/><text x="742" y="350" text-anchor="middle" class="flow-label" fill="#a78bfa">SERVE</text>
+  <line x1="966" y1="360" x2="998" y2="360" stroke="#52525b" stroke-width="2" marker-end="url(#abom-arrow)"/><text x="982" y="350" text-anchor="middle" class="flow-label">DELIVER</text>
 
-  <!-- Footer guarantee bar -->
-  <rect x="40" y="608" width="1120" height="30" rx="8" fill="#0e1420" stroke="#1e293b"/>
-  <text x="600" y="627" text-anchor="middle" class="footer">READ-ONLY BY DEFAULT · never writes target configs · never runs servers · never stores secret values · self-hosted · evidence signed end-to-end</text>
+  <!-- footer trust bar -->
+  <rect x="40" y="608" width="1120" height="30" rx="9" fill="#0c1a14" stroke="#1f4438"/>
+  <text x="600" y="627" text-anchor="middle" class="footer">READ-ONLY BY DEFAULT · no target writes · never runs servers · no secret values · self-hosted · evidence signed end-to-end</text>
 </svg>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -1,244 +1,161 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 660" fill="none" role="img" aria-labelledby="abom-archl-title abom-archl-desc">
   <title id="abom-archl-title">agent-bom architecture and data flow</title>
-  <desc id="abom-archl-desc">Left-to-right flow: evidence sources are scanned and ingested into one unified Finding and ContextGraph, served through the control plane (API, Gateway, MCP server) to human and headless-agent consumers, emitting SARIF, CycloneDX, SPDX, and OCSF artifacts.</desc>
+  <desc id="abom-archl-desc">Left-to-right flow: read-only sources are scanned and enriched into one unified Finding and ContextGraph, served through the control plane (API, Gateway, MCP server) to human and headless-agent consumers, emitting SARIF, CycloneDX, SPDX, and OCSF artifacts.</desc>
   <defs>
     <linearGradient id="abom-accent-l" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#2563eb"/>
-      <stop offset="100%" stop-color="#7c3aed"/>
+      <stop offset="0%" stop-color="#7c3aed"/>
+      <stop offset="100%" stop-color="#4f46e5"/>
     </linearGradient>
-    <marker id="abom-arrow-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto">
-      <path d="M0 0 L10 4 L0 8 Z" fill="#94a3b8"/>
-    </marker>
-    <marker id="abom-arrow-accent-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto">
-      <path d="M0 0 L10 4 L0 8 Z" fill="#6366f1"/>
-    </marker>
+    <marker id="abom-arrow-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
+    <marker id="abom-arrow-accent-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
     <style>
-      text { font-family: system-ui, -apple-system, 'Segoe UI', sans-serif; }
-      .title { font-size: 21px; font-weight: 800; fill: #0f172a; }
-      .subtitle { font-size: 11.5px; font-weight: 400; fill: #475569; }
-      .lane-label { font-size: 10px; font-weight: 700; letter-spacing: 0.14em; }
-      .node-title { font-size: 12.5px; font-weight: 700; fill: #1e293b; }
-      .node-sub { font-size: 9px; font-weight: 400; fill: #64748b; }
-      .pill { font-size: 9px; font-weight: 600; fill: #475569; }
-      .flow-label { font-size: 8.5px; font-weight: 700; letter-spacing: 0.08em; fill: #94a3b8; }
-      .footer { font-size: 9px; font-weight: 600; letter-spacing: 0.05em; fill: #64748b; }
+      text { font-family: Inter, system-ui, -apple-system, 'Segoe UI', sans-serif; }
+      .title { font-size: 22px; font-weight: 800; fill: #18181b; }
+      .subtitle { font-size: 11.5px; font-weight: 400; fill: #6b6b75; }
+      .lane-label { font-size: 10px; font-weight: 800; letter-spacing: 0.16em; fill: #7c3aed; }
+      .lane-sub { font-size: 9px; font-weight: 500; fill: #9a9aa4; }
+      .node-title { font-size: 12.5px; font-weight: 700; fill: #18181b; }
+      .node-sub { font-size: 9px; font-weight: 400; fill: #71717a; }
+      .pill { font-size: 9px; font-weight: 600; fill: #7c3aed; }
+      .flow-label { font-size: 8.5px; font-weight: 800; letter-spacing: 0.1em; fill: #9a9aa4; }
+      .chip { font-size: 9px; font-weight: 700; fill: #52525b; }
+      .footer { font-size: 9.5px; font-weight: 600; letter-spacing: 0.04em; fill: #15803d; }
+      .ic { fill: none; stroke: #6b6b76; stroke-width: 1.55; stroke-linecap: round; stroke-linejoin: round; }
+      .ic-a { fill: none; stroke: #7c3aed; stroke-width: 1.55; stroke-linecap: round; stroke-linejoin: round; }
     </style>
   </defs>
 
   <rect width="1200" height="660" rx="14" fill="#ffffff"/>
-
-  <!-- Header -->
   <text x="40" y="42" class="title">agent-bom <tspan fill="url(#abom-accent-l)">architecture</tspan></text>
-  <text x="40" y="63" class="subtitle">One evidence model, left to right: collect from every AI-supply-chain surface, normalize into one Finding and ContextGraph, serve through the control plane, deliver to humans and headless agents.</text>
+  <text x="40" y="63" class="subtitle">One evidence model, left to right — collect read-only, normalize into one Finding + ContextGraph, serve through the control plane, deliver to people and agents.</text>
 
-  <!-- Lane connector arrows -->
-  <line x1="246" y1="360" x2="270" y2="360" stroke="#94a3b8" stroke-width="2" marker-end="url(#abom-arrow-l)"/>
-  <text x="258" y="350" text-anchor="middle" class="flow-label">SCAN</text>
-  <line x1="486" y1="360" x2="510" y2="360" stroke="#94a3b8" stroke-width="2" marker-end="url(#abom-arrow-l)"/>
-  <text x="498" y="350" text-anchor="middle" class="flow-label">NORMALIZE</text>
-  <line x1="726" y1="360" x2="750" y2="360" stroke="#6366f1" stroke-width="2" marker-end="url(#abom-arrow-accent-l)"/>
-  <text x="738" y="350" text-anchor="middle" class="flow-label" fill="#6366f1">SERVE</text>
-  <line x1="966" y1="360" x2="990" y2="360" stroke="#94a3b8" stroke-width="2" marker-end="url(#abom-arrow-l)"/>
-  <text x="978" y="350" text-anchor="middle" class="flow-label">DELIVER</text>
+  <!-- LANE 1 -->
+  <rect x="40" y="92" width="206" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
+  <text x="56" y="118" class="lane-label">SOURCES</text><text x="56" y="134" class="lane-sub">Read-only · no writes · no secret values</text>
+  <g><rect x="52" y="148" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="62" y="161" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M69 168h7l3 3v9h-13z M76 168v3h3"/>
+    <text x="98" y="170" class="node-title">Supply chain</text><text x="98" y="185" class="node-sub">15 ecosystems + OS packages</text></g>
+  <g><rect x="52" y="206" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="62" y="219" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="75" cy="227" r="3"/><circle class="ic" cx="70" cy="238" r="2.4"/><circle class="ic" cx="80" cy="238" r="2.4"/><path class="ic" d="M73 230l-2 6 M77 230l2 6"/>
+    <text x="98" y="228" class="node-title">Agents &amp; MCP</text><text x="98" y="243" class="node-sub">29 clients · servers · tools</text></g>
+  <g><rect x="52" y="264" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="62" y="277" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M68 293h12a4 4 0 0 0 .6-7.9 6 6 0 0 0-11.3-1.6A4.2 4.2 0 0 0 68 293z"/>
+    <text x="98" y="286" class="node-title">Cloud inventory</text><text x="98" y="301" class="node-sub">AWS · Azure · GCP · Snowflake</text></g>
+  <g><rect x="52" y="322" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="62" y="335" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M75 333l7 3.5-7 3.5-7-3.5z M68 341l7 3.5 7-3.5 M68 345l7 3.5 7-3.5"/>
+    <text x="98" y="344" class="node-title">IaC &amp; containers</text><text x="98" y="359" class="node-sub">Terraform · K8s · OCI images</text></g>
+  <g><rect x="52" y="380" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="62" y="393" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="72" cy="403" r="3.4"/><path class="ic" d="M74.4 405.4l7 7 M79 410l2.5-2.5 M81.5 412.5l2.5-2.5"/>
+    <text x="98" y="402" class="node-title">Secrets</text><text x="98" y="417" class="node-sub">credential refs · token patterns</text></g>
+  <g><rect x="52" y="438" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="62" y="451" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M75 458l7 3.5v7l-7 3.5-7-3.5v-7z M75 458v14 M68 461.5l14 7"/>
+    <text x="98" y="460" class="node-title">Models &amp; data</text><text x="98" y="475" class="node-sub">weights · cards · PII/PHI</text></g>
+  <g><rect x="52" y="496" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="62" y="509" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M70 515h10v14h-10z M73 520h7 M73 524h7 M73 528h4"/>
+    <text x="98" y="518" class="node-title">SBOM ingest</text><text x="98" y="533" class="node-sub">CycloneDX · SPDX import</text></g>
 
-  <!-- ════════ LANE 1 — SOURCES ════════ -->
-  <rect x="40" y="92" width="206" height="500" rx="12" fill="#f1f5fd" stroke="#dbeafe" stroke-width="1"/>
-  <text x="52" y="116" class="lane-label" fill="#2563eb">SOURCES</text>
-  <text x="52" y="132" class="node-sub">Read-only · no writes · no secrets stored</text>
+  <!-- LANE 2 -->
+  <rect x="280" y="92" width="206" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
+  <text x="296" y="118" class="lane-label">SCAN &amp; ENRICH</text><text x="296" y="134" class="lane-sub">Parallel · local-only</text>
+  <g><rect x="292" y="148" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="302" y="164" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="313" cy="175" r="4.2"/><path class="ic" d="M316 178l4 4"/>
+    <text x="338" y="172" class="node-title">Vulnerability scan</text><text x="338" y="188" class="node-sub">OSV batch across all packages</text></g>
+  <g><rect x="292" y="214" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="302" y="230" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M313 233l1.6 3.4 3.4 1.6-3.4 1.6L313 245l-1.6-3.4-3.4-1.6 3.4-1.6z"/>
+    <text x="338" y="238" class="node-title">Threat enrichment</text><text x="338" y="254" class="node-sub">NVD · EPSS · KEV · GHSA</text></g>
+  <g><rect x="292" y="280" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="302" y="296" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M313 300l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M310 308l2 2 4-4.5"/>
+    <text x="338" y="304" class="node-title">Posture checks</text><text x="338" y="320" class="node-sub">MCP/A2A auth · CIS · NHI</text></g>
+  <g><rect x="292" y="346" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="302" y="362" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M307 384v-8 M313 384v-12 M319 384v-6 M306 384h15"/>
+    <text x="338" y="370" class="node-title">Cost / FinOps</text><text x="338" y="386" class="node-sub">model + cloud spend signals</text></g>
+  <g><rect x="292" y="412" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="302" y="428" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M308 434h12 M308 440h12 M308 446h8"/><path class="ic-a" d="M305 434l1.4 1.4 2-2.4"/>
+    <text x="338" y="436" class="node-title">Policy engine</text><text x="338" y="452" class="node-sub">policy-as-code · frameworks</text></g>
+  <g><rect x="292" y="478" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="302" y="494" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="315" cy="507" r="8"/><circle class="ic" cx="315" cy="507" r="4"/><circle class="ic-a" cx="315" cy="507" r="1.4"/>
+    <text x="338" y="502" class="node-title">Blast-radius</text><text x="338" y="518" class="node-sub">pkg → finding → agent fusion</text></g>
 
-  <g>
-    <rect x="52" y="146" width="182" height="50" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="66" y="168" class="node-title">Supply chain</text>
-    <text x="66" y="184" class="node-sub">15 ecosystem parsers · npm/pip/go/maven + OS pkgs</text>
-  </g>
-  <g>
-    <rect x="52" y="204" width="182" height="50" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="66" y="226" class="node-title">AI agents &amp; MCP</text>
-    <text x="66" y="242" class="node-sub">29 client configs · servers · tools · registry</text>
-  </g>
-  <g>
-    <rect x="52" y="262" width="182" height="50" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="66" y="284" class="node-title">Cloud inventory</text>
-    <text x="66" y="300" class="node-sub">AWS · Azure · GCP + 13 AI/data providers</text>
-  </g>
-  <g>
-    <rect x="52" y="320" width="182" height="50" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="66" y="342" class="node-title">IaC &amp; containers</text>
-    <text x="66" y="358" class="node-sub">Terraform · CFN · Helm · K8s · OCI images</text>
-  </g>
-  <g>
-    <rect x="52" y="378" width="182" height="50" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="66" y="400" class="node-title">Secrets</text>
-    <text x="66" y="416" class="node-sub">credential refs · env names · token leak patterns</text>
-  </g>
-  <g>
-    <rect x="52" y="436" width="182" height="50" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="66" y="458" class="node-title">Models &amp; datasets</text>
-    <text x="66" y="474" class="node-sub">weight formats · dataset cards · PII/PHI scan</text>
-  </g>
-  <g>
-    <rect x="52" y="494" width="182" height="50" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="66" y="516" class="node-title">SBOM ingest</text>
-    <text x="66" y="532" class="node-sub">CycloneDX + SPDX import · re-scan inventory</text>
-  </g>
+  <!-- LANE 3 -->
+  <rect x="520" y="92" width="206" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
+  <text x="536" y="118" class="lane-label">EVIDENCE CORE</text><text x="536" y="134" class="lane-sub">One normalized truth</text>
+  <g><rect x="532" y="150" width="182" height="86" rx="9" fill="#f6f4ff" stroke="#c4b5fd"/>
+    <rect x="542" y="164" width="26" height="26" rx="7" fill="#efeaff" stroke="#c4b5fd"/><path class="ic-a" d="M549 170h7l3 3v9h-13z M556 170v3h3 M551 182l1.6 1.6 3-3.4"/>
+    <text x="578" y="172" class="node-title">Unified Finding</text><text x="578" y="188" class="node-sub">CVE · misconfig · secret · auth</text>
+    <text x="578" y="205" class="node-sub">+ severity · CVSS · EPSS · KEV</text>
+    <text x="546" y="225" class="pill">one schema for every modality</text></g>
+  <g><rect x="532" y="244" width="182" height="86" rx="9" fill="#f6f4ff" stroke="#c4b5fd"/>
+    <rect x="542" y="258" width="26" height="26" rx="7" fill="#efeaff" stroke="#c4b5fd"/><circle class="ic-a" cx="551" cy="265" r="2.6"/><circle class="ic-a" cx="561" cy="263" r="2.6"/><circle class="ic-a" cx="556" cy="278" r="2.6"/><path class="ic-a" d="M553 266l2 9 M559 265l-2 10"/>
+    <text x="578" y="266" class="node-title">ContextGraph</text><text x="578" y="282" class="node-sub">entities + edges across</text>
+    <text x="578" y="299" class="node-sub">env · identity · MCP · model</text>
+    <text x="546" y="319" class="pill">multi-hop attack-path fusion</text></g>
+  <g><rect x="532" y="338" width="182" height="56" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="542" y="353" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="555" cy="366" r="7.5"/><path class="ic" d="M555 362v4.5l3 2"/>
+    <text x="578" y="362" class="node-title">Asset tracker</text><text x="578" y="378" class="node-sub">first_seen · MTTR · drift</text></g>
+  <g><rect x="532" y="402" width="182" height="56" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="542" y="417" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M555 424l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M552 432l2 2 4-4.5"/>
+    <text x="578" y="426" class="node-title">Audit &amp; provenance</text><text x="578" y="442" class="node-sub">signed · hash chain · tenant</text></g>
+  <g><rect x="532" y="466" width="182" height="40" rx="9" fill="#f6f5fa" stroke="#e6e3ef"/>
+    <rect x="542" y="475" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M547 481c0-1.7 2.7-3 6-3s6 1.3 6 3-2.7 3-6 3-6-1.3-6-3z M547 481v8c0 1.7 2.7 3 6 3s6-1.3 6-3v-8"/>
+    <text x="574" y="491" class="node-sub" fill="#52525b">Postgres / SQLite · tenant-isolated</text></g>
 
-  <!-- ════════ LANE 2 — SCAN / INGEST ════════ -->
-  <rect x="280" y="92" width="206" height="500" rx="12" fill="#fdf6e9" stroke="#fde9c4" stroke-width="1"/>
-  <text x="292" y="116" class="lane-label" fill="#b45309">SCAN / INGEST</text>
-  <text x="292" y="132" class="node-sub">Parallel enrichment, local-only</text>
+  <!-- LANE 4 -->
+  <rect x="760" y="92" width="206" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
+  <text x="776" y="118" class="lane-label">CONTROL PLANE</text><text x="776" y="134" class="lane-sub">Self-hosted · tenant-scoped auth</text>
+  <g><rect x="772" y="150" width="182" height="86" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="782" y="164" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M792 170l-4 7 4 7 M798 170l4 7-4 7"/>
+    <text x="818" y="172" class="node-title">REST API</text><text x="818" y="188" class="node-sub">scans · findings · graph</text>
+    <text x="818" y="205" class="node-sub">compliance · identity · cost</text>
+    <text x="786" y="225" class="pill">OIDC · SAML · SCIM · RBAC</text></g>
+  <g><rect x="772" y="244" width="182" height="86" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="782" y="258" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M795 264l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M791 272l3 3 5-5.5"/>
+    <text x="818" y="266" class="node-title">Gateway / Proxy</text><text x="818" y="282" class="node-sub">inline firewall + identity</text>
+    <text x="818" y="299" class="node-sub">inspect · block · sign · audit</text>
+    <text x="786" y="319" class="pill">runtime MCP enforcement</text></g>
+  <g><rect x="772" y="338" width="182" height="76" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="782" y="356" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><rect class="ic" x="788" y="361" width="14" height="6" rx="2"/><rect class="ic" x="788" y="371" width="14" height="6" rx="2"/><path class="ic" d="M792 364h.01 M792 374h.01"/>
+    <text x="818" y="362" class="node-title">MCP server</text><text x="818" y="378" class="node-sub">70 tools · scan · graph · shield</text>
+    <text x="786" y="400" class="pill">stdio · SSE · streamable-HTTP</text></g>
+  <g><rect x="772" y="422" width="182" height="66" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="782" y="438" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><rect class="ic" x="788" y="444" width="6" height="6" rx="1.5"/><rect class="ic" x="796" y="444" width="6" height="6" rx="1.5"/><rect class="ic" x="788" y="452" width="6" height="6" rx="1.5"/><rect class="ic" x="796" y="452" width="6" height="6" rx="1.5"/>
+    <text x="818" y="446" class="node-title">Fleet &amp; scheduling</text><text x="818" y="462" class="node-sub">multi-replica dispatch</text>
+    <text x="818" y="478" class="node-sub">Helm / EKS deployable</text></g>
+  <g><rect x="772" y="496" width="182" height="40" rx="9" fill="#f6f5fa" stroke="#e6e3ef"/>
+    <text x="863" y="520" text-anchor="middle" class="node-sub" fill="#52525b">fail-closed auth · RBAC · scopes · audit</text></g>
 
-  <g>
-    <rect x="292" y="146" width="182" height="58" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="306" y="168" class="node-title">Vulnerability scan</text>
-    <text x="306" y="184" class="node-sub">OSV.dev batch lookup across</text>
-    <text x="306" y="197" class="node-sub">all discovered packages</text>
-  </g>
-  <g>
-    <rect x="292" y="212" width="182" height="72" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="306" y="234" class="node-title">Threat enrichment</text>
-    <text x="306" y="250" class="node-sub">NVD CVSS v3.1/v4.0 · EPSS</text>
-    <text x="306" y="263" class="node-sub">CISA KEV · GHSA · CSAF</text>
-    <text x="306" y="276" class="node-sub">exploit + known-exploited signals</text>
-  </g>
-  <g>
-    <rect x="292" y="292" width="182" height="58" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="306" y="314" class="node-title">Posture checks</text>
-    <text x="306" y="330" class="node-sub">MCP / A2A auth posture · NHI</text>
-    <text x="306" y="343" class="node-sub">identity · IaC misconfig · CIS</text>
-  </g>
-  <g>
-    <rect x="292" y="358" width="182" height="58" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="306" y="380" class="node-title">Cost / FinOps</text>
-    <text x="306" y="396" class="node-sub">model + cloud spend signals</text>
-    <text x="306" y="409" class="node-sub">budget context per workload</text>
-  </g>
-  <g>
-    <rect x="292" y="424" width="182" height="58" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="306" y="446" class="node-title">Policy engine</text>
-    <text x="306" y="462" class="node-sub">policy-as-code conditions</text>
-    <text x="306" y="475" class="node-sub">compliance + framework tagging</text>
-  </g>
-  <g>
-    <rect x="292" y="490" width="182" height="54" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="306" y="512" class="node-title">Blast-radius scoring</text>
-    <text x="306" y="528" class="node-sub">pkg → finding → server →</text>
-    <text x="306" y="541" class="node-sub">agent → creds → tools fusion</text>
-  </g>
+  <!-- LANE 5 -->
+  <rect x="1000" y="92" width="160" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
+  <text x="1016" y="118" class="lane-label">CONSUMERS</text><text x="1016" y="134" class="lane-sub">People + agents</text>
+  <text x="1016" y="162" class="chip" fill="#7c3aed" letter-spacing="0.1em">PEOPLE</text>
+  <g><rect x="1012" y="170" width="136" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="1022" y="182" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M1028 190l4 4-4 4 M1034 198h5"/>
+    <text x="1056" y="190" class="node-title">CLI</text><text x="1056" y="205" class="node-sub">terminal · CI gate</text></g>
+  <g><rect x="1012" y="224" width="136" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="1022" y="236" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><rect class="ic" x="1027" y="241" width="14" height="11" rx="2"/><path class="ic" d="M1027 245h14"/>
+    <text x="1056" y="244" class="node-title">Web UI</text><text x="1056" y="259" class="node-sub">dashboard · graph</text></g>
+  <text x="1016" y="298" class="chip" fill="#7c3aed" letter-spacing="0.1em">AGENTS</text>
+  <g><rect x="1012" y="306" width="136" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="1022" y="318" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="1031" cy="325" r="2.4"/><circle class="ic" cx="1027" cy="335" r="2"/><circle class="ic" cx="1036" cy="335" r="2"/><path class="ic" d="M1030 327l-2 6 M1033 327l2 6"/>
+    <text x="1056" y="326" class="node-title">MCP clients</text><text x="1056" y="341" class="node-sub">tool calls over MCP</text></g>
+  <g><rect x="1012" y="360" width="136" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+    <rect x="1022" y="372" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M1031 378l-4 6 4 6 M1037 378l4 6-4 6"/>
+    <text x="1056" y="380" class="node-title">API / SDK</text><text x="1056" y="395" class="node-sub">programmatic</text></g>
+  <text x="1016" y="434" class="chip" fill="#7c3aed" letter-spacing="0.1em">ARTIFACTS</text>
+  <g><rect x="1012" y="442" width="136" height="102" rx="9" fill="#f6f5fa" stroke="#e6e3ef"/>
+    <rect x="1024" y="454" width="50" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1049" y="466" text-anchor="middle" class="chip">SARIF</text>
+    <rect x="1080" y="454" width="56" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1108" y="466" text-anchor="middle" class="chip">CycloneDX</text>
+    <rect x="1024" y="478" width="44" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1046" y="490" text-anchor="middle" class="chip">SPDX</text>
+    <rect x="1074" y="478" width="44" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1096" y="490" text-anchor="middle" class="chip">OCSF</text>
+    <rect x="1024" y="502" width="44" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1046" y="514" text-anchor="middle" class="chip">HTML</text>
+    <rect x="1074" y="502" width="44" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1096" y="514" text-anchor="middle" class="chip">JSON</text>
+    <text x="1080" y="535" text-anchor="middle" class="node-sub">→ SIEM · webhooks</text></g>
 
-  <!-- ════════ LANE 3 — CORE MODEL ════════ -->
-  <rect x="520" y="92" width="206" height="500" rx="12" fill="#fdf2f6" stroke="#fbd5e2" stroke-width="1"/>
-  <text x="532" y="116" class="lane-label" fill="#be123c">CORE MODEL</text>
-  <text x="532" y="132" class="node-sub">One normalized truth</text>
+  <!-- flow arrows (drawn on top so labels are never clipped by lane panels) -->
+  <line x1="246" y1="360" x2="278" y2="360" stroke="#a1a1aa" stroke-width="2" marker-end="url(#abom-arrow-l)"/><text x="262" y="350" text-anchor="middle" class="flow-label">SCAN</text>
+  <line x1="486" y1="360" x2="518" y2="360" stroke="#a1a1aa" stroke-width="2" marker-end="url(#abom-arrow-l)"/><text x="502" y="350" text-anchor="middle" class="flow-label">NORMALIZE</text>
+  <line x1="726" y1="360" x2="758" y2="360" stroke="#7c3aed" stroke-width="2.2" marker-end="url(#abom-arrow-accent-l)"/><text x="742" y="350" text-anchor="middle" class="flow-label" fill="#7c3aed">SERVE</text>
+  <line x1="966" y1="360" x2="998" y2="360" stroke="#a1a1aa" stroke-width="2" marker-end="url(#abom-arrow-l)"/><text x="982" y="350" text-anchor="middle" class="flow-label">DELIVER</text>
 
-  <g>
-    <rect x="532" y="150" width="182" height="92" rx="8" fill="#ffffff" stroke="#fbd5e2"/>
-    <text x="546" y="174" class="node-title">Unified Finding</text>
-    <text x="546" y="191" class="node-sub">one schema for every modality:</text>
-    <text x="546" y="204" class="node-sub">CVE · misconfig · secret · auth</text>
-    <text x="546" y="217" class="node-sub">+ severity, CVSS, EPSS, KEV,</text>
-    <text x="546" y="230" class="node-sub">compliance controls, provenance</text>
-  </g>
-  <g>
-    <rect x="532" y="252" width="182" height="98" rx="8" fill="#ffffff" stroke="#fbd5e2"/>
-    <text x="546" y="276" class="node-title">ContextGraph</text>
-    <text x="546" y="293" class="node-sub">entities + edges across env,</text>
-    <text x="546" y="306" class="node-sub">identity, MCP, package, cred,</text>
-    <text x="546" y="319" class="node-sub">model, dataset, finding</text>
-    <text x="546" y="337" class="pill" fill="#be123c">multi-hop attack-path fusion</text>
-  </g>
-  <g>
-    <rect x="532" y="360" width="182" height="62" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="546" y="382" class="node-title">Asset tracker</text>
-    <text x="546" y="398" class="node-sub">first_seen · resolved · MTTR</text>
-    <text x="546" y="411" class="node-sub">drift over time per asset</text>
-  </g>
-  <g>
-    <rect x="532" y="432" width="182" height="62" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="546" y="454" class="node-title">Audit &amp; provenance</text>
-    <text x="546" y="470" class="node-sub">signed evidence · hash chain</text>
-    <text x="546" y="483" class="node-sub">tenant scope · replay</text>
-  </g>
-  <g>
-    <rect x="532" y="504" width="182" height="40" rx="8" fill="#fdf2f6" stroke="#fbd5e2"/>
-    <text x="546" y="527" class="node-sub" fill="#475569">Postgres / SQLite store · tenant-isolated, cluster-safe</text>
-  </g>
-
-  <!-- ════════ LANE 4 — CONTROL PLANE ════════ -->
-  <rect x="760" y="92" width="206" height="500" rx="12" fill="#ecfdfa" stroke="#bbf3ea" stroke-width="1.5"/>
-  <text x="772" y="116" class="lane-label" fill="#0f766e">CONTROL PLANE</text>
-  <text x="772" y="132" class="node-sub">Self-hosted · tenant-scoped auth</text>
-
-  <g>
-    <rect x="772" y="150" width="182" height="100" rx="8" fill="#ffffff" stroke="#99e6da"/>
-    <text x="786" y="174" class="node-title" fill="#0f766e">REST API</text>
-    <text x="786" y="191" class="node-sub">272 routes · scans, findings,</text>
-    <text x="786" y="204" class="node-sub">graph, fleet, compliance,</text>
-    <text x="786" y="217" class="node-sub">identity, cost, audit</text>
-    <text x="786" y="237" class="pill" fill="#0f766e">OIDC / SAML / SCIM · RBAC · keys</text>
-  </g>
-  <g>
-    <rect x="772" y="260" width="182" height="98" rx="8" fill="#ffffff" stroke="#99e6da"/>
-    <text x="786" y="284" class="node-title" fill="#0f766e">Gateway / Proxy</text>
-    <text x="786" y="301" class="node-sub">enforce firewall + budget +</text>
-    <text x="786" y="314" class="node-sub">identity inline in the relay</text>
-    <text x="786" y="327" class="node-sub">inspect · block · sign · audit</text>
-    <text x="786" y="346" class="pill" fill="#0f766e">runtime MCP traffic enforcement</text>
-  </g>
-  <g>
-    <rect x="772" y="368" width="182" height="88" rx="8" fill="#ffffff" stroke="#99e6da"/>
-    <text x="786" y="392" class="node-title" fill="#0f766e">MCP server</text>
-    <text x="786" y="409" class="node-sub">70 tools · scan, intel, graph,</text>
-    <text x="786" y="422" class="node-sub">remediate, identity, shield</text>
-    <text x="786" y="441" class="pill" fill="#0f766e">stdio · SSE · streamable-HTTP</text>
-  </g>
-  <g>
-    <rect x="772" y="466" width="182" height="78" rx="8" fill="#ffffff" stroke="#99e6da"/>
-    <text x="786" y="490" class="node-title" fill="#0f766e">Fleet &amp; scheduling</text>
-    <text x="786" y="507" class="node-sub">multi-replica scan dispatch</text>
-    <text x="786" y="520" class="node-sub">lifecycle review · quarantine</text>
-    <text x="786" y="536" class="node-sub">Helm / EKS deployable</text>
-  </g>
-
-  <!-- ════════ LANE 5 — CONSUMERS ════════ -->
-  <rect x="1000" y="92" width="160" height="500" rx="12" fill="#f6f2fd" stroke="#e4d9f8" stroke-width="1"/>
-  <text x="1012" y="116" class="lane-label" fill="#7c3aed">CONSUMERS</text>
-  <text x="1012" y="132" class="node-sub">Humans + agents</text>
-
-  <text x="1012" y="160" class="pill" fill="#7c3aed" letter-spacing="0.1em">HUMANS</text>
-  <g>
-    <rect x="1012" y="168" width="136" height="48" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="1026" y="189" class="node-title">CLI</text>
-    <text x="1026" y="205" class="node-sub">terminal · CI gate · Docker</text>
-  </g>
-  <g>
-    <rect x="1012" y="222" width="136" height="48" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="1026" y="243" class="node-title">Web UI</text>
-    <text x="1026" y="259" class="node-sub">dashboard · graph · fleet</text>
-  </g>
-
-  <text x="1012" y="296" class="pill" fill="#7c3aed" letter-spacing="0.1em">HEADLESS AGENTS</text>
-  <g>
-    <rect x="1012" y="304" width="136" height="48" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="1026" y="325" class="node-title">MCP clients</text>
-    <text x="1026" y="341" class="node-sub">tool calls over MCP</text>
-  </g>
-  <g>
-    <rect x="1012" y="358" width="136" height="48" rx="8" fill="#ffffff" stroke="#e2e8f0"/>
-    <text x="1026" y="379" class="node-title">API / SDK</text>
-    <text x="1026" y="395" class="node-sub">programmatic automation</text>
-  </g>
-
-  <text x="1012" y="432" class="pill" fill="#7c3aed" letter-spacing="0.1em">ARTIFACTS</text>
-  <g>
-    <rect x="1012" y="440" width="136" height="104" rx="8" fill="#f6f2fd" stroke="#e4d9f8"/>
-    <text x="1026" y="461" class="node-sub" fill="#475569">SARIF · GitHub Security</text>
-    <text x="1026" y="479" class="node-sub" fill="#475569">CycloneDX SBOM</text>
-    <text x="1026" y="497" class="node-sub" fill="#475569">SPDX SBOM</text>
-    <text x="1026" y="515" class="node-sub" fill="#475569">OCSF events → SIEM</text>
-    <text x="1026" y="533" class="node-sub" fill="#475569">HTML · JSON · webhooks</text>
-  </g>
-
-  <!-- Footer guarantee bar -->
-  <rect x="40" y="608" width="1120" height="30" rx="8" fill="#f1f5fd" stroke="#dbeafe"/>
-  <text x="600" y="627" text-anchor="middle" class="footer">READ-ONLY BY DEFAULT · never writes target configs · never runs servers · never stores secret values · self-hosted · evidence signed end-to-end</text>
+  <rect x="40" y="608" width="1120" height="30" rx="9" fill="#ecfdf5" stroke="#a7f3d0"/>
+  <text x="600" y="627" text-anchor="middle" class="footer">READ-ONLY BY DEFAULT · no target writes · never runs servers · no secret values · self-hosted · evidence signed end-to-end</text>
 </svg>

--- a/docs/images/how-it-works-dark.svg
+++ b/docs/images/how-it-works-dark.svg
@@ -1,159 +1,134 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 650" fill="none" role="img" aria-labelledby="how-title how-desc">
 <title id="how-title">How agent-bom works</title>
-<desc id="how-desc">A concise visual flow from read-only inputs through scan and enrichment, unified evidence graph, control plane, outputs, reports, posture, and enforcement.</desc>
-<defs><marker id="arrow" viewBox="0 0 10 8" refX="8.2" refY="4" markerWidth="7" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#69707d"/></marker>
+<desc id="how-desc">A visual flow from read-only inputs through the scan engine, into one unified Finding and ContextGraph, served by the control plane, and exported as reports, gates, and runtime controls.</desc>
+<defs>
+<marker id="hiw-arrow" viewBox="0 0 10 8" refX="8.2" refY="4" markerWidth="7" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
 <style>
-text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif; letter-spacing: 0; }
-.title { font-size: 30px; font-weight: 850; } .subtitle { font-size: 13px; font-weight: 550; } .label { font-size: 11px; font-weight: 850; letter-spacing: .14em; }
-.step { font-size: 22px; font-weight: 850; } .chip { font-size: 13px; font-weight: 850; } .badge { font-size: 10.5px; font-weight: 850; } .tiny { font-size: 10px; font-weight: 700; } .node { font-size: 10px; font-weight: 850; }
+text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif; }
+.title { font-size: 30px; font-weight: 850; } .subtitle { font-size: 13px; font-weight: 500; } .label { font-size: 11px; font-weight: 800; letter-spacing: .15em; }
+.step { font-size: 22px; font-weight: 800; } .chip { font-size: 13px; font-weight: 700; } .badge { font-size: 10.5px; font-weight: 700; } .tiny { font-size: 10px; font-weight: 600; } .node { font-size: 11px; font-weight: 800; }
+.ic { fill: none; stroke: #9a9aa4; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
+.ic-a { fill: none; stroke: #a78bfa; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
 </style></defs>
-<rect x="0" y="0" width="1320" height="650" rx="18" fill="#09090b" stroke="#2a2a30" stroke-width="0" />
+<rect x="0" y="0" width="1320" height="650" rx="18" fill="#0a0a0c"/>
 <text x="48" y="52" class="title" fill="#f4f4f5">From inventory to enforceable evidence</text>
-<text x="48" y="78" class="subtitle" fill="#a1a1aa">Read-only collection becomes deterministic matching, enriched findings, graph-backed blast radius, and operational outputs.</text>
-<rect x="40" y="118" width="240" height="392" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1" />
-<text x="58" y="149" class="label" fill="#60a5fa">READ-ONLY INTAKE</text>
-<rect x="330" y="118" width="230" height="392" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1" />
-<text x="348" y="149" class="label" fill="#fbbf24">SCAN ENGINE</text>
-<rect x="610" y="118" width="270" height="392" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1" />
+<text x="48" y="78" class="subtitle" fill="#82828c">Read-only collection becomes deterministic matching, enriched findings, graph-backed blast radius, and operational outputs.</text>
+
+<rect x="40" y="118" width="240" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
+<text x="58" y="149" class="label" fill="#a78bfa">READ-ONLY INTAKE</text>
+<rect x="330" y="118" width="230" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
+<text x="348" y="149" class="label" fill="#a78bfa">SCAN ENGINE</text>
+<rect x="610" y="118" width="270" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
 <text x="628" y="149" class="label" fill="#a78bfa">EVIDENCE CORE</text>
-<rect x="930" y="118" width="200" height="392" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1" />
-<text x="948" y="149" class="label" fill="#34d399">CONTROL PLANE</text>
-<rect x="1170" y="118" width="120" height="392" rx="18" fill="#111114" stroke="#2a2a30" stroke-width="1" />
-<text x="1188" y="149" class="label" fill="#67e8f9">OUTPUTS</text>
-<rect x="62" y="165" width="92" height="42" rx="13" fill="#0f1d35" stroke="#2563eb" stroke-width="1.7" />
-<rect x="73" y="175" width="22" height="22" rx="7" fill="#18181b" stroke="#2563eb" stroke-width="1.2" />
-<path d="M77 178h11l5 5v13h-16z M88 178v5h5" stroke="#60a5fa" stroke-width="1.8" fill="none" stroke-linejoin="round"/>
-<text x="105" y="191" class="chip" fill="#f4f4f5">Repo</text>
-<rect x="166" y="165" width="92" height="42" rx="13" fill="#0f1d35" stroke="#2563eb" stroke-width="1.7" />
-<rect x="177" y="175" width="22" height="22" rx="7" fill="#18181b" stroke="#2563eb" stroke-width="1.2" />
-<path d="M180 186l5 5 11-12" stroke="#60a5fa" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="209" y="191" class="chip" fill="#f4f4f5">CI</text>
-<rect x="62" y="229" width="92" height="42" rx="13" fill="#1d1230" stroke="#7c3aed" stroke-width="1.7" />
-<rect x="73" y="239" width="22" height="22" rx="7" fill="#18181b" stroke="#7c3aed" stroke-width="1.2" />
-<circle cx="84" cy="250" r="3" fill="#a78bfa"/><circle cx="76" cy="257" r="3" fill="#a78bfa"/><circle cx="92" cy="257" r="3" fill="#a78bfa"/><path d="M83 252l-5 4 M85 252l5 4" stroke="#a78bfa" stroke-width="1.6"/>
-<text x="105" y="255" class="chip" fill="#f4f4f5">MCP</text>
-<rect x="166" y="229" width="92" height="42" rx="13" fill="#072229" stroke="#0891b2" stroke-width="1.7" />
-<rect x="177" y="239" width="22" height="22" rx="7" fill="#18181b" stroke="#0891b2" stroke-width="1.2" />
-<path d="M178 255h19a5 5 0 0 0 1-10 8 8 0 0 0-15-3 6 6 0 0 0-5 13z" stroke="#67e8f9" stroke-width="1.8" fill="none" stroke-linecap="round"/>
-<text x="209" y="255" class="chip" fill="#f4f4f5">Cloud</text>
-<rect x="62" y="293" width="92" height="42" rx="13" fill="#271a05" stroke="#b45309" stroke-width="1.7" />
-<rect x="73" y="303" width="22" height="22" rx="7" fill="#18181b" stroke="#b45309" stroke-width="1.2" />
-<rect x="75" y="306" width="18" height="16" rx="3" stroke="#fbbf24" stroke-width="1.8" fill="none"/><path d="M77 319l5-5 4 4 3-3 6 6" stroke="#fbbf24" stroke-width="1.5" fill="none"/>
-<text x="105" y="319" class="chip" fill="#f4f4f5">Image</text>
-<rect x="166" y="293" width="92" height="42" rx="13" fill="#261306" stroke="#ea580c" stroke-width="1.7" />
-<rect x="177" y="303" width="22" height="22" rx="7" fill="#18181b" stroke="#ea580c" stroke-width="1.2" />
-<path d="M182 306c-5 3-5 13 0 16 M194 306c5 3 5 13 0 16" stroke="#fdba74" stroke-width="2" fill="none" stroke-linecap="round"/>
-<text x="209" y="319" class="chip" fill="#f4f4f5">IaC</text>
-<rect x="62" y="357" width="92" height="42" rx="13" fill="#062419" stroke="#059669" stroke-width="1.7" />
-<rect x="73" y="367" width="22" height="22" rx="7" fill="#18181b" stroke="#059669" stroke-width="1.2" />
-<path d="M76 370h16v16h-16z M80 375h8 M80 379h8 M80 383h5" stroke="#34d399" stroke-width="1.6" fill="none" stroke-linecap="round"/>
-<text x="105" y="383" class="chip" fill="#f4f4f5">SBOM</text>
-<rect x="166" y="357" width="92" height="42" rx="13" fill="#2a0d17" stroke="#e11d48" stroke-width="1.7" />
-<rect x="177" y="367" width="22" height="22" rx="7" fill="#18181b" stroke="#e11d48" stroke-width="1.2" />
-<path d="M188 368l9 5v10l-9 5-9-5v-10z M188 368v20 M179 373l18 10" stroke="#fb7185" stroke-width="1.5" fill="none" stroke-linejoin="round"/>
-<text x="209" y="383" class="chip" fill="#f4f4f5">Model</text>
-<rect x="62" y="438" width="46" height="26" rx="13" fill="#261306" stroke="#ea580c" stroke-width="1.4" />
-<text x="85.0" y="455" class="badge" fill="#fdba74" text-anchor="middle">AWS</text>
-<rect x="114" y="438" width="46" height="26" rx="13" fill="#0f1d35" stroke="#2563eb" stroke-width="1.4" />
-<text x="137.0" y="455" class="badge" fill="#60a5fa" text-anchor="middle">AZ</text>
-<rect x="166" y="438" width="46" height="26" rx="13" fill="#062419" stroke="#059669" stroke-width="1.4" />
-<text x="189.0" y="455" class="badge" fill="#34d399" text-anchor="middle">GCP</text>
-<rect x="218" y="438" width="46" height="26" rx="13" fill="#072229" stroke="#0891b2" stroke-width="1.4" />
-<text x="241.0" y="455" class="badge" fill="#67e8f9" text-anchor="middle">SNOW</text>
-<text x="160" y="486" class="tiny" fill="#71717a" text-anchor="middle">no writes · no secret values</text>
-<circle cx="368" cy="183" r="18" fill="#0f1d35" stroke="#2563eb" stroke-width="2"/>
-<text x="368" y="188" class="badge" fill="#60a5fa" text-anchor="middle">1</text>
-<text x="410" y="190" class="step" fill="#f4f4f5">Discover</text>
-<path d="M368 202 C368 211, 368 214, 368 221" stroke="#3f4652" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="241" r="18" fill="#271a05" stroke="#b45309" stroke-width="2"/>
-<text x="368" y="246" class="badge" fill="#fbbf24" text-anchor="middle">2</text>
-<text x="410" y="248" class="step" fill="#f4f4f5">Match</text>
-<path d="M368 260 C368 269, 368 272, 368 279" stroke="#3f4652" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="299" r="18" fill="#2a0d17" stroke="#e11d48" stroke-width="2"/>
-<text x="368" y="304" class="badge" fill="#fb7185" text-anchor="middle">3</text>
-<text x="410" y="306" class="step" fill="#f4f4f5">Enrich</text>
-<path d="M368 318 C368 327, 368 330, 368 337" stroke="#3f4652" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="357" r="18" fill="#072229" stroke="#0891b2" stroke-width="2"/>
-<text x="368" y="362" class="badge" fill="#67e8f9" text-anchor="middle">4</text>
-<text x="410" y="364" class="step" fill="#f4f4f5">Evaluate</text>
-<path d="M368 376 C368 385, 368 388, 368 395" stroke="#3f4652" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="415" r="18" fill="#1d1230" stroke="#7c3aed" stroke-width="2"/>
-<text x="368" y="420" class="badge" fill="#a78bfa" text-anchor="middle">5</text>
-<text x="410" y="422" class="step" fill="#f4f4f5">Normalize</text>
-<rect x="350" y="446" width="76" height="26" rx="13" fill="#2a0d17" stroke="#e11d48" stroke-width="1.4" />
-<text x="388.0" y="463" class="badge" fill="#fb7185" text-anchor="middle">OSV</text>
-<rect x="440" y="446" width="76" height="26" rx="13" fill="#2a0d17" stroke="#e11d48" stroke-width="1.4" />
-<text x="478.0" y="463" class="badge" fill="#fb7185" text-anchor="middle">GHSA</text>
-<rect x="350" y="477" width="76" height="26" rx="13" fill="#2a0d17" stroke="#e11d48" stroke-width="1.4" />
-<text x="388.0" y="494" class="badge" fill="#fb7185" text-anchor="middle">NVD</text>
-<rect x="440" y="477" width="76" height="26" rx="13" fill="#261306" stroke="#ea580c" stroke-width="1.4" />
-<text x="478.0" y="494" class="badge" fill="#fdba74" text-anchor="middle">KEV</text>
-<rect x="350" y="508" width="76" height="26" rx="13" fill="#271a05" stroke="#b45309" stroke-width="1.4" />
-<text x="388.0" y="525" class="badge" fill="#fbbf24" text-anchor="middle">EPSS</text>
-<text x="745" y="175" class="step" fill="#f4f4f5" text-anchor="middle">Finding + ContextGraph</text>
-<line x1="745" y1="256" x2="673" y2="312" stroke="#3f4652" stroke-width="1.6" opacity="0.82"/>
-<line x1="745" y1="256" x2="817" y2="312" stroke="#3f4652" stroke-width="1.6" opacity="0.82"/>
-<line x1="745" y1="256" x2="703" y2="372" stroke="#3f4652" stroke-width="1.6" opacity="0.82"/>
-<line x1="745" y1="256" x2="789" y2="372" stroke="#3f4652" stroke-width="1.6" opacity="0.82"/>
-<line x1="673" y1="312" x2="703" y2="372" stroke="#3f4652" stroke-width="1.6" opacity="0.82"/>
-<line x1="817" y1="312" x2="789" y2="372" stroke="#3f4652" stroke-width="1.6" opacity="0.82"/>
-<line x1="703" y1="372" x2="789" y2="372" stroke="#3f4652" stroke-width="1.6" opacity="0.82"/>
-<circle cx="745" cy="256" r="36" fill="#2a0d17" stroke="#e11d48" stroke-width="2.2"/>
-<text x="745" y="260" class="node" fill="#fb7185" text-anchor="middle">Finding</text>
-<circle cx="673" cy="312" r="34" fill="#0f1d35" stroke="#2563eb" stroke-width="2.2"/>
-<text x="673" y="316" class="node" fill="#60a5fa" text-anchor="middle">Asset</text>
-<circle cx="817" cy="312" r="34" fill="#1d1230" stroke="#7c3aed" stroke-width="2.2"/>
-<text x="817" y="316" class="node" fill="#a78bfa" text-anchor="middle">Agent</text>
-<circle cx="703" cy="372" r="32" fill="#072229" stroke="#0891b2" stroke-width="2.2"/>
-<text x="703" y="376" class="node" fill="#67e8f9" text-anchor="middle">Tool</text>
-<circle cx="789" cy="372" r="32" fill="#261306" stroke="#ea580c" stroke-width="2.2"/>
-<text x="789" y="376" class="node" fill="#fdba74" text-anchor="middle">Cred</text>
-<rect x="650" y="410" width="84" height="26" rx="13" fill="#2a0d17" stroke="#e11d48" stroke-width="1.4" />
-<text x="692.0" y="427" class="badge" fill="#fb7185" text-anchor="middle">severity</text>
-<rect x="746" y="410" width="106" height="26" rx="13" fill="#1d1230" stroke="#7c3aed" stroke-width="1.4" />
-<text x="799.0" y="427" class="badge" fill="#a78bfa" text-anchor="middle">provenance</text>
-<rect x="696" y="446" width="108" height="26" rx="13" fill="#062419" stroke="#059669" stroke-width="1.4" />
-<text x="750.0" y="463" class="badge" fill="#34d399" text-anchor="middle">tenant scope</text>
-<text x="745" y="486" class="tiny" fill="#71717a" text-anchor="middle">one model across scan, cloud, runtime, and imports</text>
-<rect x="958" y="165" width="144" height="38" rx="12" fill="#062419" stroke="#059669" stroke-width="1.7" />
-<circle cx="981" cy="184" r="9" fill="#34d399"/>
-<text x="1004" y="189" class="chip" fill="#f4f4f5">API</text>
-<rect x="958" y="215" width="144" height="38" rx="12" fill="#1d1230" stroke="#7c3aed" stroke-width="1.7" />
-<circle cx="981" cy="234" r="9" fill="#a78bfa"/>
-<text x="1004" y="239" class="chip" fill="#f4f4f5">UI</text>
-<rect x="958" y="265" width="144" height="38" rx="12" fill="#072229" stroke="#0891b2" stroke-width="1.7" />
-<circle cx="981" cy="284" r="9" fill="#67e8f9"/>
-<text x="1004" y="289" class="chip" fill="#f4f4f5">MCP</text>
-<rect x="958" y="315" width="144" height="38" rx="12" fill="#2a0d17" stroke="#e11d48" stroke-width="1.7" />
-<circle cx="981" cy="334" r="9" fill="#fb7185"/>
-<text x="1004" y="339" class="chip" fill="#f4f4f5">Gate</text>
-<rect x="958" y="365" width="144" height="38" rx="12" fill="#271a05" stroke="#b45309" stroke-width="1.7" />
-<circle cx="981" cy="384" r="9" fill="#fbbf24"/>
-<text x="1004" y="389" class="chip" fill="#f4f4f5">Work</text>
-<rect x="958" y="415" width="144" height="38" rx="12" fill="#261306" stroke="#ea580c" stroke-width="1.7" />
-<circle cx="981" cy="434" r="9" fill="#fdba74"/>
-<text x="1004" y="439" class="chip" fill="#f4f4f5">Audit</text>
-<text x="1030" y="486" class="tiny" fill="#71717a" text-anchor="middle">auth · RBAC · scopes · audit</text>
-<rect x="1195" y="165" width="70" height="26" rx="13" fill="#062419" stroke="#059669" stroke-width="1.4" />
-<text x="1230.0" y="182" class="badge" fill="#34d399" text-anchor="middle">SARIF</text>
-<rect x="1195" y="210" width="70" height="26" rx="13" fill="#271a05" stroke="#b45309" stroke-width="1.4" />
-<text x="1230.0" y="227" class="badge" fill="#fbbf24" text-anchor="middle">SBOM</text>
-<rect x="1195" y="255" width="70" height="26" rx="13" fill="#0f1d35" stroke="#2563eb" stroke-width="1.4" />
-<text x="1230.0" y="272" class="badge" fill="#60a5fa" text-anchor="middle">HTML</text>
-<rect x="1195" y="300" width="70" height="26" rx="13" fill="#072229" stroke="#0891b2" stroke-width="1.4" />
-<text x="1230.0" y="317" class="badge" fill="#67e8f9" text-anchor="middle">JSON</text>
-<rect x="1195" y="345" width="70" height="26" rx="13" fill="#1d1230" stroke="#7c3aed" stroke-width="1.4" />
-<text x="1230.0" y="362" class="badge" fill="#a78bfa" text-anchor="middle">POSTURE</text>
-<rect x="1195" y="390" width="70" height="26" rx="13" fill="#2a0d17" stroke="#e11d48" stroke-width="1.4" />
-<text x="1230.0" y="407" class="badge" fill="#fb7185" text-anchor="middle">FIX</text>
-<text x="1230" y="452" class="tiny" fill="#71717a" text-anchor="middle">reports</text>
-<text x="1230" y="474" class="tiny" fill="#71717a" text-anchor="middle">gates</text>
-<text x="1230" y="496" class="tiny" fill="#71717a" text-anchor="middle">runtime</text>
-<path d="M280 314 C302.5 314, 307.5 314, 330 314" stroke="#69707d" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="305.0" y="302" class="tiny" fill="#71717a" text-anchor="middle">collect</text>
-<path d="M560 314 C582.5 314, 587.5 314, 610 314" stroke="#69707d" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="585.0" y="302" class="tiny" fill="#71717a" text-anchor="middle">canonicalize</text>
-<path d="M880 314 C902.5 314, 907.5 314, 930 314" stroke="#69707d" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="905.0" y="302" class="tiny" fill="#71717a" text-anchor="middle">serve</text>
-<path d="M1130 314 C1148.0 314, 1152.0 314, 1170 314" stroke="#69707d" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="1150.0" y="302" class="tiny" fill="#71717a" text-anchor="middle">export</text>
-<rect x="40" y="548" width="1250" height="46" rx="15" fill="#062419" stroke="#059669" stroke-width="1" />
-<text x="66" y="577" class="tiny" fill="#34d399">Trust boundary:</text>
-<text x="172" y="577" class="tiny" fill="#a1a1aa">default-off cloud connectors · read-only permissions · secret redaction · signed evidence · same model everywhere</text>
+<rect x="930" y="118" width="200" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
+<text x="948" y="149" class="label" fill="#a78bfa">CONTROL PLANE</text>
+<rect x="1170" y="118" width="120" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
+<text x="1188" y="149" class="label" fill="#a78bfa">OUTPUTS</text>
+
+<!-- intake nodes -->
+<rect x="62" y="165" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
+<rect x="71" y="175" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M77 178h8l4 4v11h-12z M85 178v4h4"/>
+<text x="103" y="191" class="chip" fill="#f4f4f5">Repo</text>
+<rect x="166" y="165" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
+<rect x="175" y="175" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M180 186l4 4 9-10"/>
+<text x="207" y="191" class="chip" fill="#f4f4f5">CI</text>
+<rect x="62" y="229" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
+<rect x="71" y="239" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="82" cy="247" r="2.6"/><circle class="ic" cx="77" cy="256" r="2.2"/><circle class="ic" cx="87" cy="256" r="2.2"/><path class="ic" d="M80 250l-2 5 M84 250l2 5"/>
+<text x="103" y="255" class="chip" fill="#f4f4f5">MCP</text>
+<rect x="166" y="229" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
+<rect x="175" y="239" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M180 256h12a4 4 0 0 0 .6-7.9 6 6 0 0 0-11.3-1.6A4 4 0 0 0 180 256z"/>
+<text x="207" y="255" class="chip" fill="#f4f4f5">Cloud</text>
+<rect x="62" y="293" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
+<rect x="71" y="303" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><rect class="ic" x="76" y="307" width="12" height="11" rx="2"/><path class="ic" d="M78 316l3-3 2 2 3-3 2 4"/>
+<text x="103" y="319" class="chip" fill="#f4f4f5">Image</text>
+<rect x="166" y="293" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
+<rect x="175" y="303" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M182 306c-4 3-4 13 0 16 M190 306c4 3 4 13 0 16"/>
+<text x="207" y="319" class="chip" fill="#f4f4f5">IaC</text>
+<rect x="62" y="357" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
+<rect x="71" y="367" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M76 370h12v16h-12z M79 375h6 M79 379h6 M79 383h4"/>
+<text x="103" y="383" class="chip" fill="#f4f4f5">SBOM</text>
+<rect x="166" y="357" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
+<rect x="175" y="367" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M186 369l6 3v8l-6 3-6-3v-8z M186 369v14 M180 372l12 6"/>
+<text x="207" y="383" class="chip" fill="#f4f4f5">Model</text>
+<rect x="62" y="438" width="46" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="85" y="455" class="badge" fill="#a1a1aa" text-anchor="middle">AWS</text>
+<rect x="114" y="438" width="46" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="137" y="455" class="badge" fill="#a1a1aa" text-anchor="middle">AZ</text>
+<rect x="166" y="438" width="46" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="189" y="455" class="badge" fill="#a1a1aa" text-anchor="middle">GCP</text>
+<rect x="218" y="438" width="46" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="241" y="455" class="badge" fill="#a1a1aa" text-anchor="middle">SNOW</text>
+<text x="160" y="486" class="tiny" fill="#6b6b75" text-anchor="middle">no writes · no secret values</text>
+
+<!-- scan steps -->
+<circle cx="368" cy="183" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="188" class="badge" fill="#a78bfa" text-anchor="middle">1</text>
+<text x="406" y="190" class="step" fill="#f4f4f5">Discover</text>
+<path d="M368 201 C368 210 368 213 368 220" stroke="#3a3a42" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="241" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="246" class="badge" fill="#a78bfa" text-anchor="middle">2</text>
+<text x="406" y="248" class="step" fill="#f4f4f5">Match</text>
+<path d="M368 259 C368 268 368 271 368 278" stroke="#3a3a42" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="299" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="304" class="badge" fill="#a78bfa" text-anchor="middle">3</text>
+<text x="406" y="306" class="step" fill="#f4f4f5">Enrich</text>
+<path d="M368 317 C368 326 368 329 368 336" stroke="#3a3a42" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="357" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="362" class="badge" fill="#a78bfa" text-anchor="middle">4</text>
+<text x="406" y="364" class="step" fill="#f4f4f5">Evaluate</text>
+<path d="M368 375 C368 384 368 387 368 394" stroke="#3a3a42" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="415" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="420" class="badge" fill="#a78bfa" text-anchor="middle">5</text>
+<text x="406" y="422" class="step" fill="#f4f4f5">Normalize</text>
+<rect x="350" y="446" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="388" y="463" class="badge" fill="#a1a1aa" text-anchor="middle">OSV</text>
+<rect x="440" y="446" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="478" y="463" class="badge" fill="#a1a1aa" text-anchor="middle">GHSA</text>
+<rect x="350" y="477" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="388" y="494" class="badge" fill="#a1a1aa" text-anchor="middle">NVD</text>
+<rect x="440" y="477" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="478" y="494" class="badge" fill="#a1a1aa" text-anchor="middle">KEV</text>
+<rect x="350" y="508" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="388" y="525" class="badge" fill="#a1a1aa" text-anchor="middle">EPSS</text>
+
+<!-- evidence graph -->
+<text x="745" y="178" class="step" fill="#f4f4f5" text-anchor="middle">Finding + ContextGraph</text>
+<line x1="745" y1="256" x2="673" y2="312" stroke="#3a3a42" stroke-width="1.5"/>
+<line x1="745" y1="256" x2="817" y2="312" stroke="#3a3a42" stroke-width="1.5"/>
+<line x1="745" y1="256" x2="703" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
+<line x1="745" y1="256" x2="789" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
+<line x1="673" y1="312" x2="703" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
+<line x1="817" y1="312" x2="789" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
+<line x1="703" y1="372" x2="789" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
+<circle cx="745" cy="256" r="36" fill="#15121f" stroke="#7c5cff" stroke-width="2.4"/><text x="745" y="260" class="node" fill="#c4b5fd" text-anchor="middle">Finding</text>
+<circle cx="673" cy="312" r="33" fill="#161619" stroke="#3a3a42" stroke-width="2"/><text x="673" y="316" class="node" fill="#d4d4d8" text-anchor="middle">Asset</text>
+<circle cx="817" cy="312" r="33" fill="#161619" stroke="#3a3a42" stroke-width="2"/><text x="817" y="316" class="node" fill="#d4d4d8" text-anchor="middle">Agent</text>
+<circle cx="703" cy="372" r="31" fill="#161619" stroke="#3a3a42" stroke-width="2"/><text x="703" y="376" class="node" fill="#d4d4d8" text-anchor="middle">Tool</text>
+<circle cx="789" cy="372" r="31" fill="#161619" stroke="#3a3a42" stroke-width="2"/><text x="789" y="376" class="node" fill="#d4d4d8" text-anchor="middle">Cred</text>
+<rect x="650" y="410" width="84" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="692" y="427" class="badge" fill="#a1a1aa" text-anchor="middle">severity</text>
+<rect x="746" y="410" width="106" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="799" y="427" class="badge" fill="#a1a1aa" text-anchor="middle">provenance</text>
+<rect x="696" y="446" width="108" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="750" y="463" class="badge" fill="#a1a1aa" text-anchor="middle">tenant scope</text>
+<text x="745" y="490" class="tiny" fill="#6b6b75" text-anchor="middle">one model across scan, cloud, runtime, and imports</text>
+
+<!-- control plane rows -->
+<rect x="958" y="165" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
+<path class="ic" d="M974 175l-4 7 4 7 M982 175l4 7-4 7"/><text x="1000" y="189" class="chip" fill="#f4f4f5">API</text>
+<rect x="958" y="215" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect class="ic" x="970" y="226" width="14" height="11" rx="2"/><path class="ic" d="M970 230h14"/><text x="1000" y="239" class="chip" fill="#f4f4f5">UI</text>
+<rect x="958" y="265" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
+<circle class="ic" cx="977" cy="280" r="2.4"/><circle class="ic" cx="973" cy="288" r="2"/><circle class="ic" cx="981" cy="288" r="2"/><path class="ic" d="M975.5 282l-2 5 M978.5 282l2 5"/><text x="1000" y="289" class="chip" fill="#f4f4f5">MCP</text>
+<rect x="958" y="315" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
+<path class="ic" d="M977 326l6 2v4c0 4-2.6 6-6 7-3.4-1-6-3-6-7v-4z M974 333l2 2 3.5-4"/><text x="1000" y="339" class="chip" fill="#f4f4f5">Gate</text>
+<rect x="958" y="365" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect class="ic" x="971" y="377" width="5" height="5" rx="1.3"/><rect class="ic" x="979" y="377" width="5" height="5" rx="1.3"/><rect class="ic" x="971" y="385" width="5" height="5" rx="1.3"/><rect class="ic" x="979" y="385" width="5" height="5" rx="1.3"/><text x="1000" y="389" class="chip" fill="#f4f4f5">Work</text>
+<rect x="958" y="415" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
+<path class="ic" d="M973 427h10v12h-10z M976 427v-2h4v2 M975 432l1.5 1.5 3-3"/><text x="1000" y="439" class="chip" fill="#f4f4f5">Audit</text>
+<text x="1030" y="486" class="tiny" fill="#6b6b75" text-anchor="middle">fail-closed auth · RBAC · scopes · audit</text>
+
+<!-- outputs -->
+<rect x="1195" y="165" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="182" class="badge" fill="#a1a1aa" text-anchor="middle">SARIF</text>
+<rect x="1195" y="210" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="227" class="badge" fill="#a1a1aa" text-anchor="middle">SBOM</text>
+<rect x="1195" y="255" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="272" class="badge" fill="#a1a1aa" text-anchor="middle">HTML</text>
+<rect x="1195" y="300" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="317" class="badge" fill="#a1a1aa" text-anchor="middle">JSON</text>
+<rect x="1195" y="345" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="362" class="badge" fill="#a1a1aa" text-anchor="middle">POSTURE</text>
+<rect x="1195" y="390" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="407" class="badge" fill="#a1a1aa" text-anchor="middle">FIX</text>
+<text x="1230" y="452" class="tiny" fill="#6b6b75" text-anchor="middle">reports</text>
+<text x="1230" y="474" class="tiny" fill="#6b6b75" text-anchor="middle">gates</text>
+<text x="1230" y="496" class="tiny" fill="#6b6b75" text-anchor="middle">runtime</text>
+
+<!-- flow arrows -->
+<path d="M280 314 C302 314 308 314 330 314" stroke="#52525b" stroke-width="2.2" fill="none" marker-end="url(#hiw-arrow)" stroke-linecap="round"/><text x="305" y="302" class="tiny" fill="#6b6b75" text-anchor="middle">collect</text>
+<path d="M560 314 C582 314 588 314 610 314" stroke="#52525b" stroke-width="2.2" fill="none" marker-end="url(#hiw-arrow)" stroke-linecap="round"/><text x="585" y="302" class="tiny" fill="#6b6b75" text-anchor="middle">canonicalize</text>
+<path d="M880 314 C902 314 908 314 930 314" stroke="#8b5cf6" stroke-width="2.4" fill="none" marker-end="url(#hiw-arrow)" stroke-linecap="round"/><text x="905" y="302" class="tiny" fill="#a78bfa" text-anchor="middle">serve</text>
+<path d="M1130 314 C1148 314 1152 314 1170 314" stroke="#52525b" stroke-width="2.2" fill="none" marker-end="url(#hiw-arrow)" stroke-linecap="round"/><text x="1150" y="302" class="tiny" fill="#6b6b75" text-anchor="middle">export</text>
+
+<rect x="40" y="548" width="1250" height="46" rx="14" fill="#0c1a14" stroke="#1f4438"/>
+<text x="66" y="577" class="tiny" fill="#4ade80" font-weight="800">Trust boundary:</text>
+<text x="180" y="577" class="tiny" fill="#a1a1aa">default-off cloud connectors · read-only permissions · secret redaction · signed evidence · same model everywhere</text>
 </svg>

--- a/docs/images/how-it-works-light.svg
+++ b/docs/images/how-it-works-light.svg
@@ -1,159 +1,128 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 650" fill="none" role="img" aria-labelledby="how-title how-desc">
-<title id="how-title">How agent-bom works</title>
-<desc id="how-desc">A concise visual flow from read-only inputs through scan and enrichment, unified evidence graph, control plane, outputs, reports, posture, and enforcement.</desc>
-<defs><marker id="arrow" viewBox="0 0 10 8" refX="8.2" refY="4" markerWidth="7" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#9aa3b2"/></marker>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 650" fill="none" role="img" aria-labelledby="howl-title howl-desc">
+<title id="howl-title">How agent-bom works</title>
+<desc id="howl-desc">A visual flow from read-only inputs through the scan engine, into one unified Finding and ContextGraph, served by the control plane, and exported as reports, gates, and runtime controls.</desc>
+<defs>
+<marker id="hiwl-arrow" viewBox="0 0 10 8" refX="8.2" refY="4" markerWidth="7" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
 <style>
-text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif; letter-spacing: 0; }
-.title { font-size: 30px; font-weight: 850; } .subtitle { font-size: 13px; font-weight: 550; } .label { font-size: 11px; font-weight: 850; letter-spacing: .14em; }
-.step { font-size: 22px; font-weight: 850; } .chip { font-size: 13px; font-weight: 850; } .badge { font-size: 10.5px; font-weight: 850; } .tiny { font-size: 10px; font-weight: 700; } .node { font-size: 10px; font-weight: 850; }
+text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif; }
+.title { font-size: 30px; font-weight: 850; } .subtitle { font-size: 13px; font-weight: 500; } .label { font-size: 11px; font-weight: 800; letter-spacing: .15em; }
+.step { font-size: 22px; font-weight: 800; } .chip { font-size: 13px; font-weight: 700; } .badge { font-size: 10.5px; font-weight: 700; } .tiny { font-size: 10px; font-weight: 600; } .node { font-size: 11px; font-weight: 800; }
+.ic { fill: none; stroke: #6b6b76; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
+.ic-a { fill: none; stroke: #7c3aed; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
 </style></defs>
-<rect x="0" y="0" width="1320" height="650" rx="18" fill="#ffffff" stroke="#d7dce5" stroke-width="0" />
-<text x="48" y="52" class="title" fill="#111827">From inventory to enforceable evidence</text>
-<text x="48" y="78" class="subtitle" fill="#4b5563">Read-only collection becomes deterministic matching, enriched findings, graph-backed blast radius, and operational outputs.</text>
-<rect x="40" y="118" width="240" height="392" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1" />
-<text x="58" y="149" class="label" fill="#1d4ed8">READ-ONLY INTAKE</text>
-<rect x="330" y="118" width="230" height="392" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1" />
-<text x="348" y="149" class="label" fill="#b45309">SCAN ENGINE</text>
-<rect x="610" y="118" width="270" height="392" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1" />
-<text x="628" y="149" class="label" fill="#6d28d9">EVIDENCE CORE</text>
-<rect x="930" y="118" width="200" height="392" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1" />
-<text x="948" y="149" class="label" fill="#047857">CONTROL PLANE</text>
-<rect x="1170" y="118" width="120" height="392" rx="18" fill="#f8fafc" stroke="#d7dce5" stroke-width="1" />
-<text x="1188" y="149" class="label" fill="#0e7490">OUTPUTS</text>
-<rect x="62" y="165" width="92" height="42" rx="13" fill="#eff6ff" stroke="#60a5fa" stroke-width="1.7" />
-<rect x="73" y="175" width="22" height="22" rx="7" fill="#ffffff" stroke="#60a5fa" stroke-width="1.2" />
-<path d="M77 178h11l5 5v13h-16z M88 178v5h5" stroke="#1d4ed8" stroke-width="1.8" fill="none" stroke-linejoin="round"/>
-<text x="105" y="191" class="chip" fill="#111827">Repo</text>
-<rect x="166" y="165" width="92" height="42" rx="13" fill="#eff6ff" stroke="#60a5fa" stroke-width="1.7" />
-<rect x="177" y="175" width="22" height="22" rx="7" fill="#ffffff" stroke="#60a5fa" stroke-width="1.2" />
-<path d="M180 186l5 5 11-12" stroke="#1d4ed8" stroke-width="2.4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-<text x="209" y="191" class="chip" fill="#111827">CI</text>
-<rect x="62" y="229" width="92" height="42" rx="13" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1.7" />
-<rect x="73" y="239" width="22" height="22" rx="7" fill="#ffffff" stroke="#a78bfa" stroke-width="1.2" />
-<circle cx="84" cy="250" r="3" fill="#6d28d9"/><circle cx="76" cy="257" r="3" fill="#6d28d9"/><circle cx="92" cy="257" r="3" fill="#6d28d9"/><path d="M83 252l-5 4 M85 252l5 4" stroke="#6d28d9" stroke-width="1.6"/>
-<text x="105" y="255" class="chip" fill="#111827">MCP</text>
-<rect x="166" y="229" width="92" height="42" rx="13" fill="#ecfeff" stroke="#22d3ee" stroke-width="1.7" />
-<rect x="177" y="239" width="22" height="22" rx="7" fill="#ffffff" stroke="#22d3ee" stroke-width="1.2" />
-<path d="M178 255h19a5 5 0 0 0 1-10 8 8 0 0 0-15-3 6 6 0 0 0-5 13z" stroke="#0e7490" stroke-width="1.8" fill="none" stroke-linecap="round"/>
-<text x="209" y="255" class="chip" fill="#111827">Cloud</text>
-<rect x="62" y="293" width="92" height="42" rx="13" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.7" />
-<rect x="73" y="303" width="22" height="22" rx="7" fill="#ffffff" stroke="#f59e0b" stroke-width="1.2" />
-<rect x="75" y="306" width="18" height="16" rx="3" stroke="#b45309" stroke-width="1.8" fill="none"/><path d="M77 319l5-5 4 4 3-3 6 6" stroke="#b45309" stroke-width="1.5" fill="none"/>
-<text x="105" y="319" class="chip" fill="#111827">Image</text>
-<rect x="166" y="293" width="92" height="42" rx="13" fill="#fff7ed" stroke="#fb923c" stroke-width="1.7" />
-<rect x="177" y="303" width="22" height="22" rx="7" fill="#ffffff" stroke="#fb923c" stroke-width="1.2" />
-<path d="M182 306c-5 3-5 13 0 16 M194 306c5 3 5 13 0 16" stroke="#c2410c" stroke-width="2" fill="none" stroke-linecap="round"/>
-<text x="209" y="319" class="chip" fill="#111827">IaC</text>
-<rect x="62" y="357" width="92" height="42" rx="13" fill="#ecfdf5" stroke="#34d399" stroke-width="1.7" />
-<rect x="73" y="367" width="22" height="22" rx="7" fill="#ffffff" stroke="#34d399" stroke-width="1.2" />
-<path d="M76 370h16v16h-16z M80 375h8 M80 379h8 M80 383h5" stroke="#047857" stroke-width="1.6" fill="none" stroke-linecap="round"/>
-<text x="105" y="383" class="chip" fill="#111827">SBOM</text>
-<rect x="166" y="357" width="92" height="42" rx="13" fill="#fff1f2" stroke="#fb7185" stroke-width="1.7" />
-<rect x="177" y="367" width="22" height="22" rx="7" fill="#ffffff" stroke="#fb7185" stroke-width="1.2" />
-<path d="M188 368l9 5v10l-9 5-9-5v-10z M188 368v20 M179 373l18 10" stroke="#be123c" stroke-width="1.5" fill="none" stroke-linejoin="round"/>
-<text x="209" y="383" class="chip" fill="#111827">Model</text>
-<rect x="62" y="438" width="46" height="26" rx="13" fill="#fff7ed" stroke="#fb923c" stroke-width="1.4" />
-<text x="85.0" y="455" class="badge" fill="#c2410c" text-anchor="middle">AWS</text>
-<rect x="114" y="438" width="46" height="26" rx="13" fill="#eff6ff" stroke="#60a5fa" stroke-width="1.4" />
-<text x="137.0" y="455" class="badge" fill="#1d4ed8" text-anchor="middle">AZ</text>
-<rect x="166" y="438" width="46" height="26" rx="13" fill="#ecfdf5" stroke="#34d399" stroke-width="1.4" />
-<text x="189.0" y="455" class="badge" fill="#047857" text-anchor="middle">GCP</text>
-<rect x="218" y="438" width="46" height="26" rx="13" fill="#ecfeff" stroke="#22d3ee" stroke-width="1.4" />
-<text x="241.0" y="455" class="badge" fill="#0e7490" text-anchor="middle">SNOW</text>
-<text x="160" y="486" class="tiny" fill="#6b7280" text-anchor="middle">no writes · no secret values</text>
-<circle cx="368" cy="183" r="18" fill="#eff6ff" stroke="#60a5fa" stroke-width="2"/>
-<text x="368" y="188" class="badge" fill="#1d4ed8" text-anchor="middle">1</text>
-<text x="410" y="190" class="step" fill="#111827">Discover</text>
-<path d="M368 202 C368 211, 368 214, 368 221" stroke="#c4cbd6" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="241" r="18" fill="#fffbeb" stroke="#f59e0b" stroke-width="2"/>
-<text x="368" y="246" class="badge" fill="#b45309" text-anchor="middle">2</text>
-<text x="410" y="248" class="step" fill="#111827">Match</text>
-<path d="M368 260 C368 269, 368 272, 368 279" stroke="#c4cbd6" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="299" r="18" fill="#fff1f2" stroke="#fb7185" stroke-width="2"/>
-<text x="368" y="304" class="badge" fill="#be123c" text-anchor="middle">3</text>
-<text x="410" y="306" class="step" fill="#111827">Enrich</text>
-<path d="M368 318 C368 327, 368 330, 368 337" stroke="#c4cbd6" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="357" r="18" fill="#ecfeff" stroke="#22d3ee" stroke-width="2"/>
-<text x="368" y="362" class="badge" fill="#0e7490" text-anchor="middle">4</text>
-<text x="410" y="364" class="step" fill="#111827">Evaluate</text>
-<path d="M368 376 C368 385, 368 388, 368 395" stroke="#c4cbd6" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="415" r="18" fill="#f5f3ff" stroke="#a78bfa" stroke-width="2"/>
-<text x="368" y="420" class="badge" fill="#6d28d9" text-anchor="middle">5</text>
-<text x="410" y="422" class="step" fill="#111827">Normalize</text>
-<rect x="350" y="446" width="76" height="26" rx="13" fill="#fff1f2" stroke="#fb7185" stroke-width="1.4" />
-<text x="388.0" y="463" class="badge" fill="#be123c" text-anchor="middle">OSV</text>
-<rect x="440" y="446" width="76" height="26" rx="13" fill="#fff1f2" stroke="#fb7185" stroke-width="1.4" />
-<text x="478.0" y="463" class="badge" fill="#be123c" text-anchor="middle">GHSA</text>
-<rect x="350" y="477" width="76" height="26" rx="13" fill="#fff1f2" stroke="#fb7185" stroke-width="1.4" />
-<text x="388.0" y="494" class="badge" fill="#be123c" text-anchor="middle">NVD</text>
-<rect x="440" y="477" width="76" height="26" rx="13" fill="#fff7ed" stroke="#fb923c" stroke-width="1.4" />
-<text x="478.0" y="494" class="badge" fill="#c2410c" text-anchor="middle">KEV</text>
-<rect x="350" y="508" width="76" height="26" rx="13" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.4" />
-<text x="388.0" y="525" class="badge" fill="#b45309" text-anchor="middle">EPSS</text>
-<text x="745" y="175" class="step" fill="#111827" text-anchor="middle">Finding + ContextGraph</text>
-<line x1="745" y1="256" x2="673" y2="312" stroke="#c4cbd6" stroke-width="1.6" opacity="0.82"/>
-<line x1="745" y1="256" x2="817" y2="312" stroke="#c4cbd6" stroke-width="1.6" opacity="0.82"/>
-<line x1="745" y1="256" x2="703" y2="372" stroke="#c4cbd6" stroke-width="1.6" opacity="0.82"/>
-<line x1="745" y1="256" x2="789" y2="372" stroke="#c4cbd6" stroke-width="1.6" opacity="0.82"/>
-<line x1="673" y1="312" x2="703" y2="372" stroke="#c4cbd6" stroke-width="1.6" opacity="0.82"/>
-<line x1="817" y1="312" x2="789" y2="372" stroke="#c4cbd6" stroke-width="1.6" opacity="0.82"/>
-<line x1="703" y1="372" x2="789" y2="372" stroke="#c4cbd6" stroke-width="1.6" opacity="0.82"/>
-<circle cx="745" cy="256" r="36" fill="#fff1f2" stroke="#fb7185" stroke-width="2.2"/>
-<text x="745" y="260" class="node" fill="#be123c" text-anchor="middle">Finding</text>
-<circle cx="673" cy="312" r="34" fill="#eff6ff" stroke="#60a5fa" stroke-width="2.2"/>
-<text x="673" y="316" class="node" fill="#1d4ed8" text-anchor="middle">Asset</text>
-<circle cx="817" cy="312" r="34" fill="#f5f3ff" stroke="#a78bfa" stroke-width="2.2"/>
-<text x="817" y="316" class="node" fill="#6d28d9" text-anchor="middle">Agent</text>
-<circle cx="703" cy="372" r="32" fill="#ecfeff" stroke="#22d3ee" stroke-width="2.2"/>
-<text x="703" y="376" class="node" fill="#0e7490" text-anchor="middle">Tool</text>
-<circle cx="789" cy="372" r="32" fill="#fff7ed" stroke="#fb923c" stroke-width="2.2"/>
-<text x="789" y="376" class="node" fill="#c2410c" text-anchor="middle">Cred</text>
-<rect x="650" y="410" width="84" height="26" rx="13" fill="#fff1f2" stroke="#fb7185" stroke-width="1.4" />
-<text x="692.0" y="427" class="badge" fill="#be123c" text-anchor="middle">severity</text>
-<rect x="746" y="410" width="106" height="26" rx="13" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1.4" />
-<text x="799.0" y="427" class="badge" fill="#6d28d9" text-anchor="middle">provenance</text>
-<rect x="696" y="446" width="108" height="26" rx="13" fill="#ecfdf5" stroke="#34d399" stroke-width="1.4" />
-<text x="750.0" y="463" class="badge" fill="#047857" text-anchor="middle">tenant scope</text>
-<text x="745" y="486" class="tiny" fill="#6b7280" text-anchor="middle">one model across scan, cloud, runtime, and imports</text>
-<rect x="958" y="165" width="144" height="38" rx="12" fill="#ecfdf5" stroke="#34d399" stroke-width="1.7" />
-<circle cx="981" cy="184" r="9" fill="#047857"/>
-<text x="1004" y="189" class="chip" fill="#111827">API</text>
-<rect x="958" y="215" width="144" height="38" rx="12" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1.7" />
-<circle cx="981" cy="234" r="9" fill="#6d28d9"/>
-<text x="1004" y="239" class="chip" fill="#111827">UI</text>
-<rect x="958" y="265" width="144" height="38" rx="12" fill="#ecfeff" stroke="#22d3ee" stroke-width="1.7" />
-<circle cx="981" cy="284" r="9" fill="#0e7490"/>
-<text x="1004" y="289" class="chip" fill="#111827">MCP</text>
-<rect x="958" y="315" width="144" height="38" rx="12" fill="#fff1f2" stroke="#fb7185" stroke-width="1.7" />
-<circle cx="981" cy="334" r="9" fill="#be123c"/>
-<text x="1004" y="339" class="chip" fill="#111827">Gate</text>
-<rect x="958" y="365" width="144" height="38" rx="12" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.7" />
-<circle cx="981" cy="384" r="9" fill="#b45309"/>
-<text x="1004" y="389" class="chip" fill="#111827">Work</text>
-<rect x="958" y="415" width="144" height="38" rx="12" fill="#fff7ed" stroke="#fb923c" stroke-width="1.7" />
-<circle cx="981" cy="434" r="9" fill="#c2410c"/>
-<text x="1004" y="439" class="chip" fill="#111827">Audit</text>
-<text x="1030" y="486" class="tiny" fill="#6b7280" text-anchor="middle">auth · RBAC · scopes · audit</text>
-<rect x="1195" y="165" width="70" height="26" rx="13" fill="#ecfdf5" stroke="#34d399" stroke-width="1.4" />
-<text x="1230.0" y="182" class="badge" fill="#047857" text-anchor="middle">SARIF</text>
-<rect x="1195" y="210" width="70" height="26" rx="13" fill="#fffbeb" stroke="#f59e0b" stroke-width="1.4" />
-<text x="1230.0" y="227" class="badge" fill="#b45309" text-anchor="middle">SBOM</text>
-<rect x="1195" y="255" width="70" height="26" rx="13" fill="#eff6ff" stroke="#60a5fa" stroke-width="1.4" />
-<text x="1230.0" y="272" class="badge" fill="#1d4ed8" text-anchor="middle">HTML</text>
-<rect x="1195" y="300" width="70" height="26" rx="13" fill="#ecfeff" stroke="#22d3ee" stroke-width="1.4" />
-<text x="1230.0" y="317" class="badge" fill="#0e7490" text-anchor="middle">JSON</text>
-<rect x="1195" y="345" width="70" height="26" rx="13" fill="#f5f3ff" stroke="#a78bfa" stroke-width="1.4" />
-<text x="1230.0" y="362" class="badge" fill="#6d28d9" text-anchor="middle">POSTURE</text>
-<rect x="1195" y="390" width="70" height="26" rx="13" fill="#fff1f2" stroke="#fb7185" stroke-width="1.4" />
-<text x="1230.0" y="407" class="badge" fill="#be123c" text-anchor="middle">FIX</text>
-<text x="1230" y="452" class="tiny" fill="#6b7280" text-anchor="middle">reports</text>
-<text x="1230" y="474" class="tiny" fill="#6b7280" text-anchor="middle">gates</text>
-<text x="1230" y="496" class="tiny" fill="#6b7280" text-anchor="middle">runtime</text>
-<path d="M280 314 C302.5 314, 307.5 314, 330 314" stroke="#9aa3b2" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="305.0" y="302" class="tiny" fill="#6b7280" text-anchor="middle">collect</text>
-<path d="M560 314 C582.5 314, 587.5 314, 610 314" stroke="#9aa3b2" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="585.0" y="302" class="tiny" fill="#6b7280" text-anchor="middle">canonicalize</text>
-<path d="M880 314 C902.5 314, 907.5 314, 930 314" stroke="#9aa3b2" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="905.0" y="302" class="tiny" fill="#6b7280" text-anchor="middle">serve</text>
-<path d="M1130 314 C1148.0 314, 1152.0 314, 1170 314" stroke="#9aa3b2" stroke-width="2.2" fill="none" marker-end="url(#arrow)" stroke-linecap="round"/><text x="1150.0" y="302" class="tiny" fill="#6b7280" text-anchor="middle">export</text>
-<rect x="40" y="548" width="1250" height="46" rx="15" fill="#ecfdf5" stroke="#34d399" stroke-width="1" />
-<text x="66" y="577" class="tiny" fill="#047857">Trust boundary:</text>
-<text x="172" y="577" class="tiny" fill="#4b5563">default-off cloud connectors · read-only permissions · secret redaction · signed evidence · same model everywhere</text>
+<rect x="0" y="0" width="1320" height="650" rx="18" fill="#ffffff"/>
+<text x="48" y="52" class="title" fill="#18181b">From inventory to enforceable evidence</text>
+<text x="48" y="78" class="subtitle" fill="#6b6b75">Read-only collection becomes deterministic matching, enriched findings, graph-backed blast radius, and operational outputs.</text>
+
+<rect x="40" y="118" width="240" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
+<text x="58" y="149" class="label" fill="#7c3aed">READ-ONLY INTAKE</text>
+<rect x="330" y="118" width="230" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
+<text x="348" y="149" class="label" fill="#7c3aed">SCAN ENGINE</text>
+<rect x="610" y="118" width="270" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
+<text x="628" y="149" class="label" fill="#7c3aed">EVIDENCE CORE</text>
+<rect x="930" y="118" width="200" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
+<text x="948" y="149" class="label" fill="#7c3aed">CONTROL PLANE</text>
+<rect x="1170" y="118" width="120" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
+<text x="1188" y="149" class="label" fill="#7c3aed">OUTPUTS</text>
+
+<rect x="62" y="165" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="71" y="175" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M77 178h8l4 4v11h-12z M85 178v4h4"/>
+<text x="103" y="191" class="chip" fill="#18181b">Repo</text>
+<rect x="166" y="165" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="175" y="175" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M180 186l4 4 9-10"/>
+<text x="207" y="191" class="chip" fill="#18181b">CI</text>
+<rect x="62" y="229" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="71" y="239" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="82" cy="247" r="2.6"/><circle class="ic" cx="77" cy="256" r="2.2"/><circle class="ic" cx="87" cy="256" r="2.2"/><path class="ic" d="M80 250l-2 5 M84 250l2 5"/>
+<text x="103" y="255" class="chip" fill="#18181b">MCP</text>
+<rect x="166" y="229" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="175" y="239" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M180 256h12a4 4 0 0 0 .6-7.9 6 6 0 0 0-11.3-1.6A4 4 0 0 0 180 256z"/>
+<text x="207" y="255" class="chip" fill="#18181b">Cloud</text>
+<rect x="62" y="293" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="71" y="303" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><rect class="ic" x="76" y="307" width="12" height="11" rx="2"/><path class="ic" d="M78 316l3-3 2 2 3-3 2 4"/>
+<text x="103" y="319" class="chip" fill="#18181b">Image</text>
+<rect x="166" y="293" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="175" y="303" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M182 306c-4 3-4 13 0 16 M190 306c4 3 4 13 0 16"/>
+<text x="207" y="319" class="chip" fill="#18181b">IaC</text>
+<rect x="62" y="357" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="71" y="367" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M76 370h12v16h-12z M79 375h6 M79 379h6 M79 383h4"/>
+<text x="103" y="383" class="chip" fill="#18181b">SBOM</text>
+<rect x="166" y="357" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="175" y="367" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M186 369l6 3v8l-6 3-6-3v-8z M186 369v14 M180 372l12 6"/>
+<text x="207" y="383" class="chip" fill="#18181b">Model</text>
+<rect x="62" y="438" width="46" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="85" y="455" class="badge" fill="#71717a" text-anchor="middle">AWS</text>
+<rect x="114" y="438" width="46" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="137" y="455" class="badge" fill="#71717a" text-anchor="middle">AZ</text>
+<rect x="166" y="438" width="46" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="189" y="455" class="badge" fill="#71717a" text-anchor="middle">GCP</text>
+<rect x="218" y="438" width="46" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="241" y="455" class="badge" fill="#71717a" text-anchor="middle">SNOW</text>
+<text x="160" y="486" class="tiny" fill="#9a9aa4" text-anchor="middle">no writes · no secret values</text>
+
+<circle cx="368" cy="183" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="188" class="badge" fill="#7c3aed" text-anchor="middle">1</text>
+<text x="406" y="190" class="step" fill="#18181b">Discover</text>
+<path d="M368 201 C368 210 368 213 368 220" stroke="#d4d4d8" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="241" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="246" class="badge" fill="#7c3aed" text-anchor="middle">2</text>
+<text x="406" y="248" class="step" fill="#18181b">Match</text>
+<path d="M368 259 C368 268 368 271 368 278" stroke="#d4d4d8" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="299" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="304" class="badge" fill="#7c3aed" text-anchor="middle">3</text>
+<text x="406" y="306" class="step" fill="#18181b">Enrich</text>
+<path d="M368 317 C368 326 368 329 368 336" stroke="#d4d4d8" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="357" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="362" class="badge" fill="#7c3aed" text-anchor="middle">4</text>
+<text x="406" y="364" class="step" fill="#18181b">Evaluate</text>
+<path d="M368 375 C368 384 368 387 368 394" stroke="#d4d4d8" stroke-width="2" fill="none" stroke-linecap="round"/>
+<circle cx="368" cy="415" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="420" class="badge" fill="#7c3aed" text-anchor="middle">5</text>
+<text x="406" y="422" class="step" fill="#18181b">Normalize</text>
+<rect x="350" y="446" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="388" y="463" class="badge" fill="#71717a" text-anchor="middle">OSV</text>
+<rect x="440" y="446" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="478" y="463" class="badge" fill="#71717a" text-anchor="middle">GHSA</text>
+<rect x="350" y="477" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="388" y="494" class="badge" fill="#71717a" text-anchor="middle">NVD</text>
+<rect x="440" y="477" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="478" y="494" class="badge" fill="#71717a" text-anchor="middle">KEV</text>
+<rect x="350" y="508" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="388" y="525" class="badge" fill="#71717a" text-anchor="middle">EPSS</text>
+
+<text x="745" y="178" class="step" fill="#18181b" text-anchor="middle">Finding + ContextGraph</text>
+<line x1="745" y1="256" x2="673" y2="312" stroke="#d4d4d8" stroke-width="1.5"/>
+<line x1="745" y1="256" x2="817" y2="312" stroke="#d4d4d8" stroke-width="1.5"/>
+<line x1="745" y1="256" x2="703" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
+<line x1="745" y1="256" x2="789" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
+<line x1="673" y1="312" x2="703" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
+<line x1="817" y1="312" x2="789" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
+<line x1="703" y1="372" x2="789" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
+<circle cx="745" cy="256" r="36" fill="#f6f4ff" stroke="#7c5cff" stroke-width="2.4"/><text x="745" y="260" class="node" fill="#6d28d9" text-anchor="middle">Finding</text>
+<circle cx="673" cy="312" r="33" fill="#ffffff" stroke="#d4d4d8" stroke-width="2"/><text x="673" y="316" class="node" fill="#3f3f46" text-anchor="middle">Asset</text>
+<circle cx="817" cy="312" r="33" fill="#ffffff" stroke="#d4d4d8" stroke-width="2"/><text x="817" y="316" class="node" fill="#3f3f46" text-anchor="middle">Agent</text>
+<circle cx="703" cy="372" r="31" fill="#ffffff" stroke="#d4d4d8" stroke-width="2"/><text x="703" y="376" class="node" fill="#3f3f46" text-anchor="middle">Tool</text>
+<circle cx="789" cy="372" r="31" fill="#ffffff" stroke="#d4d4d8" stroke-width="2"/><text x="789" y="376" class="node" fill="#3f3f46" text-anchor="middle">Cred</text>
+<rect x="650" y="410" width="84" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="692" y="427" class="badge" fill="#71717a" text-anchor="middle">severity</text>
+<rect x="746" y="410" width="106" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="799" y="427" class="badge" fill="#71717a" text-anchor="middle">provenance</text>
+<rect x="696" y="446" width="108" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="750" y="463" class="badge" fill="#71717a" text-anchor="middle">tenant scope</text>
+<text x="745" y="490" class="tiny" fill="#9a9aa4" text-anchor="middle">one model across scan, cloud, runtime, and imports</text>
+
+<rect x="958" y="165" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<path class="ic" d="M974 175l-4 7 4 7 M982 175l4 7-4 7"/><text x="1000" y="189" class="chip" fill="#18181b">API</text>
+<rect x="958" y="215" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect class="ic" x="970" y="226" width="14" height="11" rx="2"/><path class="ic" d="M970 230h14"/><text x="1000" y="239" class="chip" fill="#18181b">UI</text>
+<rect x="958" y="265" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<circle class="ic" cx="977" cy="280" r="2.4"/><circle class="ic" cx="973" cy="288" r="2"/><circle class="ic" cx="981" cy="288" r="2"/><path class="ic" d="M975.5 282l-2 5 M978.5 282l2 5"/><text x="1000" y="289" class="chip" fill="#18181b">MCP</text>
+<rect x="958" y="315" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<path class="ic" d="M977 326l6 2v4c0 4-2.6 6-6 7-3.4-1-6-3-6-7v-4z M974 333l2 2 3.5-4"/><text x="1000" y="339" class="chip" fill="#18181b">Gate</text>
+<rect x="958" y="365" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect class="ic" x="971" y="377" width="5" height="5" rx="1.3"/><rect class="ic" x="979" y="377" width="5" height="5" rx="1.3"/><rect class="ic" x="971" y="385" width="5" height="5" rx="1.3"/><rect class="ic" x="979" y="385" width="5" height="5" rx="1.3"/><text x="1000" y="389" class="chip" fill="#18181b">Work</text>
+<rect x="958" y="415" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<path class="ic" d="M973 427h10v12h-10z M976 427v-2h4v2 M975 432l1.5 1.5 3-3"/><text x="1000" y="439" class="chip" fill="#18181b">Audit</text>
+<text x="1030" y="486" class="tiny" fill="#9a9aa4" text-anchor="middle">fail-closed auth · RBAC · scopes · audit</text>
+
+<rect x="1195" y="165" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="182" class="badge" fill="#71717a" text-anchor="middle">SARIF</text>
+<rect x="1195" y="210" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="227" class="badge" fill="#71717a" text-anchor="middle">SBOM</text>
+<rect x="1195" y="255" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="272" class="badge" fill="#71717a" text-anchor="middle">HTML</text>
+<rect x="1195" y="300" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="317" class="badge" fill="#71717a" text-anchor="middle">JSON</text>
+<rect x="1195" y="345" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="362" class="badge" fill="#71717a" text-anchor="middle">POSTURE</text>
+<rect x="1195" y="390" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="407" class="badge" fill="#71717a" text-anchor="middle">FIX</text>
+<text x="1230" y="452" class="tiny" fill="#9a9aa4" text-anchor="middle">reports</text>
+<text x="1230" y="474" class="tiny" fill="#9a9aa4" text-anchor="middle">gates</text>
+<text x="1230" y="496" class="tiny" fill="#9a9aa4" text-anchor="middle">runtime</text>
+
+<path d="M280 314 C302 314 308 314 330 314" stroke="#a1a1aa" stroke-width="2.2" fill="none" marker-end="url(#hiwl-arrow)" stroke-linecap="round"/><text x="305" y="302" class="tiny" fill="#9a9aa4" text-anchor="middle">collect</text>
+<path d="M560 314 C582 314 588 314 610 314" stroke="#a1a1aa" stroke-width="2.2" fill="none" marker-end="url(#hiwl-arrow)" stroke-linecap="round"/><text x="585" y="302" class="tiny" fill="#9a9aa4" text-anchor="middle">canonicalize</text>
+<path d="M880 314 C902 314 908 314 930 314" stroke="#7c3aed" stroke-width="2.4" fill="none" marker-end="url(#hiwl-arrow)" stroke-linecap="round"/><text x="905" y="302" class="tiny" fill="#7c3aed" text-anchor="middle">serve</text>
+<path d="M1130 314 C1148 314 1152 314 1170 314" stroke="#a1a1aa" stroke-width="2.2" fill="none" marker-end="url(#hiwl-arrow)" stroke-linecap="round"/><text x="1150" y="302" class="tiny" fill="#9a9aa4" text-anchor="middle">export</text>
+
+<rect x="40" y="548" width="1250" height="46" rx="14" fill="#ecfdf5" stroke="#a7f3d0"/>
+<text x="66" y="577" class="tiny" fill="#15803d" font-weight="800">Trust boundary:</text>
+<text x="180" y="577" class="tiny" fill="#52525b">default-off cloud connectors · read-only permissions · secret redaction · signed evidence · same model everywhere</text>
 </svg>


### PR DESCRIPTION
## Summary
Redesigns the two README hero diagrams that read as dense, multi-colored, and text-heavy (no consistent iconography) into a single, calm design system.

**Diagrams:** `architecture` and `how-it-works` — both **dark + light** (4 SVGs).

## What changed
- **One accent, not a rainbow.** Replaced per-node/per-lane bright strokes (blue/amber/red/teal/purple) with one brand-violet accent on neutral surfaces. Color now carries meaning only: violet = flow + evidence core, green = trust boundary.
- **Real icons on every node** — consistent monochrome line icons in uniform tiles (repo, CI, MCP, cloud, container, IaC, key, model, magnifier, shield, braces, server, grid, clipboard, database…), replacing colored dots / bare text.
- **Less to read** — collapsed multi-line node blurbs to title + one sub-line; artifact formats are tidy neutral chips.
- **Bug fix** — `NORMALIZE` / `DELIVER` flow labels were being clipped by the lane panels; now drawn on top and fully legible.

## Compatibility
- `viewBox` dimensions unchanged, so the README `<picture>` layout and dark/light theme swap are unaffected.
- All four validated as well-formed XML and rendered via `rsvg-convert`.

## Not included
`scan-pipeline` and `blast-radius` are left as-is; can follow in the same system if wanted.