### PR TITLE
fix(ui): wire cloud connection scan schedules

### DIFF
--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -205,10 +205,24 @@ const SCANNABLE_PROVIDERS = new Set(
   PROVIDER_OPTIONS.map((option) => option.value),
 );
 
+const SCHEDULE_OPTIONS = [
+  { label: "Manual", value: "" },
+  { label: "Hourly", value: "60" },
+  { label: "Every 6 hours", value: "360" },
+  { label: "Daily", value: "1440" },
+];
+
 function formatWhen(value: string | null): string {
   if (!value) return "Never";
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function formatSchedule(minutes: number | null): string {
+  if (!minutes) return "Manual";
+  if (minutes % 1440 === 0) return `Every ${minutes / 1440}d`;
+  if (minutes % 60 === 0) return `Every ${minutes / 60}h`;
+  return `Every ${minutes}m`;
 }
 
 function statusTone(status: string): string {
@@ -273,6 +287,10 @@ export default function ConnectionsPage() {
     Record<string, CloudConnectionScanResponse>
   >({});
   const [scanErrors, setScanErrors] = useState<Record<string, string>>({});
+  const [scheduleBusyId, setScheduleBusyId] = useState<string | null>(null);
+  const [scheduleErrors, setScheduleErrors] = useState<Record<string, string>>(
+    {},
+  );
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -344,6 +362,38 @@ export default function ConnectionsPage() {
       );
     } finally {
       setBusyId(null);
+    }
+  }
+
+  async function handleScheduleChange(
+    connection: CloudConnectionRecord,
+    value: string,
+  ) {
+    const scanIntervalMinutes = value === "" ? null : Number(value);
+    setScheduleBusyId(connection.id);
+    setScheduleErrors((prev) => {
+      const next = { ...prev };
+      delete next[connection.id];
+      return next;
+    });
+    try {
+      const updated = await api.updateCloudConnection(connection.id, {
+        scan_interval_minutes: scanIntervalMinutes,
+      });
+      setConnections((prev) =>
+        prev.map((item) => (item.id === updated.id ? updated : item)),
+      );
+      setMessage(
+        `${updated.display_name} scan schedule set to ${formatSchedule(
+          updated.scan_interval_minutes,
+        )}.`,
+      );
+    } catch (err) {
+      const detail =
+        err instanceof Error ? err.message : "Failed to update schedule.";
+      setScheduleErrors((prev) => ({ ...prev, [connection.id]: detail }));
+    } finally {
+      setScheduleBusyId(null);
     }
   }
 
@@ -464,6 +514,7 @@ export default function ConnectionsPage() {
                     <th className="px-4 py-3 font-medium">Provider</th>
                     <th className="px-4 py-3 font-medium">Status</th>
                     <th className="px-4 py-3 font-medium">Last scan</th>
+                    <th className="px-4 py-3 font-medium">Schedule</th>
                     <th className="px-4 py-3 text-right font-medium">
                       Actions
                     </th>
@@ -486,12 +537,17 @@ export default function ConnectionsPage() {
                         scannable={scannable}
                         result={result}
                         scanError={scanError}
+                        scheduleBusy={scheduleBusyId === connection.id}
+                        scheduleError={scheduleErrors[connection.id]}
                         statusDetail={
                           connection.status === "error"
                             ? connection.status_detail
                             : ""
                         }
                         onScan={() => void handleScan(connection)}
+                        onScheduleChange={(value) =>
+                          void handleScheduleChange(connection, value)
+                        }
                         onDelete={() => void handleDelete(connection)}
                       />
                     );
@@ -522,8 +578,11 @@ function FragmentRow({
   scannable,
   result,
   scanError,
+  scheduleBusy,
+  scheduleError,
   statusDetail,
   onScan,
+  onScheduleChange,
   onDelete,
 }: {
   connection: CloudConnectionRecord;
@@ -532,11 +591,14 @@ function FragmentRow({
   scannable: boolean;
   result: CloudConnectionScanResponse | undefined;
   scanError: string | undefined;
+  scheduleBusy: boolean;
+  scheduleError: string | undefined;
   statusDetail: string;
   onScan: () => void;
+  onScheduleChange: (value: string) => void;
   onDelete: () => void;
 }) {
-  const showDetail = Boolean(result || scanError || statusDetail);
+  const showDetail = Boolean(result || scanError || scheduleError || statusDetail);
   return (
     <>
       <tr className="border-b border-[color:var(--border-subtle)] last:border-b-0 align-top">
@@ -578,6 +640,29 @@ function FragmentRow({
           {formatWhen(connection.last_scan_at)}
         </td>
         <td className="px-4 py-3">
+          <label className="sr-only" htmlFor={`schedule-${connection.id}`}>
+            Recurring scan schedule for {connection.display_name}
+          </label>
+          <select
+            id={`schedule-${connection.id}`}
+            value={connection.scan_interval_minutes?.toString() ?? ""}
+            disabled={scheduleBusy || !canManage}
+            onChange={(event) => onScheduleChange(event.target.value)}
+            className="w-36 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1.5 text-xs text-[var(--foreground)] outline-none transition focus:border-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {SCHEDULE_OPTIONS.map((option) => (
+              <option key={option.label} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <p className="mt-1 text-[10px] text-[var(--text-tertiary)]">
+            {scheduleBusy
+              ? "Saving…"
+              : `Runs ${formatSchedule(connection.scan_interval_minutes).toLowerCase()}`}
+          </p>
+        </td>
+        <td className="px-4 py-3">
           <div className="flex justify-end gap-2">
             <button
               onClick={onScan}
@@ -606,14 +691,19 @@ function FragmentRow({
       </tr>
       {showDetail ? (
         <tr className="border-b border-[color:var(--border-subtle)] last:border-b-0 bg-[color:var(--surface-elevated)]/40">
-          <td colSpan={5} className="px-4 pb-4 pt-0">
+          <td colSpan={6} className="px-4 pb-4 pt-0">
             {result ? <ScanResultPanel result={result} /> : null}
             {!result && scanError ? (
               <div className="rounded-xl border border-red-900/60 bg-red-950/20 p-3 text-xs text-red-300">
                 {scanError}
               </div>
             ) : null}
-            {!result && !scanError && statusDetail ? (
+            {!result && !scanError && scheduleError ? (
+              <div className="rounded-xl border border-red-900/60 bg-red-950/20 p-3 text-xs text-red-300">
+                {scheduleError}
+              </div>
+            ) : null}
+            {!result && !scanError && !scheduleError && statusDetail ? (
               <div className="rounded-xl border border-amber-900/60 bg-amber-950/20 p-3 text-xs text-amber-200">
                 {statusDetail}
               </div>

--- a/ui/e2e/connections-screenshot.spec.ts
+++ b/ui/e2e/connections-screenshot.spec.ts
@@ -16,6 +16,7 @@ const CONNECTION = {
   created_at: "2026-06-27T00:00:00Z",
   updated_at: "2026-06-27T01:00:00Z",
   last_scan_at: "2026-06-27T01:00:00Z",
+  scan_interval_minutes: 60,
 };
 
 const PENDING = {
@@ -25,6 +26,7 @@ const PENDING = {
   status: "pending",
   last_scan_at: null,
   regions: ["eu-west-1"],
+  scan_interval_minutes: null,
 };
 
 async function routeConnections(page: Page) {

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2568,6 +2568,8 @@ export interface CloudConnectionRecord {
   created_at: string;
   updated_at: string;
   last_scan_at: string | null;
+  /** Recurring read-only scan cadence. Null means manual-only. */
+  scan_interval_minutes: number | null;
   /** Non-secret provider-specific params (Azure tenant/subscription, GCP project, Snowflake user/role/warehouse). */
   auth_params?: Record<string, string>;
 }
@@ -2588,6 +2590,13 @@ export interface CloudConnectionCreateRequest {
   regions: string[];
   /** Non-secret provider-specific params. Never carries a secret (that is `external_id`). */
   auth_params?: Record<string, string>;
+  /** Optional recurring read-only scan cadence. Null/default means manual-only. */
+  scan_interval_minutes?: number | null;
+}
+
+export interface CloudConnectionUpdateRequest {
+  /** Recurring read-only scan cadence. Null disables scheduling. */
+  scan_interval_minutes: number | null;
 }
 
 export interface CloudConnectionScanInventory {

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -103,6 +103,7 @@ import type {
   CloudConnectionRecord,
   CloudConnectionsResponse,
   CloudConnectionCreateRequest,
+  CloudConnectionUpdateRequest,
   CloudConnectionScanResponse
 } from "./api-types";
 export type {
@@ -286,6 +287,7 @@ export type {
   CloudConnectionRecord,
   CloudConnectionsResponse,
   CloudConnectionCreateRequest,
+  CloudConnectionUpdateRequest,
   CloudConnectionScanInventory,
   CloudConnectionScanCis,
   CloudConnectionScanResponse,
@@ -413,6 +415,18 @@ async function put<T>(path: string, body: unknown): Promise<T> {
     body: JSON.stringify(body),
     signal: withTimeout(),
   }, "PUT");
+  _runInvalidations(path);
+  return res.json() as Promise<T>;
+}
+
+async function patch<T>(path: string, body: unknown): Promise<T> {
+  const res = await _doFetch(path, {
+    method: "PATCH",
+    credentials: "include",
+    headers: { "Content-Type": "application/json", ...getSessionAuthHeaders() },
+    body: JSON.stringify(body),
+    signal: withTimeout(),
+  }, "PATCH");
   _runInvalidations(path);
   return res.json() as Promise<T>;
 }
@@ -985,6 +999,9 @@ export const api = {
    */
   createCloudConnection: (body: CloudConnectionCreateRequest) =>
     post<CloudConnectionRecord>("/v1/cloud/connections", body),
+  /** Update non-secret connection controls such as recurring scan cadence. */
+  updateCloudConnection: (id: string, body: CloudConnectionUpdateRequest) =>
+    patch<CloudConnectionRecord>(`/v1/cloud/connections/${encodeURIComponent(id)}`, body),
   /** Delete a connection owned by this tenant. */
   deleteCloudConnection: (id: string) => del(`/v1/cloud/connections/${encodeURIComponent(id)}`),
   /** Launch a read-only scan via the credential broker (AWS today). */

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -8,6 +8,7 @@ const { apiMock } = vi.hoisted(() => ({
     listCloudConnections: vi.fn(),
     getCloudConnection: vi.fn(),
     createCloudConnection: vi.fn(),
+    updateCloudConnection: vi.fn(),
     deleteCloudConnection: vi.fn(),
     scanCloudConnection: vi.fn(),
   },
@@ -56,6 +57,7 @@ const CREATED_RECORD = {
   created_at: "2026-06-27T00:00:00Z",
   updated_at: "2026-06-27T00:00:00Z",
   last_scan_at: null,
+  scan_interval_minutes: null,
 };
 
 beforeEach(() => {
@@ -272,6 +274,41 @@ describe("ConnectionsPage", () => {
       "href",
       "/graph?scan_id=abcdef12-3456-7890-abcd-ef1234567890",
     );
+  });
+
+  it("updates the recurring scan schedule without exposing secrets", async () => {
+    apiMock.listCloudConnections.mockResolvedValue({
+      schema_version: "cloud.connections.v1",
+      tenant_id: "tenant-acme",
+      connections: [CREATED_RECORD],
+      count: 1,
+    });
+    apiMock.updateCloudConnection.mockResolvedValue({
+      ...CREATED_RECORD,
+      scan_interval_minutes: 60,
+      updated_at: "2026-06-27T02:00:00Z",
+    });
+
+    render(<ConnectionsPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Production account")).toBeInTheDocument(),
+    );
+
+    fireEvent.change(
+      screen.getByLabelText(
+        "Recurring scan schedule for Production account",
+      ),
+      { target: { value: "60" } },
+    );
+
+    await waitFor(() =>
+      expect(apiMock.updateCloudConnection).toHaveBeenCalledWith("conn-1", {
+        scan_interval_minutes: 60,
+      }),
+    );
+    await waitFor(() => expect(screen.getByText("Runs every 1h")).toBeInTheDocument());
+    expect(document.body.textContent).not.toContain(SECRET);
   });
 
   it("deletes a connection through the API", async () => {


### PR DESCRIPTION
## Why
Cloud connections already support scan_interval_minutes in the backend, but the UI/API client did not model or update it. That made recurring read-only cloud scans an API-only feature and created another hidden-state gap in the hosted demo workflow.

## What
- Add typed CloudConnectionUpdateRequest and scan_interval_minutes to CloudConnectionRecord/CreateRequest.
- Add PATCH support to the UI API client and expose updateCloudConnection.
- Render a compact schedule selector on the Connections table: manual, hourly, every 6 hours, daily.
- Show save errors inline and keep external IDs/secrets out of the DOM.

## Tests
- npm run typecheck
- npm run lint -- app/connections/page.tsx lib/api.ts lib/api-types.ts tests/connections-page.test.tsx e2e/connections-screenshot.spec.ts
- npm run test:run -- connections-page.test.tsx