### PR TITLE
feat(dspm): add opt-in GCS content sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ posture re-evaluation, not a full runtime CDR product.
 
 For DSPM, Snowflake has the deepest current support because agent-bom can read
 warehouse metadata, grants, tags, lineage, and governance activity visible to
-the configured role. AWS S3 also has an opt-in bounded content-sampling lane for
-classifier-backed PII/PHI/PCI/secrets evidence; it stores only redacted
-classification counts, never raw object bytes. Other cloud data-store
+the configured role. AWS S3 and GCP Cloud Storage also have opt-in bounded
+content-sampling lanes for classifier-backed PII/PHI/PCI/secrets evidence; they
+store only redacted classification counts, never raw object bytes. Other cloud data-store
 sensitivity is posture and metadata based until broader provider DLP/Macie
 wrapping, database/warehouse sampling, and object/table/column-level access
 mapping land. Snowflake is therefore a strong optional lane for

--- a/docs/DATABASE_EVIDENCE.md
+++ b/docs/DATABASE_EVIDENCE.md
@@ -45,8 +45,8 @@ query source.
   webhooks or runtime emitter plugins.
 - Generic database evidence is not full DSPM by itself. Only call data
   sensitive when explicit tags, classifications, imported classifier evidence,
-  target-scoped dataset scan results, or opt-in S3 content-sampling evidence
-  support that label.
+  target-scoped dataset scan results, or opt-in object-store content-sampling
+  evidence support that label.
 - ODBC/JDBC do not replace native Snowflake, Postgres/Supabase, Databricks,
   BigQuery, Redshift, or Athena paths where native APIs are available.
 - The default wheel does not bundle ODBC drivers, JDBC drivers, a JVM, or

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -94,8 +94,10 @@ so they cannot regress silently, but they are not part of this reference.
 ## DSPM content sampling
 | Env var | Type | Default | Description |
 |---|---|---|---|
+| `AGENT_BOM_DSPM_GCS_MAX_BYTES_PER_OBJECT` | `int` | `64 * 1024` | — |
+| `AGENT_BOM_DSPM_GCS_MAX_OBJECTS_PER_BUCKET` | `int` | `10` | — |
 | `AGENT_BOM_DSPM_S3_MAX_BYTES_PER_OBJECT` | `int` | `64 * 1024` | — |
-| `AGENT_BOM_DSPM_S3_MAX_OBJECTS_PER_BUCKET` | `int` | `10` | Content reads are opt-in at the caller/module level. These caps bound the amount of object-store data read when an operator enables S3 sampling. |
+| `AGENT_BOM_DSPM_S3_MAX_OBJECTS_PER_BUCKET` | `int` | `10` | Content reads are opt-in at the caller/module level. These caps bound the amount of object-store data read when an operator enables object-store sampling. |
 
 ## EPSS Thresholds
 | Env var | Type | Default | Description |

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -88,6 +88,8 @@ AGENT_BOM_CLICKHOUSE_USER
 AGENT_BOM_CLOUD_INVENTORY
 # Opt-in (default OFF) bounded S3 object byte-range sampling for DSPM content classification. Stores redacted classification counts, never raw object bytes.
 AGENT_BOM_DSPM_S3_SAMPLING
+# Opt-in (default OFF) bounded GCS object byte-range sampling for DSPM content classification. Stores redacted classification counts, never raw object bytes.
+AGENT_BOM_DSPM_GCS_SAMPLING
 # base64 Fernet key for at-rest encryption of cloud-connection secrets (ExternalId); secret, env/KMS-only, never in config.py or ENV_VARS.md. With provider=aws-kms it holds the base64 KMS-wrapped data key instead. Accepts a comma-separated list of keys for MultiFernet rotation (first key = primary/encrypt, any key decrypts).
 AGENT_BOM_CONNECTIONS_KEY
 # Selects how the connection encryption key is resolved: env (default) | aws-secrets | aws-kms | vault; read at key-load time in api/connection_crypto.py.

