### PR TITLE
fix(security): bind webhook signatures to timestamps

### DIFF
--- a/src/agent_bom/delivery.py
+++ b/src/agent_bom/delivery.py
@@ -53,6 +53,8 @@ logger = logging.getLogger(__name__)
 _RETRYABLE_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504})
 # 4xx (other than the retryable transient ones above) = permanent; do not retry.
 _PERMANENT_4XX_FLOOR = 400
+WEBHOOK_SIGNATURE_TIMESTAMP_HEADER = "x-agent-bom-timestamp"
+WEBHOOK_SIGNATURE_FRESHNESS_SECONDS = 300
 
 
 class DeliveryError(RuntimeError):
@@ -530,7 +532,10 @@ class DeliveryClient:
         }
         headers.update({str(k): str(v) for k, v in destination.headers.items()})
         if destination.signing_secret:
-            sig = hmac.new(destination.signing_secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+            timestamp = str(int(self._now()))
+            signing_payload = timestamp.encode("utf-8") + b"." + body
+            sig = hmac.new(destination.signing_secret.encode("utf-8"), signing_payload, hashlib.sha256).hexdigest()
+            headers[WEBHOOK_SIGNATURE_TIMESTAMP_HEADER] = timestamp
             headers["x-agent-bom-signature"] = f"sha256={sig}"
         scheme = destination.auth_scheme.strip().lower()
         if scheme and destination.auth_token:
@@ -817,6 +822,8 @@ __all__ = [
     "RetryPolicy",
     "SendOutcome",
     "Sender",
+    "WEBHOOK_SIGNATURE_FRESHNESS_SECONDS",
+    "WEBHOOK_SIGNATURE_TIMESTAMP_HEADER",
     "default_delivery_store_path",
     "get_delivery_client",
     "http_sender",

--- a/src/agent_bom/posture_streaming.py
+++ b/src/agent_bom/posture_streaming.py
@@ -23,6 +23,8 @@ from urllib.parse import urlparse
 from agent_bom.security import sanitize_error, sanitize_sensitive_payload
 
 POSTURE_EVENT_SCHEMA_VERSION = "1"
+WEBHOOK_SIGNATURE_FRESHNESS_SECONDS = 300
+WEBHOOK_SIGNATURE_TIMESTAMP_HEADER = "x-agent-bom-timestamp"
 WebhookSender = Callable[[str, dict[str, str], dict[str, Any]], Awaitable[int]]
 POSTURE_EVENT_TYPES = frozenset(
     {
@@ -443,13 +445,22 @@ def _outbox_record_from_row(row: sqlite3.Row) -> OutboxRecord:
     )
 
 
-def signed_webhook_headers(event: PostureEvent, destination: WebhookDestination, *, attempt: int = 1) -> dict[str, str]:
+def signed_webhook_headers(
+    event: PostureEvent,
+    destination: WebhookDestination,
+    *,
+    attempt: int = 1,
+    timestamp: float | int | str | None = None,
+) -> dict[str, str]:
     payload_json = _canonical_json(event.to_dict())
-    signature = hmac.new(destination.signing_secret.encode("utf-8"), payload_json.encode("utf-8"), hashlib.sha256).hexdigest()
+    signed_at = str(int(_now() if timestamp is None else float(timestamp)))
+    signing_payload = f"{signed_at}.{payload_json}".encode("utf-8")
+    signature = hmac.new(destination.signing_secret.encode("utf-8"), signing_payload, hashlib.sha256).hexdigest()
     return {
         "content-type": "application/json",
         "x-agent-bom-event-id": event.event_id,
         "x-agent-bom-tenant-id": event.tenant_id,
+        WEBHOOK_SIGNATURE_TIMESTAMP_HEADER: signed_at,
         "x-agent-bom-signature": f"sha256={signature}",
         "x-agent-bom-delivery-attempt": str(attempt),
         "idempotency-key": event.idempotency_key,
@@ -509,6 +520,8 @@ async def deliver_due_webhooks(
 __all__ = [
     "POSTURE_EVENT_SCHEMA_VERSION",
     "POSTURE_EVENT_TYPES",
+    "WEBHOOK_SIGNATURE_FRESHNESS_SECONDS",
+    "WEBHOOK_SIGNATURE_TIMESTAMP_HEADER",
     "OutboxRecord",
     "PostureEvent",
     "PostureStreamingError",

--- a/src/agent_bom/sbom.py
+++ b/src/agent_bom/sbom.py
@@ -34,12 +34,13 @@ def _ecosystem_from_purl(purl: str) -> str:
         return "unknown"
     parts = purl[4:].split("/", 1)
     eco = parts[0].lower()
-    # Normalise aliases
+    # Normalize Package URL ecosystem aliases to the scanner-facing ecosystem
+    # keys. SBOM imports must resolve against the same advisory databases as
+    # lockfile/image scans; language names like "ruby" or "php" are too broad.
     return {
+        "gem": "rubygems",
         "golang": "go",
-        "rubygems": "ruby",
-        "hex": "erlang",
-        "composer": "php",
+        "rubygems": "rubygems",
     }.get(eco, eco)
 
 
@@ -52,8 +53,11 @@ def _ecosystem_from_type(component_type: str) -> str:
         "cargo": "cargo",
         "maven": "maven",
         "nuget": "nuget",
-        "gem": "ruby",
-        "composer": "php",
+        "gem": "rubygems",
+        "rubygems": "rubygems",
+        "composer": "composer",
+        "hex": "hex",
+        "pub": "pub",
     }.get(component_type.lower(), component_type.lower())
 
 

--- a/tests/test_delivery_foundation.py
+++ b/tests/test_delivery_foundation.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 from agent_bom.delivery import (
+    WEBHOOK_SIGNATURE_TIMESTAMP_HEADER,
     BreakerPolicy,
     Delivery,
     DeliveryClient,
@@ -305,7 +306,7 @@ def test_signing_secret_never_logged(tmp_path: Path) -> None:
 
 
 def test_hmac_signature_and_bearer_auth_headers(tmp_path: Path) -> None:
-    clock = FakeClock()
+    clock = FakeClock(start=1770000000.0)
     sender = ScriptedSender([SendOutcome(http_status=200)])
     client = _client(tmp_path, sender, clock=clock)
     dest = Destination(destination_id="dst1", url="https://example.test/h", signing_secret="s3cret", auth_scheme="bearer", auth_token="tok")
@@ -314,11 +315,13 @@ def test_hmac_signature_and_bearer_auth_headers(tmp_path: Path) -> None:
     assert headers["x-agent-bom-signature"].startswith("sha256=")
     assert headers["Authorization"] == "Bearer tok"
     assert headers["idempotency-key"]
-    # Signature is an HMAC of the exact body sent.
+    assert headers[WEBHOOK_SIGNATURE_TIMESTAMP_HEADER] == "1770000000"
+    # Signature binds the timestamp and exact body so receivers can reject stale
+    # replayed deliveries.
     import hashlib
     import hmac
 
-    expected = "sha256=" + hmac.new(b"s3cret", body, hashlib.sha256).hexdigest()
+    expected = "sha256=" + hmac.new(b"s3cret", b"1770000000." + body, hashlib.sha256).hexdigest()
     assert headers["x-agent-bom-signature"] == expected
 
 
@@ -367,6 +370,7 @@ def test_webhook_store_delivers_through_foundation(tmp_path: Path) -> None:
     _url, headers, _body = sender.calls[0]
     assert headers["x-agent-bom-event-type"] == "identity.revoked"
     assert headers["x-agent-bom-tenant-id"] == "tenant-a"
+    assert headers[WEBHOOK_SIGNATURE_TIMESTAMP_HEADER] == "1000"
     assert headers["x-agent-bom-signature"].startswith("sha256=")
 
 

--- a/tests/test_posture_streaming.py
+++ b/tests/test_posture_streaming.py
@@ -8,6 +8,7 @@ import json
 import pytest
 
 from agent_bom.posture_streaming import (
+    WEBHOOK_SIGNATURE_TIMESTAMP_HEADER,
     PostureEvent,
     WebhookDestination,
     WebhookOutbox,
@@ -94,14 +95,16 @@ def test_signed_headers_are_verifiable():
         signing_secret="top-secret",
     )
 
-    headers = signed_webhook_headers(event, destination, attempt=3)
+    headers = signed_webhook_headers(event, destination, attempt=3, timestamp=1770000000)
 
     assert headers["x-agent-bom-event-id"] == event.event_id
     assert headers["x-agent-bom-tenant-id"] == "tenant-a"
     assert headers["x-agent-bom-delivery-attempt"] == "3"
+    assert headers[WEBHOOK_SIGNATURE_TIMESTAMP_HEADER] == "1770000000"
+    payload_json = json.dumps(event.to_dict(), sort_keys=True, separators=(",", ":"), default=str)
     expected = hmac.new(
         b"top-secret",
-        json.dumps(event.to_dict(), sort_keys=True, separators=(",", ":"), default=str).encode("utf-8"),
+        f"1770000000.{payload_json}".encode("utf-8"),
         "sha256",
     ).hexdigest()
     assert headers["x-agent-bom-signature"] == f"sha256={expected}"

--- a/tests/test_sbom_ingestion.py
+++ b/tests/test_sbom_ingestion.py
@@ -28,6 +28,14 @@ def test_ecosystem_from_purl_golang_alias():
     assert _ecosystem_from_purl("pkg:golang/github.com/x/y@v1") == "go"
 
 
+def test_ecosystem_from_purl_scanner_aliases():
+    assert _ecosystem_from_purl("pkg:gem/rails@7.1.3") == "rubygems"
+    assert _ecosystem_from_purl("pkg:rubygems/rack@3.0.8") == "rubygems"
+    assert _ecosystem_from_purl("pkg:composer/symfony/console@7.0.4") == "composer"
+    assert _ecosystem_from_purl("pkg:hex/decimal@2.1.1") == "hex"
+    assert _ecosystem_from_purl("pkg:pub/path@1.9.0") == "pub"
+
+
 def test_ecosystem_from_purl_empty():
     assert _ecosystem_from_purl("") == "unknown"
 
@@ -40,7 +48,13 @@ def test_ecosystem_from_type_npm():
 
 
 def test_ecosystem_from_type_gem():
-    assert _ecosystem_from_type("gem") == "ruby"
+    assert _ecosystem_from_type("gem") == "rubygems"
+
+
+def test_ecosystem_from_type_scanner_aliases():
+    assert _ecosystem_from_type("composer") == "composer"
+    assert _ecosystem_from_type("hex") == "hex"
+    assert _ecosystem_from_type("pub") == "pub"
 
 
 # ─── parse_cyclonedx ─────────────────────────────────────────────────────────
@@ -75,6 +89,46 @@ def test_parse_cyclonedx_with_purl():
     assert packages[0].resolved_from_registry is False
     assert packages[1].name == "requests"
     assert packages[1].ecosystem == "pypi"
+
+
+def test_parse_cyclonedx_preserves_scanner_ecosystems_from_purl():
+    data = {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "components": [
+            {
+                "type": "library",
+                "name": "rails",
+                "version": "7.1.3",
+                "purl": "pkg:gem/rails@7.1.3",
+            },
+            {
+                "type": "library",
+                "name": "symfony/console",
+                "version": "7.0.4",
+                "purl": "pkg:composer/symfony/console@7.0.4",
+            },
+            {
+                "type": "library",
+                "name": "decimal",
+                "version": "2.1.1",
+                "purl": "pkg:hex/decimal@2.1.1",
+            },
+            {
+                "type": "library",
+                "name": "path",
+                "version": "1.9.0",
+                "purl": "pkg:pub/path@1.9.0",
+            },
+        ],
+    }
+    packages = parse_cyclonedx(data)
+    assert [(pkg.name, pkg.ecosystem) for pkg in packages] == [
+        ("rails", "rubygems"),
+        ("symfony/console", "composer"),
+        ("decimal", "hex"),
+        ("path", "pub"),
+    ]
 
 
 def test_parse_cyclonedx_without_purl():


### PR DESCRIPTION
## Summary
- bind outbound delivery and posture webhook signatures to an `x-agent-bom-timestamp` header
- expose a 5-minute freshness contract for webhook receivers
- preserve scanner-facing SBOM ecosystems for Gem/RubyGems, Composer, Hex, and Pub imports so SBOM-origin packages hit the same advisory sources as native scans

## Validation
- `uv run pytest tests/test_delivery_foundation.py tests/test_posture_streaming.py tests/test_posture_webhook_outbox_api.py tests/test_sbom_ingestion.py tests/test_beam_parsers.py tests/test_scanner_ecosystems.py -q`
- `uv run ruff check src/agent_bom/delivery.py src/agent_bom/posture_streaming.py src/agent_bom/sbom.py tests/test_delivery_foundation.py tests/test_posture_streaming.py tests/test_sbom_ingestion.py`

Part of #3242.