### PR TITLE
feat(ui): share pagination controls across list pages

### DIFF
--- a/ui/app/audit/page.tsx
+++ b/ui/app/audit/page.tsx
@@ -9,6 +9,7 @@ import {
   type AuthPolicyResponse,
   formatDate,
 } from "@/lib/api";
+import { PaginationBar } from "@/components/pagination-bar";
 import {
   FileText,
   RefreshCw,
@@ -17,8 +18,6 @@ import {
   ShieldCheck,
   ShieldAlert,
   Search,
-  ChevronLeft,
-  ChevronRight,
   CheckCircle2,
   Filter,
 } from "lucide-react";
@@ -342,31 +341,18 @@ export default function AuditLogPage() {
             </div>
           )}
 
-          {/* Pagination */}
           {totalPages > 1 && (
-            <div className="flex items-center justify-between pt-2">
-              <span className="text-xs text-zinc-500">
-                Page {page + 1} of {totalPages} ({total.toLocaleString()} entries)
-              </span>
-              <div className="flex gap-1">
-                <button
-                  onClick={() => setPage((p) => Math.max(0, p - 1))}
-                  disabled={page === 0}
-                  className="flex items-center gap-1 px-2.5 py-1 rounded bg-zinc-800 hover:bg-zinc-700 disabled:opacity-40 text-xs text-zinc-300 transition-colors"
-                >
-                  <ChevronLeft className="w-3.5 h-3.5" />
-                  Prev
-                </button>
-                <button
-                  onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-                  disabled={page >= totalPages - 1}
-                  className="flex items-center gap-1 px-2.5 py-1 rounded bg-zinc-800 hover:bg-zinc-700 disabled:opacity-40 text-xs text-zinc-300 transition-colors"
-                >
-                  Next
-                  <ChevronRight className="w-3.5 h-3.5" />
-                </button>
-              </div>
-            </div>
+            <PaginationBar
+              page={page + 1}
+              totalPages={totalPages}
+              totalItems={total}
+              itemLabel="entries"
+              onPrevious={() => setPage((p) => Math.max(0, p - 1))}
+              onNext={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              previousDisabled={page === 0}
+              nextDisabled={page >= totalPages - 1}
+              className="pt-2"
+            />
           )}
         </>
       )}

--- a/ui/app/fleet/page.tsx
+++ b/ui/app/fleet/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { PaginationBar } from "@/components/pagination-bar";
 import {
   api,
   type FleetAgent,
@@ -560,30 +561,15 @@ export default function FleetPage() {
       )}
 
       {!loading && fleetTotal > FLEET_PAGE_SIZE && (
-        <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-zinc-800 bg-zinc-900 px-4 py-3">
-          <div className="text-xs text-zinc-500">
-            Page <span className="font-mono text-zinc-300">{pageNumber}</span> of{" "}
-            <span className="font-mono text-zinc-300">{totalPages}</span>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => setFleetOffset((current) => Math.max(0, current - FLEET_PAGE_SIZE))}
-              disabled={fleetOffset === 0}
-              className="rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-1.5 text-xs text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              Previous
-            </button>
-            <button
-              type="button"
-              onClick={() => setFleetOffset((current) => current + FLEET_PAGE_SIZE)}
-              disabled={fleetOffset + agents.length >= fleetTotal}
-              className="rounded-lg border border-zinc-700 bg-zinc-950 px-3 py-1.5 text-xs text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              Next
-            </button>
-          </div>
-        </div>
+        <PaginationBar
+          page={pageNumber}
+          totalPages={totalPages}
+          onPrevious={() => setFleetOffset((current) => Math.max(0, current - FLEET_PAGE_SIZE))}
+          onNext={() => setFleetOffset((current) => current + FLEET_PAGE_SIZE)}
+          previousDisabled={fleetOffset === 0}
+          nextDisabled={fleetOffset + agents.length >= fleetTotal}
+          className="rounded-xl border border-zinc-800 bg-zinc-900 px-4 py-3"
+        />
       )}
     </div>
   );

