### PR TITLE
fix(hosted): fail closed on POC compose exposure

### DIFF
--- a/deploy/caddy/Caddyfile.hosted-poc
+++ b/deploy/caddy/Caddyfile.hosted-poc
@@ -14,7 +14,7 @@
 		-X-Powered-By
 	}
 
-	@api path /v1/* /health /version /openapi.json
+	@api path /v1/* /health /healthz /readyz /livez /status /ping /version /openapi.json /ws/*
 	reverse_proxy @api 127.0.0.1:8422
 
 	reverse_proxy 127.0.0.1:3000

--- a/deploy/docker-compose.hosted-poc.yml
+++ b/deploy/docker-compose.hosted-poc.yml
@@ -11,15 +11,12 @@ version: "3.8"
 #     -f deploy/docker-compose.hosted-poc.yml \
 #     up -d --build
 #
-# The base platform file is reusable for local operators and clusters. This
-# overlay makes the customer-0 VM posture explicit: API and UI bind to loopback
-# only, while Caddy terminates TLS on 443 and proxies to these local ports.
+# The base platform file now binds API and UI to loopback by default. This
+# overlay keeps the customer-0 VM posture explicit and sets browser-session
+# cookies to Secure because Caddy terminates public TLS on 443 and proxies to
+# local HTTP ports.
 
 services:
   api:
-    ports:
-      - "127.0.0.1:${API_PORT:-8422}:8422"
-
-  ui:
-    ports:
-      - "127.0.0.1:${UI_PORT:-3000}:3000"
+    environment:
+      - AGENT_BOM_SESSION_COOKIE_SECURE=1

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -23,10 +23,10 @@ version: "3.8"
 #         deploy/secrets/postgres_password
 #         deploy/secrets/postgres_app_password   (optional, for DML-only role)
 #     A non-secret placeholder lives at deploy/secrets/postgres_password.example
-#     so `docker compose config --env-file .env.example` can render for
-#     first-run inspection. Replace it with deploy/secrets/postgres_password
-#     before starting any shared or long-lived stack. The api service still
-#     consumes POSTGRES_APP_PASSWORD via env to construct AGENT_BOM_POSTGRES_URL
+#     for documentation only. The compose file defaults to the real
+#     deploy/secrets/postgres_password path so shared stacks fail closed when
+#     the operator has not mounted a secret. The api service still consumes
+#     POSTGRES_APP_PASSWORD via env to construct AGENT_BOM_POSTGRES_URL
 #     (URL-form requirement);
 #     wrapper-based file-only injection is tracked as a #1962 follow-up.
 #
@@ -86,7 +86,7 @@ services:
     container_name: agent-bom-api
     command: api --host 0.0.0.0 --port 8422
     ports:
-      - "8422:8422"
+      - "${AGENT_BOM_API_BIND_HOST:-127.0.0.1}:${API_PORT:-8422}:8422"
     environment:
       # Use app user (DML only) when available, fall back to admin for dev
       - AGENT_BOM_POSTGRES_URL=postgresql://${POSTGRES_APP_USER:-${POSTGRES_USER:-agent_bom}}:${POSTGRES_APP_PASSWORD:-${POSTGRES_PASSWORD:?err}}@postgres:5432/${POSTGRES_DB:-agent_bom}
@@ -97,6 +97,7 @@ services:
       - AGENT_BOM_REQUIRE_AUDIT_HMAC=${AGENT_BOM_REQUIRE_AUDIT_HMAC:-1}
       - AGENT_BOM_CONNECTIONS_KEY=${AGENT_BOM_CONNECTIONS_KEY:-}
       - AGENT_BOM_BROWSER_SESSION_SIGNING_KEY=${AGENT_BOM_BROWSER_SESSION_SIGNING_KEY:-}
+      - AGENT_BOM_SESSION_COOKIE_SECURE=${AGENT_BOM_SESSION_COOKIE_SECURE:-1}
       - AGENT_BOM_DISABLE_DOCS=1
       - AGENT_BOM_API_LOCAL_PATH_SCANS=disabled
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:3000,http://ui:3000}
@@ -127,7 +128,7 @@ services:
     image: agentbom/agent-bom-ui:0.89.2
     container_name: agent-bom-ui
     ports:
-      - "3000:3000"
+      - "${AGENT_BOM_UI_BIND_HOST:-127.0.0.1}:${UI_PORT:-3000}:3000"
     environment:
       - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8422}
     depends_on:
@@ -152,7 +153,7 @@ secrets:
   # Mount-provisioned credentials. Populate the files before `docker compose up`.
   # See the header comment for permissions guidance (chmod 0400).
   postgres_password:
-    file: ${POSTGRES_PASSWORD_FILE:-./secrets/postgres_password.example}
+    file: ${POSTGRES_PASSWORD_FILE:-./secrets/postgres_password}
 
 networks:
   backend:

--- a/deploy/secrets/README.md
+++ b/deploy/secrets/README.md
@@ -11,9 +11,9 @@ printf %s "$POSTGRES_PASSWORD" > deploy/secrets/postgres_password
 chmod 0400 deploy/secrets/postgres_password
 ```
 
-`postgres_password.example` is a non-secret placeholder for first-run
-`docker compose config` rendering only. Copy it to `postgres_password` or
-write a real secret before starting any shared or long-lived stack.
+`postgres_password.example` is a non-secret placeholder for documentation only.
+The platform compose file defaults to `deploy/secrets/postgres_password` so a
+shared stack fails closed if a real secret file is missing.
 
 The `chmod 0400` prevents the file from being world-readable; Docker still
 mounts it read-only inside the container at `/run/secrets/postgres_password`.
@@ -21,3 +21,16 @@ mounts it read-only inside the container at `/run/secrets/postgres_password`.
 The postgres image natively reads `POSTGRES_PASSWORD_FILE` from this mount,
 so the password never appears in `docker inspect`, `docker compose config`,
 or process environment listings. Tracking: #1962.
+
+Hosted POC preflight:
+
+```bash
+POSTGRES_PASSWORD=preflight POSTGRES_APP_PASSWORD=preflight docker compose \
+  -f deploy/docker-compose.platform.yml \
+  -f deploy/docker-compose.hosted-poc.yml \
+  config | grep -E '0.0.0.0:3000|0.0.0.0:8422|postgres_password.example' && \
+  { echo "Unsafe hosted compose output"; exit 1; } || true
+```
+
+For the hosted POC, also set `AGENT_BOM_SESSION_COOKIE_SECURE=1`; the hosted
+overlay sets it for the API service by default.

--- a/docs/HOSTED_POC.md
+++ b/docs/HOSTED_POC.md
@@ -92,6 +92,7 @@ PY
 )"
 export NEXT_PUBLIC_API_URL="https://demo.agent-bom.com"
 export CORS_ORIGINS="https://demo.agent-bom.com,http://ui:3000"
+export AGENT_BOM_SESSION_COOKIE_SECURE=1
 
 mkdir -p deploy/secrets
 printf '%s' "$POSTGRES_PASSWORD" > deploy/secrets/postgres_password
@@ -125,6 +126,18 @@ docker compose \
 The compose profile persists `/root/.agent-bom` in a named volume so the seeded
 demo graph survives container replacement. Replace it with real connected
 cloud scans as soon as the first account is connected.
+
+Before opening the VM to testers, confirm the composed stack does not expose
+API/UI ports on all interfaces and does not mount the placeholder Postgres
+password:
+
+```bash
+POSTGRES_PASSWORD=preflight POSTGRES_APP_PASSWORD=preflight docker compose \
+  -f deploy/docker-compose.platform.yml \
+  -f deploy/docker-compose.hosted-poc.yml \
+  config | grep -E '0.0.0.0:3000|0.0.0.0:8422|postgres_password.example' && \
+  { echo "Unsafe hosted compose output"; exit 1; } || true
+```
 
 ### Caddy front door
 

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -39,11 +39,10 @@ HEALTHCHECK_EXEMPT: dict[str, set[str]] = {
         "mcp-server",
     },
     "docker-compose.hosted-poc.yml": {
-        # Overlay applied on top of docker-compose.platform.yml; it only
-        # narrows the api/ui port bindings to loopback. Their healthchecks are
-        # defined once in the base platform compose and inherited at merge time.
+        # Overlay applied on top of docker-compose.platform.yml; it only sets
+        # hosted-specific environment. Healthchecks are defined once in the
+        # base platform compose and inherited at merge time.
         "api",
-        "ui",
     },
 }
 
@@ -76,10 +75,9 @@ def test_platform_compose_uses_docker_secrets_for_postgres_password() -> None:
     assert secret_file, (
         "postgres_password secret must be file-sourced (file: ./secrets/postgres_password) so docker-compose binds it read-only."
     )
-    assert str(secret_file).endswith("postgres_password.example}"), (
-        "platform compose must retain a non-secret example fallback so "
-        "`docker compose config --env-file .env.example` renders before operators "
-        "replace it with deploy/secrets/postgres_password."
+    assert str(secret_file).endswith("postgres_password}"), (
+        "platform compose must default to the real deploy/secrets/postgres_password "
+        "path so shared stacks fail closed when the operator has not mounted a secret."
     )
 
     postgres = (data.get("services") or {}).get("postgres") or {}
@@ -102,7 +100,7 @@ def test_platform_compose_uses_docker_secrets_for_postgres_password() -> None:
     )
 
 
-def test_env_example_unblocks_compose_first_run_without_real_secrets() -> None:
+def test_env_example_keeps_obvious_placeholder_values_for_local_rendering() -> None:
     env_values: dict[str, str] = {}
     for line in ENV_EXAMPLE.read_text(encoding="utf-8").splitlines():
         stripped = line.strip()
@@ -116,7 +114,7 @@ def test_env_example_unblocks_compose_first_run_without_real_secrets() -> None:
         assert "change-me" in env_values[key], f".env.example {key} should be an obvious placeholder, not a real-looking secret"
 
     placeholder = COMPOSE_DIR / "secrets" / "postgres_password.example"
-    assert placeholder.exists(), "platform compose default secret placeholder must exist for config rendering"
+    assert placeholder.exists(), "documented placeholder must remain available for local inspection examples"
     assert placeholder.read_text(encoding="utf-8").strip() == env_values["POSTGRES_PASSWORD"]
 
 
@@ -132,6 +130,16 @@ def test_platform_api_fails_closed_for_auth_docs_and_local_scans() -> None:
     assert "--allow-insecure-no-auth" not in api.get("command", "")
     assert env_map.get("AGENT_BOM_DISABLE_DOCS") == "1"
     assert env_map.get("AGENT_BOM_API_LOCAL_PATH_SCANS") == "disabled"
+    assert env_map.get("AGENT_BOM_SESSION_COOKIE_SECURE") == "${AGENT_BOM_SESSION_COOKIE_SECURE:-1}"
+    assert api.get("ports") == ["${AGENT_BOM_API_BIND_HOST:-127.0.0.1}:${API_PORT:-8422}:8422"]
+
+
+def test_platform_ui_binds_loopback_by_default() -> None:
+    path = COMPOSE_DIR / "docker-compose.platform.yml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    ui = (data.get("services") or {}).get("ui") or {}
+
+    assert ui.get("ports") == ["${AGENT_BOM_UI_BIND_HOST:-127.0.0.1}:${UI_PORT:-3000}:3000"]
 
 
 def test_fullstack_is_loopback_only_auth_required_and_matches_runtime_user_home() -> None:
@@ -152,8 +160,10 @@ def test_hosted_poc_overlay_keeps_api_and_ui_loopback_only() -> None:
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
     services = data.get("services") or {}
 
-    assert services["api"]["ports"] == ["127.0.0.1:${API_PORT:-8422}:8422"]
-    assert services["ui"]["ports"] == ["127.0.0.1:${UI_PORT:-3000}:3000"]
+    api_env = services["api"]["environment"]
+    assert "ports" not in services["api"]
+    assert "ui" not in services
+    assert api_env == ["AGENT_BOM_SESSION_COOKIE_SECURE=1"]
 
 
 def test_active_docker_docs_do_not_mount_config_under_root_home() -> None:


### PR DESCRIPTION
## Summary
- bind platform API/UI ports to loopback by default instead of public interfaces
- default the Postgres compose secret to the real secret file, not the placeholder
- set hosted POC browser-session cookies to Secure and expand Caddy API readiness routes
- add hosted preflight docs and regression tests for compose safety

## Validation
- uv run pytest tests/test_compose_secrets_healthcheck.py tests/test_deployment.py -q
- POSTGRES_PASSWORD=preflight POSTGRES_APP_PASSWORD=preflight docker compose -f deploy/docker-compose.platform.yml -f deploy/docker-compose.hosted-poc.yml config > /tmp/agent-bom-hosted-compose.yml
- rg '0\.0\.0\.0:3000|0\.0\.0\.0:8422|postgres_password\.example|127\.0\.0\.1|AGENT_BOM_SESSION_COOKIE_SECURE|source: .*postgres_password' /tmp/agent-bom-hosted-compose.yml