### PR TITLE
Enhance README architecture and workflow SVG diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,19 @@
 
 ## What It Is
 
-`agent-bom` scans AI infrastructure across local projects, agent fleets, and
-cloud estates (AWS, Azure, GCP, Snowflake), and builds one AI BOM of agents,
-MCP servers, tools, packages, credential references, non-human identities,
-models, datasets, and runtime. Every source converges into a unified `Finding`
-model and a unified `ContextGraph`, so blast radius, multi-hop exposure paths,
-and exposure scoring all read from the same evidence. That evidence is reachable
-through CLI/CI, a REST API, MCP tools, and a self-hosted dashboard; runtime
-proxy/gateway enforcement is optional and scoped to where it earns its cost.
+`agent-bom` scans AI infrastructure across local projects, agent fleets, cloud
+estates (AWS, Azure, GCP, Snowflake), registries, IaC, SBOMs, models, datasets,
+and runtime. It builds one evidence graph of agents, MCP servers, tools,
+packages, credential references, non-human identities, data systems, and exposed
+resources. Every source converges into a unified `Finding` model and a unified
+`ContextGraph`, so blast radius, multi-hop exposure paths, and exposure scoring
+all read from the same evidence.
+
+The product goal is interoperability for humans and agents: developers get a
+CLI/CI scanner, security teams get an API and dashboard, automation gets MCP
+tools and typed schemas, and runtime controls can enforce the same evidence when
+the operator chooses to enable them. Snowflake is one supported connector and
+deployment lane; it is not the product center.
 
 ## How It Works
 
@@ -127,7 +132,9 @@ For DSPM, Snowflake has the deepest current support because agent-bom can read
 warehouse metadata, grants, tags, lineage, and governance activity visible to
 the configured role. Other cloud data-store sensitivity is posture and metadata
 based until classifier-backed content inspection, provider DLP/Macie wrapping,
-and object/table/column-level access mapping land.
+and object/table/column-level access mapping land. Snowflake is therefore a
+strong optional lane for Snowflake-heavy customers, not the required data plane
+for the product.
 
 ## Product Map
 
@@ -147,6 +154,25 @@ credential boundary, and operator surface.
 See [docs/PRODUCT_MAP.md](docs/PRODUCT_MAP.md) for the longer workflow map,
 including backend choices, auth modes, and where each capability lives in the
 CLI, API, MCP server, dashboard, and deployment docs.
+
+## How Data Gets In
+
+Today, agent-bom ingests through read-only pulls and explicit pushes, not
+Snowpipe or a required streaming bus.
+
+| Ingest lane | Current mechanism | Typical sources | Cadence |
+|---|---|---|---|
+| Read-only cloud / warehouse connectors | Assumable role, managed identity, ADC, or Snowflake key-pair; SDK/SQL `list`/`get`/`SELECT` calls only | AWS, Azure, GCP, Snowflake | on demand or scheduled polling |
+| Direct scans | CLI/API scan job over local or submitted targets | repo, image, IaC, SBOM, MCP config, model, dataset | per command or job |
+| Artifact import | Operator-provided standard evidence | CycloneDX, SPDX, SARIF, scanner JSON, OCSF-like evidence | per import |
+| Runtime / gateway events | Authenticated API ingest from configured runtimes | MCP/tool-call auth, DLP decisions, LLM spans, proxy audit | event push |
+
+Scheduled connectors re-run with the stored tenant-scoped connection and detect
+new, changed, and removed assets at the next cadence through graph history and
+diff evidence. Snowpipe/Streams are a future Snowflake-native option for
+near-real-time telemetry landing in customer-owned Snowflake tables; they are
+not required for the hosted demo, self-hosted platform, CLI, or current
+Snowflake connector.
 
 <details>
 <summary><b>Product proof — dashboard, graph, and identity surfaces</b></summary>
@@ -237,15 +263,19 @@ agent-bom cloud scan --fail-on-severity high
 
 AWS, Azure, GCP, and Snowflake setup, the full grant templates, per-cloud permission
 catalogs, and the "why read-only is enough" rationale live in
-[docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md). agent-bom is a **scanner, not a
-platform** — it reads inventory and posture, normalizes it into one graph, and
-emits findings; it never writes, never reads secret contents, and never moves
-data out of your account.
+[docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md). agent-bom is one interoperable
+scanner and control plane: it reads inventory and posture, normalizes it into
+one graph, serves humans and agents from the same evidence, and emits findings;
+it never writes, never reads secret contents, and never moves data out of your
+account unless you explicitly configure an export destination.
 
 ## Deploy In Your Boundary
 
-`agent-bom` is built for customer-controlled deployment across three tiers of one
-product: a laptop CLI, your own Kubernetes, or a hosted control plane you run.
+`agent-bom` is built for customer-controlled deployment across four lanes of one
+product: the OSS CLI, the self-hosted API/UI platform, a gated hosted POC you
+operate, and an optional Snowflake-native deployment for Snowflake-heavy
+customers. A managed public SaaS control plane is roadmap work gated on
+self-serve signup, tenant lifecycle, quotas, billing, and abuse controls.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml

--- a/docs/VISUAL_LANGUAGE.md
+++ b/docs/VISUAL_LANGUAGE.md
@@ -18,6 +18,8 @@ Use when:
 
 Files live in `docs/images/`, always shipped as `*-light.svg` + `*-dark.svg`
 with `<picture>`+`prefers-color-scheme` switching. Hand-tuned, no auto-layout.
+Regenerate `how-it-works` and `architecture` pairs from
+`scripts/generate_doc_architecture_svgs.py` when lane content or counts change.
 
 Current SVG inventory:
 

--- a/docs/VISUAL_LANGUAGE.md
+++ b/docs/VISUAL_LANGUAGE.md
@@ -9,6 +9,13 @@ For product screenshots, the source of truth is the packaged Next.js
 dashboard. Snowflake Streamlit views may still exist for Snowflake-native
 deployments, but they are not the primary product visuals for README or docs.
 
