### PR TITLE
fix(graph): offload expensive API graph compute

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1177,6 +1177,137 @@ async def _graph_store_call(fn, /, *args, **kwargs):
         raise HTTPException(status_code=429, detail=exc.to_dict(), headers={"Retry-After": str(exc.retry_after_seconds)}) from exc
 
 
+async def _graph_compute_call(fn, /, *args, **kwargs):
+    """Run CPU-heavy graph derivation and serialization off the event loop."""
+    try:
+        async with adaptive_backpressure("graph"):
+            return await asyncio.to_thread(fn, *args, **kwargs)
+    except BackpressureRejectedError as exc:
+        raise HTTPException(status_code=429, detail=exc.to_dict(), headers={"Retry-After": str(exc.retry_after_seconds)}) from exc
+
+
+def _filtered_graph_response(graph: UnifiedGraph, *, offset: int, limit: int) -> dict[str, Any]:
+    stats = graph.stats()
+    all_nodes = list(graph.nodes.values())
+    paged_nodes, pagination = _paginate(all_nodes, offset, limit)
+    paged_ids = {n.id for n in paged_nodes}
+    paged_edges = [e for e in graph.edges if e.source in paged_ids and e.target in paged_ids]
+    attack_paths = [
+        _serialize_attack_path(p, graph.edges, nodes_by_id=graph.nodes, scan_id=graph.scan_id)
+        for p in _derived_attack_paths(graph)
+        if p.hops and all(hop in paged_ids for hop in p.hops)
+    ]
+    interaction_risks = [
+        r.to_dict() for r in graph.interaction_risks if r.agents and all(f"agent:{agent_name}" in paged_ids for agent_name in r.agents)
+    ]
+
+    return {
+        "scan_id": graph.scan_id,
+        "tenant_id": graph.tenant_id,
+        "created_at": graph.created_at,
+        "nodes": [n.to_dict() for n in paged_nodes],
+        "edges": [e.to_dict() for e in paged_edges],
+        "attack_paths": attack_paths,
+        "interaction_risks": interaction_risks,
+        "stats": stats,
+        "pagination": pagination,
+    }
+
+
+def _fix_first_graph_view_payload(graph: UnifiedGraph, *, cve: str, package: str, agent: str, limit: int) -> dict[str, Any]:
+    available_paths = _derived_attack_paths(graph)
+    ranked_paths = sorted(
+        (path for path in available_paths if _path_matches_focus(graph, path, cve=cve, package=package, agent=agent)),
+        key=lambda path: (path.composite_risk, len(path.hops), len(path.credential_exposure), len(path.tool_exposure)),
+        reverse=True,
+    )
+    cards = [_fix_first_card_for_path(graph, path, index + 1) for index, path in enumerate(ranked_paths[:limit])]
+    covered_findings = {finding for card in cards for finding in card["affected"]["findings"]}
+    return {
+        "scan_id": graph.scan_id,
+        "tenant_id": graph.tenant_id,
+        "created_at": graph.created_at,
+        "cards": cards,
+        "summary": {
+            "total_paths": len(available_paths),
+            "matched_paths": len(ranked_paths),
+            "returned_paths": len(cards),
+            "highest_risk": cards[0]["attack_path"]["composite_risk"] if cards else 0.0,
+            "covered_findings": len(covered_findings),
+            "node_count": len(graph.nodes),
+            "edge_count": len(graph.edges),
+        },
+        "focus": {
+            "cve": cve,
+            "package": package,
+            "agent": agent,
+        },
+    }
+
+
+def _derived_attack_path_page(graph: UnifiedGraph, *, offset: int, limit: int) -> tuple[str, str, list[AttackPath], int]:
+    derived_paths = _derived_attack_paths(graph)
+    return graph.scan_id, graph.created_at, derived_paths[offset : offset + limit], len(derived_paths)
+
+
+def _serialize_attack_path_queue(
+    *,
+    scan_id: str,
+    tenant: str,
+    created_at: str,
+    nodes: list[Any],
+    path_edges: list[Any],
+    paths: list[AttackPath],
+    total: int,
+    offset: int,
+    limit: int,
+    stats: dict[str, Any],
+) -> dict[str, Any]:
+    nodes_by_id = {node.id: node for node in nodes}
+    if total and int(stats.get("attack_path_count") or 0) == 0:
+        stats = {
+            **stats,
+            "attack_path_count": total,
+            "max_attack_path_risk": max((path.composite_risk for path in paths), default=0.0),
+        }
+    return {
+        "scan_id": scan_id,
+        "tenant_id": tenant,
+        "created_at": created_at,
+        "nodes": [node.to_dict() for node in nodes],
+        "edges": [edge.to_dict() for edge in path_edges],
+        "attack_paths": [
+            _serialize_attack_path(path, path_edges, nodes_by_id=nodes_by_id, rank=offset + index + 1, scan_id=scan_id)
+            for index, path in enumerate(paths)
+        ],
+        "interaction_risks": [],
+        "stats": stats,
+        "pagination": _page_meta(total, offset, limit),
+    }
+
+
+def _semantic_cluster_payload(
+    graph: UnifiedGraph,
+    *,
+    selected_kinds: set[str],
+    min_members: int,
+    limit: int,
+) -> dict[str, Any]:
+    clusters = [
+        cluster
+        for cluster in build_semantic_clusters(graph.nodes.values(), graph.edges, min_members=min_members)
+        if cluster.kind in selected_kinds
+    ][:limit]
+    return {
+        "scan_id": graph.scan_id,
+        "tenant_id": graph.tenant_id,
+        "created_at": graph.created_at,
+        "clusters": [cluster.to_dict() for cluster in clusters],
+        "stats": semantic_cluster_stats(clusters),
+        "available_kinds": list(SEMANTIC_CLUSTER_KINDS),
+    }
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Preset model
 # ═══════════════════════════════════════════════════════════════════════════
