### PR TITLE
feat(cli): zero-config loopback serve — auto-generate + print a dev API key

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -121,6 +121,8 @@ AGENT_BOM_CRED_MAX_AGE_DAYS
 AGENT_BOM_CRED_NEAR_EXPIRY_DAYS
 # Default rotation interval (days) for credentials without a per-secret interval; read in api/credential_expiry.py (#2923).
 AGENT_BOM_CRED_ROTATION_DAYS
+# Opt-out flag for the zero-config loopback dev API key; when set, `agent-bom serve` stays fail-closed on loopback instead of auto-minting a dev key. Read in cli/_server.py.
+AGENT_BOM_NO_AUTO_DEV_KEY
 # Dormancy window (days, default 90) before a non-human identity with no recent usage is flagged dormant; read in graph/nhi_governance.py.
 AGENT_BOM_NHI_DORMANT_DAYS
 # Opt-in window (days, default 0 = disabled) after which a dormant agent-bom-issued identity is auto-revoked; read in api/agent_identity_store.py.

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -95,7 +95,7 @@ def _api_extra_import_error_message(exc: ImportError) -> str:
 
 
 try:
-    from fastapi import FastAPI
+    from fastapi import FastAPI, Request
     from fastapi.middleware.cors import CORSMiddleware
     from fastapi.responses import JSONResponse, RedirectResponse
     from pydantic import BaseModel  # noqa: F401 — presence check for [api] extra
@@ -579,6 +579,29 @@ DEFAULT_RATE_LIMIT_RPM = DEFAULT_SCAN_RATE_LIMIT_RPM
 _rate_limit_rpm: int = DEFAULT_RATE_LIMIT_RPM
 _env_api_keys_seeded = False
 _runtime_api_key_seeded = False
+# Ephemeral, per-process loopback dev API key. Only ever set by the CLI
+# (`agent-bom serve`) on a LOOPBACK bind when no other auth is configured, so
+# the same-origin dashboard can mint a matching browser session and load with
+# zero flags. Never persisted; non-loopback binds never set this (the CLI auth
+# gate refuses them first). See cli/_server._should_auto_generate_dev_key.
+_dev_api_key: str | None = None
+
+
+def set_dev_api_key(raw_key: str | None) -> None:
+    """Register (or clear) the ephemeral loopback dev API key for the UI.
+
+    The key itself is seeded into the RBAC key store by ``configure_api``; this
+    holder only lets the dashboard HTML routes issue a matching browser-session
+    cookie so the first-party same-origin UI authenticates automatically on a
+    loopback bind. Process-local and never written to disk.
+    """
+    global _dev_api_key
+    _dev_api_key = (raw_key or "").strip() or None
+
+
+def get_dev_api_key() -> str | None:
+    """Return the active ephemeral loopback dev API key, if any."""
+    return _dev_api_key
 
 
 def _env_truthy(name: str) -> bool:
@@ -1017,11 +1040,76 @@ def _dashboard_html_response(dashboard_file: _DashboardFile):
     return HTMLResponse(_DASHBOARD_CSP_META_RE.sub("", html))
 
 
