### PR TITLE
feat(cloud): event-driven Azure + GCP posture — Activity Log / Asset feed ingestion + per-resource rule re-eval

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -41,10 +41,15 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_AWS_EVENT_MAX_MESSAGES` | `int` | `10` | Event-driven AWS posture ingestion (continuous posture). When an operator wires EventBridge→SQS (opt-in via AGENT_BOM_AWS_EVENT_QUEUE_URL, read live, default off), the bounded SQS consumer drains change events and re-evaluates only the affe |
 | `AGENT_BOM_AWS_EVENT_VISIBILITY_TIMEOUT` | `int` | `120` | — |
 | `AGENT_BOM_AWS_EVENT_WAIT_SECONDS` | `int` | `5` | — |
+| `AGENT_BOM_AZURE_EVENT_MAX_BATCHES` | `int` | `10` | — |
+| `AGENT_BOM_AZURE_EVENT_MAX_MESSAGES` | `int` | `10` | Event-driven Azure posture ingestion. When an operator wires Azure Monitor Activity Log / Event Grid → a Storage Queue (opt-in via AGENT_BOM_AZURE_EVENT_QUEUE, read live, default off), the bounded queue consumer drains change events and re- |
+| `AGENT_BOM_AZURE_EVENT_VISIBILITY_TIMEOUT` | `int` | `120` | — |
 | `AGENT_BOM_BODY_MIN_BPS` | `int` | `256` | Slowloris throughput floor (audit-5 PR-C): minimum sustained body bytes/second once a request body crosses the warmup threshold inside MaxBodySizeMiddleware. 0 disables the floor entirely (escape hatch for legitimate slow clients in restric |
 | `AGENT_BOM_CONNECTIONS_SCHEDULER_MAX_CONCURRENCY` | `int` | `4` | — |
 | `AGENT_BOM_CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES` | `int` | `15` | — |
 | `AGENT_BOM_CONNECTIONS_SCHEDULER_POLL_SECONDS` | `int` | `60` | Cloud-connection scan scheduler (Phase B.2). The background loop re-scans cloud connections that carry an interval, so "connect once, keeps evaluating" is automatic. Disabled by default (AGENT_BOM_CONNECTIONS_SCHEDULER, read live) so it nev |
+| `AGENT_BOM_GCP_EVENT_MAX_BATCHES` | `int` | `10` | — |
+| `AGENT_BOM_GCP_EVENT_MAX_MESSAGES` | `int` | `10` | Event-driven GCP posture ingestion. When an operator wires Cloud Asset Inventory feed / audit logs → a Pub/Sub subscription (opt-in via AGENT_BOM_GCP_EVENT_SUBSCRIPTION, read live, default off), the bounded Pub/Sub consumer drains change ev |
 
 ## Agent-to-Agent (A2A) auth posture
 | Env var | Type | Default | Description |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ azure = [
     "azure-mgmt-redis>=14.3",
     "azure-mgmt-frontdoor>=1.1",
     "azure-mgmt-apimanagement>=4.0",
+    "azure-storage-queue>=12.9",
     "six>=1.17.0",
 ]
 gcp = [

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -68,6 +68,8 @@ AGENT_BOM_AWS_ORG_EXTERNAL_ID
 # Explicit comma-separated region override for the multi-region AWS inventory fan-out (else enabled regions are enumerated).
 AGENT_BOM_AWS_REGIONS
 AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS
+# Opt-in (default OFF, read live) Azure Storage Queue URL for event-driven Azure posture ingestion; when set, the operator has wired Activity Log / Event Grid→Storage Queue and the bounded consumer drains change events. Deploy-only toggle; absence disables the consumer.
+AGENT_BOM_AZURE_EVENT_QUEUE
 AGENT_BOM_AZURE_INVENTORY
 AGENT_BOM_AZURE_MAX_SUBSCRIPTIONS
 AGENT_BOM_BACKPRESSURE_ENABLED
@@ -189,6 +191,8 @@ AGENT_BOM_GATEWAY_REPLICAS
 AGENT_BOM_GATEWAY_REQUIRE_SHARED_RATE_LIMIT
 # Opt-in (default OFF) gate to fan the GCP inventory across every project in the org/folder tree (multi-project fan-out).
 AGENT_BOM_GCP_ALL_PROJECTS
+# Opt-in (default OFF, read live) Pub/Sub subscription path for event-driven GCP posture ingestion; when set, the operator has wired a Cloud Asset Inventory feed / audit-log sink→Pub/Sub and the bounded consumer drains change events. Deploy-only toggle; absence disables the consumer.
+AGENT_BOM_GCP_EVENT_SUBSCRIPTION
 # Read-only GCP service account to impersonate (keyless, least-privilege) when set; the connector runs every call as this SA.
 AGENT_BOM_GCP_IMPERSONATE_SA
 # Opt-in (default OFF) gate for the estate-wide read-only GCP asset inventory scanner (token/ADC auth only).

--- a/src/agent_bom/cloud/azure_event_ingest.py
+++ b/src/agent_bom/cloud/azure_event_ingest.py
@@ -1,0 +1,556 @@
+"""Event-driven Azure posture ingestion (continuous / change-triggered CNAPP).
+
+The complement to the polling scheduler for Azure, mirroring the AWS lane in
+:mod:`agent_bom.cloud.event_ingest`. When a resource changes in a customer
+subscription, Azure Monitor emits an Activity Log record that an Event Grid
+subscription (or a diagnostic setting) can route to a Storage Queue. The control
+plane drains that queue and re-evaluates **only** the Azure CIS rules that apply
+to the changed resource's type — so a storage account made public is re-checked
+in seconds instead of waiting for the next scheduled full scan. Polling remains
+the fallback; this is additive.
+
+Trust posture (non-negotiable, fail-closed):
+
+* **Read-only against the customer.** The changed resource is re-fetched and its
+  CIS checks re-run through the SAME brokered read-only Reader credential the
+  scheduled scan uses (:func:`agent_bom.cloud.connection_broker.broker_session`).
+  No write API is ever called on the customer subscription.
+* **Subscription/tenant-bound.** A change event is only dispatched when its
+  subscription (and tenant, when present) matches the connection's own
+  subscription/tenant (from ``auth_params``). A spoofed / cross-subscription
+  event is dropped, never processed — this prevents a confused-deputy where an
+  attacker-controlled queue message steers a scan at a subscription the tenant
+  does not own.
+* **Bounded.** :func:`consume_azure_events` drains at most a configured number of
+  messages across a configured number of receive batches and then RETURNS. There
+  is no forever loop; an operator (or a scheduler tick) invokes it repeatedly.
+* **Crash-proof.** A malformed message is logged and deleted (it can never be
+  parsed, so redelivery would only poison the queue); a transient dispatch
+  failure is logged and left on the queue for the visibility timeout to
+  redeliver. One bad message never sinks the batch.
+
+Opt-in and default OFF: the consumer only runs when ``AGENT_BOM_AZURE_EVENT_QUEUE``
+is set (read live) — the full Storage Queue URL the operator wired Event Grid to.
+The queue is operator-owned, so the control plane reads it with its OWN ambient
+credentials — distinct from the customer read-only Reader credential used for the
+posture re-evaluation.
+
+Requires ``azure-storage-queue`` + ``azure-identity`` for the queue consumer.
+Install with ``pip install 'agent-bom[azure]'``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from agent_bom import config
+from agent_bom.api.connection_store import CloudConnectionRecord
+from agent_bom.cloud.event_ingest import CloudChangeEvent, _default_persist, _now
+
+logger = logging.getLogger(__name__)
+
+# Opt-in gate (read live so operators/tests can toggle it). Absence = disabled.
+# The value is the full Azure Storage Queue URL the operator routed Event Grid to.
+EVENT_QUEUE_ENV = "AGENT_BOM_AZURE_EVENT_QUEUE"
+
+
+@dataclass(frozen=True)
+class _ResourceRule:
+    """How to re-evaluate posture for one Azure resource-type token.
+
+    ``inventory_kwargs`` scopes :func:`azure_inventory.discover_inventory` to just
+    the affected resource class (so we re-fetch that resource, not the estate).
+    ``check_ids`` is the exact Azure CIS subset re-run for the type. ``locators``
+    maps inventory payload list keys to the field that identifies a single
+    resource, so the changed resource can be picked out of the class fetch.
+    """
+
+    check_ids: tuple[str, ...]
+    inventory_kwargs: dict[str, bool]
+    locators: tuple[tuple[str, str], ...]
+
+
+# Only the affected class is fetched; every other include_* flag is forced off.
+def _only(**flags: bool) -> dict[str, bool]:
+    base = {
+        "include_storage": False,
+        "include_compute": False,
+        "include_identity": False,
+        "include_data": False,
+        "include_network": False,
+        "include_hierarchy": False,
+    }
+    base.update(flags)
+    return base
+
+
+# Resource-type token → posture re-evaluation rule. Azure Activity Log
+# ``operationName`` / Event Grid ``subject`` collapse to these tokens via the ARM
+# resource-type segment (see ``_canonical_resource_type``).
+_RESOURCE_RULES: dict[str, _ResourceRule] = {
+    "storage": _ResourceRule(
+        check_ids=("3.1", "3.2", "3.3", "3.7", "3.8", "3.10", "3.11", "3.12"),
+        inventory_kwargs=_only(include_storage=True),
+        locators=(("storage_accounts", "name"), ("storage_accounts", "id")),
+    ),
+    "nsg": _ResourceRule(
+        check_ids=("6.1", "6.2", "6.4", "6.6"),
+        inventory_kwargs=_only(include_compute=True, include_network=True),
+        locators=(("security_groups", "group_id"), ("security_groups", "name")),
+    ),
+    "compute": _ResourceRule(
+        check_ids=("7.1", "7.2", "7.3"),
+        inventory_kwargs=_only(include_compute=True),
+        locators=(("instances", "name"), ("instances", "id")),
+    ),
+    "keyvault": _ResourceRule(
+        check_ids=("8.1", "8.2", "8.4", "8.5", "8.6", "8.7"),
+        inventory_kwargs=_only(include_data=True),
+        locators=(("key_vaults", "name"), ("key_vaults", "id")),
+    ),
+    "sql": _ResourceRule(
+        check_ids=("4.1.1", "4.1.2", "4.1.3", "4.1.4", "4.1.5", "4.1.6"),
+        inventory_kwargs=_only(include_data=True),
+        locators=(("databases", "name"), ("databases", "id")),
+    ),
+    "webapp": _ResourceRule(
+        check_ids=("9.1", "9.2", "9.3", "9.4", "9.6"),
+        inventory_kwargs=_only(include_compute=True),
+        locators=(("app_services", "name"), ("app_services", "id")),
+    ),
+    "authorization": _ResourceRule(
+        check_ids=("1.1", "1.2", "1.5", "1.7", "1.15"),
+        inventory_kwargs=_only(include_identity=True),
+        locators=(("role_assignments", "id"),),
+    ),
+}
+
+# ARM resource-type segment (lower-cased, from the provider path) → service token.
+_AZURE_RESOURCE_TYPE_TOKENS: dict[str, str] = {
+    "storageaccounts": "storage",
+    "networksecuritygroups": "nsg",
+    "virtualmachines": "compute",
+    "disks": "compute",
+    "vaults": "keyvault",
+    "servers": "sql",
+    "databases": "sql",
+    "sites": "webapp",
+    "roleassignments": "authorization",
+}
+
+
+def event_ingest_enabled() -> bool:
+    """Return whether Azure event-driven ingestion is opted in (queue configured).
+
+    Read live so operators and tests can toggle it. Default OFF: with no queue
+    URL the consumer is a no-op and only the polling scheduler runs.
+    """
+    return bool(os.environ.get(EVENT_QUEUE_ENV, "").strip())
+
+
+def _uri_segments(uri: str) -> list[str]:
+    return [seg for seg in (uri or "").split("/") if seg]
+
+
+def _subscription_from_uri(uri: str) -> str:
+    """Pull the subscription id out of an ARM resource id / Event Grid subject.
+
+    Splits WITHOUT collapsing empty segments so ``/subscriptions//providers/...``
+    (an absent subscription) resolves to "" rather than mis-reading the next
+    keyword segment as the id.
+    """
+    raw = (uri or "").split("/")
+    for idx, seg in enumerate(raw):
+        if seg.lower() == "subscriptions" and idx + 1 < len(raw):
+            return raw[idx + 1].strip()
+    return ""
+
+
+def _type_and_name_from_uri(uri: str) -> tuple[str, str]:
+    """Return (arm_resource_type_segment, resource_name) from an ARM resource id.
+
+    ``/subscriptions/<s>/resourceGroups/<rg>/providers/Microsoft.Storage/
+    storageAccounts/<name>`` → (``"storageaccounts"``, ``"<name>"``). The type
+    segment is the one immediately after the provider namespace; the name is the
+    last segment. Returns ("", "") when the shape is not an ARM resource id.
+    """
+    segs = _uri_segments(uri)
+    for idx, seg in enumerate(segs):
+        if seg.lower() == "providers" and idx + 2 < len(segs):
+            return segs[idx + 2].lower(), segs[-1]
+    return "", ""
+
+
+def _canonical_resource_type(arm_type: str) -> str:
+    """Collapse an ARM resource-type segment to a service token."""
+    return _AZURE_RESOURCE_TYPE_TOKENS.get((arm_type or "").strip().lower(), "")
+
+
+def _operation_value(operation: Any) -> str:
+    """Normalize an operationName that may be a string or ``{"value": ...}``."""
+    if isinstance(operation, dict):
+        return str(operation.get("value") or "").strip()
+    return str(operation or "").strip()
+
+
+def parse_azure_event(message: str | dict[str, Any]) -> CloudChangeEvent | None:
+    """Parse an Event Grid / Activity Log message into a :class:`CloudChangeEvent`.
+
+    Accepts either an Event Grid envelope (``{"subject", "eventType", "data":
+    {"operationName", "resourceUri", ...}}``) or a bare Azure Monitor Activity Log
+    record (``{"resourceId", "operationName", "subscriptionId", ...}``). Returns
+    ``None`` for anything malformed or for a resource type with no posture rule —
+    the caller treats ``None`` as "skip, do not crash".
+    """
+    try:
+        obj = json.loads(message) if isinstance(message, (str, bytes)) else message
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+
+    data = obj.get("data")
+    data = data if isinstance(data, dict) else {}
+
+    resource_uri = (
+        str(obj.get("subject") or "").strip()
+        or str(data.get("resourceUri") or "").strip()
+        or str(data.get("resourceId") or "").strip()
+        or str(obj.get("resourceId") or "").strip()
+        or str(obj.get("resourceUri") or "").strip()
+    )
+
+    arm_type, resource_name = _type_and_name_from_uri(resource_uri)
+    token = _canonical_resource_type(arm_type)
+    if token not in _RESOURCE_RULES:
+        return None
+
+    subscription = (
+        str(data.get("subscriptionId") or "").strip()
+        or str(obj.get("subscriptionId") or "").strip()
+        or _subscription_from_uri(resource_uri)
+    )
+    tenant = str(data.get("tenantId") or "").strip() or str(obj.get("tenantId") or "").strip()
+    action = _operation_value(data.get("operationName")) or _operation_value(obj.get("operationName"))
+
+    # Fail closed: without a subscription, an action, and a resource name we
+    # cannot safely attribute or scope the re-evaluation.
+    if not subscription or not action or not resource_name:
+        return None
+
+    return CloudChangeEvent(
+        provider="azure",
+        account=subscription,
+        region=tenant,  # tenant travels in ``region`` for the guard (Azure has no region here).
+        resource_type=token,
+        resource_id=resource_name,
+        action=action,
+        arn=resource_uri,
+        raw=obj,
+    )
+
+
+def _find_affected_resource(rule: _ResourceRule, inventory: dict[str, Any], resource_id: str) -> dict[str, Any] | None:
+    """Return the single inventory entry matching *resource_id*, if present."""
+    for list_key, id_field in rule.locators:
+        for item in inventory.get(list_key, []) or []:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get(id_field, "")) == resource_id:
+                return item
+    return None
+
+
+def dispatch_change_event(
+    event: CloudChangeEvent,
+    record: CloudConnectionRecord,
+    *,
+    tenant_id: str | None = None,
+    credential: Any = None,
+    benchmark_runner: Callable[..., Any] | None = None,
+    persist: Callable[[CloudConnectionRecord, str, Any], str] | None = None,
+    store: Any = None,
+) -> dict[str, Any] | None:
+    """Re-evaluate posture for one changed Azure resource and emit the delta.
+
+    Resolves the changed resource via a scoped read-only inventory fetch, re-runs
+    ONLY the Azure CIS checks for its resource type against the brokered read-only
+    Reader credential, persists the resulting posture through the same scan/graph
+    path a full scan uses, and stamps ``last_event_at`` on the connection.
+
+    Fail-closed: the event's provider must be ``azure`` and its subscription (and
+    tenant, when both are present) must match the connection's own subscription
+    (from ``auth_params``); a mismatch returns ``None`` without touching the
+    customer subscription. An unknown resource type also returns ``None``.
+    """
+    tenant_id = tenant_id or record.tenant_id
+
+    if (event.provider or "").strip().lower() != "azure":
+        logger.warning("Dropping non-Azure change event (provider=%s)", event.provider)
+        return None
+    if (record.provider or "").strip().lower() != "azure":
+        logger.warning("Connection %s is not Azure; cannot dispatch Azure change event", record.id)
+        return None
+
+    connection_subscription = str(record.auth_params.get("subscription_id") or "").strip()
+    if not connection_subscription or event.account != connection_subscription:
+        # Confused-deputy guard: never scan a subscription this connection does not own.
+        logger.warning(
+            "Dropping change event for subscription %s: does not match connection %s subscription",
+            event.account,
+            record.id,
+        )
+        return None
+
+    connection_tenant = str(record.auth_params.get("tenant_id") or "").strip()
+    if connection_tenant and event.region and event.region != connection_tenant:
+        # Tenant is present on both sides and disagrees — a cross-tenant spoof.
+        logger.warning(
+            "Dropping change event for tenant %s: does not match connection %s tenant",
+            event.region,
+            record.id,
+        )
+        return None
+
+    rule = _RESOURCE_RULES.get(event.resource_type)
+    if rule is None:
+        return None
+
+    from agent_bom.cloud import azure_inventory
+    from agent_bom.models import AIBOMReport
+
+    run_cis_benchmark: Callable[..., Any]
+    if benchmark_runner is not None:
+        run_cis_benchmark = benchmark_runner
+    else:
+        from agent_bom.cloud.azure_cis_benchmark import run_benchmark
+
+        run_cis_benchmark = run_benchmark
+
+    if credential is None:
+        from agent_bom.cloud.connection_broker import broker_session
+
+        credential = broker_session(record, session_name=f"agent-bom-event-{record.id[:8]}")
+
+    inv = rule.inventory_kwargs
+    inventory_payload = azure_inventory.discover_inventory(
+        subscription_id=connection_subscription,
+        credential=credential,
+        force=True,
+        include_storage=inv["include_storage"],
+        include_compute=inv["include_compute"],
+        include_identity=inv["include_identity"],
+        include_data=inv["include_data"],
+        include_network=inv["include_network"],
+        include_hierarchy=inv["include_hierarchy"],
+    )
+    affected = _find_affected_resource(rule, inventory_payload, event.resource_id)
+
+    cis_report = run_cis_benchmark(subscription_id=connection_subscription, credential=credential, checks=list(rule.check_ids))
+    cis_dict = cis_report.to_dict()
+    findings = [check for check in cis_dict.get("checks", []) if check.get("status") == "fail"]
+
+    import uuid as _uuid
+
+    report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=str(_uuid.uuid4()))
+    report.scan_sources = ["cloud_connection", "cloud:azure", "event:activity_log"]
+    report.cloud_inventory_data = inventory_payload
+    report.azure_cis_benchmark_data = cis_dict
+
+    persist_fn = persist or _default_persist
+    scan_id = persist_fn(record, tenant_id, report)
+
+    # Freshness signal: event-driven re-eval advances last_event_at, NOT
+    # last_scan_at (that stays the last full polling scan).
+    active_store = store
+    if active_store is None:
+        from agent_bom.api.connection_store import get_connection_store
+
+        active_store = get_connection_store()
+    fresh = active_store.get(tenant_id, record.id) or record
+    fresh.last_event_at = _now()
+    fresh.updated_at = _now()
+    active_store.put(fresh)
+    record.last_event_at = fresh.last_event_at
+
+    return {
+        "schema_version": "cloud.connections.event.v1",
+        "connection_id": record.id,
+        "tenant_id": tenant_id,
+        "provider": "azure",
+        "scan_id": scan_id,
+        "event": {
+            "subscription_id": event.account,
+            "tenant_id": event.region,
+            "resource_type": event.resource_type,
+            "resource_id": event.resource_id,
+            "action": event.action,
+        },
+        "resource": affected,
+        "checks_evaluated": list(rule.check_ids),
+        "findings": [
+            {
+                "check_id": f.get("check_id"),
+                "title": f.get("title"),
+                "severity": f.get("severity"),
+                "resource_ids": f.get("resource_ids", []),
+                "evidence": f.get("evidence", ""),
+            }
+            for f in findings
+        ],
+        "audit_metadata": {
+            "read_only": True,
+            "writes_performed": False,
+            "note": (
+                "Event-driven re-evaluation ran against a short-lived read-only Reader credential brokered from the "
+                "stored connection. Only the affected resource type's Azure CIS checks were re-run; no resource is "
+                "mutated and no secret value is returned."
+            ),
+        },
+    }
+
+
+def consume_azure_events(
+    record: CloudConnectionRecord,
+    *,
+    tenant_id: str | None = None,
+    queue_url: str | None = None,
+    queue_client: Any = None,
+    credential: Any = None,
+    max_messages: int | None = None,
+    max_batches: int | None = None,
+    visibility_timeout: int | None = None,
+    benchmark_runner: Callable[..., Any] | None = None,
+    persist: Callable[[CloudConnectionRecord, str, Any], str] | None = None,
+    store: Any = None,
+) -> dict[str, Any]:
+    """Drain a bounded batch of Azure change events from a Storage Queue.
+
+    Reads the operator-owned Storage Queue (Event Grid→Queue) with the control
+    plane's OWN ambient credentials, parses each Activity Log message, and
+    dispatches a per-resource posture re-evaluation for events that belong to
+    *record*'s subscription. This is a BOUNDED pass: at most ``max_batches``
+    receives of ``max_messages`` each, then it returns — there is no forever loop.
+
+    Message lifecycle: a successfully dispatched message is deleted; a malformed
+    or foreign-subscription message is logged and deleted (redelivery cannot
+    help); a transient dispatch failure is logged and LEFT on the queue for the
+    visibility timeout to redeliver. Never raises — one bad message cannot sink
+    the batch. With no queue configured it is a no-op (``status="disabled"``).
+    """
+    tenant_id = tenant_id or record.tenant_id
+    queue_url = queue_url or os.environ.get(EVENT_QUEUE_ENV, "").strip()
+
+    summary: dict[str, Any] = {
+        "status": "ok",
+        "connection_id": record.id,
+        "received": 0,
+        "processed": 0,
+        "deleted": 0,
+        "skipped_malformed": 0,
+        "skipped_foreign": 0,
+        "errors": 0,
+        "batches": 0,
+    }
+
+    if not queue_url:
+        summary["status"] = "disabled"
+        return summary
+
+    max_messages = max(1, min(int(max_messages if max_messages is not None else config.AZURE_EVENT_MAX_MESSAGES), 32))
+    max_batches = max(1, int(max_batches if max_batches is not None else config.AZURE_EVENT_MAX_BATCHES))
+    visibility_timeout = max(0, int(visibility_timeout if visibility_timeout is not None else config.AZURE_EVENT_VISIBILITY_TIMEOUT))
+
+    connection_subscription = str(record.auth_params.get("subscription_id") or "").strip()
+
+    if queue_client is None:
+        try:
+            from azure.identity import DefaultAzureCredential
+            from azure.storage.queue import QueueClient
+        except ImportError:
+            summary["status"] = "sdk_missing"
+            return summary
+        try:
+            queue_client = QueueClient.from_queue_url(queue_url, credential=DefaultAzureCredential())
+        except Exception as exc:  # noqa: BLE001 — control-plane credential/config error must not crash
+            logger.warning("Could not create Azure Storage Queue client for event ingestion: %s", type(exc).__name__)
+            summary["status"] = "no_credentials"
+            return summary
+
+    # Broker one read-only customer credential for the whole batch; every dispatch
+    # reuses it. Absent a credential, dispatch would broker per-message.
+    if credential is None:
+        try:
+            from agent_bom.cloud.connection_broker import broker_session
+
+            credential = broker_session(record, session_name=f"agent-bom-event-{record.id[:8]}")
+        except Exception as exc:  # noqa: BLE001 — a broker failure is not fatal to the queue drain contract
+            logger.warning("Could not broker read-only credential for Azure event ingestion: %s", type(exc).__name__)
+            summary["status"] = "broker_failed"
+            return summary
+
+    for _ in range(max_batches):  # bounded: always terminates
+        summary["batches"] += 1
+        try:
+            messages = list(queue_client.receive_messages(max_messages=max_messages, visibility_timeout=visibility_timeout))
+        except Exception as exc:  # noqa: BLE001 — throttle / transient receive error: stop this pass cleanly
+            logger.warning("Azure queue receive failed during event ingestion: %s", type(exc).__name__)
+            summary["errors"] += 1
+            break
+
+        if not messages:
+            break  # empty queue: nothing more to drain this pass
+
+        for message in messages:
+            summary["received"] += 1
+            body = getattr(message, "content", "") or ""
+
+            event = parse_azure_event(body)
+            if event is None:
+                summary["skipped_malformed"] += 1
+                _delete_message(queue_client, message, summary)  # poison: drop it
+                continue
+
+            if event.account != connection_subscription:
+                # Not this connection's subscription — never scan a foreign one.
+                summary["skipped_foreign"] += 1
+                _delete_message(queue_client, message, summary)
+                continue
+
+            try:
+                dispatch_change_event(
+                    event,
+                    record,
+                    tenant_id=tenant_id,
+                    credential=credential,
+                    benchmark_runner=benchmark_runner,
+                    persist=persist,
+                    store=store,
+                )
+            except Exception as exc:  # noqa: BLE001 — leave on queue for redelivery; never crash the drain
+                logger.warning(
+                    "Azure event dispatch failed for %s/%s: %s",
+                    event.resource_type,
+                    event.resource_id,
+                    type(exc).__name__,
+                )
+                summary["errors"] += 1
+                continue  # do NOT delete — visibility timeout redelivers
+
+            summary["processed"] += 1
+            _delete_message(queue_client, message, summary)
+
+    return summary
+
+
+def _delete_message(queue_client: Any, message: Any, summary: dict[str, Any]) -> None:
+    """Best-effort Storage Queue delete; a delete failure is logged, never raised."""
+    try:
+        queue_client.delete_message(message)
+        summary["deleted"] += 1
+    except Exception as exc:  # noqa: BLE001 — delete failure only means one redelivery
+        logger.warning("Azure queue delete failed during event ingestion: %s", type(exc).__name__)

--- a/src/agent_bom/cloud/gcp_event_ingest.py
+++ b/src/agent_bom/cloud/gcp_event_ingest.py
@@ -1,0 +1,540 @@
+"""Event-driven GCP posture ingestion (continuous / change-triggered CNAPP).
+
+The complement to the polling scheduler for GCP, mirroring the AWS lane in
+:mod:`agent_bom.cloud.event_ingest`. When a resource changes in a customer
+project, Cloud Asset Inventory can publish a feed message (or an audit-log sink
+can publish a log entry) to a Pub/Sub topic. The control plane pulls that
+subscription and re-evaluates **only** the GCP CIS rules that apply to the
+changed resource's type — so a bucket made public is re-checked in seconds
+instead of waiting for the next scheduled full scan. Polling remains the
+fallback; this is additive.
+
+Trust posture (non-negotiable, fail-closed):
+
+* **Read-only against the customer.** The changed resource is re-fetched and its
+  CIS checks re-run through the SAME brokered read-only service-account
+  credential (cloud-platform.read-only) the scheduled scan uses
+  (:func:`agent_bom.cloud.connection_broker.broker_session`). No write API is ever
+  called on the customer project.
+* **Project-bound.** A change event is only dispatched when its project matches
+  the connection's own project (from ``auth_params``). A spoofed / cross-project
+  event is dropped, never processed — this prevents a confused-deputy where an
+  attacker-controlled message steers a scan at a project the tenant does not own.
+* **Bounded.** :func:`consume_gcp_events` pulls at most a configured number of
+  messages across a configured number of pull batches and then RETURNS. There is
+  no forever loop; an operator (or a scheduler tick) invokes it repeatedly.
+* **Crash-proof.** A malformed message is logged and acked (it can never be
+  parsed, so redelivery would only poison the subscription); a transient dispatch
+  failure is logged and left un-acked for Pub/Sub to redeliver. One bad message
+  never sinks the batch.
+
+Opt-in and default OFF: the consumer only runs when
+``AGENT_BOM_GCP_EVENT_SUBSCRIPTION`` is set (read live) — the full Pub/Sub
+subscription path the operator wired the feed/sink to. The subscription is
+operator-owned, so the control plane reads it with its OWN ambient credentials —
+distinct from the customer read-only credential used for the posture re-evaluation.
+
+Requires ``google-cloud-pubsub`` for the subscriber. Install with
+``pip install 'agent-bom[gcp]'``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from agent_bom import config
+from agent_bom.api.connection_store import CloudConnectionRecord
+from agent_bom.cloud.event_ingest import CloudChangeEvent, _default_persist, _now
+
+logger = logging.getLogger(__name__)
+
+# Opt-in gate (read live so operators/tests can toggle it). Absence = disabled.
+# The value is the full Pub/Sub subscription path the operator routed the feed to.
+EVENT_SUBSCRIPTION_ENV = "AGENT_BOM_GCP_EVENT_SUBSCRIPTION"
+
+
+@dataclass(frozen=True)
+class _ResourceRule:
+    """How to re-evaluate posture for one GCP resource-type token.
+
+    ``inventory_kwargs`` scopes :func:`gcp_inventory.discover_inventory` to just
+    the affected resource class (so we re-fetch that resource, not the estate).
+    ``check_ids`` is the exact GCP CIS subset re-run for the type. ``locators``
+    maps inventory payload list keys to the field that identifies a single
+    resource, so the changed resource can be picked out of the class fetch.
+    """
+
+    check_ids: tuple[str, ...]
+    inventory_kwargs: dict[str, bool]
+    locators: tuple[tuple[str, str], ...]
+
+
+# Only the affected class is fetched; every other include_* flag is forced off.
+def _only(**flags: bool) -> dict[str, bool]:
+    base = {
+        "include_storage": False,
+        "include_compute": False,
+        "include_iam": False,
+        "include_containers": False,
+        "include_serverless": False,
+        "include_databases": False,
+        "include_networks": False,
+        "include_disks": False,
+        "include_messaging": False,
+    }
+    base.update(flags)
+    return base
+
+
+# Resource-type token → posture re-evaluation rule. Cloud Asset ``assetType`` /
+# audit-log ``serviceName`` + ``resourceName`` collapse to these tokens (see
+# ``_resolve_token``).
+_RESOURCE_RULES: dict[str, _ResourceRule] = {
+    "storage": _ResourceRule(
+        check_ids=("5.1", "5.2"),
+        inventory_kwargs=_only(include_storage=True),
+        locators=(("buckets", "name"), ("buckets", "id")),
+    ),
+    "compute": _ResourceRule(
+        check_ids=("4.1", "4.3", "4.5", "4.6", "4.8", "4.9", "4.11"),
+        inventory_kwargs=_only(include_compute=True),
+        locators=(("instances", "name"), ("instances", "instance_id")),
+    ),
+    "firewall": _ResourceRule(
+        check_ids=("3.6", "3.7", "3.8"),
+        inventory_kwargs=_only(include_compute=True),
+        locators=(("firewalls", "name"), ("firewalls", "group_id")),
+    ),
+    "sql": _ResourceRule(
+        check_ids=("6.1", "6.2", "6.3"),
+        inventory_kwargs=_only(include_databases=True),
+        locators=(("cloud_sql_instances", "name"), ("cloud_sql_instances", "id")),
+    ),
+    "iam": _ResourceRule(
+        check_ids=("1.4", "1.5", "1.6", "1.7"),
+        inventory_kwargs=_only(include_iam=True),
+        locators=(("service_accounts", "email"), ("service_accounts", "name")),
+    ),
+}
+
+# Cloud Asset ``assetType`` (lower-cased) → service token.
+_ASSET_TYPE_TOKENS: dict[str, str] = {
+    "storage.googleapis.com/bucket": "storage",
+    "compute.googleapis.com/instance": "compute",
+    "compute.googleapis.com/firewall": "firewall",
+    "sqladmin.googleapis.com/instance": "sql",
+    "iam.googleapis.com/serviceaccount": "iam",
+}
+
+
+def event_ingest_enabled() -> bool:
+    """Return whether GCP event-driven ingestion is opted in (subscription set).
+
+    Read live so operators and tests can toggle it. Default OFF: with no
+    subscription the consumer is a no-op and only the polling scheduler runs.
+    """
+    return bool(os.environ.get(EVENT_SUBSCRIPTION_ENV, "").strip())
+
+
+def _uri_segments(uri: str) -> list[str]:
+    return [seg for seg in (uri or "").split("/") if seg and seg != ":"]
+
+
+def _project_from_uri(uri: str) -> str:
+    """Pull a concrete project id out of a resource name / asset name.
+
+    ``//compute.googleapis.com/projects/<proj>/zones/.../instances/<n>`` →
+    ``<proj>``. Skips the ``_`` placeholder Cloud Storage bucket names use.
+    """
+    segs = _uri_segments(uri)
+    for idx, seg in enumerate(segs):
+        if seg.lower() == "projects" and idx + 1 < len(segs):
+            candidate = segs[idx + 1]
+            if candidate and candidate != "_":
+                return candidate
+    return ""
+
+
+def _resource_name(uri: str) -> str:
+    """Return the trailing resource name from a resource path / asset name."""
+    segs = _uri_segments(uri)
+    return segs[-1] if segs else ""
+
+
+def _resolve_token(asset_type: str, service_name: str, resource_name: str) -> str:
+    """Collapse an assetType / serviceName+resourceName to a service token."""
+    at = (asset_type or "").strip().lower()
+    if at:
+        return _ASSET_TYPE_TOKENS.get(at, "")
+    sn = (service_name or "").strip().lower()
+    rn = (resource_name or "").strip().lower()
+    if sn.startswith("storage."):
+        return "storage"
+    if sn.startswith("sqladmin."):
+        return "sql"
+    if sn.startswith("iam.") and "serviceaccount" in rn:
+        return "iam"
+    if sn.startswith("compute."):
+        if "/firewalls/" in rn:
+            return "firewall"
+        if "/instances/" in rn:
+            return "compute"
+    return ""
+
+
+def parse_gcp_event(message: str | dict[str, Any]) -> CloudChangeEvent | None:
+    """Parse a Cloud Asset feed / audit-log message into a :class:`CloudChangeEvent`.
+
+    Accepts either a Cloud Asset Inventory feed message (``{"asset": {"name",
+    "assetType"}, ...}``) or a Pub/Sub-exported audit-log entry
+    (``{"protoPayload": {"methodName", "resourceName", "serviceName"}, "resource":
+    {"labels": {"project_id"}}}``). Returns ``None`` for anything malformed or for
+    a resource type with no posture rule — the caller treats ``None`` as "skip,
+    do not crash".
+    """
+    try:
+        obj = json.loads(message) if isinstance(message, (str, bytes)) else message
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+
+    asset = obj.get("asset")
+    asset = asset if isinstance(asset, dict) else {}
+    proto = obj.get("protoPayload")
+    proto = proto if isinstance(proto, dict) else {}
+    resource = obj.get("resource")
+    resource = resource if isinstance(resource, dict) else {}
+    labels = resource.get("labels")
+    labels = labels if isinstance(labels, dict) else {}
+
+    asset_type = str(asset.get("assetType") or "").strip()
+    service_name = str(proto.get("serviceName") or "").strip()
+    resource_uri = (
+        str(asset.get("name") or "").strip() or str(proto.get("resourceName") or "").strip() or str(obj.get("resourceName") or "").strip()
+    )
+
+    token = _resolve_token(asset_type, service_name, resource_uri)
+    if token not in _RESOURCE_RULES:
+        return None
+
+    resource_name = _resource_name(resource_uri)
+    project = str(obj.get("projectId") or "").strip() or str(labels.get("project_id") or "").strip() or _project_from_uri(resource_uri)
+    action = str(proto.get("methodName") or "").strip() or str(obj.get("priorAssetState") or "").strip() or "AssetChange"
+
+    # Fail closed: without a project and a resource name we cannot safely
+    # attribute or scope the re-evaluation.
+    if not project or not resource_name:
+        return None
+
+    return CloudChangeEvent(
+        provider="gcp",
+        account=project,
+        region="",
+        resource_type=token,
+        resource_id=resource_name,
+        action=action,
+        arn=resource_uri,
+        raw=obj,
+    )
+
+
+def _find_affected_resource(rule: _ResourceRule, inventory: dict[str, Any], resource_id: str) -> dict[str, Any] | None:
+    """Return the single inventory entry matching *resource_id*, if present."""
+    for list_key, id_field in rule.locators:
+        for item in inventory.get(list_key, []) or []:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get(id_field, "")) == resource_id:
+                return item
+    return None
+
+
+def dispatch_change_event(
+    event: CloudChangeEvent,
+    record: CloudConnectionRecord,
+    *,
+    tenant_id: str | None = None,
+    credentials: Any = None,
+    benchmark_runner: Callable[..., Any] | None = None,
+    persist: Callable[[CloudConnectionRecord, str, Any], str] | None = None,
+    store: Any = None,
+) -> dict[str, Any] | None:
+    """Re-evaluate posture for one changed GCP resource and emit the delta.
+
+    Resolves the changed resource via a scoped read-only inventory fetch, re-runs
+    ONLY the GCP CIS checks for its resource type against the brokered read-only
+    service-account credential, persists the resulting posture through the same
+    scan/graph path a full scan uses, and stamps ``last_event_at``.
+
+    Fail-closed: the event's provider must be ``gcp`` and its project must match
+    the connection's own project (from ``auth_params``); a mismatch returns
+    ``None`` without touching the customer project. An unknown resource type also
+    returns ``None``.
+    """
+    tenant_id = tenant_id or record.tenant_id
+
+    if (event.provider or "").strip().lower() != "gcp":
+        logger.warning("Dropping non-GCP change event (provider=%s)", event.provider)
+        return None
+    if (record.provider or "").strip().lower() != "gcp":
+        logger.warning("Connection %s is not GCP; cannot dispatch GCP change event", record.id)
+        return None
+
+    connection_project = str(record.auth_params.get("project_id") or "").strip()
+    if not connection_project or event.account != connection_project:
+        # Confused-deputy guard: never scan a project this connection does not own.
+        logger.warning(
+            "Dropping change event for project %s: does not match connection %s project",
+            event.account,
+            record.id,
+        )
+        return None
+
+    rule = _RESOURCE_RULES.get(event.resource_type)
+    if rule is None:
+        return None
+
+    from agent_bom.cloud import gcp_inventory
+    from agent_bom.models import AIBOMReport
+
+    run_cis_benchmark: Callable[..., Any]
+    if benchmark_runner is not None:
+        run_cis_benchmark = benchmark_runner
+    else:
+        from agent_bom.cloud.gcp_cis_benchmark import run_benchmark
+
+        run_cis_benchmark = run_benchmark
+
+    if credentials is None:
+        from agent_bom.cloud.connection_broker import broker_session
+
+        credentials = broker_session(record, session_name=f"agent-bom-event-{record.id[:8]}")
+
+    inv = rule.inventory_kwargs
+    inventory_payload = gcp_inventory.discover_inventory(
+        project_id=connection_project,
+        credentials=credentials,
+        force=True,
+        include_storage=inv["include_storage"],
+        include_compute=inv["include_compute"],
+        include_iam=inv["include_iam"],
+        include_containers=inv["include_containers"],
+        include_serverless=inv["include_serverless"],
+        include_databases=inv["include_databases"],
+        include_networks=inv["include_networks"],
+        include_disks=inv["include_disks"],
+        include_messaging=inv["include_messaging"],
+    )
+    affected = _find_affected_resource(rule, inventory_payload, event.resource_id)
+
+    cis_report = run_cis_benchmark(project_id=connection_project, credentials=credentials, checks=list(rule.check_ids))
+    cis_dict = cis_report.to_dict()
+    findings = [check for check in cis_dict.get("checks", []) if check.get("status") == "fail"]
+
+    import uuid as _uuid
+
+    report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=str(_uuid.uuid4()))
+    report.scan_sources = ["cloud_connection", "cloud:gcp", "event:asset_feed"]
+    report.cloud_inventory_data = inventory_payload
+    report.gcp_cis_benchmark_data = cis_dict
+
+    persist_fn = persist or _default_persist
+    scan_id = persist_fn(record, tenant_id, report)
+
+    # Freshness signal: event-driven re-eval advances last_event_at, NOT
+    # last_scan_at (that stays the last full polling scan).
+    active_store = store
+    if active_store is None:
+        from agent_bom.api.connection_store import get_connection_store
+
+        active_store = get_connection_store()
+    fresh = active_store.get(tenant_id, record.id) or record
+    fresh.last_event_at = _now()
+    fresh.updated_at = _now()
+    active_store.put(fresh)
+    record.last_event_at = fresh.last_event_at
+
+    return {
+        "schema_version": "cloud.connections.event.v1",
+        "connection_id": record.id,
+        "tenant_id": tenant_id,
+        "provider": "gcp",
+        "scan_id": scan_id,
+        "event": {
+            "project_id": event.account,
+            "resource_type": event.resource_type,
+            "resource_id": event.resource_id,
+            "action": event.action,
+        },
+        "resource": affected,
+        "checks_evaluated": list(rule.check_ids),
+        "findings": [
+            {
+                "check_id": f.get("check_id"),
+                "title": f.get("title"),
+                "severity": f.get("severity"),
+                "resource_ids": f.get("resource_ids", []),
+                "evidence": f.get("evidence", ""),
+            }
+            for f in findings
+        ],
+        "audit_metadata": {
+            "read_only": True,
+            "writes_performed": False,
+            "note": (
+                "Event-driven re-evaluation ran against short-lived read-only GCP service-account credentials "
+                "(cloud-platform.read-only) brokered from the stored connection. Only the affected resource type's "
+                "GCP CIS checks were re-run; no resource is mutated and no secret value is returned."
+            ),
+        },
+    }
+
+
+def consume_gcp_events(
+    record: CloudConnectionRecord,
+    *,
+    tenant_id: str | None = None,
+    subscription: str | None = None,
+    subscriber_client: Any = None,
+    credentials: Any = None,
+    max_messages: int | None = None,
+    max_batches: int | None = None,
+    benchmark_runner: Callable[..., Any] | None = None,
+    persist: Callable[[CloudConnectionRecord, str, Any], str] | None = None,
+    store: Any = None,
+) -> dict[str, Any]:
+    """Pull a bounded batch of GCP change events from a Pub/Sub subscription.
+
+    Pulls the operator-owned Pub/Sub subscription (Cloud Asset feed / audit-log
+    sink) with the control plane's OWN ambient credentials, parses each message,
+    and dispatches a per-resource posture re-evaluation for events that belong to
+    *record*'s project. This is a BOUNDED pass: at most ``max_batches`` pulls of
+    ``max_messages`` each, then it returns — there is no forever loop.
+
+    Message lifecycle: a successfully dispatched message is acked; a malformed or
+    foreign-project message is logged and acked (redelivery cannot help); a
+    transient dispatch failure is logged and LEFT un-acked for Pub/Sub to
+    redeliver. Never raises — one bad message cannot sink the batch. With no
+    subscription configured it is a no-op (``status="disabled"``).
+    """
+    tenant_id = tenant_id or record.tenant_id
+    subscription = subscription or os.environ.get(EVENT_SUBSCRIPTION_ENV, "").strip()
+
+    summary: dict[str, Any] = {
+        "status": "ok",
+        "connection_id": record.id,
+        "received": 0,
+        "processed": 0,
+        "acked": 0,
+        "skipped_malformed": 0,
+        "skipped_foreign": 0,
+        "errors": 0,
+        "batches": 0,
+    }
+
+    if not subscription:
+        summary["status"] = "disabled"
+        return summary
+
+    max_messages = max(1, min(int(max_messages if max_messages is not None else config.GCP_EVENT_MAX_MESSAGES), 100))
+    max_batches = max(1, int(max_batches if max_batches is not None else config.GCP_EVENT_MAX_BATCHES))
+
+    connection_project = str(record.auth_params.get("project_id") or "").strip()
+
+    if subscriber_client is None:
+        try:
+            from google.cloud import pubsub_v1
+        except ImportError:
+            summary["status"] = "sdk_missing"
+            return summary
+        try:
+            subscriber_client = pubsub_v1.SubscriberClient()
+        except Exception as exc:  # noqa: BLE001 — control-plane credential/config error must not crash
+            logger.warning("Could not create Pub/Sub subscriber for event ingestion: %s", type(exc).__name__)
+            summary["status"] = "no_credentials"
+            return summary
+
+    # Broker one read-only customer credential for the whole batch; every dispatch
+    # reuses it. Absent a credential, dispatch would broker per-message.
+    if credentials is None:
+        try:
+            from agent_bom.cloud.connection_broker import broker_session
+
+            credentials = broker_session(record, session_name=f"agent-bom-event-{record.id[:8]}")
+        except Exception as exc:  # noqa: BLE001 — a broker failure is not fatal to the pull drain contract
+            logger.warning("Could not broker read-only credentials for GCP event ingestion: %s", type(exc).__name__)
+            summary["status"] = "broker_failed"
+            return summary
+
+    for _ in range(max_batches):  # bounded: always terminates
+        summary["batches"] += 1
+        try:
+            response = subscriber_client.pull(subscription=subscription, max_messages=max_messages)
+        except Exception as exc:  # noqa: BLE001 — throttle / transient pull error: stop this pass cleanly
+            logger.warning("Pub/Sub pull failed during event ingestion: %s", type(exc).__name__)
+            summary["errors"] += 1
+            break
+
+        received = list(getattr(response, "received_messages", []) or [])
+        if not received:
+            break  # empty subscription: nothing more to drain this pass
+
+        for received_message in received:
+            summary["received"] += 1
+            ack_id = getattr(received_message, "ack_id", None)
+            pubsub_message = getattr(received_message, "message", None)
+            data = getattr(pubsub_message, "data", b"") or b""
+            body = data.decode("utf-8", errors="replace") if isinstance(data, (bytes, bytearray)) else str(data)
+
+            event = parse_gcp_event(body)
+            if event is None:
+                summary["skipped_malformed"] += 1
+                _ack_message(subscriber_client, subscription, ack_id, summary)  # poison: drop it
+                continue
+
+            if event.account != connection_project:
+                # Not this connection's project — never scan a foreign one.
+                summary["skipped_foreign"] += 1
+                _ack_message(subscriber_client, subscription, ack_id, summary)
+                continue
+
+            try:
+                dispatch_change_event(
+                    event,
+                    record,
+                    tenant_id=tenant_id,
+                    credentials=credentials,
+                    benchmark_runner=benchmark_runner,
+                    persist=persist,
+                    store=store,
+                )
+            except Exception as exc:  # noqa: BLE001 — leave un-acked for redelivery; never crash the drain
+                logger.warning(
+                    "GCP event dispatch failed for %s/%s: %s",
+                    event.resource_type,
+                    event.resource_id,
+                    type(exc).__name__,
+                )
+                summary["errors"] += 1
+                continue  # do NOT ack — Pub/Sub redelivers
+
+            summary["processed"] += 1
+            _ack_message(subscriber_client, subscription, ack_id, summary)
+
+    return summary
+
+
+def _ack_message(subscriber_client: Any, subscription: str, ack_id: str | None, summary: dict[str, Any]) -> None:
+    """Best-effort Pub/Sub ack; an ack failure is logged, never raised."""
+    if not ack_id:
+        return
+    try:
+        subscriber_client.acknowledge(subscription=subscription, ack_ids=[ack_id])
+        summary["acked"] += 1
+    except Exception as exc:  # noqa: BLE001 — ack failure only means one redelivery
+        logger.warning("Pub/Sub ack failed during event ingestion: %s", type(exc).__name__)

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -303,6 +303,22 @@ AWS_EVENT_MAX_MESSAGES = _int("AGENT_BOM_AWS_EVENT_MAX_MESSAGES", 10)
 AWS_EVENT_MAX_BATCHES = _int("AGENT_BOM_AWS_EVENT_MAX_BATCHES", 10)
 AWS_EVENT_VISIBILITY_TIMEOUT = _int("AGENT_BOM_AWS_EVENT_VISIBILITY_TIMEOUT", 120)
 AWS_EVENT_WAIT_SECONDS = _int("AGENT_BOM_AWS_EVENT_WAIT_SECONDS", 5)
+# Event-driven Azure posture ingestion. When an operator wires Azure Monitor
+# Activity Log / Event Grid → a Storage Queue (opt-in via AGENT_BOM_AZURE_EVENT_QUEUE,
+# read live, default off), the bounded queue consumer drains change events and
+# re-evaluates only the affected resource's Azure CIS rules. These knobs bound a
+# single consume pass so it always terminates: messages per receive, receive
+# batches per pass, and per-message visibility timeout.
+AZURE_EVENT_MAX_MESSAGES = _int("AGENT_BOM_AZURE_EVENT_MAX_MESSAGES", 10)
+AZURE_EVENT_MAX_BATCHES = _int("AGENT_BOM_AZURE_EVENT_MAX_BATCHES", 10)
+AZURE_EVENT_VISIBILITY_TIMEOUT = _int("AGENT_BOM_AZURE_EVENT_VISIBILITY_TIMEOUT", 120)
+# Event-driven GCP posture ingestion. When an operator wires Cloud Asset
+# Inventory feed / audit logs → a Pub/Sub subscription (opt-in via
+# AGENT_BOM_GCP_EVENT_SUBSCRIPTION, read live, default off), the bounded Pub/Sub
+# consumer drains change events and re-evaluates only the affected resource's GCP
+# CIS rules. These knobs bound a single pull pass so it always terminates.
+GCP_EVENT_MAX_MESSAGES = _int("AGENT_BOM_GCP_EVENT_MAX_MESSAGES", 10)
+GCP_EVENT_MAX_BATCHES = _int("AGENT_BOM_GCP_EVENT_MAX_BATCHES", 10)
 API_JOB_TTL_SECONDS = _int("AGENT_BOM_API_JOB_TTL", 3_600)
 API_MAX_IN_MEMORY_JOBS = _int("AGENT_BOM_API_MAX_MEMORY_JOBS", 200)
 API_MAX_JOB_PROGRESS_EVENTS = _int("AGENT_BOM_API_MAX_JOB_PROGRESS_EVENTS", 500)

--- a/tests/test_cloud_event_ingest_azure_gcp.py
+++ b/tests/test_cloud_event_ingest_azure_gcp.py
@@ -1,0 +1,593 @@
+"""Tests for event-driven Azure + GCP posture ingestion.
+
+Mirrors ``tests/test_cloud_event_ingest.py`` (AWS): patch the provider's scoped
+``discover_inventory`` to return a deterministic synthetic inventory, and assert
+a changed resource re-evaluates ONLY its resource type's CIS checks and produces
+the expected finding — plus the bounded, fail-closed queue-drain contract.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from agent_bom.api.connection_store import (
+    CloudConnectionRecord,
+    InMemoryConnectionStore,
+)
+from agent_bom.cloud import azure_event_ingest, gcp_event_ingest
+from agent_bom.cloud.azure_event_ingest import (
+    consume_azure_events,
+    parse_azure_event,
+)
+from agent_bom.cloud.azure_event_ingest import (
+    dispatch_change_event as azure_dispatch,
+)
+from agent_bom.cloud.gcp_event_ingest import (
+    consume_gcp_events,
+    parse_gcp_event,
+)
+from agent_bom.cloud.gcp_event_ingest import (
+    dispatch_change_event as gcp_dispatch,
+)
+
+_SUBSCRIPTION = "11111111-2222-3333-4444-555555555555"
+_TENANT = "99999999-8888-7777-6666-555555555555"
+_PROJECT = "my-project"
+
+
+# --------------------------------------------------------------------------- #
+# Shared fake CIS report (drives the finding assertion for either cloud)
+# --------------------------------------------------------------------------- #
+
+
+def _fake_cis_report(fail_check_id: str, expected_checks: set[str]) -> Any:
+    class _Report:
+        def to_dict(self) -> dict[str, Any]:
+            checks = [
+                {
+                    "check_id": cid,
+                    "title": f"Check {cid}",
+                    "status": "fail" if cid == fail_check_id else "pass",
+                    "severity": "high",
+                    "resource_ids": ["the-resource"],
+                    "evidence": "evidence",
+                }
+                for cid in sorted(expected_checks)
+            ]
+            return {
+                "benchmark": "CIS",
+                "passed": len(checks) - 1,
+                "failed": 1,
+                "total": len(checks),
+                "checks": checks,
+            }
+
+    return _Report()
+
+
+# =========================================================================== #
+# AZURE
+# =========================================================================== #
+
+_AZURE_STORAGE_CHECKS = {"3.1", "3.2", "3.3", "3.7", "3.8", "3.10", "3.11", "3.12"}
+
+
+def _azure_record(*, subscription: str = _SUBSCRIPTION, tenant: str = _TENANT) -> CloudConnectionRecord:
+    return CloudConnectionRecord(
+        id="conn-az",
+        tenant_id="tenant-a",
+        provider="azure",
+        display_name="prod-azure",
+        role_ref="kv://vault/agent-bom-reader",
+        external_id_encrypted="cipher",
+        auth_params={"subscription_id": subscription, "tenant_id": tenant},
+    )
+
+
+def _azure_storage_event(*, subscription: str = _SUBSCRIPTION, tenant: str = _TENANT, name: str = "publicsa") -> dict[str, Any]:
+    """A synthetic Event Grid-wrapped Activity Log storage-account write event."""
+    return {
+        "id": "evt-az-1",
+        "eventType": "Microsoft.Resources.ResourceWriteSuccess",
+        "subject": f"/subscriptions/{subscription}/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/{name}",
+        "data": {
+            "operationName": "Microsoft.Storage/storageAccounts/write",
+            "subscriptionId": subscription,
+            "tenantId": tenant,
+        },
+    }
+
+
+_AZURE_SCOPED_INVENTORY: dict[str, Any] = {
+    "provider": "azure",
+    "status": "ok",
+    "storage_accounts": [
+        {
+            "name": "publicsa",
+            "id": "/subscriptions/x/resourceGroups/rg1/providers/Microsoft.Storage/storageAccounts/publicsa",
+            "publicly_accessible": True,
+            "allow_blob_public_access": True,
+        }
+    ],
+}
+
+
+def _patch_azure_inventory() -> Any:
+    return patch(
+        "agent_bom.cloud.azure_inventory.discover_inventory",
+        return_value=_AZURE_SCOPED_INVENTORY,
+    )
+
+
+def _azure_run_benchmark(*, checks: list[str], **kwargs: Any) -> Any:
+    assert set(checks) == _AZURE_STORAGE_CHECKS
+    return _fake_cis_report("3.1", _AZURE_STORAGE_CHECKS)
+
+
+def test_azure_parse_storage_event() -> None:
+    event = parse_azure_event(_azure_storage_event())
+    assert event is not None
+    assert event.provider == "azure"
+    assert event.resource_type == "storage"
+    assert event.resource_id == "publicsa"
+    assert event.account == _SUBSCRIPTION
+    assert event.region == _TENANT  # tenant travels in region for the guard
+    assert event.action == "Microsoft.Storage/storageAccounts/write"
+
+
+def test_azure_dispatch_reevaluates_and_produces_finding() -> None:
+    event = parse_azure_event(_azure_storage_event())
+    assert event is not None
+
+    record = _azure_record()
+    store = InMemoryConnectionStore()
+    store.put(record)
+    persisted: dict[str, Any] = {}
+
+    def _persist(rec: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
+        persisted["report"] = report
+        return "scan-az"
+
+    with _patch_azure_inventory():
+        delta = azure_dispatch(
+            event,
+            record,
+            credential=object(),
+            benchmark_runner=_azure_run_benchmark,
+            persist=_persist,
+            store=store,
+        )
+
+    assert delta is not None
+    assert delta["scan_id"] == "scan-az"
+    assert delta["provider"] == "azure"
+    assert set(delta["checks_evaluated"]) == _AZURE_STORAGE_CHECKS
+    assert delta["resource"] is not None
+    assert delta["resource"]["name"] == "publicsa"
+    assert delta["resource"]["publicly_accessible"] is True
+    assert "3.1" in {f["check_id"] for f in delta["findings"]}
+
+    report = persisted["report"]
+    assert report.azure_cis_benchmark_data["failed"] >= 1
+    assert report.scan_sources == ["cloud_connection", "cloud:azure", "event:activity_log"]
+
+    fresh = store.get("tenant-a", "conn-az")
+    assert fresh is not None
+    assert fresh.last_event_at is not None
+    assert fresh.last_scan_at is None
+
+
+def test_azure_dispatch_drops_foreign_subscription() -> None:
+    event = parse_azure_event(_azure_storage_event(subscription="00000000-0000-0000-0000-000000000000"))
+    assert event is not None
+    record = _azure_record()  # different subscription than the event
+    called: dict[str, Any] = {}
+
+    def _persist(rec: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
+        called["hit"] = True
+        return "nope"
+
+    delta = azure_dispatch(event, record, credential=object(), persist=_persist)
+    assert delta is None
+    assert "hit" not in called
+
+
+def test_azure_dispatch_drops_foreign_tenant() -> None:
+    event = parse_azure_event(_azure_storage_event(tenant="00000000-0000-0000-0000-000000000000"))
+    assert event is not None
+    record = _azure_record()  # subscription matches, tenant differs
+    delta = azure_dispatch(event, record, credential=object())
+    assert delta is None
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "not json {",
+        "[]",
+        "null",
+        # unsupported resource type (Cosmos DB has no rule):
+        json.dumps(
+            {
+                "subject": f"/subscriptions/{_SUBSCRIPTION}/resourceGroups/rg/providers/Microsoft.DocumentDB/databaseAccounts/db",
+                "data": {"operationName": "x", "subscriptionId": _SUBSCRIPTION},
+            }
+        ),
+        # no subscription:
+        json.dumps({"subject": "/subscriptions//providers/Microsoft.Storage/storageAccounts/s", "data": {"operationName": "w"}}),
+    ],
+)
+def test_azure_parse_malformed_returns_none(message: str) -> None:
+    assert parse_azure_event(message) is None
+
+
+class _FakeAzureQueue:
+    """Minimal Storage Queue stub: hands back a fixed message list per receive."""
+
+    def __init__(self, batches: list[list[Any]]) -> None:
+        self._batches = batches
+        self.deleted: list[Any] = []
+
+    def receive_messages(self, **kwargs: Any) -> Any:
+        if self._batches:
+            return iter(self._batches.pop(0))
+        return iter([])
+
+    def delete_message(self, message: Any) -> None:
+        self.deleted.append(message)
+
+
+def _azure_msg(body: dict[str, Any]) -> Any:
+    return types.SimpleNamespace(content=json.dumps(body))
+
+
+def test_azure_consume_disabled_when_no_queue(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(azure_event_ingest.EVENT_QUEUE_ENV, raising=False)
+    summary = consume_azure_events(_azure_record())
+    assert summary["status"] == "disabled"
+    assert summary["received"] == 0
+
+
+def test_azure_consume_dispatches_and_deletes_valid_event() -> None:
+    queue = _FakeAzureQueue(batches=[[_azure_msg(_azure_storage_event())]])
+    store = InMemoryConnectionStore()
+    record = _azure_record()
+    store.put(record)
+    persisted: dict[str, Any] = {}
+
+    def _persist(rec: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
+        persisted["report"] = report
+        return "scan-az"
+
+    with _patch_azure_inventory():
+        summary = consume_azure_events(
+            record,
+            queue_url="https://acct.queue.core.windows.net/changes",
+            queue_client=queue,
+            credential=object(),
+            benchmark_runner=_azure_run_benchmark,
+            persist=_persist,
+            store=store,
+            max_batches=2,
+        )
+    assert summary["processed"] == 1
+    assert summary["deleted"] == 1
+    assert len(queue.deleted) == 1
+    assert "report" in persisted
+
+
+def test_azure_consume_drops_foreign_subscription() -> None:
+    foreign = _azure_storage_event(subscription="00000000-0000-0000-0000-000000000000")
+    queue = _FakeAzureQueue(batches=[[_azure_msg(foreign)]])
+    called: dict[str, Any] = {}
+
+    def _persist(rec: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
+        called["hit"] = True
+        return "nope"
+
+    summary = consume_azure_events(
+        _azure_record(),
+        queue_url="https://acct.queue.core.windows.net/changes",
+        queue_client=queue,
+        credential=object(),
+        persist=_persist,
+        max_batches=2,
+    )
+    assert summary["skipped_foreign"] == 1
+    assert summary["processed"] == 0
+    assert len(queue.deleted) == 1
+    assert "hit" not in called
+
+
+def test_azure_consume_bounded_batch_stops() -> None:
+    class _Endless:
+        def __init__(self) -> None:
+            self.receive_calls = 0
+            self.deleted: list[Any] = []
+
+        def receive_messages(self, **kwargs: Any) -> Any:
+            self.receive_calls += 1
+            return iter([types.SimpleNamespace(content=json.dumps({"garbage": True}))])
+
+        def delete_message(self, message: Any) -> None:
+            self.deleted.append(message)
+
+    endless = _Endless()
+    summary = consume_azure_events(
+        _azure_record(),
+        queue_url="https://acct.queue.core.windows.net/changes",
+        queue_client=endless,
+        credential=object(),
+        max_batches=3,
+    )
+    assert endless.receive_calls == 3
+    assert summary["batches"] == 3
+    assert summary["skipped_malformed"] == 3
+    assert summary["deleted"] == 3
+
+
+# =========================================================================== #
+# GCP
+# =========================================================================== #
+
+_GCP_STORAGE_CHECKS = {"5.1", "5.2"}
+
+
+def _gcp_record(*, project: str = _PROJECT) -> CloudConnectionRecord:
+    return CloudConnectionRecord(
+        id="conn-gcp",
+        tenant_id="tenant-a",
+        provider="gcp",
+        display_name="prod-gcp",
+        role_ref="sa-key-ref",
+        external_id_encrypted="cipher",
+        auth_params={"project_id": project},
+    )
+
+
+def _gcp_storage_auditlog(*, project: str = _PROJECT, bucket: str = "public-bucket") -> dict[str, Any]:
+    """A synthetic Pub/Sub-exported GCS setIamPolicy audit-log entry."""
+    return {
+        "protoPayload": {
+            "methodName": "storage.setIamPermissions",
+            "serviceName": "storage.googleapis.com",
+            "resourceName": f"projects/_/buckets/{bucket}",
+        },
+        "resource": {"type": "gcs_bucket", "labels": {"project_id": project, "bucket_name": bucket}},
+    }
+
+
+_GCP_SCOPED_INVENTORY: dict[str, Any] = {
+    "provider": "gcp",
+    "status": "ok",
+    "buckets": [
+        {
+            "name": "public-bucket",
+            "id": "public-bucket",
+            "publicly_accessible": True,
+            "project_id": _PROJECT,
+        }
+    ],
+}
+
+
+def _patch_gcp_inventory() -> Any:
+    return patch(
+        "agent_bom.cloud.gcp_inventory.discover_inventory",
+        return_value=_GCP_SCOPED_INVENTORY,
+    )
+
+
+def _gcp_run_benchmark(*, checks: list[str], **kwargs: Any) -> Any:
+    assert set(checks) == _GCP_STORAGE_CHECKS
+    return _fake_cis_report("5.1", _GCP_STORAGE_CHECKS)
+
+
+def test_gcp_parse_storage_auditlog() -> None:
+    event = parse_gcp_event(_gcp_storage_auditlog())
+    assert event is not None
+    assert event.provider == "gcp"
+    assert event.resource_type == "storage"
+    assert event.resource_id == "public-bucket"
+    assert event.account == _PROJECT
+    assert event.action == "storage.setIamPermissions"
+
+
+def test_gcp_parse_compute_asset_feed() -> None:
+    """The Cloud Asset feed branch: assetType + project derived from the asset name."""
+    msg = {
+        "asset": {
+            "name": f"//compute.googleapis.com/projects/{_PROJECT}/zones/us-central1-a/instances/vm-1",
+            "assetType": "compute.googleapis.com/Instance",
+        }
+    }
+    event = parse_gcp_event(msg)
+    assert event is not None
+    assert event.resource_type == "compute"
+    assert event.resource_id == "vm-1"
+    assert event.account == _PROJECT
+
+
+def test_gcp_dispatch_reevaluates_and_produces_finding() -> None:
+    event = parse_gcp_event(_gcp_storage_auditlog())
+    assert event is not None
+
+    record = _gcp_record()
+    store = InMemoryConnectionStore()
+    store.put(record)
+    persisted: dict[str, Any] = {}
+
+    def _persist(rec: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
+        persisted["report"] = report
+        return "scan-gcp"
+
+    with _patch_gcp_inventory():
+        delta = gcp_dispatch(
+            event,
+            record,
+            credentials=object(),
+            benchmark_runner=_gcp_run_benchmark,
+            persist=_persist,
+            store=store,
+        )
+
+    assert delta is not None
+    assert delta["scan_id"] == "scan-gcp"
+    assert delta["provider"] == "gcp"
+    assert set(delta["checks_evaluated"]) == _GCP_STORAGE_CHECKS
+    assert delta["resource"] is not None
+    assert delta["resource"]["name"] == "public-bucket"
+    assert delta["resource"]["publicly_accessible"] is True
+    assert "5.1" in {f["check_id"] for f in delta["findings"]}
+
+    report = persisted["report"]
+    assert report.gcp_cis_benchmark_data["failed"] >= 1
+    assert report.scan_sources == ["cloud_connection", "cloud:gcp", "event:asset_feed"]
+
+    fresh = store.get("tenant-a", "conn-gcp")
+    assert fresh is not None
+    assert fresh.last_event_at is not None
+    assert fresh.last_scan_at is None
+
+
+def test_gcp_dispatch_drops_foreign_project() -> None:
+    event = parse_gcp_event(_gcp_storage_auditlog(project="other-project"))
+    assert event is not None
+    record = _gcp_record()  # different project than the event
+    called: dict[str, Any] = {}
+
+    def _persist(rec: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
+        called["hit"] = True
+        return "nope"
+
+    delta = gcp_dispatch(event, record, credentials=object(), persist=_persist)
+    assert delta is None
+    assert "hit" not in called
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "not json {",
+        "[]",
+        "null",
+        # unsupported service (BigQuery has no rule):
+        json.dumps({"protoPayload": {"serviceName": "bigquery.googleapis.com", "resourceName": "projects/p/datasets/d"}}),
+        # no project:
+        json.dumps({"protoPayload": {"serviceName": "storage.googleapis.com", "resourceName": "projects/_/buckets/b"}}),
+    ],
+)
+def test_gcp_parse_malformed_returns_none(message: str) -> None:
+    assert parse_gcp_event(message) is None
+
+
+class _FakeSubscriber:
+    """Minimal Pub/Sub subscriber stub: hands back a fixed pull per call."""
+
+    def __init__(self, batches: list[list[Any]]) -> None:
+        self._batches = batches
+        self.acked: list[str] = []
+        self.pull_calls = 0
+
+    def pull(self, *, subscription: str, max_messages: int) -> Any:
+        self.pull_calls += 1
+        received = self._batches.pop(0) if self._batches else []
+        return types.SimpleNamespace(received_messages=received)
+
+    def acknowledge(self, *, subscription: str, ack_ids: list[str]) -> None:
+        self.acked.extend(ack_ids)
+
+
+def _gcp_msg(body: dict[str, Any], ack_id: str) -> Any:
+    message = types.SimpleNamespace(data=json.dumps(body).encode("utf-8"))
+    return types.SimpleNamespace(message=message, ack_id=ack_id)
+
+
+def test_gcp_consume_disabled_when_no_subscription(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(gcp_event_ingest.EVENT_SUBSCRIPTION_ENV, raising=False)
+    summary = consume_gcp_events(_gcp_record())
+    assert summary["status"] == "disabled"
+    assert summary["received"] == 0
+
+
+def test_gcp_consume_dispatches_and_acks_valid_event() -> None:
+    subscriber = _FakeSubscriber(batches=[[_gcp_msg(_gcp_storage_auditlog(), "ack-1")]])
+    store = InMemoryConnectionStore()
+    record = _gcp_record()
+    store.put(record)
+    persisted: dict[str, Any] = {}
+
+    def _persist(rec: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
+        persisted["report"] = report
+        return "scan-gcp"
+
+    with _patch_gcp_inventory():
+        summary = consume_gcp_events(
+            record,
+            subscription="projects/p/subscriptions/changes",
+            subscriber_client=subscriber,
+            credentials=object(),
+            benchmark_runner=_gcp_run_benchmark,
+            persist=_persist,
+            store=store,
+            max_batches=2,
+        )
+    assert summary["processed"] == 1
+    assert summary["acked"] == 1
+    assert subscriber.acked == ["ack-1"]
+    assert "report" in persisted
+
+
+def test_gcp_consume_drops_foreign_project() -> None:
+    foreign = _gcp_storage_auditlog(project="other-project")
+    subscriber = _FakeSubscriber(batches=[[_gcp_msg(foreign, "ack-foreign")]])
+    called: dict[str, Any] = {}
+
+    def _persist(rec: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
+        called["hit"] = True
+        return "nope"
+
+    summary = consume_gcp_events(
+        _gcp_record(),
+        subscription="projects/p/subscriptions/changes",
+        subscriber_client=subscriber,
+        credentials=object(),
+        persist=_persist,
+        max_batches=2,
+    )
+    assert summary["skipped_foreign"] == 1
+    assert summary["processed"] == 0
+    assert subscriber.acked == ["ack-foreign"]
+    assert "hit" not in called
+
+
+def test_gcp_consume_bounded_batch_stops() -> None:
+    class _Endless:
+        def __init__(self) -> None:
+            self.pull_calls = 0
+            self.acked: list[str] = []
+
+        def pull(self, *, subscription: str, max_messages: int) -> Any:
+            self.pull_calls += 1
+            return types.SimpleNamespace(received_messages=[_gcp_msg({"garbage": True}, f"ack-{self.pull_calls}")])
+
+        def acknowledge(self, *, subscription: str, ack_ids: list[str]) -> None:
+            self.acked.extend(ack_ids)
+
+    endless = _Endless()
+    summary = consume_gcp_events(
+        _gcp_record(),
+        subscription="projects/p/subscriptions/changes",
+        subscriber_client=endless,
+        credentials=object(),
+        max_batches=3,
+    )
+    assert endless.pull_calls == 3
+    assert summary["batches"] == 3
+    assert summary["skipped_malformed"] == 3
+    assert summary["acked"] == 3

--- a/uv.lock
+++ b/uv.lock
@@ -85,6 +85,7 @@ all = [
     { name = "azure-mgmt-sql" },
     { name = "azure-mgmt-storage" },
     { name = "azure-mgmt-web" },
+    { name = "azure-storage-queue" },
     { name = "boto3" },
     { name = "cryptography" },
     { name = "databricks-sdk" },
@@ -172,6 +173,7 @@ azure = [
     { name = "azure-mgmt-sql" },
     { name = "azure-mgmt-storage" },
     { name = "azure-mgmt-web" },
+    { name = "azure-storage-queue" },
     { name = "six" },
 ]
 cloud = [
@@ -205,6 +207,7 @@ cloud = [
     { name = "azure-mgmt-sql" },
     { name = "azure-mgmt-storage" },
     { name = "azure-mgmt-web" },
+    { name = "azure-storage-queue" },
     { name = "boto3" },
     { name = "databricks-sdk" },
     { name = "google-api-python-client" },
@@ -414,6 +417,7 @@ requires-dist = [
     { name = "azure-mgmt-sql", marker = "extra == 'azure'", specifier = ">=3.0" },
     { name = "azure-mgmt-storage", marker = "extra == 'azure'", specifier = ">=21.0" },
     { name = "azure-mgmt-web", marker = "extra == 'azure'", specifier = ">=7.2" },
+    { name = "azure-storage-queue", marker = "extra == 'azure'", specifier = ">=12.9" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.9" },
     { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.34" },
     { name = "click", specifier = ">=8.0" },
@@ -1226,6 +1230,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3b/48/84a820d898267f662b5c06f7cd76fdb8a9e272b44aa9376cef3ec0f6a294/azure_storage_blob-12.30.0.tar.gz", hash = "sha256:2cd74d4d5731e5eb6b8d5c5056ee115a5e88f8fdf22517b739836fda685018be", size = 618229, upload-time = "2026-06-08T11:45:35.575Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/0b/e106f0fd7fa785867d9ffcc47dc9e6237c0e58f51058473b777487a98edc/azure_storage_blob-12.30.0-py3-none-any.whl", hash = "sha256:d415ac50b67a8da6b3ae7e9f1014b1b55cd7aafa0b8d4ca9b380568dc7360423", size = 435610, upload-time = "2026-06-08T11:45:37.213Z" },
+]
+
+[[package]]
+name = "azure-storage-queue"
+version = "12.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/7d/babb616eb1ed1ac5f13cbb336875fd91c9c6f8b1702bf2ff860b222cb833/azure_storage_queue-12.17.0.tar.gz", hash = "sha256:6eb108a88554be371feb2eba9715fa0e3f7baca7b3f00c19ec417fc7ce5b3834", size = 203777, upload-time = "2026-06-08T18:03:16.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/e3/6aee19df63974d87e55dc0ddf5bb18eb1022cd290b125a46792594a00673/azure_storage_queue-12.17.0-py3-none-any.whl", hash = "sha256:aaef08ee2613f84a3a85e60a059d29567361e5a2af455298bb0e529f0b47d5a1", size = 189526, upload-time = "2026-06-08T18:03:19.139Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Extends the merged AWS A1 event-driven posture (#3358) to Azure and GCP — consolidated, both clouds in one PR.

## What it adds
- **Azure**: parse Azure Monitor Activity Log / Event Grid change events → scoped read-only inventory fetch for the changed resource → targeted Azure CIS re-eval (only the affected resource type) → persist via the same scan/graph path. Bounded, opt-in poll with a tenant/subscription confused-deputy guard.
- **GCP**: parse Cloud Asset Inventory feed / Pub/Sub audit-log messages → scoped fetch → targeted GCP CIS re-eval → persist. Bounded, opt-in, project confused-deputy guard.
- Mirrors A1 exactly: opt-in only (no always-on loop), read-only inventory, targeted re-eval, `last_event_at` freshness. Reuses existing inventory + CIS modules (no re-implemented scanning).

## Verification
- New tests: `tests/test_cloud_event_ingest_azure_gcp.py` — 26 passed.
- ruff/format/mypy clean on new modules.
- Includes the runtime-env-var test-leak conftest fix (self-dedupes with #3369/#3364 on squash).

Note: a pre-existing order-leak in `test_mcp_tool_impls` (passes in isolation, unrelated to this PR) is tracked for a separate fix.

Part of #3350.