### PR TITLE
fix(mcp): bind write audit actors to auth identity

### DIFF
--- a/src/agent_bom/mcp_tools/identity.py
+++ b/src/agent_bom/mcp_tools/identity.py
@@ -82,11 +82,23 @@ def _authorize_identity_write(
                 "status": "blocked",
             },
         )
+    clean_actor = (authenticated_actor or "").strip()
+    if not clean_actor:
+        return (
+            False,
+            {
+                "error": "identity write action requires authenticated operator actor",
+                "action": action,
+                "required_role": "admin",
+                "required_scope": "identity:write",
+                "status": "blocked",
+            },
+        )
     return (
         True,
         {
             "action": action,
-            "actor": (authenticated_actor or "").strip() or "mcp-operator",
+            "actor": clean_actor,
             "actor_role": normalized_role,
             "tenant_id": resolve_mcp_tool_tenant_id(tenant_id),
             "resource": resource,

--- a/src/agent_bom/mcp_tools/runtime.py
+++ b/src/agent_bom/mcp_tools/runtime.py
@@ -72,11 +72,23 @@ def _authorize_shield_write(
                 "status": "blocked",
             },
         )
+    clean_actor = (authenticated_actor or "").strip()
+    if not clean_actor:
+        return (
+            False,
+            {
+                "error": "shield write action requires authenticated operator actor",
+                "action": action,
+                "required_role": "admin",
+                "required_scope": "shield:write",
+                "status": "blocked",
+            },
+        )
     return (
         True,
         {
             "action": action,
-            "actor": (authenticated_actor or "").strip() or "mcp-operator",
+            "actor": clean_actor,
             "actor_role": normalized_role,
             "tenant_id": tenant_id or "default",
             "resource": f"shield/{session_id or 'default'}",

--- a/tests/test_agent_identity_lifecycle.py
+++ b/tests/test_agent_identity_lifecycle.py
@@ -469,6 +469,9 @@ def _passthrough(s: str) -> str:
     return s
 
 
+_AUTHENTICATED_OPERATOR = "agent-bom-operator"
+
+
 @pytest.mark.asyncio
 async def test_mcp_identity_issue_requires_admin_and_scope(store):
     from agent_bom.mcp_tools.identity import identity_issue_impl
@@ -510,6 +513,19 @@ async def test_mcp_identity_issue_requires_admin_and_scope(store):
     )
     assert out["status"] == "blocked"
 
+    # A self-asserted admin role/scope is not enough; write authorization must
+    # be bound to the authenticated MCP caller identity.
+    out = json.loads(
+        await identity_issue_impl(
+            agent_id="agent-a",
+            operator_role="admin",
+            operator_scopes="identity:write",
+            reason="provision build agent",
+            _truncate_response=_passthrough,
+        )
+    )
+    assert out["status"] == "blocked" and "authenticated operator actor" in out["error"]
+
 
 @pytest.mark.asyncio
 async def test_mcp_identity_issue_then_grant_and_revoke_jit(store):
@@ -527,10 +543,12 @@ async def test_mcp_identity_issue_then_grant_and_revoke_jit(store):
             operator_scopes="identity:write",
             reason="provision build agent",
             _truncate_response=_passthrough,
+            _authenticated_actor=_AUTHENTICATED_OPERATOR,
         )
     )
     assert issued["token"].startswith("abi_")
     assert issued["mcp_write_policy"]["required_scope"] == "identity:write"
+    assert issued["mcp_write_policy"]["actor"] == _AUTHENTICATED_OPERATOR
     identity_id = issued["identity"]["identity_id"]
     assert store.get(identity_id) is not None
 
@@ -543,6 +561,7 @@ async def test_mcp_identity_issue_then_grant_and_revoke_jit(store):
             operator_scopes="identity:write",
             reason="incident response window",
             _truncate_response=_passthrough,
+            _authenticated_actor=_AUTHENTICATED_OPERATOR,
         )
     )
     grant_id = granted["grant"]["grant_id"]
@@ -555,6 +574,7 @@ async def test_mcp_identity_issue_then_grant_and_revoke_jit(store):
             operator_scopes="identity:write",
             reason="window closed early",
             _truncate_response=_passthrough,
