### PR TITLE
docs(deploy): add hosted POC Caddy front door

### DIFF
--- a/deploy/caddy/Caddyfile.hosted-poc
+++ b/deploy/caddy/Caddyfile.hosted-poc
@@ -1,0 +1,21 @@
+{
+	email {$ACME_EMAIL}
+}
+
+{$AGENT_BOM_HOSTED_DOMAIN:demo.agent-bom.com} {
+	encode zstd gzip
+
+	header {
+		Strict-Transport-Security "max-age=15552000"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		Permissions-Policy "camera=(), microphone=(), geolocation=()"
+		-X-Powered-By
+	}
+
+	@api path /v1/* /health /version /openapi.json
+	reverse_proxy @api 127.0.0.1:8422
+
+	reverse_proxy 127.0.0.1:3000
+}


### PR DESCRIPTION
## Why
The hosted POC runbook now describes the AWS VM + Cloudflare + Caddy path, but the repo should also carry the reusable Caddy profile operators can deploy directly for demo.agent-bom.com or app.agent-bom.com.

## What
- Add deploy/caddy/Caddyfile.hosted-poc.
- Route API paths to the FastAPI service and all other traffic to the UI.
- Enable compression and baseline browser security headers.

## Validation
- docker run --rm -e ACME_EMAIL=security@example.com -e AGENT_BOM_HOSTED_DOMAIN=demo.agent-bom.com -v "/Users/mohamedsaad/repos/Agent-Bom/deploy/caddy/Caddyfile.hosted-poc:/etc/caddy/Caddyfile:ro" caddy:2 caddy validate --config /etc/caddy/Caddyfile