+Diagrams should center the interoperable evidence model: sources and connectors
+feed `Finding` + `ContextGraph`, then humans and agents consume the same
+evidence through CLI, API, UI, MCP, CI, reports, and gateway controls. AWS,
+Azure, GCP, Snowflake, registries, repos, IaC, SBOMs, and runtime streams are
+connector lanes. None should be drawn as the product center unless the page is
+specifically about that connector.
+
 ## SVG — for hero visuals + dense product imagery
 
 Use when:

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -1,174 +1,133 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 660" fill="none" role="img" aria-labelledby="abom-arch-title abom-arch-desc">
-  <title id="abom-arch-title">agent-bom architecture and data flow</title>
-  <desc id="abom-arch-desc">Left-to-right flow: read-only sources are scanned and enriched into one unified Finding and ContextGraph, served through the control plane (API, Gateway, MCP server) to human and headless-agent consumers, emitting SARIF, CycloneDX, SPDX, and OCSF artifacts.</desc>
-  <defs>
-    <linearGradient id="abom-accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#a78bfa"/>
-      <stop offset="100%" stop-color="#818cf8"/>
-    </linearGradient>
-    <marker id="abom-arrow" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
-    <marker id="abom-arrow-accent" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
-    <style>
-      text { font-family: Inter, system-ui, -apple-system, 'Segoe UI', sans-serif; }
-      .title { font-size: 22px; font-weight: 800; fill: #f4f4f5; }
-      .subtitle { font-size: 11.5px; font-weight: 400; fill: #8a8a93; }
-      .lane-label { font-size: 10px; font-weight: 800; letter-spacing: 0.16em; fill: #a78bfa; }
-      .lane-sub { font-size: 9px; font-weight: 500; fill: #6b6b75; }
-      .node-title { font-size: 12.5px; font-weight: 700; fill: #e9e9ec; }
-      .node-sub { font-size: 9px; font-weight: 400; fill: #82828c; }
-      .pill { font-size: 9px; font-weight: 600; fill: #a78bfa; }
-      .flow-label { font-size: 8.5px; font-weight: 800; letter-spacing: 0.1em; fill: #6b6b75; }
-      .chip { font-size: 9px; font-weight: 700; fill: #a1a1aa; }
-      .footer { font-size: 9.5px; font-weight: 600; letter-spacing: 0.04em; fill: #4ade80; }
-      .ic { fill: none; stroke: #9a9aa4; stroke-width: 1.55; stroke-linecap: round; stroke-linejoin: round; }
-      .ic-a { fill: none; stroke: #a78bfa; stroke-width: 1.55; stroke-linecap: round; stroke-linejoin: round; }
-    </style>
-  </defs>
-
-  <rect width="1200" height="660" rx="14" fill="#0a0a0c"/>
-  <text x="40" y="42" class="title">agent-bom <tspan fill="url(#abom-accent)">architecture</tspan></text>
-  <text x="40" y="63" class="subtitle">One evidence model, left to right — collect read-only, normalize into one Finding + ContextGraph, serve through the control plane, deliver to people and agents.</text>
-
-  <!-- ===== LANE 1 SOURCES ===== -->
-  <rect x="40" y="92" width="206" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
-  <text x="56" y="118" class="lane-label">SOURCES</text>
-  <text x="56" y="134" class="lane-sub">Read-only · no writes · no secret values</text>
-
-  <g><rect x="52" y="148" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="62" y="161" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M69 168h7l3 3v9h-13z M76 168v3h3"/>
-    <text x="98" y="170" class="node-title">Supply chain</text><text x="98" y="185" class="node-sub">15 ecosystems + OS packages</text></g>
-  <g><rect x="52" y="206" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="62" y="219" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="75" cy="227" r="3"/><circle class="ic" cx="70" cy="238" r="2.4"/><circle class="ic" cx="80" cy="238" r="2.4"/><path class="ic" d="M73 230l-2 6 M77 230l2 6"/>
-    <text x="98" y="228" class="node-title">Agents &amp; MCP</text><text x="98" y="243" class="node-sub">29 clients · servers · tools</text></g>
-  <g><rect x="52" y="264" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="62" y="277" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M68 293h12a4 4 0 0 0 .6-7.9 6 6 0 0 0-11.3-1.6A4.2 4.2 0 0 0 68 293z"/>
-    <text x="98" y="286" class="node-title">Cloud inventory</text><text x="98" y="301" class="node-sub">AWS · Azure · GCP · Snowflake</text></g>
-  <g><rect x="52" y="322" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="62" y="335" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M75 333l7 3.5-7 3.5-7-3.5z M68 341l7 3.5 7-3.5 M68 345l7 3.5 7-3.5"/>
-    <text x="98" y="344" class="node-title">IaC &amp; containers</text><text x="98" y="359" class="node-sub">Terraform · K8s · OCI images</text></g>
-  <g><rect x="52" y="380" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="62" y="393" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="72" cy="403" r="3.4"/><path class="ic" d="M74.4 405.4l7 7 M79 410l2.5-2.5 M81.5 412.5l2.5-2.5"/>
-    <text x="98" y="402" class="node-title">Secrets</text><text x="98" y="417" class="node-sub">credential refs · token patterns</text></g>
-  <g><rect x="52" y="438" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="62" y="451" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M75 458l7 3.5v7l-7 3.5-7-3.5v-7z M75 458v14 M68 461.5l14 7"/>
-    <text x="98" y="460" class="node-title">Models &amp; data</text><text x="98" y="475" class="node-sub">weights · cards · PII/PHI</text></g>
-  <g><rect x="52" y="496" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="62" y="509" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M70 515h10v14h-10z M73 520h7 M73 524h7 M73 528h4"/>
-    <text x="98" y="518" class="node-title">SBOM ingest</text><text x="98" y="533" class="node-sub">CycloneDX · SPDX import</text></g>
-
-  <!-- ===== LANE 2 SCAN / INGEST ===== -->
-  <rect x="280" y="92" width="206" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
-  <text x="296" y="118" class="lane-label">SCAN &amp; ENRICH</text>
-  <text x="296" y="134" class="lane-sub">Parallel · local-only</text>
-
-  <g><rect x="292" y="148" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="302" y="164" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="313" cy="175" r="4.2"/><path class="ic" d="M316 178l4 4"/>
-    <text x="338" y="172" class="node-title">Vulnerability scan</text><text x="338" y="188" class="node-sub">OSV batch across all packages</text></g>
-  <g><rect x="292" y="214" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="302" y="230" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M313 233l1.6 3.4 3.4 1.6-3.4 1.6L313 245l-1.6-3.4-3.4-1.6 3.4-1.6z"/>
-    <text x="338" y="238" class="node-title">Threat enrichment</text><text x="338" y="254" class="node-sub">NVD · EPSS · KEV · GHSA</text></g>
-  <g><rect x="292" y="280" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="302" y="296" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M313 300l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M310 308l2 2 4-4.5"/>
-    <text x="338" y="304" class="node-title">Posture checks</text><text x="338" y="320" class="node-sub">MCP/A2A auth · CIS · NHI</text></g>
-  <g><rect x="292" y="346" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="302" y="362" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M307 384v-8 M313 384v-12 M319 384v-6 M306 384h15"/>
-    <text x="338" y="370" class="node-title">Cost / FinOps</text><text x="338" y="386" class="node-sub">model + cloud spend signals</text></g>
-  <g><rect x="292" y="412" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="302" y="428" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M308 434h12 M308 440h12 M308 446h8"/><path class="ic-a" d="M305 434l1.4 1.4 2-2.4"/>
-    <text x="338" y="436" class="node-title">Policy engine</text><text x="338" y="452" class="node-sub">policy-as-code · frameworks</text></g>
-  <g><rect x="292" y="478" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="302" y="494" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="315" cy="507" r="8"/><circle class="ic" cx="315" cy="507" r="4"/><circle class="ic-a" cx="315" cy="507" r="1.4"/>
-    <text x="338" y="502" class="node-title">Blast-radius</text><text x="338" y="518" class="node-sub">pkg → finding → agent fusion</text></g>
-
-  <!-- ===== LANE 3 CORE MODEL ===== -->
-  <rect x="520" y="92" width="206" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
-  <text x="536" y="118" class="lane-label">EVIDENCE CORE</text>
-  <text x="536" y="134" class="lane-sub">One normalized truth</text>
-
-  <g><rect x="532" y="150" width="182" height="86" rx="9" fill="#15121f" stroke="#5b4bbd"/>
-    <rect x="542" y="164" width="26" height="26" rx="7" fill="#1a1530" stroke="#4c3f9e"/><path class="ic-a" d="M549 170h7l3 3v9h-13z M556 170v3h3 M551 182l1.6 1.6 3-3.4"/>
-    <text x="578" y="172" class="node-title" fill="#f4f4f5">Unified Finding</text><text x="578" y="188" class="node-sub">CVE · misconfig · secret · auth</text>
-    <text x="578" y="205" class="node-sub">+ severity · CVSS · EPSS · KEV</text>
-    <text x="546" y="225" class="pill">one schema for every modality</text></g>
-  <g><rect x="532" y="244" width="182" height="86" rx="9" fill="#15121f" stroke="#5b4bbd"/>
-    <rect x="542" y="258" width="26" height="26" rx="7" fill="#1a1530" stroke="#4c3f9e"/><circle class="ic-a" cx="551" cy="265" r="2.6"/><circle class="ic-a" cx="561" cy="263" r="2.6"/><circle class="ic-a" cx="556" cy="278" r="2.6"/><path class="ic-a" d="M553 266l2 9 M559 265l-2 10"/>
-    <text x="578" y="266" class="node-title" fill="#f4f4f5">ContextGraph</text><text x="578" y="282" class="node-sub">entities + edges across</text>
-    <text x="578" y="299" class="node-sub">env · identity · MCP · model</text>
-    <text x="546" y="319" class="pill">multi-hop attack-path fusion</text></g>
-  <g><rect x="532" y="338" width="182" height="56" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="542" y="353" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="555" cy="366" r="7.5"/><path class="ic" d="M555 362v4.5l3 2"/>
-    <text x="578" y="362" class="node-title">Asset tracker</text><text x="578" y="378" class="node-sub">first_seen · MTTR · drift</text></g>
-  <g><rect x="532" y="402" width="182" height="56" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="542" y="417" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M555 424l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M552 432l2 2 4-4.5"/>
-    <text x="578" y="426" class="node-title">Audit &amp; provenance</text><text x="578" y="442" class="node-sub">signed · hash chain · tenant</text></g>
-  <g><rect x="532" y="466" width="182" height="40" rx="9" fill="#121016" stroke="#2a2733"/>
-    <rect x="542" y="475" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M547 481c0-1.7 2.7-3 6-3s6 1.3 6 3-2.7 3-6 3-6-1.3-6-3z M547 481v8c0 1.7 2.7 3 6 3s6-1.3 6-3v-8"/>
-    <text x="574" y="491" class="node-sub" fill="#a1a1aa">Postgres / SQLite · tenant-isolated</text></g>
-
-  <!-- ===== LANE 4 CONTROL PLANE ===== -->
-  <rect x="760" y="92" width="206" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
-  <text x="776" y="118" class="lane-label">CONTROL PLANE</text>
-  <text x="776" y="134" class="lane-sub">Self-hosted · tenant-scoped auth</text>
-
-  <g><rect x="772" y="150" width="182" height="86" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="782" y="164" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M792 170l-4 7 4 7 M798 170l4 7-4 7"/>
-    <text x="818" y="172" class="node-title">REST API</text><text x="818" y="188" class="node-sub">scans · findings · graph</text>
-    <text x="818" y="205" class="node-sub">compliance · identity · cost</text>
-    <text x="786" y="225" class="pill">OIDC · SAML · SCIM · RBAC</text></g>
-  <g><rect x="772" y="244" width="182" height="86" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="782" y="258" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M795 264l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M791 272l3 3 5-5.5"/>
-    <text x="818" y="266" class="node-title">Gateway / Proxy</text><text x="818" y="282" class="node-sub">inline firewall + identity</text>
-    <text x="818" y="299" class="node-sub">inspect · block · sign · audit</text>
-    <text x="786" y="319" class="pill">runtime MCP enforcement</text></g>
-  <g><rect x="772" y="338" width="182" height="76" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="782" y="356" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><rect class="ic" x="788" y="361" width="14" height="6" rx="2"/><rect class="ic" x="788" y="371" width="14" height="6" rx="2"/><path class="ic" d="M792 364h.01 M792 374h.01"/>
-    <text x="818" y="362" class="node-title">MCP server</text><text x="818" y="378" class="node-sub">70 tools · scan · graph · shield</text>
-    <text x="786" y="400" class="pill">stdio · SSE · streamable-HTTP</text></g>
-  <g><rect x="772" y="422" width="182" height="66" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="782" y="438" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><rect class="ic" x="788" y="444" width="6" height="6" rx="1.5"/><rect class="ic" x="796" y="444" width="6" height="6" rx="1.5"/><rect class="ic" x="788" y="452" width="6" height="6" rx="1.5"/><rect class="ic" x="796" y="452" width="6" height="6" rx="1.5"/>
-    <text x="818" y="446" class="node-title">Fleet &amp; scheduling</text><text x="818" y="462" class="node-sub">multi-replica dispatch</text>
-    <text x="818" y="478" class="node-sub">Helm / EKS deployable</text></g>
-  <g><rect x="772" y="496" width="182" height="40" rx="9" fill="#121016" stroke="#2a2733"/>
-    <text x="863" y="520" text-anchor="middle" class="node-sub" fill="#a1a1aa">fail-closed auth · RBAC · scopes · audit</text></g>
-
-  <!-- ===== LANE 5 CONSUMERS ===== -->
-  <rect x="1000" y="92" width="160" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
-  <text x="1016" y="118" class="lane-label">CONSUMERS</text>
-  <text x="1016" y="134" class="lane-sub">People + agents</text>
-
-  <text x="1016" y="162" class="chip" fill="#a78bfa" letter-spacing="0.1em">PEOPLE</text>
-  <g><rect x="1012" y="170" width="136" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="1022" y="182" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M1028 190l4 4-4 4 M1034 198h5"/>
-    <text x="1056" y="190" class="node-title">CLI</text><text x="1056" y="205" class="node-sub">terminal · CI gate</text></g>
-  <g><rect x="1012" y="224" width="136" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="1022" y="236" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><rect class="ic" x="1027" y="241" width="14" height="11" rx="2"/><path class="ic" d="M1027 245h14"/>
-    <text x="1056" y="244" class="node-title">Web UI</text><text x="1056" y="259" class="node-sub">dashboard · graph</text></g>
-
-  <text x="1016" y="298" class="chip" fill="#a78bfa" letter-spacing="0.1em">AGENTS</text>
-  <g><rect x="1012" y="306" width="136" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="1022" y="318" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="1031" cy="325" r="2.4"/><circle class="ic" cx="1027" cy="335" r="2"/><circle class="ic" cx="1036" cy="335" r="2"/><path class="ic" d="M1030 327l-2 6 M1033 327l2 6"/>
-    <text x="1056" y="326" class="node-title">MCP clients</text><text x="1056" y="341" class="node-sub">tool calls over MCP</text></g>
-  <g><rect x="1012" y="360" width="136" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="1022" y="372" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M1031 378l-4 6 4 6 M1037 378l4 6-4 6"/>
-    <text x="1056" y="380" class="node-title">API / SDK</text><text x="1056" y="395" class="node-sub">programmatic</text></g>
-
-  <text x="1016" y="434" class="chip" fill="#a78bfa" letter-spacing="0.1em">ARTIFACTS</text>
-  <g><rect x="1012" y="442" width="136" height="102" rx="9" fill="#121016" stroke="#2a2733"/>
-    <rect x="1024" y="454" width="50" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1049" y="466" text-anchor="middle" class="chip">SARIF</text>
-    <rect x="1080" y="454" width="56" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1108" y="466" text-anchor="middle" class="chip">CycloneDX</text>
-    <rect x="1024" y="478" width="44" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1046" y="490" text-anchor="middle" class="chip">SPDX</text>
-    <rect x="1074" y="478" width="44" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1096" y="490" text-anchor="middle" class="chip">OCSF</text>
-    <rect x="1024" y="502" width="44" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1046" y="514" text-anchor="middle" class="chip">HTML</text>
-    <rect x="1074" y="502" width="44" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1096" y="514" text-anchor="middle" class="chip">JSON</text>
-    <text x="1080" y="535" text-anchor="middle" class="node-sub">→ SIEM · webhooks</text></g>
-
-  <!-- flow arrows (drawn on top so labels are never clipped by lane panels) -->
-  <line x1="246" y1="360" x2="278" y2="360" stroke="#52525b" stroke-width="2" marker-end="url(#abom-arrow)"/><text x="262" y="350" text-anchor="middle" class="flow-label">SCAN</text>
-  <line x1="486" y1="360" x2="518" y2="360" stroke="#52525b" stroke-width="2" marker-end="url(#abom-arrow)"/><text x="502" y="350" text-anchor="middle" class="flow-label">NORMALIZE</text>
-  <line x1="726" y1="360" x2="758" y2="360" stroke="#8b5cf6" stroke-width="2.2" marker-end="url(#abom-arrow-accent)"/><text x="742" y="350" text-anchor="middle" class="flow-label" fill="#a78bfa">SERVE</text>
-  <line x1="966" y1="360" x2="998" y2="360" stroke="#52525b" stroke-width="2" marker-end="url(#abom-arrow)"/><text x="982" y="350" text-anchor="middle" class="flow-label">DELIVER</text>
-
-  <!-- footer trust bar -->
-  <rect x="40" y="608" width="1120" height="30" rx="9" fill="#0c1a14" stroke="#1f4438"/>
-  <text x="600" y="627" text-anchor="middle" class="footer">READ-ONLY BY DEFAULT · no target writes · never runs servers · no secret values · self-hosted · evidence signed end-to-end</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 620" fill="none" role="img" aria-labelledby="arch-d-title arch-d-desc">
+<title id="arch-d-title">agent-bom control-plane architecture</title>
+<desc id="arch-d-desc">Sources through scan and evidence core to control plane and consumers.</desc>
+<defs>
+<marker id="arch-d" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
+<marker id="arch-a-d" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
+</defs>
+<rect width="1200" height="620" rx="14" fill="#0a0a0c"/>
+<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="#f4f4f5">Control-plane <tspan fill="#a78bfa">architecture</tspan></text>
+<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="#71717a">Sources → scan → one Finding + ContextGraph → API · Gateway · MCP → people + agents</text>
+<rect x="32" y="82" width="184" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="32" y="82" width="184" height="36" rx="10" fill="#1e3a5f"/><rect x="32" y="104" width="184" height="14" fill="#1e3a5f"/><text x="46" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">SOURCES</text><text x="204" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">read-only</text>
+<rect x="228" y="82" width="184" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="228" y="82" width="184" height="36" rx="10" fill="#78350f"/><rect x="228" y="104" width="184" height="14" fill="#78350f"/><text x="242" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#fde68a">SCAN</text><text x="400" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#fbbf24" opacity="0.85">local</text>
+<rect x="424" y="82" width="184" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="424" y="82" width="184" height="36" rx="10" fill="#5b21b6"/><rect x="424" y="104" width="184" height="14" fill="#5b21b6"/><text x="438" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#ddd6fe">EVIDENCE</text><text x="596" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a78bfa" opacity="0.85">normalized</text>
+<rect x="620" y="82" width="184" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="620" y="82" width="184" height="36" rx="10" fill="#065f46"/><rect x="620" y="104" width="184" height="14" fill="#065f46"/><text x="634" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#a7f3d0">CONTROL</text><text x="792" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#34d399" opacity="0.85">tenant auth</text>
+<rect x="816" y="82" width="352" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="816" y="82" width="352" height="36" rx="10" fill="#1e3a8a"/><rect x="816" y="104" width="352" height="14" fill="#1e3a8a"/><text x="830" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">CONSUMERS</text><text x="1156" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">people+agents</text>
+<rect x="44" y="128" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="54" y="139" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,144)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="88" y="150" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Supply chain</text>
+<text x="88" y="164" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">15 eco</text>
+<rect x="44" y="186" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="54" y="197" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,202)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="88" y="208" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Agents & MCP</text>
+<text x="88" y="222" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">29 clients</text>
+<rect x="44" y="244" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="54" y="255" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,260)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="88" y="266" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Cloud</text>
+<text x="88" y="280" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">4 providers</text>
+<rect x="44" y="302" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="54" y="313" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,318)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="88" y="324" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">IaC & OCI</text>
+<text x="88" y="338" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">TF·K8s·img</text>
+<rect x="44" y="360" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="54" y="371" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,376)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="88" y="382" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Secrets</text>
+<text x="88" y="396" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">refs only</text>
+<rect x="44" y="418" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="54" y="429" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,434)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="88" y="440" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Models</text>
+<text x="88" y="454" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">13 formats</text>
+<rect x="44" y="476" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="54" y="487" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,492)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="88" y="498" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">SBOM import</text>
+<text x="88" y="512" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">CDX·SPDX</text>
+<rect x="240" y="128" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="250" y="145" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,150)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="284" y="158" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">OSV scan</text>
+<text x="284" y="172" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">batch</text>
+<rect x="240" y="200" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="250" y="217" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,222)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="284" y="230" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Enrichment</text>
+<text x="284" y="244" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">NVD·EPSS</text>
+<rect x="240" y="272" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="250" y="289" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,294)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="284" y="302" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Posture</text>
+<text x="284" y="316" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">CIS·MCP</text>
+<rect x="240" y="344" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="250" y="361" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,366)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="284" y="374" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Blast radius</text>
+<text x="284" y="388" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">fusion</text>
+<rect x="240" y="416" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="250" y="433" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,438)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="284" y="446" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Policy</text>
+<text x="284" y="460" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">as-code</text>
+<rect x="436" y="128" width="160" height="72" rx="9" fill="#15121f" stroke="#5b4bbd" stroke-width="1.6"/>
+<rect x="446" y="151" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(451,156)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="480" y="162" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Unified Finding</text>
+<text x="480" y="178" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#a78bfa">one schema</text>
+<rect x="436" y="216" width="160" height="72" rx="9" fill="#15121f" stroke="#5b4bbd" stroke-width="1.6"/>
+<rect x="446" y="239" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(451,244)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="480" y="250" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">ContextGraph</text>
+<text x="480" y="266" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#a78bfa">attack paths</text>
+<rect x="436" y="304" width="160" height="72" rx="9" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="446" y="327" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(451,332)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
+<text x="480" y="338" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Stores</text>
+<text x="480" y="354" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">PG·SQLite</text>
+<rect x="436" y="392" width="160" height="72" rx="9" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="446" y="415" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(451,420)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="480" y="426" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Audit chain</text>
+<text x="480" y="442" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">signed</text>
+<rect x="632" y="128" width="156" height="72" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="642" y="151" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(647,156)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="676" y="162" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">REST API</text>
+<text x="676" y="178" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">271 ops</text>
+<rect x="632" y="216" width="156" height="72" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="642" y="239" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(647,244)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="676" y="250" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Gateway</text>
+<text x="676" y="266" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">runtime</text>
+<rect x="632" y="304" width="156" height="72" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="642" y="327" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(647,332)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="676" y="338" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">MCP server</text>
+<text x="676" y="354" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">70 tools</text>
+<rect x="632" y="392" width="156" height="72" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="642" y="415" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(647,420)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="676" y="426" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Fleet jobs</text>
+<text x="676" y="442" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">Helm·EKS</text>
+<rect x="632" y="490" width="156" height="32" rx="8" fill="#121016" stroke="#2a2733"/><text x="710" y="510" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#a1a1aa">OIDC · SAML · SCIM · RBAC</text>
+<text x="880" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">PEOPLE</text>
+<rect x="828" y="136" width="104" height="44" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="836" y="145" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(841,150)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
+<text x="868" y="163" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#e9e9ec">CLI</text>
+<rect x="828" y="190" width="104" height="44" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="836" y="199" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(841,204)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="868" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#e9e9ec">Web UI</text>
+<text x="998" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">AGENTS</text>
+<rect x="946" y="136" width="104" height="44" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="954" y="145" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(959,150)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="986" y="163" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#e9e9ec">MCP</text>
+<rect x="946" y="190" width="104" height="44" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="954" y="199" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(959,204)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="986" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#e9e9ec">SDK</text>
+<text x="1116" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">ARTIFACTS</text>
+<rect x="1064" y="136" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1091" y="151" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">SARIF</text>
+<rect x="1122" y="136" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1149" y="151" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">CDX</text>
+<rect x="1064" y="164" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1091" y="179" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">SPDX</text>
+<rect x="1122" y="164" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1149" y="179" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">OCSF</text>
+<rect x="1064" y="192" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1091" y="207" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">HTML</text>
+<rect x="1122" y="192" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1149" y="207" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">JSON</text>
+<text x="1116" y="248" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#6b6b75">→ SIEM · webhooks</text>
+<line x1="216" y1="318" x2="228" y2="318" stroke="#52525b" stroke-width="2" marker-end="url(#arch-d)"/>
+<text x="222" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">SCAN</text>
+<line x1="412" y1="318" x2="424" y2="318" stroke="#52525b" stroke-width="2" marker-end="url(#arch-d)"/>
+<text x="418" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">NORMALIZE</text>
+<line x1="608" y1="318" x2="620" y2="318" stroke="#8b5cf6" stroke-width="2.3" marker-end="url(#arch-a-d)"/>
+<text x="614" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">SERVE</text>
+<line x1="804" y1="318" x2="816" y2="318" stroke="#52525b" stroke-width="2" marker-end="url(#arch-d)"/>
+<text x="810" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">DELIVER</text>
+<rect x="32" y="568" width="1136" height="32" rx="9" fill="#0c1a14" stroke="#1f4438"/><text x="600" y="588" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#4ade80">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -1,161 +1,133 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 660" fill="none" role="img" aria-labelledby="abom-archl-title abom-archl-desc">
-  <title id="abom-archl-title">agent-bom architecture and data flow</title>
-  <desc id="abom-archl-desc">Left-to-right flow: read-only sources are scanned and enriched into one unified Finding and ContextGraph, served through the control plane (API, Gateway, MCP server) to human and headless-agent consumers, emitting SARIF, CycloneDX, SPDX, and OCSF artifacts.</desc>
-  <defs>
-    <linearGradient id="abom-accent-l" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#7c3aed"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
-    </linearGradient>
-    <marker id="abom-arrow-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
-    <marker id="abom-arrow-accent-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
-    <style>
-      text { font-family: Inter, system-ui, -apple-system, 'Segoe UI', sans-serif; }
-      .title { font-size: 22px; font-weight: 800; fill: #18181b; }
-      .subtitle { font-size: 11.5px; font-weight: 400; fill: #6b6b75; }
-      .lane-label { font-size: 10px; font-weight: 800; letter-spacing: 0.16em; fill: #7c3aed; }
-      .lane-sub { font-size: 9px; font-weight: 500; fill: #9a9aa4; }
-      .node-title { font-size: 12.5px; font-weight: 700; fill: #18181b; }
-      .node-sub { font-size: 9px; font-weight: 400; fill: #71717a; }
-      .pill { font-size: 9px; font-weight: 600; fill: #7c3aed; }
-      .flow-label { font-size: 8.5px; font-weight: 800; letter-spacing: 0.1em; fill: #9a9aa4; }
-      .chip { font-size: 9px; font-weight: 700; fill: #52525b; }
-      .footer { font-size: 9.5px; font-weight: 600; letter-spacing: 0.04em; fill: #15803d; }
-      .ic { fill: none; stroke: #6b6b76; stroke-width: 1.55; stroke-linecap: round; stroke-linejoin: round; }
-      .ic-a { fill: none; stroke: #7c3aed; stroke-width: 1.55; stroke-linecap: round; stroke-linejoin: round; }
-    </style>
-  </defs>
-
-  <rect width="1200" height="660" rx="14" fill="#ffffff"/>
-  <text x="40" y="42" class="title">agent-bom <tspan fill="url(#abom-accent-l)">architecture</tspan></text>
-  <text x="40" y="63" class="subtitle">One evidence model, left to right — collect read-only, normalize into one Finding + ContextGraph, serve through the control plane, deliver to people and agents.</text>
-
-  <!-- LANE 1 -->
-  <rect x="40" y="92" width="206" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
-  <text x="56" y="118" class="lane-label">SOURCES</text><text x="56" y="134" class="lane-sub">Read-only · no writes · no secret values</text>
-  <g><rect x="52" y="148" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="62" y="161" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M69 168h7l3 3v9h-13z M76 168v3h3"/>
-    <text x="98" y="170" class="node-title">Supply chain</text><text x="98" y="185" class="node-sub">15 ecosystems + OS packages</text></g>
-  <g><rect x="52" y="206" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="62" y="219" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="75" cy="227" r="3"/><circle class="ic" cx="70" cy="238" r="2.4"/><circle class="ic" cx="80" cy="238" r="2.4"/><path class="ic" d="M73 230l-2 6 M77 230l2 6"/>
-    <text x="98" y="228" class="node-title">Agents &amp; MCP</text><text x="98" y="243" class="node-sub">29 clients · servers · tools</text></g>
-  <g><rect x="52" y="264" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="62" y="277" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M68 293h12a4 4 0 0 0 .6-7.9 6 6 0 0 0-11.3-1.6A4.2 4.2 0 0 0 68 293z"/>
-    <text x="98" y="286" class="node-title">Cloud inventory</text><text x="98" y="301" class="node-sub">AWS · Azure · GCP · Snowflake</text></g>
-  <g><rect x="52" y="322" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="62" y="335" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M75 333l7 3.5-7 3.5-7-3.5z M68 341l7 3.5 7-3.5 M68 345l7 3.5 7-3.5"/>
-    <text x="98" y="344" class="node-title">IaC &amp; containers</text><text x="98" y="359" class="node-sub">Terraform · K8s · OCI images</text></g>
-  <g><rect x="52" y="380" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="62" y="393" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="72" cy="403" r="3.4"/><path class="ic" d="M74.4 405.4l7 7 M79 410l2.5-2.5 M81.5 412.5l2.5-2.5"/>
-    <text x="98" y="402" class="node-title">Secrets</text><text x="98" y="417" class="node-sub">credential refs · token patterns</text></g>
-  <g><rect x="52" y="438" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="62" y="451" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M75 458l7 3.5v7l-7 3.5-7-3.5v-7z M75 458v14 M68 461.5l14 7"/>
-    <text x="98" y="460" class="node-title">Models &amp; data</text><text x="98" y="475" class="node-sub">weights · cards · PII/PHI</text></g>
-  <g><rect x="52" y="496" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="62" y="509" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M70 515h10v14h-10z M73 520h7 M73 524h7 M73 528h4"/>
-    <text x="98" y="518" class="node-title">SBOM ingest</text><text x="98" y="533" class="node-sub">CycloneDX · SPDX import</text></g>
-
-  <!-- LANE 2 -->
-  <rect x="280" y="92" width="206" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
-  <text x="296" y="118" class="lane-label">SCAN &amp; ENRICH</text><text x="296" y="134" class="lane-sub">Parallel · local-only</text>
-  <g><rect x="292" y="148" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="302" y="164" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="313" cy="175" r="4.2"/><path class="ic" d="M316 178l4 4"/>
-    <text x="338" y="172" class="node-title">Vulnerability scan</text><text x="338" y="188" class="node-sub">OSV batch across all packages</text></g>
-  <g><rect x="292" y="214" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="302" y="230" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M313 233l1.6 3.4 3.4 1.6-3.4 1.6L313 245l-1.6-3.4-3.4-1.6 3.4-1.6z"/>
-    <text x="338" y="238" class="node-title">Threat enrichment</text><text x="338" y="254" class="node-sub">NVD · EPSS · KEV · GHSA</text></g>
-  <g><rect x="292" y="280" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="302" y="296" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M313 300l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M310 308l2 2 4-4.5"/>
-    <text x="338" y="304" class="node-title">Posture checks</text><text x="338" y="320" class="node-sub">MCP/A2A auth · CIS · NHI</text></g>
-  <g><rect x="292" y="346" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="302" y="362" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M307 384v-8 M313 384v-12 M319 384v-6 M306 384h15"/>
-    <text x="338" y="370" class="node-title">Cost / FinOps</text><text x="338" y="386" class="node-sub">model + cloud spend signals</text></g>
-  <g><rect x="292" y="412" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="302" y="428" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M308 434h12 M308 440h12 M308 446h8"/><path class="ic-a" d="M305 434l1.4 1.4 2-2.4"/>
-    <text x="338" y="436" class="node-title">Policy engine</text><text x="338" y="452" class="node-sub">policy-as-code · frameworks</text></g>
-  <g><rect x="292" y="478" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="302" y="494" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="315" cy="507" r="8"/><circle class="ic" cx="315" cy="507" r="4"/><circle class="ic-a" cx="315" cy="507" r="1.4"/>
-    <text x="338" y="502" class="node-title">Blast-radius</text><text x="338" y="518" class="node-sub">pkg → finding → agent fusion</text></g>
-
-  <!-- LANE 3 -->
-  <rect x="520" y="92" width="206" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
-  <text x="536" y="118" class="lane-label">EVIDENCE CORE</text><text x="536" y="134" class="lane-sub">One normalized truth</text>
-  <g><rect x="532" y="150" width="182" height="86" rx="9" fill="#f6f4ff" stroke="#c4b5fd"/>
-    <rect x="542" y="164" width="26" height="26" rx="7" fill="#efeaff" stroke="#c4b5fd"/><path class="ic-a" d="M549 170h7l3 3v9h-13z M556 170v3h3 M551 182l1.6 1.6 3-3.4"/>
-    <text x="578" y="172" class="node-title">Unified Finding</text><text x="578" y="188" class="node-sub">CVE · misconfig · secret · auth</text>
-    <text x="578" y="205" class="node-sub">+ severity · CVSS · EPSS · KEV</text>
-    <text x="546" y="225" class="pill">one schema for every modality</text></g>
-  <g><rect x="532" y="244" width="182" height="86" rx="9" fill="#f6f4ff" stroke="#c4b5fd"/>
-    <rect x="542" y="258" width="26" height="26" rx="7" fill="#efeaff" stroke="#c4b5fd"/><circle class="ic-a" cx="551" cy="265" r="2.6"/><circle class="ic-a" cx="561" cy="263" r="2.6"/><circle class="ic-a" cx="556" cy="278" r="2.6"/><path class="ic-a" d="M553 266l2 9 M559 265l-2 10"/>
-    <text x="578" y="266" class="node-title">ContextGraph</text><text x="578" y="282" class="node-sub">entities + edges across</text>
-    <text x="578" y="299" class="node-sub">env · identity · MCP · model</text>
-    <text x="546" y="319" class="pill">multi-hop attack-path fusion</text></g>
-  <g><rect x="532" y="338" width="182" height="56" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="542" y="353" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="555" cy="366" r="7.5"/><path class="ic" d="M555 362v4.5l3 2"/>
-    <text x="578" y="362" class="node-title">Asset tracker</text><text x="578" y="378" class="node-sub">first_seen · MTTR · drift</text></g>
-  <g><rect x="532" y="402" width="182" height="56" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="542" y="417" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M555 424l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M552 432l2 2 4-4.5"/>
-    <text x="578" y="426" class="node-title">Audit &amp; provenance</text><text x="578" y="442" class="node-sub">signed · hash chain · tenant</text></g>
-  <g><rect x="532" y="466" width="182" height="40" rx="9" fill="#f6f5fa" stroke="#e6e3ef"/>
-    <rect x="542" y="475" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M547 481c0-1.7 2.7-3 6-3s6 1.3 6 3-2.7 3-6 3-6-1.3-6-3z M547 481v8c0 1.7 2.7 3 6 3s6-1.3 6-3v-8"/>
-    <text x="574" y="491" class="node-sub" fill="#52525b">Postgres / SQLite · tenant-isolated</text></g>
-
-  <!-- LANE 4 -->
-  <rect x="760" y="92" width="206" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
-  <text x="776" y="118" class="lane-label">CONTROL PLANE</text><text x="776" y="134" class="lane-sub">Self-hosted · tenant-scoped auth</text>
-  <g><rect x="772" y="150" width="182" height="86" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="782" y="164" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M792 170l-4 7 4 7 M798 170l4 7-4 7"/>
-    <text x="818" y="172" class="node-title">REST API</text><text x="818" y="188" class="node-sub">scans · findings · graph</text>
-    <text x="818" y="205" class="node-sub">compliance · identity · cost</text>
-    <text x="786" y="225" class="pill">OIDC · SAML · SCIM · RBAC</text></g>
-  <g><rect x="772" y="244" width="182" height="86" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="782" y="258" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M795 264l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M791 272l3 3 5-5.5"/>
-    <text x="818" y="266" class="node-title">Gateway / Proxy</text><text x="818" y="282" class="node-sub">inline firewall + identity</text>
-    <text x="818" y="299" class="node-sub">inspect · block · sign · audit</text>
-    <text x="786" y="319" class="pill">runtime MCP enforcement</text></g>
-  <g><rect x="772" y="338" width="182" height="76" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="782" y="356" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><rect class="ic" x="788" y="361" width="14" height="6" rx="2"/><rect class="ic" x="788" y="371" width="14" height="6" rx="2"/><path class="ic" d="M792 364h.01 M792 374h.01"/>
-    <text x="818" y="362" class="node-title">MCP server</text><text x="818" y="378" class="node-sub">70 tools · scan · graph · shield</text>
-    <text x="786" y="400" class="pill">stdio · SSE · streamable-HTTP</text></g>
-  <g><rect x="772" y="422" width="182" height="66" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="782" y="438" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><rect class="ic" x="788" y="444" width="6" height="6" rx="1.5"/><rect class="ic" x="796" y="444" width="6" height="6" rx="1.5"/><rect class="ic" x="788" y="452" width="6" height="6" rx="1.5"/><rect class="ic" x="796" y="452" width="6" height="6" rx="1.5"/>
-    <text x="818" y="446" class="node-title">Fleet &amp; scheduling</text><text x="818" y="462" class="node-sub">multi-replica dispatch</text>
-    <text x="818" y="478" class="node-sub">Helm / EKS deployable</text></g>
-  <g><rect x="772" y="496" width="182" height="40" rx="9" fill="#f6f5fa" stroke="#e6e3ef"/>
-    <text x="863" y="520" text-anchor="middle" class="node-sub" fill="#52525b">fail-closed auth · RBAC · scopes · audit</text></g>
-
-  <!-- LANE 5 -->
-  <rect x="1000" y="92" width="160" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
-  <text x="1016" y="118" class="lane-label">CONSUMERS</text><text x="1016" y="134" class="lane-sub">People + agents</text>
-  <text x="1016" y="162" class="chip" fill="#7c3aed" letter-spacing="0.1em">PEOPLE</text>
-  <g><rect x="1012" y="170" width="136" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="1022" y="182" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M1028 190l4 4-4 4 M1034 198h5"/>
-    <text x="1056" y="190" class="node-title">CLI</text><text x="1056" y="205" class="node-sub">terminal · CI gate</text></g>
-  <g><rect x="1012" y="224" width="136" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="1022" y="236" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><rect class="ic" x="1027" y="241" width="14" height="11" rx="2"/><path class="ic" d="M1027 245h14"/>
-    <text x="1056" y="244" class="node-title">Web UI</text><text x="1056" y="259" class="node-sub">dashboard · graph</text></g>
-  <text x="1016" y="298" class="chip" fill="#7c3aed" letter-spacing="0.1em">AGENTS</text>
-  <g><rect x="1012" y="306" width="136" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="1022" y="318" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="1031" cy="325" r="2.4"/><circle class="ic" cx="1027" cy="335" r="2"/><circle class="ic" cx="1036" cy="335" r="2"/><path class="ic" d="M1030 327l-2 6 M1033 327l2 6"/>
-    <text x="1056" y="326" class="node-title">MCP clients</text><text x="1056" y="341" class="node-sub">tool calls over MCP</text></g>
-  <g><rect x="1012" y="360" width="136" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="1022" y="372" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M1031 378l-4 6 4 6 M1037 378l4 6-4 6"/>
-    <text x="1056" y="380" class="node-title">API / SDK</text><text x="1056" y="395" class="node-sub">programmatic</text></g>
-  <text x="1016" y="434" class="chip" fill="#7c3aed" letter-spacing="0.1em">ARTIFACTS</text>
-  <g><rect x="1012" y="442" width="136" height="102" rx="9" fill="#f6f5fa" stroke="#e6e3ef"/>
-    <rect x="1024" y="454" width="50" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1049" y="466" text-anchor="middle" class="chip">SARIF</text>
-    <rect x="1080" y="454" width="56" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1108" y="466" text-anchor="middle" class="chip">CycloneDX</text>
-    <rect x="1024" y="478" width="44" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1046" y="490" text-anchor="middle" class="chip">SPDX</text>
-    <rect x="1074" y="478" width="44" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1096" y="490" text-anchor="middle" class="chip">OCSF</text>
-    <rect x="1024" y="502" width="44" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1046" y="514" text-anchor="middle" class="chip">HTML</text>
-    <rect x="1074" y="502" width="44" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1096" y="514" text-anchor="middle" class="chip">JSON</text>
-    <text x="1080" y="535" text-anchor="middle" class="node-sub">→ SIEM · webhooks</text></g>
-
-  <!-- flow arrows (drawn on top so labels are never clipped by lane panels) -->
-  <line x1="246" y1="360" x2="278" y2="360" stroke="#a1a1aa" stroke-width="2" marker-end="url(#abom-arrow-l)"/><text x="262" y="350" text-anchor="middle" class="flow-label">SCAN</text>
-  <line x1="486" y1="360" x2="518" y2="360" stroke="#a1a1aa" stroke-width="2" marker-end="url(#abom-arrow-l)"/><text x="502" y="350" text-anchor="middle" class="flow-label">NORMALIZE</text>
-  <line x1="726" y1="360" x2="758" y2="360" stroke="#7c3aed" stroke-width="2.2" marker-end="url(#abom-arrow-accent-l)"/><text x="742" y="350" text-anchor="middle" class="flow-label" fill="#7c3aed">SERVE</text>
-  <line x1="966" y1="360" x2="998" y2="360" stroke="#a1a1aa" stroke-width="2" marker-end="url(#abom-arrow-l)"/><text x="982" y="350" text-anchor="middle" class="flow-label">DELIVER</text>
-
-  <rect x="40" y="608" width="1120" height="30" rx="9" fill="#ecfdf5" stroke="#a7f3d0"/>
-  <text x="600" y="627" text-anchor="middle" class="footer">READ-ONLY BY DEFAULT · no target writes · never runs servers · no secret values · self-hosted · evidence signed end-to-end</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 620" fill="none" role="img" aria-labelledby="arch-l-title arch-l-desc">
+<title id="arch-l-title">agent-bom control-plane architecture</title>
+<desc id="arch-l-desc">Sources through scan and evidence core to control plane and consumers.</desc>
+<defs>
+<marker id="arch-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
+<marker id="arch-a-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
+</defs>
+<rect width="1200" height="620" rx="14" fill="#ffffff"/>
+<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="#18181b">Control-plane <tspan fill="#7c3aed">architecture</tspan></text>
+<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="#71717a">Sources → scan → one Finding + ContextGraph → API · Gateway · MCP → people + agents</text>
+<rect x="32" y="82" width="184" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="32" y="82" width="184" height="36" rx="10" fill="#1e3a5f"/><rect x="32" y="104" width="184" height="14" fill="#1e3a5f"/><text x="46" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">SOURCES</text><text x="204" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">read-only</text>
+<rect x="228" y="82" width="184" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="228" y="82" width="184" height="36" rx="10" fill="#78350f"/><rect x="228" y="104" width="184" height="14" fill="#78350f"/><text x="242" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#fde68a">SCAN</text><text x="400" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#fbbf24" opacity="0.85">local</text>
+<rect x="424" y="82" width="184" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="424" y="82" width="184" height="36" rx="10" fill="#5b21b6"/><rect x="424" y="104" width="184" height="14" fill="#5b21b6"/><text x="438" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#ddd6fe">EVIDENCE</text><text x="596" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a78bfa" opacity="0.85">normalized</text>
+<rect x="620" y="82" width="184" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="620" y="82" width="184" height="36" rx="10" fill="#065f46"/><rect x="620" y="104" width="184" height="14" fill="#065f46"/><text x="634" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#a7f3d0">CONTROL</text><text x="792" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#34d399" opacity="0.85">tenant auth</text>
+<rect x="816" y="82" width="352" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="816" y="82" width="352" height="36" rx="10" fill="#1e3a8a"/><rect x="816" y="104" width="352" height="14" fill="#1e3a8a"/><text x="830" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">CONSUMERS</text><text x="1156" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">people+agents</text>
+<rect x="44" y="128" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="54" y="139" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,144)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="88" y="150" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Supply chain</text>
+<text x="88" y="164" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">15 eco</text>
+<rect x="44" y="186" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="54" y="197" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,202)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="88" y="208" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Agents & MCP</text>
+<text x="88" y="222" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">29 clients</text>
+<rect x="44" y="244" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="54" y="255" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,260)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="88" y="266" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Cloud</text>
+<text x="88" y="280" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">4 providers</text>
+<rect x="44" y="302" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="54" y="313" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,318)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="88" y="324" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">IaC & OCI</text>
+<text x="88" y="338" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">TF·K8s·img</text>
+<rect x="44" y="360" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="54" y="371" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,376)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="88" y="382" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Secrets</text>
+<text x="88" y="396" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">refs only</text>
+<rect x="44" y="418" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="54" y="429" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,434)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="88" y="440" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Models</text>
+<text x="88" y="454" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">13 formats</text>
+<rect x="44" y="476" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="54" y="487" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,492)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="88" y="498" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">SBOM import</text>
+<text x="88" y="512" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">CDX·SPDX</text>
+<rect x="240" y="128" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="250" y="145" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,150)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="284" y="158" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">OSV scan</text>
+<text x="284" y="172" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">batch</text>
+<rect x="240" y="200" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="250" y="217" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,222)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="284" y="230" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Enrichment</text>
+<text x="284" y="244" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">NVD·EPSS</text>
+<rect x="240" y="272" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="250" y="289" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,294)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="284" y="302" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Posture</text>
+<text x="284" y="316" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">CIS·MCP</text>
+<rect x="240" y="344" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="250" y="361" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,366)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="284" y="374" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Blast radius</text>
+<text x="284" y="388" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">fusion</text>
+<rect x="240" y="416" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="250" y="433" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,438)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="284" y="446" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Policy</text>
+<text x="284" y="460" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">as-code</text>
+<rect x="436" y="128" width="160" height="72" rx="9" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.6"/>
+<rect x="446" y="151" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(451,156)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="480" y="162" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Unified Finding</text>
+<text x="480" y="178" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#7c3aed">one schema</text>
+<rect x="436" y="216" width="160" height="72" rx="9" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.6"/>
+<rect x="446" y="239" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(451,244)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="480" y="250" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">ContextGraph</text>
+<text x="480" y="266" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#7c3aed">attack paths</text>
+<rect x="436" y="304" width="160" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="446" y="327" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(451,332)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
+<text x="480" y="338" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Stores</text>
+<text x="480" y="354" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">PG·SQLite</text>
+<rect x="436" y="392" width="160" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="446" y="415" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(451,420)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="480" y="426" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Audit chain</text>
+<text x="480" y="442" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">signed</text>
+<rect x="632" y="128" width="156" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="642" y="151" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(647,156)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="676" y="162" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">REST API</text>
+<text x="676" y="178" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">271 ops</text>
+<rect x="632" y="216" width="156" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="642" y="239" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(647,244)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="676" y="250" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Gateway</text>
+<text x="676" y="266" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">runtime</text>
+<rect x="632" y="304" width="156" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="642" y="327" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(647,332)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="676" y="338" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">MCP server</text>
+<text x="676" y="354" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">70 tools</text>
+<rect x="632" y="392" width="156" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="642" y="415" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(647,420)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="676" y="426" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Fleet jobs</text>
+<text x="676" y="442" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">Helm·EKS</text>
+<rect x="632" y="490" width="156" height="32" rx="8" fill="#f4f4f6" stroke="#e4e4e7"/><text x="710" y="510" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#52525b">OIDC · SAML · SCIM · RBAC</text>
+<text x="880" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">PEOPLE</text>
+<rect x="828" y="136" width="104" height="44" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="836" y="145" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(841,150)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
+<text x="868" y="163" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#18181b">CLI</text>
+<rect x="828" y="190" width="104" height="44" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="836" y="199" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(841,204)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="868" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#18181b">Web UI</text>
+<text x="998" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">AGENTS</text>
+<rect x="946" y="136" width="104" height="44" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="954" y="145" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(959,150)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="986" y="163" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#18181b">MCP</text>
+<rect x="946" y="190" width="104" height="44" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="954" y="199" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(959,204)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="986" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#18181b">SDK</text>
+<text x="1116" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">ARTIFACTS</text>
+<rect x="1064" y="136" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1091" y="151" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">SARIF</text>
+<rect x="1122" y="136" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1149" y="151" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">CDX</text>
+<rect x="1064" y="164" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1091" y="179" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">SPDX</text>
+<rect x="1122" y="164" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1149" y="179" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">OCSF</text>
+<rect x="1064" y="192" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1091" y="207" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">HTML</text>
+<rect x="1122" y="192" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1149" y="207" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">JSON</text>
+<text x="1116" y="248" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#9a9aa4">→ SIEM · webhooks</text>
+<line x1="216" y1="318" x2="228" y2="318" stroke="#a1a1aa" stroke-width="2" marker-end="url(#arch-l)"/>
+<text x="222" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">SCAN</text>
+<line x1="412" y1="318" x2="424" y2="318" stroke="#a1a1aa" stroke-width="2" marker-end="url(#arch-l)"/>
+<text x="418" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">NORMALIZE</text>
+<line x1="608" y1="318" x2="620" y2="318" stroke="#7c3aed" stroke-width="2.3" marker-end="url(#arch-a-l)"/>
+<text x="614" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">SERVE</text>
+<line x1="804" y1="318" x2="816" y2="318" stroke="#a1a1aa" stroke-width="2" marker-end="url(#arch-l)"/>
+<text x="810" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">DELIVER</text>
+<rect x="32" y="568" width="1136" height="32" rx="9" fill="#ecfdf5" stroke="#bbf7d0"/><text x="600" y="588" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#15803d">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/how-it-works-dark.svg
+++ b/docs/images/how-it-works-dark.svg
@@ -1,134 +1,133 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 650" fill="none" role="img" aria-labelledby="how-title how-desc">
-<title id="how-title">How agent-bom works</title>
-<desc id="how-desc">A visual flow from read-only inputs through the scan engine, into one unified Finding and ContextGraph, served by the control plane, and exported as reports, gates, and runtime controls.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 560" fill="none" role="img" aria-labelledby="hiw-d-title hiw-d-desc">
+<title id="hiw-d-title">How agent-bom works</title>
+<desc id="hiw-d-desc">Read-only intake through scan pipeline into unified Finding and ContextGraph, served by control plane, exported as reports and gates.</desc>
 <defs>
