### PR TITLE
feat(sca): CPE vendor disambiguation + accuracy harness (CPE — PR 3/3)

### DIFF
--- a/src/agent_bom/cpe_match.py
+++ b/src/agent_bom/cpe_match.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import re
 import sqlite3
-from typing import Any
+from typing import Any, Optional
 
 from agent_bom.advisory_ids import MATCH_CONFIDENCE_NVD_CPE_CANDIDATE
 from agent_bom.version_utils import version_in_range
@@ -67,13 +67,16 @@ def match_component_cpe(
     name: str,
     version: str,
     *,
+    vendor: Optional[str] = None,
     limit: int = 500,
 ) -> list[dict[str, Any]]:
     """Return ``nvd_cpe_candidate`` CVE matches for a component (name, version).
 
-    Empty when the component has no name/version, no candidate CPE product is in
-    the cache, or no version range applies. Each result carries the matched CVE
-    id, the CPE criteria string, and the ``nvd_cpe_candidate`` tier.
+    When ``vendor`` is supplied (e.g. inferred from a purl namespace or
+    Maven groupId) the candidate set is constrained to that CPE vendor, which is
+    the main false-positive control: it disambiguates same-named products from
+    different vendors. Empty when the component has no name/version, no candidate
+    CPE product is in the cache, or no version range applies.
     """
     if not name or not version:
         return []
