### PR TITLE
feat(ui): add full-canvas graph lens bar

### DIFF
--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/lib/graph-utils";
 import { graphFitViewOptions, shouldShowGraphMiniMap } from "@/lib/graph-viewport";
 import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
+import { GraphLensSwitcher } from "@/components/graph-lens-switcher";
 import { GraphEmptyState, GraphPanelSkeleton, GraphRefreshOverlay } from "@/components/graph-state-panels";
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
@@ -523,6 +524,7 @@ export default function ContextPage() {
       <div className="flex-1 flex overflow-hidden">
         {/* Graph */}
         <div className="flex-1 relative">
+          <GraphLensSwitcher variant="floating" />
           {detailLoading && graphData && (
             <GraphRefreshOverlay label="Updating context graph" />
           )}

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -23,6 +23,7 @@ import {
   GraphLegend,
   FullscreenButton,
 } from "@/components/graph-chrome";
+import { GraphLensSwitcher } from "@/components/graph-lens-switcher";
 import { LargeGraphOverview } from "@/components/large-graph-overview";
 import { LineageDetailPanel } from "@/components/lineage-detail";
 import {
@@ -2239,6 +2240,7 @@ function GraphPageInner() {
 
       <div className="flex-1 flex relative min-h-[68vh]">
         <div className="flex-1 relative min-h-[60vh]">
+          <GraphLensSwitcher variant="floating" />
           {loadingGraph && !graphData ? (
             <GraphPanelSkeleton
               title="Loading graph window"

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/lib/graph-utils";
 import { graphFitViewOptions, shouldShowGraphMiniMap } from "@/lib/graph-viewport";
 import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
+import { GraphLensSwitcher } from "@/components/graph-lens-switcher";
 import { GraphEmptyState, GraphPanelSkeleton, GraphRefreshOverlay } from "@/components/graph-state-panels";
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
@@ -551,6 +552,7 @@ export default function MeshPage() {
 
       {/* Graph */}
       <div className="flex-1 relative">
+        <GraphLensSwitcher variant="floating" />
         {detailLoading && activeResult && (
           <GraphRefreshOverlay label="Updating agent mesh" />
         )}

--- a/ui/components/graph-lens-switcher.tsx
+++ b/ui/components/graph-lens-switcher.tsx
@@ -46,7 +46,13 @@ const GRAPH_LENSES: GraphLens[] = [
   },
 ];
 
-export function GraphLensSwitcher() {
+interface GraphLensSwitcherProps {
+  variant?: "inline" | "floating";
+}
+
+export function GraphLensSwitcher({
+  variant = "inline",
+}: GraphLensSwitcherProps) {
   const path = usePathname() ?? "/security-graph";
   const router = useRouter();
 
@@ -63,17 +69,40 @@ export function GraphLensSwitcher() {
     router.push(lens.href);
   };
 
-  return (
-    <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3">
+  const content = (
+    <div
+      className={
+        variant === "floating"
+          ? "pointer-events-auto flex min-w-0 flex-wrap items-center justify-between gap-2 rounded-2xl border border-zinc-700/80 bg-zinc-950/85 px-3 py-2 shadow-2xl shadow-black/40 backdrop-blur"
+          : "flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3"
+      }
+    >
       <div className="min-w-0">
         <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-[color:var(--text-tertiary)]">
-          Security Graph
+          {variant === "floating" ? "Security Graph Lens" : "Security Graph"}
         </p>
-        <p className="mt-0.5 text-xs text-[color:var(--text-secondary)]">
+        <p
+          className={`mt-0.5 text-xs text-[color:var(--text-secondary)] ${
+            variant === "floating" ? "hidden sm:block" : ""
+          }`}
+        >
           One graph, multiple lenses — switch how you read the same estate.
         </p>
       </div>
       <InsightLayerToggle layers={layers} onToggle={onToggle} />
     </div>
   );
+
+  if (variant === "floating") {
+    return (
+      <div
+        data-testid="graph-lens-floating-bar"
+        className="pointer-events-none absolute left-1/2 top-3 z-30 w-[min(760px,calc(100%-2rem))] -translate-x-1/2"
+      >
+        {content}
+      </div>
+    );
+  }
+
+  return content;
 }

--- a/ui/components/insight-layer-toggle.tsx
+++ b/ui/components/insight-layer-toggle.tsx
@@ -7,17 +7,19 @@ interface InsightLayerToggleProps {
 
 export function InsightLayerToggle({ layers, onToggle }: InsightLayerToggleProps) {
   return (
-    <div className="flex items-center gap-1">
-      <span className="text-xs text-zinc-500 mr-1">Insight Layers:</span>
+    <div className="flex min-w-0 flex-wrap items-center gap-1">
+      <span className="mr-1 whitespace-nowrap text-xs text-zinc-500">
+        Insight Layers:
+      </span>
       {layers.map((layer) => (
         <button key={layer.id} onClick={() => onToggle(layer.id)}
-          className={`flex items-center gap-1 px-2 py-1 rounded text-xs transition-colors ${
+          className={`flex max-w-full items-center gap-1 rounded px-2 py-1 text-xs transition-colors ${
             layer.active
               ? "bg-purple-500/20 text-purple-300 border border-purple-500/30"
               : "bg-zinc-900 text-zinc-500 hover:text-zinc-300 border border-zinc-800"
           }`}>
           <span>{layer.icon}</span>
-          <span>{layer.label}</span>
+          <span className="truncate">{layer.label}</span>
         </button>
       ))}
     </div>

--- a/ui/tests/graph-lens-switcher.test.tsx
+++ b/ui/tests/graph-lens-switcher.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { GraphLensSwitcher } from "@/components/graph-lens-switcher";
+
+const push = vi.fn();
+let pathname = "/graph";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+  useRouter: () => ({ push }),
+}));
+
+describe("GraphLensSwitcher", () => {
+  beforeEach(() => {
+    pathname = "/graph";
+    push.mockClear();
+  });
+
+  it("renders the floating lens bar for full-canvas graph pages", () => {
+    render(<GraphLensSwitcher variant="floating" />);
+
+    expect(screen.getByTestId("graph-lens-floating-bar")).toBeInTheDocument();
+    expect(screen.getByText("Security Graph Lens")).toBeInTheDocument();
+    expect(screen.getByText("Attack Paths")).toBeInTheDocument();
+    expect(screen.getByText("Lineage")).toBeInTheDocument();
+    expect(screen.getByText("Agent Mesh")).toBeInTheDocument();
+    expect(screen.getByText("Context")).toBeInTheDocument();
+  });
+
+  it("routes to another graph lens without shifting the canvas route shell", () => {
+    render(<GraphLensSwitcher variant="floating" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /agent mesh/i }));
+
+    expect(push).toHaveBeenCalledWith("/mesh");
+  });
+
+  it("does not reroute when the active lens is selected", () => {
+    pathname = "/mesh";
+    render(<GraphLensSwitcher variant="floating" />);
+
+    fireEvent.click(screen.getByRole("button", { name: /agent mesh/i }));
+
+    expect(push).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- adds the graph lens switcher as a floating overlay on the full-canvas Lineage, Agent Mesh, and Context graph pages
- keeps the existing React Flow viewport layout unchanged by layering the switcher inside the graph canvas container
- makes the shared insight-layer toggle wrap safely so labels do not overflow narrow graph headers

## Validation
- cd ui && npm run typecheck
- cd ui && npm run lint -- components/graph-lens-switcher.tsx components/insight-layer-toggle.tsx app/graph/graph-page-client.tsx app/mesh/page.tsx app/context/page.tsx tests/graph-lens-switcher.test.tsx
- cd ui && npm run test:run -- graph-lens-switcher.test.tsx insight-layer-toggle.test.tsx

Closes #3374