### PR TITLE
docs(product): clarify CSPM, DSPM, and hosted coverage boundaries

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -101,8 +101,8 @@ helm upgrade --install agent-bom deploy/helm/agent-bom \
 
 - **Agents + MCP** — MCP clients, servers, tools, transports, trust posture
 - **Skills + instructions** — `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.windsurfrules`, `skills/*`
-- **Package risk** — supply-chain scanning across 15 package ecosystems with OSV/GHSA enrichment and blast radius
-- **AI models + datasets** — malicious-model detection via safe pickle-opcode disassembly (no execution), model/dataset cards, and PII/PHI dataset scanning
+- **Package risk** — supply-chain scanning across common application and OS package ecosystems with OSV/GHSA enrichment and blast radius; Hex/Pub are advisory ecosystem identifiers today, not native lockfile parsers
+- **AI models + datasets** — malicious-model detection via safe pickle-opcode disassembly (no execution), model/dataset cards, and target-scoped PII/PHI dataset-file scanning
 - **Container images + IaC** — native OCI parsing plus Dockerfile, Terraform, CloudFormation, Helm, and Kubernetes coverage
 - **Cloud estate** — read-only, gated asset inventory across AWS/Azure/GCP plus AI/GPU posture and CIS benchmarks
 - **Identity (NHI)** — non-human identity discovery (Okta/Entra), credential-expiry posture, and access-review campaigns

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ credential environment names in reach, and the agents that can call it.
 
 | Domain | Coverage |
 |---|---|
-| Supply chain | 15 package ecosystems (npm, PyPI, Maven, Go, Cargo, NuGet, Composer, RubyGems, conda, Hex, Pub, Swift, plus apk/deb/rpm) with OSV/GHSA enrichment, transitive resolution, and dependency-confusion detection |
+| Supply chain | Package and OS risk across npm, PyPI, Maven, Go, Cargo, NuGet, Composer, RubyGems, conda, Swift, apk, deb, and rpm, with OSV/GHSA enrichment, transitive resolution, and dependency-confusion detection; Hex/Pub are advisory ecosystem identifiers, not first-class lockfile parsers yet |
 | Agents + MCP | MCP clients, servers, tools, transports, and trust posture with live introspection across 29 first-class client types |
-| AI models + datasets | Malicious-model detection via safe pickle-opcode disassembly (no deserialization), model/dataset cards, and PII/PHI dataset scanning |
+| AI models + datasets | Malicious-model detection via safe pickle-opcode disassembly (no deserialization), model/dataset cards, and target-scoped PII/PHI dataset-file scanning |
 | Cloud estate | Read-only, gated asset inventory and CIS posture across AWS, Azure, GCP, and Snowflake, plus AI/GPU provider posture |
 | Identity (NHI) | Non-human identity discovery (Okta/Entra, gated), credential-expiry posture, and access-review recertification |
 | LLM cost | Spend forecasting, budget runway, chargeback/allocation, and seasonal-aware spend-anomaly detection |
@@ -109,10 +109,25 @@ credential environment names in reach, and the agents that can call it.
 CIS misconfigurations and graph toxic-combinations converge into the same
 `Finding` stream and exit-code gate as package vulnerabilities, so a real
 exposure can fail a pipeline. The graph adds correlation overlays on the same
-base: AppSec findings organized around their application, LLM cost fused onto the
-resources that incur it, read-only cloud audit-trail activity as behavioral
+base: AppSec findings organized around their application, LLM cost fused onto
+the resources that incur it, read-only cloud audit-trail activity as behavioral
 edges, and an estate-scale `CONTAINS` roll-up with drill-down so large clouds
 stay readable.
+
+### Current Coverage Boundaries
+
+agent-bom is strongest today as a read-only CSPM/CIS, vuln/SCA, compliance,
+runtime-policy, and graph-posture product. Connected account scans can run on a
+schedule, so new or removed assets are picked up at the next scan and graph
+history can show appeared/removed evidence. It is not yet an event-streaming
+CDR product: CloudTrail/EventBridge, Azure Activity Log/Event Grid, and GCP
+Audit Log/Pub/Sub ingestion are roadmap work.
+
+For DSPM, Snowflake has the deepest current support because agent-bom can read
+warehouse metadata, grants, tags, lineage, and governance activity visible to
+the configured role. Other cloud data-store sensitivity is posture and metadata
+based until classifier-backed content inspection, provider DLP/Macie wrapping,
+and object/table/column-level access mapping land.
 
 ## Product Map
 
