### PR TITLE
Persist cloud connection last scan handoff

### DIFF
--- a/src/agent_bom/api/connection_store.py
+++ b/src/agent_bom/api/connection_store.py
@@ -56,6 +56,7 @@ class CloudConnectionRecord:
     created_at: str = ""
     updated_at: str = ""
     last_scan_at: str | None = None
+    last_scan_id: str | None = None
     scan_interval_minutes: int | None = None
     # Non-secret, provider-specific connection parameters (e.g. Azure
     # tenant_id/subscription_id, GCP project_id, Snowflake user/role/warehouse).
@@ -113,6 +114,7 @@ CONNECTION_STORAGE_SCHEMA = StorageSchema(
                 "created_at",
                 "updated_at",
                 "last_scan_at",
+                "last_scan_id",
                 "scan_interval_minutes",
                 "auth_params",
             ),
@@ -123,8 +125,8 @@ CONNECTION_STORAGE_SCHEMA = StorageSchema(
                     "role_ref TEXT NOT NULL, external_id_encrypted TEXT NOT NULL DEFAULT '', "
                     "regions TEXT NOT NULL DEFAULT '[]', status TEXT NOT NULL DEFAULT 'pending', "
                     "status_detail TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL, "
-                    "updated_at TEXT NOT NULL, last_scan_at TEXT, scan_interval_minutes INTEGER, "
-                    "auth_params TEXT NOT NULL DEFAULT '{}')"
+                    "updated_at TEXT NOT NULL, last_scan_at TEXT, last_scan_id TEXT, "
+                    "scan_interval_minutes INTEGER, auth_params TEXT NOT NULL DEFAULT '{}')"
                 ),
                 "postgres": (
                     "CREATE TABLE IF NOT EXISTS cloud_connections (id TEXT PRIMARY KEY, "
@@ -132,8 +134,8 @@ CONNECTION_STORAGE_SCHEMA = StorageSchema(
                     "role_ref TEXT NOT NULL, external_id_encrypted TEXT NOT NULL DEFAULT '', "
                     "regions TEXT NOT NULL DEFAULT '[]', status TEXT NOT NULL DEFAULT 'pending', "
                     "status_detail TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL, "
-                    "updated_at TEXT NOT NULL, last_scan_at TEXT, scan_interval_minutes INTEGER, "
-                    "auth_params TEXT NOT NULL DEFAULT '{}')"
+                    "updated_at TEXT NOT NULL, last_scan_at TEXT, last_scan_id TEXT, "
+                    "scan_interval_minutes INTEGER, auth_params TEXT NOT NULL DEFAULT '{}')"
                 ),
             },
         ),
@@ -183,6 +185,7 @@ def _decode_auth_params(raw: Any) -> dict[str, Any]:
 
 def _row_to_record(row: Sequence[Any]) -> CloudConnectionRecord:
     """Map a ``cloud_connections`` row tuple to a record (shared by backends)."""
+    has_last_scan_id = len(row) > 14
     return CloudConnectionRecord(
         id=row[0],
         tenant_id=row[1],
@@ -196,8 +199,11 @@ def _row_to_record(row: Sequence[Any]) -> CloudConnectionRecord:
         created_at=row[9] or "",
         updated_at=row[10] or "",
         last_scan_at=row[11] if len(row) > 11 else None,
-        scan_interval_minutes=_decode_interval(row[12]) if len(row) > 12 else None,
-        auth_params=_decode_auth_params(row[13]) if len(row) > 13 else {},
+        last_scan_id=row[12] if has_last_scan_id else None,
+        scan_interval_minutes=(
+            _decode_interval(row[13] if has_last_scan_id else row[12]) if len(row) > 12 else None
+        ),
+        auth_params=_decode_auth_params(row[14] if has_last_scan_id else row[13]) if len(row) > 13 else {},
     )
 
 
@@ -293,6 +299,8 @@ class SQLiteConnectionStore:
         if ddl:
             self._conn.execute(ddl)
         columns = {row[1] for row in self._conn.execute("PRAGMA table_info(cloud_connections)").fetchall()}
