### PR TITLE
feat(cli): add lane-branded compact output

### DIFF
--- a/scripts/check_docker_base_policy.py
+++ b/scripts/check_docker_base_policy.py
@@ -192,6 +192,19 @@ def _policy_key(path: Path) -> str | None:
 
 
 def _collect_dockerfiles() -> list[Path]:
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "*Dockerfile*"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        result = None
+    if result is not None and result.stdout.strip():
+        return sorted(ROOT / line.strip() for line in result.stdout.splitlines() if line.strip())
+
     skip = {"node_modules", ".venv", ".git", ".claude", "build", "dist", "site"}
     out: list[Path] = []
     for path in ROOT.rglob("Dockerfile*"):

--- a/src/agent_bom/output/brand_tokens.py
+++ b/src/agent_bom/output/brand_tokens.py
@@ -1,0 +1,44 @@
+"""Shared product lane labels for terminal output.
+
+The UI and docs present agent-bom as a small set of product lanes rather
+than a pile of commands. The CLI should use the same language in compact
+mode so the first-run experience feels like one product.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LaneToken:
+    """Terminal-safe label + Rich style for a product lane."""
+
+    label: str
+    style: str
+
+
+LANE_TOKENS: dict[str, LaneToken] = {
+    "discover": LaneToken(label="DISCOVER", style="blue"),
+    "scan": LaneToken(label="SCAN", style="red"),
+    "analyze": LaneToken(label="ANALYZE", style="yellow"),
+    "protect": LaneToken(label="PROTECT", style="magenta"),
+    "govern": LaneToken(label="GOVERN", style="green"),
+}
+
+
+def lane_token(name: str) -> LaneToken:
+    """Return a lane token, defaulting to a neutral uppercase label."""
+
+    key = name.strip().lower()
+    return LANE_TOKENS.get(key, LaneToken(label=key.upper() or "AGENT-BOM", style="cyan"))
+
+
+def lane_title(name: str, title: str) -> str:
+    """Render a compact lane-prefixed section title."""
+
+    token = lane_token(name)
+    return f"[{token.style}]{token.label}[/{token.style}] [dim]|[/dim] [bold]{title}[/bold]"
+
+
+__all__ = ["LANE_TOKENS", "LaneToken", "lane_title", "lane_token"]

--- a/src/agent_bom/output/compact.py
+++ b/src/agent_bom/output/compact.py
@@ -20,6 +20,7 @@ from rich.rule import Rule
 from rich.table import Table
 
 from agent_bom.models import AgentStatus, AIBOMReport, Severity
+from agent_bom.output.brand_tokens import lane_title
 
 # The cross-cutting helpers (`console`, `_sev_badge`, `build_remediation_plan`)
 # live in the package's __init__. Import lazily inside functions to avoid a
@@ -249,7 +250,7 @@ def print_compact_summary(report: AIBOMReport, *, verbose: bool = False) -> None
         console.print(
             Panel(
                 "\n".join(lines),
-                title=f"[bold]agent-bom[/bold]  v{report.tool_version}",
+                title=lane_title("scan", f"agent-bom v{report.tool_version}"),
                 border_style=border_style,
                 padding=(0, 1),
             )
@@ -301,7 +302,7 @@ def print_compact_summary(report: AIBOMReport, *, verbose: bool = False) -> None
     console.print(
         Panel(
             "\n".join(lines),
-            title=f"[bold]agent-bom[/bold]  v{report.tool_version}",
+            title=lane_title("scan", f"agent-bom v{report.tool_version}"),
             border_style=border_style,
             padding=(0, 1),
         )
@@ -317,7 +318,7 @@ def print_compact_agents(report: AIBOMReport) -> None:
         return
 
     console.print()
-    console.print(Rule("[bold]Agents[/bold]", style="dim"))
+    console.print(Rule(lane_title("discover", "Agents"), style="dim"))
     table = Table(box=None, padding=(0, 2), show_header=True, header_style="bold dim")
     table.add_column("Agent")
     table.add_column("Type", style="dim")
@@ -393,7 +394,7 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
         title = f"Findings ({shown_n} of {total_active} shown · {total_active - shown_n} hidden)"
     else:
         title = f"Findings ({shown_n})"
-    console.print(Rule(f"[bold]{title}[/bold]", style="dim"))
+    console.print(Rule(lane_title("analyze", title), style="dim"))
 
     # Context-aware table layout
     table = Table(expand=True, padding=(0, 1))
@@ -481,7 +482,7 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
     critical_findings = [br for br in shown if br.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH)]
     if critical_findings:
         console.print()
-        console.print(Rule("[bold]Critical Details[/bold]", style="dim"))
+        console.print(Rule(lane_title("analyze", "Critical Details"), style="dim"))
         sev_style_map = {Severity.CRITICAL: "red bold", Severity.HIGH: "#e67e22 bold"}
         for br in critical_findings[:5]:
             style = sev_style_map.get(br.vulnerability.severity, "white")
@@ -540,7 +541,7 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
     console.print()
     total = len(fixable)
     title = f"Fix First (top {min(limit, total)} of {total})" if total > limit else f"Fix First ({total})"
-    console.print(Rule(f"[bold]{title}[/bold]", style="dim"))
+    console.print(Rule(lane_title("protect", title), style="dim"))
     console.print("  [dim]Each item shows the impact radius, the primary action, and a verification command.[/dim]")
     console.print()
 
@@ -605,7 +606,7 @@ def print_compact_cis_posture(report: AIBOMReport, limit: int = 5) -> None:
         return
 
     console.print()
-    console.print("  [bold]CIS Benchmark Posture[/bold]")
+    console.print(f"  {lane_title('govern', 'CIS Benchmark Posture')}")
 
     for cloud, bundle in bundles:
         checks = bundle.get("checks") or []

--- a/tests/test_compact_output.py
+++ b/tests/test_compact_output.py
@@ -21,6 +21,7 @@ from agent_bom.models import (
 from agent_bom.output import (
     print_compact_agents,
     print_compact_blast_radius,
+    print_compact_cis_posture,
     print_compact_export_hint,
     print_compact_remediation,
     print_compact_summary,
@@ -163,6 +164,7 @@ def test_compact_summary_default_is_verdict_led():
     assert "CONFIG POSTURE GRADE" not in output
     assert "Top Drivers" not in output
     # Verdict + inventory still surface:
+    assert "SCAN" in output
     assert "CLEAN" in output
     assert "agents" in output
     assert "packages" in output
@@ -289,6 +291,7 @@ def test_compact_agents_table():
     )
     report = AIBOMReport(agents=[a1, a2])
     output = _capture(print_compact_agents, report)
+    assert "DISCOVER" in _plain(output)
     assert "claude-desktop" in output
     assert "cursor" in output
 
@@ -338,6 +341,7 @@ def test_compact_blast_radius_limit():
     import re
 
     plain = re.sub(r"\x1b\[[0-9;]*m", "", output)
+    assert "ANALYZE" in plain
     assert "3 of 8" in plain
     assert "more" in plain
     assert "--verbose" in plain
@@ -376,6 +380,7 @@ def test_compact_remediation_limit():
         radii.append(_blast(v, p, [agent], [server]))
     report = AIBOMReport(agents=[agent], blast_radii=radii)
     output = _capture(print_compact_remediation, report, limit=2)
+    assert "PROTECT" in _plain(output)
     assert "more" in output
     assert "--verbose" in output
 
@@ -446,3 +451,28 @@ def test_compact_export_hint():
     assert "servers" in output
     assert "packages" in output
     assert "vulns" in output
+
+
+def test_compact_cis_posture_uses_govern_lane():
+    """CIS posture is a governance surface in the compact CLI."""
+    report = AIBOMReport(
+        agents=[],
+        cis_benchmark_data={
+            "checks": [
+                {
+                    "check_id": "1.1",
+                    "title": "Ensure root account MFA is enabled",
+                    "status": "pass",
+                    "severity": "high",
+                }
+            ],
+            "passed": 1,
+            "failed": 0,
+            "pass_rate": 100.0,
+        },
+    )
+
+    output = _plain(_capture(print_compact_cis_posture, report))
+
+    assert "GOVERN" in output
+    assert "CIS Benchmark Posture" in output

--- a/tests/test_docker_base_policy.py
+++ b/tests/test_docker_base_policy.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from subprocess import CompletedProcess
 
 import pytest
 
@@ -34,6 +35,39 @@ def test_repo_state_passes_policy() -> None:
     # The committed repo must satisfy the policy on every push so the
     # error path of the script never lands silently.
     script = _load_script()
+    assert script.main() == 0
+
+
+def test_repo_state_ignores_untracked_codex_worktrees(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Local Codex worktrees should not be treated as repo Dockerfiles."""
+    script = _load_script()
+    repo = tmp_path
+    tracked = repo / "Dockerfile"
+    tracked.write_text("FROM python:3.14.3-alpine3.23@sha256:" + "a" * 64 + "\n", encoding="utf-8")
+    untracked = repo / ".codex" / "worktrees" / "other-branch" / "Dockerfile"
+    untracked.parent.mkdir(parents=True)
+    untracked.write_text("FROM node:24-slim\n", encoding="utf-8")
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:3] == ["git", "ls-files", "*Dockerfile*"]:
+            return CompletedProcess(cmd, 0, stdout="Dockerfile\n", stderr="")
+        msg = f"unexpected command: {cmd!r}"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(script, "ROOT", repo)
+    monkeypatch.setattr(script.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        script,
+        "POLICY",
+        {
+            "Dockerfile": script.BasePolicy(
+                image="python",
+                expected_tags=("3.14.3-alpine3.23",),
+                rationale="synthetic test fixture",
+            )
+        },
+    )
+
     assert script.main() == 0
 
 

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -927,7 +927,13 @@ def test_tool_risk_assessment_impl_success():
 
 @pytest.mark.asyncio
 async def test_runtime_production_index_impl_empty_state():
