### PR TITLE
fix(ui): default static deploys to same-origin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ credential environment names in reach, and the agents that can call it.
 
 | Domain | Coverage |
 |---|---|
-| Supply chain | Package and OS risk across npm, PyPI, Maven, Go, Cargo, NuGet, Composer, RubyGems, conda, Swift, apk, deb, and rpm, with OSV/GHSA enrichment, transitive resolution, and dependency-confusion detection; Hex/Pub are advisory ecosystem identifiers, not first-class lockfile parsers yet |
+| Supply chain | Package and OS risk across npm, PyPI, Maven, Go, Cargo, NuGet, Composer, RubyGems, conda, Swift, Hex, Pub, apk, deb, and rpm, with OSV/GHSA enrichment, transitive resolution, and dependency-confusion detection |
 | Agents + MCP | MCP clients, servers, tools, transports, and trust posture with live introspection across 29 first-class client types |
 | AI models + datasets | Malicious-model detection via safe pickle-opcode disassembly (no deserialization), model/dataset cards, and target-scoped PII/PHI dataset-file scanning |
 | Cloud estate | Read-only, gated asset inventory and CIS posture across AWS, Azure, GCP, and Snowflake, plus AI/GPU provider posture |

--- a/ui/tests/security-headers.test.ts
+++ b/ui/tests/security-headers.test.ts
@@ -54,4 +54,9 @@ describe("security-headers", () => {
     const expected = securityHeaders();
     expect(onDisk).toEqual(expected);
   });
+
+  it("static hosted builds default to same-origin API calls", () => {
+    const vercel = JSON.parse(readFileSync(VERCEL_PATH, "utf8"));
+    expect(vercel.env?.NEXT_PUBLIC_API_URL).toBe("");
+  });
 });

--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -4,7 +4,7 @@
   "installCommand": "npm install",
   "outputDirectory": ".next",
   "env": {
-    "NEXT_PUBLIC_API_URL": "http://localhost:8422"
+    "NEXT_PUBLIC_API_URL": ""
   },
   "headers": [
     {


### PR DESCRIPTION
## Summary

- default Vercel/static UI deployments to same-origin API calls instead of baking `http://localhost:8422`
- add a regression assertion so static hosted builds do not silently drift back to localhost
- update the README supply-chain coverage row now that Hex and Pub lockfile parsers are present on `main`

## Why

The dashboard runtime already rejects cross-origin build-time API URLs in the browser and prefers same-origin routing, but `ui/vercel.json` still carried a localhost default. That is a hosted-deploy footgun: a static deployment can look healthy while browser API calls go nowhere. The README also still described Hex/Pub as advisory-only even though parser coverage and tests have landed.

## Validation

- `npm run headers:check`
- `npm run test:run -- security-headers.test.ts api.test.ts`
- `uv run pytest tests/test_beam_parsers.py tests/test_public_docs_cli_alignment.py -q`
