### PR TITLE
fix(mcp): enforce bearer token expiry

### DIFF
--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -112,6 +112,10 @@ The regular bearer token is read-only. To enable audited Shield or identity
 write tools, configure a separate `AGENT_BOM_MCP_OPERATOR_TOKEN`; write calls
 still need `operator_role=admin`, the matching `operator_scopes` value, and an
 audit reason, but those arguments no longer authorize the write by themselves.
+For hosted or shared deployments, set ISO-8601 expiries for both tokens with
+`AGENT_BOM_MCP_BEARER_TOKEN_EXPIRES_AT` and
+`AGENT_BOM_MCP_OPERATOR_TOKEN_EXPIRES_AT`; expired tokens are rejected before
+any read or write scope is returned.
 
 ### Enterprise Control-Plane Contract
 

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -197,9 +197,13 @@ AGENT_BOM_LOG_JSON
 AGENT_BOM_LOG_LEVEL
 AGENT_BOM_MAX_MANIFEST_BYTES
 AGENT_BOM_MCP_BEARER_TOKEN
+# Time-bound MCP read token expiry; deploy/runtime secret lifecycle, read at server startup.
+AGENT_BOM_MCP_BEARER_TOKEN_EXPIRES_AT
 # Separate MCP operator bearer token for write tools; secret reference only,
 # read at server startup to bind Shield/identity writes to authenticated scopes.
 AGENT_BOM_MCP_OPERATOR_TOKEN
+# Time-bound MCP operator token expiry; deploy/runtime secret lifecycle, read at server startup.
+AGENT_BOM_MCP_OPERATOR_TOKEN_EXPIRES_AT
 AGENT_BOM_MCP_SANDBOX
 AGENT_BOM_MCP_SANDBOX_CPUS
 AGENT_BOM_MCP_SANDBOX_EGRESS

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -11,7 +11,11 @@ identities and granting or revoking just-in-time access.
 Those write arguments are audit context only — they no longer authorize the
 write by themselves. The request must authenticate with a separate
 `AGENT_BOM_MCP_OPERATOR_TOKEN` (the regular `AGENT_BOM_MCP_BEARER_TOKEN` is
-read-only). Because the local stdio transport has no token channel, Shield and
+read-only). Remote deployments should also set
+`AGENT_BOM_MCP_BEARER_TOKEN_EXPIRES_AT` and
+`AGENT_BOM_MCP_OPERATOR_TOKEN_EXPIRES_AT` to timezone-aware ISO-8601 timestamps;
+expired tokens are rejected before any scope is returned. Because the local
+stdio transport has no token channel, Shield and
 identity **write** tools are unavailable over stdio — run those actions from the
 CLI or the authenticated REST control plane instead. Read-only tools work over
 stdio as before.

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -89,6 +89,7 @@ import os
 import re
 import time
 from collections import OrderedDict, deque
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Annotated, Any, Awaitable, Callable, Optional, TypeVar
 
