### PR TITLE
docs(hosted): add live-link POC overlay

### DIFF
--- a/deploy/docker-compose.hosted-poc.yml
+++ b/deploy/docker-compose.hosted-poc.yml
@@ -1,0 +1,25 @@
+version: "3.8"
+
+# ── Profile: HOSTED POC OVERLAY ──────────────────────────────────────────────
+# Hosted POC hardening overlay.
+#
+# Use with docker-compose.platform.yml when a public Caddy/ALB front door is
+# the only internet-facing listener:
+#
+#   docker compose \
+#     -f deploy/docker-compose.platform.yml \
+#     -f deploy/docker-compose.hosted-poc.yml \
+#     up -d --build
+#
+# The base platform file is reusable for local operators and clusters. This
+# overlay makes the customer-0 VM posture explicit: API and UI bind to loopback
+# only, while Caddy terminates TLS on 443 and proxies to these local ports.
+
+services:
+  api:
+    ports:
+      - "127.0.0.1:${API_PORT:-8422}:8422"
+
+  ui:
+    ports:
+      - "127.0.0.1:${UI_PORT:-3000}:3000"

--- a/docs/DEPLOY_PLATFORM.md
+++ b/docs/DEPLOY_PLATFORM.md
@@ -146,8 +146,9 @@ just pointed at a hosted scanner instead of a local one.
 For a gated customer-0 URL, start with the smaller hosted POC runbook instead
 of presenting a generally available SaaS product:
 [`HOSTED_POC.md`](HOSTED_POC.md). The recommended first proof is one AWS VM
-behind HTTPS; the Snowflake Native App lane remains the enterprise
-customer-owned install path.
+behind HTTPS with `deploy/docker-compose.hosted-poc.yml` layered on top of the
+platform compose so Caddy is the only public listener. The Snowflake Native App
+lane remains the enterprise customer-owned install path.
 
 ---
 

--- a/docs/HOSTED_POC.md
+++ b/docs/HOSTED_POC.md
@@ -15,6 +15,11 @@ the enterprise distribution lane. Recommended domain split:
 - `demo.agent-bom.com` — public seeded demo.
 - `app.agent-bom.com` — gated customer-0 / hot-lead POC.
 
+For the domains you already own, use `agent-bom.com` on Cloudflare for the
+first live link because DNS, proxying, and TLS controls are already in one
+place. Keep `agentbom.io` for the cleaner product site once the public surface
+is ready.
+
 | Need | Use | Why |
 |---|---|---|
 | Public demo link | AWS VM + Caddy + platform compose | Fastest custom URL, simple TLS, works for any tester |
@@ -48,6 +53,25 @@ Run one small CPU-only VM. Recommended starting point:
 This gives prospects the product experience: sign in, connect read-only,
 scan, inspect graph/blast radius, and export evidence.
 
+### Cloudflare DNS
+
+For `agent-bom.com`, create one proxied `A` record per lane:
+
+| Record | Target | Purpose |
+|---|---|---|
+| `demo.agent-bom.com` | AWS VM public IPv4 | seeded public demo |
+| `app.agent-bom.com` | AWS VM public IPv4 | gated customer-0 account |
+
+Use Cloudflare proxy mode or DNS-only mode consistently with the chosen TLS
+setup:
+
+- **DNS-only + Caddy** — simplest. Caddy terminates Let's Encrypt directly.
+- **Proxied + Caddy** — set Cloudflare SSL mode to `Full (strict)` and let
+  Caddy still hold a valid origin certificate.
+
+Do not point the apex/root domain at the POC VM unless it is also serving the
+product site.
+
 ### Minimal VM setup
 
 Generate local secrets on the VM:
