### PR TITLE
docs(deploy): define hosted POC and Snowflake lane

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,7 @@ NEXT_PUBLIC_API_URL=http://localhost:8422
 # Production control planes should use separate, customer-managed secrets for
 # each cryptographic purpose. Do not reuse the API key or audit HMAC key here.
 # AGENT_BOM_AUDIT_HMAC_KEY=replace-with-audit-integrity-key
+# AGENT_BOM_CONNECTIONS_KEY=replace-with-fernet-key-from-python-cryptography
 # AGENT_BOM_RATE_LIMIT_KEY=replace-with-rate-limit-fingerprint-key
 # AGENT_BOM_BROWSER_SESSION_SIGNING_KEY=replace-with-browser-session-signing-key
 # AGENT_BOM_TRUST_PROXY_AUTH_SECRET=replace-with-32-plus-byte-proxy-attestation-secret

--- a/.github/workflows/release-snowflake.yml
+++ b/.github/workflows/release-snowflake.yml
@@ -77,7 +77,11 @@ jobs:
 
           root = Path("deploy/snowflake/native-app")
           version = os.environ["PACKAGE_VERSION"]
-          documents = [root / "manifest.yml", *sorted((root / "service-specs").glob("*.yaml"))]
+          documents = [
+              root / "manifest.yml",
+              root / "service-spec.yaml",
+              *sorted((root / "service-specs").glob("*.yaml")),
+          ]
           for path in documents:
               text = path.read_text()
               assert ":latest" not in text, f"{path} uses a mutable :latest image tag"

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -35,6 +35,9 @@ version: "3.8"
 #   echo -n "$POSTGRES_PASSWORD" > deploy/secrets/postgres_password
 #   chmod 0400 deploy/secrets/postgres_password
 #   export AGENT_BOM_API_KEY="$(openssl rand -hex 32)"  # or set OIDC env below
+#   export AGENT_BOM_AUDIT_HMAC_KEY="$(openssl rand -hex 32)"
+#   export AGENT_BOM_BROWSER_SESSION_SIGNING_KEY="$(openssl rand -hex 32)"
+#   export AGENT_BOM_CONNECTIONS_KEY="$(python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')"
 #   docker compose -f deploy/docker-compose.platform.yml up --build
 
 services:
@@ -90,10 +93,16 @@ services:
       - AGENT_BOM_API_KEY=${AGENT_BOM_API_KEY:-}
       - AGENT_BOM_OIDC_ISSUER=${AGENT_BOM_OIDC_ISSUER:-}
       - AGENT_BOM_OIDC_AUDIENCE=${AGENT_BOM_OIDC_AUDIENCE:-}
+      - AGENT_BOM_AUDIT_HMAC_KEY=${AGENT_BOM_AUDIT_HMAC_KEY:-}
+      - AGENT_BOM_REQUIRE_AUDIT_HMAC=${AGENT_BOM_REQUIRE_AUDIT_HMAC:-1}
+      - AGENT_BOM_CONNECTIONS_KEY=${AGENT_BOM_CONNECTIONS_KEY:-}
+      - AGENT_BOM_BROWSER_SESSION_SIGNING_KEY=${AGENT_BOM_BROWSER_SESSION_SIGNING_KEY:-}
       - AGENT_BOM_DISABLE_DOCS=1
       - AGENT_BOM_API_LOCAL_PATH_SCANS=disabled
-      - CORS_ORIGINS=http://localhost:3000,http://ui:3000
+      - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:3000,http://ui:3000}
       - NVD_API_KEY=${NVD_API_KEY:-}
+    volumes:
+      - agent-bom-state:/root/.agent-bom
     depends_on:
       postgres:
         condition: service_healthy
@@ -114,13 +123,13 @@ services:
       context: ../ui
       dockerfile: Dockerfile
       args:
-        NEXT_PUBLIC_API_URL: http://localhost:8422
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8422}
     image: agentbom/agent-bom-ui:0.89.2
     container_name: agent-bom-ui
     ports:
       - "3000:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=http://localhost:8422
+      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8422}
     depends_on:
       api:
         condition: service_healthy
@@ -137,6 +146,7 @@ services:
 
 volumes:
   postgres-data:
+  agent-bom-state:
 
 secrets:
   # Mount-provisioned credentials. Populate the files before `docker compose up`.

