### PR TITLE
chore(deps): consolidate low-risk dependency updates

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -69,7 +69,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/agent-bom
           subject-digest: ${{ steps.build-stdio.outputs.digest }}
@@ -135,7 +135,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/agent-bom-sse
           subject-digest: ${{ steps.build-sse.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,7 +387,7 @@ jobs:
         run: cosign sign --yes "agentbom/agent-bom@${{ steps.build-api-image.outputs.digest }}"
 
       - name: Attest API image provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: index.docker.io/agentbom/agent-bom
           subject-digest: ${{ steps.build-api-image.outputs.digest }}
@@ -581,7 +581,7 @@ jobs:
         run: cosign sign --yes "agentbom/agent-bom-ui@${{ steps.build-ui-image.outputs.digest }}"
 
       - name: Attest UI image provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-name: index.docker.io/agentbom/agent-bom-ui
           subject-digest: ${{ steps.build-ui-image.outputs.digest }}
@@ -678,7 +678,7 @@ jobs:
         run: helm push "dist/helm/agent-bom-${{ steps.meta.outputs.version }}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"
 
       - name: Attest Helm chart package
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/helm/agent-bom-${{ steps.meta.outputs.version }}.tgz
 
@@ -962,7 +962,7 @@ jobs:
           path: dist/
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
           subject-path: dist/*
 

--- a/action.yml
+++ b/action.yml
@@ -187,7 +187,7 @@ runs:
         cache: pip
 
     - name: Cache agent-bom vulnerability database
-      uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6.0.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.agent-bom/vulns.db
         key: agent-bom-vulndb-${{ runner.os }}-${{ inputs.python-version }}-v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "jsonschema>=4.0",
     # Transitive dep pins — fix known CVEs flagged by OpenSSF/OSV
     "jinja2>=3.1.6",  # GHSA-cpwx-vrp4-4pq7, GHSA-gmj6-6f8f-6699 (sandbox breakout)
-    "werkzeug>=3.1.6",  # GHSA-29vq-49wr-vm6x, GHSA-2g68-c3qc-8985, GHSA-87hc-h4r5-73f7, GHSA-f9vj-2wh5-fj8j, GHSA-hgf8-39gv-g3f2, GHSA-hrfv-mqp8-q5rw, GHSA-px8h-6qxv-m22q, GHSA-q34m-jh98-gwm2, GHSA-xg9f-g7g7-2323
+    "werkzeug>=3.1.8",  # GHSA-29vq-49wr-vm6x, GHSA-2g68-c3qc-8985, GHSA-87hc-h4r5-73f7, GHSA-f9vj-2wh5-fj8j, GHSA-hgf8-39gv-g3f2, GHSA-hrfv-mqp8-q5rw, GHSA-px8h-6qxv-m22q, GHSA-q34m-jh98-gwm2, GHSA-xg9f-g7g7-2323
     "flask>=3.1.3",  # GHSA-68rp-wp8r-4726, GHSA-m2qf-hxjv-5gpq (Vary: Cookie session exposure; transitive via mlflow)
     "requests>=2.33.0",  # GHSA-9hjg-9r4m-mvj7, GHSA-j8r2-6x86-q33q (session cookie leak)
     # NOTE: nltk pin removed — safety (which pulled nltk) was replaced by pip-audit.
@@ -100,7 +100,7 @@ azure = [
     "azure-mgmt-redis>=14.3",
     "azure-mgmt-frontdoor>=1.1",
     "azure-mgmt-apimanagement>=4.0",
-    "six>=1.16",
+    "six>=1.17.0",
 ]
 gcp = [
     "google-cloud-aiplatform>=1.38",
@@ -201,10 +201,10 @@ dev = [
     "mypy>=1.0",
     "types-PyYAML>=6.0",
     "types-requests>=2.31",
-    "types-toml>=0.10",
+    "types-toml>=0.10.8.20260518",
     "bandit>=1.9",      # Static security analysis
     "pytest-cov>=4.1",  # Coverage reporting
-    "pytest-benchmark>=5.0",  # Performance benchmarking — see docs/PERFORMANCE_BENCHMARKS.md
+    "pytest-benchmark>=5.2.3",  # Performance benchmarking — see docs/PERFORMANCE_BENCHMARKS.md
     "pytest-xdist>=3.5",  # Parallel test execution (-n auto) — cuts CI test wall time
     "pytest-randomly>=3.15",  # Randomize test order to surface order-dependence early
 ]

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,10 +10,10 @@
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@tanstack/react-table": "^8.21.3",
-        "@tanstack/react-virtual": "^3.14.3",
+        "@tanstack/react-virtual": "^3.14.4",
         "@xyflow/react": "^12.11.1",
         "graphology": "^0.26.0",
-        "lucide-react": "^1.21.0",
+        "lucide-react": "^1.22.0",
         "next": "^16.2.9",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -2247,12 +2247,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.14.3",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.3.tgz",
-      "integrity": "sha512-k/cnHPVaOfn46hSbiY6n4Dzf4QjCGWSF40zR5QIIYUqPAjpA6TN7InfYmcMiDVQGP2iUn9xsRbAl8u1v3UmeVQ==",
+      "version": "3.14.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.4.tgz",
+      "integrity": "sha512-dZzAQP2uCDAd+9sAehqmx/DcU+B91Q4Gb0aDSM7t9bJvWDyGF9sapFNW5r1gNLsHs4wTb6ScZENJeYaHxJLiOw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.17.1"
+        "@tanstack/virtual-core": "3.17.2"
       },
       "funding": {
         "type": "github",
@@ -2277,9 +2277,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.1.tgz",
-      "integrity": "sha512-VZyW2Uiml5tmBZwPGrSD3Sz73OxzljQMCmzYHsUTPEuTsERf5xwa+uWb01xEzkz3ZSYTjj8NEb/mKHvgKxyZdA==",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.2.tgz",
+      "integrity": "sha512-w43MvWvmShpb6kIC9MOoLyUkLmRTLPjt61bHWs+X29hACSpX+n8DvgZ3qM7cUfflKlRRcHR9KVJE6TmcqnQvcA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -6601,9 +6601,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
-      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.22.0.tgz",
+      "integrity": "sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,10 +27,10 @@
   "dependencies": {
     "@dagrejs/dagre": "^3.0.0",
     "@tanstack/react-table": "^8.21.3",
-    "@tanstack/react-virtual": "^3.14.3",
+    "@tanstack/react-virtual": "^3.14.4",
     "@xyflow/react": "^12.11.1",
     "graphology": "^0.26.0",
-    "lucide-react": "^1.21.0",
+    "lucide-react": "^1.22.0",
     "next": "^16.2.9",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/uv.lock
+++ b/uv.lock
@@ -466,7 +466,7 @@ requires-dist = [
     { name = "pytesseract", marker = "extra == 'visual'", specifier = ">=0.3.10" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
-    { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.0" },
+    { name = "pytest-benchmark", marker = "extra == 'dev'", specifier = ">=5.2.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1" },
     { name = "pytest-randomly", marker = "extra == 'dev'", specifier = ">=3.15" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
@@ -477,7 +477,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.4" },
     { name = "scipy", marker = "extra == 'graph'", specifier = ">=1.13" },
-    { name = "six", marker = "extra == 'azure'", specifier = ">=1.16" },
+    { name = "six", marker = "extra == 'azure'", specifier = ">=1.17.0" },
     { name = "smithery", marker = "extra == 'mcp-server'", specifier = ">=0.4" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.6" },
     { name = "sse-starlette", marker = "extra == 'api'", specifier = ">=2.1" },
@@ -486,11 +486,11 @@ requires-dist = [
     { name = "tornado", specifier = ">=6.5.5" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.31" },
-    { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10" },
+    { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.8.20260518" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'api'", specifier = ">=0.32" },
     { name = "wandb", marker = "extra == 'wandb'", specifier = ">=0.16" },
     { name = "watchdog", marker = "extra == 'watch'", specifier = ">=4.0" },
-    { name = "werkzeug", specifier = ">=3.1.6" },
+    { name = "werkzeug", specifier = ">=3.1.8" },
 ]
 provides-extras = ["api", "otel", "ui", "aws", "azure", "gcp", "coreweave", "databricks", "snowflake", "nebius", "huggingface", "wandb", "openai", "ai-enrich", "graph", "pdf", "postgres", "watch", "runtime", "visual", "mcp-server", "dashboard", "snyk", "interactive", "oidc", "saml", "cloud", "all", "docs", "dev", "dev-all"]
 


### PR DESCRIPTION
Consolidates **9 low-risk** bot/dependabot PRs into one batch so they can land together. Major-version bumps are in #3278.

| PR | Update |
|----|--------|
| #3265 | werkzeug `>=3.1.6` → `>=3.1.8` (security floor) |
| #3273 | six `>=1.16` → `>=1.17.0` |
| #3272 | types-toml `>=0.10` → `>=0.10.8.20260518` |
| #3269 | pytest-benchmark `>=5.0` → `>=5.2.3` |
| #3264 | lucide-react `^1.21.0` → `^1.22.0` |
| #3262 | @tanstack/react-virtual `^3.14.3` → `^3.14.4` |
| #3259 | actions/cache `v6.0.0` → `v6.1.0` |
| #3261 | actions/attest-build-provenance `v4.1.0` → `v4.1.1` |
| #3274 | weekly uv.lock refresh |

**Excluded — MCP registry sync (#3275):** 3-way applying its data over current main desynced the `_total_servers` header (862) from the actual entry count (880) and disturbed the openclaw CVE set, failing registry-consistency tests. It's auto-generated data, not a dependency, so it stays as its own bot PR.

**Validation:** `uv lock` resolves cleanly (only the 4 constraint specifiers change; resolved versions unchanged). UI lockfile picks up the matching `@tanstack/virtual-core` transitive only. `npm run lint` passes. No source changes.

Supersedes #3259, #3261, #3262, #3264, #3265, #3269, #3272, #3273, #3274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)