### PR TITLE
feat(cli): add findings triage commands

### DIFF
--- a/docs/CLI_MAP.md
+++ b/docs/CLI_MAP.md
@@ -75,6 +75,7 @@ Graph, mesh, dashboard, and narrative reporting workflows.
 | `graph` | Build / export the context graph. |
 | `mesh` | Agent-mesh view. |
 | `report` | Reporting group (history, narrative, exports). |
+| `findings` | Findings workbench for CLI users: list normalized findings, triage queue items, decisions, and signed OpenVEX export. |
 
 ## Governance
 

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -69,6 +69,7 @@ verbs are additive entry points that delegate to the underlying implementations.
 | `graph-evidence` | Export retained graph snapshot history or a signed evidence manifest digest |
 | `mesh` | Show lightweight agent/MCP topology without CVE scanning |
 | `report` | History, diff, pipeline-event artifacts, local queries, analytics, dashboard, and compliance narrative workflows |
+| `findings` | List normalized findings, manage the triage queue, record decisions, and export signed OpenVEX evidence |
 
 ### Governance And Operations
 

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -202,6 +202,10 @@ from agent_bom.cli._firewall import firewall_group  # noqa: E402
 
 main.add_command(firewall_group)
 
+from agent_bom.cli._findings_group import findings_cmd  # noqa: E402
+
+main.add_command(findings_cmd, "findings")
+
 from agent_bom.cli._server import api_cmd, mcp_server_cmd, serve_cmd  # noqa: E402
 
 main.add_command(serve_cmd, "serve")