@@ -82,12 +85,18 @@ def match_component_cpe(
         return []
 
     placeholders = ",".join("?" * len(products))
-    rows = conn.execute(
+    query = (
         "SELECT cve_id, criteria, version, version_start, version_start_op, "
         "version_end, version_end_op "
-        f"FROM cpe_matches WHERE product IN ({placeholders}) LIMIT ?",  # nosec B608 - placeholders are generated solely from "?" markers
-        (*products, limit),
-    ).fetchall()
+        f"FROM cpe_matches WHERE product IN ({placeholders})"  # nosec B608 - placeholders are generated solely from "?" markers
+    )
+    params: list[Any] = [*products]
+    if vendor:
+        query += " AND vendor = ?"
+        params.append(normalize_cpe_product(vendor))
+    query += " LIMIT ?"
+    params.append(limit)
+    rows = conn.execute(query, params).fetchall()
 
     matched: dict[str, str] = {}
     for row in rows:

--- a/src/agent_bom/db/lookup.py
+++ b/src/agent_bom/db/lookup.py
@@ -200,7 +200,9 @@ def lookup_package(
         return results
 
 
-def cpe_lookup_package(conn: sqlite3.Connection, name: str, version: str, *, limit: int = 500) -> list[LocalVuln]:
+def cpe_lookup_package(
+    conn: sqlite3.Connection, name: str, version: str, *, vendor: Optional[str] = None, limit: int = 500
+) -> list[LocalVuln]:
     """Long-tail CPE-candidate matches for a component, hydrated from ``vulns``.
 
     Maps the component to NVD CPE applicability ranges (see
@@ -211,7 +213,7 @@ def cpe_lookup_package(conn: sqlite3.Connection, name: str, version: str, *, lim
     """
     from agent_bom.cpe_match import MATCH_CONFIDENCE_NVD_CPE_CANDIDATE, match_component_cpe
 
-    matches = match_component_cpe(conn, name, version, limit=limit)
+    matches = match_component_cpe(conn, name, version, vendor=vendor, limit=limit)
     if not matches:
         return []
     cve_ids = [m["cve_id"] for m in matches]

--- a/tests/test_cpe_accuracy.py
+++ b/tests/test_cpe_accuracy.py
@@ -1,0 +1,78 @@
+"""CPE matcher accuracy / parity harness.
+
+Validates the ``nvd_cpe_candidate`` matcher against a curated ground-truth set of
+NVD-shaped CPE applicability statements + components with known expected results.
+Asserts **precision** (no false positives across vendors/products/versions) and
+**recall** (every truly-affected component is caught) — the same idea as the
+frozen Trivy/Grype image-parity baseline, applied to CPE matching. It also pins
+the value of vendor disambiguation (the main false-positive control).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_bom.cpe_match import match_component_cpe
+from agent_bom.db.schema import init_db
+
+# Ground truth: (cve, vendor, product, exact_version, vstart, vstart_op, vend, vend_op)
+_GROUND_TRUTH = [
+    # apache struts RCE affecting [2.0.0, 2.5.30)
+    ("CVE-T-STRUTS", "apache", "struts", None, "2.0.0", "including", "2.5.30", "excluding"),
+    # log4j exact 2.14.1
+    ("CVE-T-LOG4J", "apache", "log4j", "2.14.1", None, None, None, None),
+    # openssl <= 3.0.6 (inclusive end)
+    ("CVE-T-OPENSSL", "openssl", "openssl", None, None, None, "3.0.6", "including"),
+    # a DIFFERENT vendor's product also named "log4j" with no version bounds — the
+    # cross-vendor name collision that vendor filtering must suppress.
+    ("CVE-T-FAKELOG", "acme", "log4j", None, None, None, None, None),
+]
+
+# (component_name, version, vendor_hint, expected_cves)
+_CASES = [
+    ("struts", "2.5.0", "apache", {"CVE-T-STRUTS"}),   # in range
+    ("struts", "2.5.30", "apache", set()),             # exclusive end -> excluded
+    ("struts", "1.9.0", "apache", set()),              # below start
+    ("log4j", "2.14.1", "apache", {"CVE-T-LOG4J"}),    # exact hit
+    ("log4j", "2.14.2", "apache", set()),              # exact mismatch
+    ("openssl", "3.0.6", None, {"CVE-T-OPENSSL"}),     # inclusive end -> included
+    ("openssl", "3.0.7", None, set()),                 # above inclusive end
+    # No vendor hint: the acme no-bounds "log4j" collision DOES match (apache log4j
+    # is exact-2.14.1 so it does not at 9.9.9). This is the false-positive risk.
+    ("log4j", "9.9.9", None, {"CVE-T-FAKELOG"}),
+    # With the correct vendor hint, the acme collision is suppressed -> clean.
+    ("log4j", "9.9.9", "apache", set()),
+    ("nonexistent", "1.0", None, set()),               # unknown product
+]
+
+
+def _seed(conn) -> None:
+    conn.executemany(
+        "INSERT INTO cpe_matches (cve_id, criteria, vendor, product, version, "
+        "version_start, version_start_op, version_end, version_end_op) VALUES (?,?,?,?,?,?,?,?,?)",
+        [
+            (cve, f"cpe:2.3:a:{vendor}:{product}", vendor, product, ver, vs, vso, ve, veo)
+            for (cve, vendor, product, ver, vs, vso, ve, veo) in _GROUND_TRUTH
+        ],
+    )
+    conn.commit()
+
+
+@pytest.mark.parametrize("name,version,vendor,expected", _CASES)
+def test_cpe_matcher_precision_recall(name, version, vendor, expected) -> None:
+    conn = init_db(Path(":memory:"))
+    _seed(conn)
+    got = {m["cve_id"] for m in match_component_cpe(conn, name, version, vendor=vendor)}
+    assert got == expected, f"{name}@{version} vendor={vendor}: expected {expected}, got {got}"
+
+
+def test_vendor_filter_eliminates_cross_vendor_false_positive() -> None:
+    """The headline precision property: a vendor hint removes same-named-product noise."""
+    conn = init_db(Path(":memory:"))
+    _seed(conn)
+    no_hint = {m["cve_id"] for m in match_component_cpe(conn, "log4j", "9.9.9")}
+    with_hint = {m["cve_id"] for m in match_component_cpe(conn, "log4j", "9.9.9", vendor="apache")}
+    assert "CVE-T-FAKELOG" in no_hint  # the collision is reachable without a vendor
+    assert "CVE-T-FAKELOG" not in with_hint  # ...and suppressed with one


### PR DESCRIPTION
**PR 3 of the CPE-matching track** — false-positive control + accuracy validation. Completes the track.

## What it adds
- **Vendor-aware matching:** `match_component_cpe` / `cpe_lookup_package` gain an optional `vendor` hint. When supplied (from a purl namespace / Maven groupId), candidates are constrained to that CPE vendor — suppressing **same-named-product collisions across vendors**, the main FP lever (vendor was already stored in #3306).
- **Accuracy/parity harness** (`tests/test_cpe_accuracy.py`): a curated NVD-shaped ground-truth + components with known expected results, asserting **precision** (no cross-vendor / out-of-range false positives) and **recall** (every truly-affected component caught). Includes a case pinning the vendor-filter value (a no-bounds `acme:log4j` collision matches without a hint, is suppressed with one).

## Why this matters
CPE matching is review-grade by nature (product ≠ package name). This PR makes that safety explicit and tested — the same discipline as the frozen Trivy/Grype image-parity baseline, applied to CPE.

ruff + mypy clean; 21 CPE tests green; release-consistency passes.

## Track complete
PR 1 #3306 (extract+store) → PR 2 #3307 (matcher+scan wiring) → **PR 3 (vendor precision + accuracy)**. Next: cut v0.90.0 with the full SCA+CPE gains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)