### PR TITLE
fix(api): bind audit tenant server-side, harden rate-limit identity + global ceiling

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -139,6 +139,8 @@ so they cannot regress silently, but they are not part of this reference.
 |---|---|---|---|
 | `AGENT_BOM_MCP_CALLER_RATE_LIMIT` | `int` | `120` | — |
 | `AGENT_BOM_MCP_CALLER_WINDOW_SECONDS` | `float` | `60.0` | — |
+| `AGENT_BOM_MCP_GLOBAL_RATE_LIMIT` | `int` | `MCP_CALLER_RATE_LIMIT * 20` | Process-wide ceiling across all MCP callers, enforced in addition to the per-caller window. Backstops a flood that spreads across many distinct (or unverified per-connection) caller identities. Defaults to a generous multiple of the per-cal |
+| `AGENT_BOM_MCP_GLOBAL_WINDOW_SECONDS` | `float` | `MCP_CALLER_WINDOW_SECONDS` | — |
 | `AGENT_BOM_MCP_MAX_CALLER_STATES` | `int` | `256` | — |
 | `AGENT_BOM_MCP_MAX_CONCURRENT_TOOLS` | `int` | `8` | — |
 | `AGENT_BOM_MCP_MAX_FILE_SIZE` | `int` | `50 * 1024 * 1024` | Used by mcp_server.py for file-size and response-size guards, tool execution governance, and lightweight in-process observability.  50 MB max file size prevents accidental ingestion of large binaries. 500,000 char response cap keeps MCP too |

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -374,3 +374,8 @@ AGENT_BOM_VERSION
 AGENT_BOM_VISUAL_LEAK_TIMEOUT_SECONDS
 AGENT_BOM_VULN_DB_MAX_AGE_HOURS  # runtime override for vuln-cache staleness threshold (hours, default 24); re-read at scan time so tests can monkeypatch; read in vuln_freshness.py
 AGENT_BOM_VULN_DB_OFFLINE  # airgap toggle that forces existing-cache-only freshness with no network refresh; mirrors --offline for non-CLI callers; read in vuln_freshness.py
+
+# Coarse per-IP rate-limit ceiling override; resolved at call-time with bounds-checking in middleware.global_ip_rate_limit_rpm().
+AGENT_BOM_GLOBAL_IP_RATE_LIMIT_RPM
+# Trusted reverse-proxy hop count for X-Forwarded-For parsing; resolved at call-time in routes/enterprise._trusted_proxy_hops().
+AGENT_BOM_TRUSTED_PROXY_HOPS

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1370,6 +1370,39 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
 DEFAULT_SCAN_RATE_LIMIT_RPM = 600
 DEFAULT_READ_RATE_LIMIT_RPM = DEFAULT_SCAN_RATE_LIMIT_RPM * 5
 MAX_RATE_LIMIT_RPM = 60_000
+# Coarse per-client-IP ceiling enforced OUTERMOST (before authentication) so an
+# unauthenticated flood is capped regardless of auth outcome. Deliberately much
+# higher than the per-tenant read budget so it never trips legitimate
+# single-tenant traffic; it exists to bound abuse from a single source address.
+DEFAULT_GLOBAL_IP_RATE_LIMIT_RPM = DEFAULT_READ_RATE_LIMIT_RPM * 4
+
+
+def _build_rate_limit_store(window_seconds: int):
+    """Build the shared/in-memory limiter store with fail-closed semantics."""
+    if os.environ.get("AGENT_BOM_POSTGRES_URL"):
+        try:
+            return PostgresRateLimitStore(window_seconds=window_seconds)
+        except Exception as exc:
+            raise RuntimeError(
+                "Configured Postgres rate limiter could not initialize; refusing to fall back to process-local state"
+            ) from exc
+    if _shared_rate_limit_required():
+        raise RuntimeError(
+            "Shared rate limiting is required for multi-replica or fail-closed deployments. "
+            "Configure AGENT_BOM_POSTGRES_URL before starting the API."
+        )
+    return InMemoryRateLimitStore(window_seconds=window_seconds)
+
+
+def global_ip_rate_limit_rpm() -> int:
+    """Resolve the coarse per-IP ceiling, honoring an operator override."""
+    raw = (os.environ.get("AGENT_BOM_GLOBAL_IP_RATE_LIMIT_RPM") or "").strip()
+    if raw:
+        try:
+            return _validate_rate_limit("global_ip_rpm", int(raw), max_rpm=MAX_RATE_LIMIT_RPM * 5)
+        except ValueError:
+            _logger.warning("Invalid AGENT_BOM_GLOBAL_IP_RATE_LIMIT_RPM=%r; using default", raw)
+    return DEFAULT_GLOBAL_IP_RATE_LIMIT_RPM
 
 
 def _validate_rate_limit(name: str, value: int, *, max_rpm: int) -> int:
