### PR TITLE
chore(release): v0.91.0

### DIFF
--- a/.github/workflows/mcp-change-scan.yml
+++ b/.github/workflows/mcp-change-scan.yml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install agent-bom
-        run: uv tool install agent-bom==0.90.0  # pinned — bump on each release
+        run: uv tool install agent-bom==0.91.0  # pinned — bump on each release
 
       - name: Scan changed MCP configs
         id: scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,74 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.91.0] - 2026-06-30
+
+A platform release: AI agents, MCP servers, and their tools become first-class
+governed assets behind a runtime broker, while the SCA/SBOM/identity/cost depth
+and the UI all level up. Availability, accuracy, security, and scalability are
+treated as non-negotiable throughout.
+
+### Runtime broker / gateway
+- **OAuth 2.1 Authorization Server conformance** for the MCP auth spec — AS
+  metadata (RFC 8414), dynamic client registration (RFC 7591), PKCE
+  authorize/token endpoints, and JWKS — so standard MCP clients auto-authenticate
+  to brokered MCP servers.
+- **Inline agent-to-agent (A2A) mutual-auth enforcement** at the gateway relay
+  (`off`/`warn`/`enforce`): rejects anonymous / unverified inter-agent and
+  agent→MCP edges.
+- **Per-tool-call OAuth scope mapping + DLP** on tool args/results: denies
+  insufficient-scope calls and redacts/blocks sensitive data.
+
+### SCA / reachability
+- **Function-level reachability → CVE** — joins the Python symbol call-graph to
+  advisory affected-symbols, marking findings `function_reachable` vs
+  `package_reachable` for noise reduction.
+- **`match_confidence_tier` surfaced across SARIF, JSON, and HTML** (not only the
+  unified Finding), with canonical `cve_ids`.
+- NVD capped-sync now ingests its unsynced tail across runs (no silent CVE
+  drops); CPE inclusive/exclusive version bounds honored exactly; Go
+  pseudo-version bounds; CycloneDX component de-duplication + finding-id scoping.
+
+### SBOM / supply chain
+- **Sign + attest generated SBOMs** (Ed25519 / HMAC, in-toto / SLSA) via
+  `agent-bom attest`.
+- **SPDX 2.2 / 2.3 emitter** + per-component checksums.
+
+### Identity / FinOps
+- **Owner-binding + attribution** on issued agent identities.
+- **Reconcilable / actual cost rates** (vs static list price) with
+  estimated-vs-reconciled provenance.
+
+### Security hardening
+- **SSRF blocked in the MCP repo-scan path** (egress validation, no
+  redirect-follow, fail-closed remote bind) and the clone offloaded off the
+  event loop.
+- Server-authoritative tenant binding on audit ingest; pre-auth global IP rate
+  limiter; X-Forwarded-For spoof fix; identity-keyed MCP rate limiter.
+- Pickle scanner now scans oversized / disguised pickles (size-gate + memo
+  evasion closed); `--fail-on-severity` fails closed on unknown/none.
+- DB resilience: SQLite `busy_timeout` + WAL checkpoint; OSV archive streamed to
+  disk (no OOM); KEV/NVD/GHSA wrong-shape + partial-sync guards.
+
+### UI
+- **Design-system foundation** — Collapsible, Card/Section, StatCard, shared
+  entity icons, vendor logos, and consolidated state primitives.
+- **Real connections experience** wired to the backend with vendor logos and
+  honest provider readiness.
+- Declutter + **capability-driven IA** ("Set up" badges, summary surfaces), a
+  **data-driven AI-agent trust stack**, and interaction-state fixes (graph filter
+  soft-lock, provider re-select, URL-as-source-of-truth filters).
+
+### Output
+- De-duplicated cloud CIS findings in SARIF and HTML; canonical OWASP-MCP/LLM
+  codes from the tool-abuse rules.
+
 ## [0.90.0] - 2026-06-30
 
-Native, self-sufficient SCA: distro-confirmed findings match or exceed Trivy on
-published benchmarks (e.g. alpine 3.14.2), with an optional NVD CPE candidate
+Native, self-sufficient SCA: distro-confirmed findings are benchmark-grade
+(e.g. alpine 3.14.2), with an optional NVD CPE candidate
 tier (review-grade, opt-in) for the long tail OSV and distro feeds do not cover —
