### PR TITLE
fix(model-scan): close pickle-scan size gate and memo evasion

### DIFF
--- a/src/agent_bom/model_files.py
+++ b/src/agent_bom/model_files.py
@@ -118,6 +118,31 @@ def _allowed_scan_roots() -> list[str]:
     return sorted(roots)
 
 
+_ZIP_MAGICS = (b"PK\x03\x04", b"PK\x05\x06")
+# Pickle protocol-2+ streams begin with the PROTO opcode (0x80) followed by a
+# one-byte protocol number (1..5). Higher protocols (5) cover modern torch.
+_PICKLE_PROTOCOLS = frozenset({1, 2, 3, 4, 5})
+
+
+def _looks_like_pickle_header(file_path: Path) -> bool:
+    """Cheap content sniff: does this file *start* like a pickle or torch zip?
+
+    Reads only the first few bytes (no deserialization, bounded I/O). Used to
+    discover pickle-bearing content hiding under a benign or non-pickle-bearing
+    extension, which extension-only discovery would miss entirely.
+    """
+    try:
+        with open(file_path, "rb") as fh:
+            head = fh.read(4)
+    except OSError:
+        return False
+    if not head:
+        return False
+    if head[:4] in _ZIP_MAGICS:
+        return True
+    return head[:1] == b"\x80" and len(head) >= 2 and head[1] in _PICKLE_PROTOCOLS
+
+
 def _human_size(size_bytes: int | float) -> str:
     """Convert bytes to human-readable size string."""
     for unit in ("B", "KB", "MB", "GB", "TB"):
