### PR TITLE
fix(ui): standardize offline and empty-state next steps

### DIFF
--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -58,6 +58,7 @@ import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-
 import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/states/page-state";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
+import { FIRST_SCAN_ACTIONS } from "@/lib/empty-state-actions";
 
 // ─── Agents List Helpers ────────────────────────────────────────────────────
 
@@ -387,7 +388,7 @@ function AgentsList() {
               "Open the mesh view after discovery to inspect agent and server relationships.",
             ]}
             command="agent-bom agents --demo --offline"
-            action={{ label: "Open scan", href: "/scan" }}
+            actions={FIRST_SCAN_ACTIONS}
             data-testid="agents-empty-state"
           />
         ))}

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -47,6 +47,7 @@ import { CISBenchmarkDetail } from "@/components/cis-benchmark-detail";
 import { ApiOfflineState } from "@/components/api-offline-state";
 import { PageEmptyState, PageLoadingState } from "@/components/states/page-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
+import { FIRST_EVIDENCE_ACTIONS } from "@/lib/empty-state-actions";
 
 function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
   if (err instanceof ApiAuthError) return "auth";
@@ -978,7 +979,7 @@ function CompliancePageContent() {
             "Use the matrix view once multiple frameworks have populated control coverage.",
           ]}
           command="agent-bom agents --demo --offline"
-          action={{ label: "Start a scan", href: "/scan" }}
+          actions={FIRST_EVIDENCE_ACTIONS}
           data-testid="compliance-empty-state"
         />
       )}

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -40,10 +40,12 @@ import {
   type CloudConnectionScanResponse,
 } from "@/lib/api";
 import { useAuthState } from "@/components/auth-provider";
-import { EmptyState, ErrorBanner } from "@/components/empty-state";
+import { ErrorBanner } from "@/components/empty-state";
+import { PageEmptyState } from "@/components/states/page-state";
 import { Card, Section } from "@/components/card";
 import { Collapsible } from "@/components/collapsible";
 import { StatCard } from "@/components/stat-card";
+import { RUN_SCAN_ACTION } from "@/lib/empty-state-actions";
 import { vendorLogo } from "@/lib/vendor-logos";
 
 // ── Provider catalog ──────────────────────────────────────────────────────────
@@ -664,10 +666,19 @@ export default function ConnectionsPage() {
               ))}
             </div>
           ) : connections.length === 0 ? (
-            <EmptyState
+            <PageEmptyState
               icon={Cloud}
               title="No cloud accounts connected"
-              description="Add a read-only AWS, Azure, GCP, or Snowflake account to launch inventory and CIS discovery from the control plane."
+              detail="Add a read-only AWS, Azure, GCP, or Snowflake account to launch inventory and CIS discovery from the control plane."
+              suggestions={[
+                "Start with AWS when you want the deepest CSPM and inventory coverage.",
+                "Use Snowflake when you want warehouse governance and activity evidence.",
+                "Run a local scan if you need repo, image, IaC, or MCP evidence first.",
+              ]}
+              actions={[
+                { label: "Connect cloud", onClick: () => openWizard("aws") },
+                { ...RUN_SCAN_ACTION, variant: "secondary" },
+              ]}
             />
           ) : (
             <div className="overflow-x-auto rounded-xl border border-[color:var(--border-subtle)]">

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -22,6 +22,7 @@ import { ApiOfflineState } from "@/components/api-offline-state";
 import { PaginationBar } from "@/components/pagination-bar";
 import { PageEmptyState, PageLoadingState } from "@/components/states/page-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
+import { FIRST_SCAN_ACTIONS } from "@/lib/empty-state-actions";
 import { severityRank } from "@/lib/severity";
 import { Bug, Download, ExternalLink, ChevronDown, ChevronRight, ChevronUp, Layers, Loader2, Package, Server, ShieldOff, Radar, FileSearch, ShieldAlert, ClipboardCheck, X } from "lucide-react";
 
@@ -821,7 +822,7 @@ function VulnsPage() {
             "Use all completed scans when you need aggregate evidence across jobs.",
           ]}
           command="agent-bom agents --demo --offline"
-          action={{ label: "Open scan", href: "/scan" }}
+          actions={FIRST_SCAN_ACTIONS}
           data-testid="findings-empty-state"
         />
       )}

--- a/ui/components/graph-state-panels.tsx
+++ b/ui/components/graph-state-panels.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { buildFindingsHref } from "@/lib/attack-paths";
 import { getOsvVulnerabilityUrl } from "@/lib/vulnerabilities";
 import { PageEmptyState, PageLoadingState } from "@/components/states/page-state";
+import type { PageStateAction } from "@/components/states/page-state";
 import type { LineageNodeData } from "./lineage-nodes";
 
 const FINDINGS_VIRTUALIZE_THRESHOLD = 80;