+        if "last_scan_id" not in columns:
+            self._conn.execute("ALTER TABLE cloud_connections ADD COLUMN last_scan_id TEXT")
         if "scan_interval_minutes" not in columns:
             self._conn.execute("ALTER TABLE cloud_connections ADD COLUMN scan_interval_minutes INTEGER")
         if "auth_params" not in columns:
@@ -311,8 +319,8 @@ class SQLiteConnectionStore:
             INSERT OR REPLACE INTO cloud_connections
                 (id, tenant_id, provider, display_name, role_ref, external_id_encrypted,
                  regions, status, status_detail, created_at, updated_at, last_scan_at,
-                 scan_interval_minutes, auth_params)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 last_scan_id, scan_interval_minutes, auth_params)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 record.id,
@@ -327,6 +335,7 @@ class SQLiteConnectionStore:
                 record.created_at,
                 record.updated_at,
                 record.last_scan_at,
+                record.last_scan_id,
                 record.scan_interval_minutes,
                 json.dumps(record.auth_params),
             ),
@@ -336,7 +345,7 @@ class SQLiteConnectionStore:
     def get(self, tenant_id: str, connection_id: str) -> CloudConnectionRecord | None:
         row = self._conn.execute(
             "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-            "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params "
+            "regions, status, status_detail, created_at, updated_at, last_scan_at, last_scan_id, scan_interval_minutes, auth_params "
             "FROM cloud_connections WHERE tenant_id = ? AND id = ?",
             (tenant_id, connection_id),
         ).fetchone()
@@ -345,7 +354,7 @@ class SQLiteConnectionStore:
     def list_for_tenant(self, tenant_id: str) -> list[CloudConnectionRecord]:
         rows = self._conn.execute(
             "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-            "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params "
+            "regions, status, status_detail, created_at, updated_at, last_scan_at, last_scan_id, scan_interval_minutes, auth_params "
             "FROM cloud_connections WHERE tenant_id = ? ORDER BY created_at, id",
             (tenant_id,),
         ).fetchall()
