### PR TITLE
feat(sca): extract & store NVD CPE applicability (CPE matching — PR 1/3)

### DIFF
--- a/src/agent_bom/db/schema.py
+++ b/src/agent_bom/db/schema.py
@@ -109,6 +109,20 @@ CREATE TABLE IF NOT EXISTS affected (
 );
 CREATE INDEX IF NOT EXISTS idx_affected_pkg ON affected(ecosystem, package_name);
 
+CREATE TABLE IF NOT EXISTS cpe_matches (
+    cve_id           TEXT NOT NULL,      -- CVE the applicability statement belongs to
+    criteria         TEXT NOT NULL,      -- full cpe:2.3:part:vendor:product:... string
+    vendor           TEXT NOT NULL,      -- CPE vendor field
+    product          TEXT NOT NULL,      -- CPE product field
+    version          TEXT,               -- exact version, or NULL when a range is used
+    version_start    TEXT,               -- range lower bound (NULL = unbounded)
+    version_start_op TEXT,               -- including | excluding
+    version_end      TEXT,               -- range upper bound (NULL = unbounded)
+    version_end_op   TEXT,               -- including | excluding
+    PRIMARY KEY (cve_id, criteria, version_start, version_end)
+);
+CREATE INDEX IF NOT EXISTS idx_cpe_product ON cpe_matches(vendor, product);
+
 CREATE TABLE IF NOT EXISTS epss_scores (
     cve_id          TEXT PRIMARY KEY,
     probability     REAL NOT NULL,      -- 0.0–1.0

--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -1356,6 +1356,73 @@ def _extract_nvd_cve_fields(cve_data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _cpe_version_bound(match: dict[str, Any], including_key: str, excluding_key: str) -> tuple[Optional[str], Optional[str]]:
+    """Return (value, op) for one CPE version bound — 'including'/'excluding' or (None, None)."""
+    inc = match.get(including_key)
+    if inc:
+        return str(inc), "including"
+    exc = match.get(excluding_key)
+    if exc:
+        return str(exc), "excluding"
+    return None, None
+
+
+def _extract_nvd_cpe_matches(cve_data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract vulnerable CPE applicability ranges from one NVD CVE object.
+
+    NVD 2.0 nests applicability as ``configurations[].nodes[].cpeMatch[]``; each
+    match carries a ``cpe:2.3:part:vendor:product:version:...`` criteria string
+    plus optional version-range bounds. Only ``vulnerable`` matches are kept.
+    """
+    rows: list[dict[str, Any]] = []
+    seen: set[tuple[str, Optional[str], Optional[str]]] = set()
+    for config in cve_data.get("configurations") or []:
+        for node in config.get("nodes") or []:
+            for match in node.get("cpeMatch") or []:
+                if not match.get("vulnerable"):
+                    continue
+                criteria = str(match.get("criteria") or "")
+                parts = criteria.split(":")
+                if not criteria.startswith("cpe:2.3:") or len(parts) < 6:
+                    continue
+                vendor, product, version = parts[3], parts[4], parts[5]
+                start, start_op = _cpe_version_bound(match, "versionStartIncluding", "versionStartExcluding")
+                end, end_op = _cpe_version_bound(match, "versionEndIncluding", "versionEndExcluding")
+                key = (criteria, start, end)
+                if key in seen:
+                    continue
+                seen.add(key)
+                rows.append(
+                    {
+                        "criteria": criteria,
+                        "vendor": vendor,
+                        "product": product,
+                        "version": version if version not in ("*", "-", "") else None,
+                        "version_start": start,
+                        "version_start_op": start_op,
+                        "version_end": end,
+                        "version_end_op": end_op,
+                    }
+                )
+    return rows
+
+
+def _upsert_cpe_matches(conn: sqlite3.Connection, cve_id: str, rows: list[dict[str, Any]]) -> int:
+    """Replace the stored CPE applicability rows for one CVE."""
+    conn.execute("DELETE FROM cpe_matches WHERE cve_id = ?", (cve_id,))
+    if not rows:
+        return 0
+    conn.executemany(
+        """
+        INSERT OR IGNORE INTO cpe_matches
+            (cve_id, criteria, vendor, product, version, version_start, version_start_op, version_end, version_end_op)
+        VALUES (:cve_id, :criteria, :vendor, :product, :version, :version_start, :version_start_op, :version_end, :version_end_op)
+        """,
+        [{"cve_id": cve_id, **r} for r in rows],
+    )
+    return len(rows)
+
+
 def _upsert_nvd_enrichment_row(conn: sqlite3.Connection, cve_id: str, fields: dict[str, Any]) -> bool:
     """Insert or update one CVE row from parsed NVD fields."""
     if not fields.get("cvss_score") and not fields.get("cwe_ids"):
@@ -1469,6 +1536,10 @@ def sync_nvd_incremental(
             if not cve_id.startswith("CVE-"):
                 continue
             fields = _extract_nvd_cve_fields(cve_data)
+            # Store CPE applicability for every synced CVE — it powers the
+            # nvd_cpe_candidate matcher independently of whether the CVE already
+            # has an enrichment row.
+            _upsert_cpe_matches(conn, cve_id, _extract_nvd_cpe_matches(cve_data))
             if _upsert_nvd_enrichment_row(conn, cve_id, fields):
                 enriched += 1
                 if enriched >= max_results:

--- a/tests/test_nvd_cpe_extraction.py
+++ b/tests/test_nvd_cpe_extraction.py
@@ -1,0 +1,88 @@
+"""Tests for NVD CPE applicability extraction + storage (CPE matching foundation)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from agent_bom.db.schema import init_db
+from agent_bom.db.sync import _extract_nvd_cpe_matches, sync_nvd_incremental
+
+
+def _cve_with_cpe() -> dict:
+    return {
+        "id": "CVE-2026-9999",
+        "descriptions": [{"lang": "en", "value": "Example CPE CVE"}],
+        "metrics": {"cvssMetricV31": [{"cvssData": {"baseScore": 9.8, "baseSeverity": "CRITICAL"}}]},
+        "configurations": [
+            {
+                "nodes": [
+                    {
+                        "cpeMatch": [
+                            {
+                                "vulnerable": True,
+                                "criteria": "cpe:2.3:a:acme:widget:*:*:*:*:*:*:*:*",
+                                "versionStartIncluding": "1.0",
+                                "versionEndExcluding": "2.0",
+                            },
+                            {
+                                "vulnerable": True,
+                                "criteria": "cpe:2.3:a:acme:gadget:3.1:*:*:*:*:*:*:*",
+                            },
+                            {
+                                # not vulnerable -> must be ignored
+                                "vulnerable": False,
+                                "criteria": "cpe:2.3:o:acme:os:*:*:*:*:*:*:*:*",
+                            },
+                        ]
+                    }
+                ]
+            }
+        ],
+    }
+
+
+def test_extract_nvd_cpe_matches_filters_and_parses() -> None:
+    rows = _extract_nvd_cpe_matches(_cve_with_cpe())
+    assert len(rows) == 2  # the non-vulnerable match is dropped
+    by_product = {r["product"]: r for r in rows}
+
+    widget = by_product["widget"]
+    assert widget["vendor"] == "acme"
+    assert widget["version"] is None  # "*" -> range, no exact version
+    assert widget["version_start"] == "1.0" and widget["version_start_op"] == "including"
+    assert widget["version_end"] == "2.0" and widget["version_end_op"] == "excluding"
+
+    gadget = by_product["gadget"]
+    assert gadget["version"] == "3.1"  # exact version pinned in the criteria
+    assert gadget["version_start"] is None and gadget["version_end"] is None
+
+
+def test_sync_persists_cpe_matches() -> None:
+    conn = init_db(Path(":memory:"))
+    payload = {
+        "resultsPerPage": 1,
+        "startIndex": 0,
+        "totalResults": 1,
+        "vulnerabilities": [{"cve": _cve_with_cpe()}],
+    }
+
+    def fake_fetch(url, *, timeout=60, headers=None):
+        return payload
+
+    with patch("agent_bom.http_client.fetch_json", side_effect=fake_fetch):
+        with patch("time.sleep"):
+            sync_nvd_incremental(
+                conn,
+                nvd_api_key="test-key",
+                url="https://services.nvd.nist.gov/rest/json/cves/2.0",
+                max_results=10,
+            )
+
+    rows = conn.execute(
+        "SELECT vendor, product, version, version_start, version_end FROM cpe_matches WHERE cve_id = 'CVE-2026-9999' ORDER BY product"
+    ).fetchall()
+    assert len(rows) == 2
+    assert rows[0]["product"] == "gadget" and rows[0]["version"] == "3.1"
+    assert rows[1]["product"] == "widget"
+    assert rows[1]["version_start"] == "1.0" and rows[1]["version_end"] == "2.0"


### PR DESCRIPTION
**PR 1 of the CPE-matching track** — the foundation for Wiz/Orca-style matching of non-ecosystem / OS / vendor software that OSV + distro feeds don't cover.

## This PR (storage only)
- New `cpe_matches` table: `(cve_id, vendor, product, version, version_start/op, version_end/op)`.
- `_extract_nvd_cpe_matches` parses NVD `configurations[].nodes[].cpeMatch[]` — **vulnerable matches only** — into vendor/product + version-range rows (handles exact-version pins and including/excluding bounds).
- Wired into the NVD incremental sync so every synced CVE's CPE applicability is captured alongside CVSS/CWE.

## Tests
`tests/test_nvd_cpe_extraction.py` — extraction filtering/parsing + end-to-end sync persistence. Existing NVD sync test still green. ruff + mypy clean.

## Next in the track (separate PRs)
- **PR 2 — matcher:** component → candidate `cpe:2.3` → version-range check (reusing `version_utils.version_in_range`) → emit findings at the `nvd_cpe_candidate` tier; wire into the scan path + output (CLI/API/UI) + graph.
- **PR 3 — accuracy:** vendor/product mapping heuristics + a parity harness validating CPE matches against Trivy/Grype/NVD ground-truth (false-positive control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)