--- a/deploy/snowflake/native-app/service-spec.yaml
+++ b/deploy/snowflake/native-app/service-spec.yaml
@@ -1,0 +1,53 @@
+spec:
+  containers:
+    - name: agent-bom
+      image: /db/schema/agent_bom_repo/agent-bom:v0_89_2
+      env:
+        AGENT_BOM_STORE_BACKEND: snowflake
+        AGENT_BOM_SNOWFLAKE_NATIVE_APP: "1"
+        AGENT_BOM_MCP_MODE: "0"
+        AGENT_BOM_LOG_LEVEL: "INFO"
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp/agent-bom
+      readinessProbe:
+        port: 8422
+        path: /health
+      resources:
+        requests:
+          memory: 512M
+          cpu: 0.5
+        limits:
+          memory: 2G
+          cpu: 2
+
+    - name: agent-bom-ui
+      image: /db/schema/agent_bom_repo/agent-bom-ui:v0_89_2
+      env:
+        NEXT_PUBLIC_API_URL: "http://localhost:8422"
+        NODE_ENV: production
+        PORT: "3000"
+      readinessProbe:
+        port: 3000
+        path: /api/health
+      resources:
+        requests:
+          memory: 256M
+          cpu: 0.25
+        limits:
+          memory: 1G
+          cpu: 1
+
+  volumes:
+    - name: tmp
+      source: local
+      size: 1Gi
+
+  endpoints:
+    - name: api
+      port: 8422
+      public: false
+
+    - name: ui
+      port: 3000
+      public: false

--- a/docs/DEPLOY_PLATFORM.md
+++ b/docs/DEPLOY_PLATFORM.md
@@ -143,6 +143,12 @@ customers connecting read-only across the control-plane / collector seam:
 This is the same primitive used by `create_aws_connect_role` in the EKS module,
 just pointed at a hosted scanner instead of a local one.
 
+For a gated customer-0 URL, start with the smaller hosted POC runbook instead
+of presenting a generally available SaaS product:
+[`HOSTED_POC.md`](HOSTED_POC.md). The recommended first proof is one AWS VM
+behind HTTPS; the Snowflake Native App lane remains the enterprise
+customer-owned install path.
+
 ---
 
 ## Choosing a tier
@@ -154,6 +160,7 @@ just pointed at a hosted scanner instead of a local one.
 | Production on AWS, one command | 2A — `platform-eks` Terraform |
 | Production on an existing/any cluster | 2B — Helm |
 | Multi-tenant, you operate it for others | 3 — Hosted + connect roles |
+| Gated customer-0 demo link | [`HOSTED_POC.md`](HOSTED_POC.md) |
 
 ## Related
 