--- a/src/agent_bom/cloud/gcp_inventory.py
+++ b/src/agent_bom/cloud/gcp_inventory.py
@@ -549,16 +549,22 @@ def _discover_buckets(
             name = str(getattr(bucket, "name", "") or "").strip()
             if not name:
                 continue
-            buckets.append(
-                {
-                    "name": name,
-                    "id": f"//storage.googleapis.com/{name}",
-                    "location": str(getattr(bucket, "location", "") or ""),
-                    "publicly_accessible": _bucket_public(bucket, name, warnings),
-                    "tags": _clean_labels(getattr(bucket, "labels", None)),
-                    "project_id": project_id,
-                }
-            )
+            bucket_record = {
+                "name": name,
+                "id": f"//storage.googleapis.com/{name}",
+                "location": str(getattr(bucket, "location", "") or ""),
+                "publicly_accessible": _bucket_public(bucket, name, warnings),
+                "tags": _clean_labels(getattr(bucket, "labels", None)),
+                "project_id": project_id,
+            }
+            try:
+                from agent_bom.cloud.gcs_data_classifier import classify_gcs_bucket, gcs_sampling_enabled
+
+                if gcs_sampling_enabled():
+                    bucket_record["content_classification"] = classify_gcs_bucket(client, name).to_dict()
+            except Exception as exc:  # noqa: BLE001
+                warnings.append(f"Could not classify GCS bucket {name}: {sanitize_discovery_warning(exc)}")
+            buckets.append(bucket_record)
     except Exception as exc:  # noqa: BLE001 — one failed GCS buckets list must not sink the scan
         record_discovery_failure(
             exc=exc,

--- a/src/agent_bom/cloud/gcs_data_classifier.py
+++ b/src/agent_bom/cloud/gcs_data_classifier.py
@@ -1,0 +1,183 @@
+"""Opt-in GCS content classification for DSPM evidence.
+
+The default GCP inventory path is metadata-only. This module is deliberately
+separate and gated by ``AGENT_BOM_DSPM_GCS_SAMPLING`` because it reads bounded
+object byte ranges. It never stores object bytes or matched values; the output
+contains only counts, redacted finding markers, object names, and warnings.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+from agent_bom import config
+from agent_bom.cloud.normalization import sanitize_discovery_warning
+from agent_bom.parsers.dataset_pii_scanner import DatasetPiiResult, scan_text_for_pii
+
+DSPM_GCS_SAMPLING_ENV_VAR = "AGENT_BOM_DSPM_GCS_SAMPLING"
+
+
+def gcs_sampling_enabled() -> bool:
+    """Return whether bounded GCS content sampling is explicitly enabled."""
+    return os.environ.get(DSPM_GCS_SAMPLING_ENV_VAR, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+@dataclass
+class GCSObjectClassification:
+    bucket: str
+    name: str
+    size: int | None
+    bytes_sampled: int
+    rows_sampled: int
+    total_findings: int
+    findings_by_type: dict[str, int] = field(default_factory=dict)
+    top_findings: list[dict[str, Any]] = field(default_factory=list)
+    skipped: bool = False
+    skip_reason: str = ""
+
+    @classmethod
+    def from_result(
+        cls,
+        *,
+        bucket: str,
+        name: str,
+        size: int | None,
+        bytes_sampled: int,
+        result: DatasetPiiResult,
+    ) -> "GCSObjectClassification":
+        return cls(
+            bucket=bucket,
+            name=name,
+            size=size,
+            bytes_sampled=bytes_sampled,
+            rows_sampled=result.rows_sampled,
+            total_findings=result.total_findings,
+            findings_by_type=dict(result.findings_by_type),
+            top_findings=[
+                {
+                    "pii_type": finding.pii_type,
+                    "severity": finding.severity,
+                    "sample": finding.sample,
+                }
+                for finding in result.top_findings
+            ],
+            skipped=result.skipped,
+            skip_reason=result.skip_reason,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "bucket": self.bucket,
+            "name": self.name,
+            "size": self.size,
+            "bytes_sampled": self.bytes_sampled,
+            "rows_sampled": self.rows_sampled,
+            "total_findings": self.total_findings,
+            "findings_by_type": dict(self.findings_by_type),
+            "top_findings": list(self.top_findings),
+            "skipped": self.skipped,
+            "skip_reason": self.skip_reason,
+        }
+
+
+@dataclass
+class GCSBucketClassification:
+    bucket: str
+    status: str
+    objects_sampled: int = 0
+    total_findings: int = 0
+    findings_by_type: dict[str, int] = field(default_factory=dict)
+    objects: list[GCSObjectClassification] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def sensitivity_score(self) -> int:
+        if not self.total_findings:
+            return 0
+        high = sum(self.findings_by_type.get(kind, 0) for kind in {"ssn", "credit_card", "iban", "passport", "nhs_number"})
+        if high:
+            return 90
+        if any(kind in self.findings_by_type for kind in {"email", "phone", "date_of_birth", "drivers_license", "medical_record_keyword"}):
+            return 60
+        return 30
+
+    @property
+    def data_sensitivity(self) -> str:
+        if self.sensitivity_score >= 60:
+            return "sensitive"
+        if self.sensitivity_score > 0:
+            return "review"
+        return "none"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": "agent-bom.dspm.gcs_classification.v1",
+            "bucket": self.bucket,
+            "status": self.status,
+            "objects_sampled": self.objects_sampled,
+            "total_findings": self.total_findings,
+            "findings_by_type": dict(self.findings_by_type),
+            "sensitivity_score": self.sensitivity_score,
+            "data_sensitivity": self.data_sensitivity,
+            "objects": [obj.to_dict() for obj in self.objects],
+            "warnings": list(self.warnings),
+            "redaction": "raw object bytes and matched values are not stored",
+        }
+
+
+def classify_gcs_bucket(
+    storage_client: Any,
+    bucket: str,
+    *,
+    max_objects: int | None = None,
+    max_bytes_per_object: int | None = None,
+) -> GCSBucketClassification:
+    """Classify a bounded sample of GCS objects in *bucket*.
+
+    Callers must check :func:`gcs_sampling_enabled` before invoking this
+    function from production scan paths. Tests may call it directly with fake
+    clients.
+    """
+    max_objects = max(1, int(max_objects if max_objects is not None else config.DSPM_GCS_MAX_OBJECTS_PER_BUCKET))
+    max_bytes_per_object = max(1, int(max_bytes_per_object if max_bytes_per_object is not None else config.DSPM_GCS_MAX_BYTES_PER_OBJECT))
+    result = GCSBucketClassification(bucket=bucket, status="ok")
+
+    try:
+        blobs = list(storage_client.list_blobs(bucket, max_results=max_objects))
+    except Exception as exc:  # noqa: BLE001
+        result.status = "list_failed"
+        result.warnings.append(f"Could not list GCS objects for {bucket}: {sanitize_discovery_warning(exc)}")
+        return result
+
+    for blob in blobs[:max_objects]:
+        name = str(getattr(blob, "name", "") or "").strip()
+        if not name:
+            continue
+        size = getattr(blob, "size", None)
+        size_int = int(size) if isinstance(size, int) else None
+        try:
+            raw = blob.download_as_bytes(start=0, end=max_bytes_per_object - 1)
+            if not isinstance(raw, (bytes, bytearray)):
+                raw = str(raw).encode("utf-8", errors="replace")
+            sample = bytes(raw[:max_bytes_per_object]).decode("utf-8", errors="replace")
+        except Exception as exc:  # noqa: BLE001
+            result.warnings.append(f"Could not sample gs://{bucket}/{name}: {sanitize_discovery_warning(exc)}")
+            continue
+
+        pii_result = scan_text_for_pii(sample, source=f"gs://{bucket}/{name}", max_chars=max_bytes_per_object)
+        classified = GCSObjectClassification.from_result(
+            bucket=bucket,
+            name=name,
+            size=size_int,
+            bytes_sampled=len(sample.encode("utf-8", errors="replace")),
+            result=pii_result,
+        )
+        result.objects.append(classified)
+        result.objects_sampled += 1
+        result.total_findings += classified.total_findings
+        for pii_type, count in classified.findings_by_type.items():
+            result.findings_by_type[pii_type] = result.findings_by_type.get(pii_type, 0) + count
+
+    return result

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -229,10 +229,12 @@ SCAN_CACHE_MAX_ENTRIES = _int("AGENT_BOM_SCAN_CACHE_MAX_ENTRIES", 100_000)
 
 # ── DSPM content sampling ────────────────────────────────────────────────────
 # Content reads are opt-in at the caller/module level. These caps bound the
-# amount of object-store data read when an operator enables S3 sampling.
+# amount of object-store data read when an operator enables object-store sampling.
 
 DSPM_S3_MAX_OBJECTS_PER_BUCKET = _int("AGENT_BOM_DSPM_S3_MAX_OBJECTS_PER_BUCKET", 10)
 DSPM_S3_MAX_BYTES_PER_OBJECT = _int("AGENT_BOM_DSPM_S3_MAX_BYTES_PER_OBJECT", 64 * 1024)
+DSPM_GCS_MAX_OBJECTS_PER_BUCKET = _int("AGENT_BOM_DSPM_GCS_MAX_OBJECTS_PER_BUCKET", 10)
+DSPM_GCS_MAX_BYTES_PER_OBJECT = _int("AGENT_BOM_DSPM_GCS_MAX_BYTES_PER_OBJECT", 64 * 1024)
 
 
 # ── Local Analytics ─────────────────────────────────────────────────────────

--- a/tests/test_gcs_data_classifier.py
+++ b/tests/test_gcs_data_classifier.py
@@ -1,0 +1,92 @@
+"""Tests for opt-in GCS content classification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agent_bom.cloud import gcp_inventory
+from agent_bom.cloud.gcs_data_classifier import classify_gcs_bucket, gcs_sampling_enabled
+
+
+@dataclass
+class _Blob:
+    name: str
+    size: int
+    data: bytes
+
+    def download_as_bytes(self, *, start: int = 0, end: int | None = None) -> bytes:
+        end_idx = end + 1 if end is not None else None
+        return self.data[start:end_idx]
+
+
+class _Bucket:
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.location = "US"
+        self.labels = {"env": "prod"}
+
+    def get_iam_policy(self) -> dict[str, list[dict[str, list[str]]]]:
+        return {"bindings": []}
+
+
+class _FakeStorageClient:
+    def __init__(self, *, expected_max_results: int | None = None) -> None:
+        self.expected_max_results = expected_max_results
+        self.list_bucket_calls = 0
+        self.list_blob_calls: list[tuple[str, int | None]] = []
+
+    def list_buckets(self) -> list[_Bucket]:
+        self.list_bucket_calls += 1
+        return [_Bucket("prod-data")]
+
+    def list_blobs(self, bucket: str, *, max_results: int | None = None) -> list[_Blob]:
+        self.list_blob_calls.append((bucket, max_results))
+        if self.expected_max_results is not None:
+            assert max_results == self.expected_max_results
+        return [
+            _Blob("customers.csv", 128, b"email,ssn\nalice@example.com,123-45-6789\n"),
+            _Blob("readme.txt", 8, b"hello"),
+            _Blob("ignored.txt", 8, b"ignored"),
+        ]
+
+
+def test_gcs_sampling_flag_is_disabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_DSPM_GCS_SAMPLING", raising=False)
+
+    assert gcs_sampling_enabled() is False
+
+
+def test_gcs_classifier_is_bounded_and_redacted() -> None:
+    client = _FakeStorageClient(expected_max_results=2)
+
+    result = classify_gcs_bucket(client, "prod-data", max_objects=2, max_bytes_per_object=32)
+    payload = result.to_dict()
+
+    assert result.objects_sampled == 2
+    assert result.total_findings >= 1
+    assert payload["data_sensitivity"] == "sensitive"
+    assert payload["redaction"] == "raw object bytes and matched values are not stored"
+    assert client.list_blob_calls == [("prod-data", 2)]
+    assert "alice@example.com" not in repr(payload)
+    assert "123-45-6789" not in repr(payload)
+    assert "[email:REDACTED]" in repr(payload)
+
+
+def test_gcp_bucket_inventory_attaches_content_classification_when_enabled(monkeypatch) -> None:
+    fake_client = _FakeStorageClient()
+    monkeypatch.setenv("AGENT_BOM_DSPM_GCS_SAMPLING", "1")
+
+    storage_module = type("_StorageModule", (), {"Client": staticmethod(lambda *_args, **_kwargs: fake_client)})
+
+    real_import = __import__
+
+    def _fake_import(name: str, globals=None, locals=None, fromlist=(), level: int = 0):  # noqa: ANN001
+        if name == "google.cloud" and "storage" in fromlist:
+            return type("_GoogleCloud", (), {"storage": storage_module})
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", _fake_import)
+
+    buckets = gcp_inventory._discover_buckets("project-1", credentials=None, warnings=[])
+
+    assert buckets[0]["content_classification"]["data_sensitivity"] == "sensitive"


### PR DESCRIPTION
Summary
- adds bounded, opt-in GCS object byte-range sampling for classifier-backed DSPM evidence
- wires GCS classification into GCP bucket inventory only when AGENT_BOM_DSPM_GCS_SAMPLING is enabled
- keeps the storage contract explicit: redacted finding counts only, no raw object bytes or matched values persisted
- updates env-var docs and DSPM positioning so object-store content classification now covers S3 and GCS without claiming full DSPM

Validation
- uv run ruff check src/agent_bom/cloud/gcs_data_classifier.py src/agent_bom/cloud/gcp_inventory.py src/agent_bom/config.py tests/test_gcs_data_classifier.py
- uv run ruff format --check src/agent_bom/cloud/gcs_data_classifier.py src/agent_bom/cloud/gcp_inventory.py src/agent_bom/config.py tests/test_gcs_data_classifier.py
- uv run mypy src/agent_bom/cloud/gcs_data_classifier.py src/agent_bom/cloud/gcp_inventory.py
- uv run pytest tests/test_gcs_data_classifier.py tests/test_s3_data_classifier.py tests/test_dataset_pii_scanner.py -q
- git diff --check
- uv run python scripts/generate_env_var_reference.py --check
- uv run python scripts/check_release_consistency.py

Refs #3352