+_DEV_SESSION_MAX_AGE_SECONDS = 8 * 60 * 60
+
+
+def _maybe_attach_dev_session_cookie(response: Any, request: Request) -> None:
+    """Seed a loopback browser session so the zero-config dev key authenticates
+    the same-origin dashboard without any flag or manual key entry.
+
+    No-op unless an ephemeral dev key is active. The dev key is only ever set on
+    a loopback bind (the CLI auth gate refuses non-loopback binds before the key
+    is generated), so a set key already means "loopback, no other auth". The
+    minted session carries no ``key_id``, so it stays valid for the process
+    lifetime without depending on key-store lookups, and is re-used across page
+    loads instead of churning a fresh nonce each request.
+    """
+    if _dev_api_key is None:
+        return
+    from agent_bom.api.browser_session import (
+        CSRF_COOKIE_NAME,
+        SESSION_COOKIE_NAME,
+        BrowserSessionError,
+        create_browser_session_token,
+        verify_browser_session_token,
+    )
+
+    existing = request.cookies.get(SESSION_COOKIE_NAME, "")
+    if existing:
+        try:
+            verify_browser_session_token(existing)
+            return
+        except BrowserSessionError:
+            pass
+    try:
+        token, csrf = create_browser_session_token(
+            subject="loopback-dev-key",
+            role="admin",
+            tenant_id="default",
+            auth_method="browser_session_dev_key",
+            key_id=None,
+            scopes=[],
+            max_age_seconds=_DEV_SESSION_MAX_AGE_SECONDS,
+        )
+    except BrowserSessionError:
+        return
+    response.set_cookie(
+        SESSION_COOKIE_NAME,
+        token,
+        max_age=_DEV_SESSION_MAX_AGE_SECONDS,
+        httponly=True,
+        secure=False,
+        samesite="strict",
+        path="/",
+    )
+    response.set_cookie(
+        CSRF_COOKIE_NAME,
+        csrf,
+        max_age=_DEV_SESSION_MAX_AGE_SECONDS,
+        httponly=False,
+        secure=False,
+        samesite="strict",
+        path="/",
+    )
+
+
 @app.api_route("/", methods=["GET", "HEAD"], include_in_schema=False)
-async def root():
+async def root(request: Request):
     dashboard_index = _dashboard_index_file()
     if dashboard_index:
-        return _dashboard_html_response(dashboard_index)
+        response = _dashboard_html_response(dashboard_index)
+        _maybe_attach_dev_session_cookie(response, request)
+        return response
     return RedirectResponse(url="/docs")
 
 
@@ -1127,7 +1215,7 @@ def _mount_dashboard(application: FastAPI) -> None:
 
     # SPA catch-all for client-side routing
     @application.api_route("/{path:path}", methods=["GET", "HEAD"], include_in_schema=False)
-    async def _spa_catch_all(path: str):
+    async def _spa_catch_all(path: str, request: Request):
         # Skip API and docs paths
         if path.startswith(("v1/", "docs", "redoc", "openapi.json", "health", "version", "readyz", "metrics")):
             raise _HTTPException(status_code=404)
@@ -1140,13 +1228,15 @@ def _mount_dashboard(application: FastAPI) -> None:
             or (normalized_path and _static_file_map.get(f"{normalized_path}/index.html"))
         )
         if resolved:
-            if path.lower().endswith(".html"):
-                return _dashboard_html_response(resolved)
-            if resolved.relative_path.lower().endswith(".html"):
-                return _dashboard_html_response(resolved)
+            if path.lower().endswith(".html") or resolved.relative_path.lower().endswith(".html"):
+                html_response = _dashboard_html_response(resolved)
+                _maybe_attach_dev_session_cookie(html_response, request)
+                return html_response
             return FileResponse(resolved.path)
         # SPA fallback — serve index.html for client-side routing
-        return _dashboard_html_response(_index_html)
+        fallback_response = _dashboard_html_response(_index_html)
+        _maybe_attach_dev_session_cookie(fallback_response, request)
+        return fallback_response
 
 
 _mount_dashboard(app)

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import ipaddress
 import os
+import secrets
 import ssl
 import sys
 from pathlib import Path
@@ -233,21 +234,59 @@ def _resolve_allow_unauthenticated(allow_insecure_no_auth: bool) -> bool:
     return bool(allow_insecure_no_auth) or _env_truthy("AGENT_BOM_ALLOW_UNAUTHENTICATED_API")
 
 
