### PR TITLE
fix(compliance): make CLI export evidence-backed

### DIFF
--- a/src/agent_bom/output/compliance_export.py
+++ b/src/agent_bom/output/compliance_export.py
@@ -1,13 +1,186 @@
-"""Compliance evidence bundle export (CMMC, FedRAMP, NIST AI RMF)."""
+"""Compliance evidence bundle export for local CLI scans."""
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
+import os
 import zipfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
 
+from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS, ComplianceFrameworkMetadata
+from agent_bom.compliance_utils import effective_blast_radius_tags, framework_qualified_finding_tags
 from agent_bom.models import AIBOMReport
 from agent_bom.output.cyclonedx_fmt import to_cyclonedx
 from agent_bom.output.finding_views import cve_findings, package_name, package_version, severity_value
+
+_FRAMEWORKS_BY_SLUG: dict[str, ComplianceFrameworkMetadata] = {framework.slug: framework for framework in TAG_MAPPED_FRAMEWORKS}
+_FRAMEWORK_ALIASES: dict[str, str] = {
+    "nist-ai-rmf": "nist",
+    "nist_ai_rmf": "nist",
+    "nist-rmf": "nist",
+    "nist-cybersecurity-framework": "nist-csf",
+    "nist-csf-2": "nist-csf",
+    "nist-sp-800-53": "nist-800-53",
+    "iso27001": "iso-27001",
+    "iso-27001-2022": "iso-27001",
+    "pci": "pci-dss",
+    "pcidss": "pci-dss",
+    "owasp": "owasp-llm",
+    "owasp-llm-top10": "owasp-llm",
+    "owasp-mcp-top10": "owasp-mcp",
+}
+_HIGH_SEVERITIES = {"critical", "high"}
+
+
+@dataclass(frozen=True)
+class _EvidenceRow:
+    finding_id: str
+    source: str
+    control: str
+    severity: str
+    package: str
+    version: str
+    risk_score: float | None
+    affected_agents: list[str]
+    affected_servers: list[str]
+
+    def as_json(self) -> dict[str, Any]:
+        return {
+            "finding_id": self.finding_id,
+            "source": self.source,
+            "control": self.control,
+            "severity": self.severity,
+            "package": self.package,
+            "version": self.version,
+            "risk_score": self.risk_score,
+            "affected_agents": self.affected_agents,
+            "affected_servers": self.affected_servers,
+        }
+
+
+def _canonical_framework(framework: str) -> ComplianceFrameworkMetadata:
+    slug = framework.strip().lower().replace("_", "-")
+    slug = _FRAMEWORK_ALIASES.get(slug, slug)
+    try:
+        return _FRAMEWORKS_BY_SLUG[slug]
+    except KeyError as exc:
+        supported = ", ".join(sorted(_FRAMEWORKS_BY_SLUG))
+        raise ValueError(f"unsupported compliance framework {framework!r}; supported frameworks: {supported}") from exc
+
+
+def _control_key(tag: str, catalog: Mapping[str, str]) -> str | None:
+    value = tag.strip()
+    if value in catalog:
+        return value
+    for prefix in ("FedRAMP-", "CMMC-", "NIST-", "ISO-", "SOC2-", "CIS-", "PCI-"):
+        if value.startswith(prefix) and value.removeprefix(prefix) in catalog:
+            return value.removeprefix(prefix)
+    return None
+
+
+def _severity_from_blast_radius(br: object) -> str:
+    severity = getattr(getattr(br, "vulnerability", None), "severity", "")
+    value = getattr(severity, "value", severity)
+    return str(value or "unknown").lower()
+
+
+def _blast_radius_evidence(report: AIBOMReport, metadata: ComplianceFrameworkMetadata) -> dict[str, list[_EvidenceRow]]:
+    evidence: dict[str, list[_EvidenceRow]] = {}
+    for index, br in enumerate(report.blast_radii, start=1):
+        for tag in effective_blast_radius_tags(br).get(metadata.tag_field, []):
+            control = _control_key(tag, metadata.catalog)
+            if control is None:
+                continue
+            row = _EvidenceRow(
+                finding_id=getattr(br.vulnerability, "id", "") or f"blast-radius-{index}",
+                source="blast_radius",
+                control=control,
+                severity=_severity_from_blast_radius(br),
+                package=br.package.name,
+                version=br.package.version,
+                risk_score=br.risk_score,
+                affected_agents=[agent.name for agent in br.affected_agents],
+                affected_servers=[server.name for server in br.affected_servers],
+            )
+            evidence.setdefault(control, []).append(row)
+    return evidence
+
+
+def _finding_evidence(report: AIBOMReport, metadata: ComplianceFrameworkMetadata) -> dict[str, list[_EvidenceRow]]:
+    accepted_frameworks = {
+        metadata.output_key,
+        metadata.summary_prefix,
+        metadata.slug.replace("-", "_"),
+    }
+    evidence: dict[str, list[_EvidenceRow]] = {}
+    for finding in cve_findings(report):
+        for qualified_tag in framework_qualified_finding_tags(finding):
+            framework_key, _, control_value = qualified_tag.partition(":")
+            if framework_key not in accepted_frameworks:
+                continue
+            control = _control_key(control_value, metadata.catalog)
+            if control is None:
+                continue
+            row = _EvidenceRow(
+                finding_id=finding.cve_id or finding.id,
+                source="unified_finding",
+                control=control,
+                severity=severity_value(finding).lower(),
+                package=package_name(finding),
+                version=package_version(finding),
+                risk_score=finding.risk_score,
+                affected_agents=list(finding.affected_agents),
+                affected_servers=list(finding.affected_servers),
+            )
+            evidence.setdefault(control, []).append(row)
+    return evidence
+
+
+def _merged_evidence(report: AIBOMReport, metadata: ComplianceFrameworkMetadata) -> dict[str, list[_EvidenceRow]]:
+    merged = _blast_radius_evidence(report, metadata)
+    for control, rows in _finding_evidence(report, metadata).items():
+        merged.setdefault(control, []).extend(rows)
+    for control, rows in list(merged.items()):
+        seen: set[tuple[str, str, str, str]] = set()
+        unique_rows: list[_EvidenceRow] = []
+        for row in rows:
+            key = (row.control, row.finding_id, row.package, row.version)
+            if key in seen:
+                continue
+            seen.add(key)
+            unique_rows.append(row)
+        merged[control] = unique_rows
+    return merged
+
+
+def _bundle_completeness(report: AIBOMReport, mapped_evidence_count: int) -> str:
+    has_scan_input = any(
+        (
+            report.total_agents,
+            report.total_servers,
+            report.total_packages,
+            report.total_vulnerabilities,
+            len(report.blast_radii),
+            len(cve_findings(report)),
+        )
+    )
+    if not has_scan_input:
+        return "incomplete"
+    if mapped_evidence_count == 0:
+        return "not_evaluated"
+    return "complete"
+
+
+def _digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _json_bytes(value: object) -> bytes:
+    return json.dumps(value, indent=2, sort_keys=True, default=str).encode("utf-8")
 
 
 def export_compliance_bundle(
@@ -15,17 +188,11 @@ def export_compliance_bundle(
     framework: str,
     output_path: str,
 ) -> str:
-    """Export CMMC/FedRAMP/NIST-AI-RMF compliance evidence bundle as ZIP.
+    """Export a local compliance evidence bundle as ZIP.
 
     Returns the path to the written ZIP file.
     """
-    cmmc_control_map = {
-        "CM-8": "Configuration Management — Component Inventory",
-        "SI-2": "System & Information Integrity — Flaw Remediation",
-        "SR-3": "Supply Chain Risk Management — Supply Chain Controls",
-        "RA-3": "Risk Assessment — Risk Assessment",
-        "AU-2": "Audit & Accountability — Event Logging",
-    }
+    metadata = _canonical_framework(framework)
 
     # Build SBOM (CycloneDX)
     sbom_data = to_cyclonedx(report)
@@ -48,10 +215,16 @@ def export_compliance_bundle(
         )
 
     # Build policy results
+    mapped_evidence = _merged_evidence(report, metadata)
+    mapped_evidence_count = sum(len(rows) for rows in mapped_evidence.values())
+    evidence_completeness = _bundle_completeness(report, mapped_evidence_count)
     policy_results = {
-        "framework": framework,
+        "framework": metadata.slug,
+        "framework_label": metadata.report_label,
         "scan_date": report.generated_at.isoformat(),
         "tool_version": report.tool_version,
+        "evidence_completeness": evidence_completeness,
+        "mapped_evidence_count": mapped_evidence_count,
         "total_agents": report.total_agents,
         "total_servers": report.total_servers,
         "total_packages": report.total_packages,
@@ -61,29 +234,24 @@ def export_compliance_bundle(
 
     # Build control mapping
     control_mapping = {}
-    for ctrl_id, ctrl_desc in cmmc_control_map.items():
-        findings = []
-        if ctrl_id == "CM-8":
-            findings = [{"type": "inventory", "count": report.total_packages}]
-        elif ctrl_id == "SI-2":
-            findings = [{"type": "vulnerabilities", "count": report.total_vulnerabilities}]
-        elif ctrl_id == "SR-3":
-            findings = [{"type": "supply_chain", "servers": report.total_servers}]
-        elif ctrl_id == "RA-3":
-            findings = [{"type": "risk_assessment", "findings": len(cve_rows), "blast_radii": len(cve_rows)}]
-        elif ctrl_id == "AU-2":
-            findings = [{"type": "audit_trail", "scan_date": report.generated_at.isoformat()}]
+    for ctrl_id, ctrl_desc in metadata.catalog.items():
+        evidence_rows = mapped_evidence.get(ctrl_id, [])
+        status = "not_evaluated"
+        if evidence_rows:
+            status = "fail" if any(row.severity in _HIGH_SEVERITIES for row in evidence_rows) else "review"
         control_mapping[ctrl_id] = {
             "description": ctrl_desc,
-            "status": "pass" if not findings or report.total_vulnerabilities == 0 else "review",
-            "findings": findings,
+            "status": status,
+            "evidence_count": len(evidence_rows),
+            "evidence": [row.as_json() for row in evidence_rows],
         }
 
     # Executive summary text
     summary_lines = [
-        f"Compliance Evidence Bundle — {framework.upper()}",
+        f"Compliance Evidence Bundle — {metadata.report_label}",
         f"Generated: {report.generated_at.isoformat()}",
         f"Tool: agent-bom v{report.tool_version}",
+        f"Evidence completeness: {evidence_completeness}",
         "",
         f"Agents scanned: {report.total_agents}",
         f"MCP servers: {report.total_servers}",
@@ -91,15 +259,58 @@ def export_compliance_bundle(
         f"Vulnerabilities found: {report.total_vulnerabilities}",
         f"Critical findings: {len(report.critical_vulns)}",
         "",
-        "Controls mapped: " + ", ".join(cmmc_control_map.keys()),
+        "Controls mapped: " + ", ".join(metadata.catalog.keys()),
+        "",
+        "Note: this local CLI bundle is evidence-backed but unsigned unless AGENT_BOM_AUDIT_HMAC_KEY is set. "
+        "For tenant-scoped signed reports, use the API compliance report endpoint.",
     ]
+
+    artifacts = {
+        "sbom.cdx.json": _json_bytes(sbom_data),
+        "vulnerability_report.json": _json_bytes(vuln_entries),
+        "policy_results.json": _json_bytes(policy_results),
+        "compliance_mapping.json": _json_bytes(control_mapping),
+        "summary.txt": "\n".join(summary_lines).encode("utf-8"),
+    }
+    signature_key = os.environ.get("AGENT_BOM_AUDIT_HMAC_KEY", "")
+    signature_status = "signed" if signature_key else "unsigned_local_bundle"
+    manifest = {
+        "schema_version": "agent-bom.compliance_cli_bundle/v1",
+        "framework": metadata.slug,
+        "framework_label": metadata.report_label,
+        "generated_at": report.generated_at.isoformat(),
+        "tool_version": report.tool_version,
+        "evidence_completeness": evidence_completeness,
+        "mapped_evidence_count": mapped_evidence_count,
+        "input_summary": {
+            "agents": report.total_agents,
+            "servers": report.total_servers,
+            "packages": report.total_packages,
+            "vulnerabilities": report.total_vulnerabilities,
+            "findings": len(cve_rows),
+        },
+        "files": {name: {"sha256": _digest(payload), "bytes": len(payload)} for name, payload in artifacts.items()},
+        "signature": {
+            "status": signature_status,
+            "algorithm": "HMAC-SHA256" if signature_key else None,
+            "signed_payload": "manifest.json" if signature_key else None,
+        },
+    }
+    manifest_bytes = _json_bytes(manifest)
+    artifacts["manifest.json"] = manifest_bytes
+    if signature_key:
+        signature = hmac.new(signature_key.encode("utf-8"), manifest_bytes, hashlib.sha256).hexdigest()
+        artifacts["signature.json"] = _json_bytes(
+            {
+                "algorithm": "HMAC-SHA256",
+                "manifest_sha256": _digest(manifest_bytes),
+                "signature": signature,
+            }
+        )
 
     zip_path = output_path if output_path.endswith(".zip") else output_path + ".zip"
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr("sbom.cdx.json", json.dumps(sbom_data, indent=2, default=str))
-        zf.writestr("vulnerability_report.json", json.dumps(vuln_entries, indent=2, default=str))
-        zf.writestr("policy_results.json", json.dumps(policy_results, indent=2, default=str))
-        zf.writestr("compliance_mapping.json", json.dumps(control_mapping, indent=2, default=str))
-        zf.writestr("summary.txt", "\n".join(summary_lines))
+        for name, payload in artifacts.items():
+            zf.writestr(name, payload)
 
     return zip_path

--- a/tests/test_compliance_export.py
+++ b/tests/test_compliance_export.py
@@ -33,6 +33,8 @@ def _make_report(with_vulns: bool = True) -> AIBOMReport:
             exposed_tools=[],
             risk_score=6.0,
         )
+        br.cmmc_tags = ["RA.L2-3.11.2"]
+        br.fedramp_tags = ["RA-5"]
         blast_radii.append(br)
     return AIBOMReport(agents=agents, blast_radii=blast_radii)
 
@@ -48,6 +50,7 @@ def test_zip_structure(tmp_path: Path):
         assert "vulnerability_report.json" in names
         assert "policy_results.json" in names
         assert "compliance_mapping.json" in names
+        assert "manifest.json" in names
         assert "summary.txt" in names
 
 
@@ -57,11 +60,25 @@ def test_control_mapping_keys(tmp_path: Path):
     export_compliance_bundle(report, "cmmc", str(out))
     with zipfile.ZipFile(str(out)) as zf:
         mapping = json.loads(zf.read("compliance_mapping.json"))
-    assert "CM-8" in mapping
-    assert "SI-2" in mapping
-    assert "SR-3" in mapping
-    assert "RA-3" in mapping
-    assert "AU-2" in mapping
+    assert "RA.L2-3.11.2" in mapping
+    assert "SI.L2-3.14.1" in mapping
+    assert "CM.L2-3.4.3" in mapping
+    assert mapping["RA.L2-3.11.2"]["status"] == "fail"
+    assert mapping["RA.L2-3.11.2"]["evidence_count"] == 1
+
+
+def test_framework_specific_controls_are_not_cmmc_for_fedramp(tmp_path: Path):
+    report = _make_report()
+    out = tmp_path / "evidence.zip"
+    export_compliance_bundle(report, "fedramp", str(out))
+    with zipfile.ZipFile(str(out)) as zf:
+        mapping = json.loads(zf.read("compliance_mapping.json"))
+        policy = json.loads(zf.read("policy_results.json"))
+    assert policy["framework"] == "fedramp"
+    assert "RA-5" in mapping
+    assert "RA.L2-3.11.2" not in mapping
+    assert mapping["RA-5"]["status"] == "fail"
+    assert mapping["RA-5"]["evidence_count"] == 1
 
 
 def test_vulnerability_report_content(tmp_path: Path):
@@ -75,14 +92,29 @@ def test_vulnerability_report_content(tmp_path: Path):
     assert vulns[0]["severity"] == "high"
 
 
-def test_clean_report_produces_pass(tmp_path: Path):
+def test_empty_report_is_incomplete_not_pass(tmp_path: Path):
+    report = _make_report(with_vulns=False)
+    report.agents = []
+    out = tmp_path / "evidence.zip"
+    export_compliance_bundle(report, "fedramp", str(out))
+    with zipfile.ZipFile(str(out)) as zf:
+        mapping = json.loads(zf.read("compliance_mapping.json"))
+        policy = json.loads(zf.read("policy_results.json"))
+        manifest = json.loads(zf.read("manifest.json"))
+    assert policy["evidence_completeness"] == "incomplete"
+    assert manifest["evidence_completeness"] == "incomplete"
+    assert all(ctrl["status"] == "not_evaluated" for ctrl in mapping.values())
+
+
+def test_partial_report_without_framework_evidence_is_not_evaluated(tmp_path: Path):
     report = _make_report(with_vulns=False)
     out = tmp_path / "evidence.zip"
     export_compliance_bundle(report, "fedramp", str(out))
     with zipfile.ZipFile(str(out)) as zf:
         mapping = json.loads(zf.read("compliance_mapping.json"))
-    for ctrl in mapping.values():
-        assert ctrl["status"] == "pass"
+        policy = json.loads(zf.read("policy_results.json"))
+    assert policy["evidence_completeness"] == "not_evaluated"
+    assert all(ctrl["status"] == "not_evaluated" for ctrl in mapping.values())
 
 
 def test_summary_text(tmp_path: Path):
@@ -91,8 +123,9 @@ def test_summary_text(tmp_path: Path):
     export_compliance_bundle(report, "nist-ai-rmf", str(out))
     with zipfile.ZipFile(str(out)) as zf:
         summary = zf.read("summary.txt").decode()
-    assert "NIST-AI-RMF" in summary
+    assert "NIST AI RMF" in summary
     assert "Vulnerabilities found:" in summary
+    assert "Evidence completeness:" in summary
 
 
 def test_unified_findings_populate_vulnerability_report(tmp_path: Path):
@@ -129,3 +162,48 @@ def test_unified_findings_populate_vulnerability_report(tmp_path: Path):
             "affected_servers": ["s1"],
         }
     ]
+
+
+def test_manifest_has_digests_and_unsigned_status(tmp_path: Path):
+    report = _make_report()
+    out = tmp_path / "evidence.zip"
+
+    export_compliance_bundle(report, "cmmc", str(out))
+
+    with zipfile.ZipFile(str(out)) as zf:
+        manifest = json.loads(zf.read("manifest.json"))
+        names = zf.namelist()
+
+    assert "signature.json" not in names
+    assert manifest["schema_version"] == "agent-bom.compliance_cli_bundle/v1"
+    assert manifest["signature"]["status"] == "unsigned_local_bundle"
+    assert manifest["files"]["compliance_mapping.json"]["sha256"]
+    assert manifest["mapped_evidence_count"] == 1
+
+
+def test_hmac_signature_when_key_is_set(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_AUDIT_HMAC_KEY", "test-local-key")
+    report = _make_report()
+    out = tmp_path / "evidence.zip"
+
+    export_compliance_bundle(report, "cmmc", str(out))
+
+    with zipfile.ZipFile(str(out)) as zf:
+        manifest = json.loads(zf.read("manifest.json"))
+        signature = json.loads(zf.read("signature.json"))
+
+    assert manifest["signature"]["status"] == "signed"
+    assert signature["algorithm"] == "HMAC-SHA256"
+    assert signature["signature"]
+
+
+def test_unknown_framework_is_rejected(tmp_path: Path):
+    report = _make_report()
+    out = tmp_path / "evidence.zip"
+
+    try:
+        export_compliance_bundle(report, "fake-framework", str(out))
+    except ValueError as exc:
+        assert "unsupported compliance framework" in str(exc)
+    else:
+        raise AssertionError("unsupported compliance framework should fail")


### PR DESCRIPTION
## Summary
- replace the legacy hard-coded compliance ZIP with framework-aware evidence mapping from the canonical compliance catalogs
- mark missing evidence as `incomplete` / `not_evaluated` instead of `pass`
- add a manifest with SHA-256 file digests and optional local HMAC signature via `AGENT_BOM_AUDIT_HMAC_KEY`

## Why
The CLI `--compliance-export` path was producing a counts-only bundle and reused CMMC-shaped controls for other frameworks. That made the local export look more authoritative than the evidence supported.

## Validation
- `uv run pytest tests/test_compliance_export.py -q --tb=short`
- `uv run ruff check --fix src/agent_bom/output/compliance_export.py tests/test_compliance_export.py`
- `uv run ruff check src/agent_bom/output/compliance_export.py tests/test_compliance_export.py`
- `uv run mypy src/agent_bom/output/compliance_export.py`
- `git diff --check`

Refs #3242
