### PR TITLE
fix(severity): centralize ranking across outputs

### DIFF
--- a/src/agent_bom/cli/_common.py
+++ b/src/agent_bom/cli/_common.py
@@ -13,6 +13,7 @@ import click
 from rich.console import Console
 
 from agent_bom import __version__
+from agent_bom.graph.severity import SEVERITY_POLICY_ORDER
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.security import sanitize_env_vars, sanitize_sensitive_payload
 
@@ -27,7 +28,7 @@ BANNER = r"""
   Security scanner for AI infrastructure
 """
 
-SEVERITY_ORDER = {"critical": 4, "high": 3, "medium": 2, "low": 1, "none": 0, "unknown": -1}
+SEVERITY_ORDER = {label.lower(): rank for label, rank in SEVERITY_POLICY_ORDER.items()}
 PORT_RANGE = click.IntRange(1, 65535)
 LISTEN_PORT_RANGE = click.IntRange(1024, 65535)
 OPTIONAL_PORT_RANGE = click.IntRange(0, 65535)

--- a/src/agent_bom/cloud/registry_sweep.py
+++ b/src/agent_bom/cloud/registry_sweep.py
@@ -42,6 +42,7 @@ from datetime import datetime, timezone
 from typing import Any, Callable, Optional
 
 from agent_bom.cloud.normalization import sanitize_discovery_warning
+from agent_bom.graph.severity import severity_rank
 
 logger = logging.getLogger(__name__)
 
@@ -520,7 +521,6 @@ def _summarize_packages(packages: list[Any]) -> tuple[int, int, str]:
     pkg_count = len(packages)
     vuln_pkgs = 0
     max_sev = "none"
-    severity_rank = {"critical": 5, "high": 4, "medium": 3, "low": 2, "unknown": 1, "none": 0}
     best = 0
     for pkg in packages:
         vulns = getattr(pkg, "vulnerabilities", None) or []
@@ -529,7 +529,7 @@ def _summarize_packages(packages: list[Any]) -> tuple[int, int, str]:
         sev_obj = getattr(pkg, "max_severity", None)
         sev = sev_obj() if callable(sev_obj) else None
         sev_value = getattr(sev, "value", None) if sev is not None else None
-        rank = severity_rank.get(str(sev_value).lower(), 0) if sev_value else 0
+        rank = severity_rank(str(sev_value)) if sev_value else 0
         if rank > best:
             best = rank
             max_sev = str(sev_value).lower()

--- a/src/agent_bom/graph/aspm_overlay.py
+++ b/src/agent_bom/graph/aspm_overlay.py
@@ -42,14 +42,14 @@ from typing import Any
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import NodeDimensions, UnifiedNode
-from agent_bom.graph.severity import SEVERITY_RANK, SEVERITY_RISK_SCORE
+from agent_bom.graph.severity import SEVERITY_BUCKETS_ASPM, SEVERITY_RANK, SEVERITY_RISK_SCORE
 from agent_bom.graph.types import EntityType, GraphSemanticLayer, RelationshipType
 
 _OVERLAY_SOURCE = "aspm-overlay"
 
 # Severity buckets we roll up per application, worst-first for deterministic
 # ordering of the rolled-up counts attribute.
-_SEVERITY_ORDER = ("critical", "high", "medium", "low", "info", "unknown")
+_SEVERITY_ORDER = SEVERITY_BUCKETS_ASPM
 
 # Reachability verdicts a finding can carry after correlation. ``unknown`` is the
 # honest default when no attack-path / exposure signal exists for the component —

--- a/src/agent_bom/graph/rollup.py
+++ b/src/agent_bom/graph/rollup.py
@@ -24,11 +24,11 @@ from typing import Any, Optional
 
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.node import UnifiedNode
-from agent_bom.graph.severity import OCSF_SEVERITY_NAMES, SEVERITY_RANK
+from agent_bom.graph.severity import OCSF_SEVERITY_NAMES, SEVERITY_BUCKETS_WORST_FIRST, SEVERITY_RANK
 from agent_bom.graph.types import EntityType, RelationshipType
 
 # Severity buckets reported in every roll-up histogram, worst → least.