+_DEV_API_KEY_PREFIX = "abk"
+
+
+def _generate_dev_api_key() -> str:
+    """Return a fresh ephemeral loopback dev API key (per-process, not persisted)."""
+    return f"{_DEV_API_KEY_PREFIX}_{secrets.token_urlsafe(24)}"
+
+
+def _should_auto_generate_dev_key(*, host: str, api_key: str | None, allow_insecure_no_auth: bool) -> bool:
+    """Decide whether a zero-config loopback dev API key should be auto-generated.
+
+    Fail-closed by construction: only ever true on a loopback bind with no other
+    auth path configured. Any explicit key, override, configured auth backend, or
+    the ``AGENT_BOM_NO_AUTO_DEV_KEY`` opt-out keeps the current behaviour (fail
+    closed on loopback, or the existing non-loopback refusal in
+    ``_enforce_auth_defaults``). A non-loopback host NEVER auto-generates a key.
+    """
+    if not _is_loopback_host(host):
+        return False
+    if _env_truthy("AGENT_BOM_NO_AUTO_DEV_KEY"):
+        return False
+    if api_key or allow_insecure_no_auth:
+        return False
+    if os.environ.get("AGENT_BOM_API_KEYS", "").strip():
+        return False
+    if _oidc_enabled() or _scim_bearer_enabled():
+        return False
+    if _env_truthy("AGENT_BOM_ALLOW_UNAUTHENTICATED_API"):
+        return False
+    if _env_truthy("AGENT_BOM_TRUST_PROXY_AUTH"):
+        return False
+    return True
+
+
 def _api_auth_summary(
     *,
     host: str,
     api_key: str | None,
     oidc_enabled: bool,
     allow_unauthenticated: bool,
+    dev_api_key: str | None = None,
 ) -> str:
     """Return a startup banner that matches the server's real auth posture.
 
     Derived from the same inputs ``configure_api`` uses so the banner can never
     claim unauthenticated access while the API actually fails closed (or vice
     versa). ``allow_unauthenticated`` is the resolved flag-OR-env value.
+    ``dev_api_key`` is the auto-generated loopback key, if one was minted.
     """
     if api_key or os.environ.get("AGENT_BOM_API_KEYS", "").strip():
         return "API key required (Bearer / X-API-Key)"
+    if dev_api_key:
+        return "auto dev API key (loopback only); the local UI uses it automatically"
     if oidc_enabled:
         return "OIDC bearer token required"
     if _scim_bearer_enabled():
@@ -430,13 +469,24 @@ def serve_cmd(
     _enforce_control_plane_listener_posture(host)
     tls_kwargs = _uvicorn_tls_kwargs()
 
-    from agent_bom.api.server import configure_api
+    # Zero-config loopback: when bound to loopback with no auth configured and no
+    # opt-out, mint an ephemeral dev key so the dashboard loads without flags.
+    # Non-loopback binds never reach here unauthenticated (see the gate above),
+    # so this can only ever fire on loopback.
+    dev_api_key = (
+        _generate_dev_api_key()
+        if _should_auto_generate_dev_key(host=host, api_key=api_key, allow_insecure_no_auth=allow_insecure_no_auth)
+        else None
+    )
+
+    from agent_bom.api.server import configure_api, set_dev_api_key
 
     configure_api(
         cors_allow_all=cors_allow_all,
-        api_key=api_key,
+        api_key=api_key or dev_api_key,
         allow_unauthenticated=allow_insecure_no_auth,
     )
+    set_dev_api_key(dev_api_key)
 
     _ui_dist = Path(__file__).resolve().parents[1] / "ui_dist"
     rows = [
@@ -453,6 +503,7 @@ def serve_cmd(
                 api_key=api_key,
                 oidc_enabled=_oidc_enabled(),
                 allow_unauthenticated=_resolve_allow_unauthenticated(allow_insecure_no_auth),
+                dev_api_key=dev_api_key,
             ),
         ),
         ("TLS", "app-native mTLS" if tls_kwargs.get("ssl_ca_certs") else ("server TLS" if tls_kwargs else "delegated/none")),
@@ -466,6 +517,17 @@ def serve_cmd(
         ),
     ]
     _emit_runtime_summary("agent-bom serve", rows)
+    if dev_api_key:
+        click.secho(
+            f"  Dev API key (loopback only): {dev_api_key}",
+            fg="cyan",
+            bold=True,
+        )
+        click.echo(
+            "  The local dashboard uses this automatically. Send it as "
+            "'Authorization: Bearer <key>' for CLI/API calls.\n"
+            "  Ephemeral (per-process, not saved). Set AGENT_BOM_NO_AUTO_DEV_KEY=1 to disable.\n"
+        )
 
     try:
         import uvicorn as _uvicorn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,7 +129,9 @@ def _reset_api_runtime_state() -> None:
 
         set_key_store(KeyStore())
         api_server._env_api_keys_seeded = False
