### PR TITLE
fix(audit): harden post-release cleanup surfaces

### DIFF
--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -7,7 +7,8 @@
 # Local pilot only:
 #   - binds to 127.0.0.1 only
 #   - uses SQLite persistence in a named Docker volume
-#   - allows no-auth browser access for fast evaluation on one workstation
+#   - allows no-auth browser access only because both API/UI ports are
+#     loopback-bound for fast evaluation on one workstation
 #
 # For a multi-developer dev stack, see docker-compose.fullstack.yml.
 # For a production-shaped deployment, see docker-compose.platform.yml.
@@ -30,6 +31,7 @@ services:
       --allow-insecure-no-auth
     environment:
       AGENT_BOM_DB_PATH: /var/lib/agent-bom/vulns.db
+      AGENT_BOM_DEPLOYMENT_ENV: pilot-loopback
     ports:
       - "127.0.0.1:8422:8422"
     volumes:

--- a/deploy/supabase/clickhouse/docker-compose.yml
+++ b/deploy/supabase/clickhouse/docker-compose.yml
@@ -4,7 +4,7 @@
 #   cd deploy/supabase/clickhouse
 #   docker compose up -d
 #   # ClickHouse: http://localhost:8123
-#   # Grafana:    http://localhost:3001 (admin/admin)
+#   # Grafana:    http://localhost:3001 (set GRAFANA_ADMIN_PASSWORD first)
 #
 # Then run scans with analytics enabled:
 #   agent-bom agents --clickhouse-url http://localhost:8123
@@ -16,8 +16,8 @@ services:
   clickhouse:
     image: clickhouse/clickhouse-server:24.3
     ports:
-      - "8123:8123"   # HTTP API
-      - "9000:9000"   # Native protocol
+      - "127.0.0.1:8123:8123"   # HTTP API
+      - "127.0.0.1:9000:9000"   # Native protocol
     volumes:
       - clickhouse-data:/var/lib/clickhouse
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql:ro
@@ -33,13 +33,14 @@ services:
   grafana:
     image: grafana/grafana:10.4-ubuntu
     ports:
-      - "3001:3000"
+      - "127.0.0.1:3001:3000"
     depends_on:
       clickhouse:
         condition: service_healthy
     environment:
       GF_INSTALL_PLUGINS: grafana-clickhouse-datasource
-      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD before starting this analytics stack}
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/agent-bom.json
     volumes:
       - grafana-data:/var/lib/grafana

--- a/src/agent_bom/api/auth.py
+++ b/src/agent_bom/api/auth.py
@@ -13,17 +13,9 @@ import secrets
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from enum import Enum
 from typing import Protocol
 
