### PR TITLE
fix(graph): offload estate rollup compute

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1308,6 +1308,29 @@ def _semantic_cluster_payload(
     }
 
 
+def _graph_rollup_payload(
+    graph: UnifiedGraph,
+    *,
+    node: str | None,
+    min_severity: str,
+    exposed: bool,
+    toxic: bool,
+    mode: Literal["rollup", "attack_path"],
+) -> dict[str, Any]:
+    from agent_bom.graph.rollup import RollupFilters, attack_path_view, drill_down, rollup_view
+
+    filters = RollupFilters(
+        min_severity=min_severity,
+        exposed_only=exposed,
+        toxic_only=toxic,
+    )
+    if node:
+        return drill_down(graph, node, filters=filters)
+    if mode == "attack_path":
+        return attack_path_view(graph, _derived_attack_paths(graph), filters=filters)
+    return rollup_view(graph, filters=filters)
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # Preset model
 # ═══════════════════════════════════════════════════════════════════════════
@@ -2981,8 +3004,6 @@ async def get_graph_rollup(
     Backend for the UI graph-navigation surface. Read-only: never mutates the
     source graph.
     """
-    from agent_bom.graph.rollup import RollupFilters, attack_path_view, drill_down, rollup_view
-
     tenant = _tenant(request)
     graph_store = _get_graph_store_or_503()
     requested_scan_id = scan_id or ""
@@ -3002,18 +3023,16 @@ async def get_graph_rollup(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
 
-    filters = RollupFilters(
-        min_severity=(min_severity or "").lower(),
-        exposed_only=exposed,
-        toxic_only=toxic,
-    )
-
     try:
-        if node:
-            return drill_down(graph, node, filters=filters)
-        if mode == "attack_path":
-            return attack_path_view(graph, _derived_attack_paths(graph), filters=filters)
-        return rollup_view(graph, filters=filters)
+        return await _graph_compute_call(
+            _graph_rollup_payload,
+            graph,
+            node=node,
+            min_severity=(min_severity or "").lower(),
+            exposed=exposed,
+            toxic=toxic,
+            mode=mode,
+        )
     except HTTPException:
         raise
     except Exception as exc:  # noqa: BLE001

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -2088,12 +2088,15 @@ class TestGraphStoreBackendSelection:
 
         fix_first = client.get("/v1/graph/views/fix-first", params={"scan_id": "store-scan"})
         attack_paths = client.get("/v1/graph/attack-paths", params={"scan_id": "store-scan", "limit": 5})
+        rollup = client.get("/v1/graph/rollup", params={"scan_id": "store-scan", "mode": "attack_path"})
 
         assert fix_first.status_code == 200
         assert attack_paths.status_code == 200
+        assert rollup.status_code == 200
         assert "_fix_first_graph_view_payload" in compute_calls
         assert "_derived_attack_path_page" in compute_calls
         assert "_serialize_attack_path_queue" in compute_calls
+        assert "_graph_rollup_payload" in compute_calls
 
     def test_graph_route_returns_429_when_backpressure_opens(self, recording_graph_store, monkeypatch):
         from agent_bom.backpressure import reset_backpressure_for_tests


### PR DESCRIPTION
## Summary
- move the graph roll-up, drill-down, and attack-path transforms behind the existing graph compute offload boundary
- keep graph store reads and graph compute under the same graph backpressure/threading model
- add regression coverage so roll-up compute does not drift back onto request handlers

## Validation
- uv run pytest tests/test_graph_api.py::TestGraphStoreBackendSelection::test_graph_routes_offload_derived_path_compute tests/test_graph_api.py::TestGraphStoreBackendSelection::test_graph_clusters_return_reversible_semantic_rollups -q --tb=short
- uv run ruff check src/agent_bom/api/routes/graph.py tests/test_graph_api.py
- git diff --check

Refs #3241
