### PR TITLE
docs(release): 0.90.1 hygiene — soften SCA framing, fix stale pins, README callouts

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
 #
 #   repos:
 #     - repo: https://github.com/msaad00/agent-bom
-#       rev: v0.89.2
+#       rev: v0.90.0
 #       hooks:
 #         - id: agent-bom-secrets
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [0.90.0] - 2026-06-30
 
-Native, self-sufficient SCA reaches Trivy/Grype/Syft-replacing maturity and adds
-NVD CPE candidate matching for the long tail OSV and distro feeds do not cover —
-on top of the multi-account CNAPP estate work below. No external scanner
-subprocess is required for the vulnerability path.
+Native, self-sufficient SCA: distro-confirmed findings match or exceed Trivy on
+published benchmarks (e.g. alpine 3.14.2), with an optional NVD CPE candidate
+tier (review-grade, opt-in) for the long tail OSV and distro feeds do not cover —
+on top of the multi-account CNAPP estate work below. No Trivy/Grype/Syft
+subprocess is required on the vulnerability path.
 
 ### Vulnerability scanning / SCA
 - **Canonical CVE identity + match-confidence tiers.** `ALPINE-CVE-*` /

--- a/README.md
+++ b/README.md
@@ -38,6 +38,39 @@ resources. Every source converges into a unified `Finding` model and a unified
 `ContextGraph`, so blast radius, multi-hop exposure paths, and exposure scoring
 all read from the same evidence.
 
+> `ContextGraph` is the customer-facing name for the unified evidence graph; it
+> is persisted and served as `UnifiedGraph` in the API and MCP exports.
+
+<details>
+<summary><strong>What's new in 0.90.0</strong></summary>
+
+- **Canonical CVE IDs** — `ALPINE-CVE-*` / `DEBIAN-CVE-*` are mapped to `CVE-*` for cross-tool parity.
+- **Match-confidence tiers** on every finding: `distro_confirmed` > `osv_range` > `osv_ecosystem` > `unfixed_distro` > `nvd_cpe_candidate`.
+- **NVD incremental sync** + **NVD CPE candidate matching** (opt-in via `AGENT_BOM_ENABLE_CPE_MATCH`) for non-ecosystem / OS / vendor software the OSV and distro feeds miss.
+- **Parallel OSV** batches with bounded concurrency.
+
+**Accuracy model.** Distro-confirmed findings match or exceed Trivy on published
+benchmarks (e.g. alpine 3.14.2). The optional `nvd_cpe_candidate` tier is
+review-grade and **off by default** — it widens long-tail coverage without
+inflating confirmed counts. No Trivy/Grype/Syft subprocess is required.
+
+**NVD key model.** CVE/CPE enrichment ships in the distributed vuln database
+(built server-side with an org key), so end users — and MCP/agent callers — do
+**not** supply an NVD key. `NVD_API_KEY` is an optional self-host/freshness knob,
+never a per-user requirement.
+</details>
+
+<details>
+<summary><strong>Who it's for</strong></summary>
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/persona-value-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/persona-value-light.svg" alt="agent-bom value by persona: developers (CLI/CI), security teams (API/dashboard), and automation (MCP tools)" width="980" />
+  </picture>
+</p>
+</details>
+
 The product goal is interoperability for humans and agents: developers get a
 CLI/CI scanner, security teams get an API and dashboard, automation gets MCP
 tools and typed schemas, and runtime controls can enforce the same evidence when

--- a/deploy/cloudformation/README.md
+++ b/deploy/cloudformation/README.md
@@ -74,7 +74,7 @@ S3 console.
 | `Region`              | `us-east-1`                                           | AWS region passed to `agent-bom cloud aws --region`.                    |
 | `FailOnSeverity`      | `none`                                                | `none\|low\|medium\|high\|critical` — fail the build at/above severity. |
 | `AddViewOnlyAccess`   | `false`                                               | Also attach AWS-managed `ViewOnlyAccess` (still read-only).             |
