### PR TITLE
fix(ui): hand off cloud scans to evidence surfaces

### DIFF
--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -377,6 +377,11 @@ def _persist_connection_report(record: CloudConnectionRecord, tenant_id: str, re
     return str(report.scan_id)
 
 
+def _mark_connection_report_sources(report: Any, provider: str) -> None:
+    """Stamp connection-originated scans so downstream UI/compliance do not look local."""
+    report.scan_sources = ["cloud_connection", f"cloud:{provider}"]
+
+
 def _scan_audit_metadata(note: str) -> dict[str, Any]:
     """Read-only audit envelope attached to every connection-scan summary."""
     return {"read_only": True, "writes_performed": False, "note": note}
@@ -408,6 +413,7 @@ def _run_aws_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> d
     cis_dict = cis_report.to_dict()
 
     report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=str(_uuid.uuid4()))
+    _mark_connection_report_sources(report, "aws")
     report.cloud_inventory_data = inventory_payload
     report.cis_benchmark_data = cis_dict
     scan_id = _persist_connection_report(record, tenant_id, report)
@@ -451,6 +457,7 @@ def _run_azure_connection_scan(record: CloudConnectionRecord, tenant_id: str) ->
     cis_dict = cis_report.to_dict()
 
     report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=str(_uuid.uuid4()))
+    _mark_connection_report_sources(report, "azure")
     report.cloud_inventory_data = inventory_payload
     report.azure_cis_benchmark_data = cis_dict
     scan_id = _persist_connection_report(record, tenant_id, report)
@@ -494,6 +501,7 @@ def _run_gcp_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> d
     cis_dict = cis_report.to_dict()
 
     report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=str(_uuid.uuid4()))
+    _mark_connection_report_sources(report, "gcp")
     report.cloud_inventory_data = inventory_payload
     report.gcp_cis_benchmark_data = cis_dict
     scan_id = _persist_connection_report(record, tenant_id, report)
