### PR TITLE
test(ui): align connections E2E heading with merged Connectors redesign

### DIFF
--- a/ui/e2e/connections-screenshot.spec.ts
+++ b/ui/e2e/connections-screenshot.spec.ts
@@ -81,7 +81,7 @@ test("captures connections page and wizard", async ({ page }, testInfo) => {
 
   await page.goto("/connections");
   await page.waitForLoadState("networkidle");
-  await expect(page.getByRole("heading", { name: "Cloud accounts" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Connectors" })).toBeVisible();
   await expect(page.getByText("Production account")).toBeVisible();
   await page.screenshot({ path: testInfo.outputPath("connections-page.png"), fullPage: true });
   // Also write a stable copy under the worktree for reporting.


### PR DESCRIPTION
Main is currently red on UI Validate for **every** PR: #3340 merged the connections redesign (`<h1>` `Cloud accounts` → `Connectors`) but its E2E spec fix landed on the branch *after* the squash-merge and was stranded. So main has page=`Connectors` / spec=`Cloud accounts` → `connections-screenshot.spec.ts:84` fails everywhere.

One-line alignment of the spec to the shipped page. Unblocks UI Validate across all open + future PRs.