@@ -1400,19 +1433,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         self._store = self._build_store()
 
     def _build_store(self):
-        if os.environ.get("AGENT_BOM_POSTGRES_URL"):
-            try:
-                return PostgresRateLimitStore(window_seconds=self._window)
-            except Exception as exc:
-                raise RuntimeError(
-                    "Configured Postgres rate limiter could not initialize; refusing to fall back to process-local state"
-                ) from exc
-        if _shared_rate_limit_required():
-            raise RuntimeError(
-                "Shared rate limiting is required for multi-replica or fail-closed deployments. "
-                "Configure AGENT_BOM_POSTGRES_URL before starting the API."
-            )
-        return InMemoryRateLimitStore(window_seconds=self._window)
+        return _build_rate_limit_store(self._window)
 
     def _resolve_tenant_scope(self, request: StarletteRequest, raw_key: str) -> str | None:
         tenant_id = getattr(request.state, "tenant_id", "").strip() or None
@@ -1481,6 +1502,47 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         response.headers["X-RateLimit-Remaining"] = str(remaining)
         response.headers["X-RateLimit-Reset"] = str(reset_at)
         return response
+
+
+class GlobalRateLimitMiddleware(BaseHTTPMiddleware):
+    """Coarse per-client-IP request ceiling enforced OUTERMOST.
+
+    Mounted before :class:`APIKeyMiddleware` so an unauthenticated flood is
+    capped regardless of auth outcome — a rejected (401) request never reaches
+    the inner tenant/auth-scoped :class:`RateLimitMiddleware`, so without this
+    backstop an anonymous attacker could pound the auth layer without being
+    throttled. Keyed on the transport peer address; the inner limiter keeps
+    fine-grained per-tenant budgets.
+    """
+
+    def __init__(self, app: ASGIApp, rpm: int = DEFAULT_GLOBAL_IP_RATE_LIMIT_RPM):
+        super().__init__(app)
+        self._rpm = _validate_rate_limit("global_ip_rpm", rpm, max_rpm=MAX_RATE_LIMIT_RPM * 5)
+        self._window = 60
+        self._store = _build_rate_limit_store(self._window)
+
+    def _bucket_key(self, request: StarletteRequest) -> str:
+        client_ip = request.client.host if request.client else "unknown"
+        return f"global-ip:{client_ip}"
+
+    async def dispatch(self, request: StarletteRequest, call_next):
+        if RateLimitMiddleware._is_dashboard_static_asset(request.url.path, request.method):
+            return await call_next(request)
+
+        now = time.time()
+        key = self._bucket_key(request)
+        hit_count, reset_at = await asyncio.to_thread(self._store.hit, key, now)
+        if hit_count > self._rpm:
+            retry_after = max(int(reset_at - now), 1)
+            return JSONResponse(
+                status_code=429,
+                content={"detail": "Global rate limit exceeded"},
+                headers={
+                    "Retry-After": str(retry_after),
+                    "X-RateLimit-Scope": "global-ip",
+                },
+            )
+        return await call_next(request)
 
 
 def _configured_api_replicas() -> int:

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -87,10 +87,42 @@ _TRIAGE_PREFIX = "[finding_triage]"
 _LEGACY_FALSE_POSITIVE_PREFIX = "[false_positive]"
 
 
+def _trusted_proxy_hops() -> int:
+    raw = (os.environ.get("AGENT_BOM_TRUSTED_PROXY_HOPS") or "").strip()
+    if not raw:
+        return 0
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 0
+
+
+def _forwarded_for_trusted() -> bool:
+    """Honor X-Forwarded-For only when a trusted reverse proxy is declared."""
+    flag = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH", "").strip().lower() in {"1", "true", "yes", "on"}
+    return flag or _trusted_proxy_hops() > 0
+
+
 def _client_fingerprint(request: Request) -> str:
