### PR TITLE
test(sca): real offline + online scan-accuracy validation

### DIFF
--- a/tests/test_offline_scan_validation.py
+++ b/tests/test_offline_scan_validation.py
@@ -1,0 +1,104 @@
+"""Offline end-to-end scan-accuracy validation (deterministic, CI-safe).
+
+Unlike the canonicalization parity test, this drives the *real* offline scan
+path (``_scan_packages_db_conn``) against a seeded local DB and asserts that each
+component is matched to the right CVE at the right confidence tier across all
+three matchers — OSV/ecosystem version-range, distro advisory, and the new NVD
+CPE candidate path. No network: it's the regression net for the matching engine.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_bom.db.schema import init_db
+from agent_bom.models import Package
+from agent_bom.scanners import _db_ecosystems_for_package, _scan_packages_db_conn
+
+
+def _seed(conn) -> None:
+    # 1) OSV / ecosystem version-range hit (PyPI requests in [2.0.0, 2.6.0))
+    osv_pkg = Package(name="requests", version="2.5.0", ecosystem="pypi")
+    osv_eco = _db_ecosystems_for_package(osv_pkg)[0]
+    conn.execute(
+        "INSERT INTO vulns(id, summary, severity, source) VALUES (?,?,?,?)",
+        ("CVE-OSV-0001", "requests SSRF", "high", "osv"),
+    )
+    conn.execute(
+        "INSERT INTO affected(vuln_id, ecosystem, package_name, introduced, fixed) VALUES (?,?,?,?,?)",
+        ("CVE-OSV-0001", osv_eco, "requests", "2.0.0", "2.6.0"),
+    )
+
+    # 2) Distro advisory hit (apk busybox under the branch key)
+    apk_pkg = Package(name="busybox", version="1.35.0-r17", ecosystem="apk", distro_name="alpine", distro_version="3.16.9")
+    apk_eco = _db_ecosystems_for_package(apk_pkg)[0]
+    conn.execute(
+        "INSERT INTO vulns(id, summary, severity, source) VALUES (?,?,?,?)",
+        ("CVE-DISTRO-0002", "busybox overflow", "high", "alpine-secdb"),
+    )
+    conn.execute(
+        "INSERT INTO affected(vuln_id, ecosystem, package_name, introduced, fixed) VALUES (?,?,?,?,?)",
+        ("CVE-DISTRO-0002", apk_eco, "busybox", "0", "1.35.0-r18"),
+    )
+
+    # 3) CPE candidate hit — a non-ecosystem component OSV/distro never cover.
+    conn.execute(
+        "INSERT INTO vulns(id, summary, severity, source) VALUES (?,?,?,?)",
+        ("CVE-CPE-0003", "acmehttpd RCE", "critical", "nvd"),
+    )
+    conn.execute(
+        "INSERT INTO cpe_matches (cve_id, criteria, vendor, product, version, "
+        "version_start, version_start_op, version_end, version_end_op) VALUES (?,?,?,?,?,?,?,?,?)",
+        ("CVE-CPE-0003", "cpe:2.3:a:acme:acmehttpd:*", "acme", "acmehttpd", None, "1.0.0", "including", "2.0.0", "excluding"),
+    )
+    conn.commit()
+
+
+def _vuln_ids(pkg: Package) -> set[str]:
+    return {v.id for v in pkg.vulnerabilities}
+
+
+def test_offline_scan_matches_all_three_tiers(monkeypatch) -> None:
+    monkeypatch.setattr("agent_bom.config.ENABLE_CPE_MATCH", True)
+    conn = init_db(Path(":memory:"))
+    _seed(conn)
+
+    osv_pkg = Package(name="requests", version="2.5.0", ecosystem="pypi")
+    apk_pkg = Package(name="busybox", version="1.35.0-r17", ecosystem="apk", distro_name="alpine", distro_version="3.16.9")
+    cpe_pkg = Package(name="acmehttpd", version="1.5.0", ecosystem="generic")
+    packages = [osv_pkg, apk_pkg, cpe_pkg]
+
+    total = _scan_packages_db_conn(conn, packages, set())
+
+    assert total >= 3
+    assert "CVE-OSV-0001" in _vuln_ids(osv_pkg)
+    assert "CVE-DISTRO-0002" in _vuln_ids(apk_pkg)
+    assert "CVE-CPE-0003" in _vuln_ids(cpe_pkg)
+
+    # The CPE-matched finding must carry the review-grade candidate tier.
+    cpe_vuln = next(v for v in cpe_pkg.vulnerabilities if v.id == "CVE-CPE-0003")
+    assert cpe_vuln.match_confidence_tier == "nvd_cpe_candidate"
+
+
+def test_offline_scan_no_false_positive_out_of_range(monkeypatch) -> None:
+    monkeypatch.setattr("agent_bom.config.ENABLE_CPE_MATCH", True)
+    conn = init_db(Path(":memory:"))
+    _seed(conn)
+
+    # requests 3.0.0 is past the fixed 2.6.0; acmehttpd 3.0.0 past the CPE end.
+    clean_osv = Package(name="requests", version="3.0.0", ecosystem="pypi")
+    clean_cpe = Package(name="acmehttpd", version="3.0.0", ecosystem="generic")
+    _scan_packages_db_conn(conn, [clean_osv, clean_cpe], set())
+
+    assert _vuln_ids(clean_osv) == set()
+    assert _vuln_ids(clean_cpe) == set()
+
+
+def test_cpe_off_by_default_no_candidate_noise(monkeypatch) -> None:
+    monkeypatch.setattr("agent_bom.config.ENABLE_CPE_MATCH", False)
+    conn = init_db(Path(":memory:"))
+    _seed(conn)
+    cpe_pkg = Package(name="acmehttpd", version="1.5.0", ecosystem="generic")
+    _scan_packages_db_conn(conn, [cpe_pkg], set())
+    # With the toggle off, no CPE candidate findings leak in.
+    assert _vuln_ids(cpe_pkg) == set()

--- a/tests/test_online_scan_validation.py
+++ b/tests/test_online_scan_validation.py
@@ -1,0 +1,85 @@
+"""Online scan-accuracy validation against live sources + a real Trivy diff.
+
+These are ``network``-marked (skipped by CI's ``-m "not network"``) and meant to
+run on demand / on a scheduled job as the *live* regression net that the
+deterministic offline test cannot provide:
+
+* live OSV — known-vulnerable packages must still resolve to their **specific**
+  ground-truth CVE (not just "len > 0"), so a recall regression is caught.
+* live Trivy binary diff — when the ``trivy`` binary is installed, agent-bom's
+  native distro-confirmed CVEs for a pinned image must be a near-superset of
+  Trivy's, proving real parity rather than canonicalization-only.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import subprocess  # nosec B404 - controlled, fixed-arg invocation of the trivy CLI in a gated test
+
+import pytest
+
+from agent_bom.models import Package, normalize_package_name
+from agent_bom.scanners import query_osv_batch
+
+pytestmark = pytest.mark.network
+
+
+def _scan_one(pkg: Package) -> set[str]:
+    results = asyncio.run(query_osv_batch([pkg]))
+    key = f"{pkg.ecosystem.lower()}:{normalize_package_name(pkg.name, pkg.ecosystem)}@{pkg.version}"
+    vulns = results.get(key, [])
+    ids: set[str] = set()
+    for v in vulns:
+        ids.add(str(v.get("id", "")))
+        ids.update(str(a) for a in (v.get("aliases") or []))
+    return ids
+
+
+# (package, version, ecosystem, a CVE that MUST appear) — real OSV ground truth.
+_GROUND_TRUTH = [
+    ("requests", "2.25.0", "pypi", "CVE-2023-32681"),   # header leak on redirect
+    ("jinja2", "3.1.2", "pypi", "CVE-2024-22195"),      # xmlattr XSS
+    ("pyyaml", "5.3", "pypi", "CVE-2020-14343"),        # arbitrary code exec on load
+]
+
+
+@pytest.mark.parametrize("name,version,eco,expected_cve", _GROUND_TRUTH)
+def test_live_osv_finds_specific_ground_truth_cve(name, version, eco, expected_cve) -> None:
+    found = _scan_one(Package(name=name, version=version, ecosystem=eco))
+    assert expected_cve in found, f"{name} {version}: live OSV must still flag {expected_cve}; got {sorted(found)[:8]}"
+
+
+@pytest.mark.skipif(shutil.which("trivy") is None, reason="trivy binary not installed")
+def test_agent_bom_recall_matches_trivy_on_pinned_image(tmp_path) -> None:
+    """agent-bom's native image scan must recall >=90% of Trivy's CVEs (real diff)."""
+    image = "alpine:3.14.2"
+    # Trivy ground truth
+    out = subprocess.run(  # nosec B603 - fixed args, trivy from PATH, gated by skipif
+        ["trivy", "image", "--quiet", "--format", "json", "--scanners", "vuln", image],
+        capture_output=True,
+        text=True,
+        timeout=600,
+        check=True,
+    )
+    trivy_cves = {
+        v["VulnerabilityID"]
+        for res in (json.loads(out.stdout).get("Results") or [])
+        for v in (res.get("Vulnerabilities") or [])
+        if str(v.get("VulnerabilityID", "")).startswith("CVE-")
+    }
+    assert trivy_cves, "trivy returned no CVEs — image/network problem, not an agent-bom result"
+
+    from agent_bom.scanners.image import scan_image  # local import: heavy module
+
+    report = scan_image(image)
+    ab_cves: set[str] = set()
+    for pkg in getattr(report, "packages", []) or []:
+        for v in getattr(pkg, "vulnerabilities", []) or []:
+            ab_cves.add(str(getattr(v, "id", "")))
+            ab_cves.update(str(a) for a in (getattr(v, "aliases", []) or []))
+
+    recall = len(trivy_cves & ab_cves) / len(trivy_cves)
+    missed = sorted(trivy_cves - ab_cves)
+    assert recall >= 0.90, f"recall {recall:.0%} (<90%) vs Trivy on {image}; missed {missed[:15]}"


### PR DESCRIPTION
Turns the synthetic canonicalization parity into **real end-to-end validation** — closing the pre-release coverage caveats (synthetic parity / network tests skipped).

## Offline (CI-default, deterministic — `test_offline_scan_validation.py`)
Drives the real offline scan path (`_scan_packages_db_conn`) against a seeded DB and asserts each component matches the right CVE at the right tier across **all three matchers** — OSV/ecosystem version-range, distro advisory, and the new `nvd_cpe_candidate` CPE path — plus out-of-range **false-positive control** and **CPE-off-by-default** (no candidate noise). Runs in CI; deterministic, no network.

## Online (network-marked — `test_online_scan_validation.py`)
- **Live OSV ground truth:** known-vulnerable packages must still resolve to their *specific* CVE (requests→CVE-2023-32681, jinja2→CVE-2024-22195, pyyaml→CVE-2020-14343) — a real recall regression net, stronger than "len>0".
- **Live Trivy diff:** when the `trivy` binary is present, asserts agent-bom's native image scan recalls **≥90%** of Trivy's CVEs on a pinned image (`alpine:3.14.2`) — real binary parity, not canonicalization.

ruff clean; offline 3/3 pass; online 4 tests collect (skip without network/trivy).

**Follow-up (noted, not in this PR):** wire a scheduled CI job that runs `pytest -m network` so the live nets execute regularly instead of being perpetually skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)