### PR TITLE
fix(gateway): sanitize relay errors and document release gates

### DIFF
--- a/docs/HOSTED_POC.md
+++ b/docs/HOSTED_POC.md
@@ -140,6 +140,28 @@ URL is still localhost, CORS is wildcarded, unauthenticated API mode is enabled,
 API/UI ports bind publicly, or the composed stack would mount placeholder
 secrets. Run it again after any `.env`, DNS, or compose change.
 
+### Production auth checklist
+
+For the gated POC, users are invited manually. Do not enable public signup until
+tenant lifecycle, abuse controls, quotas, billing, and self-service credential
+rotation exist.
+
+Before sharing the link, verify:
+
+| Boundary | Required setting |
+|---|---|
+| Browser session | `AGENT_BOM_BROWSER_SESSION_SIGNING_KEY` is set, random, and stored as a secret. `AGENT_BOM_SESSION_COOKIE_SECURE=1` is enabled behind HTTPS. |
+| API auth | `AGENT_BOM_API_KEY` or OIDC/SAML/proxy auth is configured. `AGENT_BOM_ALLOW_UNAUTHENTICATED_API` is unset. |
+| Tenant binding | Each invited account has an explicit tenant. Do not use default-tenant OIDC/SAML fallbacks for multi-tenant testing. |
+| Connection broker | `AGENT_BOM_CONNECTIONS_KEY` is a Fernet key and is never committed, logged, or reused across unrelated environments. |
+| Audit integrity | `AGENT_BOM_AUDIT_HMAC_KEY` is set and survives restarts so audit signatures remain verifiable. |
+| MCP read access | `AGENT_BOM_MCP_BEARER_TOKEN` is tenant/environment-scoped and has an expiry where possible. |
+| MCP write access | `AGENT_BOM_MCP_OPERATOR_TOKEN` is separate from the read token, expires, and is issued only to operators who need Shield/gateway write tools. |
+| CORS/TLS | `CORS_ORIGINS` contains only the hosted URL and internal UI origin. Caddy/ALB terminates HTTPS; API/UI bind to loopback/private network only. |
+| Usage control | Invitees have explicit scan windows, provider/account scope, and a manual revoke path before they connect a cloud or Snowflake account. |
+
+If any row is unknown, stop and keep the deployment internal.
+
 ### Caddy front door
 
 Example `Caddyfile`:

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -10,6 +10,29 @@ For each tagged GitHub Release, expect:
 - SLSA provenance bundles for each distribution: `*.intoto.jsonl`
 - CycloneDX SBOM: `agent-bom-sbom.cdx.json`
 
