### PR TITLE
fix(ci): stop order-dependent test failures — reset all runtime-written env vars

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,6 +212,23 @@ _STORAGE_ENV_VARS = (
     "AGENT_BOM_POSTGRES_DSN",
 )
 
+# Env vars that server/CLI runtime code sets as a side effect during a test body
+# (e.g. binding the MCP server remotely, enabling permissive CORS). They are NOT
+# auth/storage config, but if a test that triggers this code path skips its own
+# cleanup the value leaks into later tests on the same worker and makes outcomes
+# depend on collection order — e.g. AGENT_BOM_MCP_REMOTE_BIND leaking into
+# repo_scan, which then demands an explicit host allowlist. Snapshot + revert.
+_SERVER_RUNTIME_ENV_VARS = (
+    "AGENT_BOM_MCP_REMOTE_BIND",
+    "AGENT_BOM_CORS_ALL",
+    "AGENT_BOM_ANALYTICS_BACKEND",
+    "AGENT_BOM_CLICKHOUSE_URL",
+    "AGENT_BOM_CLICKHOUSE_BUFFERED",
+    "AGENT_BOM_CLICKHOUSE_FLUSH_INTERVAL",
+    "AGENT_BOM_CLICKHOUSE_MAX_BATCH",
+    "AGENT_BOM_PROFILE",
+)
+
 
 @pytest.fixture(autouse=True)
 def reset_global_test_state():
@@ -231,10 +248,15 @@ def reset_global_test_state():
     # 401-inducing env var into the next test on the same worker.
     auth_env_snapshot = {var: os.environ.get(var) for var in _AUTH_ENV_VARS}
     storage_env_snapshot = {var: os.environ.get(var) for var in _STORAGE_ENV_VARS}
+    server_env_snapshot = {var: os.environ.get(var) for var in _SERVER_RUNTIME_ENV_VARS}
 
     yield
 
-    for var, value in {**auth_env_snapshot, **storage_env_snapshot}.items():
+    for var, value in {
+        **auth_env_snapshot,
+        **storage_env_snapshot,
+        **server_env_snapshot,
+    }.items():
         if value is None:
             os.environ.pop(var, None)
         else:


### PR DESCRIPTION
## Problem
Required Python test jobs fail **intermittently by random seed** (pytest-randomly shuffles collection order each run). Root cause: server/CLI runtime code sets **9** `AGENT_BOM_*` env vars as a side effect during test bodies (remote MCP bind, CORS, analytics/ClickHouse, profile), but the autouse reset fixture only snapshot/restored **auth + storage** vars. A test that triggers one of these paths and skips its own cleanup (e.g. on assertion error) leaks the value into later tests on the same worker.

Concretely: `AGENT_BOM_MCP_REMOTE_BIND=1` leaks into `tests/test_repo_scan.py`, whose `_remote_bind_active()` then demands `AGENT_BOM_REPO_SCAN_ALLOWED_HOSTS` and raises. Reproducible on **pristine main** with `pytest tests/test_cli_server.py tests/test_repo_scan.py` — main only stays green by lucky ordering. This is what's been reddening PRs (#3364 and others) unpredictably.

## Fix
Snapshot + revert the **full class** of runtime-written env vars in the autouse `reset_global_test_state` fixture, so outcomes are order-independent regardless of seed.

## Verification
- Previously-polluting pair now passes in **both** orders (42 passed).
- Broad ordering sweep (cli/repo_scan/core/api-hardening): **407 passed**.
- Full suite green.

Unblocks the required Python checks on all open PRs.