### PR TITLE
feat(dspm): add opt-in S3 content sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,13 @@ Audit Log/Pub/Sub ingestion are roadmap work.
 
 For DSPM, Snowflake has the deepest current support because agent-bom can read
 warehouse metadata, grants, tags, lineage, and governance activity visible to
-the configured role. Other cloud data-store sensitivity is posture and metadata
-based until classifier-backed content inspection, provider DLP/Macie wrapping,
-and object/table/column-level access mapping land. Snowflake is therefore a
-strong optional lane for Snowflake-heavy customers, not the required data plane
-for the product.
+the configured role. AWS S3 also has an opt-in bounded content-sampling lane for
+classifier-backed PII/PHI/PCI/secrets evidence; it stores only redacted
+classification counts, never raw object bytes. Other cloud data-store
+sensitivity is posture and metadata based until broader provider DLP/Macie
+wrapping, database/warehouse sampling, and object/table/column-level access
+mapping land. Snowflake is therefore a strong optional lane for
+Snowflake-heavy customers, not the required data plane for the product.
 
 ## Product Map
 

--- a/docs/DATABASE_EVIDENCE.md
+++ b/docs/DATABASE_EVIDENCE.md
@@ -45,7 +45,8 @@ query source.
   webhooks or runtime emitter plugins.
 - Generic database evidence is not full DSPM by itself. Only call data
   sensitive when explicit tags, classifications, imported classifier evidence,
-  or target-scoped dataset scan results support that label.
+  target-scoped dataset scan results, or opt-in S3 content-sampling evidence
+  support that label.
 - ODBC/JDBC do not replace native Snowflake, Postgres/Supabase, Databricks,
   BigQuery, Redshift, or Athena paths where native APIs are available.
 - The default wheel does not bundle ODBC drivers, JDBC drivers, a JVM, or

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -91,6 +91,12 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_AUDIT_TRAIL_LOOKBACK_HOURS` | `int` | `24` | Lookback window (hours) for audit events; the reader clamps to two weeks. |
 | `AGENT_BOM_AUDIT_TRAIL_MAX_EVENTS` | `int` | `2000` | Per-provider event cap; the reader clamps to a hard ceiling and warns when hit. |
 
+## DSPM content sampling
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_DSPM_S3_MAX_BYTES_PER_OBJECT` | `int` | `64 * 1024` | — |
+| `AGENT_BOM_DSPM_S3_MAX_OBJECTS_PER_BUCKET` | `int` | `10` | Content reads are opt-in at the caller/module level. These caps bound the amount of object-store data read when an operator enables S3 sampling. |
+
 ## EPSS Thresholds
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -86,6 +86,8 @@ AGENT_BOM_CLICKHOUSE_URL
 AGENT_BOM_CLICKHOUSE_USER
 # Opt-in (default OFF) gate for the estate-wide read-only AWS asset inventory scanner.
 AGENT_BOM_CLOUD_INVENTORY
+# Opt-in (default OFF) bounded S3 object byte-range sampling for DSPM content classification. Stores redacted classification counts, never raw object bytes.
+AGENT_BOM_DSPM_S3_SAMPLING
 # base64 Fernet key for at-rest encryption of cloud-connection secrets (ExternalId); secret, env/KMS-only, never in config.py or ENV_VARS.md. With provider=aws-kms it holds the base64 KMS-wrapped data key instead. Accepts a comma-separated list of keys for MultiFernet rotation (first key = primary/encrypt, any key decrypts).
 AGENT_BOM_CONNECTIONS_KEY
 # Selects how the connection encryption key is resolved: env (default) | aws-secrets | aws-kms | vault; read at key-load time in api/connection_crypto.py.