+        api_server._runtime_api_key_seeded = False
         api_server._api_key = None
+        api_server.set_dev_api_key(None)
     except Exception:
         pass
 

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -1553,15 +1553,11 @@ async def test_auth_session_xff_spoof_does_not_reset_bruteforce_window(monkeypat
         )
 
     with pytest.raises(HTTPException) as first:
-        await enterprise.create_browser_session(
-            make_request("1.1.1.1"), Response(), enterprise.BrowserSessionRequest(api_key="bad-1")
-        )
+        await enterprise.create_browser_session(make_request("1.1.1.1"), Response(), enterprise.BrowserSessionRequest(api_key="bad-1"))
     assert first.value.status_code == 401
 
     with pytest.raises(HTTPException) as second:
-        await enterprise.create_browser_session(
-            make_request("2.2.2.2"), Response(), enterprise.BrowserSessionRequest(api_key="bad-2")
-        )
+        await enterprise.create_browser_session(make_request("2.2.2.2"), Response(), enterprise.BrowserSessionRequest(api_key="bad-2"))
     assert second.value.status_code == 429
 
 
@@ -1618,3 +1614,100 @@ def test_configure_api_mounts_global_limiter_outermost(monkeypatch):
         server_app.user_middleware = original
         if server_app.middleware_stack is not None:
             server_app.middleware_stack = server_app.build_middleware_stack()
