### PR TITLE
fix(release): harden post-0.90 audit findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ credential environment names in reach, and the agents that can call it.
 
 | Domain | Coverage |
 |---|---|
-| Supply chain | Package and OS risk across npm, PyPI, Maven, Go, Cargo, NuGet, Composer, RubyGems, conda, Swift, Hex, Pub, apk, deb, and rpm, with OSV/GHSA/NVD enrichment, NVD CPE candidate matching for non-ecosystem software, transitive resolution, and dependency-confusion detection |
+| Supply chain | Package and OS risk across npm, PyPI, Maven, Go, Cargo, NuGet, Composer, RubyGems, conda, Swift, Hex, Pub, apk, deb, and rpm, with OSV/GHSA/NVD enrichment, opt-in review-grade NVD CPE candidate matching for non-ecosystem software, transitive resolution, and dependency-confusion detection |
 | Agents + MCP | MCP clients, servers, tools, transports, and trust posture with live introspection across 29 first-class client types |
 | AI models + datasets | Malicious-model detection via safe pickle-opcode disassembly (no deserialization), model/dataset cards, and target-scoped PII/PHI dataset-file scanning |
 | Cloud estate | Read-only, gated asset inventory and CIS posture across AWS, Azure, GCP, and Snowflake, plus AI/GPU provider posture |

