### PR TITLE
fix(deploy): harden shared compose defaults

### DIFF
--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -7,7 +7,7 @@
 # For a single-workstation pilot, see docker-compose.pilot.yml.
 #
 # Usage (local dev):
-#   cp .env.example .env   # fill in POSTGRES_PASSWORD at minimum
+#   cp .env.example .env   # fill in POSTGRES_PASSWORD and AGENT_BOM_API_KEY
 #   docker compose -f deploy/docker-compose.fullstack.yml up
 #
 # Then open:
@@ -30,7 +30,7 @@ services:
     image: agentbom/agent-bom:0.89.2
     container_name: agent-bom-api
     restart: unless-stopped
-    command: api --host 0.0.0.0 --port 8422 --allow-insecure-no-auth
+    command: api --host 0.0.0.0 --port 8422
     environment:
       AGENT_BOM_POSTGRES_URL: >-
         postgresql://${POSTGRES_USER:-agent_bom}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-agent_bom}
@@ -44,8 +44,9 @@ services:
       AWS_REGION: ${AWS_REGION:-us-east-1}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
-      # Optional: protect the API with a key
-      AGENT_BOM_API_KEY: ${AGENT_BOM_API_KEY:-}
+      # Required for the shared full-stack profile. Use docker-compose.pilot.yml
+      # for the explicit loopback-only no-auth workstation demo.
+      AGENT_BOM_API_KEY: ${AGENT_BOM_API_KEY:?Set AGENT_BOM_API_KEY or use docker-compose.pilot.yml for loopback no-auth}
       # Local dev stack only: filesystem scans should be explicit in shared API setups.
       AGENT_BOM_API_LOCAL_PATH_SCANS: ${AGENT_BOM_API_LOCAL_PATH_SCANS:-disabled}
     ports:

--- a/deploy/supabase/clickhouse/docker-compose.yml
+++ b/deploy/supabase/clickhouse/docker-compose.yml
@@ -4,7 +4,7 @@
 #   cd deploy/supabase/clickhouse
 #   docker compose up -d
 #   # ClickHouse: http://localhost:8123
-#   # Grafana:    http://localhost:3001 (set GRAFANA_ADMIN_PASSWORD first)
+#   # Grafana:    http://localhost:3001 (set GRAFANA_ADMIN_USER and GRAFANA_ADMIN_PASSWORD first)
 #
 # Then run scans with analytics enabled:
 #   agent-bom agents --clickhouse-url http://localhost:8123
@@ -39,7 +39,7 @@ services:
         condition: service_healthy
     environment:
       GF_INSTALL_PLUGINS: grafana-clickhouse-datasource
-      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:?set GRAFANA_ADMIN_USER before starting this analytics stack}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD before starting this analytics stack}
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/agent-bom.json
     volumes:

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -127,12 +127,14 @@ def test_platform_api_fails_closed_for_auth_docs_and_local_scans() -> None:
     assert env_map.get("AGENT_BOM_API_LOCAL_PATH_SCANS") == "disabled"
 
 
-def test_fullstack_is_loopback_only_and_matches_runtime_user_home() -> None:
+def test_fullstack_is_loopback_only_auth_required_and_matches_runtime_user_home() -> None:
     path = COMPOSE_DIR / "docker-compose.fullstack.yml"
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
     api = (data.get("services") or {}).get("api") or {}
+    env = api.get("environment") or {}
 
-    assert "--allow-insecure-no-auth" in api.get("command", "")
+    assert "--allow-insecure-no-auth" not in api.get("command", "")
+    assert "AGENT_BOM_API_KEY:?" in env.get("AGENT_BOM_API_KEY", "")
     assert api.get("ports") == ["127.0.0.1:${API_PORT:-8422}:8422"]
     assert "~/.config:/home/abom/.config:ro" in (api.get("volumes") or [])
     assert "~/.claude:/home/abom/.claude:ro" in (api.get("volumes") or [])

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -119,6 +119,8 @@ def test_clickhouse_grafana_compose_has_no_default_admin_password():
     grafana = data["services"]["grafana"]
     clickhouse = data["services"]["clickhouse"]
 
+    assert grafana["environment"]["GF_SECURITY_ADMIN_USER"] != "admin"
+    assert "GRAFANA_ADMIN_USER:?" in grafana["environment"]["GF_SECURITY_ADMIN_USER"]
     assert grafana["environment"]["GF_SECURITY_ADMIN_PASSWORD"] != "admin"
     assert "GRAFANA_ADMIN_PASSWORD:?" in grafana["environment"]["GF_SECURITY_ADMIN_PASSWORD"]
     assert grafana["ports"] == ["127.0.0.1:3001:3000"]


### PR DESCRIPTION
## Summary
- require AGENT_BOM_API_KEY for the shared full-stack compose profile instead of starting the API with insecure no-auth
- keep the explicit no-auth path confined to the loopback-only pilot compose
- require a configured Grafana admin user and password for the ClickHouse/Grafana analytics compose

## Validation
- uv run pytest tests/test_compose_secrets_healthcheck.py::test_fullstack_is_loopback_only_auth_required_and_matches_runtime_user_home tests/test_deployment.py::test_pilot_insecure_mode_is_loopback_scoped tests/test_deployment.py::test_clickhouse_grafana_compose_has_no_default_admin_password -q --tb=short
- uv run ruff check tests/test_compose_secrets_healthcheck.py tests/test_deployment.py
- git diff --check

Refs #3242