-<marker id="hiw-arrow" viewBox="0 0 10 8" refX="8.2" refY="4" markerWidth="7" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
-<style>
-text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif; }
-.title { font-size: 30px; font-weight: 850; } .subtitle { font-size: 13px; font-weight: 500; } .label { font-size: 11px; font-weight: 800; letter-spacing: .15em; }
-.step { font-size: 22px; font-weight: 800; } .chip { font-size: 13px; font-weight: 700; } .badge { font-size: 10.5px; font-weight: 700; } .tiny { font-size: 10px; font-weight: 600; } .node { font-size: 11px; font-weight: 800; }
-.ic { fill: none; stroke: #9a9aa4; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
-.ic-a { fill: none; stroke: #a78bfa; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
-</style></defs>
-<rect x="0" y="0" width="1320" height="650" rx="18" fill="#0a0a0c"/>
-<text x="48" y="52" class="title" fill="#f4f4f5">From inventory to enforceable evidence</text>
-<text x="48" y="78" class="subtitle" fill="#82828c">Read-only collection becomes deterministic matching, enriched findings, graph-backed blast radius, and operational outputs.</text>
-
-<rect x="40" y="118" width="240" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
-<text x="58" y="149" class="label" fill="#a78bfa">READ-ONLY INTAKE</text>
-<rect x="330" y="118" width="230" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
-<text x="348" y="149" class="label" fill="#a78bfa">SCAN ENGINE</text>
-<rect x="610" y="118" width="270" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
-<text x="628" y="149" class="label" fill="#a78bfa">EVIDENCE CORE</text>
-<rect x="930" y="118" width="200" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
-<text x="948" y="149" class="label" fill="#a78bfa">CONTROL PLANE</text>
-<rect x="1170" y="118" width="120" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
-<text x="1188" y="149" class="label" fill="#a78bfa">OUTPUTS</text>
-
-<!-- intake nodes -->
-<rect x="62" y="165" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="71" y="175" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M77 178h8l4 4v11h-12z M85 178v4h4"/>
-<text x="103" y="191" class="chip" fill="#f4f4f5">Repo</text>
-<rect x="166" y="165" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="175" y="175" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M180 186l4 4 9-10"/>
-<text x="207" y="191" class="chip" fill="#f4f4f5">CI</text>
-<rect x="62" y="229" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="71" y="239" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="82" cy="247" r="2.6"/><circle class="ic" cx="77" cy="256" r="2.2"/><circle class="ic" cx="87" cy="256" r="2.2"/><path class="ic" d="M80 250l-2 5 M84 250l2 5"/>
-<text x="103" y="255" class="chip" fill="#f4f4f5">MCP</text>
-<rect x="166" y="229" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="175" y="239" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M180 256h12a4 4 0 0 0 .6-7.9 6 6 0 0 0-11.3-1.6A4 4 0 0 0 180 256z"/>
-<text x="207" y="255" class="chip" fill="#f4f4f5">Cloud</text>
-<rect x="62" y="293" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="71" y="303" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><rect class="ic" x="76" y="307" width="12" height="11" rx="2"/><path class="ic" d="M78 316l3-3 2 2 3-3 2 4"/>
-<text x="103" y="319" class="chip" fill="#f4f4f5">Image</text>
-<rect x="166" y="293" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="175" y="303" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M182 306c-4 3-4 13 0 16 M190 306c4 3 4 13 0 16"/>
-<text x="207" y="319" class="chip" fill="#f4f4f5">IaC</text>
-<rect x="62" y="357" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="71" y="367" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M76 370h12v16h-12z M79 375h6 M79 379h6 M79 383h4"/>
-<text x="103" y="383" class="chip" fill="#f4f4f5">SBOM</text>
-<rect x="166" y="357" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="175" y="367" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M186 369l6 3v8l-6 3-6-3v-8z M186 369v14 M180 372l12 6"/>
-<text x="207" y="383" class="chip" fill="#f4f4f5">Model</text>
-<rect x="62" y="438" width="46" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="85" y="455" class="badge" fill="#a1a1aa" text-anchor="middle">AWS</text>
-<rect x="114" y="438" width="46" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="137" y="455" class="badge" fill="#a1a1aa" text-anchor="middle">AZ</text>
-<rect x="166" y="438" width="46" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="189" y="455" class="badge" fill="#a1a1aa" text-anchor="middle">GCP</text>
-<rect x="218" y="438" width="46" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="241" y="455" class="badge" fill="#a1a1aa" text-anchor="middle">SNOW</text>
-<text x="160" y="486" class="tiny" fill="#6b6b75" text-anchor="middle">no writes · no secret values</text>
-
-<!-- scan steps -->
-<circle cx="368" cy="183" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="188" class="badge" fill="#a78bfa" text-anchor="middle">1</text>
-<text x="406" y="190" class="step" fill="#f4f4f5">Discover</text>
-<path d="M368 201 C368 210 368 213 368 220" stroke="#3a3a42" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="241" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="246" class="badge" fill="#a78bfa" text-anchor="middle">2</text>
-<text x="406" y="248" class="step" fill="#f4f4f5">Match</text>
-<path d="M368 259 C368 268 368 271 368 278" stroke="#3a3a42" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="299" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="304" class="badge" fill="#a78bfa" text-anchor="middle">3</text>
-<text x="406" y="306" class="step" fill="#f4f4f5">Enrich</text>
-<path d="M368 317 C368 326 368 329 368 336" stroke="#3a3a42" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="357" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="362" class="badge" fill="#a78bfa" text-anchor="middle">4</text>
-<text x="406" y="364" class="step" fill="#f4f4f5">Evaluate</text>
-<path d="M368 375 C368 384 368 387 368 394" stroke="#3a3a42" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="415" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="420" class="badge" fill="#a78bfa" text-anchor="middle">5</text>
-<text x="406" y="422" class="step" fill="#f4f4f5">Normalize</text>
-<rect x="350" y="446" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="388" y="463" class="badge" fill="#a1a1aa" text-anchor="middle">OSV</text>
-<rect x="440" y="446" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="478" y="463" class="badge" fill="#a1a1aa" text-anchor="middle">GHSA</text>
-<rect x="350" y="477" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="388" y="494" class="badge" fill="#a1a1aa" text-anchor="middle">NVD</text>
-<rect x="440" y="477" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="478" y="494" class="badge" fill="#a1a1aa" text-anchor="middle">KEV</text>
-<rect x="350" y="508" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="388" y="525" class="badge" fill="#a1a1aa" text-anchor="middle">EPSS</text>
-
-<!-- evidence graph -->
-<text x="745" y="178" class="step" fill="#f4f4f5" text-anchor="middle">Finding + ContextGraph</text>
-<line x1="745" y1="256" x2="673" y2="312" stroke="#3a3a42" stroke-width="1.5"/>
-<line x1="745" y1="256" x2="817" y2="312" stroke="#3a3a42" stroke-width="1.5"/>
-<line x1="745" y1="256" x2="703" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
-<line x1="745" y1="256" x2="789" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
-<line x1="673" y1="312" x2="703" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
-<line x1="817" y1="312" x2="789" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
-<line x1="703" y1="372" x2="789" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
-<circle cx="745" cy="256" r="36" fill="#15121f" stroke="#7c5cff" stroke-width="2.4"/><text x="745" y="260" class="node" fill="#c4b5fd" text-anchor="middle">Finding</text>
-<circle cx="673" cy="312" r="33" fill="#161619" stroke="#3a3a42" stroke-width="2"/><text x="673" y="316" class="node" fill="#d4d4d8" text-anchor="middle">Asset</text>
-<circle cx="817" cy="312" r="33" fill="#161619" stroke="#3a3a42" stroke-width="2"/><text x="817" y="316" class="node" fill="#d4d4d8" text-anchor="middle">Agent</text>
-<circle cx="703" cy="372" r="31" fill="#161619" stroke="#3a3a42" stroke-width="2"/><text x="703" y="376" class="node" fill="#d4d4d8" text-anchor="middle">Tool</text>
-<circle cx="789" cy="372" r="31" fill="#161619" stroke="#3a3a42" stroke-width="2"/><text x="789" y="376" class="node" fill="#d4d4d8" text-anchor="middle">Cred</text>
-<rect x="650" y="410" width="84" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="692" y="427" class="badge" fill="#a1a1aa" text-anchor="middle">severity</text>
-<rect x="746" y="410" width="106" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="799" y="427" class="badge" fill="#a1a1aa" text-anchor="middle">provenance</text>
-<rect x="696" y="446" width="108" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="750" y="463" class="badge" fill="#a1a1aa" text-anchor="middle">tenant scope</text>
-<text x="745" y="490" class="tiny" fill="#6b6b75" text-anchor="middle">one model across scan, cloud, runtime, and imports</text>
-
-<!-- control plane rows -->
-<rect x="958" y="165" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
-<path class="ic" d="M974 175l-4 7 4 7 M982 175l4 7-4 7"/><text x="1000" y="189" class="chip" fill="#f4f4f5">API</text>
-<rect x="958" y="215" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect class="ic" x="970" y="226" width="14" height="11" rx="2"/><path class="ic" d="M970 230h14"/><text x="1000" y="239" class="chip" fill="#f4f4f5">UI</text>
-<rect x="958" y="265" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
-<circle class="ic" cx="977" cy="280" r="2.4"/><circle class="ic" cx="973" cy="288" r="2"/><circle class="ic" cx="981" cy="288" r="2"/><path class="ic" d="M975.5 282l-2 5 M978.5 282l2 5"/><text x="1000" y="289" class="chip" fill="#f4f4f5">MCP</text>
-<rect x="958" y="315" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
-<path class="ic" d="M977 326l6 2v4c0 4-2.6 6-6 7-3.4-1-6-3-6-7v-4z M974 333l2 2 3.5-4"/><text x="1000" y="339" class="chip" fill="#f4f4f5">Gate</text>
-<rect x="958" y="365" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect class="ic" x="971" y="377" width="5" height="5" rx="1.3"/><rect class="ic" x="979" y="377" width="5" height="5" rx="1.3"/><rect class="ic" x="971" y="385" width="5" height="5" rx="1.3"/><rect class="ic" x="979" y="385" width="5" height="5" rx="1.3"/><text x="1000" y="389" class="chip" fill="#f4f4f5">Work</text>
-<rect x="958" y="415" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
-<path class="ic" d="M973 427h10v12h-10z M976 427v-2h4v2 M975 432l1.5 1.5 3-3"/><text x="1000" y="439" class="chip" fill="#f4f4f5">Audit</text>
-<text x="1030" y="486" class="tiny" fill="#6b6b75" text-anchor="middle">fail-closed auth · RBAC · scopes · audit</text>
-
-<!-- outputs -->
-<rect x="1195" y="165" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="182" class="badge" fill="#a1a1aa" text-anchor="middle">SARIF</text>
-<rect x="1195" y="210" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="227" class="badge" fill="#a1a1aa" text-anchor="middle">SBOM</text>
-<rect x="1195" y="255" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="272" class="badge" fill="#a1a1aa" text-anchor="middle">HTML</text>
-<rect x="1195" y="300" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="317" class="badge" fill="#a1a1aa" text-anchor="middle">JSON</text>
-<rect x="1195" y="345" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="362" class="badge" fill="#a1a1aa" text-anchor="middle">POSTURE</text>
-<rect x="1195" y="390" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="407" class="badge" fill="#a1a1aa" text-anchor="middle">FIX</text>
-<text x="1230" y="452" class="tiny" fill="#6b6b75" text-anchor="middle">reports</text>
-<text x="1230" y="474" class="tiny" fill="#6b6b75" text-anchor="middle">gates</text>
-<text x="1230" y="496" class="tiny" fill="#6b6b75" text-anchor="middle">runtime</text>
-
-<!-- flow arrows -->
-<path d="M280 314 C302 314 308 314 330 314" stroke="#52525b" stroke-width="2.2" fill="none" marker-end="url(#hiw-arrow)" stroke-linecap="round"/><text x="305" y="302" class="tiny" fill="#6b6b75" text-anchor="middle">collect</text>
-<path d="M560 314 C582 314 588 314 610 314" stroke="#52525b" stroke-width="2.2" fill="none" marker-end="url(#hiw-arrow)" stroke-linecap="round"/><text x="585" y="302" class="tiny" fill="#6b6b75" text-anchor="middle">canonicalize</text>
-<path d="M880 314 C902 314 908 314 930 314" stroke="#8b5cf6" stroke-width="2.4" fill="none" marker-end="url(#hiw-arrow)" stroke-linecap="round"/><text x="905" y="302" class="tiny" fill="#a78bfa" text-anchor="middle">serve</text>
-<path d="M1130 314 C1148 314 1152 314 1170 314" stroke="#52525b" stroke-width="2.2" fill="none" marker-end="url(#hiw-arrow)" stroke-linecap="round"/><text x="1150" y="302" class="tiny" fill="#6b6b75" text-anchor="middle">export</text>
-
-<rect x="40" y="548" width="1250" height="46" rx="14" fill="#0c1a14" stroke="#1f4438"/>
-<text x="66" y="577" class="tiny" fill="#4ade80" font-weight="800">Trust boundary:</text>
-<text x="180" y="577" class="tiny" fill="#a1a1aa">default-off cloud connectors · read-only permissions · secret redaction · signed evidence · same model everywhere</text>
+<marker id="hiw" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
+<marker id="hiw-a" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
+<linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#a78bfa" stop-opacity="0.35"/><stop offset="100%" stop-color="#a78bfa" stop-opacity="0"/></linearGradient>
+</defs>
+<rect width="1200" height="560" rx="16" fill="#0a0a0c"/>
+<text x="36" y="44" font-family="Inter,system-ui,sans-serif" font-size="24" font-weight="850" fill="#f4f4f5">From inventory to enforceable evidence</text>
+<text x="36" y="66" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="500" fill="#71717a">One read-only pipeline · one Finding + ContextGraph · CLI · API · UI · MCP · runtime gates</text>
+<rect x="28" y="88" width="210" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
+<rect x="28" y="88" width="210" height="36" rx="10" fill="#1e3a5f"/><rect x="28" y="110" width="210" height="14" fill="#1e3a5f"/><text x="42" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">INTAKE</text><text x="226" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">read-only</text>
+<rect x="258" y="88" width="188" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
+<rect x="258" y="88" width="188" height="36" rx="10" fill="#78350f"/><rect x="258" y="110" width="188" height="14" fill="#78350f"/><text x="272" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#fde68a">SCAN</text><text x="434" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#fbbf24" opacity="0.85">6 steps</text>
+<rect x="466" y="88" width="248" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
+<rect x="466" y="88" width="248" height="36" rx="10" fill="#5b21b6"/><rect x="466" y="110" width="248" height="14" fill="#5b21b6"/><text x="480" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#ddd6fe">EVIDENCE</text><text x="702" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a78bfa" opacity="0.85">one model</text>
+<rect x="734" y="88" width="188" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
+<rect x="734" y="88" width="188" height="36" rx="10" fill="#065f46"/><rect x="734" y="110" width="188" height="14" fill="#065f46"/><text x="748" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#a7f3d0">CONTROL</text><text x="910" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#34d399" opacity="0.85">self-hosted</text>
+<rect x="942" y="88" width="108" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
+<rect x="942" y="88" width="108" height="36" rx="10" fill="#3f3f46"/><rect x="942" y="110" width="108" height="14" fill="#3f3f46"/><text x="956" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#d4d4d8">OUT</text><text x="1038" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a1a1aa" opacity="0.85">artifacts</text>
+<rect x="44" y="138" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="52" y="147" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(57,152)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h8l3 3v11H4z M12 6v3h3"/></g>
+<text x="86" y="166" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Repo</text>
+<rect x="142" y="138" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="150" y="147" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(155,152)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 14l4 4 10-11"/></g>
+<text x="184" y="166" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">CI</text>
+<rect x="44" y="192" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="52" y="201" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(57,206)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="86" y="220" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">MCP</text>
+<rect x="142" y="192" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="150" y="201" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(155,206)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="184" y="220" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Cloud</text>
+<rect x="44" y="246" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="52" y="255" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(57,260)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
+<text x="86" y="274" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Image</text>
+<rect x="142" y="246" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="150" y="255" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(155,260)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="184" y="274" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">IaC</text>
+<rect x="44" y="300" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="52" y="309" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(57,314)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="86" y="328" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">SBOM</text>
+<rect x="142" y="300" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="150" y="309" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(155,314)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="184" y="328" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Model</text>
+<rect x="44" y="360" width="46" height="34" rx="9" fill="#161619" stroke="#2a2a31"/><g transform="translate(55,366) scale(0.9)"><path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/></g><text x="67" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#ff9900">AWS</text><rect x="96" y="360" width="46" height="34" rx="9" fill="#161619" stroke="#2a2a31"/><g transform="translate(107,366) scale(0.9)"><path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/></g><text x="119" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#0078d4">Azure</text><rect x="148" y="360" width="46" height="34" rx="9" fill="#161619" stroke="#2a2a31"/><g transform="translate(159,366) scale(0.9)"><circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/></g><text x="171" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#4285f4">GCP</text><rect x="200" y="360" width="46" height="34" rx="9" fill="#161619" stroke="#2a2a31"/><g transform="translate(211,366) scale(0.9)"><path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/></g><text x="223" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#29b5e8">Snow</text>
+<rect x="44" y="408" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(49,413)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="78" y="426" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#6b6b75">no writes · no secret values</text>
+<circle cx="278" cy="146" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="150" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">1</text>
+<rect x="304" y="132" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,137)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="6"/><path d="M15 15l4 4"/></g>
+<text x="340" y="149" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Discover</text>
+<path d="M278 160 V170" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="198" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="202" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">2</text>
+<rect x="304" y="184" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,189)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="340" y="201" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Extract</text>
+<path d="M278 212 V222" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="250" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="254" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">3</text>
+<rect x="304" y="236" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,241)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="340" y="253" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Scan</text>
+<path d="M278 264 V274" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="302" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="306" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">4</text>
+<rect x="304" y="288" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,293)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="340" y="305" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Enrich</text>
+<path d="M278 316 V326" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="354" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">5</text>
+<rect x="304" y="340" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,345)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="340" y="357" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Analyze</text>
+<path d="M278 368 V378" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="406" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="410" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">6</text>
+<rect x="304" y="392" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,397)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="340" y="409" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Report</text>
+<rect x="272" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="287" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">OSV</text>
+<rect x="306" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="321" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">GHSA</text>
+<rect x="340" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="355" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">NVD</text>
+<rect x="374" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="389" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">KEV</text>
+<rect x="408" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="423" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">EPSS</text>
+<circle cx="590" cy="268" r="78" fill="url(#core-glow)"/>
+<line x1="590" y1="268" x2="518" y2="258" stroke="#222228" stroke-width="1.4" opacity="0.75"/>
+<line x1="590" y1="268" x2="662" y2="258" stroke="#222228" stroke-width="1.4" opacity="0.75"/>
+<line x1="590" y1="268" x2="538" y2="326" stroke="#222228" stroke-width="1.4" opacity="0.75"/>
+<line x1="590" y1="268" x2="642" y2="326" stroke="#222228" stroke-width="1.4" opacity="0.75"/>
+<circle cx="590" cy="210" r="34" fill="#15121f" stroke="#5b4bbd" stroke-width="2"/>
+<rect x="577" y="197" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(582,202)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="590" y="232" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" fill="#a78bfa">Finding</text>
+<circle cx="518" cy="258" r="28" fill="#161619" stroke="#2a2a31" stroke-width="1.5"/>
+<text x="518" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#e9e9ec">Asset</text>
+<circle cx="662" cy="258" r="28" fill="#161619" stroke="#2a2a31" stroke-width="1.5"/>
+<text x="662" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#e9e9ec">Agent</text>
+<circle cx="538" cy="326" r="28" fill="#161619" stroke="#2a2a31" stroke-width="1.5"/>
+<text x="538" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#e9e9ec">Tool</text>
+<circle cx="642" cy="326" r="28" fill="#161619" stroke="#2a2a31" stroke-width="1.5"/>
+<text x="642" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#e9e9ec">Cred</text>
+<rect x="494" y="390" width="64" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="526" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#a1a1aa">severity</text>
+<rect x="566" y="390" width="64" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="598" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#a1a1aa">provenance</text>
+<rect x="638" y="390" width="64" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="670" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#a1a1aa">tenant</text>
+<rect x="748" y="136" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="756" y="149" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(761,154)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="788" y="168" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">REST API</text>
+<rect x="834" y="136" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="842" y="149" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(847,154)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="874" y="168" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Dashboard</text>
+<rect x="748" y="198" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="756" y="211" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(761,216)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="788" y="230" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">MCP srv</text>
+<rect x="834" y="198" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="842" y="211" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(847,216)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="874" y="230" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Gateway</text>
+<rect x="748" y="260" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="756" y="273" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(761,278)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="788" y="292" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Fleet</text>
+<rect x="834" y="260" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="842" y="273" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(847,278)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="874" y="292" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Audit</text>
+<rect x="748" y="340" width="162" height="28" rx="8" fill="#121016" stroke="#2a2733"/><text x="829" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a1a1aa">fail-closed · RBAC · audit</text>
+<rect x="956" y="136" width="80" height="36" rx="10" fill="#161619" stroke="#f87171" stroke-width="1.2"/><circle cx="970" cy="154" r="4" fill="#f87171" opacity="0.85"/><text x="982" y="158" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">SARIF</text>
+<rect x="956" y="188" width="80" height="36" rx="10" fill="#161619" stroke="#fbbf24" stroke-width="1.2"/><circle cx="970" cy="206" r="4" fill="#fbbf24" opacity="0.85"/><text x="982" y="210" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">SBOM</text>
+<rect x="956" y="240" width="80" height="36" rx="10" fill="#161619" stroke="#60a5fa" stroke-width="1.2"/><circle cx="970" cy="258" r="4" fill="#60a5fa" opacity="0.85"/><text x="982" y="262" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">HTML</text>
+<rect x="956" y="292" width="80" height="36" rx="10" fill="#161619" stroke="#a78bfa" stroke-width="1.2"/><circle cx="970" cy="310" r="4" fill="#a78bfa" opacity="0.85"/><text x="982" y="314" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">JSON</text>
+<rect x="956" y="344" width="80" height="36" rx="10" fill="#161619" stroke="#34d399" stroke-width="1.2"/><circle cx="970" cy="362" r="4" fill="#34d399" opacity="0.85"/><text x="982" y="366" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">GATE</text>
+<rect x="956" y="396" width="80" height="36" rx="10" fill="#161619" stroke="#fb7185" stroke-width="1.2"/><circle cx="970" cy="414" r="4" fill="#fb7185" opacity="0.85"/><text x="982" y="418" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">FIX</text>
+<text x="996" y="468" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#6b6b75">reports · gates · runtime</text>
+<line x1="238" y1="288" x2="256" y2="288" stroke="#52525b" stroke-width="2" marker-end="url(#hiw)"/><text x="247" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">collect</text>
+<line x1="446" y1="288" x2="464" y2="288" stroke="#52525b" stroke-width="2" marker-end="url(#hiw)"/><text x="455" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">normalize</text>
+<line x1="714" y1="288" x2="732" y2="288" stroke="#8b5cf6" stroke-width="2.4" marker-end="url(#hiw-a)"/><text x="723" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">serve</text>
+<line x1="922" y1="288" x2="940" y2="288" stroke="#52525b" stroke-width="2" marker-end="url(#hiw)"/><text x="931" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">export</text>
+<rect x="28" y="508" width="1144" height="36" rx="10" fill="#0c1a14" stroke="#1f4438"/><text x="52" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#4ade80">TRUST</text><text x="100" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#a1a1aa">read-only connectors · secret redaction · signed evidence · same model everywhere</text>
 </svg>