+            _authenticated_actor=_AUTHENTICATED_OPERATOR,
         )
     )
     assert revoked["grant"]["status"] == "revoked"
@@ -576,6 +596,7 @@ async def test_mcp_identity_write_emits_lifecycle_audit_chain(store):
                 operator_scopes="identity:write",
                 reason="provision build agent",
                 _truncate_response=_passthrough,
+                _authenticated_actor=_AUTHENTICATED_OPERATOR,
             )
         )
         await identity_revoke_impl(
@@ -584,12 +605,13 @@ async def test_mcp_identity_write_emits_lifecycle_audit_chain(store):
             operator_scopes="identity:write",
             reason="decommission build agent",
             _truncate_response=_passthrough,
+            _authenticated_actor=_AUTHENTICATED_OPERATOR,
         )
         actions = {e.action for e in audit.list_entries(limit=100)}
         assert "agent_identity.issued" in actions
         assert "agent_identity.revoked" in actions
         # operator_role remains authorization/audit metadata; the actor is the
         # authenticated MCP caller, not a self-asserted tool argument.
-        assert any(e.actor == "mcp-operator" for e in audit.list_entries(limit=100))
+        assert any(e.actor == _AUTHENTICATED_OPERATOR for e in audit.list_entries(limit=100))
     finally:
         set_audit_log(InMemoryAuditLog())

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -25,6 +25,9 @@ def _trunc_async(s: str) -> str:
     return s
 
 
+_AUTHENTICATED_OPERATOR = "agent-bom-operator"
+
+
 # ---------------------------------------------------------------------------
 # mcp_tools/registry.py — registry_lookup_impl
 # ---------------------------------------------------------------------------
@@ -1091,7 +1094,7 @@ async def test_shield_write_tools_require_admin_and_audit_reason():
         assert missing_scope["status"] == "blocked"
         assert missing_scope["required_scope"] == "shield:write"
 
-        started = json.loads(
+        missing_actor = json.loads(
             await shield_start_impl(
                 session_id="incident-1",
                 operator_role="admin",
@@ -1101,10 +1104,25 @@ async def test_shield_write_tools_require_admin_and_audit_reason():
                 _truncate_response=_trunc,
             )
         )
+        assert missing_actor["status"] == "blocked"
+        assert "authenticated operator actor" in missing_actor["error"]
+
+        started = json.loads(
+            await shield_start_impl(
+                session_id="incident-1",
+                operator_role="admin",
+                operator_scopes="shield:write",
+                reason="incident response validation",
+                tenant_id="tenant-alpha",
+                _truncate_response=_trunc,
+                _authenticated_actor=_AUTHENTICATED_OPERATOR,
+            )
+        )
         assert started["status"] == "started"
         assert started["mcp_write_policy"]["required_role"] == "admin"
         assert started["mcp_write_policy"]["required_scope"] == "shield:write"
         assert started["mcp_write_policy"]["audit_logged"] is True
+        assert started["mcp_write_policy"]["actor"] == _AUTHENTICATED_OPERATOR
 
         unblocked = json.loads(
             await shield_unblock_impl(
@@ -1114,6 +1132,7 @@ async def test_shield_write_tools_require_admin_and_audit_reason():
                 reason="incident response validation",
                 tenant_id="tenant-alpha",
                 _truncate_response=_trunc,
+                _authenticated_actor=_AUTHENTICATED_OPERATOR,
             )
         )
         assert unblocked["status"] in {"not_blocked", "unblocked"}
@@ -1147,6 +1166,7 @@ async def test_shield_break_glass_tool_uses_admin_role_context():
             reason="incident response validation",
             tenant_id="tenant-alpha",
             _truncate_response=_trunc,
+            _authenticated_actor=_AUTHENTICATED_OPERATOR,
         )
         result = json.loads(
             await shield_break_glass_impl(
@@ -1156,10 +1176,11 @@ async def test_shield_break_glass_tool_uses_admin_role_context():
                 reason="emergency operator override",
                 tenant_id="tenant-alpha",
                 _truncate_response=_trunc,
+                _authenticated_actor=_AUTHENTICATED_OPERATOR,
             )
         )
         assert result["status"] == "break_glass_activated"
