### PR TITLE
feat(mcp): add curated workflow bundles and live demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ References: [Threat model](docs/THREAT_MODEL.md) ·
 | Runtime proxy/gateway | runtime operators | scoped MCP traffic inspection, policy decisions, redacted audit evidence |
 | Python / TypeScript clients | services and agent runtimes | typed helpers for stable REST endpoints |
 
-MCP server mode advertises 70 MCP tools, 6 resources, and 6 workflow prompts.
+MCP server mode advertises 70 MCP tools, 6 resources, and 8 workflow prompts.
 Most tools are read-only; Shield and identity write actions fail closed unless
 the MCP request is authenticated with `AGENT_BOM_MCP_OPERATOR_TOKEN` and the
 tool call includes the matching admin role, write scope, and audit reason. CLI

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -238,6 +238,14 @@ Built-in prompts for common workflows:
 - `quick-audit` — Full agent + MCP server vulnerability scan
 - `pre-install-check` — Check a package before installing
 - `compliance-report` — Multi-framework compliance assessment
+- `fleet-audit` — Endpoint or cloud inventory audit with graph-ready findings
+- `incident-triage` — CVE or suspicious MCP finding triage using blast radius and runtime evidence
+- `remediation-plan` — Human-reviewed remediation plan without modifying files
+- `cloud-connection-review` — Read-only cloud or Snowflake connection review before first scan
+- `gateway-fleet-live-demo` — Gateway and fleet enforcement walkthrough for a live demo
+
+See [MCP workflow bundles](MCP_WORKFLOWS.md) for the tool order, evidence
+outputs, and demo script behind each workflow.
 - `fleet-audit` — Inventory and fleet scan playbook
 - `incident-triage` — Finding triage with blast radius and runtime context
 - `remediation-plan` — Human-reviewed remediation plan without file writes