@@ -33,11 +34,13 @@ export function GraphEmptyState({
   detail,
   suggestions,
   command,
+  actions,
 }: {
   title: string;
   detail: string;
   suggestions: string[];
   command?: string | undefined;
+  actions?: PageStateAction[] | undefined;
 }) {
   return (
     <PageEmptyState
@@ -45,6 +48,7 @@ export function GraphEmptyState({
       detail={detail}
       suggestions={suggestions}
       command={command}
+      actions={actions}
     />
   );
 }

--- a/ui/components/states/page-state.tsx
+++ b/ui/components/states/page-state.tsx
@@ -4,10 +4,11 @@ import Link from "next/link";
 import type { ElementType, ReactNode } from "react";
 import { AlertTriangle, Loader2, SearchX } from "lucide-react";
 
-type PageStateAction = {
+export type PageStateAction = {
   label: string;
   href?: string | undefined;
   onClick?: (() => void) | undefined;
+  variant?: "primary" | "secondary" | undefined;
 };
 
 type PageStateProps = {
@@ -17,6 +18,7 @@ type PageStateProps = {
   suggestions?: string[] | undefined;
   command?: string | undefined;
   action?: PageStateAction | undefined;
+  actions?: PageStateAction[] | undefined;
   tone?: "neutral" | "warning" | "danger" | "success" | undefined;
   children?: ReactNode;
   "data-testid"?: string | undefined;
@@ -36,10 +38,13 @@ export function PageState({
   suggestions = [],
   command,
   action,
+  actions,
   tone = "neutral",
   children,
   "data-testid": testId,
 }: PageStateProps) {
+  const resolvedActions = actions ?? (action ? [action] : []);
+
   return (
     <div className="flex min-h-[18rem] items-center justify-center px-4 py-10" data-testid={testId}>
       <div className={`w-full max-w-2xl rounded-2xl border p-6 shadow-lg ${TONE_CLASS[tone]}`}>
@@ -73,28 +78,39 @@ export function PageState({
 
         {children}
 
-        {action ? (
-          <div className="mt-5">
-            {action.href ? (
-              <Link
-                href={action.href}
-                className="inline-flex items-center justify-center rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm font-medium text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20"
-              >
-                {action.label}
-              </Link>
-            ) : (
-              <button
-                type="button"
-                onClick={action.onClick}
-                className="inline-flex items-center justify-center rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm font-medium text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20"
-              >
-                {action.label}
-              </button>
-            )}
+        {resolvedActions.length > 0 ? (
+          <div className="mt-5 flex flex-wrap gap-2">
+            {resolvedActions.map((currentAction) => (
+              <PageStateActionButton
+                key={`${currentAction.label}:${currentAction.href ?? "button"}`}
+                action={currentAction}
+              />
+            ))}
           </div>
         ) : null}
       </div>
     </div>
+  );
+}
+
+function PageStateActionButton({ action }: { action: PageStateAction }) {
+  const className =
+    action.variant === "secondary"
+      ? "inline-flex items-center justify-center rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-sm font-medium text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
+      : "inline-flex items-center justify-center rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm font-medium text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20";
+
+  if (action.href) {
+    return (
+      <Link href={action.href} className={className}>
+        {action.label}
+      </Link>
+    );
+  }
+
+  return (
+    <button type="button" onClick={action.onClick} className={className}>
+      {action.label}
+    </button>
   );
 }
 

--- a/ui/lib/empty-state-actions.ts
+++ b/ui/lib/empty-state-actions.ts
@@ -1,0 +1,35 @@
+import type { PageStateAction } from "@/components/states/page-state";
+
+export const CONNECT_CLOUD_ACTION: PageStateAction = {
+  label: "Connect cloud",
+  href: "/connections",
+};
+
+export const RUN_SCAN_ACTION: PageStateAction = {
+  label: "Run scan",
+  href: "/scan",
+};
+
+export const OPEN_SECURITY_GRAPH_ACTION: PageStateAction = {
+  label: "Open graph",
+  href: "/security-graph",
+  variant: "secondary",
+};
+
+export const OPEN_FINDINGS_ACTION: PageStateAction = {
+  label: "Open findings",
+  href: "/findings",
+  variant: "secondary",
+};
+
+export const FIRST_SCAN_ACTIONS: PageStateAction[] = [
+  RUN_SCAN_ACTION,
+  CONNECT_CLOUD_ACTION,
+  OPEN_SECURITY_GRAPH_ACTION,
+];
+
+export const FIRST_EVIDENCE_ACTIONS: PageStateAction[] = [
+  RUN_SCAN_ACTION,
+  CONNECT_CLOUD_ACTION,
+  OPEN_FINDINGS_ACTION,
+];

--- a/ui/tests/page-state.test.tsx
+++ b/ui/tests/page-state.test.tsx
@@ -40,4 +40,22 @@ describe("page state components", () => {
     expect(screen.getByTestId("error-state")).toHaveTextContent("Could not load agents");
     expect(screen.getByTestId("loading-state")).toHaveTextContent("Loading compliance posture");
   });
+
+  it("renders multiple empty-state actions without replacing the primary action path", () => {
+    render(
+      <PageEmptyState
+        title="No evidence yet"
+        detail="Choose the next setup step."
+        actions={[
+          { label: "Run scan", href: "/scan" },
+          { label: "Connect cloud", href: "/connections", variant: "secondary" },
+          { label: "Open graph", href: "/security-graph", variant: "secondary" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Run scan" })).toHaveAttribute("href", "/scan");
+    expect(screen.getByRole("link", { name: "Connect cloud" })).toHaveAttribute("href", "/connections");
+    expect(screen.getByRole("link", { name: "Open graph" })).toHaveAttribute("href", "/security-graph");
+  });
 });


### PR DESCRIPTION
## Summary
- extends the shared page-state component to support a compact row of primary/secondary actions
- centralizes the common first-run CTAs for run scan, connect cloud, open graph, and open findings
- wires Findings, Compliance, Agents, and Connections empty states to the same next-step pattern so offline/no-data paths are not dead ends

## Validation
- cd ui && npm run typecheck
- cd ui && npm run lint -- components/states/page-state.tsx components/graph-state-panels.tsx app/vulns/page.tsx app/compliance/page.tsx app/agents/page.tsx app/connections/page.tsx lib/empty-state-actions.ts tests/page-state.test.tsx
- cd ui && npm run test:run -- page-state.test.tsx vulns-page.test.tsx connections-page.test.tsx auth-gate.test.tsx

Closes #3375