@@ -541,7 +549,10 @@ def _run_snowflake_connection_scan(record: CloudConnectionRecord, tenant_id: str
             _logger.debug("Snowflake broker connection close failed for connection %s", record.id)
     cis_dict = cis_report.to_dict()
 
+    inventory_summary = {"provider": "snowflake", "status": "ok", "agent_count": len(agents)}
     report = AIBOMReport(agents=agents, blast_radii=[], findings=[], scan_id=str(_uuid.uuid4()))
+    _mark_connection_report_sources(report, "snowflake")
+    report.cloud_inventory_data = inventory_summary
     report.snowflake_cis_benchmark_data = cis_dict
     scan_id = _persist_connection_report(record, tenant_id, report)
 
@@ -551,7 +562,7 @@ def _run_snowflake_connection_scan(record: CloudConnectionRecord, tenant_id: str
         "tenant_id": tenant_id,
         "provider": "snowflake",
         "scan_id": scan_id,
-        "inventory": {"provider": "snowflake", "status": "ok", "agent_count": len(agents)},
+        "inventory": inventory_summary,
         "cis_benchmark": _cis_summary(cis_dict),
         "audit_metadata": _scan_audit_metadata(
             "Scan ran against a read-only Snowflake key-pair connection brokered from the stored connection. "

--- a/tests/test_cloud_connections.py
+++ b/tests/test_cloud_connections.py
@@ -1113,6 +1113,7 @@ def test_scan_launch_brokers_runs_persists_and_marks_active(monkeypatch: pytest.
     assert job.result is not None
     assert job.result.get("cloud_inventory", {}).get("provider") == "aws"
     assert job.result.get("cis_benchmark", {}).get("total") == 2
+    assert job.result.get("scan_sources") == ["cloud_connection", "cloud:aws"]
 
     # Connection status flipped to active with last_scan_at set, no error detail.
     fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
@@ -1233,7 +1234,10 @@ def test_scan_azure_brokers_runs_persists_and_marks_active(monkeypatch: pytest.M
 
     from agent_bom.api.stores import _get_store
 
-    assert _get_store().get(body["scan_id"], "tenant-alpha") is not None
+    job = _get_store().get(body["scan_id"], "tenant-alpha")
+    assert job is not None
+    assert job.result is not None
+    assert job.result.get("scan_sources") == ["cloud_connection", "cloud:azure"]
     fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
     assert fetched["status"] == "active"
     assert fetched["last_scan_at"]
@@ -1267,6 +1271,12 @@ def test_scan_gcp_brokers_runs_persists_and_marks_active(monkeypatch: pytest.Mon
     assert calls["cis_creds"] is _BROKER_SESSION_SENTINEL
     assert calls["inv_force"] is True
     assert body["cis_benchmark"]["total"] == 2
+    from agent_bom.api.stores import _get_store
+
+    job = _get_store().get(body["scan_id"], "tenant-alpha")
+    assert job is not None
+    assert job.result is not None
+    assert job.result.get("scan_sources") == ["cloud_connection", "cloud:gcp"]
     fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
     assert fetched["status"] == "active"
 
@@ -1303,6 +1313,13 @@ def test_scan_snowflake_brokers_runs_persists_and_marks_active(monkeypatch: pyte
     assert conn.closed is True
     assert body["inventory"]["agent_count"] == 0
     assert body["cis_benchmark"]["total"] == 2
+    from agent_bom.api.stores import _get_store
+
+    job = _get_store().get(body["scan_id"], "tenant-alpha")
+    assert job is not None
+    assert job.result is not None
+    assert job.result.get("scan_sources") == ["cloud_connection", "cloud:snowflake"]
+    assert job.result.get("cloud_inventory", {}).get("agent_count") == 0
     fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
     assert fetched["status"] == "active"
 

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 import {
   Cloud,
   Plus,
@@ -17,6 +18,10 @@ import {
   Boxes,
   Fingerprint,
   KeyRound,
+  FileSearch,
+  GitGraph,
+  ListChecks,
+  ClipboardList,
 } from "lucide-react";
 
 import {
@@ -241,6 +246,17 @@ function formatPassRate(rate: number | null): string {
   // pass_rate may be 0–1 or 0–100 depending on the benchmark; normalize to a percent.
   const pct = rate <= 1 ? rate * 100 : rate;
   return `${pct.toFixed(0)}%`;
+}
+
+function evidenceLinks(scanId: string) {
+  const encoded = encodeURIComponent(scanId);
+  return [
+    { label: "Scan result", href: `/scan?id=${encoded}`, icon: FileSearch },
+    { label: "Jobs", href: `/jobs?q=${encoded}`, icon: ClipboardList },
+    { label: "Findings", href: `/vulns?scan=${encoded}`, icon: ListChecks },
+    { label: "Graph", href: `/graph?scan_id=${encoded}`, icon: GitGraph },
+    { label: "Compliance", href: `/compliance?q=${encoded}`, icon: ShieldCheck },
+  ];
 }
 
 export default function ConnectionsPage() {
@@ -568,12 +584,13 @@ function FragmentRow({
               disabled={isBusy || !canManage || !scannable}
               title={
                 scannable
-                  ? "Run a read-only scan"
+                  ? "Validate credentials and run a read-only scan"
                   : "Scanning for this provider is unavailable"
               }
-              className="rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {isBusy ? "Scanning…" : "Scan now"}
+              <ShieldCheck className="h-3.5 w-3.5" />
+              {isBusy ? "Scanning…" : "Test and scan"}
             </button>
             <button
               onClick={onDelete}
@@ -665,6 +682,18 @@ function ScanResultPanel({ result }: { result: CloudConnectionScanResponse }) {
       <p className="mt-3 text-[11px] leading-5 text-[var(--text-tertiary)]">
         {result.audit_metadata.note}
       </p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {evidenceLinks(result.scan_id).map(({ label, href, icon: Icon }) => (
+          <Link
+            key={label}
+            href={href}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1.5 text-[11px] font-medium text-[var(--foreground)] transition hover:border-emerald-700 hover:text-emerald-300"
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {label}
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }

--- a/ui/components/scan-result.tsx
+++ b/ui/components/scan-result.tsx
@@ -9,6 +9,7 @@ import { SeverityBadge } from "@/components/severity-badge";
 import {
   ArrowLeft, Loader2, CheckCircle, Clock, Zap, Key, Wrench,
   ArrowUpCircle, AlertTriangle, ChevronDown, ChevronRight, Download, GitBranch, Server,
+  Cloud, Database, ShieldCheck,
 } from "lucide-react";
 
 // ─── Scan Result View ───────────────────────────────────────────────────────
@@ -93,6 +94,7 @@ export function ScanResultView({ id }: { id: string }) {
   const result = job?.result as ScanResult | undefined;
   const summary = result?.summary;
   const blastRadius = result?.blast_radius ?? [];
+  const cloudEvidence = result ? summarizeCloudEvidence(result) : null;
 
   async function handleExport(format: GraphExportFormat = "json") {
     setExporting(true);
@@ -200,6 +202,8 @@ export function ScanResultView({ id }: { id: string }) {
           <MiniStat label="Critical" value={summary.critical_findings} accent="red" />
         </div>
       )}
+
+      {cloudEvidence ? <CloudEvidencePanel evidence={cloudEvidence} /> : null}
 
       {/* Blast radius */}
       {blastRadius.length > 0 && (
@@ -325,6 +329,13 @@ export function ScanResultView({ id }: { id: string }) {
         </section>
       )}
 
+      {result && cloudEvidence && blastRadius.length === 0 && (!result.agents || result.agents.length === 0) ? (
+        <div className="rounded-xl border border-cyan-900/50 bg-cyan-950/20 px-4 py-3 text-sm text-cyan-100">
+          Cloud inventory and posture evidence was persisted for this scan. No
+          package attack-path findings were produced for this evidence set.
+        </div>
+      ) : null}
+
       {/* Scan metadata */}
       {job?.completed_at && (
         <div className="text-xs text-zinc-600 flex items-center gap-2">
@@ -337,6 +348,203 @@ export function ScanResultView({ id }: { id: string }) {
 }
 
 // ─── Sub-Components ─────────────────────────────────────────────────────────
+
+interface CloudBenchmarkDisplay {
+  key: string;
+  label: string;
+  passed: number | null;
+  failed: number | null;
+  total: number | null;
+  passRate: number | null;
+}
+
+interface CloudEvidenceDisplay {
+  providers: string[];
+  resourceCount: number | null;
+  identityCount: number | null;
+  agentCount: number | null;
+  inventoryItems: number | null;
+  benchmarks: CloudBenchmarkDisplay[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function uniqueValues(values: Array<string | null | undefined>): string[] {
+  return Array.from(new Set(values.filter((value): value is string => Boolean(value)))).sort();
+}
+
+function countChecksByStatus(checks: unknown): Pick<CloudBenchmarkDisplay, "passed" | "failed" | "total"> {
+  if (!Array.isArray(checks)) return { passed: null, failed: null, total: null };
+  let passed = 0;
+  let failed = 0;
+  for (const raw of checks) {
+    if (!isRecord(raw)) continue;
+    const status = String(raw.status ?? raw.result ?? "").toLowerCase();
+    if (["pass", "passed", "ok", "success"].includes(status)) passed += 1;
+    if (["fail", "failed", "error"].includes(status)) failed += 1;
+  }
+  return { passed, failed, total: checks.length };
+}
+
+function benchmarkDisplay(key: string, label: string, data: unknown): CloudBenchmarkDisplay | null {
+  if (!isRecord(data)) return null;
+  const counted = countChecksByStatus(data.checks);
+  const passed = asNumber(data.passed) ?? counted.passed;
+  const failed = asNumber(data.failed) ?? counted.failed;
+  const total = asNumber(data.total) ?? counted.total;
+  const passRate = asNumber(data.pass_rate);
+  return { key, label, passed, failed, total, passRate };
+}
+
+function summarizeCloudInventory(inventory: unknown): Pick<
+  CloudEvidenceDisplay,
+  "providers" | "resourceCount" | "identityCount" | "agentCount" | "inventoryItems"
+> {
+  if (Array.isArray(inventory)) {
+    const providers = uniqueValues(
+      inventory.map((item) => (isRecord(item) ? String(item.provider ?? item.cloud ?? "") : "")),
+    );
+    let resourceCount = 0;
+    let identityCount = 0;
+    let agentCount = 0;
+    for (const item of inventory) {
+      if (!isRecord(item)) continue;
+      resourceCount += asNumber(item.resource_count) ?? 0;
+      identityCount += asNumber(item.identity_count) ?? 0;
+      agentCount += asNumber(item.agent_count) ?? 0;
+    }
+    return {
+      providers,
+      resourceCount: resourceCount || null,
+      identityCount: identityCount || null,
+      agentCount: agentCount || null,
+      inventoryItems: inventory.length,
+    };
+  }
+
+  if (!isRecord(inventory)) {
+    return { providers: [], resourceCount: null, identityCount: null, agentCount: null, inventoryItems: null };
+  }
+
+  let resourceCount = asNumber(inventory.resource_count);
+  const nodeSummary = inventory.node_summary;
+  if (resourceCount == null && isRecord(nodeSummary)) {
+    resourceCount = Object.values(nodeSummary).reduce<number>(
+      (sum, value) => sum + (asNumber(value) ?? 0),
+      0,
+    );
+  }
+
+  return {
+    providers: uniqueValues([String(inventory.provider ?? inventory.cloud ?? "")]),
+    resourceCount,
+    identityCount: asNumber(inventory.identity_count),
+    agentCount: asNumber(inventory.agent_count),
+    inventoryItems: null,
+  };
+}
+
+function summarizeCloudEvidence(result: ScanResult): CloudEvidenceDisplay | null {
+  const inventory = summarizeCloudInventory(result.cloud_inventory);
+  const benchmarks = [
+    benchmarkDisplay("aws", "AWS CIS", result.cis_benchmark),
+    benchmarkDisplay("azure", "Azure CIS", result.azure_cis_benchmark),
+    benchmarkDisplay("gcp", "GCP CIS", result.gcp_cis_benchmark),
+    benchmarkDisplay("snowflake", "Snowflake CIS", result.snowflake_cis_benchmark),
+    benchmarkDisplay("databricks", "Databricks", result.databricks_cis_benchmark),
+  ].filter((item): item is CloudBenchmarkDisplay => item !== null);
+
+  const hasInventory =
+    inventory.providers.length > 0 ||
+    inventory.resourceCount != null ||
+    inventory.identityCount != null ||
+    inventory.agentCount != null ||
+    inventory.inventoryItems != null;
+  if (!hasInventory && benchmarks.length === 0) return null;
+  return { ...inventory, benchmarks };
+}
+
+function formatEvidenceCount(value: number | null): string {
+  return value == null ? "—" : value.toLocaleString();
+}
+
+function formatBenchmarkRate(benchmark: CloudBenchmarkDisplay): string {
+  if (benchmark.passRate != null) {
+    const pct = benchmark.passRate <= 1 ? benchmark.passRate * 100 : benchmark.passRate;
+    return `${pct.toFixed(0)}%`;
+  }
+  if (benchmark.total && benchmark.passed != null) {
+    return `${((benchmark.passed / benchmark.total) * 100).toFixed(0)}%`;
+  }
+  return "—";
+}
+
+function CloudEvidencePanel({ evidence }: { evidence: CloudEvidenceDisplay }) {
+  const providerLabel = evidence.providers.length > 0 ? evidence.providers.join(", ").toUpperCase() : "Cloud";
+  return (
+    <section className="rounded-xl border border-cyan-900/50 bg-cyan-950/20 p-4">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <Cloud className="h-4 w-4 text-cyan-300" />
+          <h2 className="text-sm font-semibold text-cyan-100">Cloud evidence</h2>
+        </div>
+        <span className="font-mono text-[11px] uppercase tracking-wide text-cyan-300/80">{providerLabel}</span>
+      </div>
+      <div className="mt-4 grid grid-cols-2 gap-3 md:grid-cols-4">
+        <EvidenceMetric icon={Database} label="Resources" value={formatEvidenceCount(evidence.resourceCount ?? evidence.inventoryItems)} />
+        <EvidenceMetric icon={Key} label="Identities" value={formatEvidenceCount(evidence.identityCount)} />
+        <EvidenceMetric icon={Server} label="Agents" value={formatEvidenceCount(evidence.agentCount)} />
+        <EvidenceMetric icon={ShieldCheck} label="Benchmarks" value={formatEvidenceCount(evidence.benchmarks.length)} />
+      </div>
+      {evidence.benchmarks.length > 0 ? (
+        <div className="mt-4 grid gap-2 lg:grid-cols-2">
+          {evidence.benchmarks.map((benchmark) => (
+            <div
+              key={benchmark.key}
+              className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-cyan-900/40 bg-zinc-950/40 px-3 py-2"
+            >
+              <span className="text-xs font-medium text-zinc-200">{benchmark.label}</span>
+              <span className="font-mono text-xs text-cyan-200">
+                {benchmark.passed ?? "—"}/{benchmark.total ?? "—"} passed · {formatBenchmarkRate(benchmark)}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function EvidenceMetric({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: React.ElementType;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-lg border border-cyan-900/40 bg-zinc-950/40 p-3">
+      <div className="flex items-center gap-2 text-[10px] uppercase tracking-[0.16em] text-cyan-300/80">
+        <Icon className="h-3.5 w-3.5" />
+        {label}
+      </div>
+      <p className="mt-1.5 text-lg font-semibold text-zinc-100">{value}</p>
+    </div>
+  );
+}
 
 function JobStatusBadge({ status, streaming }: { status: string; streaming: boolean }) {
   if (status === "done") return <span className="text-xs bg-emerald-950 border border-emerald-900 text-emerald-400 rounded-full px-2 py-0.5 font-mono">done</span>;

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -85,6 +85,13 @@ export interface ScanResult {
   has_mcp_context?: boolean | undefined;
   has_agent_context?: boolean | undefined;
   scan_sources?: string[] | undefined;
+  /** Cloud estate evidence persisted by cloud connection and CLI cloud scans. */
+  cloud_inventory?: unknown | undefined;
+  cis_benchmark?: unknown | undefined;
+  azure_cis_benchmark?: unknown | undefined;
+  gcp_cis_benchmark?: unknown | undefined;
+  snowflake_cis_benchmark?: unknown | undefined;
+  databricks_cis_benchmark?: unknown | undefined;
 }
 
 export interface GraphPagination {

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -247,7 +247,7 @@ describe("ConnectionsPage", () => {
       expect(screen.getByText("Production account")).toBeInTheDocument(),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Scan now" }));
+    fireEvent.click(screen.getByRole("button", { name: "Test and scan" }));
 
     await waitFor(() =>
       expect(apiMock.scanCloudConnection).toHaveBeenCalledWith("conn-1"),
@@ -260,6 +260,18 @@ describe("ConnectionsPage", () => {
     expect(screen.getByText("7")).toBeInTheDocument(); // identities
     expect(screen.getByText("30/40")).toBeInTheDocument(); // CIS passed
     expect(screen.getByText("75%")).toBeInTheDocument(); // pass rate
+    expect(screen.getByRole("link", { name: "Scan result" })).toHaveAttribute(
+      "href",
+      "/scan?id=abcdef12-3456-7890-abcd-ef1234567890",
+    );
+    expect(screen.getByRole("link", { name: "Findings" })).toHaveAttribute(
+      "href",
+      "/vulns?scan=abcdef12-3456-7890-abcd-ef1234567890",
+    );
+    expect(screen.getByRole("link", { name: "Graph" })).toHaveAttribute(
+      "href",
+      "/graph?scan_id=abcdef12-3456-7890-abcd-ef1234567890",
+    );
   });
 
   it("deletes a connection through the API", async () => {

--- a/ui/tests/scan-result-cloud-evidence.test.tsx
+++ b/ui/tests/scan-result-cloud-evidence.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ScanResultView } from "@/components/scan-result";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    getScanStatus: vi.fn(),
+    getScan: vi.fn(),
+    downloadScanGraph: vi.fn(),
+  },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    className,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/use-scan-stream", () => ({
+  useScanStream: () => ({
+    messages: [],
+    pipelineSteps: new Map(),
+    streaming: false,
+  }),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: apiMock,
+  };
+});
+
+describe("ScanResultView cloud evidence", () => {
+  beforeEach(() => {
+    Object.values(apiMock).forEach((mockFn) => mockFn.mockReset());
+    apiMock.getScanStatus.mockResolvedValue({
+      job_id: "scan-cloud-1",
+      status: "done",
+      created_at: "2026-06-27T00:00:00Z",
+      completed_at: "2026-06-27T00:05:00Z",
+      request: {},
+    });
+    apiMock.getScan.mockResolvedValue({
+      job_id: "scan-cloud-1",
+      status: "done",
+      created_at: "2026-06-27T00:00:00Z",
+      completed_at: "2026-06-27T00:05:00Z",
+      request: {},
+      progress: [],
+      result: {
+        agents: [],
+        blast_radius: [],
+        cloud_inventory: {
+          provider: "aws",
+          resource_count: 42,
+          identity_count: 7,
+        },
+        cis_benchmark: {
+          benchmark: "CIS AWS",
+          benchmark_version: "1.5",
+          passed: 30,
+          failed: 10,
+          total: 40,
+          pass_rate: 0.75,
+        },
+      },
+    });
+  });
+
+  it("renders persisted cloud inventory and CIS evidence even without attack-path findings", async () => {
+    render(<ScanResultView id="scan-cloud-1" />);
+
+    await waitFor(() => expect(apiMock.getScan).toHaveBeenCalledWith("scan-cloud-1"));
+
+    expect(screen.getByText("Cloud evidence")).toBeInTheDocument();
+    expect(screen.getByText("AWS")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("AWS CIS")).toBeInTheDocument();
+    expect(screen.getByText("30/40 passed · 75%")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Cloud inventory and posture evidence was persisted/i),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What

- Adds cloud scan evidence links from the Connections row to Scan result, Jobs, Findings, Graph, and Compliance.
- Renames the connection scan action to `Test and scan` to make the credential validation behavior clearer.
- Renders persisted cloud inventory and CIS evidence on the scan result page, even when the scan has no package attack-path findings.
- Persists `scan_sources` for AWS, Azure, GCP, and Snowflake connection scans.
- Persists Snowflake connection scan inventory (`agent_count`) into the stored scan result, not only the immediate scan response.

## Why

Cloud connection scans were technically persisted, but the hosted/customer-0 workflow stopped at summary counts. A successful cloud scan with no CVE attack path could look empty in scan details, and Snowflake lost its immediate inventory count on later views.

## Validation

- `uv run pytest tests/test_cloud_connections.py -q`
- `npm run test:run -- connections-page.test.tsx scan-result-cloud-evidence.test.tsx`
- `npm run typecheck`
- `uv run ruff check src/agent_bom/api/routes/cloud_connections.py tests/test_cloud_connections.py`
- `npm run lint -- app/connections/page.tsx components/scan-result.tsx lib/api-types.ts tests/connections-page.test.tsx tests/scan-result-cloud-evidence.test.tsx`