@@ -123,7 +138,7 @@ credential boundary, and operator surface.
 | Need | Surface | First action | Auth / data boundary | Main artifact |
 |---|---|---|---|---|
 | Scan a repo, image, or local agent config | CLI / CI | `agent-bom agents -p .` | local files only unless an opt-in connector is enabled | JSON, SARIF, SBOM, HTML |
-| Connect cloud and data estates | Cloud connectors | `agent-bom connect aws` then `agent-bom cloud scan` | read-only provider credentials; no secret values read or stored | cloud assets, CIS findings, graph edges |
+| Connect cloud and selected data-estate evidence | Cloud and warehouse connectors | `agent-bom connect aws` then `agent-bom cloud scan` | read-only provider credentials; no secret values read or stored | cloud assets, CIS findings, Snowflake governance evidence, graph edges |
 | Review posture as a team | API + dashboard | `pip install 'agent-bom[ui]' && agent-bom serve` | API key/OIDC/SAML/SCIM where configured; tenant-scoped state | findings, graph, audit, compliance |
 | Give agents security tools | MCP server | `agent-bom mcp server` | read-mostly tools; Shield writes require admin role, scope, and audit reason | strict MCP tool responses |
 | Govern runtime tool calls | Proxy / gateway | configure proxy or gateway policy | inline policy checks; redacted, auditable decisions | allow/warn/block audit trail |

--- a/docs/DATABASE_EVIDENCE.md
+++ b/docs/DATABASE_EVIDENCE.md
@@ -5,6 +5,10 @@ event streams. Connectors query customer-owned systems for inventory,
 governance, access, and lineage evidence, then map that evidence into the
 same findings and graph model used by local scans and runtime telemetry.
 
+The concrete shipped warehouse governance lane is Snowflake. Other database and
+warehouse sources should be described as connector-contract, fallback, or
+roadmap paths unless the specific connector and fixtures are present in code.
+
 ## Connector Lanes
 
 | Lane | Status | Default wheel | Use when | Credential boundary |
@@ -39,6 +43,9 @@ query source.
 
 - ODBC/JDBC are not event streaming connectors. Posture-event streaming uses
   webhooks or runtime emitter plugins.
+- Generic database evidence is not full DSPM by itself. Only call data
+  sensitive when explicit tags, classifications, imported classifier evidence,
+  or target-scoped dataset scan results support that label.
 - ODBC/JDBC do not replace native Snowflake, Postgres/Supabase, Databricks,
   BigQuery, Redshift, or Athena paths where native APIs are available.
 - The default wheel does not bundle ODBC drivers, JDBC drivers, a JVM, or

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -150,8 +150,10 @@ collapses deep source trees along these `CONTAINS` edges the same way it
 collapses the cloud `org → account → resource` hierarchy.
 
 `DATA_STORE` is a cloud-CNAPP primitive — a database / bucket / lake / warehouse
