### PR TITLE
fix(sca): honor NVD CPE inclusive/exclusive version bounds exactly

### DIFF
--- a/src/agent_bom/cpe_match.py
+++ b/src/agent_bom/cpe_match.py
@@ -19,10 +19,10 @@ import sqlite3
 from typing import Any, Optional
 
 from agent_bom.advisory_ids import MATCH_CONFIDENCE_NVD_CPE_CANDIDATE
-from agent_bom.version_utils import version_in_range
+from agent_bom.version_utils import compare_version_order
 
 # CPE versions are bare dotted strings with no ecosystem; use the generic
-# comparator path in version_in_range.
+# comparator path.
 _CPE_ECOSYSTEM = "generic"
 
 
@@ -46,20 +46,44 @@ def candidate_cpe_products(name: str) -> list[str]:
 
 
 def _cpe_range_applies(version: str, row: sqlite3.Row) -> bool:
-    """Whether ``version`` falls inside one stored CPE applicability row."""
+    """Whether ``version`` falls inside one stored CPE applicability row.
+
+    Honors NVD's inclusive/exclusive bounds *exactly* — a boundary version is
+    only vulnerable when the source says so. e.g. with versionStartExcluding=1.0.0
+    and versionEndExcluding=2.0.0: 1.0.0 is NOT vulnerable, 1.0.1 IS, 2.0.0 is NOT.
+    Fails safe: if a version is incomparable to a bound, the row does not apply
+    (a candidate match must never invent a boundary hit).
+    """
     exact = row["version"]
     if exact:
         # The criteria pins a specific version (e.g. cpe:2.3:a:acme:gadget:3.1).
         return str(version).strip() == str(exact).strip()
 
-    introduced = row["version_start"]  # start bound (incl/excl) -> inclusive lower
-    fixed = row["version_end"] if row["version_end_op"] == "excluding" else None
-    last_affected = row["version_end"] if row["version_end_op"] == "including" else None
-
-    if not (introduced or fixed or last_affected):
+    start = row["version_start"]
+    end = row["version_end"]
+    if not (start or end):
         # Product matches with no version bounds -> every version is affected.
         return True
-    return version_in_range(version, introduced, fixed, last_affected, _CPE_ECOSYSTEM)
+
+    if start:
+        order = compare_version_order(version, start, _CPE_ECOSYSTEM)
+        if order is None:
+            return False  # incomparable -> fail safe
+        if row["version_start_op"] == "excluding":
+            if order <= 0:  # need version > start (strict)
+                return False
+        elif order < 0:  # including: need version >= start
+            return False
+    if end:
+        order = compare_version_order(version, end, _CPE_ECOSYSTEM)
+        if order is None:
+            return False  # incomparable -> fail safe
+        if row["version_end_op"] == "including":
+            if order > 0:  # need version <= end
+                return False
+        elif order >= 0:  # excluding (NVD default for upper bound): need version < end
+            return False
+    return True
 
 
 def match_component_cpe(

--- a/tests/test_cpe_version_bounds.py
+++ b/tests/test_cpe_version_bounds.py
@@ -1,0 +1,61 @@
+"""CPE version-bound semantics — inclusive/exclusive must be honored exactly.
+
+NVD stores ``versionStartExcluding`` / ``versionEndExcluding`` etc. A boundary
+version must only be vulnerable when the source says so, or agent-bom flags false
+positives. Regression net for the exclusive-bound fix.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_bom.cpe_match import match_component_cpe
+from agent_bom.db.schema import init_db
+
+
+def _seed(conn, *, start=None, start_op=None, end=None, end_op=None) -> None:
+    conn.execute(
+        "INSERT INTO cpe_matches (cve_id, criteria, vendor, product, version, "
+        "version_start, version_start_op, version_end, version_end_op) "
+        "VALUES (?,?,?,?,?,?,?,?,?)",
+        ("CVE-BOUND", "cpe:2.3:a:acme:widget:*", "acme", "widget", None, start, start_op, end, end_op),
+    )
+    conn.commit()
+
+
+def _hits(conn, version: str) -> bool:
+    return bool(match_component_cpe(conn, "widget", version))
+
+
+# The canonical example: versionStartExcluding=1.0.0, versionEndExcluding=2.0.0
+@pytest.mark.parametrize(
+    "version,expected",
+    [("0.9.9", False), ("1.0.0", False), ("1.0.1", True), ("1.9.9", True), ("2.0.0", False), ("2.1.0", False)],
+)
+def test_exclusive_start_and_end(version, expected) -> None:
+    conn = init_db(Path(":memory:"))
+    _seed(conn, start="1.0.0", start_op="excluding", end="2.0.0", end_op="excluding")
+    assert _hits(conn, version) is expected, f"{version}: expected vulnerable={expected}"
+
+
+def test_inclusive_start_includes_boundary() -> None:
+    conn = init_db(Path(":memory:"))
+    _seed(conn, start="1.0.0", start_op="including", end="2.0.0", end_op="excluding")
+    assert _hits(conn, "1.0.0") is True   # inclusive start -> boundary IS vulnerable
+    assert _hits(conn, "0.9.9") is False
+
+
+def test_inclusive_end_includes_boundary() -> None:
+    conn = init_db(Path(":memory:"))
+    _seed(conn, start="1.0.0", start_op="including", end="2.0.0", end_op="including")
+    assert _hits(conn, "2.0.0") is True   # inclusive end -> boundary IS vulnerable
+    assert _hits(conn, "2.0.1") is False
+
+
+def test_incomparable_version_fails_safe() -> None:
+    conn = init_db(Path(":memory:"))
+    _seed(conn, start="1.0.0", start_op="including", end="2.0.0", end_op="excluding")
+    # A garbage version that can't be ordered must NOT be flagged (no boundary invention).
+    assert _hits(conn, "not-a-version") is False


### PR DESCRIPTION
**Correctness fix — eliminates a CPE boundary false positive shipped in 0.90.0.**

The CPE matcher treated every `version_start` as **inclusive**, so a `versionStartExcluding=X` applicability would falsely flag version `X` even though NVD says the vulnerable range starts *after* it.

## The fix
`_cpe_range_applies` now honors all four bound kinds exactly via `compare_version_order`:
| bound | rule |
|---|---|
| versionStartIncluding | version **≥** start |
| versionStartExcluding | version **>** start |
| versionEndIncluding | version **≤** end |
| versionEndExcluding | version **<** end |

…and **fails safe** (no match) when a version is incomparable to a bound — a candidate match must never invent a boundary hit.

## Canonical example (now correct)
`versionStartExcluding=1.0.0`, `versionEndExcluding=2.0.0`:
- `1.0.0` → **not** vulnerable · `1.0.1` → vulnerable · `2.0.0` → **not** vulnerable

## Tests
`tests/test_cpe_version_bounds.py` covers the canonical example + inclusive-start/end boundaries + incomparable-version fail-safe. All 33 CPE tests pass; ruff + mypy clean.

This brings agent-bom to the Wiz/Orca/Snyk discipline of **preserving advisory bounds exactly** — fewer false positives, true NVD parity, more trustworthy triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)