--- a/ui/app/jobs/page.tsx
+++ b/ui/app/jobs/page.tsx
@@ -3,11 +3,10 @@
 import { Suspense, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
+import { PaginationBar } from "@/components/pagination-bar";
 import { api, formatDate, type JobListItem, type JobStatus, type ScanSchedule, type SourceRecord } from "@/lib/api";
 import {
   CheckCircle2,
-  ChevronLeft,
-  ChevronRight,
   Clock,
   Download,
   Loader2,
@@ -418,30 +417,13 @@ function JobsPageContent() {
             </table>
           </div>
 
-          {/* Pagination */}
-          <div className="flex items-center justify-between">
-            <p className="text-xs text-zinc-600">
-              Page {page} of {totalPages} ({filteredJobs.length} total)
-            </p>
-            <div className="flex items-center gap-1">
-              <button
-                onClick={() => setPage((p) => Math.max(1, p - 1))}
-                disabled={page === 1}
-                className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md border border-zinc-800 text-zinc-400 hover:text-zinc-200 hover:border-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-              >
-                <ChevronLeft className="w-3 h-3" />
-                Prev
-              </button>
-              <button
-                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                disabled={page === totalPages}
-                className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md border border-zinc-800 text-zinc-400 hover:text-zinc-200 hover:border-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-              >
-                Next
-                <ChevronRight className="w-3 h-3" />
-              </button>
-            </div>
-          </div>
+          <PaginationBar
+            page={page}
+            totalPages={totalPages}
+            totalItems={filteredJobs.length}
+            onPrevious={() => setPage((p) => Math.max(1, p - 1))}
+            onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
+          />
         </>
       )}
     </div>

--- a/ui/app/remediation/page.tsx
+++ b/ui/app/remediation/page.tsx
@@ -7,13 +7,12 @@ import {
   severityColor,
   severityDot,
 } from "@/lib/api";
+import { PaginationBar } from "@/components/pagination-bar";
 import {
   Wrench,
   Download,
   ChevronDown,
   ChevronUp,
-  ChevronLeft,
-  ChevronRight,
   Loader2,
   Ticket,
 } from "lucide-react";
@@ -837,30 +836,13 @@ function RemediationPage() {
             )}
           </div>
 
-          {/* Pagination */}
-          <div className="flex items-center justify-between">
-            <p className="text-xs text-zinc-600">
-              Page {page} of {totalPages} ({displayed.length} total)
-            </p>
-            <div className="flex items-center gap-1">
-              <button
-                onClick={() => setPage((p) => Math.max(1, p - 1))}
-                disabled={page === 1}
-                className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md border border-zinc-800 text-zinc-400 hover:text-zinc-200 hover:border-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-              >
-                <ChevronLeft className="w-3 h-3" />
-                Prev
-              </button>
-              <button
-                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                disabled={page === totalPages}
-                className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md border border-zinc-800 text-zinc-400 hover:text-zinc-200 hover:border-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-              >
-                Next
-                <ChevronRight className="w-3 h-3" />
-              </button>
-            </div>
-          </div>
+          <PaginationBar
+            page={page}
+            totalPages={totalPages}
+            totalItems={displayed.length}
+            onPrevious={() => setPage((p) => Math.max(1, p - 1))}
+            onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
+          />
         </>
       )}
 

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -19,10 +19,11 @@ import {
   type UnifiedGraphResponse,
 } from "@/lib/api";
 import { ApiOfflineState } from "@/components/api-offline-state";
+import { PaginationBar } from "@/components/pagination-bar";
 import { PageEmptyState, PageLoadingState } from "@/components/states/page-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
 import { severityRank } from "@/lib/severity";
