### PR TITLE
fix(output): surface match_confidence_tier across SARIF, JSON, HTML

### DIFF
--- a/src/agent_bom/output/html.py
+++ b/src/agent_bom/output/html.py
@@ -269,11 +269,23 @@ def _vuln_table(blast_radii: list["BlastRadius"]) -> str:
         vendor_hint = ""
         if vendor_sev and vendor_sev.lower() != sev:
             vendor_hint = f'<br><span style="font-size:.62rem;color:#94a3b8;font-style:italic">vendor: {_esc(vendor_sev)}</span>'
+        # Match-confidence tier — how the finding was matched to this package.
+        # nvd_cpe_candidate is review-grade (lower confidence); render it muted/amber.
+        tier = getattr(v, "match_confidence_tier", None)
+        tier_hint = ""
+        if tier:
+            _tier_color = "#f59e0b" if tier == "nvd_cpe_candidate" else "#64748b"
+            tier_hint = (
+                f'<br><span class="match-tier" data-tier="{_esc(tier)}" '
+                f'title="match confidence: {_esc(tier)}" '
+                f'style="font-size:.6rem;color:{_tier_color}">{_esc(tier.replace("_", " "))}</span>'
+            )
         rows.append(
             f'<tr data-severity="{sev}" data-kev="{"1" if v.is_kev else "0"}" '
             f'data-exploit-likelihood="{exploit_level}" '
+            f'data-match-tier="{_esc(tier or "")}" '
             f'data-cvss="{v.cvss_score if v.cvss_score else 0}">'
-            f'<td><code class="vuln-id">{_esc(v.id)}</code></td>'
+            f'<td><code class="vuln-id">{_esc(v.id)}</code>{tier_hint}</td>'
             f"<td>{_sev_badge(sev)}{vendor_hint}</td>"
             f'<td><strong style="color:#e2e8f0">{_esc(br.package.name)}</strong>'
             f'<span style="color:#475569;font-size:.78rem">@{_esc(br.package.version)}</span></td>'

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -1025,6 +1025,7 @@ def to_json(report: AIBOMReport) -> dict:
                                         "advisory_sources": v.all_advisory_sources,
                                         "primary_advisory_source": v.all_advisory_sources[0] if v.all_advisory_sources else None,
                                         "advisory_coverage_state": v.advisory_coverage_state,
+                                        "match_confidence_tier": v.match_confidence_tier,
                                         "confidence": v.confidence,
                                         "cvss_score": v.cvss_score,
                                         "epss_score": v.epss_score,

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -423,8 +423,11 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
         # Always emit structured properties so downstream consumers get
         # the exploit_likelihood (#486) + blast metrics without needing
         # a compliance tag to trigger enrichment.
+        cve_ids = sorted({cid for cid in (vuln.id, *vuln.aliases) if isinstance(cid, str) and cid.upper().startswith("CVE-")})
         result_properties: dict = {
             "blast_score": br.risk_score,
+            "match_confidence_tier": vuln.match_confidence_tier,
+            "cve_ids": cve_ids,
             "exposure_path": exposure_path,
             "exposure_chain": exposure_chain or None,
             "epss_score": vuln.epss_score,

--- a/tests/test_match_confidence_tier_exports.py
+++ b/tests/test_match_confidence_tier_exports.py
@@ -1,0 +1,88 @@
+"""match_confidence_tier + canonical cve_ids must surface across every report
+export, not just the unified ``finding.py`` JSON. A buyer filtering on the
+``nvd_cpe_candidate`` (review-grade) tier needs it in SARIF, the JSON report,
+and the HTML dashboard alike.
+"""
+
+from __future__ import annotations
+
+import json
+
+from agent_bom.models import (
+    Agent,
+    AgentType,
+    AIBOMReport,
+    BlastRadius,
+    Package,
+    Severity,
+    Vulnerability,
+)
+from agent_bom.output.html import to_html
+from agent_bom.output.json_fmt import to_json
+from agent_bom.output.sarif import to_sarif
+
+
+def _report_with_tier() -> AIBOMReport:
+    vuln = Vulnerability(
+        id="GHSA-xxxx-yyyy-zzzz",
+        summary="Candidate match via NVD CPE",
+        severity=Severity.HIGH,
+        cvss_score=7.5,
+        fixed_version="2.0.0",
+        aliases=["CVE-2026-12345", "CVE-2026-99999"],
+        match_confidence_tier="nvd_cpe_candidate",
+    )
+    pkg = Package(
+        name="acme-lib",
+        version="1.4.2",
+        ecosystem="pypi",
+        purl="pkg:pypi/acme-lib@1.4.2",
+        vulnerabilities=[vuln],
+        is_direct=True,
+    )
+    agent = Agent(
+        name="claude-desktop",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/claude-desktop.json",
+        mcp_servers=[],
+        version="1.0",
+    )
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=[],
+        affected_agents=[agent],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+    br.calculate_risk_score()
+    return AIBOMReport(
+        agents=[agent],
+        blast_radii=[br],
+        findings=[],
+        scan_sources=["agent_discovery"],
+        scan_id="tier-test-001",
+    )
+
+
+def test_sarif_carries_tier_and_canonical_cve_ids() -> None:
+    doc = to_sarif(_report_with_tier())
+    result = doc["runs"][0]["results"][0]
+    props = result["properties"]
+    assert props["match_confidence_tier"] == "nvd_cpe_candidate"
+    # Canonical CVE list derives from id + aliases, deduped/sorted, CVE-only.
+    assert props["cve_ids"] == ["CVE-2026-12345", "CVE-2026-99999"]
+
+
+def test_json_report_carries_tier() -> None:
+    payload = to_json(_report_with_tier())  # to_json returns a dict
+    blob = json.dumps(payload)
+    assert "nvd_cpe_candidate" in blob
+    assert '"match_confidence_tier"' in blob
+
+
+def test_html_dashboard_renders_tier() -> None:
+    report = _report_with_tier()
+    html = to_html(report, report.blast_radii)
+    assert "nvd_cpe_candidate" in html
+    assert "match-tier" in html


### PR DESCRIPTION
## Summary
The match-confidence tier (`distro_confirmed > osv_range > osv_ecosystem > unfixed_distro > nvd_cpe_candidate`) was only serialized in the unified `finding.py` model. Consumers reading **SARIF**, the **JSON report**, or the **HTML dashboard** could not tell *how* a finding was matched — a review-grade `nvd_cpe_candidate` looked identical to a `distro_confirmed` hit. This closes the reviewer's "show the tier everywhere" gap.

## Changes
- **SARIF** (`sarif.py`): `result.properties.match_confidence_tier` + canonical `cve_ids` (derived from `id` + `aliases`, CVE-only, deduped/sorted).
- **JSON report** (`json_fmt.py`): `match_confidence_tier` on each vulnerability.
- **HTML** (`html.py`): muted tier badge under the vuln id (amber for the lower-confidence `nvd_cpe_candidate`) + `data-match-tier` row attribute for client-side filtering.

## Tests
`tests/test_match_confidence_tier_exports.py` — asserts the tier (and canonical CVE list) surfaces in all three exports. Regression: SARIF schema 2.1.0, report-UX, trust-assessment, NVD-status suites green (88 passed); ruff clean.