### PR TITLE
feat(cli): page compact findings output

### DIFF
--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -433,6 +433,7 @@ def scan(
     siem_format: str,
     clickhouse_url: Optional[str],
     verbose: bool,
+    page: int,
     log_level: Optional[str],
     log_json: bool,
     log_file: Optional[str],
@@ -2502,6 +2503,7 @@ def scan(
             agent_mode=agent_mode,
             agent_token_budget=agent_token_budget,
             agent_mode_full=agent_mode_full,
+            page=page,
         )
 
     # ── Posture summary mode (--posture) ──────────────────────────────────────

--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -246,6 +246,7 @@ def render_output(
     report = ctx.report
     blast_radii = ctx.blast_radii
     is_stdout = output == "-"
+    compact_page = int(kwargs.get("page") or 1)
 
     def _emit_report() -> None:
         """All console/stdout/file emission for the report.
@@ -335,7 +336,7 @@ def render_output(
                 print_compact_summary(report, verbose=verbose)
                 print_scan_performance_summary(report)
                 print_compact_agents(report)
-                print_compact_blast_radius(report, fixable_only=fixable_only)
+                print_compact_blast_radius(report, fixable_only=fixable_only, page=compact_page)
 
             # AI enrichment output (both modes)
             if report.executive_summary:
@@ -387,7 +388,7 @@ def render_output(
                 print_compact_cis_posture(report, limit=20)
                 print_export_hint(report)
             else:
-                print_compact_remediation(report)
+                print_compact_remediation(report, page=compact_page)
                 print_compact_cis_posture(report)
                 print_compact_export_hint(report)
         elif output_format in ("text", "plain") and not output:

--- a/src/agent_bom/cli/options_sources.py
+++ b/src/agent_bom/cli/options_sources.py
@@ -204,6 +204,13 @@ def output_options(fn):
                 help="Full output — dependency tree, all findings, severity chart, threat frameworks, debug logging",
             ),
             click.option(
+                "--page",
+                type=click.IntRange(min=1),
+                default=1,
+                show_default=True,
+                help="Compact console page for findings and remediation when the default output is truncated.",
+            ),
+            click.option(
                 "--log-level",
                 "log_level",
                 type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR"], case_sensitive=False),

--- a/src/agent_bom/output/compact.py
+++ b/src/agent_bom/output/compact.py
@@ -66,6 +66,16 @@ def _compact_detail(text: str, limit: int = 88) -> str:
     return clean[: limit - 1].rstrip() + "…"
 
 
+def _page_window(total: int, limit: int, page: int) -> tuple[int, int, int]:
+    """Return a bounded page window as (page, start, end)."""
+    safe_limit = max(1, limit)
+    total_pages = max(1, (total + safe_limit - 1) // safe_limit)
+    safe_page = min(max(1, page), total_pages)
+    start = (safe_page - 1) * safe_limit
+    end = min(start + safe_limit, total)
+    return safe_page, start, end
+
+
 def _forward_fix_version(br: object) -> str | None:
     """Return a fix version only when it is a forward upgrade for this package."""
     fixed = getattr(getattr(br, "vulnerability", None), "fixed_version", None)
@@ -346,7 +356,7 @@ def print_compact_agents(report: AIBOMReport) -> None:
     console.print(table)
 
 
-def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_only: bool = False) -> None:
+def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_only: bool = False, page: int = 1) -> None:
     """Show top N findings in a compact table.
 
     Context-aware: shows blast radius chain (agent → server → credential) only
@@ -371,22 +381,24 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
         display_list = [br for br in active_findings if _forward_fix_version(br)] if fixable_only else active_findings
     else:
         display_list = priority
-    shown = display_list[:limit]
+    total = len(display_list)
+    page, start, end = _page_window(total, limit, page)
+    shown = display_list[start:end]
 
     # Detect if we have blast radius context (agents/servers/credentials)
     has_blast_context = any(br.affected_agents and (br.affected_servers or br.exposed_credentials) for br in shown)
 
     console.print()
-    total = len(display_list)
     shown_n = len(shown)
     total_active = len(active_findings)
+    total_pages = max(1, (total + max(1, limit) - 1) // max(1, limit))
     if total > limit:
         # Priority list truncated by --limit; tell the operator how many
         # additional priority rows aren't shown.
         suffix = ""
         if total_active > total:
             suffix = f" · {total_active - total} more below priority"
-        title = f"Top Findings ({min(limit, total)} of {total}{suffix})"
+        title = f"Top Findings (page {page}/{total_pages} · {start + 1}-{end} of {total}{suffix})"
     elif total_active > shown_n:
         # Display list fits in --limit but priority filtering hid some
         # lower-severity rows further down. Tell the operator both numbers
@@ -469,14 +481,23 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
 
     console.print(table)
 
-    overflow = total - len(shown)
-    if overflow > 0 or rest_count > 0:
+    overflow = total - end
+    hidden_before = start
+    if overflow > 0 or hidden_before > 0 or rest_count > 0:
         parts = []
+        if hidden_before > 0:
+            parts.append(f"{hidden_before} earlier hidden")
         if overflow > 0:
             parts.append(f"{overflow} more critical/high")
         if rest_count > 0:
             parts.append(f"{rest_count} medium/low hidden")
-        console.print(f"  [dim]+ {' · '.join(parts)} — use --verbose for full list[/dim]")
+        nav_hints = []
+        if page < total_pages:
+            nav_hints.append(f"--page {page + 1} next")
+        if page > 1:
+            nav_hints.append(f"--page {page - 1} previous")
+        nav_hints.append("--verbose full list")
+        console.print(f"  [dim]+ {' · '.join(parts)} — {' · '.join(nav_hints)}[/dim]")
 
     # Critical details section — show description and blast chain for CRIT/HIGH only
     critical_findings = [br for br in shown if br.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH)]
@@ -516,6 +537,8 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
     kev_count = sum(1 for br in report.blast_radii if br.vulnerability.is_kev)
     unknown_sev = sum(1 for br in report.blast_radii if br.vulnerability.severity == Severity.NONE)
     hints = ["[dim]--verbose[/dim] full details", "[dim]-f html[/dim] interactive report"]
+    if page < total_pages:
+        hints.insert(0, f"[dim]--page {page + 1}[/dim] next findings")
     if fixable:
         hints.insert(0, f"[green]{fixable} fixable[/green]")
     if kev_count:
@@ -526,7 +549,7 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
     console.print(f"  {' · '.join(hints)}")
 
 
-def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
+def print_compact_remediation(report: AIBOMReport, limit: int = 5, page: int = 1) -> None:
     """Top N remediation items, one-liner each."""
     from agent_bom.output import build_remediation_plan, console
 
@@ -540,7 +563,12 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
 
     console.print()
     total = len(fixable)
-    title = f"Fix First (top {min(limit, total)} of {total})" if total > limit else f"Fix First ({total})"
+    page, start, end = _page_window(total, limit, page)
+    total_pages = max(1, (total + max(1, limit) - 1) // max(1, limit))
+    if total > limit:
+        title = f"Fix First (page {page}/{total_pages} · {start + 1}-{end} of {total})"
+    else:
+        title = f"Fix First ({total})"
     console.print(Rule(lane_title("protect", title), style="dim"))
     console.print("  [dim]Each item shows the impact radius, the primary action, and a verification command.[/dim]")
     console.print()
@@ -553,8 +581,8 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
         Severity.NONE: "white",
     }
 
-    shown = fixable[:limit]
-    for i, item in enumerate(shown, 1):
+    shown = fixable[start:end]
+    for row_number, item in enumerate(shown, start + 1):
         style = sev_style.get(item["max_severity"], "white")
         kev = " [red]KEV[/red]" if item["has_kev"] else ""
         reach_parts = [f"{len(item['vulns'])} vuln(s)", f"{len(item['agents'])} agent(s)"]
@@ -564,7 +592,8 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
             reach_parts.append(f"{len(item['tools'])} tool(s)")
         reach = ", ".join(reach_parts)
         console.print(
-            f"  [{style}]{i}.[/{style}] [bold]{item['package']}[/bold] [dim]{item['current']}[/dim] → [green]{item['fix']}[/green]{kev}"
+            f"  [{style}]{row_number}.[/{style}] "
+            f"[bold]{item['package']}[/bold] [dim]{item['current']}[/dim] → [green]{item['fix']}[/green]{kev}"
         )
         console.print(f"     [bold]Priority:[/bold] {item['priority']} [dim]· clears {reach}[/dim]")
         console.print(f"     [bold]Action:[/bold] [dim]{_compact_detail(item['action'], limit=96)}[/dim]")
@@ -574,12 +603,18 @@ def print_compact_remediation(report: AIBOMReport, limit: int = 5) -> None:
             console.print(
                 f"     [bold dim cyan]Verify:[/bold dim cyan] [dim cyan]$ {item['verify_command']}[/dim cyan] [dim](verify)[/dim]"
             )
-        if i < len(shown):
+        if row_number < end:
             console.print()
 
     if total > limit:
         console.print()
-        console.print(f"  [dim]... {total - limit} more (use --verbose for full plan)[/dim]")
+        nav_hints = []
+        if page < total_pages:
+            nav_hints.append(f"--page {page + 1} next")
+        if page > 1:
+            nav_hints.append(f"--page {page - 1} previous")
+        nav_hints.append("--verbose full plan")
+        console.print(f"  [dim]... {total - end} more · {' · '.join(nav_hints)}[/dim]")
     console.print()
 
 

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -54,6 +54,7 @@ class TestAgentBom:
         r = CliRunner().invoke(main, ["agents", "--help"])
         assert r.exit_code == 0
         assert "OpenSSF Scorecard" in r.output
+        assert "--page" in r.output
 
     def test_report_dashboard_help_points_to_serve_for_next_ui(self):
         from agent_bom.cli import main

--- a/tests/test_compact_output.py
+++ b/tests/test_compact_output.py
@@ -347,6 +347,28 @@ def test_compact_blast_radius_limit():
     assert "--verbose" in plain
 
 
+def test_compact_blast_radius_page_two():
+    """Compact findings can page through a noisy scan without switching to verbose mode."""
+    pkg = Package(name="lodash", version="4.17.20", ecosystem="npm")
+    server = _make_server(packages=[pkg])
+    agent = _make_agent(servers=[server])
+    radii = []
+    for i in range(8):
+        v = _vuln(vid=f"CVE-2024-{i:04d}", severity=Severity.HIGH)
+        radii.append(_blast(v, pkg, [agent], [server]))
+    report = AIBOMReport(agents=[agent], blast_radii=radii)
+    plain = _plain(_capture(print_compact_blast_radius, report, limit=3, page=2))
+
+    assert "page 2/3" in plain
+    assert "4-6 of 8" in plain
+    assert "CVE-2024-0000" not in plain
+    assert "CVE-2024-0003" in plain
+    assert "CVE-2024-0005" in plain
+    assert "CVE-2024-0006" not in plain
+    assert "--page 3 next" in plain
+    assert "--page 1 previous" in plain
+
+
 def test_compact_blast_radius_empty():
     """No output when no blast radii."""
     report = AIBOMReport(agents=[])
@@ -383,6 +405,28 @@ def test_compact_remediation_limit():
     assert "PROTECT" in _plain(output)
     assert "more" in output
     assert "--verbose" in output
+
+
+def test_compact_remediation_page_two():
+    """Compact remediation can page through fix-first output."""
+    server = _make_server()
+    agent = _make_agent(servers=[server])
+    radii = []
+    for i in range(5):
+        v = _vuln(vid=f"CVE-2024-{i:04d}", severity=Severity.HIGH, fixed="9.9.9")
+        p = Package(name=f"pkg-{i}", version="1.0.0", ecosystem="npm", vulnerabilities=[v])
+        radii.append(_blast(v, p, [agent], [server]))
+    report = AIBOMReport(agents=[agent], blast_radii=radii)
+    plain = _plain(_capture(print_compact_remediation, report, limit=2, page=2))
+
+    assert "page 2/3" in plain
+    assert "3-4 of 5" in plain
+    assert "pkg-0" not in plain
+    assert "pkg-2" in plain
+    assert "pkg-3" in plain
+    assert "pkg-4" not in plain
+    assert "--page 3 next" in plain
+    assert "--page 1 previous" in plain
 
 
 def test_compact_remediation_shows_priority_and_action():


### PR DESCRIPTION
## Summary
- add a compact console --page option for paged findings/remediation output
- keep JSON/SARIF/agent-mode/verbose output unchanged
- add renderer and CLI-help regression coverage

Advances #3373.

## Validation
- uv run pytest tests/test_compact_output.py tests/test_cli_entry_points.py::TestAgentBom::test_agents_help -q
- uv run ruff check src/agent_bom/output/compact.py src/agent_bom/cli/options_sources.py src/agent_bom/cli/agents/__init__.py src/agent_bom/cli/agents/_output.py tests/test_compact_output.py tests/test_cli_entry_points.py
- uv run mypy src/agent_bom/output/compact.py src/agent_bom/cli/agents/_output.py
- git diff --check