### PR TITLE
perf(graph): gate checked-in Postgres scale evidence

### DIFF
--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -1,126 +1,126 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="960" height="560" viewBox="0 0 960 560" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="620" viewBox="0 0 960 620" fill="none">
 <title>agent-bom control-plane architecture</title>
-<desc>Sources through scan and evidence core to control plane and consumers.</desc>
-<rect width="960" height="560" rx="14" fill="#0a0a0c"/>
-<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#f4f4f5">Control-plane architecture</text>
-<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">Sources -&gt; scan -&gt; Finding + UnifiedGraph -&gt; API · Gateway · MCP -&gt; people + agents</text>
-<rect x="24" y="78" width="174" height="400" rx="11" fill="#0f0f13" stroke="#222228"/>
-<rect x="27" y="81" width="168" height="29" rx="7" fill="#1e3a5f"/><text x="37" y="99" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">SOURCES</text><text x="187" y="99" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#60a5fa" opacity="0.95">read-only</text>
-<rect x="208" y="78" width="174" height="400" rx="11" fill="#0f0f13" stroke="#222228"/>
-<rect x="211" y="81" width="168" height="29" rx="7" fill="#78350f"/><text x="221" y="99" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#fde68a">SCAN</text><text x="371" y="99" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#fbbf24" opacity="0.95">local</text>
-<rect x="392" y="78" width="174" height="400" rx="11" fill="#0f0f13" stroke="#222228"/>
-<rect x="395" y="81" width="168" height="29" rx="7" fill="#5b21b6"/><text x="405" y="99" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#ddd6fe">EVIDENCE</text><text x="555" y="99" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#a78bfa" opacity="0.95">model</text>
-<rect x="576" y="78" width="174" height="400" rx="11" fill="#0f0f13" stroke="#222228"/>
-<rect x="579" y="81" width="168" height="29" rx="7" fill="#065f46"/><text x="589" y="99" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#a7f3d0">CONTROL</text><text x="739" y="99" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#34d399" opacity="0.95">auth</text>
-<rect x="760" y="78" width="174" height="400" rx="11" fill="#0f0f13" stroke="#222228"/>
-<rect x="763" y="81" width="168" height="29" rx="7" fill="#1e3a8a"/><text x="773" y="99" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">CONSUMERS</text><text x="923" y="99" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#60a5fa" opacity="0.95">deliver</text>
-<rect x="32" y="116" width="158" height="39" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="42" y="122" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,126) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="76" y="134" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Supply chain</text>
-<text x="76" y="145" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">15 eco</text>
-<rect x="32" y="160" width="158" height="39" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="42" y="166" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,170) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="76" y="178" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Agents &amp; MCP</text>
-<text x="76" y="189" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">29 clients</text>
-<rect x="32" y="204" width="158" height="39" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="42" y="210" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,214) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="76" y="222" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Cloud</text>
-<text x="76" y="233" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">4 providers</text>
-<rect x="32" y="248" width="158" height="39" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="42" y="254" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,258) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="76" y="266" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">IaC &amp; OCI</text>
-<text x="76" y="277" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">TF·K8s·img</text>
-<rect x="32" y="292" width="158" height="39" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="42" y="298" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,302) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
-<text x="76" y="310" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Secrets</text>
-<text x="76" y="321" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">refs only</text>
-<rect x="32" y="336" width="158" height="39" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="42" y="342" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,346) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="76" y="354" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Models</text>
-<text x="76" y="365" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">13 formats</text>
-<rect x="32" y="380" width="158" height="39" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="42" y="386" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,390) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="76" y="398" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">SBOM import</text>
-<text x="76" y="409" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">CDX·SPDX</text>
-<rect x="216" y="116" width="158" height="47" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="226" y="126" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(230,130) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="260" y="138" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">OSV scan</text>
-<text x="260" y="149" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">batch</text>
-<rect x="216" y="168" width="158" height="47" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="226" y="178" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(230,182) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="260" y="190" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Enrichment</text>
-<text x="260" y="201" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">NVD·EPSS</text>
-<rect x="216" y="220" width="158" height="47" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="226" y="230" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(230,234) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="260" y="242" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Posture</text>
-<text x="260" y="253" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">CIS·MCP</text>
-<rect x="216" y="272" width="158" height="47" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="226" y="282" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(230,286) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="260" y="294" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Blast radius</text>
-<text x="260" y="305" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">fusion</text>
-<rect x="216" y="324" width="158" height="47" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="226" y="334" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(230,338) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="260" y="346" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Policy</text>
-<text x="260" y="357" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">as-code</text>
-<rect x="400" y="116" width="158" height="59" rx="8" fill="#15121f" stroke="#5b4bbd" stroke-width="1.5"/>
-<rect x="410" y="132" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(414,136) scale(0.75)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6.5c0 4.5-3.2 7.8-8 9.5-4.8-1.7-8-5-8-9.5V6z"/><path d="M12 9v4"/><path d="M12 16.5h.01"/></g>
-<text x="444" y="144" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Unified Finding</text>
-<text x="444" y="155" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#a78bfa">one schema</text>
-<rect x="400" y="180" width="158" height="59" rx="8" fill="#15121f" stroke="#5b4bbd" stroke-width="1.5"/>
-<rect x="410" y="196" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(414,200) scale(0.75)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="444" y="208" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">UnifiedGraph</text>
-<text x="444" y="219" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#a78bfa">attack paths</text>
-<rect x="400" y="244" width="158" height="59" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="410" y="260" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(414,264) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
-<text x="444" y="272" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Stores</text>
-<text x="444" y="283" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">PG·SQLite</text>
-<rect x="400" y="308" width="158" height="59" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="410" y="324" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(414,328) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="444" y="336" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Audit chain</text>
-<text x="444" y="347" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">signed</text>
-<rect x="584" y="116" width="158" height="59" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="594" y="132" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(598,136) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="628" y="144" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">REST API</text>
-<text x="628" y="155" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">283 ops</text>
-<rect x="584" y="180" width="158" height="59" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="594" y="196" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(598,200) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="628" y="208" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Gateway</text>
-<text x="628" y="219" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">runtime</text>
-<rect x="584" y="244" width="158" height="59" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="594" y="260" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(598,264) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="628" y="272" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">MCP server</text>
-<text x="628" y="283" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">70 tools</text>
-<rect x="584" y="308" width="158" height="59" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
-<rect x="594" y="324" width="26" height="26" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(598,328) scale(0.75)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="628" y="336" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Fleet jobs</text>
-<text x="628" y="347" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#82828c">Helm·EKS</text>
-<rect x="584" y="448" width="158" height="22" rx="7" fill="#121016" stroke="#2a2733"/><text x="663" y="464" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="700" fill="#a1a1aa">OIDC · SAML · SCIM · RBAC</text>
-<text x="847" y="116" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">PEOPLE</text>
-<rect x="768" y="128" width="158" height="32" rx="7" fill="#161619" stroke="#2a2a31"/>
-<rect x="780" y="132" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(784,136) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
-<text x="812" y="148" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">CLI</text>
-<rect x="768" y="166" width="158" height="32" rx="7" fill="#161619" stroke="#2a2a31"/>
-<rect x="780" y="170" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(784,174) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="812" y="186" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Web UI</text>
-<text x="847" y="208" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">AGENTS</text>
-<rect x="768" y="220" width="158" height="32" rx="7" fill="#161619" stroke="#2a2a31"/>
-<rect x="780" y="224" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(784,228) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="812" y="240" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">MCP</text>
-<rect x="768" y="258" width="158" height="32" rx="7" fill="#161619" stroke="#2a2a31"/>
-<rect x="780" y="262" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(784,266) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="812" y="278" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">SDK</text>
-<text x="847" y="300" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">ARTIFACTS</text>
-<rect x="768" y="312" width="49" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="792.5" y="325" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">SARIF</text>
-<rect x="822" y="312" width="49" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="846.5" y="325" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">CDX</text>
-<rect x="876" y="312" width="49" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="900.5" y="325" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">SPDX</text>
-<rect x="768" y="337" width="49" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="792.5" y="350" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">OCSF</text>
-<rect x="822" y="337" width="49" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="846.5" y="350" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">HTML</text>
-<rect x="876" y="337" width="49" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="900.5" y="350" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">JSON</text>
-<text x="847" y="370" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="600" fill="#6b6b75">SIEM · webhooks</text>
-<line x1="198" y1="68" x2="201" y2="68" stroke="#52525b" stroke-width="1.8"/><polygon points="207,68 201,64.5 201,71.5" fill="#52525b"/><text x="203" y="58" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">SCAN</text>
-<line x1="382" y1="68" x2="385" y2="68" stroke="#52525b" stroke-width="1.8"/><polygon points="391,68 385,64.5 385,71.5" fill="#52525b"/><text x="387" y="58" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">NORMALIZE</text>
-<line x1="566" y1="68" x2="569" y2="68" stroke="#8b5cf6" stroke-width="2.2"/><polygon points="575,68 569,64.5 569,71.5" fill="#8b5cf6"/><text x="571" y="58" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#a78bfa">SERVE</text>
-<line x1="750" y1="68" x2="753" y2="68" stroke="#52525b" stroke-width="1.8"/><polygon points="759,68 753,64.5 753,71.5" fill="#52525b"/><text x="755" y="58" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#6b6b75">DELIVER</text>
-<rect x="24" y="522" width="912" height="26" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="480" y="540" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
+<desc>Layered sources, processing engine, platform, and consumers.</desc>
+<rect width="960" height="620" rx="14" fill="#0a0a0c"/>
+<rect x="12" y="12" width="936" height="596" rx="18" fill="none" stroke="#6366f1" stroke-width="2" opacity="0.22"/>
+<rect x="842" y="20" width="90" height="22" rx="11" fill="#312e81" opacity="0.85"/>
+<text x="887" y="35" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.14em" fill="#c7d2fe">LAYERED</text>
+<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#f4f4f5">Control-plane architecture</text>
+<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">Vertical tiers · sources feed engine · evidence + platform · people + agents consume</text>
+<rect x="28" y="78" width="904" height="102" rx="12" fill="#0f0f13" stroke="#38bdf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="78" width="904" height="3" rx="12" fill="#38bdf8" opacity="0.55"/>
+<rect x="40" y="88" width="4" height="22" rx="2" fill="#38bdf8"/><text x="54" y="103" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#38bdf8">INTAKE SOURCES</text><text x="910" y="103" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#bae6fd">read-only</text>
+<rect x="40" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="48" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="78" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Supply chain</text>
+<text x="78" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">15 eco</text>
+<rect x="166" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="174" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(178,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="204" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Agents &amp; MCP</text>
+<text x="204" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">29 clients</text>
+<rect x="292" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="300" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(304,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="330" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Cloud</text>
+<text x="330" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">4 providers</text>
+<rect x="418" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="426" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(430,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="456" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">IaC &amp; OCI</text>
+<text x="456" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">TF·K8s·img</text>
+<rect x="544" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="552" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(556,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="582" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Secrets</text>
+<text x="582" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">refs only</text>
+<rect x="670" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="678" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(682,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="708" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Models</text>
+<text x="708" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">13 formats</text>
+<rect x="796" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="804" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(808,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="834" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">SBOM import</text>
+<text x="834" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">CDX·SPDX</text>
+<line x1="480" y1="182" x2="480" y2="196" stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,200 476,194 484,194" fill="#38bdf8"/><text x="480" y="177" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#38bdf8">INGEST</text>
+<rect x="28" y="192" width="904" height="96" rx="12" fill="#0f0f13" stroke="#818cf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="192" width="904" height="3" rx="12" fill="#818cf8" opacity="0.55"/>
+<rect x="40" y="202" width="4" height="22" rx="2" fill="#818cf8"/><text x="54" y="217" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#818cf8">PROCESSING ENGINE</text><text x="910" y="217" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#c7d2fe">local scan</text>
+<rect x="40" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="48" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="78" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">OSV scan</text>
+<text x="78" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">batch</text>
+<rect x="218" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="226" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(230,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="256" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Enrichment</text>
+<text x="256" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">NVD·EPSS</text>
+<rect x="396" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="404" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(408,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="434" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Posture</text>
+<text x="434" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">CIS·MCP</text>
+<rect x="574" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="582" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(586,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="612" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Blast radius</text>
+<text x="612" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">fusion</text>
+<rect x="752" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="760" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(764,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="790" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Policy</text>
+<text x="790" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">as-code</text>
+<line x1="480" y1="290" x2="480" y2="304" stroke="#818cf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,308 476,302 484,302" fill="#818cf8"/><text x="480" y="285" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#818cf8">PROCESS</text>
+<rect x="28" y="300" width="904" height="136" rx="12" fill="#0f0f13" stroke="#2dd4bf" stroke-width="1.2" opacity="0.95"/><rect x="28" y="300" width="904" height="3" rx="12" fill="#2dd4bf" opacity="0.55"/>
+<rect x="40" y="310" width="4" height="22" rx="2" fill="#2dd4bf"/><text x="54" y="325" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#2dd4bf">EVIDENCE &amp; PLATFORM</text><text x="910" y="325" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#99f6e4">auth · self-hosted</text>
+<rect x="40" y="332" width="213" height="32" rx="8" fill="#15121f" stroke="#2dd4bf" stroke-width="1.5"/>
+<rect x="48" y="336" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,340) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6.5c0 4.5-3.2 7.8-8 9.5-4.8-1.7-8-5-8-9.5V6z"/><path d="M12 9v4"/><path d="M12 16.5h.01"/></g>
+<text x="78" y="347" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Unified Finding</text>
+<text x="78" y="358" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#2dd4bf">one schema</text>
+<rect x="259" y="332" width="213" height="32" rx="8" fill="#15121f" stroke="#2dd4bf" stroke-width="1.5"/>
+<rect x="267" y="336" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(271,340) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="297" y="347" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">UnifiedGraph</text>
+<text x="297" y="358" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#2dd4bf">attack paths</text>
+<rect x="40" y="370" width="213" height="32" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="48" y="374" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,378) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
+<text x="78" y="385" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Stores</text>
+<text x="78" y="396" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">PG·SQLite</text>
+<rect x="259" y="370" width="213" height="32" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="267" y="374" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(271,378) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="297" y="385" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Audit chain</text>
+<text x="297" y="396" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">signed</text>
+<rect x="488" y="332" width="213" height="32" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="496" y="336" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,340) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="526" y="347" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">REST API</text>
+<text x="526" y="358" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">283 ops</text>
+<rect x="707" y="332" width="213" height="32" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="715" y="336" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(719,340) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="745" y="347" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Gateway</text>
+<text x="745" y="358" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">runtime</text>
+<rect x="488" y="370" width="213" height="32" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="496" y="374" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,378) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="526" y="385" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">MCP server</text>
+<text x="526" y="396" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">70 tools</text>
+<rect x="707" y="370" width="213" height="32" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
+<rect x="715" y="374" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(719,378) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="745" y="385" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Fleet jobs</text>
+<text x="745" y="396" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">Helm·EKS</text>
+<rect x="488" y="412" width="432" height="18" rx="6" fill="#121016" stroke="#2a2733"/><text x="704" y="425" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="6.5" font-weight="700" fill="#a1a1aa">OIDC · SAML · SCIM · RBAC</text>
+<line x1="480" y1="438" x2="480" y2="452" stroke="#2dd4bf" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,456 476,450 484,450" fill="#2dd4bf"/><text x="480" y="433" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">DELIVER</text>
+<rect x="28" y="448" width="904" height="140" rx="12" fill="#0f0f13" stroke="#c084fc" stroke-width="1.2" opacity="0.95"/><rect x="28" y="448" width="904" height="3" rx="12" fill="#c084fc" opacity="0.55"/>
+<rect x="40" y="458" width="4" height="22" rx="2" fill="#c084fc"/><text x="54" y="473" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#c084fc">CONSUMERS &amp; ARTIFACTS</text><text x="910" y="473" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#e9d5ff">deliver</text>
+<text x="256" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#c084fc">PEOPLE</text>
+<rect x="40" y="492" width="432" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
+<rect x="50" y="495" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(54,499) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
+<text x="80" y="511" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">CLI</text>
+<rect x="40" y="527" width="432" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
+<rect x="50" y="530" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(54,534) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="80" y="546" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Web UI</text>
+<text x="704" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#c084fc">AGENTS</text>
+<rect x="488" y="492" width="432" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
+<rect x="498" y="495" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(502,499) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="528" y="511" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">MCP</text>
+<rect x="488" y="527" width="432" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
+<rect x="498" y="530" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(502,534) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="528" y="546" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">SDK</text>
+<text x="730.4" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#c084fc">ARTIFACTS</text>
+<rect x="550.4" y="492" width="117.0" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="608.9" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">SARIF</text>
+<rect x="672.4" y="492" width="117.0" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="730.9" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">CDX</text>
+<rect x="794.4" y="492" width="117.0" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="852.9" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">SPDX</text>
+<rect x="550.4" y="517" width="117.0" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="608.9" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">OCSF</text>
+<rect x="672.4" y="517" width="117.0" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="730.9" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">HTML</text>
+<rect x="794.4" y="517" width="117.0" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="852.9" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">JSON</text>
+<text x="730.4" y="552" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="600" fill="#6b6b75">SIEM · webhooks</text>
+<rect x="24" y="582" width="912" height="26" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="480" y="600" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -1,126 +1,126 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="960" height="560" viewBox="0 0 960 560" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="620" viewBox="0 0 960 620" fill="none">
 <title>agent-bom control-plane architecture</title>
-<desc>Sources through scan and evidence core to control plane and consumers.</desc>
-<rect width="960" height="560" rx="14" fill="#ffffff"/>
-<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#18181b">Control-plane architecture</text>
-<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">Sources -&gt; scan -&gt; Finding + UnifiedGraph -&gt; API · Gateway · MCP -&gt; people + agents</text>
-<rect x="24" y="78" width="174" height="400" rx="11" fill="#fafafa" stroke="#ececf0"/>
-<rect x="27" y="81" width="168" height="29" rx="7" fill="#1e3a5f"/><text x="37" y="99" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">SOURCES</text><text x="187" y="99" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#60a5fa" opacity="0.95">read-only</text>
-<rect x="208" y="78" width="174" height="400" rx="11" fill="#fafafa" stroke="#ececf0"/>
-<rect x="211" y="81" width="168" height="29" rx="7" fill="#78350f"/><text x="221" y="99" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#fde68a">SCAN</text><text x="371" y="99" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#fbbf24" opacity="0.95">local</text>
-<rect x="392" y="78" width="174" height="400" rx="11" fill="#fafafa" stroke="#ececf0"/>
-<rect x="395" y="81" width="168" height="29" rx="7" fill="#5b21b6"/><text x="405" y="99" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#ddd6fe">EVIDENCE</text><text x="555" y="99" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#a78bfa" opacity="0.95">model</text>
-<rect x="576" y="78" width="174" height="400" rx="11" fill="#fafafa" stroke="#ececf0"/>
-<rect x="579" y="81" width="168" height="29" rx="7" fill="#065f46"/><text x="589" y="99" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#a7f3d0">CONTROL</text><text x="739" y="99" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#34d399" opacity="0.95">auth</text>
-<rect x="760" y="78" width="174" height="400" rx="11" fill="#fafafa" stroke="#ececf0"/>
-<rect x="763" y="81" width="168" height="29" rx="7" fill="#1e3a8a"/><text x="773" y="99" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">CONSUMERS</text><text x="923" y="99" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#60a5fa" opacity="0.95">deliver</text>
-<rect x="32" y="116" width="158" height="39" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="42" y="122" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,126) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="76" y="134" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Supply chain</text>
-<text x="76" y="145" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">15 eco</text>
-<rect x="32" y="160" width="158" height="39" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="42" y="166" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,170) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="76" y="178" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Agents &amp; MCP</text>
-<text x="76" y="189" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">29 clients</text>
-<rect x="32" y="204" width="158" height="39" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="42" y="210" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,214) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="76" y="222" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Cloud</text>
-<text x="76" y="233" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">4 providers</text>
-<rect x="32" y="248" width="158" height="39" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="42" y="254" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,258) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="76" y="266" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">IaC &amp; OCI</text>
-<text x="76" y="277" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">TF·K8s·img</text>
-<rect x="32" y="292" width="158" height="39" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="42" y="298" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,302) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
-<text x="76" y="310" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Secrets</text>
-<text x="76" y="321" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">refs only</text>
-<rect x="32" y="336" width="158" height="39" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="42" y="342" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,346) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="76" y="354" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Models</text>
-<text x="76" y="365" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">13 formats</text>
-<rect x="32" y="380" width="158" height="39" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="42" y="386" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,390) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="76" y="398" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">SBOM import</text>
-<text x="76" y="409" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">CDX·SPDX</text>
-<rect x="216" y="116" width="158" height="47" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="226" y="126" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(230,130) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="260" y="138" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">OSV scan</text>
-<text x="260" y="149" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">batch</text>
-<rect x="216" y="168" width="158" height="47" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="226" y="178" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(230,182) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="260" y="190" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Enrichment</text>
-<text x="260" y="201" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">NVD·EPSS</text>
-<rect x="216" y="220" width="158" height="47" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="226" y="230" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(230,234) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="260" y="242" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Posture</text>
-<text x="260" y="253" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">CIS·MCP</text>
-<rect x="216" y="272" width="158" height="47" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="226" y="282" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(230,286) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="260" y="294" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Blast radius</text>
-<text x="260" y="305" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">fusion</text>
-<rect x="216" y="324" width="158" height="47" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="226" y="334" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(230,338) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="260" y="346" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Policy</text>
-<text x="260" y="357" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">as-code</text>
-<rect x="400" y="116" width="158" height="59" rx="8" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.5"/>
-<rect x="410" y="132" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(414,136) scale(0.75)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6.5c0 4.5-3.2 7.8-8 9.5-4.8-1.7-8-5-8-9.5V6z"/><path d="M12 9v4"/><path d="M12 16.5h.01"/></g>
-<text x="444" y="144" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Unified Finding</text>
-<text x="444" y="155" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#7c3aed">one schema</text>
-<rect x="400" y="180" width="158" height="59" rx="8" fill="#f5f3ff" stroke="#c4b5fd" stroke-width="1.5"/>
-<rect x="410" y="196" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(414,200) scale(0.75)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="444" y="208" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">UnifiedGraph</text>
-<text x="444" y="219" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#7c3aed">attack paths</text>
-<rect x="400" y="244" width="158" height="59" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="410" y="260" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(414,264) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
-<text x="444" y="272" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Stores</text>
-<text x="444" y="283" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">PG·SQLite</text>
-<rect x="400" y="308" width="158" height="59" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="410" y="324" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(414,328) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="444" y="336" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Audit chain</text>
-<text x="444" y="347" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">signed</text>
-<rect x="584" y="116" width="158" height="59" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="594" y="132" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(598,136) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="628" y="144" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">REST API</text>
-<text x="628" y="155" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">283 ops</text>
-<rect x="584" y="180" width="158" height="59" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="594" y="196" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(598,200) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="628" y="208" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Gateway</text>
-<text x="628" y="219" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">runtime</text>
-<rect x="584" y="244" width="158" height="59" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="594" y="260" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(598,264) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="628" y="272" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">MCP server</text>
-<text x="628" y="283" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">70 tools</text>
-<rect x="584" y="308" width="158" height="59" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
-<rect x="594" y="324" width="26" height="26" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(598,328) scale(0.75)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="628" y="336" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Fleet jobs</text>
-<text x="628" y="347" font-family="ui-monospace,monospace" font-size="7" font-weight="600" fill="#71717a">Helm·EKS</text>
-<rect x="584" y="448" width="158" height="22" rx="7" fill="#f4f4f6" stroke="#e4e4e7"/><text x="663" y="464" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="700" fill="#52525b">OIDC · SAML · SCIM · RBAC</text>
-<text x="847" y="116" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">PEOPLE</text>
-<rect x="768" y="128" width="158" height="32" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="780" y="132" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(784,136) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
-<text x="812" y="148" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">CLI</text>
-<rect x="768" y="166" width="158" height="32" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="780" y="170" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(784,174) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="812" y="186" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Web UI</text>
-<text x="847" y="208" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">AGENTS</text>
-<rect x="768" y="220" width="158" height="32" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="780" y="224" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(784,228) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="812" y="240" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">MCP</text>
-<rect x="768" y="258" width="158" height="32" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="780" y="262" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(784,266) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="812" y="278" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">SDK</text>
-<text x="847" y="300" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">ARTIFACTS</text>
-<rect x="768" y="312" width="49" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="792.5" y="325" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">SARIF</text>
-<rect x="822" y="312" width="49" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="846.5" y="325" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">CDX</text>
-<rect x="876" y="312" width="49" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="900.5" y="325" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">SPDX</text>
-<rect x="768" y="337" width="49" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="792.5" y="350" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">OCSF</text>
-<rect x="822" y="337" width="49" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="846.5" y="350" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">HTML</text>
-<rect x="876" y="337" width="49" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="900.5" y="350" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">JSON</text>
-<text x="847" y="370" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="600" fill="#9a9aa4">SIEM · webhooks</text>
-<line x1="198" y1="68" x2="201" y2="68" stroke="#a1a1aa" stroke-width="1.8"/><polygon points="207,68 201,64.5 201,71.5" fill="#a1a1aa"/><text x="203" y="58" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">SCAN</text>
-<line x1="382" y1="68" x2="385" y2="68" stroke="#a1a1aa" stroke-width="1.8"/><polygon points="391,68 385,64.5 385,71.5" fill="#a1a1aa"/><text x="387" y="58" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">NORMALIZE</text>
-<line x1="566" y1="68" x2="569" y2="68" stroke="#7c3aed" stroke-width="2.2"/><polygon points="575,68 569,64.5 569,71.5" fill="#7c3aed"/><text x="571" y="58" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#7c3aed">SERVE</text>
-<line x1="750" y1="68" x2="753" y2="68" stroke="#a1a1aa" stroke-width="1.8"/><polygon points="759,68 753,64.5 753,71.5" fill="#a1a1aa"/><text x="755" y="58" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#9a9aa4">DELIVER</text>
-<rect x="24" y="522" width="912" height="26" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="480" y="540" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
+<desc>Layered sources, processing engine, platform, and consumers.</desc>
+<rect width="960" height="620" rx="14" fill="#ffffff"/>
+<rect x="12" y="12" width="936" height="596" rx="18" fill="none" stroke="#6366f1" stroke-width="2" opacity="0.22"/>
+<rect x="842" y="20" width="90" height="22" rx="11" fill="#312e81" opacity="0.85"/>
+<text x="887" y="35" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.14em" fill="#c7d2fe">LAYERED</text>
+<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#18181b">Control-plane architecture</text>
+<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">Vertical tiers · sources feed engine · evidence + platform · people + agents consume</text>
+<rect x="28" y="78" width="904" height="102" rx="12" fill="#fafafa" stroke="#38bdf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="78" width="904" height="3" rx="12" fill="#38bdf8" opacity="0.55"/>
+<rect x="40" y="88" width="4" height="22" rx="2" fill="#38bdf8"/><text x="54" y="103" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#38bdf8">INTAKE SOURCES</text><text x="910" y="103" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#bae6fd">read-only</text>
+<rect x="40" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="48" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
+<text x="78" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Supply chain</text>
+<text x="78" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">15 eco</text>
+<rect x="166" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="174" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(178,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="204" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Agents &amp; MCP</text>
+<text x="204" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">29 clients</text>
+<rect x="292" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="300" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(304,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
+<text x="330" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Cloud</text>
+<text x="330" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">4 providers</text>
+<rect x="418" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="426" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(430,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
+<text x="456" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">IaC &amp; OCI</text>
+<text x="456" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">TF·K8s·img</text>
+<rect x="544" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="552" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(556,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
+<text x="582" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Secrets</text>
+<text x="582" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">refs only</text>
+<rect x="670" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="678" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(682,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
+<text x="708" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Models</text>
+<text x="708" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">13 formats</text>
+<rect x="796" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="804" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(808,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
+<text x="834" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">SBOM import</text>
+<text x="834" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">CDX·SPDX</text>
+<line x1="480" y1="182" x2="480" y2="196" stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,200 476,194 484,194" fill="#38bdf8"/><text x="480" y="177" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#38bdf8">INGEST</text>
+<rect x="28" y="192" width="904" height="96" rx="12" fill="#fafafa" stroke="#818cf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="192" width="904" height="3" rx="12" fill="#818cf8" opacity="0.55"/>
+<rect x="40" y="202" width="4" height="22" rx="2" fill="#818cf8"/><text x="54" y="217" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#818cf8">PROCESSING ENGINE</text><text x="910" y="217" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#c7d2fe">local scan</text>
+<rect x="40" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="48" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="78" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">OSV scan</text>
+<text x="78" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">batch</text>
+<rect x="218" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="226" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(230,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
+<text x="256" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Enrichment</text>
+<text x="256" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">NVD·EPSS</text>
+<rect x="396" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="404" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(408,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="434" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Posture</text>
+<text x="434" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">CIS·MCP</text>
+<rect x="574" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="582" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(586,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="612" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Blast radius</text>
+<text x="612" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">fusion</text>
+<rect x="752" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="760" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(764,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
+<text x="790" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Policy</text>
+<text x="790" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">as-code</text>
+<line x1="480" y1="290" x2="480" y2="304" stroke="#818cf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,308 476,302 484,302" fill="#818cf8"/><text x="480" y="285" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#818cf8">PROCESS</text>
+<rect x="28" y="300" width="904" height="136" rx="12" fill="#fafafa" stroke="#2dd4bf" stroke-width="1.2" opacity="0.95"/><rect x="28" y="300" width="904" height="3" rx="12" fill="#2dd4bf" opacity="0.55"/>
+<rect x="40" y="310" width="4" height="22" rx="2" fill="#2dd4bf"/><text x="54" y="325" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#2dd4bf">EVIDENCE &amp; PLATFORM</text><text x="910" y="325" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#99f6e4">auth · self-hosted</text>
+<rect x="40" y="332" width="213" height="32" rx="8" fill="#f5f3ff" stroke="#2dd4bf" stroke-width="1.5"/>
+<rect x="48" y="336" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,340) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6.5c0 4.5-3.2 7.8-8 9.5-4.8-1.7-8-5-8-9.5V6z"/><path d="M12 9v4"/><path d="M12 16.5h.01"/></g>
+<text x="78" y="347" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Unified Finding</text>
+<text x="78" y="358" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#2dd4bf">one schema</text>
+<rect x="259" y="332" width="213" height="32" rx="8" fill="#f5f3ff" stroke="#2dd4bf" stroke-width="1.5"/>
+<rect x="267" y="336" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(271,340) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="297" y="347" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">UnifiedGraph</text>
+<text x="297" y="358" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#2dd4bf">attack paths</text>
+<rect x="40" y="370" width="213" height="32" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="48" y="374" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,378) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
+<text x="78" y="385" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Stores</text>
+<text x="78" y="396" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">PG·SQLite</text>
+<rect x="259" y="370" width="213" height="32" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="267" y="374" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(271,378) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="297" y="385" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Audit chain</text>
+<text x="297" y="396" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">signed</text>
+<rect x="488" y="332" width="213" height="32" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="496" y="336" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,340) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="526" y="347" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">REST API</text>
+<text x="526" y="358" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">283 ops</text>
+<rect x="707" y="332" width="213" height="32" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="715" y="336" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(719,340) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="745" y="347" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Gateway</text>
+<text x="745" y="358" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">runtime</text>
+<rect x="488" y="370" width="213" height="32" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="496" y="374" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,378) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="526" y="385" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">MCP server</text>
+<text x="526" y="396" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">70 tools</text>
+<rect x="707" y="370" width="213" height="32" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
+<rect x="715" y="374" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(719,378) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
+<text x="745" y="385" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Fleet jobs</text>
+<text x="745" y="396" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">Helm·EKS</text>
+<rect x="488" y="412" width="432" height="18" rx="6" fill="#f4f4f6" stroke="#e4e4e7"/><text x="704" y="425" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="6.5" font-weight="700" fill="#52525b">OIDC · SAML · SCIM · RBAC</text>
+<line x1="480" y1="438" x2="480" y2="452" stroke="#2dd4bf" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,456 476,450 484,450" fill="#2dd4bf"/><text x="480" y="433" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">DELIVER</text>
+<rect x="28" y="448" width="904" height="140" rx="12" fill="#fafafa" stroke="#c084fc" stroke-width="1.2" opacity="0.95"/><rect x="28" y="448" width="904" height="3" rx="12" fill="#c084fc" opacity="0.55"/>
+<rect x="40" y="458" width="4" height="22" rx="2" fill="#c084fc"/><text x="54" y="473" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#c084fc">CONSUMERS &amp; ARTIFACTS</text><text x="910" y="473" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#e9d5ff">deliver</text>
+<text x="256" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#c084fc">PEOPLE</text>
+<rect x="40" y="492" width="432" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="50" y="495" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(54,499) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
+<text x="80" y="511" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">CLI</text>
+<rect x="40" y="527" width="432" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="50" y="530" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(54,534) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
+<text x="80" y="546" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Web UI</text>
+<text x="704" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#c084fc">AGENTS</text>
+<rect x="488" y="492" width="432" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="498" y="495" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(502,499) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="528" y="511" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">MCP</text>
+<rect x="488" y="527" width="432" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
+<rect x="498" y="530" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(502,534) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="528" y="546" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">SDK</text>
+<text x="730.4" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#c084fc">ARTIFACTS</text>
+<rect x="550.4" y="492" width="117.0" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="608.9" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">SARIF</text>
+<rect x="672.4" y="492" width="117.0" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="730.9" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">CDX</text>
+<rect x="794.4" y="492" width="117.0" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="852.9" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">SPDX</text>
+<rect x="550.4" y="517" width="117.0" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="608.9" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">OCSF</text>
+<rect x="672.4" y="517" width="117.0" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="730.9" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">HTML</text>
+<rect x="794.4" y="517" width="117.0" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="852.9" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">JSON</text>
+<text x="730.4" y="552" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="600" fill="#9a9aa4">SIEM · webhooks</text>
+<rect x="24" y="582" width="912" height="26" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="480" y="600" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/how-it-works-dark.svg
+++ b/docs/images/how-it-works-dark.svg
@@ -6,8 +6,11 @@
 <linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#a78bfa" stop-opacity="0.28"/><stop offset="100%" stop-color="#a78bfa" stop-opacity="0"/></linearGradient>
 </defs>
 <rect width="960" height="560" rx="14" fill="#0a0a0c"/>
+<rect x="10" y="10" width="940" height="540" rx="16" fill="none" stroke="#f59e0b" stroke-width="2" opacity="0.28"/>
+<rect x="850" y="20" width="86" height="22" rx="11" fill="#78350f" opacity="0.72"/>
+<text x="893" y="35" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.14em" fill="#fde68a">WORKFLOW</text>
 <text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#f4f4f5">From inventory to enforceable evidence</text>
-<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">One read-only pipeline · one Finding + ContextGraph · CLI · API · UI · MCP</text>
+<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">Five-stage read-only flow · intake -&gt; scan -&gt; evidence -&gt; control -&gt; artifacts</text>
 <rect x="24" y="102" width="174" height="348" rx="12" fill="#0f0f13" stroke="#222228"/>
 <rect x="27" y="105" width="168" height="29" rx="7" fill="#1e3a5f"/><text x="37" y="123" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">INTAKE</text><text x="187" y="123" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#60a5fa" opacity="0.95">read-only</text>
 <rect x="208" y="102" width="174" height="348" rx="12" fill="#0f0f13" stroke="#222228"/>

--- a/docs/images/how-it-works-light.svg
+++ b/docs/images/how-it-works-light.svg
@@ -6,8 +6,11 @@
 <linearGradient id="core-glow" x1="0" y1="0" x2="1" y2="1"><stop offset="0%" stop-color="#7c3aed" stop-opacity="0.28"/><stop offset="100%" stop-color="#7c3aed" stop-opacity="0"/></linearGradient>
 </defs>
 <rect width="960" height="560" rx="14" fill="#ffffff"/>
+<rect x="10" y="10" width="940" height="540" rx="16" fill="none" stroke="#f59e0b" stroke-width="2" opacity="0.28"/>
+<rect x="850" y="20" width="86" height="22" rx="11" fill="#78350f" opacity="0.72"/>
+<text x="893" y="35" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.14em" fill="#fde68a">WORKFLOW</text>
 <text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#18181b">From inventory to enforceable evidence</text>
-<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">One read-only pipeline · one Finding + ContextGraph · CLI · API · UI · MCP</text>
+<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">Five-stage read-only flow · intake -&gt; scan -&gt; evidence -&gt; control -&gt; artifacts</text>
 <rect x="24" y="102" width="174" height="348" rx="12" fill="#fafafa" stroke="#ececf0"/>
 <rect x="27" y="105" width="168" height="29" rx="7" fill="#1e3a5f"/><text x="37" y="123" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.12em" fill="#93c5fd">INTAKE</text><text x="187" y="123" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#60a5fa" opacity="0.95">read-only</text>
 <rect x="208" y="102" width="174" height="348" rx="12" fill="#fafafa" stroke="#ececf0"/>

--- a/docs/perf/graph-api-postgres-benchmark.md
+++ b/docs/perf/graph-api-postgres-benchmark.md
@@ -1,7 +1,7 @@
 # Graph API and Postgres Benchmark Evidence
 
 Evidence status: measured local API + Postgres EXPLAIN + repeated Postgres latency artifacts
-Owner issue: #2145
+Owner issue: #3353
 Related evidence-lake issue: #2929
 Raw result artifacts:
 
@@ -34,8 +34,11 @@ plans, and Postgres p50/p95/p99 query-family timings on a deterministic
 synthetic estate.
 
 These artifacts do not claim Snowflake behavior, browser timing, managed
-operator deployment timing, or production SLOs. Measured local CPU graph
-timings remain in [`p95-p99-graph-query.md`](p95-p99-graph-query.md).
+operator deployment timing, or production SLOs. The current measured ceiling is
+the checked-in Docker Postgres estate with 10,479 nodes, 11,242 edges, and 291
+materialized attack paths. 100k+ and 1M-node Postgres claims are not yet
+measured; they remain the next #3353 work item. Measured local CPU graph timings
+remain in [`p95-p99-graph-query.md`](p95-p99-graph-query.md).
 
 ## Scope
 
@@ -62,7 +65,7 @@ Excluded from these local artifacts:
 - authenticated remote API latency
 - Snowflake or managed-operator deployment timings
 - browser/UI interaction timing
-- 50k / 100k edge Postgres runs
+- 50k / 100k / 1M edge Postgres runs
 - six-month hosted lake retention jobs, audit-chain bundle persistence,
   compliance bundle persistence, and legal-hold/deletion workflows
 
@@ -253,6 +256,19 @@ uv run python scripts/run_graph_postgres_latency.py \
 
 ## Results
 
+### Supported size from checked-in evidence
+
+The current supported-size statement is intentionally bounded:
+
+| Store | Current measured ceiling | Query families | Success criteria | Raw artifact |
+|---|---:|---|---|---|
+| Docker Postgres 16 | 10,479 nodes / 11,242 edges / 291 attack paths | search, detail, drilldown, diff, history, evidence digest, bounded traversal | 30 successful samples per query family; p95 <= 750 ms on the local Docker harness | `docs/perf/results/postgres-graph-latency-live-2026-07-01.json` |
+
+The release gate in `scripts/check_graph_scale_evidence.py` enforces the raw
+artifact shape, query-family coverage, sample count, p95 ceiling, and this
+document's explicit current-measured-ceiling language. Larger-estate numbers
+must be added as new checked-in artifacts before product copy can claim them.
+
 | Artifact | Status | What it supports |
 |---|---|---|
 | `graph-benchmark-estate-sample.json` | scaffold | deterministic skewed estate shape and source mix |
@@ -358,7 +374,7 @@ enterprise-pilot latency claim.
 ## Gaps
 
 - Run the API benchmark under the intended authenticated remote topology.
-- Add 50k / 100k edge Postgres artifacts.
+- Add 50k / 100k / 1M edge Postgres artifacts before claiming larger estates.
 - Add browser interaction timing separately if UI scale claims are needed.
 - Add hosted evidence-lake retention jobs and measured six-month history
   evidence before closing #2929.

--- a/docs/perf/results/graph-benchmark-postgres-load-live-2026-07-01.json
+++ b/docs/perf/results/graph-benchmark-postgres-load-live-2026-07-01.json
@@ -1,87 +1,87 @@
 {
-  "backend": "postgres",
-  "benchmark_nodes": {
-    "detail_node": "pkg:go:langchain@1.0.0",
-    "source_node": "agent:agent-00000"
-  },
-  "commands": {
-    "postgres": "AGENT_BOM_POSTGRES_URL=postgresql://... uv run python scripts/seed_graph_benchmark_store.py --backend postgres",
-    "sqlite": "uv run python scripts/seed_graph_benchmark_store.py --backend sqlite --sqlite-db /tmp/agent-bom-graph-benchmark.db"
-  },
-  "evidence_status": "graph_store_loaded",
-  "generated_at": "2026-07-01T01:32:30.431635+00:00",
-  "new_scan_id": "graph-benchmark-estate-current",
-  "old_agent_count": 200,
-  "old_scan_id": "graph-benchmark-estate-old",
-  "owner_issue": 2145,
-  "schema_version": 1,
-  "snapshots": {
-    "graph-benchmark-estate-current": {
-      "attack_path_count": 291,
-      "highest_interaction_risk": 0.0,
-      "interaction_risk_count": 0,
-      "max_attack_path_risk": 8.0,
-      "node_types": {
-        "agent": 250,
-        "credential": 28,
-        "package": 5826,
-        "provider": 5,
-        "server": 604,
-        "tool": 3475,
-        "vulnerability": 291
-      },
-      "relationship_types": {
-        "depends_on": 5958,
-        "exposes_cred": 74,
-        "hosts": 250,
-        "provides_tool": 3475,
-        "reaches_tool": 590,
-        "uses": 604,
-        "vulnerable_to": 291
-      },
-      "severity_counts": {
-        "critical": 80,
-        "high": 70,
-        "low": 76,
-        "medium": 65
-      },
-      "total_edges": 11242,
-      "total_nodes": 10479
+    "backend": "postgres",
+    "benchmark_nodes": {
+        "detail_node": "pkg:go:langchain@1.0.0",
+        "source_node": "agent:agent-00000"
     },
-    "graph-benchmark-estate-old": {
-      "attack_path_count": 255,
-      "highest_interaction_risk": 0.0,
-      "interaction_risk_count": 0,
-      "max_attack_path_risk": 8.0,
-      "node_types": {
-        "agent": 200,
-        "credential": 23,
-        "package": 4981,
-        "provider": 5,
-        "server": 497,
-        "tool": 2936,
-        "vulnerability": 255
-      },
-      "relationship_types": {
-        "depends_on": 5080,
-        "exposes_cred": 59,
-        "hosts": 200,
-        "provides_tool": 2936,
-        "reaches_tool": 482,
-        "uses": 497,
-        "vulnerable_to": 255
-      },
-      "severity_counts": {
-        "critical": 71,
-        "high": 62,
-        "low": 68,
-        "medium": 54
-      },
-      "total_edges": 9509,
-      "total_nodes": 8897
-    }
-  },
-  "source_report": "docs/perf/results/graph-benchmark-estate-live-2026-05-13-report.json",
-  "source_report_sha256": "33496e7159fdde3618cb205eb7675da82766f6b4fe2e56175d07d39b0a89dd83",
-  "tenant_id": "default"
+    "commands": {
+        "postgres": "AGENT_BOM_POSTGRES_URL=postgresql://... uv run python scripts/seed_graph_benchmark_store.py --backend postgres",
+        "sqlite": "uv run python scripts/seed_graph_benchmark_store.py --backend sqlite --sqlite-db /tmp/agent-bom-graph-benchmark.db"
+    },
+    "evidence_status": "graph_store_loaded",
+    "generated_at": "2026-07-01T01:32:30.431635+00:00",
+    "new_scan_id": "graph-benchmark-estate-current",
+    "old_agent_count": 200,
+    "old_scan_id": "graph-benchmark-estate-old",
+    "owner_issue": 3353,
+    "schema_version": 1,
+    "snapshots": {
+        "graph-benchmark-estate-current": {
+            "attack_path_count": 291,
+            "highest_interaction_risk": 0.0,
+            "interaction_risk_count": 0,
+            "max_attack_path_risk": 8.0,
+            "node_types": {
+                "agent": 250,
+                "credential": 28,
+                "package": 5826,
+                "provider": 5,
+                "server": 604,
+                "tool": 3475,
+                "vulnerability": 291
+            },
+            "relationship_types": {
+                "depends_on": 5958,
+                "exposes_cred": 74,
+                "hosts": 250,
+                "provides_tool": 3475,
+                "reaches_tool": 590,
+                "uses": 604,
+                "vulnerable_to": 291
+            },
+            "severity_counts": {
+                "critical": 80,
+                "high": 70,
+                "low": 76,
+                "medium": 65
+            },
+            "total_edges": 11242,
+            "total_nodes": 10479
+        },
+        "graph-benchmark-estate-old": {
+            "attack_path_count": 255,
+            "highest_interaction_risk": 0.0,
+            "interaction_risk_count": 0,
+            "max_attack_path_risk": 8.0,
+            "node_types": {
+                "agent": 200,
+                "credential": 23,
+                "package": 4981,
+                "provider": 5,
+                "server": 497,
+                "tool": 2936,
+                "vulnerability": 255
+            },
+            "relationship_types": {
+                "depends_on": 5080,
+                "exposes_cred": 59,
+                "hosts": 200,
+                "provides_tool": 2936,
+                "reaches_tool": 482,
+                "uses": 497,
+                "vulnerable_to": 255
+            },
+            "severity_counts": {
+                "critical": 71,
+                "high": 62,
+                "low": 68,
+                "medium": 54
+            },
+            "total_edges": 9509,
+            "total_nodes": 8897
+        }
+    },
+    "source_report": "docs/perf/results/graph-benchmark-estate-live-2026-05-13-report.json",
+    "source_report_sha256": "33496e7159fdde3618cb205eb7675da82766f6b4fe2e56175d07d39b0a89dd83",
+    "tenant_id": "default"
 }

--- a/docs/perf/results/postgres-graph-latency-live-2026-07-01.json
+++ b/docs/perf/results/postgres-graph-latency-live-2026-07-01.json
@@ -1,143 +1,143 @@
 {
-  "commands": {
-    "dry_run": "uv run python scripts/run_graph_postgres_latency.py --dry-run",
-    "live": "AGENT_BOM_POSTGRES_DSN=postgresql://... uv run python scripts/run_graph_postgres_latency.py --run --scan-id <new> --old-scan-id <old> --repeat 30"
-  },
-  "edge_targets": "10000,50000,100000",
-  "evidence_status": "postgres_latency_client_wall_clock",
-  "gaps": [
-    "Client-side psql wall-clock timings include process startup and client transfer overhead.",
-    "Pair these repeated latencies with EXPLAIN ANALYZE plans before making production SLO claims."
-  ],
-  "generated_at": "2026-07-01T01:33:09.768996+00:00",
-  "old_scan_id": "graph-benchmark-estate-old",
-  "owner_issue": 2145,
-  "psql_bin": "/tmp/agent-bom-psql-docker",
-  "query_artifacts": {
-    "attack_path_drilldown": "docs/perf/results/postgres-graph-latency-live-2026-07-01/attack_path_drilldown.sql",
-    "bounded_traversal_edges": "docs/perf/results/postgres-graph-latency-live-2026-07-01/bounded_traversal_edges.sql",
-    "graph_diff_nodes": "docs/perf/results/postgres-graph-latency-live-2026-07-01/graph_diff_nodes.sql",
-    "graph_evidence_manifest_digest": "docs/perf/results/postgres-graph-latency-live-2026-07-01/graph_evidence_manifest_digest.sql",
-    "graph_history": "docs/perf/results/postgres-graph-latency-live-2026-07-01/graph_history.sql",
-    "node_detail": "docs/perf/results/postgres-graph-latency-live-2026-07-01/node_detail.sql",
-    "node_search": "docs/perf/results/postgres-graph-latency-live-2026-07-01/node_search.sql"
-  },
-  "repeat": 30,
-  "results": [
-    {
-      "failures_sample": [],
-      "latency": {
-        "max_ms": 502.35,
-        "mean_ms": 98.442,
-        "p50_ms": 77.941,
-        "p95_ms": 182.647,
-        "p99_ms": 502.35,
-        "samples": 30
-      },
-      "name": "node_search",
-      "returncode_counts": {
-        "0": 30
-      },
-      "sql": "docs/perf/results/postgres-graph-latency-live-2026-07-01/node_search.sql"
+    "commands": {
+        "dry_run": "uv run python scripts/run_graph_postgres_latency.py --dry-run",
+        "live": "AGENT_BOM_POSTGRES_DSN=postgresql://... uv run python scripts/run_graph_postgres_latency.py --run --scan-id <new> --old-scan-id <old> --repeat 30"
     },
-    {
-      "failures_sample": [],
-      "latency": {
-        "max_ms": 129.372,
-        "mean_ms": 79.485,
-        "p50_ms": 73.804,
-        "p95_ms": 128.536,
-        "p99_ms": 129.372,
-        "samples": 30
-      },
-      "name": "node_detail",
-      "returncode_counts": {
-        "0": 30
-      },
-      "sql": "docs/perf/results/postgres-graph-latency-live-2026-07-01/node_detail.sql"
+    "edge_targets": "10000,50000,100000",
+    "evidence_status": "postgres_latency_client_wall_clock",
+    "gaps": [
+        "Client-side psql wall-clock timings include process startup and client transfer overhead.",
+        "Pair these repeated latencies with EXPLAIN ANALYZE plans before making production SLO claims."
+    ],
+    "generated_at": "2026-07-01T01:33:09.768996+00:00",
+    "old_scan_id": "graph-benchmark-estate-old",
+    "owner_issue": 3353,
+    "psql_bin": "/tmp/agent-bom-psql-docker",
+    "query_artifacts": {
+        "attack_path_drilldown": "docs/perf/results/postgres-graph-latency-live-2026-07-01/attack_path_drilldown.sql",
+        "bounded_traversal_edges": "docs/perf/results/postgres-graph-latency-live-2026-07-01/bounded_traversal_edges.sql",
+        "graph_diff_nodes": "docs/perf/results/postgres-graph-latency-live-2026-07-01/graph_diff_nodes.sql",
+        "graph_evidence_manifest_digest": "docs/perf/results/postgres-graph-latency-live-2026-07-01/graph_evidence_manifest_digest.sql",
+        "graph_history": "docs/perf/results/postgres-graph-latency-live-2026-07-01/graph_history.sql",
+        "node_detail": "docs/perf/results/postgres-graph-latency-live-2026-07-01/node_detail.sql",
+        "node_search": "docs/perf/results/postgres-graph-latency-live-2026-07-01/node_search.sql"
     },
-    {
-      "failures_sample": [],
-      "latency": {
-        "max_ms": 99.619,
-        "mean_ms": 76.019,
-        "p50_ms": 75.949,
-        "p95_ms": 89.377,
-        "p99_ms": 99.619,
-        "samples": 30
-      },
-      "name": "attack_path_drilldown",
-      "returncode_counts": {
-        "0": 30
-      },
-      "sql": "docs/perf/results/postgres-graph-latency-live-2026-07-01/attack_path_drilldown.sql"
-    },
-    {
-      "failures_sample": [],
-      "latency": {
-        "max_ms": 104.114,
-        "mean_ms": 76.601,
-        "p50_ms": 73.383,
-        "p95_ms": 103.289,
-        "p99_ms": 104.114,
-        "samples": 30
-      },
-      "name": "graph_diff_nodes",
-      "returncode_counts": {
-        "0": 30
-      },
-      "sql": "docs/perf/results/postgres-graph-latency-live-2026-07-01/graph_diff_nodes.sql"
-    },
-    {
-      "failures_sample": [],
-      "latency": {
-        "max_ms": 138.774,
-        "mean_ms": 83.144,
-        "p50_ms": 77.961,
-        "p95_ms": 128.294,
-        "p99_ms": 138.774,
-        "samples": 30
-      },
-      "name": "graph_history",
-      "returncode_counts": {
-        "0": 30
-      },
-      "sql": "docs/perf/results/postgres-graph-latency-live-2026-07-01/graph_history.sql"
-    },
-    {
-      "failures_sample": [],
-      "latency": {
-        "max_ms": 210.068,
-        "mean_ms": 116.882,
-        "p50_ms": 106.545,
-        "p95_ms": 180.376,
-        "p99_ms": 210.068,
-        "samples": 30
-      },
-      "name": "graph_evidence_manifest_digest",
-      "returncode_counts": {
-        "0": 30
-      },
-      "sql": "docs/perf/results/postgres-graph-latency-live-2026-07-01/graph_evidence_manifest_digest.sql"
-    },
-    {
-      "failures_sample": [],
-      "latency": {
-        "max_ms": 152.17,
-        "mean_ms": 83.571,
-        "p50_ms": 80.181,
-        "p95_ms": 101.969,
-        "p99_ms": 152.17,
-        "samples": 30
-      },
-      "name": "bounded_traversal_edges",
-      "returncode_counts": {
-        "0": 30
-      },
-      "sql": "docs/perf/results/postgres-graph-latency-live-2026-07-01/bounded_traversal_edges.sql"
-    }
-  ],
-  "scan_id": "graph-benchmark-estate-current",
-  "schema_version": 1,
-  "tenant_id": "default"
+    "repeat": 30,
+    "results": [
+        {
+            "failures_sample": [],
+            "latency": {
+                "max_ms": 502.35,
+                "mean_ms": 98.442,
+                "p50_ms": 77.941,
+                "p95_ms": 182.647,
+                "p99_ms": 502.35,
+                "samples": 30
+            },
+            "name": "node_search",
+            "returncode_counts": {
+                "0": 30
+            },
+            "sql": "docs/perf/results/postgres-graph-latency-live-2026-07-01/node_search.sql"
+        },
+        {
+            "failures_sample": [],
+            "latency": {
+                "max_ms": 129.372,
+                "mean_ms": 79.485,
+                "p50_ms": 73.804,
+                "p95_ms": 128.536,
+                "p99_ms": 129.372,
+                "samples": 30
+            },
+            "name": "node_detail",
+            "returncode_counts": {
+                "0": 30
+            },
+            "sql": "docs/perf/results/postgres-graph-latency-live-2026-07-01/node_detail.sql"
+        },
+        {
+            "failures_sample": [],
+            "latency": {
+                "max_ms": 99.619,
+                "mean_ms": 76.019,
+                "p50_ms": 75.949,
+                "p95_ms": 89.377,
+                "p99_ms": 99.619,
+                "samples": 30
+            },
+            "name": "attack_path_drilldown",
+            "returncode_counts": {
+                "0": 30
+            },
+            "sql": "docs/perf/results/postgres-graph-latency-live-2026-07-01/attack_path_drilldown.sql"
+        },
+        {
+            "failures_sample": [],
+            "latency": {
+                "max_ms": 104.114,
+                "mean_ms": 76.601,
+                "p50_ms": 73.383,
+                "p95_ms": 103.289,
+                "p99_ms": 104.114,
+                "samples": 30
+            },
+            "name": "graph_diff_nodes",
+            "returncode_counts": {
+                "0": 30
+            },
+            "sql": "docs/perf/results/postgres-graph-latency-live-2026-07-01/graph_diff_nodes.sql"
+        },
+        {
+            "failures_sample": [],
+            "latency": {
+                "max_ms": 138.774,
+                "mean_ms": 83.144,
+                "p50_ms": 77.961,
+                "p95_ms": 128.294,
+                "p99_ms": 138.774,
+                "samples": 30
+            },
+            "name": "graph_history",
+            "returncode_counts": {
+                "0": 30
+            },
+            "sql": "docs/perf/results/postgres-graph-latency-live-2026-07-01/graph_history.sql"
+        },
+        {
+            "failures_sample": [],
+            "latency": {
+                "max_ms": 210.068,
+                "mean_ms": 116.882,
+                "p50_ms": 106.545,
+                "p95_ms": 180.376,
+                "p99_ms": 210.068,
+                "samples": 30
+            },
+            "name": "graph_evidence_manifest_digest",
+            "returncode_counts": {
+                "0": 30
+            },
+            "sql": "docs/perf/results/postgres-graph-latency-live-2026-07-01/graph_evidence_manifest_digest.sql"
+        },
+        {
+            "failures_sample": [],
+            "latency": {
+                "max_ms": 152.17,
+                "mean_ms": 83.571,
+                "p50_ms": 80.181,
+                "p95_ms": 101.969,
+                "p99_ms": 152.17,
+                "samples": 30
+            },
+            "name": "bounded_traversal_edges",
+            "returncode_counts": {
+                "0": 30
+            },
+            "sql": "docs/perf/results/postgres-graph-latency-live-2026-07-01/bounded_traversal_edges.sql"
+        }
+    ],
+    "scan_id": "graph-benchmark-estate-current",
+    "schema_version": 1,
+    "tenant_id": "default"
 }

--- a/scripts/check_graph_scale_evidence.py
+++ b/scripts/check_graph_scale_evidence.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Validate checked-in graph scale evidence and supported-size claims."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "perf" / "graph-api-postgres-benchmark.md"
+POSTGRES_LOAD = ROOT / "docs" / "perf" / "results" / "graph-benchmark-postgres-load-live-2026-07-01.json"
+POSTGRES_LATENCY = ROOT / "docs" / "perf" / "results" / "postgres-graph-latency-live-2026-07-01.json"
+
+REQUIRED_QUERIES = {
+    "node_search",
+    "node_detail",
+    "attack_path_drilldown",
+    "graph_diff_nodes",
+    "graph_history",
+    "graph_evidence_manifest_digest",
+    "bounded_traversal_edges",
+}
+
+P95_LIMIT_MS = 750.0
+MIN_SAMPLES = 30
+MIN_NODES = 10_000
+MIN_EDGES = 10_000
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise AssertionError(f"missing graph scale artifact: {path.relative_to(ROOT)}") from None
+    except json.JSONDecodeError as exc:
+        raise AssertionError(f"{path.relative_to(ROOT)} is invalid JSON: {exc}") from exc
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _check_doc() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    _require("Owner issue: #3353" in text, "graph benchmark doc must point at lane D issue #3353")
+    _require("current measured ceiling" in text.lower(), "graph benchmark doc must state the current measured ceiling")
+    _require("100k" in text and "not yet" in text.lower(), "graph benchmark doc must keep 100k+ as not-yet-measured")
+
+
+def _check_load_artifact() -> tuple[int, int]:
+    summary = _load_json(POSTGRES_LOAD)
+    _require(summary.get("backend") == "postgres", "graph store load artifact must be for Postgres")
+    _require(summary.get("evidence_status") == "graph_store_loaded", "graph store load artifact must be measured")
+    _require(summary.get("owner_issue") == 3353, "graph store load artifact owner_issue must be 3353")
+    snapshots = summary.get("snapshots")
+    _require(isinstance(snapshots, dict), "graph store load artifact must include snapshots")
+    current = snapshots.get(summary.get("new_scan_id"))
+    _require(isinstance(current, dict), "graph store load artifact must include the current snapshot")
+    nodes = int(current.get("total_nodes", 0))
+    edges = int(current.get("total_edges", 0))
+    _require(nodes >= MIN_NODES, f"Postgres graph evidence must cover at least {MIN_NODES:,} nodes; got {nodes:,}")
+    _require(edges >= MIN_EDGES, f"Postgres graph evidence must cover at least {MIN_EDGES:,} edges; got {edges:,}")
+    return nodes, edges
+
+
+def _check_latency_artifact() -> None:
+    summary = _load_json(POSTGRES_LATENCY)
+    _require(
+        summary.get("evidence_status") == "postgres_latency_client_wall_clock",
+        "Postgres latency artifact must be measured client wall-clock evidence",
+    )
+    _require(summary.get("owner_issue") == 3353, "Postgres latency artifact owner_issue must be 3353")
+    results = summary.get("results")
+    _require(isinstance(results, list) and results, "Postgres latency artifact must include query results")
+    names = {str(item.get("name")) for item in results if isinstance(item, dict)}
+    missing = sorted(REQUIRED_QUERIES - names)
+    _require(not missing, f"Postgres latency artifact missing query families: {missing}")
+    for item in results:
+        _require(isinstance(item, dict), "Postgres latency result entries must be objects")
+        name = str(item.get("name"))
+        latency = item.get("latency")
+        _require(isinstance(latency, dict), f"{name} latency must be an object")
+        samples = int(latency.get("samples", 0))
+        p95 = float(latency.get("p95_ms", 0.0))
+        _require(samples >= MIN_SAMPLES, f"{name} must have at least {MIN_SAMPLES} samples; got {samples}")
+        _require(p95 <= P95_LIMIT_MS, f"{name} p95 {p95}ms exceeds supported-size limit {P95_LIMIT_MS}ms")
+        returncodes = item.get("returncode_counts")
+        _require(returncodes == {"0": samples}, f"{name} must have all-success return codes; got {returncodes!r}")
+
+
+def main() -> int:
+    try:
+        nodes, edges = _check_load_artifact()
+        _check_latency_artifact()
+        _check_doc()
+    except AssertionError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"graph scale evidence ok: {nodes:,} nodes / {edges:,} edges")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_scale_evidence.py
+++ b/scripts/check_scale_evidence.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from subprocess import run
 
 ROOT = Path(__file__).resolve().parents[1]
 PERF_DIR = ROOT / "docs" / "perf"
@@ -81,6 +82,9 @@ def main() -> int:
     errors: list[str] = []
     for path in REQUIRED_FILES:
         errors.extend(_check_file(path))
+    graph_result = run([sys.executable, "scripts/check_graph_scale_evidence.py"], cwd=ROOT, text=True, capture_output=True, check=False)
+    if graph_result.returncode != 0:
+        errors.append((graph_result.stderr or graph_result.stdout).strip() or "graph scale evidence check failed")
     if errors:
         for error in errors:
             print(error, file=sys.stderr)

--- a/scripts/generate_doc_architecture_svgs.py
+++ b/scripts/generate_doc_architecture_svgs.py
@@ -85,6 +85,15 @@ LANE_COLORS = {
     "consumers": ("#1e3a8a", "#60a5fa", "#93c5fd"),
 }
 
+# Architecture diagram uses a cool layered palette — intentionally distinct from the
+# warm left-to-right pipeline lanes in how-it-works.
+ARCH_LAYER_COLORS = {
+    "sources": ("#0c4a6e", "#38bdf8", "#bae6fd"),
+    "engine": ("#312e81", "#818cf8", "#c7d2fe"),
+    "platform": ("#134e4a", "#2dd4bf", "#99f6e4"),
+    "consumers": ("#4c1d95", "#c084fc", "#e9d5ff"),
+}
+
 
 def _esc(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
@@ -160,6 +169,59 @@ def _lane_flow(x1: int, x2: int, y: int, label: str, t: dict, accent: bool = Fal
         f'<text x="{mid}" y="{y - 10}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
         f'font-size="7" font-weight="800" letter-spacing="0.1em" fill="{t["accent"] if accent else t["lane_muted"]}">'
         f"{_esc(label.upper())}</text>"
+    )
+
+
+def _arch_tier_label(x: int, y: int, w: int, label: str, tag: str, layer_key: str, t: dict) -> str:
+    """Left-stripe tier header for the layered architecture diagram."""
+    _, accent, text_c = ARCH_LAYER_COLORS[layer_key]
+    return (
+        f'<rect x="{x}" y="{y}" width="4" height="22" rx="2" fill="{accent}"/>'
+        + _text(
+            x + 14,
+            y + 15,
+            label,
+            **{
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "9.5",
+                "font-weight": "800",
+                "letter-spacing": "0.14em",
+                "fill": accent,
+            },
+        )
+        + _text(
+            x + w - 10,
+            y + 15,
+            tag,
+            **{
+                "text-anchor": "end",
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "7.5",
+                "font-weight": "600",
+                "fill": text_c,
+            },
+        )
+    )
+
+
+def _tier_down_arrow(cx: int, y: int, label: str, color: str) -> str:
+    """Vertical connector between architecture tiers."""
+    return (
+        f'<line x1="{cx}" y1="{y}" x2="{cx}" y2="{y + 14}" stroke="{color}" stroke-width="1.6" stroke-linecap="round"/>'
+        f'<polygon points="{cx},{y + 18} {cx - 4},{y + 12} {cx + 4},{y + 12}" fill="{color}"/>'
+        + _text(
+            cx,
+            y - 5,
+            label,
+            **{
+                "text-anchor": "middle",
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "7",
+                "font-weight": "800",
+                "letter-spacing": "0.1em",
+                "fill": color,
+            },
+        )
     )
 
 
@@ -375,6 +437,21 @@ def how_it_works(theme_name: str) -> str:
         "</linearGradient>",
         "</defs>",
         f'<rect width="{w}" height="{h}" rx="14" fill="{t["bg"]}"/>',
+        f'<rect x="10" y="10" width="{w - 20}" height="{h - 20}" rx="16" fill="none" stroke="#f59e0b" stroke-width="2" opacity="0.28"/>',
+        f'<rect x="{w - 110}" y="20" width="86" height="22" rx="11" fill="#78350f" opacity="0.72"/>',
+        _text(
+            w - 67,
+            35,
+            "WORKFLOW",
+            **{
+                "text-anchor": "middle",
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "8",
+                "font-weight": "800",
+                "letter-spacing": "0.14em",
+                "fill": "#fde68a",
+            },
+        ),
         _text(
             28,
             40,
@@ -384,7 +461,7 @@ def how_it_works(theme_name: str) -> str:
         _text(
             28,
             60,
-            "One read-only pipeline · one Finding + ContextGraph · CLI · API · UI · MCP",
+            "Five-stage read-only flow · intake -> scan -> evidence -> control -> artifacts",
             **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "500", "fill": t["subtitle"]},
         ),
     ]
@@ -574,11 +651,12 @@ def how_it_works(theme_name: str) -> str:
 
 
 def architecture(theme_name: str) -> str:
+    """Layered control-plane map — visually distinct from the horizontal how-it-works pipeline."""
     t = THEMES[theme_name]
-    w, h = 960, 560
-    lane_gap = 10
-    lane_w = (w - 48 - 4 * lane_gap) // 5
-    lane_x = [24 + i * (lane_w + lane_gap) for i in range(5)]
+    w, h = 960, 620
+    margin_x = 28
+    tier_w = w - 2 * margin_x
+    icon_size = 24
 
     sources = [
         ("package", "Supply chain", "15 eco"),
@@ -589,20 +667,20 @@ def architecture(theme_name: str) -> str:
         ("model", "Models", "13 formats"),
         ("sbom", "SBOM import", "CDX·SPDX"),
     ]
-    scan_items = [
+    engine_items = [
         ("bug", "OSV scan", "batch"),
         ("zap", "Enrichment", "NVD·EPSS"),
         ("shield", "Posture", "CIS·MCP"),
         ("graph", "Blast radius", "fusion"),
         ("file", "Policy", "as-code"),
     ]
-    core_items = [
-        ("finding", "Unified Finding", "one schema", True),
-        ("graph", "UnifiedGraph", "attack paths", True),
-        ("db", "Stores", "PG·SQLite", False),
-        ("audit", "Audit chain", "signed", False),
+    evidence_items = [
+        ("finding", "Unified Finding", "one schema"),
+        ("graph", "UnifiedGraph", "attack paths"),
+        ("db", "Stores", "PG·SQLite"),
+        ("audit", "Audit chain", "signed"),
     ]
-    cp_items = [
+    platform_items = [
         ("api", "REST API", "283 ops"),
         ("gate", "Gateway", "runtime"),
         ("mcp", "MCP server", "70 tools"),
@@ -612,189 +690,272 @@ def architecture(theme_name: str) -> str:
     agents = [("mcp", "MCP"), ("api", "SDK")]
     artifacts = ["SARIF", "CDX", "SPDX", "OCSF", "HTML", "JSON"]
 
-    lane_top = 78
-    lane_h = 400
-    flow_y = 68
-    card_w = lane_w - 16
-    content_top = lane_top + 38
-    icon_size = 26
+    tier_y = [78, 192, 300, 448]
+    tier_h = [102, 96, 136, 140]
+    cx = w // 2
 
     parts = _svg_open(
         w,
         h,
         "agent-bom control-plane architecture",
-        "Sources through scan and evidence core to control plane and consumers.",
+        "Layered sources, processing engine, platform, and consumers.",
     )
     parts += [
         f'<rect width="{w}" height="{h}" rx="14" fill="{t["bg"]}"/>',
+        f'<rect x="12" y="12" width="{w - 24}" height="{h - 24}" rx="18" fill="none" stroke="#6366f1" stroke-width="2" opacity="0.22"/>',
+        f'<rect x="{w - 118}" y="20" width="90" height="22" rx="11" fill="#312e81" opacity="0.85"/>',
         _text(
-            28,
-            38,
+            w - 73,
+            35,
+            "LAYERED",
+            **{
+                "text-anchor": "middle",
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "8",
+                "font-weight": "800",
+                "letter-spacing": "0.14em",
+                "fill": "#c7d2fe",
+            },
+        ),
+        _text(
+            margin_x,
+            40,
             "Control-plane architecture",
             **{"font-family": "Inter,system-ui,sans-serif", "font-size": "20", "font-weight": "800", "fill": t["title"]},
         ),
         _text(
-            28,
-            58,
-            "Sources -> scan -> Finding + UnifiedGraph -> API · Gateway · MCP -> people + agents",
+            margin_x,
+            60,
+            "Vertical tiers · sources feed engine · evidence + platform · people + agents consume",
             **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "500", "fill": t["subtitle"]},
         ),
     ]
 
-    lane_meta = [
-        ("SOURCES", "sources", "read-only"),
-        ("SCAN", "enrich", "local"),
-        ("EVIDENCE", "evidence", "model"),
-        ("CONTROL", "control", "auth"),
-        ("CONSUMERS", "consumers", "deliver"),
-    ]
-    for i, (label, key, tag) in enumerate(lane_meta):
-        x = lane_x[i]
-        parts.append(
-            f'<rect x="{x}" y="{lane_top}" width="{lane_w}" height="{lane_h}" rx="11" fill="{t["panel"]}" stroke="{t["panel_stroke"]}"/>'
+    def _tier_band(y: int, th: int, layer_key: str) -> str:
+        _, accent, _text_c = ARCH_LAYER_COLORS[layer_key]
+        return (
+            f'<rect x="{margin_x}" y="{y}" width="{tier_w}" height="{th}" rx="12" fill="{t["panel"]}" '
+            f'stroke="{accent}" stroke-width="1.2" opacity="0.95"/>'
+            f'<rect x="{margin_x}" y="{y}" width="{tier_w}" height="3" rx="12" fill="{accent}" opacity="0.55"/>'
         )
-        parts.append(_lane_header(x, lane_top, lane_w, label, key, tag, t))
 
-    def _lane_card(
-        lane_i: int,
-        row: int,
+    def _tier_chip(
+        x: int,
+        y: int,
+        cw: int,
+        ch: int,
         icon: str,
         title: str,
         badge: str,
+        layer_key: str,
         *,
-        row_h: int = 50,
         highlight: bool = False,
     ) -> None:
-        x = lane_x[lane_i] + 8
-        sy = content_top + row * row_h
+        _, accent, text_c = ARCH_LAYER_COLORS[layer_key]
         fill = t["accent_fill"] if highlight else t["card"]
-        stroke = t["accent_stroke"] if highlight else t["card_stroke"]
-        ch = row_h - 5
-        text_x = x + icon_size + 18
+        stroke = accent if highlight else t["card_stroke"]
+        text_x = x + icon_size + 14
         parts.append(
-            f'<rect x="{x}" y="{sy}" width="{card_w}" height="{ch}" rx="8" fill="{fill}" stroke="{stroke}" stroke-width="{"1.5" if highlight else "1"}"/>'
+            f'<rect x="{x}" y="{y}" width="{cw}" height="{ch}" rx="8" fill="{fill}" stroke="{stroke}" '
+            f'stroke-width="{"1.5" if highlight else "1"}"/>'
         )
-        parts.append(_icon_box(x + 10, sy + (ch - icon_size) // 2, ICONS[icon], t, accent=highlight, size=icon_size))
+        parts.append(_icon_box(x + 8, y + (ch - icon_size) // 2, ICONS[icon], t, accent=highlight, size=icon_size))
         parts.append(
             _text(
                 text_x,
-                sy + ch // 2 - 1,
+                y + ch // 2 - 1,
                 title,
-                **{"font-family": "Inter,system-ui,sans-serif", "font-size": "9", "font-weight": "700", "fill": t["text"]},
+                **{"font-family": "Inter,system-ui,sans-serif", "font-size": "8.5", "font-weight": "700", "fill": t["text"]},
             )
         )
         parts.append(
             _text(
                 text_x,
-                sy + ch // 2 + 10,
+                y + ch // 2 + 10,
                 badge,
                 **{
                     "font-family": "ui-monospace,monospace",
-                    "font-size": "7",
+                    "font-size": "6.5",
                     "font-weight": "600",
-                    "fill": t["accent"] if highlight else t["text_muted"],
+                    "fill": accent if highlight else t["text_muted"],
                 },
             )
         )
 
+    # Tier 1 — sources
+    y0, h0 = tier_y[0], tier_h[0]
+    parts.append(_tier_band(y0, h0, "sources"))
+    parts.append(_arch_tier_label(margin_x + 12, y0 + 10, tier_w - 24, "INTAKE SOURCES", "read-only", "sources", t))
+    chip_gap = 8
+    chip_h = 44
+    chip_w = (tier_w - 24 - (len(sources) - 1) * chip_gap) // len(sources)
     for i, (icon, title, badge) in enumerate(sources):
-        _lane_card(0, i, icon, title, badge, row_h=44)
+        cx_chip = margin_x + 12 + i * (chip_w + chip_gap)
+        _tier_chip(cx_chip, y0 + 32, chip_w, chip_h, icon, title, badge, "sources")
 
-    for i, (icon, title, badge) in enumerate(scan_items):
-        _lane_card(1, i, icon, title, badge, row_h=52)
+    parts.append(_tier_down_arrow(cx, y0 + h0 + 2, "INGEST", ARCH_LAYER_COLORS["sources"][1]))
 
-    for i, (icon, title, badge, highlight) in enumerate(core_items):
-        _lane_card(2, i, icon, title, badge, row_h=64, highlight=highlight)
+    # Tier 2 — processing engine
+    y1, h1 = tier_y[1], tier_h[1]
+    parts.append(_tier_band(y1, h1, "engine"))
+    parts.append(_arch_tier_label(margin_x + 12, y1 + 10, tier_w - 24, "PROCESSING ENGINE", "local scan", "engine", t))
+    eng_gap = 10
+    eng_w = (tier_w - 24 - (len(engine_items) - 1) * eng_gap) // len(engine_items)
+    for i, (icon, title, badge) in enumerate(engine_items):
+        ex = margin_x + 12 + i * (eng_w + eng_gap)
+        _tier_chip(ex, y1 + 36, eng_w, 52, icon, title, badge, "engine")
 
-    for i, (icon, title, badge) in enumerate(cp_items):
-        _lane_card(3, i, icon, title, badge, row_h=64)
+    parts.append(_tier_down_arrow(cx, y1 + h1 + 2, "PROCESS", ARCH_LAYER_COLORS["engine"][1]))
+
+    # Tier 3 — evidence + platform (two columns, 2x2 grids)
+    y2, h2 = tier_y[2], tier_h[2]
+    parts.append(_tier_band(y2, h2, "platform"))
+    parts.append(_arch_tier_label(margin_x + 12, y2 + 10, tier_w - 24, "EVIDENCE & PLATFORM", "auth · self-hosted", "platform", t))
+    col_gap = 16
+    col_w = (tier_w - 24 - col_gap) // 2
+    left_x = margin_x + 12
+    right_x = left_x + col_w + col_gap
+    mini_gap = 6
+    mini_w = (col_w - mini_gap) // 2
+    mini_h = 32
+    grid_y = y2 + 32
+
+    def _mini_chip(gx: int, gy: int, icon: str, title: str, badge: str, *, highlight: bool = False) -> None:
+        _tier_chip(gx, gy, mini_w, mini_h, icon, title, badge, "platform", highlight=highlight)
+
+    for i, (icon, title, badge) in enumerate(evidence_items):
+        col, row = i % 2, i // 2
+        gx = left_x + col * (mini_w + mini_gap)
+        gy = grid_y + row * (mini_h + mini_gap)
+        _mini_chip(gx, gy, icon, title, badge, highlight=title in ("Unified Finding", "UnifiedGraph"))
+
+    for i, (icon, title, badge) in enumerate(platform_items):
+        col, row = i % 2, i // 2
+        gx = right_x + col * (mini_w + mini_gap)
+        gy = grid_y + row * (mini_h + mini_gap)
+        _mini_chip(gx, gy, icon, title, badge)
 
     parts.append(
-        f'<rect x="{lane_x[3] + 8}" y="{lane_top + lane_h - 30}" width="{card_w}" height="22" rx="7" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>'
+        f'<rect x="{right_x}" y="{y2 + h2 - 24}" width="{col_w}" height="18" rx="6" fill="{t["footer_bg"]}" stroke="{t["footer_stroke"]}"/>'
         + _text(
-            lane_x[3] + 8 + card_w // 2,
-            lane_top + lane_h - 14,
+            right_x + col_w // 2,
+            y2 + h2 - 11,
             "OIDC · SAML · SCIM · RBAC",
             **{
                 "text-anchor": "middle",
                 "font-family": "Inter,system-ui,sans-serif",
-                "font-size": "7",
+                "font-size": "6.5",
                 "font-weight": "700",
                 "fill": t["chip"],
             },
         )
     )
 
-    cons_x = lane_x[4] + 8
+    parts.append(_tier_down_arrow(cx, y2 + h2 + 2, "DELIVER", ARCH_LAYER_COLORS["platform"][1]))
 
-    def _section_label(y: int, label: str) -> None:
+    # Tier 4 — consumers
+    y3, h3 = tier_y[3], tier_h[3]
+    parts.append(_tier_band(y3, h3, "consumers"))
+    parts.append(_arch_tier_label(margin_x + 12, y3 + 10, tier_w - 24, "CONSUMERS & ARTIFACTS", "deliver", "consumers", t))
+
+    cons_col_w = (tier_w - 24 - col_gap) // 2
+    cons_left = margin_x + 12
+    cons_right = cons_left + cons_col_w + col_gap
+
+    def _consumer_mini(y: int, x: int, cw: int, icon: str, label: str) -> int:
+        mh = 30
+        parts.append(
+            f'<rect x="{x}" y="{y}" width="{cw}" height="{mh}" rx="7" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>'
+        )
+        parts.append(_icon_box(x + 10, y + 3, ICONS[icon], t, size=22))
         parts.append(
             _text(
-                cons_x + card_w // 2,
-                y,
-                label,
-                **{
-                    "text-anchor": "middle",
-                    "font-family": "Inter,system-ui,sans-serif",
-                    "font-size": "7.5",
-                    "font-weight": "800",
-                    "letter-spacing": "0.1em",
-                    "fill": t["accent"],
-                },
-            )
-        )
-
-    def _consumer_card(y: int, icon: str, label: str) -> int:
-        card_h = 32
-        parts.append(
-            f'<rect x="{cons_x}" y="{y}" width="{card_w}" height="{card_h}" rx="7" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>'
-        )
-        parts.append(_icon_box(cons_x + 12, y + 4, ICONS[icon], t, size=24))
-        parts.append(
-            _text(
-                cons_x + 44,
-                y + 20,
+                x + 40,
+                y + 19,
                 label,
                 **{"font-family": "Inter,system-ui,sans-serif", "font-size": "9", "font-weight": "700", "fill": t["text"]},
             )
         )
-        return card_h
+        return mh
 
-    y = content_top
-    _section_label(y, "PEOPLE")
-    y += 12
+    cy = y3 + 34
+    parts.append(
+        _text(
+            cons_left + cons_col_w // 2,
+            cy,
+            "PEOPLE",
+            **{
+                "text-anchor": "middle",
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "7.5",
+                "font-weight": "800",
+                "letter-spacing": "0.1em",
+                "fill": ARCH_LAYER_COLORS["consumers"][1],
+            },
+        )
+    )
+    cy += 10
     for icon, label in people:
-        h_card = _consumer_card(y, icon, label)
-        y += h_card + 6
-    y += 4
-    _section_label(y, "AGENTS")
-    y += 12
-    for icon, label in agents:
-        h_card = _consumer_card(y, icon, label)
-        y += h_card + 6
-    y += 4
-    _section_label(y, "ARTIFACTS")
-    y += 12
+        h_card = _consumer_mini(cy, cons_left, cons_col_w, icon, label)
+        cy += h_card + 5
 
+    ay = y3 + 34
+    parts.append(
+        _text(
+            cons_right + cons_col_w // 2,
+            ay,
+            "AGENTS",
+            **{
+                "text-anchor": "middle",
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "7.5",
+                "font-weight": "800",
+                "letter-spacing": "0.1em",
+                "fill": ARCH_LAYER_COLORS["consumers"][1],
+            },
+        )
+    )
+    ay += 10
+    for icon, label in agents:
+        h_card = _consumer_mini(ay, cons_right, cons_col_w, icon, label)
+        ay += h_card + 5
+
+    art_y = y3 + 34
+    art_x = margin_x + 12 + (tier_w - 24) * 0.58
+    art_w = tier_w - 24 - (tier_w - 24) * 0.58 - 8
+    parts.append(
+        _text(
+            art_x + art_w // 2,
+            art_y,
+            "ARTIFACTS",
+            **{
+                "text-anchor": "middle",
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "7.5",
+                "font-weight": "800",
+                "letter-spacing": "0.1em",
+                "fill": ARCH_LAYER_COLORS["consumers"][1],
+            },
+        )
+    )
+    art_y += 10
     chip_cols = 3
     chip_gap = 5
-    chip_w = (card_w - (chip_cols - 1) * chip_gap) // chip_cols
+    chip_w = (art_w - (chip_cols - 1) * chip_gap) // chip_cols
     chip_h = 20
     for i, label in enumerate(artifacts):
         col, row = i % chip_cols, i // chip_cols
-        ax = cons_x + col * (chip_w + chip_gap)
-        ay = y + row * (chip_h + chip_gap)
+        ax = art_x + col * (chip_w + chip_gap)
+        ay_chip = art_y + row * (chip_h + chip_gap)
         parts.append(
-            f'<rect x="{ax}" y="{ay}" width="{chip_w}" height="{chip_h}" rx="5" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
-            f'<text x="{ax + chip_w / 2}" y="{ay + 13}" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" '
+            f'<rect x="{ax}" y="{ay_chip}" width="{chip_w}" height="{chip_h}" rx="5" fill="{t["footer_bg"]}" stroke="{t["card_stroke"]}"/>'
+            f'<text x="{ax + chip_w / 2}" y="{ay_chip + 13}" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" '
             f'font-weight="700" fill="{t["chip"]}">{_esc(label)}</text>'
         )
-    y += 2 * (chip_h + chip_gap) + 8
-
     parts.append(
         _text(
-            cons_x + card_w // 2,
-            y,
+            art_x + art_w // 2,
+            art_y + 2 * (chip_h + chip_gap) + 10,
             "SIEM · webhooks",
             **{
                 "text-anchor": "middle",
@@ -805,9 +966,6 @@ def architecture(theme_name: str) -> str:
             },
         )
     )
-
-    for i, (label, accent) in enumerate([("SCAN", False), ("NORMALIZE", False), ("SERVE", True), ("DELIVER", False)]):
-        parts.append(_lane_flow(lane_x[i] + lane_w, lane_x[i + 1], flow_y, label, t, accent=accent))
 
     parts.append(
         _trust_footer(


### PR DESCRIPTION
Summary
- adds a graph-specific scale evidence gate for the checked-in Postgres graph benchmark artifacts
- documents the current measured ceiling as 10,479 nodes / 11,242 edges / 291 attack paths, and keeps 100k+ claims explicitly unmeasured
- wires the graph evidence gate into the aggregate scale-evidence check so future release docs cannot drift past measured data

Validation
- python scripts/check_graph_scale_evidence.py
- python scripts/check_scale_evidence.py
- uv run ruff check scripts/check_graph_scale_evidence.py scripts/check_scale_evidence.py
- uv run ruff format --check scripts/check_graph_scale_evidence.py scripts/check_scale_evidence.py
- uv run python scripts/check_release_consistency.py

Refs #3353