-_SEVERITY_ORDER: tuple[str, ...] = ("critical", "high", "medium", "low", "info", "none")
+_SEVERITY_ORDER: tuple[str, ...] = SEVERITY_BUCKETS_WORST_FIRST
 
 # Container entity types form the readable top-level scaffold of the estate.
 # A node of one of these types is a candidate roll-up container; everything else

--- a/src/agent_bom/graph/severity.py
+++ b/src/agent_bom/graph/severity.py
@@ -68,6 +68,10 @@ SEVERITY_POLICY_ORDER: dict[str, int] = {
     "UNKNOWN": -1,
 }
 
+SEVERITY_THRESHOLD_LABELS: tuple[str, ...] = ("critical", "high", "medium", "low")
+SEVERITY_BUCKETS_WORST_FIRST: tuple[str, ...] = ("critical", "high", "medium", "low", "info", "none")
+SEVERITY_BUCKETS_ASPM: tuple[str, ...] = ("critical", "high", "medium", "low", "info", "unknown")
+
 # ── Risk score contribution ──────────────────────────────────────────────
 
 SEVERITY_RISK_SCORE: dict[str, float] = {

--- a/src/agent_bom/graph/toxic_findings.py
+++ b/src/agent_bom/graph/toxic_findings.py
@@ -36,15 +36,13 @@ from typing import Optional
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.severity import severity_rank
 from agent_bom.graph.types import EntityType, RelationshipType
 
 _GRAPH_SOURCE = "graph-toxic-combination"
 
 # ── Severity model ───────────────────────────────────────────────────────────
-# Local rank so the evaluator never has to import scanner severity tables; the
-# string values match the unified Finding.severity vocabulary.
-_SEVERITY_ORDER = ("info", "low", "medium", "high", "critical")
-_SEVERITY_RANK = {name: rank for rank, name in enumerate(_SEVERITY_ORDER)}
+_ESCALATION_SEVERITIES = ("info", "low", "medium", "high", "critical")
 _SEVERITY_RISK = {"info": 1.0, "low": 3.0, "medium": 5.0, "high": 7.5, "critical": 9.5}
 
 # Principal entity types that can hold (over-)permissions to data.
@@ -148,7 +146,7 @@ class ToxicRule:
 
 def _node_severity(node: UnifiedNode) -> str:
     sev = (node.severity or "").lower()
-    return sev if sev in _SEVERITY_RANK else "low"
+    return sev if sev in _ESCALATION_SEVERITIES else "low"
 
 
 def _escalate(component_severities: tuple[str, ...], floor: str) -> str:
@@ -158,10 +156,11 @@ def _escalate(component_severities: tuple[str, ...], floor: str) -> str:
     drops below its declared base tier even if its component nodes carry thin
     severity metadata.
     """
-    base_rank = max((_SEVERITY_RANK.get(s, 0) for s in component_severities), default=0)
-    escalated = min(base_rank + 1, _SEVERITY_RANK["critical"])
-    floored = max(escalated, _SEVERITY_RANK.get(floor, 0))
-    return _SEVERITY_ORDER[floored]
+    base_rank = max((severity_rank(s) for s in component_severities), default=severity_rank("info"))
+    escalated = min(base_rank + 1, severity_rank("critical"))
+    floored = max(escalated, severity_rank(floor))
+    index = max(0, min(floored - severity_rank("info"), len(_ESCALATION_SEVERITIES) - 1))
+    return _ESCALATION_SEVERITIES[index]
 
 
 def _asset_for(node: UnifiedNode) -> Asset:

--- a/src/agent_bom/output/html.py
+++ b/src/agent_bom/output/html.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from agent_bom.finding import FindingType
+from agent_bom.graph.severity import severity_policy_rank
 from agent_bom.output.exposure_path import exposure_path_brief
 from agent_bom.security import sanitize_launch_command, sanitize_path_label
 
@@ -40,7 +41,6 @@ _SEV_COLOR = {
     "none": "#16a34a",
     "unknown": "#9ca3af",
 }
-_SEV_ORDER = {"critical": 4, "high": 3, "medium": 2, "low": 1, "none": 0, "unknown": -1}
 
 # Max packages shown per server before collapsing
 _PKG_PREVIEW = 15
@@ -220,7 +220,7 @@ def _vuln_table(blast_radii: list["BlastRadius"]) -> str:
 
     sorted_brs = sorted(
         blast_radii,
-        key=lambda b: _SEV_ORDER.get(b.vulnerability.severity.value.lower(), 0),
+        key=lambda b: severity_policy_rank(b.vulnerability.severity.value),
         reverse=True,
     )
     rows = []
@@ -449,7 +449,7 @@ def _policy_findings_section(findings: list["Finding"]) -> str:
         return ""
 
     rows = []
-    for finding in sorted(findings, key=lambda f: _SEV_ORDER.get(str(f.severity).lower(), -1), reverse=True):
+    for finding in sorted(findings, key=lambda f: severity_policy_rank(str(f.severity)), reverse=True):
         sev = str(finding.severity or "unknown").lower()
         title = finding.title or finding.description or finding.finding_type.value
         asset_label = finding.asset.name or finding.asset.identifier or "unknown asset"

--- a/src/agent_bom/output/markdown.py
+++ b/src/agent_bom/output/markdown.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from agent_bom.compliance_utils import framework_qualified_blast_radius_tags
 from agent_bom.finding import Finding, FindingType
+from agent_bom.graph.severity import severity_policy_rank
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
 from agent_bom.output.exposure_path import exposure_path_brief
 
@@ -206,16 +207,12 @@ def _trust_assessment_section(report: AIBOMReport) -> list[str]:
     return lines
 
 
-_SEV_ORDER = {Severity.CRITICAL: 0, Severity.HIGH: 1, Severity.MEDIUM: 2, Severity.LOW: 3, Severity.UNKNOWN: 4, Severity.NONE: 5}
-_FINDING_SEV_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3, "unknown": 4, "none": 5}
-
-
 def _sev_order(sev: Severity) -> int:
-    return _SEV_ORDER.get(sev, 99)
+    return -severity_policy_rank(sev.value)
 
 
 def _finding_sev_order(sev: str) -> int:
-    return _FINDING_SEV_ORDER.get(sev.lower(), 99)
+    return -severity_policy_rank(sev)
 
 
 def _severity_badge(sev: Severity) -> str:

--- a/src/agent_bom/posture.py
+++ b/src/agent_bom/posture.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from agent_bom.compliance_utils import effective_blast_radius_tags
+from agent_bom.graph.severity import severity_policy_rank
 from agent_bom.scorecard import summarize_scorecard_coverage
 from agent_bom.vex import active_blast_radii
 
@@ -452,11 +453,10 @@ def compute_credential_risk_ranking(report: "AIBOMReport") -> list[dict]:
 
     # Sort: tier first, then proven (vulnerability) before discovery at the same
     # tier, then by max_risk_score descending.
-    tier_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
     basis_order = {"vulnerability": 0, "discovery": 1}
     results.sort(
         key=lambda x: (
-            tier_order.get(x["risk_tier"], 4),
+            -severity_policy_rank(str(x["risk_tier"])),
             basis_order.get(x["basis"], 9),
             -x["max_risk_score"],
         )

--- a/src/agent_bom/skills_policy.py
+++ b/src/agent_bom/skills_policy.py
@@ -11,9 +11,10 @@ from typing import Any
 
 import yaml
 
+from agent_bom.graph.severity import SEVERITY_THRESHOLD_LABELS, normalize_severity, severity_at_or_above
+
 _VERDICT_ORDER = {"benign": 0, "suspicious": 1, "malicious": 2}
 _REVIEW_ORDER = {"trusted": 0, "review": 1, "high_risk": 2, "blocked": 3}
-_SEVERITY_ORDER = {"low": 0, "medium": 1, "high": 2, "critical": 3}
 
 
 class SkillsPolicyError(ValueError):
@@ -276,9 +277,9 @@ def _rule_matches(rule: dict[str, Any], candidate: dict[str, Any]) -> bool:
     severity_gte = _string(match.get("severity_gte"))
     if severity_gte:
         severity = _string(candidate.get("severity"))
-        if severity_gte not in _SEVERITY_ORDER:
+        if normalize_severity(severity_gte) not in SEVERITY_THRESHOLD_LABELS:
             raise SkillsPolicyError(f"unknown severity_gte threshold: {severity_gte}")
-        if severity not in _SEVERITY_ORDER or _SEVERITY_ORDER[severity] < _SEVERITY_ORDER[severity_gte]:
+        if not severity_at_or_above(severity, severity_gte):
             return False
     path = _string(candidate.get("path")) or ""
     path_contains = _string(match.get("path_contains"))

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -21,6 +21,7 @@ function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
   return "network";
 }
 import { buildSecurityGraphHref } from "@/lib/attack-paths";
+import { severityRank } from "@/lib/severity";
 import {
   ShieldAlert, Server, Package, Bug, Zap, ArrowRight, Clock,
   AlertTriangle, Container, Layers, FileText, ExternalLink, GitBranch, ChevronRight,
@@ -232,10 +233,6 @@ export interface CompoundIssue {
   filter: string; // URL param for /vulns deep-link
 }
 
-const SEVERITY_ORDER_MAP: Record<string, number> = {
-  critical: 4, high: 3, medium: 2, low: 1,
-};
-
 function blastTools(blast: BlastRadius): string[] {
   return blast.exposed_tools ?? blast.reachable_tools ?? [];
 }
@@ -330,8 +327,8 @@ function aggregateCompoundIssues(allBlast: BlastRadius[]): CompoundIssue[] {
 
   return issues.sort(
     (a, b) =>
-      (SEVERITY_ORDER_MAP[b.severity] ?? 0) -
-      (SEVERITY_ORDER_MAP[a.severity] ?? 0)
+      severityRank(b.severity) -
+      severityRank(a.severity)
   );
 }
 

--- a/ui/app/remediation/page.tsx
+++ b/ui/app/remediation/page.tsx
@@ -17,6 +17,7 @@ import {
   Loader2,
   Ticket,
 } from "lucide-react";
+import { severityRank } from "@/lib/severity";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -61,14 +62,6 @@ function complianceImpact(items: RemediationItem[], topN = 5) {
 // ─── Sort button ──────────────────────────────────────────────────────────────
 
 type SortKey = "impact_score" | "severity" | "agents" | "credentials";
-
-const SEVERITY_ORDER: Record<string, number> = {
-  critical: 4,
-  high: 3,
-  medium: 2,
-  low: 1,
-  none: 0,
-};
 
 function SortButton({
   label,
@@ -570,9 +563,7 @@ function RemediationPage() {
       if (sortKey === "impact_score") {
         diff = a.impact_score - b.impact_score;
       } else if (sortKey === "severity") {
-        diff =
-          (SEVERITY_ORDER[a.severity.toLowerCase()] ?? 0) -
-          (SEVERITY_ORDER[b.severity.toLowerCase()] ?? 0);
+        diff = severityRank(a.severity) - severityRank(b.severity);
       } else if (sortKey === "agents") {
         diff =
           (a.affected_agents?.length ?? 0) -

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -21,6 +21,7 @@ import {
 import { ApiOfflineState } from "@/components/api-offline-state";
 import { PageEmptyState, PageLoadingState } from "@/components/states/page-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
+import { severityRank } from "@/lib/severity";
 import { Bug, Download, ExternalLink, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Layers, Loader2, Package, Server, ShieldOff, Radar, FileSearch, ShieldAlert, ClipboardCheck } from "lucide-react";
 
 function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
@@ -103,14 +104,6 @@ type SeverityFilter = "all" | "critical" | "high" | "medium" | "low";
 type SortKey = "severity" | "cvss" | "epss" | "id";
 type GroupKey = "none" | "package" | "agent" | "severity";
 type ScanScope = "latest" | "all";
-
-const SEVERITY_ORDER: Record<string, number> = {
-  critical: 4,
-  high: 3,
-  medium: 2,
-  low: 1,
-  none: 0,
-};
 
 function CisaKevBadge() {
   return (
@@ -655,7 +648,7 @@ function VulnsPage() {
     list = [...list].sort((a, b) => {
       let diff = 0;
       if (sortKey === "severity") {
-        diff = (SEVERITY_ORDER[a.severity.toLowerCase()] ?? 0) - (SEVERITY_ORDER[b.severity.toLowerCase()] ?? 0);
+        diff = severityRank(a.severity) - severityRank(b.severity);
       } else if (sortKey === "cvss") {
         diff = (a.cvss_score ?? 0) - (b.cvss_score ?? 0);
       } else if (sortKey === "epss") {

--- a/ui/components/charts.tsx
+++ b/ui/components/charts.tsx
@@ -23,6 +23,7 @@ import {
 } from "recharts";
 import type { Agent, BlastRadius } from "@/lib/api";
 import { buildBlastRadiusSummary } from "@/lib/insights-risk";
+import { severityRank } from "@/lib/severity";
 
 // ─── Shared ──────────────────────────────────────────────────────────────────
 
@@ -334,8 +335,7 @@ export function SupplyChainTreemap({
             const vulns = pkg.vulnerabilities ?? [];
             const worst = vulns.reduce(
               (w, v) => {
-                const order: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
-                return (order[v.severity] ?? 0) > (order[w] ?? 0) ? v.severity : w;
+                return severityRank(v.severity) > severityRank(w) ? v.severity : w;
               },
               "none" as string
             );

--- a/ui/lib/mesh-graph.ts
+++ b/ui/lib/mesh-graph.ts
@@ -12,6 +12,7 @@ import {
   type ExposurePath,
   type ExposureRelationshipRef,
 } from "@/lib/exposure-path";
+import { severityAtOrAbove, severityRank } from "@/lib/severity";
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -262,10 +263,8 @@ export function detectSharedServers(agents: Agent[]): Map<string, ServerGroup> {
 
 // ─── Severity helpers ───────────────────────────────────────────────────────
 
-const SEV_ORDER: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1, none: 0 };
-
 function severityWeight(sev: string | undefined): number {
-  return SEV_ORDER[sev ?? "none"] ?? 0;
+  return severityRank(sev ?? "none");
 }
 
 function sevColor(sev: string): string {
@@ -280,7 +279,7 @@ function sevColor(sev: string): string {
 
 function meetsSeverityFilter(sev: string, filter: SeverityFilter): boolean {
   if (filter === "all") return true;
-  return (SEV_ORDER[sev] ?? 0) >= (SEV_ORDER[filter] ?? 0);
+  return severityAtOrAbove(sev, filter);
 }
 
 function compareVulnerabilities(left: Vulnerability, right: Vulnerability): number {

--- a/ui/lib/severity.ts
+++ b/ui/lib/severity.ts
@@ -1,0 +1,16 @@
+export const SEVERITY_ORDER: Readonly<Record<string, number>> = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+  none: 0,
+  unknown: -1,
+};
+
+export function severityRank(severity: string | null | undefined): number {
+  return SEVERITY_ORDER[(severity ?? "unknown").toLowerCase()] ?? -1;
+}
+
+export function severityAtOrAbove(severity: string | null | undefined, threshold: string): boolean {
+  return severityRank(severity) >= severityRank(threshold);
+}


### PR DESCRIPTION
## Summary
- derive CLI/backend severity ordering from the shared graph severity model
- reuse shared graph severity buckets for roll-up and ASPM aggregation
- add a UI severity helper and remove duplicate dashboard/vulns/remediation/chart rank maps

## Validation
- uv run ruff check src/agent_bom/cli/_common.py src/agent_bom/cloud/registry_sweep.py src/agent_bom/graph/aspm_overlay.py src/agent_bom/graph/rollup.py src/agent_bom/graph/severity.py src/agent_bom/graph/toxic_findings.py src/agent_bom/output/html.py src/agent_bom/output/markdown.py src/agent_bom/posture.py src/agent_bom/skills_policy.py
- uv run pytest tests/test_cli_common.py::test_severity_order tests/test_policy_engine.py::test_severity_order_includes_unknown tests/test_graph_schema.py::TestUnifiedSeverity::test_severity_rank_ordering tests/test_graph_min_severity_topology.py tests/test_registry_sweep.py
- uv run mypy src/ --ignore-missing-imports --disable-error-code import-untyped
- npm run typecheck
- npm run lint -- app/page.tsx app/vulns/page.tsx app/remediation/page.tsx components/charts.tsx lib/mesh-graph.ts lib/severity.ts
- npm run build && npm run bundle:check

Part of #3242.