### PR TITLE
fix(cli): centralize severity gate comparisons

### DIFF
--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -15,6 +15,7 @@ from rich.console import Console
 from agent_bom import __version__
 from agent_bom.cli._common import _sync_runtime_consoles
 from agent_bom.ecosystems import SUPPORTED_PACKAGE_ECOSYSTEMS
+from agent_bom.graph.severity import severity_at_or_above
 
 
 def _response_has_version(response, ecosystem: str, version: str) -> bool:
@@ -406,14 +407,10 @@ def _format_vulnerability_count(count: int) -> str:
     return f"{count} vulnerability found" if count == 1 else f"{count} vulnerabilities found"
 
 
-_CHECK_SEVERITY_RANK = {"none": 0, "unknown": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
-
-
 def _vulns_at_or_above(vulnerabilities: list, threshold: str | None) -> list:
     if not threshold:
         return list(vulnerabilities)
-    threshold_rank = _CHECK_SEVERITY_RANK[threshold.lower()]
-    return [vuln for vuln in vulnerabilities if _CHECK_SEVERITY_RANK.get(str(vuln.severity.value).lower(), 0) >= threshold_rank]
+    return [vuln for vuln in vulnerabilities if severity_at_or_above(str(vuln.severity.value), threshold)]
 
 
 def _resolve_check_ecosystems(name: str, version: str, ecosystem: Optional[str], detected_eco: str) -> list[str]:

--- a/src/agent_bom/cli/_focused_commands.py
+++ b/src/agent_bom/cli/_focused_commands.py
@@ -20,6 +20,8 @@ from typing import Optional
 
 import click
 
+from agent_bom.graph.severity import severity_at_or_above
+
 
 def _validate_json_or_console_format(command_name: str, output_format: str) -> str:
     """Focused intelligence commands do not emit SARIF or implement vuln gates."""
@@ -32,9 +34,6 @@ def _validate_json_or_console_format(command_name: str, output_format: str) -> s
     return normalized
 
 
-_FOCUSED_GATE_ORDER = {"critical": 0, "high": 1, "medium": 2, "low": 3}
-
-
 def _focused_default_output(output_format: str, output_path: Optional[str]) -> Optional[str]:
     """Focused scan JSON/SARIF modes stream by default instead of creating a report file."""
     if output_path is None and output_format.lower() in {"json", "sarif"}:
@@ -44,8 +43,7 @@ def _focused_default_output(output_format: str, output_path: Optional[str]) -> O
 
 def _has_finding_at_or_above(findings, threshold: str = "high") -> bool:
     """Return True when focused findings should fail CI by default."""
-    threshold_rank = _FOCUSED_GATE_ORDER.get(threshold.lower(), 1)
-    return any(_FOCUSED_GATE_ORDER.get(str(getattr(finding, "severity", "low")).lower(), 99) <= threshold_rank for finding in findings)
+    return any(severity_at_or_above(str(getattr(finding, "severity", "unknown")), threshold) for finding in findings)
 
 
 @click.command("image")

--- a/src/agent_bom/cli/agents/_preflight.py
+++ b/src/agent_bom/cli/agents/_preflight.py
@@ -18,6 +18,7 @@ import click
 
 from agent_bom.cli.agents._context import ScanContext
 from agent_bom.cli.agents._output import render_output
+from agent_bom.graph.severity import severity_at_or_above
 from agent_bom.models import AIBOMReport
 
 
@@ -331,7 +332,5 @@ def run_iac_only_scan(
         )
 
     if fail_on_severity and all_iac_findings:
-        severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
-        threshold = severity_order.get(fail_on_severity, 99)
-        if any(severity_order.get(finding.severity, 99) <= threshold for finding in all_iac_findings):
+        if any(severity_at_or_above(finding.severity, fail_on_severity) for finding in all_iac_findings):
             sys.exit(1)

--- a/tests/test_focused_security_gates.py
+++ b/tests/test_focused_security_gates.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
+from rich.console import Console
 
 from agent_bom.cli import main
+from agent_bom.cli._focused_commands import _has_finding_at_or_above
+from agent_bom.cli.agents._preflight import run_iac_only_scan
 from agent_bom.iac.models import IaCFinding, ScannerVerdict, ScanResult
 from agent_bom.secret_scanner import SecretFinding, SecretScanResult
 
@@ -143,6 +149,79 @@ def test_iac_command_exits_zero_when_clean(tmp_path: Path):
 
     assert result.exit_code == 0
     assert "no misconfigurations" in " ".join(result.output.split())
+
+
+def test_focused_gate_uses_canonical_severity_order():
+    findings = [SimpleNamespace(severity="medium"), SimpleNamespace(severity="unknown")]
+
+    assert _has_finding_at_or_above(findings, "medium") is True
+    assert _has_finding_at_or_above(findings, "high") is False
+
+
+def test_iac_preflight_gate_uses_canonical_severity_order(tmp_path: Path):
+    finding = IaCFinding(
+        rule_id="TF-TEST",
+        severity="medium",
+        title="Open storage",
+        message="Bucket is public",
+        file_path="main.tf",
+        line_number=1,
+        category="terraform",
+    )
+    scan_result = ScanResult(findings=[finding], verdicts=[ScannerVerdict("terraform", "ran", 1)])
+
+    with patch("agent_bom.iac.scan_iac_with_context", return_value=scan_result):
+        run_iac_only_scan(
+            con=Console(file=StringIO(), force_terminal=False),
+            iac_paths=(str(tmp_path),),
+            k8s_live=False,
+            k8s_live_namespace="default",
+            k8s_live_all_namespaces=False,
+            k8s_live_context=None,
+            output=None,
+            output_format="console",
+            no_tree=False,
+            quiet=True,
+            no_color=True,
+            open_report=False,
+            compliance_export=None,
+            mermaid_mode="auto",
+            push_gateway=None,
+            otel_endpoint=None,
+            baseline=None,
+            delta_mode=False,
+            verbose=False,
+            exclude_unfixable=False,
+            fixable_only=False,
+            fail_on_severity="high",
+        )
+
+    with patch("agent_bom.iac.scan_iac_with_context", return_value=scan_result):
+        with pytest.raises(SystemExit):
+            run_iac_only_scan(
+                con=Console(file=StringIO(), force_terminal=False),
+                iac_paths=(str(tmp_path),),
+                k8s_live=False,
+                k8s_live_namespace="default",
+                k8s_live_all_namespaces=False,
+                k8s_live_context=None,
+                output=None,
+                output_format="console",
+                no_tree=False,
+                quiet=True,
+                no_color=True,
+                open_report=False,
+                compliance_export=None,
+                mermaid_mode="auto",
+                push_gateway=None,
+                otel_endpoint=None,
+                baseline=None,
+                delta_mode=False,
+                verbose=False,
+                exclude_unfixable=False,
+                fixable_only=False,
+                fail_on_severity="medium",
+            )
 
 
 def test_drop_unfixable_drops_findings_without_fix():


### PR DESCRIPTION
## Summary
- replace remaining CLI-local severity rank maps with the canonical `graph.severity.severity_at_or_above` helper
- keep focused-mode, package-check, and IaC preflight gates aligned with graph/API policy ordering
- add focused regression tests for focused scan and IaC threshold behavior

## Validation
- `uv run pytest tests/test_focused_security_gates.py tests/test_cli_check.py -q --tb=short`
- `uv run ruff check src/agent_bom/cli/_focused_commands.py src/agent_bom/cli/_check.py src/agent_bom/cli/agents/_preflight.py tests/test_focused_security_gates.py`
- `uv run mypy src/agent_bom/cli/_focused_commands.py src/agent_bom/cli/_check.py src/agent_bom/cli/agents/_preflight.py`
- `git diff --check`

Refs #3242
