### PR TITLE
feat(cloud): surface event posture freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,11 @@ stay readable.
 agent-bom is strongest today as a read-only CSPM/CIS, vuln/SCA, compliance,
 runtime-policy, and graph-posture product. Connected account scans can run on a
 schedule, so new or removed assets are picked up at the next scan and graph
-history can show appeared/removed evidence. It is not yet an event-streaming
-CDR product: CloudTrail/EventBridge, Azure Activity Log/Event Grid, and GCP
-Audit Log/Pub/Sub ingestion are roadmap work.
+history can show appeared/removed evidence. For cloud posture, opt-in event
+consumers can also drain AWS CloudTrail/EventBridge→SQS, Azure Activity
+Log/Event Grid→Storage Queue, and GCP Cloud Asset/Audit Log→Pub/Sub to re-check
+the affected resource class between scheduled scans. That is change-triggered
+posture re-evaluation, not a full runtime CDR product.
 
 For DSPM, Snowflake has the deepest current support because agent-bom can read
 warehouse metadata, grants, tags, lineage, and governance activity visible to

--- a/docs/POSTURE_EVENT_STREAMING.md
+++ b/docs/POSTURE_EVENT_STREAMING.md
@@ -20,6 +20,10 @@ push-delivery primitive:
 - REST outbox observability at `GET /v1/posture/webhooks/outbox`,
   `GET /v1/posture/webhooks/outbox/stats`, and
   `POST /v1/posture/webhooks/outbox/{row_id}/retry`
+- opt-in cloud posture event consumers:
+  AWS CloudTrail/EventBridge→SQS, Azure Activity Log/Event Grid→Storage Queue,
+  and GCP Cloud Asset/Audit Log→Pub/Sub. These are bounded re-evaluation lanes
+  for connected cloud accounts, not a managed streaming service.
 
 The shipped webhook outbox core does not create hidden egress. Operators must
 provide an explicit `WebhookDestination` and delivery function. Managed
@@ -74,16 +78,21 @@ they are separate from the durable generic webhook path.
 3. OCSF envelope shared by all connector adapters.
 4. Kafka connector for enterprise posture-event sinks covering findings,
    `ExposurePath` changes, skill verdicts, deploy decisions, and audit deltas.
-5. AWS EventBridge plus S3/SQS CloudTrail ingestion for cloud activity
-   evidence.
-6. GCP Pub/Sub plus Azure Event Hub/Event Grid for multi-cloud parity.
-7. Kinesis/Firehose as a later AWS high-volume adapter for customers that
+5. AWS CloudTrail/EventBridge→SQS posture re-evaluation for connected accounts.
+   Shipped as an opt-in bounded consumer.
+6. Azure Activity Log/Event Grid→Storage Queue and GCP Cloud Asset/Audit
+   Log→Pub/Sub posture re-evaluation for connected accounts. Shipped as opt-in
+   bounded consumers.
+7. General EventBridge/Pub/Sub/Event Hub connector packages for posture-event
+   delivery. Roadmap: these are broader sink/source adapters, not the same as
+   the provider-specific posture re-evaluation lanes above.
+8. Kinesis/Firehose as a later AWS high-volume adapter for customers that
    already centralize telemetry there.
-8. MCP posture subscription tool backed by the same replay contract.
+9. MCP posture subscription tool backed by the same replay contract.
 
-Do not document Kafka, EventBridge, Pub/Sub, Event Hub, Kinesis, Firehose, or
-MCP posture subscriptions as shipped until their adapters and tests land. The
-current claim is: posture/event streaming has a signed webhook outbox core;
-Kafka-style sinks are next; AWS cloud-log ingestion should start with
-CloudTrail S3/SQS and EventBridge. Kinesis is a later adapter, not a release
-blocker.
+Do not document Kafka, generic EventBridge/Pub/Sub/Event Hub connector
+packages, Kinesis, Firehose, or MCP posture subscriptions as shipped until their
+adapters and tests land. The current claim is: posture/event streaming has a
+signed webhook outbox core; connected cloud posture has opt-in AWS/Azure/GCP
+event consumers that re-evaluate affected resources; Kafka-style sinks and
+general event connector packages remain roadmap.