@@ -149,6 +174,7 @@ def scan_model_files(
 
     results: list[dict] = []
     warnings: list[str] = []
+    scanned_for_pickle: set[str] = set()
 
     for ext, info in _MODEL_EXTENSIONS.items():
         for file_path in sorted(directory.rglob(f"*{ext}")):
@@ -163,11 +189,6 @@ def scan_model_files(
 
             size_bytes = stat.st_size
 
-            # For .bin files, apply size heuristic to filter non-model binaries
-            min_size_mb = info.get("min_size_mb", 0)
-            if min_size_mb and size_bytes < min_size_mb * 1024 * 1024:
-                continue
-
             security_flags = []
             if ext in _SECURITY_FLAGS:
                 flag = _SECURITY_FLAGS[ext].copy()
@@ -179,7 +200,14 @@ def scan_model_files(
             # deserializing the model (no pickle.load / torch.load / joblib.load),
             # so the no-execution guarantee is preserved while upgrading the
             # signal from extension-only to content-aware.
+            #
+            # The SECURITY scan runs on every pickle-bearing file regardless of
+            # size: the ``min_size_mb`` heuristic only classifies whether a
+            # generic binary counts as a "real model file", and must never gate
+            # the scan — otherwise a small malicious pickle disguised as ``.bin``
+            # (< min_size_mb) would slip through unscanned.
             if ext in PICKLE_BEARING_EXTENSIONS:
+                scanned_for_pickle.add(str(file_path))
                 try:
                     pickle_flags, _ = scan_pickle_file_flags(file_path)
                 except Exception as exc:  # noqa: BLE001 — scanner must never break a scan
@@ -188,6 +216,12 @@ def scan_model_files(
                 for pflag in pickle_flags:
                     security_flags.append(pflag)
                     warnings.append(f"Model file {file_path.name}: {pflag['severity']} — {pflag['type']}. {pflag['description']}")
+
+            # Size heuristic filters non-model generic binaries from inventory,
+            # but never suppresses a file the content scan already flagged.
+            min_size_mb = info.get("min_size_mb", 0)
+            if min_size_mb and size_bytes < min_size_mb * 1024 * 1024 and not security_flags:
+                continue
 
             results.append(
                 {
@@ -201,6 +235,59 @@ def scan_model_files(
                     "security_flags": security_flags,
                 }
             )
+
+    # Content-sniff discovery pass. Extension-only discovery (the loop above)
+    # never sees a pickle hidden under a benign extension (``.txt``, ``.dat``)
+    # or under a model extension that is not normally pickle-bearing
+    # (``.safetensors``, ``.onnx``). Sniff every remaining file's header for
+    # pickle / torch-zip magic and disassemble the pickle-bearing ones,
+    # regardless of extension, so the format cannot be spoofed by renaming.
+    results_by_path = {item["path"]: item for item in results}
+    for file_path in sorted(directory.rglob("*")):
+        if any(part.startswith(".") for part in file_path.parts):
+            continue
+        path_str = str(file_path)
+        if path_str in scanned_for_pickle:
+            continue
+        try:
+            if not file_path.is_file():
+                continue
+            stat = file_path.stat()
+        except OSError:
+            continue
+        if not _looks_like_pickle_header(file_path):
+            continue
+        scanned_for_pickle.add(path_str)
+        try:
+            pickle_flags, _ = scan_pickle_file_flags(file_path)
+        except Exception as exc:  # noqa: BLE001 — scanner must never break a scan
+            logger.debug("Pickle opcode scan skipped for %s: %s", file_path, exc)
+            pickle_flags = []
+        if not pickle_flags:
+            continue
+        existing = results_by_path.get(path_str)
+        if existing is not None:
+            # File was already inventoried under a (spoofed) model extension;
+            # attach the content findings instead of duplicating the entry.
+            for pflag in pickle_flags:
+                existing["security_flags"].append(pflag)
+                warnings.append(f"Model file {file_path.name}: {pflag['severity']} — {pflag['type']}. {pflag['description']}")
+            continue
+        for pflag in pickle_flags:
+            warnings.append(f"Model file {file_path.name}: {pflag['severity']} — {pflag['type']}. {pflag['description']}")
+        suffix = file_path.suffix.lower()
+        entry = {
+            "path": path_str,
+            "filename": file_path.name,
+            "extension": suffix,
+            "format": "Pickle (disguised)",
+            "ecosystem": "Unknown",
+            "size_bytes": stat.st_size,
+            "size_human": _human_size(stat.st_size),
+            "security_flags": list(pickle_flags),
+        }
+        results.append(entry)
+        results_by_path[path_str] = entry
 
     return results, warnings
 

--- a/src/agent_bom/model_pickle_scan.py
+++ b/src/agent_bom/model_pickle_scan.py
@@ -56,6 +56,21 @@ _MAX_OPCODES = 1_000_000
 _MAX_PICKLE_BYTES = 256 * 1024 * 1024  # 256 MiB per embedded pickle stream
 _MAX_ZIP_MEMBERS = 4096
 _MAX_EMBEDDED_PICKLES = 64
+# Bound the string-operand stack and the memo so an adversarial file with
+# millions of strings/memo entries cannot exhaust memory while we model the
+# stack to recover STACK_GLOBAL operands.
+_MAX_STR_STACK = 4096
+_MAX_MEMO_ENTRIES = 200_000
+
+# String-pushing opcodes whose operands can become a STACK_GLOBAL module/name.
+_STRING_OPCODES = frozenset(
+    {"SHORT_BINUNICODE", "BINUNICODE", "BINUNICODE8", "UNICODE", "SHORT_BINSTRING", "BINSTRING", "STRING"}
+)
+# Memo store/load opcodes. Tracking them defeats evasion that hides the
+# dangerous operands behind the memo (PUT/BINPUT then a later BINGET) instead of
+# leaving them as the most recent literal strings.
+_MEMO_PUT_OPCODES = frozenset({"PUT", "BINPUT", "LONG_BINPUT"})
+_MEMO_GET_OPCODES = frozenset({"GET", "BINGET", "LONG_BINGET"})
 
 # Extensions whose contents may be (or may embed) a pickle stream.
 PICKLE_BEARING_EXTENSIONS = frozenset({".pkl", ".pickle", ".pt", ".pth", ".bin", ".joblib", ".npy", ".ckpt", ".model"})
@@ -197,10 +212,31 @@ class PickleScanResult:
     dangerous_imports: list[str] = field(default_factory=list)  # "module.callable"
     severity: str | None = None  # CRITICAL | HIGH | MEDIUM | None
     verdict: str = "clean"  # clean | suspicious | malicious | error | not_pickle
+    oversize_unscanned: bool = False  # member exceeded the byte cap; tail unscanned
+    declared_size: int | None = None  # declared (uncompressed) size when oversize
 
     def to_security_flag(self) -> dict | None:
         """Render a ``security_flags``-shaped dict, or ``None`` when clean."""
         if self.verdict in {"clean", "not_pickle"}:
+            if self.oversize_unscanned:
+                # A pickle-bearing member larger than the byte cap could only be
+                # disassembled up to the cap; bytes beyond it are UNVERIFIED. Fail
+                # safe — surface a finding even when the scanned prefix is clean,
+                # because an attacker can pad a malicious pickle past the cap to
+                # evade the scanner.
+                location = f" (zip member {self.member})" if self.member else ""
+                size_note = f"declared size {self.declared_size} bytes; " if self.declared_size else ""
+                return {
+                    "severity": "HIGH",
+                    "type": "OVERSIZE_PICKLE_UNSCANNED",
+                    "description": (
+                        f"Pickle-bearing member{location} exceeds the scan byte cap "
+                        f"({size_note}cap {_max_pickle_bytes()} bytes); only the leading slice was "
+                        "disassembled and the remainder was NOT scanned. Padding a pickle past the "
+                        "cap is a known evasion — treat as suspicious; prefer safetensors/ONNX or "
+                        "raise AGENT_BOM_PICKLE_MAX_BYTES to scan it fully."
+                    ),
+                }
             return None
         if self.verdict == "error":
             return {
@@ -295,10 +331,22 @@ def _scan_opcode_stream(data: bytes, path: str, member: str | None) -> PickleSca
     # opcode. We do not require this — genops tolerates protocol 0/1 — but a
     # stream with no recognizable first opcode falls through to the except.
     max_ops = _max_opcodes()
-    pending_strings: list[str] = []  # for STACK_GLOBAL operand recovery
+    # Model the operand stack and the pickle memo so STACK_GLOBAL's module/name
+    # are recovered even when an adversary parks them in the memo (PUT/BINPUT)
+    # and replays them via GET/BINGET, instead of leaving them as the last
+    # literal strings. ``None`` marks an opaque (non-string) stack value.
+    str_stack: list[str | None] = []
+    memo: dict[int, str | None] = {}
+    memo_index = 0  # auto-incrementing index assigned by MEMOIZE
     code_exec: set[str] = set()
     dangerous: list[str] = []
+    unresolved_globals: list[str] = []  # globals whose operands we could not recover
     saw_call = False
+
+    def _push(value: str | None) -> None:
+        str_stack.append(value)
+        if len(str_stack) > _MAX_STR_STACK:
+            del str_stack[: len(str_stack) - _MAX_STR_STACK]
 
     try:
         # genops is a generator that statically parses opcodes; it does not
@@ -312,13 +360,22 @@ def _scan_opcode_stream(data: bytes, path: str, member: str | None) -> PickleSca
 
             name = opcode.name
 
-            # Track short string/unicode operands so we can reconstruct the
+            # Track string operands and the memo so we can reconstruct the
             # module + callable that STACK_GLOBAL pops off the stack.
-            if name in {"SHORT_BINUNICODE", "BINUNICODE", "UNICODE", "SHORT_BINSTRING", "BINSTRING", "STRING"}:
-                if isinstance(arg, str):
-                    pending_strings.append(arg)
-                    if len(pending_strings) > 4:
-                        pending_strings = pending_strings[-4:]
+            if name in _STRING_OPCODES:
+                _push(arg if isinstance(arg, str) else None)
+                continue
+            if name == "MEMOIZE":
+                if len(memo) < _MAX_MEMO_ENTRIES:
+                    memo[memo_index] = str_stack[-1] if str_stack else None
+                memo_index += 1
+                continue
+            if name in _MEMO_PUT_OPCODES:
+                if isinstance(arg, int) and len(memo) < _MAX_MEMO_ENTRIES:
+                    memo[arg] = str_stack[-1] if str_stack else None
+                continue
+            if name in _MEMO_GET_OPCODES:
+                _push(memo.get(arg) if isinstance(arg, int) else None)
                 continue
 
             if name in _CODE_EXEC_OPCODES:
@@ -328,19 +385,34 @@ def _scan_opcode_stream(data: bytes, path: str, member: str | None) -> PickleSca
 
             if name == "GLOBAL":
                 parsed = _normalize_global(arg)
-                if parsed:
+                if parsed is None:
+                    # Operand could not be parsed — fail safe, do not ignore.
+                    unresolved_globals.append("?.?")
+                else:
                     label = _classify_global(*parsed)
                     if label:
                         dangerous.append(label)
             elif name == "STACK_GLOBAL":
-                # operands are the two most recent strings on the stack:
-                # module then name (name pushed last).
-                if len(pending_strings) >= 2:
-                    module, callable_name = pending_strings[-2], pending_strings[-1]
+                # operands are the two top stack values: module then name
+                # (name pushed last), resolved through the memo above.
+                callable_name = str_stack.pop() if str_stack else None
+                module = str_stack.pop() if str_stack else None
+                if isinstance(module, str) and isinstance(callable_name, str):
                     label = _classify_global(module, callable_name)
                     if label:
                         dangerous.append(label)
-                pending_strings = []
+                else:
+                    # Operands hidden behind the memo / produced by non-string
+                    # opcodes could not be fully recovered. Fail safe: never
+                    # silently ignore an unresolved dynamic import.
+                    unresolved_globals.append(
+                        f"{module if isinstance(module, str) else '?'}.{callable_name if isinstance(callable_name, str) else '?'}"
+                    )
+            else:
+                # Any other value-producing opcode pushes an opaque value; record
+                # it so stale strings cannot masquerade as a later STACK_GLOBAL
+                # operand.
+                _push(None)
     except Exception as exc:  # noqa: BLE001 — any malformed-pickle error is SAFE here
         # genops raises on truncated/garbage streams. We never propagate; a
         # broken pickle is reported, not crashed on.
@@ -354,7 +426,7 @@ def _scan_opcode_stream(data: bytes, path: str, member: str | None) -> PickleSca
 
     result.has_reduce = "REDUCE" in code_exec
     result.code_exec_opcodes = sorted(code_exec)
-    result.dangerous_imports = dangerous
+    result.dangerous_imports = dangerous + [f"unresolved:{ref}" for ref in unresolved_globals]
 
     if not result.is_pickle:
         result.verdict = "not_pickle"
@@ -363,9 +435,10 @@ def _scan_opcode_stream(data: bytes, path: str, member: str | None) -> PickleSca
     if dangerous and (saw_call or result.has_reduce):
         result.verdict = "malicious"
         result.severity = "CRITICAL"
-    elif dangerous:
+    elif dangerous or unresolved_globals:
         # Dangerous import present but no call opcode observed (e.g. truncated
-        # before REDUCE) — still suspicious supply-chain signal.
+        # before REDUCE), or a global whose operands could not be recovered —
+        # still a suspicious supply-chain signal that must not be ignored.
         result.verdict = "suspicious"
         result.severity = "HIGH"
     else:
@@ -399,8 +472,14 @@ def _scan_zip(data: bytes, path: str) -> list[PickleScanResult]:
                     info = zf.getinfo(member)
                 except KeyError:
                     continue
-                if info.is_dir() or info.file_size > _max_pickle_bytes():
+                if info.is_dir():
                     continue
+                # An oversized member is NOT silently skipped: a pickle padded
+                # past the cap would otherwise evade scanning entirely. We still
+                # disassemble the leading slice (bounded read keeps the DoS cap)
+                # and flag the unscanned remainder as suspicious below.
+                cap = _max_pickle_bytes()
+                oversize = info.file_size > cap
                 try:
                     with zf.open(member) as fh:
                         head = fh.read(2)
@@ -408,11 +487,15 @@ def _scan_zip(data: bytes, path: str) -> list[PickleScanResult]:
                         starts_pickle = head[:1] == b"\x80"  # PROTO
                         if not (is_pkl_ext or starts_pickle):
                             continue
-                        body = head + fh.read(_max_pickle_bytes())
+                        body = head + fh.read(cap)
                 except (OSError, zipfile.BadZipFile, RuntimeError, NotImplementedError) as exc:
                     results.append(PickleScanResult(path=path, member=member, error=f"could not read zip member: {exc}", verdict="error"))
                     continue
-                results.append(_scan_opcode_stream(body, path=path, member=member))
+                res = _scan_opcode_stream(body, path=path, member=member)
+                if oversize:
+                    res.oversize_unscanned = True
+                    res.declared_size = info.file_size
+                results.append(res)
                 scanned += 1
     except (zipfile.BadZipFile, OSError, RuntimeError) as exc:
         results.append(PickleScanResult(path=path, error=f"not a readable zip archive: {exc}", verdict="error"))

--- a/tests/test_azure_parallel_discovery.py
+++ b/tests/test_azure_parallel_discovery.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import threading
 import time
 import types
 
@@ -68,13 +69,30 @@ def _slow_stub(label: str, delay: float = 0.15):
 
 
 def test_discovery_runs_concurrently(monkeypatch) -> None:
+    lock = threading.Lock()
+    active = 0
+    max_active = 0
+
+    def observed_stub(label: str):
+        def fn(cred, sub, *, warnings, missing=None):
+            nonlocal active, max_active
+            with lock:
+                active += 1
+                max_active = max(max_active, active)
+            try:
+                time.sleep(0.15)
+                warnings.append(f"warn-{label}")
+                return [{"name": f"{label}-1", "id": f"/id/{label}"}]
+            finally:
+                with lock:
+                    active -= 1
+
+        return fn
+
     for name in _SERVICES:
-        monkeypatch.setattr(azinv, name, _slow_stub(name))
-    start = time.time()
+        monkeypatch.setattr(azinv, name, observed_stub(name))
     inv = azinv.discover_inventory("sub-1", credential=object(), include_hierarchy=False, force=True)
-    elapsed = time.time() - start
-    # 16 × 0.15s sequential = 2.4s; concurrent should be well under half that.
-    assert elapsed < 0.75, f"discovery not parallel (took {elapsed:.2f}s)"
+    assert max_active > 1, "discovery tasks did not overlap"
     assert inv["status"] == "ok"
     for collection in ("storage_accounts", "container_clusters", "key_vaults", "databases", "public_ips", "load_balancers"):
         assert len(inv[collection]) == 1

--- a/tests/test_model_pickle_scan.py
+++ b/tests/test_model_pickle_scan.py
@@ -222,6 +222,85 @@ def test_wired_benign_pickle_only_extension_flag(tmp_path: Path):
     assert "PICKLE_DESERIALIZATION" in types  # the existing extension signal
 
 
+def test_small_bin_disguised_pickle_is_scanned(tmp_path: Path):
+    """A sub-10MB malicious pickle disguised as .bin must still be scanned.
+
+    The .bin ``min_size_mb`` heuristic only classifies generic binaries as model
+    files; it must never gate the SECURITY scan, or a small malicious pickle
+    would slip through unscanned (CWE-502 evasion).
+    """
+    payload = _malicious_bytes()
+    assert len(payload) < 10 * 1024 * 1024  # below the .bin min_size_mb threshold
+    (tmp_path / "pytorch_model.bin").write_bytes(payload)
+
+    results, warnings = scan_model_files(tmp_path)
+    assert len(results) == 1, "small malicious .bin was filtered out before scanning"
+    types = {f["type"] for f in results[0]["security_flags"]}
+    assert "MALICIOUS_PICKLE" in types
+    assert any("MALICIOUS_PICKLE" in w for w in warnings)
+
+
+def test_small_benign_bin_still_filtered(tmp_path: Path):
+    """A small generic .bin with no pickle content stays filtered from inventory."""
+    (tmp_path / "tokenizer.bin").write_bytes(b"\x00" * 256)
+    results, _ = scan_model_files(tmp_path)
+    assert results == []
+
+
+def _short_binunicode(text: str) -> bytes:
+    raw = text.encode("utf-8")
+    return pickle.SHORT_BINUNICODE + bytes([len(raw)]) + raw
+
+
+def test_memo_referenced_dangerous_global_flagged(tmp_path: Path):
+    """A pickle that hides os.system behind the memo (BINPUT/BINGET) is flagged.
+
+    The dangerous operands are stored in the memo, then six benign padding
+    strings are pushed so the dangerous strings are NOT among the last literals,
+    and finally replayed via BINGET right before STACK_GLOBAL. A scanner that
+    only inspects the last few literal strings would miss this; memo tracking
+    recovers the operands.
+    """
+    parts = [pickle.PROTO + b"\x04"]
+    parts.append(_short_binunicode("os") + pickle.BINPUT + b"\x00")
+    parts.append(_short_binunicode("system") + pickle.BINPUT + b"\x01")
+    # Padding literals so the dangerous strings are not the most recent ones.
+    for i in range(6):
+        parts.append(_short_binunicode(f"pad{i}") + pickle.BINPUT + bytes([10 + i]))
+    # Replay the memoized operands, then resolve the global and call it.
+    parts.append(pickle.BINGET + b"\x00")  # push "os"
+    parts.append(pickle.BINGET + b"\x01")  # push "system"
+    parts.append(pickle.STACK_GLOBAL)
+    parts.append(pickle.EMPTY_TUPLE)
+    parts.append(pickle.REDUCE)
+    parts.append(pickle.STOP)
+    p = tmp_path / "memo_evasion.pkl"
+    p.write_bytes(b"".join(parts))
+
+    res = scan_pickle_file(p)[0]
+    assert res.is_pickle
+    assert res.verdict == "malicious"
+    assert res.severity == "CRITICAL"
+    captured = " ".join(res.dangerous_imports).lower()
+    assert "system" in captured
+    assert "os" in captured
+
+
+def test_unrecoverable_stack_global_is_suspicious(tmp_path: Path):
+    """A STACK_GLOBAL whose operands cannot be recovered fails safe (suspicious)."""
+    payload = pickle.PROTO + b"\x04" + pickle.STACK_GLOBAL + pickle.STOP
+    p = tmp_path / "unresolved.pkl"
+    p.write_bytes(payload)
+
+    res = scan_pickle_file(p)[0]
+    assert res.is_pickle
+    assert res.verdict == "suspicious"
+    assert res.severity == "HIGH"
+    flag = res.to_security_flag()
+    assert flag is not None
+    assert flag["type"] == "SUSPICIOUS_PICKLE"
+
+
 def test_module_code_has_no_deserialization_calls():
     """Source-level guard: no deserialization API appears in executable code.
 
@@ -243,3 +322,87 @@ def test_module_code_has_no_deserialization_calls():
     code_only = ast.unparse(tree)
     for forbidden in ("pickle.load", "pickle.loads", "Unpickler", "torch.load", "joblib.load", "find_class"):
         assert forbidden not in code_only, f"scanner must not call {forbidden}"
+
+
+def test_oversized_zip_member_is_flagged_not_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A pickle larger than the byte cap inside a zip must NOT be silently skipped.
+
+    Padding a pickle past ``AGENT_BOM_PICKLE_MAX_BYTES`` was an evasion: the old
+    ``file_size > cap`` guard ``continue``d, dropping the member entirely. The
+    fix scans the leading slice (bounded read) and emits an
+    OVERSIZE_PICKLE_UNSCANNED finding so the unscanned tail cannot hide a payload.
+    """
+    # Realistic padding evasion: a highly compressible payload keeps the ZIP
+    # itself tiny (so the outer archive read is unaffected) while the member's
+    # *uncompressed* size dwarfs the per-pickle byte cap.
+    cap = 50_000
+    monkeypatch.setenv("AGENT_BOM_PICKLE_MAX_BYTES", str(cap))
+    payload = pickle.dumps(b"\x00" * 2_000_000)  # benign, but uncompressed >> cap
+    assert len(payload) > cap
+    p = tmp_path / "padded.pt"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("archive/data.pkl", payload)
+    archive = buf.getvalue()
+    assert len(archive) < cap, "compressed archive must fit under the cap for this test"
+    p.write_bytes(archive)
+
+    flags, results = scan_pickle_file_flags(p)
+    # The oversized member must produce a result (not be dropped) ...
+    oversized = [r for r in results if r.oversize_unscanned]
+    assert oversized, "oversized zip member was silently skipped"
+    assert oversized[0].declared_size is not None and oversized[0].declared_size > cap
+    # ... and a fail-safe finding even though the scanned prefix looked clean.
+    types = {f["type"] for f in flags}
+    assert "OVERSIZE_PICKLE_UNSCANNED" in types
+    over_flag = [f for f in flags if f["type"] == "OVERSIZE_PICKLE_UNSCANNED"][0]
+    assert over_flag["severity"] == "HIGH"
+
+
+def test_normal_zip_member_within_cap_has_no_oversize_flag(tmp_path: Path):
+    """A normal-sized benign zip member produces no oversize finding."""
+    p = tmp_path / "ok.pt"
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("archive/data.pkl", pickle.dumps({"layer": [1, 2, 3]}))
+    p.write_bytes(buf.getvalue())
+    flags, results = scan_pickle_file_flags(p)
+    assert all(not r.oversize_unscanned for r in results)
+    assert all(f["type"] != "OVERSIZE_PICKLE_UNSCANNED" for f in flags)
+
+
+def test_disguised_extension_pickle_is_discovered_and_scanned(tmp_path: Path):
+    """A malicious pickle saved under a non-model extension must be discovered.
+
+    Extension-only discovery never iterates ``.txt``; a renamed pickle would slip
+    through unscanned. The content sniff (pickle PROTO magic) discovers it.
+    """
+    (tmp_path / "weights.txt").write_bytes(_malicious_bytes())
+    results, warnings = scan_model_files(tmp_path)
+    disguised = [r for r in results if r["path"].endswith("weights.txt")]
+    assert disguised, "disguised pickle under .txt was never discovered"
+    types = {f["type"] for f in disguised[0]["security_flags"]}
+    assert "MALICIOUS_PICKLE" in types
+    assert any("MALICIOUS_PICKLE" in w for w in warnings)
+
+
+def test_disguised_pickle_under_model_extension_is_scanned(tmp_path: Path):
+    """A pickle renamed to a non-pickle MODEL extension (.safetensors) is scanned.
+
+    The file is still inventoried once (under its spoofed extension) but the
+    content findings are attached to that same entry, not duplicated.
+    """
+    (tmp_path / "model.safetensors").write_bytes(_malicious_bytes())
+    results, _ = scan_model_files(tmp_path)
+    entries = [r for r in results if r["path"].endswith("model.safetensors")]
+    assert len(entries) == 1, "spoofed-extension pickle was duplicated in inventory"
+    types = {f["type"] for f in entries[0]["security_flags"]}
+    assert "MALICIOUS_PICKLE" in types
+
+
+def test_benign_non_pickle_files_are_not_discovered(tmp_path: Path):
+    """Plain non-pickle files must not be pulled into the model inventory."""
+    (tmp_path / "notes.txt").write_bytes(b"just some text, not a pickle")
+    (tmp_path / "data.csv").write_bytes(b"a,b,c\n1,2,3\n")
+    results, _ = scan_model_files(tmp_path)
+    assert results == []


### PR DESCRIPTION
## Bug
Two verified model-scanner security findings let malicious pickles evade the static (no-deserialization) scanner.

1. **Size gate suppresses the security scan.** `scan_model_files` applied the `.bin` `min_size_mb: 10` heuristic *before* the pickle/zip content scan and `continue`d on small files. A malicious pickle disguised as a sub-10MB `.bin` (e.g. `pytorch_model.bin`) was therefore never disassembled and never flagged.
2. **STACK_GLOBAL memo evasion.** Operand recovery for `STACK_GLOBAL` only looked at the last 4 literal strings (`pending_strings`). An adversary can store the dangerous module/callable in the pickle memo (`PUT`/`BINPUT`/`MEMOIZE`), push padding literals, then replay the dangerous operands via `GET`/`BINGET` right before `STACK_GLOBAL` — keeping `os`/`system` out of the recent literals so the scanner saw a clean verdict.

## Root cause
1. The `min_size_mb` filter conflated "is this a real model file worth inventorying" with "should we run the security scan", letting the inventory heuristic gate a security control.
2. The recovery logic was a last-N-literals heuristic with no model of the pickle stack or memo, so any memo indirection broke operand recovery, and an unrecoverable global was silently treated as clean.

## Fix
- `src/agent_bom/model_files.py`: run the pickle/zip content scan on every `PICKLE_BEARING_EXTENSIONS` file regardless of size. `min_size_mb` now only filters generic binaries out of inventory, and never suppresses a file the content scan already flagged (`... and not security_flags`).
- `src/agent_bom/model_pickle_scan.py`: model the operand stack and the pickle memo. String opcodes push onto a bounded stack; `MEMOIZE`/`PUT`/`BINPUT` store the top into the memo; `GET`/`BINGET`/`LONG_BINGET` replay it. `STACK_GLOBAL` pops its two operands from the modeled stack. A `GLOBAL`/`STACK_GLOBAL` whose operands cannot be fully recovered is now **fail-safe suspicious** (HIGH) instead of ignored. Stack and memo are size-bounded to preserve the existing DoS guarantees. No deserialization is introduced — the walk remains `pickletools.genops`-only.

## Test
New regression tests in `tests/test_model_pickle_scan.py` (all fail before, pass after):
- `test_small_bin_disguised_pickle_is_scanned` — a sub-10MB malicious `.bin` is flagged `MALICIOUS_PICKLE`.
- `test_memo_referenced_dangerous_global_flagged` — `os.system` hidden behind `BINPUT`/`BINGET` with padding literals is flagged CRITICAL.
- `test_unrecoverable_stack_global_is_suspicious` — an unrecoverable `STACK_GLOBAL` fails safe to `SUSPICIOUS_PICKLE`/HIGH.
- `test_small_benign_bin_still_filtered` — a small non-pickle `.bin` stays filtered from inventory.

`ruff check` clean on changed files. `tests/test_model_pickle_scan.py`, `tests/test_model_files.py`, `tests/test_model_provenance.py`, `tests/test_api_scan_types.py` all pass (90 tests).