### PR TITLE
fix(scan): alpine APK coverage, metrics sync, and doc SVG accuracy

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -28,7 +28,7 @@ For the layered architecture and data-flow diagrams, see
 | `sdks/` | Client SDKs: `python`, `go`, `typescript`, `typescript-client`, `shared`. | Yes — typed control-plane clients (not scanner SDKs). |
 | `deploy/` | Helm chart, docker-compose pilot, EKS reference, deployment manifests. | Yes. |
 | `contracts/` | Cross-surface contract fixtures. | Yes. |
-| `docs/openapi/v1.json` | Committed OpenAPI spec — the canonical REST contract (230 paths / 271 operations). | **Yes** — SDK + client contract checks read this. |
+| `docs/openapi/v1.json` | Committed OpenAPI spec — the canonical REST contract (239 paths / 283 operations). | **Yes** — SDK + client contract checks read this. |
 | `scripts/` | Release, deploy, and consistency tooling (e.g. `check_release_consistency.py`). | Yes. |
 | `integrations/` | External tool integrations and examples. | Yes. |
 | `examples/`, `config/`, `security/`, `fuzz/` | Samples, config, security policy, fuzz harnesses. | Support material. |
@@ -84,7 +84,7 @@ The self-hosted operator surface. Same evidence, multi-tenant, audited.
 
 | Subsystem | Path | Responsibility |
 |---|---|---|
-| API | `api/` | FastAPI app. `routes/` (30 route modules; 271 REST operations + 2 WebSocket), `middleware.py` (4 layers), and `*_store.py`/`postgres_*.py` persistence (SQLite default, Postgres for clusters, optional Snowflake/ClickHouse). |
+| API | `api/` | FastAPI app. `routes/` (32 route modules; 283 REST operations + 2 WebSocket), `middleware.py` (4 layers), and `*_store.py`/`postgres_*.py` persistence (SQLite default, Postgres for clusters, optional Snowflake/ClickHouse). |
 | MCP server | `mcp_server*.py`, `mcp_tools/` | FastMCP server advertising 69 tools, 6 resources, 6 prompts (mostly read-only; 3 Shield write actions fail closed). |
 | Runtime enforcement | `proxy*.py`, `gateway*.py`, `firewall*.py`, `shield.py`, `runtime/`, `enforcement.py` | MCP traffic proxy, secure-by-default gateway, inline firewall, Shield enforcement. **Spread by design** — see [Runtime enforcement spread](#runtime-enforcement-spread). |
 | Auth / tenancy | `rbac.py`, `permissions.py`, `entitlements.py`, `mcp_tenant.py`, `api/auth.py`, `api/oidc.py` | RBAC roles, tenant scoping, API keys, OIDC/SAML/SCIM. |

--- a/README.md
+++ b/README.md
@@ -170,9 +170,15 @@ and [docs/images/product-screenshots.json](docs/images/product-screenshots.json)
 
 ```bash
 pip install agent-bom
+agent-bom db update                      # populate ~/.agent-bom vuln DB before --offline scans
 agent-bom quickstart --run --offline    # write sample, scan, seed gateway policy, populate the cockpit
 agent-bom agents -p . -f html -o agent-bom-report.html   # a real local scan
 ```
+
+Offline image and package scans require a populated local vulnerability database.
+Run `agent-bom db update` (or allow the first online scan to warm the cache)
+before `agent-bom image --offline`, `agent-bom agents --offline`, or CI jobs
+that pass `--offline`.
 
 The demo uses bundled advisory-backed OSV/GHSA ranges against intentionally
 vulnerable sample packages, producing graph-ready inventory without touching

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,7 +81,7 @@ flowchart TB
     subgraph L5["Control plane - same evidence, multi-tenant + audited"]
         direction TB
         MW["Middleware: auth · RBAC · tenant scope · rate-limit · audit"]
-        API["REST API (271 ops)"]
+        API["REST API (283 ops)"]
         GW["Gateway / MCP server / proxy"]
         MW --> API
         MW --> GW
@@ -143,7 +143,7 @@ flowchart TB
         M4["Max body size"]
     end
     subgraph BE["Backend - FastAPI"]
-        R["271 REST operations across 30 route modules\nplus 2 WebSocket routes"]
+        R["283 REST operations across 32 route modules\nplus 2 WebSocket routes"]
     end
     subgraph ST["Stores - start on SQLite, scale to a cluster without rewrites"]
         S1["SQLite (default / single node)"]

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,10 +1,10 @@
 {
-  "generated_on": "2026-05-22",
+  "generated_on": "2026-06-29",
   "version": "0.89.2",
   "metrics": [
     {
       "name": "MCP tools",
-      "value": 55,
+      "value": 70,
       "source": "src/agent_bom/mcp_server_metadata.py",
       "notes": "Counted from the advertised server-card tools."
     },
@@ -22,31 +22,31 @@
     },
     {
       "name": "GitHub workflow files",
-      "value": 35,
+      "value": 37,
       "source": ".github/workflows",
       "notes": "Counts .yml and .yaml workflow definitions."
     },
     {
       "name": "Test files",
-      "value": 486,
+      "value": 658,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
     {
       "name": "API route modules",
-      "value": 25,
+      "value": 33,
       "source": "src/agent_bom/api/routes",
       "notes": "Counts Python files in the routes package, including __init__.py."
     },
     {
       "name": "UI app pages",
-      "value": 24,
+      "value": 29,
       "source": "ui/app",
       "notes": "Counts page.tsx and page.jsx files recursively."
     },
     {
       "name": "Python modules",
-      "value": 487,
+      "value": 593,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },
@@ -70,7 +70,7 @@
     },
     {
       "name": "Runtime protection engine detectors",
-      "value": 8,
+      "value": 11,
       "source": "src/agent_bom/runtime/protection.py",
       "notes": "Broader protection engine used outside the lighter proxy-only path."
     }

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,28 +5,28 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-05-22`
+- Generated on: `2026-06-29`
 - Version: `0.89.2`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
-| MCP tools | 55 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
+| MCP tools | 70 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
-| GitHub workflow files | 35 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 486 | `tests/` | Counts files matching test_*.py. |
-| API route modules | 25 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
-| UI app pages | 24 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 487 | `src/agent_bom` | Counts all Python files recursively. |
+| GitHub workflow files | 37 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
+| Test files | 658 | `tests/` | Counts files matching test_*.py. |
+| API route modules | 33 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
+| UI app pages | 29 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
+| Python modules | 593 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 14 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |
-| Runtime protection engine detectors | 8 | `src/agent_bom/runtime/protection.py` | Broader protection engine used outside the lighter proxy-only path. |
+| Runtime protection engine detectors | 11 | `src/agent_bom/runtime/protection.py` | Broader protection engine used outside the lighter proxy-only path. |
 
 ## Runtime wording
 
 - `agent-bom proxy` uses `7` inline detectors in the MCP JSON-RPC path.
-- The broader runtime protection engine uses `8` detectors.
+- The broader runtime protection engine uses `11` detectors.
 
 ## Regenerate
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ material. The index below groups the canonical docs by audience.
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (230 paths / 271 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (239 paths / 283 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -44,7 +44,7 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 
 - Deployment chooser (Docker / Helm / EKS / Postgres):
   [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
-- API contract (271 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- API contract (283 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
 - Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
   [`PERMISSIONS.md`](PERMISSIONS.md)
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the

--- a/docs/VISUAL_LANGUAGE.md
+++ b/docs/VISUAL_LANGUAGE.md
@@ -19,12 +19,18 @@ Use when:
 Files live in `docs/images/`, always shipped as `*-light.svg` + `*-dark.svg`
 with `<picture>`+`prefers-color-scheme` switching. Hand-tuned, no auto-layout.
 
+Regenerate `how-it-works`, `architecture`, and `persona-value` SVGs from
+`scripts/generate_doc_architecture_svgs.py` after changing lane content or counts.
+The generator escapes XML text (`&` → `&amp;`) so GitHub can render diffs.
+
 Current SVG inventory:
 
 | File | What it shows | Where it lives in the README |
 |---|---|---|
 | `logo-{light,dark}.svg` | Brand mark | hero |
-| `architecture-{light,dark}.svg` | End-to-end LR data flow: sources → scan/ingest → unified Finding + ContextGraph → control plane (API / Gateway / MCP) → consumers (humans + headless agents) + artifacts | `docs/ARCHITECTURE.md` System Overview; available for README architecture section |
+| `architecture-{light,dark}.svg` | End-to-end LR data flow: sources → scan/ingest → unified Finding + UnifiedGraph → control plane (API / Gateway / MCP) → consumers (humans + headless agents) + artifacts | `docs/ARCHITECTURE.md` System Overview; available for README architecture section |
+| `how-it-works-{light,dark}.svg` | Six-step scan pipeline from read-only intake through evidence core to outputs | README "How It Works" |
+| `persona-value-{light,dark}.svg` | Buyer personas mapped to product value proof points | README / GTM collateral |
 | `blast-radius-{light,dark}.svg` | CVE, package, MCP server, agent, credentials, and tools in one blast-radius path | hero, under tagline |
 | `scan-pipeline-{light,dark}.svg` | 5-stage pipeline (discover → scan → analyze → report → enforce) | "How a scan moves" |
 | `engine-internals-{light,dark}.svg` | Inside the scanner | available for deeper architecture docs; not currently embedded in the README |

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -1,174 +1,133 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 660" fill="none" role="img" aria-labelledby="abom-arch-title abom-arch-desc">
-  <title id="abom-arch-title">agent-bom architecture and data flow</title>
-  <desc id="abom-arch-desc">Left-to-right flow: read-only sources are scanned and enriched into one unified Finding and ContextGraph, served through the control plane (API, Gateway, MCP server) to human and headless-agent consumers, emitting SARIF, CycloneDX, SPDX, and OCSF artifacts.</desc>
-  <defs>
-    <linearGradient id="abom-accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#a78bfa"/>
-      <stop offset="100%" stop-color="#818cf8"/>
-    </linearGradient>
-    <marker id="abom-arrow" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
-    <marker id="abom-arrow-accent" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
-    <style>
-      text { font-family: Inter, system-ui, -apple-system, 'Segoe UI', sans-serif; }
-      .title { font-size: 22px; font-weight: 800; fill: #f4f4f5; }
-      .subtitle { font-size: 11.5px; font-weight: 400; fill: #8a8a93; }
-      .lane-label { font-size: 10px; font-weight: 800; letter-spacing: 0.16em; fill: #a78bfa; }
-      .lane-sub { font-size: 9px; font-weight: 500; fill: #6b6b75; }
-      .node-title { font-size: 12.5px; font-weight: 700; fill: #e9e9ec; }
-      .node-sub { font-size: 9px; font-weight: 400; fill: #82828c; }
-      .pill { font-size: 9px; font-weight: 600; fill: #a78bfa; }
-      .flow-label { font-size: 8.5px; font-weight: 800; letter-spacing: 0.1em; fill: #6b6b75; }
-      .chip { font-size: 9px; font-weight: 700; fill: #a1a1aa; }
-      .footer { font-size: 9.5px; font-weight: 600; letter-spacing: 0.04em; fill: #4ade80; }
-      .ic { fill: none; stroke: #9a9aa4; stroke-width: 1.55; stroke-linecap: round; stroke-linejoin: round; }
-      .ic-a { fill: none; stroke: #a78bfa; stroke-width: 1.55; stroke-linecap: round; stroke-linejoin: round; }
-    </style>
-  </defs>
-
-  <rect width="1200" height="660" rx="14" fill="#0a0a0c"/>
-  <text x="40" y="42" class="title">agent-bom <tspan fill="url(#abom-accent)">architecture</tspan></text>
-  <text x="40" y="63" class="subtitle">One evidence model, left to right — collect read-only, normalize into one Finding + ContextGraph, serve through the control plane, deliver to people and agents.</text>
-
-  <!-- ===== LANE 1 SOURCES ===== -->
-  <rect x="40" y="92" width="206" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
-  <text x="56" y="118" class="lane-label">SOURCES</text>
-  <text x="56" y="134" class="lane-sub">Read-only · no writes · no secret values</text>
-
-  <g><rect x="52" y="148" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="62" y="161" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M69 168h7l3 3v9h-13z M76 168v3h3"/>
-    <text x="98" y="170" class="node-title">Supply chain</text><text x="98" y="185" class="node-sub">15 ecosystems + OS packages</text></g>
-  <g><rect x="52" y="206" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="62" y="219" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="75" cy="227" r="3"/><circle class="ic" cx="70" cy="238" r="2.4"/><circle class="ic" cx="80" cy="238" r="2.4"/><path class="ic" d="M73 230l-2 6 M77 230l2 6"/>
-    <text x="98" y="228" class="node-title">Agents &amp; MCP</text><text x="98" y="243" class="node-sub">29 clients · servers · tools</text></g>
-  <g><rect x="52" y="264" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="62" y="277" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M68 293h12a4 4 0 0 0 .6-7.9 6 6 0 0 0-11.3-1.6A4.2 4.2 0 0 0 68 293z"/>
-    <text x="98" y="286" class="node-title">Cloud inventory</text><text x="98" y="301" class="node-sub">AWS · Azure · GCP · Snowflake</text></g>
-  <g><rect x="52" y="322" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="62" y="335" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M75 333l7 3.5-7 3.5-7-3.5z M68 341l7 3.5 7-3.5 M68 345l7 3.5 7-3.5"/>
-    <text x="98" y="344" class="node-title">IaC &amp; containers</text><text x="98" y="359" class="node-sub">Terraform · K8s · OCI images</text></g>
-  <g><rect x="52" y="380" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="62" y="393" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="72" cy="403" r="3.4"/><path class="ic" d="M74.4 405.4l7 7 M79 410l2.5-2.5 M81.5 412.5l2.5-2.5"/>
-    <text x="98" y="402" class="node-title">Secrets</text><text x="98" y="417" class="node-sub">credential refs · token patterns</text></g>
-  <g><rect x="52" y="438" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="62" y="451" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M75 458l7 3.5v7l-7 3.5-7-3.5v-7z M75 458v14 M68 461.5l14 7"/>
-    <text x="98" y="460" class="node-title">Models &amp; data</text><text x="98" y="475" class="node-sub">weights · cards · PII/PHI</text></g>
-  <g><rect x="52" y="496" width="182" height="52" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="62" y="509" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M70 515h10v14h-10z M73 520h7 M73 524h7 M73 528h4"/>
-    <text x="98" y="518" class="node-title">SBOM ingest</text><text x="98" y="533" class="node-sub">CycloneDX · SPDX import</text></g>
-
-  <!-- ===== LANE 2 SCAN / INGEST ===== -->
-  <rect x="280" y="92" width="206" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
-  <text x="296" y="118" class="lane-label">SCAN &amp; ENRICH</text>
-  <text x="296" y="134" class="lane-sub">Parallel · local-only</text>
-
-  <g><rect x="292" y="148" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="302" y="164" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="313" cy="175" r="4.2"/><path class="ic" d="M316 178l4 4"/>
-    <text x="338" y="172" class="node-title">Vulnerability scan</text><text x="338" y="188" class="node-sub">OSV batch across all packages</text></g>
-  <g><rect x="292" y="214" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="302" y="230" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M313 233l1.6 3.4 3.4 1.6-3.4 1.6L313 245l-1.6-3.4-3.4-1.6 3.4-1.6z"/>
-    <text x="338" y="238" class="node-title">Threat enrichment</text><text x="338" y="254" class="node-sub">NVD · EPSS · KEV · GHSA</text></g>
-  <g><rect x="292" y="280" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="302" y="296" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M313 300l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M310 308l2 2 4-4.5"/>
-    <text x="338" y="304" class="node-title">Posture checks</text><text x="338" y="320" class="node-sub">MCP/A2A auth · CIS · NHI</text></g>
-  <g><rect x="292" y="346" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="302" y="362" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M307 384v-8 M313 384v-12 M319 384v-6 M306 384h15"/>
-    <text x="338" y="370" class="node-title">Cost / FinOps</text><text x="338" y="386" class="node-sub">model + cloud spend signals</text></g>
-  <g><rect x="292" y="412" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="302" y="428" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M308 434h12 M308 440h12 M308 446h8"/><path class="ic-a" d="M305 434l1.4 1.4 2-2.4"/>
-    <text x="338" y="436" class="node-title">Policy engine</text><text x="338" y="452" class="node-sub">policy-as-code · frameworks</text></g>
-  <g><rect x="292" y="478" width="182" height="58" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="302" y="494" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="315" cy="507" r="8"/><circle class="ic" cx="315" cy="507" r="4"/><circle class="ic-a" cx="315" cy="507" r="1.4"/>
-    <text x="338" y="502" class="node-title">Blast-radius</text><text x="338" y="518" class="node-sub">pkg → finding → agent fusion</text></g>
-
-  <!-- ===== LANE 3 CORE MODEL ===== -->
-  <rect x="520" y="92" width="206" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
-  <text x="536" y="118" class="lane-label">EVIDENCE CORE</text>
-  <text x="536" y="134" class="lane-sub">One normalized truth</text>
-
-  <g><rect x="532" y="150" width="182" height="86" rx="9" fill="#15121f" stroke="#5b4bbd"/>
-    <rect x="542" y="164" width="26" height="26" rx="7" fill="#1a1530" stroke="#4c3f9e"/><path class="ic-a" d="M549 170h7l3 3v9h-13z M556 170v3h3 M551 182l1.6 1.6 3-3.4"/>
-    <text x="578" y="172" class="node-title" fill="#f4f4f5">Unified Finding</text><text x="578" y="188" class="node-sub">CVE · misconfig · secret · auth</text>
-    <text x="578" y="205" class="node-sub">+ severity · CVSS · EPSS · KEV</text>
-    <text x="546" y="225" class="pill">one schema for every modality</text></g>
-  <g><rect x="532" y="244" width="182" height="86" rx="9" fill="#15121f" stroke="#5b4bbd"/>
-    <rect x="542" y="258" width="26" height="26" rx="7" fill="#1a1530" stroke="#4c3f9e"/><circle class="ic-a" cx="551" cy="265" r="2.6"/><circle class="ic-a" cx="561" cy="263" r="2.6"/><circle class="ic-a" cx="556" cy="278" r="2.6"/><path class="ic-a" d="M553 266l2 9 M559 265l-2 10"/>
-    <text x="578" y="266" class="node-title" fill="#f4f4f5">ContextGraph</text><text x="578" y="282" class="node-sub">entities + edges across</text>
-    <text x="578" y="299" class="node-sub">env · identity · MCP · model</text>
-    <text x="546" y="319" class="pill">multi-hop attack-path fusion</text></g>
-  <g><rect x="532" y="338" width="182" height="56" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="542" y="353" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="555" cy="366" r="7.5"/><path class="ic" d="M555 362v4.5l3 2"/>
-    <text x="578" y="362" class="node-title">Asset tracker</text><text x="578" y="378" class="node-sub">first_seen · MTTR · drift</text></g>
-  <g><rect x="532" y="402" width="182" height="56" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="542" y="417" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M555 424l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M552 432l2 2 4-4.5"/>
-    <text x="578" y="426" class="node-title">Audit &amp; provenance</text><text x="578" y="442" class="node-sub">signed · hash chain · tenant</text></g>
-  <g><rect x="532" y="466" width="182" height="40" rx="9" fill="#121016" stroke="#2a2733"/>
-    <rect x="542" y="475" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M547 481c0-1.7 2.7-3 6-3s6 1.3 6 3-2.7 3-6 3-6-1.3-6-3z M547 481v8c0 1.7 2.7 3 6 3s6-1.3 6-3v-8"/>
-    <text x="574" y="491" class="node-sub" fill="#a1a1aa">Postgres / SQLite · tenant-isolated</text></g>
-
-  <!-- ===== LANE 4 CONTROL PLANE ===== -->
-  <rect x="760" y="92" width="206" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
-  <text x="776" y="118" class="lane-label">CONTROL PLANE</text>
-  <text x="776" y="134" class="lane-sub">Self-hosted · tenant-scoped auth</text>
-
-  <g><rect x="772" y="150" width="182" height="86" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="782" y="164" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M792 170l-4 7 4 7 M798 170l4 7-4 7"/>
-    <text x="818" y="172" class="node-title">REST API</text><text x="818" y="188" class="node-sub">scans · findings · graph</text>
-    <text x="818" y="205" class="node-sub">compliance · identity · cost</text>
-    <text x="786" y="225" class="pill">OIDC · SAML · SCIM · RBAC</text></g>
-  <g><rect x="772" y="244" width="182" height="86" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="782" y="258" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M795 264l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M791 272l3 3 5-5.5"/>
-    <text x="818" y="266" class="node-title">Gateway / Proxy</text><text x="818" y="282" class="node-sub">inline firewall + identity</text>
-    <text x="818" y="299" class="node-sub">inspect · block · sign · audit</text>
-    <text x="786" y="319" class="pill">runtime MCP enforcement</text></g>
-  <g><rect x="772" y="338" width="182" height="76" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="782" y="356" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><rect class="ic" x="788" y="361" width="14" height="6" rx="2"/><rect class="ic" x="788" y="371" width="14" height="6" rx="2"/><path class="ic" d="M792 364h.01 M792 374h.01"/>
-    <text x="818" y="362" class="node-title">MCP server</text><text x="818" y="378" class="node-sub">70 tools · scan · graph · shield</text>
-    <text x="786" y="400" class="pill">stdio · SSE · streamable-HTTP</text></g>
-  <g><rect x="772" y="422" width="182" height="66" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="782" y="438" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><rect class="ic" x="788" y="444" width="6" height="6" rx="1.5"/><rect class="ic" x="796" y="444" width="6" height="6" rx="1.5"/><rect class="ic" x="788" y="452" width="6" height="6" rx="1.5"/><rect class="ic" x="796" y="452" width="6" height="6" rx="1.5"/>
-    <text x="818" y="446" class="node-title">Fleet &amp; scheduling</text><text x="818" y="462" class="node-sub">multi-replica dispatch</text>
-    <text x="818" y="478" class="node-sub">Helm / EKS deployable</text></g>
-  <g><rect x="772" y="496" width="182" height="40" rx="9" fill="#121016" stroke="#2a2733"/>
-    <text x="863" y="520" text-anchor="middle" class="node-sub" fill="#a1a1aa">fail-closed auth · RBAC · scopes · audit</text></g>
-
-  <!-- ===== LANE 5 CONSUMERS ===== -->
-  <rect x="1000" y="92" width="160" height="500" rx="13" fill="#0f0f13" stroke="#222228"/>
-  <text x="1016" y="118" class="lane-label">CONSUMERS</text>
-  <text x="1016" y="134" class="lane-sub">People + agents</text>
-
-  <text x="1016" y="162" class="chip" fill="#a78bfa" letter-spacing="0.1em">PEOPLE</text>
-  <g><rect x="1012" y="170" width="136" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="1022" y="182" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M1028 190l4 4-4 4 M1034 198h5"/>
-    <text x="1056" y="190" class="node-title">CLI</text><text x="1056" y="205" class="node-sub">terminal · CI gate</text></g>
-  <g><rect x="1012" y="224" width="136" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="1022" y="236" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><rect class="ic" x="1027" y="241" width="14" height="11" rx="2"/><path class="ic" d="M1027 245h14"/>
-    <text x="1056" y="244" class="node-title">Web UI</text><text x="1056" y="259" class="node-sub">dashboard · graph</text></g>
-
-  <text x="1016" y="298" class="chip" fill="#a78bfa" letter-spacing="0.1em">AGENTS</text>
-  <g><rect x="1012" y="306" width="136" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="1022" y="318" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="1031" cy="325" r="2.4"/><circle class="ic" cx="1027" cy="335" r="2"/><circle class="ic" cx="1036" cy="335" r="2"/><path class="ic" d="M1030 327l-2 6 M1033 327l2 6"/>
-    <text x="1056" y="326" class="node-title">MCP clients</text><text x="1056" y="341" class="node-sub">tool calls over MCP</text></g>
-  <g><rect x="1012" y="360" width="136" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-    <rect x="1022" y="372" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M1031 378l-4 6 4 6 M1037 378l4 6-4 6"/>
-    <text x="1056" y="380" class="node-title">API / SDK</text><text x="1056" y="395" class="node-sub">programmatic</text></g>
-
-  <text x="1016" y="434" class="chip" fill="#a78bfa" letter-spacing="0.1em">ARTIFACTS</text>
-  <g><rect x="1012" y="442" width="136" height="102" rx="9" fill="#121016" stroke="#2a2733"/>
-    <rect x="1024" y="454" width="50" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1049" y="466" text-anchor="middle" class="chip">SARIF</text>
-    <rect x="1080" y="454" width="56" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1108" y="466" text-anchor="middle" class="chip">CycloneDX</text>
-    <rect x="1024" y="478" width="44" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1046" y="490" text-anchor="middle" class="chip">SPDX</text>
-    <rect x="1074" y="478" width="44" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1096" y="490" text-anchor="middle" class="chip">OCSF</text>
-    <rect x="1024" y="502" width="44" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1046" y="514" text-anchor="middle" class="chip">HTML</text>
-    <rect x="1074" y="502" width="44" height="18" rx="9" fill="#17171c" stroke="#2e2e35"/><text x="1096" y="514" text-anchor="middle" class="chip">JSON</text>
-    <text x="1080" y="535" text-anchor="middle" class="node-sub">→ SIEM · webhooks</text></g>
-
-  <!-- flow arrows (drawn on top so labels are never clipped by lane panels) -->
-  <line x1="246" y1="360" x2="278" y2="360" stroke="#52525b" stroke-width="2" marker-end="url(#abom-arrow)"/><text x="262" y="350" text-anchor="middle" class="flow-label">SCAN</text>
-  <line x1="486" y1="360" x2="518" y2="360" stroke="#52525b" stroke-width="2" marker-end="url(#abom-arrow)"/><text x="502" y="350" text-anchor="middle" class="flow-label">NORMALIZE</text>
-  <line x1="726" y1="360" x2="758" y2="360" stroke="#8b5cf6" stroke-width="2.2" marker-end="url(#abom-arrow-accent)"/><text x="742" y="350" text-anchor="middle" class="flow-label" fill="#a78bfa">SERVE</text>
-  <line x1="966" y1="360" x2="998" y2="360" stroke="#52525b" stroke-width="2" marker-end="url(#abom-arrow)"/><text x="982" y="350" text-anchor="middle" class="flow-label">DELIVER</text>
-
-  <!-- footer trust bar -->
-  <rect x="40" y="608" width="1120" height="30" rx="9" fill="#0c1a14" stroke="#1f4438"/>
-  <text x="600" y="627" text-anchor="middle" class="footer">READ-ONLY BY DEFAULT · no target writes · never runs servers · no secret values · self-hosted · evidence signed end-to-end</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 620" fill="none" role="img" aria-labelledby="arch-d-title arch-d-desc">
+<title id="arch-d-title">agent-bom control-plane architecture</title>
+<desc id="arch-d-desc">Sources through scan and evidence core to control plane and consumers.</desc>
+<defs>
+<marker id="arch-d" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
+<marker id="arch-a-d" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
+</defs>
+<rect width="1200" height="620" rx="14" fill="#0a0a0c"/>
+<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="#f4f4f5">Control-plane <tspan fill="#a78bfa">architecture</tspan></text>
+<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="#71717a">Sources → scan → one Finding + UnifiedGraph → API · Gateway · MCP → people + agents</text>
+<rect x="32" y="82" width="184" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="32" y="82" width="184" height="36" rx="10" fill="#1e3a5f"/><rect x="32" y="104" width="184" height="14" fill="#1e3a5f"/><text x="46" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">SOURCES</text><text x="204" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">read-only</text>
+<rect x="228" y="82" width="184" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="228" y="82" width="184" height="36" rx="10" fill="#78350f"/><rect x="228" y="104" width="184" height="14" fill="#78350f"/><text x="242" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#fde68a">SCAN</text><text x="400" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#fbbf24" opacity="0.85">local</text>
+<rect x="424" y="82" width="184" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="424" y="82" width="184" height="36" rx="10" fill="#5b21b6"/><rect x="424" y="104" width="184" height="14" fill="#5b21b6"/><text x="438" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#ddd6fe">EVIDENCE</text><text x="596" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a78bfa" opacity="0.85">normalized</text>
+<rect x="620" y="82" width="184" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="620" y="82" width="184" height="36" rx="10" fill="#065f46"/><rect x="620" y="104" width="184" height="14" fill="#065f46"/><text x="634" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#a7f3d0">CONTROL</text><text x="792" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#34d399" opacity="0.85">tenant auth</text>
+<rect x="816" y="82" width="352" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="816" y="82" width="352" height="36" rx="10" fill="#1e3a8a"/><rect x="816" y="104" width="352" height="14" fill="#1e3a8a"/><text x="830" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">CONSUMERS</text><text x="1156" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">people+agents</text>
+<rect x="44" y="128" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="54" y="139" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,144)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="88" y="150" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Supply chain</text>
+<text x="88" y="164" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">15 eco</text>
+<rect x="44" y="186" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="54" y="197" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,202)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="88" y="208" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Agents &amp; MCP</text>
+<text x="88" y="222" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">29 clients</text>
+<rect x="44" y="244" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="54" y="255" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,260)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="88" y="266" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Cloud</text>
+<text x="88" y="280" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">4 providers</text>
+<rect x="44" y="302" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="54" y="313" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,318)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="88" y="324" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">IaC &amp; OCI</text>
+<text x="88" y="338" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">TF·K8s·img</text>
+<rect x="44" y="360" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="54" y="371" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,376)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="88" y="382" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Secrets</text>
+<text x="88" y="396" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">refs only</text>
+<rect x="44" y="418" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="54" y="429" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,434)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="88" y="440" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Models</text>
+<text x="88" y="454" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">13 formats</text>
+<rect x="44" y="476" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="54" y="487" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,492)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="88" y="498" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">SBOM import</text>
+<text x="88" y="512" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">CDX·SPDX</text>
+<rect x="240" y="128" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="250" y="145" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,150)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="284" y="158" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">OSV scan</text>
+<text x="284" y="172" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">batch</text>
+<rect x="240" y="200" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="250" y="217" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,222)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="284" y="230" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Enrichment</text>
+<text x="284" y="244" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">NVD·EPSS</text>
+<rect x="240" y="272" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="250" y="289" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,294)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="284" y="302" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Posture</text>
+<text x="284" y="316" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">CIS·MCP</text>
+<rect x="240" y="344" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="250" y="361" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,366)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="284" y="374" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Blast radius</text>
+<text x="284" y="388" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">fusion</text>
+<rect x="240" y="416" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="250" y="433" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,438)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="284" y="446" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Policy</text>
+<text x="284" y="460" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">as-code</text>
+<rect x="436" y="128" width="160" height="72" rx="9" fill="#15121f" stroke="#5b4bbd" stroke-width="1.6"/>
+<rect x="446" y="151" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(451,156)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="480" y="162" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Unified Finding</text>
+<text x="480" y="178" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#a78bfa">one schema</text>
+<rect x="436" y="216" width="160" height="72" rx="9" fill="#15121f" stroke="#5b4bbd" stroke-width="1.6"/>
+<rect x="446" y="239" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(451,244)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="480" y="250" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">UnifiedGraph</text>
+<text x="480" y="266" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#a78bfa">attack paths</text>
+<rect x="436" y="304" width="160" height="72" rx="9" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="446" y="327" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(451,332)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
+<text x="480" y="338" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Stores</text>
+<text x="480" y="354" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">PG·SQLite</text>
+<rect x="436" y="392" width="160" height="72" rx="9" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="446" y="415" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(451,420)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="480" y="426" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Audit chain</text>
+<text x="480" y="442" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">signed</text>
+<rect x="632" y="128" width="156" height="72" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="642" y="151" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(647,156)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="676" y="162" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">REST API</text>
+<text x="676" y="178" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">283 ops</text>
+<rect x="632" y="216" width="156" height="72" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="642" y="239" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(647,244)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="676" y="250" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Gateway</text>
+<text x="676" y="266" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">runtime</text>
+<rect x="632" y="304" width="156" height="72" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="642" y="327" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(647,332)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="676" y="338" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">MCP server</text>
+<text x="676" y="354" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">70 tools</text>
+<rect x="632" y="392" width="156" height="72" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="642" y="415" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(647,420)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="676" y="426" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Fleet jobs</text>
+<text x="676" y="442" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">Helm·EKS</text>
+<rect x="632" y="490" width="156" height="32" rx="8" fill="#121016" stroke="#2a2733"/><text x="710" y="510" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#a1a1aa">OIDC · SAML · SCIM · RBAC</text>
+<text x="880" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">PEOPLE</text>
+<rect x="828" y="136" width="104" height="44" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="836" y="145" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(841,150)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
+<text x="868" y="163" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#e9e9ec">CLI</text>
+<rect x="828" y="190" width="104" height="44" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="836" y="199" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(841,204)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="868" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#e9e9ec">Web UI</text>
+<text x="998" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">AGENTS</text>
+<rect x="946" y="136" width="104" height="44" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="954" y="145" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(959,150)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="986" y="163" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#e9e9ec">MCP</text>
+<rect x="946" y="190" width="104" height="44" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="954" y="199" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(959,204)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="986" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#e9e9ec">SDK</text>
+<text x="1116" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">ARTIFACTS</text>
+<rect x="1064" y="136" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1091" y="151" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">SARIF</text>
+<rect x="1122" y="136" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1149" y="151" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">CDX</text>
+<rect x="1064" y="164" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1091" y="179" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">SPDX</text>
+<rect x="1122" y="164" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1149" y="179" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">OCSF</text>
+<rect x="1064" y="192" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1091" y="207" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">HTML</text>
+<rect x="1122" y="192" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1149" y="207" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">JSON</text>
+<text x="1116" y="248" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#6b6b75">→ SIEM · webhooks</text>
+<line x1="216" y1="318" x2="228" y2="318" stroke="#52525b" stroke-width="2" marker-end="url(#arch-d)"/>
+<text x="222" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">SCAN</text>
+<line x1="412" y1="318" x2="424" y2="318" stroke="#52525b" stroke-width="2" marker-end="url(#arch-d)"/>
+<text x="418" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">NORMALIZE</text>
+<line x1="608" y1="318" x2="620" y2="318" stroke="#8b5cf6" stroke-width="2.3" marker-end="url(#arch-a-d)"/>
+<text x="614" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">SERVE</text>
+<line x1="804" y1="318" x2="816" y2="318" stroke="#52525b" stroke-width="2" marker-end="url(#arch-d)"/>
+<text x="810" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">DELIVER</text>
+<rect x="32" y="568" width="1136" height="32" rx="9" fill="#0c1a14" stroke="#1f4438"/><text x="600" y="588" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#4ade80">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -1,129 +1,126 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 600" fill="none" role="img" aria-labelledby="arch-d-title arch-d-desc">
-<title id="arch-d-title">agent-bom control-plane architecture</title>
-<desc id="arch-d-desc">Sources through scan and evidence core to control plane and consumers.</desc>
-<defs>
-<marker id="arch-d" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
-<marker id="arch-a-d" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
-</defs>
-<rect width="1180" height="600" rx="14" fill="#0a0a0c"/>
-<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="21" font-weight="850" fill="#f4f4f5">Control-plane architecture</text>
-<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">Sources → scan → Finding + UnifiedGraph → API · Gateway · MCP → people + agents</text>
-<rect x="24" y="78" width="168" height="430" rx="11" fill="#0f0f13" stroke="#222228"/>
-<rect x="24" y="78" width="168" height="32" rx="8" fill="#1e3a5f"/><text x="36" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">SOURCES</text><text x="182" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">read-only</text>
-<rect x="204" y="78" width="168" height="430" rx="11" fill="#0f0f13" stroke="#222228"/>
-<rect x="204" y="78" width="168" height="32" rx="8" fill="#78350f"/><text x="216" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#fde68a">SCAN</text><text x="362" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#fbbf24" opacity="0.9">local</text>
-<rect x="384" y="78" width="168" height="430" rx="11" fill="#0f0f13" stroke="#222228"/>
-<rect x="384" y="78" width="168" height="32" rx="8" fill="#5b21b6"/><text x="396" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#ddd6fe">EVIDENCE</text><text x="542" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a78bfa" opacity="0.9">normalized</text>
-<rect x="564" y="78" width="168" height="430" rx="11" fill="#0f0f13" stroke="#222228"/>
-<rect x="564" y="78" width="168" height="32" rx="8" fill="#065f46"/><text x="576" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#a7f3d0">CONTROL</text><text x="722" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#34d399" opacity="0.9">tenant auth</text>
-<rect x="744" y="78" width="412" height="430" rx="11" fill="#0f0f13" stroke="#222228"/>
-<rect x="744" y="78" width="412" height="32" rx="8" fill="#1e3a8a"/><text x="756" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">CONSUMERS</text><text x="1146" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">people+agents</text>
-<rect x="36" y="120" width="144" height="44" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="44" y="130" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,134)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="76" y="140" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Supply chain</text>
-<text x="76" y="153" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">15 eco</text>
-<rect x="36" y="172" width="144" height="44" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="44" y="182" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,186)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="76" y="192" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Agents &amp; MCP</text>
-<text x="76" y="205" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">29 clients</text>
-<rect x="36" y="224" width="144" height="44" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="44" y="234" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,238)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="76" y="244" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Cloud</text>
-<text x="76" y="257" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">4 providers</text>
-<rect x="36" y="276" width="144" height="44" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="44" y="286" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,290)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="76" y="296" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">IaC &amp; OCI</text>
-<text x="76" y="309" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">TF·K8s·img</text>
-<rect x="36" y="328" width="144" height="44" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="44" y="338" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,342)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
-<text x="76" y="348" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Secrets</text>
-<text x="76" y="361" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">refs only</text>
-<rect x="36" y="380" width="144" height="44" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="44" y="390" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,394)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="76" y="400" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Models</text>
-<text x="76" y="413" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">13 formats</text>
-<rect x="36" y="432" width="144" height="44" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="44" y="442" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,446)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="76" y="452" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">SBOM import</text>
-<text x="76" y="465" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">CDX·SPDX</text>
-<rect x="216" y="120" width="144" height="52" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="224" y="134" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,138)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="256" y="146" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">OSV scan</text>
-<text x="256" y="158" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">batch</text>
-<rect x="216" y="184" width="144" height="52" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="224" y="198" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,202)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="256" y="210" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Enrichment</text>
-<text x="256" y="222" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">NVD·EPSS</text>
-<rect x="216" y="248" width="144" height="52" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="224" y="262" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,266)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="256" y="274" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Posture</text>
-<text x="256" y="286" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">CIS·MCP</text>
-<rect x="216" y="312" width="144" height="52" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="224" y="326" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,330)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="256" y="338" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Blast radius</text>
-<text x="256" y="350" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">fusion</text>
-<rect x="216" y="376" width="144" height="52" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="224" y="390" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,394)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="256" y="402" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Policy</text>
-<text x="256" y="414" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">as-code</text>
-<rect x="396" y="120" width="144" height="64" rx="8" fill="#15121f" stroke="#5b4bbd" stroke-width="1.5"/>
-<rect x="404" y="138" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(408,142)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
-<text x="436" y="148" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Unified Finding</text>
-<text x="436" y="162" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#a78bfa">one schema</text>
-<rect x="396" y="198" width="144" height="64" rx="8" fill="#15121f" stroke="#5b4bbd" stroke-width="1.5"/>
-<rect x="404" y="216" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(408,220)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="436" y="226" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">UnifiedGraph</text>
-<text x="436" y="240" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#a78bfa">attack paths</text>
-<rect x="396" y="276" width="144" height="64" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="404" y="294" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(408,298)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
-<text x="436" y="304" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Stores</text>
-<text x="436" y="318" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">PG·SQLite</text>
-<rect x="396" y="354" width="144" height="64" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="404" y="372" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(408,376)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="436" y="382" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Audit chain</text>
-<text x="436" y="396" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">signed</text>
-<rect x="576" y="120" width="144" height="64" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="584" y="138" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(588,142)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="616" y="148" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">REST API</text>
-<text x="616" y="162" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">283 ops</text>
-<rect x="576" y="198" width="144" height="64" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="584" y="216" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(588,220)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="616" y="226" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Gateway</text>
-<text x="616" y="240" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">runtime</text>
-<rect x="576" y="276" width="144" height="64" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="584" y="294" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(588,298)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="616" y="304" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">MCP server</text>
-<text x="616" y="318" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">70 tools</text>
-<rect x="576" y="354" width="144" height="64" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="584" y="372" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(588,376)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="616" y="382" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Fleet jobs</text>
-<text x="616" y="396" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">Helm·EKS</text>
-<rect x="576" y="472" width="144" height="26" rx="7" fill="#121016" stroke="#2a2733"/><text x="648" y="489" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#a1a1aa">OIDC · SAML · SCIM · RBAC</text>
-<text x="818" y="116" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">PEOPLE</text>
-<rect x="756" y="126" width="124" height="40" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="764" y="134" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(768,138)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
-<text x="794" y="151" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">CLI</text>
-<rect x="756" y="176" width="124" height="40" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="764" y="184" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(768,188)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="794" y="201" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Web UI</text>
-<text x="952" y="116" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">AGENTS</text>
-<rect x="890" y="126" width="124" height="40" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="898" y="134" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(902,138)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="928" y="151" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">MCP</text>
-<rect x="890" y="176" width="124" height="40" rx="8" fill="#161619" stroke="#2a2a31"/>
-<rect x="898" y="184" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(902,188)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="928" y="201" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">SDK</text>
-<text x="1086" y="116" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">ARTIFACTS</text>
-<rect x="1024" y="126" width="58" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="1053" y="139" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">SARIF</text>
-<rect x="1088" y="126" width="58" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="1117" y="139" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">CDX</text>
-<rect x="1024" y="152" width="58" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="1053" y="165" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">SPDX</text>
-<rect x="1088" y="152" width="58" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="1117" y="165" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">OCSF</text>
-<rect x="1024" y="178" width="58" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="1053" y="191" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">HTML</text>
-<rect x="1088" y="178" width="58" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="1117" y="191" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">JSON</text>
-<text x="1086" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#6b6b75">SIEM · webhooks</text>
-<line x1="192" y1="92" x2="204" y2="92" stroke="#52525b" stroke-width="1.8" marker-end="url(#arch-d)"/><text x="198" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">SCAN</text>
-<line x1="372" y1="92" x2="384" y2="92" stroke="#52525b" stroke-width="1.8" marker-end="url(#arch-d)"/><text x="378" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">NORMALIZE</text>
-<line x1="552" y1="92" x2="564" y2="92" stroke="#8b5cf6" stroke-width="2.2" marker-end="url(#arch-a-d)"/><text x="558" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#a78bfa">SERVE</text>
-<line x1="732" y1="92" x2="744" y2="92" stroke="#52525b" stroke-width="1.8" marker-end="url(#arch-d)"/><text x="738" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">DELIVER</text>
-<rect x="24" y="560" width="1132" height="26" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="590" y="578" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="560" viewBox="0 0 960 560" fill="none">
+<title>agent-bom control-plane architecture</title>
+<desc>Sources through scan and evidence core to control plane and consumers.</desc>
+<rect width="960" height="560" rx="14" fill="#0a0a0c"/>
+<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#f4f4f5">Control-plane architecture</text>
+<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">Sources -&gt; scan -&gt; Finding + UnifiedGraph -&gt; API · Gateway · MCP -&gt; people + agents</text>
+<rect x="24" y="78" width="176" height="400" rx="11" fill="#0f0f13" stroke="#222228"/>
+<rect x="24" y="78" width="176" height="32" rx="8" fill="#1e3a5f"/><text x="36" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">SOURCES</text><text x="190" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">read-only</text>
+<rect x="208" y="78" width="176" height="400" rx="11" fill="#0f0f13" stroke="#222228"/>
+<rect x="208" y="78" width="176" height="32" rx="8" fill="#78350f"/><text x="220" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#fde68a">SCAN</text><text x="374" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#fbbf24" opacity="0.9">local</text>
+<rect x="392" y="78" width="176" height="400" rx="11" fill="#0f0f13" stroke="#222228"/>
+<rect x="392" y="78" width="176" height="32" rx="8" fill="#5b21b6"/><text x="404" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#ddd6fe">EVIDENCE</text><text x="558" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a78bfa" opacity="0.9">normalized</text>
+<rect x="576" y="78" width="176" height="400" rx="11" fill="#0f0f13" stroke="#222228"/>
+<rect x="576" y="78" width="176" height="32" rx="8" fill="#065f46"/><text x="588" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#a7f3d0">CONTROL</text><text x="742" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#34d399" opacity="0.9">tenant auth</text>
+<rect x="760" y="78" width="176" height="400" rx="11" fill="#0f0f13" stroke="#222228"/>
+<rect x="760" y="78" width="176" height="32" rx="8" fill="#1e3a8a"/><text x="772" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">CONSUMERS</text><text x="926" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">deliver</text>
+<rect x="32" y="118" width="160" height="42" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="40" y="127" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(44,131)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="70" y="137" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Supply chain</text>
+<text x="70" y="150" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">15 eco</text>
+<rect x="32" y="166" width="160" height="42" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="40" y="175" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(44,179)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="70" y="185" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Agents &amp; MCP</text>
+<text x="70" y="198" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">29 clients</text>
+<rect x="32" y="214" width="160" height="42" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="40" y="223" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(44,227)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="70" y="233" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Cloud</text>
+<text x="70" y="246" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">4 providers</text>
+<rect x="32" y="262" width="160" height="42" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="40" y="271" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(44,275)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="70" y="281" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">IaC &amp; OCI</text>
+<text x="70" y="294" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">TF·K8s·img</text>
+<rect x="32" y="310" width="160" height="42" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="40" y="319" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(44,323)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="70" y="329" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Secrets</text>
+<text x="70" y="342" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">refs only</text>
+<rect x="32" y="358" width="160" height="42" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="40" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(44,371)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="70" y="377" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Models</text>
+<text x="70" y="390" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">13 formats</text>
+<rect x="32" y="406" width="160" height="42" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="40" y="415" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(44,419)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="70" y="425" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">SBOM import</text>
+<text x="70" y="438" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">CDX·SPDX</text>
+<rect x="216" y="118" width="160" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="224" y="132" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,136)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="254" y="142" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">OSV scan</text>
+<text x="254" y="155" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">batch</text>
+<rect x="216" y="176" width="160" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="224" y="190" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,194)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="254" y="200" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Enrichment</text>
+<text x="254" y="213" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">NVD·EPSS</text>
+<rect x="216" y="234" width="160" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="224" y="248" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,252)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="254" y="258" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Posture</text>
+<text x="254" y="271" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">CIS·MCP</text>
+<rect x="216" y="292" width="160" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="224" y="306" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,310)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="254" y="316" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Blast radius</text>
+<text x="254" y="329" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">fusion</text>
+<rect x="216" y="350" width="160" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="224" y="364" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,368)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="254" y="374" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Policy</text>
+<text x="254" y="387" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">as-code</text>
+<rect x="400" y="118" width="160" height="66" rx="8" fill="#15121f" stroke="#5b4bbd" stroke-width="1.5"/>
+<rect x="408" y="139" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(412,143)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="438" y="149" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Unified Finding</text>
+<text x="438" y="162" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#a78bfa">one schema</text>
+<rect x="400" y="190" width="160" height="66" rx="8" fill="#15121f" stroke="#5b4bbd" stroke-width="1.5"/>
+<rect x="408" y="211" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(412,215)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="438" y="221" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">UnifiedGraph</text>
+<text x="438" y="234" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#a78bfa">attack paths</text>
+<rect x="400" y="262" width="160" height="66" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="408" y="283" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(412,287)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
+<text x="438" y="293" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Stores</text>
+<text x="438" y="306" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">PG·SQLite</text>
+<rect x="400" y="334" width="160" height="66" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="408" y="355" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(412,359)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="438" y="365" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Audit chain</text>
+<text x="438" y="378" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">signed</text>
+<rect x="584" y="118" width="160" height="66" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="592" y="139" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(596,143)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="622" y="149" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">REST API</text>
+<text x="622" y="162" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">283 ops</text>
+<rect x="584" y="190" width="160" height="66" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="592" y="211" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(596,215)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="622" y="221" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Gateway</text>
+<text x="622" y="234" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">runtime</text>
+<rect x="584" y="262" width="160" height="66" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="592" y="283" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(596,287)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="622" y="293" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">MCP server</text>
+<text x="622" y="306" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">70 tools</text>
+<rect x="584" y="334" width="160" height="66" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="592" y="355" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(596,359)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="622" y="365" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Fleet jobs</text>
+<text x="622" y="378" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">Helm·EKS</text>
+<rect x="584" y="446" width="160" height="22" rx="7" fill="#121016" stroke="#2a2733"/><text x="664" y="462" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="700" fill="#a1a1aa">OIDC · SAML · SCIM · RBAC</text>
+<text x="848" y="118" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">PEOPLE</text>
+<rect x="768" y="128" width="160" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
+<rect x="774" y="131" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(778,135)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
+<text x="802" y="147" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">CLI</text>
+<rect x="768" y="164" width="160" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
+<rect x="774" y="167" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(778,171)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="802" y="183" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Web UI</text>
+<text x="848" y="206" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">AGENTS</text>
+<rect x="768" y="216" width="160" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
+<rect x="774" y="219" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(778,223)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="802" y="235" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">MCP</text>
+<rect x="768" y="252" width="160" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
+<rect x="774" y="255" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(778,259)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="802" y="271" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">SDK</text>
+<text x="848" y="294" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">ARTIFACTS</text>
+<rect x="768" y="306" width="48" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="792" y="318" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#a1a1aa">SARIF</text>
+<rect x="820" y="306" width="48" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="844" y="318" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#a1a1aa">CDX</text>
+<rect x="768" y="328" width="48" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="792" y="340" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#a1a1aa">SPDX</text>
+<rect x="820" y="328" width="48" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="844" y="340" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#a1a1aa">OCSF</text>
+<rect x="768" y="350" width="48" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="792" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#a1a1aa">HTML</text>
+<rect x="820" y="350" width="48" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="844" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#a1a1aa">JSON</text>
+<text x="848" y="368" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="600" fill="#6b6b75">SIEM · webhooks</text>
+<line x1="200" y1="92" x2="201" y2="92" stroke="#52525b" stroke-width="1.8"/><polygon points="207,92 201,88.5 201,95.5" fill="#52525b"/><text x="204" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">SCAN</text>
+<line x1="384" y1="92" x2="385" y2="92" stroke="#52525b" stroke-width="1.8"/><polygon points="391,92 385,88.5 385,95.5" fill="#52525b"/><text x="388" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">NORMALIZE</text>
+<line x1="568" y1="92" x2="569" y2="92" stroke="#8b5cf6" stroke-width="2.2"/><polygon points="575,92 569,88.5 569,95.5" fill="#8b5cf6"/><text x="572" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#a78bfa">SERVE</text>
+<line x1="752" y1="92" x2="753" y2="92" stroke="#52525b" stroke-width="1.8"/><polygon points="759,92 753,88.5 753,95.5" fill="#52525b"/><text x="756" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">DELIVER</text>
+<rect x="24" y="522" width="912" height="26" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="480" y="540" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -1,133 +1,129 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 620" fill="none" role="img" aria-labelledby="arch-d-title arch-d-desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 600" fill="none" role="img" aria-labelledby="arch-d-title arch-d-desc">
 <title id="arch-d-title">agent-bom control-plane architecture</title>
 <desc id="arch-d-desc">Sources through scan and evidence core to control plane and consumers.</desc>
 <defs>
-<marker id="arch-d" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
-<marker id="arch-a-d" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
+<marker id="arch-d" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
+<marker id="arch-a-d" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
 </defs>
-<rect width="1200" height="620" rx="14" fill="#0a0a0c"/>
-<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="#f4f4f5">Control-plane <tspan fill="#a78bfa">architecture</tspan></text>
-<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="#71717a">Sources → scan → one Finding + UnifiedGraph → API · Gateway · MCP → people + agents</text>
-<rect x="32" y="82" width="184" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
-<rect x="32" y="82" width="184" height="36" rx="10" fill="#1e3a5f"/><rect x="32" y="104" width="184" height="14" fill="#1e3a5f"/><text x="46" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">SOURCES</text><text x="204" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">read-only</text>
-<rect x="228" y="82" width="184" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
-<rect x="228" y="82" width="184" height="36" rx="10" fill="#78350f"/><rect x="228" y="104" width="184" height="14" fill="#78350f"/><text x="242" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#fde68a">SCAN</text><text x="400" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#fbbf24" opacity="0.85">local</text>
-<rect x="424" y="82" width="184" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
-<rect x="424" y="82" width="184" height="36" rx="10" fill="#5b21b6"/><rect x="424" y="104" width="184" height="14" fill="#5b21b6"/><text x="438" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#ddd6fe">EVIDENCE</text><text x="596" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a78bfa" opacity="0.85">normalized</text>
-<rect x="620" y="82" width="184" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
-<rect x="620" y="82" width="184" height="36" rx="10" fill="#065f46"/><rect x="620" y="104" width="184" height="14" fill="#065f46"/><text x="634" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#a7f3d0">CONTROL</text><text x="792" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#34d399" opacity="0.85">tenant auth</text>
-<rect x="816" y="82" width="352" height="468" rx="12" fill="#0f0f13" stroke="#222228"/>
-<rect x="816" y="82" width="352" height="36" rx="10" fill="#1e3a8a"/><rect x="816" y="104" width="352" height="14" fill="#1e3a8a"/><text x="830" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">CONSUMERS</text><text x="1156" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">people+agents</text>
-<rect x="44" y="128" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="54" y="139" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,144)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="88" y="150" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Supply chain</text>
-<text x="88" y="164" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">15 eco</text>
-<rect x="44" y="186" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="54" y="197" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,202)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="88" y="208" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Agents &amp; MCP</text>
-<text x="88" y="222" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">29 clients</text>
-<rect x="44" y="244" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="54" y="255" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,260)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="88" y="266" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Cloud</text>
-<text x="88" y="280" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">4 providers</text>
-<rect x="44" y="302" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="54" y="313" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,318)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="88" y="324" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">IaC &amp; OCI</text>
-<text x="88" y="338" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">TF·K8s·img</text>
-<rect x="44" y="360" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="54" y="371" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,376)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
-<text x="88" y="382" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Secrets</text>
-<text x="88" y="396" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">refs only</text>
-<rect x="44" y="418" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="54" y="429" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,434)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="88" y="440" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Models</text>
-<text x="88" y="454" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">13 formats</text>
-<rect x="44" y="476" width="160" height="48" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="54" y="487" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(59,492)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="88" y="498" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">SBOM import</text>
-<text x="88" y="512" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">CDX·SPDX</text>
-<rect x="240" y="128" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="250" y="145" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,150)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="284" y="158" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">OSV scan</text>
-<text x="284" y="172" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">batch</text>
-<rect x="240" y="200" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="250" y="217" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,222)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="284" y="230" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Enrichment</text>
-<text x="284" y="244" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">NVD·EPSS</text>
-<rect x="240" y="272" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="250" y="289" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,294)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="284" y="302" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Posture</text>
-<text x="284" y="316" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">CIS·MCP</text>
-<rect x="240" y="344" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="250" y="361" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,366)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="284" y="374" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Blast radius</text>
-<text x="284" y="388" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">fusion</text>
-<rect x="240" y="416" width="160" height="60" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="250" y="433" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(255,438)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="284" y="446" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Policy</text>
-<text x="284" y="460" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">as-code</text>
-<rect x="436" y="128" width="160" height="72" rx="9" fill="#15121f" stroke="#5b4bbd" stroke-width="1.6"/>
-<rect x="446" y="151" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(451,156)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
-<text x="480" y="162" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Unified Finding</text>
-<text x="480" y="178" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#a78bfa">one schema</text>
-<rect x="436" y="216" width="160" height="72" rx="9" fill="#15121f" stroke="#5b4bbd" stroke-width="1.6"/>
-<rect x="446" y="239" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(451,244)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="480" y="250" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">UnifiedGraph</text>
-<text x="480" y="266" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#a78bfa">attack paths</text>
-<rect x="436" y="304" width="160" height="72" rx="9" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="446" y="327" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(451,332)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
-<text x="480" y="338" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Stores</text>
-<text x="480" y="354" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">PG·SQLite</text>
-<rect x="436" y="392" width="160" height="72" rx="9" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="446" y="415" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(451,420)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="480" y="426" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Audit chain</text>
-<text x="480" y="442" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">signed</text>
-<rect x="632" y="128" width="156" height="72" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="642" y="151" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(647,156)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="676" y="162" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">REST API</text>
-<text x="676" y="178" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">283 ops</text>
-<rect x="632" y="216" width="156" height="72" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="642" y="239" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(647,244)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="676" y="250" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Gateway</text>
-<text x="676" y="266" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">runtime</text>
-<rect x="632" y="304" width="156" height="72" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="642" y="327" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(647,332)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="676" y="338" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">MCP server</text>
-<text x="676" y="354" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">70 tools</text>
-<rect x="632" y="392" width="156" height="72" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="642" y="415" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(647,420)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="676" y="426" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Fleet jobs</text>
-<text x="676" y="442" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">Helm·EKS</text>
-<rect x="632" y="490" width="156" height="32" rx="8" fill="#121016" stroke="#2a2733"/><text x="710" y="510" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#a1a1aa">OIDC · SAML · SCIM · RBAC</text>
-<text x="880" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">PEOPLE</text>
-<rect x="828" y="136" width="104" height="44" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="836" y="145" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(841,150)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
-<text x="868" y="163" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#e9e9ec">CLI</text>
-<rect x="828" y="190" width="104" height="44" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="836" y="199" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(841,204)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="868" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#e9e9ec">Web UI</text>
-<text x="998" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">AGENTS</text>
-<rect x="946" y="136" width="104" height="44" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="954" y="145" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(959,150)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="986" y="163" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#e9e9ec">MCP</text>
-<rect x="946" y="190" width="104" height="44" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="954" y="199" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(959,204)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="986" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#e9e9ec">SDK</text>
-<text x="1116" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">ARTIFACTS</text>
-<rect x="1064" y="136" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1091" y="151" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">SARIF</text>
-<rect x="1122" y="136" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1149" y="151" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">CDX</text>
-<rect x="1064" y="164" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1091" y="179" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">SPDX</text>
-<rect x="1122" y="164" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1149" y="179" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">OCSF</text>
-<rect x="1064" y="192" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1091" y="207" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">HTML</text>
-<rect x="1122" y="192" width="54" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="1149" y="207" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#a1a1aa">JSON</text>
-<text x="1116" y="248" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#6b6b75">→ SIEM · webhooks</text>
-<line x1="216" y1="318" x2="228" y2="318" stroke="#52525b" stroke-width="2" marker-end="url(#arch-d)"/>
-<text x="222" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">SCAN</text>
-<line x1="412" y1="318" x2="424" y2="318" stroke="#52525b" stroke-width="2" marker-end="url(#arch-d)"/>
-<text x="418" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">NORMALIZE</text>
-<line x1="608" y1="318" x2="620" y2="318" stroke="#8b5cf6" stroke-width="2.3" marker-end="url(#arch-a-d)"/>
-<text x="614" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">SERVE</text>
-<line x1="804" y1="318" x2="816" y2="318" stroke="#52525b" stroke-width="2" marker-end="url(#arch-d)"/>
-<text x="810" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">DELIVER</text>
-<rect x="32" y="568" width="1136" height="32" rx="9" fill="#0c1a14" stroke="#1f4438"/><text x="600" y="588" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#4ade80">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
+<rect width="1180" height="600" rx="14" fill="#0a0a0c"/>
+<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="21" font-weight="850" fill="#f4f4f5">Control-plane architecture</text>
+<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">Sources → scan → Finding + UnifiedGraph → API · Gateway · MCP → people + agents</text>
+<rect x="24" y="78" width="168" height="430" rx="11" fill="#0f0f13" stroke="#222228"/>
+<rect x="24" y="78" width="168" height="32" rx="8" fill="#1e3a5f"/><text x="36" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">SOURCES</text><text x="182" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">read-only</text>
+<rect x="204" y="78" width="168" height="430" rx="11" fill="#0f0f13" stroke="#222228"/>
+<rect x="204" y="78" width="168" height="32" rx="8" fill="#78350f"/><text x="216" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#fde68a">SCAN</text><text x="362" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#fbbf24" opacity="0.9">local</text>
+<rect x="384" y="78" width="168" height="430" rx="11" fill="#0f0f13" stroke="#222228"/>
+<rect x="384" y="78" width="168" height="32" rx="8" fill="#5b21b6"/><text x="396" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#ddd6fe">EVIDENCE</text><text x="542" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a78bfa" opacity="0.9">normalized</text>
+<rect x="564" y="78" width="168" height="430" rx="11" fill="#0f0f13" stroke="#222228"/>
+<rect x="564" y="78" width="168" height="32" rx="8" fill="#065f46"/><text x="576" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#a7f3d0">CONTROL</text><text x="722" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#34d399" opacity="0.9">tenant auth</text>
+<rect x="744" y="78" width="412" height="430" rx="11" fill="#0f0f13" stroke="#222228"/>
+<rect x="744" y="78" width="412" height="32" rx="8" fill="#1e3a8a"/><text x="756" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">CONSUMERS</text><text x="1146" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">people+agents</text>
+<rect x="36" y="120" width="144" height="44" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="44" y="130" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,134)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="76" y="140" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Supply chain</text>
+<text x="76" y="153" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">15 eco</text>
+<rect x="36" y="172" width="144" height="44" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="44" y="182" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,186)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="76" y="192" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Agents &amp; MCP</text>
+<text x="76" y="205" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">29 clients</text>
+<rect x="36" y="224" width="144" height="44" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="44" y="234" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,238)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="76" y="244" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Cloud</text>
+<text x="76" y="257" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">4 providers</text>
+<rect x="36" y="276" width="144" height="44" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="44" y="286" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,290)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="76" y="296" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">IaC &amp; OCI</text>
+<text x="76" y="309" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">TF·K8s·img</text>
+<rect x="36" y="328" width="144" height="44" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="44" y="338" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,342)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="76" y="348" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Secrets</text>
+<text x="76" y="361" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">refs only</text>
+<rect x="36" y="380" width="144" height="44" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="44" y="390" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,394)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="76" y="400" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Models</text>
+<text x="76" y="413" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">13 formats</text>
+<rect x="36" y="432" width="144" height="44" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="44" y="442" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,446)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="76" y="452" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">SBOM import</text>
+<text x="76" y="465" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">CDX·SPDX</text>
+<rect x="216" y="120" width="144" height="52" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="224" y="134" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,138)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="256" y="146" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">OSV scan</text>
+<text x="256" y="158" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">batch</text>
+<rect x="216" y="184" width="144" height="52" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="224" y="198" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,202)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="256" y="210" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Enrichment</text>
+<text x="256" y="222" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">NVD·EPSS</text>
+<rect x="216" y="248" width="144" height="52" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="224" y="262" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,266)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="256" y="274" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Posture</text>
+<text x="256" y="286" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">CIS·MCP</text>
+<rect x="216" y="312" width="144" height="52" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="224" y="326" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,330)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="256" y="338" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Blast radius</text>
+<text x="256" y="350" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">fusion</text>
+<rect x="216" y="376" width="144" height="52" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="224" y="390" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(228,394)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="256" y="402" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Policy</text>
+<text x="256" y="414" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">as-code</text>
+<rect x="396" y="120" width="144" height="64" rx="8" fill="#15121f" stroke="#5b4bbd" stroke-width="1.5"/>
+<rect x="404" y="138" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(408,142)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="436" y="148" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Unified Finding</text>
+<text x="436" y="162" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#a78bfa">one schema</text>
+<rect x="396" y="198" width="144" height="64" rx="8" fill="#15121f" stroke="#5b4bbd" stroke-width="1.5"/>
+<rect x="404" y="216" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(408,220)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="436" y="226" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">UnifiedGraph</text>
+<text x="436" y="240" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#a78bfa">attack paths</text>
+<rect x="396" y="276" width="144" height="64" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="404" y="294" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(408,298)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
+<text x="436" y="304" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Stores</text>
+<text x="436" y="318" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">PG·SQLite</text>
+<rect x="396" y="354" width="144" height="64" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="404" y="372" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(408,376)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="436" y="382" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Audit chain</text>
+<text x="436" y="396" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">signed</text>
+<rect x="576" y="120" width="144" height="64" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="584" y="138" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(588,142)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="616" y="148" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">REST API</text>
+<text x="616" y="162" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">283 ops</text>
+<rect x="576" y="198" width="144" height="64" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="584" y="216" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(588,220)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="616" y="226" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Gateway</text>
+<text x="616" y="240" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">runtime</text>
+<rect x="576" y="276" width="144" height="64" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="584" y="294" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(588,298)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="616" y="304" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">MCP server</text>
+<text x="616" y="318" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">70 tools</text>
+<rect x="576" y="354" width="144" height="64" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="584" y="372" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(588,376)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="616" y="382" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Fleet jobs</text>
+<text x="616" y="396" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">Helm·EKS</text>
+<rect x="576" y="472" width="144" height="26" rx="7" fill="#121016" stroke="#2a2733"/><text x="648" y="489" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#a1a1aa">OIDC · SAML · SCIM · RBAC</text>
+<text x="818" y="116" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">PEOPLE</text>
+<rect x="756" y="126" width="124" height="40" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="764" y="134" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(768,138)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
+<text x="794" y="151" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">CLI</text>
+<rect x="756" y="176" width="124" height="40" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="764" y="184" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(768,188)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="794" y="201" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Web UI</text>
+<text x="952" y="116" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">AGENTS</text>
+<rect x="890" y="126" width="124" height="40" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="898" y="134" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(902,138)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="928" y="151" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">MCP</text>
+<rect x="890" y="176" width="124" height="40" rx="8" fill="#161619" stroke="#2a2a31"/>
+<rect x="898" y="184" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(902,188)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="928" y="201" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">SDK</text>
+<text x="1086" y="116" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">ARTIFACTS</text>
+<rect x="1024" y="126" width="58" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="1053" y="139" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">SARIF</text>
+<rect x="1088" y="126" width="58" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="1117" y="139" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">CDX</text>
+<rect x="1024" y="152" width="58" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="1053" y="165" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">SPDX</text>
+<rect x="1088" y="152" width="58" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="1117" y="165" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">OCSF</text>
+<rect x="1024" y="178" width="58" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="1053" y="191" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">HTML</text>
+<rect x="1088" y="178" width="58" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="1117" y="191" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">JSON</text>
+<text x="1086" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#6b6b75">SIEM · webhooks</text>
+<line x1="192" y1="92" x2="204" y2="92" stroke="#52525b" stroke-width="1.8" marker-end="url(#arch-d)"/><text x="198" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">SCAN</text>
+<line x1="372" y1="92" x2="384" y2="92" stroke="#52525b" stroke-width="1.8" marker-end="url(#arch-d)"/><text x="378" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">NORMALIZE</text>
+<line x1="552" y1="92" x2="564" y2="92" stroke="#8b5cf6" stroke-width="2.2" marker-end="url(#arch-a-d)"/><text x="558" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#a78bfa">SERVE</text>
+<line x1="732" y1="92" x2="744" y2="92" stroke="#52525b" stroke-width="1.8" marker-end="url(#arch-d)"/><text x="738" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">DELIVER</text>
+<rect x="24" y="560" width="1132" height="26" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="590" y="578" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -1,129 +1,126 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 600" fill="none" role="img" aria-labelledby="arch-l-title arch-l-desc">
-<title id="arch-l-title">agent-bom control-plane architecture</title>
-<desc id="arch-l-desc">Sources through scan and evidence core to control plane and consumers.</desc>
-<defs>
-<marker id="arch-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
-<marker id="arch-a-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
-</defs>
-<rect width="1180" height="600" rx="14" fill="#ffffff"/>
-<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="21" font-weight="850" fill="#18181b">Control-plane architecture</text>
-<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">Sources → scan → Finding + UnifiedGraph → API · Gateway · MCP → people + agents</text>
-<rect x="24" y="78" width="168" height="430" rx="11" fill="#fafafa" stroke="#ececf0"/>
-<rect x="24" y="78" width="168" height="32" rx="8" fill="#1e3a5f"/><text x="36" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">SOURCES</text><text x="182" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">read-only</text>
-<rect x="204" y="78" width="168" height="430" rx="11" fill="#fafafa" stroke="#ececf0"/>
-<rect x="204" y="78" width="168" height="32" rx="8" fill="#78350f"/><text x="216" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#fde68a">SCAN</text><text x="362" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#fbbf24" opacity="0.9">local</text>
-<rect x="384" y="78" width="168" height="430" rx="11" fill="#fafafa" stroke="#ececf0"/>
-<rect x="384" y="78" width="168" height="32" rx="8" fill="#5b21b6"/><text x="396" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#ddd6fe">EVIDENCE</text><text x="542" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a78bfa" opacity="0.9">normalized</text>
-<rect x="564" y="78" width="168" height="430" rx="11" fill="#fafafa" stroke="#ececf0"/>
-<rect x="564" y="78" width="168" height="32" rx="8" fill="#065f46"/><text x="576" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#a7f3d0">CONTROL</text><text x="722" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#34d399" opacity="0.9">tenant auth</text>
-<rect x="744" y="78" width="412" height="430" rx="11" fill="#fafafa" stroke="#ececf0"/>
-<rect x="744" y="78" width="412" height="32" rx="8" fill="#1e3a8a"/><text x="756" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">CONSUMERS</text><text x="1146" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">people+agents</text>
-<rect x="36" y="120" width="144" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="44" y="130" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,134)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="76" y="140" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Supply chain</text>
-<text x="76" y="153" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">15 eco</text>
-<rect x="36" y="172" width="144" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="44" y="182" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,186)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="76" y="192" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Agents &amp; MCP</text>
-<text x="76" y="205" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">29 clients</text>
-<rect x="36" y="224" width="144" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="44" y="234" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,238)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="76" y="244" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Cloud</text>
-<text x="76" y="257" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">4 providers</text>
-<rect x="36" y="276" width="144" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="44" y="286" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,290)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="76" y="296" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">IaC &amp; OCI</text>
-<text x="76" y="309" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">TF·K8s·img</text>
-<rect x="36" y="328" width="144" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="44" y="338" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,342)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
-<text x="76" y="348" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Secrets</text>
-<text x="76" y="361" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">refs only</text>
-<rect x="36" y="380" width="144" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="44" y="390" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,394)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="76" y="400" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Models</text>
-<text x="76" y="413" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">13 formats</text>
-<rect x="36" y="432" width="144" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="44" y="442" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,446)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="76" y="452" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">SBOM import</text>
-<text x="76" y="465" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">CDX·SPDX</text>
-<rect x="216" y="120" width="144" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="224" y="134" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,138)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="256" y="146" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">OSV scan</text>
-<text x="256" y="158" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">batch</text>
-<rect x="216" y="184" width="144" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="224" y="198" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,202)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="256" y="210" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Enrichment</text>
-<text x="256" y="222" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">NVD·EPSS</text>
-<rect x="216" y="248" width="144" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="224" y="262" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,266)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="256" y="274" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Posture</text>
-<text x="256" y="286" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">CIS·MCP</text>
-<rect x="216" y="312" width="144" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="224" y="326" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,330)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="256" y="338" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Blast radius</text>
-<text x="256" y="350" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">fusion</text>
-<rect x="216" y="376" width="144" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="224" y="390" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,394)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="256" y="402" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Policy</text>
-<text x="256" y="414" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">as-code</text>
-<rect x="396" y="120" width="144" height="64" rx="8" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.5"/>
-<rect x="404" y="138" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(408,142)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
-<text x="436" y="148" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Unified Finding</text>
-<text x="436" y="162" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#7c3aed">one schema</text>
-<rect x="396" y="198" width="144" height="64" rx="8" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.5"/>
-<rect x="404" y="216" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(408,220)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="436" y="226" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">UnifiedGraph</text>
-<text x="436" y="240" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#7c3aed">attack paths</text>
-<rect x="396" y="276" width="144" height="64" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="404" y="294" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(408,298)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
-<text x="436" y="304" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Stores</text>
-<text x="436" y="318" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">PG·SQLite</text>
-<rect x="396" y="354" width="144" height="64" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="404" y="372" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(408,376)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="436" y="382" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Audit chain</text>
-<text x="436" y="396" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">signed</text>
-<rect x="576" y="120" width="144" height="64" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="584" y="138" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(588,142)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="616" y="148" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">REST API</text>
-<text x="616" y="162" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">283 ops</text>
-<rect x="576" y="198" width="144" height="64" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="584" y="216" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(588,220)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="616" y="226" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Gateway</text>
-<text x="616" y="240" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">runtime</text>
-<rect x="576" y="276" width="144" height="64" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="584" y="294" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(588,298)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="616" y="304" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">MCP server</text>
-<text x="616" y="318" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">70 tools</text>
-<rect x="576" y="354" width="144" height="64" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="584" y="372" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(588,376)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="616" y="382" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Fleet jobs</text>
-<text x="616" y="396" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">Helm·EKS</text>
-<rect x="576" y="472" width="144" height="26" rx="7" fill="#f4f4f6" stroke="#e4e4e7"/><text x="648" y="489" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#52525b">OIDC · SAML · SCIM · RBAC</text>
-<text x="818" y="116" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">PEOPLE</text>
-<rect x="756" y="126" width="124" height="40" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="764" y="134" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(768,138)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
-<text x="794" y="151" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">CLI</text>
-<rect x="756" y="176" width="124" height="40" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="764" y="184" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(768,188)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="794" y="201" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Web UI</text>
-<text x="952" y="116" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">AGENTS</text>
-<rect x="890" y="126" width="124" height="40" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="898" y="134" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(902,138)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="928" y="151" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">MCP</text>
-<rect x="890" y="176" width="124" height="40" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="898" y="184" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(902,188)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="928" y="201" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">SDK</text>
-<text x="1086" y="116" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">ARTIFACTS</text>
-<rect x="1024" y="126" width="58" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1053" y="139" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">SARIF</text>
-<rect x="1088" y="126" width="58" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1117" y="139" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">CDX</text>
-<rect x="1024" y="152" width="58" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1053" y="165" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">SPDX</text>
-<rect x="1088" y="152" width="58" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1117" y="165" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">OCSF</text>
-<rect x="1024" y="178" width="58" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1053" y="191" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">HTML</text>
-<rect x="1088" y="178" width="58" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1117" y="191" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">JSON</text>
-<text x="1086" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#9a9aa4">SIEM · webhooks</text>
-<line x1="192" y1="92" x2="204" y2="92" stroke="#a1a1aa" stroke-width="1.8" marker-end="url(#arch-l)"/><text x="198" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">SCAN</text>
-<line x1="372" y1="92" x2="384" y2="92" stroke="#a1a1aa" stroke-width="1.8" marker-end="url(#arch-l)"/><text x="378" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">NORMALIZE</text>
-<line x1="552" y1="92" x2="564" y2="92" stroke="#7c3aed" stroke-width="2.2" marker-end="url(#arch-a-l)"/><text x="558" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#7c3aed">SERVE</text>
-<line x1="732" y1="92" x2="744" y2="92" stroke="#a1a1aa" stroke-width="1.8" marker-end="url(#arch-l)"/><text x="738" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">DELIVER</text>
-<rect x="24" y="560" width="1132" height="26" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="590" y="578" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="560" viewBox="0 0 960 560" fill="none">
+<title>agent-bom control-plane architecture</title>
+<desc>Sources through scan and evidence core to control plane and consumers.</desc>
+<rect width="960" height="560" rx="14" fill="#ffffff"/>
+<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#18181b">Control-plane architecture</text>
+<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">Sources -&gt; scan -&gt; Finding + UnifiedGraph -&gt; API · Gateway · MCP -&gt; people + agents</text>
+<rect x="24" y="78" width="176" height="400" rx="11" fill="#fafafa" stroke="#ececf0"/>
+<rect x="24" y="78" width="176" height="32" rx="8" fill="#1e3a5f"/><text x="36" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">SOURCES</text><text x="190" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">read-only</text>
+<rect x="208" y="78" width="176" height="400" rx="11" fill="#fafafa" stroke="#ececf0"/>
+<rect x="208" y="78" width="176" height="32" rx="8" fill="#78350f"/><text x="220" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#fde68a">SCAN</text><text x="374" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#fbbf24" opacity="0.9">local</text>
+<rect x="392" y="78" width="176" height="400" rx="11" fill="#fafafa" stroke="#ececf0"/>
+<rect x="392" y="78" width="176" height="32" rx="8" fill="#5b21b6"/><text x="404" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#ddd6fe">EVIDENCE</text><text x="558" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a78bfa" opacity="0.9">normalized</text>
+<rect x="576" y="78" width="176" height="400" rx="11" fill="#fafafa" stroke="#ececf0"/>
+<rect x="576" y="78" width="176" height="32" rx="8" fill="#065f46"/><text x="588" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#a7f3d0">CONTROL</text><text x="742" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#34d399" opacity="0.9">tenant auth</text>
+<rect x="760" y="78" width="176" height="400" rx="11" fill="#fafafa" stroke="#ececf0"/>
+<rect x="760" y="78" width="176" height="32" rx="8" fill="#1e3a8a"/><text x="772" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">CONSUMERS</text><text x="926" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">deliver</text>
+<rect x="32" y="118" width="160" height="42" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="40" y="127" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(44,131)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="70" y="137" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Supply chain</text>
+<text x="70" y="150" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">15 eco</text>
+<rect x="32" y="166" width="160" height="42" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="40" y="175" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(44,179)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="70" y="185" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Agents &amp; MCP</text>
+<text x="70" y="198" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">29 clients</text>
+<rect x="32" y="214" width="160" height="42" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="40" y="223" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(44,227)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="70" y="233" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Cloud</text>
+<text x="70" y="246" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">4 providers</text>
+<rect x="32" y="262" width="160" height="42" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="40" y="271" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(44,275)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="70" y="281" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">IaC &amp; OCI</text>
+<text x="70" y="294" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">TF·K8s·img</text>
+<rect x="32" y="310" width="160" height="42" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="40" y="319" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(44,323)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="70" y="329" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Secrets</text>
+<text x="70" y="342" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">refs only</text>
+<rect x="32" y="358" width="160" height="42" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="40" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(44,371)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="70" y="377" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Models</text>
+<text x="70" y="390" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">13 formats</text>
+<rect x="32" y="406" width="160" height="42" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="40" y="415" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(44,419)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="70" y="425" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">SBOM import</text>
+<text x="70" y="438" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">CDX·SPDX</text>
+<rect x="216" y="118" width="160" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="224" y="132" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,136)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="254" y="142" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">OSV scan</text>
+<text x="254" y="155" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">batch</text>
+<rect x="216" y="176" width="160" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="224" y="190" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,194)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="254" y="200" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Enrichment</text>
+<text x="254" y="213" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">NVD·EPSS</text>
+<rect x="216" y="234" width="160" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="224" y="248" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,252)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="254" y="258" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Posture</text>
+<text x="254" y="271" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">CIS·MCP</text>
+<rect x="216" y="292" width="160" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="224" y="306" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,310)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="254" y="316" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Blast radius</text>
+<text x="254" y="329" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">fusion</text>
+<rect x="216" y="350" width="160" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="224" y="364" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,368)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="254" y="374" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Policy</text>
+<text x="254" y="387" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">as-code</text>
+<rect x="400" y="118" width="160" height="66" rx="8" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.5"/>
+<rect x="408" y="139" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(412,143)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="438" y="149" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Unified Finding</text>
+<text x="438" y="162" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#7c3aed">one schema</text>
+<rect x="400" y="190" width="160" height="66" rx="8" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.5"/>
+<rect x="408" y="211" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(412,215)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="438" y="221" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">UnifiedGraph</text>
+<text x="438" y="234" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#7c3aed">attack paths</text>
+<rect x="400" y="262" width="160" height="66" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="408" y="283" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(412,287)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
+<text x="438" y="293" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Stores</text>
+<text x="438" y="306" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">PG·SQLite</text>
+<rect x="400" y="334" width="160" height="66" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="408" y="355" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(412,359)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="438" y="365" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Audit chain</text>
+<text x="438" y="378" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">signed</text>
+<rect x="584" y="118" width="160" height="66" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="592" y="139" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(596,143)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="622" y="149" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">REST API</text>
+<text x="622" y="162" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">283 ops</text>
+<rect x="584" y="190" width="160" height="66" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="592" y="211" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(596,215)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="622" y="221" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Gateway</text>
+<text x="622" y="234" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">runtime</text>
+<rect x="584" y="262" width="160" height="66" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="592" y="283" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(596,287)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="622" y="293" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">MCP server</text>
+<text x="622" y="306" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">70 tools</text>
+<rect x="584" y="334" width="160" height="66" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="592" y="355" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(596,359)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="622" y="365" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Fleet jobs</text>
+<text x="622" y="378" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">Helm·EKS</text>
+<rect x="584" y="446" width="160" height="22" rx="7" fill="#f4f4f6" stroke="#e4e4e7"/><text x="664" y="462" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="700" fill="#52525b">OIDC · SAML · SCIM · RBAC</text>
+<text x="848" y="118" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">PEOPLE</text>
+<rect x="768" y="128" width="160" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="774" y="131" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(778,135)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
+<text x="802" y="147" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">CLI</text>
+<rect x="768" y="164" width="160" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="774" y="167" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(778,171)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="802" y="183" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Web UI</text>
+<text x="848" y="206" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">AGENTS</text>
+<rect x="768" y="216" width="160" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="774" y="219" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(778,223)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="802" y="235" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">MCP</text>
+<rect x="768" y="252" width="160" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="774" y="255" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(778,259)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="802" y="271" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">SDK</text>
+<text x="848" y="294" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">ARTIFACTS</text>
+<rect x="768" y="306" width="48" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="792" y="318" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#52525b">SARIF</text>
+<rect x="820" y="306" width="48" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="844" y="318" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#52525b">CDX</text>
+<rect x="768" y="328" width="48" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="792" y="340" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#52525b">SPDX</text>
+<rect x="820" y="328" width="48" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="844" y="340" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#52525b">OCSF</text>
+<rect x="768" y="350" width="48" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="792" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#52525b">HTML</text>
+<rect x="820" y="350" width="48" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="844" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#52525b">JSON</text>
+<text x="848" y="368" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="600" fill="#9a9aa4">SIEM · webhooks</text>
+<line x1="200" y1="92" x2="201" y2="92" stroke="#a1a1aa" stroke-width="1.8"/><polygon points="207,92 201,88.5 201,95.5" fill="#a1a1aa"/><text x="204" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">SCAN</text>
+<line x1="384" y1="92" x2="385" y2="92" stroke="#a1a1aa" stroke-width="1.8"/><polygon points="391,92 385,88.5 385,95.5" fill="#a1a1aa"/><text x="388" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">NORMALIZE</text>
+<line x1="568" y1="92" x2="569" y2="92" stroke="#7c3aed" stroke-width="2.2"/><polygon points="575,92 569,88.5 569,95.5" fill="#7c3aed"/><text x="572" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#7c3aed">SERVE</text>
+<line x1="752" y1="92" x2="753" y2="92" stroke="#a1a1aa" stroke-width="1.8"/><polygon points="759,92 753,88.5 753,95.5" fill="#a1a1aa"/><text x="756" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">DELIVER</text>
+<rect x="24" y="522" width="912" height="26" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="480" y="540" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -1,133 +1,129 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 620" fill="none" role="img" aria-labelledby="arch-l-title arch-l-desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 600" fill="none" role="img" aria-labelledby="arch-l-title arch-l-desc">
 <title id="arch-l-title">agent-bom control-plane architecture</title>
 <desc id="arch-l-desc">Sources through scan and evidence core to control plane and consumers.</desc>
 <defs>
-<marker id="arch-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
-<marker id="arch-a-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
+<marker id="arch-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
+<marker id="arch-a-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
 </defs>
-<rect width="1200" height="620" rx="14" fill="#ffffff"/>
-<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="#18181b">Control-plane <tspan fill="#7c3aed">architecture</tspan></text>
-<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="#71717a">Sources → scan → one Finding + UnifiedGraph → API · Gateway · MCP → people + agents</text>
-<rect x="32" y="82" width="184" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
-<rect x="32" y="82" width="184" height="36" rx="10" fill="#1e3a5f"/><rect x="32" y="104" width="184" height="14" fill="#1e3a5f"/><text x="46" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">SOURCES</text><text x="204" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">read-only</text>
-<rect x="228" y="82" width="184" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
-<rect x="228" y="82" width="184" height="36" rx="10" fill="#78350f"/><rect x="228" y="104" width="184" height="14" fill="#78350f"/><text x="242" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#fde68a">SCAN</text><text x="400" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#fbbf24" opacity="0.85">local</text>
-<rect x="424" y="82" width="184" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
-<rect x="424" y="82" width="184" height="36" rx="10" fill="#5b21b6"/><rect x="424" y="104" width="184" height="14" fill="#5b21b6"/><text x="438" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#ddd6fe">EVIDENCE</text><text x="596" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a78bfa" opacity="0.85">normalized</text>
-<rect x="620" y="82" width="184" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
-<rect x="620" y="82" width="184" height="36" rx="10" fill="#065f46"/><rect x="620" y="104" width="184" height="14" fill="#065f46"/><text x="634" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#a7f3d0">CONTROL</text><text x="792" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#34d399" opacity="0.85">tenant auth</text>
-<rect x="816" y="82" width="352" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
-<rect x="816" y="82" width="352" height="36" rx="10" fill="#1e3a8a"/><rect x="816" y="104" width="352" height="14" fill="#1e3a8a"/><text x="830" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">CONSUMERS</text><text x="1156" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">people+agents</text>
-<rect x="44" y="128" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="54" y="139" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,144)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="88" y="150" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Supply chain</text>
-<text x="88" y="164" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">15 eco</text>
-<rect x="44" y="186" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="54" y="197" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,202)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="88" y="208" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Agents &amp; MCP</text>
-<text x="88" y="222" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">29 clients</text>
-<rect x="44" y="244" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="54" y="255" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,260)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="88" y="266" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Cloud</text>
-<text x="88" y="280" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">4 providers</text>
-<rect x="44" y="302" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="54" y="313" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,318)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="88" y="324" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">IaC &amp; OCI</text>
-<text x="88" y="338" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">TF·K8s·img</text>
-<rect x="44" y="360" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="54" y="371" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,376)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
-<text x="88" y="382" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Secrets</text>
-<text x="88" y="396" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">refs only</text>
-<rect x="44" y="418" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="54" y="429" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,434)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="88" y="440" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Models</text>
-<text x="88" y="454" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">13 formats</text>
-<rect x="44" y="476" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="54" y="487" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,492)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="88" y="498" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">SBOM import</text>
-<text x="88" y="512" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">CDX·SPDX</text>
-<rect x="240" y="128" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="250" y="145" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,150)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="284" y="158" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">OSV scan</text>
-<text x="284" y="172" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">batch</text>
-<rect x="240" y="200" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="250" y="217" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,222)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="284" y="230" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Enrichment</text>
-<text x="284" y="244" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">NVD·EPSS</text>
-<rect x="240" y="272" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="250" y="289" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,294)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="284" y="302" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Posture</text>
-<text x="284" y="316" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">CIS·MCP</text>
-<rect x="240" y="344" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="250" y="361" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,366)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="284" y="374" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Blast radius</text>
-<text x="284" y="388" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">fusion</text>
-<rect x="240" y="416" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="250" y="433" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,438)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="284" y="446" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Policy</text>
-<text x="284" y="460" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">as-code</text>
-<rect x="436" y="128" width="160" height="72" rx="9" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.6"/>
-<rect x="446" y="151" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(451,156)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
-<text x="480" y="162" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Unified Finding</text>
-<text x="480" y="178" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#7c3aed">one schema</text>
-<rect x="436" y="216" width="160" height="72" rx="9" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.6"/>
-<rect x="446" y="239" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(451,244)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="480" y="250" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">UnifiedGraph</text>
-<text x="480" y="266" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#7c3aed">attack paths</text>
-<rect x="436" y="304" width="160" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="446" y="327" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(451,332)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
-<text x="480" y="338" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Stores</text>
-<text x="480" y="354" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">PG·SQLite</text>
-<rect x="436" y="392" width="160" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="446" y="415" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(451,420)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="480" y="426" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Audit chain</text>
-<text x="480" y="442" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">signed</text>
-<rect x="632" y="128" width="156" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="642" y="151" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(647,156)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="676" y="162" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">REST API</text>
-<text x="676" y="178" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">283 ops</text>
-<rect x="632" y="216" width="156" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="642" y="239" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(647,244)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="676" y="250" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Gateway</text>
-<text x="676" y="266" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">runtime</text>
-<rect x="632" y="304" width="156" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="642" y="327" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(647,332)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="676" y="338" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">MCP server</text>
-<text x="676" y="354" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">70 tools</text>
-<rect x="632" y="392" width="156" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="642" y="415" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(647,420)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="676" y="426" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Fleet jobs</text>
-<text x="676" y="442" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">Helm·EKS</text>
-<rect x="632" y="490" width="156" height="32" rx="8" fill="#f4f4f6" stroke="#e4e4e7"/><text x="710" y="510" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#52525b">OIDC · SAML · SCIM · RBAC</text>
-<text x="880" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">PEOPLE</text>
-<rect x="828" y="136" width="104" height="44" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="836" y="145" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(841,150)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
-<text x="868" y="163" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#18181b">CLI</text>
-<rect x="828" y="190" width="104" height="44" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="836" y="199" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(841,204)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="868" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#18181b">Web UI</text>
-<text x="998" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">AGENTS</text>
-<rect x="946" y="136" width="104" height="44" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="954" y="145" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(959,150)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="986" y="163" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#18181b">MCP</text>
-<rect x="946" y="190" width="104" height="44" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="954" y="199" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(959,204)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="986" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#18181b">SDK</text>
-<text x="1116" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">ARTIFACTS</text>
-<rect x="1064" y="136" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1091" y="151" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">SARIF</text>
-<rect x="1122" y="136" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1149" y="151" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">CDX</text>
-<rect x="1064" y="164" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1091" y="179" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">SPDX</text>
-<rect x="1122" y="164" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1149" y="179" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">OCSF</text>
-<rect x="1064" y="192" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1091" y="207" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">HTML</text>
-<rect x="1122" y="192" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1149" y="207" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">JSON</text>
-<text x="1116" y="248" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#9a9aa4">→ SIEM · webhooks</text>
-<line x1="216" y1="318" x2="228" y2="318" stroke="#a1a1aa" stroke-width="2" marker-end="url(#arch-l)"/>
-<text x="222" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">SCAN</text>
-<line x1="412" y1="318" x2="424" y2="318" stroke="#a1a1aa" stroke-width="2" marker-end="url(#arch-l)"/>
-<text x="418" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">NORMALIZE</text>
-<line x1="608" y1="318" x2="620" y2="318" stroke="#7c3aed" stroke-width="2.3" marker-end="url(#arch-a-l)"/>
-<text x="614" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">SERVE</text>
-<line x1="804" y1="318" x2="816" y2="318" stroke="#a1a1aa" stroke-width="2" marker-end="url(#arch-l)"/>
-<text x="810" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">DELIVER</text>
-<rect x="32" y="568" width="1136" height="32" rx="9" fill="#ecfdf5" stroke="#bbf7d0"/><text x="600" y="588" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#15803d">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
+<rect width="1180" height="600" rx="14" fill="#ffffff"/>
+<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="21" font-weight="850" fill="#18181b">Control-plane architecture</text>
+<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">Sources → scan → Finding + UnifiedGraph → API · Gateway · MCP → people + agents</text>
+<rect x="24" y="78" width="168" height="430" rx="11" fill="#fafafa" stroke="#ececf0"/>
+<rect x="24" y="78" width="168" height="32" rx="8" fill="#1e3a5f"/><text x="36" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">SOURCES</text><text x="182" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">read-only</text>
+<rect x="204" y="78" width="168" height="430" rx="11" fill="#fafafa" stroke="#ececf0"/>
+<rect x="204" y="78" width="168" height="32" rx="8" fill="#78350f"/><text x="216" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#fde68a">SCAN</text><text x="362" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#fbbf24" opacity="0.9">local</text>
+<rect x="384" y="78" width="168" height="430" rx="11" fill="#fafafa" stroke="#ececf0"/>
+<rect x="384" y="78" width="168" height="32" rx="8" fill="#5b21b6"/><text x="396" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#ddd6fe">EVIDENCE</text><text x="542" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a78bfa" opacity="0.9">normalized</text>
+<rect x="564" y="78" width="168" height="430" rx="11" fill="#fafafa" stroke="#ececf0"/>
+<rect x="564" y="78" width="168" height="32" rx="8" fill="#065f46"/><text x="576" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#a7f3d0">CONTROL</text><text x="722" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#34d399" opacity="0.9">tenant auth</text>
+<rect x="744" y="78" width="412" height="430" rx="11" fill="#fafafa" stroke="#ececf0"/>
+<rect x="744" y="78" width="412" height="32" rx="8" fill="#1e3a8a"/><text x="756" y="98" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">CONSUMERS</text><text x="1146" y="98" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">people+agents</text>
+<rect x="36" y="120" width="144" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="44" y="130" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,134)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="76" y="140" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Supply chain</text>
+<text x="76" y="153" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">15 eco</text>
+<rect x="36" y="172" width="144" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="44" y="182" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,186)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="76" y="192" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Agents &amp; MCP</text>
+<text x="76" y="205" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">29 clients</text>
+<rect x="36" y="224" width="144" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="44" y="234" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,238)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="76" y="244" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Cloud</text>
+<text x="76" y="257" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">4 providers</text>
+<rect x="36" y="276" width="144" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="44" y="286" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,290)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="76" y="296" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">IaC &amp; OCI</text>
+<text x="76" y="309" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">TF·K8s·img</text>
+<rect x="36" y="328" width="144" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="44" y="338" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,342)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="76" y="348" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Secrets</text>
+<text x="76" y="361" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">refs only</text>
+<rect x="36" y="380" width="144" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="44" y="390" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,394)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="76" y="400" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Models</text>
+<text x="76" y="413" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">13 formats</text>
+<rect x="36" y="432" width="144" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="44" y="442" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,446)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="76" y="452" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">SBOM import</text>
+<text x="76" y="465" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">CDX·SPDX</text>
+<rect x="216" y="120" width="144" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="224" y="134" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,138)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="256" y="146" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">OSV scan</text>
+<text x="256" y="158" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">batch</text>
+<rect x="216" y="184" width="144" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="224" y="198" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,202)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="256" y="210" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Enrichment</text>
+<text x="256" y="222" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">NVD·EPSS</text>
+<rect x="216" y="248" width="144" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="224" y="262" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,266)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="256" y="274" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Posture</text>
+<text x="256" y="286" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">CIS·MCP</text>
+<rect x="216" y="312" width="144" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="224" y="326" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,330)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="256" y="338" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Blast radius</text>
+<text x="256" y="350" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">fusion</text>
+<rect x="216" y="376" width="144" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="224" y="390" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(228,394)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="256" y="402" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Policy</text>
+<text x="256" y="414" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">as-code</text>
+<rect x="396" y="120" width="144" height="64" rx="8" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.5"/>
+<rect x="404" y="138" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(408,142)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="436" y="148" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Unified Finding</text>
+<text x="436" y="162" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#7c3aed">one schema</text>
+<rect x="396" y="198" width="144" height="64" rx="8" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.5"/>
+<rect x="404" y="216" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(408,220)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="436" y="226" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">UnifiedGraph</text>
+<text x="436" y="240" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#7c3aed">attack paths</text>
+<rect x="396" y="276" width="144" height="64" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="404" y="294" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(408,298)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
+<text x="436" y="304" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Stores</text>
+<text x="436" y="318" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">PG·SQLite</text>
+<rect x="396" y="354" width="144" height="64" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="404" y="372" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(408,376)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="436" y="382" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Audit chain</text>
+<text x="436" y="396" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">signed</text>
+<rect x="576" y="120" width="144" height="64" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="584" y="138" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(588,142)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="616" y="148" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">REST API</text>
+<text x="616" y="162" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">283 ops</text>
+<rect x="576" y="198" width="144" height="64" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="584" y="216" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(588,220)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="616" y="226" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Gateway</text>
+<text x="616" y="240" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">runtime</text>
+<rect x="576" y="276" width="144" height="64" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="584" y="294" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(588,298)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="616" y="304" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">MCP server</text>
+<text x="616" y="318" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">70 tools</text>
+<rect x="576" y="354" width="144" height="64" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="584" y="372" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(588,376)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="616" y="382" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Fleet jobs</text>
+<text x="616" y="396" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">Helm·EKS</text>
+<rect x="576" y="472" width="144" height="26" rx="7" fill="#f4f4f6" stroke="#e4e4e7"/><text x="648" y="489" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#52525b">OIDC · SAML · SCIM · RBAC</text>
+<text x="818" y="116" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">PEOPLE</text>
+<rect x="756" y="126" width="124" height="40" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="764" y="134" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(768,138)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
+<text x="794" y="151" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">CLI</text>
+<rect x="756" y="176" width="124" height="40" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="764" y="184" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(768,188)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="794" y="201" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Web UI</text>
+<text x="952" y="116" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">AGENTS</text>
+<rect x="890" y="126" width="124" height="40" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="898" y="134" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(902,138)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="928" y="151" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">MCP</text>
+<rect x="890" y="176" width="124" height="40" rx="8" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="898" y="184" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(902,188)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="928" y="201" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">SDK</text>
+<text x="1086" y="116" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">ARTIFACTS</text>
+<rect x="1024" y="126" width="58" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1053" y="139" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">SARIF</text>
+<rect x="1088" y="126" width="58" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1117" y="139" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">CDX</text>
+<rect x="1024" y="152" width="58" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1053" y="165" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">SPDX</text>
+<rect x="1088" y="152" width="58" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1117" y="165" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">OCSF</text>
+<rect x="1024" y="178" width="58" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1053" y="191" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">HTML</text>
+<rect x="1088" y="178" width="58" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1117" y="191" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">JSON</text>
+<text x="1086" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#9a9aa4">SIEM · webhooks</text>
+<line x1="192" y1="92" x2="204" y2="92" stroke="#a1a1aa" stroke-width="1.8" marker-end="url(#arch-l)"/><text x="198" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">SCAN</text>
+<line x1="372" y1="92" x2="384" y2="92" stroke="#a1a1aa" stroke-width="1.8" marker-end="url(#arch-l)"/><text x="378" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">NORMALIZE</text>
+<line x1="552" y1="92" x2="564" y2="92" stroke="#7c3aed" stroke-width="2.2" marker-end="url(#arch-a-l)"/><text x="558" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#7c3aed">SERVE</text>
+<line x1="732" y1="92" x2="744" y2="92" stroke="#a1a1aa" stroke-width="1.8" marker-end="url(#arch-l)"/><text x="738" y="84" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">DELIVER</text>
+<rect x="24" y="560" width="1132" height="26" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="590" y="578" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -1,161 +1,133 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 660" fill="none" role="img" aria-labelledby="abom-archl-title abom-archl-desc">
-  <title id="abom-archl-title">agent-bom architecture and data flow</title>
-  <desc id="abom-archl-desc">Left-to-right flow: read-only sources are scanned and enriched into one unified Finding and ContextGraph, served through the control plane (API, Gateway, MCP server) to human and headless-agent consumers, emitting SARIF, CycloneDX, SPDX, and OCSF artifacts.</desc>
-  <defs>
-    <linearGradient id="abom-accent-l" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#7c3aed"/>
-      <stop offset="100%" stop-color="#4f46e5"/>
-    </linearGradient>
-    <marker id="abom-arrow-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
-    <marker id="abom-arrow-accent-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
-    <style>
-      text { font-family: Inter, system-ui, -apple-system, 'Segoe UI', sans-serif; }
-      .title { font-size: 22px; font-weight: 800; fill: #18181b; }
-      .subtitle { font-size: 11.5px; font-weight: 400; fill: #6b6b75; }
-      .lane-label { font-size: 10px; font-weight: 800; letter-spacing: 0.16em; fill: #7c3aed; }
-      .lane-sub { font-size: 9px; font-weight: 500; fill: #9a9aa4; }
-      .node-title { font-size: 12.5px; font-weight: 700; fill: #18181b; }
-      .node-sub { font-size: 9px; font-weight: 400; fill: #71717a; }
-      .pill { font-size: 9px; font-weight: 600; fill: #7c3aed; }
-      .flow-label { font-size: 8.5px; font-weight: 800; letter-spacing: 0.1em; fill: #9a9aa4; }
-      .chip { font-size: 9px; font-weight: 700; fill: #52525b; }
-      .footer { font-size: 9.5px; font-weight: 600; letter-spacing: 0.04em; fill: #15803d; }
-      .ic { fill: none; stroke: #6b6b76; stroke-width: 1.55; stroke-linecap: round; stroke-linejoin: round; }
-      .ic-a { fill: none; stroke: #7c3aed; stroke-width: 1.55; stroke-linecap: round; stroke-linejoin: round; }
-    </style>
-  </defs>
-
-  <rect width="1200" height="660" rx="14" fill="#ffffff"/>
-  <text x="40" y="42" class="title">agent-bom <tspan fill="url(#abom-accent-l)">architecture</tspan></text>
-  <text x="40" y="63" class="subtitle">One evidence model, left to right — collect read-only, normalize into one Finding + ContextGraph, serve through the control plane, deliver to people and agents.</text>
-
-  <!-- LANE 1 -->
-  <rect x="40" y="92" width="206" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
-  <text x="56" y="118" class="lane-label">SOURCES</text><text x="56" y="134" class="lane-sub">Read-only · no writes · no secret values</text>
-  <g><rect x="52" y="148" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="62" y="161" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M69 168h7l3 3v9h-13z M76 168v3h3"/>
-    <text x="98" y="170" class="node-title">Supply chain</text><text x="98" y="185" class="node-sub">15 ecosystems + OS packages</text></g>
-  <g><rect x="52" y="206" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="62" y="219" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="75" cy="227" r="3"/><circle class="ic" cx="70" cy="238" r="2.4"/><circle class="ic" cx="80" cy="238" r="2.4"/><path class="ic" d="M73 230l-2 6 M77 230l2 6"/>
-    <text x="98" y="228" class="node-title">Agents &amp; MCP</text><text x="98" y="243" class="node-sub">29 clients · servers · tools</text></g>
-  <g><rect x="52" y="264" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="62" y="277" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M68 293h12a4 4 0 0 0 .6-7.9 6 6 0 0 0-11.3-1.6A4.2 4.2 0 0 0 68 293z"/>
-    <text x="98" y="286" class="node-title">Cloud inventory</text><text x="98" y="301" class="node-sub">AWS · Azure · GCP · Snowflake</text></g>
-  <g><rect x="52" y="322" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="62" y="335" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M75 333l7 3.5-7 3.5-7-3.5z M68 341l7 3.5 7-3.5 M68 345l7 3.5 7-3.5"/>
-    <text x="98" y="344" class="node-title">IaC &amp; containers</text><text x="98" y="359" class="node-sub">Terraform · K8s · OCI images</text></g>
-  <g><rect x="52" y="380" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="62" y="393" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="72" cy="403" r="3.4"/><path class="ic" d="M74.4 405.4l7 7 M79 410l2.5-2.5 M81.5 412.5l2.5-2.5"/>
-    <text x="98" y="402" class="node-title">Secrets</text><text x="98" y="417" class="node-sub">credential refs · token patterns</text></g>
-  <g><rect x="52" y="438" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="62" y="451" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M75 458l7 3.5v7l-7 3.5-7-3.5v-7z M75 458v14 M68 461.5l14 7"/>
-    <text x="98" y="460" class="node-title">Models &amp; data</text><text x="98" y="475" class="node-sub">weights · cards · PII/PHI</text></g>
-  <g><rect x="52" y="496" width="182" height="52" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="62" y="509" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M70 515h10v14h-10z M73 520h7 M73 524h7 M73 528h4"/>
-    <text x="98" y="518" class="node-title">SBOM ingest</text><text x="98" y="533" class="node-sub">CycloneDX · SPDX import</text></g>
-
-  <!-- LANE 2 -->
-  <rect x="280" y="92" width="206" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
-  <text x="296" y="118" class="lane-label">SCAN &amp; ENRICH</text><text x="296" y="134" class="lane-sub">Parallel · local-only</text>
-  <g><rect x="292" y="148" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="302" y="164" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="313" cy="175" r="4.2"/><path class="ic" d="M316 178l4 4"/>
-    <text x="338" y="172" class="node-title">Vulnerability scan</text><text x="338" y="188" class="node-sub">OSV batch across all packages</text></g>
-  <g><rect x="292" y="214" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="302" y="230" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M313 233l1.6 3.4 3.4 1.6-3.4 1.6L313 245l-1.6-3.4-3.4-1.6 3.4-1.6z"/>
-    <text x="338" y="238" class="node-title">Threat enrichment</text><text x="338" y="254" class="node-sub">NVD · EPSS · KEV · GHSA</text></g>
-  <g><rect x="292" y="280" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="302" y="296" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M313 300l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M310 308l2 2 4-4.5"/>
-    <text x="338" y="304" class="node-title">Posture checks</text><text x="338" y="320" class="node-sub">MCP/A2A auth · CIS · NHI</text></g>
-  <g><rect x="292" y="346" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="302" y="362" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M307 384v-8 M313 384v-12 M319 384v-6 M306 384h15"/>
-    <text x="338" y="370" class="node-title">Cost / FinOps</text><text x="338" y="386" class="node-sub">model + cloud spend signals</text></g>
-  <g><rect x="292" y="412" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="302" y="428" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M308 434h12 M308 440h12 M308 446h8"/><path class="ic-a" d="M305 434l1.4 1.4 2-2.4"/>
-    <text x="338" y="436" class="node-title">Policy engine</text><text x="338" y="452" class="node-sub">policy-as-code · frameworks</text></g>
-  <g><rect x="292" y="478" width="182" height="58" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="302" y="494" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="315" cy="507" r="8"/><circle class="ic" cx="315" cy="507" r="4"/><circle class="ic-a" cx="315" cy="507" r="1.4"/>
-    <text x="338" y="502" class="node-title">Blast-radius</text><text x="338" y="518" class="node-sub">pkg → finding → agent fusion</text></g>
-
-  <!-- LANE 3 -->
-  <rect x="520" y="92" width="206" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
-  <text x="536" y="118" class="lane-label">EVIDENCE CORE</text><text x="536" y="134" class="lane-sub">One normalized truth</text>
-  <g><rect x="532" y="150" width="182" height="86" rx="9" fill="#f6f4ff" stroke="#c4b5fd"/>
-    <rect x="542" y="164" width="26" height="26" rx="7" fill="#efeaff" stroke="#c4b5fd"/><path class="ic-a" d="M549 170h7l3 3v9h-13z M556 170v3h3 M551 182l1.6 1.6 3-3.4"/>
-    <text x="578" y="172" class="node-title">Unified Finding</text><text x="578" y="188" class="node-sub">CVE · misconfig · secret · auth</text>
-    <text x="578" y="205" class="node-sub">+ severity · CVSS · EPSS · KEV</text>
-    <text x="546" y="225" class="pill">one schema for every modality</text></g>
-  <g><rect x="532" y="244" width="182" height="86" rx="9" fill="#f6f4ff" stroke="#c4b5fd"/>
-    <rect x="542" y="258" width="26" height="26" rx="7" fill="#efeaff" stroke="#c4b5fd"/><circle class="ic-a" cx="551" cy="265" r="2.6"/><circle class="ic-a" cx="561" cy="263" r="2.6"/><circle class="ic-a" cx="556" cy="278" r="2.6"/><path class="ic-a" d="M553 266l2 9 M559 265l-2 10"/>
-    <text x="578" y="266" class="node-title">ContextGraph</text><text x="578" y="282" class="node-sub">entities + edges across</text>
-    <text x="578" y="299" class="node-sub">env · identity · MCP · model</text>
-    <text x="546" y="319" class="pill">multi-hop attack-path fusion</text></g>
-  <g><rect x="532" y="338" width="182" height="56" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="542" y="353" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="555" cy="366" r="7.5"/><path class="ic" d="M555 362v4.5l3 2"/>
-    <text x="578" y="362" class="node-title">Asset tracker</text><text x="578" y="378" class="node-sub">first_seen · MTTR · drift</text></g>
-  <g><rect x="532" y="402" width="182" height="56" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="542" y="417" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M555 424l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M552 432l2 2 4-4.5"/>
-    <text x="578" y="426" class="node-title">Audit &amp; provenance</text><text x="578" y="442" class="node-sub">signed · hash chain · tenant</text></g>
-  <g><rect x="532" y="466" width="182" height="40" rx="9" fill="#f6f5fa" stroke="#e6e3ef"/>
-    <rect x="542" y="475" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M547 481c0-1.7 2.7-3 6-3s6 1.3 6 3-2.7 3-6 3-6-1.3-6-3z M547 481v8c0 1.7 2.7 3 6 3s6-1.3 6-3v-8"/>
-    <text x="574" y="491" class="node-sub" fill="#52525b">Postgres / SQLite · tenant-isolated</text></g>
-
-  <!-- LANE 4 -->
-  <rect x="760" y="92" width="206" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
-  <text x="776" y="118" class="lane-label">CONTROL PLANE</text><text x="776" y="134" class="lane-sub">Self-hosted · tenant-scoped auth</text>
-  <g><rect x="772" y="150" width="182" height="86" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="782" y="164" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M792 170l-4 7 4 7 M798 170l4 7-4 7"/>
-    <text x="818" y="172" class="node-title">REST API</text><text x="818" y="188" class="node-sub">scans · findings · graph</text>
-    <text x="818" y="205" class="node-sub">compliance · identity · cost</text>
-    <text x="786" y="225" class="pill">OIDC · SAML · SCIM · RBAC</text></g>
-  <g><rect x="772" y="244" width="182" height="86" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="782" y="258" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M795 264l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z M791 272l3 3 5-5.5"/>
-    <text x="818" y="266" class="node-title">Gateway / Proxy</text><text x="818" y="282" class="node-sub">inline firewall + identity</text>
-    <text x="818" y="299" class="node-sub">inspect · block · sign · audit</text>
-    <text x="786" y="319" class="pill">runtime MCP enforcement</text></g>
-  <g><rect x="772" y="338" width="182" height="76" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="782" y="356" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><rect class="ic" x="788" y="361" width="14" height="6" rx="2"/><rect class="ic" x="788" y="371" width="14" height="6" rx="2"/><path class="ic" d="M792 364h.01 M792 374h.01"/>
-    <text x="818" y="362" class="node-title">MCP server</text><text x="818" y="378" class="node-sub">70 tools · scan · graph · shield</text>
-    <text x="786" y="400" class="pill">stdio · SSE · streamable-HTTP</text></g>
-  <g><rect x="772" y="422" width="182" height="66" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="782" y="438" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><rect class="ic" x="788" y="444" width="6" height="6" rx="1.5"/><rect class="ic" x="796" y="444" width="6" height="6" rx="1.5"/><rect class="ic" x="788" y="452" width="6" height="6" rx="1.5"/><rect class="ic" x="796" y="452" width="6" height="6" rx="1.5"/>
-    <text x="818" y="446" class="node-title">Fleet &amp; scheduling</text><text x="818" y="462" class="node-sub">multi-replica dispatch</text>
-    <text x="818" y="478" class="node-sub">Helm / EKS deployable</text></g>
-  <g><rect x="772" y="496" width="182" height="40" rx="9" fill="#f6f5fa" stroke="#e6e3ef"/>
-    <text x="863" y="520" text-anchor="middle" class="node-sub" fill="#52525b">fail-closed auth · RBAC · scopes · audit</text></g>
-
-  <!-- LANE 5 -->
-  <rect x="1000" y="92" width="160" height="500" rx="13" fill="#fafafa" stroke="#ececf0"/>
-  <text x="1016" y="118" class="lane-label">CONSUMERS</text><text x="1016" y="134" class="lane-sub">People + agents</text>
-  <text x="1016" y="162" class="chip" fill="#7c3aed" letter-spacing="0.1em">PEOPLE</text>
-  <g><rect x="1012" y="170" width="136" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="1022" y="182" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M1028 190l4 4-4 4 M1034 198h5"/>
-    <text x="1056" y="190" class="node-title">CLI</text><text x="1056" y="205" class="node-sub">terminal · CI gate</text></g>
-  <g><rect x="1012" y="224" width="136" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="1022" y="236" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><rect class="ic" x="1027" y="241" width="14" height="11" rx="2"/><path class="ic" d="M1027 245h14"/>
-    <text x="1056" y="244" class="node-title">Web UI</text><text x="1056" y="259" class="node-sub">dashboard · graph</text></g>
-  <text x="1016" y="298" class="chip" fill="#7c3aed" letter-spacing="0.1em">AGENTS</text>
-  <g><rect x="1012" y="306" width="136" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="1022" y="318" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="1031" cy="325" r="2.4"/><circle class="ic" cx="1027" cy="335" r="2"/><circle class="ic" cx="1036" cy="335" r="2"/><path class="ic" d="M1030 327l-2 6 M1033 327l2 6"/>
-    <text x="1056" y="326" class="node-title">MCP clients</text><text x="1056" y="341" class="node-sub">tool calls over MCP</text></g>
-  <g><rect x="1012" y="360" width="136" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-    <rect x="1022" y="372" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M1031 378l-4 6 4 6 M1037 378l4 6-4 6"/>
-    <text x="1056" y="380" class="node-title">API / SDK</text><text x="1056" y="395" class="node-sub">programmatic</text></g>
-  <text x="1016" y="434" class="chip" fill="#7c3aed" letter-spacing="0.1em">ARTIFACTS</text>
-  <g><rect x="1012" y="442" width="136" height="102" rx="9" fill="#f6f5fa" stroke="#e6e3ef"/>
-    <rect x="1024" y="454" width="50" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1049" y="466" text-anchor="middle" class="chip">SARIF</text>
-    <rect x="1080" y="454" width="56" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1108" y="466" text-anchor="middle" class="chip">CycloneDX</text>
-    <rect x="1024" y="478" width="44" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1046" y="490" text-anchor="middle" class="chip">SPDX</text>
-    <rect x="1074" y="478" width="44" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1096" y="490" text-anchor="middle" class="chip">OCSF</text>
-    <rect x="1024" y="502" width="44" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1046" y="514" text-anchor="middle" class="chip">HTML</text>
-    <rect x="1074" y="502" width="44" height="18" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1096" y="514" text-anchor="middle" class="chip">JSON</text>
-    <text x="1080" y="535" text-anchor="middle" class="node-sub">→ SIEM · webhooks</text></g>
-
-  <!-- flow arrows (drawn on top so labels are never clipped by lane panels) -->
-  <line x1="246" y1="360" x2="278" y2="360" stroke="#a1a1aa" stroke-width="2" marker-end="url(#abom-arrow-l)"/><text x="262" y="350" text-anchor="middle" class="flow-label">SCAN</text>
-  <line x1="486" y1="360" x2="518" y2="360" stroke="#a1a1aa" stroke-width="2" marker-end="url(#abom-arrow-l)"/><text x="502" y="350" text-anchor="middle" class="flow-label">NORMALIZE</text>
-  <line x1="726" y1="360" x2="758" y2="360" stroke="#7c3aed" stroke-width="2.2" marker-end="url(#abom-arrow-accent-l)"/><text x="742" y="350" text-anchor="middle" class="flow-label" fill="#7c3aed">SERVE</text>
-  <line x1="966" y1="360" x2="998" y2="360" stroke="#a1a1aa" stroke-width="2" marker-end="url(#abom-arrow-l)"/><text x="982" y="350" text-anchor="middle" class="flow-label">DELIVER</text>
-
-  <rect x="40" y="608" width="1120" height="30" rx="9" fill="#ecfdf5" stroke="#a7f3d0"/>
-  <text x="600" y="627" text-anchor="middle" class="footer">READ-ONLY BY DEFAULT · no target writes · never runs servers · no secret values · self-hosted · evidence signed end-to-end</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 620" fill="none" role="img" aria-labelledby="arch-l-title arch-l-desc">
+<title id="arch-l-title">agent-bom control-plane architecture</title>
+<desc id="arch-l-desc">Sources through scan and evidence core to control plane and consumers.</desc>
+<defs>
+<marker id="arch-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
+<marker id="arch-a-l" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
+</defs>
+<rect width="1200" height="620" rx="14" fill="#ffffff"/>
+<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="#18181b">Control-plane <tspan fill="#7c3aed">architecture</tspan></text>
+<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="#71717a">Sources → scan → one Finding + UnifiedGraph → API · Gateway · MCP → people + agents</text>
+<rect x="32" y="82" width="184" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="32" y="82" width="184" height="36" rx="10" fill="#1e3a5f"/><rect x="32" y="104" width="184" height="14" fill="#1e3a5f"/><text x="46" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">SOURCES</text><text x="204" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">read-only</text>
+<rect x="228" y="82" width="184" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="228" y="82" width="184" height="36" rx="10" fill="#78350f"/><rect x="228" y="104" width="184" height="14" fill="#78350f"/><text x="242" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#fde68a">SCAN</text><text x="400" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#fbbf24" opacity="0.85">local</text>
+<rect x="424" y="82" width="184" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="424" y="82" width="184" height="36" rx="10" fill="#5b21b6"/><rect x="424" y="104" width="184" height="14" fill="#5b21b6"/><text x="438" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#ddd6fe">EVIDENCE</text><text x="596" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a78bfa" opacity="0.85">normalized</text>
+<rect x="620" y="82" width="184" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="620" y="82" width="184" height="36" rx="10" fill="#065f46"/><rect x="620" y="104" width="184" height="14" fill="#065f46"/><text x="634" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#a7f3d0">CONTROL</text><text x="792" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#34d399" opacity="0.85">tenant auth</text>
+<rect x="816" y="82" width="352" height="468" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="816" y="82" width="352" height="36" rx="10" fill="#1e3a8a"/><rect x="816" y="104" width="352" height="14" fill="#1e3a8a"/><text x="830" y="104" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">CONSUMERS</text><text x="1156" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">people+agents</text>
+<rect x="44" y="128" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="54" y="139" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,144)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="88" y="150" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Supply chain</text>
+<text x="88" y="164" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">15 eco</text>
+<rect x="44" y="186" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="54" y="197" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,202)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="88" y="208" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Agents &amp; MCP</text>
+<text x="88" y="222" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">29 clients</text>
+<rect x="44" y="244" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="54" y="255" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,260)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="88" y="266" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Cloud</text>
+<text x="88" y="280" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">4 providers</text>
+<rect x="44" y="302" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="54" y="313" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,318)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="88" y="324" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">IaC &amp; OCI</text>
+<text x="88" y="338" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">TF·K8s·img</text>
+<rect x="44" y="360" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="54" y="371" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,376)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="88" y="382" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Secrets</text>
+<text x="88" y="396" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">refs only</text>
+<rect x="44" y="418" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="54" y="429" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,434)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="88" y="440" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Models</text>
+<text x="88" y="454" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">13 formats</text>
+<rect x="44" y="476" width="160" height="48" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="54" y="487" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(59,492)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="88" y="498" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">SBOM import</text>
+<text x="88" y="512" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">CDX·SPDX</text>
+<rect x="240" y="128" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="250" y="145" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,150)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="284" y="158" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">OSV scan</text>
+<text x="284" y="172" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">batch</text>
+<rect x="240" y="200" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="250" y="217" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,222)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="284" y="230" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Enrichment</text>
+<text x="284" y="244" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">NVD·EPSS</text>
+<rect x="240" y="272" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="250" y="289" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,294)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="284" y="302" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Posture</text>
+<text x="284" y="316" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">CIS·MCP</text>
+<rect x="240" y="344" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="250" y="361" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,366)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="284" y="374" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Blast radius</text>
+<text x="284" y="388" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">fusion</text>
+<rect x="240" y="416" width="160" height="60" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="250" y="433" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(255,438)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="284" y="446" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Policy</text>
+<text x="284" y="460" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">as-code</text>
+<rect x="436" y="128" width="160" height="72" rx="9" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.6"/>
+<rect x="446" y="151" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(451,156)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="480" y="162" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Unified Finding</text>
+<text x="480" y="178" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#7c3aed">one schema</text>
+<rect x="436" y="216" width="160" height="72" rx="9" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.6"/>
+<rect x="446" y="239" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(451,244)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="480" y="250" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">UnifiedGraph</text>
+<text x="480" y="266" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#7c3aed">attack paths</text>
+<rect x="436" y="304" width="160" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="446" y="327" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(451,332)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
+<text x="480" y="338" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Stores</text>
+<text x="480" y="354" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">PG·SQLite</text>
+<rect x="436" y="392" width="160" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="446" y="415" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(451,420)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="480" y="426" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Audit chain</text>
+<text x="480" y="442" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">signed</text>
+<rect x="632" y="128" width="156" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="642" y="151" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(647,156)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="676" y="162" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">REST API</text>
+<text x="676" y="178" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">283 ops</text>
+<rect x="632" y="216" width="156" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="642" y="239" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(647,244)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="676" y="250" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Gateway</text>
+<text x="676" y="266" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">runtime</text>
+<rect x="632" y="304" width="156" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="642" y="327" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(647,332)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="676" y="338" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">MCP server</text>
+<text x="676" y="354" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">70 tools</text>
+<rect x="632" y="392" width="156" height="72" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="642" y="415" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(647,420)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="676" y="426" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Fleet jobs</text>
+<text x="676" y="442" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">Helm·EKS</text>
+<rect x="632" y="490" width="156" height="32" rx="8" fill="#f4f4f6" stroke="#e4e4e7"/><text x="710" y="510" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#52525b">OIDC · SAML · SCIM · RBAC</text>
+<text x="880" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">PEOPLE</text>
+<rect x="828" y="136" width="104" height="44" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="836" y="145" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(841,150)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
+<text x="868" y="163" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#18181b">CLI</text>
+<rect x="828" y="190" width="104" height="44" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="836" y="199" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(841,204)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="868" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#18181b">Web UI</text>
+<text x="998" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">AGENTS</text>
+<rect x="946" y="136" width="104" height="44" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="954" y="145" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(959,150)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="986" y="163" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#18181b">MCP</text>
+<rect x="946" y="190" width="104" height="44" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="954" y="199" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(959,204)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="986" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="#18181b">SDK</text>
+<text x="1116" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">ARTIFACTS</text>
+<rect x="1064" y="136" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1091" y="151" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">SARIF</text>
+<rect x="1122" y="136" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1149" y="151" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">CDX</text>
+<rect x="1064" y="164" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1091" y="179" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">SPDX</text>
+<rect x="1122" y="164" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1149" y="179" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">OCSF</text>
+<rect x="1064" y="192" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1091" y="207" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">HTML</text>
+<rect x="1122" y="192" width="54" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="1149" y="207" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" font-weight="700" fill="#52525b">JSON</text>
+<text x="1116" y="248" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#9a9aa4">→ SIEM · webhooks</text>
+<line x1="216" y1="318" x2="228" y2="318" stroke="#a1a1aa" stroke-width="2" marker-end="url(#arch-l)"/>
+<text x="222" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">SCAN</text>
+<line x1="412" y1="318" x2="424" y2="318" stroke="#a1a1aa" stroke-width="2" marker-end="url(#arch-l)"/>
+<text x="418" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">NORMALIZE</text>
+<line x1="608" y1="318" x2="620" y2="318" stroke="#7c3aed" stroke-width="2.3" marker-end="url(#arch-a-l)"/>
+<text x="614" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">SERVE</text>
+<line x1="804" y1="318" x2="816" y2="318" stroke="#a1a1aa" stroke-width="2" marker-end="url(#arch-l)"/>
+<text x="810" y="308" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">DELIVER</text>
+<rect x="32" y="568" width="1136" height="32" rx="9" fill="#ecfdf5" stroke="#bbf7d0"/><text x="600" y="588" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#15803d">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/how-it-works-dark.svg
+++ b/docs/images/how-it-works-dark.svg
@@ -1,133 +1,132 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 560" fill="none" role="img" aria-labelledby="hiw-d-title hiw-d-desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 580" fill="none" role="img" aria-labelledby="hiw-d-title hiw-d-desc">
 <title id="hiw-d-title">How agent-bom works</title>
-<desc id="hiw-d-desc">Read-only intake through scan pipeline into unified Finding and UnifiedGraph, served by control plane, exported as reports and gates.</desc>
+<desc id="hiw-d-desc">Read-only intake through scan pipeline into unified Finding and UnifiedGraph.</desc>
 <defs>
-<marker id="hiw" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
-<marker id="hiw-a" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
-<linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#a78bfa" stop-opacity="0.35"/><stop offset="100%" stop-color="#a78bfa" stop-opacity="0"/></linearGradient>
+<marker id="hiw" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
+<marker id="hiw-a" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
+<linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#a78bfa" stop-opacity="0.28"/><stop offset="100%" stop-color="#a78bfa" stop-opacity="0"/></linearGradient>
 </defs>
-<rect width="1200" height="560" rx="16" fill="#0a0a0c"/>
-<text x="36" y="44" font-family="Inter,system-ui,sans-serif" font-size="24" font-weight="850" fill="#f4f4f5">From inventory to enforceable evidence</text>
-<text x="36" y="66" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="500" fill="#71717a">One read-only pipeline · one Finding + UnifiedGraph · CLI · API · UI · MCP · runtime gates</text>
-<rect x="28" y="88" width="210" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
-<rect x="28" y="88" width="210" height="36" rx="10" fill="#1e3a5f"/><rect x="28" y="110" width="210" height="14" fill="#1e3a5f"/><text x="42" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">INTAKE</text><text x="226" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">read-only</text>
-<rect x="258" y="88" width="188" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
-<rect x="258" y="88" width="188" height="36" rx="10" fill="#78350f"/><rect x="258" y="110" width="188" height="14" fill="#78350f"/><text x="272" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#fde68a">SCAN</text><text x="434" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#fbbf24" opacity="0.85">6 steps</text>
-<rect x="466" y="88" width="248" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
-<rect x="466" y="88" width="248" height="36" rx="10" fill="#5b21b6"/><rect x="466" y="110" width="248" height="14" fill="#5b21b6"/><text x="480" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#ddd6fe">EVIDENCE</text><text x="702" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a78bfa" opacity="0.85">one model</text>
-<rect x="734" y="88" width="188" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
-<rect x="734" y="88" width="188" height="36" rx="10" fill="#065f46"/><rect x="734" y="110" width="188" height="14" fill="#065f46"/><text x="748" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#a7f3d0">CONTROL</text><text x="910" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#34d399" opacity="0.85">self-hosted</text>
-<rect x="942" y="88" width="108" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
-<rect x="942" y="88" width="108" height="36" rx="10" fill="#3f3f46"/><rect x="942" y="110" width="108" height="14" fill="#3f3f46"/><text x="956" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#d4d4d8">OUT</text><text x="1038" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a1a1aa" opacity="0.85">artifacts</text>
-<rect x="44" y="138" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect x="52" y="147" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(57,152)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h8l3 3v11H4z M12 6v3h3"/></g>
-<text x="86" y="166" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Repo</text>
-<rect x="142" y="138" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect x="150" y="147" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(155,152)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 14l4 4 10-11"/></g>
-<text x="184" y="166" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">CI</text>
-<rect x="44" y="192" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect x="52" y="201" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(57,206)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="86" y="220" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">MCP</text>
-<rect x="142" y="192" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect x="150" y="201" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(155,206)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="184" y="220" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Cloud</text>
-<rect x="44" y="246" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect x="52" y="255" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(57,260)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
-<text x="86" y="274" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Image</text>
-<rect x="142" y="246" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect x="150" y="255" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(155,260)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="184" y="274" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">IaC</text>
-<rect x="44" y="300" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect x="52" y="309" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(57,314)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="86" y="328" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">SBOM</text>
-<rect x="142" y="300" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect x="150" y="309" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(155,314)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="184" y="328" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Model</text>
-<rect x="44" y="360" width="46" height="34" rx="9" fill="#161619" stroke="#2a2a31"/><g transform="translate(55,366) scale(0.9)"><path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/></g><text x="67" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#ff9900">AWS</text><rect x="96" y="360" width="46" height="34" rx="9" fill="#161619" stroke="#2a2a31"/><g transform="translate(107,366) scale(0.9)"><path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/></g><text x="119" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#0078d4">Azure</text><rect x="148" y="360" width="46" height="34" rx="9" fill="#161619" stroke="#2a2a31"/><g transform="translate(159,366) scale(0.9)"><circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/></g><text x="171" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#4285f4">GCP</text><rect x="200" y="360" width="46" height="34" rx="9" fill="#161619" stroke="#2a2a31"/><g transform="translate(211,366) scale(0.9)"><path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/></g><text x="223" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#29b5e8">Snow</text>
-<rect x="44" y="408" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(49,413)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
-<text x="78" y="426" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#6b6b75">no writes · no secret values</text>
-<circle cx="278" cy="146" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
-<text x="278" y="150" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">1</text>
-<rect x="304" y="132" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,137)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="6"/><path d="M15 15l4 4"/></g>
-<text x="340" y="149" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Discover</text>
-<path d="M278 160 V170" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
-<circle cx="278" cy="198" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
-<text x="278" y="202" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">2</text>
-<rect x="304" y="184" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,189)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="340" y="201" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Extract</text>
-<path d="M278 212 V222" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
-<circle cx="278" cy="250" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
-<text x="278" y="254" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">3</text>
-<rect x="304" y="236" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,241)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="340" y="253" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Scan</text>
-<path d="M278 264 V274" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
-<circle cx="278" cy="302" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
-<text x="278" y="306" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">4</text>
-<rect x="304" y="288" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,293)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="340" y="305" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Enrich</text>
-<path d="M278 316 V326" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
-<circle cx="278" cy="354" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
-<text x="278" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">5</text>
-<rect x="304" y="340" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,345)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="340" y="357" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Analyze</text>
-<path d="M278 368 V378" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
-<circle cx="278" cy="406" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
-<text x="278" y="410" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">6</text>
-<rect x="304" y="392" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,397)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="340" y="409" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Report</text>
-<rect x="272" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="287" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">OSV</text>
-<rect x="306" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="321" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">GHSA</text>
-<rect x="340" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="355" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">NVD</text>
-<rect x="374" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="389" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">KEV</text>
-<rect x="408" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="423" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">EPSS</text>
-<circle cx="590" cy="268" r="78" fill="url(#core-glow)"/>
-<line x1="590" y1="268" x2="518" y2="258" stroke="#222228" stroke-width="1.4" opacity="0.75"/>
-<line x1="590" y1="268" x2="662" y2="258" stroke="#222228" stroke-width="1.4" opacity="0.75"/>
-<line x1="590" y1="268" x2="538" y2="326" stroke="#222228" stroke-width="1.4" opacity="0.75"/>
-<line x1="590" y1="268" x2="642" y2="326" stroke="#222228" stroke-width="1.4" opacity="0.75"/>
-<circle cx="590" cy="210" r="34" fill="#15121f" stroke="#5b4bbd" stroke-width="2"/>
-<rect x="577" y="197" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(582,202)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
-<text x="590" y="232" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" fill="#a78bfa">Finding</text>
-<circle cx="518" cy="258" r="28" fill="#161619" stroke="#2a2a31" stroke-width="1.5"/>
-<text x="518" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#e9e9ec">Asset</text>
-<circle cx="662" cy="258" r="28" fill="#161619" stroke="#2a2a31" stroke-width="1.5"/>
-<text x="662" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#e9e9ec">Agent</text>
-<circle cx="538" cy="326" r="28" fill="#161619" stroke="#2a2a31" stroke-width="1.5"/>
-<text x="538" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#e9e9ec">Tool</text>
-<circle cx="642" cy="326" r="28" fill="#161619" stroke="#2a2a31" stroke-width="1.5"/>
-<text x="642" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#e9e9ec">Cred</text>
-<rect x="494" y="390" width="64" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="526" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#a1a1aa">severity</text>
-<rect x="566" y="390" width="64" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="598" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#a1a1aa">provenance</text>
-<rect x="638" y="390" width="64" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="670" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#a1a1aa">tenant</text>
-<rect x="748" y="136" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
-<rect x="756" y="149" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(761,154)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="788" y="168" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">REST API</text>
-<rect x="834" y="136" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
-<rect x="842" y="149" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(847,154)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="874" y="168" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Dashboard</text>
-<rect x="748" y="198" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
-<rect x="756" y="211" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(761,216)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="788" y="230" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">MCP srv</text>
-<rect x="834" y="198" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
-<rect x="842" y="211" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(847,216)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="874" y="230" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Gateway</text>
-<rect x="748" y="260" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
-<rect x="756" y="273" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(761,278)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="788" y="292" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Fleet</text>
-<rect x="834" y="260" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
-<rect x="842" y="273" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(847,278)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="874" y="292" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Audit</text>
-<rect x="748" y="340" width="162" height="28" rx="8" fill="#121016" stroke="#2a2733"/><text x="829" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a1a1aa">fail-closed · RBAC · audit</text>
-<rect x="956" y="136" width="80" height="36" rx="10" fill="#161619" stroke="#f87171" stroke-width="1.2"/><circle cx="970" cy="154" r="4" fill="#f87171" opacity="0.85"/><text x="982" y="158" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">SARIF</text>
-<rect x="956" y="188" width="80" height="36" rx="10" fill="#161619" stroke="#fbbf24" stroke-width="1.2"/><circle cx="970" cy="206" r="4" fill="#fbbf24" opacity="0.85"/><text x="982" y="210" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">SBOM</text>
-<rect x="956" y="240" width="80" height="36" rx="10" fill="#161619" stroke="#60a5fa" stroke-width="1.2"/><circle cx="970" cy="258" r="4" fill="#60a5fa" opacity="0.85"/><text x="982" y="262" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">HTML</text>
-<rect x="956" y="292" width="80" height="36" rx="10" fill="#161619" stroke="#a78bfa" stroke-width="1.2"/><circle cx="970" cy="310" r="4" fill="#a78bfa" opacity="0.85"/><text x="982" y="314" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">JSON</text>
-<rect x="956" y="344" width="80" height="36" rx="10" fill="#161619" stroke="#34d399" stroke-width="1.2"/><circle cx="970" cy="362" r="4" fill="#34d399" opacity="0.85"/><text x="982" y="366" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">GATE</text>
-<rect x="956" y="396" width="80" height="36" rx="10" fill="#161619" stroke="#fb7185" stroke-width="1.2"/><circle cx="970" cy="414" r="4" fill="#fb7185" opacity="0.85"/><text x="982" y="418" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">FIX</text>
-<text x="996" y="468" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#6b6b75">reports · gates · runtime</text>
-<line x1="238" y1="288" x2="256" y2="288" stroke="#52525b" stroke-width="2" marker-end="url(#hiw)"/><text x="247" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">collect</text>
-<line x1="446" y1="288" x2="464" y2="288" stroke="#52525b" stroke-width="2" marker-end="url(#hiw)"/><text x="455" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">normalize</text>
-<line x1="714" y1="288" x2="732" y2="288" stroke="#8b5cf6" stroke-width="2.4" marker-end="url(#hiw-a)"/><text x="723" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">serve</text>
-<line x1="922" y1="288" x2="940" y2="288" stroke="#52525b" stroke-width="2" marker-end="url(#hiw)"/><text x="931" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">export</text>
-<rect x="28" y="508" width="1144" height="36" rx="10" fill="#0c1a14" stroke="#1f4438"/><text x="52" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#4ade80">TRUST</text><text x="100" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#a1a1aa">read-only connectors · secret redaction · signed evidence · same model everywhere</text>
+<rect width="1180" height="580" rx="14" fill="#0a0a0c"/>
+<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="#f4f4f5">From inventory to enforceable evidence</text>
+<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="#71717a">One read-only pipeline · one Finding + UnifiedGraph · CLI · API · UI · MCP</text>
+<rect x="24" y="84" width="200" height="380" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="24" y="84" width="200" height="32" rx="8" fill="#1e3a5f"/><text x="36" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">INTAKE</text><text x="214" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">read-only</text>
+<rect x="236" y="84" width="176" height="380" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="236" y="84" width="176" height="32" rx="8" fill="#78350f"/><text x="248" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#fde68a">SCAN</text><text x="402" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#fbbf24" opacity="0.9">6 steps</text>
+<rect x="424" y="84" width="232" height="380" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="424" y="84" width="232" height="32" rx="8" fill="#5b21b6"/><text x="436" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#ddd6fe">EVIDENCE</text><text x="646" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a78bfa" opacity="0.9">one model</text>
+<rect x="668" y="84" width="176" height="380" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="668" y="84" width="176" height="32" rx="8" fill="#065f46"/><text x="680" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#a7f3d0">CONTROL</text><text x="834" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#34d399" opacity="0.9">self-hosted</text>
+<rect x="856" y="84" width="108" height="380" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="856" y="84" width="108" height="32" rx="8" fill="#3f3f46"/><text x="868" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#d4d4d8">OUT</text><text x="954" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a1a1aa" opacity="0.9">artifacts</text>
+<rect x="36" y="128" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="42" y="136" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,140)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h8l3 3v11H4z M12 6v3h3"/></g>
+<text x="72" y="153" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Repo</text>
+<rect x="130" y="128" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="136" y="136" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(140,140)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 14l4 4 10-11"/></g>
+<text x="166" y="153" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">CI</text>
+<rect x="36" y="178" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="42" y="186" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,190)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="72" y="203" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">MCP</text>
+<rect x="130" y="178" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="136" y="186" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(140,190)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="166" y="203" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Cloud</text>
+<rect x="36" y="228" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="42" y="236" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,240)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
+<text x="72" y="253" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Image</text>
+<rect x="130" y="228" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="136" y="236" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(140,240)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="166" y="253" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">IaC</text>
+<rect x="36" y="278" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="42" y="286" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,290)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="72" y="303" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">SBOM</text>
+<rect x="130" y="278" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="136" y="286" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(140,290)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="166" y="303" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Model</text>
+<rect x="36" y="336" width="42" height="30" rx="8" fill="#161619" stroke="#2a2a31"/><g transform="translate(45,341) scale(0.85)"><path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/></g><text x="57" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#ff9900">AWS</text><rect x="84" y="336" width="42" height="30" rx="8" fill="#161619" stroke="#2a2a31"/><g transform="translate(93,341) scale(0.85)"><path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/></g><text x="105" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#0078d4">Azure</text><rect x="132" y="336" width="42" height="30" rx="8" fill="#161619" stroke="#2a2a31"/><g transform="translate(141,341) scale(0.85)"><circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/></g><text x="153" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#4285f4">GCP</text><rect x="180" y="336" width="42" height="30" rx="8" fill="#161619" stroke="#2a2a31"/><g transform="translate(189,341) scale(0.85)"><path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/></g><text x="201" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#29b5e8">Snow</text>
+<rect x="36" y="376" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(40,380)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="64" y="392" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#6b6b75">no writes · no secret values</text>
+<circle cx="248" cy="140" r="11" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="144" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">1</text>
+<rect x="268" y="128" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,132)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="6"/><path d="M15 15l4 4"/></g>
+<text x="298" y="144" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Discover</text>
+<path d="M248 152 V160" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="188" r="11" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="192" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">2</text>
+<rect x="268" y="176" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,180)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="298" y="192" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Extract</text>
+<path d="M248 200 V208" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="236" r="11" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="240" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">3</text>
+<rect x="268" y="224" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,228)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="298" y="240" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Scan</text>
+<path d="M248 248 V256" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="284" r="11" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="288" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">4</text>
+<rect x="268" y="272" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,276)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="298" y="288" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Enrich</text>
+<path d="M248 296 V304" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="332" r="11" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="336" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">5</text>
+<rect x="268" y="320" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,324)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="298" y="336" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Analyze</text>
+<path d="M248 344 V352" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="380" r="11" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="384" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">6</text>
+<rect x="268" y="368" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,372)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="298" y="384" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Report</text>
+<rect x="242" y="430" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="255" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">OSV</text>
+<rect x="272" y="430" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="285" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">GHSA</text>
+<rect x="302" y="430" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="315" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">NVD</text>
+<rect x="332" y="430" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="345" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">KEV</text>
+<rect x="362" y="430" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="375" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">EPSS</text>
+<circle cx="540" cy="284" r="62" fill="url(#core-glow)"/>
+<line x1="540" y1="284" x2="482" y2="278" stroke="#222228" stroke-width="1.2" opacity="0.7"/>
+<line x1="540" y1="284" x2="598" y2="278" stroke="#222228" stroke-width="1.2" opacity="0.7"/>
+<line x1="540" y1="284" x2="498" y2="330" stroke="#222228" stroke-width="1.2" opacity="0.7"/>
+<line x1="540" y1="284" x2="582" y2="330" stroke="#222228" stroke-width="1.2" opacity="0.7"/>
+<circle cx="540" cy="236" r="28" fill="#15121f" stroke="#5b4bbd" stroke-width="1.8"/>
+<rect x="528" y="224" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(532,228)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="540" y="254" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#a78bfa">Finding</text>
+<circle cx="482" cy="278" r="22" fill="#161619" stroke="#2a2a31" stroke-width="1.3"/>
+<text x="482" y="294" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#e9e9ec">Asset</text>
+<circle cx="598" cy="278" r="22" fill="#161619" stroke="#2a2a31" stroke-width="1.3"/>
+<text x="598" y="294" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#e9e9ec">Agent</text>
+<circle cx="498" cy="330" r="22" fill="#161619" stroke="#2a2a31" stroke-width="1.3"/>
+<text x="498" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#e9e9ec">Tool</text>
+<circle cx="582" cy="330" r="22" fill="#161619" stroke="#2a2a31" stroke-width="1.3"/>
+<text x="582" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#e9e9ec">Cred</text>
+<rect x="438" y="424" width="60" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="468" y="437" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#a1a1aa">severity</text>
+<rect x="506" y="424" width="60" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="536" y="437" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#a1a1aa">provenance</text>
+<rect x="574" y="424" width="60" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="604" y="437" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#a1a1aa">tenant</text>
+<rect x="680" y="128" width="72" height="46" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="688" y="139" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(692,143)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="718" y="156" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">REST API</text>
+<rect x="760" y="128" width="72" height="46" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="768" y="139" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(772,143)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="798" y="156" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Dashboard</text>
+<rect x="680" y="184" width="72" height="46" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="688" y="195" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(692,199)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="718" y="212" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">MCP srv</text>
+<rect x="760" y="184" width="72" height="46" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="768" y="195" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(772,199)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="798" y="212" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Gateway</text>
+<rect x="680" y="240" width="72" height="46" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="688" y="251" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(692,255)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="718" y="268" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Fleet</text>
+<rect x="760" y="240" width="72" height="46" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="768" y="251" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(772,255)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="798" y="268" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Audit</text>
+<rect x="680" y="426" width="152" height="24" rx="7" fill="#121016" stroke="#2a2733"/><text x="756" y="442" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#a1a1aa">fail-closed · RBAC · audit</text>
+<rect x="868" y="128" width="76" height="32" rx="8" fill="#161619" stroke="#f87171" stroke-width="1.1"/><circle cx="880" cy="144" r="3.5" fill="#f87171"/><text x="890" y="148" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#e9e9ec">SARIF</text>
+<rect x="868" y="176" width="76" height="32" rx="8" fill="#161619" stroke="#fbbf24" stroke-width="1.1"/><circle cx="880" cy="192" r="3.5" fill="#fbbf24"/><text x="890" y="196" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#e9e9ec">SBOM</text>
+<rect x="868" y="224" width="76" height="32" rx="8" fill="#161619" stroke="#60a5fa" stroke-width="1.1"/><circle cx="880" cy="240" r="3.5" fill="#60a5fa"/><text x="890" y="244" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#e9e9ec">HTML</text>
+<rect x="868" y="272" width="76" height="32" rx="8" fill="#161619" stroke="#a78bfa" stroke-width="1.1"/><circle cx="880" cy="288" r="3.5" fill="#a78bfa"/><text x="890" y="292" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#e9e9ec">JSON</text>
+<rect x="868" y="320" width="76" height="32" rx="8" fill="#161619" stroke="#34d399" stroke-width="1.1"/><circle cx="880" cy="336" r="3.5" fill="#34d399"/><text x="890" y="340" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#e9e9ec">GATE</text>
+<rect x="868" y="368" width="76" height="32" rx="8" fill="#161619" stroke="#fb7185" stroke-width="1.1"/><circle cx="880" cy="384" r="3.5" fill="#fb7185"/><text x="890" y="388" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#e9e9ec">FIX</text>
+<line x1="224" y1="100" x2="236" y2="100" stroke="#52525b" stroke-width="1.8" marker-end="url(#hiw)"/><text x="230" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">collect</text>
+<line x1="412" y1="100" x2="424" y2="100" stroke="#52525b" stroke-width="1.8" marker-end="url(#hiw)"/><text x="418" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">normalize</text>
+<line x1="656" y1="100" x2="668" y2="100" stroke="#8b5cf6" stroke-width="2.2" marker-end="url(#hiw-a)"/><text x="662" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#a78bfa">serve</text>
+<line x1="844" y1="100" x2="856" y2="100" stroke="#52525b" stroke-width="1.8" marker-end="url(#hiw)"/><text x="850" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">export</text>
+<rect x="24" y="536" width="1132" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="44" y="554" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="800" fill="#4ade80">TRUST</text><text x="88" y="554" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a1a1aa">read-only · secret redaction · signed evidence · same model everywhere</text>
 </svg>

--- a/docs/images/how-it-works-dark.svg
+++ b/docs/images/how-it-works-dark.svg
@@ -1,132 +1,131 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 580" fill="none" role="img" aria-labelledby="hiw-d-title hiw-d-desc">
-<title id="hiw-d-title">How agent-bom works</title>
-<desc id="hiw-d-desc">Read-only intake through scan pipeline into unified Finding and UnifiedGraph.</desc>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="560" viewBox="0 0 960 560" fill="none">
+<title>How agent-bom works</title>
+<desc>Read-only intake through scan pipeline into unified Finding and UnifiedGraph.</desc>
 <defs>
-<marker id="hiw" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
-<marker id="hiw-a" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
 <linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#a78bfa" stop-opacity="0.28"/><stop offset="100%" stop-color="#a78bfa" stop-opacity="0"/></linearGradient>
 </defs>
-<rect width="1180" height="580" rx="14" fill="#0a0a0c"/>
-<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="#f4f4f5">From inventory to enforceable evidence</text>
-<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="#71717a">One read-only pipeline · one Finding + UnifiedGraph · CLI · API · UI · MCP</text>
-<rect x="24" y="84" width="200" height="380" rx="12" fill="#0f0f13" stroke="#222228"/>
-<rect x="24" y="84" width="200" height="32" rx="8" fill="#1e3a5f"/><text x="36" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">INTAKE</text><text x="214" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">read-only</text>
-<rect x="236" y="84" width="176" height="380" rx="12" fill="#0f0f13" stroke="#222228"/>
-<rect x="236" y="84" width="176" height="32" rx="8" fill="#78350f"/><text x="248" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#fde68a">SCAN</text><text x="402" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#fbbf24" opacity="0.9">6 steps</text>
-<rect x="424" y="84" width="232" height="380" rx="12" fill="#0f0f13" stroke="#222228"/>
-<rect x="424" y="84" width="232" height="32" rx="8" fill="#5b21b6"/><text x="436" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#ddd6fe">EVIDENCE</text><text x="646" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a78bfa" opacity="0.9">one model</text>
-<rect x="668" y="84" width="176" height="380" rx="12" fill="#0f0f13" stroke="#222228"/>
-<rect x="668" y="84" width="176" height="32" rx="8" fill="#065f46"/><text x="680" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#a7f3d0">CONTROL</text><text x="834" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#34d399" opacity="0.9">self-hosted</text>
-<rect x="856" y="84" width="108" height="380" rx="12" fill="#0f0f13" stroke="#222228"/>
-<rect x="856" y="84" width="108" height="32" rx="8" fill="#3f3f46"/><text x="868" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#d4d4d8">OUT</text><text x="954" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a1a1aa" opacity="0.9">artifacts</text>
-<rect x="36" y="128" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="42" y="136" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,140)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h8l3 3v11H4z M12 6v3h3"/></g>
-<text x="72" y="153" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Repo</text>
-<rect x="130" y="128" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="136" y="136" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(140,140)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 14l4 4 10-11"/></g>
-<text x="166" y="153" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">CI</text>
-<rect x="36" y="178" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="42" y="186" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,190)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="72" y="203" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">MCP</text>
-<rect x="130" y="178" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="136" y="186" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(140,190)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="166" y="203" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Cloud</text>
-<rect x="36" y="228" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="42" y="236" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,240)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
-<text x="72" y="253" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Image</text>
-<rect x="130" y="228" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="136" y="236" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(140,240)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="166" y="253" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">IaC</text>
-<rect x="36" y="278" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="42" y="286" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,290)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="72" y="303" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">SBOM</text>
-<rect x="130" y="278" width="84" height="40" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="136" y="286" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(140,290)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="166" y="303" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Model</text>
-<rect x="36" y="336" width="42" height="30" rx="8" fill="#161619" stroke="#2a2a31"/><g transform="translate(45,341) scale(0.85)"><path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/></g><text x="57" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#ff9900">AWS</text><rect x="84" y="336" width="42" height="30" rx="8" fill="#161619" stroke="#2a2a31"/><g transform="translate(93,341) scale(0.85)"><path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/></g><text x="105" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#0078d4">Azure</text><rect x="132" y="336" width="42" height="30" rx="8" fill="#161619" stroke="#2a2a31"/><g transform="translate(141,341) scale(0.85)"><circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/></g><text x="153" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#4285f4">GCP</text><rect x="180" y="336" width="42" height="30" rx="8" fill="#161619" stroke="#2a2a31"/><g transform="translate(189,341) scale(0.85)"><path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/></g><text x="201" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#29b5e8">Snow</text>
-<rect x="36" y="376" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(40,380)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<rect width="960" height="560" rx="14" fill="#0a0a0c"/>
+<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#f4f4f5">From inventory to enforceable evidence</text>
+<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">One read-only pipeline · one Finding + UnifiedGraph · CLI · API · UI · MCP</text>
+<rect x="24" y="84" width="176" height="360" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="24" y="84" width="176" height="32" rx="8" fill="#1e3a5f"/><text x="36" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">INTAKE</text><text x="190" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">read-only</text>
+<rect x="208" y="84" width="176" height="360" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="208" y="84" width="176" height="32" rx="8" fill="#78350f"/><text x="220" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#fde68a">SCAN</text><text x="374" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#fbbf24" opacity="0.9">6 steps</text>
+<rect x="392" y="84" width="176" height="360" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="392" y="84" width="176" height="32" rx="8" fill="#5b21b6"/><text x="404" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#ddd6fe">EVIDENCE</text><text x="558" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a78bfa" opacity="0.9">one model</text>
+<rect x="576" y="84" width="176" height="360" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="576" y="84" width="176" height="32" rx="8" fill="#065f46"/><text x="588" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#a7f3d0">CONTROL</text><text x="742" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#34d399" opacity="0.9">self-hosted</text>
+<rect x="760" y="84" width="176" height="360" rx="12" fill="#0f0f13" stroke="#222228"/>
+<rect x="760" y="84" width="176" height="32" rx="8" fill="#3f3f46"/><text x="772" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#d4d4d8">OUT</text><text x="926" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a1a1aa" opacity="0.9">artifacts</text>
+<rect x="32" y="128" width="74" height="38" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="38" y="135" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(42,139)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h8l3 3v11H4z M12 6v3h3"/></g>
+<text x="66" y="152" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Repo</text>
+<rect x="114" y="128" width="74" height="38" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="120" y="135" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(124,139)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 14l4 4 10-11"/></g>
+<text x="148" y="152" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">CI</text>
+<rect x="32" y="176" width="74" height="38" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="38" y="183" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(42,187)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="66" y="200" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">MCP</text>
+<rect x="114" y="176" width="74" height="38" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="120" y="183" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(124,187)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="148" y="200" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Cloud</text>
+<rect x="32" y="224" width="74" height="38" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="38" y="231" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(42,235)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
+<text x="66" y="248" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Image</text>
+<rect x="114" y="224" width="74" height="38" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="120" y="231" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(124,235)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="148" y="248" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">IaC</text>
+<rect x="32" y="272" width="74" height="38" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="38" y="279" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(42,283)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="66" y="296" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">SBOM</text>
+<rect x="114" y="272" width="74" height="38" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="120" y="279" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(124,283)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="148" y="296" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Model</text>
+<rect x="32" y="320" width="42" height="30" rx="8" fill="#161619" stroke="#2a2a31"/><g transform="translate(41,325) scale(0.85)"><path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/></g><text x="53" y="346" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#ff9900">AWS</text><rect x="80" y="320" width="42" height="30" rx="8" fill="#161619" stroke="#2a2a31"/><g transform="translate(89,325) scale(0.85)"><path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/></g><text x="101" y="346" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#0078d4">Azure</text><rect x="128" y="320" width="42" height="30" rx="8" fill="#161619" stroke="#2a2a31"/><g transform="translate(137,325) scale(0.85)"><circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/></g><text x="149" y="346" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#4285f4">GCP</text><rect x="176" y="320" width="42" height="30" rx="8" fill="#161619" stroke="#2a2a31"/><g transform="translate(185,325) scale(0.85)"><path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/></g><text x="197" y="346" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#29b5e8">Snow</text>
+<rect x="32" y="360" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(36,364)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
 <text x="64" y="392" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#6b6b75">no writes · no secret values</text>
-<circle cx="248" cy="140" r="11" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
+<circle cx="248" cy="140" r="10" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
 <text x="248" y="144" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">1</text>
 <rect x="268" y="128" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,132)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="6"/><path d="M15 15l4 4"/></g>
-<text x="298" y="144" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Discover</text>
-<path d="M248 152 V160" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
-<circle cx="248" cy="188" r="11" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
-<text x="248" y="192" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">2</text>
-<rect x="268" y="176" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,180)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="298" y="192" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Extract</text>
-<path d="M248 200 V208" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
-<circle cx="248" cy="236" r="11" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
-<text x="248" y="240" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">3</text>
-<rect x="268" y="224" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,228)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="298" y="240" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Scan</text>
-<path d="M248 248 V256" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
-<circle cx="248" cy="284" r="11" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
-<text x="248" y="288" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">4</text>
-<rect x="268" y="272" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,276)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="298" y="288" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Enrich</text>
-<path d="M248 296 V304" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
-<circle cx="248" cy="332" r="11" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
-<text x="248" y="336" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">5</text>
-<rect x="268" y="320" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,324)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="298" y="336" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Analyze</text>
-<path d="M248 344 V352" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
-<circle cx="248" cy="380" r="11" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
-<text x="248" y="384" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">6</text>
-<rect x="268" y="368" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,372)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="298" y="384" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Report</text>
-<rect x="242" y="430" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="255" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">OSV</text>
-<rect x="272" y="430" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="285" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">GHSA</text>
-<rect x="302" y="430" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="315" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">NVD</text>
-<rect x="332" y="430" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="345" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">KEV</text>
-<rect x="362" y="430" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="375" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">EPSS</text>
-<circle cx="540" cy="284" r="62" fill="url(#core-glow)"/>
-<line x1="540" y1="284" x2="482" y2="278" stroke="#222228" stroke-width="1.2" opacity="0.7"/>
-<line x1="540" y1="284" x2="598" y2="278" stroke="#222228" stroke-width="1.2" opacity="0.7"/>
-<line x1="540" y1="284" x2="498" y2="330" stroke="#222228" stroke-width="1.2" opacity="0.7"/>
-<line x1="540" y1="284" x2="582" y2="330" stroke="#222228" stroke-width="1.2" opacity="0.7"/>
-<circle cx="540" cy="236" r="28" fill="#15121f" stroke="#5b4bbd" stroke-width="1.8"/>
-<rect x="528" y="224" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(532,228)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
-<text x="540" y="254" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#a78bfa">Finding</text>
-<circle cx="482" cy="278" r="22" fill="#161619" stroke="#2a2a31" stroke-width="1.3"/>
-<text x="482" y="294" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#e9e9ec">Asset</text>
-<circle cx="598" cy="278" r="22" fill="#161619" stroke="#2a2a31" stroke-width="1.3"/>
-<text x="598" y="294" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#e9e9ec">Agent</text>
-<circle cx="498" cy="330" r="22" fill="#161619" stroke="#2a2a31" stroke-width="1.3"/>
-<text x="498" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#e9e9ec">Tool</text>
-<circle cx="582" cy="330" r="22" fill="#161619" stroke="#2a2a31" stroke-width="1.3"/>
-<text x="582" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#e9e9ec">Cred</text>
-<rect x="438" y="424" width="60" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="468" y="437" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#a1a1aa">severity</text>
-<rect x="506" y="424" width="60" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="536" y="437" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#a1a1aa">provenance</text>
-<rect x="574" y="424" width="60" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="604" y="437" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#a1a1aa">tenant</text>
-<rect x="680" y="128" width="72" height="46" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="688" y="139" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(692,143)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="718" y="156" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">REST API</text>
-<rect x="760" y="128" width="72" height="46" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="768" y="139" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(772,143)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="798" y="156" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Dashboard</text>
-<rect x="680" y="184" width="72" height="46" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="688" y="195" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(692,199)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="718" y="212" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">MCP srv</text>
-<rect x="760" y="184" width="72" height="46" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="768" y="195" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(772,199)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="798" y="212" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Gateway</text>
-<rect x="680" y="240" width="72" height="46" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="688" y="251" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(692,255)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="718" y="268" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Fleet</text>
-<rect x="760" y="240" width="72" height="46" rx="9" fill="#161619" stroke="#2a2a31"/>
-<rect x="768" y="251" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(772,255)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="798" y="268" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Audit</text>
-<rect x="680" y="426" width="152" height="24" rx="7" fill="#121016" stroke="#2a2733"/><text x="756" y="442" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#a1a1aa">fail-closed · RBAC · audit</text>
-<rect x="868" y="128" width="76" height="32" rx="8" fill="#161619" stroke="#f87171" stroke-width="1.1"/><circle cx="880" cy="144" r="3.5" fill="#f87171"/><text x="890" y="148" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#e9e9ec">SARIF</text>
-<rect x="868" y="176" width="76" height="32" rx="8" fill="#161619" stroke="#fbbf24" stroke-width="1.1"/><circle cx="880" cy="192" r="3.5" fill="#fbbf24"/><text x="890" y="196" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#e9e9ec">SBOM</text>
-<rect x="868" y="224" width="76" height="32" rx="8" fill="#161619" stroke="#60a5fa" stroke-width="1.1"/><circle cx="880" cy="240" r="3.5" fill="#60a5fa"/><text x="890" y="244" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#e9e9ec">HTML</text>
-<rect x="868" y="272" width="76" height="32" rx="8" fill="#161619" stroke="#a78bfa" stroke-width="1.1"/><circle cx="880" cy="288" r="3.5" fill="#a78bfa"/><text x="890" y="292" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#e9e9ec">JSON</text>
-<rect x="868" y="320" width="76" height="32" rx="8" fill="#161619" stroke="#34d399" stroke-width="1.1"/><circle cx="880" cy="336" r="3.5" fill="#34d399"/><text x="890" y="340" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#e9e9ec">GATE</text>
-<rect x="868" y="368" width="76" height="32" rx="8" fill="#161619" stroke="#fb7185" stroke-width="1.1"/><circle cx="880" cy="384" r="3.5" fill="#fb7185"/><text x="890" y="388" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#e9e9ec">FIX</text>
-<line x1="224" y1="100" x2="236" y2="100" stroke="#52525b" stroke-width="1.8" marker-end="url(#hiw)"/><text x="230" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">collect</text>
-<line x1="412" y1="100" x2="424" y2="100" stroke="#52525b" stroke-width="1.8" marker-end="url(#hiw)"/><text x="418" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">normalize</text>
-<line x1="656" y1="100" x2="668" y2="100" stroke="#8b5cf6" stroke-width="2.2" marker-end="url(#hiw-a)"/><text x="662" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#a78bfa">serve</text>
-<line x1="844" y1="100" x2="856" y2="100" stroke="#52525b" stroke-width="1.8" marker-end="url(#hiw)"/><text x="850" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">export</text>
-<rect x="24" y="536" width="1132" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="44" y="554" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="800" fill="#4ade80">TRUST</text><text x="88" y="554" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a1a1aa">read-only · secret redaction · signed evidence · same model everywhere</text>
+<text x="296" y="144" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Discover</text>
+<path d="M248 152 V158" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="186" r="10" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="190" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">2</text>
+<rect x="268" y="174" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,178)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="296" y="190" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Extract</text>
+<path d="M248 198 V204" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="232" r="10" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="236" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">3</text>
+<rect x="268" y="220" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,224)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="296" y="236" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Scan</text>
+<path d="M248 244 V250" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="278" r="10" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="282" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">4</text>
+<rect x="268" y="266" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,270)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="296" y="282" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Enrich</text>
+<path d="M248 290 V296" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="324" r="10" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="328" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">5</text>
+<rect x="268" y="312" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,316)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="296" y="328" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Analyze</text>
+<path d="M248 336 V342" stroke="#222228" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="370" r="10" fill="#161619" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="374" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">6</text>
+<rect x="268" y="358" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(272,362)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="296" y="374" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#e9e9ec">Report</text>
+<rect x="216" y="412" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="229" y="424" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">OSV</text>
+<rect x="248" y="412" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="261" y="424" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">GHSA</text>
+<rect x="280" y="412" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="293" y="424" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">NVD</text>
+<rect x="312" y="412" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="325" y="424" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">KEV</text>
+<rect x="344" y="412" width="26" height="18" rx="5" fill="#121016" stroke="#2a2a31"/><text x="357" y="424" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">EPSS</text>
+<circle cx="480" cy="272" r="54" fill="url(#core-glow)"/>
+<line x1="480" y1="272" x2="422" y2="266" stroke="#222228" stroke-width="1.2" opacity="0.7"/>
+<line x1="480" y1="272" x2="538" y2="266" stroke="#222228" stroke-width="1.2" opacity="0.7"/>
+<line x1="480" y1="272" x2="438" y2="318" stroke="#222228" stroke-width="1.2" opacity="0.7"/>
+<line x1="480" y1="272" x2="522" y2="318" stroke="#222228" stroke-width="1.2" opacity="0.7"/>
+<circle cx="480" cy="224" r="28" fill="#15121f" stroke="#5b4bbd" stroke-width="1.8"/>
+<rect x="468" y="212" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(472,216)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="480" y="242" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#a78bfa">Finding</text>
+<circle cx="422" cy="266" r="22" fill="#161619" stroke="#2a2a31" stroke-width="1.3"/>
+<text x="422" y="282" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#e9e9ec">Asset</text>
+<circle cx="538" cy="266" r="22" fill="#161619" stroke="#2a2a31" stroke-width="1.3"/>
+<text x="538" y="282" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#e9e9ec">Agent</text>
+<circle cx="438" cy="318" r="22" fill="#161619" stroke="#2a2a31" stroke-width="1.3"/>
+<text x="438" y="334" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#e9e9ec">Tool</text>
+<circle cx="522" cy="318" r="22" fill="#161619" stroke="#2a2a31" stroke-width="1.3"/>
+<text x="522" y="334" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#e9e9ec">Cred</text>
+<rect x="402" y="408" width="48" height="18" rx="6" fill="#121016" stroke="#2a2a31"/><text x="426" y="420" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="700" fill="#a1a1aa">severity</text>
+<rect x="454" y="408" width="48" height="18" rx="6" fill="#121016" stroke="#2a2a31"/><text x="478" y="420" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="700" fill="#a1a1aa">provenance</text>
+<rect x="506" y="408" width="48" height="18" rx="6" fill="#121016" stroke="#2a2a31"/><text x="530" y="420" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="700" fill="#a1a1aa">tenant</text>
+<rect x="584" y="128" width="70" height="42" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="592" y="139" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(596,143)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="622" y="156" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">REST API</text>
+<rect x="662" y="128" width="70" height="42" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="670" y="139" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(674,143)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="700" y="156" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Dashboard</text>
+<rect x="584" y="180" width="70" height="42" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="592" y="191" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(596,195)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="622" y="208" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">MCP srv</text>
+<rect x="662" y="180" width="70" height="42" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="670" y="191" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(674,195)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="700" y="208" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Gateway</text>
+<rect x="584" y="232" width="70" height="42" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="592" y="243" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(596,247)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="622" y="260" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Fleet</text>
+<rect x="662" y="232" width="70" height="42" rx="9" fill="#161619" stroke="#2a2a31"/>
+<rect x="670" y="243" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(674,247)" fill="none" stroke="#9a9aa4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="700" y="260" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Audit</text>
+<rect x="584" y="410" width="160" height="22" rx="7" fill="#121016" stroke="#2a2733"/><text x="664" y="426" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#a1a1aa">fail-closed · RBAC · audit</text>
+<rect x="768" y="128" width="160" height="30" rx="8" fill="#161619" stroke="#f87171" stroke-width="1.1"/><circle cx="778" cy="143" r="3" fill="#f87171"/><text x="786" y="147" font-family="ui-monospace,monospace" font-size="8.5" font-weight="800" fill="#e9e9ec">SARIF</text>
+<rect x="768" y="174" width="160" height="30" rx="8" fill="#161619" stroke="#fbbf24" stroke-width="1.1"/><circle cx="778" cy="189" r="3" fill="#fbbf24"/><text x="786" y="193" font-family="ui-monospace,monospace" font-size="8.5" font-weight="800" fill="#e9e9ec">SBOM</text>
+<rect x="768" y="220" width="160" height="30" rx="8" fill="#161619" stroke="#60a5fa" stroke-width="1.1"/><circle cx="778" cy="235" r="3" fill="#60a5fa"/><text x="786" y="239" font-family="ui-monospace,monospace" font-size="8.5" font-weight="800" fill="#e9e9ec">HTML</text>
+<rect x="768" y="266" width="160" height="30" rx="8" fill="#161619" stroke="#a78bfa" stroke-width="1.1"/><circle cx="778" cy="281" r="3" fill="#a78bfa"/><text x="786" y="285" font-family="ui-monospace,monospace" font-size="8.5" font-weight="800" fill="#e9e9ec">JSON</text>
+<rect x="768" y="312" width="160" height="30" rx="8" fill="#161619" stroke="#34d399" stroke-width="1.1"/><circle cx="778" cy="327" r="3" fill="#34d399"/><text x="786" y="331" font-family="ui-monospace,monospace" font-size="8.5" font-weight="800" fill="#e9e9ec">GATE</text>
+<rect x="768" y="358" width="160" height="30" rx="8" fill="#161619" stroke="#fb7185" stroke-width="1.1"/><circle cx="778" cy="373" r="3" fill="#fb7185"/><text x="786" y="377" font-family="ui-monospace,monospace" font-size="8.5" font-weight="800" fill="#e9e9ec">FIX</text>
+<line x1="200" y1="100" x2="201" y2="100" stroke="#52525b" stroke-width="1.8"/><polygon points="207,100 201,96.5 201,103.5" fill="#52525b"/><text x="204" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">collect</text>
+<line x1="384" y1="100" x2="385" y2="100" stroke="#52525b" stroke-width="1.8"/><polygon points="391,100 385,96.5 385,103.5" fill="#52525b"/><text x="388" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">normalize</text>
+<line x1="568" y1="100" x2="569" y2="100" stroke="#8b5cf6" stroke-width="2.2"/><polygon points="575,100 569,96.5 569,103.5" fill="#8b5cf6"/><text x="572" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#a78bfa">serve</text>
+<line x1="752" y1="100" x2="753" y2="100" stroke="#52525b" stroke-width="1.8"/><polygon points="759,100 753,96.5 753,103.5" fill="#52525b"/><text x="756" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#6b6b75">export</text>
+<rect x="24" y="520" width="912" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="480" y="540" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">read-only · secret redaction · signed evidence · same model everywhere</text>
 </svg>

--- a/docs/images/how-it-works-dark.svg
+++ b/docs/images/how-it-works-dark.svg
@@ -1,134 +1,133 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 650" fill="none" role="img" aria-labelledby="how-title how-desc">
-<title id="how-title">How agent-bom works</title>
-<desc id="how-desc">A visual flow from read-only inputs through the scan engine, into one unified Finding and ContextGraph, served by the control plane, and exported as reports, gates, and runtime controls.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 560" fill="none" role="img" aria-labelledby="hiw-d-title hiw-d-desc">
+<title id="hiw-d-title">How agent-bom works</title>
+<desc id="hiw-d-desc">Read-only intake through scan pipeline into unified Finding and UnifiedGraph, served by control plane, exported as reports and gates.</desc>
 <defs>
-<marker id="hiw-arrow" viewBox="0 0 10 8" refX="8.2" refY="4" markerWidth="7" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
-<style>
-text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif; }
-.title { font-size: 30px; font-weight: 850; } .subtitle { font-size: 13px; font-weight: 500; } .label { font-size: 11px; font-weight: 800; letter-spacing: .15em; }
-.step { font-size: 22px; font-weight: 800; } .chip { font-size: 13px; font-weight: 700; } .badge { font-size: 10.5px; font-weight: 700; } .tiny { font-size: 10px; font-weight: 600; } .node { font-size: 11px; font-weight: 800; }
-.ic { fill: none; stroke: #9a9aa4; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
-.ic-a { fill: none; stroke: #a78bfa; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
-</style></defs>
-<rect x="0" y="0" width="1320" height="650" rx="18" fill="#0a0a0c"/>
-<text x="48" y="52" class="title" fill="#f4f4f5">From inventory to enforceable evidence</text>
-<text x="48" y="78" class="subtitle" fill="#82828c">Read-only collection becomes deterministic matching, enriched findings, graph-backed blast radius, and operational outputs.</text>
-
-<rect x="40" y="118" width="240" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
-<text x="58" y="149" class="label" fill="#a78bfa">READ-ONLY INTAKE</text>
-<rect x="330" y="118" width="230" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
-<text x="348" y="149" class="label" fill="#a78bfa">SCAN ENGINE</text>
-<rect x="610" y="118" width="270" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
-<text x="628" y="149" class="label" fill="#a78bfa">EVIDENCE CORE</text>
-<rect x="930" y="118" width="200" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
-<text x="948" y="149" class="label" fill="#a78bfa">CONTROL PLANE</text>
-<rect x="1170" y="118" width="120" height="392" rx="18" fill="#0f0f13" stroke="#222228"/>
-<text x="1188" y="149" class="label" fill="#a78bfa">OUTPUTS</text>
-
-<!-- intake nodes -->
-<rect x="62" y="165" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="71" y="175" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M77 178h8l4 4v11h-12z M85 178v4h4"/>
-<text x="103" y="191" class="chip" fill="#f4f4f5">Repo</text>
-<rect x="166" y="165" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="175" y="175" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M180 186l4 4 9-10"/>
-<text x="207" y="191" class="chip" fill="#f4f4f5">CI</text>
-<rect x="62" y="229" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="71" y="239" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><circle class="ic" cx="82" cy="247" r="2.6"/><circle class="ic" cx="77" cy="256" r="2.2"/><circle class="ic" cx="87" cy="256" r="2.2"/><path class="ic" d="M80 250l-2 5 M84 250l2 5"/>
-<text x="103" y="255" class="chip" fill="#f4f4f5">MCP</text>
-<rect x="166" y="229" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="175" y="239" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M180 256h12a4 4 0 0 0 .6-7.9 6 6 0 0 0-11.3-1.6A4 4 0 0 0 180 256z"/>
-<text x="207" y="255" class="chip" fill="#f4f4f5">Cloud</text>
-<rect x="62" y="293" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="71" y="303" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><rect class="ic" x="76" y="307" width="12" height="11" rx="2"/><path class="ic" d="M78 316l3-3 2 2 3-3 2 4"/>
-<text x="103" y="319" class="chip" fill="#f4f4f5">Image</text>
-<rect x="166" y="293" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="175" y="303" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M182 306c-4 3-4 13 0 16 M190 306c4 3 4 13 0 16"/>
-<text x="207" y="319" class="chip" fill="#f4f4f5">IaC</text>
-<rect x="62" y="357" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="71" y="367" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M76 370h12v16h-12z M79 375h6 M79 379h6 M79 383h4"/>
-<text x="103" y="383" class="chip" fill="#f4f4f5">SBOM</text>
-<rect x="166" y="357" width="92" height="42" rx="12" fill="#161619" stroke="#2a2a31"/>
-<rect x="175" y="367" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><path class="ic" d="M186 369l6 3v8l-6 3-6-3v-8z M186 369v14 M180 372l12 6"/>
-<text x="207" y="383" class="chip" fill="#f4f4f5">Model</text>
-<rect x="62" y="438" width="46" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="85" y="455" class="badge" fill="#a1a1aa" text-anchor="middle">AWS</text>
-<rect x="114" y="438" width="46" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="137" y="455" class="badge" fill="#a1a1aa" text-anchor="middle">AZ</text>
-<rect x="166" y="438" width="46" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="189" y="455" class="badge" fill="#a1a1aa" text-anchor="middle">GCP</text>
-<rect x="218" y="438" width="46" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="241" y="455" class="badge" fill="#a1a1aa" text-anchor="middle">SNOW</text>
-<text x="160" y="486" class="tiny" fill="#6b6b75" text-anchor="middle">no writes · no secret values</text>
-
-<!-- scan steps -->
-<circle cx="368" cy="183" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="188" class="badge" fill="#a78bfa" text-anchor="middle">1</text>
-<text x="406" y="190" class="step" fill="#f4f4f5">Discover</text>
-<path d="M368 201 C368 210 368 213 368 220" stroke="#3a3a42" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="241" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="246" class="badge" fill="#a78bfa" text-anchor="middle">2</text>
-<text x="406" y="248" class="step" fill="#f4f4f5">Match</text>
-<path d="M368 259 C368 268 368 271 368 278" stroke="#3a3a42" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="299" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="304" class="badge" fill="#a78bfa" text-anchor="middle">3</text>
-<text x="406" y="306" class="step" fill="#f4f4f5">Enrich</text>
-<path d="M368 317 C368 326 368 329 368 336" stroke="#3a3a42" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="357" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="362" class="badge" fill="#a78bfa" text-anchor="middle">4</text>
-<text x="406" y="364" class="step" fill="#f4f4f5">Evaluate</text>
-<path d="M368 375 C368 384 368 387 368 394" stroke="#3a3a42" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="415" r="17" fill="#161619" stroke="#2a2a31" stroke-width="1.6"/><text x="368" y="420" class="badge" fill="#a78bfa" text-anchor="middle">5</text>
-<text x="406" y="422" class="step" fill="#f4f4f5">Normalize</text>
-<rect x="350" y="446" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="388" y="463" class="badge" fill="#a1a1aa" text-anchor="middle">OSV</text>
-<rect x="440" y="446" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="478" y="463" class="badge" fill="#a1a1aa" text-anchor="middle">GHSA</text>
-<rect x="350" y="477" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="388" y="494" class="badge" fill="#a1a1aa" text-anchor="middle">NVD</text>
-<rect x="440" y="477" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="478" y="494" class="badge" fill="#a1a1aa" text-anchor="middle">KEV</text>
-<rect x="350" y="508" width="76" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="388" y="525" class="badge" fill="#a1a1aa" text-anchor="middle">EPSS</text>
-
-<!-- evidence graph -->
-<text x="745" y="178" class="step" fill="#f4f4f5" text-anchor="middle">Finding + ContextGraph</text>
-<line x1="745" y1="256" x2="673" y2="312" stroke="#3a3a42" stroke-width="1.5"/>
-<line x1="745" y1="256" x2="817" y2="312" stroke="#3a3a42" stroke-width="1.5"/>
-<line x1="745" y1="256" x2="703" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
-<line x1="745" y1="256" x2="789" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
-<line x1="673" y1="312" x2="703" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
-<line x1="817" y1="312" x2="789" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
-<line x1="703" y1="372" x2="789" y2="372" stroke="#3a3a42" stroke-width="1.5"/>
-<circle cx="745" cy="256" r="36" fill="#15121f" stroke="#7c5cff" stroke-width="2.4"/><text x="745" y="260" class="node" fill="#c4b5fd" text-anchor="middle">Finding</text>
-<circle cx="673" cy="312" r="33" fill="#161619" stroke="#3a3a42" stroke-width="2"/><text x="673" y="316" class="node" fill="#d4d4d8" text-anchor="middle">Asset</text>
-<circle cx="817" cy="312" r="33" fill="#161619" stroke="#3a3a42" stroke-width="2"/><text x="817" y="316" class="node" fill="#d4d4d8" text-anchor="middle">Agent</text>
-<circle cx="703" cy="372" r="31" fill="#161619" stroke="#3a3a42" stroke-width="2"/><text x="703" y="376" class="node" fill="#d4d4d8" text-anchor="middle">Tool</text>
-<circle cx="789" cy="372" r="31" fill="#161619" stroke="#3a3a42" stroke-width="2"/><text x="789" y="376" class="node" fill="#d4d4d8" text-anchor="middle">Cred</text>
-<rect x="650" y="410" width="84" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="692" y="427" class="badge" fill="#a1a1aa" text-anchor="middle">severity</text>
-<rect x="746" y="410" width="106" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="799" y="427" class="badge" fill="#a1a1aa" text-anchor="middle">provenance</text>
-<rect x="696" y="446" width="108" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="750" y="463" class="badge" fill="#a1a1aa" text-anchor="middle">tenant scope</text>
-<text x="745" y="490" class="tiny" fill="#6b6b75" text-anchor="middle">one model across scan, cloud, runtime, and imports</text>
-
-<!-- control plane rows -->
-<rect x="958" y="165" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
-<path class="ic" d="M974 175l-4 7 4 7 M982 175l4 7-4 7"/><text x="1000" y="189" class="chip" fill="#f4f4f5">API</text>
-<rect x="958" y="215" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect class="ic" x="970" y="226" width="14" height="11" rx="2"/><path class="ic" d="M970 230h14"/><text x="1000" y="239" class="chip" fill="#f4f4f5">UI</text>
-<rect x="958" y="265" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
-<circle class="ic" cx="977" cy="280" r="2.4"/><circle class="ic" cx="973" cy="288" r="2"/><circle class="ic" cx="981" cy="288" r="2"/><path class="ic" d="M975.5 282l-2 5 M978.5 282l2 5"/><text x="1000" y="289" class="chip" fill="#f4f4f5">MCP</text>
-<rect x="958" y="315" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
-<path class="ic" d="M977 326l6 2v4c0 4-2.6 6-6 7-3.4-1-6-3-6-7v-4z M974 333l2 2 3.5-4"/><text x="1000" y="339" class="chip" fill="#f4f4f5">Gate</text>
-<rect x="958" y="365" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect class="ic" x="971" y="377" width="5" height="5" rx="1.3"/><rect class="ic" x="979" y="377" width="5" height="5" rx="1.3"/><rect class="ic" x="971" y="385" width="5" height="5" rx="1.3"/><rect class="ic" x="979" y="385" width="5" height="5" rx="1.3"/><text x="1000" y="389" class="chip" fill="#f4f4f5">Work</text>
-<rect x="958" y="415" width="144" height="38" rx="11" fill="#161619" stroke="#2a2a31"/>
-<path class="ic" d="M973 427h10v12h-10z M976 427v-2h4v2 M975 432l1.5 1.5 3-3"/><text x="1000" y="439" class="chip" fill="#f4f4f5">Audit</text>
-<text x="1030" y="486" class="tiny" fill="#6b6b75" text-anchor="middle">fail-closed auth · RBAC · scopes · audit</text>
-
-<!-- outputs -->
-<rect x="1195" y="165" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="182" class="badge" fill="#a1a1aa" text-anchor="middle">SARIF</text>
-<rect x="1195" y="210" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="227" class="badge" fill="#a1a1aa" text-anchor="middle">SBOM</text>
-<rect x="1195" y="255" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="272" class="badge" fill="#a1a1aa" text-anchor="middle">HTML</text>
-<rect x="1195" y="300" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="317" class="badge" fill="#a1a1aa" text-anchor="middle">JSON</text>
-<rect x="1195" y="345" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="362" class="badge" fill="#a1a1aa" text-anchor="middle">POSTURE</text>
-<rect x="1195" y="390" width="70" height="26" rx="9" fill="#161619" stroke="#2a2a31"/><text x="1230" y="407" class="badge" fill="#a1a1aa" text-anchor="middle">FIX</text>
-<text x="1230" y="452" class="tiny" fill="#6b6b75" text-anchor="middle">reports</text>
-<text x="1230" y="474" class="tiny" fill="#6b6b75" text-anchor="middle">gates</text>
-<text x="1230" y="496" class="tiny" fill="#6b6b75" text-anchor="middle">runtime</text>
-
-<!-- flow arrows -->
-<path d="M280 314 C302 314 308 314 330 314" stroke="#52525b" stroke-width="2.2" fill="none" marker-end="url(#hiw-arrow)" stroke-linecap="round"/><text x="305" y="302" class="tiny" fill="#6b6b75" text-anchor="middle">collect</text>
-<path d="M560 314 C582 314 588 314 610 314" stroke="#52525b" stroke-width="2.2" fill="none" marker-end="url(#hiw-arrow)" stroke-linecap="round"/><text x="585" y="302" class="tiny" fill="#6b6b75" text-anchor="middle">canonicalize</text>
-<path d="M880 314 C902 314 908 314 930 314" stroke="#8b5cf6" stroke-width="2.4" fill="none" marker-end="url(#hiw-arrow)" stroke-linecap="round"/><text x="905" y="302" class="tiny" fill="#a78bfa" text-anchor="middle">serve</text>
-<path d="M1130 314 C1148 314 1152 314 1170 314" stroke="#52525b" stroke-width="2.2" fill="none" marker-end="url(#hiw-arrow)" stroke-linecap="round"/><text x="1150" y="302" class="tiny" fill="#6b6b75" text-anchor="middle">export</text>
-
-<rect x="40" y="548" width="1250" height="46" rx="14" fill="#0c1a14" stroke="#1f4438"/>
-<text x="66" y="577" class="tiny" fill="#4ade80" font-weight="800">Trust boundary:</text>
-<text x="180" y="577" class="tiny" fill="#a1a1aa">default-off cloud connectors · read-only permissions · secret redaction · signed evidence · same model everywhere</text>
+<marker id="hiw" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#52525b"/></marker>
+<marker id="hiw-a" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
+<linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#a78bfa" stop-opacity="0.35"/><stop offset="100%" stop-color="#a78bfa" stop-opacity="0"/></linearGradient>
+</defs>
+<rect width="1200" height="560" rx="16" fill="#0a0a0c"/>
+<text x="36" y="44" font-family="Inter,system-ui,sans-serif" font-size="24" font-weight="850" fill="#f4f4f5">From inventory to enforceable evidence</text>
+<text x="36" y="66" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="500" fill="#71717a">One read-only pipeline · one Finding + UnifiedGraph · CLI · API · UI · MCP · runtime gates</text>
+<rect x="28" y="88" width="210" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
+<rect x="28" y="88" width="210" height="36" rx="10" fill="#1e3a5f"/><rect x="28" y="110" width="210" height="14" fill="#1e3a5f"/><text x="42" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">INTAKE</text><text x="226" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">read-only</text>
+<rect x="258" y="88" width="188" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
+<rect x="258" y="88" width="188" height="36" rx="10" fill="#78350f"/><rect x="258" y="110" width="188" height="14" fill="#78350f"/><text x="272" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#fde68a">SCAN</text><text x="434" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#fbbf24" opacity="0.85">6 steps</text>
+<rect x="466" y="88" width="248" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
+<rect x="466" y="88" width="248" height="36" rx="10" fill="#5b21b6"/><rect x="466" y="110" width="248" height="14" fill="#5b21b6"/><text x="480" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#ddd6fe">EVIDENCE</text><text x="702" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a78bfa" opacity="0.85">one model</text>
+<rect x="734" y="88" width="188" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
+<rect x="734" y="88" width="188" height="36" rx="10" fill="#065f46"/><rect x="734" y="110" width="188" height="14" fill="#065f46"/><text x="748" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#a7f3d0">CONTROL</text><text x="910" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#34d399" opacity="0.85">self-hosted</text>
+<rect x="942" y="88" width="108" height="400" rx="14" fill="#0f0f13" stroke="#222228"/>
+<rect x="942" y="88" width="108" height="36" rx="10" fill="#3f3f46"/><rect x="942" y="110" width="108" height="14" fill="#3f3f46"/><text x="956" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#d4d4d8">OUT</text><text x="1038" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a1a1aa" opacity="0.85">artifacts</text>
+<rect x="44" y="138" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="52" y="147" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(57,152)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h8l3 3v11H4z M12 6v3h3"/></g>
+<text x="86" y="166" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Repo</text>
+<rect x="142" y="138" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="150" y="147" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(155,152)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 14l4 4 10-11"/></g>
+<text x="184" y="166" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">CI</text>
+<rect x="44" y="192" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="52" y="201" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(57,206)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="86" y="220" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">MCP</text>
+<rect x="142" y="192" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="150" y="201" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(155,206)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="184" y="220" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Cloud</text>
+<rect x="44" y="246" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="52" y="255" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(57,260)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
+<text x="86" y="274" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Image</text>
+<rect x="142" y="246" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="150" y="255" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(155,260)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="184" y="274" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">IaC</text>
+<rect x="44" y="300" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="52" y="309" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(57,314)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="86" y="328" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">SBOM</text>
+<rect x="142" y="300" width="88" height="44" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="150" y="309" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(155,314)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="184" y="328" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Model</text>
+<rect x="44" y="360" width="46" height="34" rx="9" fill="#161619" stroke="#2a2a31"/><g transform="translate(55,366) scale(0.9)"><path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/></g><text x="67" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#ff9900">AWS</text><rect x="96" y="360" width="46" height="34" rx="9" fill="#161619" stroke="#2a2a31"/><g transform="translate(107,366) scale(0.9)"><path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/></g><text x="119" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#0078d4">Azure</text><rect x="148" y="360" width="46" height="34" rx="9" fill="#161619" stroke="#2a2a31"/><g transform="translate(159,366) scale(0.9)"><circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/></g><text x="171" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#4285f4">GCP</text><rect x="200" y="360" width="46" height="34" rx="9" fill="#161619" stroke="#2a2a31"/><g transform="translate(211,366) scale(0.9)"><path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/></g><text x="223" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#29b5e8">Snow</text>
+<rect x="44" y="408" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(49,413)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="78" y="426" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#6b6b75">no writes · no secret values</text>
+<circle cx="278" cy="146" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="150" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">1</text>
+<rect x="304" y="132" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,137)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="6"/><path d="M15 15l4 4"/></g>
+<text x="340" y="149" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Discover</text>
+<path d="M278 160 V170" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="198" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="202" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">2</text>
+<rect x="304" y="184" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,189)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="340" y="201" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Extract</text>
+<path d="M278 212 V222" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="250" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="254" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">3</text>
+<rect x="304" y="236" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,241)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="340" y="253" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Scan</text>
+<path d="M278 264 V274" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="302" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="306" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">4</text>
+<rect x="304" y="288" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,293)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="340" y="305" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Enrich</text>
+<path d="M278 316 V326" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="354" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">5</text>
+<rect x="304" y="340" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,345)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="340" y="357" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Analyze</text>
+<path d="M278 368 V378" stroke="#222228" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="406" r="14" fill="#161619" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="410" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">6</text>
+<rect x="304" y="392" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(309,397)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="340" y="409" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Report</text>
+<rect x="272" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="287" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">OSV</text>
+<rect x="306" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="321" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">GHSA</text>
+<rect x="340" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="355" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">NVD</text>
+<rect x="374" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="389" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">KEV</text>
+<rect x="408" y="448" width="30" height="20" rx="6" fill="#121016" stroke="#2a2a31"/><text x="423" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">EPSS</text>
+<circle cx="590" cy="268" r="78" fill="url(#core-glow)"/>
+<line x1="590" y1="268" x2="518" y2="258" stroke="#222228" stroke-width="1.4" opacity="0.75"/>
+<line x1="590" y1="268" x2="662" y2="258" stroke="#222228" stroke-width="1.4" opacity="0.75"/>
+<line x1="590" y1="268" x2="538" y2="326" stroke="#222228" stroke-width="1.4" opacity="0.75"/>
+<line x1="590" y1="268" x2="642" y2="326" stroke="#222228" stroke-width="1.4" opacity="0.75"/>
+<circle cx="590" cy="210" r="34" fill="#15121f" stroke="#5b4bbd" stroke-width="2"/>
+<rect x="577" y="197" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(582,202)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="590" y="232" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" fill="#a78bfa">Finding</text>
+<circle cx="518" cy="258" r="28" fill="#161619" stroke="#2a2a31" stroke-width="1.5"/>
+<text x="518" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#e9e9ec">Asset</text>
+<circle cx="662" cy="258" r="28" fill="#161619" stroke="#2a2a31" stroke-width="1.5"/>
+<text x="662" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#e9e9ec">Agent</text>
+<circle cx="538" cy="326" r="28" fill="#161619" stroke="#2a2a31" stroke-width="1.5"/>
+<text x="538" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#e9e9ec">Tool</text>
+<circle cx="642" cy="326" r="28" fill="#161619" stroke="#2a2a31" stroke-width="1.5"/>
+<text x="642" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#e9e9ec">Cred</text>
+<rect x="494" y="390" width="64" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="526" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#a1a1aa">severity</text>
+<rect x="566" y="390" width="64" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="598" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#a1a1aa">provenance</text>
+<rect x="638" y="390" width="64" height="22" rx="7" fill="#121016" stroke="#2a2a31"/><text x="670" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#a1a1aa">tenant</text>
+<rect x="748" y="136" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="756" y="149" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(761,154)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="788" y="168" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">REST API</text>
+<rect x="834" y="136" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="842" y="149" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(847,154)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="874" y="168" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Dashboard</text>
+<rect x="748" y="198" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="756" y="211" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(761,216)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="788" y="230" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">MCP srv</text>
+<rect x="834" y="198" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="842" y="211" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(847,216)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="874" y="230" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Gateway</text>
+<rect x="748" y="260" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="756" y="273" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(761,278)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="788" y="292" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Fleet</text>
+<rect x="834" y="260" width="78" height="52" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="842" y="273" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(847,278)" fill="none" stroke="#9a9aa4" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="874" y="292" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#e9e9ec">Audit</text>
+<rect x="748" y="340" width="162" height="28" rx="8" fill="#121016" stroke="#2a2733"/><text x="829" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a1a1aa">fail-closed · RBAC · audit</text>
+<rect x="956" y="136" width="80" height="36" rx="10" fill="#161619" stroke="#f87171" stroke-width="1.2"/><circle cx="970" cy="154" r="4" fill="#f87171" opacity="0.85"/><text x="982" y="158" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">SARIF</text>
+<rect x="956" y="188" width="80" height="36" rx="10" fill="#161619" stroke="#fbbf24" stroke-width="1.2"/><circle cx="970" cy="206" r="4" fill="#fbbf24" opacity="0.85"/><text x="982" y="210" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">SBOM</text>
+<rect x="956" y="240" width="80" height="36" rx="10" fill="#161619" stroke="#60a5fa" stroke-width="1.2"/><circle cx="970" cy="258" r="4" fill="#60a5fa" opacity="0.85"/><text x="982" y="262" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">HTML</text>
+<rect x="956" y="292" width="80" height="36" rx="10" fill="#161619" stroke="#a78bfa" stroke-width="1.2"/><circle cx="970" cy="310" r="4" fill="#a78bfa" opacity="0.85"/><text x="982" y="314" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">JSON</text>
+<rect x="956" y="344" width="80" height="36" rx="10" fill="#161619" stroke="#34d399" stroke-width="1.2"/><circle cx="970" cy="362" r="4" fill="#34d399" opacity="0.85"/><text x="982" y="366" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">GATE</text>
+<rect x="956" y="396" width="80" height="36" rx="10" fill="#161619" stroke="#fb7185" stroke-width="1.2"/><circle cx="970" cy="414" r="4" fill="#fb7185" opacity="0.85"/><text x="982" y="418" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#e9e9ec">FIX</text>
+<text x="996" y="468" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#6b6b75">reports · gates · runtime</text>
+<line x1="238" y1="288" x2="256" y2="288" stroke="#52525b" stroke-width="2" marker-end="url(#hiw)"/><text x="247" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">collect</text>
+<line x1="446" y1="288" x2="464" y2="288" stroke="#52525b" stroke-width="2" marker-end="url(#hiw)"/><text x="455" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">normalize</text>
+<line x1="714" y1="288" x2="732" y2="288" stroke="#8b5cf6" stroke-width="2.4" marker-end="url(#hiw-a)"/><text x="723" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">serve</text>
+<line x1="922" y1="288" x2="940" y2="288" stroke="#52525b" stroke-width="2" marker-end="url(#hiw)"/><text x="931" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">export</text>
+<rect x="28" y="508" width="1144" height="36" rx="10" fill="#0c1a14" stroke="#1f4438"/><text x="52" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#4ade80">TRUST</text><text x="100" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#a1a1aa">read-only connectors · secret redaction · signed evidence · same model everywhere</text>
 </svg>

--- a/docs/images/how-it-works-light.svg
+++ b/docs/images/how-it-works-light.svg
@@ -1,133 +1,132 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 560" fill="none" role="img" aria-labelledby="hiw-l-title hiw-l-desc">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 580" fill="none" role="img" aria-labelledby="hiw-l-title hiw-l-desc">
 <title id="hiw-l-title">How agent-bom works</title>
-<desc id="hiw-l-desc">Read-only intake through scan pipeline into unified Finding and UnifiedGraph, served by control plane, exported as reports and gates.</desc>
+<desc id="hiw-l-desc">Read-only intake through scan pipeline into unified Finding and UnifiedGraph.</desc>
 <defs>
-<marker id="hiw" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
-<marker id="hiw-a" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
-<linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#7c3aed" stop-opacity="0.35"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0"/></linearGradient>
+<marker id="hiw" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
+<marker id="hiw-a" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
+<linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#7c3aed" stop-opacity="0.28"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0"/></linearGradient>
 </defs>
-<rect width="1200" height="560" rx="16" fill="#ffffff"/>
-<text x="36" y="44" font-family="Inter,system-ui,sans-serif" font-size="24" font-weight="850" fill="#18181b">From inventory to enforceable evidence</text>
-<text x="36" y="66" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="500" fill="#71717a">One read-only pipeline · one Finding + UnifiedGraph · CLI · API · UI · MCP · runtime gates</text>
-<rect x="28" y="88" width="210" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
-<rect x="28" y="88" width="210" height="36" rx="10" fill="#1e3a5f"/><rect x="28" y="110" width="210" height="14" fill="#1e3a5f"/><text x="42" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">INTAKE</text><text x="226" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">read-only</text>
-<rect x="258" y="88" width="188" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
-<rect x="258" y="88" width="188" height="36" rx="10" fill="#78350f"/><rect x="258" y="110" width="188" height="14" fill="#78350f"/><text x="272" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#fde68a">SCAN</text><text x="434" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#fbbf24" opacity="0.85">6 steps</text>
-<rect x="466" y="88" width="248" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
-<rect x="466" y="88" width="248" height="36" rx="10" fill="#5b21b6"/><rect x="466" y="110" width="248" height="14" fill="#5b21b6"/><text x="480" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#ddd6fe">EVIDENCE</text><text x="702" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a78bfa" opacity="0.85">one model</text>
-<rect x="734" y="88" width="188" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
-<rect x="734" y="88" width="188" height="36" rx="10" fill="#065f46"/><rect x="734" y="110" width="188" height="14" fill="#065f46"/><text x="748" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#a7f3d0">CONTROL</text><text x="910" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#34d399" opacity="0.85">self-hosted</text>
-<rect x="942" y="88" width="108" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
-<rect x="942" y="88" width="108" height="36" rx="10" fill="#3f3f46"/><rect x="942" y="110" width="108" height="14" fill="#3f3f46"/><text x="956" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#d4d4d8">OUT</text><text x="1038" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a1a1aa" opacity="0.85">artifacts</text>
-<rect x="44" y="138" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="52" y="147" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(57,152)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h8l3 3v11H4z M12 6v3h3"/></g>
-<text x="86" y="166" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Repo</text>
-<rect x="142" y="138" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="150" y="147" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(155,152)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 14l4 4 10-11"/></g>
-<text x="184" y="166" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">CI</text>
-<rect x="44" y="192" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="52" y="201" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(57,206)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="86" y="220" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">MCP</text>
-<rect x="142" y="192" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="150" y="201" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(155,206)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="184" y="220" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Cloud</text>
-<rect x="44" y="246" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="52" y="255" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(57,260)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
-<text x="86" y="274" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Image</text>
-<rect x="142" y="246" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="150" y="255" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(155,260)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="184" y="274" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">IaC</text>
-<rect x="44" y="300" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="52" y="309" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(57,314)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="86" y="328" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">SBOM</text>
-<rect x="142" y="300" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="150" y="309" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(155,314)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="184" y="328" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Model</text>
-<rect x="44" y="360" width="46" height="34" rx="9" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(55,366) scale(0.9)"><path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/></g><text x="67" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#ff9900">AWS</text><rect x="96" y="360" width="46" height="34" rx="9" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(107,366) scale(0.9)"><path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/></g><text x="119" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#0078d4">Azure</text><rect x="148" y="360" width="46" height="34" rx="9" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(159,366) scale(0.9)"><circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/></g><text x="171" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#4285f4">GCP</text><rect x="200" y="360" width="46" height="34" rx="9" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(211,366) scale(0.9)"><path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/></g><text x="223" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#29b5e8">Snow</text>
-<rect x="44" y="408" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(49,413)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
-<text x="78" y="426" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#9a9aa4">no writes · no secret values</text>
-<circle cx="278" cy="146" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
-<text x="278" y="150" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">1</text>
-<rect x="304" y="132" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,137)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="6"/><path d="M15 15l4 4"/></g>
-<text x="340" y="149" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Discover</text>
-<path d="M278 160 V170" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
-<circle cx="278" cy="198" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
-<text x="278" y="202" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">2</text>
-<rect x="304" y="184" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,189)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="340" y="201" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Extract</text>
-<path d="M278 212 V222" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
-<circle cx="278" cy="250" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
-<text x="278" y="254" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">3</text>
-<rect x="304" y="236" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,241)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="340" y="253" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Scan</text>
-<path d="M278 264 V274" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
-<circle cx="278" cy="302" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
-<text x="278" y="306" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">4</text>
-<rect x="304" y="288" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,293)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="340" y="305" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Enrich</text>
-<path d="M278 316 V326" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
-<circle cx="278" cy="354" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
-<text x="278" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">5</text>
-<rect x="304" y="340" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,345)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="340" y="357" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Analyze</text>
-<path d="M278 368 V378" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
-<circle cx="278" cy="406" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
-<text x="278" y="410" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">6</text>
-<rect x="304" y="392" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,397)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="340" y="409" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Report</text>
-<rect x="272" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="287" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">OSV</text>
-<rect x="306" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="321" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">GHSA</text>
-<rect x="340" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="355" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">NVD</text>
-<rect x="374" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="389" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">KEV</text>
-<rect x="408" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="423" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">EPSS</text>
-<circle cx="590" cy="268" r="78" fill="url(#core-glow)"/>
-<line x1="590" y1="268" x2="518" y2="258" stroke="#ececf0" stroke-width="1.4" opacity="0.75"/>
-<line x1="590" y1="268" x2="662" y2="258" stroke="#ececf0" stroke-width="1.4" opacity="0.75"/>
-<line x1="590" y1="268" x2="538" y2="326" stroke="#ececf0" stroke-width="1.4" opacity="0.75"/>
-<line x1="590" y1="268" x2="642" y2="326" stroke="#ececf0" stroke-width="1.4" opacity="0.75"/>
-<circle cx="590" cy="210" r="34" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="2"/>
-<rect x="577" y="197" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(582,202)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
-<text x="590" y="232" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" fill="#7c3aed">Finding</text>
-<circle cx="518" cy="258" r="28" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.5"/>
-<text x="518" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#18181b">Asset</text>
-<circle cx="662" cy="258" r="28" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.5"/>
-<text x="662" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#18181b">Agent</text>
-<circle cx="538" cy="326" r="28" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.5"/>
-<text x="538" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#18181b">Tool</text>
-<circle cx="642" cy="326" r="28" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.5"/>
-<text x="642" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#18181b">Cred</text>
-<rect x="494" y="390" width="64" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="526" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#52525b">severity</text>
-<rect x="566" y="390" width="64" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="598" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#52525b">provenance</text>
-<rect x="638" y="390" width="64" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="670" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#52525b">tenant</text>
-<rect x="748" y="136" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="756" y="149" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(761,154)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="788" y="168" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">REST API</text>
-<rect x="834" y="136" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="842" y="149" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(847,154)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="874" y="168" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Dashboard</text>
-<rect x="748" y="198" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="756" y="211" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(761,216)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="788" y="230" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">MCP srv</text>
-<rect x="834" y="198" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="842" y="211" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(847,216)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="874" y="230" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Gateway</text>
-<rect x="748" y="260" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="756" y="273" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(761,278)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="788" y="292" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Fleet</text>
-<rect x="834" y="260" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="842" y="273" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(847,278)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="874" y="292" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Audit</text>
-<rect x="748" y="340" width="162" height="28" rx="8" fill="#f4f4f6" stroke="#e4e4e7"/><text x="829" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#52525b">fail-closed · RBAC · audit</text>
-<rect x="956" y="136" width="80" height="36" rx="10" fill="#ffffff" stroke="#f87171" stroke-width="1.2"/><circle cx="970" cy="154" r="4" fill="#f87171" opacity="0.85"/><text x="982" y="158" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">SARIF</text>
-<rect x="956" y="188" width="80" height="36" rx="10" fill="#ffffff" stroke="#fbbf24" stroke-width="1.2"/><circle cx="970" cy="206" r="4" fill="#fbbf24" opacity="0.85"/><text x="982" y="210" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">SBOM</text>
-<rect x="956" y="240" width="80" height="36" rx="10" fill="#ffffff" stroke="#60a5fa" stroke-width="1.2"/><circle cx="970" cy="258" r="4" fill="#60a5fa" opacity="0.85"/><text x="982" y="262" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">HTML</text>
-<rect x="956" y="292" width="80" height="36" rx="10" fill="#ffffff" stroke="#a78bfa" stroke-width="1.2"/><circle cx="970" cy="310" r="4" fill="#a78bfa" opacity="0.85"/><text x="982" y="314" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">JSON</text>
-<rect x="956" y="344" width="80" height="36" rx="10" fill="#ffffff" stroke="#34d399" stroke-width="1.2"/><circle cx="970" cy="362" r="4" fill="#34d399" opacity="0.85"/><text x="982" y="366" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">GATE</text>
-<rect x="956" y="396" width="80" height="36" rx="10" fill="#ffffff" stroke="#fb7185" stroke-width="1.2"/><circle cx="970" cy="414" r="4" fill="#fb7185" opacity="0.85"/><text x="982" y="418" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">FIX</text>
-<text x="996" y="468" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#9a9aa4">reports · gates · runtime</text>
-<line x1="238" y1="288" x2="256" y2="288" stroke="#a1a1aa" stroke-width="2" marker-end="url(#hiw)"/><text x="247" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">collect</text>
-<line x1="446" y1="288" x2="464" y2="288" stroke="#a1a1aa" stroke-width="2" marker-end="url(#hiw)"/><text x="455" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">normalize</text>
-<line x1="714" y1="288" x2="732" y2="288" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#hiw-a)"/><text x="723" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">serve</text>
-<line x1="922" y1="288" x2="940" y2="288" stroke="#a1a1aa" stroke-width="2" marker-end="url(#hiw)"/><text x="931" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">export</text>
-<rect x="28" y="508" width="1144" height="36" rx="10" fill="#ecfdf5" stroke="#bbf7d0"/><text x="52" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#15803d">TRUST</text><text x="100" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#52525b">read-only connectors · secret redaction · signed evidence · same model everywhere</text>
+<rect width="1180" height="580" rx="14" fill="#ffffff"/>
+<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="#18181b">From inventory to enforceable evidence</text>
+<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="#71717a">One read-only pipeline · one Finding + UnifiedGraph · CLI · API · UI · MCP</text>
+<rect x="24" y="84" width="200" height="380" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="24" y="84" width="200" height="32" rx="8" fill="#1e3a5f"/><text x="36" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">INTAKE</text><text x="214" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">read-only</text>
+<rect x="236" y="84" width="176" height="380" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="236" y="84" width="176" height="32" rx="8" fill="#78350f"/><text x="248" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#fde68a">SCAN</text><text x="402" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#fbbf24" opacity="0.9">6 steps</text>
+<rect x="424" y="84" width="232" height="380" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="424" y="84" width="232" height="32" rx="8" fill="#5b21b6"/><text x="436" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#ddd6fe">EVIDENCE</text><text x="646" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a78bfa" opacity="0.9">one model</text>
+<rect x="668" y="84" width="176" height="380" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="668" y="84" width="176" height="32" rx="8" fill="#065f46"/><text x="680" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#a7f3d0">CONTROL</text><text x="834" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#34d399" opacity="0.9">self-hosted</text>
+<rect x="856" y="84" width="108" height="380" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="856" y="84" width="108" height="32" rx="8" fill="#3f3f46"/><text x="868" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#d4d4d8">OUT</text><text x="954" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a1a1aa" opacity="0.9">artifacts</text>
+<rect x="36" y="128" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="42" y="136" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,140)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h8l3 3v11H4z M12 6v3h3"/></g>
+<text x="72" y="153" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Repo</text>
+<rect x="130" y="128" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="136" y="136" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(140,140)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 14l4 4 10-11"/></g>
+<text x="166" y="153" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">CI</text>
+<rect x="36" y="178" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="42" y="186" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,190)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="72" y="203" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">MCP</text>
+<rect x="130" y="178" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="136" y="186" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(140,190)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="166" y="203" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Cloud</text>
+<rect x="36" y="228" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="42" y="236" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,240)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
+<text x="72" y="253" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Image</text>
+<rect x="130" y="228" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="136" y="236" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(140,240)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="166" y="253" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">IaC</text>
+<rect x="36" y="278" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="42" y="286" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,290)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="72" y="303" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">SBOM</text>
+<rect x="130" y="278" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="136" y="286" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(140,290)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="166" y="303" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Model</text>
+<rect x="36" y="336" width="42" height="30" rx="8" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(45,341) scale(0.85)"><path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/></g><text x="57" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#ff9900">AWS</text><rect x="84" y="336" width="42" height="30" rx="8" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(93,341) scale(0.85)"><path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/></g><text x="105" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#0078d4">Azure</text><rect x="132" y="336" width="42" height="30" rx="8" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(141,341) scale(0.85)"><circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/></g><text x="153" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#4285f4">GCP</text><rect x="180" y="336" width="42" height="30" rx="8" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(189,341) scale(0.85)"><path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/></g><text x="201" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#29b5e8">Snow</text>
+<rect x="36" y="376" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(40,380)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="64" y="392" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#9a9aa4">no writes · no secret values</text>
+<circle cx="248" cy="140" r="11" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="144" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">1</text>
+<rect x="268" y="128" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,132)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="6"/><path d="M15 15l4 4"/></g>
+<text x="298" y="144" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Discover</text>
+<path d="M248 152 V160" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="188" r="11" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="192" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">2</text>
+<rect x="268" y="176" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,180)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="298" y="192" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Extract</text>
+<path d="M248 200 V208" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="236" r="11" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="240" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">3</text>
+<rect x="268" y="224" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,228)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="298" y="240" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Scan</text>
+<path d="M248 248 V256" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="284" r="11" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="288" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">4</text>
+<rect x="268" y="272" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,276)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="298" y="288" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Enrich</text>
+<path d="M248 296 V304" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="332" r="11" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="336" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">5</text>
+<rect x="268" y="320" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,324)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="298" y="336" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Analyze</text>
+<path d="M248 344 V352" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="380" r="11" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="384" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">6</text>
+<rect x="268" y="368" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,372)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="298" y="384" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Report</text>
+<rect x="242" y="430" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="255" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">OSV</text>
+<rect x="272" y="430" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="285" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">GHSA</text>
+<rect x="302" y="430" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="315" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">NVD</text>
+<rect x="332" y="430" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="345" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">KEV</text>
+<rect x="362" y="430" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="375" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">EPSS</text>
+<circle cx="540" cy="284" r="62" fill="url(#core-glow)"/>
+<line x1="540" y1="284" x2="482" y2="278" stroke="#ececf0" stroke-width="1.2" opacity="0.7"/>
+<line x1="540" y1="284" x2="598" y2="278" stroke="#ececf0" stroke-width="1.2" opacity="0.7"/>
+<line x1="540" y1="284" x2="498" y2="330" stroke="#ececf0" stroke-width="1.2" opacity="0.7"/>
+<line x1="540" y1="284" x2="582" y2="330" stroke="#ececf0" stroke-width="1.2" opacity="0.7"/>
+<circle cx="540" cy="236" r="28" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.8"/>
+<rect x="528" y="224" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(532,228)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="540" y="254" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#7c3aed">Finding</text>
+<circle cx="482" cy="278" r="22" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.3"/>
+<text x="482" y="294" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#18181b">Asset</text>
+<circle cx="598" cy="278" r="22" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.3"/>
+<text x="598" y="294" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#18181b">Agent</text>
+<circle cx="498" cy="330" r="22" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.3"/>
+<text x="498" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#18181b">Tool</text>
+<circle cx="582" cy="330" r="22" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.3"/>
+<text x="582" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#18181b">Cred</text>
+<rect x="438" y="424" width="60" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="468" y="437" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#52525b">severity</text>
+<rect x="506" y="424" width="60" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="536" y="437" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#52525b">provenance</text>
+<rect x="574" y="424" width="60" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="604" y="437" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#52525b">tenant</text>
+<rect x="680" y="128" width="72" height="46" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="688" y="139" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(692,143)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="718" y="156" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">REST API</text>
+<rect x="760" y="128" width="72" height="46" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="768" y="139" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(772,143)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="798" y="156" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Dashboard</text>
+<rect x="680" y="184" width="72" height="46" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="688" y="195" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(692,199)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="718" y="212" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">MCP srv</text>
+<rect x="760" y="184" width="72" height="46" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="768" y="195" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(772,199)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="798" y="212" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Gateway</text>
+<rect x="680" y="240" width="72" height="46" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="688" y="251" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(692,255)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="718" y="268" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Fleet</text>
+<rect x="760" y="240" width="72" height="46" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="768" y="251" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(772,255)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="798" y="268" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Audit</text>
+<rect x="680" y="426" width="152" height="24" rx="7" fill="#f4f4f6" stroke="#e4e4e7"/><text x="756" y="442" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#52525b">fail-closed · RBAC · audit</text>
+<rect x="868" y="128" width="76" height="32" rx="8" fill="#ffffff" stroke="#f87171" stroke-width="1.1"/><circle cx="880" cy="144" r="3.5" fill="#f87171"/><text x="890" y="148" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#18181b">SARIF</text>
+<rect x="868" y="176" width="76" height="32" rx="8" fill="#ffffff" stroke="#fbbf24" stroke-width="1.1"/><circle cx="880" cy="192" r="3.5" fill="#fbbf24"/><text x="890" y="196" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#18181b">SBOM</text>
+<rect x="868" y="224" width="76" height="32" rx="8" fill="#ffffff" stroke="#60a5fa" stroke-width="1.1"/><circle cx="880" cy="240" r="3.5" fill="#60a5fa"/><text x="890" y="244" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#18181b">HTML</text>
+<rect x="868" y="272" width="76" height="32" rx="8" fill="#ffffff" stroke="#a78bfa" stroke-width="1.1"/><circle cx="880" cy="288" r="3.5" fill="#a78bfa"/><text x="890" y="292" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#18181b">JSON</text>
+<rect x="868" y="320" width="76" height="32" rx="8" fill="#ffffff" stroke="#34d399" stroke-width="1.1"/><circle cx="880" cy="336" r="3.5" fill="#34d399"/><text x="890" y="340" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#18181b">GATE</text>
+<rect x="868" y="368" width="76" height="32" rx="8" fill="#ffffff" stroke="#fb7185" stroke-width="1.1"/><circle cx="880" cy="384" r="3.5" fill="#fb7185"/><text x="890" y="388" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#18181b">FIX</text>
+<line x1="224" y1="100" x2="236" y2="100" stroke="#a1a1aa" stroke-width="1.8" marker-end="url(#hiw)"/><text x="230" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">collect</text>
+<line x1="412" y1="100" x2="424" y2="100" stroke="#a1a1aa" stroke-width="1.8" marker-end="url(#hiw)"/><text x="418" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">normalize</text>
+<line x1="656" y1="100" x2="668" y2="100" stroke="#7c3aed" stroke-width="2.2" marker-end="url(#hiw-a)"/><text x="662" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#7c3aed">serve</text>
+<line x1="844" y1="100" x2="856" y2="100" stroke="#a1a1aa" stroke-width="1.8" marker-end="url(#hiw)"/><text x="850" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">export</text>
+<rect x="24" y="536" width="1132" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="44" y="554" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="800" fill="#15803d">TRUST</text><text x="88" y="554" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#52525b">read-only · secret redaction · signed evidence · same model everywhere</text>
 </svg>

--- a/docs/images/how-it-works-light.svg
+++ b/docs/images/how-it-works-light.svg
@@ -1,128 +1,133 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1320 650" fill="none" role="img" aria-labelledby="howl-title howl-desc">
-<title id="howl-title">How agent-bom works</title>
-<desc id="howl-desc">A visual flow from read-only inputs through the scan engine, into one unified Finding and ContextGraph, served by the control plane, and exported as reports, gates, and runtime controls.</desc>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 560" fill="none" role="img" aria-labelledby="hiw-l-title hiw-l-desc">
+<title id="hiw-l-title">How agent-bom works</title>
+<desc id="hiw-l-desc">Read-only intake through scan pipeline into unified Finding and UnifiedGraph, served by control plane, exported as reports and gates.</desc>
 <defs>
-<marker id="hiwl-arrow" viewBox="0 0 10 8" refX="8.2" refY="4" markerWidth="7" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
-<style>
-text { font-family: Inter, ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif; }
-.title { font-size: 30px; font-weight: 850; } .subtitle { font-size: 13px; font-weight: 500; } .label { font-size: 11px; font-weight: 800; letter-spacing: .15em; }
-.step { font-size: 22px; font-weight: 800; } .chip { font-size: 13px; font-weight: 700; } .badge { font-size: 10.5px; font-weight: 700; } .tiny { font-size: 10px; font-weight: 600; } .node { font-size: 11px; font-weight: 800; }
-.ic { fill: none; stroke: #6b6b76; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
-.ic-a { fill: none; stroke: #7c3aed; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
-</style></defs>
-<rect x="0" y="0" width="1320" height="650" rx="18" fill="#ffffff"/>
-<text x="48" y="52" class="title" fill="#18181b">From inventory to enforceable evidence</text>
-<text x="48" y="78" class="subtitle" fill="#6b6b75">Read-only collection becomes deterministic matching, enriched findings, graph-backed blast radius, and operational outputs.</text>
-
-<rect x="40" y="118" width="240" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
-<text x="58" y="149" class="label" fill="#7c3aed">READ-ONLY INTAKE</text>
-<rect x="330" y="118" width="230" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
-<text x="348" y="149" class="label" fill="#7c3aed">SCAN ENGINE</text>
-<rect x="610" y="118" width="270" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
-<text x="628" y="149" class="label" fill="#7c3aed">EVIDENCE CORE</text>
-<rect x="930" y="118" width="200" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
-<text x="948" y="149" class="label" fill="#7c3aed">CONTROL PLANE</text>
-<rect x="1170" y="118" width="120" height="392" rx="18" fill="#fafafa" stroke="#ececf0"/>
-<text x="1188" y="149" class="label" fill="#7c3aed">OUTPUTS</text>
-
-<rect x="62" y="165" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="71" y="175" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M77 178h8l4 4v11h-12z M85 178v4h4"/>
-<text x="103" y="191" class="chip" fill="#18181b">Repo</text>
-<rect x="166" y="165" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="175" y="175" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M180 186l4 4 9-10"/>
-<text x="207" y="191" class="chip" fill="#18181b">CI</text>
-<rect x="62" y="229" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="71" y="239" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><circle class="ic" cx="82" cy="247" r="2.6"/><circle class="ic" cx="77" cy="256" r="2.2"/><circle class="ic" cx="87" cy="256" r="2.2"/><path class="ic" d="M80 250l-2 5 M84 250l2 5"/>
-<text x="103" y="255" class="chip" fill="#18181b">MCP</text>
-<rect x="166" y="229" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="175" y="239" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M180 256h12a4 4 0 0 0 .6-7.9 6 6 0 0 0-11.3-1.6A4 4 0 0 0 180 256z"/>
-<text x="207" y="255" class="chip" fill="#18181b">Cloud</text>
-<rect x="62" y="293" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="71" y="303" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><rect class="ic" x="76" y="307" width="12" height="11" rx="2"/><path class="ic" d="M78 316l3-3 2 2 3-3 2 4"/>
-<text x="103" y="319" class="chip" fill="#18181b">Image</text>
-<rect x="166" y="293" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="175" y="303" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M182 306c-4 3-4 13 0 16 M190 306c4 3 4 13 0 16"/>
-<text x="207" y="319" class="chip" fill="#18181b">IaC</text>
-<rect x="62" y="357" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="71" y="367" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M76 370h12v16h-12z M79 375h6 M79 379h6 M79 383h4"/>
-<text x="103" y="383" class="chip" fill="#18181b">SBOM</text>
-<rect x="166" y="357" width="92" height="42" rx="12" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="175" y="367" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><path class="ic" d="M186 369l6 3v8l-6 3-6-3v-8z M186 369v14 M180 372l12 6"/>
-<text x="207" y="383" class="chip" fill="#18181b">Model</text>
-<rect x="62" y="438" width="46" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="85" y="455" class="badge" fill="#71717a" text-anchor="middle">AWS</text>
-<rect x="114" y="438" width="46" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="137" y="455" class="badge" fill="#71717a" text-anchor="middle">AZ</text>
-<rect x="166" y="438" width="46" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="189" y="455" class="badge" fill="#71717a" text-anchor="middle">GCP</text>
-<rect x="218" y="438" width="46" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="241" y="455" class="badge" fill="#71717a" text-anchor="middle">SNOW</text>
-<text x="160" y="486" class="tiny" fill="#9a9aa4" text-anchor="middle">no writes · no secret values</text>
-
-<circle cx="368" cy="183" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="188" class="badge" fill="#7c3aed" text-anchor="middle">1</text>
-<text x="406" y="190" class="step" fill="#18181b">Discover</text>
-<path d="M368 201 C368 210 368 213 368 220" stroke="#d4d4d8" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="241" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="246" class="badge" fill="#7c3aed" text-anchor="middle">2</text>
-<text x="406" y="248" class="step" fill="#18181b">Match</text>
-<path d="M368 259 C368 268 368 271 368 278" stroke="#d4d4d8" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="299" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="304" class="badge" fill="#7c3aed" text-anchor="middle">3</text>
-<text x="406" y="306" class="step" fill="#18181b">Enrich</text>
-<path d="M368 317 C368 326 368 329 368 336" stroke="#d4d4d8" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="357" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="362" class="badge" fill="#7c3aed" text-anchor="middle">4</text>
-<text x="406" y="364" class="step" fill="#18181b">Evaluate</text>
-<path d="M368 375 C368 384 368 387 368 394" stroke="#d4d4d8" stroke-width="2" fill="none" stroke-linecap="round"/>
-<circle cx="368" cy="415" r="17" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.6"/><text x="368" y="420" class="badge" fill="#7c3aed" text-anchor="middle">5</text>
-<text x="406" y="422" class="step" fill="#18181b">Normalize</text>
-<rect x="350" y="446" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="388" y="463" class="badge" fill="#71717a" text-anchor="middle">OSV</text>
-<rect x="440" y="446" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="478" y="463" class="badge" fill="#71717a" text-anchor="middle">GHSA</text>
-<rect x="350" y="477" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="388" y="494" class="badge" fill="#71717a" text-anchor="middle">NVD</text>
-<rect x="440" y="477" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="478" y="494" class="badge" fill="#71717a" text-anchor="middle">KEV</text>
-<rect x="350" y="508" width="76" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="388" y="525" class="badge" fill="#71717a" text-anchor="middle">EPSS</text>
-
-<text x="745" y="178" class="step" fill="#18181b" text-anchor="middle">Finding + ContextGraph</text>
-<line x1="745" y1="256" x2="673" y2="312" stroke="#d4d4d8" stroke-width="1.5"/>
-<line x1="745" y1="256" x2="817" y2="312" stroke="#d4d4d8" stroke-width="1.5"/>
-<line x1="745" y1="256" x2="703" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
-<line x1="745" y1="256" x2="789" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
-<line x1="673" y1="312" x2="703" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
-<line x1="817" y1="312" x2="789" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
-<line x1="703" y1="372" x2="789" y2="372" stroke="#d4d4d8" stroke-width="1.5"/>
-<circle cx="745" cy="256" r="36" fill="#f6f4ff" stroke="#7c5cff" stroke-width="2.4"/><text x="745" y="260" class="node" fill="#6d28d9" text-anchor="middle">Finding</text>
-<circle cx="673" cy="312" r="33" fill="#ffffff" stroke="#d4d4d8" stroke-width="2"/><text x="673" y="316" class="node" fill="#3f3f46" text-anchor="middle">Asset</text>
-<circle cx="817" cy="312" r="33" fill="#ffffff" stroke="#d4d4d8" stroke-width="2"/><text x="817" y="316" class="node" fill="#3f3f46" text-anchor="middle">Agent</text>
-<circle cx="703" cy="372" r="31" fill="#ffffff" stroke="#d4d4d8" stroke-width="2"/><text x="703" y="376" class="node" fill="#3f3f46" text-anchor="middle">Tool</text>
-<circle cx="789" cy="372" r="31" fill="#ffffff" stroke="#d4d4d8" stroke-width="2"/><text x="789" y="376" class="node" fill="#3f3f46" text-anchor="middle">Cred</text>
-<rect x="650" y="410" width="84" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="692" y="427" class="badge" fill="#71717a" text-anchor="middle">severity</text>
-<rect x="746" y="410" width="106" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="799" y="427" class="badge" fill="#71717a" text-anchor="middle">provenance</text>
-<rect x="696" y="446" width="108" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="750" y="463" class="badge" fill="#71717a" text-anchor="middle">tenant scope</text>
-<text x="745" y="490" class="tiny" fill="#9a9aa4" text-anchor="middle">one model across scan, cloud, runtime, and imports</text>
-
-<rect x="958" y="165" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<path class="ic" d="M974 175l-4 7 4 7 M982 175l4 7-4 7"/><text x="1000" y="189" class="chip" fill="#18181b">API</text>
-<rect x="958" y="215" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect class="ic" x="970" y="226" width="14" height="11" rx="2"/><path class="ic" d="M970 230h14"/><text x="1000" y="239" class="chip" fill="#18181b">UI</text>
-<rect x="958" y="265" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<circle class="ic" cx="977" cy="280" r="2.4"/><circle class="ic" cx="973" cy="288" r="2"/><circle class="ic" cx="981" cy="288" r="2"/><path class="ic" d="M975.5 282l-2 5 M978.5 282l2 5"/><text x="1000" y="289" class="chip" fill="#18181b">MCP</text>
-<rect x="958" y="315" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<path class="ic" d="M977 326l6 2v4c0 4-2.6 6-6 7-3.4-1-6-3-6-7v-4z M974 333l2 2 3.5-4"/><text x="1000" y="339" class="chip" fill="#18181b">Gate</text>
-<rect x="958" y="365" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect class="ic" x="971" y="377" width="5" height="5" rx="1.3"/><rect class="ic" x="979" y="377" width="5" height="5" rx="1.3"/><rect class="ic" x="971" y="385" width="5" height="5" rx="1.3"/><rect class="ic" x="979" y="385" width="5" height="5" rx="1.3"/><text x="1000" y="389" class="chip" fill="#18181b">Work</text>
-<rect x="958" y="415" width="144" height="38" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<path class="ic" d="M973 427h10v12h-10z M976 427v-2h4v2 M975 432l1.5 1.5 3-3"/><text x="1000" y="439" class="chip" fill="#18181b">Audit</text>
-<text x="1030" y="486" class="tiny" fill="#9a9aa4" text-anchor="middle">fail-closed auth · RBAC · scopes · audit</text>
-
-<rect x="1195" y="165" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="182" class="badge" fill="#71717a" text-anchor="middle">SARIF</text>
-<rect x="1195" y="210" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="227" class="badge" fill="#71717a" text-anchor="middle">SBOM</text>
-<rect x="1195" y="255" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="272" class="badge" fill="#71717a" text-anchor="middle">HTML</text>
-<rect x="1195" y="300" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="317" class="badge" fill="#71717a" text-anchor="middle">JSON</text>
-<rect x="1195" y="345" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="362" class="badge" fill="#71717a" text-anchor="middle">POSTURE</text>
-<rect x="1195" y="390" width="70" height="26" rx="9" fill="#ffffff" stroke="#e6e6ea"/><text x="1230" y="407" class="badge" fill="#71717a" text-anchor="middle">FIX</text>
-<text x="1230" y="452" class="tiny" fill="#9a9aa4" text-anchor="middle">reports</text>
-<text x="1230" y="474" class="tiny" fill="#9a9aa4" text-anchor="middle">gates</text>
-<text x="1230" y="496" class="tiny" fill="#9a9aa4" text-anchor="middle">runtime</text>
-
-<path d="M280 314 C302 314 308 314 330 314" stroke="#a1a1aa" stroke-width="2.2" fill="none" marker-end="url(#hiwl-arrow)" stroke-linecap="round"/><text x="305" y="302" class="tiny" fill="#9a9aa4" text-anchor="middle">collect</text>
-<path d="M560 314 C582 314 588 314 610 314" stroke="#a1a1aa" stroke-width="2.2" fill="none" marker-end="url(#hiwl-arrow)" stroke-linecap="round"/><text x="585" y="302" class="tiny" fill="#9a9aa4" text-anchor="middle">canonicalize</text>
-<path d="M880 314 C902 314 908 314 930 314" stroke="#7c3aed" stroke-width="2.4" fill="none" marker-end="url(#hiwl-arrow)" stroke-linecap="round"/><text x="905" y="302" class="tiny" fill="#7c3aed" text-anchor="middle">serve</text>
-<path d="M1130 314 C1148 314 1152 314 1170 314" stroke="#a1a1aa" stroke-width="2.2" fill="none" marker-end="url(#hiwl-arrow)" stroke-linecap="round"/><text x="1150" y="302" class="tiny" fill="#9a9aa4" text-anchor="middle">export</text>
-
-<rect x="40" y="548" width="1250" height="46" rx="14" fill="#ecfdf5" stroke="#a7f3d0"/>
-<text x="66" y="577" class="tiny" fill="#15803d" font-weight="800">Trust boundary:</text>
-<text x="180" y="577" class="tiny" fill="#52525b">default-off cloud connectors · read-only permissions · secret redaction · signed evidence · same model everywhere</text>
+<marker id="hiw" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
+<marker id="hiw-a" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
+<linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#7c3aed" stop-opacity="0.35"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0"/></linearGradient>
+</defs>
+<rect width="1200" height="560" rx="16" fill="#ffffff"/>
+<text x="36" y="44" font-family="Inter,system-ui,sans-serif" font-size="24" font-weight="850" fill="#18181b">From inventory to enforceable evidence</text>
+<text x="36" y="66" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="500" fill="#71717a">One read-only pipeline · one Finding + UnifiedGraph · CLI · API · UI · MCP · runtime gates</text>
+<rect x="28" y="88" width="210" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
+<rect x="28" y="88" width="210" height="36" rx="10" fill="#1e3a5f"/><rect x="28" y="110" width="210" height="14" fill="#1e3a5f"/><text x="42" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#93c5fd">INTAKE</text><text x="226" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#60a5fa" opacity="0.85">read-only</text>
+<rect x="258" y="88" width="188" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
+<rect x="258" y="88" width="188" height="36" rx="10" fill="#78350f"/><rect x="258" y="110" width="188" height="14" fill="#78350f"/><text x="272" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#fde68a">SCAN</text><text x="434" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#fbbf24" opacity="0.85">6 steps</text>
+<rect x="466" y="88" width="248" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
+<rect x="466" y="88" width="248" height="36" rx="10" fill="#5b21b6"/><rect x="466" y="110" width="248" height="14" fill="#5b21b6"/><text x="480" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#ddd6fe">EVIDENCE</text><text x="702" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a78bfa" opacity="0.85">one model</text>
+<rect x="734" y="88" width="188" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
+<rect x="734" y="88" width="188" height="36" rx="10" fill="#065f46"/><rect x="734" y="110" width="188" height="14" fill="#065f46"/><text x="748" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#a7f3d0">CONTROL</text><text x="910" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#34d399" opacity="0.85">self-hosted</text>
+<rect x="942" y="88" width="108" height="400" rx="14" fill="#fafafa" stroke="#ececf0"/>
+<rect x="942" y="88" width="108" height="36" rx="10" fill="#3f3f46"/><rect x="942" y="110" width="108" height="14" fill="#3f3f46"/><text x="956" y="110" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" letter-spacing="0.14em" fill="#d4d4d8">OUT</text><text x="1038" y="110" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#a1a1aa" opacity="0.85">artifacts</text>
+<rect x="44" y="138" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="52" y="147" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(57,152)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h8l3 3v11H4z M12 6v3h3"/></g>
+<text x="86" y="166" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Repo</text>
+<rect x="142" y="138" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="150" y="147" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(155,152)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 14l4 4 10-11"/></g>
+<text x="184" y="166" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">CI</text>
+<rect x="44" y="192" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="52" y="201" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(57,206)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="86" y="220" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">MCP</text>
+<rect x="142" y="192" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="150" y="201" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(155,206)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="184" y="220" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Cloud</text>
+<rect x="44" y="246" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="52" y="255" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(57,260)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
+<text x="86" y="274" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Image</text>
+<rect x="142" y="246" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="150" y="255" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(155,260)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="184" y="274" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">IaC</text>
+<rect x="44" y="300" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="52" y="309" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(57,314)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="86" y="328" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">SBOM</text>
+<rect x="142" y="300" width="88" height="44" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="150" y="309" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(155,314)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="184" y="328" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Model</text>
+<rect x="44" y="360" width="46" height="34" rx="9" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(55,366) scale(0.9)"><path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/></g><text x="67" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#ff9900">AWS</text><rect x="96" y="360" width="46" height="34" rx="9" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(107,366) scale(0.9)"><path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/></g><text x="119" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#0078d4">Azure</text><rect x="148" y="360" width="46" height="34" rx="9" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(159,366) scale(0.9)"><circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/></g><text x="171" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#4285f4">GCP</text><rect x="200" y="360" width="46" height="34" rx="9" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(211,366) scale(0.9)"><path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/></g><text x="223" y="390" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#29b5e8">Snow</text>
+<rect x="44" y="408" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(49,413)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="78" y="426" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#9a9aa4">no writes · no secret values</text>
+<circle cx="278" cy="146" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="150" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">1</text>
+<rect x="304" y="132" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,137)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="6"/><path d="M15 15l4 4"/></g>
+<text x="340" y="149" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Discover</text>
+<path d="M278 160 V170" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="198" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="202" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">2</text>
+<rect x="304" y="184" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,189)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="340" y="201" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Extract</text>
+<path d="M278 212 V222" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="250" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="254" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">3</text>
+<rect x="304" y="236" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,241)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="340" y="253" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Scan</text>
+<path d="M278 264 V274" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="302" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="306" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">4</text>
+<rect x="304" y="288" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,293)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="340" y="305" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Enrich</text>
+<path d="M278 316 V326" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="354" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">5</text>
+<rect x="304" y="340" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,345)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="340" y="357" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Analyze</text>
+<path d="M278 368 V378" stroke="#ececf0" stroke-width="1.5" stroke-linecap="round"/>
+<circle cx="278" cy="406" r="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.5"/>
+<text x="278" y="410" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#fbbf24">6</text>
+<rect x="304" y="392" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(309,397)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="340" y="409" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Report</text>
+<rect x="272" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="287" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">OSV</text>
+<rect x="306" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="321" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">GHSA</text>
+<rect x="340" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="355" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">NVD</text>
+<rect x="374" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="389" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">KEV</text>
+<rect x="408" y="448" width="30" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="423" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#fbbf24">EPSS</text>
+<circle cx="590" cy="268" r="78" fill="url(#core-glow)"/>
+<line x1="590" y1="268" x2="518" y2="258" stroke="#ececf0" stroke-width="1.4" opacity="0.75"/>
+<line x1="590" y1="268" x2="662" y2="258" stroke="#ececf0" stroke-width="1.4" opacity="0.75"/>
+<line x1="590" y1="268" x2="538" y2="326" stroke="#ececf0" stroke-width="1.4" opacity="0.75"/>
+<line x1="590" y1="268" x2="642" y2="326" stroke="#ececf0" stroke-width="1.4" opacity="0.75"/>
+<circle cx="590" cy="210" r="34" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="2"/>
+<rect x="577" y="197" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(582,202)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="590" y="232" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" fill="#7c3aed">Finding</text>
+<circle cx="518" cy="258" r="28" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.5"/>
+<text x="518" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#18181b">Asset</text>
+<circle cx="662" cy="258" r="28" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.5"/>
+<text x="662" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#18181b">Agent</text>
+<circle cx="538" cy="326" r="28" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.5"/>
+<text x="538" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#18181b">Tool</text>
+<circle cx="642" cy="326" r="28" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.5"/>
+<text x="642" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#18181b">Cred</text>
+<rect x="494" y="390" width="64" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="526" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#52525b">severity</text>
+<rect x="566" y="390" width="64" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="598" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#52525b">provenance</text>
+<rect x="638" y="390" width="64" height="22" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><text x="670" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#52525b">tenant</text>
+<rect x="748" y="136" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="756" y="149" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(761,154)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="788" y="168" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">REST API</text>
+<rect x="834" y="136" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="842" y="149" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(847,154)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="874" y="168" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Dashboard</text>
+<rect x="748" y="198" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="756" y="211" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(761,216)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="788" y="230" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">MCP srv</text>
+<rect x="834" y="198" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="842" y="211" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(847,216)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="874" y="230" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Gateway</text>
+<rect x="748" y="260" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="756" y="273" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(761,278)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="788" y="292" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Fleet</text>
+<rect x="834" y="260" width="78" height="52" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="842" y="273" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(847,278)" fill="none" stroke="#6b6b76" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="874" y="292" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Audit</text>
+<rect x="748" y="340" width="162" height="28" rx="8" fill="#f4f4f6" stroke="#e4e4e7"/><text x="829" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#52525b">fail-closed · RBAC · audit</text>
+<rect x="956" y="136" width="80" height="36" rx="10" fill="#ffffff" stroke="#f87171" stroke-width="1.2"/><circle cx="970" cy="154" r="4" fill="#f87171" opacity="0.85"/><text x="982" y="158" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">SARIF</text>
+<rect x="956" y="188" width="80" height="36" rx="10" fill="#ffffff" stroke="#fbbf24" stroke-width="1.2"/><circle cx="970" cy="206" r="4" fill="#fbbf24" opacity="0.85"/><text x="982" y="210" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">SBOM</text>
+<rect x="956" y="240" width="80" height="36" rx="10" fill="#ffffff" stroke="#60a5fa" stroke-width="1.2"/><circle cx="970" cy="258" r="4" fill="#60a5fa" opacity="0.85"/><text x="982" y="262" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">HTML</text>
+<rect x="956" y="292" width="80" height="36" rx="10" fill="#ffffff" stroke="#a78bfa" stroke-width="1.2"/><circle cx="970" cy="310" r="4" fill="#a78bfa" opacity="0.85"/><text x="982" y="314" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">JSON</text>
+<rect x="956" y="344" width="80" height="36" rx="10" fill="#ffffff" stroke="#34d399" stroke-width="1.2"/><circle cx="970" cy="362" r="4" fill="#34d399" opacity="0.85"/><text x="982" y="366" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">GATE</text>
+<rect x="956" y="396" width="80" height="36" rx="10" fill="#ffffff" stroke="#fb7185" stroke-width="1.2"/><circle cx="970" cy="414" r="4" fill="#fb7185" opacity="0.85"/><text x="982" y="418" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="#18181b">FIX</text>
+<text x="996" y="468" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#9a9aa4">reports · gates · runtime</text>
+<line x1="238" y1="288" x2="256" y2="288" stroke="#a1a1aa" stroke-width="2" marker-end="url(#hiw)"/><text x="247" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">collect</text>
+<line x1="446" y1="288" x2="464" y2="288" stroke="#a1a1aa" stroke-width="2" marker-end="url(#hiw)"/><text x="455" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">normalize</text>
+<line x1="714" y1="288" x2="732" y2="288" stroke="#7c3aed" stroke-width="2.4" marker-end="url(#hiw-a)"/><text x="723" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">serve</text>
+<line x1="922" y1="288" x2="940" y2="288" stroke="#a1a1aa" stroke-width="2" marker-end="url(#hiw)"/><text x="931" y="278" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">export</text>
+<rect x="28" y="508" width="1144" height="36" rx="10" fill="#ecfdf5" stroke="#bbf7d0"/><text x="52" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#15803d">TRUST</text><text x="100" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#52525b">read-only connectors · secret redaction · signed evidence · same model everywhere</text>
 </svg>

--- a/docs/images/how-it-works-light.svg
+++ b/docs/images/how-it-works-light.svg
@@ -1,132 +1,131 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 580" fill="none" role="img" aria-labelledby="hiw-l-title hiw-l-desc">
-<title id="hiw-l-title">How agent-bom works</title>
-<desc id="hiw-l-desc">Read-only intake through scan pipeline into unified Finding and UnifiedGraph.</desc>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="560" viewBox="0 0 960 560" fill="none">
+<title>How agent-bom works</title>
+<desc>Read-only intake through scan pipeline into unified Finding and UnifiedGraph.</desc>
 <defs>
-<marker id="hiw" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#a1a1aa"/></marker>
-<marker id="hiw-a" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
 <linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#7c3aed" stop-opacity="0.28"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0"/></linearGradient>
 </defs>
-<rect width="1180" height="580" rx="14" fill="#ffffff"/>
-<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="#18181b">From inventory to enforceable evidence</text>
-<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="#71717a">One read-only pipeline · one Finding + UnifiedGraph · CLI · API · UI · MCP</text>
-<rect x="24" y="84" width="200" height="380" rx="12" fill="#fafafa" stroke="#ececf0"/>
-<rect x="24" y="84" width="200" height="32" rx="8" fill="#1e3a5f"/><text x="36" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">INTAKE</text><text x="214" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">read-only</text>
-<rect x="236" y="84" width="176" height="380" rx="12" fill="#fafafa" stroke="#ececf0"/>
-<rect x="236" y="84" width="176" height="32" rx="8" fill="#78350f"/><text x="248" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#fde68a">SCAN</text><text x="402" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#fbbf24" opacity="0.9">6 steps</text>
-<rect x="424" y="84" width="232" height="380" rx="12" fill="#fafafa" stroke="#ececf0"/>
-<rect x="424" y="84" width="232" height="32" rx="8" fill="#5b21b6"/><text x="436" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#ddd6fe">EVIDENCE</text><text x="646" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a78bfa" opacity="0.9">one model</text>
-<rect x="668" y="84" width="176" height="380" rx="12" fill="#fafafa" stroke="#ececf0"/>
-<rect x="668" y="84" width="176" height="32" rx="8" fill="#065f46"/><text x="680" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#a7f3d0">CONTROL</text><text x="834" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#34d399" opacity="0.9">self-hosted</text>
-<rect x="856" y="84" width="108" height="380" rx="12" fill="#fafafa" stroke="#ececf0"/>
-<rect x="856" y="84" width="108" height="32" rx="8" fill="#3f3f46"/><text x="868" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#d4d4d8">OUT</text><text x="954" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a1a1aa" opacity="0.9">artifacts</text>
-<rect x="36" y="128" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="42" y="136" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,140)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h8l3 3v11H4z M12 6v3h3"/></g>
-<text x="72" y="153" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Repo</text>
-<rect x="130" y="128" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="136" y="136" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(140,140)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 14l4 4 10-11"/></g>
-<text x="166" y="153" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">CI</text>
-<rect x="36" y="178" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="42" y="186" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,190)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="72" y="203" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">MCP</text>
-<rect x="130" y="178" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="136" y="186" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(140,190)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="166" y="203" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Cloud</text>
-<rect x="36" y="228" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="42" y="236" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,240)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
-<text x="72" y="253" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Image</text>
-<rect x="130" y="228" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="136" y="236" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(140,240)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="166" y="253" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">IaC</text>
-<rect x="36" y="278" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="42" y="286" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,290)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="72" y="303" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">SBOM</text>
-<rect x="130" y="278" width="84" height="40" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="136" y="286" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(140,290)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="166" y="303" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Model</text>
-<rect x="36" y="336" width="42" height="30" rx="8" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(45,341) scale(0.85)"><path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/></g><text x="57" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#ff9900">AWS</text><rect x="84" y="336" width="42" height="30" rx="8" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(93,341) scale(0.85)"><path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/></g><text x="105" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#0078d4">Azure</text><rect x="132" y="336" width="42" height="30" rx="8" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(141,341) scale(0.85)"><circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/></g><text x="153" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#4285f4">GCP</text><rect x="180" y="336" width="42" height="30" rx="8" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(189,341) scale(0.85)"><path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/></g><text x="201" y="362" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#29b5e8">Snow</text>
-<rect x="36" y="376" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(40,380)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<rect width="960" height="560" rx="14" fill="#ffffff"/>
+<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#18181b">From inventory to enforceable evidence</text>
+<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">One read-only pipeline · one Finding + UnifiedGraph · CLI · API · UI · MCP</text>
+<rect x="24" y="84" width="176" height="360" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="24" y="84" width="176" height="32" rx="8" fill="#1e3a5f"/><text x="36" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">INTAKE</text><text x="190" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#60a5fa" opacity="0.9">read-only</text>
+<rect x="208" y="84" width="176" height="360" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="208" y="84" width="176" height="32" rx="8" fill="#78350f"/><text x="220" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#fde68a">SCAN</text><text x="374" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#fbbf24" opacity="0.9">6 steps</text>
+<rect x="392" y="84" width="176" height="360" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="392" y="84" width="176" height="32" rx="8" fill="#5b21b6"/><text x="404" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#ddd6fe">EVIDENCE</text><text x="558" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a78bfa" opacity="0.9">one model</text>
+<rect x="576" y="84" width="176" height="360" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="576" y="84" width="176" height="32" rx="8" fill="#065f46"/><text x="588" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#a7f3d0">CONTROL</text><text x="742" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#34d399" opacity="0.9">self-hosted</text>
+<rect x="760" y="84" width="176" height="360" rx="12" fill="#fafafa" stroke="#ececf0"/>
+<rect x="760" y="84" width="176" height="32" rx="8" fill="#3f3f46"/><text x="772" y="104" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#d4d4d8">OUT</text><text x="926" y="104" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="#a1a1aa" opacity="0.9">artifacts</text>
+<rect x="32" y="128" width="74" height="38" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="38" y="135" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(42,139)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h8l3 3v11H4z M12 6v3h3"/></g>
+<text x="66" y="152" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Repo</text>
+<rect x="114" y="128" width="74" height="38" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="120" y="135" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(124,139)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 14l4 4 10-11"/></g>
+<text x="148" y="152" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">CI</text>
+<rect x="32" y="176" width="74" height="38" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="38" y="183" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(42,187)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="66" y="200" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">MCP</text>
+<rect x="114" y="176" width="74" height="38" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="120" y="183" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(124,187)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="148" y="200" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Cloud</text>
+<rect x="32" y="224" width="74" height="38" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="38" y="231" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(42,235)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
+<text x="66" y="248" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Image</text>
+<rect x="114" y="224" width="74" height="38" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="120" y="231" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(124,235)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="148" y="248" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">IaC</text>
+<rect x="32" y="272" width="74" height="38" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="38" y="279" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(42,283)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="66" y="296" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">SBOM</text>
+<rect x="114" y="272" width="74" height="38" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="120" y="279" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(124,283)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="148" y="296" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="700" fill="#18181b">Model</text>
+<rect x="32" y="320" width="42" height="30" rx="8" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(41,325) scale(0.85)"><path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/></g><text x="53" y="346" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#ff9900">AWS</text><rect x="80" y="320" width="42" height="30" rx="8" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(89,325) scale(0.85)"><path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/></g><text x="101" y="346" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#0078d4">Azure</text><rect x="128" y="320" width="42" height="30" rx="8" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(137,325) scale(0.85)"><circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/></g><text x="149" y="346" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#4285f4">GCP</text><rect x="176" y="320" width="42" height="30" rx="8" fill="#ffffff" stroke="#e6e6ea"/><g transform="translate(185,325) scale(0.85)"><path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/></g><text x="197" y="346" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#29b5e8">Snow</text>
+<rect x="32" y="360" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(36,364)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
 <text x="64" y="392" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#9a9aa4">no writes · no secret values</text>
-<circle cx="248" cy="140" r="11" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
+<circle cx="248" cy="140" r="10" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
 <text x="248" y="144" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">1</text>
 <rect x="268" y="128" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,132)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="10" cy="10" r="6"/><path d="M15 15l4 4"/></g>
-<text x="298" y="144" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Discover</text>
-<path d="M248 152 V160" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
-<circle cx="248" cy="188" r="11" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
-<text x="248" y="192" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">2</text>
-<rect x="268" y="176" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,180)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="298" y="192" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Extract</text>
-<path d="M248 200 V208" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
-<circle cx="248" cy="236" r="11" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
-<text x="248" y="240" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">3</text>
-<rect x="268" y="224" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,228)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="298" y="240" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Scan</text>
-<path d="M248 248 V256" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
-<circle cx="248" cy="284" r="11" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
-<text x="248" y="288" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">4</text>
-<rect x="268" y="272" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,276)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="298" y="288" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Enrich</text>
-<path d="M248 296 V304" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
-<circle cx="248" cy="332" r="11" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
-<text x="248" y="336" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">5</text>
-<rect x="268" y="320" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,324)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="298" y="336" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Analyze</text>
-<path d="M248 344 V352" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
-<circle cx="248" cy="380" r="11" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
-<text x="248" y="384" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">6</text>
-<rect x="268" y="368" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,372)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="298" y="384" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Report</text>
-<rect x="242" y="430" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="255" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">OSV</text>
-<rect x="272" y="430" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="285" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">GHSA</text>
-<rect x="302" y="430" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="315" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">NVD</text>
-<rect x="332" y="430" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="345" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">KEV</text>
-<rect x="362" y="430" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="375" y="442" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">EPSS</text>
-<circle cx="540" cy="284" r="62" fill="url(#core-glow)"/>
-<line x1="540" y1="284" x2="482" y2="278" stroke="#ececf0" stroke-width="1.2" opacity="0.7"/>
-<line x1="540" y1="284" x2="598" y2="278" stroke="#ececf0" stroke-width="1.2" opacity="0.7"/>
-<line x1="540" y1="284" x2="498" y2="330" stroke="#ececf0" stroke-width="1.2" opacity="0.7"/>
-<line x1="540" y1="284" x2="582" y2="330" stroke="#ececf0" stroke-width="1.2" opacity="0.7"/>
-<circle cx="540" cy="236" r="28" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.8"/>
-<rect x="528" y="224" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(532,228)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
-<text x="540" y="254" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#7c3aed">Finding</text>
-<circle cx="482" cy="278" r="22" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.3"/>
-<text x="482" y="294" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#18181b">Asset</text>
-<circle cx="598" cy="278" r="22" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.3"/>
-<text x="598" y="294" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#18181b">Agent</text>
-<circle cx="498" cy="330" r="22" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.3"/>
-<text x="498" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#18181b">Tool</text>
-<circle cx="582" cy="330" r="22" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.3"/>
-<text x="582" y="346" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#18181b">Cred</text>
-<rect x="438" y="424" width="60" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="468" y="437" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#52525b">severity</text>
-<rect x="506" y="424" width="60" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="536" y="437" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#52525b">provenance</text>
-<rect x="574" y="424" width="60" height="20" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="604" y="437" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#52525b">tenant</text>
-<rect x="680" y="128" width="72" height="46" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="688" y="139" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(692,143)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="718" y="156" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">REST API</text>
-<rect x="760" y="128" width="72" height="46" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="768" y="139" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(772,143)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="798" y="156" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Dashboard</text>
-<rect x="680" y="184" width="72" height="46" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="688" y="195" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(692,199)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="718" y="212" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">MCP srv</text>
-<rect x="760" y="184" width="72" height="46" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="768" y="195" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(772,199)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="798" y="212" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Gateway</text>
-<rect x="680" y="240" width="72" height="46" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="688" y="251" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(692,255)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="718" y="268" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Fleet</text>
-<rect x="760" y="240" width="72" height="46" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="768" y="251" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(772,255)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="798" y="268" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Audit</text>
-<rect x="680" y="426" width="152" height="24" rx="7" fill="#f4f4f6" stroke="#e4e4e7"/><text x="756" y="442" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="#52525b">fail-closed · RBAC · audit</text>
-<rect x="868" y="128" width="76" height="32" rx="8" fill="#ffffff" stroke="#f87171" stroke-width="1.1"/><circle cx="880" cy="144" r="3.5" fill="#f87171"/><text x="890" y="148" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#18181b">SARIF</text>
-<rect x="868" y="176" width="76" height="32" rx="8" fill="#ffffff" stroke="#fbbf24" stroke-width="1.1"/><circle cx="880" cy="192" r="3.5" fill="#fbbf24"/><text x="890" y="196" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#18181b">SBOM</text>
-<rect x="868" y="224" width="76" height="32" rx="8" fill="#ffffff" stroke="#60a5fa" stroke-width="1.1"/><circle cx="880" cy="240" r="3.5" fill="#60a5fa"/><text x="890" y="244" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#18181b">HTML</text>
-<rect x="868" y="272" width="76" height="32" rx="8" fill="#ffffff" stroke="#a78bfa" stroke-width="1.1"/><circle cx="880" cy="288" r="3.5" fill="#a78bfa"/><text x="890" y="292" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#18181b">JSON</text>
-<rect x="868" y="320" width="76" height="32" rx="8" fill="#ffffff" stroke="#34d399" stroke-width="1.1"/><circle cx="880" cy="336" r="3.5" fill="#34d399"/><text x="890" y="340" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#18181b">GATE</text>
-<rect x="868" y="368" width="76" height="32" rx="8" fill="#ffffff" stroke="#fb7185" stroke-width="1.1"/><circle cx="880" cy="384" r="3.5" fill="#fb7185"/><text x="890" y="388" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="#18181b">FIX</text>
-<line x1="224" y1="100" x2="236" y2="100" stroke="#a1a1aa" stroke-width="1.8" marker-end="url(#hiw)"/><text x="230" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">collect</text>
-<line x1="412" y1="100" x2="424" y2="100" stroke="#a1a1aa" stroke-width="1.8" marker-end="url(#hiw)"/><text x="418" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">normalize</text>
-<line x1="656" y1="100" x2="668" y2="100" stroke="#7c3aed" stroke-width="2.2" marker-end="url(#hiw-a)"/><text x="662" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#7c3aed">serve</text>
-<line x1="844" y1="100" x2="856" y2="100" stroke="#a1a1aa" stroke-width="1.8" marker-end="url(#hiw)"/><text x="850" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">export</text>
-<rect x="24" y="536" width="1132" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="44" y="554" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="800" fill="#15803d">TRUST</text><text x="88" y="554" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#52525b">read-only · secret redaction · signed evidence · same model everywhere</text>
+<text x="296" y="144" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Discover</text>
+<path d="M248 152 V158" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="186" r="10" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="190" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">2</text>
+<rect x="268" y="174" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,178)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="296" y="190" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Extract</text>
+<path d="M248 198 V204" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="232" r="10" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="236" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">3</text>
+<rect x="268" y="220" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,224)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="296" y="236" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Scan</text>
+<path d="M248 244 V250" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="278" r="10" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="282" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">4</text>
+<rect x="268" y="266" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,270)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="296" y="282" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Enrich</text>
+<path d="M248 290 V296" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="324" r="10" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="328" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">5</text>
+<rect x="268" y="312" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,316)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="296" y="328" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Analyze</text>
+<path d="M248 336 V342" stroke="#ececf0" stroke-width="1.4" stroke-linecap="round"/>
+<circle cx="248" cy="370" r="10" fill="#ffffff" stroke="#fbbf24" stroke-width="1.4"/>
+<text x="248" y="374" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#fbbf24">6</text>
+<rect x="268" y="358" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(272,362)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="296" y="374" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="700" fill="#18181b">Report</text>
+<rect x="216" y="412" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="229" y="424" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">OSV</text>
+<rect x="248" y="412" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="261" y="424" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">GHSA</text>
+<rect x="280" y="412" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="293" y="424" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">NVD</text>
+<rect x="312" y="412" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="325" y="424" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">KEV</text>
+<rect x="344" y="412" width="26" height="18" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="357" y="424" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" font-weight="700" fill="#fbbf24">EPSS</text>
+<circle cx="480" cy="272" r="54" fill="url(#core-glow)"/>
+<line x1="480" y1="272" x2="422" y2="266" stroke="#ececf0" stroke-width="1.2" opacity="0.7"/>
+<line x1="480" y1="272" x2="538" y2="266" stroke="#ececf0" stroke-width="1.2" opacity="0.7"/>
+<line x1="480" y1="272" x2="438" y2="318" stroke="#ececf0" stroke-width="1.2" opacity="0.7"/>
+<line x1="480" y1="272" x2="522" y2="318" stroke="#ececf0" stroke-width="1.2" opacity="0.7"/>
+<circle cx="480" cy="224" r="28" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.8"/>
+<rect x="468" y="212" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(472,216)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/></g>
+<text x="480" y="242" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="#7c3aed">Finding</text>
+<circle cx="422" cy="266" r="22" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.3"/>
+<text x="422" y="282" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#18181b">Asset</text>
+<circle cx="538" cy="266" r="22" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.3"/>
+<text x="538" y="282" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#18181b">Agent</text>
+<circle cx="438" cy="318" r="22" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.3"/>
+<text x="438" y="334" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#18181b">Tool</text>
+<circle cx="522" cy="318" r="22" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.3"/>
+<text x="522" y="334" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" fill="#18181b">Cred</text>
+<rect x="402" y="408" width="48" height="18" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="426" y="420" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="700" fill="#52525b">severity</text>
+<rect x="454" y="408" width="48" height="18" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="478" y="420" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="700" fill="#52525b">provenance</text>
+<rect x="506" y="408" width="48" height="18" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><text x="530" y="420" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="700" fill="#52525b">tenant</text>
+<rect x="584" y="128" width="70" height="42" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="592" y="139" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(596,143)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="622" y="156" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">REST API</text>
+<rect x="662" y="128" width="70" height="42" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="670" y="139" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(674,143)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="700" y="156" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Dashboard</text>
+<rect x="584" y="180" width="70" height="42" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="592" y="191" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(596,195)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="622" y="208" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">MCP srv</text>
+<rect x="662" y="180" width="70" height="42" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="670" y="191" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(674,195)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="700" y="208" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Gateway</text>
+<rect x="584" y="232" width="70" height="42" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="592" y="243" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(596,247)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="622" y="260" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Fleet</text>
+<rect x="662" y="232" width="70" height="42" rx="9" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="670" y="243" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(674,247)" fill="none" stroke="#6b6b76" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="700" y="260" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Audit</text>
+<rect x="584" y="410" width="160" height="22" rx="7" fill="#f4f4f6" stroke="#e4e4e7"/><text x="664" y="426" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="700" fill="#52525b">fail-closed · RBAC · audit</text>
+<rect x="768" y="128" width="160" height="30" rx="8" fill="#ffffff" stroke="#f87171" stroke-width="1.1"/><circle cx="778" cy="143" r="3" fill="#f87171"/><text x="786" y="147" font-family="ui-monospace,monospace" font-size="8.5" font-weight="800" fill="#18181b">SARIF</text>
+<rect x="768" y="174" width="160" height="30" rx="8" fill="#ffffff" stroke="#fbbf24" stroke-width="1.1"/><circle cx="778" cy="189" r="3" fill="#fbbf24"/><text x="786" y="193" font-family="ui-monospace,monospace" font-size="8.5" font-weight="800" fill="#18181b">SBOM</text>
+<rect x="768" y="220" width="160" height="30" rx="8" fill="#ffffff" stroke="#60a5fa" stroke-width="1.1"/><circle cx="778" cy="235" r="3" fill="#60a5fa"/><text x="786" y="239" font-family="ui-monospace,monospace" font-size="8.5" font-weight="800" fill="#18181b">HTML</text>
+<rect x="768" y="266" width="160" height="30" rx="8" fill="#ffffff" stroke="#a78bfa" stroke-width="1.1"/><circle cx="778" cy="281" r="3" fill="#a78bfa"/><text x="786" y="285" font-family="ui-monospace,monospace" font-size="8.5" font-weight="800" fill="#18181b">JSON</text>
+<rect x="768" y="312" width="160" height="30" rx="8" fill="#ffffff" stroke="#34d399" stroke-width="1.1"/><circle cx="778" cy="327" r="3" fill="#34d399"/><text x="786" y="331" font-family="ui-monospace,monospace" font-size="8.5" font-weight="800" fill="#18181b">GATE</text>
+<rect x="768" y="358" width="160" height="30" rx="8" fill="#ffffff" stroke="#fb7185" stroke-width="1.1"/><circle cx="778" cy="373" r="3" fill="#fb7185"/><text x="786" y="377" font-family="ui-monospace,monospace" font-size="8.5" font-weight="800" fill="#18181b">FIX</text>
+<line x1="200" y1="100" x2="201" y2="100" stroke="#a1a1aa" stroke-width="1.8"/><polygon points="207,100 201,96.5 201,103.5" fill="#a1a1aa"/><text x="204" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">collect</text>
+<line x1="384" y1="100" x2="385" y2="100" stroke="#a1a1aa" stroke-width="1.8"/><polygon points="391,100 385,96.5 385,103.5" fill="#a1a1aa"/><text x="388" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">normalize</text>
+<line x1="568" y1="100" x2="569" y2="100" stroke="#7c3aed" stroke-width="2.2"/><polygon points="575,100 569,96.5 569,103.5" fill="#7c3aed"/><text x="572" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#7c3aed">serve</text>
+<line x1="752" y1="100" x2="753" y2="100" stroke="#a1a1aa" stroke-width="1.8"/><polygon points="759,100 753,96.5 753,103.5" fill="#a1a1aa"/><text x="756" y="92" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="#9a9aa4">export</text>
+<rect x="24" y="520" width="912" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="480" y="540" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">read-only · secret redaction · signed evidence · same model everywhere</text>
 </svg>

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -1,11 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 400" fill="none" role="img" aria-labelledby="pv-dark-title">
-<title id="pv-dark-title">agent-bom personas and value</title>
-<defs>
-<marker id="pv-dark" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
-</defs>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="400" viewBox="0 0 960 400" fill="none">
+<title>agent-bom personas and value</title>
 <rect width="960" height="400" rx="12" fill="#0a0a0c"/>
-<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="850" fill="#f4f4f5">Who it serves · what they get</text>
-<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">One evidence model — inventory → findings → graph → gates</text>
+<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#f4f4f5">Who it serves · what they get</text>
+<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">One evidence model — inventory -&gt; findings -&gt; graph -&gt; gates</text>
 <text x="28" y="88" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">PERSONAS</text>
 <text x="500" y="88" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">VALUE PROOF</text>
 <rect x="28" y="108" width="432" height="54" rx="10" fill="#161619" stroke="#2a2a31"/>
@@ -28,21 +26,21 @@
 <rect x="512" y="122" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(516,126)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
 <text x="548" y="132" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Accurate SCA</text>
 <text x="548" y="148" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">15 ecosystems · distro-aware</text>
-<line x1="468" y1="135" x2="492" y2="135" stroke="#8b5cf6" stroke-width="1.6" marker-end="url(#pv-dark)"/>
+<line x1="468" y1="135" x2="485" y2="135" stroke="#8b5cf6" stroke-width="1.6"/><polygon points="491,135 484,131.5 484,138.5" fill="#8b5cf6"/>
 <rect x="500" y="176" width="432" height="54" rx="10" fill="#15121f" stroke="#5b4bbd"/>
 <rect x="512" y="190" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(516,194)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
 <text x="548" y="200" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Container coverage</text>
 <text x="548" y="216" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">OCI native · Grype opt-in</text>
-<line x1="468" y1="203" x2="492" y2="203" stroke="#8b5cf6" stroke-width="1.6" marker-end="url(#pv-dark)"/>
+<line x1="468" y1="203" x2="485" y2="203" stroke="#8b5cf6" stroke-width="1.6"/><polygon points="491,203 484,199.5 484,206.5" fill="#8b5cf6"/>
 <rect x="500" y="244" width="432" height="54" rx="10" fill="#15121f" stroke="#5b4bbd"/>
 <rect x="512" y="258" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(516,262)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
 <text x="548" y="268" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Self-hosted evidence</text>
 <text x="548" y="284" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">your VPC · signed audit</text>
-<line x1="468" y1="271" x2="492" y2="271" stroke="#8b5cf6" stroke-width="1.6" marker-end="url(#pv-dark)"/>
+<line x1="468" y1="271" x2="485" y2="271" stroke="#8b5cf6" stroke-width="1.6"/><polygon points="491,271 484,267.5 484,274.5" fill="#8b5cf6"/>
 <rect x="500" y="312" width="432" height="54" rx="10" fill="#15121f" stroke="#5b4bbd"/>
 <rect x="512" y="326" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(516,330)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
 <text x="548" y="336" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Agent-native API</text>
 <text x="548" y="352" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">283 ops · 70 MCP tools</text>
-<line x1="468" y1="339" x2="492" y2="339" stroke="#8b5cf6" stroke-width="1.6" marker-end="url(#pv-dark)"/>
-<rect x="28" y="364" width="904" height="24" rx="7" fill="#0c1a14" stroke="#1f4438"/><text x="480" y="380" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<line x1="468" y1="339" x2="485" y2="339" stroke="#8b5cf6" stroke-width="1.6"/><polygon points="491,339 484,335.5 484,342.5" fill="#8b5cf6"/>
+<rect x="24" y="364" width="912" height="24" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="480" y="380" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -1,46 +1,48 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 420" fill="none" role="img" aria-labelledby="pv-dark-title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 400" fill="none" role="img" aria-labelledby="pv-dark-title">
 <title id="pv-dark-title">agent-bom personas and value</title>
-<rect width="980" height="420" rx="14" fill="#0a0a0c"/>
-<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="#f4f4f5">Who it serves · what they get</text>
-<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="#71717a">One evidence model — different buyers, same inventory → findings → graph → gates</text>
-<defs><marker id="pv-dark" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker></defs>
-<text x="36" y="98" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">PERSONAS</text>
-<text x="500" y="98" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">VALUE PROOF</text>
-<rect x="36" y="112" width="420" height="56" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect x="48" y="126" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(53,131)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="88" y="138" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">AppSec / GRC</text>
-<text x="88" y="154" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#34d399">SARIF · compliance · audit chain</text>
-<rect x="36" y="180" width="420" height="56" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect x="48" y="194" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(53,199)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="88" y="206" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Platform / SRE</text>
-<text x="88" y="222" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#fbbf24">fleet · Helm · CI gates</text>
-<rect x="36" y="248" width="420" height="56" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect x="48" y="262" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(53,267)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="88" y="274" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Agent builders</text>
-<text x="88" y="290" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#60a5fa">MCP inventory · runtime shield</text>
-<rect x="36" y="316" width="420" height="56" rx="11" fill="#161619" stroke="#2a2a31"/>
-<rect x="48" y="330" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(53,335)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="88" y="342" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Security engineers</text>
-<text x="88" y="358" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#a78bfa">blast radius · attack paths</text>
-<rect x="500" y="112" width="444" height="56" rx="11" fill="#15121f" stroke="#5b4bbd"/>
-<rect x="512" y="126" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(517,131)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="552" y="138" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Accurate SCA</text>
-<text x="552" y="154" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#82828c">15 ecosystems · distro-aware</text>
-<line x1="456" y1="140" x2="500" y2="140" stroke="#8b5cf6" stroke-width="1.8" marker-end="url(#pv-dark)"/>
-<rect x="500" y="180" width="444" height="56" rx="11" fill="#15121f" stroke="#5b4bbd"/>
-<rect x="512" y="194" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(517,199)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
-<text x="552" y="206" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Container coverage</text>
-<text x="552" y="222" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#82828c">OCI native · optional Grype</text>
-<line x1="456" y1="208" x2="500" y2="208" stroke="#8b5cf6" stroke-width="1.8" marker-end="url(#pv-dark)"/>
-<rect x="500" y="248" width="444" height="56" rx="11" fill="#15121f" stroke="#5b4bbd"/>
-<rect x="512" y="262" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(517,267)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="552" y="274" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Self-hosted evidence</text>
-<text x="552" y="290" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#82828c">your VPC · signed audit</text>
-<line x1="456" y1="276" x2="500" y2="276" stroke="#8b5cf6" stroke-width="1.8" marker-end="url(#pv-dark)"/>
-<rect x="500" y="316" width="444" height="56" rx="11" fill="#15121f" stroke="#5b4bbd"/>
-<rect x="512" y="330" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(517,335)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="552" y="342" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Agent-native API</text>
-<text x="552" y="358" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#82828c">283 ops · 70 MCP tools</text>
-<line x1="456" y1="344" x2="500" y2="344" stroke="#8b5cf6" stroke-width="1.8" marker-end="url(#pv-dark)"/>
-<rect x="36" y="372" width="908" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="490" y="390" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME ENFORCEMENT — same Finding + UnifiedGraph everywhere</text>
+<defs>
+<marker id="pv-dark" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker>
+</defs>
+<rect width="960" height="400" rx="12" fill="#0a0a0c"/>
+<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="850" fill="#f4f4f5">Who it serves · what they get</text>
+<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">One evidence model — inventory → findings → graph → gates</text>
+<text x="28" y="88" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">PERSONAS</text>
+<text x="500" y="88" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">VALUE PROOF</text>
+<rect x="28" y="108" width="432" height="54" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="40" y="122" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(44,126)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="76" y="132" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">AppSec / GRC</text>
+<text x="76" y="148" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#34d399">SARIF · compliance · audit</text>
+<rect x="28" y="176" width="432" height="54" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="40" y="190" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(44,194)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="76" y="200" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Platform / SRE</text>
+<text x="76" y="216" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#fbbf24">fleet · Helm · CI gates</text>
+<rect x="28" y="244" width="432" height="54" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="40" y="258" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(44,262)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="76" y="268" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Agent builders</text>
+<text x="76" y="284" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#60a5fa">MCP inventory · shield</text>
+<rect x="28" y="312" width="432" height="54" rx="10" fill="#161619" stroke="#2a2a31"/>
+<rect x="40" y="326" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(44,330)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="76" y="336" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Security engineers</text>
+<text x="76" y="352" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#a78bfa">blast radius · paths</text>
+<rect x="500" y="108" width="432" height="54" rx="10" fill="#15121f" stroke="#5b4bbd"/>
+<rect x="512" y="122" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(516,126)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="548" y="132" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Accurate SCA</text>
+<text x="548" y="148" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">15 ecosystems · distro-aware</text>
+<line x1="468" y1="135" x2="492" y2="135" stroke="#8b5cf6" stroke-width="1.6" marker-end="url(#pv-dark)"/>
+<rect x="500" y="176" width="432" height="54" rx="10" fill="#15121f" stroke="#5b4bbd"/>
+<rect x="512" y="190" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(516,194)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
+<text x="548" y="200" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Container coverage</text>
+<text x="548" y="216" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">OCI native · Grype opt-in</text>
+<line x1="468" y1="203" x2="492" y2="203" stroke="#8b5cf6" stroke-width="1.6" marker-end="url(#pv-dark)"/>
+<rect x="500" y="244" width="432" height="54" rx="10" fill="#15121f" stroke="#5b4bbd"/>
+<rect x="512" y="258" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(516,262)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="548" y="268" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Self-hosted evidence</text>
+<text x="548" y="284" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">your VPC · signed audit</text>
+<line x1="468" y1="271" x2="492" y2="271" stroke="#8b5cf6" stroke-width="1.6" marker-end="url(#pv-dark)"/>
+<rect x="500" y="312" width="432" height="54" rx="10" fill="#15121f" stroke="#5b4bbd"/>
+<rect x="512" y="326" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(516,330)" fill="none" stroke="#a78bfa" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="548" y="336" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Agent-native API</text>
+<text x="548" y="352" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#82828c">283 ops · 70 MCP tools</text>
+<line x1="468" y1="339" x2="492" y2="339" stroke="#8b5cf6" stroke-width="1.6" marker-end="url(#pv-dark)"/>
+<rect x="28" y="364" width="904" height="24" rx="7" fill="#0c1a14" stroke="#1f4438"/><text x="480" y="380" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 420" fill="none" role="img" aria-labelledby="pv-dark-title">
+<title id="pv-dark-title">agent-bom personas and value</title>
+<rect width="980" height="420" rx="14" fill="#0a0a0c"/>
+<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="#f4f4f5">Who it serves · what they get</text>
+<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="#71717a">One evidence model — different buyers, same inventory → findings → graph → gates</text>
+<defs><marker id="pv-dark" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#8b5cf6"/></marker></defs>
+<text x="36" y="98" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">PERSONAS</text>
+<text x="500" y="98" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">VALUE PROOF</text>
+<rect x="36" y="112" width="420" height="56" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="48" y="126" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(53,131)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="88" y="138" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">AppSec / GRC</text>
+<text x="88" y="154" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#34d399">SARIF · compliance · audit chain</text>
+<rect x="36" y="180" width="420" height="56" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="48" y="194" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(53,199)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="88" y="206" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Platform / SRE</text>
+<text x="88" y="222" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#fbbf24">fleet · Helm · CI gates</text>
+<rect x="36" y="248" width="420" height="56" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="48" y="262" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(53,267)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="88" y="274" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Agent builders</text>
+<text x="88" y="290" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#60a5fa">MCP inventory · runtime shield</text>
+<rect x="36" y="316" width="420" height="56" rx="11" fill="#161619" stroke="#2a2a31"/>
+<rect x="48" y="330" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(53,335)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="88" y="342" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Security engineers</text>
+<text x="88" y="358" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#a78bfa">blast radius · attack paths</text>
+<rect x="500" y="112" width="444" height="56" rx="11" fill="#15121f" stroke="#5b4bbd"/>
+<rect x="512" y="126" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(517,131)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="552" y="138" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Accurate SCA</text>
+<text x="552" y="154" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#82828c">15 ecosystems · distro-aware</text>
+<line x1="456" y1="140" x2="500" y2="140" stroke="#8b5cf6" stroke-width="1.8" marker-end="url(#pv-dark)"/>
+<rect x="500" y="180" width="444" height="56" rx="11" fill="#15121f" stroke="#5b4bbd"/>
+<rect x="512" y="194" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(517,199)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
+<text x="552" y="206" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Container coverage</text>
+<text x="552" y="222" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#82828c">OCI native · optional Grype</text>
+<line x1="456" y1="208" x2="500" y2="208" stroke="#8b5cf6" stroke-width="1.8" marker-end="url(#pv-dark)"/>
+<rect x="500" y="248" width="444" height="56" rx="11" fill="#15121f" stroke="#5b4bbd"/>
+<rect x="512" y="262" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(517,267)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="552" y="274" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Self-hosted evidence</text>
+<text x="552" y="290" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#82828c">your VPC · signed audit</text>
+<line x1="456" y1="276" x2="500" y2="276" stroke="#8b5cf6" stroke-width="1.8" marker-end="url(#pv-dark)"/>
+<rect x="500" y="316" width="444" height="56" rx="11" fill="#15121f" stroke="#5b4bbd"/>
+<rect x="512" y="330" width="26" height="26" rx="7" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(517,335)" fill="none" stroke="#a78bfa" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="552" y="342" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#e9e9ec">Agent-native API</text>
+<text x="552" y="358" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#82828c">283 ops · 70 MCP tools</text>
+<line x1="456" y1="344" x2="500" y2="344" stroke="#8b5cf6" stroke-width="1.8" marker-end="url(#pv-dark)"/>
+<rect x="36" y="372" width="908" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="490" y="390" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME ENFORCEMENT — same Finding + UnifiedGraph everywhere</text>
+</svg>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -1,46 +1,48 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 420" fill="none" role="img" aria-labelledby="pv-light-title">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 400" fill="none" role="img" aria-labelledby="pv-light-title">
 <title id="pv-light-title">agent-bom personas and value</title>
-<rect width="980" height="420" rx="14" fill="#ffffff"/>
-<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="#18181b">Who it serves · what they get</text>
-<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="#71717a">One evidence model — different buyers, same inventory → findings → graph → gates</text>
-<defs><marker id="pv-light" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker></defs>
-<text x="36" y="98" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">PERSONAS</text>
-<text x="500" y="98" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">VALUE PROOF</text>
-<rect x="36" y="112" width="420" height="56" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="48" y="126" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(53,131)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="88" y="138" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">AppSec / GRC</text>
-<text x="88" y="154" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#34d399">SARIF · compliance · audit chain</text>
-<rect x="36" y="180" width="420" height="56" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="48" y="194" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(53,199)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="88" y="206" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Platform / SRE</text>
-<text x="88" y="222" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#fbbf24">fleet · Helm · CI gates</text>
-<rect x="36" y="248" width="420" height="56" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="48" y="262" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(53,267)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="88" y="274" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Agent builders</text>
-<text x="88" y="290" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#60a5fa">MCP inventory · runtime shield</text>
-<rect x="36" y="316" width="420" height="56" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="48" y="330" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(53,335)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="88" y="342" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Security engineers</text>
-<text x="88" y="358" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#a78bfa">blast radius · attack paths</text>
-<rect x="500" y="112" width="444" height="56" rx="11" fill="#f5f3ff" stroke="#c4b5fd"/>
-<rect x="512" y="126" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(517,131)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="552" y="138" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Accurate SCA</text>
-<text x="552" y="154" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#71717a">15 ecosystems · distro-aware</text>
-<line x1="456" y1="140" x2="500" y2="140" stroke="#7c3aed" stroke-width="1.8" marker-end="url(#pv-light)"/>
-<rect x="500" y="180" width="444" height="56" rx="11" fill="#f5f3ff" stroke="#c4b5fd"/>
-<rect x="512" y="194" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(517,199)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
-<text x="552" y="206" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Container coverage</text>
-<text x="552" y="222" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#71717a">OCI native · optional Grype</text>
-<line x1="456" y1="208" x2="500" y2="208" stroke="#7c3aed" stroke-width="1.8" marker-end="url(#pv-light)"/>
-<rect x="500" y="248" width="444" height="56" rx="11" fill="#f5f3ff" stroke="#c4b5fd"/>
-<rect x="512" y="262" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(517,267)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="552" y="274" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Self-hosted evidence</text>
-<text x="552" y="290" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#71717a">your VPC · signed audit</text>
-<line x1="456" y1="276" x2="500" y2="276" stroke="#7c3aed" stroke-width="1.8" marker-end="url(#pv-light)"/>
-<rect x="500" y="316" width="444" height="56" rx="11" fill="#f5f3ff" stroke="#c4b5fd"/>
-<rect x="512" y="330" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(517,335)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="552" y="342" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Agent-native API</text>
-<text x="552" y="358" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#71717a">283 ops · 70 MCP tools</text>
-<line x1="456" y1="344" x2="500" y2="344" stroke="#7c3aed" stroke-width="1.8" marker-end="url(#pv-light)"/>
-<rect x="36" y="372" width="908" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="490" y="390" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME ENFORCEMENT — same Finding + UnifiedGraph everywhere</text>
+<defs>
+<marker id="pv-light" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
+</defs>
+<rect width="960" height="400" rx="12" fill="#ffffff"/>
+<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="850" fill="#18181b">Who it serves · what they get</text>
+<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">One evidence model — inventory → findings → graph → gates</text>
+<text x="28" y="88" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">PERSONAS</text>
+<text x="500" y="88" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">VALUE PROOF</text>
+<rect x="28" y="108" width="432" height="54" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="40" y="122" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(44,126)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="76" y="132" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">AppSec / GRC</text>
+<text x="76" y="148" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#34d399">SARIF · compliance · audit</text>
+<rect x="28" y="176" width="432" height="54" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="40" y="190" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(44,194)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="76" y="200" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Platform / SRE</text>
+<text x="76" y="216" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#fbbf24">fleet · Helm · CI gates</text>
+<rect x="28" y="244" width="432" height="54" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="40" y="258" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(44,262)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="76" y="268" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Agent builders</text>
+<text x="76" y="284" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#60a5fa">MCP inventory · shield</text>
+<rect x="28" y="312" width="432" height="54" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="40" y="326" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(44,330)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="76" y="336" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Security engineers</text>
+<text x="76" y="352" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#a78bfa">blast radius · paths</text>
+<rect x="500" y="108" width="432" height="54" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
+<rect x="512" y="122" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(516,126)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="548" y="132" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Accurate SCA</text>
+<text x="548" y="148" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">15 ecosystems · distro-aware</text>
+<line x1="468" y1="135" x2="492" y2="135" stroke="#7c3aed" stroke-width="1.6" marker-end="url(#pv-light)"/>
+<rect x="500" y="176" width="432" height="54" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
+<rect x="512" y="190" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(516,194)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
+<text x="548" y="200" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Container coverage</text>
+<text x="548" y="216" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">OCI native · Grype opt-in</text>
+<line x1="468" y1="203" x2="492" y2="203" stroke="#7c3aed" stroke-width="1.6" marker-end="url(#pv-light)"/>
+<rect x="500" y="244" width="432" height="54" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
+<rect x="512" y="258" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(516,262)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="548" y="268" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Self-hosted evidence</text>
+<text x="548" y="284" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">your VPC · signed audit</text>
+<line x1="468" y1="271" x2="492" y2="271" stroke="#7c3aed" stroke-width="1.6" marker-end="url(#pv-light)"/>
+<rect x="500" y="312" width="432" height="54" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
+<rect x="512" y="326" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(516,330)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="548" y="336" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Agent-native API</text>
+<text x="548" y="352" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">283 ops · 70 MCP tools</text>
+<line x1="468" y1="339" x2="492" y2="339" stroke="#7c3aed" stroke-width="1.6" marker-end="url(#pv-light)"/>
+<rect x="28" y="364" width="904" height="24" rx="7" fill="#ecfdf5" stroke="#bbf7d0"/><text x="480" y="380" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -1,0 +1,46 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 420" fill="none" role="img" aria-labelledby="pv-light-title">
+<title id="pv-light-title">agent-bom personas and value</title>
+<rect width="980" height="420" rx="14" fill="#ffffff"/>
+<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="#18181b">Who it serves · what they get</text>
+<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="#71717a">One evidence model — different buyers, same inventory → findings → graph → gates</text>
+<defs><marker id="pv-light" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="9" markerHeight="7" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker></defs>
+<text x="36" y="98" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">PERSONAS</text>
+<text x="500" y="98" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">VALUE PROOF</text>
+<rect x="36" y="112" width="420" height="56" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="48" y="126" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(53,131)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="88" y="138" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">AppSec / GRC</text>
+<text x="88" y="154" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#34d399">SARIF · compliance · audit chain</text>
+<rect x="36" y="180" width="420" height="56" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="48" y="194" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(53,199)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="88" y="206" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Platform / SRE</text>
+<text x="88" y="222" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#fbbf24">fleet · Helm · CI gates</text>
+<rect x="36" y="248" width="420" height="56" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="48" y="262" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(53,267)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="88" y="274" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Agent builders</text>
+<text x="88" y="290" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#60a5fa">MCP inventory · runtime shield</text>
+<rect x="36" y="316" width="420" height="56" rx="11" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="48" y="330" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(53,335)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="88" y="342" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Security engineers</text>
+<text x="88" y="358" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#a78bfa">blast radius · attack paths</text>
+<rect x="500" y="112" width="444" height="56" rx="11" fill="#f5f3ff" stroke="#c4b5fd"/>
+<rect x="512" y="126" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(517,131)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="552" y="138" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Accurate SCA</text>
+<text x="552" y="154" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#71717a">15 ecosystems · distro-aware</text>
+<line x1="456" y1="140" x2="500" y2="140" stroke="#7c3aed" stroke-width="1.8" marker-end="url(#pv-light)"/>
+<rect x="500" y="180" width="444" height="56" rx="11" fill="#f5f3ff" stroke="#c4b5fd"/>
+<rect x="512" y="194" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(517,199)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
+<text x="552" y="206" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Container coverage</text>
+<text x="552" y="222" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#71717a">OCI native · optional Grype</text>
+<line x1="456" y1="208" x2="500" y2="208" stroke="#7c3aed" stroke-width="1.8" marker-end="url(#pv-light)"/>
+<rect x="500" y="248" width="444" height="56" rx="11" fill="#f5f3ff" stroke="#c4b5fd"/>
+<rect x="512" y="262" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(517,267)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="552" y="274" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Self-hosted evidence</text>
+<text x="552" y="290" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#71717a">your VPC · signed audit</text>
+<line x1="456" y1="276" x2="500" y2="276" stroke="#7c3aed" stroke-width="1.8" marker-end="url(#pv-light)"/>
+<rect x="500" y="316" width="444" height="56" rx="11" fill="#f5f3ff" stroke="#c4b5fd"/>
+<rect x="512" y="330" width="26" height="26" rx="7" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(517,335)" fill="none" stroke="#7c3aed" stroke-width="1.55" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="552" y="342" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="#18181b">Agent-native API</text>
+<text x="552" y="358" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#71717a">283 ops · 70 MCP tools</text>
+<line x1="456" y1="344" x2="500" y2="344" stroke="#7c3aed" stroke-width="1.8" marker-end="url(#pv-light)"/>
+<rect x="36" y="372" width="908" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="490" y="390" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME ENFORCEMENT — same Finding + UnifiedGraph everywhere</text>
+</svg>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -1,11 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 960 400" fill="none" role="img" aria-labelledby="pv-light-title">
-<title id="pv-light-title">agent-bom personas and value</title>
-<defs>
-<marker id="pv-light" viewBox="0 0 10 8" refX="8.5" refY="4" markerWidth="8" markerHeight="6" orient="auto"><path d="M0 0 L10 4 L0 8 Z" fill="#7c3aed"/></marker>
-</defs>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="400" viewBox="0 0 960 400" fill="none">
+<title>agent-bom personas and value</title>
 <rect width="960" height="400" rx="12" fill="#ffffff"/>
-<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="850" fill="#18181b">Who it serves · what they get</text>
-<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">One evidence model — inventory → findings → graph → gates</text>
+<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#18181b">Who it serves · what they get</text>
+<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">One evidence model — inventory -&gt; findings -&gt; graph -&gt; gates</text>
 <text x="28" y="88" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">PERSONAS</text>
 <text x="500" y="88" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">VALUE PROOF</text>
 <rect x="28" y="108" width="432" height="54" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
@@ -28,21 +26,21 @@
 <rect x="512" y="122" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(516,126)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
 <text x="548" y="132" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Accurate SCA</text>
 <text x="548" y="148" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">15 ecosystems · distro-aware</text>
-<line x1="468" y1="135" x2="492" y2="135" stroke="#7c3aed" stroke-width="1.6" marker-end="url(#pv-light)"/>
+<line x1="468" y1="135" x2="485" y2="135" stroke="#7c3aed" stroke-width="1.6"/><polygon points="491,135 484,131.5 484,138.5" fill="#7c3aed"/>
 <rect x="500" y="176" width="432" height="54" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
 <rect x="512" y="190" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(516,194)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
 <text x="548" y="200" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Container coverage</text>
 <text x="548" y="216" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">OCI native · Grype opt-in</text>
-<line x1="468" y1="203" x2="492" y2="203" stroke="#7c3aed" stroke-width="1.6" marker-end="url(#pv-light)"/>
+<line x1="468" y1="203" x2="485" y2="203" stroke="#7c3aed" stroke-width="1.6"/><polygon points="491,203 484,199.5 484,206.5" fill="#7c3aed"/>
 <rect x="500" y="244" width="432" height="54" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
 <rect x="512" y="258" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(516,262)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
 <text x="548" y="268" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Self-hosted evidence</text>
 <text x="548" y="284" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">your VPC · signed audit</text>
-<line x1="468" y1="271" x2="492" y2="271" stroke="#7c3aed" stroke-width="1.6" marker-end="url(#pv-light)"/>
+<line x1="468" y1="271" x2="485" y2="271" stroke="#7c3aed" stroke-width="1.6"/><polygon points="491,271 484,267.5 484,274.5" fill="#7c3aed"/>
 <rect x="500" y="312" width="432" height="54" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
 <rect x="512" y="326" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(516,330)" fill="none" stroke="#7c3aed" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
 <text x="548" y="336" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Agent-native API</text>
 <text x="548" y="352" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="#71717a">283 ops · 70 MCP tools</text>
-<line x1="468" y1="339" x2="492" y2="339" stroke="#7c3aed" stroke-width="1.6" marker-end="url(#pv-light)"/>
-<rect x="28" y="364" width="904" height="24" rx="7" fill="#ecfdf5" stroke="#bbf7d0"/><text x="480" y="380" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<line x1="468" y1="339" x2="485" y2="339" stroke="#7c3aed" stroke-width="1.6"/><polygon points="491,339 484,335.5 484,342.5" fill="#7c3aed"/>
+<rect x="24" y="364" width="912" height="24" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="480" y="380" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/docs/images/scan-pipeline-dark.svg
+++ b/docs/images/scan-pipeline-dark.svg
@@ -206,5 +206,5 @@
 
   <!-- ═══ BOTTOM BAR: Security guarantee ═══ -->
   <rect x="20" y="380" width="920" height="28" rx="8" fill="#18181b" stroke="#27272a" stroke-width="1"/>
-  <text x="480" y="399" text-anchor="middle" font-size="9" font-weight="600" fill="#52525b" letter-spacing="0.06em" font-family="system-ui, sans-serif">READ-ONLY GUARANTEE · never writes configs · never runs servers · never stores secrets · --dry-run previews everything · Sigstore signed</text>
+  <text x="480" y="399" text-anchor="middle" font-size="9" font-weight="600" fill="#52525b" letter-spacing="0.06em" font-family="system-ui, sans-serif">READ-ONLY SCAN · no target writes · no secret values · --dry-run previews everything · offline-capable with local DB</text>
 </svg>

--- a/docs/images/scan-pipeline-light.svg
+++ b/docs/images/scan-pipeline-light.svg
@@ -206,5 +206,5 @@
 
   <!-- ═══ BOTTOM BAR ═══ -->
   <rect x="20" y="380" width="920" height="28" rx="8" fill="#fafafa" stroke="#e4e4e7" stroke-width="1"/>
-  <text x="480" y="399" text-anchor="middle" font-size="9" font-weight="600" fill="#a1a1aa" letter-spacing="0.06em" font-family="system-ui, sans-serif">READ-ONLY GUARANTEE · never writes configs · never runs servers · never stores secrets · --dry-run previews everything · Sigstore signed</text>
+  <text x="480" y="399" text-anchor="middle" font-size="9" font-weight="600" fill="#a1a1aa" letter-spacing="0.06em" font-family="system-ui, sans-serif">READ-ONLY SCAN · no target writes · no secret values · --dry-run previews everything · offline-capable with local DB</text>
 </svg>

--- a/docs/issues/alpine-apk-coverage-gap.md
+++ b/docs/issues/alpine-apk-coverage-gap.md
@@ -1,0 +1,77 @@
+# Alpine APK advisory coverage gap
+
+Status: **tracked** — partial fix in [#TBD]; remaining work below.
+
+## Summary
+
+Hands-on container scans show major under-detection on Alpine Linux images compared
+with reference scanners. Package extraction (OCI/APK inventory) is correct; the gap
+is **advisory coverage and matching** for distro-scoped apk packages.
+
+Example (`alpine:3.14` tarball, 14 apk packages extracted):
+
+| Scanner | Vulns reported |
+| --- | ---: |
+| agent-bom (pre-fix, stale DB) | 2 |
+| Reference scanner (Grype) | 37 |
+
+This is a **P1 accuracy** issue for security buyers evaluating container scanning.
+
+## Root causes (confirmed)
+
+1. **SecDB sync window too narrow** — `sync_alpine_secdb` only ingested `v3.18`–`v3.23`,
+   missing EOL-but-common branches such as `v3.14`–`v3.17`.
+2. **OSV fallback list matched sync window** — apk packages without `distro_version`
+   fell back to the same narrow branch list.
+3. **Release keying** — fixed separately in `alpine_release_branch()` (point releases
+   like `3.16.9` must map to `v3.16`). Do not regress.
+4. **Subpackage matching** — Alpine secdb keys advisories by origin/source package;
+   installed subpackages (`musl-utils`, `ssl_client`) must query via `source_package`.
+
+## Shipped in the scan-accuracy PR
+
+- [x] Extend `ALPINE_SECDB_BRANCHES` to `v3.14`–`v3.23` (shared constant in
+  `package_utils.py`).
+- [x] Align `_ALPINE_OSV_FALLBACKS` with the same branch list.
+- [x] Optional `AGENT_BOM_IMAGE_GRYPE_FALLBACK=1` bridge for `agent-bom image --tar`
+  (`docker-archive:` target) when native matching under-reports.
+- [x] Regression tests for branch constants and release keying.
+
+## Remaining work
+
+- [ ] **DB refresh cadence** — document that existing installs need
+  `agent-bom db update` after upgrading to pick up new secdb branches.
+- [ ] **Accuracy baseline** — add alpine:3.14 (or fixture tar) to
+  `tests/fixtures/accuracy/` with a minimum vuln floor once DB is warm.
+- [ ] **Coverage-gap UX** — when apk advisories are sparse for a detected release,
+  surface the existing `detect_release_coverage_gaps()` warning in `agent-bom image`
+  focused output (not only full `agents` scan).
+- [ ] **OSV online fallback** — for offline=false image scans on EOL Alpine branches,
+  consider OSV `Alpine:v3.xx` batch lookup when local secdb row count is below threshold.
+- [ ] **Benchmark table** — publish reproducible compare script output in
+  `docs/PERFORMANCE_BENCHMARKS.md` (no competitor names in marketing copy; script
+  may reference tools for internal QA).
+
+## Verification commands
+
+```bash
+# After agent-bom db update
+agent-bom image --tar /path/to/alpine-3.14.tar -f json | jq '[.[] | .. | objects | select(has("vulnerabilities"))] | length'
+
+# Optional bridge when local DB is stale or branch is sparse
+AGENT_BOM_IMAGE_GRYPE_FALLBACK=1 agent-bom image --tar /path/to/alpine-3.14.tar -f json
+
+pytest tests/test_alpine_release_keying.py tests/test_image_grype_tar_fallback.py -q
+python scripts/generate_doc_architecture_svgs.py
+pytest tests/test_doc_architecture_svgs.py -q
+```
+
+## Acceptance criteria
+
+1. `alpine:3.14` tarball scan reports **materially more** than 2 vulnerabilities after
+   `db update` on a fresh install (target: within ~20% of Grype on the same tar, acknowledging
+   EOL distro variance).
+2. `agent-bom db update` ingests secdb rows for `alpine:v3.14` (verify with
+   `sqlite3 ~/.agent-bom/vulns.db "select count(*) from affected where ecosystem='alpine:v3.14'"`).
+3. Coverage-gap warning appears when advisory row count for a detected release is near zero.
+4. No regression on npm/pypi spot-check accuracy or red-team corpus tests.

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -117,6 +117,11 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_HTTP_MAX_RETRIES` | `int` | `3` | Used by http_client.create_client() and request_with_retry().  Defaults: 3 retries with 1s initial backoff (doubles each retry, capped at 30s).  30s per-request timeout covers most external APIs; NVD can be slow so operators may raise this. |
 | `AGENT_BOM_HTTP_RATE_LIMIT_BREAKER_THRESHOLD` | `int` | `3` | Registry rate-limit circuit breaker: number of HTTP 429 responses from a single host within one scan before live lookups to that host are short- circuited to the cached/bundled fallback path for the rest of the run. Keeps a registry throttl |
 
+## Image Scanning
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_IMAGE_GRYPE_FALLBACK` | `bool` | `False` | Optional Grype fallback for ``agent-bom image --tar`` when native OCI/archive extraction yields no packages. Off by default — enable only when bridging legacy tarballs that Grype handles better than the native parser. |
+
 ## Local Analytics
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -395,7 +395,7 @@ ignore = []
 "__init__.py" = ["F401"]  # Allow unused imports in __init__.py
 "fuzz/*.py" = ["N802", "T201"]  # TestOneInput is required atheris entry; harnesses print repro output
 "src/agent_bom/output/html.py" = ["E501"]  # Inline HTML/CSS/JS template strings cannot be meaningfully wrapped
-"src/agent_bom/cloud/*_cis_benchmark.py" = ["E501"]  # CIS benchmark remediation strings are naturally long
+"scripts/generate_doc_architecture_svgs.py" = ["E501"]  # SVG coordinate strings are intentionally single-line
 # T201 allowlist — places where bare `print()` is legitimately the contract:
 "scripts/*.py" = ["T201"]  # Ops scripts — stdout is the documented interface
 "tests/**/*.py" = ["T201"]  # Pytest assertions + debug tracebacks

--- a/scripts/generate_doc_architecture_svgs.py
+++ b/scripts/generate_doc_architecture_svgs.py
@@ -90,6 +90,19 @@ def _esc(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
+def _svg_open(w: int, h: int, title: str, desc: str | None = None) -> list[str]:
+    """GitHub-safe SVG root — explicit dimensions, no role/aria (sanitizer-friendly)."""
+    parts = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{w}" height="{h}" '
+        f'viewBox="0 0 {w} {h}" fill="none">',
+        f"<title>{_esc(title)}</title>",
+    ]
+    if desc:
+        parts.append(f"<desc>{_esc(desc)}</desc>")
+    return parts
+
+
 def _text(x: int | float, y: int | float, content: str, **attrs: str) -> str:
     attr_bits = " ".join(f'{key}="{value}"' for key, value in attrs.items())
     prefix = f'<text x="{x}" y="{y}"'
@@ -98,21 +111,9 @@ def _text(x: int | float, y: int | float, content: str, **attrs: str) -> str:
     return f"{prefix}>{_esc(content)}</text>"
 
 
-def _marker(theme: dict, name: str, color_key: str) -> str:
-    return (
-        f'<marker id="{name}" viewBox="0 0 10 8" refX="8.5" refY="4" '
-        f'markerWidth="8" markerHeight="6" orient="auto">'
-        f'<path d="M0 0 L10 4 L0 8 Z" fill="{theme[color_key]}"/></marker>'
-    )
-
-
 def _icon_box(x: int, y: int, paths: str, t: dict, accent: bool = False, *, box: bool = True) -> str:
     stroke = t["ic_accent"] if accent else t["ic"]
-    box_svg = (
-        f'<rect x="{x}" y="{y}" width="24" height="24" rx="6" fill="{t["icon_bg"]}" stroke="{t["icon_stroke"]}"/>'
-        if box
-        else ""
-    )
+    box_svg = f'<rect x="{x}" y="{y}" width="24" height="24" rx="6" fill="{t["icon_bg"]}" stroke="{t["icon_stroke"]}"/>' if box else ""
     return (
         f"{box_svg}"
         f'<g transform="translate({x + 4},{y + 4})" fill="none" stroke="{stroke}" stroke-width="1.5" '
@@ -131,16 +132,54 @@ def _lane_header(x: int, y: int, w: int, label: str, lane_key: str, tag: str, t:
     )
 
 
-def _lane_flow(x1: int, x2: int, y: int, label: str, t: dict, marker: str, accent: bool = False) -> str:
+def _lane_flow(x1: int, x2: int, y: int, label: str, t: dict, accent: bool = False) -> str:
+    """Header-band connector without marker url(#…) refs (GitHub PR preview rejects those)."""
     color = t["arrow_accent"] if accent else t["arrow"]
     width = "2.2" if accent else "1.8"
+    tip = x2 - 1
+    stem = x2 - 7
     return (
-        f'<line x1="{x1}" y1="{y}" x2="{x2}" y2="{y}" stroke="{color}" stroke-width="{width}" '
-        f'marker-end="url(#{marker})"/>'
+        f'<line x1="{x1}" y1="{y}" x2="{stem}" y2="{y}" stroke="{color}" stroke-width="{width}"/>'
+        f'<polygon points="{tip},{y} {stem},{y - 3.5} {stem},{y + 3.5}" fill="{color}"/>'
         f'<text x="{(x1 + x2) // 2}" y="{y - 8}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
         f'font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="{t["accent"] if accent else t["lane_muted"]}">'
         f"{_esc(label)}</text>"
     )
+
+
+def _trust_footer(w: int, h: int, t: dict, message: str, *, height: int = 28) -> str:
+    y = h - height - 12
+    return (
+        f'<rect x="24" y="{y}" width="{w - 48}" height="{height}" rx="8" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
+        + _text(
+            w // 2,
+            y + height - 8,
+            message,
+            **{
+                "text-anchor": "middle",
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "8.5",
+                "font-weight": "600",
+                "fill": t["trust"],
+            },
+        )
+    )
+
+
+def _audit_github_safe(svg: str) -> list[str]:
+    """Checks that block GitHub PR SVG previews and README embeds."""
+    issues: list[str] = []
+    if 'marker-end="url(#' in svg:
+        issues.append("marker-end url(#…) references are not GitHub-safe")
+    if 'role="img"' in svg or "aria-labelledby" in svg:
+        issues.append("role/aria-labelledby attributes are not GitHub-safe")
+    if not re.search(r'<svg[^>]+width="\d+"', svg):
+        issues.append("missing explicit svg width")
+    if re.search(r'&(?!amp;|lt;|gt;|quot;|apos;|#\d+;|#x[0-9a-fA-F]+;)', svg):
+        issues.append("unescaped ampersand in SVG text")
+    if "→" in svg or "←" in svg:
+        issues.append("raw Unicode arrows — use ASCII -> instead")
+    return issues
 
 
 ICONS = {
@@ -175,7 +214,11 @@ def _cloud_logos(x: int, y: int, t: dict) -> str:
     items = [
         ("AWS", "#ff9900", '<path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/>'),
         ("Azure", "#0078d4", '<path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/>'),
-        ("GCP", "#4285f4", '<circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/>'),
+        (
+            "GCP",
+            "#4285f4",
+            '<circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/>',
+        ),
         ("Snow", "#29b5e8", '<path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/>'),
     ]
     out = []
@@ -192,8 +235,10 @@ def _cloud_logos(x: int, y: int, t: dict) -> str:
 
 def how_it_works(theme_name: str) -> str:
     t = THEMES[theme_name]
-    suffix = "d" if theme_name == "dark" else "l"
-    w, h = 1180, 580
+    w, h = 960, 560
+    lane_gap = 8
+    lane_w = (w - 48 - 4 * lane_gap) // 5
+    lane_x = [24 + i * (lane_w + lane_gap) for i in range(5)]
 
     steps = [
         ("search", "Discover"),
@@ -224,88 +269,110 @@ def how_it_works(theme_name: str) -> str:
     outputs = ["SARIF", "SBOM", "HTML", "JSON", "GATE", "FIX"]
 
     lane_top = 84
-    lane_h = 380
+    lane_h = 360
     flow_y = lane_top + 16
 
-    lanes = [
-        (24, 200, "INTAKE", "intake", "read-only"),
-        (236, 176, "SCAN", "scan", "6 steps"),
-        (424, 232, "EVIDENCE", "core", "one model"),
-        (668, 176, "CONTROL", "control", "self-hosted"),
-        (856, 108, "OUT", "output", "artifacts"),
-    ]
-
-    parts = [
-        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" fill="none" role="img" '
-        f'aria-labelledby="hiw-{suffix}-title hiw-{suffix}-desc">',
-        f'<title id="hiw-{suffix}-title">How agent-bom works</title>',
-        f'<desc id="hiw-{suffix}-desc">Read-only intake through scan pipeline into unified Finding and UnifiedGraph.</desc>',
+    parts = _svg_open(w, h, "How agent-bom works", "Read-only intake through scan pipeline into unified Finding and UnifiedGraph.")
+    parts += [
         "<defs>",
-        _marker(t, "hiw", "arrow"),
-        _marker(t, "hiw-a", "arrow_accent"),
         '<linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1">'
         f'<stop offset="0%" stop-color="{t["accent"]}" stop-opacity="0.28"/>'
         f'<stop offset="100%" stop-color="{t["accent"]}" stop-opacity="0"/>'
         "</linearGradient>",
         "</defs>",
         f'<rect width="{w}" height="{h}" rx="14" fill="{t["bg"]}"/>',
-        _text(28, 40, "From inventory to enforceable evidence", **{"font-family": "Inter,system-ui,sans-serif", "font-size": "22", "font-weight": "850", "fill": t["title"]}),
+        _text(
+            28,
+            40,
+            "From inventory to enforceable evidence",
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "20", "font-weight": "800", "fill": t["title"]},
+        ),
         _text(
             28,
             60,
             "One read-only pipeline · one Finding + UnifiedGraph · CLI · API · UI · MCP",
-            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10.5", "font-weight": "500", "fill": t["subtitle"]},
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "500", "fill": t["subtitle"]},
         ),
     ]
 
-    for x, lw, label, key, tag in lanes:
+    lane_meta = [
+        ("INTAKE", "intake", "read-only"),
+        ("SCAN", "scan", "6 steps"),
+        ("EVIDENCE", "core", "one model"),
+        ("CONTROL", "control", "self-hosted"),
+        ("OUT", "output", "artifacts"),
+    ]
+    for i, (label, key, tag) in enumerate(lane_meta):
+        x = lane_x[i]
         parts.append(
-            f'<rect x="{x}" y="{lane_top}" width="{lw}" height="{lane_h}" rx="12" fill="{t["panel"]}" stroke="{t["panel_stroke"]}"/>'
+            f'<rect x="{x}" y="{lane_top}" width="{lane_w}" height="{lane_h}" rx="12" fill="{t["panel"]}" stroke="{t["panel_stroke"]}"/>'
         )
-        parts.append(_lane_header(x, lane_top, lw, label, key, tag, t))
+        parts.append(_lane_header(x, lane_top, lane_w, label, key, tag, t))
 
-    # Intake grid (2×4) — fits inside 200px lane with padding
+    intake_x = lane_x[0] + 8
     for i, (icon, label) in enumerate(intake):
         col, row = i % 2, i // 2
-        tx, ty = 36 + col * 94, lane_top + 44 + row * 50
-        parts.append(f'<rect x="{tx}" y="{ty}" width="84" height="40" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(tx + 6, ty + 8, ICONS[icon], t))
-        parts.append(_text(tx + 36, ty + 25, label, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]}))
+        tx, ty = intake_x + col * 82, lane_top + 44 + row * 48
+        parts.append(f'<rect x="{tx}" y="{ty}" width="74" height="38" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(tx + 6, ty + 7, ICONS[icon], t))
+        parts.append(
+            _text(
+                tx + 34,
+                ty + 24,
+                label,
+                **{"font-family": "Inter,system-ui,sans-serif", "font-size": "9.5", "font-weight": "700", "fill": t["text"]},
+            )
+        )
 
-    parts.append(_cloud_logos(36, lane_top + 252, t))
-    parts.append(_icon_box(36, lane_top + 292, ICONS["lock"], t, accent=True))
+    parts.append(_cloud_logos(intake_x, lane_top + 236, t))
+    parts.append(_icon_box(intake_x, lane_top + 276, ICONS["lock"], t, accent=True))
     parts.append(
-        _text(64, lane_top + 308, "no writes · no secret values", **{"font-family": "Inter,system-ui,sans-serif", "font-size": "8.5", "font-weight": "600", "fill": t["lane_muted"]})
+        _text(
+            64,
+            lane_top + 308,
+            "no writes · no secret values",
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "8.5", "font-weight": "600", "fill": t["lane_muted"]},
+        )
     )
 
-    # Scan steps — vertical list inside scan lane
+    scan_x = lane_x[1]
     scan_accent = LANE_COLORS["scan"][1]
+    step_cx = scan_x + 40
     for i, (icon, label) in enumerate(steps):
-        sy = lane_top + 44 + i * 48
-        parts.append(f'<circle cx="{248}" cy="{sy + 12}" r="11" fill="{t["card"]}" stroke="{scan_accent}" stroke-width="1.4"/>')
+        sy = lane_top + 44 + i * 46
         parts.append(
-            f'<text x="248" y="{sy + 16}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
+            f'<circle cx="{step_cx}" cy="{sy + 12}" r="10" fill="{t["card"]}" stroke="{scan_accent}" stroke-width="1.4"/>'
+        )
+        parts.append(
+            f'<text x="{step_cx}" y="{sy + 16}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
             f'font-size="8" font-weight="800" fill="{scan_accent}">{i + 1}</text>'
         )
-        parts.append(_icon_box(268, sy, ICONS[icon], t))
-        parts.append(_text(298, sy + 16, label, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "11", "font-weight": "700", "fill": t["text"]}))
+        parts.append(_icon_box(step_cx + 20, sy, ICONS[icon], t))
+        parts.append(
+            _text(
+                step_cx + 48,
+                sy + 16,
+                label,
+                **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]},
+            )
+        )
         if i < len(steps) - 1:
             parts.append(
-                f'<path d="M248 {sy + 24} V{sy + 32}" stroke="{t["panel_stroke"]}" stroke-width="1.4" stroke-linecap="round"/>'
+                f'<path d="M{step_cx} {sy + 24} V{sy + 30}" stroke="{t["panel_stroke"]}" stroke-width="1.4" stroke-linecap="round"/>'
             )
 
     for i, adv in enumerate(["OSV", "GHSA", "NVD", "KEV", "EPSS"]):
-        ax = 242 + i * 30
-        ay = lane_top + lane_h - 34
+        ax = scan_x + 8 + i * 32
+        ay = lane_top + lane_h - 32
         parts.append(
             f'<rect x="{ax}" y="{ay}" width="26" height="18" rx="5" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
             f'<text x="{ax + 13}" y="{ay + 12}" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" '
             f'font-weight="700" fill="{scan_accent}">{adv}</text>'
         )
 
-    # Evidence hub — compact radial graph
-    cx, cy = 540, lane_top + 200
-    parts.append(f'<circle cx="{cx}" cy="{cy}" r="62" fill="url(#core-glow)"/>')
+    evidence_x = lane_x[2]
+    cx, cy = evidence_x + lane_w // 2, lane_top + 188
+    parts.append(f'<circle cx="{cx}" cy="{cy}" r="54" fill="url(#core-glow)"/>')
     nodes = [
         (cx, cy - 48, "Finding", True, "finding"),
         (cx - 58, cy - 6, "Asset", False, "package"),
@@ -315,9 +382,7 @@ def how_it_works(theme_name: str) -> str:
     ]
     for nx, ny, nlabel, center, icon in nodes:
         if not center:
-            parts.append(
-                f'<line x1="{cx}" y1="{cy}" x2="{nx}" y2="{ny}" stroke="{t["panel_stroke"]}" stroke-width="1.2" opacity="0.7"/>'
-            )
+            parts.append(f'<line x1="{cx}" y1="{cy}" x2="{nx}" y2="{ny}" stroke="{t["panel_stroke"]}" stroke-width="1.2" opacity="0.7"/>')
     for nx, ny, nlabel, center, icon in nodes:
         r = 28 if center else 22
         fill = t["accent_fill"] if center else t["card"]
@@ -326,62 +391,84 @@ def how_it_works(theme_name: str) -> str:
         if center:
             parts.append(_icon_box(nx - 12, ny - 12, ICONS[icon], t, accent=True))
         parts.append(
-            _text(nx, ny + (18 if center else 16), nlabel, **{"text-anchor": "middle", "font-family": "Inter,system-ui,sans-serif", "font-size": "9" if center else "8", "font-weight": "800", "fill": t["accent"] if center else t["text"]})
+            _text(
+                nx,
+                ny + (18 if center else 16),
+                nlabel,
+                **{
+                    "text-anchor": "middle",
+                    "font-family": "Inter,system-ui,sans-serif",
+                    "font-size": "9" if center else "8",
+                    "font-weight": "800",
+                    "fill": t["accent"] if center else t["text"],
+                },
+            )
         )
 
     for i, chip in enumerate(["severity", "provenance", "tenant"]):
-        mx = 438 + i * 68
-        my = lane_top + lane_h - 40
+        mx = evidence_x + 10 + i * 52
+        my = lane_top + lane_h - 36
         parts.append(
-            f'<rect x="{mx}" y="{my}" width="60" height="20" rx="6" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
-            f'<text x="{mx + 30}" y="{my + 13}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" '
-            f'font-weight="700" fill="{t["chip"]}">{chip}</text>'
+            f'<rect x="{mx}" y="{my}" width="48" height="18" rx="6" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
+            f'<text x="{mx + 24}" y="{my + 12}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" '
+            f'font-weight="700" fill="{t["chip"]}">{_esc(chip)}</text>'
         )
 
-    # Control plane tiles (2×3)
+    control_x = lane_x[3] + 8
     for i, (icon, label) in enumerate(control):
         col, row = i % 2, i // 2
-        tx, ty = 680 + col * 80, lane_top + 44 + row * 56
-        parts.append(f'<rect x="{tx}" y="{ty}" width="72" height="46" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        tx, ty = control_x + col * 78, lane_top + 44 + row * 52
+        parts.append(f'<rect x="{tx}" y="{ty}" width="70" height="42" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
         parts.append(_icon_box(tx + 8, ty + 11, ICONS[icon], t))
-        parts.append(_text(tx + 38, ty + 28, label, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "9", "font-weight": "700", "fill": t["text"]}))
-
-    parts.append(
-        f'<rect x="680" y="{lane_top + lane_h - 38}" width="152" height="24" rx="7" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>'
-        f'<text x="756" y="{lane_top + lane_h - 22}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" '
-        f'font-weight="700" fill="{t["chip"]}">fail-closed · RBAC · audit</text>'
-    )
-
-    # Outputs — vertical stack
-    out_colors = ["#f87171", "#fbbf24", "#60a5fa", "#a78bfa", "#34d399", "#fb7185"]
-    for i, (label, color) in enumerate(zip(outputs, out_colors, strict=True)):
-        oy = lane_top + 44 + i * 48
         parts.append(
-            f'<rect x="868" y="{oy}" width="76" height="32" rx="8" fill="{t["card"]}" stroke="{color}" stroke-width="1.1"/>'
-            f'<circle cx="880" cy="{oy + 16}" r="3.5" fill="{color}"/>'
-            f'<text x="890" y="{oy + 20}" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="{t["text"]}">{_esc(label)}</text>'
+            _text(
+                tx + 38,
+                ty + 28,
+                label,
+                **{"font-family": "Inter,system-ui,sans-serif", "font-size": "9", "font-weight": "700", "fill": t["text"]},
+            )
         )
 
-    # Lane-to-lane flow in header band only (no crossing cards)
-    parts.append(_lane_flow(24 + 200, 236, flow_y, "collect", t, "hiw"))
-    parts.append(_lane_flow(236 + 176, 424, flow_y, "normalize", t, "hiw"))
-    parts.append(_lane_flow(424 + 232, 668, flow_y, "serve", t, "hiw-a", accent=True))
-    parts.append(_lane_flow(668 + 176, 856, flow_y, "export", t, "hiw"))
-
     parts.append(
-        f'<rect x="24" y="{h - 44}" width="{w - 48}" height="28" rx="8" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
-        f'<text x="44" y="{h - 26}" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="800" fill="{t["trust"]}">TRUST</text>'
-        f'<text x="88" y="{h - 26}" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="{t["chip"]}">'
-        "read-only · secret redaction · signed evidence · same model everywhere</text>"
+        f'<rect x="{control_x}" y="{lane_top + lane_h - 34}" width="{lane_w - 16}" height="22" rx="7" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>'
+        + _text(
+            control_x + (lane_w - 16) // 2,
+            lane_top + lane_h - 18,
+            "fail-closed · RBAC · audit",
+            **{
+                "text-anchor": "middle",
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "7.5",
+                "font-weight": "700",
+                "fill": t["chip"],
+            },
+        )
     )
+
+    out_x = lane_x[4] + 8
+    out_colors = ["#f87171", "#fbbf24", "#60a5fa", "#a78bfa", "#34d399", "#fb7185"]
+    for i, (label, color) in enumerate(zip(outputs, out_colors, strict=True)):
+        oy = lane_top + 44 + i * 46
+        parts.append(
+            f'<rect x="{out_x}" y="{oy}" width="{lane_w - 16}" height="30" rx="8" fill="{t["card"]}" stroke="{color}" stroke-width="1.1"/>'
+            f'<circle cx="{out_x + 10}" cy="{oy + 15}" r="3" fill="{color}"/>'
+            f'<text x="{out_x + 18}" y="{oy + 19}" font-family="ui-monospace,monospace" font-size="8.5" font-weight="800" fill="{t["text"]}">{_esc(label)}</text>'
+        )
+
+    for i in range(4):
+        parts.append(_lane_flow(lane_x[i] + lane_w, lane_x[i + 1], flow_y, ["collect", "normalize", "serve", "export"][i], t, accent=(i == 2)))
+
+    parts.append(_trust_footer(w, h, t, "read-only · secret redaction · signed evidence · same model everywhere"))
     parts.append("</svg>")
     return "\n".join(parts)
 
 
 def architecture(theme_name: str) -> str:
     t = THEMES[theme_name]
-    suffix = "d" if theme_name == "dark" else "l"
-    w, h = 1180, 600
+    w, h = 960, 560
+    lane_gap = 8
+    lane_w = (w - 48 - 4 * lane_gap) // 5
+    lane_x = [24 + i * (lane_w + lane_gap) for i in range(5)]
 
     sources = [
         ("package", "Supply chain", "15 eco"),
@@ -416,26 +503,28 @@ def architecture(theme_name: str) -> str:
     artifacts = ["SARIF", "CDX", "SPDX", "OCSF", "HTML", "JSON"]
 
     lane_top = 78
-    lane_h = 430
+    lane_h = 400
     flow_y = lane_top + 14
-    lane_x = [24, 204, 384, 564, 744]
-    lane_w = [168, 168, 168, 168, 412]
+    card_w = lane_w - 16
 
-    parts = [
-        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" fill="none" role="img" '
-        f'aria-labelledby="arch-{suffix}-title arch-{suffix}-desc">',
-        f'<title id="arch-{suffix}-title">agent-bom control-plane architecture</title>',
-        f'<desc id="arch-{suffix}-desc">Sources through scan and evidence core to control plane and consumers.</desc>',
-        "<defs>",
-        _marker(t, f"arch-{suffix}", "arrow"),
-        _marker(t, f"arch-a-{suffix}", "arrow_accent"),
-        "</defs>",
+    parts = _svg_open(
+        w,
+        h,
+        "agent-bom control-plane architecture",
+        "Sources through scan and evidence core to control plane and consumers.",
+    )
+    parts += [
         f'<rect width="{w}" height="{h}" rx="14" fill="{t["bg"]}"/>',
-        _text(28, 38, "Control-plane architecture", **{"font-family": "Inter,system-ui,sans-serif", "font-size": "21", "font-weight": "850", "fill": t["title"]}),
+        _text(
+            28,
+            38,
+            "Control-plane architecture",
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "20", "font-weight": "800", "fill": t["title"]},
+        ),
         _text(
             28,
             58,
-            "Sources → scan → Finding + UnifiedGraph → API · Gateway · MCP → people + agents",
+            "Sources -> scan -> Finding + UnifiedGraph -> API · Gateway · MCP -> people + agents",
             **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "500", "fill": t["subtitle"]},
         ),
     ]
@@ -445,118 +534,149 @@ def architecture(theme_name: str) -> str:
         ("SCAN", "enrich", "local"),
         ("EVIDENCE", "evidence", "normalized"),
         ("CONTROL", "control", "tenant auth"),
-        ("CONSUMERS", "consumers", "people+agents"),
+        ("CONSUMERS", "consumers", "deliver"),
     ]
     for i, (label, key, tag) in enumerate(lane_meta):
-        x, lw = lane_x[i], lane_w[i]
+        x = lane_x[i]
         parts.append(
-            f'<rect x="{x}" y="{lane_top}" width="{lw}" height="{lane_h}" rx="11" fill="{t["panel"]}" stroke="{t["panel_stroke"]}"/>'
+            f'<rect x="{x}" y="{lane_top}" width="{lane_w}" height="{lane_h}" rx="11" fill="{t["panel"]}" stroke="{t["panel_stroke"]}"/>'
         )
-        parts.append(_lane_header(x, lane_top, lw, label, key, tag, t))
+        parts.append(_lane_header(x, lane_top, lane_w, label, key, tag, t))
 
-    # Sources — compact cards
-    for i, (icon, title, badge) in enumerate(sources):
-        sy = lane_top + 42 + i * 52
-        parts.append(f'<rect x="36" y="{sy}" width="144" height="44" rx="8" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(44, sy + 10, ICONS[icon], t))
-        parts.append(_text(76, sy + 20, title, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]}))
-        parts.append(_text(76, sy + 33, badge, **{"font-family": "ui-monospace,monospace", "font-size": "7.5", "font-weight": "600", "fill": t["text_muted"]}))
-
-    for i, (icon, title, badge) in enumerate(scan_items):
-        sy = lane_top + 42 + i * 64
-        parts.append(f'<rect x="216" y="{sy}" width="144" height="52" rx="8" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(224, sy + 14, ICONS[icon], t))
-        parts.append(_text(256, sy + 26, title, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]}))
-        parts.append(_text(256, sy + 38, badge, **{"font-family": "ui-monospace,monospace", "font-size": "7.5", "font-weight": "600", "fill": t["text_muted"]}))
-
-    for i, (icon, title, badge, highlight) in enumerate(core_items):
-        sy = lane_top + 42 + i * 78
+    def _lane_card(lane_i: int, row: int, icon: str, title: str, badge: str, *, row_h: int = 50, highlight: bool = False) -> None:
+        x = lane_x[lane_i] + 8
+        sy = lane_top + 40 + row * row_h
         fill = t["accent_fill"] if highlight else t["card"]
         stroke = t["accent_stroke"] if highlight else t["card_stroke"]
+        ch = row_h - 6
         parts.append(
-            f'<rect x="396" y="{sy}" width="144" height="64" rx="8" fill="{fill}" stroke="{stroke}" stroke-width="{"1.5" if highlight else "1"}"/>'
+            f'<rect x="{x}" y="{sy}" width="{card_w}" height="{ch}" rx="8" fill="{fill}" stroke="{stroke}" stroke-width="{"1.5" if highlight else "1"}"/>'
         )
-        parts.append(_icon_box(404, sy + 18, ICONS[icon], t, accent=highlight))
-        parts.append(_text(436, sy + 28, title, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]}))
+        parts.append(_icon_box(x + 8, sy + (ch - 24) // 2, ICONS[icon], t, accent=highlight))
         parts.append(
             _text(
-                436,
-                sy + 42,
+                x + 38,
+                sy + ch // 2 - 2,
+                title,
+                **{"font-family": "Inter,system-ui,sans-serif", "font-size": "9.5", "font-weight": "700", "fill": t["text"]},
+            )
+        )
+        parts.append(
+            _text(
+                x + 38,
+                sy + ch // 2 + 11,
                 badge,
-                **{"font-family": "ui-monospace,monospace", "font-size": "7.5", "font-weight": "600", "fill": t["accent"] if highlight else t["text_muted"]},
+                **{
+                    "font-family": "ui-monospace,monospace",
+                    "font-size": "7",
+                    "font-weight": "600",
+                    "fill": t["accent"] if highlight else t["text_muted"],
+                },
             )
         )
 
+    for i, (icon, title, badge) in enumerate(sources):
+        _lane_card(0, i, icon, title, badge, row_h=48)
+
+    for i, (icon, title, badge) in enumerate(scan_items):
+        _lane_card(1, i, icon, title, badge, row_h=58)
+
+    for i, (icon, title, badge, highlight) in enumerate(core_items):
+        _lane_card(2, i, icon, title, badge, row_h=72, highlight=highlight)
+
     for i, (icon, title, badge) in enumerate(cp_items):
-        sy = lane_top + 42 + i * 78
-        parts.append(f'<rect x="576" y="{sy}" width="144" height="64" rx="8" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(584, sy + 18, ICONS[icon], t))
-        parts.append(_text(616, sy + 28, title, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]}))
-        parts.append(_text(616, sy + 42, badge, **{"font-family": "ui-monospace,monospace", "font-size": "7.5", "font-weight": "600", "fill": t["text_muted"]}))
+        _lane_card(3, i, icon, title, badge, row_h=72)
 
     parts.append(
-        f'<rect x="576" y="{lane_top + lane_h - 36}" width="144" height="26" rx="7" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>'
-        f'<text x="648" y="{lane_top + lane_h - 19}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" '
-        f'font-weight="700" fill="{t["chip"]}">OIDC · SAML · SCIM · RBAC</text>'
+        f'<rect x="{lane_x[3] + 8}" y="{lane_top + lane_h - 32}" width="{card_w}" height="22" rx="7" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>'
+        + _text(
+            lane_x[3] + 8 + card_w // 2,
+            lane_top + lane_h - 16,
+            "OIDC · SAML · SCIM · RBAC",
+            **{
+                "text-anchor": "middle",
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "7",
+                "font-weight": "700",
+                "fill": t["chip"],
+            },
+        )
     )
 
-    # Consumers — three padded sub-columns inside 412px lane (744..1156)
-    cons_x = 756
-    col_w = 124
-    gap = 10
-    people_x = cons_x
-    agents_x = cons_x + col_w + gap
-    artifacts_x = cons_x + 2 * (col_w + gap)
+    cons_x = lane_x[4] + 8
+    for section, items, y0 in (
+        ("PEOPLE", people, 40),
+        ("AGENTS", agents, 128),
+        ("ARTIFACTS", [], 216),
+    ):
+        parts.append(
+            _text(
+                cons_x + card_w // 2,
+                lane_top + y0,
+                section,
+                **{
+                    "text-anchor": "middle",
+                    "font-family": "Inter,system-ui,sans-serif",
+                    "font-size": "7",
+                    "font-weight": "800",
+                    "letter-spacing": "0.1em",
+                    "fill": t["accent"],
+                },
+            )
+        )
+        if section != "ARTIFACTS":
+            for j, (icon, label) in enumerate(items):
+                sy = lane_top + y0 + 10 + j * 36
+                parts.append(
+                    f'<rect x="{cons_x}" y="{sy}" width="{card_w}" height="30" rx="7" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>'
+                )
+                parts.append(_icon_box(cons_x + 6, sy + 3, ICONS[icon], t))
+                parts.append(
+                    _text(
+                        cons_x + 34,
+                        sy + 19,
+                        label,
+                        **{"font-family": "Inter,system-ui,sans-serif", "font-size": "9.5", "font-weight": "700", "fill": t["text"]},
+                    )
+                )
 
-    parts.append(_text(people_x + col_w // 2, lane_top + 38, "PEOPLE", **{"text-anchor": "middle", "font-family": "Inter,system-ui,sans-serif", "font-size": "7.5", "font-weight": "800", "letter-spacing": "0.1em", "fill": t["accent"]}))
-    for i, (icon, label) in enumerate(people):
-        sy = lane_top + 48 + i * 50
-        parts.append(f'<rect x="{people_x}" y="{sy}" width="{col_w}" height="40" rx="8" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(people_x + 8, sy + 8, ICONS[icon], t))
-        parts.append(_text(people_x + 38, sy + 25, label, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]}))
-
-    parts.append(_text(agents_x + col_w // 2, lane_top + 38, "AGENTS", **{"text-anchor": "middle", "font-family": "Inter,system-ui,sans-serif", "font-size": "7.5", "font-weight": "800", "letter-spacing": "0.1em", "fill": t["accent"]}))
-    for i, (icon, label) in enumerate(agents):
-        sy = lane_top + 48 + i * 50
-        parts.append(f'<rect x="{agents_x}" y="{sy}" width="{col_w}" height="40" rx="8" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(agents_x + 8, sy + 8, ICONS[icon], t))
-        parts.append(_text(agents_x + 38, sy + 25, label, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]}))
-
-    parts.append(_text(artifacts_x + col_w // 2, lane_top + 38, "ARTIFACTS", **{"text-anchor": "middle", "font-family": "Inter,system-ui,sans-serif", "font-size": "7.5", "font-weight": "800", "letter-spacing": "0.1em", "fill": t["accent"]}))
-    chip_w, chip_h, chip_gap = 58, 20, 6
+    chip_w, chip_h, chip_gap = 48, 18, 4
     for i, label in enumerate(artifacts):
         col, row = i % 2, i // 2
-        ax = artifacts_x + col * (chip_w + chip_gap)
-        ay = lane_top + 48 + row * (chip_h + chip_gap)
+        ax = cons_x + col * (chip_w + chip_gap)
+        ay = lane_top + 228 + row * (chip_h + chip_gap)
         parts.append(
-            f'<rect x="{ax}" y="{ay}" width="{chip_w}" height="{chip_h}" rx="6" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
-            f'<text x="{ax + chip_w // 2}" y="{ay + 13}" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" '
+            f'<rect x="{ax}" y="{ay}" width="{chip_w}" height="{chip_h}" rx="5" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
+            f'<text x="{ax + chip_w // 2}" y="{ay + 12}" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" '
             f'font-weight="700" fill="{t["chip"]}">{_esc(label)}</text>'
         )
 
     parts.append(
         _text(
-            artifacts_x + col_w // 2,
-            lane_top + 200,
+            cons_x + card_w // 2,
+            lane_top + 290,
             "SIEM · webhooks",
-            **{"text-anchor": "middle", "font-family": "Inter,system-ui,sans-serif", "font-size": "7.5", "font-weight": "600", "fill": t["lane_muted"]},
+            **{
+                "text-anchor": "middle",
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "7",
+                "font-weight": "600",
+                "fill": t["lane_muted"],
+            },
         )
     )
 
-    # Header-band flow arrows (never cross cards)
-    for x1, x2, label, accent in [
-        (lane_x[0] + lane_w[0], lane_x[1], "SCAN", False),
-        (lane_x[1] + lane_w[1], lane_x[2], "NORMALIZE", False),
-        (lane_x[2] + lane_w[2], lane_x[3], "SERVE", True),
-        (lane_x[3] + lane_w[3], lane_x[4], "DELIVER", False),
-    ]:
-        marker = f"arch-a-{suffix}" if accent else f"arch-{suffix}"
-        parts.append(_lane_flow(x1, x2, flow_y, label, t, marker, accent=accent))
+    for i, (label, accent) in enumerate([("SCAN", False), ("NORMALIZE", False), ("SERVE", True), ("DELIVER", False)]):
+        parts.append(_lane_flow(lane_x[i] + lane_w, lane_x[i + 1], flow_y, label, t, accent=accent))
 
     parts.append(
-        f'<rect x="24" y="{h - 40}" width="{w - 48}" height="26" rx="8" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
-        f'<text x="{w // 2}" y="{h - 22}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="{t["trust"]}">'
-        "READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>"
+        _trust_footer(
+            w,
+            h,
+            t,
+            "READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence",
+            height=26,
+        )
     )
     parts.append("</svg>")
     return "\n".join(parts)
@@ -564,7 +684,6 @@ def architecture(theme_name: str) -> str:
 
 def persona_value(theme: str) -> str:
     t = THEMES[theme]
-    suffix = theme
     w, h = 960, 400
 
     personas = [
@@ -586,51 +705,103 @@ def persona_value(theme: str) -> str:
     row_gap = 14
     start_y = 108
 
-    parts = [
-        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" fill="none" role="img" '
-        f'aria-labelledby="pv-{suffix}-title">',
-        f'<title id="pv-{suffix}-title">agent-bom personas and value</title>',
-        "<defs>",
-        _marker(t, f"pv-{suffix}", "arrow_accent"),
-        "</defs>",
+    parts = _svg_open(w, h, "agent-bom personas and value")
+    parts += [
         f'<rect width="{w}" height="{h}" rx="12" fill="{t["bg"]}"/>',
-        _text(28, 38, "Who it serves · what they get", **{"font-family": "Inter,system-ui,sans-serif", "font-size": "20", "font-weight": "850", "fill": t["title"]}),
+        _text(
+            28,
+            38,
+            "Who it serves · what they get",
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "20", "font-weight": "800", "fill": t["title"]},
+        ),
         _text(
             28,
             58,
-            "One evidence model — inventory → findings → graph → gates",
+            "One evidence model — inventory -> findings -> graph -> gates",
             **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "500", "fill": t["subtitle"]},
         ),
-        _text(left_x, 88, "PERSONAS", **{"font-family": "Inter,system-ui,sans-serif", "font-size": "7.5", "font-weight": "800", "letter-spacing": "0.12em", "fill": t["accent"]}),
-        _text(right_x, 88, "VALUE PROOF", **{"font-family": "Inter,system-ui,sans-serif", "font-size": "7.5", "font-weight": "800", "letter-spacing": "0.12em", "fill": t["accent"]}),
+        _text(
+            left_x,
+            88,
+            "PERSONAS",
+            **{
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "7.5",
+                "font-weight": "800",
+                "letter-spacing": "0.12em",
+                "fill": t["accent"],
+            },
+        ),
+        _text(
+            right_x,
+            88,
+            "VALUE PROOF",
+            **{
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "7.5",
+                "font-weight": "800",
+                "letter-spacing": "0.12em",
+                "fill": t["accent"],
+            },
+        ),
     ]
 
     for i, (icon, title, subtitle, lane) in enumerate(personas):
         y = start_y + i * (row_h + row_gap)
         _, accent, _ = LANE_COLORS[lane]
-        parts.append(f'<rect x="{left_x}" y="{y}" width="{col_w}" height="{row_h}" rx="10" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(
+            f'<rect x="{left_x}" y="{y}" width="{col_w}" height="{row_h}" rx="10" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>'
+        )
         parts.append(_icon_box(left_x + 12, y + 14, ICONS[icon], t, accent=True))
-        parts.append(_text(left_x + 48, y + 24, title, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "11", "font-weight": "700", "fill": t["text"]}))
-        parts.append(_text(left_x + 48, y + 40, subtitle, **{"font-family": "ui-monospace,monospace", "font-size": "8", "font-weight": "600", "fill": accent}))
+        parts.append(
+            _text(
+                left_x + 48,
+                y + 24,
+                title,
+                **{"font-family": "Inter,system-ui,sans-serif", "font-size": "11", "font-weight": "700", "fill": t["text"]},
+            )
+        )
+        parts.append(
+            _text(
+                left_x + 48,
+                y + 40,
+                subtitle,
+                **{"font-family": "ui-monospace,monospace", "font-size": "8", "font-weight": "600", "fill": accent},
+            )
+        )
 
     arrow_x1 = left_x + col_w + 8
     arrow_x2 = right_x - 8
     for i, (icon, title, subtitle) in enumerate(values):
         y = start_y + i * (row_h + row_gap)
-        parts.append(f'<rect x="{right_x}" y="{y}" width="{col_w}" height="{row_h}" rx="10" fill="{t["accent_fill"]}" stroke="{t["accent_stroke"]}"/>')
-        parts.append(_icon_box(right_x + 12, y + 14, ICONS[icon], t, accent=True))
-        parts.append(_text(right_x + 48, y + 24, title, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "11", "font-weight": "700", "fill": t["text"]}))
-        parts.append(_text(right_x + 48, y + 40, subtitle, **{"font-family": "ui-monospace,monospace", "font-size": "8", "font-weight": "600", "fill": t["text_muted"]}))
         parts.append(
-            f'<line x1="{arrow_x1}" y1="{y + row_h // 2}" x2="{arrow_x2}" y2="{y + row_h // 2}" '
-            f'stroke="{t["arrow_accent"]}" stroke-width="1.6" marker-end="url(#pv-{suffix})"/>'
+            f'<rect x="{right_x}" y="{y}" width="{col_w}" height="{row_h}" rx="10" fill="{t["accent_fill"]}" stroke="{t["accent_stroke"]}"/>'
+        )
+        parts.append(_icon_box(right_x + 12, y + 14, ICONS[icon], t, accent=True))
+        parts.append(
+            _text(
+                right_x + 48,
+                y + 24,
+                title,
+                **{"font-family": "Inter,system-ui,sans-serif", "font-size": "11", "font-weight": "700", "fill": t["text"]},
+            )
+        )
+        parts.append(
+            _text(
+                right_x + 48,
+                y + 40,
+                subtitle,
+                **{"font-family": "ui-monospace,monospace", "font-size": "8", "font-weight": "600", "fill": t["text_muted"]},
+            )
+        )
+        parts.append(
+            f'<line x1="{arrow_x1}" y1="{y + row_h // 2}" x2="{arrow_x2 - 7}" y2="{y + row_h // 2}" '
+            f'stroke="{t["arrow_accent"]}" stroke-width="1.6"/>'
+            f'<polygon points="{arrow_x2 - 1},{y + row_h // 2} {arrow_x2 - 8},{y + row_h // 2 - 3.5} '
+            f'{arrow_x2 - 8},{y + row_h // 2 + 3.5}" fill="{t["arrow_accent"]}"/>'
         )
 
-    parts.append(
-        f'<rect x="28" y="{h - 36}" width="{w - 56}" height="24" rx="7" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
-        f'<text x="{w // 2}" y="{h - 20}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="{t["trust"]}">'
-        "LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>"
-    )
+    parts.append(_trust_footer(w, h, t, "LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph", height=24))
     parts.append("</svg>")
     return "\n".join(parts)
 
@@ -664,6 +835,9 @@ def main() -> None:
         issues = _audit_layout(svg)
         if issues:
             raise SystemExit(f"{filename} layout issues: {issues[:5]}")
+        github_issues = _audit_github_safe(svg)
+        if github_issues:
+            raise SystemExit(f"{filename} GitHub SVG issues: {github_issues}")
         path = OUT / filename
         path.write_text(svg, encoding="utf-8")
         print(f"wrote {path}")

--- a/scripts/generate_doc_architecture_svgs.py
+++ b/scripts/generate_doc_architecture_svgs.py
@@ -1,0 +1,700 @@
+#!/usr/bin/env python3
+"""Generate README architecture SVGs (how-it-works + control-plane architecture).
+
+Hand-tuned layout with theme tokens — run after changing lane content or counts.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+OUT = Path(__file__).resolve().parents[1] / "docs" / "images"
+
+THEMES = {
+    "dark": {
+        "bg": "#0a0a0c",
+        "panel": "#0f0f13",
+        "panel_stroke": "#222228",
+        "card": "#161619",
+        "card_stroke": "#2a2a31",
+        "icon_bg": "#1c1c21",
+        "icon_stroke": "#2e2e35",
+        "title": "#f4f4f5",
+        "subtitle": "#71717a",
+        "lane": "#a78bfa",
+        "lane_muted": "#6b6b75",
+        "text": "#e9e9ec",
+        "text_muted": "#82828c",
+        "chip": "#a1a1aa",
+        "arrow": "#52525b",
+        "arrow_accent": "#8b5cf6",
+        "accent": "#a78bfa",
+        "accent_fill": "#15121f",
+        "accent_stroke": "#5b4bbd",
+        "trust_bg": "#0c1a14",
+        "trust_stroke": "#1f4438",
+        "trust": "#4ade80",
+        "ic": "#9a9aa4",
+        "ic_accent": "#a78bfa",
+        "highlight": "#15121f",
+        "footer_bg": "#121016",
+        "footer_stroke": "#2a2733",
+    },
+    "light": {
+        "bg": "#ffffff",
+        "panel": "#fafafa",
+        "panel_stroke": "#ececf0",
+        "card": "#ffffff",
+        "card_stroke": "#e6e6ea",
+        "icon_bg": "#f4f4f6",
+        "icon_stroke": "#e6e6ea",
+        "title": "#18181b",
+        "subtitle": "#71717a",
+        "lane": "#7c3aed",
+        "lane_muted": "#9a9aa4",
+        "text": "#18181b",
+        "text_muted": "#71717a",
+        "chip": "#52525b",
+        "arrow": "#a1a1aa",
+        "arrow_accent": "#7c3aed",
+        "accent": "#7c3aed",
+        "accent_fill": "#f5f3ff",
+        "accent_stroke": "#c4b5fd",
+        "trust_bg": "#ecfdf5",
+        "trust_stroke": "#bbf7d0",
+        "trust": "#15803d",
+        "ic": "#6b6b76",
+        "ic_accent": "#7c3aed",
+        "highlight": "#f5f3ff",
+        "footer_bg": "#f4f4f6",
+        "footer_stroke": "#e4e4e7",
+    },
+}
+
+LANE_COLORS = {
+    "intake": ("#1e3a5f", "#60a5fa", "#93c5fd"),
+    "scan": ("#78350f", "#fbbf24", "#fde68a"),
+    "core": ("#5b21b6", "#a78bfa", "#ddd6fe"),
+    "control": ("#065f46", "#34d399", "#a7f3d0"),
+    "output": ("#3f3f46", "#a1a1aa", "#d4d4d8"),
+    "sources": ("#1e3a5f", "#60a5fa", "#93c5fd"),
+    "enrich": ("#78350f", "#fbbf24", "#fde68a"),
+    "evidence": ("#5b21b6", "#a78bfa", "#ddd6fe"),
+    "consumers": ("#1e3a8a", "#60a5fa", "#93c5fd"),
+}
+
+
+def _esc(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
+def _text(x: int | float, y: int | float, content: str, **attrs: str) -> str:
+    """Emit a text element with XML-safe content."""
+    attr_bits = " ".join(f'{key}="{value}"' for key, value in attrs.items())
+    prefix = f'<text x="{x}" y="{y}"'
+    if attr_bits:
+        prefix += f" {attr_bits}"
+    return f"{prefix}>{_esc(content)}</text>"
+
+
+def _marker(theme: dict, name: str, color_key: str) -> str:
+    return (
+        f'<marker id="{name}" viewBox="0 0 10 8" refX="8.5" refY="4" '
+        f'markerWidth="9" markerHeight="7" orient="auto">'
+        f'<path d="M0 0 L10 4 L0 8 Z" fill="{theme[color_key]}"/></marker>'
+    )
+
+
+def _icon_box(x: int, y: int, paths: str, t: dict, accent: bool = False, *, box: bool = True) -> str:
+    stroke = t["ic_accent"] if accent else t["ic"]
+    box_svg = (
+        f'<rect x="{x}" y="{y}" width="26" height="26" rx="7" fill="{t["icon_bg"]}" stroke="{t["icon_stroke"]}"/>'
+        if box
+        else ""
+    )
+    return (
+        f"{box_svg}"
+        f'<g transform="translate({x + 5},{y + 5})" fill="none" stroke="{stroke}" stroke-width="1.55" '
+        f'stroke-linecap="round" stroke-linejoin="round">{paths}</g>'
+    )
+
+
+def _lane_header(x: int, y: int, w: int, label: str, lane_key: str, tag: str, t: dict) -> str:
+    bg, accent, text = LANE_COLORS[lane_key]
+    return (
+        f'<rect x="{x}" y="{y}" width="{w}" height="36" rx="10" fill="{bg}"/>'
+        f'<rect x="{x}" y="{y + 22}" width="{w}" height="14" fill="{bg}"/>'
+        f'<text x="{x + 14}" y="{y + 22}" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" '
+        f'letter-spacing="0.14em" fill="{text}">{_esc(label)}</text>'
+        f'<text x="{x + w - 12}" y="{y + 22}" text-anchor="end" font-family="Inter,system-ui,sans-serif" '
+        f'font-size="8.5" font-weight="600" fill="{accent}" opacity="0.85">{_esc(tag)}</text>'
+    )
+
+
+def _flow_arrow(x1: int, y1: int, x2: int, y2: int, label: str, t: dict, accent: bool = False) -> str:
+    color = t["arrow_accent"] if accent else t["arrow"]
+    marker = "hiw-a" if accent else "hiw"
+    width = "2.4" if accent else "2"
+    return (
+        f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{color}" stroke-width="{width}" '
+        f'marker-end="url(#{marker})"/>'
+        f'<text x="{(x1 + x2) // 2}" y="{y1 - 10}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
+        f'font-size="8" font-weight="800" letter-spacing="0.1em" fill="{t["accent"] if accent else t["lane_muted"]}">'
+        f'{_esc(label)}</text>'
+    )
+
+
+# ── Icon path snippets (24×24 viewBox, placed at x+5,y+5 in 26×26 box) ───────
+
+ICONS = {
+    "repo": '<path d="M4 6h8l3 3v11H4z M12 6v3h3"/>',
+    "ci": '<path d="M6 14l4 4 10-11"/>',
+    "mcp": '<circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/>',
+    "cloud": '<path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/>',
+    "image": '<rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/>',
+    "iac": '<path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/>',
+    "sbom": '<path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/>',
+    "model": '<path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/>',
+    "runtime": '<circle cx="12" cy="12" r="7"/><path d="M12 8v4l3 2"/>',
+    "search": '<circle cx="10" cy="10" r="6"/><path d="M15 15l4 4"/>',
+    "package": '<path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/>',
+    "bug": '<path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/>',
+    "zap": '<path d="M13 3L5 14h6l-1 7 8-11h-6z"/>',
+    "shield": '<path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/>',
+    "file": '<path d="M7 4h7l4 4v12H7z M14 4v4h4"/>',
+    "api": '<path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/>',
+    "ui": '<rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/>',
+    "gate": '<path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/>',
+    "fleet": '<rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/>',
+    "audit": '<path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/>',
+    "cli": '<path d="M7 8l-4 4 4 4 M13 16h7"/>',
+    "sarif": '<path d="M6 5h12v14H6z M9 9h8 M9 13h5"/>',
+    "lock": '<rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/>',
+    "finding": '<path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/>',
+    "graph": '<circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/>',
+    "db": '<ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/>',
+}
+
+
+def _cloud_logos(x: int, y: int, t: dict) -> str:
+  """Simplified provider marks — brand-inspired colors, not official logos."""
+  items = [
+      ("AWS", "#ff9900", '<path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/>'),
+      ("Azure", "#0078d4", '<path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/>'),
+      ("GCP", "#4285f4", '<circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/>'),
+      ("Snow", "#29b5e8", '<path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/>'),
+  ]
+  out = []
+  for i, (label, color, art) in enumerate(items):
+      bx = x + i * 52
+      out.append(
+          f'<rect x="{bx}" y="{y}" width="46" height="34" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>'
+          f'<g transform="translate({bx + 11},{y + 6}) scale(0.9)">{art}</g>'
+          f'<text x="{bx + 23}" y="{y + 30}" text-anchor="middle" font-family="ui-monospace,monospace" '
+          f'font-size="7" font-weight="700" fill="{color}">{_esc(label)}</text>'
+      )
+  return "".join(out)
+
+
+def how_it_works(theme_name: str) -> str:
+    t = THEMES[theme_name]
+    suffix = "d" if theme_name == "dark" else "l"
+    w, h = 1200, 560
+
+  # Pipeline steps — mirrors src/agent_bom/api/pipeline.py PIPELINE_STEPS
+    steps = [
+        ("search", "Discover"),
+        ("package", "Extract"),
+        ("bug", "Scan"),
+        ("zap", "Enrich"),
+        ("shield", "Analyze"),
+        ("file", "Report"),
+    ]
+
+    intake = [
+        ("repo", "Repo"),
+        ("ci", "CI"),
+        ("mcp", "MCP"),
+        ("cloud", "Cloud"),
+        ("image", "Image"),
+        ("iac", "IaC"),
+        ("sbom", "SBOM"),
+        ("model", "Model"),
+    ]
+
+    control = [
+        ("api", "REST API"),
+        ("ui", "Dashboard"),
+        ("mcp", "MCP srv"),
+        ("gate", "Gateway"),
+        ("fleet", "Fleet"),
+        ("audit", "Audit"),
+    ]
+
+    outputs = ["SARIF", "SBOM", "HTML", "JSON", "GATE", "FIX"]
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" fill="none" role="img" '
+        f'aria-labelledby="hiw-{suffix}-title hiw-{suffix}-desc">',
+        f'<title id="hiw-{suffix}-title">How agent-bom works</title>',
+        '<desc id="hiw-{suffix}-desc">Read-only intake through scan pipeline into unified Finding and '
+        'UnifiedGraph, served by control plane, exported as reports and gates.</desc>'.format(suffix=suffix),
+        "<defs>",
+        _marker(t, "hiw", "arrow"),
+        _marker(t, "hiw-a", "arrow_accent"),
+        '<linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1">'
+        f'<stop offset="0%" stop-color="{t["accent"]}" stop-opacity="0.35"/>'
+        f'<stop offset="100%" stop-color="{t["accent"]}" stop-opacity="0"/>'
+        "</linearGradient>",
+        "</defs>",
+        f'<rect width="{w}" height="{h}" rx="16" fill="{t["bg"]}"/>',
+        f'<text x="36" y="44" font-family="Inter,system-ui,sans-serif" font-size="24" font-weight="850" fill="{t["title"]}">'
+        "From inventory to enforceable evidence</text>",
+        f'<text x="36" y="66" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="500" fill="{t["subtitle"]}">'
+        "One read-only pipeline · one Finding + UnifiedGraph · CLI · API · UI · MCP · runtime gates</text>",
+    ]
+
+    # Lane panels
+    lanes = [
+        (28, 88, 210, "INTAKE", "intake", "read-only"),
+        (258, 88, 188, "SCAN", "scan", "6 steps"),
+        (466, 88, 248, "EVIDENCE", "core", "one model"),
+        (734, 88, 188, "CONTROL", "control", "self-hosted"),
+        (942, 88, 108, "OUT", "output", "artifacts"),
+    ]
+    for x, y, lw, label, key, tag in lanes:
+        parts.append(
+            f'<rect x="{x}" y="{y}" width="{lw}" height="400" rx="14" fill="{t["panel"]}" stroke="{t["panel_stroke"]}"/>'
+        )
+        parts.append(_lane_header(x, y, lw, label, key, tag, t))
+
+    # Intake icon grid
+    for i, (icon, label) in enumerate(intake):
+        col, row = i % 2, i // 2
+        tx, ty = 44 + col * 98, 138 + row * 54
+        parts.append(f'<rect x="{tx}" y="{ty}" width="88" height="44" rx="11" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(tx + 8, ty + 9, ICONS[icon], t))
+        parts.append(_text(tx + 42, ty + 28, label, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "11", "font-weight": "700", "fill": t["text"]}))
+
+    parts.append(_cloud_logos(44, 360, t))
+    parts.append(_icon_box(44, 408, ICONS["lock"], t, accent=True))
+    parts.append(
+        f'<text x="78" y="426" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="{t["lane_muted"]}">'
+        "no writes · no secret values</text>"
+    )
+
+    # Scan pipeline — vertical stepped flow
+    scan_bg, scan_accent, scan_text = LANE_COLORS["scan"]
+    for i, (icon, label) in enumerate(steps):
+        sy = 132 + i * 52
+        parts.append(f'<circle cx="278" cy="{sy + 14}" r="14" fill="{t["card"]}" stroke="{scan_accent}" stroke-width="1.5"/>')
+        parts.append(
+            f'<text x="278" y="{sy + 18}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
+            f'font-size="9" font-weight="800" fill="{scan_accent}">{i + 1}</text>'
+        )
+        parts.append(_icon_box(304, sy, ICONS[icon], t))
+        parts.append(
+            f'<text x="340" y="{sy + 17}" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="{t["text"]}">{_esc(label)}</text>'
+        )
+        if i < len(steps) - 1:
+            parts.append(
+                f'<path d="M278 {sy + 28} V{sy + 38}" stroke="{t["panel_stroke"]}" stroke-width="1.5" stroke-linecap="round"/>'
+            )
+
+    advisories = ["OSV", "GHSA", "NVD", "KEV", "EPSS"]
+    for i, adv in enumerate(advisories):
+        ax = 272 + i * 34
+        parts.append(
+            f'<rect x="{ax}" y="448" width="30" height="20" rx="6" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
+            f'<text x="{ax + 15}" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" '
+            f'font-weight="700" fill="{scan_accent}">{adv}</text>'
+        )
+
+    # Evidence graph hub
+    cx, cy = 590, 268
+    parts.append(f'<circle cx="{cx}" cy="{cy}" r="78" fill="url(#core-glow)"/>')
+    nodes = [
+        (cx, cy - 58, "Finding", True, "finding"),
+        (cx - 72, cy - 10, "Asset", False, "package"),
+        (cx + 72, cy - 10, "Agent", False, "mcp"),
+        (cx - 52, cy + 58, "Tool", False, "bug"),
+        (cx + 52, cy + 58, "Cred", False, "lock"),
+    ]
+    for nx, ny, nlabel, center, icon in nodes:
+        if not center:
+            parts.append(
+                f'<line x1="{cx}" y1="{cy}" x2="{nx}" y2="{ny}" stroke="{t["panel_stroke"]}" stroke-width="1.4" opacity="0.75"/>'
+            )
+    for nx, ny, nlabel, center, icon in nodes:
+        r = 34 if center else 28
+        fill = t["accent_fill"] if center else t["card"]
+        stroke = t["accent_stroke"] if center else t["card_stroke"]
+        parts.append(f'<circle cx="{nx}" cy="{ny}" r="{r}" fill="{fill}" stroke="{stroke}" stroke-width="{"2" if center else "1.5"}"/>')
+        if center:
+            parts.append(_icon_box(nx - 13, ny - 13, ICONS[icon], t, accent=True))
+        parts.append(
+            f'<text x="{nx}" y="{ny + (22 if center else 20)}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
+            f'font-size="{"10" if center else "9"}" font-weight="800" fill="{t["accent"] if center else t["text"]}">{_esc(nlabel)}</text>'
+        )
+
+    meta = ["severity", "provenance", "tenant"]
+    for i, chip in enumerate(meta):
+        mx = 494 + i * 72
+        parts.append(
+            f'<rect x="{mx}" y="390" width="64" height="22" rx="7" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
+            f'<text x="{mx + 32}" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" '
+            f'font-weight="700" fill="{t["chip"]}">{chip}</text>'
+        )
+
+    # Control plane tiles
+    for i, (icon, label) in enumerate(control):
+        col, row = i % 2, i // 2
+        tx, ty = 748 + col * 86, 136 + row * 62
+        parts.append(f'<rect x="{tx}" y="{ty}" width="78" height="52" rx="10" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(tx + 8, ty + 13, ICONS[icon], t))
+        parts.append(_text(tx + 40, ty + 32, label, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "9.5", "font-weight": "700", "fill": t["text"]}))
+
+    parts.append(
+        f'<rect x="748" y="340" width="162" height="28" rx="8" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>'
+        f'<text x="829" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" '
+        f'font-weight="700" fill="{t["chip"]}">fail-closed · RBAC · audit</text>'
+    )
+
+    # Outputs column
+    out_colors = ["#f87171", "#fbbf24", "#60a5fa", "#a78bfa", "#34d399", "#fb7185"]
+    for i, (label, color) in enumerate(zip(outputs, out_colors, strict=True)):
+        oy = 136 + i * 52
+        parts.append(
+            f'<rect x="956" y="{oy}" width="80" height="36" rx="10" fill="{t["card"]}" stroke="{color}" stroke-width="1.2"/>'
+            f'<circle cx="970" cy="{oy + 18}" r="4" fill="{color}" opacity="0.85"/>'
+            f'<text x="982" y="{oy + 22}" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="{t["text"]}">{_esc(label)}</text>'
+        )
+
+    parts.append(
+        f'<text x="996" y="468" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" '
+        f'font-weight="600" fill="{t["lane_muted"]}">reports · gates · runtime</text>'
+    )
+
+    # Flow arrows between lanes
+    parts.append(_flow_arrow(238, 288, 256, 288, "collect", t))
+    parts.append(_flow_arrow(446, 288, 464, 288, "normalize", t))
+    parts.append(_flow_arrow(714, 288, 732, 288, "serve", t, accent=True))
+    parts.append(_flow_arrow(922, 288, 940, 288, "export", t))
+
+    # Trust bar
+    parts.append(
+        f'<rect x="28" y="508" width="1144" height="36" rx="10" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
+        f'<text x="52" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="{t["trust"]}">'
+        "TRUST</text>"
+        f'<text x="100" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="{t["chip"]}">'
+        "read-only connectors · secret redaction · signed evidence · same model everywhere</text>"
+    )
+
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+def architecture(theme_name: str) -> str:
+    t = THEMES[theme_name]
+    suffix = "d" if theme_name == "dark" else "l"
+    w, h = 1200, 620
+
+    sources = [
+        ("package", "Supply chain", "15 eco"),
+        ("mcp", "Agents & MCP", "29 clients"),
+        ("cloud", "Cloud", "4 providers"),
+        ("iac", "IaC & OCI", "TF·K8s·img"),
+        ("lock", "Secrets", "refs only"),
+        ("model", "Models", "13 formats"),
+        ("sbom", "SBOM import", "CDX·SPDX"),
+    ]
+
+    scan_items = [
+        ("bug", "OSV scan", "batch"),
+        ("zap", "Enrichment", "NVD·EPSS"),
+        ("shield", "Posture", "CIS·MCP"),
+        ("graph", "Blast radius", "fusion"),
+        ("file", "Policy", "as-code"),
+    ]
+
+    core_items = [
+        ("finding", "Unified Finding", "one schema", True),
+        ("graph", "UnifiedGraph", "attack paths", True),
+        ("db", "Stores", "PG·SQLite", False),
+        ("audit", "Audit chain", "signed", False),
+    ]
+
+    cp_items = [
+        ("api", "REST API", "283 ops"),
+        ("gate", "Gateway", "runtime"),
+        ("mcp", "MCP server", "70 tools"),
+        ("fleet", "Fleet jobs", "Helm·EKS"),
+    ]
+
+    people = [("cli", "CLI"), ("ui", "Web UI")]
+    agents = [("mcp", "MCP"), ("api", "SDK")]
+    artifacts = ["SARIF", "CDX", "SPDX", "OCSF", "HTML", "JSON"]
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" fill="none" role="img" '
+        f'aria-labelledby="arch-{suffix}-title arch-{suffix}-desc">',
+        f'<title id="arch-{suffix}-title">agent-bom control-plane architecture</title>',
+        '<desc id="arch-{suffix}-desc">Sources through scan and evidence core to control plane and consumers.</desc>'.format(
+            suffix=suffix
+        ),
+        "<defs>",
+        _marker(t, f"arch-{suffix}", "arrow"),
+        _marker(t, f"arch-a-{suffix}", "arrow_accent"),
+        "</defs>",
+        f'<rect width="{w}" height="{h}" rx="14" fill="{t["bg"]}"/>',
+        f'<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="{t["title"]}">'
+        f'Control-plane <tspan fill="{t["accent"]}">architecture</tspan></text>',
+        f'<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="{t["subtitle"]}">'
+        "Sources → scan → one Finding + UnifiedGraph → API · Gateway · MCP → people + agents</text>",
+    ]
+
+    lane_x = [32, 228, 424, 620, 816]
+    lane_w = [184, 184, 184, 184, 352]
+    lane_meta = [
+        ("SOURCES", "sources", "read-only"),
+        ("SCAN", "enrich", "local"),
+        ("EVIDENCE", "evidence", "normalized"),
+        ("CONTROL", "control", "tenant auth"),
+        ("CONSUMERS", "consumers", "people+agents"),
+    ]
+
+    for i, (label, key, tag) in enumerate(lane_meta):
+        x, lw = lane_x[i], lane_w[i]
+        parts.append(
+            f'<rect x="{x}" y="82" width="{lw}" height="468" rx="12" fill="{t["panel"]}" stroke="{t["panel_stroke"]}"/>'
+        )
+        parts.append(_lane_header(x, 82, lw, label, key, tag, t))
+
+    # Sources column
+    for i, (icon, title, badge) in enumerate(sources):
+        sy = 128 + i * 58
+        parts.append(f'<rect x="44" y="{sy}" width="160" height="48" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(54, sy + 11, ICONS[icon], t))
+        parts.append(
+            f'<text x="88" y="{sy + 22}" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="{t["text"]}">{_esc(title)}</text>'
+        )
+        parts.append(
+            f'<text x="88" y="{sy + 36}" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="{t["text_muted"]}">{_esc(badge)}</text>'
+        )
+
+    for i, (icon, title, badge) in enumerate(scan_items):
+        sy = 128 + i * 72
+        parts.append(f'<rect x="240" y="{sy}" width="160" height="60" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(250, sy + 17, ICONS[icon], t))
+        parts.append(
+            f'<text x="284" y="{sy + 30}" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="{t["text"]}">{_esc(title)}</text>'
+        )
+        parts.append(
+            f'<text x="284" y="{sy + 44}" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="{t["text_muted"]}">{_esc(badge)}</text>'
+        )
+
+    # Evidence column — highlighted core cards
+    for i, (icon, title, badge, highlight) in enumerate(core_items):
+        sy = 128 + i * 88
+        fill = t["accent_fill"] if highlight else t["card"]
+        stroke = t["accent_stroke"] if highlight else t["card_stroke"]
+        parts.append(f'<rect x="436" y="{sy}" width="160" height="72" rx="9" fill="{fill}" stroke="{stroke}" stroke-width="{"1.6" if highlight else "1"}"/>')
+        parts.append(_icon_box(446, sy + 23, ICONS[icon], t, accent=highlight))
+        parts.append(
+            f'<text x="480" y="{sy + 34}" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="{t["text"]}">{_esc(title)}</text>'
+        )
+        parts.append(
+            f'<text x="480" y="{sy + 50}" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="{t["accent"] if highlight else t["text_muted"]}">{_esc(badge)}</text>'
+        )
+
+    # Control plane
+    for i, (icon, title, badge) in enumerate(cp_items):
+        sy = 128 + i * 88
+        parts.append(f'<rect x="632" y="{sy}" width="156" height="72" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(642, sy + 23, ICONS[icon], t))
+        parts.append(
+            f'<text x="676" y="{sy + 34}" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="{t["text"]}">{_esc(title)}</text>'
+        )
+        parts.append(
+            f'<text x="676" y="{sy + 50}" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="{t["text_muted"]}">{_esc(badge)}</text>'
+        )
+
+    parts.append(
+        f'<rect x="632" y="490" width="156" height="32" rx="8" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>'
+        f'<text x="710" y="510" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="{t["chip"]}">'
+        "OIDC · SAML · SCIM · RBAC</text>"
+    )
+
+    # Consumers — three sub-columns inside the wide lane
+    cx_base = 828
+    parts.append(
+        f'<text x="{cx_base + 52}" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" '
+        f'letter-spacing="0.12em" fill="{t["accent"]}">PEOPLE</text>'
+    )
+    for i, (icon, label) in enumerate(people):
+        sy = 136 + i * 54
+        parts.append(f'<rect x="{cx_base}" y="{sy}" width="104" height="44" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(cx_base + 8, sy + 9, ICONS[icon], t))
+        parts.append(
+            f'<text x="{cx_base + 40}" y="{sy + 27}" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="{t["text"]}">{_esc(label)}</text>'
+        )
+
+    ax_base = cx_base + 118
+    parts.append(
+        f'<text x="{ax_base + 52}" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" '
+        f'letter-spacing="0.12em" fill="{t["accent"]}">AGENTS</text>'
+    )
+    for i, (icon, label) in enumerate(agents):
+        sy = 136 + i * 54
+        parts.append(f'<rect x="{ax_base}" y="{sy}" width="104" height="44" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(ax_base + 8, sy + 9, ICONS[icon], t))
+        parts.append(
+            f'<text x="{ax_base + 40}" y="{sy + 27}" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="{t["text"]}">{_esc(label)}</text>'
+        )
+
+    art_base = cx_base + 236
+    parts.append(
+        f'<text x="{art_base + 52}" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" '
+        f'letter-spacing="0.12em" fill="{t["accent"]}">ARTIFACTS</text>'
+    )
+    for i, label in enumerate(artifacts):
+        col, row = i % 2, i // 2
+        ax, ay = art_base + col * 58, 136 + row * 28
+        parts.append(
+            f'<rect x="{ax}" y="{ay}" width="54" height="22" rx="7" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
+            f'<text x="{ax + 27}" y="{ay + 15}" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" '
+            f'font-weight="700" fill="{t["chip"]}">{_esc(label)}</text>'
+        )
+
+    parts.append(
+        f'<text x="{art_base + 52}" y="248" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="{t["lane_muted"]}">'
+        "→ SIEM · webhooks</text>"
+    )
+
+    # Inter-lane flow
+    y_flow = 318
+    flows = [
+        (lane_x[0] + lane_w[0], y_flow, lane_x[1], y_flow, "SCAN", False),
+        (lane_x[1] + lane_w[1], y_flow, lane_x[2], y_flow, "NORMALIZE", False),
+        (lane_x[2] + lane_w[2], y_flow, lane_x[3], y_flow, "SERVE", True),
+        (lane_x[3] + lane_w[3], y_flow, lane_x[4], y_flow, "DELIVER", False),
+    ]
+    for x1, y1, x2, y2, label, accent in flows:
+        color = t["arrow_accent"] if accent else t["arrow"]
+        marker = f"arch-a-{suffix}" if accent else f"arch-{suffix}"
+        width = "2.3" if accent else "2"
+        parts.append(
+            f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{color}" stroke-width="{width}" marker-end="url(#{marker})"/>'
+        )
+        parts.append(
+            f'<text x="{(x1 + x2) // 2}" y="{y1 - 10}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
+            f'font-size="8" font-weight="800" letter-spacing="0.1em" fill="{t["accent"] if accent else t["lane_muted"]}">{_esc(label)}</text>'
+        )
+
+    parts.append(
+        f'<rect x="32" y="568" width="1136" height="32" rx="9" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
+        f'<text x="600" y="588" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="{t["trust"]}">'
+        "READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>"
+    )
+
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+def persona_value(theme: str) -> str:
+    """Buyer persona → product value lanes (GTM visual, not a code map)."""
+    t = THEMES[theme]
+    suffix = theme
+    w, h = 980, 420
+    personas = [
+        ("shield", "AppSec / GRC", "SARIF · compliance · audit chain", "control"),
+        ("gate", "Platform / SRE", "fleet · Helm · CI gates", "scan"),
+        ("mcp", "Agent builders", "MCP inventory · runtime shield", "intake"),
+        ("graph", "Security engineers", "blast radius · attack paths", "core"),
+    ]
+    values = [
+        ("bug", "Accurate SCA", "15 ecosystems · distro-aware"),
+        ("image", "Container coverage", "OCI native · optional Grype"),
+        ("audit", "Self-hosted evidence", "your VPC · signed audit"),
+        ("api", "Agent-native API", "283 ops · 70 MCP tools"),
+    ]
+
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" fill="none" role="img" '
+        f'aria-labelledby="pv-{suffix}-title">',
+        f'<title id="pv-{suffix}-title">agent-bom personas and value</title>',
+        f'<rect width="{w}" height="{h}" rx="14" fill="{t["bg"]}"/>',
+        f'<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="{t["title"]}">'
+        "Who it serves · what they get</text>",
+        f'<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="{t["subtitle"]}">'
+        "One evidence model — different buyers, same inventory → findings → graph → gates</text>",
+        f'<text x="36" y="98" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" '
+        f'letter-spacing="0.12em" fill="{t["accent"]}">PERSONAS</text>',
+        f'<text x="500" y="98" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" '
+        f'letter-spacing="0.12em" fill="{t["accent"]}">VALUE PROOF</text>',
+    ]
+
+    for i, (icon, title, subtitle, lane) in enumerate(personas):
+        y = 112 + i * 68
+        bg, accent, _ = LANE_COLORS[lane]
+        parts.append(f'<rect x="36" y="{y}" width="420" height="56" rx="11" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(48, y + 14, ICONS[icon], t, accent=True))
+        parts.append(
+            f'<text x="88" y="{y + 26}" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="{t["text"]}">{_esc(title)}</text>'
+        )
+        parts.append(
+            f'<text x="88" y="{y + 42}" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="{accent}">{_esc(subtitle)}</text>'
+        )
+
+    for i, (icon, title, subtitle) in enumerate(values):
+        y = 112 + i * 68
+        parts.append(f'<rect x="500" y="{y}" width="444" height="56" rx="11" fill="{t["accent_fill"]}" stroke="{t["accent_stroke"]}"/>')
+        parts.append(_icon_box(512, y + 14, ICONS[icon], t, accent=True))
+        parts.append(
+            f'<text x="552" y="{y + 26}" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="{t["text"]}">{_esc(title)}</text>'
+        )
+        parts.append(
+            f'<text x="552" y="{y + 42}" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="{t["text_muted"]}">{_esc(subtitle)}</text>'
+        )
+        parts.append(
+            f'<line x1="456" y1="{y + 28}" x2="500" y2="{y + 28}" stroke="{t["arrow_accent"]}" stroke-width="1.8" marker-end="url(#pv-{suffix})"/>'
+        )
+
+    parts.insert(
+        5,
+        "<defs>"
+        + _marker(t, f"pv-{suffix}", "arrow_accent")
+        + "</defs>",
+    )
+
+    parts.append(
+        f'<rect x="36" y="372" width="908" height="28" rx="8" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
+        f'<text x="490" y="390" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="{t["trust"]}">'
+        "LOCAL SCAN · CONTROL PLANE · RUNTIME ENFORCEMENT — same Finding + UnifiedGraph everywhere</text>"
+    )
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+def main() -> None:
+    OUT.mkdir(parents=True, exist_ok=True)
+    mapping = {
+        "how-it-works-dark.svg": ("dark", how_it_works),
+        "how-it-works-light.svg": ("light", how_it_works),
+        "architecture-dark.svg": ("dark", architecture),
+        "architecture-light.svg": ("light", architecture),
+        "persona-value-dark.svg": ("dark", persona_value),
+        "persona-value-light.svg": ("light", persona_value),
+    }
+    for filename, (theme, fn) in mapping.items():
+        path = OUT / filename
+        path.write_text(fn(theme) + "\n", encoding="utf-8")
+        print(f"wrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_doc_architecture_svgs.py
+++ b/scripts/generate_doc_architecture_svgs.py
@@ -2,10 +2,12 @@
 """Generate README architecture SVGs (how-it-works + control-plane architecture).
 
 Hand-tuned layout with theme tokens — run after changing lane content or counts.
+All coordinates are checked to stay inside lane panels (no text or card overflow).
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 OUT = Path(__file__).resolve().parents[1] / "docs" / "images"
@@ -85,15 +87,10 @@ LANE_COLORS = {
 
 
 def _esc(text: str) -> str:
-    return (
-        text.replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-    )
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
 def _text(x: int | float, y: int | float, content: str, **attrs: str) -> str:
-    """Emit a text element with XML-safe content."""
     attr_bits = " ".join(f'{key}="{value}"' for key, value in attrs.items())
     prefix = f'<text x="{x}" y="{y}"'
     if attr_bits:
@@ -104,7 +101,7 @@ def _text(x: int | float, y: int | float, content: str, **attrs: str) -> str:
 def _marker(theme: dict, name: str, color_key: str) -> str:
     return (
         f'<marker id="{name}" viewBox="0 0 10 8" refX="8.5" refY="4" '
-        f'markerWidth="9" markerHeight="7" orient="auto">'
+        f'markerWidth="8" markerHeight="6" orient="auto">'
         f'<path d="M0 0 L10 4 L0 8 Z" fill="{theme[color_key]}"/></marker>'
     )
 
@@ -112,13 +109,13 @@ def _marker(theme: dict, name: str, color_key: str) -> str:
 def _icon_box(x: int, y: int, paths: str, t: dict, accent: bool = False, *, box: bool = True) -> str:
     stroke = t["ic_accent"] if accent else t["ic"]
     box_svg = (
-        f'<rect x="{x}" y="{y}" width="26" height="26" rx="7" fill="{t["icon_bg"]}" stroke="{t["icon_stroke"]}"/>'
+        f'<rect x="{x}" y="{y}" width="24" height="24" rx="6" fill="{t["icon_bg"]}" stroke="{t["icon_stroke"]}"/>'
         if box
         else ""
     )
     return (
         f"{box_svg}"
-        f'<g transform="translate({x + 5},{y + 5})" fill="none" stroke="{stroke}" stroke-width="1.55" '
+        f'<g transform="translate({x + 4},{y + 4})" fill="none" stroke="{stroke}" stroke-width="1.5" '
         f'stroke-linecap="round" stroke-linejoin="round">{paths}</g>'
     )
 
@@ -126,29 +123,25 @@ def _icon_box(x: int, y: int, paths: str, t: dict, accent: bool = False, *, box:
 def _lane_header(x: int, y: int, w: int, label: str, lane_key: str, tag: str, t: dict) -> str:
     bg, accent, text = LANE_COLORS[lane_key]
     return (
-        f'<rect x="{x}" y="{y}" width="{w}" height="36" rx="10" fill="{bg}"/>'
-        f'<rect x="{x}" y="{y + 22}" width="{w}" height="14" fill="{bg}"/>'
-        f'<text x="{x + 14}" y="{y + 22}" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="800" '
-        f'letter-spacing="0.14em" fill="{text}">{_esc(label)}</text>'
-        f'<text x="{x + w - 12}" y="{y + 22}" text-anchor="end" font-family="Inter,system-ui,sans-serif" '
-        f'font-size="8.5" font-weight="600" fill="{accent}" opacity="0.85">{_esc(tag)}</text>'
+        f'<rect x="{x}" y="{y}" width="{w}" height="32" rx="8" fill="{bg}"/>'
+        f'<text x="{x + 12}" y="{y + 20}" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" '
+        f'letter-spacing="0.12em" fill="{text}">{_esc(label)}</text>'
+        f'<text x="{x + w - 10}" y="{y + 20}" text-anchor="end" font-family="Inter,system-ui,sans-serif" '
+        f'font-size="8" font-weight="600" fill="{accent}" opacity="0.9">{_esc(tag)}</text>'
     )
 
 
-def _flow_arrow(x1: int, y1: int, x2: int, y2: int, label: str, t: dict, accent: bool = False) -> str:
+def _lane_flow(x1: int, x2: int, y: int, label: str, t: dict, marker: str, accent: bool = False) -> str:
     color = t["arrow_accent"] if accent else t["arrow"]
-    marker = "hiw-a" if accent else "hiw"
-    width = "2.4" if accent else "2"
+    width = "2.2" if accent else "1.8"
     return (
-        f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{color}" stroke-width="{width}" '
+        f'<line x1="{x1}" y1="{y}" x2="{x2}" y2="{y}" stroke="{color}" stroke-width="{width}" '
         f'marker-end="url(#{marker})"/>'
-        f'<text x="{(x1 + x2) // 2}" y="{y1 - 10}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
-        f'font-size="8" font-weight="800" letter-spacing="0.1em" fill="{t["accent"] if accent else t["lane_muted"]}">'
-        f'{_esc(label)}</text>'
+        f'<text x="{(x1 + x2) // 2}" y="{y - 8}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
+        f'font-size="7.5" font-weight="800" letter-spacing="0.08em" fill="{t["accent"] if accent else t["lane_muted"]}">'
+        f"{_esc(label)}</text>"
     )
 
-
-# ── Icon path snippets (24×24 viewBox, placed at x+5,y+5 in 26×26 box) ───────
 
 ICONS = {
     "repo": '<path d="M4 6h8l3 3v11H4z M12 6v3h3"/>',
@@ -159,7 +152,6 @@ ICONS = {
     "iac": '<path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/>',
     "sbom": '<path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/>',
     "model": '<path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/>',
-    "runtime": '<circle cx="12" cy="12" r="7"/><path d="M12 8v4l3 2"/>',
     "search": '<circle cx="10" cy="10" r="6"/><path d="M15 15l4 4"/>',
     "package": '<path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/>',
     "bug": '<path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/>',
@@ -172,7 +164,6 @@ ICONS = {
     "fleet": '<rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/>',
     "audit": '<path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/>',
     "cli": '<path d="M7 8l-4 4 4 4 M13 16h7"/>',
-    "sarif": '<path d="M6 5h12v14H6z M9 9h8 M9 13h5"/>',
     "lock": '<rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/>',
     "finding": '<path d="M8 6h7l3 3v9H8z M15 6v3h3 M10 14l1.5 1.5 3-3"/>',
     "graph": '<circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/>',
@@ -181,31 +172,29 @@ ICONS = {
 
 
 def _cloud_logos(x: int, y: int, t: dict) -> str:
-  """Simplified provider marks — brand-inspired colors, not official logos."""
-  items = [
-      ("AWS", "#ff9900", '<path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/>'),
-      ("Azure", "#0078d4", '<path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/>'),
-      ("GCP", "#4285f4", '<circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/>'),
-      ("Snow", "#29b5e8", '<path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/>'),
-  ]
-  out = []
-  for i, (label, color, art) in enumerate(items):
-      bx = x + i * 52
-      out.append(
-          f'<rect x="{bx}" y="{y}" width="46" height="34" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>'
-          f'<g transform="translate({bx + 11},{y + 6}) scale(0.9)">{art}</g>'
-          f'<text x="{bx + 23}" y="{y + 30}" text-anchor="middle" font-family="ui-monospace,monospace" '
-          f'font-size="7" font-weight="700" fill="{color}">{_esc(label)}</text>'
-      )
-  return "".join(out)
+    items = [
+        ("AWS", "#ff9900", '<path d="M6 14c4-1 8-1 12 0M8 11c2.5-.8 5.5-.8 8 0" stroke="#ff9900" fill="none" stroke-width="1.4"/>'),
+        ("Azure", "#0078d4", '<path d="M5 16 L12 5 L19 16 Z" fill="#0078d4" opacity="0.9"/>'),
+        ("GCP", "#4285f4", '<circle cx="9" cy="12" r="3" fill="#ea4335"/><circle cx="15" cy="12" r="3" fill="#fbbc04"/><circle cx="12" cy="16" r="3" fill="#34a853"/>'),
+        ("Snow", "#29b5e8", '<path d="M12 5v14M5 12h14M7.5 7.5l9 9M16.5 7.5l-9 9" stroke="#29b5e8" stroke-width="1.2"/>'),
+    ]
+    out = []
+    for i, (label, color, art) in enumerate(items):
+        bx = x + i * 48
+        out.append(
+            f'<rect x="{bx}" y="{y}" width="42" height="30" rx="8" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>'
+            f'<g transform="translate({bx + 9},{y + 5}) scale(0.85)">{art}</g>'
+            f'<text x="{bx + 21}" y="{y + 26}" text-anchor="middle" font-family="ui-monospace,monospace" '
+            f'font-size="6.5" font-weight="700" fill="{color}">{_esc(label)}</text>'
+        )
+    return "".join(out)
 
 
 def how_it_works(theme_name: str) -> str:
     t = THEMES[theme_name]
     suffix = "d" if theme_name == "dark" else "l"
-    w, h = 1200, 560
+    w, h = 1180, 580
 
-  # Pipeline steps — mirrors src/agent_bom/api/pipeline.py PIPELINE_STEPS
     steps = [
         ("search", "Discover"),
         ("package", "Extract"),
@@ -214,7 +203,6 @@ def how_it_works(theme_name: str) -> str:
         ("shield", "Analyze"),
         ("file", "Report"),
     ]
-
     intake = [
         ("repo", "Repo"),
         ("ci", "CI"),
@@ -225,7 +213,6 @@ def how_it_works(theme_name: str) -> str:
         ("sbom", "SBOM"),
         ("model", "Model"),
     ]
-
     control = [
         ("api", "REST API"),
         ("ui", "Dashboard"),
@@ -234,166 +221,159 @@ def how_it_works(theme_name: str) -> str:
         ("fleet", "Fleet"),
         ("audit", "Audit"),
     ]
-
     outputs = ["SARIF", "SBOM", "HTML", "JSON", "GATE", "FIX"]
+
+    lane_top = 84
+    lane_h = 380
+    flow_y = lane_top + 16
+
+    lanes = [
+        (24, 200, "INTAKE", "intake", "read-only"),
+        (236, 176, "SCAN", "scan", "6 steps"),
+        (424, 232, "EVIDENCE", "core", "one model"),
+        (668, 176, "CONTROL", "control", "self-hosted"),
+        (856, 108, "OUT", "output", "artifacts"),
+    ]
 
     parts = [
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" fill="none" role="img" '
         f'aria-labelledby="hiw-{suffix}-title hiw-{suffix}-desc">',
         f'<title id="hiw-{suffix}-title">How agent-bom works</title>',
-        '<desc id="hiw-{suffix}-desc">Read-only intake through scan pipeline into unified Finding and '
-        'UnifiedGraph, served by control plane, exported as reports and gates.</desc>'.format(suffix=suffix),
+        f'<desc id="hiw-{suffix}-desc">Read-only intake through scan pipeline into unified Finding and UnifiedGraph.</desc>',
         "<defs>",
         _marker(t, "hiw", "arrow"),
         _marker(t, "hiw-a", "arrow_accent"),
         '<linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1">'
-        f'<stop offset="0%" stop-color="{t["accent"]}" stop-opacity="0.35"/>'
+        f'<stop offset="0%" stop-color="{t["accent"]}" stop-opacity="0.28"/>'
         f'<stop offset="100%" stop-color="{t["accent"]}" stop-opacity="0"/>'
         "</linearGradient>",
         "</defs>",
-        f'<rect width="{w}" height="{h}" rx="16" fill="{t["bg"]}"/>',
-        f'<text x="36" y="44" font-family="Inter,system-ui,sans-serif" font-size="24" font-weight="850" fill="{t["title"]}">'
-        "From inventory to enforceable evidence</text>",
-        f'<text x="36" y="66" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="500" fill="{t["subtitle"]}">'
-        "One read-only pipeline · one Finding + UnifiedGraph · CLI · API · UI · MCP · runtime gates</text>",
+        f'<rect width="{w}" height="{h}" rx="14" fill="{t["bg"]}"/>',
+        _text(28, 40, "From inventory to enforceable evidence", **{"font-family": "Inter,system-ui,sans-serif", "font-size": "22", "font-weight": "850", "fill": t["title"]}),
+        _text(
+            28,
+            60,
+            "One read-only pipeline · one Finding + UnifiedGraph · CLI · API · UI · MCP",
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10.5", "font-weight": "500", "fill": t["subtitle"]},
+        ),
     ]
 
-    # Lane panels
-    lanes = [
-        (28, 88, 210, "INTAKE", "intake", "read-only"),
-        (258, 88, 188, "SCAN", "scan", "6 steps"),
-        (466, 88, 248, "EVIDENCE", "core", "one model"),
-        (734, 88, 188, "CONTROL", "control", "self-hosted"),
-        (942, 88, 108, "OUT", "output", "artifacts"),
-    ]
-    for x, y, lw, label, key, tag in lanes:
+    for x, lw, label, key, tag in lanes:
         parts.append(
-            f'<rect x="{x}" y="{y}" width="{lw}" height="400" rx="14" fill="{t["panel"]}" stroke="{t["panel_stroke"]}"/>'
+            f'<rect x="{x}" y="{lane_top}" width="{lw}" height="{lane_h}" rx="12" fill="{t["panel"]}" stroke="{t["panel_stroke"]}"/>'
         )
-        parts.append(_lane_header(x, y, lw, label, key, tag, t))
+        parts.append(_lane_header(x, lane_top, lw, label, key, tag, t))
 
-    # Intake icon grid
+    # Intake grid (2×4) — fits inside 200px lane with padding
     for i, (icon, label) in enumerate(intake):
         col, row = i % 2, i // 2
-        tx, ty = 44 + col * 98, 138 + row * 54
-        parts.append(f'<rect x="{tx}" y="{ty}" width="88" height="44" rx="11" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(tx + 8, ty + 9, ICONS[icon], t))
-        parts.append(_text(tx + 42, ty + 28, label, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "11", "font-weight": "700", "fill": t["text"]}))
+        tx, ty = 36 + col * 94, lane_top + 44 + row * 50
+        parts.append(f'<rect x="{tx}" y="{ty}" width="84" height="40" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(tx + 6, ty + 8, ICONS[icon], t))
+        parts.append(_text(tx + 36, ty + 25, label, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]}))
 
-    parts.append(_cloud_logos(44, 360, t))
-    parts.append(_icon_box(44, 408, ICONS["lock"], t, accent=True))
+    parts.append(_cloud_logos(36, lane_top + 252, t))
+    parts.append(_icon_box(36, lane_top + 292, ICONS["lock"], t, accent=True))
     parts.append(
-        f'<text x="78" y="426" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="{t["lane_muted"]}">'
-        "no writes · no secret values</text>"
+        _text(64, lane_top + 308, "no writes · no secret values", **{"font-family": "Inter,system-ui,sans-serif", "font-size": "8.5", "font-weight": "600", "fill": t["lane_muted"]})
     )
 
-    # Scan pipeline — vertical stepped flow
-    scan_bg, scan_accent, scan_text = LANE_COLORS["scan"]
+    # Scan steps — vertical list inside scan lane
+    scan_accent = LANE_COLORS["scan"][1]
     for i, (icon, label) in enumerate(steps):
-        sy = 132 + i * 52
-        parts.append(f'<circle cx="278" cy="{sy + 14}" r="14" fill="{t["card"]}" stroke="{scan_accent}" stroke-width="1.5"/>')
+        sy = lane_top + 44 + i * 48
+        parts.append(f'<circle cx="{248}" cy="{sy + 12}" r="11" fill="{t["card"]}" stroke="{scan_accent}" stroke-width="1.4"/>')
         parts.append(
-            f'<text x="278" y="{sy + 18}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
-            f'font-size="9" font-weight="800" fill="{scan_accent}">{i + 1}</text>'
+            f'<text x="248" y="{sy + 16}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
+            f'font-size="8" font-weight="800" fill="{scan_accent}">{i + 1}</text>'
         )
-        parts.append(_icon_box(304, sy, ICONS[icon], t))
-        parts.append(
-            f'<text x="340" y="{sy + 17}" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="{t["text"]}">{_esc(label)}</text>'
-        )
+        parts.append(_icon_box(268, sy, ICONS[icon], t))
+        parts.append(_text(298, sy + 16, label, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "11", "font-weight": "700", "fill": t["text"]}))
         if i < len(steps) - 1:
             parts.append(
-                f'<path d="M278 {sy + 28} V{sy + 38}" stroke="{t["panel_stroke"]}" stroke-width="1.5" stroke-linecap="round"/>'
+                f'<path d="M248 {sy + 24} V{sy + 32}" stroke="{t["panel_stroke"]}" stroke-width="1.4" stroke-linecap="round"/>'
             )
 
-    advisories = ["OSV", "GHSA", "NVD", "KEV", "EPSS"]
-    for i, adv in enumerate(advisories):
-        ax = 272 + i * 34
+    for i, adv in enumerate(["OSV", "GHSA", "NVD", "KEV", "EPSS"]):
+        ax = 242 + i * 30
+        ay = lane_top + lane_h - 34
         parts.append(
-            f'<rect x="{ax}" y="448" width="30" height="20" rx="6" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
-            f'<text x="{ax + 15}" y="461" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" '
+            f'<rect x="{ax}" y="{ay}" width="26" height="18" rx="5" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
+            f'<text x="{ax + 13}" y="{ay + 12}" text-anchor="middle" font-family="ui-monospace,monospace" font-size="6.5" '
             f'font-weight="700" fill="{scan_accent}">{adv}</text>'
         )
 
-    # Evidence graph hub
-    cx, cy = 590, 268
-    parts.append(f'<circle cx="{cx}" cy="{cy}" r="78" fill="url(#core-glow)"/>')
+    # Evidence hub — compact radial graph
+    cx, cy = 540, lane_top + 200
+    parts.append(f'<circle cx="{cx}" cy="{cy}" r="62" fill="url(#core-glow)"/>')
     nodes = [
-        (cx, cy - 58, "Finding", True, "finding"),
-        (cx - 72, cy - 10, "Asset", False, "package"),
-        (cx + 72, cy - 10, "Agent", False, "mcp"),
-        (cx - 52, cy + 58, "Tool", False, "bug"),
-        (cx + 52, cy + 58, "Cred", False, "lock"),
+        (cx, cy - 48, "Finding", True, "finding"),
+        (cx - 58, cy - 6, "Asset", False, "package"),
+        (cx + 58, cy - 6, "Agent", False, "mcp"),
+        (cx - 42, cy + 46, "Tool", False, "bug"),
+        (cx + 42, cy + 46, "Cred", False, "lock"),
     ]
     for nx, ny, nlabel, center, icon in nodes:
         if not center:
             parts.append(
-                f'<line x1="{cx}" y1="{cy}" x2="{nx}" y2="{ny}" stroke="{t["panel_stroke"]}" stroke-width="1.4" opacity="0.75"/>'
+                f'<line x1="{cx}" y1="{cy}" x2="{nx}" y2="{ny}" stroke="{t["panel_stroke"]}" stroke-width="1.2" opacity="0.7"/>'
             )
     for nx, ny, nlabel, center, icon in nodes:
-        r = 34 if center else 28
+        r = 28 if center else 22
         fill = t["accent_fill"] if center else t["card"]
         stroke = t["accent_stroke"] if center else t["card_stroke"]
-        parts.append(f'<circle cx="{nx}" cy="{ny}" r="{r}" fill="{fill}" stroke="{stroke}" stroke-width="{"2" if center else "1.5"}"/>')
+        parts.append(f'<circle cx="{nx}" cy="{ny}" r="{r}" fill="{fill}" stroke="{stroke}" stroke-width="{"1.8" if center else "1.3"}"/>')
         if center:
-            parts.append(_icon_box(nx - 13, ny - 13, ICONS[icon], t, accent=True))
+            parts.append(_icon_box(nx - 12, ny - 12, ICONS[icon], t, accent=True))
         parts.append(
-            f'<text x="{nx}" y="{ny + (22 if center else 20)}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
-            f'font-size="{"10" if center else "9"}" font-weight="800" fill="{t["accent"] if center else t["text"]}">{_esc(nlabel)}</text>'
+            _text(nx, ny + (18 if center else 16), nlabel, **{"text-anchor": "middle", "font-family": "Inter,system-ui,sans-serif", "font-size": "9" if center else "8", "font-weight": "800", "fill": t["accent"] if center else t["text"]})
         )
 
-    meta = ["severity", "provenance", "tenant"]
-    for i, chip in enumerate(meta):
-        mx = 494 + i * 72
+    for i, chip in enumerate(["severity", "provenance", "tenant"]):
+        mx = 438 + i * 68
+        my = lane_top + lane_h - 40
         parts.append(
-            f'<rect x="{mx}" y="390" width="64" height="22" rx="7" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
-            f'<text x="{mx + 32}" y="404" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" '
+            f'<rect x="{mx}" y="{my}" width="60" height="20" rx="6" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
+            f'<text x="{mx + 30}" y="{my + 13}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" '
             f'font-weight="700" fill="{t["chip"]}">{chip}</text>'
         )
 
-    # Control plane tiles
+    # Control plane tiles (2×3)
     for i, (icon, label) in enumerate(control):
         col, row = i % 2, i // 2
-        tx, ty = 748 + col * 86, 136 + row * 62
-        parts.append(f'<rect x="{tx}" y="{ty}" width="78" height="52" rx="10" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(tx + 8, ty + 13, ICONS[icon], t))
-        parts.append(_text(tx + 40, ty + 32, label, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "9.5", "font-weight": "700", "fill": t["text"]}))
+        tx, ty = 680 + col * 80, lane_top + 44 + row * 56
+        parts.append(f'<rect x="{tx}" y="{ty}" width="72" height="46" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(tx + 8, ty + 11, ICONS[icon], t))
+        parts.append(_text(tx + 38, ty + 28, label, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "9", "font-weight": "700", "fill": t["text"]}))
 
     parts.append(
-        f'<rect x="748" y="340" width="162" height="28" rx="8" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>'
-        f'<text x="829" y="358" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" '
+        f'<rect x="680" y="{lane_top + lane_h - 38}" width="152" height="24" rx="7" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>'
+        f'<text x="756" y="{lane_top + lane_h - 22}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" '
         f'font-weight="700" fill="{t["chip"]}">fail-closed · RBAC · audit</text>'
     )
 
-    # Outputs column
+    # Outputs — vertical stack
     out_colors = ["#f87171", "#fbbf24", "#60a5fa", "#a78bfa", "#34d399", "#fb7185"]
     for i, (label, color) in enumerate(zip(outputs, out_colors, strict=True)):
-        oy = 136 + i * 52
+        oy = lane_top + 44 + i * 48
         parts.append(
-            f'<rect x="956" y="{oy}" width="80" height="36" rx="10" fill="{t["card"]}" stroke="{color}" stroke-width="1.2"/>'
-            f'<circle cx="970" cy="{oy + 18}" r="4" fill="{color}" opacity="0.85"/>'
-            f'<text x="982" y="{oy + 22}" font-family="ui-monospace,monospace" font-size="10" font-weight="800" fill="{t["text"]}">{_esc(label)}</text>'
+            f'<rect x="868" y="{oy}" width="76" height="32" rx="8" fill="{t["card"]}" stroke="{color}" stroke-width="1.1"/>'
+            f'<circle cx="880" cy="{oy + 16}" r="3.5" fill="{color}"/>'
+            f'<text x="890" y="{oy + 20}" font-family="ui-monospace,monospace" font-size="9" font-weight="800" fill="{t["text"]}">{_esc(label)}</text>'
         )
 
+    # Lane-to-lane flow in header band only (no crossing cards)
+    parts.append(_lane_flow(24 + 200, 236, flow_y, "collect", t, "hiw"))
+    parts.append(_lane_flow(236 + 176, 424, flow_y, "normalize", t, "hiw"))
+    parts.append(_lane_flow(424 + 232, 668, flow_y, "serve", t, "hiw-a", accent=True))
+    parts.append(_lane_flow(668 + 176, 856, flow_y, "export", t, "hiw"))
+
     parts.append(
-        f'<text x="996" y="468" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" '
-        f'font-weight="600" fill="{t["lane_muted"]}">reports · gates · runtime</text>'
+        f'<rect x="24" y="{h - 44}" width="{w - 48}" height="28" rx="8" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
+        f'<text x="44" y="{h - 26}" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="800" fill="{t["trust"]}">TRUST</text>'
+        f'<text x="88" y="{h - 26}" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="{t["chip"]}">'
+        "read-only · secret redaction · signed evidence · same model everywhere</text>"
     )
-
-    # Flow arrows between lanes
-    parts.append(_flow_arrow(238, 288, 256, 288, "collect", t))
-    parts.append(_flow_arrow(446, 288, 464, 288, "normalize", t))
-    parts.append(_flow_arrow(714, 288, 732, 288, "serve", t, accent=True))
-    parts.append(_flow_arrow(922, 288, 940, 288, "export", t))
-
-    # Trust bar
-    parts.append(
-        f'<rect x="28" y="508" width="1144" height="36" rx="10" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
-        f'<text x="52" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="800" fill="{t["trust"]}">'
-        "TRUST</text>"
-        f'<text x="100" y="530" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="{t["chip"]}">'
-        "read-only connectors · secret redaction · signed evidence · same model everywhere</text>"
-    )
-
     parts.append("</svg>")
     return "\n".join(parts)
 
@@ -401,7 +381,7 @@ def how_it_works(theme_name: str) -> str:
 def architecture(theme_name: str) -> str:
     t = THEMES[theme_name]
     suffix = "d" if theme_name == "dark" else "l"
-    w, h = 1200, 620
+    w, h = 1180, 600
 
     sources = [
         ("package", "Supply chain", "15 eco"),
@@ -412,7 +392,6 @@ def architecture(theme_name: str) -> str:
         ("model", "Models", "13 formats"),
         ("sbom", "SBOM import", "CDX·SPDX"),
     ]
-
     scan_items = [
         ("bug", "OSV scan", "batch"),
         ("zap", "Enrichment", "NVD·EPSS"),
@@ -420,45 +399,47 @@ def architecture(theme_name: str) -> str:
         ("graph", "Blast radius", "fusion"),
         ("file", "Policy", "as-code"),
     ]
-
     core_items = [
         ("finding", "Unified Finding", "one schema", True),
         ("graph", "UnifiedGraph", "attack paths", True),
         ("db", "Stores", "PG·SQLite", False),
         ("audit", "Audit chain", "signed", False),
     ]
-
     cp_items = [
         ("api", "REST API", "283 ops"),
         ("gate", "Gateway", "runtime"),
         ("mcp", "MCP server", "70 tools"),
         ("fleet", "Fleet jobs", "Helm·EKS"),
     ]
-
     people = [("cli", "CLI"), ("ui", "Web UI")]
     agents = [("mcp", "MCP"), ("api", "SDK")]
     artifacts = ["SARIF", "CDX", "SPDX", "OCSF", "HTML", "JSON"]
+
+    lane_top = 78
+    lane_h = 430
+    flow_y = lane_top + 14
+    lane_x = [24, 204, 384, 564, 744]
+    lane_w = [168, 168, 168, 168, 412]
 
     parts = [
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" fill="none" role="img" '
         f'aria-labelledby="arch-{suffix}-title arch-{suffix}-desc">',
         f'<title id="arch-{suffix}-title">agent-bom control-plane architecture</title>',
-        '<desc id="arch-{suffix}-desc">Sources through scan and evidence core to control plane and consumers.</desc>'.format(
-            suffix=suffix
-        ),
+        f'<desc id="arch-{suffix}-desc">Sources through scan and evidence core to control plane and consumers.</desc>',
         "<defs>",
         _marker(t, f"arch-{suffix}", "arrow"),
         _marker(t, f"arch-a-{suffix}", "arrow_accent"),
         "</defs>",
         f'<rect width="{w}" height="{h}" rx="14" fill="{t["bg"]}"/>',
-        f'<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="{t["title"]}">'
-        f'Control-plane <tspan fill="{t["accent"]}">architecture</tspan></text>',
-        f'<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="{t["subtitle"]}">'
-        "Sources → scan → one Finding + UnifiedGraph → API · Gateway · MCP → people + agents</text>",
+        _text(28, 38, "Control-plane architecture", **{"font-family": "Inter,system-ui,sans-serif", "font-size": "21", "font-weight": "850", "fill": t["title"]}),
+        _text(
+            28,
+            58,
+            "Sources → scan → Finding + UnifiedGraph → API · Gateway · MCP → people + agents",
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "500", "fill": t["subtitle"]},
+        ),
     ]
 
-    lane_x = [32, 228, 424, 620, 816]
-    lane_w = [184, 184, 184, 184, 352]
     lane_meta = [
         ("SOURCES", "sources", "read-only"),
         ("SCAN", "enrich", "local"),
@@ -466,218 +447,206 @@ def architecture(theme_name: str) -> str:
         ("CONTROL", "control", "tenant auth"),
         ("CONSUMERS", "consumers", "people+agents"),
     ]
-
     for i, (label, key, tag) in enumerate(lane_meta):
         x, lw = lane_x[i], lane_w[i]
         parts.append(
-            f'<rect x="{x}" y="82" width="{lw}" height="468" rx="12" fill="{t["panel"]}" stroke="{t["panel_stroke"]}"/>'
+            f'<rect x="{x}" y="{lane_top}" width="{lw}" height="{lane_h}" rx="11" fill="{t["panel"]}" stroke="{t["panel_stroke"]}"/>'
         )
-        parts.append(_lane_header(x, 82, lw, label, key, tag, t))
+        parts.append(_lane_header(x, lane_top, lw, label, key, tag, t))
 
-    # Sources column
+    # Sources — compact cards
     for i, (icon, title, badge) in enumerate(sources):
-        sy = 128 + i * 58
-        parts.append(f'<rect x="44" y="{sy}" width="160" height="48" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(54, sy + 11, ICONS[icon], t))
-        parts.append(
-            f'<text x="88" y="{sy + 22}" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="{t["text"]}">{_esc(title)}</text>'
-        )
-        parts.append(
-            f'<text x="88" y="{sy + 36}" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="{t["text_muted"]}">{_esc(badge)}</text>'
-        )
+        sy = lane_top + 42 + i * 52
+        parts.append(f'<rect x="36" y="{sy}" width="144" height="44" rx="8" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(44, sy + 10, ICONS[icon], t))
+        parts.append(_text(76, sy + 20, title, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]}))
+        parts.append(_text(76, sy + 33, badge, **{"font-family": "ui-monospace,monospace", "font-size": "7.5", "font-weight": "600", "fill": t["text_muted"]}))
 
     for i, (icon, title, badge) in enumerate(scan_items):
-        sy = 128 + i * 72
-        parts.append(f'<rect x="240" y="{sy}" width="160" height="60" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(250, sy + 17, ICONS[icon], t))
-        parts.append(
-            f'<text x="284" y="{sy + 30}" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="{t["text"]}">{_esc(title)}</text>'
-        )
-        parts.append(
-            f'<text x="284" y="{sy + 44}" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="{t["text_muted"]}">{_esc(badge)}</text>'
-        )
+        sy = lane_top + 42 + i * 64
+        parts.append(f'<rect x="216" y="{sy}" width="144" height="52" rx="8" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(224, sy + 14, ICONS[icon], t))
+        parts.append(_text(256, sy + 26, title, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]}))
+        parts.append(_text(256, sy + 38, badge, **{"font-family": "ui-monospace,monospace", "font-size": "7.5", "font-weight": "600", "fill": t["text_muted"]}))
 
-    # Evidence column — highlighted core cards
     for i, (icon, title, badge, highlight) in enumerate(core_items):
-        sy = 128 + i * 88
+        sy = lane_top + 42 + i * 78
         fill = t["accent_fill"] if highlight else t["card"]
         stroke = t["accent_stroke"] if highlight else t["card_stroke"]
-        parts.append(f'<rect x="436" y="{sy}" width="160" height="72" rx="9" fill="{fill}" stroke="{stroke}" stroke-width="{"1.6" if highlight else "1"}"/>')
-        parts.append(_icon_box(446, sy + 23, ICONS[icon], t, accent=highlight))
         parts.append(
-            f'<text x="480" y="{sy + 34}" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="{t["text"]}">{_esc(title)}</text>'
+            f'<rect x="396" y="{sy}" width="144" height="64" rx="8" fill="{fill}" stroke="{stroke}" stroke-width="{"1.5" if highlight else "1"}"/>'
         )
+        parts.append(_icon_box(404, sy + 18, ICONS[icon], t, accent=highlight))
+        parts.append(_text(436, sy + 28, title, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]}))
         parts.append(
-            f'<text x="480" y="{sy + 50}" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="{t["accent"] if highlight else t["text_muted"]}">{_esc(badge)}</text>'
+            _text(
+                436,
+                sy + 42,
+                badge,
+                **{"font-family": "ui-monospace,monospace", "font-size": "7.5", "font-weight": "600", "fill": t["accent"] if highlight else t["text_muted"]},
+            )
         )
 
-    # Control plane
     for i, (icon, title, badge) in enumerate(cp_items):
-        sy = 128 + i * 88
-        parts.append(f'<rect x="632" y="{sy}" width="156" height="72" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(642, sy + 23, ICONS[icon], t))
-        parts.append(
-            f'<text x="676" y="{sy + 34}" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="{t["text"]}">{_esc(title)}</text>'
-        )
-        parts.append(
-            f'<text x="676" y="{sy + 50}" font-family="ui-monospace,monospace" font-size="8" font-weight="600" fill="{t["text_muted"]}">{_esc(badge)}</text>'
-        )
+        sy = lane_top + 42 + i * 78
+        parts.append(f'<rect x="576" y="{sy}" width="144" height="64" rx="8" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(584, sy + 18, ICONS[icon], t))
+        parts.append(_text(616, sy + 28, title, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]}))
+        parts.append(_text(616, sy + 42, badge, **{"font-family": "ui-monospace,monospace", "font-size": "7.5", "font-weight": "600", "fill": t["text_muted"]}))
 
     parts.append(
-        f'<rect x="632" y="490" width="156" height="32" rx="8" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>'
-        f'<text x="710" y="510" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="700" fill="{t["chip"]}">'
-        "OIDC · SAML · SCIM · RBAC</text>"
+        f'<rect x="576" y="{lane_top + lane_h - 36}" width="144" height="26" rx="7" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>'
+        f'<text x="648" y="{lane_top + lane_h - 19}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" '
+        f'font-weight="700" fill="{t["chip"]}">OIDC · SAML · SCIM · RBAC</text>'
     )
 
-    # Consumers — three sub-columns inside the wide lane
-    cx_base = 828
-    parts.append(
-        f'<text x="{cx_base + 52}" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" '
-        f'letter-spacing="0.12em" fill="{t["accent"]}">PEOPLE</text>'
-    )
+    # Consumers — three padded sub-columns inside 412px lane (744..1156)
+    cons_x = 756
+    col_w = 124
+    gap = 10
+    people_x = cons_x
+    agents_x = cons_x + col_w + gap
+    artifacts_x = cons_x + 2 * (col_w + gap)
+
+    parts.append(_text(people_x + col_w // 2, lane_top + 38, "PEOPLE", **{"text-anchor": "middle", "font-family": "Inter,system-ui,sans-serif", "font-size": "7.5", "font-weight": "800", "letter-spacing": "0.1em", "fill": t["accent"]}))
     for i, (icon, label) in enumerate(people):
-        sy = 136 + i * 54
-        parts.append(f'<rect x="{cx_base}" y="{sy}" width="104" height="44" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(cx_base + 8, sy + 9, ICONS[icon], t))
-        parts.append(
-            f'<text x="{cx_base + 40}" y="{sy + 27}" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="{t["text"]}">{_esc(label)}</text>'
-        )
+        sy = lane_top + 48 + i * 50
+        parts.append(f'<rect x="{people_x}" y="{sy}" width="{col_w}" height="40" rx="8" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(people_x + 8, sy + 8, ICONS[icon], t))
+        parts.append(_text(people_x + 38, sy + 25, label, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]}))
 
-    ax_base = cx_base + 118
-    parts.append(
-        f'<text x="{ax_base + 52}" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" '
-        f'letter-spacing="0.12em" fill="{t["accent"]}">AGENTS</text>'
-    )
+    parts.append(_text(agents_x + col_w // 2, lane_top + 38, "AGENTS", **{"text-anchor": "middle", "font-family": "Inter,system-ui,sans-serif", "font-size": "7.5", "font-weight": "800", "letter-spacing": "0.1em", "fill": t["accent"]}))
     for i, (icon, label) in enumerate(agents):
-        sy = 136 + i * 54
-        parts.append(f'<rect x="{ax_base}" y="{sy}" width="104" height="44" rx="9" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(ax_base + 8, sy + 9, ICONS[icon], t))
-        parts.append(
-            f'<text x="{ax_base + 40}" y="{sy + 27}" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="700" fill="{t["text"]}">{_esc(label)}</text>'
-        )
+        sy = lane_top + 48 + i * 50
+        parts.append(f'<rect x="{agents_x}" y="{sy}" width="{col_w}" height="40" rx="8" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(agents_x + 8, sy + 8, ICONS[icon], t))
+        parts.append(_text(agents_x + 38, sy + 25, label, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "700", "fill": t["text"]}))
 
-    art_base = cx_base + 236
-    parts.append(
-        f'<text x="{art_base + 52}" y="128" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" '
-        f'letter-spacing="0.12em" fill="{t["accent"]}">ARTIFACTS</text>'
-    )
+    parts.append(_text(artifacts_x + col_w // 2, lane_top + 38, "ARTIFACTS", **{"text-anchor": "middle", "font-family": "Inter,system-ui,sans-serif", "font-size": "7.5", "font-weight": "800", "letter-spacing": "0.1em", "fill": t["accent"]}))
+    chip_w, chip_h, chip_gap = 58, 20, 6
     for i, label in enumerate(artifacts):
         col, row = i % 2, i // 2
-        ax, ay = art_base + col * 58, 136 + row * 28
+        ax = artifacts_x + col * (chip_w + chip_gap)
+        ay = lane_top + 48 + row * (chip_h + chip_gap)
         parts.append(
-            f'<rect x="{ax}" y="{ay}" width="54" height="22" rx="7" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
-            f'<text x="{ax + 27}" y="{ay + 15}" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.5" '
+            f'<rect x="{ax}" y="{ay}" width="{chip_w}" height="{chip_h}" rx="6" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
+            f'<text x="{ax + chip_w // 2}" y="{ay + 13}" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" '
             f'font-weight="700" fill="{t["chip"]}">{_esc(label)}</text>'
         )
 
     parts.append(
-        f'<text x="{art_base + 52}" y="248" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="600" fill="{t["lane_muted"]}">'
-        "→ SIEM · webhooks</text>"
+        _text(
+            artifacts_x + col_w // 2,
+            lane_top + 200,
+            "SIEM · webhooks",
+            **{"text-anchor": "middle", "font-family": "Inter,system-ui,sans-serif", "font-size": "7.5", "font-weight": "600", "fill": t["lane_muted"]},
+        )
     )
 
-    # Inter-lane flow
-    y_flow = 318
-    flows = [
-        (lane_x[0] + lane_w[0], y_flow, lane_x[1], y_flow, "SCAN", False),
-        (lane_x[1] + lane_w[1], y_flow, lane_x[2], y_flow, "NORMALIZE", False),
-        (lane_x[2] + lane_w[2], y_flow, lane_x[3], y_flow, "SERVE", True),
-        (lane_x[3] + lane_w[3], y_flow, lane_x[4], y_flow, "DELIVER", False),
-    ]
-    for x1, y1, x2, y2, label, accent in flows:
-        color = t["arrow_accent"] if accent else t["arrow"]
+    # Header-band flow arrows (never cross cards)
+    for x1, x2, label, accent in [
+        (lane_x[0] + lane_w[0], lane_x[1], "SCAN", False),
+        (lane_x[1] + lane_w[1], lane_x[2], "NORMALIZE", False),
+        (lane_x[2] + lane_w[2], lane_x[3], "SERVE", True),
+        (lane_x[3] + lane_w[3], lane_x[4], "DELIVER", False),
+    ]:
         marker = f"arch-a-{suffix}" if accent else f"arch-{suffix}"
-        width = "2.3" if accent else "2"
-        parts.append(
-            f'<line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{color}" stroke-width="{width}" marker-end="url(#{marker})"/>'
-        )
-        parts.append(
-            f'<text x="{(x1 + x2) // 2}" y="{y1 - 10}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
-            f'font-size="8" font-weight="800" letter-spacing="0.1em" fill="{t["accent"] if accent else t["lane_muted"]}">{_esc(label)}</text>'
-        )
+        parts.append(_lane_flow(x1, x2, flow_y, label, t, marker, accent=accent))
 
     parts.append(
-        f'<rect x="32" y="568" width="1136" height="32" rx="9" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
-        f'<text x="600" y="588" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="{t["trust"]}">'
+        f'<rect x="24" y="{h - 40}" width="{w - 48}" height="26" rx="8" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
+        f'<text x="{w // 2}" y="{h - 22}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="{t["trust"]}">'
         "READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>"
     )
-
     parts.append("</svg>")
     return "\n".join(parts)
 
 
 def persona_value(theme: str) -> str:
-    """Buyer persona → product value lanes (GTM visual, not a code map)."""
     t = THEMES[theme]
     suffix = theme
-    w, h = 980, 420
+    w, h = 960, 400
+
     personas = [
-        ("shield", "AppSec / GRC", "SARIF · compliance · audit chain", "control"),
+        ("shield", "AppSec / GRC", "SARIF · compliance · audit", "control"),
         ("gate", "Platform / SRE", "fleet · Helm · CI gates", "scan"),
-        ("mcp", "Agent builders", "MCP inventory · runtime shield", "intake"),
-        ("graph", "Security engineers", "blast radius · attack paths", "core"),
+        ("mcp", "Agent builders", "MCP inventory · shield", "intake"),
+        ("graph", "Security engineers", "blast radius · paths", "core"),
     ]
     values = [
         ("bug", "Accurate SCA", "15 ecosystems · distro-aware"),
-        ("image", "Container coverage", "OCI native · optional Grype"),
+        ("image", "Container coverage", "OCI native · Grype opt-in"),
         ("audit", "Self-hosted evidence", "your VPC · signed audit"),
         ("api", "Agent-native API", "283 ops · 70 MCP tools"),
     ]
+
+    left_x, right_x = 28, 500
+    col_w = 432
+    row_h = 54
+    row_gap = 14
+    start_y = 108
 
     parts = [
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" fill="none" role="img" '
         f'aria-labelledby="pv-{suffix}-title">',
         f'<title id="pv-{suffix}-title">agent-bom personas and value</title>',
-        f'<rect width="{w}" height="{h}" rx="14" fill="{t["bg"]}"/>',
-        f'<text x="36" y="42" font-family="Inter,system-ui,sans-serif" font-size="22" font-weight="850" fill="{t["title"]}">'
-        "Who it serves · what they get</text>",
-        f'<text x="36" y="62" font-family="Inter,system-ui,sans-serif" font-size="10.5" font-weight="500" fill="{t["subtitle"]}">'
-        "One evidence model — different buyers, same inventory → findings → graph → gates</text>",
-        f'<text x="36" y="98" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" '
-        f'letter-spacing="0.12em" fill="{t["accent"]}">PERSONAS</text>',
-        f'<text x="500" y="98" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" '
-        f'letter-spacing="0.12em" fill="{t["accent"]}">VALUE PROOF</text>',
+        "<defs>",
+        _marker(t, f"pv-{suffix}", "arrow_accent"),
+        "</defs>",
+        f'<rect width="{w}" height="{h}" rx="12" fill="{t["bg"]}"/>',
+        _text(28, 38, "Who it serves · what they get", **{"font-family": "Inter,system-ui,sans-serif", "font-size": "20", "font-weight": "850", "fill": t["title"]}),
+        _text(
+            28,
+            58,
+            "One evidence model — inventory → findings → graph → gates",
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "500", "fill": t["subtitle"]},
+        ),
+        _text(left_x, 88, "PERSONAS", **{"font-family": "Inter,system-ui,sans-serif", "font-size": "7.5", "font-weight": "800", "letter-spacing": "0.12em", "fill": t["accent"]}),
+        _text(right_x, 88, "VALUE PROOF", **{"font-family": "Inter,system-ui,sans-serif", "font-size": "7.5", "font-weight": "800", "letter-spacing": "0.12em", "fill": t["accent"]}),
     ]
 
     for i, (icon, title, subtitle, lane) in enumerate(personas):
-        y = 112 + i * 68
-        bg, accent, _ = LANE_COLORS[lane]
-        parts.append(f'<rect x="36" y="{y}" width="420" height="56" rx="11" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
-        parts.append(_icon_box(48, y + 14, ICONS[icon], t, accent=True))
-        parts.append(
-            f'<text x="88" y="{y + 26}" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="{t["text"]}">{_esc(title)}</text>'
-        )
-        parts.append(
-            f'<text x="88" y="{y + 42}" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="{accent}">{_esc(subtitle)}</text>'
-        )
+        y = start_y + i * (row_h + row_gap)
+        _, accent, _ = LANE_COLORS[lane]
+        parts.append(f'<rect x="{left_x}" y="{y}" width="{col_w}" height="{row_h}" rx="10" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
+        parts.append(_icon_box(left_x + 12, y + 14, ICONS[icon], t, accent=True))
+        parts.append(_text(left_x + 48, y + 24, title, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "11", "font-weight": "700", "fill": t["text"]}))
+        parts.append(_text(left_x + 48, y + 40, subtitle, **{"font-family": "ui-monospace,monospace", "font-size": "8", "font-weight": "600", "fill": accent}))
 
+    arrow_x1 = left_x + col_w + 8
+    arrow_x2 = right_x - 8
     for i, (icon, title, subtitle) in enumerate(values):
-        y = 112 + i * 68
-        parts.append(f'<rect x="500" y="{y}" width="444" height="56" rx="11" fill="{t["accent_fill"]}" stroke="{t["accent_stroke"]}"/>')
-        parts.append(_icon_box(512, y + 14, ICONS[icon], t, accent=True))
+        y = start_y + i * (row_h + row_gap)
+        parts.append(f'<rect x="{right_x}" y="{y}" width="{col_w}" height="{row_h}" rx="10" fill="{t["accent_fill"]}" stroke="{t["accent_stroke"]}"/>')
+        parts.append(_icon_box(right_x + 12, y + 14, ICONS[icon], t, accent=True))
+        parts.append(_text(right_x + 48, y + 24, title, **{"font-family": "Inter,system-ui,sans-serif", "font-size": "11", "font-weight": "700", "fill": t["text"]}))
+        parts.append(_text(right_x + 48, y + 40, subtitle, **{"font-family": "ui-monospace,monospace", "font-size": "8", "font-weight": "600", "fill": t["text_muted"]}))
         parts.append(
-            f'<text x="552" y="{y + 26}" font-family="Inter,system-ui,sans-serif" font-size="12" font-weight="700" fill="{t["text"]}">{_esc(title)}</text>'
+            f'<line x1="{arrow_x1}" y1="{y + row_h // 2}" x2="{arrow_x2}" y2="{y + row_h // 2}" '
+            f'stroke="{t["arrow_accent"]}" stroke-width="1.6" marker-end="url(#pv-{suffix})"/>'
         )
-        parts.append(
-            f'<text x="552" y="{y + 42}" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="{t["text_muted"]}">{_esc(subtitle)}</text>'
-        )
-        parts.append(
-            f'<line x1="456" y1="{y + 28}" x2="500" y2="{y + 28}" stroke="{t["arrow_accent"]}" stroke-width="1.8" marker-end="url(#pv-{suffix})"/>'
-        )
-
-    parts.insert(
-        5,
-        "<defs>"
-        + _marker(t, f"pv-{suffix}", "arrow_accent")
-        + "</defs>",
-    )
 
     parts.append(
-        f'<rect x="36" y="372" width="908" height="28" rx="8" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
-        f'<text x="490" y="390" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="600" fill="{t["trust"]}">'
-        "LOCAL SCAN · CONTROL PLANE · RUNTIME ENFORCEMENT — same Finding + UnifiedGraph everywhere</text>"
+        f'<rect x="28" y="{h - 36}" width="{w - 56}" height="24" rx="7" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
+        f'<text x="{w // 2}" y="{h - 20}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="{t["trust"]}">'
+        "LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>"
     )
     parts.append("</svg>")
     return "\n".join(parts)
+
+
+def _audit_layout(svg: str, *, margin: int = 2) -> list[str]:
+    """Return human-readable layout violations for generator self-check."""
+    vb = re.search(r'viewBox="0 0 (\d+) (\d+)"', svg)
+    if not vb:
+        return ["missing viewBox"]
+    width, height = map(int, vb.groups())
+    issues: list[str] = []
+    for match in re.finditer(r'<rect x="(\d+)" y="(\d+)" width="(\d+)" height="(\d+)"', svg):
+        x, y, w, h = map(int, match.groups())
+        if x < -margin or y < -margin or x + w > width + margin or y + h > height + margin:
+            issues.append(f"rect ({x},{y},{w},{h}) outside {width}x{height}")
+    return issues
 
 
 def main() -> None:
@@ -691,8 +660,12 @@ def main() -> None:
         "persona-value-light.svg": ("light", persona_value),
     }
     for filename, (theme, fn) in mapping.items():
+        svg = fn(theme) + "\n"
+        issues = _audit_layout(svg)
+        if issues:
+            raise SystemExit(f"{filename} layout issues: {issues[:5]}")
         path = OUT / filename
-        path.write_text(fn(theme) + "\n", encoding="utf-8")
+        path.write_text(svg, encoding="utf-8")
         print(f"wrote {path}")
 
 

--- a/scripts/product_metrics_snapshot.py
+++ b/scripts/product_metrics_snapshot.py
@@ -220,13 +220,25 @@ def render_markdown(snapshot: dict[str, object]) -> str:
     ]
     for entry in cast(list[dict[str, object]], snapshot["metrics"]):
         lines.append(f"| {entry['name']} | {entry['value']} | `{entry['source']}` | {entry['notes']} |")
+    proxy_detectors = next(
+        (entry["value"] for entry in cast(list[dict[str, object]], snapshot["metrics"]) if entry["name"] == "Proxy inline detectors"),
+        "7",
+    )
+    runtime_detectors = next(
+        (
+            entry["value"]
+            for entry in cast(list[dict[str, object]], snapshot["metrics"])
+            if entry["name"] == "Runtime protection engine detectors"
+        ),
+        "8",
+    )
     lines.extend(
         [
             "",
             "## Runtime wording",
             "",
-            "- `agent-bom proxy` uses `7` inline detectors in the MCP JSON-RPC path.",
-            "- The broader runtime protection engine uses `8` detectors.",
+            f"- `agent-bom proxy` uses `{proxy_detectors}` inline detectors in the MCP JSON-RPC path.",
+            f"- The broader runtime protection engine uses `{runtime_detectors}` detectors.",
             "",
             "## Regenerate",
             "",

--- a/src/agent_bom/cloud/azure_cis_benchmark.py
+++ b/src/agent_bom/cloud/azure_cis_benchmark.py
@@ -384,7 +384,7 @@ def _check_1_10() -> CISCheckResult:
         recommendation="Disable 'Remember MFA on trusted devices' to ensure MFA is prompted on every sign-in.",
         cis_section=_IAM_SECTION,
     )
-    result.evidence = "This check requires Microsoft Graph API access. Verify manually in Azure AD > Security > MFA > Additional cloud-based MFA settings."
+    result.evidence = "This check requires Microsoft Graph API access. Verify manually in Azure AD > Security > MFA > Additional cloud-based MFA settings."  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
     return result
 
 
@@ -409,7 +409,7 @@ def _check_1_12() -> CISCheckResult:
         title="Ensure that 'User consent for applications' is set to 'Do not allow user consent'",
         status=CheckStatus.NOT_APPLICABLE,
         severity="high",
-        recommendation="Set User consent settings to 'Do not allow user consent' in Azure AD > Enterprise Applications > Consent and permissions.",
+        recommendation="Set User consent settings to 'Do not allow user consent' in Azure AD > Enterprise Applications > Consent and permissions.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_IAM_SECTION,
     )
     result.evidence = (
@@ -439,7 +439,7 @@ def _check_1_14() -> CISCheckResult:
         title="Ensure that 'Guest users access restrictions' is set to restrict guest access",
         status=CheckStatus.NOT_APPLICABLE,
         severity="medium",
-        recommendation="Configure guest user access restrictions to 'Guest user access is restricted to properties and memberships of their own directory objects'.",
+        recommendation="Configure guest user access restrictions to 'Guest user access is restricted to properties and memberships of their own directory objects'.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_IAM_SECTION,
     )
     result.evidence = (
@@ -769,7 +769,7 @@ def _check_2_8(security_client: Any, subscription_id: str) -> CISCheckResult:
         title="Ensure Microsoft Defender for Open-Source Relational Databases is set to On",
         status=CheckStatus.ERROR,
         severity="high",
-        recommendation="Enable Microsoft Defender for Open-Source Relational Databases (Standard tier) in Defender for Cloud > Environment settings.",
+        recommendation="Enable Microsoft Defender for Open-Source Relational Databases (Standard tier) in Defender for Cloud > Environment settings.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_DEFENDER_SECTION,
     )
     try:
@@ -844,7 +844,7 @@ def _check_2_11(security_client: Any, subscription_id: str) -> CISCheckResult:
         title="Ensure that auto-provisioning of the Log Analytics agent is set to On",
         status=CheckStatus.ERROR,
         severity="medium",
-        recommendation="Enable auto-provisioning of the Log Analytics agent in Defender for Cloud > Environment settings > Auto provisioning.",
+        recommendation="Enable auto-provisioning of the Log Analytics agent in Defender for Cloud > Environment settings > Auto provisioning.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_DEFENDER_SECTION,
     )
     try:
@@ -904,7 +904,7 @@ def _check_2_13(security_client: Any, subscription_id: str) -> CISCheckResult:
         title="Ensure that email notification for high severity alerts is enabled",
         status=CheckStatus.ERROR,
         severity="medium",
-        recommendation="Enable email notifications for high severity alerts in Defender for Cloud > Environment settings > Email notifications.",
+        recommendation="Enable email notifications for high severity alerts in Defender for Cloud > Environment settings > Email notifications.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_DEFENDER_SECTION,
     )
     try:
@@ -2525,7 +2525,7 @@ def _check_7_5(compute_client: Any) -> CISCheckResult:
         title="Ensure that the latest OS patches for all Virtual Machines are applied",
         status=CheckStatus.ERROR,
         severity="high",
-        recommendation="Enable automatic OS updates or apply latest patches to all VMs. Use Azure Update Management for compliance tracking.",
+        recommendation="Enable automatic OS updates or apply latest patches to all VMs. Use Azure Update Management for compliance tracking.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_VM_SECTION,
     )
     try:

--- a/src/agent_bom/cloud/gcp_cis_benchmark.py
+++ b/src/agent_bom/cloud/gcp_cis_benchmark.py
@@ -246,7 +246,7 @@ def _check_1_2(project_id: str) -> CISCheckResult:
         title="Ensure multi-factor authentication is enforced for all users",
         status=CheckStatus.NOT_APPLICABLE,
         severity="high",
-        evidence="MFA enforcement is configured at the Google Workspace / Cloud Identity level and cannot be verified via project-level API calls. Manual verification required.",
+        evidence="MFA enforcement is configured at the Google Workspace / Cloud Identity level and cannot be verified via project-level API calls. Manual verification required.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         recommendation="Enable 2-Step Verification enforcement in Google Workspace Admin Console under Security > 2-Step Verification.",
         cis_section=_IAM_SECTION,
     )
@@ -259,7 +259,7 @@ def _check_1_3(project_id: str) -> CISCheckResult:
         title="Ensure Security Key enforcement is enabled for all admin accounts",
         status=CheckStatus.NOT_APPLICABLE,
         severity="high",
-        evidence="Security Key enforcement is configured at the Google Workspace / Cloud Identity level and cannot be verified via project-level API calls. Manual verification required.",
+        evidence="Security Key enforcement is configured at the Google Workspace / Cloud Identity level and cannot be verified via project-level API calls. Manual verification required.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         recommendation="Enforce Security Key usage for all admin accounts in Google Workspace Admin Console.",
         cis_section=_IAM_SECTION,
     )
@@ -450,7 +450,7 @@ def _check_1_8(project_id: str) -> CISCheckResult:
         title="Ensure user-managed service account keys are rotated within 90 days",
         status=CheckStatus.ERROR,
         severity="medium",
-        recommendation="Rotate user-managed service account keys every 90 days or less. Prefer short-lived credentials via Workload Identity.",
+        recommendation="Rotate user-managed service account keys every 90 days or less. Prefer short-lived credentials via Workload Identity.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_IAM_SECTION,
     )
     try:
@@ -593,7 +593,7 @@ def _check_1_11(project_id: str) -> CISCheckResult:
         title="Ensure separation of duties is enforced while assigning KMS-related roles",
         status=CheckStatus.ERROR,
         severity="high",
-        recommendation="Ensure no user has both cloudkms.admin and any of cloudkms.cryptoKeyEncrypterDecrypter, cloudkms.cryptoKeyEncrypter, or cloudkms.cryptoKeyDecrypter roles.",
+        recommendation="Ensure no user has both cloudkms.admin and any of cloudkms.cryptoKeyEncrypterDecrypter, cloudkms.cryptoKeyEncrypter, or cloudkms.cryptoKeyDecrypter roles.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_IAM_SECTION,
     )
     try:
@@ -899,7 +899,7 @@ def _check_2_3(project_id: str) -> CISCheckResult:
         title="Ensure log metric filter and alerts exist for Project Ownership changes",
         status=CheckStatus.ERROR,
         severity="medium",
-        recommendation='Create a log metric filter for (protoPayload.serviceName="cloudresourcemanager.googleapis.com") AND (ProjectOwnership OR projectOwnerInvitee).',
+        recommendation='Create a log metric filter for (protoPayload.serviceName="cloudresourcemanager.googleapis.com") AND (ProjectOwnership OR projectOwnerInvitee).',  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_LOGGING_SECTION,
     )
     try:
@@ -934,7 +934,7 @@ def _check_2_4(project_id: str) -> CISCheckResult:
         title="Ensure log metric filter and alerts exist for Audit Configuration changes",
         status=CheckStatus.ERROR,
         severity="medium",
-        recommendation='Create a log metric filter for protoPayload.methodName="SetIamPolicy" AND protoPayload.serviceData.policyDelta.auditConfigDeltas:*.',
+        recommendation='Create a log metric filter for protoPayload.methodName="SetIamPolicy" AND protoPayload.serviceData.policyDelta.auditConfigDeltas:*.',  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_LOGGING_SECTION,
     )
     try:
@@ -969,7 +969,7 @@ def _check_2_5(project_id: str) -> CISCheckResult:
         title="Ensure log metric filter and alerts exist for Custom Role changes",
         status=CheckStatus.ERROR,
         severity="medium",
-        recommendation='Create a log metric filter for resource.type="iam_role" AND (methodName="google.iam.admin.v1.CreateRole" OR methodName="google.iam.admin.v1.DeleteRole" OR methodName="google.iam.admin.v1.UpdateRole").',
+        recommendation='Create a log metric filter for resource.type="iam_role" AND (methodName="google.iam.admin.v1.CreateRole" OR methodName="google.iam.admin.v1.DeleteRole" OR methodName="google.iam.admin.v1.UpdateRole").',  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_LOGGING_SECTION,
     )
     try:
@@ -1004,7 +1004,7 @@ def _check_2_6(project_id: str) -> CISCheckResult:
         title="Ensure log metric filter and alerts exist for VPC Network Firewall Rule changes",
         status=CheckStatus.ERROR,
         severity="medium",
-        recommendation='Create a log metric filter for resource.type="gce_firewall_rule" AND (methodName:"compute.firewalls.patch" OR methodName:"compute.firewalls.insert" OR methodName:"compute.firewalls.delete").',
+        recommendation='Create a log metric filter for resource.type="gce_firewall_rule" AND (methodName:"compute.firewalls.patch" OR methodName:"compute.firewalls.insert" OR methodName:"compute.firewalls.delete").',  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_LOGGING_SECTION,
     )
     try:
@@ -1039,7 +1039,7 @@ def _check_2_7(project_id: str) -> CISCheckResult:
         title="Ensure log metric filter and alerts exist for VPC Network Route changes",
         status=CheckStatus.ERROR,
         severity="medium",
-        recommendation='Create a log metric filter for resource.type="gce_route" AND (methodName:"compute.routes.delete" OR methodName:"compute.routes.insert").',
+        recommendation='Create a log metric filter for resource.type="gce_route" AND (methodName:"compute.routes.delete" OR methodName:"compute.routes.insert").',  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_LOGGING_SECTION,
     )
     try:
@@ -1074,7 +1074,7 @@ def _check_2_8(project_id: str) -> CISCheckResult:
         title="Ensure log metric filter and alerts exist for VPC Network changes",
         status=CheckStatus.ERROR,
         severity="medium",
-        recommendation='Create a log metric filter for resource.type="gce_network" AND (methodName:"compute.networks.insert" OR methodName:"compute.networks.patch" OR methodName:"compute.networks.delete" OR methodName:"compute.networks.removePeering" OR methodName:"compute.networks.addPeering").',
+        recommendation='Create a log metric filter for resource.type="gce_network" AND (methodName:"compute.networks.insert" OR methodName:"compute.networks.patch" OR methodName:"compute.networks.delete" OR methodName:"compute.networks.removePeering" OR methodName:"compute.networks.addPeering").',  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_LOGGING_SECTION,
     )
     try:
@@ -1179,7 +1179,7 @@ def _check_2_11(project_id: str) -> CISCheckResult:
         title="Ensure log metric filter and alerts exist for DNS Zone changes",
         status=CheckStatus.ERROR,
         severity="medium",
-        recommendation='Create a log metric filter for resource.type="dns_managed_zone" AND (methodName:"dns.managedZones.create" OR methodName:"dns.managedZones.patch" OR methodName:"dns.managedZones.update" OR methodName:"dns.managedZones.delete").',
+        recommendation='Create a log metric filter for resource.type="dns_managed_zone" AND (methodName:"dns.managedZones.create" OR methodName:"dns.managedZones.patch" OR methodName:"dns.managedZones.update" OR methodName:"dns.managedZones.delete").',  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_LOGGING_SECTION,
     )
     try:
@@ -1723,7 +1723,7 @@ def _check_4_2(project_id: str) -> CISCheckResult:
         title="Ensure instances are not configured to use the default service account with full access to all APIs",
         status=CheckStatus.ERROR,
         severity="high",
-        recommendation="Remove the default service account or restrict its scopes. Do not use https://www.googleapis.com/auth/cloud-platform scope with the default SA.",
+        recommendation="Remove the default service account or restrict its scopes. Do not use https://www.googleapis.com/auth/cloud-platform scope with the default SA.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_COMPUTE_SECTION,
     )
     try:
@@ -2478,7 +2478,7 @@ def _check_6_7(project_id: str) -> CISCheckResult:
         title="Ensure that Cloud SQL for PostgreSQL instances have log_min_duration_statement set to -1",
         status=CheckStatus.ERROR,
         severity="medium",
-        recommendation="Set the log_min_duration_statement database flag to '-1' to disable logging of statement durations (prevents sensitive data leakage).",
+        recommendation="Set the log_min_duration_statement database flag to '-1' to disable logging of statement durations (prevents sensitive data leakage).",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
         cis_section=_SQL_SECTION,
     )
     try:

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -65,6 +65,14 @@ ENABLE_EXTENSION_ENTRYPOINTS = _bool("AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS", F
 INCLUDE_UNFIXED_OS_ADVISORIES = _bool("AGENT_BOM_INCLUDE_UNFIXED", False)
 
 
+# ── Image Scanning ────────────────────────────────────────────────────────────
+# Optional Grype fallback for ``agent-bom image --tar`` when native OCI/archive
+# extraction yields no packages. Off by default — enable only when bridging
+# legacy tarballs that Grype handles better than the native parser.
+
+IMAGE_GRYPE_FALLBACK = _bool("AGENT_BOM_IMAGE_GRYPE_FALLBACK", False)
+
+
 # ── EPSS Thresholds ─────────────────────────────────────────────────────────
 # EPSS (Exploit Prediction Scoring System) probability thresholds.
 # Source: https://www.first.org/epss/

--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Any, Optional
 from urllib.parse import urljoin, urlparse
 
+from agent_bom.package_utils import ALPINE_SECDB_BRANCHES as _ALPINE_SECDB_BRANCHES
 from agent_bom.scanners.risk import parse_cvss_vector
 
 _logger = logging.getLogger(__name__)
@@ -62,7 +63,6 @@ _KEV_JSON_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_
 _GHSA_REST_URL = "https://api.github.com/advisories"
 _NVD_API_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
 _ALPINE_SECDB_BASE_URL = "https://secdb.alpinelinux.org"
-from agent_bom.package_utils import ALPINE_SECDB_BRANCHES as _ALPINE_SECDB_BRANCHES
 _ALPINE_SECDB_REPOS = ("main", "community")
 
 # Debian Security Tracker — authoritative per-release vulnerability status with

--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -62,7 +62,7 @@ _KEV_JSON_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_
 _GHSA_REST_URL = "https://api.github.com/advisories"
 _NVD_API_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
 _ALPINE_SECDB_BASE_URL = "https://secdb.alpinelinux.org"
-_ALPINE_SECDB_BRANCHES = ("v3.18", "v3.19", "v3.20", "v3.21", "v3.22", "v3.23")
+from agent_bom.package_utils import ALPINE_SECDB_BRANCHES as _ALPINE_SECDB_BRANCHES
 _ALPINE_SECDB_REPOS = ("main", "community")
 
 # Debian Security Tracker — authoritative per-release vulnerability status with

--- a/src/agent_bom/image.py
+++ b/src/agent_bom/image.py
@@ -34,6 +34,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
+from agent_bom.config import _bool
 from agent_bom.models import Package, PermissionProfile, Severity, Vulnerability
 from agent_bom.package_utils import parse_debian_source_name
 from agent_bom.sbom import parse_cyclonedx
@@ -138,7 +139,7 @@ def _debian_related_cve_fallback(match: dict, vuln_data: dict) -> tuple[Optional
 
 
 def _image_grype_fallback_enabled() -> bool:
-    return os.environ.get("AGENT_BOM_IMAGE_GRYPE_FALLBACK", "").strip().lower() in {"1", "true", "yes", "on"}
+    return _bool("AGENT_BOM_IMAGE_GRYPE_FALLBACK", False)
 
 
 def _packages_from_grype_json(data: dict) -> list[Package]:

--- a/src/agent_bom/image.py
+++ b/src/agent_bom/image.py
@@ -137,47 +137,12 @@ def _debian_related_cve_fallback(match: dict, vuln_data: dict) -> tuple[Optional
     return None, None
 
 
-def _scan_with_grype(
-    image_ref: str,
-    registry_user: Optional[str] = None,
-    registry_pass: Optional[str] = None,
-    platform: Optional[str] = None,
-) -> list[Package]:
-    """Run Grype and return packages with vulnerabilities pre-populated.
+def _image_grype_fallback_enabled() -> bool:
+    return os.environ.get("AGENT_BOM_IMAGE_GRYPE_FALLBACK", "").strip().lower() in {"1", "true", "yes", "on"}
 
-    Grype returns packages + CVEs in a single call, covering all ecosystems
-    (npm, cargo, go modules, maven, gems, .NET, deb, rpm, apk, Python).
-    No secondary OSV query is needed for image packages.
-    """
-    image_ref = validate_image_ref(image_ref)
-    platform = _validate_platform(platform)
-    cmd = ["grype", image_ref, "-o", "json", "--quiet"]
-    if platform:
-        cmd += ["--platform", platform]
-    env = _build_scanner_env(registry_user, registry_pass, "GRYPE")
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=300,
-            env=env,
-        )
-    except FileNotFoundError:
-        raise ImageScanError("grype not found")
-    except subprocess.TimeoutExpired:
-        raise ImageScanError(f"grype timed out scanning {image_ref}")
 
-    if result.returncode != 0:
-        stderr = result.stderr.strip()
-        raise ImageScanError(f"grype exited {result.returncode}: {stderr[:200]}")
-
-    try:
-        data = json.loads(result.stdout)
-    except json.JSONDecodeError as e:
-        raise ImageScanError(f"grype produced invalid JSON: {e}")
-
-    # Build Package objects keyed by (ecosystem, name, version)
+def _packages_from_grype_json(data: dict) -> list[Package]:
+    """Build Package objects with pre-populated vulnerabilities from Grype JSON."""
     pkg_map: dict[tuple[str, str, str], Package] = {}
 
     for match in data.get("matches", []):
@@ -197,12 +162,10 @@ def _scan_with_grype(
 
         pkg = pkg_map[key]
 
-        # Build Vulnerability from Grype match
         vuln_id = vuln_data.get("id", "")
         if not vuln_id:
             continue
 
-        # Extract CVSS score from Grype's cvss array.
         cvss_score = _cvss_score_from_grype_vulnerability(vuln_data)
         severity = _severity_from_grype_vulnerability(vuln_data, cvss_score)
         if severity == Severity.UNKNOWN and cvss_score is None:
@@ -212,12 +175,10 @@ def _scan_with_grype(
             if fallback_severity is not None:
                 severity = fallback_severity
 
-        # Fixed version
         fix_info = vuln_data.get("fix", {})
         fixed_versions = fix_info.get("versions", [])
         fixed_version = fixed_versions[0] if fixed_versions else None
 
-        # Avoid duplicating the same CVE on a package
         if not any(v.id == vuln_id for v in pkg.vulnerabilities):
             pkg.vulnerabilities.append(
                 Vulnerability(
@@ -230,6 +191,102 @@ def _scan_with_grype(
             )
 
     return list(pkg_map.values())
+
+
+def _run_grype_json(
+    target: str,
+    *,
+    registry_user: Optional[str] = None,
+    registry_pass: Optional[str] = None,
+    platform: Optional[str] = None,
+    timeout: int = 300,
+) -> dict:
+    """Run Grype against a target and return parsed JSON."""
+    platform = _validate_platform(platform)
+    cmd = ["grype", target, "-o", "json", "--quiet"]
+    if platform:
+        cmd += ["--platform", platform]
+    env = _build_scanner_env(registry_user, registry_pass, "GRYPE")
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+    except FileNotFoundError:
+        raise ImageScanError("grype not found")
+    except subprocess.TimeoutExpired:
+        raise ImageScanError(f"grype timed out scanning {target}")
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        raise ImageScanError(f"grype exited {result.returncode}: {stderr[:200]}")
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        raise ImageScanError("grype produced empty output")
+
+    # Grype may print log lines before JSON on some versions; parse the last JSON object.
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        decoder = json.JSONDecoder()
+        data = None
+        for idx, char in enumerate(stdout):
+            if char != "{":
+                continue
+            try:
+                data, _end = decoder.raw_decode(stdout[idx:])
+            except json.JSONDecodeError:
+                continue
+        if data is None:
+            raise ImageScanError("grype produced invalid JSON")
+        return data
+
+
+def _scan_with_grype(
+    image_ref: str,
+    registry_user: Optional[str] = None,
+    registry_pass: Optional[str] = None,
+    platform: Optional[str] = None,
+) -> list[Package]:
+    """Run Grype and return packages with vulnerabilities pre-populated.
+
+    Grype returns packages + CVEs in a single call, covering all ecosystems
+    (npm, cargo, go modules, maven, gems, .NET, deb, rpm, apk, Python).
+    No secondary OSV query is needed for image packages.
+    """
+    image_ref = validate_image_ref(image_ref)
+    data = _run_grype_json(
+        image_ref,
+        registry_user=registry_user,
+        registry_pass=registry_pass,
+        platform=platform,
+    )
+    return _packages_from_grype_json(data)
+
+
+def _grype_archive_target(tar_path: Path) -> str:
+    """Return the Grype target string for a saved image archive."""
+    resolved = tar_path.resolve()
+    if resolved.is_dir():
+        return f"oci-dir:{resolved}"
+    suffix = resolved.suffix.lower()
+    if suffix in {".tar", ".tgz"} or resolved.name.endswith(".tar.gz"):
+        return f"docker-archive:{resolved}"
+    return f"oci-archive:{resolved}"
+
+
+def _scan_archive_with_grype(tar_path: str | Path) -> list[Package]:
+    """Run Grype against a docker save / OCI archive tarball or layout directory."""
+    path = Path(tar_path)
+    if not path.exists():
+        raise ImageScanError(f"Image archive not found: {tar_path}")
+    target = _grype_archive_target(path)
+    data = _run_grype_json(target)
+    return _packages_from_grype_json(data)
 
 
 # ─── Syft strategy ────────────────────────────────────────────────────────────
@@ -832,9 +889,22 @@ def scan_image_tar(tar_path: str) -> tuple[list[Package], str]:
     if not path.exists():
         raise ImageScanError(f"Image tarball not found: {tar_path}")
     try:
-        return scan_oci(path)
+        packages, strategy = scan_oci(path)
     except OCIParseError as e:
         raise ImageScanError(f"OCI parse error: {e}") from e
+
+    if _image_grype_fallback_enabled() and _grype_available():
+        try:
+            grype_packages = _scan_archive_with_grype(path)
+        except ImageScanError as exc:
+            _logger.debug("Grype archive fallback skipped for %s: %s", tar_path, exc)
+        else:
+            if grype_packages:
+                grype_vulns = sum(len(pkg.vulnerabilities) for pkg in grype_packages)
+                if grype_vulns > 0 or len(grype_packages) > len(packages):
+                    return grype_packages, "grype-archive"
+
+    return packages, strategy
 
 
 def image_to_purl(image_ref: str) -> str:

--- a/src/agent_bom/package_utils.py
+++ b/src/agent_bom/package_utils.py
@@ -149,6 +149,16 @@ def ubuntu_release_branch(distro_version: str) -> str:
     return raw
 
 
+# Alpine secdb publishes advisories per minor branch (v3.14 … v3.23). Keep this
+# tuple aligned with ``sync_alpine_secdb`` and apk OSV fallback lists.
+ALPINE_SECDB_BRANCHES: tuple[str, ...] = tuple(f"v3.{minor}" for minor in range(14, 24))
+
+
+def alpine_osv_fallback_ecosystems() -> tuple[str, ...]:
+    """OSV ecosystem identifiers used when an apk package lacks distro metadata."""
+    return tuple(f"Alpine:{branch}" for branch in ALPINE_SECDB_BRANCHES)
+
+
 @lru_cache(maxsize=4096)
 def alpine_release_branch(distro_version: str) -> str:
     """Normalize an Alpine ``VERSION_ID`` to its secdb branch key (``v{major}.{minor}``).
@@ -188,6 +198,8 @@ def parse_debian_source_name(source_field: str) -> Optional[str]:
 
 
 __all__ = [
+    "ALPINE_SECDB_BRANCHES",
+    "alpine_osv_fallback_ecosystems",
     "alpine_release_branch",
     "canonical_package_identity",
     "canonical_package_key",

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -265,7 +265,9 @@ _NON_OSV_ECOSYSTEMS: frozenset[str] = frozenset(
 )
 
 _DEBIAN_OSV_FALLBACKS = ("Debian:11", "Debian:12", "Debian:13", "Debian:14")
-_ALPINE_OSV_FALLBACKS = ("Alpine:v3.18", "Alpine:v3.19", "Alpine:v3.20", "Alpine:v3.21", "Alpine:v3.22", "Alpine:v3.23")
+from agent_bom.package_utils import alpine_osv_fallback_ecosystems
+
+_ALPINE_OSV_FALLBACKS = alpine_osv_fallback_ecosystems()
 
 
 def _osv_ecosystems_for_package(pkg: Package) -> list[str]:

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -47,6 +47,7 @@ from agent_bom.owasp import tag_blast_radius
 from agent_bom.owasp_agentic import tag_blast_radius as tag_owasp_agentic
 from agent_bom.owasp_mcp import tag_blast_radius as tag_owasp_mcp
 from agent_bom.package_utils import (
+    alpine_osv_fallback_ecosystems,
     alpine_release_branch,
     canonical_package_identity,
     canonical_package_key,
@@ -265,8 +266,6 @@ _NON_OSV_ECOSYSTEMS: frozenset[str] = frozenset(
 )
 
 _DEBIAN_OSV_FALLBACKS = ("Debian:11", "Debian:12", "Debian:13", "Debian:14")
-from agent_bom.package_utils import alpine_osv_fallback_ecosystems
-
 _ALPINE_OSV_FALLBACKS = alpine_osv_fallback_ecosystems()
 
 

--- a/tests/test_alpine_release_keying.py
+++ b/tests/test_alpine_release_keying.py
@@ -23,6 +23,21 @@ from agent_bom.package_utils import alpine_release_branch, debian_release_branch
 from agent_bom.scanners import _db_ecosystems_for_package, _osv_ecosystems_for_package, _scan_packages_db_conn
 
 
+def test_alpine_secdb_branches_cover_legacy_releases():
+    from agent_bom.package_utils import ALPINE_SECDB_BRANCHES
+
+    assert "v3.14" in ALPINE_SECDB_BRANCHES
+    assert "v3.23" in ALPINE_SECDB_BRANCHES
+
+
+def test_alpine_osv_fallbacks_track_secdb_branches():
+    from agent_bom.package_utils import ALPINE_SECDB_BRANCHES, alpine_osv_fallback_ecosystems
+
+    fallbacks = alpine_osv_fallback_ecosystems()
+    assert fallbacks[0] == "Alpine:v3.14"
+    assert len(fallbacks) == len(ALPINE_SECDB_BRANCHES)
+
+
 @pytest.mark.parametrize(
     "version_id, expected",
     [

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -1,0 +1,51 @@
+"""Smoke tests for README architecture SVG generator."""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from scripts.generate_doc_architecture_svgs import architecture, how_it_works, persona_value
+
+IMAGES = Path(__file__).resolve().parents[1] / "docs" / "images"
+
+
+def test_how_it_works_includes_pipeline_steps() -> None:
+    svg = how_it_works("dark")
+    for step in ("Discover", "Extract", "Scan", "Enrich", "Analyze", "Report"):
+        assert step in svg
+    assert "PIPELINE" not in svg
+
+
+def test_architecture_includes_core_surfaces() -> None:
+    svg = architecture("light")
+    assert "Unified Finding" in svg
+    assert "UnifiedGraph" in svg
+    assert "70 tools" in svg
+    assert "283 ops" in svg
+    assert "Agents &amp; MCP" in svg
+
+
+def test_persona_value_renders_buyer_lanes() -> None:
+    svg = persona_value("dark")
+    assert "AppSec / GRC" in svg
+    assert "283 ops" in svg
+
+
+def test_generated_files_exist_and_are_valid_svg() -> None:
+    for name in (
+        "how-it-works-dark.svg",
+        "how-it-works-light.svg",
+        "architecture-dark.svg",
+        "architecture-light.svg",
+        "persona-value-dark.svg",
+        "persona-value-light.svg",
+    ):
+        path = IMAGES / name
+        assert path.exists(), name
+        text = path.read_text(encoding="utf-8")
+        assert text.startswith("<svg")
+        assert text.rstrip().endswith("</svg>")
+        assert re.search(r'viewBox="0 0 \d+ \d+"', text)
+        ET.parse(path)

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -6,7 +6,7 @@ import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-from scripts.generate_doc_architecture_svgs import _audit_layout, architecture, how_it_works, persona_value
+from scripts.generate_doc_architecture_svgs import _audit_github_safe, _audit_layout, architecture, how_it_works, persona_value
 
 IMAGES = Path(__file__).resolve().parents[1] / "docs" / "images"
 
@@ -55,7 +55,18 @@ def test_generated_files_exist_and_are_valid_svg() -> None:
         path = IMAGES / name
         assert path.exists(), name
         text = path.read_text(encoding="utf-8")
-        assert text.startswith("<svg")
+        assert text.lstrip().startswith("<?xml") or text.startswith("<svg")
         assert text.rstrip().endswith("</svg>")
         assert re.search(r'viewBox="0 0 \d+ \d+"', text)
+        assert re.search(r'width="\d+" height="\d+"', text)
         ET.parse(path)
+
+
+def test_generated_svgs_are_github_safe() -> None:
+    for name in (
+        "how-it-works-dark.svg",
+        "architecture-dark.svg",
+        "persona-value-dark.svg",
+    ):
+        text = (IMAGES / name).read_text(encoding="utf-8")
+        assert _audit_github_safe(text) == [], name

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -6,7 +6,7 @@ import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-from scripts.generate_doc_architecture_svgs import architecture, how_it_works, persona_value
+from scripts.generate_doc_architecture_svgs import _audit_layout, architecture, how_it_works, persona_value
 
 IMAGES = Path(__file__).resolve().parents[1] / "docs" / "images"
 
@@ -31,6 +31,16 @@ def test_persona_value_renders_buyer_lanes() -> None:
     svg = persona_value("dark")
     assert "AppSec / GRC" in svg
     assert "283 ops" in svg
+
+
+def test_generated_svgs_have_no_rect_overflow() -> None:
+    for name in (
+        "how-it-works-dark.svg",
+        "architecture-dark.svg",
+        "persona-value-dark.svg",
+    ):
+        text = (IMAGES / name).read_text(encoding="utf-8")
+        assert _audit_layout(text) == [], name
 
 
 def test_generated_files_exist_and_are_valid_svg() -> None:

--- a/tests/test_image_grype_tar_fallback.py
+++ b/tests/test_image_grype_tar_fallback.py
@@ -1,0 +1,97 @@
+"""Regression tests for optional Grype archive fallback on image tar scans."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from agent_bom.image import ImageScanError, scan_image_tar
+
+
+def test_scan_image_tar_grype_fallback_uses_archive_target(monkeypatch, tmp_path: Path) -> None:
+    grype_output = {
+        "matches": [
+            {
+                "artifact": {"name": "busybox", "version": "1.35.0-r17", "type": "apk"},
+                "vulnerability": {
+                    "id": "CVE-2023-42366",
+                    "severity": "High",
+                    "description": "busybox issue",
+                    "fix": {"versions": ["1.35.0-r18"]},
+                },
+            }
+        ]
+    }
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+
+        class Result:
+            returncode = 0
+            stdout = json.dumps(grype_output)
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setenv("AGENT_BOM_IMAGE_GRYPE_FALLBACK", "1")
+    monkeypatch.setattr("agent_bom.image.subprocess.run", fake_run)
+    monkeypatch.setattr("agent_bom.image.shutil.which", lambda name: "/usr/bin/grype" if name == "grype" else None)
+    monkeypatch.setattr(
+        "agent_bom.oci_parser.scan_oci",
+        lambda path: ([], "oci-tarball"),
+    )
+
+    tar_path = tmp_path / "alpine.tar"
+    tar_path.write_bytes(b"not-a-real-tar")
+
+    packages, strategy = scan_image_tar(str(tar_path))
+    assert strategy == "grype-archive"
+    assert len(packages) == 1
+    assert packages[0].name == "busybox"
+    assert packages[0].vulnerabilities[0].id == "CVE-2023-42366"
+    assert calls
+    assert calls[0][1].startswith("docker-archive:")
+
+
+def test_scan_image_tar_grype_fallback_disabled_keeps_native(monkeypatch, tmp_path: Path) -> None:
+    from agent_bom.models import Package
+
+    native_pkg = Package(name="apk-tools", version="2.12.9-r3", ecosystem="apk")
+
+    monkeypatch.delenv("AGENT_BOM_IMAGE_GRYPE_FALLBACK", raising=False)
+    monkeypatch.setattr(
+        "agent_bom.oci_parser.scan_oci",
+        lambda path: ([native_pkg], "oci-tarball"),
+    )
+
+    tar_path = tmp_path / "image.tar"
+    tar_path.write_bytes(b"tar")
+
+    packages, strategy = scan_image_tar(str(tar_path))
+    assert strategy == "oci-tarball"
+    assert packages == [native_pkg]
+
+
+def test_scan_image_tar_grype_fallback_failure_falls_back_to_native(monkeypatch, tmp_path: Path) -> None:
+    from agent_bom.models import Package
+
+    native_pkg = Package(name="musl", version="1.2.3-r3", ecosystem="apk")
+
+    def fake_grype(_target, **kwargs):
+        raise ImageScanError("grype not found")
+
+    monkeypatch.setenv("AGENT_BOM_IMAGE_GRYPE_FALLBACK", "1")
+    monkeypatch.setattr("agent_bom.image._run_grype_json", fake_grype)
+    monkeypatch.setattr("agent_bom.image._grype_available", lambda: True)
+    monkeypatch.setattr(
+        "agent_bom.oci_parser.scan_oci",
+        lambda path: ([native_pkg], "oci-tarball"),
+    )
+
+    tar_path = tmp_path / "image.tar"
+    tar_path.write_bytes(b"tar")
+
+    packages, strategy = scan_image_tar(str(tar_path))
+    assert strategy == "oci-tarball"
+    assert packages == [native_pkg]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves merge conflicts with `main` after #3297 landed the README architecture SVG generator. Keeps this branch's generator (283 OpenAPI ops, UnifiedGraph, layout audit, persona-value diagrams) and merges in README + VISUAL_LANGUAGE updates from main.

Also includes:
- Alpine APK/secdb branch coverage (`v3.14`–`v3.23`)
- PRODUCT_METRICS regen + 283 ops sync across docs/SVGs/tests
- Scan-pipeline footer fix + README offline DB callout
- Optional Grype fallback for `image --tar` (`AGENT_BOM_IMAGE_GRYPE_FALLBACK`)
- Alpine coverage gap issue spec

## SVG / GitHub PR preview fix (19f7e107)

Architecture and workflow SVGs were failing GitHub's PR diff renderer ("Invalid image source"). Fixed by:
- Removing `marker-end="url(#…)"` (polygon arrowheads instead)
- Dropping `role`/`aria-labelledby` attrs GitHub's sanitizer strips
- Adding explicit `width`/`height` + XML declaration
- Replacing raw Unicode flow arrows with ASCII `->`
- Narrowing canvas to **960px** with five equal lanes (no 412px CONSUMERS column)
- `_audit_github_safe()` gate in generator + tests

## Lint fix (2d7da334)

- Declared `AGENT_BOM_IMAGE_GRYPE_FALLBACK` in `config.py` and regenerated `docs/operations/ENV_VARS.md`

## Test plan

- [x] `pytest tests/test_doc_architecture_svgs.py` (6 tests, incl. GitHub-safe audit)
- [x] `python scripts/generate_env_var_reference.py --check`
- [x] Merge with `origin/main` completed
- [ ] Full CI on push
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b609ffa-953a-44af-ae4c-38f5d4f980a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b609ffa-953a-44af-ae4c-38f5d4f980a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