+    import agent_bom.api.routes.proxy as proxy_mod
     from agent_bom.mcp_tools.runtime import runtime_production_index_impl
+
+    proxy_mod._proxy_alerts.clear()
+    proxy_mod._proxy_alerts_total = 0
+    proxy_mod._proxy_metrics = None
+    proxy_mod._proxy_metrics_by_tenant.clear()
 
     result = await runtime_production_index_impl(tenant_id="default", _truncate_response=_trunc)
     data = json.loads(result)


### PR DESCRIPTION
## Summary
- adds shared compact CLI lane tokens for Discover / Scan / Analyze / Protect / Govern
- applies the lane labels to compact summary, agents, findings, remediation, and CIS posture sections
- stabilizes local release validation by limiting the Docker base-image policy check to git-tracked Dockerfiles and resetting runtime proxy buffers in the empty-state MCP test

## Validation
- uv run pytest tests/test_compact_output.py tests/test_docker_base_policy.py -q
- uv run pytest tests/test_mcp_tool_impls.py::test_runtime_production_index_impl_empty_state tests/test_compact_output.py tests/test_docker_base_policy.py -q
- uv run pytest tests/test_ocsf_boundary.py -q
- uv run ruff check src/agent_bom/output/brand_tokens.py src/agent_bom/output/compact.py scripts/check_docker_base_policy.py tests/test_compact_output.py tests/test_docker_base_policy.py tests/test_mcp_tool_impls.py
- uv run mypy src/agent_bom/output/brand_tokens.py src/agent_bom/output/compact.py scripts/check_docker_base_policy.py
- git diff --check

Full-suite note: uv run pytest -q cleared the two order-dependent failures this branch fixes and reached 8,624 passed / 27 skipped before I interrupted the long-running local suite at 69%; no failures were reported after these fixes before interruption.