-
-class Role(str, Enum):
-    """User roles for RBAC."""
-
-    ADMIN = "admin"
-    ANALYST = "analyst"
-    VIEWER = "viewer"
-
+from agent_bom.rbac import Role
 
 # Role hierarchy: admin > analyst > viewer
 _ROLE_HIERARCHY: dict[Role, int] = {

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -1170,7 +1170,7 @@ def _audit_break_glass(
         tenant_id = require_request_tenant_id(request)
         log_action(
             "break_glass",
-            actor=role,
+            actor=getattr(request.state, "actor", "") or getattr(request.state, "api_key_name", "") or role,
             resource=f"shield/{session_id}",
             tenant_id=tenant_id,
             reason=reason,

--- a/src/agent_bom/enforcement.py
+++ b/src/agent_bom/enforcement.py
@@ -20,14 +20,13 @@ import unicodedata
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Optional
 
+from agent_bom.graph.severity import severity_at_or_above
 from agent_bom.models import MCPServer, Severity
 
 if TYPE_CHECKING:
     from agent_bom.mcp_introspect import IntrospectionReport, ServerIntrospection
 
 logger = logging.getLogger(__name__)
-
-_SEVERITY_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "none": 4, "unknown": -1}
 
 # Zero-width and invisible Unicode characters commonly used for evasion
 _INVISIBLE_RE = re.compile(r"[\u200b\u200c\u200d\u200e\u200f\u2060\u2061\u2062\u2063\u2064\ufeff\u00ad\u034f\u115f\u1160\u17b4\u17b5]")
@@ -757,9 +756,8 @@ def run_enforcement(
     report.findings.extend(check_tool_name_collisions(servers))
 
     # Determine pass/fail based on threshold
-    threshold = _SEVERITY_ORDER.get(fail_on_severity, 1)
     for finding in report.findings:
-        if _SEVERITY_ORDER.get(finding.severity, 3) <= threshold:
+        if severity_at_or_above(finding.severity, fail_on_severity):
             report.passed = False
             break
 

--- a/src/agent_bom/graph/severity.py
+++ b/src/agent_bom/graph/severity.py
@@ -57,6 +57,17 @@ SEVERITY_RANK: dict[str, int] = {
     "unknown": 0,
 }
 
+# Policy/threshold comparisons keep UNKNOWN below NONE, matching FIRST/CVSS
+# policy semantics. Display/risk ranking can still treat both as zero-impact.
+SEVERITY_POLICY_ORDER: dict[str, int] = {
+    "CRITICAL": 4,
+    "HIGH": 3,
+    "MEDIUM": 2,
+    "LOW": 1,
+    "NONE": 0,
+    "UNKNOWN": -1,
+}
+
 # ── Risk score contribution ──────────────────────────────────────────────
 
 SEVERITY_RISK_SCORE: dict[str, float] = {
@@ -98,6 +109,24 @@ OCSF_TO_SYSLOG: dict[int, int] = {
 def severity_rank(sev: str) -> int:
     """Return numeric rank for a severity string. Higher = worse."""
     return SEVERITY_RANK.get(sev.lower() if sev else "", 0)
+
+
+def normalize_severity(sev: str | None) -> str:
+    """Return the canonical lowercase severity label."""
+    normalized = (sev or "").strip().lower()
+    if normalized == "informational":
+        return "info"
+    return normalized if normalized in SEVERITY_RANK else "unknown"
+
+
+def severity_policy_rank(sev: str | None) -> int:
+    """Return policy comparison rank where UNKNOWN is below NONE."""
+    return SEVERITY_POLICY_ORDER.get(normalize_severity(sev).upper(), SEVERITY_POLICY_ORDER["UNKNOWN"])
+
+
+def severity_at_or_above(candidate: str | None, threshold: str | None) -> bool:
+    """Return true when ``candidate`` meets or exceeds ``threshold``."""
+    return severity_policy_rank(candidate) >= severity_policy_rank(threshold)
 
 
 def severity_to_ocsf(sev: str) -> int:

--- a/src/agent_bom/mcp_server_runtime.py
+++ b/src/agent_bom/mcp_server_runtime.py
@@ -356,6 +356,7 @@ async def execute_tool_async(
 ) -> _ToolReturn | str:
     request_meta = request_meta_factory()
     if destructive:
+        kwargs.setdefault("_authenticated_actor", request_meta.get("client_id") or request_meta.get("caller") or "mcp-operator")
         denial = authorize_destructive_tool(
             tool_name,
             operator_role=str(kwargs.get("operator_role", "") or ""),

--- a/src/agent_bom/mcp_tools/graph.py
+++ b/src/agent_bom/mcp_tools/graph.py
@@ -7,6 +7,7 @@ import json
 import logging
 from typing import Any
 
+from agent_bom.graph.severity import severity_rank
 from agent_bom.mcp_errors import CODE_INTERNAL_UNEXPECTED, CODE_VALIDATION_INVALID_ARGUMENT, mcp_error_json
 from agent_bom.mcp_tenant import resolve_mcp_tool_tenant_id
 
@@ -57,12 +58,11 @@ def _relationship_refs(path: Any, edges: list[Any]) -> list[dict[str, Any]]:
 
 
 def _severity_for_path(path: Any, nodes_by_id: dict[str, Any]) -> str:
-    severity_order = {"critical": 4, "high": 3, "medium": 2, "low": 1, "none": 0, "": 0}
     severity = ""
     for hop in getattr(path, "hops", []) or []:
         node = nodes_by_id.get(hop)
         candidate = str(getattr(node, "severity", "") or "").lower() if node is not None else ""
-        if severity_order.get(candidate, 0) > severity_order.get(severity, 0):
+        if severity_rank(candidate) > severity_rank(severity):
             severity = candidate
     if severity:
         return severity

--- a/src/agent_bom/mcp_tools/identity.py
+++ b/src/agent_bom/mcp_tools/identity.py
@@ -45,6 +45,7 @@ def _authorize_identity_write(
     reason: str,
     tenant_id: str,
     resource: str,
+    authenticated_actor: str = "",
 ) -> tuple[bool, dict[str, Any]]:
     """Gate an identity write the same way Shield write tools gate enforcement."""
     normalized_role = (operator_role or "").strip().lower()
@@ -85,7 +86,8 @@ def _authorize_identity_write(
         True,
         {
             "action": action,
-            "actor": normalized_role,
+            "actor": (authenticated_actor or "").strip() or "mcp-operator",
+            "actor_role": normalized_role,
             "tenant_id": resolve_mcp_tool_tenant_id(tenant_id),
             "resource": resource,
             "reason": clean_reason,
@@ -97,7 +99,8 @@ def _write_policy(context: dict[str, Any]) -> dict[str, Any]:
     return {
         "required_role": "admin",
         "required_scope": "identity:write",
-        "actor_role": context["actor"],
+        "actor": context["actor"],
+        "actor_role": context["actor_role"],
         "audit_logged": True,
         "tenant_id": context["tenant_id"],
     }
@@ -113,6 +116,7 @@ async def _run_write(
     resource: str,
     handler,
     _truncate_response,
+    _authenticated_actor: str = "",
 ) -> str:
     """Authorize, invoke the REST handler, and decorate the response."""
     authorized, context = _authorize_identity_write(
@@ -122,6 +126,7 @@ async def _run_write(
         reason=reason,
         tenant_id=tenant_id,
         resource=resource,
+        authenticated_actor=_authenticated_actor,
     )
     if not authorized:
         return json.dumps(context)
@@ -153,6 +158,7 @@ async def identity_issue_impl(
     reason: str = "",
     tenant_id: str = "default",
     _truncate_response,
+    _authenticated_actor: str = "",
 ) -> str:
     """Issue a managed agent identity. Returns the raw token exactly once."""
     from agent_bom.api.routes.identities import issue_agent_identity
@@ -173,6 +179,7 @@ async def identity_issue_impl(
         resource=f"identity/{agent_id}",
         handler=lambda req: issue_agent_identity(cast(Any, req), body),
         _truncate_response=_truncate_response,
+        _authenticated_actor=_authenticated_actor,
     )
 
 
@@ -186,6 +193,7 @@ async def identity_rotate_impl(
     reason: str = "",
     tenant_id: str = "default",
     _truncate_response,
+    _authenticated_actor: str = "",
 ) -> str:
     """Rotate a managed identity, keeping the old token live during the overlap."""
     from agent_bom.api.routes.identities import rotate_agent_identity
@@ -200,6 +208,7 @@ async def identity_rotate_impl(
         resource=f"identity/{identity_id}",
         handler=lambda req: rotate_agent_identity(cast(Any, req), identity_id, body),
         _truncate_response=_truncate_response,
+        _authenticated_actor=_authenticated_actor,
     )
 
 
@@ -211,6 +220,7 @@ async def identity_revoke_impl(
     reason: str = "",
     tenant_id: str = "default",
     _truncate_response,
+    _authenticated_actor: str = "",
 ) -> str:
     """Revoke a managed identity immediately; its token can no longer authenticate."""
     from agent_bom.api.routes.identities import revoke_agent_identity
@@ -225,6 +235,7 @@ async def identity_revoke_impl(
         resource=f"identity/{identity_id}",
         handler=lambda req: revoke_agent_identity(cast(Any, req), identity_id, body),
         _truncate_response=_truncate_response,
+        _authenticated_actor=_authenticated_actor,
     )
 
 
@@ -239,6 +250,7 @@ async def identity_grant_jit_impl(
     reason: str = "",
     tenant_id: str = "default",
     _truncate_response,
+    _authenticated_actor: str = "",
 ) -> str:
     """Grant one identity time-bound JIT access to one tool."""
     from agent_bom.api.routes.identities import grant_agent_identity_jit
@@ -253,6 +265,7 @@ async def identity_grant_jit_impl(
         resource=f"identity/{identity_id}",
         handler=lambda req: grant_agent_identity_jit(cast(Any, req), identity_id, body),
         _truncate_response=_truncate_response,
+        _authenticated_actor=_authenticated_actor,
     )
 
 
@@ -264,6 +277,7 @@ async def identity_revoke_jit_impl(
     reason: str = "",
     tenant_id: str = "default",
     _truncate_response,
+    _authenticated_actor: str = "",
 ) -> str:
     """Revoke an active JIT grant immediately."""
     from agent_bom.api.routes.identities import revoke_agent_identity_jit
@@ -278,4 +292,5 @@ async def identity_revoke_jit_impl(
         resource=f"identity-jit/{grant_id}",
         handler=lambda req: revoke_agent_identity_jit(cast(Any, req), grant_id, body),
         _truncate_response=_truncate_response,
+        _authenticated_actor=_authenticated_actor,
     )

--- a/src/agent_bom/mcp_tools/runtime.py
+++ b/src/agent_bom/mcp_tools/runtime.py
@@ -15,8 +15,8 @@ from agent_bom.security import sanitize_error
 logger = logging.getLogger(__name__)
 
 
-def _request_for_tenant(tenant_id: str | None = None) -> SimpleNamespace:
-    return SimpleNamespace(state=SimpleNamespace(tenant_id=resolve_mcp_tool_tenant_id(tenant_id)))
+def _request_for_tenant(tenant_id: str | None = None, actor: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace(tenant_id=resolve_mcp_tool_tenant_id(tenant_id), actor=actor or "mcp-operator"))
 
 
 def _csv_set(value: str) -> set[str]:
@@ -36,6 +36,7 @@ def _authorize_shield_write(
     reason: str,
     tenant_id: str,
     session_id: str,
+    authenticated_actor: str = "",
 ) -> tuple[bool, dict[str, Any]]:
     normalized_role = (operator_role or "").strip().lower()
     clean_reason = (reason or "").strip()
@@ -75,7 +76,8 @@ def _authorize_shield_write(
         True,
         {
             "action": action,
-            "actor": normalized_role,
+            "actor": (authenticated_actor or "").strip() or "mcp-operator",
+            "actor_role": normalized_role,
             "tenant_id": tenant_id or "default",
             "resource": f"shield/{session_id or 'default'}",
             "reason": clean_reason,
@@ -280,6 +282,7 @@ async def shield_start_impl(
     reason: str = "",
     tenant_id: str = "default",
     _truncate_response,
+    _authenticated_actor: str = "",
 ) -> str:
     """Implementation of the shield_start write tool."""
     authorized, context = _authorize_shield_write(
@@ -289,6 +292,7 @@ async def shield_start_impl(
         reason=reason,
         tenant_id=tenant_id,
         session_id=session_id,
+        authenticated_actor=_authenticated_actor,
     )
     if not authorized:
         return json.dumps(context)
@@ -304,7 +308,8 @@ async def shield_start_impl(
         payload["mcp_write_policy"] = {
             "required_role": "admin",
             "required_scope": "shield:write",
-            "actor_role": context["actor"],
+            "actor": context["actor"],
+            "actor_role": context["actor_role"],
             "audit_logged": True,
             "tenant_id": context["tenant_id"],
         }
@@ -323,6 +328,7 @@ async def shield_unblock_impl(
     reason: str = "",
     tenant_id: str = "default",
     _truncate_response,
+    _authenticated_actor: str = "",
 ) -> str:
     """Implementation of the shield_unblock write tool."""
     authorized, context = _authorize_shield_write(
@@ -332,6 +338,7 @@ async def shield_unblock_impl(
         reason=reason,
         tenant_id=tenant_id,
         session_id=session_id,
+        authenticated_actor=_authenticated_actor,
     )
     if not authorized:
         return json.dumps(context)
@@ -342,7 +349,8 @@ async def shield_unblock_impl(
         payload["mcp_write_policy"] = {
             "required_role": "admin",
             "required_scope": "shield:write",
-            "actor_role": context["actor"],
+            "actor": context["actor"],
+            "actor_role": context["actor_role"],
             "audit_logged": True,
             "tenant_id": context["tenant_id"],
         }
@@ -361,6 +369,7 @@ async def shield_break_glass_impl(
     reason: str = "",
     tenant_id: str = "default",
     _truncate_response,
+    _authenticated_actor: str = "",
 ) -> str:
     """Implementation of the shield_break_glass write tool."""
     authorized, context = _authorize_shield_write(
@@ -370,19 +379,21 @@ async def shield_break_glass_impl(
         reason=reason,
         tenant_id=tenant_id,
         session_id=session_id,
+        authenticated_actor=_authenticated_actor,
     )
     if not authorized:
         return json.dumps(context)
     try:
         from agent_bom.api.routes.proxy import break_glass
 
-        request = _request_for_tenant(context["tenant_id"])
-        request.state.api_key_role = context["actor"]
+        request = _request_for_tenant(context["tenant_id"], context["actor"])
+        request.state.api_key_role = context["actor_role"]
         payload = await break_glass(cast(Any, request), session_id=session_id or "default", reason=context["reason"])
         payload["mcp_write_policy"] = {
             "required_role": "admin",
             "required_scope": "shield:write",
-            "actor_role": context["actor"],
+            "actor": context["actor"],
+            "actor_role": context["actor_role"],
             "audit_logged": True,
             "tenant_id": context["tenant_id"],
         }

--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -8,6 +8,7 @@ import re
 
 from mcp.server.fastmcp.exceptions import ToolError
 
+from agent_bom.graph.severity import normalize_severity, severity_at_or_above
 from agent_bom.security import sanitize_error
 
 logger = logging.getLogger(__name__)
@@ -254,16 +255,14 @@ async def _scan_impl_inner(
         if fail_severity:
             from agent_bom.models import Severity
 
-            severity_order = ["critical", "high", "medium", "low"]
             try:
                 threshold = Severity(fail_severity.lower())
-                threshold_idx = severity_order.index(threshold.value)
             except (ValueError, KeyError):
                 raise ToolError(f"Invalid severity: {fail_severity}. Use: critical, high, medium, low")
             gate_fail = any(
-                severity_order.index(sev) <= threshold_idx
+                severity_at_or_above(sev, threshold.value)
                 for br in active_findings
-                if (sev := br.vulnerability.severity.value) in severity_order
+                if (sev := normalize_severity(br.vulnerability.severity.value)) in {"critical", "high", "medium", "low"}
             )
             result["gate_status"] = "fail" if gate_fail else "pass"
             result["gate_severity"] = fail_severity.lower()
@@ -272,17 +271,15 @@ async def _scan_impl_inner(
         if warn_severity and result.get("gate_status") != "fail":
             from agent_bom.models import Severity
 
-            severity_order = ["critical", "high", "medium", "low"]
             try:
                 warn_threshold = Severity(warn_severity.lower())
-                warn_threshold_idx = severity_order.index(warn_threshold.value)
             except (ValueError, KeyError):
                 raise ToolError(f"Invalid warn_severity: {warn_severity}. Use: critical, high, medium, low")
             warn_matches = [
                 br
                 for br in active_findings
-                if br.vulnerability.severity.value in severity_order
-                and severity_order.index(br.vulnerability.severity.value) <= warn_threshold_idx
+                if normalize_severity(br.vulnerability.severity.value) in {"critical", "high", "medium", "low"}
+                and severity_at_or_above(br.vulnerability.severity.value, warn_threshold.value)
             ]
             result["warn_gate_status"] = "warn" if warn_matches else "pass"
             result["warn_gate_severity"] = warn_severity.lower()

--- a/src/agent_bom/parsers/__init__.py
+++ b/src/agent_bom/parsers/__init__.py
@@ -16,6 +16,7 @@ from rich.console import Console
 from agent_bom.extensions import ExtensionCapabilities, iter_entry_point_registrations
 from agent_bom.models import MCPServer, Package
 from agent_bom.parsers.base import InventoryParserRegistration
+from agent_bom.parsers.beam_parsers import parse_hex_packages, parse_pub_packages  # noqa: F401
 
 # Re-export Go/Maven/Cargo/Gradle/conda/uvx parsers for backward compatibility
 from agent_bom.parsers.compiled_parsers import (  # noqa: F401
@@ -86,6 +87,8 @@ _BUILTIN_INVENTORY_PARSERS: dict[str, tuple[str, str, tuple[str, ...]]] = {
     "ruby": ("agent_bom.parsers.ruby_parsers", "parse_ruby_packages", ("Gemfile", "Gemfile.lock")),
     "php": ("agent_bom.parsers.php_parsers", "parse_php_packages", ("composer.json", "composer.lock")),
     "swift": ("agent_bom.parsers.swift_parsers", "parse_swift_packages", ("Package.swift", "Package.resolved")),
+    "hex": ("agent_bom.parsers.beam_parsers", "parse_hex_packages", ("mix.lock",)),
+    "pub": ("agent_bom.parsers.beam_parsers", "parse_pub_packages", ("pubspec.lock",)),
     "apk": ("agent_bom.parsers.os_parsers", "parse_apk_packages", ("lib/apk/db/installed",)),
     "dpkg": ("agent_bom.parsers.os_parsers", "parse_dpkg_packages", ("var/lib/dpkg/status",)),
     "rpm": ("agent_bom.parsers.os_parsers", "parse_rpm_packages", ("var/lib/rpm",)),
@@ -518,6 +521,11 @@ def extract_packages(
         packages.extend(parse_maven_packages(server_dir))
         packages.extend(parse_gradle_packages(server_dir))
         packages.extend(parse_nuget_packages(server_dir))
+        packages.extend(parse_ruby_packages(server_dir))
+        packages.extend(parse_php_packages(server_dir))
+        packages.extend(parse_swift_packages(server_dir))
+        packages.extend(parse_hex_packages(server_dir))
+        packages.extend(parse_pub_packages(server_dir))
 
     # If we only got npx/uvx packages (no local directory), resolve transitive deps
     if resolve_transitive and (npx_packages or uvx_packages) and not server_dir:
@@ -631,6 +639,8 @@ _MANIFEST_FILES = frozenset(
         "composer.json",
         "composer.lock",
         "Package.resolved",
+        "mix.lock",
+        "pubspec.lock",
     }
 )
 
@@ -654,6 +664,8 @@ _LOCKFILE_FILES = frozenset(
         "Gemfile.lock",
         "composer.lock",
         "Package.resolved",
+        "mix.lock",
+        "pubspec.lock",
     }
 )
 
@@ -858,6 +870,8 @@ def scan_project_directory(
             pkgs.extend(parse_ruby_packages(directory))
             pkgs.extend(parse_php_packages(directory))
             pkgs.extend(parse_swift_packages(directory))
+            pkgs.extend(parse_hex_packages(directory))
+            pkgs.extend(parse_pub_packages(directory))
 
             # Deduplicate within this directory
             seen: set[tuple] = set()

--- a/src/agent_bom/parsers/beam_parsers.py
+++ b/src/agent_bom/parsers/beam_parsers.py
@@ -1,0 +1,108 @@
+"""Hex and Pub dependency parsers."""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from agent_bom.models import Package
+
+logger = logging.getLogger(__name__)
+
+_MIX_HEX_RE = re.compile(
+    r'"(?P<name>[^"]+)"\s*:\s*\{\s*:hex\s*,\s*:(?P<package>[A-Za-z0-9_.-]+)\s*,\s*"(?P<version>[^"]+)"',
+    re.MULTILINE,
+)
+
+
+def _purl(ecosystem: str, name: str, version: str) -> str:
+    return f"pkg:{ecosystem}/{name}@{version}"
+
+
+def parse_hex_packages(directory: Path) -> list[Package]:
+    """Parse Elixir/Erlang Hex dependencies from ``mix.lock``."""
+
+    lockfile = directory / "mix.lock"
+    if not lockfile.exists():
+        return []
+    try:
+        text = lockfile.read_text(encoding="utf-8", errors="replace")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not read mix.lock at %s: %s", lockfile, exc)
+        return []
+
+    packages: list[Package] = []
+    seen: set[tuple[str, str]] = set()
+    for match in _MIX_HEX_RE.finditer(text):
+        package = match.group("package")
+        version = match.group("version")
+        key = (package, version)
+        if key in seen:
+            continue
+        seen.add(key)
+        packages.append(
+            Package(
+                name=package,
+                version=version,
+                ecosystem="hex",
+                purl=_purl("hex", package, version),
+                is_direct=False,
+                dependency_depth=1,
+                dependency_scope="runtime",
+                reachability_evidence="lockfile",
+                version_source="detected",
+            )
+        )
+    return packages
+
+
+def _load_pubspec_lock(lockfile: Path) -> dict[str, Any]:
+    try:
+        import yaml
+
+        data = yaml.safe_load(lockfile.read_text(encoding="utf-8", errors="replace"))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Could not parse pubspec.lock at %s: %s", lockfile, exc)
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def parse_pub_packages(directory: Path) -> list[Package]:
+    """Parse Dart/Flutter Pub dependencies from ``pubspec.lock``."""
+
+    lockfile = directory / "pubspec.lock"
+    if not lockfile.exists():
+        return []
+    data = _load_pubspec_lock(lockfile)
+    raw_packages = data.get("packages")
+    if not isinstance(raw_packages, dict):
+        return []
+
+    packages: list[Package] = []
+    for name, metadata in sorted(raw_packages.items()):
+        if not isinstance(metadata, dict):
+            continue
+        source = str(metadata.get("source") or "").strip().lower()
+        if source and source != "hosted":
+            continue
+        version = str(metadata.get("version") or "").strip()
+        if not version:
+            continue
+        dependency = str(metadata.get("dependency") or "transitive").strip().lower()
+        is_direct = dependency == "direct main"
+        packages.append(
+            Package(
+                name=str(name),
+                version=version,
+                ecosystem="pub",
+                purl=_purl("pub", str(name), version),
+                is_direct=is_direct,
+                dependency_depth=0 if is_direct else 1,
+                dependency_scope="runtime" if "dev" not in dependency else "dev",
+                reachability_evidence="lockfile",
+                version_source="detected",
+            )
+        )
+    return packages

--- a/src/agent_bom/policy.py
+++ b/src/agent_bom/policy.py
@@ -47,7 +47,8 @@ import operator
 import re
 from pathlib import Path
 
-SEVERITY_ORDER = {"CRITICAL": 4, "HIGH": 3, "MEDIUM": 2, "LOW": 1, "NONE": 0, "UNKNOWN": -1}
+from agent_bom.graph.severity import SEVERITY_POLICY_ORDER as SEVERITY_ORDER
+
 RISK_LEVEL_ORDER = {"high": 3, "medium": 2, "low": 1}
 
 

--- a/tests/test_agent_identity_lifecycle.py
+++ b/tests/test_agent_identity_lifecycle.py
@@ -588,7 +588,8 @@ async def test_mcp_identity_write_emits_lifecycle_audit_chain(store):
         actions = {e.action for e in audit.list_entries(limit=100)}
         assert "agent_identity.issued" in actions
         assert "agent_identity.revoked" in actions
-        # The MCP write path stamps the operator role as the audit actor.
-        assert any(e.actor == "admin" for e in audit.list_entries(limit=100))
+        # operator_role remains authorization/audit metadata; the actor is the
+        # authenticated MCP caller, not a self-asserted tool argument.
+        assert any(e.actor == "mcp-operator" for e in audit.list_entries(limit=100))
     finally:
         set_audit_log(InMemoryAuditLog())

--- a/tests/test_beam_parsers.py
+++ b/tests/test_beam_parsers.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+from agent_bom.parsers import parse_hex_packages, parse_pub_packages, scan_project_directory
+
+
+def test_parse_hex_mix_lock(tmp_path: Path) -> None:
+    (tmp_path / "mix.lock").write_text(
+        """
+%{
+  "decimal": {:hex, :decimal, "2.1.1", "checksum", [:mix], [], "hexpm", "outer"},
+  "telemetry": {:hex, :telemetry, "1.2.1", "checksum", [:rebar3], [], "hexpm", "outer"}
+}
+""",
+        encoding="utf-8",
+    )
+
+    packages = parse_hex_packages(tmp_path)
+
+    assert [(pkg.ecosystem, pkg.name, pkg.version) for pkg in packages] == [
+        ("hex", "decimal", "2.1.1"),
+        ("hex", "telemetry", "1.2.1"),
+    ]
+    assert all(pkg.reachability_evidence == "lockfile" for pkg in packages)
+
+
+def test_parse_pubspec_lock(tmp_path: Path) -> None:
+    (tmp_path / "pubspec.lock").write_text(
+        """
+packages:
+  async:
+    dependency: transitive
+    description:
+      name: async
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.0"
+  path:
+    dependency: "direct main"
+    description:
+      name: path
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.0"
+sdks:
+  dart: ">=3.0.0 <4.0.0"
+""",
+        encoding="utf-8",
+    )
+
+    packages = parse_pub_packages(tmp_path)
+
+    assert [(pkg.ecosystem, pkg.name, pkg.version, pkg.is_direct) for pkg in packages] == [
+        ("pub", "async", "2.11.0", False),
+        ("pub", "path", "1.9.0", True),
+    ]
+
+
+def test_project_scan_detects_hex_and_pub_lockfiles(tmp_path: Path) -> None:
+    (tmp_path / "mix.lock").write_text(
+        ' %{"decimal": {:hex, :decimal, "2.1.1", "", [], [], "hexpm", ""}}',
+        encoding="utf-8",
+    )
+    (tmp_path / "pubspec.lock").write_text(
+        'packages:\n  path:\n    dependency: "direct main"\n    source: hosted\n    version: "1.9.0"\n',
+        encoding="utf-8",
+    )
+
+    result = scan_project_directory(tmp_path)
+
+    packages = result[tmp_path]
+    assert sorted((pkg.ecosystem, pkg.name) for pkg in packages) == [("hex", "decimal"), ("pub", "path")]

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -110,6 +110,36 @@ def test_dockerfile_sse_does_not_opt_into_insecure_public_mode():
     assert "AGENT_BOM_MCP_BEARER_TOKEN" in content
 
 
+def test_clickhouse_grafana_compose_has_no_default_admin_password():
+    """Analytics compose must not publish admin/admin or bind public ports."""
+    import yaml
+
+    path = ROOT / "deploy" / "supabase" / "clickhouse" / "docker-compose.yml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    grafana = data["services"]["grafana"]
+    clickhouse = data["services"]["clickhouse"]
+
+    assert grafana["environment"]["GF_SECURITY_ADMIN_PASSWORD"] != "admin"
+    assert "GRAFANA_ADMIN_PASSWORD:?" in grafana["environment"]["GF_SECURITY_ADMIN_PASSWORD"]
+    assert grafana["ports"] == ["127.0.0.1:3001:3000"]
+    assert clickhouse["ports"] == ["127.0.0.1:8123:8123", "127.0.0.1:9000:9000"]
+
+
+def test_pilot_insecure_mode_is_loopback_scoped():
+    """Pilot no-auth mode is acceptable only because it is loopback-only."""
+    import yaml
+
+    path = ROOT / "deploy" / "docker-compose.pilot.yml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    api = data["services"]["api"]
+    ui = data["services"]["ui"]
+
+    assert "--allow-insecure-no-auth" in api["command"]
+    assert "--cors-allow-all" in api["command"]
+    assert api["ports"] == ["127.0.0.1:8422:8422"]
+    assert ui["ports"] == ["127.0.0.1:3000:3000"]
+
+
 # ---------------------------------------------------------------------------
 # Integration files version consistency
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -1159,6 +1159,7 @@ async def test_shield_break_glass_tool_uses_admin_role_context():
             )
         )
         assert result["status"] == "break_glass_activated"
+        assert result["mcp_write_policy"]["actor"] == "mcp-operator"
         assert result["mcp_write_policy"]["actor_role"] == "admin"
 
         entries = store.list_entries(tenant_id="tenant-alpha", limit=10)

--- a/tests/test_shield_write_audit.py
+++ b/tests/test_shield_write_audit.py
@@ -159,7 +159,7 @@ def test_admin_shield_write_emits_audit(impl: Any, action: str, extra: dict[str,
 
         log_action(
             "break_glass",
-            actor=getattr(request.state, "api_key_role", "viewer"),
+            actor=getattr(request.state, "actor", "") or getattr(request.state, "api_key_role", "viewer"),
             resource=f"shield/{session_id}",
             tenant_id="default",
             reason=reason,
@@ -185,7 +185,7 @@ def test_admin_shield_write_emits_audit(impl: Any, action: str, extra: dict[str,
     assert result.get("status") not in ("blocked", None), result
     assert len(audit_calls) == 1, f"{action} did not emit exactly one audit event: {audit_calls}"
     emitted = audit_calls[0]
-    assert emitted["actor"] == "admin", emitted
+    assert emitted["actor"] == "mcp-operator", emitted
     assert emitted.get("reason"), emitted
 
 
@@ -228,7 +228,7 @@ def test_break_glass_inactive_session_still_audits() -> None:
     actions = [entry.action for entry in entries]
     assert "break_glass" in actions, f"inactive break-glass attempt emitted no audit event: {actions}"
     glass = next(entry for entry in entries if entry.action == "break_glass")
-    assert glass.actor == "admin", glass
+    assert glass.actor == "mcp-operator", glass
     assert glass.details.get("outcome") == "not_active", glass.details
 
     proxy_routes._shield_engines.clear()


### PR DESCRIPTION
## Why

Post-audit cleanup left several non-blocking but real hardening gaps in #3242: parser truthfulness for Hex/Pub, duplicated role definitions, severity comparison drift, self-asserted MCP audit actors, and insecure deploy defaults.

## What

- Adds real `mix.lock` (Hex) and `pubspec.lock` (Pub) parsers, wires them into project scan and local MCP server directory extraction, and adds parser regression tests.
- Makes API auth import the shared `rbac.Role` instead of defining a second role enum.
- Moves policy/threshold comparisons to shared `graph.severity` helpers and removes local severity-order drift in policy, enforcement, MCP graph, and MCP scanning gates.
- Propagates authenticated MCP caller identity into Shield/identity write handlers so audit actor is derived from the request/session identity; `operator_role` stays as role metadata.
- Removes baked Grafana `admin/admin`, requires `GRAFANA_ADMIN_PASSWORD`, and binds the ClickHouse/Grafana compose ports to loopback. Documents/scopes pilot no-auth as loopback-only.

## Validation

- `uv run pytest tests/test_beam_parsers.py tests/test_auth.py tests/test_policy_engine.py tests/test_deployment.py tests/test_shield_write_audit.py tests/test_mcp_tool_impls.py -q`
- `uv run pytest tests/test_scanner_ecosystems.py tests/test_mcp_server.py -q`
- `uv run ruff check src/agent_bom/parsers/beam_parsers.py src/agent_bom/parsers/__init__.py src/agent_bom/api/auth.py src/agent_bom/graph/severity.py src/agent_bom/policy.py src/agent_bom/enforcement.py src/agent_bom/mcp_tools/graph.py src/agent_bom/mcp_tools/scanning.py src/agent_bom/mcp_server_runtime.py src/agent_bom/mcp_tools/runtime.py src/agent_bom/mcp_tools/identity.py src/agent_bom/api/routes/proxy.py tests/test_beam_parsers.py tests/test_deployment.py tests/test_shield_write_audit.py tests/test_mcp_tool_impls.py`
- `uv run mypy src/agent_bom/parsers/beam_parsers.py src/agent_bom/api/auth.py src/agent_bom/graph/severity.py src/agent_bom/mcp_server_runtime.py src/agent_bom/mcp_tools/runtime.py src/agent_bom/mcp_tools/identity.py`

Refs #3242.