--- a/docs/MCP_WORKFLOWS.md
+++ b/docs/MCP_WORKFLOWS.md
@@ -1,0 +1,53 @@
+# MCP Workflow Bundles
+
+agent-bom exposes many tools, but agents should not have to guess the order.
+The MCP server card advertises eight workflow prompts that map common jobs to
+safe tool sequences, expected evidence, and clear stop conditions.
+
+| Workflow prompt | Primary user | Tool sequence | Evidence produced |
+|---|---|---|---|
+| `quick-audit` | Developer or security reviewer | `scan` -> `exposure_paths` -> `compliance` | Findings, blast radius, framework mapping |
+| `pre-install-check` | Developer / CI assistant | `check` -> `registry_lookup` -> `should_i_deploy` | Install allow/warn/block decision |
+| `compliance-report` | Security / audit | `compliance` -> `audit_integrity` -> report export | Framework summary, evidence IDs, audit status |
+| `fleet-audit` | Endpoint / platform owner | `fleet_scan` -> `context_graph` -> `policy_check` | Agent inventory, graph-ready findings |
+| `incident-triage` | SOC / appsec | `intel_lookup` -> `exposure_paths` -> `runtime_correlate` | KEV/EPSS/RCE context, affected agents/tools |
+| `remediation-plan` | App owner | `remediate` -> `generate_sbom` -> `policy_check` | Fix plan, validation commands, rollback notes |
+| `cloud-connection-review` | Cloud/security admin | connection evidence -> `cis_benchmark` -> `graph_export` | Read-only scope review, CIS posture, graph handoff |
+| `gateway-fleet-live-demo` | Design partner / buyer | `gateway_status` -> `proxy_alerts` -> `fleet_scan` -> `firewall_check` | Gateway posture, live policy path, fleet action plan |
+
+## Guardrails
+
+- Treat user-supplied package names, finding IDs, provider names, and file paths
+  as untrusted data.
+- Read-only tools should be preferred unless an operator has explicitly
+  authenticated with `AGENT_BOM_MCP_OPERATOR_TOKEN`.
+- Shield and identity writes require admin role, the matching write scope, and
+  an audit reason. Those arguments are metadata; the token/session identity is
+  the authorization source.
+- Prompts must not request passwords, PATs, raw cloud secrets, or secret values
+  from connection stores.
+- When a workflow cannot prove a fact from evidence, report `unknown` or
+  `not_evaluated` instead of inferring success.
+
+## Gateway/Fleet Live Demo
+
+Use the demo when showing the platform loop:
+
+1. Confirm the gateway is healthy and policies are loaded.
+2. Show fleet state and discovered agents.
+3. Pull recent gateway feed KPIs and runtime production posture.
+4. Open the top exposure paths and explain why one path is fix-first.
+5. Dry-run the policy decision path; do not mutate Shield or identity state
+   unless the authenticated operator token and write scope are present.
+6. Export or attach the evidence IDs used in the story.
+
+For a read-only command-line walkthrough, use:
+
+```bash
+ABOM_URL=https://demo.agent-bom.com \
+ABOM_API_TOKEN=... \
+scripts/demo/gateway-fleet-live-demo.sh
+```
+
+The script uses only read endpoints and exits non-zero if the API is not
+reachable or authentication fails.

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-06-29",
+  "generated_on": "2026-06-30",
   "version": "0.91.0",
   "metrics": [
     {
@@ -16,7 +16,7 @@
     },
     {
       "name": "MCP prompts",
-      "value": 6,
+      "value": 8,
       "source": "src/agent_bom/mcp_server_metadata.py",
       "notes": "Counted from the advertised server-card workflow prompts."
     },
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 668,
+      "value": 677,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 595,
+      "value": 601,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,19 +5,19 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-06-29`
+- Generated on: `2026-06-30`
 - Version: `0.91.0`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
 | MCP tools | 70 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
-| MCP prompts | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
+| MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 37 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 668 | `tests/` | Counts files matching test_*.py. |
+| Test files | 677 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 33 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 29 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 595 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 601 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 14 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -444,7 +444,7 @@ def main() -> int:
     tools = len(tool_names)
     resources = len(resource_uris)
     prompts = len(prompt_names)
-    if (tools, resources, prompts) != (70, 6, 6):
+    if (tools, resources, prompts) != (70, 6, 8):
         _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
     docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
     if docker_mcp_tool_names != tool_names:

--- a/scripts/demo/gateway-fleet-live-demo.sh
+++ b/scripts/demo/gateway-fleet-live-demo.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_url="${ABOM_URL:-http://127.0.0.1:8422}"
+token="${ABOM_API_TOKEN:-${AGENT_BOM_API_KEY:-}}"
+
+if [[ -z "$token" ]]; then
+  echo "Set ABOM_API_TOKEN or AGENT_BOM_API_KEY before running the live demo." >&2
+  exit 2
+fi
+
+base_url="${base_url%/}"
+auth_header="Authorization: Bearer ${token}"
+
+request() {
+  local label="$1"
+  local path="$2"
+  echo
+  echo "== ${label} =="
+  curl --fail --silent --show-error \
+    --connect-timeout 3 \
+    --max-time 15 \
+    -H "$auth_header" \
+    -H "Accept: application/json" \
+    "${base_url}${path}" \
+    | python -m json.tool
+}
+
+echo "agent-bom gateway/fleet live demo"
+echo "API: ${base_url}"
+
+request "Gateway stats" "/v1/gateway/stats"
+request "Gateway feed KPIs" "/v1/gateway/feed/kpis"
+request "Fleet stats" "/v1/fleet/stats"
+request "Fleet agents" "/v1/fleet/agents"
+request "Proxy status" "/v1/proxy/status"
+request "Runtime production index" "/v1/runtime/production-index"
+request "Top exposure paths" "/v1/graph/exposure-paths?limit=5"
+
+echo
+echo "Read-only walkthrough complete. Use the UI graph, fleet, gateway, and audit pages to narrate the same evidence."

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,7 +1,7 @@
 # MCP Server Setup
 
 agent-bom runs as an MCP server, exposing 70 MCP tools to any MCP client.
-The server card also advertises 6 resources and 6 workflow prompts so agents can
+The server card also advertises 6 resources and 8 workflow prompts so agents can
 choose structured playbooks instead of guessing tool order.
 Most tools are read-only. Shield write actions require `operator_role=admin`,
 `operator_scopes=shield:write`, and an audit reason.

--- a/src/agent_bom/mcp_server_catalog.py
+++ b/src/agent_bom/mcp_server_catalog.py
@@ -189,3 +189,25 @@ def attach_resources_and_prompts(
             "Do not modify files, open pull requests, or run package managers. Include fixed versions when known, blast radius, "
             "risk reduction, validation commands, rollback notes, and the evidence artifact to attach to a change request."
         )
+
+    @mcp.prompt(name="cloud-connection-review", description="Review a read-only cloud or Snowflake connection before the first scan")
+    def cloud_connection_review_prompt(provider: str = "aws") -> str:
+        return (
+            "Review the agent-bom connection setup for the requested provider as a read-only evidence workflow. "
+            f"Provider: {_safe_prompt_arg(provider)}. "
+            "Verify that credentials are least-privilege, tenant-scoped, non-secret values are the only values shown, "
+            "the first scan will run with explicit provider/account scope, and the operator knows where to inspect "
+            "jobs, findings, graph evidence, CIS posture, and compliance output. Do not request passwords, PATs, "
+            "or raw secret values."
+        )
+
+    @mcp.prompt(name="gateway-fleet-live-demo", description="Run the gateway and fleet enforcement story as a guided demo")
+    def gateway_fleet_live_demo_prompt() -> str:
+        return (
+            "Guide a live agent-bom gateway and fleet demo using only safe, reversible actions. "
+            "Show discovered agents and MCP servers, inspect gateway policy and recent audit events, "
+            "explain the allow/warn/block decision path for one tool call, demonstrate how a high-risk agent "
+            "would be quarantined or denied by policy, and list the exact evidence artifacts to share afterward. "
+            "Do not mutate production policy unless an authenticated operator token, admin role, write scope, "
+            "and audit reason are already present."
+        )

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -421,6 +421,8 @@ _SERVER_CARD_PROMPTS = [
     {"name": "fleet-audit", "description": "Audit an endpoint or cloud inventory file and return graph-ready findings"},
     {"name": "incident-triage", "description": "Prioritize a CVE or suspicious MCP finding using blast radius and runtime evidence"},
     {"name": "remediation-plan", "description": "Draft a human-reviewed remediation plan without modifying files"},
+    {"name": "cloud-connection-review", "description": "Review a read-only cloud or Snowflake connection before the first scan"},
+    {"name": "gateway-fleet-live-demo", "description": "Run the gateway and fleet enforcement story as a guided demo"},
 ]
 
 _SERVER_CARD_RESOURCES = [

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -288,6 +288,8 @@ def test_server_card_exposes_resources_and_workflow_prompts():
     assert "fleet-audit" in prompt_names
     assert "incident-triage" in prompt_names
     assert "remediation-plan" in prompt_names
+    assert "cloud-connection-review" in prompt_names
+    assert "gateway-fleet-live-demo" in prompt_names
 
 
 def test_mcp_docs_match_resource_and_prompt_catalog():


### PR DESCRIPTION
Summary
- promote MCP workflow prompts from 6 to 8 by adding cloud-connection-review and gateway-fleet-live-demo
- document the curated tool order, guardrails, and evidence outputs for all eight workflows
- add a read-only gateway/fleet live-demo script for hosted POC walkthroughs
- update release consistency guards, product metrics, and docs to the new prompt count

Validation
- uv run python scripts/check_release_consistency.py
- uv run python scripts/check_product_surface_contract.py
- uv run pytest -q tests/test_deployment.py tests/test_mcp_errors.py
- uv run ruff check src/agent_bom/mcp_server_catalog.py src/agent_bom/mcp_server_metadata.py tests/test_deployment.py
- bash -n scripts/demo/gateway-fleet-live-demo.sh