--- a/docs/images/how-it-works-light.svg
+++ b/docs/images/how-it-works-light.svg
@@ -1,128 +1,133 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 650" fill="none" role="img" aria-labelledby="howl-title howl-desc">
-<title id="howl-title">How agent-bom works</title>
-<desc id="howl-desc">A visual flow from read-only inputs through the scan engine, into one unified Finding and ContextGraph, served by the control plane, and exported as reports, gates, and runtime controls.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 560" fill="none" role="img" aria-labelledby="hiw-l-title hiw-l-desc">
+<title id="hiw-l-title">How agent-bom works</title>
+<desc id="hiw-l-desc">Read-only intake through scan pipeline into unified Finding and ContextGraph, served by control plane, exported as reports and gates.</desc>
 <defs>
-<marker id="hiwl-arrow" viewBox="0 0 10 8" refX="8.2" refY="4" markerWidth="7" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
-<style>
-text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif; }
-.title { font-size: 30px; font-weight: 850; } .subtitle { font-size: 13px; font-weight: 500; } .label { font-size: 11px; font-weight: 800; letter-spacing: .15em; }
-.step { font-size: 22px; font-weight: 800; } .chip { font-size: 13px; font-weight: 700; } .badge { font-size: 10.5px; font-weight: 700; } .tiny { font-size: 10px; font-weight: 600; } .node { font-size: 11px; font-weight: 800; }
-.ic { fill: none; stroke: #6b6b76; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
-.ic-a { fill: none; stroke: #7c3aed; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
-</style></defs>
-<rect x="0" y="0" width="1320" height="650" rx="18" fill="#ffffff"/>
-<text x="48" y="52" class="title" fill="#18181b">From inventory to enforceable evidence</text>
-<text x="48" y="78" class="subtitle" fill="#6b6b75">Read-only collection becomes deterministic matching, enriched findings, graph-backed blast radius, and operational outputs.</text>
-
-<rect x="40" y="118" width="240" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
-<text x="58" y="149" class="label" fill="#7c3aed">READ-ONLY INTAKE</text>
-<rect x="330" y="118" width="230" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
-<text x="348" y="149" class="label" fill="#7c3aed">SCAN ENGINE</text>
-<rect x="610" y="118" width="270" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
-<text x="628" y="149" class="label" fill="#7c3aed">EVIDENCE CORE</text>
-<rect x="930" y="118" width="200" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
-<text x="948" y="149" class="label" fill="#7c3aed">CONTROL PLANE</text>
-<rect x="1170" y="118" width="120" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
-<text x="1188" y="149" class="label" fill="#7c3aed">OUTPUTS</text>
-
-<rect x="62" y="165" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="71" y="175" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M77 178h8l4 4v11h-12z M85 178v4h4"/>
-<text x="103" y="191" class="chip" fill="#18181b">Repo</text>
-<rect x="166" y="165" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="175" y="175" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M180 186l4 4 9-10"/>
-<text x="207" y="191" class="chip" fill="#18181b">CI</text>
-<rect x="62" y="229" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="71" y="239" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="82" cy="247" r="2.6"/><circle class="ic" cx="77" cy="256" r="2.2"/><circle class="ic" cx="87" cy="256" r="2.2"/><path class="ic" d="M80 250l-2 5 M84 250l2 5"/>
-<text x="103" y="255" class="chip" fill="#18181b">MCP</text>
-<rect x="166" y="229" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="175" y="239" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M180 256h12a4 4 0 0 0 .6-7.9 6 6 0 0 0-11.3-1.6A4 4 0 0 0 180 256z"/>
-<text x="207" y="255" class="chip" fill="#18181b">Cloud</text>
-<rect x="62" y="293" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="71" y="303" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><rect class="ic" x="76" y="307" width="12" height="11" rx="2"/><path class="ic" d="M78 316l3-3 2 2 3-3 2 4"/>
-<text x="103" y="319" class="chip" fill="#18181b">Image</text>
-<rect x="166" y="293" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="175" y="303" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M182 306c-4 3-4 13 0 16 M190 306c4 3 4 13 0 16"/>
-<text x="207" y="319" class="chip" fill="#18181b">IaC</text>
-<rect x="62" y="357" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="71" y="367" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M76 370h12v16h-12z M79 375h6 M79 379h6 M79 383h4"/>
-<text x="103" y="383" class="chip" fill="#18181b">SBOM</text>
-<rect x="166" y="357" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="175" y="367" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M186 369l6 3v8l-6 3-6-3v-8z M186 369v14 M180 372l12 6"/>
-<text x="207" y="383" class="chip" fill="#18181b">Model</text>
-<rect x="62" y="438" width="46" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="85" y="455" class="badge" fill="#71717a" text-anchor="middle">AWS</text>
-<rect x="114" y="438" width="46" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="137" y="455" class="badge" fill="#71717a" text-anchor="middle">AZ</text>
-<rect x="166" y="438" width="46" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="189" y="455" class="badge" fill="#71717a" text-anchor="middle">GCP</text>
-<rect x="218" y="438" width="46" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="241" y="455" class="badge" fill="#71717a" text-anchor="middle">SNOW</text>
-<text x="160" y="486" class="tiny" fill="#9a9aa4" text-anchor="middle">no writes · no secret values</text>
-
-<circle cx="368" cy="183" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="188" class="badge" fill="#7c3aed" text-anchor="middle">1</text>
-<text x="406" y="190" class="step" fill="#18181b">Discover</text>
-<path d="M368 201 C368 210 368 213 368 220" stroke="#d4d4d8" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="241" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="246" class="badge" fill="#7c3aed" text-anchor="middle">2</text>
-<text x="406" y="248" class="step" fill="#18181b">Match</text>
-<path d="M368 259 C368 268 368 271 368 278" stroke="#d4d4d8" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="299" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="304" class="badge" fill="#7c3aed" text-anchor="middle">3</text>
-<text x="406" y="306" class="step" fill="#18181b">Enrich</text>
-<path d="M368 317 C368 326 368 329 368 336" stroke="#d4d4d8" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="357" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="362" class="badge" fill="#7c3aed" text-anchor="middle">4</text>
-<text x="406" y="364" class="step" fill="#18181b">Evaluate</text>
-<path d="M368 375 C368 384 368 387 368 394" stroke="#d4d4d8" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="415" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="420" class="badge" fill="#7c3aed" text-anchor="middle">5</text>
-<text x="406" y="422" class="step" fill="#18181b">Normalize</text>
-<rect x="350" y="446" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="388" y="463" class="badge" fill="#71717a" text-anchor="middle">OSV</text>
-<rect x="440" y="446" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="478" y="463" class="badge" fill="#71717a" text-anchor="middle">GHSA</text>
-<rect x="350" y="477" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="388" y="494" class="badge" fill="#71717a" text-anchor="middle">NVD</text>
-<rect x="440" y="477" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="478" y="494" class="badge" fill="#71717a" text-anchor="middle">KEV</text>
-<rect x="350" y="508" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="388" y="525" class="badge" fill="#71717a" text-anchor="middle">EPSS</text>
-
-<text x="745" y="178" class="step" fill="#18181b" text-anchor="middle">Finding + ContextGraph</text>
-<line x1="745" y1="256" x2="673" y2="312" stroke="#d4d4d8" stroke-width="1.5"/>
-<line x1="745" y1="256" x2="817" y2="312" stroke="#d4d4d8" stroke-width="1.5"/>
-<line x1="745" y1="256" x2="703" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
-<line x1="745" y1="256" x2="789" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
-<line x1="673" y1="312" x2="703" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
-<line x1="817" y1="312" x2="789" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
-<line x1="703" y1="372" x2="789" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
-<circle cx="745" cy="256" r="36" fill="#f6f4ff" stroke="#7c5cff" stroke-width="2.4"/><text x="745" y="260" class="node" fill="#6d28d9" text-anchor="middle">Finding</text>
-<circle cx="673" cy="312" r="33" fill="#ffffff" stroke="#d4d4d8" stroke-width="2"/><text x="673" y="316" class="node" fill="#3f3f46" text-anchor="middle">Asset</text>
-<circle cx="817" cy="312" r="33" fill="#ffffff" stroke="#d4d4d8" stroke-width="2"/><text x="817" y="316" class="node" fill="#3f3f46" text-anchor="middle">Agent</text>
-<circle cx="703" cy="372" r="31" fill="#ffffff" stroke="#d4d4d8" stroke-width="2"/><text x="703" y="376" class="node" fill="#3f3f46" text-anchor="middle">Tool</text>
-<circle cx="789" cy="372" r="31" fill="#ffffff" stroke="#d4d4d8" stroke-width="2"/><text x="789" y="376" class="node" fill="#3f3f46" text-anchor="middle">Cred</text>
-<rect x="650" y="410" width="84" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="692" y="427" class="badge" fill="#71717a" text-anchor="middle">severity</text>
-<rect x="746" y="410" width="106" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="799" y="427" class="badge" fill="#71717a" text-anchor="middle">provenance</text>
-<rect x="696" y="446" width="108" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="750" y="463" class="badge" fill="#71717a" text-anchor="middle">tenant scope</text>
-<text x="745" y="490" class="tiny" fill="#9a9aa4" text-anchor="middle">one model across scan, cloud, runtime, and imports</text>
-
-<rect x="958" y="165" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<path class="ic" d="M974 175l-4 7 4 7 M982 175l4 7-4 7"/><text x="1000" y="189" class="chip" fill="#18181b">API</text>
-<rect x="958" y="215" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect class="ic" x="970" y="226" width="14" height="11" rx="2"/><path class="ic" d="M970 230h14"/><text x="1000" y="239" class="chip" fill="#18181b">UI</text>
-<rect x="958" y="265" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<circle class="ic" cx="977" cy="280" r="2.4"/><circle class="ic" cx="973" cy="288" r="2"/><circle class="ic" cx="981" cy="288" r="2"/><path class="ic" d="M975.5 282l-2 5 M978.5 282l2 5"/><text x="1000" y="289" class="chip" fill="#18181b">MCP</text>
-<rect x="958" y="315" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<path class="ic" d="M977 326l6 2v4c0 4-2.6 6-6 7-3.4-1-6-3-6-7v-4z M974 333l2 2 3.5-4"/><text x="1000" y="339" class="chip" fill="#18181b">Gate</text>
-<rect x="958" y="365" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect class="ic" x="971" y="377" width="5" height="5" rx="1.3"/><rect class="ic" x="979" y="377" width="5" height="5" rx="1.3"/><rect class="ic" x="971" y="385" width="5" height="5" rx="1.3"/><rect class="ic" x="979" y="385" width="5" height="5" rx="1.3"/><text x="1000" y="389" class="chip" fill="#18181b">Work</text>
-<rect x="958" y="415" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<path class="ic" d="M973 427h10v12h-10z M976 427v-2h4v2 M975 432l1.5 1.5 3-3"/><text x="1000" y="439" class="chip" fill="#18181b">Audit</text>
-<text x="1030" y="486" class="tiny" fill="#9a9aa4" text-anchor="middle">fail-closed auth · RBAC · scopes · audit</text>
-
-<rect x="1195" y="165" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="182" class="badge" fill="#71717a" text-anchor="middle">SARIF</text>
-<rect x="1195" y="210" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="227" class="badge" fill="#71717a" text-anchor="middle">SBOM</text>
-<rect x="1195" y="255" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="272" class="badge" fill="#71717a" text-anchor="middle">HTML</text>
-<rect x="1195" y="300" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="317" class="badge" fill="#71717a" text-anchor="middle">JSON</text>
-<rect x="1195" y="345" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="362" class="badge" fill="#71717a" text-anchor="middle">POSTURE</text>
-<rect x="1195" y="390" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="407" class="badge" fill="#71717a" text-anchor="middle">FIX</text>
-<text x="1230" y="452" class="tiny" fill="#9a9aa4" text-anchor="middle">reports</text>
-<text x="1230" y="474" class="tiny" fill="#9a9aa4" text-anchor="middle">gates</text>
-<text x="1230" y="496" class="tiny" fill="#9a9aa4" text-anchor="middle">runtime</text>
-
-<path d="M280 314 C302 314 308 314 330 314" stroke="#a1a1aa" stroke-width="2.2" fill="none" marker-end="url(#hiwl-arrow)" stroke-linecap="round"/><text x="305" y="302" class="tiny" fill="#9a9aa4" text-anchor="middle">collect</text>
-<path d="M560 314 C582 314 588 314 610 314" stroke="#a1a1aa" stroke-width="2.2" fill="none" marker-end="url(#hiwl-arrow)" stroke-linecap="round"/><text x="585" y="302" class="tiny" fill="#9a9aa4" text-anchor="middle">canonicalize</text>
-<path d="M880 314 C902 314 908 314 930 314" stroke="#7c3aed" stroke-width="2.4" fill="none" marker-end="url(#hiwl-arrow)" stroke-linecap="round"/><text x="905" y="302" class="tiny" fill="#7c3aed" text-anchor="middle">serve</text>
-<path d="M1130 314 C1148 314 1152 314 1170 314" stroke="#a1a1aa" stroke-width="2.2" fill="none" marker-end="url(#hiwl-arrow)" stroke-linecap="round"/><text x="1150" y="302" class="tiny" fill="#9a9aa4" text-anchor="middle">export</text>
-
-<rect x="40" y="548" width="1250" height="46" rx="14" fill="#ecfdf5" stroke="#a7f3d0"/>
-<text x="66" y="577" class="tiny" fill="#15803d" font-weight="800">Trust boundary:</text>
-<text x="180" y="577" class="tiny" fill="#52525b">default-off cloud connectors · read-only permissions · secret redaction · signed evidence · same model everywhere</text>
+<marker id="hiw" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
+<marker id="hiw-a" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
+<linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#7c3aed" stop-opacity="0.35"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0"/></linearGradient>
+</defs>
+<rect width="1200" height="560" rx="16" fill="#ffffff"/>
+<text x="36" y="44" font-family="Inter,system-ui,sans-serif" font-size="24" font-weight="850" fill="#18181b">From inventory to enforceable evidence</text>
+<text x="36" y="66" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="500" fill="#71717a">One read-only pipeline · one Finding + ContextGraph · CLI · API · UI · MCP · runtime gates</text>
+<rect x="28" y="88" width="210" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
+<rect x="28" y="88" width="210" height="36" rx="10" fill="#1e3a5f"/><rect x="28" y="110" width="210" height="14" fill="#1e3a5f"/><text x="42" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">INTAKE</text><text x="226" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">read-only</text>
+<rect x="258" y="88" width="188" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
+<rect x="258" y="88" width="188" height="36" rx="10" fill="#78350f"/><rect x="258" y="110" width="188" height="14" fill="#78350f"/><text x="272" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#fde68a">SCAN</text><text x="434" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#fbbf24" opacity="0.85">6 steps</text>
+<rect x="466" y="88" width="248" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
+<rect x="466" y="88" width="248" height="36" rx="10" fill="#5b21b6"/><rect x="466" y="110" width="248" height="14" fill="#5b21b6"/><text x="480" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#ddd6fe">EVIDENCE</text><text x="702" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a78bfa" opacity="0.85">one model</text>
+<rect x="734" y="88" width="188" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
+<rect x="734" y="88" width="188" height="36" rx="10" fill="#065f46"/><rect x="734" y="110" width="188" height="14" fill="#065f46"/><text x="748" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#a7f3d0">CONTROL</text><text x="910" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#34d399" opacity="0.85">self-hosted</text>
+<rect x="942" y="88" width="108" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
+<rect x="942" y="88" width="108" height="36" rx="10" fill="#3f3f46"/><rect x="942" y="110" width="108" height="14" fill="#3f3f46"/><text x="956" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#d4d4d8">OUT</text><text x="1038" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a1a1aa" opacity="0.85">artifacts</text>
+<rect x="44" y="138" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="52" y="147" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(57,152)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h8l3 3v11H4z M12 6v3h3"/></g>
+<text x="86" y="166" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Repo</text>
+<rect x="142" y="138" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="150" y="147" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(155,152)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 14l4 4 10-11"/></g>
+<text x="184" y="166" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">CI</text>
+<rect x="44" y="192" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="52" y="201" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(57,206)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="86" y="220" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">MCP</text>
+<rect x="142" y="192" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="150" y="201" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(155,206)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="184" y="220" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Cloud</text>
+<rect x="44" y="246" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="52" y="255" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(57,260)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
+<text x="86" y="274" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Image</text>
+<rect x="142" y="246" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="150" y="255" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(155,260)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="184" y="274" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">IaC</text>
+<rect x="44" y="300" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="52" y="309" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(57,314)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="86" y="328" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">SBOM</text>
+<rect x="142" y="300" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="150" y="309" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(155,314)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="184" y="328" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Model</text>
+<rect x="44" y="360" width="46" height="34" rx="9" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(55,366) scale(0.9)"><path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/></g><text x="67" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#ff9900">AWS</text><rect x="96" y="360" width="46" height="34" rx="9" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(107,366) scale(0.9)"><path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/></g><text x="119" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#0078d4">Azure</text><rect x="148" y="360" width="46" height="34" rx="9" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(159,366) scale(0.9)"><circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/></g><text x="171" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#4285f4">GCP</text><rect x="200" y="360" width="46" height="34" rx="9" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(211,366) scale(0.9)"><path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/></g><text x="223" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#29b5e8">Snow</text>
+<rect x="44" y="408" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(49,413)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="78" y="426" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#9a9aa4">no writes · no secret values</text>
+<circle cx="278" cy="146" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="150" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">1</text>
+<rect x="304" y="132" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,137)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="6"/><path d="M15 15l4 4"/></g>
+<text x="340" y="149" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Discover</text>
+<path d="M278 160 V170" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="198" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="202" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">2</text>
+<rect x="304" y="184" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,189)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="340" y="201" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Extract</text>
+<path d="M278 212 V222" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="250" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="254" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">3</text>
+<rect x="304" y="236" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,241)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="340" y="253" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Scan</text>
+<path d="M278 264 V274" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="302" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="306" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">4</text>
+<rect x="304" y="288" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,293)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="340" y="305" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Enrich</text>
+<path d="M278 316 V326" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="354" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">5</text>
+<rect x="304" y="340" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,345)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="340" y="357" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Analyze</text>
+<path d="M278 368 V378" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="406" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="410" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">6</text>
+<rect x="304" y="392" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,397)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="340" y="409" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Report</text>
+<rect x="272" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="287" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">OSV</text>
+<rect x="306" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="321" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">GHSA</text>
+<rect x="340" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="355" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">NVD</text>
+<rect x="374" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="389" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">KEV</text>
+<rect x="408" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="423" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">EPSS</text>
+<circle cx="590" cy="268" r="78" fill="url(#core-glow)"/>
+<line x1="590" y1="268" x2="518" y2="258" stroke="#ececf0" stroke-width="1.4" opacity="0.75"/>
+<line x1="590" y1="268" x2="662" y2="258" stroke="#ececf0" stroke-width="1.4" opacity="0.75"/>
+<line x1="590" y1="268" x2="538" y2="326" stroke="#ececf0" stroke-width="1.4" opacity="0.75"/>
+<line x1="590" y1="268" x2="642" y2="326" stroke="#ececf0" stroke-width="1.4" opacity="0.75"/>
+<circle cx="590" cy="210" r="34" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="2"/>
+<rect x="577" y="197" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(582,202)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="590" y="232" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" fill="#7c3aed">Finding</text>
+<circle cx="518" cy="258" r="28" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.5"/>
+<text x="518" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#18181b">Asset</text>
+<circle cx="662" cy="258" r="28" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.5"/>
+<text x="662" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#18181b">Agent</text>
+<circle cx="538" cy="326" r="28" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.5"/>
+<text x="538" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#18181b">Tool</text>
+<circle cx="642" cy="326" r="28" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.5"/>
+<text x="642" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#18181b">Cred</text>
+<rect x="494" y="390" width="64" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="526" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#52525b">severity</text>
+<rect x="566" y="390" width="64" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="598" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#52525b">provenance</text>
+<rect x="638" y="390" width="64" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="670" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#52525b">tenant</text>
+<rect x="748" y="136" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="756" y="149" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(761,154)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="788" y="168" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">REST API</text>
+<rect x="834" y="136" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="842" y="149" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(847,154)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="874" y="168" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Dashboard</text>
+<rect x="748" y="198" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="756" y="211" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(761,216)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="788" y="230" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">MCP srv</text>
+<rect x="834" y="198" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="842" y="211" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(847,216)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="874" y="230" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Gateway</text>
+<rect x="748" y="260" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="756" y="273" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(761,278)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="788" y="292" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Fleet</text>
+<rect x="834" y="260" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="842" y="273" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(847,278)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="874" y="292" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Audit</text>
+<rect x="748" y="340" width="162" height="28" rx="8" fill="#f4f4f6" stroke="#e4e4e7"/><text x="829" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#52525b">fail-closed · RBAC · audit</text>
+<rect x="956" y="136" width="80" height="36" rx="10" fill="#ffffff" stroke="#f87171" stroke-width="1.2"/><circle cx="970" cy="154" r="4" fill="#f87171" opacity="0.85"/><text x="982" y="158" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">SARIF</text>
+<rect x="956" y="188" width="80" height="36" rx="10" fill="#ffffff" stroke="#fbbf24" stroke-width="1.2"/><circle cx="970" cy="206" r="4" fill="#fbbf24" opacity="0.85"/><text x="982" y="210" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">SBOM</text>
+<rect x="956" y="240" width="80" height="36" rx="10" fill="#ffffff" stroke="#60a5fa" stroke-width="1.2"/><circle cx="970" cy="258" r="4" fill="#60a5fa" opacity="0.85"/><text x="982" y="262" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">HTML</text>
+<rect x="956" y="292" width="80" height="36" rx="10" fill="#ffffff" stroke="#a78bfa" stroke-width="1.2"/><circle cx="970" cy="310" r="4" fill="#a78bfa" opacity="0.85"/><text x="982" y="314" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">JSON</text>
+<rect x="956" y="344" width="80" height="36" rx="10" fill="#ffffff" stroke="#34d399" stroke-width="1.2"/><circle cx="970" cy="362" r="4" fill="#34d399" opacity="0.85"/><text x="982" y="366" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">GATE</text>
+<rect x="956" y="396" width="80" height="36" rx="10" fill="#ffffff" stroke="#fb7185" stroke-width="1.2"/><circle cx="970" cy="414" r="4" fill="#fb7185" opacity="0.85"/><text x="982" y="418" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">FIX</text>
+<text x="996" y="468" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#9a9aa4">reports · gates · runtime</text>
+<line x1="238" y1="288" x2="256" y2="288" stroke="#a1a1aa" stroke-width="2" marker-end="url(#hiw)"/><text x="247" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">collect</text>
+<line x1="446" y1="288" x2="464" y2="288" stroke="#a1a1aa" stroke-width="2" marker-end="url(#hiw)"/><text x="455" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">normalize</text>
+<line x1="714" y1="288" x2="732" y2="288" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#hiw-a)"/><text x="723" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">serve</text>
+<line x1="922" y1="288" x2="940" y2="288" stroke="#a1a1aa" stroke-width="2" marker-end="url(#hiw)"/><text x="931" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">export</text>
+<rect x="28" y="508" width="1144" height="36" rx="10" fill="#ecfdf5" stroke="#bbf7d0"/><text x="52" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#15803d">TRUST</text><text x="100" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#52525b">read-only connectors · secret redaction · signed evidence · same model everywhere</text>
 </svg>

