### PR TITLE
fix(integrity): fail closed on incomplete sigstore verification

### DIFF
--- a/src/agent_bom/integrity.py
+++ b/src/agent_bom/integrity.py
@@ -637,16 +637,16 @@ def verify_instruction_file(file_path: str | Path) -> InstructionFileVerificatio
     else:
         result.reason = "no_subject_digest_in_bundle"
 
-    # Try cosign for full cryptographic verification
+    # Try cosign for full cryptographic verification. A matching digest proves
+    # the bundle describes this file, but it does not prove who signed it.
     if result.bundle_valid:
         cosign_ok = _try_cosign_verify(path, bundle_path)
         if cosign_ok:
             result.verified = True
             result.reason = "cosign_verified"
         else:
-            # cosign not available but digest matches — partial verification
-            result.verified = True
-            result.reason = "digest_verified"
+            result.verified = False
+            result.reason = "cosign_verification_failed"
 
     return result
 

--- a/tests/test_instruction_provenance.py
+++ b/tests/test_instruction_provenance.py
@@ -222,7 +222,7 @@ class TestVerifyInstructionFile:
         assert result.reason == "no_sigstore_bundle"
         assert result.verified is False
 
-    def test_valid_bundle_digest_match(self, tmp_path):
+    def test_valid_bundle_digest_match_requires_cosign(self, tmp_path):
         f = tmp_path / "SKILL.md"
         f.write_text("# Skill file content")
         sha = _compute_sha256(f)
@@ -235,8 +235,8 @@ class TestVerifyInstructionFile:
 
         assert result.has_sigstore_bundle is True
         assert result.bundle_valid is True
-        assert result.verified is True
-        assert result.reason == "digest_verified"
+        assert result.verified is False
+        assert result.reason == "cosign_verification_failed"
         assert result.signer_identity == "test-signer"
         assert result.rekor_log_index == 123
 
@@ -375,7 +375,8 @@ class TestBatchVerification:
 
         assert len(results) == 2
         assert not results[0].verified
-        assert results[1].verified
+        assert not results[1].verified
+        assert results[1].reason == "cosign_verification_failed"
 
     def test_empty_batch(self):
         assert verify_instruction_files_batch([]) == []


### PR DESCRIPTION
## Summary
- stop accepting digest-only Sigstore bundles as verified provenance
- require cosign verification to succeed before signed instruction provenance is marked verified
- update provenance regression tests so signed-but-unverified bundles fail closed

## Validation
- `uv run pytest tests/test_instruction_provenance.py -q`
- `uv run pytest tests/test_skills_cli.py -q`
- `uv run ruff check src/agent_bom/integrity.py tests/test_instruction_provenance.py tests/test_skills_cli.py`
