### PR TITLE
fix(integrity): bind cosign verification to release identity

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -96,6 +96,10 @@ AGENT_BOM_VAULT_TOKEN
 AGENT_BOM_CONNECTIONS_SCHEDULER
 # CLI profile config path override; read at command invocation time.
 AGENT_BOM_CONFIG
+# Optional cosign signer-boundary overrides for internal non-release signing;
+# defaults stay pinned to the agent-bom release workflow and GitHub OIDC issuer.
+AGENT_BOM_COSIGN_CERTIFICATE_IDENTITY_REGEXP
+AGENT_BOM_COSIGN_CERTIFICATE_OIDC_ISSUER
 AGENT_BOM_COMPLIANCE_BUNDLE_TTL_SECONDS
 AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM
 AGENT_BOM_COMPLIANCE_SIGNING_LAST_ROTATED

--- a/src/agent_bom/integrity.py
+++ b/src/agent_bom/integrity.py
@@ -10,6 +10,7 @@ import base64
 import hashlib
 import json as _json
 import logging
+import os
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, distribution
 from pathlib import Path
@@ -24,6 +25,10 @@ logger = logging.getLogger(__name__)
 
 # npm registry provides shasum (SHA-1) and integrity (SHA-512 SRI) in dist metadata
 # PyPI provides sha256 digests in the JSON API
+_DEFAULT_COSIGN_CERTIFICATE_IDENTITY_REGEXP = r"https://github\.com/msaad00/agent-bom/\.github/workflows/release\.yml@.*"
+_DEFAULT_COSIGN_CERTIFICATE_OIDC_ISSUER = "https://token.actions.githubusercontent.com"
+_COSIGN_CERTIFICATE_IDENTITY_REGEXP_ENV = "AGENT_BOM_COSIGN_CERTIFICATE_IDENTITY_REGEXP"
+_COSIGN_CERTIFICATE_OIDC_ISSUER_ENV = "AGENT_BOM_COSIGN_CERTIFICATE_OIDC_ISSUER"
 
 
 async def verify_npm_integrity(
@@ -654,6 +659,14 @@ def _try_cosign_verify(file_path: Path, bundle_path: Path) -> bool:
     cosign = shutil.which("cosign")
     if cosign is None:
         return False
+    certificate_identity = (
+        os.environ.get(_COSIGN_CERTIFICATE_IDENTITY_REGEXP_ENV, "").strip()
+        or _DEFAULT_COSIGN_CERTIFICATE_IDENTITY_REGEXP
+    )
+    certificate_issuer = (
+        os.environ.get(_COSIGN_CERTIFICATE_OIDC_ISSUER_ENV, "").strip()
+        or _DEFAULT_COSIGN_CERTIFICATE_OIDC_ISSUER
+    )
 
     try:
         proc = subprocess.run(
@@ -663,9 +676,9 @@ def _try_cosign_verify(file_path: Path, bundle_path: Path) -> bool:
                 "--bundle",
                 str(bundle_path),
                 "--certificate-identity-regexp",
-                ".*",
-                "--certificate-oidc-issuer-regexp",
-                ".*",
+                certificate_identity,
+                "--certificate-oidc-issuer",
+                certificate_issuer,
                 str(file_path),
             ],
             capture_output=True,

--- a/tests/test_instruction_provenance.py
+++ b/tests/test_instruction_provenance.py
@@ -14,6 +14,7 @@ from agent_bom.integrity import (
     _compute_sha256,
     _find_sigstore_bundle,
     _parse_sigstore_bundle,
+    _try_cosign_verify,
     discover_instruction_files,
     verify_instruction_file,
     verify_instruction_files_batch,
@@ -266,6 +267,62 @@ class TestVerifyInstructionFile:
 
         assert result.verified is True
         assert result.reason == "cosign_verified"
+
+    def test_cosign_verify_uses_bounded_release_identity(self, tmp_path, monkeypatch):
+        f = tmp_path / "SKILL.md"
+        f.write_text("# Signed skill")
+        bundle = tmp_path / "SKILL.md.sigstore"
+        bundle.write_text("{}")
+        calls: list[list[str]] = []
+
+        class _Proc:
+            returncode = 0
+
+        def _run(cmd, **kwargs):
+            calls.append(cmd)
+            return _Proc()
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/local/bin/cosign" if name == "cosign" else None)
+        monkeypatch.setattr("subprocess.run", _run)
+        monkeypatch.delenv("AGENT_BOM_COSIGN_CERTIFICATE_IDENTITY_REGEXP", raising=False)
+        monkeypatch.delenv("AGENT_BOM_COSIGN_CERTIFICATE_OIDC_ISSUER", raising=False)
+
+        assert _try_cosign_verify(f, bundle) is True
+
+        cmd = calls[0]
+        assert "--certificate-identity-regexp" in cmd
+        assert cmd[cmd.index("--certificate-identity-regexp") + 1] == (
+            r"https://github\.com/msaad00/agent-bom/\.github/workflows/release\.yml@.*"
+        )
+        assert "--certificate-oidc-issuer" in cmd
+        assert cmd[cmd.index("--certificate-oidc-issuer") + 1] == "https://token.actions.githubusercontent.com"
+        assert "--certificate-oidc-issuer-regexp" not in cmd
+        assert ".*" not in cmd
+
+    def test_cosign_verify_allows_explicit_identity_override(self, tmp_path, monkeypatch):
+        f = tmp_path / "SKILL.md"
+        f.write_text("# Signed skill")
+        bundle = tmp_path / "SKILL.md.sigstore"
+        bundle.write_text("{}")
+        calls: list[list[str]] = []
+
+        class _Proc:
+            returncode = 0
+
+        def _run(cmd, **kwargs):
+            calls.append(cmd)
+            return _Proc()
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/local/bin/cosign" if name == "cosign" else None)
+        monkeypatch.setattr("subprocess.run", _run)
+        monkeypatch.setenv("AGENT_BOM_COSIGN_CERTIFICATE_IDENTITY_REGEXP", r"https://github\.com/acme/internal/.+")
+        monkeypatch.setenv("AGENT_BOM_COSIGN_CERTIFICATE_OIDC_ISSUER", "https://issuer.example")
+
+        assert _try_cosign_verify(f, bundle) is True
+
+        cmd = calls[0]
+        assert cmd[cmd.index("--certificate-identity-regexp") + 1] == r"https://github\.com/acme/internal/.+"
+        assert cmd[cmd.index("--certificate-oidc-issuer") + 1] == "https://issuer.example"
 
     def test_bundle_no_subject_digest(self, tmp_path):
         f = tmp_path / "CLAUDE.md"


### PR DESCRIPTION
## Why
The release audit found instruction-file Sigstore verification accepted any signer because cosign was called with wildcard certificate identity and wildcard issuer. That makes a cryptographic verification look stronger than it is.

## What
- Bind cosign verification to the agent-bom release workflow identity by default.
- Require the GitHub Actions OIDC issuer by default.
- Keep explicit env overrides for controlled non-release/internal signing flows.
- Add regression tests that inspect the actual cosign command and reject wildcard trust.

## Tests
- uv run pytest tests/test_instruction_provenance.py -q
- uv run ruff check src/agent_bom/integrity.py tests/test_instruction_provenance.py
- uv run mypy src/agent_bom/integrity.py