+
+
+# ── Zero-config loopback dev key (feat/serve-zero-config-devkey) ─────────────
+
+
+def _clear_dev_key_auth_env(monkeypatch):
+    for name in (
+        "AGENT_BOM_API_KEY",
+        "AGENT_BOM_API_KEYS",
+        "AGENT_BOM_OIDC_ISSUER",
+        "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON",
+        "AGENT_BOM_TRUST_PROXY_AUTH",
+        "AGENT_BOM_SCIM_BEARER_TOKEN",
+        "AGENT_BOM_ALLOW_UNAUTHENTICATED_API",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_loopback_dev_key_request_succeeds(monkeypatch):
+    """A request bearing the seeded dev key succeeds (200) while unauthenticated fails closed (401)."""
+    from agent_bom.api.server import configure_api as cfg
+    from agent_bom.api.server import set_dev_api_key
+    from agent_bom.cli._server import _generate_dev_api_key
+
+    _clear_dev_key_auth_env(monkeypatch)
+    dev_key = _generate_dev_api_key()
+    cfg(api_key=dev_key)
+    set_dev_api_key(dev_key)
+
+    client = TestClient(app)
+    # Fail-closed without credentials.
+    assert client.get("/v1/overview").status_code == 401
+    # Authenticated with the dev key (Bearer and X-API-Key both accepted).
+    assert client.get("/v1/overview", headers={"Authorization": f"Bearer {dev_key}"}).status_code == 200
+    assert client.get("/v1/overview", headers={"X-API-Key": dev_key}).status_code == 200
+
+
+def test_dev_session_cookie_authenticates_dashboard(monkeypatch):
+    """With a dev key active, the auto-issued browser session cookie authenticates the overview."""
+    from agent_bom.api.server import _maybe_attach_dev_session_cookie, set_dev_api_key
+    from agent_bom.api.server import configure_api as cfg
+    from agent_bom.cli._server import _generate_dev_api_key
+
+    _clear_dev_key_auth_env(monkeypatch)
+    dev_key = _generate_dev_api_key()
+    cfg(api_key=dev_key)
+    set_dev_api_key(dev_key)
+
+    response = Response()
+    _maybe_attach_dev_session_cookie(response, SimpleNamespace(cookies={}))
+    set_cookies = [v.decode() for k, v in response.raw_headers if k == b"set-cookie"]
+    session_cookie = next((c for c in set_cookies if c.startswith(f"{SESSION_COOKIE_NAME}=")), None)
+    assert session_cookie is not None, "dev session cookie should be issued when a dev key is active"
+    token = session_cookie.split("=", 1)[1].split(";", 1)[0]
+
+    client = TestClient(app)
+    client.cookies.set(SESSION_COOKIE_NAME, token)
+    assert client.get("/v1/overview").status_code == 200
+
+
+def test_no_dev_session_cookie_without_active_dev_key(monkeypatch):
+    """No dev key set => the helper is a no-op (fail-closed for non-zero-config serves)."""
+    from agent_bom.api.server import _maybe_attach_dev_session_cookie, set_dev_api_key
+
+    _clear_dev_key_auth_env(monkeypatch)
+    set_dev_api_key(None)
+
+    response = Response()
+    _maybe_attach_dev_session_cookie(response, SimpleNamespace(cookies={}))
+    set_cookies = [v.decode() for k, v in response.raw_headers if k == b"set-cookie"]
+    assert set_cookies == []
+
+
+def test_dev_session_cookie_not_reissued_when_session_present(monkeypatch):
+    """An existing valid session cookie is reused, not churned into a fresh nonce."""
+    from agent_bom.api.server import _maybe_attach_dev_session_cookie, set_dev_api_key
+    from agent_bom.api.server import configure_api as cfg
+    from agent_bom.cli._server import _generate_dev_api_key
+
+    _clear_dev_key_auth_env(monkeypatch)
+    dev_key = _generate_dev_api_key()
+    cfg(api_key=dev_key)
+    set_dev_api_key(dev_key)
+
+    existing_token, _ = create_browser_session_token(
+        subject="loopback-dev-key",
+        role="admin",
+        tenant_id="default",
+        auth_method="browser_session_dev_key",
+        key_id=None,
+        scopes=[],
+        max_age_seconds=3600,
+    )
+    response = Response()
+    _maybe_attach_dev_session_cookie(response, SimpleNamespace(cookies={SESSION_COOKIE_NAME: existing_token}))
+    set_cookies = [v.decode() for k, v in response.raw_headers if k == b"set-cookie"]
+    assert set_cookies == []

--- a/tests/test_cli_serve_auth_enforce.py
+++ b/tests/test_cli_serve_auth_enforce.py
@@ -11,7 +11,12 @@ from __future__ import annotations
 import click
 import pytest
 
-from agent_bom.cli._server import _api_auth_summary, _enforce_auth_defaults
+from agent_bom.cli._server import (
+    _api_auth_summary,
+    _enforce_auth_defaults,
+    _generate_dev_api_key,
+    _should_auto_generate_dev_key,
+)
 
 
 def test_enforce_auth_defaults_loopback_always_passes() -> None:
@@ -90,6 +95,7 @@ def _clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "AGENT_BOM_TRUST_PROXY_AUTH",
         "AGENT_BOM_SCIM_BEARER_TOKEN",
         "AGENT_BOM_ALLOW_UNAUTHENTICATED_API",
+        "AGENT_BOM_NO_AUTO_DEV_KEY",
     ):
         monkeypatch.delenv(name, raising=False)
 
@@ -147,5 +153,89 @@ def test_api_auth_summary_prefers_api_key(monkeypatch: pytest.MonkeyPatch) -> No
         api_key="secret",
         oidc_enabled=False,
         allow_unauthenticated=True,
