### PR TITLE
fix(ui): surface cloud CIS findings consistently

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -9516,6 +9516,23 @@
           },
           {
             "in": "query",
+            "name": "scan_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 128,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Scan Id"
+            }
+          },
+          {
+            "in": "query",
             "name": "sort",
             "required": false,
             "schema": {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -6234,6 +6234,15 @@ paths:
           - type: 'null'
           title: Severity
       - in: query
+        name: scan_id
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 128
+            type: string
+          - type: 'null'
+          title: Scan Id
+      - in: query
         name: sort
         required: false
         schema:

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1139,6 +1139,7 @@ def _finding_sort_key(row: dict[str, Any], sort: str) -> tuple[float, float, flo
 async def list_findings(
     request: Request,
     severity: str | None = None,
+    scan_id: Annotated[str | None, Query(max_length=128)] = None,
     sort: str = "effective_reach",
     # enforce limit cap server-side instead of trusting
     # the historical `min(limit, 1000)` clamp at use-site.
@@ -1155,8 +1156,13 @@ async def list_findings(
     tenant_id = _tenant_id(request)
     findings: list[dict[str, Any]] = []
     for job in _completed_jobs_for_tenant(tenant_id):
+        if scan_id and job.job_id != scan_id:
+            continue
         findings.extend(_iter_scan_findings(job))
-    findings.extend(_bulk_ingested_findings_for_tenant(tenant_id))
+    bulk_findings = _bulk_ingested_findings_for_tenant(tenant_id)
+    if scan_id:
+        bulk_findings = [item for item in bulk_findings if str(item.get("scan_id") or "") == scan_id]
+    findings.extend(bulk_findings)
 
     if severity:
         normalized = severity.lower()
@@ -1179,6 +1185,7 @@ async def list_findings(
         "limit": limit,
         "offset": offset,
         "sort": sort_key,
+        "scan_id": scan_id,
         "warnings": [],
     }
 

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import uuid
 from pathlib import Path
+from typing import Any
 
 from agent_bom.asset_provenance import (
     agent_discovery_provenance,
@@ -31,6 +32,7 @@ SCAN_REPORT_SCHEMA_VERSION = "1.0"
 SCAN_RUN_SCHEMA_VERSION = "1"
 BLAST_RADIUS_SCHEMA_VERSION = "1"
 INVENTORY_SNAPSHOT_SCHEMA_VERSION = "1"
+_FINDING_SEVERITIES = ("critical", "high", "medium", "low", "unknown")
 
 
 def _severity_state(severity: Severity) -> str:
@@ -76,6 +78,28 @@ def _package_occurrence_to_dict(occurrence) -> dict[str, object]:
 def _stable_report_finding_id(*parts: object) -> str:
     raw = ":".join(str(part or "") for part in parts)
     return str(uuid.uuid5(uuid.NAMESPACE_URL, f"agent-bom:finding:{raw}"))
+
+
+def _build_finding_summary(findings: list[dict[str, object]]) -> dict[str, Any]:
+    """Summarize the unified finding stream, independent of package CVE counts."""
+    by_severity = dict.fromkeys(_FINDING_SEVERITIES, 0)
+    by_type: dict[str, int] = {}
+    by_source: dict[str, int] = {}
+    for finding in findings:
+        severity = str(finding.get("effective_severity") or finding.get("severity") or "unknown").lower()
+        if severity not in by_severity:
+            severity = "unknown"
+        by_severity[severity] += 1
+        finding_type = str(finding.get("finding_type") or "UNKNOWN")
+        source = str(finding.get("source") or "UNKNOWN")
+        by_type[finding_type] = by_type.get(finding_type, 0) + 1
+        by_source[source] = by_source.get(source, 0) + 1
+    return {
+        "total": len(findings),
+        "by_severity": by_severity,
+        "by_type": dict(sorted(by_type.items())),
+        "by_source": dict(sorted(by_source.items())),
+    }
 
 
 def _prompt_scan_findings(prompt_scan: dict) -> list[dict[str, object]]:
@@ -809,6 +833,8 @@ def to_json(report: AIBOMReport) -> dict:
 
     all_packages = [pkg for agent in report.agents for server in agent.mcp_servers for pkg in server.packages]
     exposure_paths = [exposure_path_for_blast_radius(br, rank=rank) for rank, br in enumerate(report.blast_radii, start=1)]
+    unified_findings = [finding.to_dict() for finding in report.to_findings()]
+    finding_summary = _build_finding_summary(unified_findings)
     result = {
         "schema_version": SCAN_REPORT_SCHEMA_VERSION,
         "document_type": "AI-BOM",
@@ -840,8 +866,12 @@ def to_json(report: AIBOMReport) -> dict:
             "unique_packages": len(ai_bom_entities.get("packages", [])),
             "total_vulnerabilities": report.total_vulnerabilities,
             "critical_findings": len(report.critical_vulns),
+            "total_findings": finding_summary["total"],
+            "critical_unified_findings": finding_summary["by_severity"]["critical"],
+            "high_unified_findings": finding_summary["by_severity"]["high"],
             "coverage_warnings": list(report.coverage_warnings),
         },
+        "finding_summary": finding_summary,
         "coverage_warnings": list(report.coverage_warnings),
         "inventory_snapshot": inventory_snapshot,
         "agents": [
@@ -1141,7 +1171,7 @@ def to_json(report: AIBOMReport) -> dict:
             "path_count": len(exposure_paths),
             "paths": exposure_paths,
         },
-        "findings": [finding.to_dict() for finding in report.to_findings()],
+        "findings": unified_findings,
         "threat_framework_summary": _build_framework_summary(report.blast_radii),
         "scorecard_summary": summarize_scorecard_coverage(all_packages).to_dict(),
         "remediation_plan": _build_remediation_json(report),

--- a/tests/test_cloud_cis_convergence.py
+++ b/tests/test_cloud_cis_convergence.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pytest
+
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.routes import scan as scan_routes
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import set_job_store
 from agent_bom.models import AIBOMReport
+from agent_bom.output.json_fmt import to_json
 
 
 def _report() -> AIBOMReport:
@@ -109,3 +118,43 @@ def test_cis_fail_posture_and_gate_agree() -> None:
     rendered = buf.getvalue()
     assert "CLEAN" not in rendered  # headline reflects CIS fails
     assert _gate(report) != 0  # gate agrees
+
+
+def test_json_finding_summary_counts_cloud_cis_findings() -> None:
+    payload = to_json(_report())
+    assert payload["summary"]["total_vulnerabilities"] == 0
+    assert payload["summary"]["total_findings"] == 2
+    assert payload["summary"]["critical_unified_findings"] == 1
+    assert payload["summary"]["high_unified_findings"] == 1
+    assert payload["finding_summary"]["by_type"]["CIS_FAIL"] == 2
+    assert payload["finding_summary"]["by_source"]["CLOUD_CIS"] == 2
+
+
+@pytest.mark.asyncio
+async def test_findings_endpoint_filters_cloud_cis_by_scan_id() -> None:
+    store = InMemoryJobStore()
+    set_job_store(store)
+    target = _report()
+    target.scan_id = "scan-cloud"
+    other = AIBOMReport(scan_id="scan-other")
+    other.cis_benchmark_data = {"checks": [{"check_id": "1.1", "title": "Other", "status": "PASS", "severity": "high"}]}
+    for report in (target, other):
+        store.put(
+            ScanJob(
+                job_id=report.scan_id,
+                tenant_id="tenant-cis",
+                status=JobStatus.DONE,
+                created_at="2026-06-29T00:00:00Z",
+                completed_at="2026-06-29T00:00:01Z",
+                request=ScanRequest(),
+                result=to_json(report),
+            )
+        )
+
+    request = SimpleNamespace(state=SimpleNamespace(tenant_id="tenant-cis", api_key_name="tester"))
+    response = await scan_routes.list_findings(request, scan_id="scan-cloud")
+
+    assert response["scan_id"] == "scan-cloud"
+    assert response["total"] == 2
+    assert {finding["finding_type"] for finding in response["findings"]} == {"CIS_FAIL"}
+    assert {finding["scan_id"] for finding in response["findings"]} == {"scan-cloud"}

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -12,6 +12,7 @@ import {
   severityDot,
   JobListItem,
   RemediationItem,
+  UnifiedFinding,
   type FindingTriageDecision,
   type FindingTriageItem,
   type FindingTriageJustification,
@@ -234,6 +235,54 @@ function collectGraphVulns(graph: UnifiedGraphResponse): EnrichedVuln[] {
       graph_reachable: null,
       graph_min_hop_distance: null,
     }));
+}
+
+function collectUnifiedFindings(findings: UnifiedFinding[]): EnrichedVuln[] {
+  return findings.map((finding): EnrichedVuln => {
+    const assetName = finding.asset?.name?.trim() || finding.asset?.identifier || finding.asset?.stable_id || "asset";
+    const findingLabel = finding.cve_id || finding.title || finding.id;
+    const sourceLabel = uniqueStrings([finding.source, finding.finding_type, ...(finding.scan_sources ?? [])]);
+    return {
+      id: findingLabel,
+      severity: normalizedSeverity(finding.effective_severity ?? finding.severity),
+      summary: finding.title ?? finding.description,
+      description: finding.description ?? finding.title,
+      references: [],
+      advisory_sources: sourceLabel,
+      aliases: [],
+      cvss_score: finding.cvss_score ?? undefined,
+      epss_score: finding.epss_score ?? undefined,
+      is_kev: Boolean(finding.is_kev),
+      cisa_kev: Boolean(finding.is_kev),
+      fixed_version: finding.fixed_version ?? undefined,
+      packages: [assetName],
+      agents: finding.affected_agents ?? [],
+      sources: sourceLabel.length > 0 ? sourceLabel : ["finding"],
+      affected_servers: finding.affected_servers ?? [],
+      exposed_credentials: finding.exposed_credentials ?? [],
+      reachable_tools: finding.exposed_tools ?? [],
+      attack_vector_summary: finding.network_exploitable ? "Network exploitable" : undefined,
+      impact_category: finding.impact_category ?? finding.finding_type,
+      risk_score: finding.risk_score,
+      remediation_items: finding.remediation_guidance
+        ? [
+            {
+              package: assetName,
+              ecosystem: finding.asset?.asset_type ?? finding.finding_type ?? "finding",
+              current_version: "",
+              fixed_version: finding.fixed_version ?? null,
+              action: "review",
+              command: null,
+              verify_command: null,
+              references: [],
+              risk_narrative: finding.remediation_guidance,
+            },
+          ]
+        : [],
+      graph_reachable: null,
+      graph_min_hop_distance: null,
+    };
+  });
 }
 
 function SortButton({
@@ -526,6 +575,11 @@ function VulnsPage() {
         setDetailLoading(true);
         setError("");
         try {
+          const findings = await api.listFindings({ scanId: paramScan, limit: 1000 });
+          if (findings.findings.length > 0) {
+            setVulns(collectUnifiedFindings(findings.findings));
+            return;
+          }
           const graph = await api.getGraph({ scanId: paramScan, limit: 2500 });
           setVulns(collectGraphVulns(graph));
         } catch (graphError) {
@@ -682,10 +736,10 @@ function VulnsPage() {
           <p className="text-zinc-400 text-sm mt-1">
             {scope === "latest"
               ? paramScan
-                ? `${vulns.length} vulnerability findings from scan ${paramScan.slice(0, 8)}.`
-                : `${vulns.length} vulnerability findings from the latest completed scan.`
-              : `${vulns.length} vulnerability findings aggregated across all completed scans.`}{" "}
-            This surface is vulnerability-first today and will expand to broader finding types over time. CVSS and EPSS appear only when the underlying advisory includes them.
+                ? `${vulns.length} findings from scan ${paramScan.slice(0, 8)}.`
+                : `${vulns.length} findings from the latest completed scan.`
+              : `${vulns.length} findings aggregated across all completed scans.`}{" "}
+            CVSS and EPSS appear for advisory-backed vulnerabilities; cloud and governance findings use source evidence and policy severity.
           </p>
         </div>
         {vulns.length > 0 && (
@@ -741,7 +795,7 @@ function VulnsPage() {
       {!loading && !error && vulns.length === 0 && (
         <PageEmptyState
           title="No findings found"
-          detail="Run a scan with vulnerability enrichment enabled to populate CVE-backed findings, affected packages, agents, and remediation evidence."
+          detail="Run a scan or connect a cloud account to populate CVE, cloud posture, graph, and remediation evidence."
           icon={Bug}
           suggestions={[
             "Start with the offline demo if you want predictable sample data.",

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -667,6 +667,60 @@ export interface Vulnerability {
   confidence?: number | undefined;
 }
 
+export interface UnifiedFinding {
+  id: string;
+  canonical_id?: string | undefined;
+  finding_type?: string | undefined;
+  source?: string | undefined;
+  asset?: {
+    name?: string | undefined;
+    asset_type?: string | undefined;
+    identifier?: string | null | undefined;
+    location?: string | null | undefined;
+    stable_id?: string | undefined;
+  } | undefined;
+  severity: string;
+  effective_severity?: string | undefined;
+  title?: string | undefined;
+  description?: string | undefined;
+  cve_id?: string | null | undefined;
+  cwe_ids?: string[] | undefined;
+  cvss_score?: number | null | undefined;
+  cvss_vector?: string | null | undefined;
+  attack_vector?: string | null | undefined;
+  attack_complexity?: string | null | undefined;
+  privileges_required?: string | null | undefined;
+  user_interaction?: string | null | undefined;
+  network_exploitable?: boolean | undefined;
+  epss_score?: number | null | undefined;
+  is_kev?: boolean | undefined;
+  fixed_version?: string | null | undefined;
+  remediation_guidance?: string | null | undefined;
+  compliance_tags?: string[] | undefined;
+  controls?: Array<Record<string, unknown>> | undefined;
+  evidence?: Record<string, unknown> | undefined;
+  risk_score?: number | undefined;
+  impact_category?: string | null | undefined;
+  affected_servers?: string[] | undefined;
+  affected_agents?: string[] | undefined;
+  exposed_credentials?: string[] | undefined;
+  exposed_tools?: string[] | undefined;
+  scan_id?: string | undefined;
+  scan_sources?: string[] | undefined;
+}
+
+export interface FindingsResponse {
+  schema_version: string;
+  findings: UnifiedFinding[];
+  count: number;
+  total: number;
+  limit: number;
+  offset: number;
+  sort: string;
+  scan_id?: string | null | undefined;
+  warnings: string[];
+}
+
 export interface BlastRadius {
   vulnerability_id: string;
   severity: string;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -25,6 +25,7 @@ import type {
   PostureCountsResponse,
   OverviewResponse,
   RemediationItem,
+  FindingsResponse,
   FindingTriageRequest,
   FindingTriageDecisionRequest,
   FindingTriageResponse,
@@ -145,6 +146,8 @@ export type {
   OverviewDomain,
   OverviewTopRisk,
   RemediationItem,
+  FindingsResponse,
+  UnifiedFinding,
   FindingTriageQueueState,
   FindingTriageDecision,
   FindingTriageJustification,
@@ -859,6 +862,18 @@ export const api = {
     if (filters?.limit) params.set("limit", String(filters.limit));
     const qs = params.toString();
     return get<ProxyAlertsResponse>(`/v1/proxy/alerts${qs ? `?${qs}` : ""}`);
+  },
+
+  // ── Unified findings ──
+  listFindings: (filters?: { scanId?: string; severity?: string; sort?: string; limit?: number; offset?: number }) => {
+    const params = new URLSearchParams();
+    if (filters?.scanId) params.set("scan_id", filters.scanId);
+    if (filters?.severity) params.set("severity", filters.severity);
+    if (filters?.sort) params.set("sort", filters.sort);
+    if (filters?.limit != null) params.set("limit", String(filters.limit));
+    if (filters?.offset != null) params.set("offset", String(filters.offset));
+    const qs = params.toString();
+    return get<FindingsResponse>(`/v1/findings${qs ? `?${qs}` : ""}`);
   },
 
   // ── Shield / Break-Glass ──

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -19,7 +19,8 @@ const BUDGETS = {
   // Includes the cross-domain overview landing page entrypoint and API client contract.
   // Includes the self-service cloud-connections page + Add Cloud Account wizard.
   // Includes the repo folder/file structure graph layer icons and code-layer filters.
-  totalClientJsBytes: 3_065_000,
+  // Includes the cloud-connection scan schedule controls on the connections page.
+  totalClientJsBytes: 3_075_000,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };


### PR DESCRIPTION
## Summary
- add unified `finding_summary` counts to JSON output so cloud-only scans do not look clean just because package CVE counts are zero
- allow `/v1/findings` to filter by `scan_id`
- make `/vulns?scan=...` prefer normalized findings before falling back to graph/package parsing, so CIS_FAIL/cloud posture rows are visible from the scan handoff

## Validation
- `uv run pytest tests/test_cloud_cis_convergence.py tests/test_cloud_connections.py -q`
- `uv run ruff check src/agent_bom/api/routes/scan.py src/agent_bom/output/json_fmt.py tests/test_cloud_cis_convergence.py`
- `npm run typecheck`
- `npm run lint -- app/vulns/page.tsx lib/api.ts lib/api-types.ts`
- `npm run test:run -- vulnerabilities.test.ts scan-result-cloud-evidence.test.tsx`

Follows #3250 and continues #3192 / #3247 by making connection scans hand off to actual evidence surfaces.