### PR TITLE
fix(output): carry match_confidence_tier on the JSON blast_radius rollup

### DIFF
--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -1090,6 +1090,7 @@ def to_json(report: AIBOMReport) -> dict:
                 "advisory_sources": br.vulnerability.all_advisory_sources,
                 "primary_advisory_source": (br.vulnerability.all_advisory_sources[0] if br.vulnerability.all_advisory_sources else None),
                 "advisory_coverage_state": br.vulnerability.advisory_coverage_state,
+                "match_confidence_tier": br.vulnerability.match_confidence_tier,
                 "cvss_score": br.vulnerability.cvss_score,
                 "epss_score": br.vulnerability.epss_score,
                 "is_kev": br.vulnerability.is_kev,

--- a/tests/test_match_confidence_tier_exports.py
+++ b/tests/test_match_confidence_tier_exports.py
@@ -6,8 +6,6 @@ and the HTML dashboard alike.
 
 from __future__ import annotations
 
-import json
-
 from agent_bom.models import (
     Agent,
     AgentType,
@@ -76,9 +74,11 @@ def test_sarif_carries_tier_and_canonical_cve_ids() -> None:
 
 def test_json_report_carries_tier() -> None:
     payload = to_json(_report_with_tier())  # to_json returns a dict
-    blob = json.dumps(payload)
-    assert "nvd_cpe_candidate" in blob
-    assert '"match_confidence_tier"' in blob
+    # Pin the tier on the blast_radius rollup — the row-for-row analog of the
+    # SARIF results and HTML rows — rather than a loose whole-document substring
+    # check, so a regression that drops it from this subtree fails loudly.
+    blast_radius = payload["blast_radius"][0]
+    assert blast_radius["match_confidence_tier"] == "nvd_cpe_candidate"
 
 
 def test_html_dashboard_renders_tier() -> None:


### PR DESCRIPTION
## Summary
Follow-up to #3317 (surfacing `match_confidence_tier` across exports). A deep audit found the JSON **`blast_radius[]` rollup** — the row-for-row analog of the SARIF results and HTML vuln rows, both of which carry the tier — still omitted it. #3317 added the field only to `packages[].vulnerabilities[]`, so a consumer filtering SARIF/HTML on `nvd_cpe_candidate` and joining back to the JSON findings list wouldn't find it.

## Change
- `json_fmt.py`: add `match_confidence_tier` to the `blast_radius` dict (alongside `exploit_likelihood`).
- `test_match_confidence_tier_exports.py`: pin the assertion to `blast_radius[0]` instead of a loose whole-document substring check, so a regression that drops the field from this subtree fails loudly.

## Tests
`tests/test_match_confidence_tier_exports.py` — 3 passed; ruff clean.