-    forwarded = (request.headers.get("x-forwarded-for") or "").split(",", 1)[0].strip()
-    host = forwarded or (request.client.host if request.client else "unknown")
-    return host[:128]
+    """Throttle identity for the API-key-exchange brute-force limiter.
+
+    Defaults to the transport peer (``request.client.host``) so a hostile
+    client cannot reset its brute-force window by spoofing a fresh
+    ``X-Forwarded-For`` value on every attempt. The forwarded chain is only
+    consulted when the deployment declares a trusted proxy via
+    ``AGENT_BOM_TRUST_PROXY_AUTH`` or an explicit ``AGENT_BOM_TRUSTED_PROXY_HOPS``
+    count; with a hop count we take the Nth-from-rightmost entry (the address
+    the trusted proxy appended), never the attacker-controlled leftmost one.
+    """
+    host = request.client.host if request.client else "unknown"
+    if _forwarded_for_trusted():
+        forwarded = [part.strip() for part in (request.headers.get("x-forwarded-for") or "").split(",") if part.strip()]
+        hops = _trusted_proxy_hops()
+        if hops and len(forwarded) >= hops:
+            host = forwarded[-hops]
+        elif forwarded:
+            host = forwarded[0]
+    return (host or "unknown")[:128]
 
 
 def _auth_session_limit() -> int:

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -169,11 +169,12 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         enriched.setdefault("request_id", request_id)
         enriched.setdefault("trace_id", trace_id)
         enriched.setdefault("event_type", enriched.get("action") or enriched.get("type", "runtime_alert"))
-        # Tag tenant_id on the in-memory record so per-tenant posture queries
-        # (e.g. compliance has_proxy) can scope correctly. The ring buffer is
-        # process-wide; without this tag every tenant sees every other
-        # tenant's alerts on shared deployments.
-        enriched.setdefault("tenant_id", tenant_id)
+        # Force the server-authoritative tenant_id on the in-memory record so
+        # per-tenant posture queries (e.g. compliance has_proxy) scope correctly.
+        # The ring buffer is process-wide; never honor a client-supplied
+        # tenant_id here — setdefault would let a caller pre-tag another tenant
+        # and write a cross-tenant alert that surfaces in that tenant's reads.
+        enriched["tenant_id"] = tenant_id
         # dedupe by event_id so a buggy or hostile proxy
         # cannot replay credential_leak alerts and inflate per-detector
         # tallies. Empty event_id falls through to keep legacy callers working.
@@ -216,7 +217,10 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         summary.setdefault("session_id", session_id)
         summary.setdefault("request_id", request_id)
         summary.setdefault("trace_id", trace_id)
-        summary.setdefault("tenant_id", tenant_id)
+        # Server-authoritative tenant tag — never honor a client-supplied
+        # tenant_id, which would route this summary into another tenant's
+        # metrics bucket on shared deployments.
+        summary["tenant_id"] = tenant_id
         push_proxy_metrics(summary)
 
     if analytics_events:

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -27,10 +27,12 @@ from agent_bom.api.middleware import (
     DEFAULT_SCAN_RATE_LIMIT_RPM,
     MAX_RATE_LIMIT_RPM,
     APIKeyMiddleware,
+    GlobalRateLimitMiddleware,
     MaxBodySizeMiddleware,
     RateLimitMiddleware,
     TrustHeadersMiddleware,
     configure_auth_runtime,
+    global_ip_rate_limit_rpm,
     install_error_envelope,
 )
 
@@ -740,14 +742,16 @@ def configure_api(
         )
 
     # Refresh runtime-configurable middleware. _replace_middleware inserts at
-    # the front; this call order keeps body-size outermost, auth before rate
-    # limiting, and rate limiting able to read tenant/auth state.
+    # the front; this call order keeps the coarse per-IP limiter outermost
+    # (capping unauthenticated floods before auth), then body-size, then auth
+    # before the tenant-scoped rate limiter, which needs tenant/auth state.
     _replace_middleware(RateLimitMiddleware, scan_rpm=_rate_limit_rpm, read_rpm=_rate_limit_rpm * 5)
     if auth_required:
         _replace_middleware(APIKeyMiddleware, api_key=api_key)
     else:
         app.user_middleware = [m for m in app.user_middleware if m.cls is not APIKeyMiddleware]
     _replace_middleware(MaxBodySizeMiddleware)
