### PR TITLE
fix(auth): use central RBAC role ranking

### DIFF
--- a/src/agent_bom/api/auth.py
+++ b/src/agent_bom/api/auth.py
@@ -15,14 +15,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Protocol
 
-from agent_bom.rbac import Role
-
-# Role hierarchy: admin > analyst > viewer
-_ROLE_HIERARCHY: dict[Role, int] = {
-    Role.ADMIN: 3,
-    Role.ANALYST: 2,
-    Role.VIEWER: 1,
-}
+from agent_bom.rbac import Role, role_rank
 
 
 @dataclass
@@ -93,7 +86,7 @@ class ApiKey:
 
     def has_role(self, required: Role) -> bool:
         """Check if this key's role meets or exceeds the required role."""
-        return _ROLE_HIERARCHY.get(self.role, 0) >= _ROLE_HIERARCHY.get(required, 0)
+        return role_rank(self.role) >= role_rank(required)
 
     def has_scope(self, required_scope: str | None) -> bool:
         """Check whether this key's scopes allow the requested action."""
@@ -179,7 +172,7 @@ def _highest_role(values: list[str]) -> Role | None:
             candidate = Role(str(value).strip().lower())
         except ValueError:
             continue
-        if best is None or _ROLE_HIERARCHY[candidate] > _ROLE_HIERARCHY[best]:
+        if best is None or role_rank(candidate) > role_rank(best):
             best = candidate
     return best
 
@@ -229,7 +222,7 @@ def resolve_scim_user_role(tenant_id: str, *subjects: object) -> SCIMRoleResolut
         role = _highest_role(user.roles)
         if role is None:
             role = Role.VIEWER
-        if best_role is None or _ROLE_HIERARCHY[role] > _ROLE_HIERARCHY[best_role]:
+        if best_role is None or role_rank(role) > role_rank(best_role):
             best_role = role
             best_user = user
 

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -980,9 +980,9 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
 
     @staticmethod
     def _role_allows(actual: Role, required: Role) -> bool:
-        from agent_bom.api.auth import _ROLE_HIERARCHY
+        from agent_bom.rbac import role_rank
 
-        return _ROLE_HIERARCHY.get(actual, 0) >= _ROLE_HIERARCHY.get(required, 0)
+        return role_rank(actual) >= role_rank(required)
 
     @staticmethod
     def _record_scim_role_state(request: StarletteRequest, *, user_id: str | None, user_name: str | None) -> None:

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -732,14 +732,14 @@ class _WebSocketAuthContext:
 
 
 def _role_allows(actual: str, required: str = "viewer") -> bool:
-    from agent_bom.api.auth import _ROLE_HIERARCHY, Role
+    from agent_bom.rbac import Role, role_rank
 
     try:
         actual_role = Role(str(actual).strip().lower())
         required_role = Role(required)
     except ValueError:
         return False
-    return _ROLE_HIERARCHY.get(actual_role, 0) >= _ROLE_HIERARCHY.get(required_role, 0)
+    return role_rank(actual_role) >= role_rank(required_role)
 
 
 def _ws_auth_required() -> bool:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -25,6 +25,13 @@ from agent_bom.api.auth import (
 
 
 class TestRoleHierarchy:
+    def test_api_auth_uses_central_role_rank(self):
+        from agent_bom.api import auth as auth_module
+        from agent_bom.rbac import role_rank as central_role_rank
+
+        assert auth_module.role_rank is central_role_rank
+        assert not hasattr(auth_module, "_ROLE_HIERARCHY")
+
     def test_admin_has_all_roles(self):
         _, key = create_api_key("admin", Role.ADMIN)
         assert key.has_role(Role.ADMIN)


### PR DESCRIPTION
## Summary
- removes the duplicate API-auth role hierarchy
- reuses the central RBAC role_rank helper for API-key role checks and SCIM role selection
- adds a regression guard so API auth cannot silently reintroduce a private role hierarchy

## Validation
- uv run pytest tests/test_auth.py
- uv run ruff check src/agent_bom/api/auth.py tests/test_auth.py
- uv run mypy src/agent_bom/api/auth.py --ignore-missing-imports --disable-error-code import-untyped

Part of #3242.