--- a/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md
+++ b/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: msaad00/agent-bom@v0.88.1
+      - uses: msaad00/agent-bom@v0.90.0
         with:
           scan-type: agents
           format: sarif

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -237,7 +237,7 @@ For cross-agent correlation, use the broader runtime protection engine (`agent-b
 agent-bom mcp server
 ```
 
-Exposes 55 tools to any MCP-compatible AI assistant. Your agent can run scans,
+Exposes 70 tools to any MCP-compatible AI assistant. Your agent can run scans,
 check packages, query ExposurePaths, ask for deploy decisions, query threat
 intel, inspect runtime posture, run admin-gated Shield actions, and generate
 compliance reports without leaving the chat:

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -179,4 +179,4 @@ Current limitations:
 ## Review cadence
 
 This threat model is reviewed with each major release (x.0) and after any
-security advisory. Last reviewed: v0.88.1 (May 2026).
+security advisory. Last reviewed: v0.90.0 (June 2026).

--- a/docs/skills/POLICY.md
+++ b/docs/skills/POLICY.md
@@ -84,7 +84,7 @@ Actions are `warn`, `fail`, or `block`; `block` is treated as a failing gate.
 Run skills scanning as its own CI lane:
 
 ```yaml
-- uses: msaad00/agent-bom@v0.88.1
+- uses: msaad00/agent-bom@v0.90.0
   with:
     scan-type: skills
     scan-ref: .

--- a/site-docs/features/cloud-posture.md
+++ b/site-docs/features/cloud-posture.md
@@ -25,7 +25,7 @@ agent-bom iac Dockerfile k8s/ infra/main.tf --format sarif --output agent-bom-ia
 In GitHub Actions, use the `iac` scan type or the `iac` input:
 
 ```yaml
-- uses: msaad00/agent-bom@v0.88.3
+- uses: msaad00/agent-bom@v0.90.0
   with:
     scan-type: iac
     scan-ref: infra/main.tf,k8s/

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -66,7 +66,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|---|
 | **CLI / CI** | developers and pipelines | local scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
 | **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, normalized bulk findings, dataset versions, evaluation runs, graph evidence, audit, and governance |
-| **MCP tools** | AI agents and coding assistants | 55 tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture, audited Shield actions |
+| **MCP tools** | AI agents and coding assistants | 70 tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture, audited Shield actions |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |
 | **UI cockpit** | security teams and auditors | graph cockpit, compliance, audit, and evidence review over the same backend data |

--- a/site-docs/reference/agentic-workflows.md
+++ b/site-docs/reference/agentic-workflows.md
@@ -8,7 +8,7 @@ plane or runtime enforcement rollout.
 |---|---|---|---|---|
 | Local CLI | `agent-bom agents --demo --offline`, then `agent-bom agents -p .` | Reads local agent and MCP configuration from the developer machine. No control-plane credentials required. | Terminal findings, JSON, SARIF, SBOM, HTML, graph export. | Scheduled scan, Docker, GitHub Action. |
 | Claude, Cursor, Windsurf, VS Code, Cortex, Codex CLI | `agent-bom mcp server` | Exposes read-mostly security tools to the assistant. The assistant does not need direct scanner credentials beyond the local process boundary; Shield write actions require admin role, `shield:write` scope, and an audit reason. | MCP tool output, inventory, blast-radius answers, compliance checks, ranked `ExposurePath` JSON, deploy guidance. | Shared MCP configuration, skills, fleet sync. |
-| GitHub Actions | `uses: msaad00/agent-bom@v0.88.1` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
+| GitHub Actions | `uses: msaad00/agent-bom@v0.90.0` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
 | Skills and instruction files | `agent-bom skills scan . --policy skills-policy.yaml` | Reads repo-local instructions such as `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and `skills/*.md`. | Skill trust findings, referenced package and MCP inventory, credential-env names, policy warn/block result. | Signed skills, provenance verification, registry publishing. |
 | Cloud and AI infrastructure | `agent-bom agents --preset enterprise` plus provider-specific flags only where credentials are approved. | Uses read-only provider APIs or local inventory files. Keep provider secrets in the operator boundary, not in repo docs. | Cloud, warehouse, GPU, model, dataset, and runtime package evidence. | Fleet sync, compliance exports, graph-backed findings. |
 | Runtime proxy | `agent-bom proxy --no-isolate --log audit.jsonl --block-undeclared -- ...` | Wraps selected local MCP traffic. Policy can block before an upstream tool receives the call. Container containment requires a stdio MCP path plus a configured sandbox image or an existing container command. | Tier-A audit JSONL, policy decisions, runtime alerts, metrics, and sandbox posture when isolation is enabled. | Sidecar proxy, gateway policy pull, SIEM export. |
@@ -31,7 +31,7 @@ when the buyer or contributor needs to see the first finding path quickly.
 ### CI Security Review
 
 ```yaml
-- uses: msaad00/agent-bom@v0.88.1
+- uses: msaad00/agent-bom@v0.90.0
   with:
     scan-type: agents
     severity-threshold: high
@@ -62,7 +62,7 @@ so future agent and SIEM push workflows share one event envelope.
 ### Skills CI Gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.88.1
+- uses: msaad00/agent-bom@v0.90.0
   with:
     scan-type: skills
     scan-ref: .

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -176,9 +176,8 @@ def _consume_saml_response_once(saml_response: str, *, ttl_seconds: int) -> None
     digest = f"saml-response:{_relay_state_digest(saml_response)}"
     backend = get_auth_state()
     now = int(time.time())
-    if backend.is_nonce_revoked(digest, now=now):
+    if not backend.consume_nonce_once(digest, now + max(60, int(ttl_seconds)), now=now):
         raise HTTPException(status_code=401, detail="SAML assertion replay detected")
-    backend.revoke_nonce(digest, now + max(60, int(ttl_seconds)))
 
 
 def _request_actor(request: Request) -> str:
@@ -1228,19 +1227,20 @@ async def create_exception(request: Request, req: ExceptionRequest) -> dict:
     from agent_bom.api.exception_store import VulnException
 
     tenant_id = require_request_tenant_id(request)
+    actor = _request_actor(request)
     exc = VulnException(
         vuln_id=req.vuln_id,
         package_name=req.package_name,
         server_name=req.server_name,
         reason=req.reason,
-        requested_by=req.requested_by,
+        requested_by=actor,
         expires_at=req.expires_at,
         tenant_id=tenant_id,
     )
     _get_exception_store().put(exc)
     log_action(
         "exception_create",
-        actor=req.requested_by,
+        actor=actor,
         resource=f"exception/{exc.exception_id}",
         tenant_id=tenant_id,
         vuln_id=req.vuln_id,

--- a/src/agent_bom/api/shared_auth_state.py
+++ b/src/agent_bom/api/shared_auth_state.py
@@ -26,6 +26,8 @@ The contract is:
 - ``revoke_nonce(nonce, expires_at)`` — mark a nonce as revoked until
   ``expires_at`` (Unix timestamp seconds). Idempotent.
 - ``is_nonce_revoked(nonce, now=None) -> bool`` — fast lookup.
+- ``consume_nonce_once(nonce, expires_at, now=None) -> bool`` — atomically
+  mark a nonce as consumed and return ``False`` when it was already live.
 - ``cleanup_expired(now=None) -> int`` — best-effort sweep of stale
   rows; called opportunistically by route handlers. Returns the count
   of rows removed for observability.
@@ -81,6 +83,13 @@ _UPSERT_REVOKED_SQL = (
     " VALUES (%s, TO_TIMESTAMP(%s))"
     " ON CONFLICT (nonce) DO UPDATE SET expires_at = EXCLUDED.expires_at"
 )
+_DELETE_EXPIRED_NONCE_SQL = "DELETE FROM revoked_session_nonces WHERE nonce = %s AND expires_at <= TO_TIMESTAMP(%s)"
+_CONSUME_REVOKED_SQL = (
+    "INSERT INTO revoked_session_nonces (nonce, expires_at)"
+    " VALUES (%s, TO_TIMESTAMP(%s))"
+    " ON CONFLICT (nonce) DO NOTHING"
+    " RETURNING 1"
+)
 _CHECK_REVOKED_SQL = "SELECT 1 FROM revoked_session_nonces WHERE nonce = %s AND expires_at > TO_TIMESTAMP(%s)"
 _DELETE_OLD_ATTEMPTS_SWEEP_SQL = "DELETE FROM auth_session_attempts WHERE attempted_at < NOW() - INTERVAL '24 hours'"
 _DELETE_EXPIRED_REVOKED_SQL = "DELETE FROM revoked_session_nonces WHERE expires_at <= NOW()"
@@ -99,6 +108,10 @@ class AuthStateBackend(Protocol):
 
     def is_nonce_revoked(self, nonce: str, now: int | None = None) -> bool:
         """Return ``True`` when ``nonce`` is currently revoked."""
+        ...
+
+    def consume_nonce_once(self, nonce: str, expires_at: int, now: int | None = None) -> bool:
+        """Atomically mark ``nonce`` consumed. Return ``True`` only for the first live consumer."""
         ...
 
     def cleanup_expired(self, now: int | None = None) -> int:
@@ -152,6 +165,19 @@ class InMemoryAuthState:
             if expires_at <= moment:
                 self._revoked.pop(nonce, None)
                 return False
+            return True
+
+    def consume_nonce_once(self, nonce: str, expires_at: int, now: int | None = None) -> bool:
+        if not nonce:
+            return False
+        moment = int(time.time()) if now is None else int(now)
+        with self._lock:
+            stale = [k for k, exp in self._revoked.items() if exp <= moment]
+            for k in stale:
+                self._revoked.pop(k, None)
+            if nonce in self._revoked:
+                return False
+            self._revoked[nonce] = expires_at
             return True
 
     def cleanup_expired(self, now: int | None = None) -> int:
@@ -272,6 +298,27 @@ class PostgresAuthState:
         except Exception as exc:  # noqa: BLE001
             self._warn_fallback("is_nonce_revoked", exc)
             return self._fallback.is_nonce_revoked(nonce, now)
+
+    def consume_nonce_once(self, nonce: str, expires_at: int, now: int | None = None) -> bool:
+        if not nonce:
+            return False
+        if not self._ensure_schema():
+            return self._fallback.consume_nonce_once(nonce, expires_at, now)
+        try:
+            from agent_bom.api.postgres_common import _get_pool
+
+            pool = _get_pool()
+            moment = int(time.time()) if now is None else int(now)
+            with pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(_DELETE_EXPIRED_NONCE_SQL, (nonce, moment))
+                    cur.execute(_CONSUME_REVOKED_SQL, (nonce, int(expires_at)))
+                    row = cur.fetchone()
+                conn.commit()
+            return row is not None
+        except Exception as exc:  # noqa: BLE001
+            self._warn_fallback("consume_nonce_once", exc)
+            return self._fallback.consume_nonce_once(nonce, expires_at, now)
 
     def cleanup_expired(self, now: int | None = None) -> int:
         if not self._ensure_schema():

--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -162,13 +162,34 @@ GHSA_ECOSYSTEMS = (
     "maven",
     "nuget",
     "rubygems",
-    "cargo",
+    "rust",
     "composer",
     "swift",
     "pub",
     "erlang",
     "actions",
 )
+
+_GHSA_API_TO_DB_ECOSYSTEM = {
+    "actions": "actions",
+    "composer": "packagist",
+    "erlang": "hex",
+    "go": "go",
+    "maven": "maven",
+    "npm": "npm",
+    "nuget": "nuget",
+    "pip": "pypi",
+    "pub": "pub",
+    "rubygems": "rubygems",
+    "rust": "crates.io",
+    "swift": "swifturl",
+}
+
+
+def _normalize_ghsa_db_ecosystem(ecosystem: str) -> str:
+    """Map GitHub advisory ecosystem names to local DB/scanner ecosystem keys."""
+    eco = (ecosystem or "").strip().lower()
+    return _GHSA_API_TO_DB_ECOSYSTEM.get(eco, eco)
 
 # Batch insert size for performance
 _BATCH_SIZE = 500
@@ -1092,7 +1113,8 @@ def _ingest_ghsa_advisory(
         if not ecosystem or not pkg_name:
             continue
 
-        norm_name = normalize_package_name(pkg_name, ecosystem)  # type: ignore[operator]
+        db_ecosystem = _normalize_ghsa_db_ecosystem(str(ecosystem))
+        norm_name = normalize_package_name(pkg_name, db_ecosystem)  # type: ignore[operator]
         version_range = vuln.get("vulnerable_version_range") or ""
         patched = vuln.get("first_patched_version") or ""
         introduced, fixed = _parse_ghsa_version_range(version_range)
@@ -1106,7 +1128,7 @@ def _ingest_ghsa_advisory(
         affected_rows.append(
             {
                 "vuln_id": vuln_id,
-                "ecosystem": ecosystem.lower(),
+                "ecosystem": db_ecosystem,
                 "package_name": norm_name,
                 "introduced": introduced,
                 "fixed": fixed,
@@ -1164,7 +1186,7 @@ def sync_ghsa(
 ) -> int:
     """Fetch GitHub Security Advisories across all supported ecosystems and store in DB.
 
-    Iterates over each ecosystem (pip, npm, go, maven, nuget, rubygems, cargo)
+    Iterates over each ecosystem (pip, npm, go, maven, nuget, rubygems, rust)
     and paginates through ALL reviewed advisories.  No package-name filtering is
     applied — every advisory for the requested ecosystems is ingested.
 
@@ -1503,6 +1525,8 @@ def sync_nvd_incremental(
     page_size = min(2000, max_results)
 
     sync_failed = False
+    sync_truncated = False
+    total_results_seen = 0
 
     while enriched < max_results:
         params: dict[str, str | int] = {
@@ -1549,10 +1573,14 @@ def sync_nvd_incremental(
             conn.commit()
 
         total_results = int(data.get("totalResults") or 0)
+        total_results_seen = max(total_results_seen, total_results)
         start_index += len(items)
         if start_index >= total_results:
             break
         time.sleep(sleep_seconds)
+
+    if not sync_failed and enriched >= max_results and start_index < total_results_seen:
+        sync_truncated = True
 
     conn.commit()
     _update_sync_meta(
@@ -1565,10 +1593,11 @@ def sync_nvd_incremental(
             # Only advance the synced-through cursor when the whole window
             # fetched cleanly; on failure keep the window start so the next run
             # retries it instead of permanently skipping the unsynced CVEs.
-            "last_modified_end": start_ts if sync_failed else end_ts,
+            "last_modified_end": start_ts if (sync_failed or sync_truncated) else end_ts,
             "max_results": max_results,
             "api_key_used": bool(api_key),
             "sync_failed": sync_failed,
+            "sync_truncated": sync_truncated,
         },
     )
     _logger.info("NVD incremental sync complete: %d CVE rows upserted", enriched)

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -714,9 +714,8 @@ def _scan_packages_local_db(packages: list[Package]) -> tuple[int, set[str]]:
 def _scan_packages_db_conn(conn: Any, packages: list[Package], covered: set[str]) -> int:
     """Scan packages against an initialized vulnerability DB connection."""
 
-    from agent_bom import config
     from agent_bom.db import lookup_package
-    from agent_bom.db.lookup import cpe_lookup_package, package_in_db
+    from agent_bom.db.lookup import package_in_db
 
     if len(packages) > _BATCH_DB_THRESHOLD:
         return _scan_packages_local_db_batch(conn, packages, covered)
@@ -742,12 +741,7 @@ def _scan_packages_db_conn(conn: Any, packages: list[Package], covered: set[str]
 
         # Long-tail CPE matching: only for components the OSV/distro feeds miss
         # (no DB hit) and only when explicitly enabled. Review-grade candidates.
-        if config.ENABLE_CPE_MATCH and not db_hit:
-            for candidate_name in candidate_names:
-                cpe_vulns = cpe_lookup_package(conn, candidate_name, pkg.version)
-                if cpe_vulns:
-                    local_vulns.extend(cpe_vulns)
-                    break
+        _attach_cpe_candidates(conn, pkg, candidate_names, local_vulns, db_hit=db_hit)
 
         if local_vulns:
             existing_ids = {v.id for v in pkg.vulnerabilities}
@@ -770,6 +764,53 @@ def _scan_packages_db_conn(conn: Any, packages: list[Package], covered: set[str]
             flag_malicious_from_vulns(pkg)
 
     return total
+
+
+def _cpe_vendor_hint(pkg: Package) -> str | None:
+    """Best-effort vendor hint for opt-in CPE matching.
+
+    CPE is review-grade because product names collide across vendors. A namespace
+    from PURL/Maven gives the matcher a real disambiguator without inventing
+    package-specific aliases.
+    """
+    if pkg.purl:
+        try:
+            from packageurl import PackageURL
+
+            parsed = PackageURL.from_string(pkg.purl)
+        except Exception:
+            parsed = None
+        if parsed is not None and parsed.namespace:
+            namespace = parsed.namespace.strip().strip("/")
+            if namespace:
+                return namespace.rsplit("/", 1)[-1]
+    if pkg.ecosystem.lower() == "maven" and ":" in pkg.name:
+        group_id = pkg.name.split(":", 1)[0].strip()
+        if group_id:
+            return group_id.rsplit(".", 1)[-1]
+    return None
+
+
+def _attach_cpe_candidates(
+    conn: Any,
+    pkg: Package,
+    candidate_names: list[str],
+    local_vulns: list[Any],
+    *,
+    db_hit: bool,
+) -> None:
+    """Append opt-in CPE candidate matches for packages not covered by native feeds."""
+    from agent_bom import config
+    from agent_bom.db.lookup import cpe_lookup_package
+
+    if not config.ENABLE_CPE_MATCH or db_hit:
+        return
+    vendor = _cpe_vendor_hint(pkg)
+    for candidate_name in candidate_names:
+        cpe_vulns = cpe_lookup_package(conn, candidate_name, pkg.version, vendor=vendor)
+        if cpe_vulns:
+            local_vulns.extend(cpe_vulns)
+            break
 
 
 def _scan_packages_demo_advisories(packages: list[Package]) -> tuple[int, set[str]]:
@@ -834,8 +875,11 @@ def _scan_packages_local_db_batch(
             for candidate_name in candidate_names:
                 local_vulns.extend(batch_results.get((db_eco, candidate_name, pkg.version), []))
 
-        if any((db_eco.lower(), candidate_name) in existing_pairs for db_eco in db_ecos for candidate_name in candidate_names):
+        db_hit = any((db_eco.lower(), candidate_name) in existing_pairs for db_eco in db_ecos for candidate_name in candidate_names)
+        if db_hit:
             covered.add(db_key)
+
+        _attach_cpe_candidates(conn, pkg, candidate_names, local_vulns, db_hit=db_hit)
 
         if local_vulns:
             existing_ids = {v.id for v in pkg.vulnerabilities}

--- a/tests/test_api_enterprise_tenant.py
+++ b/tests/test_api_enterprise_tenant.py
@@ -14,6 +14,7 @@ from agent_bom.api.exception_store import ExceptionStatus, InMemoryExceptionStor
 from agent_bom.api.issue_mapping_store import InMemoryIssueMappingStore
 from agent_bom.api.models import (
     CreateKeyRequest,
+    ExceptionRequest,
     FindingFeedbackRequest,
     FindingTriageDecisionRequest,
     FindingTriageRequest,
@@ -194,6 +195,28 @@ async def test_get_exception_returns_404_for_cross_tenant(isolated_exception_sto
         await enterprise.get_exception(_request("tenant-alpha"), exc.exception_id)
 
     assert error.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_exception_uses_authenticated_actor_not_body(isolated_exception_store, isolated_audit_log):
+    created = await enterprise.create_exception(
+        _request("tenant-alpha", "alice-admin"),
+        ExceptionRequest(
+            vuln_id="CVE-2026-9999",
+            package_name="requests",
+            reason="temporary compensating control",
+            requested_by="mallory",
+        ),
+    )
+
+    stored = isolated_exception_store.get(created["exception_id"], tenant_id="tenant-alpha")
+    assert stored is not None
+    assert stored.requested_by == "alice-admin"
+    assert created["requested_by"] == "alice-admin"
+
+    entries = isolated_audit_log.list_entries()
+    assert entries[0].action == "exception_create"
+    assert entries[0].actor == "alice-admin"
 
 
 @pytest.mark.asyncio

--- a/tests/test_cpe_accuracy.py
+++ b/tests/test_cpe_accuracy.py
@@ -16,6 +16,8 @@ import pytest
 
 from agent_bom.cpe_match import match_component_cpe
 from agent_bom.db.schema import init_db
+from agent_bom.models import Package
+from agent_bom.scanners import _scan_packages_db_conn
 
 # Ground truth: (cve, vendor, product, exact_version, vstart, vstart_op, vend, vend_op)
 _GROUND_TRUTH = [
@@ -28,6 +30,8 @@ _GROUND_TRUTH = [
     # a DIFFERENT vendor's product also named "log4j" with no version bounds — the
     # cross-vendor name collision that vendor filtering must suppress.
     ("CVE-T-FAKELOG", "acme", "log4j", None, None, None, None, None),
+    # exclusive lower bound: versions must be strictly greater than 1.0.0
+    ("CVE-T-STARTEX", "acme", "widget", None, "1.0.0", "excluding", "2.0.0", "excluding"),
 ]
 
 # (component_name, version, vendor_hint, expected_cves)
@@ -44,6 +48,8 @@ _CASES = [
     ("log4j", "9.9.9", None, {"CVE-T-FAKELOG"}),
     # With the correct vendor hint, the acme collision is suppressed -> clean.
     ("log4j", "9.9.9", "apache", set()),
+    ("widget", "1.0.0", "acme", set()),                 # exclusive start -> excluded
+    ("widget", "1.0.1", "acme", {"CVE-T-STARTEX"}),     # above exclusive start -> included
     ("nonexistent", "1.0", None, set()),               # unknown product
 ]
 
@@ -76,3 +82,36 @@ def test_vendor_filter_eliminates_cross_vendor_false_positive() -> None:
     with_hint = {m["cve_id"] for m in match_component_cpe(conn, "log4j", "9.9.9", vendor="apache")}
     assert "CVE-T-FAKELOG" in no_hint  # the collision is reachable without a vendor
     assert "CVE-T-FAKELOG" not in with_hint  # ...and suppressed with one
+
+
+def test_batch_scanner_uses_cpe_candidates_with_vendor_hint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Large scans take the batch path; opt-in CPE matching must still run there."""
+    from agent_bom import config
+
+    monkeypatch.setattr(config, "ENABLE_CPE_MATCH", True)
+    conn = init_db(Path(":memory:"))
+    conn.execute(
+        "INSERT INTO vulns (id, summary, severity, cvss_score, cvss_vector, fixed_version, cwe_ids, aliases, source) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        ("CVE-T-BATCH", "batch CPE candidate", "high", 8.0, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "", "CWE-94", "", "nvd"),
+    )
+    conn.execute(
+        "INSERT INTO cpe_matches (cve_id, criteria, vendor, product, version, "
+        "version_start, version_start_op, version_end, version_end_op) VALUES (?,?,?,?,?,?,?,?,?)",
+        ("CVE-T-BATCH", "cpe:2.3:a:apache:widget", "apache", "widget", None, "1.0.0", "including", "2.0.0", "excluding"),
+    )
+    conn.commit()
+
+    packages = [
+        Package(name=f"dummy-{idx}", version="1.0.0", ecosystem="generic")
+        for idx in range(50)
+    ]
+    target = Package(name="widget", version="1.2.3", ecosystem="generic", purl="pkg:generic/apache/widget@1.2.3")
+    packages.append(target)
+
+    covered: set[str] = set()
+    total = _scan_packages_db_conn(conn, packages, covered)
+
+    assert total == 1
+    assert [v.id for v in target.vulnerabilities] == ["CVE-T-BATCH"]
+    assert target.vulnerabilities[0].match_confidence_tier == "nvd_cpe_candidate"

--- a/tests/test_db_sync_ghsa.py
+++ b/tests/test_db_sync_ghsa.py
@@ -11,7 +11,8 @@ from unittest.mock import patch
 import pytest
 
 from agent_bom.db.schema import init_db
-from agent_bom.db.sync import GHSA_ECOSYSTEMS, sync_ghsa
+from agent_bom.db.sync import GHSA_ECOSYSTEMS, _ingest_ghsa_advisory, _normalize_ghsa_db_ecosystem, sync_ghsa
+from agent_bom.package_utils import normalize_package_name
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -256,7 +257,7 @@ def test_sync_ghsa_ecosystem_filtering() -> None:
 def test_sync_ghsa_default_ecosystems() -> None:
     """When no ecosystems are specified, all GHSA_ECOSYSTEMS are used."""
     # Verify minimum required ecosystems are present (no hardcoded count)
-    required = {"pip", "npm", "go", "maven", "nuget", "rubygems", "cargo", "composer", "swift", "pub", "erlang", "actions"}
+    required = {"pip", "npm", "go", "maven", "nuget", "rubygems", "rust", "composer", "swift", "pub", "erlang", "actions"}
     assert required.issubset(set(GHSA_ECOSYSTEMS)), f"Missing: {required - set(GHSA_ECOSYSTEMS)}"
     assert len(GHSA_ECOSYSTEMS) >= len(required), "GHSA_ECOSYSTEMS shrunk below minimum"
     # No duplicates
@@ -291,3 +292,53 @@ def test_sync_ghsa_respects_max_entries() -> None:
     assert details["coverage"] == "truncated"
     assert details["max_entries"] == 3
     assert details["ecosystem_counts"] == {"pip": 3}
+
+
+def test_ghsa_api_ecosystems_normalize_to_scanner_db_keys() -> None:
+    assert _normalize_ghsa_db_ecosystem("pip") == "pypi"
+    assert _normalize_ghsa_db_ecosystem("composer") == "packagist"
+    assert _normalize_ghsa_db_ecosystem("rust") == "crates.io"
+    assert _normalize_ghsa_db_ecosystem("erlang") == "hex"
+    assert _normalize_ghsa_db_ecosystem("swift") == "swifturl"
+
+
+def test_ghsa_ingest_stores_affected_rows_under_scanner_keys() -> None:
+    conn = _make_conn()
+    advisory = {
+        "ghsa_id": "GHSA-test-1234",
+        "cve_id": "CVE-2026-12345",
+        "summary": "Example GHSA",
+        "severity": "high",
+        "published_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-02T00:00:00Z",
+        "vulnerabilities": [
+            {
+                "package": {"ecosystem": "pip", "name": "Requests"},
+                "vulnerable_version_range": ">= 2.0.0, < 2.32.0",
+                "first_patched_version": "2.32.0",
+            },
+            {
+                "package": {"ecosystem": "rust", "name": "serde"},
+                "vulnerable_version_range": "< 1.0.200",
+                "first_patched_version": "1.0.200",
+            },
+            {
+                "package": {"ecosystem": "composer", "name": "vendor/pkg"},
+                "vulnerable_version_range": "< 3.0.0",
+                "first_patched_version": "3.0.0",
+            },
+        ],
+        "cwes": [{"cwe_id": "CWE-79"}],
+    }
+
+    assert _ingest_ghsa_advisory(conn, advisory, normalize_package_name) is True
+
+    rows = conn.execute(
+        "SELECT ecosystem, package_name, introduced, fixed FROM affected WHERE vuln_id = ? ORDER BY ecosystem, package_name",
+        ("CVE-2026-12345",),
+    ).fetchall()
+    assert [(row["ecosystem"], row["package_name"], row["introduced"], row["fixed"]) for row in rows] == [
+        ("crates.io", "serde", "", "1.0.200"),
+        ("packagist", "vendor/pkg", "", "3.0.0"),
+        ("pypi", "requests", "2.0.0", "2.32.0"),
+    ]

--- a/tests/test_db_sync_nvd_incremental.py
+++ b/tests/test_db_sync_nvd_incremental.py
@@ -10,11 +10,11 @@ from agent_bom.db.schema import init_db
 from agent_bom.db.sync import sync_nvd_incremental
 
 
-def _incremental_payload(cve_id: str = "CVE-2026-10001") -> dict:
+def _incremental_payload(cve_id: str = "CVE-2026-10001", *, total_results: int = 1) -> dict:
     return {
         "resultsPerPage": 1,
         "startIndex": 0,
-        "totalResults": 1,
+        "totalResults": total_results,
         "vulnerabilities": [
             {
                 "cve": {
@@ -101,4 +101,27 @@ def test_sync_nvd_incremental_keeps_checkpoint_on_failure() -> None:
     # On failure the synced-through cursor must NOT jump to now — it stays at the
     # window start so the next run retries the unsynced window (no skipped CVEs).
     assert payload["sync_failed"] is True
+    assert payload["last_modified_end"] == payload["last_modified_start"]
+
+
+def test_sync_nvd_incremental_keeps_checkpoint_when_capped() -> None:
+    conn = init_db(Path(":memory:"))
+
+    def fake_fetch(url, *, timeout=60, headers=None):
+        return _incremental_payload(total_results=10)
+
+    with patch("agent_bom.http_client.fetch_json", side_effect=fake_fetch):
+        with patch("time.sleep"):
+            count = sync_nvd_incremental(
+                conn,
+                nvd_api_key="test-key",
+                url="https://services.nvd.nist.gov/rest/json/cves/2.0",
+                max_results=1,
+            )
+
+    assert count == 1
+    meta = conn.execute("SELECT metadata_json FROM sync_meta WHERE source = 'nvd'").fetchone()
+    payload = json.loads(meta[0])
+    assert payload["sync_failed"] is False
+    assert payload["sync_truncated"] is True
     assert payload["last_modified_end"] == payload["last_modified_start"]

--- a/tests/test_online_scan_validation.py
+++ b/tests/test_online_scan_validation.py
@@ -21,7 +21,7 @@ import subprocess  # nosec B404 - controlled, fixed-arg invocation of the trivy 
 import pytest
 
 from agent_bom.models import Package, normalize_package_name
-from agent_bom.scanners import query_osv_batch
+from agent_bom.scanners import default_scan_options, query_osv_batch, scan_packages
 
 pytestmark = pytest.mark.network
 
@@ -71,11 +71,12 @@ def test_agent_bom_recall_matches_trivy_on_pinned_image(tmp_path) -> None:
     }
     assert trivy_cves, "trivy returned no CVEs — image/network problem, not an agent-bom result"
 
-    from agent_bom.scanners.image import scan_image  # local import: heavy module
+    from agent_bom.image import scan_image  # local import: heavy module
 
-    report = scan_image(image)
+    packages, _strategy = scan_image(image)
+    asyncio.run(scan_packages(packages, options=default_scan_options(prefer_local_db=True)))
     ab_cves: set[str] = set()
-    for pkg in getattr(report, "packages", []) or []:
+    for pkg in packages:
         for v in getattr(pkg, "vulnerabilities", []) or []:
             ab_cves.add(str(getattr(v, "id", "")))
             ab_cves.update(str(a) for a in (getattr(v, "aliases", []) or []))

--- a/tests/test_shared_auth_state.py
+++ b/tests/test_shared_auth_state.py
@@ -110,6 +110,29 @@ class TestInMemoryRevocation:
         backend.revoke_nonce("", 9999999999)
         assert backend.is_nonce_revoked("") is False
 
+    def test_consume_nonce_once_allows_exactly_one_concurrent_winner(self) -> None:
+        backend = InMemoryAuthState()
+        winners = 0
+        lock = threading.Lock()
+        threads: list[threading.Thread] = []
+        expires_at = int(time.time()) + 300
+
+        def consume() -> None:
+            nonlocal winners
+            if backend.consume_nonce_once("saml-response:shared", expires_at):
+                with lock:
+                    winners += 1
+
+        for _ in range(50):
+            threads.append(threading.Thread(target=consume))
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert winners == 1
+        assert backend.is_nonce_revoked("saml-response:shared") is True
+
 
 class TestInMemoryCleanup:
     def test_cleanup_keeps_live_revocations_and_drops_expired(self) -> None:
@@ -217,6 +240,7 @@ def test_protocol_implementations_match_contract() -> None:
     assert hasattr(in_memory, "record_attempt")
     assert hasattr(in_memory, "revoke_nonce")
     assert hasattr(in_memory, "is_nonce_revoked")
+    assert hasattr(in_memory, "consume_nonce_once")
     assert hasattr(in_memory, "cleanup_expired")
     assert hasattr(postgres, "record_attempt")
     assert hasattr(postgres, "revoke_nonce")

--- a/ui/e2e/connections-screenshot.spec.ts
+++ b/ui/e2e/connections-screenshot.spec.ts
@@ -31,10 +31,10 @@ const PENDING = {
 
 async function routeConnections(page: Page) {
   await page.route("**/health", (route) =>
-    route.fulfill({ contentType: "application/json", body: JSON.stringify({ status: "ok", version: "0.89.2" }) }),
+    route.fulfill({ contentType: "application/json", body: JSON.stringify({ status: "ok", version: "0.90.0" }) }),
   );
   await page.route("**/version", (route) =>
-    route.fulfill({ contentType: "application/json", body: JSON.stringify({ version: "0.89.2" }) }),
+    route.fulfill({ contentType: "application/json", body: JSON.stringify({ version: "0.90.0" }) }),
   );
   await page.route("**/v1/auth/me", (route) =>
     route.fulfill({


### PR DESCRIPTION
## Summary
- harden SAML assertion replay handling with atomic nonce consumption and bind exception audit actors to authenticated request identity
- normalize GHSA API ecosystems to scanner DB keys, preserve NVD incremental cursor on capped syncs, and make CPE range/vendor matching consistent in scalar and batch scan paths
- refresh stale 0.90.0 release references in docs/examples and keep CPE wording honest as opt-in review-grade matching

## Validation
- `uv run pytest -q tests/test_db_sync_ghsa.py tests/test_cpe_accuracy.py tests/test_db_sync_nvd_incremental.py tests/test_shared_auth_state.py tests/test_api_saml.py tests/test_api_enterprise_tenant.py -m 'not network'`
- `uv run ruff check src/agent_bom/api/shared_auth_state.py src/agent_bom/api/routes/enterprise.py src/agent_bom/cpe_match.py src/agent_bom/db/sync.py src/agent_bom/scanners/__init__.py tests/test_shared_auth_state.py tests/test_api_enterprise_tenant.py tests/test_cpe_accuracy.py tests/test_db_sync_ghsa.py tests/test_db_sync_nvd_incremental.py tests/test_online_scan_validation.py`
- `uv run mypy src/agent_bom`
- `uv run python scripts/check_release_consistency.py`
- `uv run python scripts/generate_env_var_reference.py --check`
- PyPI smoke: installed `agent-bom==0.90.0`, verified `agent-bom --version`, `agent-bom upgrade` from `0.89.2` to `0.90.0`, offline package scan, package check, IaC scan, and demo agent scan

## Notes
Local `uv` commands still warn about an old `.venv` `agent_bom-0.89.2.dist-info` missing `RECORD`; checks pass and PyPI smoke used clean venvs under `/tmp`.