### PR TITLE
fix(deploy): harden monitoring example defaults

### DIFF
--- a/examples/docker-compose-monitoring.yml
+++ b/examples/docker-compose-monitoring.yml
@@ -4,12 +4,11 @@
 # scan results in real time.
 #
 # Quick start:
+#   export GRAFANA_ADMIN_PASSWORD="$(openssl rand -base64 24)"
 #   docker compose -f examples/docker-compose-monitoring.yml up -d
 #   agent-bom scan --push-gateway http://localhost:9091
-#   open http://localhost:3000   (admin / admin)
+#   open http://localhost:3000   (admin / $GRAFANA_ADMIN_PASSWORD)
 #   → Import examples/grafana-dashboard.json
-
-version: "3.8"
 
 services:
 
@@ -18,7 +17,7 @@ services:
     image: prom/prometheus:v2.51.0
     container_name: agent-bom-prometheus
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
@@ -33,7 +32,7 @@ services:
     image: prom/pushgateway:v1.8.0
     container_name: agent-bom-pushgateway
     ports:
-      - "9091:9091"
+      - "127.0.0.1:9091:9091"
     restart: unless-stopped
 
   # ── Grafana ────────────────────────────────────────────────────────────────
@@ -41,9 +40,9 @@ services:
     image: grafana/grafana:10.4.2
     container_name: agent-bom-grafana
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD}
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/var/lib/grafana/dashboards/agent-bom.json
     volumes:
@@ -62,8 +61,8 @@ services:
     volumes:
       - ./otel-collector-config.yml:/etc/otel-collector-config.yml:ro
     ports:
-      - "4317:4317"   # OTLP gRPC
-      - "4318:4318"   # OTLP HTTP  ← use with --otel-endpoint http://localhost:4318
+      - "127.0.0.1:4317:4317"   # OTLP gRPC
+      - "127.0.0.1:4318:4318"   # OTLP HTTP  ← use with --otel-endpoint http://localhost:4318
     depends_on:
       - prometheus
     restart: unless-stopped

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -127,6 +127,23 @@ def test_clickhouse_grafana_compose_has_no_default_admin_password():
     assert clickhouse["ports"] == ["127.0.0.1:8123:8123", "127.0.0.1:9000:9000"]
 
 
+def test_monitoring_example_has_no_default_admin_password_or_public_ports():
+    """Example monitoring stack must stay local-only and require a real Grafana password."""
+    import yaml
+
+    path = ROOT / "examples" / "docker-compose-monitoring.yml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    services = data["services"]
+    grafana = services["grafana"]
+
+    assert "admin / admin" not in path.read_text(encoding="utf-8")
+    assert "GRAFANA_ADMIN_PASSWORD:?" in grafana["environment"][0]
+    assert grafana["ports"] == ["127.0.0.1:3000:3000"]
+    assert services["prometheus"]["ports"] == ["127.0.0.1:9090:9090"]
+    assert services["pushgateway"]["ports"] == ["127.0.0.1:9091:9091"]
+    assert services["otel-collector"]["ports"] == ["127.0.0.1:4317:4317", "127.0.0.1:4318:4318"]
+
+
 def test_pilot_insecure_mode_is_loopback_scoped():
     """Pilot no-auth mode is acceptable only because it is loopback-only."""
     import yaml


### PR DESCRIPTION
## Summary
- require a caller-provided Grafana admin password in the monitoring compose example
- bind Prometheus, Pushgateway, Grafana, and OTel collector ports to loopback only
- remove the obsolete Compose `version` field and add a regression test for the safe defaults

## Validation
- `uv run pytest tests/test_deployment.py -q`
- `GRAFANA_ADMIN_PASSWORD=preflight docker compose -f examples/docker-compose-monitoring.yml config > /tmp/agent-bom-monitoring-compose.yml && rg -n "version:|0\\.0\\.0\\.0|3000:3000|9090:9090|9091:9091|4317:4317|4318:4318|GF_SECURITY_ADMIN_PASSWORD|admin / admin|host_ip:" /tmp/agent-bom-monitoring-compose.yml`
