### PR TITLE
fix(ui): align connections screenshot spec with redesigned headings

### DIFF
--- a/ui/e2e/connections-screenshot.spec.ts
+++ b/ui/e2e/connections-screenshot.spec.ts
@@ -81,7 +81,8 @@ test("captures connections page and wizard", async ({ page }, testInfo) => {
 
   await page.goto("/connections");
   await page.waitForLoadState("networkidle");
-  await expect(page.getByRole("heading", { name: "Cloud accounts" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Connectors" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Connected accounts" })).toBeVisible();
   await expect(page.getByText("Production account")).toBeVisible();
   await page.screenshot({ path: testInfo.outputPath("connections-page.png"), fullPage: true });
   // Also write a stable copy under the worktree for reporting.


### PR DESCRIPTION
## Summary
- update the Connections page screenshot spec to assert the redesigned top-level `Connectors` heading
- keep coverage for the `Connected accounts` evidence table section so the screenshot still verifies the handoff surface
- fixes the main CI regression from the stale Connections screenshot assertion

Fixes #3343

## Validation
- `npm run lint -- e2e/connections-screenshot.spec.ts`
- `npm run test:e2e -- connections-screenshot.spec.ts --reporter=line`
- GitHub Actions `UI Validate` passed on the rebased branch