@@ -1376,31 +1507,7 @@ async def get_graph(
         )
         graph = graph.filtered_view(filters)
 
-        stats = graph.stats()
-        all_nodes = list(graph.nodes.values())
-        paged_nodes, pagination = _paginate(all_nodes, offset, limit)
-        paged_ids = {n.id for n in paged_nodes}
-        paged_edges = [e for e in graph.edges if e.source in paged_ids and e.target in paged_ids]
-        attack_paths = [
-            _serialize_attack_path(p, graph.edges, nodes_by_id=graph.nodes, scan_id=graph.scan_id)
-            for p in _derived_attack_paths(graph)
-            if p.hops and all(hop in paged_ids for hop in p.hops)
-        ]
-        interaction_risks = [
-            r.to_dict() for r in graph.interaction_risks if r.agents and all(f"agent:{agent_name}" in paged_ids for agent_name in r.agents)
-        ]
-
-        return {
-            "scan_id": graph.scan_id,
-            "tenant_id": graph.tenant_id,
-            "created_at": graph.created_at,
-            "nodes": [n.to_dict() for n in paged_nodes],
-            "edges": [e.to_dict() for e in paged_edges],
-            "attack_paths": attack_paths,
-            "interaction_risks": interaction_risks,
-            "stats": stats,
-            "pagination": pagination,
-        }
+        return await _graph_compute_call(_filtered_graph_response, graph, offset=offset, limit=limit)
 
     try:
         effective_scan_id, created_at, paged_nodes, total, next_cursor = await _graph_store_call(
@@ -1486,34 +1593,7 @@ async def get_fix_first_graph_view(
         scan_id=requested_scan_id,
         tenant_id=tenant,
     )
-    available_paths = _derived_attack_paths(graph)
-    ranked_paths = sorted(
-        (path for path in available_paths if _path_matches_focus(graph, path, cve=cve, package=package, agent=agent)),
-        key=lambda path: (path.composite_risk, len(path.hops), len(path.credential_exposure), len(path.tool_exposure)),
-        reverse=True,
-    )
-    cards = [_fix_first_card_for_path(graph, path, index + 1) for index, path in enumerate(ranked_paths[:limit])]
-    covered_findings = {finding for card in cards for finding in card["affected"]["findings"]}
-    return {
-        "scan_id": graph.scan_id,
-        "tenant_id": graph.tenant_id,
-        "created_at": graph.created_at,
-        "cards": cards,
-        "summary": {
-            "total_paths": len(available_paths),
-            "matched_paths": len(ranked_paths),
-            "returned_paths": len(cards),
-            "highest_risk": cards[0]["attack_path"]["composite_risk"] if cards else 0.0,
-            "covered_findings": len(covered_findings),
-            "node_count": len(graph.nodes),
-            "edge_count": len(graph.edges),
-        },
-        "focus": {
-            "cve": cve,
-            "package": package,
-            "agent": agent,
-        },
-    }
+    return await _graph_compute_call(_fix_first_graph_view_payload, graph, cve=cve, package=package, agent=agent, limit=limit)
 
 
 @router.get("/v1/graph/diff", tags=["graph"])
@@ -1574,10 +1654,12 @@ async def get_graph_attack_paths(
             scan_id=effective_scan_id,
             tenant_id=tenant,
         )
-        derived_paths = _derived_attack_paths(graph)
-        total = len(derived_paths)
-        paths = derived_paths[offset : offset + limit]
-        created_at = graph.created_at
+        effective_scan_id, created_at, paths, total = await _graph_compute_call(
+            _derived_attack_path_page,
+            graph,
+            offset=offset,
+            limit=limit,
+        )
     hop_ids = {hop for path in paths for hop in path.hops}
     nodes = await _graph_store_call(
         graph_store.nodes_by_ids,
@@ -1585,7 +1667,6 @@ async def get_graph_attack_paths(
         tenant_id=tenant,
         node_ids=hop_ids,
     )
-    nodes_by_id = {node.id: node for node in nodes}
     path_edges = await _graph_store_call(
         graph_store.edges_for_node_ids,
         scan_id=effective_scan_id,
@@ -1597,26 +1678,19 @@ async def get_graph_attack_paths(
         scan_id=effective_scan_id,
         tenant_id=tenant,
     )
-    if total and int(stats.get("attack_path_count") or 0) == 0:
-        stats = {
-            **stats,
-            "attack_path_count": total,
-            "max_attack_path_risk": max((path.composite_risk for path in paths), default=0.0),
-        }
-    return {
-        "scan_id": effective_scan_id,
-        "tenant_id": tenant,
-        "created_at": created_at,
-        "nodes": [node.to_dict() for node in nodes],
-        "edges": [edge.to_dict() for edge in path_edges],
-        "attack_paths": [
-            _serialize_attack_path(path, path_edges, nodes_by_id=nodes_by_id, rank=offset + index + 1, scan_id=effective_scan_id)
-            for index, path in enumerate(paths)
-        ],
-        "interaction_risks": [],
-        "stats": stats,
-        "pagination": _page_meta(total, offset, limit),
-    }
+    return await _graph_compute_call(
+        _serialize_attack_path_queue,
+        scan_id=effective_scan_id,
+        tenant=tenant,
+        created_at=created_at,
+        nodes=nodes,
+        path_edges=path_edges,
+        paths=paths,
+        total=total,
+        offset=offset,
+        limit=limit,
+        stats=stats,
+    )
 
 
 @router.get("/v1/graph/governance", tags=["graph"])
@@ -1954,19 +2028,7 @@ async def get_graph_clusters(
         scan_id=requested_scan_id,
         tenant_id=tenant,
     )
-    clusters = [
-        cluster
-        for cluster in build_semantic_clusters(graph.nodes.values(), graph.edges, min_members=min_members)
-        if cluster.kind in selected_kinds
-    ][:limit]
-    return {
-        "scan_id": graph.scan_id,
-        "tenant_id": graph.tenant_id,
-        "created_at": graph.created_at,
-        "clusters": [cluster.to_dict() for cluster in clusters],
-        "stats": semantic_cluster_stats(clusters),
-        "available_kinds": list(SEMANTIC_CLUSTER_KINDS),
-    }
+    return await _graph_compute_call(_semantic_cluster_payload, graph, selected_kinds=selected_kinds, min_members=min_members, limit=limit)
 
 
 @router.get("/v1/graph/agents", tags=["graph"])

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -79,6 +79,11 @@ def _api_local_scans_enabled() -> bool:
     return configured.strip().lower() not in _LOCAL_SCAN_DISABLE_VALUES
 
 
+async def _scan_graph_compute_call(fn, /, *args, **kwargs):
+    """Run graph rendering/derivation for scan subresources off the event loop."""
+    return await asyncio.to_thread(fn, *args, **kwargs)
+
+
 def _api_scan_root() -> Path:
     """Return the configured API filesystem scan root.
 
@@ -426,6 +431,70 @@ def _attach_unified_graph_view(payload: dict[str, Any], result: dict[str, Any], 
         **unified.to_dict(),
     }
     return payload
+
+
+def _context_graph_payload(result: dict[str, Any], *, agent: str | None, scan_id: str, tenant_id: str) -> dict[str, Any]:
+    from agent_bom.context_graph import (
+        NodeKind,
+        build_context_graph,
+        compute_interaction_risks,
+        find_lateral_paths,
+        to_serializable,
+    )
+
+    graph = build_context_graph(
+        result.get("agents", []),
+        result.get("blast_radius", []),
+    )
+    paths: list = []
+    if agent:
+        node_id = f"agent:{agent}"
+        if node_id in graph.nodes:
+            paths = find_lateral_paths(graph, node_id)
+    else:
+        for nid, node in graph.nodes.items():
+            if node.kind == NodeKind.AGENT:
+                paths.extend(find_lateral_paths(graph, nid))
+    risks = compute_interaction_risks(graph)
+
+    payload = to_serializable(graph, paths, risks)
+    return _attach_unified_graph_view(payload, result, scan_id=scan_id, tenant_id=tenant_id)
+
+
+def _graph_export_response(result: dict[str, Any], *, format: str, mermaid_limit: int) -> dict | str | PlainTextResponse:
+    from agent_bom.output.graph_export import (
+        build_graph_from_scan_data,
+        to_cypher,
+        to_dot,
+        to_graphml,
+        to_mermaid,
+    )
+    from agent_bom.output.graph_export import (
+        to_json as graph_to_json,
+    )
+
+    graph = build_graph_from_scan_data(result)
+
+    def _render_mermaid(g):
+        if mermaid_limit == 0:
+            return PlainTextResponse(
+                to_mermaid(g, max_nodes=None, max_edges=None),
+                media_type="text/plain",
+            )
+        return PlainTextResponse(
+            to_mermaid(g, max_nodes=mermaid_limit),
+            media_type="text/plain",
+        )
+
+    formats = {
+        "dot": lambda g: PlainTextResponse(to_dot(g), media_type="text/vnd.graphviz"),
+        "mermaid": _render_mermaid,
+        "graphml": lambda g: PlainTextResponse(to_graphml(g), media_type="application/xml"),
+        "cypher": lambda g: PlainTextResponse(to_cypher(g), media_type="text/plain"),
+    }
+    if format in formats:
+        return formats[format](graph)
+    return graph_to_json(graph)
 
 
 def _iter_scan_findings(job: ScanJob) -> list[dict[str, Any]]:
@@ -796,32 +865,8 @@ async def get_context_graph(request: Request, job_id: str, agent: str | None = N
     if job.status != JobStatus.DONE or not job.result:
         raise HTTPException(status_code=409, detail="Scan not completed yet")
 
-    from agent_bom.context_graph import (
-        NodeKind,
-        build_context_graph,
-        compute_interaction_risks,
-        find_lateral_paths,
-        to_serializable,
-    )
-
-    graph = build_context_graph(
-        job.result.get("agents", []),
-        job.result.get("blast_radius", []),
-    )
-    paths: list = []
-    if agent:
-        node_id = f"agent:{agent}"
-        if node_id in graph.nodes:
-            paths = find_lateral_paths(graph, node_id)
-    else:
-        for nid, node in graph.nodes.items():
-            if node.kind == NodeKind.AGENT:
-                paths.extend(find_lateral_paths(graph, nid))
-    risks = compute_interaction_risks(graph)
-
-    payload = to_serializable(graph, paths, risks)
     tenant_id = str(getattr(request.state, "tenant_id", "") or "")
-    return _attach_unified_graph_view(payload, job.result, scan_id=job.job_id, tenant_id=tenant_id)
+    return await _scan_graph_compute_call(_context_graph_payload, job.result, agent=agent, scan_id=job.job_id, tenant_id=tenant_id)
 
 
 @router.get("/v1/scan/{job_id}/graph-export", tags=["scan"], response_model=None)
@@ -848,46 +893,12 @@ async def get_graph_export(
       ?format=cypher    Neo4j Cypher import script
       ?mermaid_limit=80 Maximum nodes rendered for Mermaid; 0 renders all
     """
-    from fastapi.responses import PlainTextResponse
-
     job = _job_for_request(request, job_id)
     if job.status != JobStatus.DONE or not job.result:
         raise HTTPException(status_code=409, detail="Scan not completed yet")
 
-    from agent_bom.output.graph_export import (
-        build_graph_from_scan_data,
-        to_cypher,
-        to_dot,
-        to_graphml,
-        to_mermaid,
-    )
-    from agent_bom.output.graph_export import (
-        to_json as graph_to_json,
-    )
-
     result = job.result if isinstance(job.result, dict) else {}
-    graph = build_graph_from_scan_data(result)
-
-    def _render_mermaid(g):
-        if mermaid_limit == 0:
-            return PlainTextResponse(
-                to_mermaid(g, max_nodes=None, max_edges=None),
-                media_type="text/plain",
-            )
-        return PlainTextResponse(
-            to_mermaid(g, max_nodes=mermaid_limit),
-            media_type="text/plain",
-        )
-
-    _formats = {
-        "dot": lambda g: PlainTextResponse(to_dot(g), media_type="text/vnd.graphviz"),
-        "mermaid": _render_mermaid,
-        "graphml": lambda g: PlainTextResponse(to_graphml(g), media_type="application/xml"),
-        "cypher": lambda g: PlainTextResponse(to_cypher(g), media_type="text/plain"),
-    }
-    if format in _formats:
-        return _formats[format](graph)
-    return graph_to_json(graph)
+    return await _scan_graph_compute_call(_graph_export_response, result, format=format, mermaid_limit=mermaid_limit)
 
 
 @router.get("/v1/scan/{job_id}/licenses", tags=["scan"])

--- a/tests/test_context_graph.py
+++ b/tests/test_context_graph.py
@@ -569,6 +569,41 @@ class TestAPIContextGraph:
         assert {"provider", "agent", "server"} <= set(data["unified_graph"]["stats"]["node_types"])
         assert {"hosts", "uses", "shares_server"} <= set(data["unified_graph"]["stats"]["relationship_types"])
 
+    def test_api_context_graph_offloads_graph_compute(self, monkeypatch):
+        """GET /v1/scan/{id}/context-graph computes graph payloads off the event loop."""
+        import asyncio
+
+        from agent_bom.api.routes import scan as scan_routes
+        from agent_bom.api.server import _get_store, app, configure_api
+
+        api_key = "context-graph-offload-test-key"
+        configure_api(api_key=api_key)
+        store = _get_store()
+        job_id = "test-cg-offload"
+        job = self._make_job(job_id, [_agent(name="a1", servers=[_server(name="shared")])])
+        store.put(job)
+        compute_calls: list[str] = []
+
+        async def _fake_scan_graph_compute_call(fn, /, *args, **kwargs):
+            compute_calls.append(fn.__name__)
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr(scan_routes, "_scan_graph_compute_call", _fake_scan_graph_compute_call)
+
+        from httpx import ASGITransport, AsyncClient
+
+        async def _call():
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                return await client.get(
+                    f"/v1/scan/{job_id}/context-graph",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+
+        resp = asyncio.run(_call())
+        assert resp.status_code == 200
+        assert "_context_graph_payload" in compute_calls
+
     def test_api_agent_filter(self):
         """GET /v1/scan/{id}/context-graph?agent=a1 filters lateral paths."""
         import asyncio

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -2058,6 +2058,43 @@ class TestGraphStoreBackendSelection:
         assert "page_nodes" in helper_calls
         assert "search_nodes" in helper_calls
 
+    def test_graph_routes_offload_derived_path_compute(self, recording_graph_store, monkeypatch):
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:a:fs", entity_type=EntityType.SERVER, label="mcp-fs"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="pkg:npm:form-data", entity_type=EntityType.PACKAGE, label="form-data"))
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="vuln:cve",
+                entity_type=EntityType.VULNERABILITY,
+                label="CVE-2026-1",
+                severity="critical",
+                risk_score=9.8,
+            )
+        )
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="agent:a", target="server:a:fs", relationship=RelationshipType.USES))
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="server:a:fs", target="pkg:npm:form-data", relationship=RelationshipType.DEPENDS_ON)
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="pkg:npm:form-data", target="vuln:cve", relationship=RelationshipType.VULNERABLE_TO)
+        )
+        client = TestClient(app)
+        compute_calls: list[str] = []
+
+        async def _fake_graph_compute_call(fn, /, *args, **kwargs):
+            compute_calls.append(fn.__name__)
+            return fn(*args, **kwargs)
+
+        monkeypatch.setattr(graph_routes, "_graph_compute_call", _fake_graph_compute_call)
+
+        fix_first = client.get("/v1/graph/views/fix-first", params={"scan_id": "store-scan"})
+        attack_paths = client.get("/v1/graph/attack-paths", params={"scan_id": "store-scan", "limit": 5})
+
+        assert fix_first.status_code == 200
+        assert attack_paths.status_code == 200
+        assert "_fix_first_graph_view_payload" in compute_calls
+        assert "_derived_attack_path_page" in compute_calls
+        assert "_serialize_attack_path_queue" in compute_calls
+
     def test_graph_route_returns_429_when_backpressure_opens(self, recording_graph_store, monkeypatch):
         from agent_bom.backpressure import reset_backpressure_for_tests
 