--- a/docs/HOSTED_POC.md
+++ b/docs/HOSTED_POC.md
@@ -1,0 +1,193 @@
+# Hosted POC Runbook
+
+This runbook is for a gated customer-0 deployment: a live URL that shows how
+agent-bom works, lets a small set of users connect read-only accounts, and
+proves the product loop before a managed cloud edition is offered.
+
+It is not a claim that public `agent-bom Cloud` is generally available.
+
+## Recommended path
+
+Use an AWS VM first for the public demo URL, then keep Snowflake Native App as
+the enterprise distribution lane. Recommended domain split:
+
+- `agentbom.io` — primary product/brand site.
+- `demo.agent-bom.com` — public seeded demo.
+- `app.agent-bom.com` — gated customer-0 / hot-lead POC.
+
+| Need | Use | Why |
+|---|---|---|
+| Public demo link | AWS VM + Caddy + platform compose | Fastest custom URL, simple TLS, works for any tester |
+| Customer-owned warehouse install | Snowflake Native App | Runs inside the customer's Snowflake account with Snowflake auth and SPCS |
+| Later managed product | Hosted chart + connect roles | Same control plane, stricter tenant onboarding and quotas |
+
+## Customer-0 AWS VM
+
+Run one small CPU-only VM. Recommended starting point:
+
+- Instance: `t3.large` or equivalent, 4 vCPU / 8-16 GB RAM
+- OS: Ubuntu LTS or Amazon Linux
+- Region: closest to you and the first demo users
+- Security group: `443` open; SSH/admin only from your IP
+
+1. Create DNS, for example `demo.agent-bom.com`, pointing to the VM.
+2. Open inbound `443` only. Restrict SSH/admin access to known IPs.
+3. Install Docker, Compose, and Caddy.
+4. Deploy `deploy/docker-compose.platform.yml`.
+5. Use Caddy or an ALB for HTTPS. Do not expose plain HTTP.
+6. Set production secrets:
+   - `AGENT_BOM_AUDIT_HMAC_KEY`
+   - `AGENT_BOM_BROWSER_SESSION_SIGNING_KEY`
+   - `AGENT_BOM_CONNECTIONS_KEY`
+   - the initial admin API key or OIDC reverse-proxy session settings
+7. Keep `AGENT_BOM_ALLOW_UNAUTHENTICATED_API` unset.
+8. Mint one admin tenant/key for the customer-0 account.
+9. Connect read-only AWS, Azure, GCP, and Snowflake targets.
+10. Run the first scan and verify findings, graph, posture, and exports.
+
+This gives prospects the product experience: sign in, connect read-only,
+scan, inspect graph/blast radius, and export evidence.
+
+### Minimal VM setup
+
+Generate local secrets on the VM:
+
+```bash
+cp .env.example .env
+
+export POSTGRES_PASSWORD="$(openssl rand -hex 32)"
+export POSTGRES_APP_PASSWORD="$(openssl rand -hex 32)"
+export AGENT_BOM_API_KEY="$(openssl rand -hex 32)"
+export AGENT_BOM_AUDIT_HMAC_KEY="$(openssl rand -hex 32)"
+export AGENT_BOM_BROWSER_SESSION_SIGNING_KEY="$(openssl rand -hex 32)"
+export AGENT_BOM_CONNECTIONS_KEY="$(
+  python - <<'PY'
+from cryptography.fernet import Fernet
+print(Fernet.generate_key().decode())
+PY
+)"
+export NEXT_PUBLIC_API_URL="https://demo.agent-bom.com"
+export CORS_ORIGINS="https://demo.agent-bom.com,http://ui:3000"
+
+mkdir -p deploy/secrets
+printf '%s' "$POSTGRES_PASSWORD" > deploy/secrets/postgres_password
+chmod 0400 deploy/secrets/postgres_password
+```
+
+Start the platform:
+
+```bash
+docker compose -f deploy/docker-compose.platform.yml up -d --build
+docker compose -f deploy/docker-compose.platform.yml ps
+```
+
+Seed a disposable demo graph after the API is healthy:
+
+```bash
+docker compose -f deploy/docker-compose.platform.yml exec api \
+  agent-bom quickstart --run --offline --force
+```
+
+The compose profile persists `/root/.agent-bom` in a named volume so the seeded
+demo graph survives container replacement. Replace it with real connected
+cloud scans as soon as the first account is connected.
+
+### Caddy front door
+
+Example `Caddyfile`:
+
+```caddyfile
+demo.agent-bom.com {
+  encode zstd gzip
+
+  reverse_proxy /v1/* localhost:8422
+  reverse_proxy /health localhost:8422
+  reverse_proxy /openapi.json localhost:8422
+  reverse_proxy localhost:3000
+}
+```
+
+Keep Caddy as the only public listener. The Postgres container remains internal
+and the API/UI ports can be restricted to the VM security boundary once the
+front door is verified.
+
+## Snowflake Native App lane
+
+Use Snowflake when the buyer wants agent-bom to run inside their Snowflake
+account. This is the stronger enterprise data-boundary story, but it has more
+packaging steps than a VM demo.
+
+### CPU sizing
+
+agent-bom is CPU-only. It scans packages, cloud metadata, IaC, graph evidence,
+and model artifacts with lightweight static analysis. It does not perform GPU
+model inference.
+
+Use:
+
+- `CPU_X64_XS` for the first smoke test.
+- `CPU_X64_S` for a more comfortable POC with UI + API + scanner.
+
+Do not use GPU pools for agent-bom.
+
+### SPCS gate
+
+Confirm the account can create a Snowpark Container Services pool:
+
+```sql
+USE ROLE ACCOUNTADMIN;
+
+CREATE COMPUTE POOL AGENT_BOM_POC_POOL
+  MIN_NODES = 1
+  MAX_NODES = 1
+  INSTANCE_FAMILY = CPU_X64_XS
+  AUTO_RESUME = TRUE;
+
+DROP COMPUTE POOL AGENT_BOM_POC_POOL;
+```
+
+If this succeeds, the account can run the Native App containers.
+
+### Stand-up checklist
+
+1. Run the Snowflake Native App package validation:
+
+   ```bash
+   gh workflow run release-snowflake.yml -f dry_run=true
+   ```
+
+2. Build and push the four release-tagged images to the Snowflake image
+   repository:
+
+   - `agent-bom`
+   - `agent-bom-ui`
+   - `agent-bom-scanner`
+   - `agent-bom-mcp-runtime`
+
+3. Create the application package and application in the demo account.
+4. Bind only the references the demo needs: cloud asset tables, IAM tables,
+   vulnerability tables, log tables, and artifact stages.
+5. Leave advisory egress disabled unless the demo needs OSV, CISA KEV, EPSS,
+   or GHSA enrichment.
+6. Open the default web endpoint for the UI.
+7. Run:
+
+   ```sql
+   CALL agent_bom.core.health_check();
+   SHOW SERVICES IN APPLICATION agent_bom;
+   ```
+
+8. Enable optional services only when needed:
+
+   ```sql
+   CALL agent_bom.core.enable_scanner_service();
+   CALL agent_bom.core.enable_mcp_runtime_service('<32+ character token>');
+   ```
+
+## What to avoid
+
+- Do not present the AWS demo as generally available managed SaaS.
+- Do not ask testers for long-lived cloud keys when assumable roles work.
+- Do not enable unauthenticated API access.
+- Do not publish Grafana, observability, or development compose profiles.
+- Do not run Snowflake GPU pools for agent-bom.