--- a/site-docs/deployment/posture-event-streaming.md
+++ b/site-docs/deployment/posture-event-streaming.md
@@ -25,6 +25,13 @@ Not shipped today:
 - long-lived `subscribe_posture_changes` MCP tool
 - guaranteed production streaming SLO
 
+Cloud posture has a narrower event-driven lane: opt-in consumers can drain AWS
+CloudTrail/EventBridge events from SQS, Azure Activity Log/Event Grid events
+from Storage Queue, and GCP Cloud Asset or Audit Log events from Pub/Sub to
+re-evaluate the affected resource class. Those consumers update connection
+freshness and persist through the normal scan/graph path. They are not a
+managed streaming service or a general posture-event connector package.
+
 ## Connector Contract
 
 Every posture event connector should preserve the same envelope so downstream
@@ -58,8 +65,10 @@ for SIEM/security-lake interoperability, not a replacement for the graph model.
 | Webhook outbox core | shipped | `agent_bom.posture_streaming.WebhookOutbox` | operator-provided sender performs explicit HTTPS POST; no hidden egress |
 | Webhook outbox observability | shipped | `GET /v1/posture/webhooks/outbox` | tenant-scoped status, stats, dead-letter inspection, admin retry |
 | Kafka | roadmap | topic-per-tenant or topic with tenant key | first enterprise stream sink for posture events |
-| AWS EventBridge + CloudTrail S3/SQS | roadmap | customer account event bus or S3/SQS trail feed | first AWS cloud activity evidence lane |
-| GCP Pub/Sub + Azure Event Hub/Event Grid | roadmap | customer-owned cloud event transports | multi-cloud parity after AWS |
+| AWS CloudTrail/EventBridge→SQS posture re-eval | shipped, opt-in | operator-owned SQS queue | bounded consumer re-checks affected AWS resource classes |
+| Azure Activity Log/Event Grid→Storage Queue posture re-eval | shipped, opt-in | operator-owned Storage Queue | bounded consumer re-checks affected Azure resource classes |
+| GCP Cloud Asset/Audit Log→Pub/Sub posture re-eval | shipped, opt-in | operator-owned Pub/Sub subscription | bounded consumer re-checks affected GCP resource classes |
+| Kafka / EventBridge / Pub/Sub connector packages | roadmap | enterprise event sinks | general posture-event delivery adapters, separate from cloud posture ingestion |
 | Kinesis/Firehose | roadmap | customer stream or delivery stream | later AWS high-volume adapter, not a release blocker |
 | Long-lived MCP subscription | roadmap | `subscribe_posture_changes` | agent-native stream; needs backpressure and replay contract |
 

--- a/site-docs/features/cloud-posture.md
+++ b/site-docs/features/cloud-posture.md
@@ -72,10 +72,13 @@ or deployments are discovered on the next run, removed resources appear in graph
 history/diff as deleted evidence, and findings are regenerated from the latest
 read-only inventory.
 
-This is scheduled polling, not provider event streaming. It does not observe a
-resource the instant it is created, and it does not replace CloudTrail,
-EventBridge, Azure Activity Log/Event Grid, or GCP Audit Log/Pub/Sub pipelines.
-Those event-driven sources are separate roadmap work.
+The default mode is scheduled polling. When an operator wires the optional event
+queues, agent-bom can also consume AWS CloudTrail/EventBridge events from SQS,
+Azure Activity Log/Event Grid events from Storage Queue, and GCP Cloud Asset or
+Audit Log events from Pub/Sub. Those consumers are bounded, provider-scoped, and
+re-evaluate the affected resource class through the same read-only connection.
+If no event queue is configured, the connection falls back to scheduled or
+manual scans.
 
 ## How to read the result
 

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -259,6 +259,32 @@ function formatWhen(value: string | null): string {
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
 }
 
