### PR TITLE
feat(mcp): make runtime startup workflow-first

### DIFF
--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -19,6 +19,7 @@ import click
 
 from agent_bom.cli._common import read_json_file_for_cli
 from agent_bom.cli._grouped_help import SuggestingGroup
+from agent_bom.cli._runtime_status import emit_runtime_status_strip
 from agent_bom.cli._server import _is_loopback_host
 
 logger = logging.getLogger(__name__)
@@ -601,6 +602,7 @@ def serve_cmd(
     for label, value in rows:
         click.echo(f"  {label:<11} {value}")
     click.echo("  Press Ctrl+C to stop.\n")
+    emit_runtime_status_strip("gateway", calls=0, blocked=0, last_decision="listening")
     uvicorn.run(app, host=host, port=port_num, log_level=log_level.lower())
 
 

--- a/src/agent_bom/cli/_runtime_status.py
+++ b/src/agent_bom/cli/_runtime_status.py
@@ -1,0 +1,95 @@
+"""Small interactive runtime status strips for local demos."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from typing import TextIO
+
+from agent_bom.proxy_audit import ProxyMetrics
+
+_MAX_DECISION_CHARS = 56
+
+
+def _clean_decision(value: object) -> str:
+    decision = str(value or "waiting").replace("\n", " ").replace("\r", " ").strip()
+    if len(decision) > _MAX_DECISION_CHARS:
+        return decision[: _MAX_DECISION_CHARS - 1] + "..."
+    return decision or "waiting"
+
+
+def render_runtime_status_strip(
+    surface: str,
+    *,
+    calls: int,
+    blocked: int,
+    last_decision: object,
+    quit_hint: str = "Ctrl+C to stop",
+) -> str:
+    """Return a single-line runtime status strip that fits terminal logs."""
+    return (
+        f"  agent-bom {surface} live | calls={max(calls, 0)} blocked={max(blocked, 0)} last={_clean_decision(last_decision)} | {quit_hint}"
+    )
+
+
+def stream_is_interactive(stream: TextIO | None = None) -> bool:
+    """True when it is safe to draw an updating status strip."""
+    stream = stream or sys.stderr
+    try:
+        return bool(stream.isatty())
+    except Exception:  # noqa: BLE001 - defensive for custom test streams
+        return False
+
+
+def emit_runtime_status_strip(
+    surface: str,
+    *,
+    calls: int = 0,
+    blocked: int = 0,
+    last_decision: object = "waiting",
+    stream: TextIO | None = None,
+    quit_hint: str = "Ctrl+C to stop",
+) -> bool:
+    """Print one TTY-only status strip to stderr and return whether it was emitted."""
+    stream = stream or sys.stderr
+    if not stream_is_interactive(stream):
+        return False
+    stream.write(
+        render_runtime_status_strip(
+            surface,
+            calls=calls,
+            blocked=blocked,
+            last_decision=last_decision,
+            quit_hint=quit_hint,
+        )
+        + "\n"
+    )
+    stream.flush()
+    return True
+
+
+def proxy_metrics_status_callback(
+    *,
+    stream: TextIO | None = None,
+    surface: str = "proxy",
+) -> tuple[bool, Callable[[ProxyMetrics], None]]:
+    """Return a best-effort callback that redraws proxy status on metric updates."""
+    stream = stream or sys.stderr
+    if not stream_is_interactive(stream):
+        return False, lambda _metrics: None
+
+    def _callback(metrics: ProxyMetrics) -> None:
+        summary = metrics.summary()
+        stream.write(
+            "\r"
+            + render_runtime_status_strip(
+                surface,
+                calls=int(summary.get("total_tool_calls", 0)),
+                blocked=int(summary.get("total_blocked", 0)),
+                last_decision=summary.get("last_decision", "waiting"),
+                quit_hint="Ctrl+C to stop",
+            )
+        )
+        stream.flush()
+
+    return True, _callback

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -207,6 +207,18 @@ _MCP_WORKFLOW_NAMES = (
 )
 
 
+def _emit_mcp_stdio_workflow_splash() -> None:
+    """Emit a TTY-only MCP workflow hint without touching protocol stdout."""
+    if not sys.stderr.isatty():
+        return
+    rows = [
+        ("Transport", "stdio"),
+        ("Workflows", f"{len(_MCP_WORKFLOW_NAMES)} prompts; see docs/MCP_WORKFLOWS.md"),
+        ("Tools", "full catalog available after workflow prompts"),
+    ]
+    _emit_runtime_summary("agent-bom MCP server", rows, err=True)
+
+
 def _auth_summary(
     *,
     host: str,
@@ -910,4 +922,5 @@ def mcp_server_cmd(
     else:
         if bearer_token:
             click.echo("  Warning:   --bearer-token applies only to SSE / Streamable HTTP transports", err=True)
+        _emit_mcp_stdio_workflow_splash()
         server.run(transport="stdio")

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -1195,6 +1195,12 @@ async def run_proxy(
 
     # Metrics
     metrics = ProxyMetrics()
+    from agent_bom.cli._runtime_status import proxy_metrics_status_callback
+
+    status_strip_active, status_update = proxy_metrics_status_callback(surface="proxy")
+    if status_strip_active:
+        metrics.set_update_callback(status_update)
+        status_update(metrics)
 
     # Prometheus metrics server
     metrics_server = ProxyMetricsServer(metrics, port=metrics_port, token=metrics_token)
@@ -2059,6 +2065,9 @@ async def run_proxy(
                         err_entry,
                     )
     finally:
+        if status_strip_active:
+            sys.stderr.write("\n")
+            sys.stderr.flush()
         # Write metrics summary + runtime alerts to audit log before closing
         summary = metrics.summary()
         summary.update(summarize_runtime_alerts(runtime_alerts))

--- a/src/agent_bom/proxy_audit.py
+++ b/src/agent_bom/proxy_audit.py
@@ -15,7 +15,7 @@ from collections import Counter, OrderedDict, defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import IO, Any, Optional
+from typing import IO, Any, Callable, Optional
 
 from agent_bom.agent_identity import ANONYMOUS
 from agent_bom.audit_integrity import (
@@ -140,14 +140,32 @@ class ProxyMetrics:
     audit_push_failures: int = 0
     audit_push_backoff_seconds: int = 0
     audit_circuit_open: bool = False
+    last_decision: str = "waiting"
+    _on_update: Callable[["ProxyMetrics"], None] | None = field(default=None, repr=False, compare=False)
 
     _MAX_LATENCY_ENTRIES = 10_000
 
+    def set_update_callback(self, callback: Callable[["ProxyMetrics"], None] | None) -> None:
+        """Attach a best-effort live status callback for interactive CLIs."""
+        self._on_update = callback
+
+    def _notify_update(self) -> None:
+        if self._on_update is None:
+            return
+        try:
+            self._on_update(self)
+        except Exception:  # noqa: BLE001 - status rendering must never affect enforcement
+            logger.debug("Proxy metrics update callback failed", exc_info=True)
+
     def record_call(self, tool_name: str) -> None:
         self.tool_calls[tool_name] += 1
+        self.last_decision = f"allowed:{tool_name}"
+        self._notify_update()
 
     def record_blocked(self, reason: str) -> None:
         self.blocked_calls[reason] += 1
+        self.last_decision = f"blocked:{reason}"
+        self._notify_update()
 
     def record_latency(self, duration_ms: float) -> None:
         self.latencies_ms.append(duration_ms)
@@ -205,6 +223,7 @@ class ProxyMetrics:
             "messages_server_to_client": self.total_messages_server_to_client,
             "replay_rejections": self.replay_rejections,
             "relay_errors": self.relay_errors,
+            "last_decision": self.last_decision,
             "audit_buffer_bytes": self.audit_buffer_bytes,
             "audit_spillover_bytes": self.audit_spillover_bytes,
             "audit_dlq_bytes": self.audit_dlq_bytes,

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -575,6 +575,7 @@ def test_proxy_metrics_record_call():
     m.record_call("write_file")
     assert m.tool_calls["read_file"] == 2
     assert m.tool_calls["write_file"] == 1
+    assert m.last_decision == "allowed:write_file"
 
 
 def test_proxy_metrics_record_blocked():
@@ -585,6 +586,19 @@ def test_proxy_metrics_record_blocked():
     m.record_blocked("undeclared")
     assert m.blocked_calls["policy"] == 2
     assert m.blocked_calls["undeclared"] == 1
+    assert m.last_decision == "blocked:undeclared"
+
+
+def test_proxy_metrics_update_callback_tracks_live_status():
+    """record_call/record_blocked notify an attached live status callback."""
+    m = ProxyMetrics()
+    seen: list[str] = []
+    m.set_update_callback(lambda metrics: seen.append(metrics.last_decision))
+
+    m.record_call("read_file")
+    m.record_blocked("policy")
+
+    assert seen == ["allowed:read_file", "blocked:policy"]
 
 
 def test_proxy_metrics_latency():
@@ -615,6 +629,7 @@ def test_proxy_metrics_summary():
     assert s["calls_by_tool"]["scan"] == 2
     assert s["calls_by_tool"]["check"] == 1
     assert s["blocked_by_reason"]["policy"] == 1
+    assert s["last_decision"] == "blocked:policy"
     assert s["latency"]["min_ms"] == 10.0
     assert s["latency"]["max_ms"] == 50.0
     assert s["latency"]["count"] == 2

--- a/tests/test_runtime_status.py
+++ b/tests/test_runtime_status.py
@@ -1,0 +1,43 @@
+from io import StringIO
+
+from agent_bom.cli._runtime_status import emit_runtime_status_strip, render_runtime_status_strip
+
+
+class TtyStringIO(StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+def test_render_runtime_status_strip_is_compact():
+    line = render_runtime_status_strip(
+        "proxy",
+        calls=12,
+        blocked=3,
+        last_decision="blocked:scanner:credential_leak",
+    )
+
+    assert line == "  agent-bom proxy live | calls=12 blocked=3 last=blocked:scanner:credential_leak | Ctrl+C to stop"
+
+
+def test_render_runtime_status_strip_truncates_multiline_decision():
+    line = render_runtime_status_strip(
+        "gateway",
+        calls=0,
+        blocked=0,
+        last_decision="blocked:very-long-decision\n" + ("x" * 100),
+    )
+
+    assert "\n" not in line
+    assert "last=blocked:very-long-decision " in line
+    assert line.endswith("... | Ctrl+C to stop")
+
+
+def test_emit_runtime_status_strip_is_tty_only():
+    tty = TtyStringIO()
+    plain = StringIO()
+
+    assert emit_runtime_status_strip("gateway", stream=tty, last_decision="listening") is True
+    assert "agent-bom gateway live" in tty.getvalue()
+
+    assert emit_runtime_status_strip("gateway", stream=plain, last_decision="listening") is False
+    assert plain.getvalue() == ""


### PR DESCRIPTION
Summary
- add a TTY-only MCP stdio workflow splash that points operators at the curated workflow prompts without writing to protocol stdout
- add live proxy status updates backed by ProxyMetrics counters and last allow/block decision
- seed gateway serve with the same status-strip language for local demos

Validation
- uv run ruff check src/agent_bom/cli/_runtime_status.py src/agent_bom/proxy_audit.py src/agent_bom/proxy.py src/agent_bom/cli/_server.py src/agent_bom/cli/_gateway.py tests/test_proxy.py tests/test_runtime_status.py
- uv run ruff format --check src/agent_bom/cli/_runtime_status.py src/agent_bom/proxy_audit.py src/agent_bom/proxy.py src/agent_bom/cli/_server.py src/agent_bom/cli/_gateway.py tests/test_proxy.py tests/test_runtime_status.py
- uv run mypy src/agent_bom/cli/_runtime_status.py src/agent_bom/proxy_audit.py src/agent_bom/proxy.py src/agent_bom/cli/_server.py src/agent_bom/cli/_gateway.py
- uv run pytest tests/test_runtime_status.py tests/test_proxy.py::test_proxy_metrics_record_call tests/test_proxy.py::test_proxy_metrics_record_blocked tests/test_proxy.py::test_proxy_metrics_update_callback_tracks_live_status tests/test_proxy.py::test_proxy_metrics_summary -q
- uv run pytest tests/test_proxy_metrics.py tests/test_proxy_cov.py::TestProxyMetrics tests/test_proxy_cov.py::TestProxyMetricsSummaryNoLatency tests/test_proxy_cov.py::TestProxyMetricsSummaryRelay -q

Closes #3376