-holding data at rest, derived from cloud resources so path-to-sensitive-data is
-traversable.
+holding data at rest, derived from cloud resources so metadata-backed
+data-store reachability is traversable. Treat data as sensitive only when
+explicit tags, classification evidence, imported DLP/Macie evidence, or
+target-scoped dataset scan evidence supports that label.
 
 `API_GATEWAY` is a network-edge primitive in the API_GATEWAY semantic layer —
 an API gateway / managed front-door populated from live cloud inventory (AWS API

--- a/docs/PRODUCT_BOUNDARIES.md
+++ b/docs/PRODUCT_BOUNDARIES.md
@@ -15,6 +15,17 @@ This is the GitHub-facing companion to
 Managed `agent-bom Cloud` is not shipped in this repository today. It can be
 discussed as a roadmap lane only when labeled that way.
 
+Current detection positioning:
+
+- CSPM/CIS, vuln/SCA, compliance evidence, IaC posture, scheduled connected
+  account scans, and graph-backed attack paths are demo-ready.
+- Scheduled scans are cadence-bound polling. They are not real-time provider
+  event streaming.
+- DSPM is real only where the configured source exposes data governance
+  metadata, grants, tags, and lineage today, with Snowflake as the strongest
+  lane. Full DSPM across cloud object stores and databases still requires
+  classifier-backed content inspection and access-to-data mapping.
+
 ## First Proofs
 
 OSS local scanner:
@@ -49,6 +60,8 @@ Use:
 - "open security scanner and self-hosted control plane"
 - "open security data plane for AI-era infrastructure"
 - "customer-owned infrastructure and data boundary"
+- "scheduled posture monitoring"
+- "Snowflake-depth data governance evidence"
 - "Snowflake Native App lane"
 - "gated hosted POC"
 - "managed cloud is not shipped today"
@@ -59,6 +72,8 @@ Avoid unless a future release proves it:
 - "Snowflake is the full control-plane backend"
 - "drop-in commercial CNAPP replacement"
 - "complete CNAPP"
+- "full DSPM across every cloud"
+- "real-time cloud event detection" unless event ingestion is enabled
 - "all cloud identity providers have live ingestion parity"
 
 See the site-docs page for the full lane matrix and release checklist.

--- a/docs/skills/ai-bom-generator.md
+++ b/docs/skills/ai-bom-generator.md
@@ -1,10 +1,10 @@
 # AI-BOM Generator
 
-> Security scanner for AI infrastructure — full asset discovery, vulnerability scanning, threat mapping, and SBOM generation.
+> Security scanner for AI infrastructure — target-scoped asset discovery, vulnerability scanning, threat mapping, and SBOM generation.
 
 ## Goal
 
-Produce a complete **AI infrastructure security report** — a structured inventory of every AI agent, MCP server, package, credential, and tool in the target environment, enriched with CVE data, blast radius analysis, OWASP LLM Top 10, and MITRE ATLAS threat mappings.
+Produce a target-scoped **AI infrastructure security report** — a structured inventory of AI agents, MCP servers, packages, credential references, and tools visible through the configured inputs, enriched with CVE data, blast radius analysis, OWASP LLM Top 10, and MITRE ATLAS threat mappings.
 
 ## Prerequisites
 
@@ -67,7 +67,7 @@ agent-bom scan --k8s --all-namespaces --enrich -f json -o ai-bom-k8s.json
 Run discovery for each cloud in scope. Combine flags for a single unified scan:
 
 ```bash
-# AWS — full depth
+# AWS — credential-scoped discovery
 agent-bom scan --aws --aws-region us-east-1 \
   --aws-include-lambda --aws-include-eks --aws-include-step-functions \
   --enrich -f json -o ai-bom-aws.json
@@ -124,7 +124,7 @@ agent-bom scan --agent-project ./my-agent-app --enrich -f json -o ai-bom-agent.j
 
 ### 7. Unified AI-BOM Generation
 
-Combine everything into one comprehensive scan:
+Combine the selected inputs into one target-scoped scan:
 
 ```bash
 agent-bom scan \
@@ -191,7 +191,7 @@ The AI-BOM JSON output includes:
 
 | Artifact | Format | Purpose |
 |----------|--------|---------|
-| `ai-bom-complete.json` | AI-BOM JSON | Machine-readable full inventory |
+| `ai-bom-complete.json` | AI-BOM JSON | Machine-readable target-scoped inventory |
 | `ai-bom.cdx.json` | CycloneDX 1.6 | SBOM standard for compliance |
 | `ai-bom.spdx.json` | SPDX 3.0 | ISO standard for auditors |
 | `results.sarif` | SARIF | GitHub Security tab integration |

--- a/docs/skills/compliance-export.md
+++ b/docs/skills/compliance-export.md
@@ -15,9 +15,10 @@ pip install agent-bom
 
 ## Steps
 
-### 1. Full Inventory Scan
+### 1. Target-Scoped Inventory Scan
 
-Run the most comprehensive scan available for your environment:
+Run the broadest scan available for the environment and credentials you
+explicitly configure:
 
 ```bash
 agent-bom scan \

--- a/site-docs/architecture/data-ingestion-and-security.md
+++ b/site-docs/architecture/data-ingestion-and-security.md
@@ -139,8 +139,8 @@ Read-only integration is for systems that already hold the relevant evidence. `a
 Typical sources:
 
 - Snowflake governance data
-- warehouse-backed security or activity data
-- connector-backed enterprise sources
+- warehouse-backed security or activity data where a shipped connector exists
+- connector-backed enterprise sources where a shipped connector exists
 - cloud account inventory where the customer grants read-only access
 
 ```mermaid

--- a/site-docs/deployment/kubernetes.md
+++ b/site-docs/deployment/kubernetes.md
@@ -41,13 +41,14 @@ described below.
 - manifest hardening
   - `agent-bom iac k8s/`
   - scans YAML/Helm content in Git or on disk
-- live cluster posture
+- point-in-time cluster posture
   - `agent-bom iac . --k8s-live --k8s-all-namespaces`
   - inspects runtime state through `kubectl`
-  - covers live pod health, live RBAC drift, and namespace NetworkPolicy coverage
+  - covers pod health, RBAC drift observed through `kubectl`, and namespace NetworkPolicy coverage
 
-The live path is intentionally scoped. It does not claim full admission-policy,
-service-mesh, or arbitrary controller-state analysis.
+The runtime path is intentionally scoped. It does not claim event-driven
+Kubernetes monitoring, full admission-policy coverage, service-mesh analysis,
+or arbitrary controller-state analysis.
 
 ## Quick start
 

--- a/site-docs/features/cloud-posture.md
+++ b/site-docs/features/cloud-posture.md
@@ -66,6 +66,17 @@ environment properties that do not appear in a pull request, such as:
 - resources created outside the reviewed IaC path
 - service posture that depends on account-level configuration
 
+Connected accounts can also be scanned on a recurring schedule from the control
+plane. That makes posture near-continuous at the chosen cadence: new resources
+or deployments are discovered on the next run, removed resources appear in graph
+history/diff as deleted evidence, and findings are regenerated from the latest
+read-only inventory.
+
+This is scheduled polling, not provider event streaming. It does not observe a
+resource the instant it is created, and it does not replace CloudTrail,
+EventBridge, Azure Activity Log/Event Grid, or GCP Audit Log/Pub/Sub pipelines.
+Those event-driven sources are separate roadmap work.
+
 ## How to read the result
 
 The useful question is not "IaC or CSPM?" It is:
@@ -83,3 +94,10 @@ agent-bom does not apply Terraform, mutate CloudFormation stacks, or change
 cloud settings as part of posture scanning. It reports evidence and exits with
 deterministic codes so the operator, CI system, or control plane can decide
 whether to block, approve, or open a remediation workflow.
+
+The current CSPM/CIS lane should be positioned as read-only inventory,
+benchmark checks, IaC misconfiguration detection, scheduled drift visibility,
+and graph-backed attack paths. Full DSPM requires classifier-backed content
+inspection and data-access resolution; Snowflake has the deepest metadata,
+grant, tag, and lineage coverage today, while other stores remain
+metadata/posture based unless imported classifier evidence is present.

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -111,7 +111,7 @@ Connect with:
 
 | Tool | Description |
 |------|-------------|
-| `scan` | Full discovery + vulnerability scan |
+| `scan` | Scoped discovery + vulnerability scan |
 | `check` | Check a package for CVEs |
 | `intel_lookup` | Look up a CVE, GHSA, or OSV advisory |
 | `intel_match` | Match package or purl inventory against local advisories |

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -55,7 +55,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|---|
 | **Local AI BOM** | `agent-bom agents --demo --offline` | terminal findings and graph-ready inventory |
 | **Repository scan** | `agent-bom agents -p . -f html -o agent-bom-report.html` | local HTML review plus exportable evidence |
-| **Cloud posture gate** | `agent-bom iac infra/ && agent-bom cloud aws --cis` | pre-cloud IaC findings plus live posture evidence |
+| **Cloud posture gate** | `agent-bom iac infra/ && agent-bom cloud aws --cis` | pre-cloud IaC findings plus point-in-time or scheduled posture evidence |
 | **CI evidence** | `uses: msaad00/agent-bom@v0.89.2` | SARIF, pull-request summary, optional code scanning |
 | **Assistant tools** | `agent-bom mcp server` | read-mostly security tools for MCP clients |
 | **Self-hosted control plane** | `docker compose -f docker-compose.pilot.yml up -d` | API and dashboard in your infrastructure |

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -10,7 +10,7 @@ audit reason.
 ## Tools
 
 ### scan
-Full discovery + vulnerability scan pipeline. Auto-discovers MCP clients,
+Scoped discovery + vulnerability scan pipeline. Auto-discovers MCP clients,
 extracts servers and packages, scans for CVEs, computes blast radius, or scans
 a direct MCP launch package when no local config is available.
 ```
@@ -383,7 +383,7 @@ ingest_external_scan(path="scan.json")
 
 | Prompt | Description |
 |--------|-------------|
-| `quick-audit` | Run a complete security audit of local AI agent and MCP setup |
+| `quick-audit` | Run a scoped security audit of local AI agent and MCP setup |
 | `pre-install-check` | Check an MCP server package before installing |
 | `compliance-report` | Generate OWASP, ATLAS, and NIST compliance posture |
 | `fleet-audit` | Audit an endpoint or cloud inventory file and return graph-ready findings |


### PR DESCRIPTION
## Summary
- clarify current CSPM/CIS, vuln/SCA, compliance, scheduled posture, and graph posture positioning
- narrow DSPM language to Snowflake-depth governance evidence plus roadmap classifier-backed coverage
- replace over-broad full/live/complete language with target-scoped and scheduled/on-demand wording
- correct README/PyPI Hex/Pub language so they are advisory ecosystem identifiers, not native lockfile parser claims

## Validation
- rg audit for full/live/DSPM-overclaim phrases
- git diff --check