+function eventMode(connection: CloudConnectionRecord): {
+  label: string;
+  detail: string;
+  tone: string;
+} {
+  if (connection.last_event_at) {
+    return {
+      label: "Event-driven",
+      detail: `Last event ${formatWhen(connection.last_event_at)}`,
+      tone: "border-cyan-900/60 bg-cyan-950/30 text-cyan-200",
+    };
+  }
+  if (connection.scan_interval_minutes) {
+    return {
+      label: "Polling fallback",
+      detail: `Every ${connection.scan_interval_minutes} min`,
+      tone: "border-amber-900/60 bg-amber-950/30 text-amber-200",
+    };
+  }
+  return {
+    label: "Manual",
+    detail: "No scheduled or event run yet",
+    tone: "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[var(--text-secondary)]",
+  };
+}
+
 function statusTone(status: string): string {
   switch (status) {
     case "active":
@@ -682,13 +708,14 @@ export default function ConnectionsPage() {
             />
           ) : (
             <div className="overflow-x-auto rounded-xl border border-[color:var(--border-subtle)]">
-              <table className="w-full min-w-[720px] border-collapse text-left text-sm">
+              <table className="w-full min-w-[880px] border-collapse text-left text-sm">
                 <thead>
                   <tr className="border-b border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[11px] uppercase tracking-[0.16em] text-[var(--text-tertiary)]">
                     <th className="px-4 py-3 font-medium">Account</th>
                     <th className="px-4 py-3 font-medium">Provider</th>
                     <th className="px-4 py-3 font-medium">Status</th>
                     <th className="px-4 py-3 font-medium">Last scan</th>
+                    <th className="px-4 py-3 font-medium">Mode</th>
                     <th className="px-4 py-3 font-medium">Schedule</th>
                     <th className="px-4 py-3 text-right font-medium">
                       Actions
@@ -879,6 +906,7 @@ function FragmentRow({
   onDelete: () => void;
 }) {
   const handoffScanId = result?.scan_id ?? connection.last_scan_id;
+  const mode = eventMode(connection);
   const showDetail = Boolean(
     result || handoffScanId || scanError || scheduleError || statusDetail,
   );
@@ -924,6 +952,18 @@ function FragmentRow({
         </td>
         <td className="px-4 py-3 text-[var(--text-secondary)]">
           {formatWhen(connection.last_scan_at)}
+        </td>
+        <td className="px-4 py-3">
+          <span
+            className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-1 text-[11px] font-medium ${mode.tone}`}
+            title={mode.detail}
+          >
+            <Clock className="h-3 w-3" />
+            {mode.label}
+          </span>
+          <p className="mt-1 max-w-44 truncate text-[10px] text-[var(--text-tertiary)]">
+            {mode.detail}
+          </p>
         </td>
         <td className="px-4 py-3">
           <label className="sr-only" htmlFor={`schedule-${connection.id}`}>
@@ -972,7 +1012,7 @@ function FragmentRow({
       </tr>
       {showDetail ? (
         <tr className="border-b border-[color:var(--border-subtle)] last:border-b-0 bg-[color:var(--surface-elevated)]/40">
-          <td colSpan={6} className="px-4 pb-4 pt-0">
+          <td colSpan={7} className="px-4 pb-4 pt-0">
             {result ? <ScanResultPanel result={result} /> : null}
             {!result && handoffScanId ? (
               <ScanHandoffLinks scanId={handoffScanId} />

--- a/ui/e2e/large-graph-overview.spec.ts
+++ b/ui/e2e/large-graph-overview.spec.ts
@@ -269,8 +269,9 @@ async function expectSigmaCanvases(page: Page) {
 test("large graph overview renders above threshold and search drills back into React Flow", async ({ page }, testInfo: TestInfo) => {
   await routeLargeGraphPage(page);
 
-  await page.goto("/graph?vulnOnly=0&severity=&depth=3&pageSize=500&layers=agent,package");
-  await page.waitForLoadState("networkidle");
+  await page.goto("/graph?vulnOnly=0&severity=&depth=3&pageSize=500&layers=agent,package", {
+    waitUntil: "domcontentloaded",
+  });
 
   await expect(page.getByTestId("large-graph-overview")).toBeVisible();
   await expect(page.getByText("Large graph overview")).toBeVisible();
@@ -291,8 +292,9 @@ test("large graph overview renders above threshold and search drills back into R
 test("sigma webgl overview renders when explicitly requested", async ({ page }, testInfo: TestInfo) => {
   await routeLargeGraphPage(page);
 
-  await page.goto("/graph?renderer=webgl&vulnOnly=0&severity=&depth=3&pageSize=500&layers=agent,package");
-  await page.waitForLoadState("networkidle");
+  await page.goto("/graph?renderer=webgl&vulnOnly=0&severity=&depth=3&pageSize=500&layers=agent,package", {
+    waitUntil: "domcontentloaded",
+  });
 
   await expect(page.getByTestId("sigma-graph-overview")).toBeVisible();
   await expect(page.getByText("WebGL graph overview")).toBeVisible();

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2635,6 +2635,8 @@ export interface CloudConnectionRecord {
   created_at: string;
   updated_at: string;
   last_scan_at: string | null;
+  /** Last event-driven posture re-evaluation. Null means polling/manual only so far. */
+  last_event_at: string | null;
   /** Last successfully persisted scan id for durable handoff links. */
   last_scan_id: string | null;
   /** Recurring read-only scan cadence. Null means manual-only. */

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -57,6 +57,7 @@ const CREATED_RECORD = {
   created_at: "2026-06-27T00:00:00Z",
   updated_at: "2026-06-27T00:00:00Z",
   last_scan_at: null,
+  last_event_at: null,
   last_scan_id: null,
   scan_interval_minutes: null,
 };
@@ -316,6 +317,32 @@ describe("ConnectionsPage", () => {
       "href",
       "/graph?scan_id=persisted-scan-123",
     );
+  });
+
+  it("surfaces event-driven freshness when a connection has processed cloud events", async () => {
+    apiMock.listCloudConnections.mockResolvedValue({
+      schema_version: "cloud.connections.v1",
+      tenant_id: "tenant-acme",
+      connections: [
+        {
+          ...CREATED_RECORD,
+          status: "active",
+          last_event_at: "2026-06-27T01:30:00Z",
+          scan_interval_minutes: 60,
+        },
+      ],
+      count: 1,
+    });
+
+    render(<ConnectionsPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Production account")).toBeInTheDocument(),
+    );
+
+    expect(screen.getByText("Event-driven")).toBeInTheDocument();
+    expect(screen.getByText(/Last event/)).toBeInTheDocument();
+    expect(screen.queryByText("Polling fallback")).toBeNull();
   });
 
   it("updates the recurring scan schedule without exposing secrets", async () => {


### PR DESCRIPTION
## Summary
- surfaces event-driven vs polling/manual freshness on cloud connections using the persisted last_event_at signal
- updates cloud posture and posture-streaming docs so shipped AWS/Azure/GCP event re-evaluation is no longer described as roadmap
- keeps the boundary explicit: this is bounded posture re-evaluation with polling fallback, not a managed event-streaming service

Closes #3350

## Validation
- git diff --check
- cd ui && npm run typecheck
- cd ui && npm run lint -- app/connections/page.tsx tests/connections-page.test.tsx
- cd ui && npm run test:run -- connections-page.test.tsx
- uv run python scripts/check_release_consistency.py