--- a/scripts/generate_doc_architecture_svgs.py
+++ b/scripts/generate_doc_architecture_svgs.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+"""Generate README architecture SVGs (how-it-works + control-plane architecture).
+
+Hand-tuned layout with theme tokens — run after changing lane content or counts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+OUT = Path(__file__).resolve().parents[1] / "docs" / "images"
+
+THEMES = {
+    "dark": {
+        "bg": "#0a0a0c",
+        "panel": "#0f0f13",
+        "panel_stroke": "#222228",
+        "card": "#161619",
+        "card_stroke": "#2a2a31",
+        "icon_bg": "#1c1c21",
+        "icon_stroke": "#2e2e35",
+        "title": "#f4f4f5",
+        "subtitle": "#71717a",
+        "lane": "#a78bfa",
+        "lane_muted": "#6b6b75",
+        "text": "#e9e9ec",
+        "text_muted": "#82828c",
+        "chip": "#a1a1aa",
+        "arrow": "#52525b",
+        "arrow_accent": "#8b5cf6",
+        "accent": "#a78bfa",
+        "accent_fill": "#15121f",
+        "accent_stroke": "#5b4bbd",
+        "trust_bg": "#0c1a14",
+        "trust_stroke": "#1f4438",
+        "trust": "#4ade80",
+        "ic": "#9a9aa4",
+        "ic_accent": "#a78bfa",
+        "highlight": "#15121f",
+        "footer_bg": "#121016",
+        "footer_stroke": "#2a2733",
+    },
+    "light": {
+        "bg": "#ffffff",
+        "panel": "#fafafa",
+        "panel_stroke": "#ececf0",
+        "card": "#ffffff",
+        "card_stroke": "#e6e6ea",
+        "icon_bg": "#f4f4f6",
+        "icon_stroke": "#e6e6ea",
+        "title": "#18181b",
+        "subtitle": "#71717a",
+        "lane": "#7c3aed",
+        "lane_muted": "#9a9aa4",
+        "text": "#18181b",
+        "text_muted": "#71717a",
+        "chip": "#52525b",
+        "arrow": "#a1a1aa",
+        "arrow_accent": "#7c3aed",
+        "accent": "#7c3aed",
+        "accent_fill": "#f5f3ff",
+        "accent_stroke": "#c4b5fd",
+        "trust_bg": "#ecfdf5",
+        "trust_stroke": "#bbf7d0",
+        "trust": "#15803d",
+        "ic": "#6b6b76",
+        "ic_accent": "#7c3aed",
+        "highlight": "#f5f3ff",
+        "footer_bg": "#f4f4f6",
+        "footer_stroke": "#e4e4e7",
+    },
+}
+
+LANE_COLORS = {
+    "intake": ("#1e3a5f", "#60a5fa", "#93c5fd"),
+    "scan": ("#78350f", "#fbbf24", "#fde68a"),
+    "core": ("#5b21b6", "#a78bfa", "#ddd6fe"),
+    "control": ("#065f46", "#34d399", "#a7f3d0"),
+    "output": ("#3f3f46", "#a1a1aa", "#d4d4d8"),
+    "sources": ("#1e3a5f", "#60a5fa", "#93c5fd"),
+    "enrich": ("#78350f", "#fbbf24", "#fde68a"),
+    "evidence": ("#5b21b6", "#a78bfa", "#ddd6fe"),
+    "consumers": ("#1e3a8a", "#60a5fa", "#93c5fd"),
+}
+
+
+def _esc(text: str) -> str:
+    return text.replace("&", "&amp;").replace("<", "&lt;")
+
+
+def _marker(theme: dict, name: str, color_key: str) -> str:
+    return (
+        f'<marker id="{name}" viewBox="0 0 10 8" refX="8.5" refY="4" '
+        f'markerWidth="9" markerHeight="7" orient="auto">'
+        f'<path d="M0 0 L10 4 L0 8 Z" fill="{theme[color_key]}"/></marker>'
+    )
+
+
+def _icon_box(x: int, y: int, paths: str, t: dict, accent: bool = False, *, box: bool = True) -> str:
+    stroke = t["ic_accent"] if accent else t["ic"]
+    box_svg = (
+        f'<rect x="{x}" y="{y}" width="26" height="26" rx="7" fill="{t["icon_bg"]}" stroke="{t["icon_stroke"]}"/>'
+        if box
+        else ""
+    )
+    return (
+        f"{box_svg}"
+        f'<g transform="translate({x + 5},{y + 5})" fill="none" stroke="{stroke}" stroke-width="1.55" '
+        f'stroke-linecap="round" stroke-linejoin="round">{paths}</g>'
+    )
+
+
+def _lane_header(x: int, y: int, w: int, label: str, lane_key: str, tag: str, t: dict) -> str:
+    bg, accent, text = LANE_COLORS[lane_key]
+    return (
+        f'<rect x="{x}" y="{y}" width="{w}" height="36" rx="10" fill="{bg}"/>'
+        f'<rect x="{x}" y="{y + 22}" width="{w}" height="14" fill="{bg}"/>'
+        f'<text x="{x + 14}" y="{y + 22}" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" '
+        f'letter-spacing="0.14em" fill="{text}">{_esc(label)}</text>'
+        f'<text x="{x + w - 12}" y="{y + 22}" text-anchor="end" font-family="Inter,system-ui,sans-serif" '
+        f'font-size="8.5" font-weight="600" fill="{accent}" opacity="0.85">{_esc(tag)}</text>'
+    )
+
+
+def _flow_arrow(x1: int, y1: int, x2: int, y2: int, label: str, t: dict, accent: bool = False) -> str:
+    color = t["arrow_accent"] if accent else t["arrow"]
+    marker = "hiw-a" if accent else "hiw"
+    width = "2.4" if accent else "2"
+    return (
+        f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{color}" stroke-width="{width}" '
+        f'marker-end="url(#{marker})"/>'
+        f'<text x="{(x1 + x2) // 2}" y="{y1 - 10}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
+        f'font-size="8" font-weight="800" letter-spacing="0.1em" fill="{t["accent"] if accent else t["lane_muted"]}">'
+        f'{_esc(label)}</text>'
+    )
+
+
+# ── Icon path snippets (24×24 viewBox, placed at x+5,y+5 in 26×26 box) ───────
+
+ICONS = {
+    "repo": '<path d="M4 6h8l3 3v11H4z M12 6v3h3"/>',
+    "ci": '<path d="M6 14l4 4 10-11"/>',
+    "mcp": '<circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/>',
+    "cloud": '<path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/>',
+    "image": '<rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/>',
+    "iac": '<path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/>',
+    "sbom": '<path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/>',
+    "model": '<path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/>',
+    "runtime": '<circle cx="12" cy="12" r="7"/><path d="M12 8v4l3 2"/>',
+    "search": '<circle cx="10" cy="10" r="6"/><path d="M15 15l4 4"/>',
+    "package": '<path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/>',
+    "bug": '<path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/>',
+    "zap": '<path d="M13 3L5 14h6l-1 7 8-11h-6z"/>',
+    "shield": '<path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/>',
+    "file": '<path d="M7 4h7l4 4v12H7z M14 4v4h4"/>',
+    "api": '<path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/>',
+    "ui": '<rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/>',
+    "gate": '<path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/>',
+    "fleet": '<rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/>',
+    "audit": '<path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/>',
+    "cli": '<path d="M7 8l-4 4 4 4 M13 16h7"/>',
+    "sarif": '<path d="M6 5h12v14H6z M9 9h8 M9 13h5"/>',
+    "lock": '<rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/>',
+    "finding": '<path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/>',
+    "graph": '<circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/>',
+    "db": '<ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/>',
+}
+
+
+def _cloud_logos(x: int, y: int, t: dict) -> str:
+  """Simplified provider marks — brand-inspired colors, not official logos."""
+  items = [
+      ("AWS", "#ff9900", '<path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/>'),
+      ("Azure", "#0078d4", '<path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/>'),
+      ("GCP", "#4285f4", '<circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/>'),
+      ("Snow", "#29b5e8", '<path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/>'),
+  ]
+  out = []
+  for i, (label, color, art) in enumerate(items):
+      bx = x + i * 52
+      out.append(
+          f'<rect x="{bx}" y="{y}" width="46" height="34" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>'
+          f'<g transform="translate({bx + 11},{y + 6}) scale(0.9)">{art}</g>'
+          f'<text x="{bx + 23}" y="{y + 30}" text-anchor="middle" font-family="ui-monospace,monospace" '
+          f'font-size="7" font-weight="700" fill="{color}">{label}</text>'
+      )
+  return "".join(out)
+
+
+def how_it_works(theme_name: str) -> str:
+    t = THEMES[theme_name]
+    suffix = "d" if theme_name == "dark" else "l"
+    w, h = 1200, 560
+
+  # Pipeline steps — mirrors src/agent_bom/api/pipeline.py PIPELINE_STEPS
+    steps = [
+        ("search", "Discover"),
+        ("package", "Extract"),
+        ("bug", "Scan"),
+        ("zap", "Enrich"),
+        ("shield", "Analyze"),
+        ("file", "Report"),
+    ]
+
+    intake = [
+        ("repo", "Repo"),
+        ("ci", "CI"),
+        ("mcp", "MCP"),
+        ("cloud", "Cloud"),
+        ("image", "Image"),
+        ("iac", "IaC"),
+        ("sbom", "SBOM"),
+        ("model", "Model"),
+    ]
+
+    control = [
+        ("api", "REST API"),
+        ("ui", "Dashboard"),
+        ("mcp", "MCP srv"),
+        ("gate", "Gateway"),
+        ("fleet", "Fleet"),
+        ("audit", "Audit"),
+    ]
+
+    outputs = ["SARIF", "SBOM", "HTML", "JSON", "GATE", "FIX"]
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" fill="none" role="img" '
+        f'aria-labelledby="hiw-{suffix}-title hiw-{suffix}-desc">',
+        f'<title id="hiw-{suffix}-title">How agent-bom works</title>',
+        '<desc id="hiw-{suffix}-desc">Read-only intake through scan pipeline into unified Finding and '
+        'ContextGraph, served by control plane, exported as reports and gates.</desc>'.format(suffix=suffix),
+        "<defs>",
+        _marker(t, "hiw", "arrow"),
+        _marker(t, "hiw-a", "arrow_accent"),
+        '<linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1">'
+        f'<stop offset="0%" stop-color="{t["accent"]}" stop-opacity="0.35"/>'
+        f'<stop offset="100%" stop-color="{t["accent"]}" stop-opacity="0"/>'
+        "</linearGradient>",
+        "</defs>",
+        f'<rect width="{w}" height="{h}" rx="16" fill="{t["bg"]}"/>',
+        f'<text x="36" y="44" font-family="Inter,system-ui,sans-serif" font-size="24" font-weight="850" fill="{t["title"]}">'
+        "From inventory to enforceable evidence</text>",
+        f'<text x="36" y="66" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="500" fill="{t["subtitle"]}">'
+        "One read-only pipeline · one Finding + ContextGraph · CLI · API · UI · MCP · runtime gates</text>",
+    ]
+
+    # Lane panels
+    lanes = [
+        (28, 88, 210, "INTAKE", "intake", "read-only"),
+        (258, 88, 188, "SCAN", "scan", "6 steps"),
+        (466, 88, 248, "EVIDENCE", "core", "one model"),
+        (734, 88, 188, "CONTROL", "control", "self-hosted"),
+        (942, 88, 108, "OUT", "output", "artifacts"),
+    ]
+    for x, y, lw, label, key, tag in lanes:
+        parts.append(
+            f'<rect x="{x}" y="{y}" width="{lw}" height="400" rx="14" fill="{t["panel"]}" stroke="{t["panel_stroke"]}"/>'
+        )
+        parts.append(_lane_header(x, y, lw, label, key, tag, t))
+
+    # Intake icon grid
+    for i, (icon, label) in enumerate(intake):
+        col, row = i % 2, i // 2
+        tx, ty = 44 + col * 98, 138 + row * 54
+        parts.append(f'<rect x="{tx}" y="{ty}" width="88" height="44" rx="11" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(tx + 8, ty + 9, ICONS[icon], t))
+        parts.append(
+            f'<text x="{tx + 42}" y="{ty + 28}" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="{t["text"]}">{label}</text>'
+        )
+
+    parts.append(_cloud_logos(44, 360, t))
+    parts.append(_icon_box(44, 408, ICONS["lock"], t, accent=True))
+    parts.append(
+        f'<text x="78" y="426" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="{t["lane_muted"]}">'
+        "no writes · no secret values</text>"
+    )
+
+    # Scan pipeline — vertical stepped flow
+    scan_bg, scan_accent, scan_text = LANE_COLORS["scan"]
+    for i, (icon, label) in enumerate(steps):
+        sy = 132 + i * 52
+        parts.append(f'<circle cx="278" cy="{sy + 14}" r="14" fill="{t["card"]}" stroke="{scan_accent}" stroke-width="1.5"/>')
+        parts.append(
+            f'<text x="278" y="{sy + 18}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
+            f'font-size="9" font-weight="800" fill="{scan_accent}">{i + 1}</text>'
+        )
+        parts.append(_icon_box(304, sy, ICONS[icon], t))
+        parts.append(
+            f'<text x="340" y="{sy + 17}" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="{t["text"]}">{label}</text>'
+        )
+        if i < len(steps) - 1:
+            parts.append(
+                f'<path d="M278 {sy + 28} V{sy + 38}" stroke="{t["panel_stroke"]}" stroke-width="1.5" stroke-linecap="round"/>'
+            )
+
+    advisories = ["OSV", "GHSA", "NVD", "KEV", "EPSS"]
+    for i, adv in enumerate(advisories):
+        ax = 272 + i * 34
+        parts.append(
+            f'<rect x="{ax}" y="448" width="30" height="20" rx="6" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
+            f'<text x="{ax + 15}" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" '
+            f'font-weight="700" fill="{scan_accent}">{adv}</text>'
+        )
+
+    # Evidence graph hub
+    cx, cy = 590, 268
+    parts.append(f'<circle cx="{cx}" cy="{cy}" r="78" fill="url(#core-glow)"/>')
+    nodes = [
+        (cx, cy - 58, "Finding", True, "finding"),
+        (cx - 72, cy - 10, "Asset", False, "package"),
+        (cx + 72, cy - 10, "Agent", False, "mcp"),
+        (cx - 52, cy + 58, "Tool", False, "bug"),
+        (cx + 52, cy + 58, "Cred", False, "lock"),
+    ]
+    for nx, ny, nlabel, center, icon in nodes:
+        if not center:
+            parts.append(
+                f'<line x1="{cx}" y1="{cy}" x2="{nx}" y2="{ny}" stroke="{t["panel_stroke"]}" stroke-width="1.4" opacity="0.75"/>'
+            )
+    for nx, ny, nlabel, center, icon in nodes:
+        r = 34 if center else 28
+        fill = t["accent_fill"] if center else t["card"]
+        stroke = t["accent_stroke"] if center else t["card_stroke"]
+        parts.append(f'<circle cx="{nx}" cy="{ny}" r="{r}" fill="{fill}" stroke="{stroke}" stroke-width="{"2" if center else "1.5"}"/>')
+        if center:
+            parts.append(_icon_box(nx - 13, ny - 13, ICONS[icon], t, accent=True))
+        parts.append(
+            f'<text x="{nx}" y="{ny + (22 if center else 20)}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
+            f'font-size="{"10" if center else "9"}" font-weight="800" fill="{t["accent"] if center else t["text"]}">{nlabel}</text>'
+        )
+
+    meta = ["severity", "provenance", "tenant"]
+    for i, chip in enumerate(meta):
+        mx = 494 + i * 72
+        parts.append(
+            f'<rect x="{mx}" y="390" width="64" height="22" rx="7" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
+            f'<text x="{mx + 32}" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" '
+            f'font-weight="700" fill="{t["chip"]}">{chip}</text>'
+        )
+
+    # Control plane tiles
+    for i, (icon, label) in enumerate(control):
+        col, row = i % 2, i // 2
+        tx, ty = 748 + col * 86, 136 + row * 62
+        parts.append(f'<rect x="{tx}" y="{ty}" width="78" height="52" rx="10" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(tx + 8, ty + 13, ICONS[icon], t))
+        parts.append(
+            f'<text x="{tx + 40}" y="{ty + 32}" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="{t["text"]}">{label}</text>'
+        )
+
+    parts.append(
+        f'<rect x="748" y="340" width="162" height="28" rx="8" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>'
+        f'<text x="829" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" '
+        f'font-weight="700" fill="{t["chip"]}">fail-closed · RBAC · audit</text>'
+    )
+
+    # Outputs column
+    out_colors = ["#f87171", "#fbbf24", "#60a5fa", "#a78bfa", "#34d399", "#fb7185"]
+    for i, (label, color) in enumerate(zip(outputs, out_colors, strict=True)):
+        oy = 136 + i * 52
+        parts.append(
+            f'<rect x="956" y="{oy}" width="80" height="36" rx="10" fill="{t["card"]}" stroke="{color}" stroke-width="1.2"/>'
+            f'<circle cx="970" cy="{oy + 18}" r="4" fill="{color}" opacity="0.85"/>'
+            f'<text x="982" y="{oy + 22}" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="{t["text"]}">{label}</text>'
+        )
+
+    parts.append(
+        f'<text x="996" y="468" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" '
+        f'font-weight="600" fill="{t["lane_muted"]}">reports · gates · runtime</text>'
+    )
+
+    # Flow arrows between lanes
+    parts.append(_flow_arrow(238, 288, 256, 288, "collect", t))
+    parts.append(_flow_arrow(446, 288, 464, 288, "normalize", t))
+    parts.append(_flow_arrow(714, 288, 732, 288, "serve", t, accent=True))
+    parts.append(_flow_arrow(922, 288, 940, 288, "export", t))
+
+    # Trust bar
+    parts.append(
+        f'<rect x="28" y="508" width="1144" height="36" rx="10" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
+        f'<text x="52" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="{t["trust"]}">'
+        "TRUST</text>"
+        f'<text x="100" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="{t["chip"]}">'
+        "read-only connectors · secret redaction · signed evidence · same model everywhere</text>"
+    )
+
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+def architecture(theme_name: str) -> str:
+    t = THEMES[theme_name]
+    suffix = "d" if theme_name == "dark" else "l"
+    w, h = 1200, 620
+
+    sources = [
+        ("package", "Supply chain", "15 eco"),
+        ("mcp", "Agents & MCP", "29 clients"),
+        ("cloud", "Cloud", "4 providers"),
+        ("iac", "IaC & OCI", "TF·K8s·img"),
+        ("lock", "Secrets", "refs only"),
+        ("model", "Models", "13 formats"),
+        ("sbom", "SBOM import", "CDX·SPDX"),
+    ]
+
+    scan_items = [
+        ("bug", "OSV scan", "batch"),
+        ("zap", "Enrichment", "NVD·EPSS"),
+        ("shield", "Posture", "CIS·MCP"),
+        ("graph", "Blast radius", "fusion"),
+        ("file", "Policy", "as-code"),
+    ]
+
+    core_items = [
+        ("finding", "Unified Finding", "one schema", True),
+        ("graph", "ContextGraph", "attack paths", True),
+        ("db", "Stores", "PG·SQLite", False),
+        ("audit", "Audit chain", "signed", False),
+    ]
+
+    cp_items = [
+        ("api", "REST API", "271 ops"),
+        ("gate", "Gateway", "runtime"),
+        ("mcp", "MCP server", "70 tools"),
+        ("fleet", "Fleet jobs", "Helm·EKS"),
+    ]
+
+    people = [("cli", "CLI"), ("ui", "Web UI")]
+    agents = [("mcp", "MCP"), ("api", "SDK")]
+    artifacts = ["SARIF", "CDX", "SPDX", "OCSF", "HTML", "JSON"]
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" fill="none" role="img" '
+        f'aria-labelledby="arch-{suffix}-title arch-{suffix}-desc">',
+        f'<title id="arch-{suffix}-title">agent-bom control-plane architecture</title>',
+        '<desc id="arch-{suffix}-desc">Sources through scan and evidence core to control plane and consumers.</desc>'.format(
+            suffix=suffix
+        ),
+        "<defs>",
+        _marker(t, f"arch-{suffix}", "arrow"),
+        _marker(t, f"arch-a-{suffix}", "arrow_accent"),
+        "</defs>",
+        f'<rect width="{w}" height="{h}" rx="14" fill="{t["bg"]}"/>',
+        f'<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="{t["title"]}">'
+        f'Control-plane <tspan fill="{t["accent"]}">architecture</tspan></text>',
+        f'<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="{t["subtitle"]}">'
+        "Sources → scan → one Finding + ContextGraph → API · Gateway · MCP → people + agents</text>",
+    ]
+
+    lane_x = [32, 228, 424, 620, 816]
+    lane_w = [184, 184, 184, 184, 352]
+    lane_meta = [
+        ("SOURCES", "sources", "read-only"),
+        ("SCAN", "enrich", "local"),
+        ("EVIDENCE", "evidence", "normalized"),
+        ("CONTROL", "control", "tenant auth"),
+        ("CONSUMERS", "consumers", "people+agents"),
+    ]
+
+    for i, (label, key, tag) in enumerate(lane_meta):
+        x, lw = lane_x[i], lane_w[i]
+        parts.append(
+            f'<rect x="{x}" y="82" width="{lw}" height="468" rx="12" fill="{t["panel"]}" stroke="{t["panel_stroke"]}"/>'
+        )
+        parts.append(_lane_header(x, 82, lw, label, key, tag, t))
+
+    # Sources column
+    for i, (icon, title, badge) in enumerate(sources):
+        sy = 128 + i * 58
+        parts.append(f'<rect x="44" y="{sy}" width="160" height="48" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(54, sy + 11, ICONS[icon], t))
+        parts.append(
+            f'<text x="88" y="{sy + 22}" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="{t["text"]}">{title}</text>'
+        )
+        parts.append(
+            f'<text x="88" y="{sy + 36}" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="{t["text_muted"]}">{badge}</text>'
+        )
+
+    for i, (icon, title, badge) in enumerate(scan_items):
+        sy = 128 + i * 72
+        parts.append(f'<rect x="240" y="{sy}" width="160" height="60" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(250, sy + 17, ICONS[icon], t))
+        parts.append(
+            f'<text x="284" y="{sy + 30}" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="{t["text"]}">{title}</text>'
+        )
+        parts.append(
+            f'<text x="284" y="{sy + 44}" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="{t["text_muted"]}">{badge}</text>'
+        )
+
+    # Evidence column — highlighted core cards
+    for i, (icon, title, badge, highlight) in enumerate(core_items):
+        sy = 128 + i * 88
+        fill = t["accent_fill"] if highlight else t["card"]
+        stroke = t["accent_stroke"] if highlight else t["card_stroke"]
+        parts.append(f'<rect x="436" y="{sy}" width="160" height="72" rx="9" fill="{fill}" stroke="{stroke}" stroke-width="{"1.6" if highlight else "1"}"/>')
+        parts.append(_icon_box(446, sy + 23, ICONS[icon], t, accent=highlight))
+        parts.append(
+            f'<text x="480" y="{sy + 34}" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="{t["text"]}">{title}</text>'
+        )
+        parts.append(
+            f'<text x="480" y="{sy + 50}" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="{t["accent"] if highlight else t["text_muted"]}">{badge}</text>'
+        )
+
+    # Control plane
+    for i, (icon, title, badge) in enumerate(cp_items):
+        sy = 128 + i * 88
+        parts.append(f'<rect x="632" y="{sy}" width="156" height="72" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(642, sy + 23, ICONS[icon], t))
+        parts.append(
+            f'<text x="676" y="{sy + 34}" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="{t["text"]}">{title}</text>'
+        )
+        parts.append(
+            f'<text x="676" y="{sy + 50}" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="{t["text_muted"]}">{badge}</text>'
+        )
+
+    parts.append(
+        f'<rect x="632" y="490" width="156" height="32" rx="8" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>'
+        f'<text x="710" y="510" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="{t["chip"]}">'
+        "OIDC · SAML · SCIM · RBAC</text>"
+    )
+
+    # Consumers — three sub-columns inside the wide lane
+    cx_base = 828
+    parts.append(
+        f'<text x="{cx_base + 52}" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" '
+        f'letter-spacing="0.12em" fill="{t["accent"]}">PEOPLE</text>'
+    )
+    for i, (icon, label) in enumerate(people):
+        sy = 136 + i * 54
+        parts.append(f'<rect x="{cx_base}" y="{sy}" width="104" height="44" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(cx_base + 8, sy + 9, ICONS[icon], t))
+        parts.append(
+            f'<text x="{cx_base + 40}" y="{sy + 27}" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="{t["text"]}">{label}</text>'
+        )
+
+    ax_base = cx_base + 118
+    parts.append(
+        f'<text x="{ax_base + 52}" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" '
+        f'letter-spacing="0.12em" fill="{t["accent"]}">AGENTS</text>'
+    )
+    for i, (icon, label) in enumerate(agents):
+        sy = 136 + i * 54
+        parts.append(f'<rect x="{ax_base}" y="{sy}" width="104" height="44" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(ax_base + 8, sy + 9, ICONS[icon], t))
+        parts.append(
+            f'<text x="{ax_base + 40}" y="{sy + 27}" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="{t["text"]}">{label}</text>'
+        )
+
+    art_base = cx_base + 236
+    parts.append(
+        f'<text x="{art_base + 52}" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" '
+        f'letter-spacing="0.12em" fill="{t["accent"]}">ARTIFACTS</text>'
+    )
+    for i, label in enumerate(artifacts):
+        col, row = i % 2, i // 2
+        ax, ay = art_base + col * 58, 136 + row * 28
+        parts.append(
+            f'<rect x="{ax}" y="{ay}" width="54" height="22" rx="7" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
+            f'<text x="{ax + 27}" y="{ay + 15}" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" '
+            f'font-weight="700" fill="{t["chip"]}">{label}</text>'
+        )
+
+    parts.append(
+        f'<text x="{art_base + 52}" y="248" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="{t["lane_muted"]}">'
+        "→ SIEM · webhooks</text>"
+    )
+
+    # Inter-lane flow
+    y_flow = 318
+    flows = [
+        (lane_x[0] + lane_w[0], y_flow, lane_x[1], y_flow, "SCAN", False),
+        (lane_x[1] + lane_w[1], y_flow, lane_x[2], y_flow, "NORMALIZE", False),
+        (lane_x[2] + lane_w[2], y_flow, lane_x[3], y_flow, "SERVE", True),
+        (lane_x[3] + lane_w[3], y_flow, lane_x[4], y_flow, "DELIVER", False),
+    ]
+    for x1, y1, x2, y2, label, accent in flows:
+        color = t["arrow_accent"] if accent else t["arrow"]
+        marker = f"arch-a-{suffix}" if accent else f"arch-{suffix}"
+        width = "2.3" if accent else "2"
+        parts.append(
+            f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{color}" stroke-width="{width}" marker-end="url(#{marker})"/>'
+        )
+        parts.append(
+            f'<text x="{(x1 + x2) // 2}" y="{y1 - 10}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
+            f'font-size="8" font-weight="800" letter-spacing="0.1em" fill="{t["accent"] if accent else t["lane_muted"]}">{label}</text>'
+        )
+
+    parts.append(
+        f'<rect x="32" y="568" width="1136" height="32" rx="9" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
+        f'<text x="600" y="588" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="{t["trust"]}">'
+        "READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>"
+    )
+
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+def main() -> None:
+    OUT.mkdir(parents=True, exist_ok=True)
+    mapping = {
+        "how-it-works-dark.svg": ("dark", how_it_works),
+        "how-it-works-light.svg": ("light", how_it_works),
+        "architecture-dark.svg": ("dark", architecture),
+        "architecture-light.svg": ("light", architecture),
+    }
+    for filename, (theme, fn) in mapping.items():
+        path = OUT / filename
+        path.write_text(fn(theme) + "\n", encoding="utf-8")
+        print(f"wrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -1,0 +1,40 @@
+"""Smoke tests for README architecture SVG generator."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from scripts.generate_doc_architecture_svgs import architecture, how_it_works
+
+IMAGES = Path(__file__).resolve().parents[1] / "docs" / "images"
+
+
+def test_how_it_works_includes_pipeline_steps() -> None:
+    svg = how_it_works("dark")
+    for step in ("Discover", "Extract", "Scan", "Enrich", "Analyze", "Report"):
+        assert step in svg
+    assert "PIPELINE" not in svg  # visual labels, not code identifiers
+
+
+def test_architecture_includes_core_surfaces() -> None:
+    svg = architecture("light")
+    assert "Unified Finding" in svg
+    assert "ContextGraph" in svg
+    assert "70 tools" in svg
+    assert "271 ops" in svg
+
+
+def test_generated_files_exist_and_are_valid_svg() -> None:
+    for name in (
+        "how-it-works-dark.svg",
+        "how-it-works-light.svg",
+        "architecture-dark.svg",
+        "architecture-light.svg",
+    ):
+        path = IMAGES / name
+        assert path.exists(), name
+        text = path.read_text(encoding="utf-8")
+        assert text.startswith("<svg")
+        assert text.rstrip().endswith("</svg>")
+        assert re.search(r'viewBox="0 0 \d+ \d+"', text)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Redesigns the two README architecture visuals (`how-it-works` and `architecture`) to be more visual, less text-heavy, and aligned with the actual product code paths.