-on top of the multi-account CNAPP estate work below. No Trivy/Grype/Syft
+on top of the multi-account CNAPP estate work below. No external-scanner
 subprocess is required on the vulnerability path.
 
 ### Vulnerability scanning / SCA
@@ -37,8 +99,8 @@ subprocess is required on the vulnerability path.
 - **Forced OSV fallback for sparse/EOL distro releases** so end-of-life images do
   not silently miss advisories.
 - **Real offline + online scan-accuracy validation** — a deterministic offline
-  three-tier (OSV / distro / CPE) regression net plus live OSV ground-truth and a
-  Trivy binary-diff harness.
+  three-tier (OSV / distro / CPE) regression net plus live OSV ground-truth and an
+  external-scanner binary-diff harness.
 
 Deepens the cloud/CNAPP estate from a single-provider inventory into a
 multi-account, multi-region, tenant-scale model that rolls up readably in the
@@ -1887,7 +1949,8 @@ Two new product surfaces (inter-agent firewall + per-run discovery envelope) plu
 
 ---
 
-[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.90.0...HEAD
+[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.91.0...HEAD
+[0.91.0]: https://github.com/msaad00/agent-bom/compare/v0.90.0...v0.91.0
 [0.90.0]: https://github.com/msaad00/agent-bom/compare/v0.89.2...v0.90.0
 [0.89.2]: https://github.com/msaad00/agent-bom/compare/v0.89.1...v0.89.2
 [0.89.1]: https://github.com/msaad00/agent-bom/compare/v0.89.0...v0.89.1

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -216,7 +216,7 @@ Focused agent mesh graph:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `0.90.0` | Current stable version (pinned) |
+| `0.91.0` | Current stable version (pinned) |
 
 Published images:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.6-alpine3.23@sha256:02da11a8d221ca167aa07de20b3cd7104c1f01227f4b02b1fa13cf6517280a81
 
-ARG VERSION=0.90.0
+ARG VERSION=0.91.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ reproduce the dashboard screenshots from a clean local control-plane store.
 | Non-human identity posture | `agent-bom identity credential-expiry` |
 | Advisory remediation plan | `agent-bom remediate -p .` |
 | Gated-capability readiness | `agent-bom capabilities` |
-| CI gate | `uses: msaad00/agent-bom@v0.90.0` |
+| CI gate | `uses: msaad00/agent-bom@v0.91.0` |
 | Local API and dashboard | `pip install 'agent-bom[ui]' && agent-bom serve` |
 
 The base wheel is the scanner and CLI path; optional runtime surfaces fail fast

--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -27,7 +27,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    image: agentbom/agent-bom:0.90.0
+    image: agentbom/agent-bom:0.91.0
     container_name: agent-bom-api
     restart: unless-stopped
     command: api --host 0.0.0.0 --port 8422
@@ -75,7 +75,7 @@ services:
       args:
         # Baked into the Next.js build — must match the publicly reachable API URL
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8422}
-    image: agentbom/agent-bom-ui:0.90.0
+    image: agentbom/agent-bom-ui:0.91.0
     container_name: agent-bom-ui
     restart: unless-stopped
     ports:

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -19,7 +19,7 @@
 
 services:
   api:
-    image: agentbom/agent-bom:0.90.0
+    image: agentbom/agent-bom:0.91.0
     container_name: agent-bom-pilot-api
     restart: unless-stopped
     command: >
@@ -47,7 +47,7 @@ services:
       start_period: 10s
 
   ui:
-    image: agentbom/agent-bom-ui:0.90.0
+    image: agentbom/agent-bom-ui:0.91.0
     container_name: agent-bom-pilot-ui
     restart: unless-stopped
     environment:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -123,7 +123,7 @@ services:
     build:
       context: ../ui
       dockerfile: Dockerfile
-    image: agentbom/agent-bom-ui:0.90.0
+    image: agentbom/agent-bom-ui:0.91.0
     container_name: agent-bom-ui
     ports:
       - "${AGENT_BOM_UI_BIND_HOST:-127.0.0.1}:${UI_PORT:-3000}:3000"

--- a/deploy/docker-compose.runtime.yml
+++ b/deploy/docker-compose.runtime.yml
@@ -31,7 +31,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/docker/Dockerfile.runtime
-    image: agentbom/agent-bom:0.90.0
+    image: agentbom/agent-bom:0.91.0
     container_name: agent-bom-runtime-proxy
     depends_on:
       - mcp-server

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -27,7 +27,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.90.0
+ARG VERSION=0.91.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY pyproject.toml README.md PYPI_README.md LICENSE ./
 COPY src/ ./src/
 
-ARG VERSION=0.90.0
+ARG VERSION=0.91.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -40,7 +40,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[runtime]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.90.0
+ARG VERSION=0.91.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -26,7 +26,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.90.0
+ARG VERSION=0.91.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -41,7 +41,7 @@ RUN pip install --no-cache-dir --prefix=/install ".[mcp-server]"
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.90.0
+ARG VERSION=0.91.0
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
-version: 0.90.0
-appVersion: "0.90.0"
+version: 0.91.0
+appVersion: "0.91.0"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -24,17 +24,17 @@
 
 image:
   repository: agentbom/agent-bom
-  tag: "0.90.0"
+  tag: "0.91.0"
   pullPolicy: IfNotPresent
 
 uiImage:
   repository: agentbom/agent-bom-ui
-  tag: "0.90.0"
+  tag: "0.91.0"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom
-  tag: "0.90.0"
+  tag: "0.91.0"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -57,7 +57,7 @@ tests:
   includeUi: true
   image:
     repository: agentbom/agent-bom
-    tag: "0.90.0"
+    tag: "0.91.0"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deploy/k8s/cronjob.yaml
+++ b/deploy/k8s/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
           serviceAccountName: agent-bom
           containers:
             - name: scanner
-              image: agentbom/agent-bom:0.90.0
+              image: agentbom/agent-bom:0.91.0
               command: ["agent-bom"]
               args:
                 - "scan"

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: agent-bom
       containers:
         - name: monitor
-          image: agentbom/agent-bom:0.90.0
+          image: agentbom/agent-bom:0.91.0
           command: ["agent-bom"]
           args:
             - "protect"

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -109,7 +109,7 @@ spec:
               cpu: "500m"
 
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.90.0
+          image: agentbom/agent-bom:0.91.0
           args:
             - "--policy"
             - "/etc/agent-bom/policy.json"

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.90.0
+          image: agentbom/agent-bom:0.91.0
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/deploy/snowflake/native-app/manifest.yml
+++ b/deploy/snowflake/native-app/manifest.yml
@@ -15,10 +15,10 @@ artifacts:
     endpoint: ui
   container_services:
     images:
-      - /db/schema/agent_bom_repo/agent-bom:v0_90_0
-      - /db/schema/agent_bom_repo/agent-bom-ui:v0_90_0
-      - /db/schema/agent_bom_repo/agent-bom-scanner:v0_90_0
-      - /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_90_0
+      - /db/schema/agent_bom_repo/agent-bom:v0_91_0
+      - /db/schema/agent_bom_repo/agent-bom-ui:v0_91_0
+      - /db/schema/agent_bom_repo/agent-bom-scanner:v0_91_0
+      - /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_91_0
   service_roles:
     - name: api
       comment: >-

--- a/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-mcp-runtime
-      image: /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_90_0
+      image: /db/schema/agent_bom_repo/agent-bom-mcp-runtime:v0_91_0
       env:
         SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
         SNOWFLAKE_DATABASE: "{{ database }}"

--- a/deploy/snowflake/native-app/service-specs/scanner-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/scanner-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-scanner
-      image: /db/schema/agent_bom_repo/agent-bom-scanner:v0_90_0
+      image: /db/schema/agent_bom_repo/agent-bom-scanner:v0_91_0
       env:
         SNOWFLAKE_ACCOUNT: "{{ snowflake_account }}"
         SNOWFLAKE_DATABASE: "{{ database }}"

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -180,7 +180,7 @@ should not store provider secret values.
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.90.0
+- uses: msaad00/agent-bom@v0.91.0
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -71,7 +71,7 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.90.0
+- uses: msaad00/agent-bom@v0.91.0
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -89,21 +89,21 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.90.0
+- uses: msaad00/agent-bom@v0.91.0
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.90.0
+- uses: msaad00/agent-bom@v0.91.0
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.90.0
+- uses: msaad00/agent-bom@v0.91.0
   with:
     auto-update-db: false
     enrich: false
@@ -498,7 +498,7 @@ AmazonEC2ReadOnlyAccess
 docker run --rm \
   -v ~/.config:/home/abom/.config:ro \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.90.0 agents --format json
+  agentbom/agent-bom:0.91.0 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -273,7 +273,7 @@ should_i_deploy     — allow/warn/block guidance from ExposurePath risk
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.90.0
+- uses: msaad00/agent-bom@v0.91.0
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,6 +1,6 @@
 {
   "generated_on": "2026-06-29",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "metrics": [
     {
       "name": "MCP tools",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -6,7 +6,7 @@ This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
 - Generated on: `2026-06-29`
-- Version: `0.90.0`
+- Version: `0.91.0`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -105,7 +105,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 clawhub publish integrations/openclaw/scan \
   --slug agent-bom-scan --name "agent-bom scan" \
-  --version "0.90.0"
+  --version "0.91.0"
 ```
 
 Release automation uses the same official `clawhub` CLI flow, not a custom
@@ -157,8 +157,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.90.0
-git push origin v0.90.0
+git tag v0.91.0
+git push origin v0.91.0
 ```
 
 This triggers:

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -13,7 +13,7 @@ For each tagged GitHub Release, expect:
 ## Download release assets
 
 ```bash
-TAG=v0.90.0
+TAG=v0.91.0
 VERSION="${TAG#v}"
 mkdir -p /tmp/agent-bom-release && cd /tmp/agent-bom-release
 gh release download "$TAG" --repo msaad00/agent-bom

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -33,7 +33,7 @@ The proxy interposes on the stdio channel between an MCP client (Claude Desktop,
 Use the published main runtime image:
 
 ```bash
-docker pull agentbom/agent-bom:0.90.0
+docker pull agentbom/agent-bom:0.91.0
 ```
 
 If you need to rebuild locally from the checked-out repo, you can still use
@@ -45,7 +45,7 @@ Run as a wrapper around any MCP server:
 ```bash
 docker run --rm \
   -v $(pwd)/audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.90.0 \
+  agentbom/agent-bom:0.91.0 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace
@@ -94,7 +94,7 @@ spec:
 
         # agent-bom runtime proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.90.0
+          image: agentbom/agent-bom:0.91.0
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"
@@ -341,7 +341,7 @@ Use the runtime container directly from Claude Desktop:
         "run", "--rm", "-i",
         "-v", "./workspace:/workspace",
         "-v", "./audit-logs:/var/log/agent-bom",
-        "agentbom/agent-bom:0.90.0",
+        "agentbom/agent-bom:0.91.0",
         "--log", "/var/log/agent-bom/audit.jsonl",
         "--block-undeclared",
         "--",

--- a/docs/archive/WINDOWS_CONTAINERS.md
+++ b/docs/archive/WINDOWS_CONTAINERS.md
@@ -113,7 +113,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.90.0`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.91.0`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.90.0 blast-radius demo
+# agent-bom v0.91.0 blast-radius demo
 # Shows: blast radius → package gate
 
 Output docs/images/demo-latest.gif

--- a/docs/images/product-screenshots.json
+++ b/docs/images/product-screenshots.json
@@ -1,5 +1,5 @@
 {
-  "release_version": "0.90.0",
+  "release_version": "0.91.0",
   "captured_at": "2026-06-26T16:46:31Z",
   "capture_note": "Captured from real Next.js dashboard routes in capture mode. The refreshed graph proof uses a deterministic Playwright harness that routes seeded scan, fleet, gateway, IAM, environment, runtime, and package evidence into the shipped pages so README media shows non-empty security graph, lineage topology, context map, fleet, and gateway states. The records are synthetic seeded evidence for docs proof, not a claim that those exact entities were discovered from a buyer environment.",
   "screenshots": [
@@ -7,67 +7,67 @@
       "path": "dashboard-live.png",
       "page": "/?capture=1",
       "scope": "Risk overview top frame with headline KPIs, posture grade, and start of attack paths",
-      "visible_version": "0.90.0"
+      "visible_version": "0.91.0"
     },
     {
       "path": "dashboard-paths-live.png",
       "page": "/?capture=1",
       "scope": "Risk overview mid-frame with attack paths and exposure KPIs",
-      "visible_version": "0.90.0"
+      "visible_version": "0.91.0"
     },
     {
       "path": "mesh-live.png",
       "page": "/mesh?capture=1",
       "scope": "Focused agent mesh graph across the active agent, MCP server, package, tool, and CVE path, cropped to the product graph surface",
-      "visible_version": "0.90.0"
+      "visible_version": "0.91.0"
     },
     {
       "path": "gateway-policies-live.png",
       "page": "/gateway?capture=1",
       "scope": "Runtime gateway policy posture with one advisory baseline policy, two rules, and two bound agents",
-      "visible_version": "0.90.0"
+      "visible_version": "0.91.0"
     },
     {
       "path": "security-graph-live.png",
       "page": "/security-graph?capture=1",
       "scope": "Fix-first attack path queue with snapshot pressure, graph evidence export, and remediation handoff",
-      "visible_version": "0.90.0"
+      "visible_version": "0.91.0"
     },
     {
       "path": "lineage-graph-live.png",
       "page": "/graph?capture=1",
       "scope": "Expanded but bounded lineage topology across environment, identity, MCP, package, credential, model, dataset, and finding nodes",
-      "visible_version": "0.90.0"
+      "visible_version": "0.91.0"
     },
     {
       "path": "context-map-live.png",
       "page": "/context?capture=1",
       "scope": "Agent-scoped context map showing reachable MCP servers and lateral movement side panel",
-      "visible_version": "0.90.0"
+      "visible_version": "0.91.0"
     },
     {
       "path": "fleet-state-live.png",
       "page": "/fleet?capture=1",
       "scope": "Expanded fleet row showing lifecycle distribution, approved state, owner metadata, environment label, and discovery state",
-      "visible_version": "0.90.0"
+      "visible_version": "0.91.0"
     },
     {
       "path": "identity-audit-live.png",
       "page": "/audit?capture=1",
       "scope": "Audit log filtered to identity resources with HMAC integrity counters and agent identity issue, rotate, revoke events",
-      "visible_version": "0.90.0"
+      "visible_version": "0.91.0"
     },
     {
       "path": "dependency-map-live.png",
       "page": "/insights?capture=1",
       "scope": "Supply chain dependency map with scan pipeline counts and package risk distribution",
-      "visible_version": "0.90.0"
+      "visible_version": "0.91.0"
     },
     {
       "path": "remediation-live.png",
       "page": "/remediation",
       "scope": "Fix-first remediation table with prioritized packages and framework context",
-      "visible_version": "0.90.0"
+      "visible_version": "0.91.0"
     }
   ]
 }

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -3409,7 +3409,7 @@
   "info": {
     "description": "Security scanner for AI supply chain and infrastructure \u2014 map the full trust chain from agents to CVEs, credentials, and blast radius.",
     "title": "agent-bom API",
-    "version": "0.90.0"
+    "version": "0.91.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -2249,7 +2249,7 @@ info:
   description: "Security scanner for AI supply chain and infrastructure \u2014 map\
     \ the full trust chain from agents to CVEs, credentials, and blast radius."
   title: agent-bom API
-  version: 0.90.0
+  version: 0.91.0
 openapi: 3.1.0
 paths:
   /health:

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
   "title": "agent-bom",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.90.0",
+      "version": "0.91.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.90.0
+    docker: ghcr.io/msaad00/agent-bom:0.91.0
   openclaw:
     requires:
       bins: []
@@ -415,6 +415,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.90.0`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.91.0`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.90.0
+    docker: ghcr.io/msaad00/agent-bom:0.91.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.90.0
+    docker: ghcr.io/msaad00/agent-bom:0.91.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover-aws/SKILL.md
+++ b/integrations/openclaw/discover-aws/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   inventory AWS Bedrock, ECS, SageMaker, Lambda, EKS, Step Functions, EC2, or
   agentic AWS infrastructure as canonical inventory. Passing that inventory
   to agent-bom is optional and operator-chosen.
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-azure/SKILL.md
+++ b/integrations/openclaw/discover-azure/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived Azure credentials. Use when a user asks to
   inventory Azure OpenAI, Container Apps, AKS, Functions, ML, or agentic Azure
   infrastructure as canonical inventory.
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-gcp/SKILL.md
+++ b/integrations/openclaw/discover-gcp/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived GCP credentials. Use when a user asks to
   inventory Vertex AI, Cloud Run, Cloud Functions, GKE, or agentic GCP
   infrastructure as canonical inventory.
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-snowflake/SKILL.md
+++ b/integrations/openclaw/discover-snowflake/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   agent-bom inventory JSON, and scan it without giving agent-bom long-lived
   Snowflake credentials. Use when a user asks to inventory Snowflake AI or
   Cortex infrastructure as canonical inventory.
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed with the snowflake extra, and

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.90.0
+    docker: ghcr.io/msaad00/agent-bom:0.91.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.90.0
+    docker: ghcr.io/msaad00/agent-bom:0.91.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/ingest/SKILL.md
+++ b/integrations/openclaw/ingest/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   GCP, Snowflake, CMDB, or endpoint collectors. Use when a user has canonical
   inventory JSON and wants local findings, graph, policy, provenance, or
   auditor-ready exports without giving agent-bom direct cloud credentials.
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom 0.84.4+. Inventory must conform to the

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.90.0
+    docker: ghcr.io/msaad00/agent-bom:0.91.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.90.0
+    docker: ghcr.io/msaad00/agent-bom:0.91.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.90.0
+    docker: ghcr.io/msaad00/agent-bom:0.91.0
   openclaw:
     requires:
       bins: []
@@ -237,6 +237,6 @@ agent-bom agents
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.90.0`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.91.0`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.90.0
+    docker: ghcr.io/msaad00/agent-bom:0.91.0
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/vulnerability-intel/SKILL.md
+++ b/integrations/openclaw/vulnerability-intel/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   with explicit data-boundary choices. Use when a user asks for CVE lookup,
   advisory intelligence, exploitability context, fix versions, GHSA/OSV/NVD
   enrichment, or package vulnerability triage.
-version: 0.90.0
+version: 0.91.0
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom installed from this repository or PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.90.0"
+version = "0.91.0"
 description = "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/site-docs/deployment/airgapped-image-bundle.md
+++ b/site-docs/deployment/airgapped-image-bundle.md
@@ -16,7 +16,7 @@ From an internet-connected build host:
 
 ```bash
 scripts/release/build-airgap-image-bundle.sh \
-  --version 0.90.0 \
+  --version 0.91.0 \
   --platform linux/amd64 \
   --output-dir dist/airgap
 ```
@@ -37,8 +37,8 @@ machine.
 ## Import On The Disconnected Host
 
 ```bash
-tar -xzf agent-bom-airgap-0.90.0-linux_amd64.tar.gz
-cd agent-bom-airgap-0.90.0-linux_amd64
+tar -xzf agent-bom-airgap-0.91.0-linux_amd64.tar.gz
+cd agent-bom-airgap-0.91.0-linux_amd64
 ./load-images.sh
 ```
 
@@ -47,7 +47,7 @@ The loader verifies archive checksums before running `docker load`.
 ## Push To An Internal Registry
 
 ```bash
-VERSION=0.90.0
+VERSION=0.91.0
 REGISTRY=registry.internal.example.com/security
 
 docker tag "agentbom/agent-bom:${VERSION}" "${REGISTRY}/agent-bom:${VERSION}"
@@ -62,13 +62,13 @@ Then point Helm at the internal registry:
 ```yaml
 image:
   repository: registry.internal.example.com/security/agent-bom
-  tag: "0.90.0"
+  tag: "0.91.0"
 
 controlPlane:
   ui:
     image:
       repository: registry.internal.example.com/security/agent-bom-ui
-      tag: "0.90.0"
+      tag: "0.91.0"
 ```
 
 ## GitHub Actions Bundle Job

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -332,8 +332,8 @@ through a managed tap instead of direct package upload.
 
 ```bash
 python3 scripts/render_homebrew_formula.py \
-  --version 0.90.0 \
-  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.90.0.tar.gz \
+  --version 0.91.0 \
+  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.91.0.tar.gz \
   --sha256 <release-sha256>
 ```
 

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -171,7 +171,7 @@ Install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.90.0 \
+  --version 0.91.0 \
   -n agent-bom --create-namespace \
   -f values.agent-bom.yaml
 ```
@@ -207,7 +207,7 @@ Then install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.90.0 \
+  --version 0.91.0 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
 ```

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -90,10 +90,10 @@ docker run --rm \
 ## Runtime proxy against a remote MCP endpoint
 
 ```bash
-docker pull agentbom/agent-bom:0.90.0
+docker pull agentbom/agent-bom:0.91.0
 docker run --rm -i \
   -v ./audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.90.0 \
+  agentbom/agent-bom:0.91.0 \
   proxy \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.90.0
+  uses: msaad00/agent-bom@v0.91.0
   with:
     policy: policy.json
     fail-on-violation: true

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -56,7 +56,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 | **Local AI BOM** | `agent-bom agents --demo --offline` | terminal findings and graph-ready inventory |
 | **Repository scan** | `agent-bom agents -p . -f html -o agent-bom-report.html` | local HTML review plus exportable evidence |
 | **Cloud posture gate** | `agent-bom iac infra/ && agent-bom cloud aws --cis` | pre-cloud IaC findings plus point-in-time or scheduled posture evidence |
-| **CI evidence** | `uses: msaad00/agent-bom@v0.90.0` | SARIF, pull-request summary, optional code scanning |
+| **CI evidence** | `uses: msaad00/agent-bom@v0.91.0` | SARIF, pull-request summary, optional code scanning |
 | **Assistant tools** | `agent-bom mcp server` | read-mostly security tools for MCP clients |
 | **Self-hosted control plane** | `docker compose -f docker-compose.pilot.yml up -d` | API and dashboard in your infrastructure |
 

--- a/site-docs/reference/remediate-output.md
+++ b/site-docs/reference/remediate-output.md
@@ -45,7 +45,7 @@ remediation remain advisory/manual in this command.
 
 ```json
 {
-  "version": "0.90.0",
+  "version": "0.91.0",
   "generated_at": "2026-04-21T12:00:00+00:00",
   "remediation_plan": [],
   "summary": {

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.90.0"
+    __version__ = "0.91.0"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.90.0",
+      "version": "0.91.0",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@tanstack/react-table": "^8.21.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.90.0' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.91.0' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,7 @@ overrides = [
 
 [[package]]
 name = "agent-bom"
-version = "0.90.0"
+version = "0.91.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## v0.91.0 — platform release

AI agents, MCP servers, and their tools become first-class governed assets behind an OAuth-2.1 / A2A-enforcing **runtime broker**, with SCA/SBOM/identity/cost depth and a UI level-up. Closes the capability-depth (#3331), broker (#3332), and UI (#3333) epics.

**Highlights**
- **Broker:** OAuth 2.1 AS conformance (RFC 8414/7591/PKCE/JWKS) · inline A2A mutual-auth enforcement · per-tool scope + DLP
- **SCA:** function-level reachability→CVE · match_confidence_tier across SARIF/JSON/HTML · NVD tail-sync · exact CPE bounds
- **SBOM:** sign + attest · SPDX 2.x + checksums
- **Identity/FinOps:** owner-binding · reconcilable rates
- **Security:** SSRF block + clone offload · tenant binding · global IP limiter · pickle-scan evasion · DB resilience
- **UI:** design-system foundation · real connections experience + vendor logos · declutter · capability-driven IA · data-driven trust stack · interaction-state fixes

Also scrubs competitor names from the 0.90.0 changelog entry.

Version bumped (103 files); CHANGELOG `## [0.91.0]` + compare links; product-screenshots stamped. Release-consistency + version-check green. Merge → tag `v0.91.0` → publish.