### PR TITLE
feat(gateway): OAuth 2.1 AS conformance + inline A2A mutual-auth enforcement + per-tool-call scope/DLP

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -158,6 +158,22 @@ AGENT_BOM_GATEWAY_ANOMALY_ENFORCEMENT
 AGENT_BOM_GATEWAY_DRIFT_ENFORCEMENT
 # opt-in fleet-quarantine gateway enforcement mode (off|warn|enforce)
 AGENT_BOM_GATEWAY_FLEET_ENFORCEMENT
+# opt-in OAuth 2.1 Authorization Server (broker AS) on the gateway: mounts RFC 8414 metadata / RFC 7591 registration / PKCE authorize+token / JWKS; read in cli/_gateway.py
+AGENT_BOM_GATEWAY_ENABLE_OAUTH_AS
+# optional public issuer base URL for the gateway OAuth AS (default unset = derived per-request); read in cli/_gateway.py
+AGENT_BOM_GATEWAY_OAUTH_AS_ISSUER
+# RSA private key PEM that signs gateway OAuth AS access tokens (default unset = ephemeral key, tokens invalidated on restart); read in api/oauth_as.py
+AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM
+# opt-in inline A2A mutual-auth enforcement at the gateway relay (off|warn|enforce); read in cli/_gateway.py
+AGENT_BOM_GATEWAY_A2A_MUTUAL_AUTH_ENFORCEMENT
+# JSON file mapping tool names to required OAuth scopes for per-tool-call scope enforcement; read in cli/_gateway.py
+AGENT_BOM_GATEWAY_TOOL_SCOPE_MAP
+# opt-in DLP pass on gateway tool-call arguments and results (default OFF); read in cli/_gateway.py
+AGENT_BOM_GATEWAY_ENABLE_DLP
+# gateway DLP posture (audit|enforce, default audit); read in cli/_gateway.py
+AGENT_BOM_GATEWAY_DLP_MODE
+# how gateway DLP handles PII matches in enforce mode (redact|block, default redact); read in cli/_gateway.py
+AGENT_BOM_GATEWAY_DLP_PII_ACTION
 # opt-in graph-reachability gateway enforcement mode (off|warn|enforce) — consume direction
 AGENT_BOM_GATEWAY_GRAPH_REACHABILITY_ENFORCEMENT
 # scan-report JSON supplying agent->privileged-node graph reachability facts