--- a/docs/PRODUCT_BOUNDARIES.md
+++ b/docs/PRODUCT_BOUNDARIES.md
@@ -10,6 +10,7 @@ This is the GitHub-facing companion to
 | OSS | CLI, Docker, GitHub Action, reports, SBOM/SARIF/HTML/JSON, graph exports, MCP tools, local API/UI pilot | no hosted service or vendor telemetry required |
 | Self-hosted enterprise | API/UI, Helm, Postgres/Supabase, auth/RBAC, tenant isolation, audit, graph, fleet, selected runtime proxy/gateway controls | operated in the customer's infrastructure |
 | Snowflake | Snowflake discovery, CIS/posture evidence, Native App packaging, selected backend paths | governance and warehouse-native lane, not full transactional parity for every feature |
+| Gated hosted POC | A small operator-run demo environment for customer-0 proof | limited-access evaluation only; not generally available managed SaaS |
 
 Managed `agent-bom Cloud` is not shipped in this repository today. It can be
 discussed as a roadmap lane only when labeled that way.
@@ -49,6 +50,7 @@ Use:
 - "open security data plane for AI-era infrastructure"
 - "customer-owned infrastructure and data boundary"
 - "Snowflake Native App lane"
+- "gated hosted POC"
 - "managed cloud is not shipped today"
 
 Avoid unless a future release proves it:


### PR DESCRIPTION
## Why

We need a clear path for showing agent-bom as a live hosted product without overclaiming generally available managed SaaS. The right split is: AWS VM for the customer-0 live demo URL, Snowflake Native App as the enterprise/customer-owned install lane.

While validating the Snowflake path, the Native App setup referenced `/service-spec.yaml`, but the package only carried `service-specs/` for scanner/MCP. This PR adds the missing API/UI service spec and makes the release validation include it.

## What

- Adds `docs/HOSTED_POC.md` with the customer-0 hosted demo plan.
- Documents CPU-only Snowflake SPCS sizing and the compute-pool gate.
- Links the hosted POC from `DEPLOY_PLATFORM.md`.
- Clarifies product boundaries: gated hosted POC is not generally available managed SaaS.
- Adds the missing Native App API/UI `service-spec.yaml` using release-pinned images.
- Extends `release-snowflake.yml` validation to catch root service spec drift and mutable tags.

## Validation

- Parsed Snowflake release workflow and service spec YAML.
- Validated Native App manifest/spec package files reject `:latest` and reference `v0_89_2`.

Refs #3246
Refs #3247