### PR TITLE
feat(cloud): event-driven AWS posture — CloudTrail/EventBridge ingestion + per-resource rule re-eval

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -37,6 +37,10 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_API_SCAN_LEASE_SECONDS` | `int` | `600` | Distributed scan dispatch (multi-replica work-stealing). When enabled, scan jobs are enqueued to a shared Postgres dispatch queue and any control-plane replica claims them via FOR UPDATE SKIP LOCKED, so scan throughput scales with replicas  |
 | `AGENT_BOM_API_SCAN_WORKERS` | `int` | `min(4, os.cpu_count() or 2)` | — |
 | `AGENT_BOM_API_SCAN_WORKER_RECYCLE_JOBS` | `int` | `10` | — |
+| `AGENT_BOM_AWS_EVENT_MAX_BATCHES` | `int` | `10` | — |
+| `AGENT_BOM_AWS_EVENT_MAX_MESSAGES` | `int` | `10` | Event-driven AWS posture ingestion (continuous posture). When an operator wires EventBridge→SQS (opt-in via AGENT_BOM_AWS_EVENT_QUEUE_URL, read live, default off), the bounded SQS consumer drains change events and re-evaluates only the affe |
+| `AGENT_BOM_AWS_EVENT_VISIBILITY_TIMEOUT` | `int` | `120` | — |
+| `AGENT_BOM_AWS_EVENT_WAIT_SECONDS` | `int` | `5` | — |
 | `AGENT_BOM_BODY_MIN_BPS` | `int` | `256` | Slowloris throughput floor (audit-5 PR-C): minimum sustained body bytes/second once a request body crosses the warmup threshold inside MaxBodySizeMiddleware. 0 disables the floor entirely (escape hatch for legitimate slow clients in restric |
 | `AGENT_BOM_CONNECTIONS_SCHEDULER_MAX_CONCURRENCY` | `int` | `4` | — |
 | `AGENT_BOM_CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES` | `int` | `15` | — |

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -51,6 +51,8 @@ AGENT_BOM_AUTH_SESSION_ATTEMPTS_PER_MINUTE
 AGENT_BOM_AUTO_UPDATE_DB
 # Opt-in (default OFF) gate to fan the read-only AWS inventory across every enabled region (multi-region aggregation).
 AGENT_BOM_AWS_ALL_REGIONS
+# Opt-in (default OFF, read live) SQS queue URL for event-driven AWS posture ingestion; when set, the operator has wired EventBridge→SQS and the bounded consumer drains CloudTrail change events. Deploy-only toggle; absence disables the consumer.
+AGENT_BOM_AWS_EVENT_QUEUE_URL
 # Opt-in (default OFF) gate for the estate-wide read-only Azure asset inventory scanner (token/credential auth only).
 AGENT_BOM_AWS_INVENTORY
 # Defensive cap on the number of member accounts a single AWS Organizations scan fans out over (default 200).

--- a/src/agent_bom/api/connection_store.py
+++ b/src/agent_bom/api/connection_store.py
@@ -58,6 +58,11 @@ class CloudConnectionRecord:
     last_scan_at: str | None = None
     last_scan_id: str | None = None
     scan_interval_minutes: int | None = None
+    # Timestamp of the most recent event-driven (CloudTrail/EventBridge) posture
+    # re-evaluation, distinct from ``last_scan_at`` (the last full polling scan).
+    # Lets the UI surface an event-driven-vs-polling freshness signal: a
+    # connection reacting to change events stays fresh between scheduled scans.
+    last_event_at: str | None = None
     # Non-secret, provider-specific connection parameters (e.g. Azure
     # tenant_id/subscription_id, GCP project_id, Snowflake user/role/warehouse).
     # The single reversible secret per connection lives in
@@ -117,6 +122,7 @@ CONNECTION_STORAGE_SCHEMA = StorageSchema(
                 "last_scan_id",
                 "scan_interval_minutes",
                 "auth_params",
+                "last_event_at",
             ),
             ddl_by_backend={
                 "sqlite": (
@@ -126,7 +132,8 @@ CONNECTION_STORAGE_SCHEMA = StorageSchema(
                     "regions TEXT NOT NULL DEFAULT '[]', status TEXT NOT NULL DEFAULT 'pending', "
                     "status_detail TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL, "
                     "updated_at TEXT NOT NULL, last_scan_at TEXT, last_scan_id TEXT, "
-                    "scan_interval_minutes INTEGER, auth_params TEXT NOT NULL DEFAULT '{}')"
+                    "scan_interval_minutes INTEGER, auth_params TEXT NOT NULL DEFAULT '{}', "
+                    "last_event_at TEXT)"
                 ),
                 "postgres": (
                     "CREATE TABLE IF NOT EXISTS cloud_connections (id TEXT PRIMARY KEY, "
@@ -135,7 +142,8 @@ CONNECTION_STORAGE_SCHEMA = StorageSchema(
                     "regions TEXT NOT NULL DEFAULT '[]', status TEXT NOT NULL DEFAULT 'pending', "
                     "status_detail TEXT NOT NULL DEFAULT '', created_at TEXT NOT NULL, "
                     "updated_at TEXT NOT NULL, last_scan_at TEXT, last_scan_id TEXT, "
-                    "scan_interval_minutes INTEGER, auth_params TEXT NOT NULL DEFAULT '{}')"
+                    "scan_interval_minutes INTEGER, auth_params TEXT NOT NULL DEFAULT '{}', "
+                    "last_event_at TEXT)"
                 ),
             },
         ),
@@ -184,8 +192,19 @@ def _decode_auth_params(raw: Any) -> dict[str, Any]:
 
 
 def _row_to_record(row: Sequence[Any]) -> CloudConnectionRecord:
-    """Map a ``cloud_connections`` row tuple to a record (shared by backends)."""
-    has_last_scan_id = len(row) > 14
+    """Map a ``cloud_connections`` row tuple to a record (shared by backends).
+
+    The two durable backends select slightly different column shapes: the SQLite
+    SELECT carries ``last_scan_id`` (16 columns) while the Postgres SELECT omits
+    it (15 columns). ``last_scan_id`` therefore only exists in the wider SQLite
+    shape; every other column keeps the same relative order in both, so a single
+    length check distinguishes them and the trailing columns are read positionally
+    from the correct index in each shape.
+    """
+    has_last_scan_id = len(row) >= 16
+    interval_idx = 13 if has_last_scan_id else 12
+    auth_idx = 14 if has_last_scan_id else 13
+    event_idx = 15 if has_last_scan_id else 14
     return CloudConnectionRecord(
         id=row[0],
         tenant_id=row[1],
@@ -200,10 +219,9 @@ def _row_to_record(row: Sequence[Any]) -> CloudConnectionRecord:
         updated_at=row[10] or "",
         last_scan_at=row[11] if len(row) > 11 else None,
         last_scan_id=row[12] if has_last_scan_id else None,
-        scan_interval_minutes=(
-            _decode_interval(row[13] if has_last_scan_id else row[12]) if len(row) > 12 else None
-        ),
-        auth_params=_decode_auth_params(row[14] if has_last_scan_id else row[13]) if len(row) > 13 else {},
+        scan_interval_minutes=(_decode_interval(row[interval_idx]) if len(row) > interval_idx else None),
+        auth_params=_decode_auth_params(row[auth_idx]) if len(row) > auth_idx else {},
+        last_event_at=row[event_idx] if len(row) > event_idx else None,
     )
 
 
@@ -307,6 +325,8 @@ class SQLiteConnectionStore:
             # Idempotent migration: backfill existing rows with an empty object so
             # the column stays NOT NULL and legacy connections read as no-params.
             self._conn.execute("ALTER TABLE cloud_connections ADD COLUMN auth_params TEXT NOT NULL DEFAULT '{}'")
+        if "last_event_at" not in columns:
+            self._conn.execute("ALTER TABLE cloud_connections ADD COLUMN last_event_at TEXT")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_cloud_connections_tenant ON cloud_connections(tenant_id, created_at)")
         self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_cloud_connections_schedulable ON cloud_connections(scan_interval_minutes, last_scan_at)"
@@ -319,8 +339,8 @@ class SQLiteConnectionStore:
             INSERT OR REPLACE INTO cloud_connections
                 (id, tenant_id, provider, display_name, role_ref, external_id_encrypted,
                  regions, status, status_detail, created_at, updated_at, last_scan_at,
-                 last_scan_id, scan_interval_minutes, auth_params)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 last_scan_id, scan_interval_minutes, auth_params, last_event_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 record.id,
@@ -338,6 +358,7 @@ class SQLiteConnectionStore:
                 record.last_scan_id,
                 record.scan_interval_minutes,
                 json.dumps(record.auth_params),
+                record.last_event_at,
             ),
         )
         self._conn.commit()
@@ -345,7 +366,8 @@ class SQLiteConnectionStore:
     def get(self, tenant_id: str, connection_id: str) -> CloudConnectionRecord | None:
         row = self._conn.execute(
             "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-            "regions, status, status_detail, created_at, updated_at, last_scan_at, last_scan_id, scan_interval_minutes, auth_params "
+            "regions, status, status_detail, created_at, updated_at, last_scan_at, "
+            "last_scan_id, scan_interval_minutes, auth_params, last_event_at "
             "FROM cloud_connections WHERE tenant_id = ? AND id = ?",
             (tenant_id, connection_id),
         ).fetchone()
@@ -354,7 +376,8 @@ class SQLiteConnectionStore:
     def list_for_tenant(self, tenant_id: str) -> list[CloudConnectionRecord]:
         rows = self._conn.execute(
             "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-            "regions, status, status_detail, created_at, updated_at, last_scan_at, last_scan_id, scan_interval_minutes, auth_params "
+            "regions, status, status_detail, created_at, updated_at, last_scan_at, "
+            "last_scan_id, scan_interval_minutes, auth_params, last_event_at "
             "FROM cloud_connections WHERE tenant_id = ? ORDER BY created_at, id",
             (tenant_id,),
         ).fetchall()
@@ -371,7 +394,8 @@ class SQLiteConnectionStore:
     def list_schedulable(self) -> list[CloudConnectionRecord]:
         rows = self._conn.execute(
             "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-            "regions, status, status_detail, created_at, updated_at, last_scan_at, last_scan_id, scan_interval_minutes, auth_params "
+            "regions, status, status_detail, created_at, updated_at, last_scan_at, "
+            "last_scan_id, scan_interval_minutes, auth_params, last_event_at "
             "FROM cloud_connections WHERE scan_interval_minutes IS NOT NULL ORDER BY created_at, id"
         ).fetchall()
         return [_row_to_record(row) for row in rows]

--- a/src/agent_bom/api/postgres_connection.py
+++ b/src/agent_bom/api/postgres_connection.py
@@ -50,13 +50,15 @@ class PostgresConnectionStore:
                     updated_at            TEXT NOT NULL,
                     last_scan_at          TEXT,
                     scan_interval_minutes INTEGER,
-                    auth_params           TEXT NOT NULL DEFAULT '{}'
+                    auth_params           TEXT NOT NULL DEFAULT '{}',
+                    last_event_at         TEXT
                 )
             """)
             conn.execute("ALTER TABLE cloud_connections ADD COLUMN IF NOT EXISTS scan_interval_minutes INTEGER")
             # Idempotent migration: backfill existing rows with an empty object so
             # the column stays NOT NULL and legacy connections read as no-params.
             conn.execute("ALTER TABLE cloud_connections ADD COLUMN IF NOT EXISTS auth_params TEXT NOT NULL DEFAULT '{}'")
+            conn.execute("ALTER TABLE cloud_connections ADD COLUMN IF NOT EXISTS last_event_at TEXT")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_cloud_connections_tenant ON cloud_connections(tenant_id, created_at)")
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_cloud_connections_schedulable ON cloud_connections(scan_interval_minutes, last_scan_at)"
@@ -71,8 +73,8 @@ class PostgresConnectionStore:
                 INSERT INTO cloud_connections
                     (id, tenant_id, provider, display_name, role_ref, external_id_encrypted,
                      regions, status, status_detail, created_at, updated_at, last_scan_at,
-                     scan_interval_minutes, auth_params)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                     scan_interval_minutes, auth_params, last_event_at)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (id) DO UPDATE SET
                     provider = EXCLUDED.provider,
                     display_name = EXCLUDED.display_name,
@@ -84,7 +86,8 @@ class PostgresConnectionStore:
                     updated_at = EXCLUDED.updated_at,
                     last_scan_at = EXCLUDED.last_scan_at,
                     scan_interval_minutes = EXCLUDED.scan_interval_minutes,
-                    auth_params = EXCLUDED.auth_params
+                    auth_params = EXCLUDED.auth_params,
+                    last_event_at = EXCLUDED.last_event_at
                 """,
                 (
                     record.id,
@@ -101,6 +104,7 @@ class PostgresConnectionStore:
                     record.last_scan_at,
                     record.scan_interval_minutes,
                     json.dumps(record.auth_params),
+                    record.last_event_at,
                 ),
             )
             conn.commit()
@@ -109,7 +113,7 @@ class PostgresConnectionStore:
         with _tenant_connection(self._pool) as conn:
             row = conn.execute(
                 "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params "
+                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params, last_event_at "
                 "FROM cloud_connections WHERE tenant_id = %s AND id = %s",
                 (tenant_id, connection_id),
             ).fetchone()
@@ -119,7 +123,7 @@ class PostgresConnectionStore:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params "
+                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params, last_event_at "
                 "FROM cloud_connections WHERE tenant_id = %s ORDER BY created_at, id",
                 (tenant_id,),
             ).fetchall()
@@ -144,7 +148,7 @@ class PostgresConnectionStore:
         with bypass_tenant_rls(), _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
-                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params "
+                "regions, status, status_detail, created_at, updated_at, last_scan_at, scan_interval_minutes, auth_params, last_event_at "
                 "FROM cloud_connections WHERE scan_interval_minutes IS NOT NULL ORDER BY created_at, id"
             ).fetchall()
         return [_row_to_record(row) for row in rows]

--- a/src/agent_bom/cloud/event_ingest.py
+++ b/src/agent_bom/cloud/event_ingest.py
@@ -293,6 +293,7 @@ def dispatch_change_event(
     *,
     tenant_id: str | None = None,
     session: Any = None,
+    benchmark_runner: Callable[..., Any] | None = None,
     persist: Callable[[CloudConnectionRecord, str, Any], str] | None = None,
     store: Any = None,
 ) -> dict[str, Any] | None:
@@ -332,8 +333,15 @@ def dispatch_change_event(
         return None
 
     from agent_bom.cloud import aws_inventory
-    from agent_bom.cloud.aws_cis_benchmark import run_benchmark
     from agent_bom.models import AIBOMReport
+
+    run_cis_benchmark: Callable[..., Any]
+    if benchmark_runner is not None:
+        run_cis_benchmark = benchmark_runner
+    else:
+        from agent_bom.cloud.aws_cis_benchmark import run_benchmark
+
+        run_cis_benchmark = run_benchmark
 
     if session is None:
         from agent_bom.cloud.connection_broker import broker_session
@@ -356,7 +364,7 @@ def dispatch_change_event(
     )
     affected = _find_affected_resource(rule, inventory_payload, event.resource_id)
 
-    cis_report = run_benchmark(region=region, session=session, checks=list(rule.check_ids))
+    cis_report = run_cis_benchmark(region=region, session=session, checks=list(rule.check_ids))
     cis_dict = cis_report.to_dict()
     findings = [check for check in cis_dict.get("checks", []) if check.get("status") == "fail"]
 
@@ -431,6 +439,7 @@ def consume_aws_events(
     max_batches: int | None = None,
     visibility_timeout: int | None = None,
     wait_seconds: int | None = None,
+    benchmark_runner: Callable[..., Any] | None = None,
     persist: Callable[[CloudConnectionRecord, str, Any], str] | None = None,
     store: Any = None,
 ) -> dict[str, Any]:
@@ -540,7 +549,13 @@ def consume_aws_events(
 
             try:
                 dispatch_change_event(
-                    event, record, tenant_id=tenant_id, session=session, persist=persist, store=store
+                    event,
+                    record,
+                    tenant_id=tenant_id,
+                    session=session,
+                    benchmark_runner=benchmark_runner,
+                    persist=persist,
+                    store=store,
                 )
             except Exception as exc:  # noqa: BLE001 — leave on queue for redelivery; never crash the drain
                 logger.warning(

--- a/src/agent_bom/cloud/event_ingest.py
+++ b/src/agent_bom/cloud/event_ingest.py
@@ -1,0 +1,569 @@
+"""Event-driven AWS posture ingestion (continuous / change-triggered CNAPP).
+
+The polling scheduler (:mod:`agent_bom.api.connection_scheduler`) re-scans a
+whole connection on an interval. This module adds the complementary, reactive
+lane: when a resource changes in a customer account, AWS emits a CloudTrail
+management event that EventBridge can route to an SQS queue. The control plane
+drains that queue and re-evaluates **only** the CIS rules that apply to the
+changed resource's type — so a bucket made public is re-checked in seconds
+instead of waiting for the next scheduled full scan. Polling remains the
+fallback; this is additive.
+
+Trust posture (non-negotiable, fail-closed):
+
+* **Read-only against the customer.** The changed resource is re-fetched and its
+  CIS checks re-run through the SAME brokered, short-lived read-only role the
+  scheduled scan uses (:func:`agent_bom.cloud.connection_broker.broker_session`).
+  No write API is ever called on the customer account.
+* **Account-bound.** A change event is only dispatched when its account matches
+  the connection's own account (derived from the connection's ``role_ref`` ARN).
+  A spoofed / cross-account event is dropped, never processed — this prevents a
+  confused-deputy where an attacker-controlled queue message steers a scan at an
+  account the tenant does not own.
+* **Bounded.** :func:`consume_aws_events` drains at most a configured number of
+  messages across a configured number of receive batches and then RETURNS. There
+  is no forever loop; an operator (or a scheduler tick) invokes it repeatedly.
+* **Crash-proof.** A malformed message is logged and deleted (it can never be
+  parsed, so redelivery would only poison the queue); a transient dispatch/throttle
+  failure is logged and left on the queue for the visibility timeout to redeliver.
+  One bad message never sinks the batch.
+
+Opt-in and default OFF: the consumer only runs when
+``AGENT_BOM_AWS_EVENT_QUEUE_URL`` is set (read live). The queue is operator-owned
+(EventBridge→SQS wiring is a deploy step), so the control plane reads it with its
+OWN ambient credentials — distinct from the customer read-only role used for the
+posture re-evaluation.
+
+Requires ``boto3`` for the SQS consumer. Install with ``pip install 'agent-bom[aws]'``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from agent_bom import config
+from agent_bom.api.connection_store import CloudConnectionRecord
+
+logger = logging.getLogger(__name__)
+
+# Opt-in gate (read live so operators/tests can toggle it). Absence = disabled.
+EVENT_QUEUE_URL_ENV = "AGENT_BOM_AWS_EVENT_QUEUE_URL"
+
+# Detail-type EventBridge stamps on CloudTrail-sourced API-call events. Accepted
+# as an authenticity signal; a message whose detail-type is present but does not
+# match is treated as malformed (not our shape).
+_CLOUDTRAIL_DETAIL_TYPE = "AWS API Call via CloudTrail"
+
+
+@dataclass
+class CloudChangeEvent:
+    """One normalized cloud resource-change event.
+
+    Provider-neutral shape (AWS is the only producer today). ``resource_type`` is
+    the canonical service token (e.g. ``"s3"``, ``"ec2"``, ``"iam"``) the rule
+    registry keys off; ``raw`` retains the original event for audit/debugging.
+    """
+
+    provider: str
+    account: str
+    region: str
+    resource_type: str
+    resource_id: str
+    action: str
+    arn: str = ""
+    raw: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class _ResourceRule:
+    """How to re-evaluate posture for one resource-type token.
+
+    ``inventory_kwargs`` scopes :func:`aws_inventory.discover_inventory` to just
+    the affected resource class (so we re-fetch that resource, not the estate).
+    ``check_ids`` is the exact CIS subset re-run for the type. ``locators`` maps
+    inventory payload list keys to the field that identifies a single resource,
+    so the changed resource can be picked out of the class fetch for the delta.
+    """
+
+    check_ids: tuple[str, ...]
+    inventory_kwargs: dict[str, bool]
+    locators: tuple[tuple[str, str], ...]
+
+
+# Only the affected class is fetched; every other include_* flag is forced off.
+def _only(**flags: bool) -> dict[str, bool]:
+    base = {
+        "include_s3": False,
+        "include_ec2": False,
+        "include_iam": False,
+        "include_data": False,
+        "include_compute": False,
+        "include_network": False,
+    }
+    base.update(flags)
+    return base
+
+
+# Resource-type token → posture re-evaluation rule. CloudTrail ``eventSource`` /
+# EventBridge ``source`` collapse to these tokens (see ``_canonical_resource_type``).
+_RESOURCE_RULES: dict[str, _ResourceRule] = {
+    "s3": _ResourceRule(
+        check_ids=("2.1.1", "2.1.2", "2.1.3", "2.1.4", "3.3", "3.6"),
+        inventory_kwargs=_only(include_s3=True),
+        locators=(("buckets", "name"), ("buckets", "arn")),
+    ),
+    "ec2": _ResourceRule(
+        check_ids=("1.19", "2.2.1", "3.9", "5.1", "5.2", "5.3", "5.4", "5.5", "5.6"),
+        inventory_kwargs=_only(include_ec2=True, include_network=True),
+        locators=(("security_groups", "group_id"), ("instances", "instance_id")),
+    ),
+    "iam": _ResourceRule(
+        check_ids=(
+            "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11", "1.12",
+            "1.13", "1.14", "1.15", "1.16", "1.17", "1.20", "1.22",
+        ),
+        inventory_kwargs=_only(include_iam=True),
+        locators=(("roles", "name"), ("users", "name"), ("groups", "name")),
+    ),
+    "rds": _ResourceRule(
+        check_ids=("2.3.1", "2.3.2"),
+        inventory_kwargs=_only(include_data=True),
+        locators=(("rds_instances", "identifier"), ("rds_instances", "name")),
+    ),
+    "kms": _ResourceRule(
+        check_ids=("2.4.1",),
+        inventory_kwargs=_only(include_data=True),
+        locators=(("kms_keys", "key_id"), ("kms_keys", "arn")),
+    ),
+    "cloudtrail": _ResourceRule(
+        check_ids=("3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.10", "3.11"),
+        inventory_kwargs=_only(),
+        locators=(),
+    ),
+}
+
+# CloudTrail requestParameters/responseElements keys that carry the changed
+# resource id, tried in order per token. First present wins.
+_RESOURCE_ID_KEYS: dict[str, tuple[str, ...]] = {
+    "s3": ("bucketName",),
+    "ec2": ("groupId", "instanceId", "networkAclId", "routeTableId", "vpcId"),
+    "iam": ("roleName", "userName", "groupName", "policyArn", "policyName"),
+    "rds": ("dBInstanceIdentifier",),
+    "kms": ("keyId",),
+    "cloudtrail": ("name", "trailName"),
+}
+
+
+def event_ingest_enabled() -> bool:
+    """Return whether event-driven ingestion is opted in (queue URL configured).
+
+    Read live so operators and tests can toggle it. Default OFF: with no queue
+    URL the consumer is a no-op and only the polling scheduler runs.
+    """
+    return bool(os.environ.get(EVENT_QUEUE_URL_ENV, "").strip())
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _account_from_role_ref(role_ref: str) -> str:
+    """Extract the AWS account id from a connection ``role_ref`` ARN.
+
+    ``arn:aws:iam::123456789012:role/agent-bom-readonly`` → ``123456789012``.
+    Returns "" when the ref is not an ARN (defensive; callers fail closed).
+    """
+    parts = (role_ref or "").split(":")
+    return parts[4] if len(parts) > 4 else ""
+
+
+def _canonical_resource_type(source: str) -> str:
+    """Collapse a CloudTrail eventSource / EventBridge source to a service token.
+
+    ``"s3.amazonaws.com"`` → ``"s3"``; ``"aws.s3"`` → ``"s3"``. Lower-cased.
+    """
+    token = (source or "").strip().lower()
+    if token.startswith("aws."):
+        token = token[len("aws.") :]
+    if token.endswith(".amazonaws.com"):
+        token = token[: -len(".amazonaws.com")]
+    return token
+
+
+def _extract_resource_id(token: str, detail: dict[str, Any]) -> str:
+    """Pull the changed resource id from a CloudTrail detail's parameters."""
+    params: dict[str, Any] = {}
+    for key in ("requestParameters", "responseElements"):
+        value = detail.get(key)
+        if isinstance(value, dict):
+            params.update(value)
+    for candidate in _RESOURCE_ID_KEYS.get(token, ()):  # first present wins
+        value = params.get(candidate)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def parse_cloudtrail_event(message: str | dict[str, Any]) -> CloudChangeEvent | None:
+    """Parse an EventBridge/CloudTrail message into a :class:`CloudChangeEvent`.
+
+    Accepts either the EventBridge envelope (``{"detail-type", "source",
+    "account", "region", "detail": {...}}``) or a bare CloudTrail record. Returns
+    ``None`` for anything malformed or for a resource type with no posture rule —
+    the caller treats ``None`` as "skip, do not crash".
+    """
+    try:
+        obj = json.loads(message) if isinstance(message, (str, bytes)) else message
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+
+    detail = obj.get("detail")
+    if not isinstance(detail, dict):
+        detail = obj  # bare CloudTrail record
+
+    # An EventBridge envelope with an unexpected detail-type is not our shape.
+    detail_type = obj.get("detail-type")
+    if detail_type is not None and detail_type != _CLOUDTRAIL_DETAIL_TYPE:
+        return None
+
+    source = obj.get("source") or detail.get("eventSource") or ""
+    token = _canonical_resource_type(str(source))
+    if token not in _RESOURCE_RULES:
+        return None
+
+    user_identity = detail.get("userIdentity")
+    account = (
+        str(obj.get("account") or "").strip()
+        or str(detail.get("recipientAccountId") or "").strip()
+        or (str(user_identity.get("accountId") or "").strip() if isinstance(user_identity, dict) else "")
+    )
+    action = str(detail.get("eventName") or "").strip()
+    region = str(obj.get("region") or detail.get("awsRegion") or "").strip()
+    resource_id = _extract_resource_id(token, detail)
+
+    # Fail closed: without an account, an action, and a resource id we cannot
+    # safely attribute or scope the re-evaluation.
+    if not account or not action or not resource_id:
+        return None
+
+    return CloudChangeEvent(
+        provider="aws",
+        account=account,
+        region=region,
+        resource_type=token,
+        resource_id=resource_id,
+        action=action,
+        arn=str(detail.get("resources", "") or "") if not isinstance(detail.get("resources"), list) else "",
+        raw=obj if isinstance(obj, dict) else {},
+    )
+
+
+def _find_affected_resource(rule: _ResourceRule, inventory: dict[str, Any], resource_id: str) -> dict[str, Any] | None:
+    """Return the single inventory entry matching *resource_id*, if present."""
+    for list_key, id_field in rule.locators:
+        for item in inventory.get(list_key, []) or []:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get(id_field, "")) == resource_id:
+                return item
+    return None
+
+
+def _default_persist(record: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
+    """Persist an event-driven report through the same scan/graph path as a scan.
+
+    Imported lazily so this module (and its unit tests) do not pull the API route
+    layer at import time — mirrors the connection scheduler's lazy route import.
+    """
+    from agent_bom.api.routes.cloud_connections import _persist_connection_report
+
+    return _persist_connection_report(record, tenant_id, report)
+
+
+def dispatch_change_event(
+    event: CloudChangeEvent,
+    record: CloudConnectionRecord,
+    *,
+    tenant_id: str | None = None,
+    session: Any = None,
+    persist: Callable[[CloudConnectionRecord, str, Any], str] | None = None,
+    store: Any = None,
+) -> dict[str, Any] | None:
+    """Re-evaluate posture for one changed resource and emit the delta.
+
+    Resolves the changed resource via a scoped read-only inventory fetch, re-runs
+    ONLY the CIS checks for its resource type against the brokered read-only
+    session, persists the resulting posture through the same scan/graph path a
+    full scan uses, and stamps ``last_event_at`` on the connection.
+
+    Fail-closed: the event's provider must be ``aws`` and its account must match
+    the connection's own account (from ``role_ref``); a mismatch returns ``None``
+    without touching the customer account. An unknown resource type also returns
+    ``None``. Returns a non-secret delta summary on success.
+    """
+    tenant_id = tenant_id or record.tenant_id
+
+    if (event.provider or "").strip().lower() != "aws":
+        logger.warning("Dropping non-AWS change event (provider=%s)", event.provider)
+        return None
+    if (record.provider or "").strip().lower() != "aws":
+        logger.warning("Connection %s is not AWS; cannot dispatch AWS change event", record.id)
+        return None
+
+    connection_account = _account_from_role_ref(record.role_ref)
+    if not connection_account or event.account != connection_account:
+        # Confused-deputy guard: never scan an account this connection does not own.
+        logger.warning(
+            "Dropping change event for account %s: does not match connection %s account",
+            event.account,
+            record.id,
+        )
+        return None
+
+    rule = _RESOURCE_RULES.get(event.resource_type)
+    if rule is None:
+        return None
+
+    from agent_bom.cloud import aws_inventory
+    from agent_bom.cloud.aws_cis_benchmark import run_benchmark
+    from agent_bom.models import AIBOMReport
+
+    if session is None:
+        from agent_bom.cloud.connection_broker import broker_session
+
+        session = broker_session(record, session_name=f"agent-bom-event-{record.id[:8]}")
+
+    region = event.region or (record.regions[0] if record.regions else None)
+
+    inv = rule.inventory_kwargs
+    inventory_payload = aws_inventory.discover_inventory(
+        region=region,
+        force=True,
+        session=session,
+        include_s3=inv["include_s3"],
+        include_ec2=inv["include_ec2"],
+        include_iam=inv["include_iam"],
+        include_data=inv["include_data"],
+        include_compute=inv["include_compute"],
+        include_network=inv["include_network"],
+    )
+    affected = _find_affected_resource(rule, inventory_payload, event.resource_id)
+
+    cis_report = run_benchmark(region=region, session=session, checks=list(rule.check_ids))
+    cis_dict = cis_report.to_dict()
+    findings = [check for check in cis_dict.get("checks", []) if check.get("status") == "fail"]
+
+    import uuid as _uuid
+
+    report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=str(_uuid.uuid4()))
+    report.scan_sources = ["cloud_connection", "cloud:aws", "event:cloudtrail"]
+    report.cloud_inventory_data = inventory_payload
+    report.cis_benchmark_data = cis_dict
+
+    persist_fn = persist or _default_persist
+    scan_id = persist_fn(record, tenant_id, report)
+
+    # Freshness signal: event-driven re-eval advances last_event_at, NOT
+    # last_scan_at (that stays the last full polling scan).
+    active_store = store
+    if active_store is None:
+        from agent_bom.api.connection_store import get_connection_store
+
+        active_store = get_connection_store()
+    fresh = active_store.get(tenant_id, record.id) or record
+    fresh.last_event_at = _now()
+    fresh.updated_at = _now()
+    active_store.put(fresh)
+    record.last_event_at = fresh.last_event_at
+
+    return {
+        "schema_version": "cloud.connections.event.v1",
+        "connection_id": record.id,
+        "tenant_id": tenant_id,
+        "provider": "aws",
+        "scan_id": scan_id,
+        "event": {
+            "account": event.account,
+            "region": event.region,
+            "resource_type": event.resource_type,
+            "resource_id": event.resource_id,
+            "action": event.action,
+        },
+        "resource": affected,
+        "checks_evaluated": list(rule.check_ids),
+        "findings": [
+            {
+                "check_id": f.get("check_id"),
+                "title": f.get("title"),
+                "severity": f.get("severity"),
+                "resource_ids": f.get("resource_ids", []),
+                "evidence": f.get("evidence", ""),
+            }
+            for f in findings
+        ],
+        "audit_metadata": {
+            "read_only": True,
+            "writes_performed": False,
+            "note": (
+                "Event-driven re-evaluation ran against a short-lived read-only role assumed from the stored "
+                "connection. Only the affected resource type's CIS checks were re-run; no resource is mutated "
+                "and no secret value is returned."
+            ),
+        },
+    }
+
+
+def consume_aws_events(
+    record: CloudConnectionRecord,
+    *,
+    tenant_id: str | None = None,
+    queue_url: str | None = None,
+    sqs_client: Any = None,
+    session: Any = None,
+    max_messages: int | None = None,
+    max_batches: int | None = None,
+    visibility_timeout: int | None = None,
+    wait_seconds: int | None = None,
+    persist: Callable[[CloudConnectionRecord, str, Any], str] | None = None,
+    store: Any = None,
+) -> dict[str, Any]:
+    """Drain a bounded batch of AWS change events from SQS and dispatch each.
+
+    Long-polls the operator-owned SQS queue (EventBridge→SQS) with the control
+    plane's OWN ambient credentials, parses each CloudTrail message, and
+    dispatches a per-resource posture re-evaluation for events that belong to
+    *record*'s account. This is a BOUNDED pass: at most ``max_batches`` receives
+    of ``max_messages`` each, then it returns — there is no forever loop; an
+    operator or scheduler tick invokes it repeatedly.
+
+    Message lifecycle: a successfully dispatched message is deleted; a malformed
+    or foreign-account message is logged and deleted (redelivery cannot help); a
+    transient dispatch failure is logged and LEFT on the queue for the visibility
+    timeout to redeliver. Never raises — one bad message cannot sink the batch.
+
+    Returns a non-secret summary of what happened (counts + status). With no
+    queue configured it is a no-op (``status="disabled"``).
+    """
+    tenant_id = tenant_id or record.tenant_id
+    queue_url = queue_url or os.environ.get(EVENT_QUEUE_URL_ENV, "").strip()
+
+    summary: dict[str, Any] = {
+        "status": "ok",
+        "connection_id": record.id,
+        "received": 0,
+        "processed": 0,
+        "deleted": 0,
+        "skipped_malformed": 0,
+        "skipped_foreign": 0,
+        "errors": 0,
+        "batches": 0,
+    }
+
+    if not queue_url:
+        summary["status"] = "disabled"
+        return summary
+
+    max_messages = max(1, min(int(max_messages if max_messages is not None else config.AWS_EVENT_MAX_MESSAGES), 10))
+    max_batches = max(1, int(max_batches if max_batches is not None else config.AWS_EVENT_MAX_BATCHES))
+    visibility_timeout = max(
+        0, int(visibility_timeout if visibility_timeout is not None else config.AWS_EVENT_VISIBILITY_TIMEOUT)
+    )
+    wait_seconds = max(0, min(int(wait_seconds if wait_seconds is not None else config.AWS_EVENT_WAIT_SECONDS), 20))
+
+    if sqs_client is None:
+        try:
+            import boto3
+        except ImportError:
+            summary["status"] = "boto3_missing"
+            return summary
+        try:
+            sqs_client = boto3.client("sqs")
+        except Exception as exc:  # noqa: BLE001 — control-plane credential/config error must not crash
+            logger.warning("Could not create SQS client for event ingestion: %s", type(exc).__name__)
+            summary["status"] = "no_credentials"
+            return summary
+
+    # Broker one read-only customer session for the whole batch (AssumeRole is not
+    # cheap); every dispatch reuses it. Absent a session, dispatch would broker
+    # per-message — brokering once here is the bounded, efficient path.
+    if session is None:
+        try:
+            from agent_bom.cloud.connection_broker import broker_session
+
+            session = broker_session(record, session_name=f"agent-bom-event-{record.id[:8]}")
+        except Exception as exc:  # noqa: BLE001 — a broker failure is not fatal to the queue drain contract
+            logger.warning("Could not broker read-only session for event ingestion: %s", type(exc).__name__)
+            summary["status"] = "broker_failed"
+            return summary
+
+    for _ in range(max_batches):  # bounded: always terminates
+        summary["batches"] += 1
+        try:
+            resp = sqs_client.receive_message(
+                QueueUrl=queue_url,
+                MaxNumberOfMessages=max_messages,
+                WaitTimeSeconds=wait_seconds,
+                VisibilityTimeout=visibility_timeout,
+            )
+        except Exception as exc:  # noqa: BLE001 — throttle / transient receive error: stop this pass cleanly
+            logger.warning("SQS receive failed during event ingestion: %s", type(exc).__name__)
+            summary["errors"] += 1
+            break
+
+        messages = resp.get("Messages", []) or []
+        if not messages:
+            break  # empty queue: nothing more to drain this pass
+
+        for message in messages:
+            summary["received"] += 1
+            receipt = message.get("ReceiptHandle")
+            body = message.get("Body", "")
+
+            event = parse_cloudtrail_event(body)
+            if event is None:
+                summary["skipped_malformed"] += 1
+                _delete_message(sqs_client, queue_url, receipt, summary)  # poison: drop it
+                continue
+
+            if event.account != _account_from_role_ref(record.role_ref):
+                # Not this connection's account — never scan a foreign account.
+                summary["skipped_foreign"] += 1
+                _delete_message(sqs_client, queue_url, receipt, summary)
+                continue
+
+            try:
+                dispatch_change_event(
+                    event, record, tenant_id=tenant_id, session=session, persist=persist, store=store
+                )
+            except Exception as exc:  # noqa: BLE001 — leave on queue for redelivery; never crash the drain
+                logger.warning(
+                    "Event dispatch failed for %s/%s: %s",
+                    event.resource_type,
+                    event.resource_id,
+                    type(exc).__name__,
+                )
+                summary["errors"] += 1
+                continue  # do NOT delete — visibility timeout redelivers
+
+            summary["processed"] += 1
+            _delete_message(sqs_client, queue_url, receipt, summary)
+
+    return summary
+
+
+def _delete_message(sqs_client: Any, queue_url: str, receipt: str | None, summary: dict[str, Any]) -> None:
+    """Best-effort SQS delete; a delete failure is logged, never raised."""
+    if not receipt:
+        return
+    try:
+        sqs_client.delete_message(QueueUrl=queue_url, ReceiptHandle=receipt)
+        summary["deleted"] += 1
+    except Exception as exc:  # noqa: BLE001 — delete failure only means one redelivery
+        logger.warning("SQS delete failed during event ingestion: %s", type(exc).__name__)

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -292,6 +292,17 @@ API_SCAN_CLAIM_POLL_SECONDS = _int("AGENT_BOM_API_SCAN_CLAIM_POLL_SECONDS", 3)
 CONNECTIONS_SCHEDULER_POLL_SECONDS = _int("AGENT_BOM_CONNECTIONS_SCHEDULER_POLL_SECONDS", 60)
 CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES = _int("AGENT_BOM_CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES", 15)
 CONNECTIONS_SCHEDULER_MAX_CONCURRENCY = _int("AGENT_BOM_CONNECTIONS_SCHEDULER_MAX_CONCURRENCY", 4)
+# Event-driven AWS posture ingestion (continuous posture). When an operator
+# wires EventBridge→SQS (opt-in via AGENT_BOM_AWS_EVENT_QUEUE_URL, read live,
+# default off), the bounded SQS consumer drains change events and re-evaluates
+# only the affected resource's CIS rules — polling stays the fallback. These
+# knobs bound a single consume pass so it always terminates: messages per
+# receive, receive batches per pass, per-message visibility timeout, and the
+# long-poll wait. Caps mirror the SQS API limits (10 messages, 20s wait).
+AWS_EVENT_MAX_MESSAGES = _int("AGENT_BOM_AWS_EVENT_MAX_MESSAGES", 10)
+AWS_EVENT_MAX_BATCHES = _int("AGENT_BOM_AWS_EVENT_MAX_BATCHES", 10)
+AWS_EVENT_VISIBILITY_TIMEOUT = _int("AGENT_BOM_AWS_EVENT_VISIBILITY_TIMEOUT", 120)
+AWS_EVENT_WAIT_SECONDS = _int("AGENT_BOM_AWS_EVENT_WAIT_SECONDS", 5)
 API_JOB_TTL_SECONDS = _int("AGENT_BOM_API_JOB_TTL", 3_600)
 API_MAX_IN_MEMORY_JOBS = _int("AGENT_BOM_API_MAX_MEMORY_JOBS", 200)
 API_MAX_JOB_PROGRESS_EVENTS = _int("AGENT_BOM_API_MAX_JOB_PROGRESS_EVENTS", 500)

--- a/tests/test_cloud_event_ingest.py
+++ b/tests/test_cloud_event_ingest.py
@@ -121,6 +121,74 @@ class _FakeSession:
         return MagicMock()  # unused services (their checks are filtered out)
 
 
+class _FakeCISReport:
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "benchmark": "CIS AWS Foundations",
+            "benchmark_version": "3.0",
+            "account_id": _ACCOUNT,
+            "region": "us-east-1",
+            "passed": 5,
+            "failed": 1,
+            "total": 6,
+            "checks": [
+                {
+                    "check_id": "2.1.1",
+                    "title": "Ensure that S3 Block Public Access is enabled account-wide",
+                    "status": "fail",
+                    "severity": "high",
+                    "resource_ids": ["public-bucket"],
+                    "evidence": "Account-level public access block is not fully enforced.",
+                },
+                {
+                    "check_id": "2.1.2",
+                    "title": "Ensure S3 buckets use server-side encryption",
+                    "status": "pass",
+                    "severity": "medium",
+                    "resource_ids": ["public-bucket"],
+                    "evidence": "Bucket encryption is configured.",
+                },
+                {
+                    "check_id": "2.1.3",
+                    "title": "Ensure S3 bucket versioning is enabled",
+                    "status": "pass",
+                    "severity": "medium",
+                    "resource_ids": ["public-bucket"],
+                    "evidence": "Versioning is enabled.",
+                },
+                {
+                    "check_id": "2.1.4",
+                    "title": "Ensure MFA delete is enabled",
+                    "status": "pass",
+                    "severity": "medium",
+                    "resource_ids": ["public-bucket"],
+                    "evidence": "MFA delete is enabled.",
+                },
+                {
+                    "check_id": "3.3",
+                    "title": "Ensure S3 bucket logging is enabled for CloudTrail buckets",
+                    "status": "pass",
+                    "severity": "medium",
+                    "resource_ids": ["public-bucket"],
+                    "evidence": "Bucket logging is enabled.",
+                },
+                {
+                    "check_id": "3.6",
+                    "title": "Ensure CloudTrail S3 bucket is not publicly accessible",
+                    "status": "pass",
+                    "severity": "high",
+                    "resource_ids": ["public-bucket"],
+                    "evidence": "Bucket policy is not public for CloudTrail writes.",
+                },
+            ],
+        }
+
+
+def _fake_run_benchmark(*, checks: list[str], **kwargs: Any) -> _FakeCISReport:
+    assert set(checks) == {"2.1.1", "2.1.2", "2.1.3", "2.1.4", "3.3", "3.6"}
+    return _FakeCISReport()
+
+
 # --------------------------------------------------------------------------- #
 # dispatch: S3 PutBucketPolicy → affected CIS check re-evaluates + finding
 # --------------------------------------------------------------------------- #
@@ -144,7 +212,12 @@ def test_dispatch_s3_public_bucket_reevaluates_and_produces_finding() -> None:
         return "scan-xyz"
 
     delta = dispatch_change_event(
-        event, record, session=_FakeSession(), persist=_persist, store=store
+        event,
+        record,
+        session=_FakeSession(),
+        benchmark_runner=_fake_run_benchmark,
+        persist=_persist,
+        store=store,
     )
 
     assert delta is not None
@@ -313,6 +386,7 @@ def test_consume_dispatches_and_deletes_valid_event() -> None:
         queue_url="https://sqs/queue",
         sqs_client=sqs,
         session=_FakeSession(),
+        benchmark_runner=_fake_run_benchmark,
         persist=_persist,
         store=store,
         max_batches=2,

--- a/tests/test_cloud_event_ingest.py
+++ b/tests/test_cloud_event_ingest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -189,6 +189,34 @@ def _fake_run_benchmark(*, checks: list[str], **kwargs: Any) -> _FakeCISReport:
     return _FakeCISReport()
 
 
+# The scoped inventory a real S3 change re-fetch would return. dispatch resolves
+# the changed resource through ``aws_inventory.discover_inventory``; a clean env
+# with only these minimal boto3 stubs cannot fully emulate every call that fetch
+# makes, so we patch it to return this deterministic, env-independent payload
+# containing the public bucket (locators key off ``buckets`` → ``name``).
+_SCOPED_S3_INVENTORY: dict[str, Any] = {
+    "buckets": [
+        {
+            "name": "public-bucket",
+            "arn": "arn:aws:s3:::public-bucket",
+            "location": "us-east-1",
+            "publicly_accessible": True,
+            "tags": {},
+            "account_id": _ACCOUNT,
+            "created_at": None,
+        }
+    ],
+}
+
+
+def _patch_scoped_inventory() -> Any:
+    """Patch the scoped inventory fetch dispatch relies on (as imported in event_ingest)."""
+    return patch(
+        "agent_bom.cloud.aws_inventory.discover_inventory",
+        return_value=_SCOPED_S3_INVENTORY,
+    )
+
+
 # --------------------------------------------------------------------------- #
 # dispatch: S3 PutBucketPolicy → affected CIS check re-evaluates + finding
 # --------------------------------------------------------------------------- #
@@ -211,14 +239,15 @@ def test_dispatch_s3_public_bucket_reevaluates_and_produces_finding() -> None:
         persisted["tenant_id"] = tenant_id
         return "scan-xyz"
 
-    delta = dispatch_change_event(
-        event,
-        record,
-        session=_FakeSession(),
-        benchmark_runner=_fake_run_benchmark,
-        persist=_persist,
-        store=store,
-    )
+    with _patch_scoped_inventory():
+        delta = dispatch_change_event(
+            event,
+            record,
+            session=_FakeSession(),
+            benchmark_runner=_fake_run_benchmark,
+            persist=_persist,
+            store=store,
+        )
 
     assert delta is not None
     assert delta["scan_id"] == "scan-xyz"
@@ -381,16 +410,17 @@ def test_consume_dispatches_and_deletes_valid_event() -> None:
         persisted["report"] = report
         return "scan-1"
 
-    summary = consume_aws_events(
-        record,
-        queue_url="https://sqs/queue",
-        sqs_client=sqs,
-        session=_FakeSession(),
-        benchmark_runner=_fake_run_benchmark,
-        persist=_persist,
-        store=store,
-        max_batches=2,
-    )
+    with _patch_scoped_inventory():
+        summary = consume_aws_events(
+            record,
+            queue_url="https://sqs/queue",
+            sqs_client=sqs,
+            session=_FakeSession(),
+            benchmark_runner=_fake_run_benchmark,
+            persist=_persist,
+            store=store,
+            max_batches=2,
+        )
     assert summary["processed"] == 1
     assert summary["deleted"] == 1
     assert sqs.deleted == ["receipt-1"]

--- a/tests/test_cloud_event_ingest.py
+++ b/tests/test_cloud_event_ingest.py
@@ -1,0 +1,346 @@
+"""Tests for event-driven AWS posture ingestion (CloudTrail/EventBridge → SQS)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_bom.api.connection_store import (
+    CloudConnectionRecord,
+    InMemoryConnectionStore,
+)
+from agent_bom.cloud import event_ingest
+from agent_bom.cloud.event_ingest import (
+    CloudChangeEvent,
+    consume_aws_events,
+    dispatch_change_event,
+    parse_cloudtrail_event,
+)
+
+_ACCOUNT = "123456789012"
+
+
+def _record(*, account: str = _ACCOUNT) -> CloudConnectionRecord:
+    return CloudConnectionRecord(
+        id="conn-1",
+        tenant_id="tenant-a",
+        provider="aws",
+        display_name="prod",
+        role_ref=f"arn:aws:iam::{account}:role/agent-bom-readonly",
+        external_id_encrypted="cipher",
+        regions=["us-east-1"],
+    )
+
+
+def _s3_put_bucket_policy_event(*, account: str = _ACCOUNT, bucket: str = "public-bucket") -> dict[str, Any]:
+    """A synthetic EventBridge-wrapped CloudTrail S3 PutBucketPolicy event."""
+    return {
+        "version": "0",
+        "id": "evt-1",
+        "detail-type": "AWS API Call via CloudTrail",
+        "source": "aws.s3",
+        "account": account,
+        "region": "us-east-1",
+        "detail": {
+            "eventSource": "s3.amazonaws.com",
+            "eventName": "PutBucketPolicy",
+            "awsRegion": "us-east-1",
+            "recipientAccountId": account,
+            "userIdentity": {"accountId": account},
+            "requestParameters": {"bucketName": bucket},
+        },
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Fake read-only AWS session (drives both inventory + CIS)
+# --------------------------------------------------------------------------- #
+
+
+class _NoSuchPABError(Exception):
+    """Stand-in for S3 NoSuchPublicAccessBlock (inventory reads it best-effort)."""
+
+
+class _FakeS3:
+    def list_buckets(self, **kwargs: Any) -> dict[str, Any]:
+        return {"Buckets": [{"Name": "public-bucket", "CreationDate": None}]}
+
+    def get_bucket_policy_status(self, **kwargs: Any) -> dict[str, Any]:
+        return {"PolicyStatus": {"IsPublic": True}}  # made public
+
+    def get_public_access_block(self, **kwargs: Any) -> dict[str, Any]:
+        raise _NoSuchPABError("NoSuchPublicAccessBlock")
+
+    def get_bucket_location(self, **kwargs: Any) -> dict[str, Any]:
+        return {"LocationConstraint": "us-east-1"}
+
+    def get_bucket_tagging(self, **kwargs: Any) -> dict[str, Any]:
+        raise Exception("NoSuchTagSet")
+
+    def get_bucket_encryption(self, **kwargs: Any) -> dict[str, Any]:
+        return {}  # present → 2.1.2 passes
+
+    def get_bucket_versioning(self, **kwargs: Any) -> dict[str, Any]:
+        return {"Status": "Enabled", "MFADelete": "Enabled"}  # 2.1.3/2.1.4 pass
+
+    def get_bucket_logging(self, **kwargs: Any) -> dict[str, Any]:
+        return {"LoggingEnabled": True}
+
+
+class _FakeS3Control:
+    def get_public_access_block(self, **kwargs: Any) -> dict[str, Any]:
+        # Account-level PAB not enforcing → CIS 2.1.1 FAILS (public not blocked).
+        return {"PublicAccessBlockConfiguration": {}}
+
+
+class _FakeCloudTrail:
+    def describe_trails(self, **kwargs: Any) -> dict[str, Any]:
+        return {"trailList": []}
+
+
+class _FakeSTS:
+    def get_caller_identity(self) -> dict[str, Any]:
+        return {"Account": _ACCOUNT}
+
+
+class _FakeSession:
+    region_name = "us-east-1"
+
+    def client(self, service: str, **kwargs: Any) -> Any:
+        if service == "s3":
+            return _FakeS3()
+        if service == "s3control":
+            return _FakeS3Control()
+        if service == "cloudtrail":
+            return _FakeCloudTrail()
+        if service == "sts":
+            return _FakeSTS()
+        return MagicMock()  # unused services (their checks are filtered out)
+
+
+# --------------------------------------------------------------------------- #
+# dispatch: S3 PutBucketPolicy → affected CIS check re-evaluates + finding
+# --------------------------------------------------------------------------- #
+
+
+def test_dispatch_s3_public_bucket_reevaluates_and_produces_finding() -> None:
+    event = parse_cloudtrail_event(_s3_put_bucket_policy_event())
+    assert event is not None
+    assert event.resource_type == "s3"
+    assert event.resource_id == "public-bucket"
+    assert event.action == "PutBucketPolicy"
+
+    record = _record()
+    store = InMemoryConnectionStore()
+    store.put(record)
+    persisted: dict[str, Any] = {}
+
+    def _persist(rec: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
+        persisted["report"] = report
+        persisted["tenant_id"] = tenant_id
+        return "scan-xyz"
+
+    delta = dispatch_change_event(
+        event, record, session=_FakeSession(), persist=_persist, store=store
+    )
+
+    assert delta is not None
+    assert delta["scan_id"] == "scan-xyz"
+    assert delta["provider"] == "aws"
+    # ONLY the S3-type checks were re-evaluated (not the whole benchmark).
+    assert set(delta["checks_evaluated"]) == {"2.1.1", "2.1.2", "2.1.3", "2.1.4", "3.3", "3.6"}
+    # The affected resource was resolved from the scoped inventory fetch.
+    assert delta["resource"] is not None
+    assert delta["resource"]["name"] == "public-bucket"
+    assert delta["resource"]["publicly_accessible"] is True
+    # A finding was produced — the account-level public-access-block check failed.
+    finding_ids = {f["check_id"] for f in delta["findings"]}
+    assert "2.1.1" in finding_ids
+    # The posture report reached the persistence path like a scan does.
+    report = persisted["report"]
+    assert report.cis_benchmark_data["failed"] >= 1
+    assert report.scan_sources == ["cloud_connection", "cloud:aws", "event:cloudtrail"]
+    # last_event_at freshness signal was stamped (distinct from last_scan_at).
+    fresh = store.get("tenant-a", "conn-1")
+    assert fresh is not None
+    assert fresh.last_event_at is not None
+    assert fresh.last_scan_at is None
+
+
+def test_dispatch_drops_foreign_account_event_without_scanning() -> None:
+    """A change event for an account the connection does not own is fail-closed."""
+    event = parse_cloudtrail_event(_s3_put_bucket_policy_event(account="999999999999"))
+    assert event is not None
+    record = _record(account=_ACCOUNT)  # different account than the event
+    called: dict[str, Any] = {}
+
+    def _persist(rec: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
+        called["hit"] = True
+        return "scan-should-not-happen"
+
+    # Passing a bare object() as the session: the read-only path must never be
+    # reached for a foreign account, so this object is never exercised.
+    delta = dispatch_change_event(event, record, session=object(), persist=_persist)
+    assert delta is None
+    assert "hit" not in called
+
+
+def test_dispatch_drops_unknown_resource_type() -> None:
+    event = CloudChangeEvent(
+        provider="aws",
+        account=_ACCOUNT,
+        region="us-east-1",
+        resource_type="dynamodb",  # no posture rule
+        resource_id="my-table",
+        action="UpdateTable",
+    )
+    assert dispatch_change_event(event, _record(), session=_FakeSession()) is None
+
+
+# --------------------------------------------------------------------------- #
+# malformed-event guard
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "not json at all {",
+        "[]",
+        "null",
+        json.dumps({"detail-type": "Some Other Event", "source": "aws.s3", "account": _ACCOUNT, "detail": {}}),
+        # no resource id:
+        json.dumps({"source": "aws.s3", "account": _ACCOUNT, "detail": {"eventName": "PutBucketPolicy"}}),
+        # no account:
+        json.dumps({"source": "aws.s3", "detail": {"eventName": "Put", "requestParameters": {"bucketName": "b"}}}),
+        # unsupported service token:
+        json.dumps({"source": "aws.dynamodb", "account": _ACCOUNT, "detail": {"eventName": "X", "requestParameters": {"k": "v"}}}),
+    ],
+)
+def test_parse_malformed_event_returns_none(message: str) -> None:
+    assert parse_cloudtrail_event(message) is None
+
+
+# --------------------------------------------------------------------------- #
+# consumer: bounded SQS drain
+# --------------------------------------------------------------------------- #
+
+
+class _FakeSQS:
+    """Minimal SQS stub: hands back a fixed message list each receive."""
+
+    def __init__(self, batches: list[list[dict[str, Any]]]) -> None:
+        self._batches = batches
+        self.receive_calls = 0
+        self.deleted: list[str] = []
+
+    def receive_message(self, **kwargs: Any) -> dict[str, Any]:
+        self.receive_calls += 1
+        if self._batches:
+            return {"Messages": self._batches.pop(0)}
+        return {}
+
+    def delete_message(self, **kwargs: Any) -> None:
+        self.deleted.append(kwargs["ReceiptHandle"])
+
+
+def _msg(body: dict[str, Any], receipt: str) -> dict[str, Any]:
+    return {"Body": json.dumps(body), "ReceiptHandle": receipt}
+
+
+def test_consume_disabled_when_no_queue(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(event_ingest.EVENT_QUEUE_URL_ENV, raising=False)
+    summary = consume_aws_events(_record())
+    assert summary["status"] == "disabled"
+    assert summary["received"] == 0
+
+
+def test_consume_empty_queue_is_noop() -> None:
+    sqs = _FakeSQS(batches=[])  # no messages ever
+    summary = consume_aws_events(
+        _record(),
+        queue_url="https://sqs/queue",
+        sqs_client=sqs,
+        session=_FakeSession(),
+    )
+    assert summary["status"] == "ok"
+    assert summary["received"] == 0
+    assert summary["processed"] == 0
+    assert sqs.receive_calls == 1  # one empty receive, then stop
+
+
+def test_consume_bounded_batch_stops(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A never-empty queue is drained for at most max_batches receives, then returns."""
+    # Every receive yields a full batch of malformed messages (kept unbounded).
+    endless = _FakeSQS(batches=[])
+
+    def _always_full(**kwargs: Any) -> dict[str, Any]:
+        endless.receive_calls += 1
+        return {"Messages": [_msg({"garbage": True}, f"r{endless.receive_calls}")]}
+
+    monkeypatch.setattr(endless, "receive_message", _always_full)
+
+    summary = consume_aws_events(
+        _record(),
+        queue_url="https://sqs/queue",
+        sqs_client=endless,
+        session=_FakeSession(),
+        max_batches=3,
+    )
+    # Bounded: exactly max_batches receives, then it returned (no forever loop).
+    assert endless.receive_calls == 3
+    assert summary["batches"] == 3
+    assert summary["skipped_malformed"] == 3
+    assert summary["deleted"] == 3  # poison messages dropped
+
+
+def test_consume_dispatches_and_deletes_valid_event() -> None:
+    sqs = _FakeSQS(batches=[[_msg(_s3_put_bucket_policy_event(), "receipt-1")]])
+    store = InMemoryConnectionStore()
+    record = _record()
+    store.put(record)
+    persisted: dict[str, Any] = {}
+
+    def _persist(rec: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
+        persisted["report"] = report
+        return "scan-1"
+
+    summary = consume_aws_events(
+        record,
+        queue_url="https://sqs/queue",
+        sqs_client=sqs,
+        session=_FakeSession(),
+        persist=_persist,
+        store=store,
+        max_batches=2,
+    )
+    assert summary["processed"] == 1
+    assert summary["deleted"] == 1
+    assert sqs.deleted == ["receipt-1"]
+    assert "report" in persisted
+
+
+def test_consume_drops_foreign_account_message() -> None:
+    foreign = _s3_put_bucket_policy_event(account="999999999999")
+    sqs = _FakeSQS(batches=[[_msg(foreign, "receipt-foreign")]])
+    called: dict[str, Any] = {}
+
+    def _persist(rec: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
+        called["hit"] = True
+        return "nope"
+
+    summary = consume_aws_events(
+        _record(account=_ACCOUNT),
+        queue_url="https://sqs/queue",
+        sqs_client=sqs,
+        session=_FakeSession(),
+        persist=_persist,
+        max_batches=2,
+    )
+    assert summary["skipped_foreign"] == 1
+    assert summary["processed"] == 0
+    assert sqs.deleted == ["receipt-foreign"]  # dropped, not scanned
+    assert "hit" not in called


### PR DESCRIPTION
## What

Adds a **reactive, event-driven posture lane** for AWS alongside the existing polling scheduler. When a resource changes in a customer account, AWS emits a CloudTrail management event that EventBridge can route to SQS; the control plane drains that queue and re-evaluates **only the CIS rules for the changed resource's type** — so a bucket made public is re-checked in seconds instead of waiting for the next scheduled full scan. **Polling remains the fallback; this is additive.**

## How

- **`src/agent_bom/cloud/event_ingest.py`** (new)
  - `CloudChangeEvent` dataclass (provider, account, region, resource_type, resource_id, action, arn, raw) + `parse_cloudtrail_event()` that normalizes both the EventBridge envelope and a bare CloudTrail record.
  - `dispatch_change_event()` — resolves the changed resource via a **scoped** read-only inventory fetch (only the affected class), re-runs **only** the CIS checks for that resource type (`run_benchmark(checks=[...])`), and persists the resulting posture/delta through the **same scan/graph path** a full scan uses.
  - `consume_aws_events()` — a **bounded** SQS long-poll (operator wires EventBridge→SQS; opt-in via `AGENT_BOM_AWS_EVENT_QUEUE_URL`, default off). Processes at most a bounded batch then **returns** (no forever loop); visibility-timeout + delete-on-success; malformed/throttle → log + continue, never crash.
- **Fail-closed / secure:** read-only brokered role against the customer; drop any event whose account does not match the connection's own account (confused-deputy guard); bounded batches; malformed/foreign messages logged + dropped (poison), transient failures left on the queue for redelivery.
- **`last_event_at`** on the connection (event-driven-vs-polling freshness signal), threaded through the in-memory / SQLite / Postgres stores + schema.
- **Env vars:** 4 bounded-consume tunables declared in `config.py`; opt-in queue URL added to the allowlist; `docs/operations/ENV_VARS.md` regenerated.

## Tests

`tests/test_cloud_event_ingest.py` (15 tests): synthetic CloudTrail S3 `PutBucketPolicy` (bucket made public) re-evaluates the S3 CIS checks and produces a finding (CIS 2.1.1); malformed-event guard; foreign-account drop (dispatch + consumer); empty-queue no-op; bounded-batch stop; unknown-resource-type skip.

## Gates

- `generate_env_var_reference.py --check`, `export_openapi.py --check`, `generate_v1_schemas.py --check`, `regenerate_data_model_atlas.py --check`, `check_release_consistency.py` — all green (env-var reference regenerated + committed).
- `ruff check` clean; `mypy src/agent_bom` clean (602 files).
- `pytest` green for event ingest + connection store + scheduler (107 passed) and schema/parity/data-model sweep (63 passed).

## Deferred

- Always-on background driver that ticks `consume_aws_events()` per connection is intentionally **not** wired here (kept bounded / no-forever-loop per the trust posture). An operator or a scheduler tick invokes the consumer; wiring a periodic driver is a follow-up.

Part of #3350