-import { Bug, Download, ExternalLink, ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Layers, Loader2, Package, Server, ShieldOff, Radar, FileSearch, ShieldAlert, ClipboardCheck, X } from "lucide-react";
+import { Bug, Download, ExternalLink, ChevronDown, ChevronRight, ChevronUp, Layers, Loader2, Package, Server, ShieldOff, Radar, FileSearch, ShieldAlert, ClipboardCheck, X } from "lucide-react";
 
 function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
   if (err instanceof ApiAuthError) return "auth";
@@ -968,31 +969,14 @@ function VulnsPage() {
             />
           )}
 
-          {/* Pagination controls (flat view only) */}
           {!grouped && (
-            <div className="flex items-center justify-between">
-              <p className="text-xs text-zinc-600">
-                Page {page} of {totalPages} ({displayed.length} total)
-              </p>
-              <div className="flex items-center gap-1">
-                <button
-                  onClick={() => setPage((p) => Math.max(1, p - 1))}
-                  disabled={page === 1}
-                  className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md border border-zinc-800 text-zinc-400 hover:text-zinc-200 hover:border-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-                >
-                  <ChevronLeft className="w-3 h-3" />
-                  Prev
-                </button>
-                <button
-                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-                  disabled={page === totalPages}
-                  className="flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md border border-zinc-800 text-zinc-400 hover:text-zinc-200 hover:border-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-                >
-                  Next
-                  <ChevronRight className="w-3 h-3" />
-                </button>
-              </div>
-            </div>
+            <PaginationBar
+              page={page}
+              totalPages={totalPages}
+              totalItems={displayed.length}
+              onPrevious={() => setPage((p) => Math.max(1, p - 1))}
+              onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
+            />
           )}
 
           {grouped && (

--- a/ui/components/pagination-bar.tsx
+++ b/ui/components/pagination-bar.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface PaginationBarProps {
+  page: number;
+  totalPages: number;
+  totalItems?: number;
+  itemLabel?: string;
+  onPrevious: () => void;
+  onNext: () => void;
+  previousDisabled?: boolean;
+  nextDisabled?: boolean;
+  className?: string;
+}
+
+export function PaginationBar({
+  page,
+  totalPages,
+  totalItems,
+  itemLabel = "total",
+  onPrevious,
+  onNext,
+  previousDisabled = page <= 1,
+  nextDisabled = page >= totalPages,
+  className = "",
+}: PaginationBarProps) {
+  const summary =
+    typeof totalItems === "number"
+      ? `Page ${page} of ${totalPages} (${totalItems.toLocaleString()} ${itemLabel})`
+      : `Page ${page} of ${totalPages}`;
+
+  return (
+    <div className={`flex flex-wrap items-center justify-between gap-3 ${className}`}>
+      <p className="text-xs text-zinc-500">{summary}</p>
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          onClick={onPrevious}
+          disabled={previousDisabled}
+          className="flex items-center gap-1 rounded-md border border-zinc-800 px-2.5 py-1 text-xs font-medium text-zinc-400 transition-colors hover:border-zinc-700 hover:text-zinc-200 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <ChevronLeft className="h-3 w-3" />
+          Prev
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          disabled={nextDisabled}
+          className="flex items-center gap-1 rounded-md border border-zinc-800 px-2.5 py-1 text-xs font-medium text-zinc-400 transition-colors hover:border-zinc-700 hover:text-zinc-200 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Next
+          <ChevronRight className="h-3 w-3" />
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- adds a shared PaginationBar component for list/table pages
- wires jobs, remediation, findings, audit, and fleet pagination through the same control
- leaves graph canvas pagination untouched to avoid viewport/layout risk

## Validation
- cd ui && npm run typecheck
- cd ui && npm run lint -- app/jobs/page.tsx app/remediation/page.tsx app/vulns/page.tsx app/audit/page.tsx app/fleet/page.tsx components/pagination-bar.tsx
- cd ui && npm run test:run -- vulns-page.test.tsx nav.test.tsx
- git diff --check