### PR TITLE
fix(deploy): scope pilot compose to loopback CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,11 @@ docker compose -f docker-compose.pilot.yml up -d
 # Dashboard -> http://localhost:3000
 ```
 
+The pilot compose profile is a single-workstation evaluator: API and UI ports
+bind to `127.0.0.1`, CORS is scoped to local UI origins, and no-auth is enabled
+only for that loopback boundary. Use `docker-compose.platform.yml` or
+`docs/HOSTED_POC.md` before sharing a link with anyone else.
+
 - [Deploy anywhere guide](docs/DEPLOY_PLATFORM.md) — laptop, your Kubernetes, or hosted control plane
 - [Helm chart](deploy/helm/agent-bom) and [one-apply EKS platform module](deploy/terraform/platform-eks)
 - [Docker Hub image](https://hub.docker.com/r/agentbom/agent-bom)

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -9,6 +9,7 @@
 #   - uses SQLite persistence in a named Docker volume
 #   - allows no-auth browser access only because both API/UI ports are
 #     loopback-bound for fast evaluation on one workstation
+#   - scopes CORS to local UI origins; do not add public origins here
 #
 # For a multi-developer dev stack, see docker-compose.fullstack.yml.
 # For a production-shaped deployment, see docker-compose.platform.yml.
@@ -27,7 +28,7 @@ services:
       --host 0.0.0.0
       --port 8422
       --persist /var/lib/agent-bom/jobs.db
-      --cors-allow-all
+      --cors-origins http://localhost:3000,http://127.0.0.1:3000
       --allow-insecure-no-auth
     environment:
       AGENT_BOM_DB_PATH: /var/lib/agent-bom/vulns.db

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -145,7 +145,7 @@ def test_monitoring_example_has_no_default_admin_password_or_public_ports():
 
 
 def test_pilot_insecure_mode_is_loopback_scoped():
-    """Pilot no-auth mode is acceptable only because it is loopback-only."""
+    """Pilot no-auth mode is acceptable only with loopback ports and local CORS."""
     import yaml
 
     path = ROOT / "deploy" / "docker-compose.pilot.yml"
@@ -154,7 +154,8 @@ def test_pilot_insecure_mode_is_loopback_scoped():
     ui = data["services"]["ui"]
 
     assert "--allow-insecure-no-auth" in api["command"]
-    assert "--cors-allow-all" in api["command"]
+    assert "--cors-allow-all" not in api["command"]
+    assert "--cors-origins http://localhost:3000,http://127.0.0.1:3000" in api["command"]
     assert api["ports"] == ["127.0.0.1:8422:8422"]
     assert ui["ports"] == ["127.0.0.1:3000:3000"]
 


### PR DESCRIPTION
Summary
- replace wildcard CORS in docker-compose.pilot.yml with explicit localhost / 127.0.0.1 UI origins
- keep no-auth limited to the existing loopback-bound single-workstation pilot profile
- add README guidance that hosted/shared links must use the platform/hosted POC profiles instead

Validation
- git diff --check
- rg -n -- "--cors-allow-all|--cors-origins" deploy/docker-compose.pilot.yml README.md
- docker compose -f deploy/docker-compose.pilot.yml config

Refs #3242