+    _replace_middleware(GlobalRateLimitMiddleware, rpm=global_ip_rate_limit_rpm())
     if app.middleware_stack is not None:
         app.middleware_stack = app.build_middleware_stack()
 

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -411,6 +411,12 @@ MCP_MAX_TOOL_METRICS = _int("AGENT_BOM_MCP_MAX_TOOL_METRICS", 128)
 MCP_CALLER_RATE_LIMIT = _int("AGENT_BOM_MCP_CALLER_RATE_LIMIT", 120)
 MCP_CALLER_WINDOW_SECONDS = _float("AGENT_BOM_MCP_CALLER_WINDOW_SECONDS", 60.0)
 MCP_MAX_CALLER_STATES = _int("AGENT_BOM_MCP_MAX_CALLER_STATES", 256)
+# Process-wide ceiling across all MCP callers, enforced in addition to the
+# per-caller window. Backstops a flood that spreads across many distinct (or
+# unverified per-connection) caller identities. Defaults to a generous multiple
+# of the per-caller budget so it only trips genuine aggregate abuse.
+MCP_GLOBAL_RATE_LIMIT = _int("AGENT_BOM_MCP_GLOBAL_RATE_LIMIT", MCP_CALLER_RATE_LIMIT * 20)
+MCP_GLOBAL_WINDOW_SECONDS = _float("AGENT_BOM_MCP_GLOBAL_WINDOW_SECONDS", MCP_CALLER_WINDOW_SECONDS)
 MCP_MAX_REQUEST_TRACES = _int("AGENT_BOM_MCP_MAX_REQUEST_TRACES", 256)
 
 

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -101,6 +101,8 @@ from agent_bom import mcp_server_runtime as _mcp_runtime
 from agent_bom import mcp_server_scan as _mcp_scan
 from agent_bom.config import MCP_CALLER_RATE_LIMIT as _MCP_CALLER_RATE_LIMIT
 from agent_bom.config import MCP_CALLER_WINDOW_SECONDS as _MCP_CALLER_WINDOW_SECONDS
+from agent_bom.config import MCP_GLOBAL_RATE_LIMIT as _MCP_GLOBAL_RATE_LIMIT
+from agent_bom.config import MCP_GLOBAL_WINDOW_SECONDS as _MCP_GLOBAL_WINDOW_SECONDS
 from agent_bom.config import MCP_MAX_CALLER_STATES as _MCP_MAX_CALLER_STATES
 from agent_bom.config import MCP_MAX_CONCURRENT_TOOLS as _MCP_MAX_CONCURRENT_TOOLS
 from agent_bom.config import MCP_MAX_FILE_SIZE as _MAX_FILE_SIZE  # noqa: F401 - retained public test import
@@ -304,6 +306,8 @@ def _check_caller_rate_limit(caller: str) -> float | None:
         caller_window_seconds=_MCP_CALLER_WINDOW_SECONDS,
         max_caller_states=_MCP_MAX_CALLER_STATES,
         monotonic_now=time.monotonic(),
+        global_rate_limit=_MCP_GLOBAL_RATE_LIMIT,
+        global_window_seconds=_MCP_GLOBAL_WINDOW_SECONDS,
     )
 
 

--- a/src/agent_bom/mcp_server_runtime.py
+++ b/src/agent_bom/mcp_server_runtime.py
@@ -8,6 +8,7 @@ unchanged while the monolith is decomposed.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import time
 from pathlib import Path
@@ -186,6 +187,37 @@ def tool_metrics_snapshot(
     }
 
 
+def _verified_token_caller(current_request: Any) -> str | None:
+    """Return a stable caller key bound to the verified access token, if any.
+
+    Keying the rate-limit window on the authenticated identity (the token's
+    ``client_id`` or, failing that, a hash of the token material) means a caller
+    cannot reset its window simply by opening a fresh connection. Returns None
+    when no verified token is attached so unauthenticated/local callers fall
+    back to the per-connection label.
+    """
+    holders: list[Any] = []
+    for holder_name in ("access_token", "auth", "token"):
+        holder = getattr(current_request, holder_name, None)
+        if holder is not None:
+            holders.append(holder)
+    experimental = getattr(current_request, "experimental", None)
+    if experimental is not None:
+        for holder_name in ("access_token", "auth", "token"):
+            holder = getattr(experimental, holder_name, None)
+            if holder is not None:
+                holders.append(holder)
+    for holder in holders:
+        client_id = getattr(holder, "client_id", None)
+        if client_id and str(client_id).strip():
+            return f"token-client:{str(client_id).strip()}"
+        for token_attr in ("token", "access_token", "jti"):
+            raw = getattr(holder, token_attr, None)
+            if isinstance(raw, str) and raw.strip():
+                return f"token-hash:{hashlib.sha256(raw.strip().encode()).hexdigest()[:32]}"
+    return None
+
+
 def current_tool_request(request_ctx_getter: Callable[[], Any]) -> dict[str, str | None]:
     try:
         current_request = request_ctx_getter()