+## Release matrix
+
+Run this matrix before tagging a release that will back a hosted POC or a
+customer self-hosted deployment. The goal is to prove the exact artifact shape
+that users will touch: package install, CLI, API, UI, hosted preflight, and
+signed release evidence.
+
+| Surface | Command | Release bar |
+|---|---|---|
+| Version alignment | `uv run python scripts/check_release_consistency.py` | Package, docs, OpenAPI, Docker, Helm, and integration versions agree. |
+| Product contract | `uv run python scripts/check_product_surface_contract.py` | README/product-surface claims match generated metrics and exposed surfaces. |
+| API schema | `uv run python scripts/generate_v1_schemas.py --check` | Published v1 schemas match the Pydantic models. |
+| CLI docs | `uv run python scripts/check_cli_reference_alignment.py` | CLI reference and implemented command tree agree. |
+| Security guards | `uv run python scripts/check_exception_sanitization.py` and `uv run python scripts/check_provisioning_readonly.py` | API/gateway/runtime errors are sanitized and cloud provisioning stays read-only. |
+| Backend tests | `uv run pytest -q` | Python 3.11/3.13/3.14 CI must pass; local focused suites should cover changed areas. |
+| UI build | `cd ui && npm run typecheck && npm run lint && npm run build && npm run bundle:check && npm run test:run` | The dashboard builds, tests pass, and client JS stays under budget. |
+| Package build | `uv build --out-dir /tmp/agent-bom-build` | Wheel and sdist build from a clean tree. |
+| PyPI smoke | `python -m venv /tmp/agent-bom-smoke && /tmp/agent-bom-smoke/bin/pip install agent-bom==<version> && /tmp/agent-bom-smoke/bin/agent-bom --version` | Published package installs in a fresh environment. |
+| Quickstart E2E | `agent-bom quickstart --run --offline --force --sample-dir /tmp/agent-bom-quickstart` | Generates a real report, graph, posture, and no coverage warnings. |
+| Hosted preflight | `python scripts/deploy/hosted_poc_preflight.py --write-postgres-secret` | Hosted compose has an HTTPS URL, no unauth mode, non-placeholder secrets, private API/UI binds, and safe CORS. |
+
+Do not publish a release as hosted-ready when any required line above is red.
+
 ## Download release assets
 
 ```bash

--- a/scripts/check_exception_sanitization.py
+++ b/scripts/check_exception_sanitization.py
@@ -49,7 +49,10 @@ INCLUDE_DIRS: tuple[str, ...] = (
     "src/agent_bom/cloud",
     "src/agent_bom/runtime",
 )
-INCLUDE_FILES: tuple[str, ...] = ("src/agent_bom/proxy.py",)
+INCLUDE_FILES: tuple[str, ...] = (
+    "src/agent_bom/gateway_server.py",
+    "src/agent_bom/proxy.py",
+)
 
 EXCLUDE_FRAGMENTS: tuple[str, ...] = (
     "/test",

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -80,6 +80,7 @@ from agent_bom.proxy_policy import (
 )
 from agent_bom.proxy_scanner import ScanConfig, redact_pii, scan_tool_call, scan_tool_response
 from agent_bom.runtime.graph_reachability import ReachabilityMap, load_reachability_map
+from agent_bom.security import sanitize_error, sanitize_text
 
 logger = logging.getLogger(__name__)
 _GATEWAY_TRACER = get_tracer("agent_bom.gateway")
@@ -98,7 +99,12 @@ _visual_detector_lock = threading.Lock()
 
 def _sanitize_for_log(value: Any) -> str:
     """Return a single-line representation safe for plain-text logs."""
-    return str(value).replace("\r", "").replace("\n", "")
+    return sanitize_text(value).replace("\r", "").replace("\n", "")
+
+
+def _public_gateway_error(exc: Exception | str) -> str:
+    """Return a non-diagnostic gateway error safe for clients and audit sinks."""
+    return sanitize_error(exc, generic=True)
 
 
 def _public_gateway_block_reason(policy_source: str) -> str:
@@ -1008,11 +1014,11 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     return False
                 next_policy = _load_policy_file(settings.policy_path)
             except FileNotFoundError as exc:
-                policy_state["last_error"] = str(exc)
+                policy_state["last_error"] = sanitize_error(exc)
                 logger.warning("gateway policy reload failed for %s: %s", settings.policy_path, _sanitize_for_log(exc))
                 return False
             except Exception as exc:  # noqa: BLE001
-                policy_state["last_error"] = str(exc)
+                policy_state["last_error"] = sanitize_error(exc)
                 logger.warning("gateway policy reload failed for %s: %s", settings.policy_path, _sanitize_for_log(exc))
                 return False
 
@@ -1070,7 +1076,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     return False
                 next_policy = load_firewall_policy_file(settings.firewall_policy_path)
             except (FileNotFoundError, FirewallPolicyError) as exc:
-                firewall_state["last_error"] = str(exc)
+                firewall_state["last_error"] = sanitize_error(exc)
                 logger.warning(
                     "gateway firewall policy reload failed for %s: %s",
                     settings.firewall_policy_path,
@@ -1078,7 +1084,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 )
                 return False
             except Exception as exc:  # noqa: BLE001
-                firewall_state["last_error"] = str(exc)
+                firewall_state["last_error"] = sanitize_error(exc)
                 logger.warning(
                     "gateway firewall policy reload failed for %s: %s",
                     settings.firewall_policy_path,
@@ -1351,7 +1357,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         try:
             body = json.loads(raw_body)
         except Exception as exc:  # noqa: BLE001
-            raise HTTPException(status_code=400, detail=f"body is not valid JSON: {exc}") from exc
+            raise HTTPException(status_code=400, detail=f"body is not valid JSON: {sanitize_error(exc)}") from exc
 
         # Parse the JSON-RPC envelope so check_policy sees the real message shape.
         if isinstance(body, dict) and "jsonrpc" in body:
@@ -2399,10 +2405,10 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                         "action": "gateway.upstream_error",
                         "upstream": upstream.name,
                         "tenant_id": tenant_id,
-                        "error": str(exc),
+                        "error": _public_gateway_error(exc),
                     }
                 )
-            raise HTTPException(status_code=502, detail=f"upstream error: {exc}") from exc
+            raise HTTPException(status_code=502, detail=f"upstream error: {_public_gateway_error(exc)}") from exc
 
         record_gateway_relay(upstream.name, "forwarded")
 

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -1014,7 +1014,7 @@ def test_relay_upstream_error_surfaces_as_502_and_is_audited() -> None:
     audit_events: list[dict[str, Any]] = []
 
     async def failing_caller(upstream, message, extra_headers):
-        raise RuntimeError("boom")
+        raise RuntimeError("boom token=SECRET123 /etc/agent-bom/upstream.yml")
 
     async def audit_sink(event):
         audit_events.append(event)
@@ -1031,8 +1031,17 @@ def test_relay_upstream_error_surfaces_as_502_and_is_audited() -> None:
         json=_json_rpc("tools/call", name="read_file", arguments={"path": "/tmp/x"}),
     )
     assert resp.status_code == 502
-    assert "boom" in resp.json()["detail"]
-    assert any(e["action"] == "gateway.upstream_error" for e in audit_events)
+    assert resp.json()["detail"] == "upstream error: An internal error occurred. Please contact support."
+    assert audit_events == [
+        {
+            "action": "gateway.upstream_error",
+            "upstream": "filesystem",
+            "tenant_id": "default",
+            "error": "An internal error occurred. Please contact support.",
+        }
+    ]
+    assert "SECRET123" not in json.dumps(audit_events)
+    assert "/etc/agent-bom" not in json.dumps(audit_events)
 
 
 def test_relay_upstream_timeout_surfaces_as_502_and_is_audited() -> None:


### PR DESCRIPTION
Summary
- sanitize gateway reload/upstream errors before exposing them through health, audit, or HTTP responses
- extend exception-sanitization guard coverage to gateway_server.py
- add release matrix and hosted POC production auth checklist

Validation
- uv run pytest -q tests/test_gateway_server.py tests/test_gateway_oauth_broker.py tests/test_exception_sanitization_guard.py
- uv run ruff check src/agent_bom/gateway_server.py scripts/check_exception_sanitization.py tests/test_gateway_server.py tests/test_exception_sanitization_guard.py
- uv run python scripts/check_exception_sanitization.py
- uv run python scripts/check_release_consistency.py
- uv run python scripts/check_product_surface_contract.py