### PR TITLE
chore(deps): combine UI dependency updates

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,14 +10,14 @@
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@tanstack/react-table": "^8.21.3",
-        "@tanstack/react-virtual": "^3.14.4",
+        "@tanstack/react-virtual": "^3.14.5",
         "@xyflow/react": "^12.11.1",
         "graphology": "^0.26.0",
         "lucide-react": "^1.22.0",
         "next": "^16.2.9",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "recharts": "^3.9.0",
+        "recharts": "^3.9.1",
         "sigma": "^3.0.3"
       },
       "devDependencies": {
@@ -1568,16 +1568,6 @@
         }
       }
     },
-    "node_modules/@reduxjs/toolkit/node_modules/immer": {
-      "version": "11.1.4",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
-      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
@@ -2247,12 +2237,12 @@
       }
     },
     "node_modules/@tanstack/react-virtual": {
-      "version": "3.14.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.4.tgz",
-      "integrity": "sha512-dZzAQP2uCDAd+9sAehqmx/DcU+B91Q4Gb0aDSM7t9bJvWDyGF9sapFNW5r1gNLsHs4wTb6ScZENJeYaHxJLiOw==",
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.5.tgz",
+      "integrity": "sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/virtual-core": "3.17.2"
+        "@tanstack/virtual-core": "3.17.3"
       },
       "funding": {
         "type": "github",
@@ -2277,9 +2267,9 @@
       }
     },
     "node_modules/@tanstack/virtual-core": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.2.tgz",
-      "integrity": "sha512-w43MvWvmShpb6kIC9MOoLyUkLmRTLPjt61bHWs+X29hACSpX+n8DvgZ3qM7cUfflKlRRcHR9KVJE6TmcqnQvcA==",
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.3.tgz",
+      "integrity": "sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5571,9 +5561,9 @@
       }
     },
     "node_modules/immer": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
-      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.9.tgz",
+      "integrity": "sha512-sc/z0Cyti70bZa0ZU4sWfAElfovFb9Ni8tArJZLuklYWxegPiK3pDOql1Rq5H0FIRAW9LSQRG6OX4KqBldbhBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -7325,9 +7315,9 @@
       }
     },
     "node_modules/recharts": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.0.tgz",
-      "integrity": "sha512-dCEcE9y20c8H2tkVeByrAXhhnBJk6/QLbxKmn+dJUptOfc5NMjwRh1jo0vZPRLD+5dMrHrP+hPEsfbGBMfnf5Q==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.1.tgz",
+      "integrity": "sha512-WMcwlXcB7l+BbxiEdyClkG+1sxrMHNZpzT577LEvU4+rXPd8oTAy1wXk72hnk2KOOmxuLvw3z5DtXT7HEAydtg==",
       "license": "MIT",
       "workspaces": [
         "www"
@@ -7338,7 +7328,7 @@
         "decimal.js-light": "^2.5.1",
         "es-toolkit": "^1.39.3",
         "eventemitter3": "^5.0.1",
-        "immer": "^10.1.1",
+        "immer": "^11.1.8",
         "react-redux": "8.x.x || 9.x.x",
         "reselect": "5.2.0",
         "tiny-invariant": "^1.3.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,14 +27,14 @@
   "dependencies": {
     "@dagrejs/dagre": "^3.0.0",
     "@tanstack/react-table": "^8.21.3",
-    "@tanstack/react-virtual": "^3.14.4",
+    "@tanstack/react-virtual": "^3.14.5",
     "@xyflow/react": "^12.11.1",
     "graphology": "^0.26.0",
     "lucide-react": "^1.22.0",
     "next": "^16.2.9",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "recharts": "^3.9.0",
+    "recharts": "^3.9.1",
     "sigma": "^3.0.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- combines the Dependabot UI bumps for `recharts` and `@tanstack/react-virtual` into one PR
- updates the npm lockfile once so the dependency graph stays coherent

## Updates
- `recharts` 3.9.0 -> 3.9.1
- `@tanstack/react-virtual` 3.14.4 -> 3.14.5

## Validation
- cd ui && npm run typecheck
- cd ui && npm run lint
- cd ui && npm run test:run
- cd ui && npm run build
- cd ui && npm run bundle:check

Supersedes #3379 and #3380.