+    )
+    assert "API key required" in summary
+
+
+# ── Zero-config loopback dev key ────────────────────────────────────────────
+
+
+def test_should_auto_generate_dev_key_loopback_no_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bare loopback serve with no auth configured => auto dev key."""
+    _clear_auth_env(monkeypatch)
+    for host in ("127.0.0.1", "localhost", "::1"):
+        assert _should_auto_generate_dev_key(host=host, api_key=None, allow_insecure_no_auth=False) is True
+
+
+def test_should_auto_generate_dev_key_never_on_non_loopback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-loopback bind must NEVER auto-generate a key (stays fail-closed)."""
+    _clear_auth_env(monkeypatch)
+    assert _should_auto_generate_dev_key(host="0.0.0.0", api_key=None, allow_insecure_no_auth=False) is False
+    assert _should_auto_generate_dev_key(host="192.168.1.10", api_key=None, allow_insecure_no_auth=False) is False
+
+
+def test_should_auto_generate_dev_key_opt_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AGENT_BOM_NO_AUTO_DEV_KEY=1 restores the current fail-closed behaviour."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_NO_AUTO_DEV_KEY", "1")
+    assert _should_auto_generate_dev_key(host="127.0.0.1", api_key=None, allow_insecure_no_auth=False) is False
+
+
+def test_should_auto_generate_dev_key_explicit_auth_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit key/flag/env auth path suppresses the auto dev key."""
+    _clear_auth_env(monkeypatch)
+    assert _should_auto_generate_dev_key(host="127.0.0.1", api_key="secret", allow_insecure_no_auth=False) is False
+    assert _should_auto_generate_dev_key(host="127.0.0.1", api_key=None, allow_insecure_no_auth=True) is False
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_API_KEYS", "raw:admin")
+    assert _should_auto_generate_dev_key(host="127.0.0.1", api_key=None, allow_insecure_no_auth=False) is False
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_SCIM_BEARER_TOKEN", "x" * 32)
+    assert _should_auto_generate_dev_key(host="127.0.0.1", api_key=None, allow_insecure_no_auth=False) is False
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", "1")
+    assert _should_auto_generate_dev_key(host="127.0.0.1", api_key=None, allow_insecure_no_auth=False) is False
+
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    assert _should_auto_generate_dev_key(host="127.0.0.1", api_key=None, allow_insecure_no_auth=False) is False
+
+
+def test_generate_dev_api_key_is_prefixed_and_unique() -> None:
+    """Dev keys carry the abk_ prefix and are per-call random."""
+    first = _generate_dev_api_key()
+    second = _generate_dev_api_key()
+    assert first.startswith("abk_")
+    assert second.startswith("abk_")
+    assert first != second
+
+
+def test_api_auth_summary_reports_dev_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When a dev key is minted (and no explicit key), the banner is honest about it."""
+    _clear_auth_env(monkeypatch)
+    summary = _api_auth_summary(
+        host="127.0.0.1",
+        api_key=None,
+        oidc_enabled=False,
+        allow_unauthenticated=False,
+        dev_api_key="abk_example",
+    )
+    assert "auto dev API key" in summary
+    assert "loopback" in summary.lower()
+    assert "fail closed" not in summary.lower()
+
+
+def test_api_auth_summary_explicit_key_beats_dev_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit --api-key always wins over an (unexpected) dev key value."""
+    _clear_auth_env(monkeypatch)
+    summary = _api_auth_summary(
+        host="127.0.0.1",
+        api_key="secret",
+        oidc_enabled=False,
+        allow_unauthenticated=False,
+        dev_api_key="abk_example",
     )
     assert "API key required" in summary

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -60,6 +60,99 @@ def test_serve_cmd_invalid_port_is_usage_error():
     assert "1024<=x<=65535" in result.output
 
 
+_AUTH_ENV_NAMES = (
+    "AGENT_BOM_API_KEY",
+    "AGENT_BOM_API_KEYS",
+    "AGENT_BOM_OIDC_ISSUER",
+    "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON",
+    "AGENT_BOM_TRUST_PROXY_AUTH",
+    "AGENT_BOM_SCIM_BEARER_TOKEN",
+    "AGENT_BOM_ALLOW_UNAUTHENTICATED_API",
+    "AGENT_BOM_NO_AUTO_DEV_KEY",
+)
+
+
+def test_serve_cmd_loopback_auto_generates_dev_key(monkeypatch):
+    """Bare loopback `serve` mints + prints an ephemeral dev key and seeds it into the API."""
+    for name in _AUTH_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    runner = CliRunner()
+    with (
+        patch("agent_bom.api.server.configure_api") as mock_configure,
+        patch("agent_bom.api.server.set_dev_api_key") as mock_set_dev,
+        patch("uvicorn.run") as mock_run,
+    ):
+        result = runner.invoke(serve_cmd, [])
+
+    assert result.exit_code == 0
+    assert mock_run.called
+    # Prominent, honest banner line with the actual key.
+    assert "Dev API key (loopback only): abk_" in result.output
+    assert "uses this automatically" in result.output
+    assert "AGENT_BOM_NO_AUTO_DEV_KEY=1 to disable" in result.output
+    # The same key is both seeded into the API and registered for the UI.
+    configured_key = mock_configure.call_args.kwargs["api_key"]
+    assert configured_key.startswith("abk_")
+    mock_set_dev.assert_called_once_with(configured_key)
+
+
+def test_serve_cmd_no_auto_dev_key_env_fails_closed(monkeypatch):
+    """AGENT_BOM_NO_AUTO_DEV_KEY=1 keeps the current fail-closed loopback behaviour."""
+    for name in _AUTH_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("AGENT_BOM_NO_AUTO_DEV_KEY", "1")
+    runner = CliRunner()
+    with (
+        patch("agent_bom.api.server.configure_api") as mock_configure,
+        patch("agent_bom.api.server.set_dev_api_key") as mock_set_dev,
+        patch("uvicorn.run") as mock_run,
+    ):
+        result = runner.invoke(serve_cmd, [])
+
+    assert result.exit_code == 0
+    assert mock_run.called
+    assert "Dev API key" not in result.output
+    assert mock_configure.call_args.kwargs["api_key"] is None
+    mock_set_dev.assert_called_once_with(None)
+    assert "fail closed" in result.output.lower()
+
+
+def test_serve_cmd_explicit_api_key_skips_dev_key(monkeypatch):
+    """An explicit --api-key suppresses the auto dev key and is used as-is."""
+    for name in _AUTH_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    runner = CliRunner()
+    with (
+        patch("agent_bom.api.server.configure_api") as mock_configure,
+        patch("agent_bom.api.server.set_dev_api_key") as mock_set_dev,
+        patch("uvicorn.run"),
+    ):
+        result = runner.invoke(serve_cmd, ["--api-key", "operator-key"])
+
+    assert result.exit_code == 0
+    assert "Dev API key" not in result.output
+    assert mock_configure.call_args.kwargs["api_key"] == "operator-key"
+    mock_set_dev.assert_called_once_with(None)
+
+
+def test_serve_cmd_non_loopback_never_auto_generates_dev_key(monkeypatch):
+    """A non-loopback bind (with real auth) must never mint a dev key."""
+    for name in _AUTH_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    runner = CliRunner()
+    with (
+        patch("agent_bom.api.server.configure_api") as mock_configure,
+        patch("agent_bom.api.server.set_dev_api_key") as mock_set_dev,
+        patch("uvicorn.run"),
+    ):
+        result = runner.invoke(serve_cmd, ["--host", "0.0.0.0", "--api-key", "operator-key"])
+
+    assert result.exit_code == 0
+    assert "Dev API key" not in result.output
+    assert mock_configure.call_args.kwargs["api_key"] == "operator-key"
+    mock_set_dev.assert_called_once_with(None)
+
+
 # ---------------------------------------------------------------------------
 # api_cmd
 # ---------------------------------------------------------------------------
@@ -263,9 +356,19 @@ def test_serve_cmd_configures_api_auth():
     assert "Storage" in result.output
 
 
-def test_serve_cmd_loopback_no_auth_reports_fail_closed(monkeypatch):
-    """Bare `serve` on loopback fails closed; the banner must say so, not claim no-auth."""
-    for name in ("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", "AGENT_BOM_API_KEYS", "AGENT_BOM_OIDC_ISSUER", "AGENT_BOM_SCIM_BEARER_TOKEN"):
+def test_serve_cmd_loopback_no_auth_mints_dev_key(monkeypatch):
+    """Bare `serve` on loopback now mints an ephemeral dev key instead of failing closed.
+
+    The banner must never claim unauthenticated access, and the opt-out hint
+    keeps the previous fail-closed posture discoverable.
+    """
+    for name in (
+        "AGENT_BOM_ALLOW_UNAUTHENTICATED_API",
+        "AGENT_BOM_API_KEYS",
+        "AGENT_BOM_OIDC_ISSUER",
+        "AGENT_BOM_SCIM_BEARER_TOKEN",
+        "AGENT_BOM_NO_AUTO_DEV_KEY",
+    ):
         monkeypatch.delenv(name, raising=False)
     runner = CliRunner()
 
@@ -276,8 +379,8 @@ def test_serve_cmd_loopback_no_auth_reports_fail_closed(monkeypatch):
     mock_configure.assert_called_once()
     mock_run.assert_called_once()
     assert "local unauthenticated mode" not in result.output
-    assert "fail closed" in result.output
-    assert "--allow-insecure-no-auth" in result.output
+    assert "Dev API key (loopback only): abk_" in result.output
+    assert "AGENT_BOM_NO_AUTO_DEV_KEY=1 to disable" in result.output
     assert "In-memory (ephemeral)" in result.output
 
 


### PR DESCRIPTION
## What this does

#3356 made loopback `agent-bom serve` **fail closed** when no auth is configured — honest, but it forced every new user to pass `--allow-insecure-no-auth` (or wire a key) before the dashboard stopped returning 401. This removes that last friction **without weakening security**.

When `serve` binds to a **loopback** host (`127.0.0.1` / `localhost` / `::1`) **and** no auth path is configured (no `--api-key`, no `--allow-insecure-no-auth`, no `AGENT_BOM_API_KEY` / `AGENT_BOM_API_KEYS` / OIDC / SCIM / trusted-proxy, no `AGENT_BOM_ALLOW_UNAUTHENTICATED_API`), `serve` now:

1. Mints a single **ephemeral** `abk_…` dev API key (per-process, `secrets.token_urlsafe`).
2. Seeds it into the RBAC key store via `configure_api(api_key=…)` so the API accepts it as an admin key (`Authorization: Bearer …` / `X-API-Key`).
3. **Prints it prominently** in the startup banner: `Dev API key (loopback only): abk_… — the local dashboard uses this automatically`.
4. Auto-authenticates the same-origin dashboard: the HTML routes (`/`, SPA fallback) issue a matching **signed browser-session cookie** (admin, `key_id=None`, httponly + CSRF cookie). The UI loads with **zero flags** and **zero manual key entry**, keeping the existing header-free, cookie-based UI auth contract unchanged (no frontend changes needed).

## Security guarantees (fail-closed preserved)

- **Non-loopback binds NEVER auto-generate a key.** `_enforce_auth_defaults` still refuses unauthenticated non-loopback binds *before* key generation, and `_should_auto_generate_dev_key` independently re-checks the host.
- The dev key is **ephemeral** — per-process, never written to disk.
- Any explicit auth (key / flag / env / OIDC / SCIM / proxy) **suppresses** the dev key; explicit `--api-key` always wins.
- **`AGENT_BOM_NO_AUTO_DEV_KEY=1`** restores the prior fail-closed loopback behavior.
- The banner stays **honest**: it labels the key a loopback-only dev key, never claims unauthenticated access.
- The auto session cookie carries no `key_id` (so it doesn't depend on key-store lookups) and is reused across page loads instead of churning fresh nonces.

## Tests

- `_should_auto_generate_dev_key`: loopback→yes; non-loopback→no; opt-out env→no; explicit key/flag/`API_KEYS`/SCIM/`ALLOW_UNAUTHENTICATED`/`TRUST_PROXY`→no.
- `serve` CLI: loopback mints + prints `abk_…` and seeds it; `AGENT_BOM_NO_AUTO_DEV_KEY=1`→fail closed; explicit `--api-key`→no dev key; non-loopback→no dev key.
- API: request with the dev key →200 while unauthenticated →401; the auto-issued browser-session cookie authenticates `/v1/overview` →200; no cookie issued when no dev key is active; existing session is reused.

Part of #13