### PR DESCRIPTION
## Why

Graph derivation, attack-path serialization, semantic clustering, and context-graph export are CPU-heavy enough to stall the FastAPI event loop on larger estates. That is one of the remaining hosted/POC scale blockers called out in #3241.

## What

- Moves filtered graph views, fix-first graph derivation, attack-path fallback derivation/serialization, semantic clusters, context-graph rendering, and graph export through bounded background thread offload.
- Keeps the existing response shapes and backpressure semantics.
- Adds regression coverage proving graph API and scan context-graph routes use the offload path.

## Validation

- All checks passed!
- pyproject.toml: note: unused section(s): module = ['agent_bom.api.durable_store', 'agent_bom.api.firewall_decision_store', 'agent_bom.api.postgres_access_review', 'agent_bom.api.postgres_agent_identity', 'agent_bom.api.postgres_compliance_hub', 'agent_bom.api.postgres_connection', 'agent_bom.api.postgres_runtime_event', 'agent_bom.api.postgres_scim', 'agent_bom.cloud.connection_broker', 'agent_bom.components.base', 'agent_bom.components.enricher_registry', 'agent_bom.components.matcher_registry', 'agent_bom.orchestration', 'agent_bom.routing']
Success: no issues found in 2 source files
- ............................................................................................................................                                                                     [100%]
=========================================================================================== warnings summary ===========================================================================================
tests/test_graph_api.py:11
  /Users/mohamedsaad/repos/Agent-Bom/tests/test_graph_api.py:11: StarletteDeprecationWarning: Using `httpx` with `starlette.testclient` is deprecated; install `httpx2` instead.
    from starlette.testclient import TestClient

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
124 passed, 1 warning in 1.32s

Refs #3241