--- a/src/agent_bom/cli/_findings_group.py
+++ b/src/agent_bom/cli/_findings_group.py
@@ -1,0 +1,298 @@
+"""CLI commands for findings and triage workflows."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import click
+
+from agent_bom.client import AgentBomApiError, AgentBomClient, JsonObject
+
+
+def _make_client(api_url: str | None, api_key: str | None, bearer_token: str | None, tenant_id: str | None) -> AgentBomClient:
+    base_url = api_url or os.getenv("AGENT_BOM_API_URL") or "http://127.0.0.1:8422"
+    resolved_api_key = api_key or os.getenv("AGENT_BOM_API_KEY")
+    resolved_bearer_token = bearer_token or os.getenv("AGENT_BOM_API_TOKEN")
+    resolved_tenant_id = tenant_id or os.getenv("AGENT_BOM_TENANT_ID")
+    return AgentBomClient(
+        base_url=base_url,
+        api_key=resolved_api_key,
+        bearer_token=resolved_bearer_token,
+        tenant_id=resolved_tenant_id,
+    )
+
+
+def _common_api_options(fn: Any) -> Any:
+    fn = click.option("--tenant", "tenant_id", envvar="AGENT_BOM_TENANT_ID", help="Tenant id for the request.")(fn)
+    fn = click.option("--bearer-token", envvar="AGENT_BOM_API_TOKEN", help="Bearer token for the API.")(fn)
+    fn = click.option("--api-key", envvar="AGENT_BOM_API_KEY", help="API key for the API.")(fn)
+    fn = click.option("--api-url", envvar="AGENT_BOM_API_URL", help="agent-bom API base URL.")(fn)
+    return fn
+
+
+def _emit_json(payload: JsonObject, *, output: Path | None = None) -> None:
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    if output is not None:
+        output.write_text(rendered + "\n", encoding="utf-8")
+        click.echo(f"Wrote {output}")
+        return
+    click.echo(rendered)
+
+
+def _string(value: object) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _finding_id(row: Mapping[str, object]) -> str:
+    for key in ("finding_id", "id", "vulnerability_id", "cve", "advisory_id"):
+        value = row.get(key)
+        if value:
+            return str(value)
+    return "-"
+
+
+def _package_name(row: Mapping[str, object]) -> str:
+    value = row.get("package") or row.get("package_name") or row.get("component")
+    if isinstance(value, dict):
+        return _string(value.get("name") or value.get("purl"))
+    return _string(value)
+
+
+def _print_findings_table(payload: JsonObject) -> None:
+    rows = payload.get("findings")
+    if not isinstance(rows, list):
+        rows = []
+    click.echo("id\tseverity\tpackage\ttitle")
+    for item in rows:
+        if not isinstance(item, dict):
+            continue
+        click.echo(
+            "\t".join(
+                [
+                    _finding_id(item),
+                    _string(item.get("severity")),
+                    _package_name(item),
+                    _string(item.get("title") or item.get("summary") or item.get("message")),
+                ]
+            )
+        )
+
+
+def _print_triage_table(payload: JsonObject) -> None:
+    rows = payload.get("triage")
+    if not isinstance(rows, list):
+        rows = []
+    click.echo("id\tvulnerability\tpackage\tstate\tdecision\tassignee")
+    for item in rows:
+        if not isinstance(item, dict):
+            continue
+        click.echo(
+            "\t".join(
+                [
+                    _string(item.get("id") or item.get("triage_id")),
+                    _string(item.get("vulnerability_id")),
+                    _string(item.get("package")),
+                    _string(item.get("queue_state")),
+                    _string(item.get("decision")),
+                    _string(item.get("assignee")),
+                ]
+            )
+        )
+
+
+def _run_request(client: AgentBomClient, callback: Any) -> JsonObject:
+    try:
+        return callback(client)
+    except AgentBomApiError as exc:
+        raise click.ClickException(f"API request failed with {exc.status_code}: {exc.body[:500]}") from exc
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    finally:
+        client.close()
+
+
+@click.group(name="findings")
+def findings_cmd() -> None:
+    """Inspect and triage normalized findings from the control plane."""
+
+
+@findings_cmd.command("list")
+@click.option("--severity", help="Filter findings by severity.")
+@click.option("--sort", default="effective_reach", show_default=True, help="Sort field used by the API.")
+@click.option("--limit", default=500, show_default=True, type=click.IntRange(min=1, max=1000), help="Maximum rows to return.")
+@click.option("--offset", default=0, show_default=True, type=click.IntRange(min=0), help="Rows to skip.")
+@click.option("--format", "output_format", type=click.Choice(["table", "json"]), default="table", show_default=True)
+@_common_api_options
+def list_findings_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    severity: str | None,
+    sort: str,
+    limit: int,
+    offset: int,
+    output_format: str,
+) -> None:
+    """List findings with the same filters as the REST API."""
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(client, lambda api: api.list_findings(severity=severity, sort=sort, limit=limit, offset=offset))
+    if output_format == "json":
+        _emit_json(payload)
+    else:
+        _print_findings_table(payload)
+
+
+@findings_cmd.group("triage")
+def triage_group() -> None:
+    """Manage finding triage decisions and OpenVEX export."""
+
+
+@triage_group.command("list")
+@click.option("--queue-state", help="Filter by triage queue state.")
+@click.option("--decision", help="Filter by triage decision.")
+@click.option("--limit", default=1000, show_default=True, type=click.IntRange(min=1, max=1000), help="Maximum rows to return.")
+@click.option("--offset", default=0, show_default=True, type=click.IntRange(min=0), help="Rows to skip.")
+@click.option("--format", "output_format", type=click.Choice(["table", "json"]), default="table", show_default=True)
+@_common_api_options
+def list_triage_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    queue_state: str | None,
+    decision: str | None,
+    limit: int,
+    offset: int,
+    output_format: str,
+) -> None:
+    """List finding triage queue items."""
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(
+        client,
+        lambda api: api.list_finding_triage(queue_state=queue_state, decision=decision, limit=limit, offset=offset),
+    )
+    if output_format == "json":
+        _emit_json(payload)
+    else:
+        _print_triage_table(payload)
+
+
+@triage_group.command("create")
+@click.argument("vulnerability_id")
+@click.option("--package", "package_name", default="*", show_default=True, help="Affected package or product.")
+@click.option("--server-name", default="", help="MCP server or asset scope for the item.")
+@click.option("--assignee", default="", help="User or team assigned to review the item.")
+@click.option("--queue-state", default="open", show_default=True, help="Initial queue state.")
+@click.option("--decision", default="under_investigation", show_default=True, help="Initial decision.")
+@click.option("--justification", help="OpenVEX justification when applicable.")
+@click.option("--reason", "decision_reason", default="", help="Human-readable decision reason.")
+@click.option("--expires-at", default="", help="Optional ISO-8601 expiry timestamp.")
+@click.option("--format", "output_format", type=click.Choice(["json"]), default="json", show_default=True)
+@_common_api_options
+def create_triage_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    vulnerability_id: str,
+    package_name: str,
+    server_name: str,
+    assignee: str,
+    queue_state: str,
+    decision: str,
+    justification: str | None,
+    decision_reason: str,
+    expires_at: str,
+    output_format: str,
+) -> None:
+    """Create a finding triage queue item."""
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(
+        client,
+        lambda api: api.create_finding_triage(
+            vulnerability_id,
+            package=package_name,
+            server_name=server_name,
+            assignee=assignee,
+            queue_state=queue_state,
+            decision=decision,
+            justification=justification,
+            decision_reason=decision_reason,
+            expires_at=expires_at,
+        ),
+    )
+    if output_format == "json":
+        _emit_json(payload)
+
+
+@triage_group.command("decide")
+@click.argument("triage_id")
+@click.option("--decision", required=True, help="Final triage decision.")
+@click.option("--justification", help="OpenVEX justification when applicable.")
+@click.option("--reason", "decision_reason", default="", help="Human-readable decision reason.")
+@click.option("--assignee", help="Reviewer recorded on the decision.")
+@click.option("--expires-at", help="Optional ISO-8601 expiry timestamp.")
+@click.option("--format", "output_format", type=click.Choice(["json"]), default="json", show_default=True)
+@_common_api_options
+def decide_triage_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    triage_id: str,
+    decision: str,
+    justification: str | None,
+    decision_reason: str,
+    assignee: str | None,
+    expires_at: str | None,
+    output_format: str,
+) -> None:
+    """Record a decision for a finding triage queue item."""
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(
+        client,
+        lambda api: api.update_finding_triage_decision(
+            triage_id,
+            decision=decision,
+            justification=justification,
+            decision_reason=decision_reason,
+            assignee=assignee,
+            expires_at=expires_at,
+        ),
+    )
+    if output_format == "json":
+        _emit_json(payload)
+
+
+@triage_group.command("export-vex")
+@click.option("-o", "--output", type=click.Path(dir_okay=False, path_type=Path), help="Write the signed OpenVEX envelope to a file.")
+@click.option("--format", "output_format", type=click.Choice(["json"]), default="json", show_default=True)
+@_common_api_options
+def export_triage_vex_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    output: Path | None,
+    output_format: str,
+) -> None:
+    """Export signed OpenVEX for eligible not_affected decisions."""
+
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(client, lambda api: api.export_finding_triage_vex())
+    if output_format == "json":
+        _emit_json(payload, output=output)
+
+
+__all__ = ["findings_cmd"]

--- a/src/agent_bom/client.py
+++ b/src/agent_bom/client.py
@@ -135,6 +135,93 @@ class AgentBomClient:
             ),
         )
 
+    def list_finding_triage(
+        self,
+        *,
+        queue_state: str | None = None,
+        decision: str | None = None,
+        limit: int = 1000,
+        offset: int = 0,
+    ) -> JsonObject:
+        """List finding triage queue items for the request tenant."""
+
+        return self._request(
+            "GET",
+            "/v1/findings/triage",
+            params=_strip_query_none(
+                {
+                    "queue_state": queue_state,
+                    "decision": decision,
+                    "limit": limit,
+                    "offset": offset,
+                }
+            ),
+        )
+
+    def create_finding_triage(
+        self,
+        vulnerability_id: str,
+        *,
+        package: str = "*",
+        server_name: str = "",
+        assignee: str = "",
+        queue_state: str = "open",
+        decision: str = "under_investigation",
+        justification: str | None = None,
+        decision_reason: str = "",
+        expires_at: str = "",
+    ) -> JsonObject:
+        """Create a finding triage queue item."""
+
+        return self._request(
+            "POST",
+            "/v1/findings/triage",
+            json=_strip_none(
+                {
+                    "vulnerability_id": vulnerability_id,
+                    "package": package,
+                    "server_name": server_name,
+                    "assignee": assignee,
+                    "queue_state": queue_state,
+                    "decision": decision,
+                    "justification": justification,
+                    "decision_reason": decision_reason,
+                    "expires_at": expires_at,
+                }
+            ),
+        )
+
+    def update_finding_triage_decision(
+        self,
+        triage_id: str,
+        *,
+        decision: str,
+        justification: str | None = None,
+        decision_reason: str = "",
+        assignee: str | None = None,
+        expires_at: str | None = None,
+    ) -> JsonObject:
+        """Record a decision for a finding triage queue item."""
+
+        return self._request(
+            "PUT",
+            f"/v1/findings/triage/{_quote_path(triage_id)}/decision",
+            json=_strip_none(
+                {
+                    "decision": decision,
+                    "justification": justification,
+                    "decision_reason": decision_reason,
+                    "assignee": assignee,
+                    "expires_at": expires_at,
+                }
+            ),
+        )
+
+    def export_finding_triage_vex(self) -> JsonObject:
+        """Export OpenVEX for eligible finding triage decisions."""
+
+        return self._request("GET", "/v1/findings/triage/vex")
+
     def ingest_findings(
         self,
         findings: Sequence[Mapping[str, JsonValue]],

--- a/tests/test_cli_findings.py
+++ b/tests/test_cli_findings.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+
+
+class FakeFindingsClient:
+    calls: list[tuple[str, dict[str, Any]]] = []
+    init_kwargs: dict[str, Any] = {}
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.__class__.init_kwargs = kwargs
+
+    def close(self) -> None:
+        self.__class__.calls.append(("close", {}))
+
+    def list_findings(self, **kwargs: Any) -> dict[str, object]:
+        self.__class__.calls.append(("list_findings", kwargs))
+        return {
+            "findings": [
+                {
+                    "id": "finding-1",
+                    "severity": "high",
+                    "package": "requests",
+                    "title": "Reachable CVE",
+                }
+            ],
+            "total": 1,
+        }
+
+    def list_finding_triage(self, **kwargs: Any) -> dict[str, object]:
+        self.__class__.calls.append(("list_finding_triage", kwargs))
+        return {
+            "triage": [
+                {
+                    "id": "triage-1",
+                    "vulnerability_id": "CVE-2026-0101",
+                    "package": "requests",
+                    "queue_state": "open",
+                    "decision": "under_investigation",
+                    "assignee": "secops@example.com",
+                }
+            ],
+            "total": 1,
+        }
+
+    def create_finding_triage(self, vulnerability_id: str, **kwargs: Any) -> dict[str, object]:
+        self.__class__.calls.append(("create_finding_triage", {"vulnerability_id": vulnerability_id, **kwargs}))
+        return {"id": "triage-1", "vulnerability_id": vulnerability_id, **kwargs}
+
+    def update_finding_triage_decision(self, triage_id: str, **kwargs: Any) -> dict[str, object]:
+        self.__class__.calls.append(("update_finding_triage_decision", {"triage_id": triage_id, **kwargs}))
+        return {"id": triage_id, **kwargs}
+
+    def export_finding_triage_vex(self) -> dict[str, object]:
+        self.__class__.calls.append(("export_finding_triage_vex", {}))
+        return {"schema_version": "findings.triage.vex.v1", "count": 1, "vex": {"statements": []}}
+
+
+def _install_fake_client(monkeypatch) -> type[FakeFindingsClient]:
+    FakeFindingsClient.calls = []
+    FakeFindingsClient.init_kwargs = {}
+    monkeypatch.setattr("agent_bom.cli._findings_group.AgentBomClient", FakeFindingsClient)
+    return FakeFindingsClient
+
+
+def test_findings_list_outputs_json_and_passes_filters(monkeypatch) -> None:
+    fake = _install_fake_client(monkeypatch)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "findings",
+            "list",
+            "--api-url",
+            "https://agent-bom.example.com",
+            "--api-key",
+            "key",
+            "--tenant",
+            "tenant-a",
+            "--severity",
+            "high",
+            "--limit",
+            "10",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["findings"][0]["id"] == "finding-1"
+    assert fake.init_kwargs["base_url"] == "https://agent-bom.example.com"
+    assert fake.init_kwargs["api_key"] == "key"
+    assert fake.init_kwargs["tenant_id"] == "tenant-a"
+    assert fake.calls[0] == (
+        "list_findings",
+        {"severity": "high", "sort": "effective_reach", "limit": 10, "offset": 0},
+    )
+
+
+def test_findings_triage_create_and_decide(monkeypatch) -> None:
+    fake = _install_fake_client(monkeypatch)
+    runner = CliRunner()
+
+    create = runner.invoke(
+        main,
+        [
+            "findings",
+            "triage",
+            "create",
+            "CVE-2026-0101",
+            "--package",
+            "requests",
+            "--assignee",
+            "secops@example.com",
+            "--reason",
+            "needs owner",
+        ],
+    )
+    decide = runner.invoke(
+        main,
+        [
+            "findings",
+            "triage",
+            "decide",
+            "triage-1",
+            "--decision",
+            "not_affected",
+            "--justification",
+            "vulnerable_code_not_in_execute_path",
+            "--reason",
+            "not reachable",
+        ],
+    )
+
+    assert create.exit_code == 0, create.output
+    assert decide.exit_code == 0, decide.output
+    assert fake.calls[0] == (
+        "create_finding_triage",
+        {
+            "vulnerability_id": "CVE-2026-0101",
+            "package": "requests",
+            "server_name": "",
+            "assignee": "secops@example.com",
+            "queue_state": "open",
+            "decision": "under_investigation",
+            "justification": None,
+            "decision_reason": "needs owner",
+            "expires_at": "",
+        },
+    )
+    assert fake.calls[2] == (
+        "update_finding_triage_decision",
+        {
+            "triage_id": "triage-1",
+            "decision": "not_affected",
+            "justification": "vulnerable_code_not_in_execute_path",
+            "decision_reason": "not reachable",
+            "assignee": None,
+            "expires_at": None,
+        },
+    )
+
+
+def test_findings_triage_export_vex_writes_file(monkeypatch, tmp_path) -> None:
+    fake = _install_fake_client(monkeypatch)
+    output = tmp_path / "triage.vex.json"
+
+    result = CliRunner().invoke(main, ["findings", "triage", "export-vex", "-o", str(output)])
+
+    assert result.exit_code == 0, result.output
+    assert "Wrote" in result.output
+    assert json.loads(output.read_text(encoding="utf-8"))["schema_version"] == "findings.triage.vex.v1"
+    assert fake.calls[0] == ("export_finding_triage_vex", {})

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -101,6 +101,20 @@ def test_client_exposes_findings_and_dataset_loop() -> None:
     client = _client(handler)
 
     client.list_findings(severity="high", limit=10)
+    client.list_finding_triage(queue_state="open", decision="under_investigation")
+    client.create_finding_triage(
+        "CVE-2026-0101",
+        package="requests",
+        assignee="secops@example.com",
+        decision_reason="needs owner",
+    )
+    client.update_finding_triage_decision(
+        "triage-1",
+        decision="not_affected",
+        justification="vulnerable_code_not_in_execute_path",
+        decision_reason="not reachable",
+    )
+    client.export_finding_triage_vex()
     client.ingest_findings(findings=[{"id": "finding-1", "severity": "high"}], source="sdk-test")
     client.register_dataset_version("dataset-a", version_id="v1")
     client.dataset_versions("dataset-a")
@@ -111,6 +125,10 @@ def test_client_exposes_findings_and_dataset_loop() -> None:
 
     assert seen == [
         ("GET", "/v1/findings"),
+        ("GET", "/v1/findings/triage"),
+        ("POST", "/v1/findings/triage"),
+        ("PUT", "/v1/findings/triage/triage-1/decision"),
+        ("GET", "/v1/findings/triage/vex"),
         ("POST", "/v1/findings/bulk"),
         ("POST", "/v1/datasets/dataset-a/versions"),
         ("GET", "/v1/datasets/dataset-a/versions"),


### PR DESCRIPTION
## Summary
- add a dedicated `agent-bom findings` CLI group for listing normalized findings
- expose finding triage queue operations from the CLI: list, create, decide, and signed OpenVEX export
- add Python client methods for the existing `/v1/findings/triage*` API routes and regression tests for route parity

Refs #3206

## Validation
- `uv run pytest tests/test_cli_findings.py tests/test_python_client.py -q --tb=short`
- `uv run ruff check src/agent_bom/cli/_findings_group.py src/agent_bom/cli/__init__.py src/agent_bom/client.py tests/test_cli_findings.py tests/test_python_client.py`
- `uv run mypy src/agent_bom/cli/_findings_group.py src/agent_bom/client.py`
- `git diff --check`
