### PR TITLE
fix(ui): restore client JS budget headroom after #3254 merge

### DIFF
--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -19,7 +19,8 @@ const BUDGETS = {
   // Includes the cross-domain overview landing page entrypoint and API client contract.
   // Includes the self-service cloud-connections page + Add Cloud Account wizard.
   // Includes the repo folder/file structure graph layer icons and code-layer filters.
-  totalClientJsBytes: 3_065_000,
+  // Includes the cloud-connection scan schedule controls on the connections page.
+  totalClientJsBytes: 3_075_000,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };


### PR DESCRIPTION
PR #3254 (`fix(ui): wire cloud connection scan schedules`) merged ~425 B of additional client JS without bumping the checked-in UI bundle budget. As a result `totalClientJsBytes` (3,065,000) is now exceeded on main (actual 3,065,425), which fails the **UI bundle budget** step of UI Validate for every PR built off main.

This raises `totalClientJsBytes` to 3,075,000 with a documenting comment, matching the existing convention. Verified locally: total client JS 2993.6 KiB / budget 3002.9 KiB — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)