### How it works (workflow)

- Color-coded lane headers (intake → scan → evidence → control → outputs)
- Six-step scan pipeline matching `PIPELINE_STEPS` in `src/agent_bom/api/pipeline.py` (Discover → Extract → Scan → Enrich → Analyze → Report)
- Icon grid for intake sources with simplified AWS/Azure/GCP/Snowflake marks
- Hub-and-spoke evidence graph for Finding + ContextGraph
- Compact control-plane tiles and color-coded output badges

### Control-plane architecture

- Five lanes with metric badges instead of long prose (15 ecosystems, 29 MCP clients, 271 REST ops, 70 MCP tools)
- Highlighted Unified Finding + ContextGraph core cards
- Three-column consumers layout (People · Agents · Artifacts)
- Shorter trust-boundary footer

### Maintenance

- Adds `scripts/generate_doc_architecture_svgs.py` to regenerate dark/light pairs from shared theme tokens
- Adds smoke tests in `tests/test_doc_architecture_svgs.py`
- Documents the generator in `docs/VISUAL_LANGUAGE.md`

## Test plan

- [x] `python3 scripts/generate_doc_architecture_svgs.py`
- [x] `pytest tests/test_doc_architecture_svgs.py`
- [ ] Visual review of README `<details>` sections in dark and light mode
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b609ffa-953a-44af-ae4c-38f5d4f980a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b609ffa-953a-44af-ae4c-38f5d4f980a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