@@ -77,14 +101,24 @@ chmod 0400 deploy/secrets/postgres_password
 Start the platform:
 
 ```bash
-docker compose -f deploy/docker-compose.platform.yml up -d --build
-docker compose -f deploy/docker-compose.platform.yml ps
+docker compose \
+  -f deploy/docker-compose.platform.yml \
+  -f deploy/docker-compose.hosted-poc.yml \
+  up -d --build
+
+docker compose \
+  -f deploy/docker-compose.platform.yml \
+  -f deploy/docker-compose.hosted-poc.yml \
+  ps
 ```
 
 Seed a disposable demo graph after the API is healthy:
 
 ```bash
-docker compose -f deploy/docker-compose.platform.yml exec api \
+docker compose \
+  -f deploy/docker-compose.platform.yml \
+  -f deploy/docker-compose.hosted-poc.yml \
+  exec api \
   agent-bom quickstart --run --offline --force
 ```
 
@@ -108,8 +142,26 @@ demo.agent-bom.com {
 ```
 
 Keep Caddy as the only public listener. The Postgres container remains internal
-and the API/UI ports can be restricted to the VM security boundary once the
-front door is verified.
+and `deploy/docker-compose.hosted-poc.yml` binds the API/UI ports to loopback,
+so they are reachable only from Caddy on the VM.
+
+### Customer-0 proof checklist
+
+Run this checklist before inviting anyone:
+
+1. `https://demo.agent-bom.com/health` returns healthy through Caddy.
+2. The UI opens at `https://demo.agent-bom.com` and does not require direct
+   access to ports `3000` or `8422`.
+3. `AGENT_BOM_ALLOW_UNAUTHENTICATED_API` is unset.
+4. A seeded scan appears in the dashboard with findings, graph, posture, and
+   export links.
+5. Connections can add at least one read-only cloud account or Snowflake
+   account.
+6. A connection scan hands off to scan details, findings, graph, jobs, and
+   compliance surfaces.
+7. Audit export and compliance export work for the customer-0 tenant.
+
+If any item fails, treat the POC as not ready for external users.
 
 ## Snowflake Native App lane
 

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -38,6 +38,13 @@ HEALTHCHECK_EXEMPT: dict[str, set[str]] = {
         # TCP listener — there is no port to probe.
         "mcp-server",
     },
+    "docker-compose.hosted-poc.yml": {
+        # Overlay applied on top of docker-compose.platform.yml; it only
+        # narrows the api/ui port bindings to loopback. Their healthchecks are
+        # defined once in the base platform compose and inherited at merge time.
+        "api",
+        "ui",
+    },
 }
 
 

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -138,6 +138,15 @@ def test_fullstack_is_loopback_only_and_matches_runtime_user_home() -> None:
     assert "~/.claude:/home/abom/.claude:ro" in (api.get("volumes") or [])
 
 
+def test_hosted_poc_overlay_keeps_api_and_ui_loopback_only() -> None:
+    path = COMPOSE_DIR / "docker-compose.hosted-poc.yml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    services = data.get("services") or {}
+
+    assert services["api"]["ports"] == ["127.0.0.1:${API_PORT:-8422}:8422"]
+    assert services["ui"]["ports"] == ["127.0.0.1:${UI_PORT:-3000}:3000"]
+
+
 def test_active_docker_docs_do_not_mount_config_under_root_home() -> None:
     active_docs = [
         ROOT / "docs" / "DEPLOYMENT.md",


### PR DESCRIPTION
## Summary
- add a hosted POC compose overlay that binds API and UI to loopback so Caddy is the only public listener
- document the Cloudflare/domain path for demo.agent-bom.com and app.agent-bom.com
- add a customer-0 proof checklist covering health, auth posture, seeded scan, connection scan handoff, graph, jobs, findings, and exports
- point the main deployment guide at the hosted overlay for gated live-link demos

## Validation
- uv run pytest tests/test_compose_secrets_healthcheck.py::test_hosted_poc_overlay_keeps_api_and_ui_loopback_only tests/test_compose_secrets_healthcheck.py::test_compose_file_declares_profile_header -q --tb=short
- uv run ruff check tests/test_compose_secrets_healthcheck.py
- git diff --check

Refs #3247
Refs #3246