### PR TITLE
fix(graph): preserve cloud provider for CIS evidence

### DIFF
--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -601,8 +601,8 @@ def build_unified_graph_from_report(
             )
 
     # ── CIS benchmark misconfigurations ──────────────────────────────
-    for section_key, legacy_key, cloud_provider in (
-        ("cis_benchmark", "cis_benchmark_data", ""),
+    for section_key, legacy_key, default_cloud_provider in (
+        ("cis_benchmark", "cis_benchmark_data", "aws"),
         ("snowflake_cis_benchmark", "snowflake_cis_benchmark_data", "snowflake"),
         ("azure_cis_benchmark", "azure_cis_benchmark_data", "azure"),
         ("gcp_cis_benchmark", "gcp_cis_benchmark_data", "gcp"),
@@ -611,8 +611,18 @@ def build_unified_graph_from_report(
         cis_data = report_json.get(section_key) or report_json.get(legacy_key)
         if not cis_data:
             continue
+        cloud_provider = (
+            _clean_graph_part(cis_data.get("provider"))
+            or _clean_graph_part(cis_data.get("cloud_provider"))
+            or default_cloud_provider
+        )
         checks = cis_data.get("checks", [])
-        cloud_account_id = _clean_graph_part(cis_data.get("subscription_id") or cis_data.get("account_id"))
+        cloud_account_id = _clean_graph_part(
+            cis_data.get("subscription_id")
+            or cis_data.get("account_id")
+            or cis_data.get("aws_account_id")
+            or cis_data.get("project_id")
+        )
         for check in checks:
             if str(check.get("status", "")).upper() != "FAIL":
                 continue

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -757,7 +757,29 @@ class TestCISMisconfigNodes:
         resources = g.nodes_by_type(EntityType.CLOUD_RESOURCE)
         assert len(resources) == 1
         assert resources[0].label == "bucket/prod-secrets"
-        assert g.has_edge("misconfig:cis_benchmark:1.1", "cloud_resource:generic:bucket/prod-secrets")
+        assert resources[0].attributes["cloud_provider"] == "aws"
+        assert g.has_edge("misconfig:cis_benchmark:1.1", "cloud_resource:aws:bucket/prod-secrets")
+        assert not g.get_node("cloud_resource:generic:bucket/prod-secrets")
+
+    def test_cis_failures_anchor_account_scope_to_provider(self):
+        report = _minimal_report()
+        report["cis_benchmark"] = {
+            "account_id": "123456789012",
+            "checks": [
+                {
+                    "check_id": "1.3",
+                    "title": "Ensure account contact is current",
+                    "status": "FAIL",
+                    "severity": "medium",
+                }
+            ],
+        }
+        g = build_unified_graph_from_report(report)
+
+        assert g.has_edge("misconfig:cis_benchmark:1.3", "account:aws:123456789012")
+        account = g.get_node("account:aws:123456789012")
+        assert account is not None
+        assert account.attributes["cloud_provider"] == "aws"
 
 
 class TestSASTNodes:


### PR DESCRIPTION
## Why
Legacy cloud CIS evidence used the generic graph provider for resource-scoped findings, so AWS CIS failures appeared as cloud_resource:generic instead of AWS resources. That breaks provider filtering, roll-up, and graph drill-down credibility.

## What
- Default the legacy cis_benchmark section to AWS while still honoring explicit provider/cloud_provider metadata.
- Include aws_account_id/project_id in account-scope anchoring fallback.
- Add regressions proving resource and account-scoped CIS failures no longer create generic nodes.

## Tests
- uv run pytest tests/test_graph_builder.py::TestCISMisconfigNodes -q
- uv run pytest tests/test_graph_builder.py tests/test_cloud_misconfig_graph_anchor.py tests/test_cloud_cis_convergence.py -q
- uv run ruff check src/agent_bom/graph/builder.py tests/test_graph_builder.py
- uv run mypy src/agent_bom/graph/builder.py