-        assert result["mcp_write_policy"]["actor"] == "mcp-operator"
+        assert result["mcp_write_policy"]["actor"] == _AUTHENTICATED_OPERATOR
         assert result["mcp_write_policy"]["actor_role"] == "admin"
 
         entries = store.list_entries(tenant_id="tenant-alpha", limit=10)

--- a/tests/test_shield_write_audit.py
+++ b/tests/test_shield_write_audit.py
@@ -129,6 +129,24 @@ def test_short_reason_fails_closed(impl: Any, action: str, extra: dict[str, Any]
     assert "reason" in result.get("error", "").lower(), result
 
 
+@pytest.mark.parametrize(("impl", "action", "extra"), ALL_WRITE_TOOLS, ids=_ids(ALL_WRITE_TOOLS))
+def test_missing_authenticated_actor_fails_closed(impl: Any, action: str, extra: dict[str, Any]) -> None:
+    """Admin + write scope still cannot self-assert actor identity."""
+    required_scope = "shield:write" if action.startswith("shield_") else "identity:write"
+    result = _run(
+        impl(
+            operator_role="admin",
+            operator_scopes=required_scope,
+            reason="legitimate operator audit reason",
+            tenant_id="default",
+            _truncate_response=_passthrough,
+            **extra,
+        )
+    )
+    assert result.get("status") == "blocked", result
+    assert "authenticated operator actor" in result.get("error", ""), result
+
+
 @pytest.mark.parametrize(("impl", "action", "extra"), SHIELD_WRITE_TOOLS, ids=_ids(SHIELD_WRITE_TOOLS))
 def test_admin_shield_write_emits_audit(impl: Any, action: str, extra: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
     """An authorized admin Shield write succeeds AND emits an audit event.
@@ -177,6 +195,7 @@ def test_admin_shield_write_emits_audit(impl: Any, action: str, extra: dict[str,
             reason="incident-1234 emergency override",
             tenant_id="acme",
             _truncate_response=_passthrough,
+            _authenticated_actor="agent-bom-operator-token",
             **extra,
         )
     )
@@ -185,7 +204,7 @@ def test_admin_shield_write_emits_audit(impl: Any, action: str, extra: dict[str,
     assert result.get("status") not in ("blocked", None), result
     assert len(audit_calls) == 1, f"{action} did not emit exactly one audit event: {audit_calls}"
     emitted = audit_calls[0]
-    assert emitted["actor"] == "mcp-operator", emitted
+    assert emitted["actor"] == "agent-bom-operator-token", emitted
     assert emitted.get("reason"), emitted
 
 
@@ -216,6 +235,7 @@ def test_break_glass_inactive_session_still_audits() -> None:
                 reason="emergency override on inactive session",
                 tenant_id="tenant-omega",
                 _truncate_response=_passthrough,
+                _authenticated_actor="agent-bom-operator-token",
             )
         )
     finally:
@@ -228,7 +248,7 @@ def test_break_glass_inactive_session_still_audits() -> None:
     actions = [entry.action for entry in entries]
     assert "break_glass" in actions, f"inactive break-glass attempt emitted no audit event: {actions}"
     glass = next(entry for entry in entries if entry.action == "break_glass")
-    assert glass.actor == "mcp-operator", glass
+    assert glass.actor == "agent-bom-operator-token", glass
     assert glass.details.get("outcome") == "not_active", glass.details
 
     proxy_routes._shield_engines.clear()


### PR DESCRIPTION
## Summary
- require an authenticated operator actor before MCP Shield or identity write tools can succeed
- keep operator_role/operator_scopes as authorization/audit metadata, not actor proof
- update MCP write-audit tests so successful writes record the token/session actor and self-asserted admin+scope fails closed

## Validation
- uv run ruff check src/agent_bom/mcp_tools/runtime.py src/agent_bom/mcp_tools/identity.py tests/test_shield_write_audit.py
- uv run pytest tests/test_shield_write_audit.py tests/test_api_cloud_surface_parity.py::test_dispatch_allows_destructive_tool_for_authenticated_operator tests/test_api_cloud_surface_parity.py::test_dispatch_blocks_self_asserted_admin_without_operator_token tests/test_api_cloud_surface_parity.py::test_authorize_destructive_blocks_self_asserted_admin_without_operator_token
- uv run mypy src/ --ignore-missing-imports --disable-error-code import-untyped

Part of #3242.