@@ -362,7 +371,7 @@ class SQLiteConnectionStore:
     def list_schedulable(self) -> list[CloudConnectionRecord]:
         rows = self._conn.execute(
             "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-            "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params "
+            "regions, status, status_detail, created_at, updated_at, last_scan_at, last_scan_id, scan_interval_minutes, auth_params "
             "FROM cloud_connections WHERE scan_interval_minutes IS NOT NULL ORDER BY created_at, id"
         ).fetchall()
         return [_row_to_record(row) for row in rows]

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -317,6 +317,7 @@ def _mark_connection(
     status: str,
     status_detail: str = "",
     last_scan_at: str | None = None,
+    last_scan_id: str | None = None,
 ) -> None:
     """Persist a connection lifecycle transition via the Phase A store's upsert.
 
@@ -330,6 +331,8 @@ def _mark_connection(
     record.updated_at = _now()
     if last_scan_at is not None:
         record.last_scan_at = last_scan_at
+    if last_scan_id is not None:
+        record.last_scan_id = last_scan_id
     get_connection_store().put(record)
 
 
@@ -630,7 +633,14 @@ async def scan_connection(request: Request, connection_id: str, _role: Any = _SC
         )
         raise HTTPException(status_code=502, detail="Cloud connection scan failed; see server logs.") from exc
 
-    _mark_connection(record, status=STATUS_ACTIVE, status_detail="", last_scan_at=_now())
+    scan_id = str(summary.get("scan_id") or "")
+    _mark_connection(
+        record,
+        status=STATUS_ACTIVE,
+        status_detail="",
+        last_scan_at=_now(),
+        last_scan_id=scan_id or None,
+    )
     log_action(
         "cloud_connection.scan",
         actor=actor,
@@ -638,7 +648,7 @@ async def scan_connection(request: Request, connection_id: str, _role: Any = _SC
         tenant_id=tenant_id,
         provider=record.provider,
         outcome="success",
-        scan_id=summary["scan_id"],
+        scan_id=scan_id,
     )
     summary["connection"] = record.to_public_dict()
     return summary

--- a/tests/test_cloud_connections.py
+++ b/tests/test_cloud_connections.py
@@ -101,6 +101,7 @@ def test_store_crud_round_trip() -> None:
     fetched = store.get("tenant-a", record.id)
     assert fetched is not None
     assert fetched.display_name == "prod-readonly"
+    assert fetched.last_scan_id is None
     assert [r.id for r in store.list_for_tenant("tenant-a")] == [record.id]
 
     assert store.delete("tenant-a", record.id) is True
@@ -138,24 +139,32 @@ def test_sqlite_store_crud_and_isolation(tmp_path: Any) -> None:
     assert store.get("tenant-b", b.id) is None
 
 
-def test_sqlite_auth_params_column_present_defaults_and_round_trips(tmp_path: Any) -> None:
+def test_sqlite_last_scan_id_and_auth_params_columns_present_defaults_and_round_trips(tmp_path: Any) -> None:
     db_path = str(tmp_path / "connections.db")
     store = SQLiteConnectionStore(db_path)
 
-    # The migrated column exists.
+    # The migrated columns exist.
     columns = {row[1] for row in sqlite3.connect(db_path).execute("PRAGMA table_info(cloud_connections)").fetchall()}
+    assert "last_scan_id" in columns
     assert "auth_params" in columns
 
-    # A record with no auth_params defaults to an empty dict on read-back.
+    # A record with no last_scan_id/auth_params defaults cleanly on read-back.
     plain = _record("tenant-a")
     store.put(plain)
-    assert store.get("tenant-a", plain.id).auth_params == {}
+    fetched_plain = store.get("tenant-a", plain.id)
+    assert fetched_plain is not None
+    assert fetched_plain.last_scan_id is None
+    assert fetched_plain.auth_params == {}
 
-    # A record with auth_params round-trips the JSON unchanged.
+    # A record with last_scan_id/auth_params round-trips unchanged.
     with_params = _record("tenant-a", provider="azure")
+    with_params.last_scan_id = "scan-123"
     with_params.auth_params = {"tenant_id": "t-guid", "subscription_id": "s-guid"}
     store.put(with_params)
-    assert store.get("tenant-a", with_params.id).auth_params == {"tenant_id": "t-guid", "subscription_id": "s-guid"}
+    fetched_params = store.get("tenant-a", with_params.id)
+    assert fetched_params is not None
+    assert fetched_params.last_scan_id == "scan-123"
+    assert fetched_params.auth_params == {"tenant_id": "t-guid", "subscription_id": "s-guid"}
 
 
 def test_sqlite_auth_params_migration_is_idempotent_on_legacy_table(tmp_path: Any) -> None:
@@ -179,10 +188,12 @@ def test_sqlite_auth_params_migration_is_idempotent_on_legacy_table(tmp_path: An
     store = SQLiteConnectionStore(db_path)  # runs the idempotent migration
     legacy = store.get("tenant-a", "legacy-1")
     assert legacy is not None
+    assert legacy.last_scan_id is None
     assert legacy.auth_params == {}
     # Re-init is a no-op (idempotent) and the backfilled column stays NOT NULL.
     store.init_schema()
     columns = {row[1] for row in sqlite3.connect(db_path).execute("PRAGMA table_info(cloud_connections)").fetchall()}
+    assert "last_scan_id" in columns
     assert "auth_params" in columns
 
 
@@ -644,6 +655,31 @@ def test_api_create_response_never_contains_secret() -> None:
     assert body["has_external_id"] is True
     assert body["provider"] == "aws"
     assert body["status"] == STATUS_PENDING
+    assert body["last_scan_id"] is None
+
+
+def test_api_list_get_include_last_scan_id_and_never_contain_secret() -> None:
+    store = InMemoryConnectionStore()
+    record = _record("tenant-alpha")
+    record.status = "active"
+    record.last_scan_at = "2026-06-27T01:00:00+00:00"
+    record.last_scan_id = "scan-123"
+    store.put(record)
+    set_connection_store(store)
+
+    client = TestClient(_app())
+    get_body = client.get(f"/v1/cloud/connections/{record.id}", headers=_proxy_headers()).json()
+    list_body = client.get("/v1/cloud/connections", headers=_proxy_headers()).json()
+    listed = list_body["connections"][0]
+
+    assert get_body["last_scan_id"] == "scan-123"
+    assert listed["last_scan_id"] == "scan-123"
+    for body in (get_body, listed):
+        flat = str(body)
+        assert "super-secret-external-id" not in flat
+        assert "external_id" not in body
+        assert "external_id_encrypted" not in body
+        assert body["has_external_id"] is True
 
 
 def test_api_list_get_delete_tenant_scoped() -> None:
@@ -1102,6 +1138,7 @@ def test_scan_launch_brokers_runs_persists_and_marks_active(monkeypatch: pytest.
     assert body["provider"] == "aws"
     scan_id = body["scan_id"]
     assert scan_id
+    assert body["connection"]["last_scan_id"] == scan_id
     assert body["cis_benchmark"]["total"] == 2
     assert body["inventory"]["status"] == "ok"
 
@@ -1119,7 +1156,10 @@ def test_scan_launch_brokers_runs_persists_and_marks_active(monkeypatch: pytest.
     fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
     assert fetched["status"] == "active"
     assert fetched["last_scan_at"]
+    assert fetched["last_scan_id"] == scan_id
     assert fetched["status_detail"] == ""
+    listing = client.get("/v1/cloud/connections", headers=_proxy_headers(tenant="tenant-alpha")).json()
+    assert listing["connections"][0]["last_scan_id"] == scan_id
     # No secret anywhere in the response surface.
     assert "super-secret-external-id" not in str(body)
 
@@ -1138,6 +1178,7 @@ def test_scan_failure_marks_error_without_secret(monkeypatch: pytest.MonkeyPatch
     assert fetched["status_detail"]
     assert "super-secret-external-id" not in fetched["status_detail"]
     assert fetched["last_scan_at"] is None
+    assert fetched["last_scan_id"] is None
 
 
 def test_scan_requires_scan_permission(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -580,7 +580,10 @@ function FragmentRow({
   onScheduleChange: (value: string) => void;
   onDelete: () => void;
 }) {
-  const showDetail = Boolean(result || scanError || scheduleError || statusDetail);
+  const handoffScanId = result?.scan_id ?? connection.last_scan_id;
+  const showDetail = Boolean(
+    result || handoffScanId || scanError || scheduleError || statusDetail,
+  );
   return (
     <>
       <tr className="border-b border-[color:var(--border-subtle)] last:border-b-0 align-top">
@@ -670,6 +673,9 @@ function FragmentRow({
         <tr className="border-b border-[color:var(--border-subtle)] last:border-b-0 bg-[color:var(--surface-elevated)]/40">
           <td colSpan={6} className="px-4 pb-4 pt-0">
             {result ? <ScanResultPanel result={result} /> : null}
+            {!result && handoffScanId ? (
+              <ScanHandoffLinks scanId={handoffScanId} />
+            ) : null}
             {!result && scanError ? (
               <div className="rounded-xl border border-red-900/60 bg-red-950/20 p-3 text-xs text-red-300">
                 {scanError}
@@ -751,17 +757,51 @@ function ScanResultPanel({ result }: { result: CloudConnectionScanResponse }) {
       </p>
       <div className="mt-4 flex flex-wrap gap-2">
         {evidenceLinks(result.scan_id).map(({ label, href, icon: Icon }) => (
-          <Link
-            key={label}
-            href={href}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1.5 text-[11px] font-medium text-[var(--foreground)] transition hover:border-emerald-700 hover:text-emerald-300"
-          >
-            <Icon className="h-3.5 w-3.5" />
-            {label}
-          </Link>
+          <HandoffLink key={label} label={label} href={href} icon={Icon} />
         ))}
       </div>
     </div>
+  );
+}
+
+function ScanHandoffLinks({ scanId }: { scanId: string }) {
+  return (
+    <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="inline-flex items-center gap-2 text-xs font-semibold text-[var(--foreground)]">
+          <FileSearch className="h-4 w-4 text-emerald-400" />
+          Last scan handoff
+        </p>
+        <span className="font-mono text-[10px] text-[var(--text-tertiary)]">
+          scan {scanId.slice(0, 8)}
+        </span>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {evidenceLinks(scanId).map(({ label, href, icon }) => (
+          <HandoffLink key={label} label={label} href={href} icon={icon} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function HandoffLink({
+  label,
+  href,
+  icon: Icon,
+}: {
+  label: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+}) {
+  return (
+    <Link
+      href={href}
+      className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1.5 text-[11px] font-medium text-[var(--foreground)] transition hover:border-emerald-700 hover:text-emerald-300"
+    >
+      <Icon className="h-3.5 w-3.5" />
+      {label}
+    </Link>
   );
 }
 

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2622,6 +2622,8 @@ export interface CloudConnectionRecord {
   created_at: string;
   updated_at: string;
   last_scan_at: string | null;
+  /** Last successfully persisted scan id for durable handoff links. */
+  last_scan_id: string | null;
   /** Recurring read-only scan cadence. Null means manual-only. */
   scan_interval_minutes: number | null;
   /** Non-secret provider-specific params (Azure tenant/subscription, GCP project, Snowflake user/role/warehouse). */

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -57,6 +57,7 @@ const CREATED_RECORD = {
   created_at: "2026-06-27T00:00:00Z",
   updated_at: "2026-06-27T00:00:00Z",
   last_scan_at: null,
+  last_scan_id: null,
   scan_interval_minutes: null,
 };
 
@@ -240,6 +241,7 @@ describe("ConnectionsPage", () => {
         ...CREATED_RECORD,
         status: "active",
         last_scan_at: "2026-06-27T01:00:00Z",
+        last_scan_id: "abcdef12-3456-7890-abcd-ef1234567890",
       },
     });
 
@@ -273,6 +275,46 @@ describe("ConnectionsPage", () => {
     expect(screen.getByRole("link", { name: "Graph" })).toHaveAttribute(
       "href",
       "/graph?scan_id=abcdef12-3456-7890-abcd-ef1234567890",
+    );
+  });
+
+  it("shows durable handoff links from the persisted last scan id after reload", async () => {
+    apiMock.listCloudConnections.mockResolvedValue({
+      schema_version: "cloud.connections.v1",
+      tenant_id: "tenant-acme",
+      connections: [
+        {
+          ...CREATED_RECORD,
+          status: "active",
+          last_scan_at: "2026-06-27T01:00:00Z",
+          last_scan_id: "persisted-scan-123",
+        },
+      ],
+      count: 1,
+    });
+
+    render(<ConnectionsPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Production account")).toBeInTheDocument(),
+    );
+
+    expect(screen.getByText("Last scan handoff")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Scan result" })).toHaveAttribute(
+      "href",
+      "/scan?id=persisted-scan-123",
+    );
+    expect(screen.getByRole("link", { name: "Jobs" })).toHaveAttribute(
+      "href",
+      "/jobs?q=persisted-scan-123",
+    );
+    expect(screen.getByRole("link", { name: "Findings" })).toHaveAttribute(
+      "href",
+      "/vulns?scan=persisted-scan-123",
+    );
+    expect(screen.getByRole("link", { name: "Graph" })).toHaveAttribute(
+      "href",
+      "/graph?scan_id=persisted-scan-123",
     );
   });
 


### PR DESCRIPTION
## Summary

- Add nullable `last_scan_id` to cloud connection records and SQLite persistence.
- Persist the successful brokered scan id alongside `last_scan_at`.
- Render durable scan handoff links from either a fresh scan result or the persisted connection `last_scan_id` after reload.

## Validation

- `python -m pytest tests/test_cloud_connections.py`
- `npm run test:run -- tests/connections-page.test.tsx`
- `npm run lint -- app/connections/page.tsx tests/connections-page.test.tsx lib/api-types.ts`
- `python -m ruff check src/agent_bom/api/connection_store.py src/agent_bom/api/routes/cloud_connections.py tests/test_cloud_connections.py`