--- a/src/agent_bom/a2a_auth_posture.py
+++ b/src/agent_bom/a2a_auth_posture.py
@@ -486,6 +486,73 @@ def _detect_unverified_actor_tokens(agents: list[Agent], policies: list[A2APolic
     return findings
 
 
+# ── Inline mutual-auth enforcement (assess → enforce) ─────────────────────────
+
+# Enforcement modes for the inline A2A mutual-auth gate at the relay.
+A2A_MUTUAL_AUTH_MODES = ("off", "warn", "enforce")
+
+# Sentinel matching agent_bom.agent_identity.ANONYMOUS without importing it here.
+ANONYMOUS_AGENT = "anonymous"
+
+
+@dataclass
+class InlineMutualAuthResult:
+    """Classification of one inter-agent / agent-MCP edge for inline enforcement."""
+
+    weak: bool
+    reason: str = ""
+    weakness: str = ""  # "invalid_identity" | "anonymous" | "unverified_identity"
+
+
+def evaluate_inline_mutual_auth(
+    *,
+    source_agent: str,
+    target: str,
+    token_present: bool,
+    verified: bool,
+    identity_invalid_reason: str | None = None,
+) -> InlineMutualAuthResult:
+    """Classify whether one relayed edge carries mutual authentication.
+
+    This is the inline, data-path counterpart to the reference-only posture
+    scan above: instead of producing a finding, it tells the gateway relay
+    whether the *current* call's caller→target edge is mutually authenticated so
+    the relay can DENY (enforce) or flag (warn) a weak edge.
+
+    An edge is weak when it does NOT carry a verified caller identity:
+      * ``invalid_identity`` — a token was presented but is invalid/revoked/
+        expired (``identity_invalid_reason`` set). Always weak.
+      * ``anonymous`` — no identity token at all (the downstream agent/MCP
+        cannot confirm who is calling).
+      * ``unverified_identity`` — a token resolved to a concrete agent but was
+        not cryptographically verified (opaque/shared/unsigned token, no
+        JWKS/AS signature), so it is not mutual auth.
+
+    Returns an :class:`InlineMutualAuthResult`; a verified, non-anonymous caller
+    yields ``weak=False``. Pure + deterministic — no I/O, no token values.
+    """
+    edge = f"{source_agent or ANONYMOUS_AGENT} -> {target or 'mcp'}"
+    if identity_invalid_reason:
+        return InlineMutualAuthResult(
+            weak=True,
+            reason=f"edge {edge} presents an invalid/revoked identity ({identity_invalid_reason})",
+            weakness="invalid_identity",
+        )
+    if not token_present or not source_agent or source_agent == ANONYMOUS_AGENT:
+        return InlineMutualAuthResult(
+            weak=True,
+            reason=f"edge {edge} has no verified caller identity (anonymous); mutual auth is required",
+            weakness="anonymous",
+        )
+    if not verified:
+        return InlineMutualAuthResult(
+            weak=True,
+            reason=(f"edge {edge} presents an unverified (opaque/shared/unsigned) identity; a signed/JWKS-backed token is required"),
+            weakness="unverified_identity",
+        )
+    return InlineMutualAuthResult(weak=False)
+
+
 # ── Public entry points ──────────────────────────────────────────────────────
 
 

--- a/src/agent_bom/agent_identity.py
+++ b/src/agent_bom/agent_identity.py
@@ -335,6 +335,37 @@ def check_identity(
     return agent_id, None
 
 
+def identity_token_scopes(token: str) -> set[str]:
+    """Extract OAuth scopes from a JWT identity token's claims.
+
+    Reads the standard ``scope`` (space-delimited string) or ``scp`` (string or
+    list) claim. Returns an empty set for opaque tokens or tokens without a
+    scope claim. The token's signature is NOT (re)verified here — callers must
+    have already validated the token (the gateway verifies via JWKS / the AS
+    before reading scopes), so this only parses the already-trusted payload.
+    """
+    if not _looks_like_jwt(token):
+        return set()
+    claims = _decode_jwt_payload(token)
+    if not isinstance(claims, dict):
+        return set()
+    return scopes_from_claims(claims)
+
+
+def scopes_from_claims(claims: dict) -> set[str]:
+    """Return the OAuth scope set declared in a JWT claims dict."""
+    scopes: set[str] = set()
+    raw_scope = claims.get("scope")
+    if isinstance(raw_scope, str):
+        scopes |= {s for s in raw_scope.replace(",", " ").split() if s}
+    scp = claims.get("scp")
+    if isinstance(scp, str):
+        scopes |= {s for s in scp.replace(",", " ").split() if s}
+    elif isinstance(scp, (list, tuple)):
+        scopes |= {str(s) for s in scp if str(s).strip()}
+    return scopes
+
+
 def check_caller_identity(
     msg: dict,
     policy: dict,

--- a/src/agent_bom/api/oauth_as.py
+++ b/src/agent_bom/api/oauth_as.py
@@ -1,0 +1,736 @@
+"""OAuth 2.1 Authorization Server for the MCP auth spec (broker AS).
+
+Implements the subset of OAuth 2.1 + the MCP authorization spec that lets a
+standard MCP client auto-discover and authenticate to agent-bom-brokered MCP
+servers fronted by the gateway:
+
+  * RFC 8414 authorization-server metadata
+    (``/.well-known/oauth-authorization-server``)
+  * RFC 7591 dynamic client registration (``/oauth/register``)
+  * PKCE-required authorization-code grant (S256 only; OAuth 2.1 forbids the
+    ``plain`` method and the implicit grant) at ``/oauth/authorize``
+  * token endpoint (``authorization_code`` + ``client_credentials``) at
+    ``/oauth/token``
+  * JWKS endpoint for RS256 access-token validation (``/oauth/jwks.json``)
+
+Access tokens are RS256 JWTs signed by a gateway-held key. The ``sub`` claim is
+the agent/client identity and ``scope`` carries the granted OAuth scopes that
+the per-tool-call scope mapping checks at the relay. The same JWTs validate
+through :mod:`agent_bom.agent_identity` (JWKS path), so an issued access token
+*is* the agent identity at the relay.
+
+Security posture (fail-closed + bounded):
+  * PKCE is mandatory for the code grant; ``code_challenge_method`` must be
+    ``S256``. The ``none`` JWT algorithm is never issued.
+  * Authorization codes are single-use, short-TTL, and bound to the client +
+    redirect_uri + PKCE challenge.
+  * Public clients (no secret) may only use the PKCE code grant; the
+    ``client_credentials`` grant requires a registered confidential client and
+    a verified secret.
+  * Every store is bounded (LRU eviction) so a registration/code flood cannot
+    exhaust memory.
+
+This module mints and validates tokens entirely in-process; it performs no
+outbound network calls. It is a deliberate, scoped auth-broker capability for
+the gateway only — the wider product remains read-only by default.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import os
+import secrets
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Bounded store sizes — a registration / code flood evicts oldest entries
+# rather than growing without limit.
+_MAX_CLIENTS = 2048
+_MAX_CODES = 4096
+
+# Default lifetimes (seconds). Codes are short-lived (single-use); access
+# tokens default to one hour. Both are clamped to sane bounds.
+_DEFAULT_CODE_TTL = 60
+_DEFAULT_TOKEN_TTL = 3600
+_MAX_TOKEN_TTL = 24 * 3600
+
+# RS256 only — OAuth 2.1 access tokens are signed with an asymmetric key so the
+# resource server (the relay) can validate without the signing secret.
+_SIGNING_ALG = "RS256"
+
+# Grant types this AS supports.
+_GRANT_AUTHZ_CODE = "authorization_code"
+_GRANT_CLIENT_CREDENTIALS = "client_credentials"
+_SUPPORTED_GRANTS = (_GRANT_AUTHZ_CODE, _GRANT_CLIENT_CREDENTIALS)
+
+
+class OAuthError(Exception):
+    """An OAuth protocol error with an RFC 6749 ``error`` code.
+
+    ``status`` is the HTTP status the endpoint should return; ``error`` is the
+    machine-readable code (e.g. ``invalid_request``, ``invalid_grant``).
+    """
+
+    def __init__(self, error: str, description: str = "", *, status: int = 400) -> None:
+        super().__init__(description or error)
+        self.error = error
+        self.description = description
+        self.status = status
+        # Set for errors that must be reported by redirecting back to the client.
+        self.redirect_location: str | None = None
+
+    def to_dict(self) -> dict[str, str]:
+        body = {"error": self.error}
+        if self.description:
+            body["error_description"] = self.description
+        return body
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_uint(value: int) -> str:
+    length = (value.bit_length() + 7) // 8 or 1
+    return _b64url(value.to_bytes(length, "big"))
+
+
+def _scope_set(scope: Any) -> set[str]:
+    if not scope or not isinstance(scope, str):
+        return set()
+    return {s for s in scope.replace(",", " ").split() if s}
+
+
+def _scope_str(scopes: set[str]) -> str:
+    return " ".join(sorted(scopes))
+
+
+# ── Signing key ──────────────────────────────────────────────────────────────
+
+
+class OAuthSigningKey:
+    """RSA signing key for access tokens, with a JWKS view for validation.
+
+    Loads a PEM private key from ``AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM`` when set
+    (so issued tokens survive a restart and are shared across replicas); else
+    generates an ephemeral RSA-2048 key and warns that tokens are invalidated on
+    restart. The ``kid`` is the RFC 7638 JWK thumbprint so it is stable for a
+    given key.
+    """
+
+    def __init__(self, private_pem: str | None = None) -> None:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        pem = private_pem if private_pem is not None else os.environ.get("AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM", "").strip()
+        if pem:
+            self._private_key = serialization.load_pem_private_key(pem.encode("utf-8"), password=None)
+            self._ephemeral = False
+        else:
+            self._private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+            self._ephemeral = True
+            logger.warning(
+                "OAuth AS using an EPHEMERAL signing key: issued access tokens are invalidated on "
+                "restart and are not shared across replicas. Set AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM "
+                "to a stable RSA private key for production."
+            )
+        self._public_key = self._private_key.public_key()
+        nums = self._public_key.public_numbers()
+        self._n = _b64url_uint(nums.n)
+        self._e = _b64url_uint(nums.e)
+        # RFC 7638 thumbprint over the canonical (lexicographically ordered) JWK.
+        thumb_input = f'{{"e":"{self._e}","kty":"RSA","n":"{self._n}"}}'.encode("ascii")
+        self.kid = _b64url(hashlib.sha256(thumb_input).digest())
+
+    @property
+    def ephemeral(self) -> bool:
+        return self._ephemeral
+
+    def sign(self, claims: dict[str, Any]) -> str:
+        import jwt as pyjwt
+
+        return pyjwt.encode(claims, self._private_pem(), algorithm=_SIGNING_ALG, headers={"kid": self.kid})
+
+    def _private_pem(self) -> bytes:
+        from cryptography.hazmat.primitives import serialization
+
+        return self._private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+
+    def public_jwk(self) -> dict[str, str]:
+        return {"kty": "RSA", "use": "sig", "alg": _SIGNING_ALG, "kid": self.kid, "n": self._n, "e": self._e}
+
+    def jwks(self) -> dict[str, list[dict[str, str]]]:
+        return {"keys": [self.public_jwk()]}
+
+    def verify(self, token: str, *, issuer: str | None = None) -> dict[str, Any]:
+        """Validate a token signed by this key. Raises on any failure."""
+        import jwt as pyjwt
+
+        options = {"require": ["exp", "iat"], "verify_aud": False}
+        return pyjwt.decode(
+            token,
+            self._public_key,
+            algorithms=[_SIGNING_ALG],
+            issuer=issuer,
+            options=options,
+        )
+
+
+# ── Registered clients + authorization codes ─────────────────────────────────
+
+
+@dataclass
+class RegisteredClient:
+    """A dynamically-registered OAuth client (RFC 7591)."""
+
+    client_id: str
+    client_name: str = ""
+    # SHA-256 hash of the client secret for confidential clients; empty for
+    # public (PKCE-only) clients. The raw secret is returned once at register
+    # time and never stored.
+    client_secret_hash: str = ""
+    redirect_uris: list[str] = field(default_factory=list)
+    grant_types: list[str] = field(default_factory=lambda: [_GRANT_AUTHZ_CODE])
+    scope: str = ""  # space-delimited allowed scopes ("" = no scope ceiling)
+    token_endpoint_auth_method: str = "none"
+    created_at: float = 0.0
+    # Subject this client authenticates as. Defaults to the client_id so the
+    # issued token's ``sub`` (the agent identity at the relay) is stable.
+    subject: str = ""
+
+    @property
+    def is_confidential(self) -> bool:
+        return bool(self.client_secret_hash)
+
+    def allowed_scopes(self) -> set[str]:
+        return _scope_set(self.scope)
+
+
+@dataclass
+class AuthorizationCode:
+    """A single-use, PKCE-bound authorization code."""
+
+    code: str
+    client_id: str
+    redirect_uri: str
+    code_challenge: str
+    code_challenge_method: str
+    scope: str
+    subject: str
+    expires_at: float
+    used: bool = False
+
+
+def _hash_secret(secret: str) -> str:
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()
+
+
+# ── Authorization server ──────────────────────────────────────────────────────
+
+
+class OAuthAuthorizationServer:
+    """In-process OAuth 2.1 Authorization Server for the gateway broker.
+
+    Thread-safe and bounded. ``issuer`` is the externally-reachable base URL of
+    the gateway; when ``None`` it is derived per-request from the incoming
+    request (so the AS works behind any host/proxy) and the first observed value
+    is cached for token ``iss`` stability.
+    """
+
+    def __init__(
+        self,
+        *,
+        issuer: str | None = None,
+        signing_key: OAuthSigningKey | None = None,
+        token_ttl_seconds: int = _DEFAULT_TOKEN_TTL,
+        code_ttl_seconds: int = _DEFAULT_CODE_TTL,
+        supported_scopes: list[str] | None = None,
+    ) -> None:
+        self._configured_issuer = issuer.rstrip("/") if issuer else None
+        self._observed_issuer: str | None = None
+        self.signing_key = signing_key or OAuthSigningKey()
+        self.token_ttl_seconds = max(60, min(int(token_ttl_seconds), _MAX_TOKEN_TTL))
+        self.code_ttl_seconds = max(10, min(int(code_ttl_seconds), 600))
+        self.supported_scopes = list(supported_scopes or [])
+        self._clients: OrderedDict[str, RegisteredClient] = OrderedDict()
+        self._codes: OrderedDict[str, AuthorizationCode] = OrderedDict()
+        self._lock = threading.Lock()
+
+    # -- issuer resolution -----------------------------------------------------
+
+    def resolve_issuer(self, request_base_url: str | None = None) -> str:
+        if self._configured_issuer:
+            return self._configured_issuer
+        if self._observed_issuer:
+            return self._observed_issuer
+        base = (request_base_url or "").rstrip("/")
+        if base:
+            with self._lock:
+                if self._observed_issuer is None:
+                    self._observed_issuer = base
+            return self._observed_issuer or base
+        return "http://localhost"
+
+    # -- RFC 8414 metadata -----------------------------------------------------
+
+    def metadata(self, request_base_url: str | None = None) -> dict[str, Any]:
+        issuer = self.resolve_issuer(request_base_url)
+        return {
+            "issuer": issuer,
+            "authorization_endpoint": f"{issuer}/oauth/authorize",
+            "token_endpoint": f"{issuer}/oauth/token",
+            "registration_endpoint": f"{issuer}/oauth/register",
+            "jwks_uri": f"{issuer}/oauth/jwks.json",
+            "scopes_supported": list(self.supported_scopes),
+            "response_types_supported": ["code"],
+            "response_modes_supported": ["query"],
+            "grant_types_supported": list(_SUPPORTED_GRANTS),
+            "token_endpoint_auth_methods_supported": ["none", "client_secret_basic", "client_secret_post"],
+            "code_challenge_methods_supported": ["S256"],
+            "token_endpoint_auth_signing_alg_values_supported": [_SIGNING_ALG],
+        }
+
+    def jwks(self) -> dict[str, Any]:
+        return self.signing_key.jwks()
+
+    # -- RFC 7591 dynamic client registration ----------------------------------
+
+    def register_client(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if not isinstance(payload, dict):
+            raise OAuthError("invalid_client_metadata", "registration body must be a JSON object")
+
+        redirect_uris = payload.get("redirect_uris", [])
+        if redirect_uris is None:
+            redirect_uris = []
+        if not isinstance(redirect_uris, list) or not all(isinstance(u, str) for u in redirect_uris):
+            raise OAuthError("invalid_redirect_uri", "redirect_uris must be a list of strings")
+        # Reject non-loopback plaintext redirect URIs (OAuth 2.1 §authorization).
+        for uri in redirect_uris:
+            self._validate_redirect_uri(uri)
+
+        grant_types_raw = payload.get("grant_types") or [_GRANT_AUTHZ_CODE]
+        if not isinstance(grant_types_raw, list):
+            raise OAuthError("invalid_client_metadata", "grant_types must be a list")
+        grant_types = [g for g in grant_types_raw if g in _SUPPORTED_GRANTS]
+        if not grant_types:
+            raise OAuthError("invalid_client_metadata", f"no supported grant_types (supported: {', '.join(_SUPPORTED_GRANTS)})")
+        if _GRANT_AUTHZ_CODE in grant_types and not redirect_uris:
+            raise OAuthError("invalid_redirect_uri", "authorization_code clients must register at least one redirect_uri")
+
+        auth_method = str(payload.get("token_endpoint_auth_method", "none"))
+        confidential = auth_method != "none" or _GRANT_CLIENT_CREDENTIALS in grant_types
+
+        scope = str(payload.get("scope", "") or "")
+        # When the AS advertises a scope ceiling, a client cannot register scopes
+        # outside it.
+        if self.supported_scopes:
+            requested = _scope_set(scope)
+            unknown = requested - set(self.supported_scopes)
+            if unknown:
+                raise OAuthError("invalid_scope", f"unsupported scope(s): {', '.join(sorted(unknown))}")
+
+        client_id = f"abc_{secrets.token_hex(12)}"
+        raw_secret = ""
+        secret_hash = ""
+        if confidential:
+            raw_secret = secrets.token_urlsafe(32)
+            secret_hash = _hash_secret(raw_secret)
+
+        subject = str(payload.get("subject") or payload.get("software_id") or client_id)
+        client = RegisteredClient(
+            client_id=client_id,
+            client_name=str(payload.get("client_name", "") or "")[:200],
+            client_secret_hash=secret_hash,
+            redirect_uris=list(redirect_uris),
+            grant_types=grant_types,
+            scope=scope,
+            token_endpoint_auth_method=auth_method if confidential else "none",
+            created_at=time.time(),
+            subject=subject[:200],
+        )
+        with self._lock:
+            self._clients[client_id] = client
+            self._evict(self._clients, _MAX_CLIENTS)
+
+        response: dict[str, Any] = {
+            "client_id": client_id,
+            "client_id_issued_at": int(client.created_at),
+            "redirect_uris": client.redirect_uris,
+            "grant_types": client.grant_types,
+            "token_endpoint_auth_method": client.token_endpoint_auth_method,
+            "scope": client.scope,
+            "response_types": ["code"] if _GRANT_AUTHZ_CODE in grant_types else [],
+        }
+        if client.client_name:
+            response["client_name"] = client.client_name
+        if raw_secret:
+            response["client_secret"] = raw_secret
+            response["client_secret_expires_at"] = 0  # non-expiring
+        return response
+
+    def get_client(self, client_id: str) -> RegisteredClient | None:
+        with self._lock:
+            return self._clients.get(client_id)
+
+    # -- authorization endpoint (PKCE-required code grant) ---------------------
+
+    def authorize(self, params: dict[str, Any]) -> str:
+        """Validate an authorization request and return a redirect URL with a code.
+
+        This is a machine-to-machine broker: a registered client that presents a
+        valid PKCE challenge is granted an authorization code immediately (no
+        interactive login UI). The code is bound to the client, redirect_uri and
+        PKCE challenge, and is single-use.
+
+        Raises :class:`OAuthError`. Errors that must be redirected back to the
+        client carry ``redirect_location`` (open-redirector protection: invalid
+        client / unregistered redirect_uri never redirect).
+        """
+        response_type = str(params.get("response_type", ""))
+        client_id = str(params.get("client_id", ""))
+        client = self.get_client(client_id)
+        if client is None:
+            raise OAuthError("invalid_client", "unknown client_id", status=400)
+
+        redirect_uri = str(params.get("redirect_uri", ""))
+        if not redirect_uri:
+            if len(client.redirect_uris) == 1:
+                redirect_uri = client.redirect_uris[0]
+            else:
+                raise OAuthError("invalid_request", "redirect_uri is required", status=400)
+        if redirect_uri not in client.redirect_uris:
+            # Never redirect to an unregistered URI.
+            raise OAuthError("invalid_request", "redirect_uri does not match a registered value", status=400)
+
+        state = str(params.get("state", "") or "")
+
+        # From here, errors redirect back to the validated redirect_uri.
+        if response_type != "code":
+            raise self._redirect_error(redirect_uri, "unsupported_response_type", "only response_type=code is supported", state)
+        if _GRANT_AUTHZ_CODE not in client.grant_types:
+            raise self._redirect_error(redirect_uri, "unauthorized_client", "client may not use the authorization_code grant", state)
+
+        code_challenge = str(params.get("code_challenge", "") or "")
+        code_challenge_method = str(params.get("code_challenge_method", "") or "")
+        if not code_challenge:
+            raise self._redirect_error(redirect_uri, "invalid_request", "PKCE code_challenge is required", state)
+        if code_challenge_method != "S256":
+            # OAuth 2.1 forbids "plain"; require S256 explicitly.
+            raise self._redirect_error(redirect_uri, "invalid_request", "code_challenge_method must be S256", state)
+
+        requested_scopes = _scope_set(params.get("scope"))
+        try:
+            granted_scopes = self._resolve_grant_scopes(client, requested_scopes)
+        except OAuthError as exc:
+            raise self._redirect_error(redirect_uri, exc.error, exc.description, state) from exc
+
+        code = f"abco_{secrets.token_urlsafe(24)}"
+        record = AuthorizationCode(
+            code=code,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            code_challenge=code_challenge,
+            code_challenge_method=code_challenge_method,
+            scope=_scope_str(granted_scopes),
+            subject=client.subject or client_id,
+            expires_at=time.time() + self.code_ttl_seconds,
+        )
+        with self._lock:
+            self._codes[code] = record
+            self._evict(self._codes, _MAX_CODES)
+
+        sep = "&" if "?" in redirect_uri else "?"
+        location = f"{redirect_uri}{sep}code={code}"
+        if state:
+            from urllib.parse import quote
+
+            location += f"&state={quote(state, safe='')}"
+        return location
+
+    # -- token endpoint --------------------------------------------------------
+
+    def token(
+        self,
+        form: dict[str, Any],
+        *,
+        basic_auth: tuple[str, str] | None = None,
+        request_base_url: str | None = None,
+    ) -> dict[str, Any]:
+        grant_type = str(form.get("grant_type", ""))
+        if grant_type == _GRANT_AUTHZ_CODE:
+            return self._token_authorization_code(form, basic_auth=basic_auth, request_base_url=request_base_url)
+        if grant_type == _GRANT_CLIENT_CREDENTIALS:
+            return self._token_client_credentials(form, basic_auth=basic_auth, request_base_url=request_base_url)
+        raise OAuthError("unsupported_grant_type", f"grant_type must be one of {', '.join(_SUPPORTED_GRANTS)}")
+
+    def _token_authorization_code(
+        self, form: dict[str, Any], *, basic_auth: tuple[str, str] | None, request_base_url: str | None
+    ) -> dict[str, Any]:
+        code = str(form.get("code", ""))
+        client_id, _client = self._authenticate_client(form, basic_auth, require_secret=False)
+
+        with self._lock:
+            record = self._codes.get(code)
+            already_used = bool(record and record.used)
+            # Single-use: mark used + drop on first valid presentation so a
+            # replay cannot mint a second token.
+            if record is not None:
+                record.used = True
+                self._codes.pop(code, None)
+
+        if record is None or already_used:
+            raise OAuthError("invalid_grant", "authorization code is invalid")
+        if record.client_id != client_id:
+            raise OAuthError("invalid_grant", "authorization code was issued to a different client")
+        if time.time() > record.expires_at:
+            raise OAuthError("invalid_grant", "authorization code expired")
+        redirect_uri = str(form.get("redirect_uri", ""))
+        if redirect_uri and redirect_uri != record.redirect_uri:
+            raise OAuthError("invalid_grant", "redirect_uri mismatch")
+
+        # PKCE verification (S256): SHA-256(verifier) b64url == stored challenge.
+        verifier = str(form.get("code_verifier", ""))
+        if not verifier:
+            raise OAuthError("invalid_request", "code_verifier is required (PKCE)")
+        computed = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+        if not secrets.compare_digest(computed, record.code_challenge):
+            raise OAuthError("invalid_grant", "PKCE verification failed")
+
+        return self._issue_access_token(
+            subject=record.subject,
+            client_id=client_id,
+            scopes=_scope_set(record.scope),
+            request_base_url=request_base_url,
+        )
+
+    def _token_client_credentials(
+        self, form: dict[str, Any], *, basic_auth: tuple[str, str] | None, request_base_url: str | None
+    ) -> dict[str, Any]:
+        client_id, client = self._authenticate_client(form, basic_auth, require_secret=True)
+        if _GRANT_CLIENT_CREDENTIALS not in client.grant_types:
+            raise OAuthError("unauthorized_client", "client may not use the client_credentials grant")
+        requested = _scope_set(form.get("scope"))
+        granted = self._resolve_grant_scopes(client, requested)
+        return self._issue_access_token(
+            subject=client.subject or client_id,
+            client_id=client_id,
+            scopes=granted,
+            request_base_url=request_base_url,
+        )
+
+    def _issue_access_token(
+        self, *, subject: str, client_id: str, scopes: set[str], request_base_url: str | None
+    ) -> dict[str, Any]:
+        now = int(time.time())
+        issuer = self.resolve_issuer(request_base_url)
+        claims = {
+            "iss": issuer,
+            "sub": subject,
+            "aud": "agent-bom-gateway",
+            "client_id": client_id,
+            "iat": now,
+            "exp": now + self.token_ttl_seconds,
+            "jti": secrets.token_hex(16),
+            "scope": _scope_str(scopes),
+        }
+        access_token = self.signing_key.sign(claims)
+        response: dict[str, Any] = {
+            "access_token": access_token,
+            "token_type": "Bearer",
+            "expires_in": self.token_ttl_seconds,
+        }
+        if scopes:
+            response["scope"] = _scope_str(scopes)
+        return response
+
+    # -- token validation (used by the relay, in-process) ----------------------
+
+    def validate_token(self, token: str) -> dict[str, Any] | None:
+        """Return verified claims for an AS-issued token, or None if invalid.
+
+        Verifies the RS256 signature against this server's key and enforces
+        ``exp``. Never raises — an invalid/expired/foreign token returns None so
+        the caller fails closed without leaking the reason to the client.
+        """
+        if not token or token.count(".") != 2:
+            return None
+        try:
+            return self.signing_key.verify(token)
+        except Exception:  # noqa: BLE001 — any verification failure → not our token
+            return None
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _authenticate_client(
+        self, form: dict[str, Any], basic_auth: tuple[str, str] | None, *, require_secret: bool
+    ) -> tuple[str, RegisteredClient]:
+        client_id = ""
+        client_secret = ""
+        if basic_auth is not None:
+            client_id, client_secret = basic_auth
+        if not client_id:
+            client_id = str(form.get("client_id", ""))
+        if not client_secret:
+            client_secret = str(form.get("client_secret", ""))
+
+        client = self.get_client(client_id)
+        if client is None:
+            raise OAuthError("invalid_client", "unknown client_id", status=401)
+
+        if client.is_confidential:
+            if not client_secret or not secrets.compare_digest(_hash_secret(client_secret), client.client_secret_hash):
+                raise OAuthError("invalid_client", "client authentication failed", status=401)
+        elif require_secret:
+            raise OAuthError("invalid_client", "client_credentials requires a confidential client", status=401)
+        return client_id, client
+
+    def _resolve_grant_scopes(self, client: RegisteredClient, requested: set[str]) -> set[str]:
+        ceiling = client.allowed_scopes()
+        if requested:
+            if ceiling:
+                unknown = requested - ceiling
+                if unknown:
+                    raise OAuthError("invalid_scope", f"requested scope(s) outside client grant: {', '.join(sorted(unknown))}")
+                return requested
+            return requested
+        return set(ceiling)
+
+    def _validate_redirect_uri(self, uri: str) -> None:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(uri)
+        if parsed.scheme == "https":
+            return
+        if parsed.scheme == "http":
+            host = (parsed.hostname or "").lower()
+            if host in ("localhost", "127.0.0.1", "::1"):
+                return
+            raise OAuthError("invalid_redirect_uri", "http redirect_uri is only allowed for loopback hosts")
+        # Custom/native schemes (e.g. an app callback) are permitted but must be
+        # absolute with a scheme.
+        if parsed.scheme and (parsed.netloc or parsed.path):
+            return
+        raise OAuthError("invalid_redirect_uri", f"invalid redirect_uri: {uri!r}")
+
+    @staticmethod
+    def _redirect_error(redirect_uri: str, error: str, description: str, state: str) -> OAuthError:
+        from urllib.parse import quote
+
+        sep = "&" if "?" in redirect_uri else "?"
+        location = f"{redirect_uri}{sep}error={quote(error, safe='')}&error_description={quote(description, safe='')}"
+        if state:
+            location += f"&state={quote(state, safe='')}"
+        exc = OAuthError(error, description, status=302)
+        exc.redirect_location = location
+        return exc
+
+    @staticmethod
+    def _evict(store: OrderedDict, max_size: int) -> None:
+        while len(store) > max_size:
+            store.popitem(last=False)
+
+
+def _basic_auth_from_header(authorization: str | None) -> tuple[str, str] | None:
+    """Parse an HTTP Basic ``Authorization`` header into (client_id, secret)."""
+    if not authorization or not authorization.lower().startswith("basic "):
+        return None
+    try:
+        decoded = base64.b64decode(authorization[6:].strip()).decode("utf-8")
+    except Exception:  # noqa: BLE001
+        return None
+    if ":" not in decoded:
+        return None
+    client_id, secret = decoded.split(":", 1)
+    return client_id, secret
+
+
+def build_oauth_as_router(server: OAuthAuthorizationServer):
+    """Build a FastAPI router exposing the OAuth 2.1 AS endpoints.
+
+    Mounted on the gateway app so a standard MCP client can discover the AS via
+    ``/.well-known/oauth-authorization-server`` and complete the PKCE flow.
+    """
+    from fastapi import APIRouter, Request
+    from fastapi.responses import JSONResponse, RedirectResponse
+
+    # The module uses ``from __future__ import annotations`` so route-handler
+    # type hints are strings; FastAPI resolves them against the module globals.
+    # Expose the FastAPI symbols there so ``request: Request`` resolves to the
+    # real type (otherwise FastAPI treats it as a query parameter).
+    globals().update({"Request": Request, "JSONResponse": JSONResponse, "RedirectResponse": RedirectResponse})
+
+    router = APIRouter()
+
+    def _request_base_url(request: Request) -> str:
+        # Honor a trusted reverse proxy's forwarded host/proto when present.
+        proto = (request.headers.get("x-forwarded-proto", "") or request.url.scheme).split(",")[0].strip()
+        host = (request.headers.get("x-forwarded-host", "") or request.headers.get("host", "")).split(",")[0].strip()
+        if host:
+            return f"{proto}://{host}"
+        return str(request.base_url).rstrip("/")
+
+    @router.get("/.well-known/oauth-authorization-server")
+    async def authorization_server_metadata(request: Request) -> JSONResponse:
+        return JSONResponse(server.metadata(_request_base_url(request)))
+
+    @router.get("/oauth/jwks.json")
+    async def jwks(_request: Request) -> JSONResponse:
+        return JSONResponse(server.jwks())
+
+    @router.post("/oauth/register")
+    async def register(request: Request) -> JSONResponse:
+        try:
+            payload = await request.json()
+        except Exception:  # noqa: BLE001
+            return JSONResponse({"error": "invalid_client_metadata", "error_description": "body must be JSON"}, status_code=400)
+        try:
+            registered = server.register_client(payload if isinstance(payload, dict) else {})
+        except OAuthError as exc:
+            return JSONResponse(exc.to_dict(), status_code=exc.status)
+        return JSONResponse(registered, status_code=201)
+
+    @router.get("/oauth/authorize")
+    async def authorize(request: Request):
+        params = dict(request.query_params)
+        try:
+            location = server.authorize(params)
+        except OAuthError as exc:
+            if exc.redirect_location:
+                return RedirectResponse(exc.redirect_location, status_code=302)
+            return JSONResponse(exc.to_dict(), status_code=exc.status)
+        return RedirectResponse(location, status_code=302)
+
+    @router.post("/oauth/token")
+    async def token(request: Request) -> JSONResponse:
+        form = dict(await request.form())
+        basic_auth = _basic_auth_from_header(request.headers.get("authorization"))
+        try:
+            issued = server.token(form, basic_auth=basic_auth, request_base_url=_request_base_url(request))
+        except OAuthError as exc:
+            headers = {"WWW-Authenticate": "Basic"} if exc.status == 401 else None
+            return JSONResponse(exc.to_dict(), status_code=exc.status, headers=headers)
+        # Tokens must never be cached (OAuth 2.1 §token-response).
+        return JSONResponse(issued, headers={"Cache-Control": "no-store", "Pragma": "no-cache"})
+
+    return router
+
+
+__all__ = [
+    "AuthorizationCode",
+    "OAuthAuthorizationServer",
+    "OAuthError",
+    "OAuthSigningKey",
+    "RegisteredClient",
+    "build_oauth_as_router",
+]

--- a/src/agent_bom/api/oauth_as.py
+++ b/src/agent_bom/api/oauth_as.py
@@ -141,8 +141,12 @@ class OAuthSigningKey:
                 "restart and are not shared across replicas. Set AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM "
                 "to a stable RSA private key for production."
             )
-        self._public_key = self._private_key.public_key()
-        nums = self._public_key.public_numbers()
+        pub = self._private_key.public_key()
+        # RS256 keypair: the key is always RSA (generated or PEM-loaded above).
+        # Narrow from cryptography's broad public-key union for the RSA-only API.
+        assert isinstance(pub, rsa.RSAPublicKey)
+        self._public_key = pub
+        nums = pub.public_numbers()
         self._n = _b64url_uint(nums.n)
         self._e = _b64url_uint(nums.e)
         # RFC 7638 thumbprint over the canonical (lexicographically ordered) JWK.
@@ -177,13 +181,12 @@ class OAuthSigningKey:
         """Validate a token signed by this key. Raises on any failure."""
         import jwt as pyjwt
 
-        options = {"require": ["exp", "iat"], "verify_aud": False}
         return pyjwt.decode(
             token,
             self._public_key,
             algorithms=[_SIGNING_ALG],
             issuer=issuer,
-            options=options,
+            options={"require": ["exp", "iat"], "verify_aud": False},
         )
 
 

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -289,6 +289,61 @@ def init_policy_cmd(output_path: Path, mode: str, output_format: str, tenant_id:
     ),
 )
 @click.option(
+    "--enable-oauth-as",
+    is_flag=True,
+    envvar="AGENT_BOM_GATEWAY_ENABLE_OAUTH_AS",
+    default=False,
+    help=(
+        "Mount an OAuth 2.1 Authorization Server (RFC 8414 metadata, RFC 7591 dynamic "
+        "registration, PKCE authorize+token, JWKS) so standard MCP clients can auto-authenticate. "
+        "Set AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM for a stable signing key."
+    ),
+)
+@click.option(
+    "--oauth-as-issuer",
+    envvar="AGENT_BOM_GATEWAY_OAUTH_AS_ISSUER",
+    default=None,
+    help="Public issuer base URL for the OAuth AS (defaults to the request URL when unset).",
+)
+@click.option(
+    "--a2a-mutual-auth-enforcement",
+    type=click.Choice(["off", "warn", "enforce"]),
+    envvar="AGENT_BOM_GATEWAY_A2A_MUTUAL_AUTH_ENFORCEMENT",
+    default="off",
+    show_default=True,
+    help="Inline A2A mutual-auth: 'enforce' rejects unauthenticated/unverified inter-agent edges, 'warn' audits them.",
+)
+@click.option(
+    "--tool-scope-map",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    envvar="AGENT_BOM_GATEWAY_TOOL_SCOPE_MAP",
+    default=None,
+    help='JSON file mapping tool names to required OAuth scopes, e.g. {"fs.write": ["tools:write"]}. "*" applies to all tools.',
+)
+@click.option(
+    "--enable-dlp",
+    is_flag=True,
+    envvar="AGENT_BOM_GATEWAY_ENABLE_DLP",
+    default=False,
+    help="Run a DLP pass on tool-call arguments and results (injection/PII/secrets/payload-vuln).",
+)
+@click.option(
+    "--dlp-mode",
+    type=click.Choice(["audit", "enforce"]),
+    envvar="AGENT_BOM_GATEWAY_DLP_MODE",
+    default="audit",
+    show_default=True,
+    help="DLP posture: 'enforce' blocks/redacts sensitive content, 'audit' only flags it.",
+)
+@click.option(
+    "--dlp-pii-action",
+    type=click.Choice(["redact", "block"]),
+    envvar="AGENT_BOM_GATEWAY_DLP_PII_ACTION",
+    default="redact",
+    show_default=True,
+    help="How DLP handles PII matches in enforce mode.",
+)
+@click.option(
     "--allow-visual-leak-best-effort",
     is_flag=True,
     default=False,
@@ -321,6 +376,13 @@ def serve_cmd(
     fleet_enforcement: str,
     graph_reachability_path: Path | None,
     graph_reachability_enforcement: str,
+    enable_oauth_as: bool,
+    oauth_as_issuer: str | None,
+    a2a_mutual_auth_enforcement: str,
+    tool_scope_map: Path | None,
+    enable_dlp: bool,
+    dlp_mode: str,
+    dlp_pii_action: str,
     allow_visual_leak_best_effort: bool,
     log_level: str,
 ) -> None:
@@ -428,6 +490,29 @@ def serve_cmd(
         control_plane_policies = [p for p in bundle_list if isinstance(p, dict)]
         click.echo(f"loaded {len(control_plane_policies)} control-plane policy/policies from {policy_bundle_path}")
 
+    # OAuth 2.1 broker AS (opt-in). Built once at startup; reuses an env-supplied
+    # signing key when present so issued tokens survive a restart.
+    oauth_as = None
+    if enable_oauth_as:
+        from agent_bom.api.oauth_as import OAuthAuthorizationServer
+
+        oauth_as = OAuthAuthorizationServer(issuer=oauth_as_issuer)
+        click.echo(f"OAuth 2.1 AS enabled (issuer={oauth_as_issuer or '<derived from request>'})")
+
+    tool_scope_mapping: dict[str, list[str]] = {}
+    if tool_scope_map is not None:
+        raw_map = read_json_file_for_cli(tool_scope_map, label="tool scope map")
+        if not isinstance(raw_map, dict):
+            raise click.ClickException("--tool-scope-map must be a JSON object of {tool_name: [scope, ...]}")
+        for tool, scopes in raw_map.items():
+            if isinstance(scopes, str):
+                tool_scope_mapping[str(tool)] = [scopes]
+            elif isinstance(scopes, list):
+                tool_scope_mapping[str(tool)] = [str(s) for s in scopes if str(s).strip()]
+            else:
+                raise click.ClickException(f"--tool-scope-map value for {tool!r} must be a string or list of strings")
+        click.echo(f"loaded OAuth scope requirements for {len(tool_scope_mapping)} tool(s)")
+
     settings = GatewaySettings(
         registry=registry,
         policy=policy,
@@ -450,6 +535,12 @@ def serve_cmd(
         fleet_enforcement_mode=fleet_enforcement,
         graph_reachability_path=graph_reachability_path,
         graph_reachability_enforcement_mode=graph_reachability_enforcement,
+        oauth_as=oauth_as,
+        a2a_mutual_auth_enforcement_mode=a2a_mutual_auth_enforcement,
+        tool_scope_map=tool_scope_mapping,
+        dlp_enabled=enable_dlp,
+        dlp_mode=dlp_mode,
+        dlp_pii_action=dlp_pii_action,
     )
     app = create_gateway_app(settings)
     policy_summary = summarize_policy_bundle(policy)

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -43,10 +43,18 @@ from typing import Any, Awaitable, Callable
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response
 
-from agent_bom.agent_identity import ANONYMOUS, check_caller_identity, extract_identity_token
+from agent_bom.a2a_auth_posture import evaluate_inline_mutual_auth
+from agent_bom.agent_identity import (
+    ANONYMOUS,
+    check_caller_identity,
+    extract_identity_token,
+    identity_token_scopes,
+    scopes_from_claims,
+)
 from agent_bom.api.auth import Role, get_key_store
 from agent_bom.api.metrics import record_gateway_relay, record_rate_limit_hit
 from agent_bom.api.middleware import InMemoryRateLimitStore, PostgresRateLimitStore
+from agent_bom.api.oauth_as import OAuthAuthorizationServer, build_oauth_as_router
 from agent_bom.api.tracing import get_tracer, inject_trace_headers, make_request_trace
 from agent_bom.firewall import (
     AgentFirewallPolicy,
@@ -70,6 +78,7 @@ from agent_bom.proxy_policy import (
     resolve_fail_mode,
     summarize_policy_bundle,
 )
+from agent_bom.proxy_scanner import ScanConfig, redact_pii, scan_tool_call, scan_tool_response
 from agent_bom.runtime.graph_reachability import ReachabilityMap, load_reachability_map
 
 logger = logging.getLogger(__name__)
@@ -106,6 +115,9 @@ def _public_gateway_block_reason(policy_source: str) -> str:
         "fleet_quarantine": "Agent is quarantined in the fleet roster",
         "identity_scope": "Identity scope blocked this tool",
         "identity_jit": "Gateway policy blocked this request",
+        "a2a_mutual_auth": "Inter-agent mutual authentication is required for this edge",
+        "oauth_scope": "The caller's OAuth token is missing a required scope for this tool",
+        "dlp": "Data-loss-prevention policy blocked sensitive content in this request",
         "firewall": "Inter-agent firewall blocked this request",
         "graph_reachability": "Graph reachability policy blocked this request",
         "policy_plugin": "A gateway policy plugin blocked this request",
@@ -210,6 +222,60 @@ class GatewaySettings:
     # AGENT_BOM_POLICY_WEBHOOK_TOKEN when left as ``None``.
     policy_webhook_url: str | None = None
     policy_webhook_token: str | None = None
+    # OAuth 2.1 Authorization Server (broker AS). When set, the gateway mounts
+    # the RFC 8414 metadata / RFC 7591 registration / PKCE authorize+token /
+    # JWKS endpoints so standard MCP clients can auto-authenticate, and accepts
+    # AS-issued access tokens (Authorization: Bearer or _meta.agent_identity) as
+    # the caller's verified agent identity. None = AS disabled (no behaviour
+    # change). The OAuth scopes carried in the token feed ``tool_scope_map``.
+    oauth_as: OAuthAuthorizationServer | None = None
+    # A2A inline mutual-auth enforcement. "off" (default) keeps the existing
+    # identity posture; "warn" audits weak (anonymous / unverified / invalid)
+    # inter-agent / agent-MCP edges; "enforce" rejects them inline at the relay.
+    # An edge is mutually authenticated only when the caller presents a
+    # cryptographically-verified identity (AS token, JWKS-verified JWT, or an
+    # agent-bom-issued managed token).
+    a2a_mutual_auth_enforcement_mode: str = "off"
+    # Per-tool-call OAuth scope mapping. ``{tool_name: [required_scope, ...]}``;
+    # a "*" key applies to every tool. A tool call is denied when the caller's
+    # token scopes do not include every required scope for that tool. Empty map
+    # = no scope gating (no behaviour change).
+    tool_scope_map: dict[str, list[str]] = field(default_factory=dict)
+    # Data-loss prevention on tool-call arguments and tool results. Off by
+    # default. "audit" flags sensitive-data matches; "enforce" blocks the call
+    # (secrets / payload-vuln / injection) and redacts PII in arguments and
+    # results before they cross the relay. Reuses the inline proxy scanner.
+    dlp_enabled: bool = False
+    dlp_mode: str = "audit"  # "audit" | "enforce"
+    dlp_pii_action: str = "redact"  # "redact" | "block"
+    dlp_scanners: list[str] = field(default_factory=lambda: ["injection", "pii", "secrets", "payload_vuln"])
+
+
+def _gateway_dlp_config(settings: GatewaySettings) -> ScanConfig:
+    """Build the inline-scanner config for the gateway DLP pass."""
+    return ScanConfig(
+        enabled=settings.dlp_enabled,
+        mode=settings.dlp_mode if settings.dlp_mode in ("audit", "enforce") else "audit",
+        scanners=list(settings.dlp_scanners),
+        pii_action=settings.dlp_pii_action if settings.dlp_pii_action in ("redact", "block") else "redact",
+    )
+
+
+def _redact_obj_pii(value: Any, *, depth: int = 0) -> Any:
+    """Recursively redact PII in string leaves of a JSON-RPC result.
+
+    Bounded depth so a deeply-nested or adversarial result cannot cause runaway
+    recursion. Non-string scalars pass through unchanged.
+    """
+    if depth > 12:
+        return value
+    if isinstance(value, str):
+        return redact_pii(value)
+    if isinstance(value, dict):
+        return {k: _redact_obj_pii(v, depth=depth + 1) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_obj_pii(v, depth=depth + 1) for v in value]
+    return value
 
 
 def _agent_cost_anomaly(tenant_id: str, source_agent: str) -> tuple[bool, str]:
@@ -757,6 +823,15 @@ def _authenticate_gateway_request(request: Request, settings: GatewaySettings) -
             raise HTTPException(status_code=401, detail="gateway authentication required")
         return "default", "static_gateway_token"
 
+    # OAuth 2.1 broker: a standard MCP client presenting an AS-issued access
+    # token in the Authorization header satisfies transport auth (the AS already
+    # authenticated the client + bound the token via PKCE). Only AS-signed,
+    # unexpired tokens pass; any other bearer falls through to API-key auth.
+    if settings.oauth_as is not None and raw_token:
+        claims = settings.oauth_as.validate_token(raw_token)
+        if claims is not None:
+            return "default", "oauth_as"
+
     try:
         store = get_key_store()
         has_keys = store.has_keys()
@@ -1052,6 +1127,17 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
 
     app = FastAPI(title="agent-bom gateway", version="1", lifespan=_lifespan)
 
+    # OAuth 2.1 Authorization Server (broker AS): mount the unauthenticated
+    # discovery/registration/PKCE/token/JWKS endpoints so standard MCP clients
+    # can auto-authenticate to brokered MCPs. These deliberately sit outside the
+    # gateway transport-auth gate — they ARE the auth bootstrap.
+    if settings.oauth_as is not None:
+        app.include_router(build_oauth_as_router(settings.oauth_as))
+        if settings.oauth_as.signing_key.ephemeral:
+            logger.warning("gateway OAuth AS enabled with an ephemeral signing key; set AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM for production")
+
+    dlp_config = _gateway_dlp_config(settings)
+
     @app.get("/healthz")
     async def healthz() -> dict[str, Any]:
         async with policy_lock:
@@ -1094,6 +1180,13 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             "rate_limit_runtime": _gateway_rate_limit_runtime_status(settings),
             "policy_runtime": policy_runtime,
             "firewall_runtime": firewall_runtime,
+            "broker_runtime": {
+                "oauth_as_enabled": settings.oauth_as is not None,
+                "a2a_mutual_auth_enforcement_mode": settings.a2a_mutual_auth_enforcement_mode,
+                "tool_scope_mapped_tools": len(settings.tool_scope_map),
+                "dlp_enabled": settings.dlp_enabled,
+                "dlp_mode": settings.dlp_mode if settings.dlp_enabled else "disabled",
+            },
         }
         if settings.enable_visual_leak_detection:
             from agent_bom.runtime.visual_leak_detector import visual_leak_runtime_health
@@ -1331,8 +1424,43 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         #   3. fully-missing token — permitted on a loopback bind (local dev)
         #      or with the explicit opt-out, else fail closed by default on a
         #      non-loopback bind (mirrors the transport-auth opt-out precedent).
-        source_agent, token_present, identity_invalid_reason = check_caller_identity(message, current_policy)
-        source_agent = source_agent or ANONYMOUS
+        # An OAuth-2.1 AS access token (broker mode) is a cryptographically
+        # verified identity: validate it in-process (no self-HTTP) and prefer it
+        # over the _meta channel. Standard MCP clients present it in the
+        # Authorization header; we also accept it in _meta.agent_identity. The
+        # ``scope`` claim drives per-tool-call scope enforcement below.
+        identity_token = extract_identity_token(message)
+        as_claims: dict[str, Any] | None = None
+        token_scopes: set[str] = set()
+        if settings.oauth_as is not None:
+            for candidate in (identity_token, _extract_request_token(request)):
+                if candidate:
+                    as_claims = settings.oauth_as.validate_token(candidate)
+                    if as_claims is not None:
+                        identity_token = candidate
+                        break
+
+        if as_claims is not None:
+            source_agent = str(as_claims.get("sub") or "").strip() or ANONYMOUS
+            token_present = True
+            identity_invalid_reason = None
+            identity_verified = source_agent != ANONYMOUS
+            token_scopes = scopes_from_claims(as_claims)
+        else:
+            source_agent, token_present, identity_invalid_reason = check_caller_identity(message, current_policy)
+            source_agent = source_agent or ANONYMOUS
+            # "Verified" for inline mutual-auth: a resolved, non-anonymous caller
+            # whose token was cryptographically checked — JWKS/OIDC-signed JWT or
+            # an agent-bom-issued managed (``abi_``) token. An opaque
+            # policy.agent_tokens mapping is NOT verified mutual auth.
+            identity_verified = bool(
+                token_present
+                and identity_invalid_reason is None
+                and source_agent != ANONYMOUS
+                and (current_policy.get("jwks_uri") or current_policy.get("oidc_issuer") or (identity_token or "").startswith("abi_"))
+            )
+            if identity_token and identity_invalid_reason is None:
+                token_scopes = identity_token_scopes(identity_token)
 
         identity_block_reason: str | None = None
         if identity_invalid_reason is not None:
@@ -1377,6 +1505,69 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 },
                 status_code=200,
             )
+
+        # A2A inline mutual-auth enforcement (assess → enforce). When enabled,
+        # every inter-agent / agent-MCP edge must carry a cryptographically
+        # verified caller identity; an anonymous / unverified / invalid edge is
+        # flagged ("warn") or rejected closed ("enforce") in-path. Off by
+        # default so the existing identity posture is unchanged.
+        if settings.a2a_mutual_auth_enforcement_mode in ("warn", "enforce"):
+            ma_result = evaluate_inline_mutual_auth(
+                source_agent=source_agent,
+                target=upstream.name,
+                token_present=token_present,
+                verified=identity_verified,
+                identity_invalid_reason=identity_invalid_reason,
+            )
+            if ma_result.weak:
+                if settings.audit_sink is not None:
+                    await settings.audit_sink(
+                        {
+                            "action": "gateway.a2a_mutual_auth_blocked"
+                            if settings.a2a_mutual_auth_enforcement_mode == "enforce"
+                            else "gateway.a2a_mutual_auth_warned",
+                            "upstream": upstream.name,
+                            "tenant_id": tenant_id,
+                            "source_agent": source_agent,
+                            "target_agent": upstream.name,
+                            "weakness": ma_result.weakness,
+                            "reason": ma_result.reason,
+                        }
+                    )
+                if settings.a2a_mutual_auth_enforcement_mode == "enforce":
+                    record_gateway_relay(upstream.name, "blocked")
+                    _emit_gateway_governance_event(
+                        "a2a.mutual_auth_blocked",
+                        tenant_id=tenant_id,
+                        subject_id=source_agent,
+                        payload={
+                            "source_agent": source_agent,
+                            "target_agent": upstream.name,
+                            "weakness": ma_result.weakness,
+                            "reason": ma_result.reason,
+                        },
+                    )
+                    logger.info(
+                        "Gateway A2A mutual-auth blocked edge source_agent=%s target=%s weakness=%s",
+                        _sanitize_for_log(source_agent),
+                        _sanitize_for_log(upstream.name),
+                        _sanitize_for_log(ma_result.weakness),
+                    )
+                    return JSONResponse(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": message.get("id"),
+                            "error": {
+                                "code": -32001,
+                                "message": "Blocked by agent-bom gateway: inter-agent mutual authentication required",
+                                "data": {
+                                    "reason": _public_gateway_block_reason("a2a_mutual_auth"),
+                                    "policy_source": "a2a_mutual_auth",
+                                },
+                            },
+                        },
+                        status_code=200,
+                    )
 
         # Inter-agent firewall enforcement in the data path (#982 PR 2). The
         # firewall is only consulted when an operator actually configured a
@@ -1946,6 +2137,70 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 elif composed == GatewayDecision.QUARANTINE:
                     quarantine, quarantine_reason, policy_source = True, composed_reason, composed_source
 
+            # Per-tool-call OAuth scope mapping. A tool with a configured
+            # required-scope set is denied unless the caller's token (AS-issued
+            # or JWKS-signed) carries every required scope. The "*" key applies a
+            # baseline scope to every tool. Empty map = no scope gating.
+            if allowed and settings.tool_scope_map:
+                required_scopes: set[str] = set()
+                for key in ("*", tool_name):
+                    mapped = settings.tool_scope_map.get(key)
+                    if mapped:
+                        required_scopes |= {s for s in mapped if s}
+                if required_scopes:
+                    missing = required_scopes - token_scopes
+                    if missing:
+                        allowed, reason, policy_source = (
+                            False,
+                            f"caller token missing required OAuth scope(s) for '{tool_name}': {', '.join(sorted(missing))}",
+                            "oauth_scope",
+                        )
+                        if settings.audit_sink is not None:
+                            await settings.audit_sink(
+                                {
+                                    "action": "gateway.oauth_scope_blocked",
+                                    "upstream": upstream.name,
+                                    "tenant_id": tenant_id,
+                                    "source_agent": source_agent,
+                                    "tool": tool_name,
+                                    "required_scopes": sorted(required_scopes),
+                                    "missing_scopes": sorted(missing),
+                                }
+                            )
+
+            # DLP pass on tool-call arguments. Reuses the inline proxy scanner
+            # (injection / PII / secrets / payload-vuln). In enforce mode a
+            # blocked finding (secrets/payload/injection) denies the call;
+            # sensitive args are redacted in-place before forwarding when
+            # pii_action=redact. Audit-only otherwise.
+            if allowed and dlp_config.enabled:
+                arg_findings = scan_tool_call(tool_name, arguments, dlp_config)
+                if arg_findings and settings.audit_sink is not None:
+                    await settings.audit_sink(
+                        {
+                            "action": "gateway.dlp_arguments",
+                            "upstream": upstream.name,
+                            "tenant_id": tenant_id,
+                            "source_agent": source_agent,
+                            "tool": tool_name,
+                            "findings": sorted({f"{f.scanner}/{f.rule_id}" for f in arg_findings}),
+                            "blocked": any(f.blocked for f in arg_findings),
+                        }
+                    )
+                if dlp_config.mode == "enforce" and any(f.blocked for f in arg_findings):
+                    first = next(f for f in arg_findings if f.blocked)
+                    allowed, reason, policy_source = (
+                        False,
+                        f"DLP blocked tool arguments: {first.scanner}/{first.rule_id}",
+                        "dlp",
+                    )
+                elif dlp_config.mode == "enforce" and dlp_config.pii_action == "redact" and arg_findings:
+                    # Redact PII in string arguments before forwarding upstream.
+                    redacted_args = {k: _redact_obj_pii(v) for k, v in arguments.items()}
+                    params = message.get("params")
+                    if isinstance(params, dict):
+                        params["arguments"] = redacted_args
+
             if not allowed:
                 record_gateway_relay(upstream.name, "blocked")
                 audit_event: dict[str, Any] = {
@@ -2194,6 +2449,53 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                                 upstream.name,
                                 safe_tool_name_for_log,
                             )
+
+        # DLP pass on the tool RESULT. Scans the serialized result for the same
+        # sensitive-data classes as the argument pass. In enforce mode a blocked
+        # finding (secrets/payload/injection) replaces the result with a DLP
+        # error so the data never reaches the caller; otherwise PII is redacted
+        # in-place when pii_action=redact. Audit-only in audit mode.
+        if dlp_config.enabled and isinstance(upstream_response, dict) and "result" in upstream_response:
+            tool_name_for_dlp = message.get("params", {}).get("name", "") if is_tools_call(message) else str(message.get("method", ""))
+            try:
+                result_text = json.dumps(upstream_response.get("result"), default=str)
+            except (TypeError, ValueError):
+                result_text = str(upstream_response.get("result"))
+            resp_findings = scan_tool_response(result_text, dlp_config)
+            if resp_findings and settings.audit_sink is not None:
+                await settings.audit_sink(
+                    {
+                        "action": "gateway.dlp_result",
+                        "upstream": upstream.name,
+                        "tenant_id": tenant_id,
+                        "source_agent": source_agent,
+                        "tool": tool_name_for_dlp,
+                        "findings": sorted({f"{f.scanner}/{f.rule_id}" for f in resp_findings}),
+                        "blocked": any(f.blocked for f in resp_findings),
+                    }
+                )
+            if dlp_config.mode == "enforce" and any(f.blocked for f in resp_findings):
+                record_gateway_relay(upstream.name, "blocked")
+                first = next(f for f in resp_findings if f.blocked)
+                return JSONResponse(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": message.get("id"),
+                        "error": {
+                            "code": -32001,
+                            "message": "Blocked by agent-bom gateway DLP: sensitive data in tool result",
+                            "data": {
+                                "reason": _public_gateway_block_reason("dlp"),
+                                "policy_source": "dlp",
+                                "rule": f"{first.scanner}/{first.rule_id}",
+                            },
+                        },
+                    },
+                    status_code=200,
+                    headers=rate_limit_headers or None,
+                )
+            if dlp_config.mode == "enforce" and dlp_config.pii_action == "redact" and resp_findings:
+                upstream_response["result"] = _redact_obj_pii(upstream_response.get("result"))
 
         if settings.audit_sink is not None:
             await settings.audit_sink(

--- a/tests/test_gateway_oauth_broker.py
+++ b/tests/test_gateway_oauth_broker.py
@@ -1,0 +1,341 @@
+"""Gateway runtime-broker integration tests.
+
+Covers the broker capabilities wired into the gateway relay:
+  * OAuth 2.1 AS endpoints mounted on the gateway app (metadata discovery).
+  * AS-issued access tokens authenticating as the caller identity.
+  * A2A inline mutual-auth enforcement (deny weak / unauthenticated edges).
+  * Per-tool-call OAuth scope mapping (scope-denied tool call).
+  * DLP redaction + block on tool arguments and results.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from typing import Any
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.oauth_as import OAuthAuthorizationServer, OAuthSigningKey
+from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+
+
+def _registry() -> UpstreamRegistry:
+    return UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://fs.local:8100")])
+
+
+def _echo_caller(result: dict[str, Any] | None = None):
+    captured: dict[str, Any] = {}
+
+    async def _caller(upstream: UpstreamConfig, message: dict[str, Any], extra_headers: dict[str, str]) -> dict[str, Any]:
+        captured["message"] = message
+        return {"jsonrpc": "2.0", "id": message.get("id"), "result": result if result is not None else {"ok": True}}
+
+    return _caller, captured
+
+
+def _tools_call(name: str, arguments: dict[str, Any], *, identity: str | None = None) -> dict[str, Any]:
+    meta = {"agent_identity": identity} if identity else {}
+    params: dict[str, Any] = {"name": name, "arguments": arguments}
+    if meta:
+        params["_meta"] = meta
+    return {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": params}
+
+
+def _server() -> OAuthAuthorizationServer:
+    return OAuthAuthorizationServer(issuer="https://gw.example", signing_key=OAuthSigningKey())
+
+
+def _issue_token(server: OAuthAuthorizationServer, *, scope: str = "", subject: str = "agent-x") -> str:
+    reg = server.register_client(
+        {
+            "redirect_uris": ["https://app.example/cb"],
+            "grant_types": ["authorization_code", "client_credentials"],
+            "token_endpoint_auth_method": "client_secret_post",
+            "scope": scope,
+            "subject": subject,
+        }
+    )
+    tokens = server.token(
+        {
+            "grant_type": "client_credentials",
+            "client_id": reg["client_id"],
+            "client_secret": reg["client_secret"],
+            "scope": scope,
+        }
+    )
+    return tokens["access_token"]
+
+
+# ── AS mounted on the gateway ─────────────────────────────────────────────────
+
+
+def test_gateway_mounts_oauth_as_metadata() -> None:
+    settings = GatewaySettings(registry=_registry(), policy={}, oauth_as=_server())
+    client = TestClient(create_gateway_app(settings))
+    resp = client.get("/.well-known/oauth-authorization-server")
+    assert resp.status_code == 200
+    assert resp.json()["code_challenge_methods_supported"] == ["S256"]
+    assert client.get("/oauth/jwks.json").json()["keys"]
+
+
+def test_gateway_healthz_reports_broker_posture() -> None:
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={},
+        oauth_as=_server(),
+        a2a_mutual_auth_enforcement_mode="enforce",
+        tool_scope_map={"fs.read": ["tools:read"]},
+        dlp_enabled=True,
+        dlp_mode="enforce",
+    )
+    client = TestClient(create_gateway_app(settings))
+    broker = client.get("/healthz").json()["broker_runtime"]
+    assert broker == {
+        "oauth_as_enabled": True,
+        "a2a_mutual_auth_enforcement_mode": "enforce",
+        "tool_scope_mapped_tools": 1,
+        "dlp_enabled": True,
+        "dlp_mode": "enforce",
+    }
+
+
+def test_as_token_authenticates_as_caller_identity() -> None:
+    server = _server()
+    token = _issue_token(server, scope="tools:read", subject="billing-agent")
+    caller, captured = _echo_caller()
+    settings = GatewaySettings(registry=_registry(), policy={}, oauth_as=server, upstream_caller=caller)
+    client = TestClient(create_gateway_app(settings))
+    # Standard MCP client presents the AS token in the Authorization header.
+    resp = client.post(
+        "/mcp/filesystem",
+        json=_tools_call("fs.read", {"path": "/tmp/x"}),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200
+    assert "error" not in resp.json()
+    assert captured["message"]["params"]["name"] == "fs.read"
+
+
+# ── A2A inline mutual-auth enforcement ────────────────────────────────────────
+
+
+def test_a2a_enforce_denies_anonymous_edge() -> None:
+    caller, _ = _echo_caller()
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={},
+        upstream_caller=caller,
+        a2a_mutual_auth_enforcement_mode="enforce",
+        # Loopback transport posture permits an anonymous caller; A2A mutual-auth
+        # enforcement is independent and still rejects the unauthenticated edge.
+        listener_host="127.0.0.1",
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_tools_call("fs.read", {"path": "/tmp/x"}))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["error"]["data"]["policy_source"] == "a2a_mutual_auth"
+
+
+def test_a2a_enforce_allows_verified_as_token() -> None:
+    server = _server()
+    token = _issue_token(server, subject="verified-agent")
+    caller, _ = _echo_caller()
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={},
+        oauth_as=server,
+        upstream_caller=caller,
+        a2a_mutual_auth_enforcement_mode="enforce",
+        listener_host="127.0.0.1",
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/filesystem",
+        json=_tools_call("fs.read", {"path": "/tmp/x"}),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert "error" not in resp.json()
+
+
+def test_a2a_enforce_denies_unverified_opaque_token() -> None:
+    # An opaque policy.agent_tokens identity authenticates but is NOT mutual auth.
+    caller, _ = _echo_caller()
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={"agent_tokens": {"opaque-shared": "agent-7"}},
+        upstream_caller=caller,
+        a2a_mutual_auth_enforcement_mode="enforce",
+        listener_host="127.0.0.1",
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_tools_call("fs.read", {"path": "/x"}, identity="opaque-shared"))
+    body = resp.json()
+    assert body["error"]["data"]["policy_source"] == "a2a_mutual_auth"
+
+
+# ── Per-tool-call OAuth scope mapping ─────────────────────────────────────────
+
+
+def test_scope_mapped_tool_denied_without_scope() -> None:
+    server = _server()
+    token = _issue_token(server, scope="tools:read", subject="reader")
+    caller, _ = _echo_caller()
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={},
+        oauth_as=server,
+        upstream_caller=caller,
+        tool_scope_map={"fs.write": ["tools:write"]},
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/filesystem",
+        json=_tools_call("fs.write", {"path": "/x", "data": "y"}),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    body = resp.json()
+    assert body["error"]["data"]["policy_source"] == "oauth_scope"
+
+
+def test_scope_mapped_tool_allowed_with_scope() -> None:
+    server = _server()
+    token = _issue_token(server, scope="tools:read tools:write", subject="writer")
+    caller, captured = _echo_caller()
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={},
+        oauth_as=server,
+        upstream_caller=caller,
+        tool_scope_map={"fs.write": ["tools:write"]},
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/filesystem",
+        json=_tools_call("fs.write", {"path": "/x", "data": "y"}),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert "error" not in resp.json()
+    assert captured["message"]["params"]["name"] == "fs.write"
+
+
+# ── DLP ───────────────────────────────────────────────────────────────────────
+
+
+def test_dlp_blocks_secret_in_arguments() -> None:
+    caller, _ = _echo_caller()
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={},
+        upstream_caller=caller,
+        dlp_enabled=True,
+        dlp_mode="enforce",
+        listener_host="127.0.0.1",
+    )
+    client = TestClient(create_gateway_app(settings))
+    # AWS secret-access-key style value trips the secrets scanner.
+    resp = client.post(
+        "/mcp/filesystem",
+        json=_tools_call("fs.write", {"body": "password=SuperSecretValue12345"}),
+    )
+    body = resp.json()
+    assert body["error"]["data"]["policy_source"] == "dlp"
+
+
+def test_dlp_redacts_pii_in_result() -> None:
+    caller, _ = _echo_caller(result={"content": "reach me at jdoe@example.com please"})
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={},
+        upstream_caller=caller,
+        dlp_enabled=True,
+        dlp_mode="enforce",
+        dlp_pii_action="redact",
+        listener_host="127.0.0.1",
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_tools_call("fs.read", {"path": "/x"}))
+    body = resp.json()
+    assert "jdoe@example.com" not in body["result"]["content"]
+    assert "[REDACTED:email]" in body["result"]["content"]
+
+
+def test_dlp_audit_mode_does_not_block() -> None:
+    caller, _ = _echo_caller()
+    audits: list[dict[str, Any]] = []
+
+    async def _sink(event: dict[str, Any]) -> None:
+        audits.append(event)
+
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={},
+        upstream_caller=caller,
+        audit_sink=_sink,
+        dlp_enabled=True,
+        dlp_mode="audit",
+        listener_host="127.0.0.1",
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post(
+        "/mcp/filesystem",
+        json=_tools_call("fs.write", {"body": "password=SuperSecretValue12345"}),
+    )
+    assert "error" not in resp.json()
+    assert any(e.get("action") == "gateway.dlp_arguments" for e in audits)
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(48)
+    challenge = base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def test_full_pkce_flow_then_relay_through_gateway() -> None:
+    server = _server()
+    caller, captured = _echo_caller()
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={},
+        oauth_as=server,
+        upstream_caller=caller,
+        tool_scope_map={"fs.read": ["tools:read"]},
+    )
+    client = TestClient(create_gateway_app(settings))
+    reg = client.post(
+        "/oauth/register",
+        json={"redirect_uris": ["https://app.example/cb"], "scope": "tools:read"},
+    ).json()
+    verifier, challenge = _pkce_pair()
+    authorize = client.get(
+        "/oauth/authorize",
+        params={
+            "response_type": "code",
+            "client_id": reg["client_id"],
+            "redirect_uri": "https://app.example/cb",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "scope": "tools:read",
+        },
+        follow_redirects=False,
+    )
+    code = authorize.headers["location"].split("code=")[1].split("&")[0]
+    token = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": reg["client_id"],
+            "code_verifier": verifier,
+        },
+    ).json()["access_token"]
+    resp = client.post(
+        "/mcp/filesystem",
+        json=_tools_call("fs.read", {"path": "/x"}),
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert "error" not in resp.json()
+    assert captured["message"]["params"]["name"] == "fs.read"

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -125,6 +125,13 @@ def test_healthz_lists_configured_upstreams() -> None:
             "enforcement_mode": "enforce",
             "tenant_id": None,
         },