@@ -159,23 +160,72 @@ class _StaticBearerTokenVerifier:
     self-assert administrative authority.
     """
 
-    def __init__(self, token: str, operator_token: str | None = None):
+    def __init__(
+        self,
+        token: str,
+        operator_token: str | None = None,
+        *,
+        token_expires_at: str | None = None,
+        operator_token_expires_at: str | None = None,
+    ):
         self._token = token
         self._operator_token = operator_token
+        self._token_expires_at = _parse_mcp_token_expiry(token_expires_at, "AGENT_BOM_MCP_BEARER_TOKEN_EXPIRES_AT")
+        self._operator_token_expires_at = _parse_mcp_token_expiry(
+            operator_token_expires_at,
+            "AGENT_BOM_MCP_OPERATOR_TOKEN_EXPIRES_AT",
+        )
 
     async def verify_token(self, token: str):
         from mcp.server.auth.provider import AccessToken
 
         if self._operator_token and token and hmac.compare_digest(token, self._operator_token):
+            if _mcp_token_expired(self._operator_token_expires_at):
+                return None
             return AccessToken(
                 token=token,
                 client_id="agent-bom-operator-token",
                 scopes=["admin", "shield:write", "identity:write"],
+                expires_at=_mcp_token_expiry_epoch(self._operator_token_expires_at),
                 resource=None,
             )
         if token and hmac.compare_digest(token, self._token):
-            return AccessToken(token=token, client_id="agent-bom-static-token", scopes=["read"], resource=None)
+            if _mcp_token_expired(self._token_expires_at):
+                return None
+            return AccessToken(
+                token=token,
+                client_id="agent-bom-static-token",
+                scopes=["read"],
+                expires_at=_mcp_token_expiry_epoch(self._token_expires_at),
+                resource=None,
+            )
         return None
+
+
+def _parse_mcp_token_expiry(value: str | None, env_name: str) -> datetime | None:
+    """Parse an optional MCP token expiry timestamp from environment/config."""
+    if not value:
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    if cleaned.endswith("Z"):
+        cleaned = f"{cleaned[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(cleaned)
+    except ValueError as exc:
+        raise ValueError(f"{env_name} must be an ISO-8601 timestamp with timezone") from exc
+    if parsed.tzinfo is None:
+        raise ValueError(f"{env_name} must include timezone information")
+    return parsed.astimezone(timezone.utc)
+
+
+def _mcp_token_expired(expires_at: datetime | None) -> bool:
+    return bool(expires_at and datetime.now(timezone.utc) >= expires_at)
+
+
+def _mcp_token_expiry_epoch(expires_at: datetime | None) -> int | None:
+    return int(expires_at.timestamp()) if expires_at else None
 
 
 def _validate_ecosystem(ecosystem: str) -> str:
@@ -420,7 +470,12 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
         port=port,
         bearer_token=bearer_token,
         version=__version__,
-        token_verifier_factory=lambda token: _StaticBearerTokenVerifier(token, os.environ.get("AGENT_BOM_MCP_OPERATOR_TOKEN")),
+        token_verifier_factory=lambda token: _StaticBearerTokenVerifier(
+            token,
+            os.environ.get("AGENT_BOM_MCP_OPERATOR_TOKEN"),
+            token_expires_at=os.environ.get("AGENT_BOM_MCP_BEARER_TOKEN_EXPIRES_AT"),
+            operator_token_expires_at=os.environ.get("AGENT_BOM_MCP_OPERATOR_TOKEN_EXPIRES_AT"),
+        ),
     )
 
     # Import tool implementations

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -104,6 +104,47 @@ def test_static_bearer_verifier_keeps_read_and_operator_tokens_separate():
     assert set(operator_access.scopes) == {"admin", "shield:write", "identity:write"}
 
 
+def test_static_bearer_verifier_rejects_expired_read_token():
+    from agent_bom.mcp_server import _StaticBearerTokenVerifier
+
+    verifier = _StaticBearerTokenVerifier(
+        "read-token",
+        operator_token="operator-token",
+        token_expires_at="2020-01-01T00:00:00Z",
+        operator_token_expires_at="2099-01-01T00:00:00Z",
+    )
+
+    assert _run(verifier.verify_token("read-token")) is None
+    operator_access = _run(verifier.verify_token("operator-token"))
+    assert operator_access is not None
+    assert operator_access.client_id == "agent-bom-operator-token"
+    assert operator_access.expires_at is not None
+
+
+def test_static_bearer_verifier_rejects_expired_operator_token():
+    from agent_bom.mcp_server import _StaticBearerTokenVerifier
+
+    verifier = _StaticBearerTokenVerifier(
+        "read-token",
+        operator_token="operator-token",
+        token_expires_at="2099-01-01T00:00:00+00:00",
+        operator_token_expires_at="2020-01-01T00:00:00+00:00",
+    )
+
+    read_access = _run(verifier.verify_token("read-token"))
+    assert read_access is not None
+    assert read_access.client_id == "agent-bom-static-token"
+    assert read_access.expires_at is not None
+    assert _run(verifier.verify_token("operator-token")) is None
+
+
+def test_static_bearer_verifier_requires_timezone_for_expiry():
+    from agent_bom.mcp_server import _StaticBearerTokenVerifier
+
+    with pytest.raises(ValueError, match="AGENT_BOM_MCP_BEARER_TOKEN_EXPIRES_AT"):
+        _StaticBearerTokenVerifier("read-token", token_expires_at="2099-01-01T00:00:00")
+
+
 # ---------------------------------------------------------------------------
 # Tool: registry_lookup (no mocking needed — reads local JSON)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add timezone-aware expiry enforcement for MCP read and operator bearer tokens
- propagate token expiry into FastMCP `AccessToken.expires_at` metadata and reject expired tokens before scopes are returned
- document the hosted/remote expiry env vars and allowlist them for the CI env-var reference guard

## Validation
- `python scripts/generate_env_var_reference.py --check`
- `uv run pytest tests/test_mcp_server.py tests/test_cli_server.py tests/test_public_docs_cli_alignment.py -q`
- `uv run ruff check src/agent_bom/mcp_server.py tests/test_mcp_server.py`
- `git diff --check`