--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -1021,17 +1021,23 @@ def _discover_s3_buckets(
         location = _bucket_location(s3, name, warnings)
         publicly_accessible = _bucket_public(s3, name, warnings)
         tags = _bucket_tags(s3, name, warnings)
-        buckets.append(
-            {
-                "name": name,
-                "arn": arn,
-                "location": location,
-                "publicly_accessible": publicly_accessible,
-                "tags": tags,
-                "account_id": account_id or "",
-                "created_at": _iso(bucket.get("CreationDate")),
-            }
-        )
+        bucket_record = {
+            "name": name,
+            "arn": arn,
+            "location": location,
+            "publicly_accessible": publicly_accessible,
+            "tags": tags,
+            "account_id": account_id or "",
+            "created_at": _iso(bucket.get("CreationDate")),
+        }
+        try:
+            from agent_bom.cloud.s3_data_classifier import classify_s3_bucket, s3_sampling_enabled
+
+            if s3_sampling_enabled():
+                bucket_record["content_classification"] = classify_s3_bucket(s3, name).to_dict()
+        except Exception as exc:  # noqa: BLE001 — sampling is optional and must not sink inventory
+            warnings.append(f"Could not classify S3 bucket {name}: {sanitize_discovery_warning(exc)}")
+        buckets.append(bucket_record)
     return buckets
 
 

--- a/src/agent_bom/cloud/s3_data_classifier.py
+++ b/src/agent_bom/cloud/s3_data_classifier.py
@@ -1,0 +1,184 @@
+"""Opt-in S3 content classification for DSPM evidence.
+
+The default AWS inventory path is metadata-only. This module is deliberately
+separate and gated by ``AGENT_BOM_DSPM_S3_SAMPLING`` because it reads bounded
+object byte ranges. It never stores object bytes or matched values; the output
+contains only counts, redacted finding markers, object keys, and warnings.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+from agent_bom import config
+from agent_bom.cloud.normalization import sanitize_discovery_warning
+from agent_bom.parsers.dataset_pii_scanner import DatasetPiiResult, scan_text_for_pii
+
+DSPM_S3_SAMPLING_ENV_VAR = "AGENT_BOM_DSPM_S3_SAMPLING"
+
+
+def s3_sampling_enabled() -> bool:
+    """Return whether bounded S3 content sampling is explicitly enabled."""
+    return os.environ.get(DSPM_S3_SAMPLING_ENV_VAR, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class S3ObjectClassification:
+    bucket: str
+    key: str
+    size: int | None
+    bytes_sampled: int
+    rows_sampled: int
+    total_findings: int
+    findings_by_type: dict[str, int] = field(default_factory=dict)
+    top_findings: list[dict[str, Any]] = field(default_factory=list)
+    skipped: bool = False
+    skip_reason: str = ""
+
+    @classmethod
+    def from_result(
+        cls,
+        *,
+        bucket: str,
+        key: str,
+        size: int | None,
+        bytes_sampled: int,
+        result: DatasetPiiResult,
+    ) -> "S3ObjectClassification":
+        return cls(
+            bucket=bucket,
+            key=key,
+            size=size,
+            bytes_sampled=bytes_sampled,
+            rows_sampled=result.rows_sampled,
+            total_findings=result.total_findings,
+            findings_by_type=dict(result.findings_by_type),
+            top_findings=[
+                {
+                    "pii_type": finding.pii_type,
+                    "severity": finding.severity,
+                    "sample": finding.sample,
+                }
+                for finding in result.top_findings
+            ],
+            skipped=result.skipped,
+            skip_reason=result.skip_reason,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "bucket": self.bucket,
+            "key": self.key,
+            "size": self.size,
+            "bytes_sampled": self.bytes_sampled,
+            "rows_sampled": self.rows_sampled,
+            "total_findings": self.total_findings,
+            "findings_by_type": dict(self.findings_by_type),
+            "top_findings": list(self.top_findings),
+            "skipped": self.skipped,
+            "skip_reason": self.skip_reason,
+        }
+
+
+@dataclass
+class S3BucketClassification:
+    bucket: str
+    status: str
+    objects_sampled: int = 0
+    total_findings: int = 0
+    findings_by_type: dict[str, int] = field(default_factory=dict)
+    objects: list[S3ObjectClassification] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def sensitivity_score(self) -> int:
+        if not self.total_findings:
+            return 0
+        high = sum(self.findings_by_type.get(kind, 0) for kind in {"ssn", "credit_card", "iban", "passport", "nhs_number"})
+        if high:
+            return 90
+        if any(kind in self.findings_by_type for kind in {"email", "phone", "date_of_birth", "drivers_license", "medical_record_keyword"}):
+            return 60
+        return 30
+
+    @property
+    def data_sensitivity(self) -> str:
+        if self.sensitivity_score >= 60:
+            return "sensitive"
+        if self.sensitivity_score > 0:
+            return "review"
+        return "none"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": "agent-bom.dspm.s3_classification.v1",
+            "bucket": self.bucket,
+            "status": self.status,
+            "objects_sampled": self.objects_sampled,
+            "total_findings": self.total_findings,
+            "findings_by_type": dict(self.findings_by_type),
+            "sensitivity_score": self.sensitivity_score,
+            "data_sensitivity": self.data_sensitivity,
+            "objects": [obj.to_dict() for obj in self.objects],
+            "warnings": list(self.warnings),
+            "redaction": "raw object bytes and matched values are not stored",
+        }
+
+
+def classify_s3_bucket(
+    s3_client: Any,
+    bucket: str,
+    *,
+    max_objects: int | None = None,
+    max_bytes_per_object: int | None = None,
+) -> S3BucketClassification:
+    """Classify a bounded sample of S3 objects in *bucket*.
+
+    Callers must check :func:`s3_sampling_enabled` before invoking this function
+    from production scan paths. Tests may call it directly with fake clients.
+    """
+    max_objects = max(1, int(max_objects if max_objects is not None else config.DSPM_S3_MAX_OBJECTS_PER_BUCKET))
+    max_bytes_per_object = max(1, int(max_bytes_per_object if max_bytes_per_object is not None else config.DSPM_S3_MAX_BYTES_PER_OBJECT))
+    result = S3BucketClassification(bucket=bucket, status="ok")
+
+    try:
+        listed = s3_client.list_objects_v2(Bucket=bucket, MaxKeys=max_objects)
+    except Exception as exc:  # noqa: BLE001
+        result.status = "list_failed"
+        result.warnings.append(f"Could not list S3 objects for {bucket}: {sanitize_discovery_warning(exc)}")
+        return result
+
+    for obj in (listed.get("Contents", []) or [])[:max_objects]:
+        key = str(obj.get("Key") or "").strip()
+        if not key:
+            continue
+        size = obj.get("Size")
+        size_int = int(size) if isinstance(size, int) else None
+        try:
+            response = s3_client.get_object(Bucket=bucket, Key=key, Range=f"bytes=0-{max_bytes_per_object - 1}")
+            body = response.get("Body")
+            raw = body.read(max_bytes_per_object) if hasattr(body, "read") else b""
+            if not isinstance(raw, (bytes, bytearray)):
+                raw = str(raw).encode("utf-8", errors="replace")
+            sample = bytes(raw[:max_bytes_per_object]).decode("utf-8", errors="replace")
+        except Exception as exc:  # noqa: BLE001
+            result.warnings.append(f"Could not sample s3://{bucket}/{key}: {sanitize_discovery_warning(exc)}")
+            continue
+
+        pii_result = scan_text_for_pii(sample, source=f"s3://{bucket}/{key}", max_chars=max_bytes_per_object)
+        classified = S3ObjectClassification.from_result(
+            bucket=bucket,
+            key=key,
+            size=size_int,
+            bytes_sampled=len(sample.encode("utf-8", errors="replace")),
+            result=pii_result,
+        )
+        result.objects.append(classified)
+        result.objects_sampled += 1
+        result.total_findings += classified.total_findings
+        for pii_type, count in classified.findings_by_type.items():
+            result.findings_by_type[pii_type] = result.findings_by_type.get(pii_type, 0) + count
+
+    return result

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -227,6 +227,14 @@ GHSA_UNAUTH_PACKAGE_BUDGET = _int("AGENT_BOM_GHSA_UNAUTH_PACKAGE_BUDGET", 25)
 SCAN_CACHE_MAX_ENTRIES = _int("AGENT_BOM_SCAN_CACHE_MAX_ENTRIES", 100_000)
 
 
+# ── DSPM content sampling ────────────────────────────────────────────────────
+# Content reads are opt-in at the caller/module level. These caps bound the
+# amount of object-store data read when an operator enables S3 sampling.
+
+DSPM_S3_MAX_OBJECTS_PER_BUCKET = _int("AGENT_BOM_DSPM_S3_MAX_OBJECTS_PER_BUCKET", 10)
+DSPM_S3_MAX_BYTES_PER_OBJECT = _int("AGENT_BOM_DSPM_S3_MAX_BYTES_PER_OBJECT", 64 * 1024)
+
+
 # ── Local Analytics ─────────────────────────────────────────────────────────
 # Optional path override for the local scan analytics SQL mirror. Empty string
 # means use ~/.agent-bom/local-analytics.sqlite.

--- a/src/agent_bom/parsers/dataset_pii_scanner.py
+++ b/src/agent_bom/parsers/dataset_pii_scanner.py
@@ -362,6 +362,25 @@ def _aggregate(result: DatasetPiiResult, findings: list[PiiFinding]) -> None:
     result.top_findings = findings[:10]
 
 
+def scan_text_for_pii(
+    text: str,
+    *,
+    source: str,
+    max_chars: int = _MAX_FILE_SIZE,
+) -> DatasetPiiResult:
+    """Scan an in-memory text sample for PII without persisting raw content.
+
+    Cloud DSPM samplers use this entry point after reading a bounded byte range
+    from an object store. The returned findings carry redacted markers only; raw
+    object bytes and matched values are never included in the result.
+    """
+    clipped = text[: max(0, max_chars)]
+    result = DatasetPiiResult(file_path=source, rows_sampled=1 if clipped else 0, total_findings=0)
+    findings = _scan_cell(clipped, 0, "content", source) if clipped else []
+    _aggregate(result, findings)
+    return result
+
+
 def scan_dataset_file(path: Path, max_rows: int = _DEFAULT_MAX_ROWS) -> DatasetPiiResult | None:
     """Dispatch to the appropriate scanner based on file extension.
 

--- a/tests/test_s3_data_classifier.py
+++ b/tests/test_s3_data_classifier.py
@@ -1,0 +1,91 @@
+"""Tests for opt-in S3 content classification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from agent_bom.cloud import aws_inventory
+from agent_bom.cloud.s3_data_classifier import classify_s3_bucket, s3_sampling_enabled
+
+
+class _Body:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self, _size: int = -1) -> bytes:
+        return self._data
+
+
+class _FakeS3:
+    def __init__(self, *, expected_max_keys: int | None = None) -> None:
+        self.expected_max_keys = expected_max_keys
+        self.get_ranges: list[str] = []
+        self.list_calls = 0
+
+    def list_objects_v2(self, **kwargs: Any) -> dict[str, Any]:
+        self.list_calls += 1
+        if self.expected_max_keys is not None:
+            assert kwargs["MaxKeys"] == self.expected_max_keys
+        return {
+            "Contents": [
+                {"Key": "customers.csv", "Size": 128},
+                {"Key": "readme.txt", "Size": 8},
+                {"Key": "ignored.txt", "Size": 8},
+            ]
+        }
+
+    def get_object(self, **kwargs: Any) -> dict[str, Any]:
+        self.get_ranges.append(kwargs["Range"])
+        if kwargs["Key"] == "customers.csv":
+            return {"Body": _Body(b"email,ssn\nalice@example.com,123-45-6789\n")}
+        return {"Body": _Body(b"hello")}
+
+
+def test_s3_sampling_flag_is_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_DSPM_S3_SAMPLING", raising=False)
+
+    assert s3_sampling_enabled() is False
+
+
+def test_s3_classifier_is_bounded_and_redacted() -> None:
+    s3 = _FakeS3(expected_max_keys=2)
+
+    result = classify_s3_bucket(s3, "prod-data", max_objects=2, max_bytes_per_object=32)
+    payload = result.to_dict()
+
+    assert result.objects_sampled == 2
+    assert result.total_findings >= 1
+    assert payload["data_sensitivity"] == "sensitive"
+    assert payload["redaction"] == "raw object bytes and matched values are not stored"
+    assert s3.get_ranges == ["bytes=0-31", "bytes=0-31"]
+    assert "alice@example.com" not in repr(payload)
+    assert "123-45-6789" not in repr(payload)
+    assert "[email:REDACTED]" in repr(payload)
+
+
+@dataclass
+class _FakeSession:
+    s3: _FakeS3
+
+    def client(self, service: str, *_args: Any, **_kwargs: Any) -> Any:
+        if service != "s3":
+            raise AssertionError(service)
+        return self.s3
+
+
+def test_aws_bucket_inventory_attaches_content_classification_when_enabled(monkeypatch) -> None:
+    fake_s3 = _FakeS3()
+    monkeypatch.setenv("AGENT_BOM_DSPM_S3_SAMPLING", "1")
+    monkeypatch.setattr(aws_inventory, "_bucket_location", lambda *_args, **_kwargs: "us-east-1")
+    monkeypatch.setattr(aws_inventory, "_bucket_public", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(aws_inventory, "_bucket_tags", lambda *_args, **_kwargs: {})
+
+    def _list_buckets() -> dict[str, Any]:
+        return {"Buckets": [{"Name": "prod-data", "CreationDate": None}]}
+
+    fake_s3.list_buckets = _list_buckets  # type: ignore[method-assign]
+
+    buckets = aws_inventory._discover_s3_buckets(_FakeSession(fake_s3), account_id="123456789012", warnings=[])
+
+    assert buckets[0]["content_classification"]["data_sensitivity"] == "sensitive"


### PR DESCRIPTION
## Summary
- adds an explicit AGENT_BOM_DSPM_S3_SAMPLING gate for bounded S3 object byte-range sampling
- reuses the dataset PII classifier through a public in-memory text scan entry point
- attaches redacted S3 content-classification counts to AWS bucket inventory only when enabled
- documents the boundary: raw object bytes and matched values are never stored; this advances #3352 C1 but does not close C2/C3

Refs #3352

## Validation
- git diff --check
- uv run ruff check src/agent_bom/cloud/s3_data_classifier.py src/agent_bom/cloud/aws_inventory.py src/agent_bom/parsers/dataset_pii_scanner.py tests/test_s3_data_classifier.py
- uv run ruff format --check src/agent_bom/cloud/s3_data_classifier.py src/agent_bom/cloud/aws_inventory.py src/agent_bom/parsers/dataset_pii_scanner.py tests/test_s3_data_classifier.py
- uv run mypy src/agent_bom/cloud/s3_data_classifier.py src/agent_bom/parsers/dataset_pii_scanner.py
- uv run pytest tests/test_s3_data_classifier.py tests/test_dataset_pii_scanner.py -q
- uv run python scripts/generate_env_var_reference.py --check
- uv run python scripts/check_release_consistency.py