+        "broker_runtime": {
+            "oauth_as_enabled": False,
+            "a2a_mutual_auth_enforcement_mode": "off",
+            "tool_scope_mapped_tools": 0,
+            "dlp_enabled": False,
+            "dlp_mode": "disabled",
+        },
     }
 
 

--- a/tests/test_oauth_as.py
+++ b/tests/test_oauth_as.py
@@ -1,0 +1,344 @@
+"""OAuth 2.1 Authorization Server (broker AS) conformance tests.
+
+Exercises the RFC 8414 metadata endpoint, RFC 7591 dynamic client
+registration, the PKCE-required authorization-code token flow, the
+client_credentials grant, JWKS publication, and token validation — both via the
+:class:`OAuthAuthorizationServer` API and the mounted FastAPI router.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from agent_bom.api.oauth_as import (
+    OAuthAuthorizationServer,
+    OAuthError,
+    OAuthSigningKey,
+    build_oauth_as_router,
+)
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _pkce_pair() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(48)
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+def _server() -> OAuthAuthorizationServer:
+    # A stable key so issued tokens validate deterministically within a test.
+    return OAuthAuthorizationServer(issuer="https://gw.example", signing_key=OAuthSigningKey())
+
+
+def _client_app() -> TestClient:
+    server = _server()
+    app = FastAPI()
+    app.include_router(build_oauth_as_router(server))
+    client = TestClient(app)
+    client.app.state.server = server  # type: ignore[attr-defined]
+    return client
+
+
+# ── RFC 8414 metadata ─────────────────────────────────────────────────────────
+
+
+def test_metadata_advertises_required_oauth21_endpoints() -> None:
+    server = _server()
+    meta = server.metadata("https://gw.example")
+    assert meta["issuer"] == "https://gw.example"
+    assert meta["authorization_endpoint"] == "https://gw.example/oauth/authorize"
+    assert meta["token_endpoint"] == "https://gw.example/oauth/token"
+    assert meta["registration_endpoint"] == "https://gw.example/oauth/register"
+    assert meta["jwks_uri"] == "https://gw.example/oauth/jwks.json"
+    # OAuth 2.1 mandates PKCE S256 and forbids the implicit grant.
+    assert meta["code_challenge_methods_supported"] == ["S256"]
+    assert "token" not in meta["response_types_supported"]
+    assert "authorization_code" in meta["grant_types_supported"]
+
+
+def test_metadata_endpoint_served_over_http() -> None:
+    client = _client_app()
+    resp = client.get("/.well-known/oauth-authorization-server")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["code_challenge_methods_supported"] == ["S256"]
+    jwks = client.get("/oauth/jwks.json").json()
+    assert jwks["keys"] and jwks["keys"][0]["kty"] == "RSA"
+
+
+# ── RFC 7591 dynamic client registration ──────────────────────────────────────
+
+
+def test_dynamic_registration_public_client_pkce() -> None:
+    server = _server()
+    reg = server.register_client({"redirect_uris": ["https://app.example/cb"], "client_name": "mcp-client"})
+    assert reg["client_id"].startswith("abc_")
+    # Public client → no secret, PKCE only.
+    assert "client_secret" not in reg
+    assert reg["token_endpoint_auth_method"] == "none"
+    assert reg["grant_types"] == ["authorization_code"]
+
+
+def test_dynamic_registration_confidential_client_gets_secret() -> None:
+    server = _server()
+    reg = server.register_client(
+        {
+            "redirect_uris": ["https://app.example/cb"],
+            "grant_types": ["authorization_code", "client_credentials"],
+            "token_endpoint_auth_method": "client_secret_basic",
+        }
+    )
+    assert reg["client_secret"]
+    assert "client_credentials" in reg["grant_types"]
+
+
+def test_registration_rejects_non_loopback_http_redirect() -> None:
+    server = _server()
+    try:
+        server.register_client({"redirect_uris": ["http://evil.example/cb"]})
+    except OAuthError as exc:
+        assert exc.error == "invalid_redirect_uri"
+    else:  # pragma: no cover
+        raise AssertionError("expected OAuthError for plaintext non-loopback redirect")
+
+
+def test_registration_endpoint_returns_201() -> None:
+    client = _client_app()
+    resp = client.post("/oauth/register", json={"redirect_uris": ["https://app.example/cb"]})
+    assert resp.status_code == 201
+    assert resp.json()["client_id"]
+
+
+# ── PKCE authorization-code token flow ────────────────────────────────────────
+
+
+def test_pkce_authorization_code_flow_issues_validatable_token() -> None:
+    server = _server()
+    reg = server.register_client({"redirect_uris": ["https://app.example/cb"], "scope": "tools:read tools:write"})
+    client_id = reg["client_id"]
+    verifier, challenge = _pkce_pair()
+
+    location = server.authorize(
+        {
+            "response_type": "code",
+            "client_id": client_id,
+            "redirect_uri": "https://app.example/cb",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "scope": "tools:read",
+            "state": "xyz",
+        }
+    )
+    assert location.startswith("https://app.example/cb?code=")
+    assert "state=xyz" in location
+    code = location.split("code=")[1].split("&")[0]
+
+    tokens = server.token(
+        {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": "https://app.example/cb",
+            "client_id": client_id,
+            "code_verifier": verifier,
+        }
+    )
+    assert tokens["token_type"] == "Bearer"
+    assert tokens["scope"] == "tools:read"
+    claims = server.validate_token(tokens["access_token"])
+    assert claims is not None
+    assert claims["sub"] == client_id
+    assert claims["scope"] == "tools:read"
+
+
+def test_authorize_requires_pkce_s256() -> None:
+    server = _server()
+    reg = server.register_client({"redirect_uris": ["https://app.example/cb"]})
+    # plain method is forbidden in OAuth 2.1 → redirect error.
+    exc_location = None
+    try:
+        server.authorize(
+            {
+                "response_type": "code",
+                "client_id": reg["client_id"],
+                "redirect_uri": "https://app.example/cb",
+                "code_challenge": "abc",
+                "code_challenge_method": "plain",
+            }
+        )
+    except OAuthError as exc:
+        exc_location = exc.redirect_location
+    assert exc_location is not None and "error=invalid_request" in exc_location
+
+
+def test_token_rejects_wrong_pkce_verifier() -> None:
+    server = _server()
+    reg = server.register_client({"redirect_uris": ["https://app.example/cb"]})
+    _verifier, challenge = _pkce_pair()
+    location = server.authorize(
+        {
+            "response_type": "code",
+            "client_id": reg["client_id"],
+            "redirect_uri": "https://app.example/cb",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        }
+    )
+    code = location.split("code=")[1].split("&")[0]
+    try:
+        server.token(
+            {
+                "grant_type": "authorization_code",
+                "code": code,
+                "client_id": reg["client_id"],
+                "code_verifier": "the-wrong-verifier",
+            }
+        )
+    except OAuthError as exc:
+        assert exc.error == "invalid_grant"
+    else:  # pragma: no cover
+        raise AssertionError("expected PKCE verification failure")
+
+
+def test_authorization_code_is_single_use() -> None:
+    server = _server()
+    reg = server.register_client({"redirect_uris": ["https://app.example/cb"]})
+    verifier, challenge = _pkce_pair()
+    location = server.authorize(
+        {
+            "response_type": "code",
+            "client_id": reg["client_id"],
+            "redirect_uri": "https://app.example/cb",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        }
+    )
+    code = location.split("code=")[1].split("&")[0]
+    form = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "client_id": reg["client_id"],
+        "code_verifier": verifier,
+    }
+    assert server.token(dict(form))["access_token"]
+    try:
+        server.token(dict(form))
+    except OAuthError as exc:
+        assert exc.error == "invalid_grant"
+    else:  # pragma: no cover
+        raise AssertionError("replayed authorization code must be rejected")
+
+
+def test_token_endpoint_full_http_flow() -> None:
+    client = _client_app()
+    reg = client.post("/oauth/register", json={"redirect_uris": ["https://app.example/cb"]}).json()
+    verifier, challenge = _pkce_pair()
+    authorize = client.get(
+        "/oauth/authorize",
+        params={
+            "response_type": "code",
+            "client_id": reg["client_id"],
+            "redirect_uri": "https://app.example/cb",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+        },
+        follow_redirects=False,
+    )
+    assert authorize.status_code == 302
+    code = authorize.headers["location"].split("code=")[1].split("&")[0]
+    token_resp = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": reg["client_id"],
+            "code_verifier": verifier,
+        },
+    )
+    assert token_resp.status_code == 200
+    assert token_resp.headers["cache-control"] == "no-store"
+    assert token_resp.json()["access_token"]
+
+
+# ── client_credentials grant ──────────────────────────────────────────────────
+
+
+def test_client_credentials_grant_requires_secret() -> None:
+    server = _server()
+    reg = server.register_client(
+        {
+            "redirect_uris": ["https://app.example/cb"],
+            "grant_types": ["authorization_code", "client_credentials"],
+            "token_endpoint_auth_method": "client_secret_post",
+            "scope": "tools:read",
+        }
+    )
+    tokens = server.token(
+        {
+            "grant_type": "client_credentials",
+            "client_id": reg["client_id"],
+            "client_secret": reg["client_secret"],
+        }
+    )
+    claims = server.validate_token(tokens["access_token"])
+    assert claims is not None and claims["scope"] == "tools:read"
+
+    # Wrong secret fails closed.
+    try:
+        server.token(
+            {
+                "grant_type": "client_credentials",
+                "client_id": reg["client_id"],
+                "client_secret": "nope",
+            }
+        )
+    except OAuthError as exc:
+        assert exc.error == "invalid_client"
+    else:  # pragma: no cover
+        raise AssertionError("client_credentials must reject a wrong secret")
+
+
+def test_requested_scope_outside_client_grant_rejected() -> None:
+    server = _server()
+    reg = server.register_client({"redirect_uris": ["https://app.example/cb"], "scope": "tools:read"})
+    _verifier, challenge = _pkce_pair()
+    try:
+        server.authorize(
+            {
+                "response_type": "code",
+                "client_id": reg["client_id"],
+                "redirect_uri": "https://app.example/cb",
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "scope": "tools:admin",
+            }
+        )
+    except OAuthError as exc:
+        assert exc.redirect_location and "error=invalid_scope" in exc.redirect_location
+    else:  # pragma: no cover
+        raise AssertionError("scope outside the client grant must be rejected")
+
+
+def test_validate_token_rejects_foreign_token() -> None:
+    server_a = _server()
+    server_b = _server()
+    reg = server_a.register_client(
+        {
+            "redirect_uris": ["https://app.example/cb"],
+            "grant_types": ["client_credentials"],
+            "token_endpoint_auth_method": "client_secret_post",
+        }
+    )
+    tokens = server_a.token(
+        {"grant_type": "client_credentials", "client_id": reg["client_id"], "client_secret": reg["client_secret"]}
+    )
+    # A token signed by server_a does not validate against server_b's key.
+    assert server_b.validate_token(tokens["access_token"]) is None
+    assert server_a.validate_token(tokens["access_token"]) is not None


### PR DESCRIPTION
## Runtime broker for the multi-MCP gateway

Turns the gateway into a standards-conformant auth broker and flips inter-agent
mutual auth from assess to enforce.

### 1. OAuth 2.1 Authorization Server (`src/agent_bom/api/oauth_as.py`)
Mounted on the gateway app so a standard MCP client can auto-discover + authenticate:
- **RFC 8414** metadata — `/.well-known/oauth-authorization-server`
- **RFC 7591** dynamic client registration — `/oauth/register`
- **PKCE-required** (S256 only; `plain`/implicit forbidden) `authorize` + `token` endpoints
- `client_credentials` grant + **JWKS** at `/oauth/jwks.json`

Access tokens are RS256 JWTs whose `sub` is the agent identity and `scope` carries the
granted OAuth scopes. The relay accepts an AS token from the `Authorization` header or
`_meta.agent_identity` as the **verified** caller identity (validated in-process via the
AS key — no self-HTTP), so the issued token *is* the agent identity at the relay.

### 2. A2A inline mutual-auth enforcement (assess → ENFORCE)
`a2a_auth_posture.evaluate_inline_mutual_auth` classifies each relayed edge; the gateway
**warns** or **rejects closed** anonymous / unverified (opaque-shared) / invalid edges
when `a2a_mutual_auth_enforcement_mode` is on. Off by default.

### 3. Per-tool-call OAuth scope mapping + DLP
- `tool_scope_map` (`{tool: [scope...]}`, `*` = baseline) denies a tool call whose token
  lacks a required scope.
- DLP pass on tool-call **arguments** and **results** reusing the inline proxy scanner:
  enforce blocks secrets/payload/injection and redacts PII; audit only flags.

### Security posture
Fail-closed + bounded: PKCE mandatory, single-use short-TTL authorization codes, no `none`
alg, LRU-bounded client/code stores, every enforcement mode off by default, AS tokens of a
foreign key rejected.

### Tests
`tests/test_oauth_as.py` (metadata, dynamic registration, full PKCE token flow, bad-PKCE /
single-use / foreign-token, client_credentials, scope ceiling) and
`tests/test_gateway_oauth_broker.py` (AS mounted on gateway, AS-token identity, A2A
enforce/deny, scope-denied call, DLP block + PII redaction, end-to-end PKCE→relay).

Gates green: env-var reference, OpenAPI, v1-schema, data-model atlas, release consistency,
product-surface, cli-reference, ruff.

Closes #3332

🤖 Generated with [Claude Code](https://claude.com/claude-code)