-| `AgentBomSpec`        | `agent-bom[aws]`                                      | pip spec; pin a version e.g. `agent-bom[aws]==0.89.2`.                  |
+| `AgentBomSpec`        | `agent-bom[aws]`                                      | pip spec; pin a version e.g. `agent-bom[aws]==0.90.0`.                  |
 | `ComputeType`         | `BUILD_GENERAL1_SMALL`                                | CodeBuild compute size.                                                 |
 | `PythonImage`         | `aws/codebuild/amazonlinux2-x86_64-standard:5.0`      | Managed CodeBuild image providing Python 3.                            |
 | `ReportRetentionDays` | `30`                                                  | Days before report objects expire.                                     |

--- a/deploy/cloudformation/agent-bom-scan.yaml
+++ b/deploy/cloudformation/agent-bom-scan.yaml
@@ -80,7 +80,7 @@ Parameters:
     AllowedPattern: "^agent-bom\\[aws\\].*$"
     Description: >-
       pip requirement spec installed before the scan. Pin a version for
-      reproducible runs, e.g. "agent-bom[aws]==0.89.2".
+      reproducible runs, e.g. "agent-bom[aws]==0.90.0".
 
   ComputeType:
     Type: String

--- a/deploy/cloudformation/buildspec.yml
+++ b/deploy/cloudformation/buildspec.yml
@@ -8,7 +8,7 @@
 #   AGENT_BOM_AWS_INVENTORY=1     enables AWS inventory enrichment
 #   SCAN_REGION                   region passed to `agent-bom cloud aws --region`
 #   REPORT_BUCKET                 private S3 bucket for reports
-#   AGENT_BOM_SPEC                pip requirement, e.g. "agent-bom[aws]==0.89.2"
+#   AGENT_BOM_SPEC                pip requirement, e.g. "agent-bom[aws]==0.90.0"
 #   FAIL_ON_SEVERITY              none|low|medium|high|critical
 #
 # The scan is read-only: every `agent-bom cloud aws` invocation discovers

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -224,7 +224,7 @@ to your repository's `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/msaad00/agent-bom
-    rev: v0.89.2
+    rev: v0.90.0
     hooks:
       - id: agent-bom-secrets
       - id: agent-bom-scan

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 658,
+      "value": 668,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 593,
+      "value": 595,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,10 +14,10 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 37 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 658 | `tests/` | Counts files matching test_*.py. |
+| Test files | 668 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 33 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 29 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 593 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 595 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 14 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -22,7 +22,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi  # pre-install allow/warn/block
 CI gate (GitHub Action):
 
 ```yaml
-- uses: msaad00/agent-bom@v0.89.2
+- uses: msaad00/agent-bom@v0.90.0
 ```
 
 - Output formats, exit codes, and the full command set:


### PR DESCRIPTION
Post-release audit follow-ups (docs-only). Most of the external review was stale (pre-#3313 tree); these are the **real remaining items**:

## Positioning honesty (was 6/10)
- CHANGELOG SCA opener softened: ~~"Trivy/Grype/Syft-replacing maturity"~~ → **"distro-confirmed findings match or exceed Trivy on published benchmarks; optional review-grade `nvd_cpe_candidate` tier (opt-in)"** — matches what we ship.
- README **Accuracy model** callout with the tier ladder + the honest "off by default" CPE note.

## Stale copy-paste pins (the 4 `0.89.2` refs bump-version misses)
`docs/START_HERE.md`, `docs/DEPLOYMENT.md` (pre-commit rev), `.pre-commit-hooks.yaml`, `deploy/cloudformation/*` examples → all 0.90.0.

## README clarity
- **ContextGraph↔UnifiedGraph** glossary note (customer-facing vs implementation).
- **"What's new in 0.90.0"** collapsible (canonical CVE, tiers, NVD incremental, parallel OSV, opt-in CPE).
- **NVD key model** note: CVE/CPE enrichment ships in the distributed DB (built server-side with an org key) — end users + MCP/agent callers need **no** NVD key; `NVD_API_KEY` is an optional self-host/freshness knob.
- Embed the previously-unused **persona-value** SVG (collapsed, no above-fold bloat).

## Metrics
Regenerated `PRODUCT_METRICS` to code-true counts.

## Deferred (needs a running 0.90.0 UI)
Re-capture product screenshots (currently show 0.89.2). That's the hosted-demo step.

All gates green; 748 targeted tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)