@@ -208,12 +240,56 @@ def current_tool_request(request_ctx_getter: Callable[[], Any]) -> dict[str, str
         scopes = getattr(holder, "scopes", None)
         if isinstance(scopes, list | tuple | set):
             auth_scopes.update(str(scope).strip().lower() for scope in scopes if str(scope).strip())
+    # Prefer the verified access-token identity so a hostile caller cannot reset
+    # its rate-limit window by reconnecting (which mints a fresh per-connection
+    # session object id). The client-declared meta.client_id is only a fallback
+    # for unauthenticated/local transports.
+    verified_caller = _verified_token_caller(current_request)
     return {
-        "caller": client_id or session_label,
+        "caller": verified_caller or client_id or session_label,
         "client_id": client_id,
         "request_id": str(getattr(current_request, "request_id", "")) or None,
         "auth_scopes": ",".join(sorted(auth_scopes)),
     }
+
+
+_GLOBAL_CALLER_KEY = "__mcp_global__"
+
+
+def _hit_rate_window(
+    caller_rate_windows,
+    key: str,
+    *,
+    limit: int,
+    window_seconds: float,
+    max_caller_states: int,
+    monotonic_now: float,
+) -> float | None:
+    """Slide one bounded window. Returns retry-after seconds when over budget."""
+    window = caller_rate_windows.get(key)
+    if window is None:
+        if len(caller_rate_windows) >= max_caller_states:
+            # Never evict the reserved global backstop bucket.
+            oldest = next(iter(caller_rate_windows))
+            if oldest == _GLOBAL_CALLER_KEY and len(caller_rate_windows) > 1:
+                caller_rate_windows.move_to_end(_GLOBAL_CALLER_KEY)
+            caller_rate_windows.popitem(last=False)
+        from collections import deque
+
+        window = deque()
+        caller_rate_windows[key] = window
+    else:
+        caller_rate_windows.move_to_end(key)
+
+    cutoff = monotonic_now - window_seconds
+    while window and window[0] <= cutoff:
+        window.popleft()
+
+    if len(window) >= limit:
+        return round(max(0.0, window_seconds - (monotonic_now - window[0])), 3)
+
+    window.append(monotonic_now)
+    return None
 
 
 def check_caller_rate_limit(
@@ -224,29 +300,32 @@ def check_caller_rate_limit(
     caller_window_seconds: float,
     max_caller_states: int,
     monotonic_now: float,
+    global_rate_limit: int = 0,
+    global_window_seconds: float | None = None,
 ) -> float | None:
-    if caller_rate_limit <= 0:
-        return None
+    if caller_rate_limit > 0:
+        retry_after = _hit_rate_window(
+            caller_rate_windows,
+            caller,
+            limit=caller_rate_limit,
+            window_seconds=caller_window_seconds,
+            max_caller_states=max_caller_states,
+            monotonic_now=monotonic_now,
+        )
+        if retry_after is not None:
+            return retry_after
 
-    window = caller_rate_windows.get(caller)
-    if window is None:
-        if len(caller_rate_windows) >= max_caller_states:
-            caller_rate_windows.popitem(last=False)
-        from collections import deque
-
-        window = deque()
-        caller_rate_windows[caller] = window
-    else:
-        caller_rate_windows.move_to_end(caller)
-
-    cutoff = monotonic_now - caller_window_seconds
-    while window and window[0] <= cutoff:
-        window.popleft()
-
-    if len(window) >= caller_rate_limit:
-        return round(max(0.0, caller_window_seconds - (monotonic_now - window[0])), 3)
-
-    window.append(monotonic_now)
+    # Process-wide backstop: a flood spread across many distinct (or
+    # per-connection) caller identities is still capped in aggregate.
+    if global_rate_limit > 0:
+        return _hit_rate_window(
+            caller_rate_windows,
+            _GLOBAL_CALLER_KEY,
+            limit=global_rate_limit,
+            window_seconds=global_window_seconds or caller_window_seconds,
+            max_caller_states=max_caller_states,
+            monotonic_now=monotonic_now,
+        )
     return None
 
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -1471,3 +1471,121 @@ def test_api_key_middleware_does_not_check_rls_bypass_when_postgres_disabled(mon
     resp = client.get("/v1/test", headers={"Authorization": "Bearer test-key-123"})
 
     assert resp.status_code == 200
+
+
+# ── Auth-session brute-force throttle identity (X-Forwarded-For spoofing) ─────
+
+
+def test_client_fingerprint_ignores_xff_without_trusted_proxy(monkeypatch):
+    """Default identity is the transport peer, not an attacker-supplied XFF."""
+    from agent_bom.api.routes import enterprise
+
+    monkeypatch.delenv("AGENT_BOM_TRUST_PROXY_AUTH", raising=False)
+    monkeypatch.delenv("AGENT_BOM_TRUSTED_PROXY_HOPS", raising=False)
+    request = SimpleNamespace(headers={"x-forwarded-for": "9.9.9.9"}, client=SimpleNamespace(host="10.0.0.5"))
+    assert enterprise._client_fingerprint(request) == "10.0.0.5"
+
+
+def test_client_fingerprint_honors_xff_with_trusted_hop_count(monkeypatch):
+    """A declared trusted-proxy hop count selects the proxy-appended address."""
+    from agent_bom.api.routes import enterprise
+
+    monkeypatch.delenv("AGENT_BOM_TRUST_PROXY_AUTH", raising=False)
+    monkeypatch.setenv("AGENT_BOM_TRUSTED_PROXY_HOPS", "1")
+    request = SimpleNamespace(
+        headers={"x-forwarded-for": "1.1.1.1, 2.2.2.2, 3.3.3.3"},
+        client=SimpleNamespace(host="10.0.0.5"),
+    )
+    assert enterprise._client_fingerprint(request) == "3.3.3.3"
+
+
+@pytest.mark.asyncio
+async def test_auth_session_xff_spoof_does_not_reset_bruteforce_window(monkeypatch):
+    """Rotating X-Forwarded-For must not let an attacker evade the limiter.
+
+    Fails before the fix: the throttle keyed on the leftmost XFF, so each forged
+    value minted a fresh bucket and the brute-force window never tripped.
+    """
+    from fastapi import HTTPException
+
+    from agent_bom.api.routes import enterprise
+    from agent_bom.api.shared_auth_state import reset_auth_state_for_tests
+
+    reset_auth_state_for_tests()
+    monkeypatch.delenv("AGENT_BOM_TRUST_PROXY_AUTH", raising=False)
+    monkeypatch.delenv("AGENT_BOM_TRUSTED_PROXY_HOPS", raising=False)
+    monkeypatch.setenv("AGENT_BOM_AUTH_SESSION_ATTEMPTS_PER_MINUTE", "1")
+    monkeypatch.setenv("AGENT_BOM_API_KEY", "valid-key")
+
+    def make_request(spoofed_xff: str):
+        return SimpleNamespace(
+            headers={"x-forwarded-for": spoofed_xff},
+            client=SimpleNamespace(host="203.0.113.10"),
+        )
+
+    with pytest.raises(HTTPException) as first:
+        await enterprise.create_browser_session(
+            make_request("1.1.1.1"), Response(), enterprise.BrowserSessionRequest(api_key="bad-1")
+        )
+    assert first.value.status_code == 401
+
+    with pytest.raises(HTTPException) as second:
+        await enterprise.create_browser_session(
+            make_request("2.2.2.2"), Response(), enterprise.BrowserSessionRequest(api_key="bad-2")
+        )
+    assert second.value.status_code == 429
+
+
+# ── Outermost coarse global rate limiter (pre-auth flood cap) ─────────────────
+
+
+def test_global_rate_limit_caps_flood_regardless_of_auth_outcome(monkeypatch):
+    """The global per-IP limiter caps traffic even when the handler rejects it.
+
+    Fails before the fix: there was no outermost limiter, so unauthenticated
+    floods reached (and were only rejected by) the auth layer without being
+    counted or capped.
+    """
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    from agent_bom.api.middleware import GlobalRateLimitMiddleware
+
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+    monkeypatch.delenv("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT", raising=False)
+    monkeypatch.delenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", raising=False)
+
+    async def unauthorized(request):
+        return StarletteJSONResponse({"detail": "unauthorized"}, status_code=401)
+
+    test_app = Starlette(routes=[Route("/v1/ping", unauthorized)])
+    test_app.add_middleware(GlobalRateLimitMiddleware, rpm=3)
+
+    client = TestClient(test_app)
+    codes = [client.get("/v1/ping").status_code for _ in range(6)]
+    # First 3 reach the (rejecting) handler; the 4th+ are capped pre-handler.
+    assert codes[0] == 401
+    assert codes[3] == 429
+    last = client.get("/v1/ping")
+    assert last.status_code == 429
+    assert last.json()["detail"] == "Global rate limit exceeded"
+
+
+def test_configure_api_mounts_global_limiter_outermost(monkeypatch):
+    """The global limiter must sit before auth and body-size middleware."""
+    from agent_bom.api.middleware import GlobalRateLimitMiddleware
+    from agent_bom.api.server import app as server_app
+    from agent_bom.api.server import configure_api as cfg
+
+    original = list(server_app.user_middleware)
+    try:
+        monkeypatch.delenv("AGENT_BOM_OIDC_ISSUER", raising=False)
+        cfg(api_key="test-key-123", rate_limit_rpm=10)
+        order = [m.cls for m in server_app.user_middleware]
+        assert order.index(GlobalRateLimitMiddleware) < order.index(APIKeyMiddleware)
+        assert order.index(GlobalRateLimitMiddleware) < order.index(MaxBodySizeMiddleware)
+    finally:
+        server_app.user_middleware = original
+        if server_app.middleware_stack is not None:
+            server_app.middleware_stack = server_app.build_middleware_stack()

--- a/tests/test_api_proxy_scorecard.py
+++ b/tests/test_api_proxy_scorecard.py
@@ -1015,3 +1015,57 @@ def test_scorecard_rejects_invalid_package():
     # Pipe is not in the [A-Za-z0-9._@/:-] allowlist
     resp = client.get("/v1/scorecard/npm/foo|bar")
     assert resp.status_code == 400
+
+
+# ── Proxy audit cross-tenant tagging ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_proxy_audit_ingest_forces_server_tenant():
+    """A client-supplied tenant_id must never override the authenticated tenant.
+
+    Fails before the fix: the ingest used ``setdefault('tenant_id', ...)`` so a
+    caller could pre-tag an alert/summary for another tenant and have it surface
+    in that victim tenant's scoped reads.
+    """
+    from agent_bom.api.models import ProxyAuditIngestRequest
+    from agent_bom.api.routes import proxy as proxy_routes
+
+    proxy_routes._proxy_alerts.clear()
+    proxy_routes._proxy_metrics = None
+    proxy_routes._proxy_metrics_by_tenant.clear()
+    proxy_routes._reset_audit_dedupe_for_tests()
+
+    request = SimpleNamespace(
+        state=SimpleNamespace(
+            tenant_id="tenant-honest",
+            api_key_name="proxy-client",
+            request_id="req-1",
+            trace_id="trace-1",
+        )
+    )
+    body = ProxyAuditIngestRequest(
+        source_id="src-1",
+        session_id="sess-1",
+        alerts=[
+            {
+                "event_id": "evt-1",
+                "tenant_id": "tenant-victim",
+                "message": "cross-tenant attempt",
+                "detector": "credential_leak",
+                "severity": "high",
+            }
+        ],
+        summary={"tenant_id": "tenant-victim", "total_tool_calls": 5},
+    )
+
+    resp = await proxy_routes.ingest_proxy_audit(request, body)
+    assert resp["ingested"] is True
+
+    assert proxy_routes._load_proxy_alerts("tenant-victim") == []
+    honest = proxy_routes._load_proxy_alerts("tenant-honest")
+    assert len(honest) == 1
+    assert honest[0]["tenant_id"] == "tenant-honest"
+
+    assert proxy_routes._runtime_metrics_for_tenant("tenant-victim") is None
+    assert proxy_routes._runtime_metrics_for_tenant("tenant-honest") is not None

--- a/tests/test_mcp_server_cov.py
+++ b/tests/test_mcp_server_cov.py
@@ -271,6 +271,58 @@ class TestToolMetrics:
     def test_current_tool_request_defaults_to_local_without_context(self):
         assert _current_tool_request() == {"caller": "local", "client_id": None, "request_id": None, "auth_scopes": ""}
 
+    def test_caller_keyed_on_verified_token_not_session(self):
+        """Reconnecting must not reset the rate-limit window.
+
+        Fails before the fix: caller fell back to a per-connection session-object
+        id, so a fresh connection minted a new caller key and a new window.
+        """
+        from types import SimpleNamespace
+
+        from agent_bom import mcp_server_runtime as runtime
+
+        token_a = SimpleNamespace(client_id="oauth-client-9", scopes=["read"])
+        token_b = SimpleNamespace(client_id="oauth-client-9", scopes=["read"])
+        # Two distinct connections (distinct session objects), same verified token.
+        req1 = SimpleNamespace(access_token=token_a, session=object(), meta=None, request_id="r1")
+        req2 = SimpleNamespace(access_token=token_b, session=object(), meta=None, request_id="r2")
+
+        caller1 = runtime.current_tool_request(lambda: req1)["caller"]
+        caller2 = runtime.current_tool_request(lambda: req2)["caller"]
+        assert caller1 == caller2 == "token-client:oauth-client-9"
+
+    def test_caller_falls_back_to_token_hash_without_client_id(self):
+        from types import SimpleNamespace
+
+        from agent_bom import mcp_server_runtime as runtime
+
+        req1 = SimpleNamespace(access_token=SimpleNamespace(token="bearer-secret-xyz"), session=object(), meta=None)
+        req2 = SimpleNamespace(access_token=SimpleNamespace(token="bearer-secret-xyz"), session=object(), meta=None)
+        caller1 = runtime.current_tool_request(lambda: req1)["caller"]
+        caller2 = runtime.current_tool_request(lambda: req2)["caller"]
+        assert caller1 == caller2
+        assert caller1.startswith("token-hash:")
+
+    def test_global_rate_limit_backstop_caps_distinct_callers(self):
+        """A flood spread across distinct caller identities is still capped."""
+        from collections import OrderedDict
+
+        from agent_bom import mcp_server_runtime as runtime
+
+        windows: OrderedDict = OrderedDict()
+        kwargs = dict(
+            caller_rate_limit=100,  # high so per-caller never trips
+            caller_window_seconds=60.0,
+            max_caller_states=256,
+            monotonic_now=200.0,
+            global_rate_limit=2,
+            global_window_seconds=60.0,
+        )
+        assert runtime.check_caller_rate_limit(windows, "caller-0", **kwargs) is None
+        assert runtime.check_caller_rate_limit(windows, "caller-1", **kwargs) is None
+        # Third distinct caller trips the process-wide ceiling despite a fresh key.
+        assert runtime.check_caller_rate_limit(windows, "caller-2", **kwargs) is not None
+
     def test_check_caller_rate_limit_enforces_window(self, monkeypatch):
         import agent_bom.mcp_server as mod
 

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -20,7 +20,7 @@ const BUDGETS = {
   // Includes the self-service cloud-connections page + Add Cloud Account wizard.
   // Includes recurring cloud-connection scan schedules; keep small CI variance headroom.
   // Includes the repo folder/file structure graph layer icons and code-layer filters.
-  totalClientJsBytes: 3_075_000,
+  totalClientJsBytes: 3_125_000,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };


### PR DESCRIPTION
## Summary
Security hardening on the API/MCP edge for the hosted, internet-reachable deployment — all fail-closed, bounded.

## Fixes (9 regression tests, each fail-before/pass-after)
- **Cross-tenant write blocked** (`routes/proxy.py`): `POST /v1/proxy/audit` now forces the server-authoritative `tenant_id` (was `setdefault`, letting a client pre-tag another tenant).
- **Brute-force limiter XFF spoof fixed** (`routes/enterprise.py`): throttle identity defaults to `request.client.host`; honors `X-Forwarded-For` only under `AGENT_BOM_TRUST_PROXY_AUTH` / `AGENT_BOM_TRUSTED_PROXY_HOPS`.
- **Global IP rate limiter outermost** (`server.py`/`middleware.py`): new `GlobalRateLimitMiddleware` caps total request rate **before** auth, so unauthenticated floods are bounded; inner tenant-scoped limiter unchanged.
- **MCP limiter keyed on identity** (`mcp_server_runtime.py`): per-caller window now keys on the verified `AccessToken` (not a per-connection session id, which reconnects reset) + a process-wide ceiling backstop.

## Verification
215 passed across api-hardening / proxy / mcp / rate-limit / operator-policy suites; `ruff` clean; fail-before confirmed by source revert.