### PR TITLE
feat(cloud): expose multi-cloud side-scan targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ credential environment names in reach, and the agents that can call it.
 | Cloud estate | Read-only, gated asset inventory and CIS posture across AWS, Azure, GCP, and Snowflake, plus AI/GPU provider posture |
 | Identity (NHI) | Non-human identity discovery (Okta/Entra, gated), credential-expiry posture, and access-review recertification |
 | LLM cost | Spend forecasting, budget runway, chargeback/allocation, and seasonal-aware spend-anomaly detection |
-| Containers + IaC | OCI images, Dockerfile, Terraform, CloudFormation, Helm, and Kubernetes; registry sweeps across ECR/ACR/GAR and agentless AWS EBS disk side-scan (read-only, snapshot-based) |
+| Containers + IaC | OCI images, Dockerfile, Terraform, CloudFormation, Helm, and Kubernetes; registry sweeps across ECR/ACR/GAR and opt-in agentless AWS EBS disk side-scan (scoped snapshot lifecycle) |
 | Secrets + runtime | Secret detection, MCP proxy/gateway, A2A and MCP auth-posture checks, inline firewall enforcement, and redaction |
 | Compliance | Mapped governance frameworks plus ZIP evidence bundles for auditors |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -433,7 +433,7 @@ graph TB
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
 | MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (70 tools across core, operator, runtime-catalog, and specialized modules) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse estate inventory + CIS posture |
-| Cloud side-scan | `src/agent_bom/cloud/side_scan.py` | Agentless AWS EBS disk scan (CWPP) — in-account snapshot/volume, guaranteed `try/finally` cleanup + orphan sweep |
+| Cloud side-scan | `src/agent_bom/cloud/side_scan.py`, `src/agent_bom/cloud/side_scan_targets.py` | Agentless workload side-scan (CWPP) — AWS EBS executor with in-account snapshot/volume cleanup; Azure Managed Disk and GCP Persistent Disk target discovery feed the same executor contract |
 | Registry sweep | `src/agent_bom/cloud/registry_sweep.py` | Registry-wide image enumeration + scan (ECR/ACR/GAR), digest-deduped, capped |
 | Audit trail | `src/agent_bom/cloud/audit_trail.py` | Read-only CloudTrail/Activity Log/Cloud Audit ingest → behavioral `ACCESSED`/`INVOKED` graph edges (counts only) |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -370,6 +370,12 @@ attached to an instance. `--no-secrets` returns SBOM + CVEs only;
 unset the command prints how to enable it and exits non-zero — it never starts a
 snapshot implicitly.
 
+Azure Managed Disk and GCP Persistent Disk inventory also emits
+`side_scan_targets` records with provider, target id, location, size, encryption,
+and execution state. Those records are target discovery only: the current
+snapshot executor is AWS EBS, and Azure/GCP snapshot lifecycle execution remains
+explicit follow-up work under the CWPP lane.
+
 ---
 
 ## 8. Why it scales and stays accurate

--- a/src/agent_bom/cloud/azure_inventory.py
+++ b/src/agent_bom/cloud/azure_inventory.py
@@ -45,6 +45,7 @@ from agent_bom.discovery_envelope import DiscoveryEnvelope, RedactionStatus, Sca
 
 from .aws_inventory import dedupe_missing_permissions, record_discovery_failure
 from .normalization import sanitize_discovery_warning
+from .side_scan_targets import azure_managed_disk_targets
 
 logger = logging.getLogger(__name__)
 
@@ -444,6 +445,7 @@ def discover_inventory(
         "service_bus_namespaces": service_bus_namespaces,
         "redis_caches": redis_caches,
         "managed_disks": managed_disks,
+        "side_scan_targets": azure_managed_disk_targets(managed_disks, subscription_id=resolved_sub),
         "app_services": app_services,
         "management_groups": management_groups,
         "warnings": warnings,

--- a/src/agent_bom/cloud/gcp_inventory.py
+++ b/src/agent_bom/cloud/gcp_inventory.py
@@ -44,6 +44,7 @@ from agent_bom.discovery_envelope import DiscoveryEnvelope, RedactionStatus, Sca
 
 from .aws_inventory import dedupe_missing_permissions, record_discovery_failure
 from .normalization import sanitize_discovery_warning
+from .side_scan_targets import gcp_persistent_disk_targets
 
 logger = logging.getLogger(__name__)
 
@@ -515,6 +516,7 @@ def discover_inventory(
         "route_tables": route_tables,
         "ip_addresses": ip_addresses,
         "disks": disks,
+        "side_scan_targets": gcp_persistent_disk_targets(disks, project_id=resolved_project),
         "pubsub_topics": pubsub_topics,
         "warnings": warnings,
         "missing_permissions": dedupe_missing_permissions(missing),

--- a/src/agent_bom/cloud/side_scan_targets.py
+++ b/src/agent_bom/cloud/side_scan_targets.py
@@ -1,0 +1,97 @@
+"""Provider-neutral agentless workload side-scan target metadata.
+
+This module does not execute snapshot lifecycle actions. It projects already
+discovered disk inventory into a shared contract that the side-scan executor can
+consume later. The output is metadata-only and safe to include in normal
+read-only inventory scans.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+CloudSideScanProvider = Literal["aws", "azure", "gcp"]
+
+
+@dataclass(frozen=True)
+class CloudSideScanTarget:
+    """A disk-like workload asset that can be scanned by an opt-in side-scan."""
+
+    provider: CloudSideScanProvider
+    target_type: str
+    target_id: str
+    name: str
+    account_id: str
+    location: str
+    size_gb: int | None
+    encryption: str
+    status: str = "eligible"
+    execution: str = "not_started"
+    requires_snapshot_role: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "target_type": self.target_type,
+            "target_id": self.target_id,
+            "name": self.name,
+            "account_id": self.account_id,
+            "location": self.location,
+            "size_gb": self.size_gb,
+            "encryption": self.encryption,
+            "status": self.status,
+            "execution": self.execution,
+            "requires_snapshot_role": self.requires_snapshot_role,
+        }
+
+
+def azure_managed_disk_targets(disks: list[dict[str, Any]], *, subscription_id: str) -> list[dict[str, Any]]:
+    """Project Azure Managed Disks into side-scan target records."""
+
+    targets: list[dict[str, Any]] = []
+    for disk in disks:
+        target_id = str(disk.get("id") or disk.get("name") or "").strip()
+        name = str(disk.get("name") or target_id).strip()
+        if not target_id or not name:
+            continue
+        size = disk.get("disk_size_gb")
+        targets.append(
+            CloudSideScanTarget(
+                provider="azure",
+                target_type="managed_disk",
+                target_id=target_id,
+                name=name,
+                account_id=subscription_id,
+                location=str(disk.get("location") or ""),
+                size_gb=size if isinstance(size, int) else None,
+                encryption=str(disk.get("encryption_type") or "unknown"),
+            ).to_dict()
+        )
+    return targets
+
+
+def gcp_persistent_disk_targets(disks: list[dict[str, Any]], *, project_id: str) -> list[dict[str, Any]]:
+    """Project GCP Persistent Disks into side-scan target records."""
+
+    targets: list[dict[str, Any]] = []
+    for disk in disks:
+        target_id = str(disk.get("id") or disk.get("name") or "").strip()
+        name = str(disk.get("name") or target_id).strip()
+        if not target_id or not name:
+            continue
+        size = disk.get("size_gb")
+        encryption = "customer-managed" if disk.get("encrypted") else "provider-managed-or-unknown"
+        targets.append(
+            CloudSideScanTarget(
+                provider="gcp",
+                target_type="persistent_disk",
+                target_id=target_id,
+                name=name,
+                account_id=project_id,
+                location=str(disk.get("location") or ""),
+                size_gb=size if isinstance(size, int) else None,
+                encryption=encryption,
+            ).to_dict()
+        )
+    return targets

--- a/tests/test_azure_parallel_discovery.py
+++ b/tests/test_azure_parallel_discovery.py
@@ -96,6 +96,21 @@ def test_discovery_runs_concurrently(monkeypatch) -> None:
     assert inv["status"] == "ok"
     for collection in ("storage_accounts", "container_clusters", "key_vaults", "databases", "public_ips", "load_balancers"):
         assert len(inv[collection]) == 1
+    assert inv["side_scan_targets"] == [
+        {
+            "provider": "azure",
+            "target_type": "managed_disk",
+            "target_id": "/id/_discover_managed_disks",
+            "name": "_discover_managed_disks-1",
+            "account_id": "sub-1",
+            "location": "",
+            "size_gb": None,
+            "encryption": "unknown",
+            "status": "eligible",
+            "execution": "not_started",
+            "requires_snapshot_role": True,
+        }
+    ]
 
 
 def test_warnings_preserved_in_deterministic_order(monkeypatch) -> None:

--- a/tests/test_cloud_gcp_inventory.py
+++ b/tests/test_cloud_gcp_inventory.py
@@ -946,6 +946,21 @@ def test_inventory_enumerates_estate_breadth(monkeypatch: pytest.MonkeyPatch) ->
     assert disks["web-disk"]["size_gb"] == 50
     assert disks["web-disk"]["encrypted"] is True
     assert disks["web-disk"]["source_image"] == "debian-12"
+    assert payload["side_scan_targets"] == [
+        {
+            "provider": "gcp",
+            "target_type": "persistent_disk",
+            "target_id": "disk-1",
+            "name": "web-disk",
+            "account_id": "proj-1",
+            "location": "us-central1-a",
+            "size_gb": 50,
+            "encryption": "customer-managed",
+            "status": "eligible",
+            "execution": "not_started",
+            "requires_snapshot_role": True,
+        }
+    ]
 
     # Pub/Sub topic.
     topics = {t["name"]: t for t in payload["pubsub_topics"]}

--- a/tests/test_cloud_side_scan_targets.py
+++ b/tests/test_cloud_side_scan_targets.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from agent_bom.cloud.side_scan_targets import azure_managed_disk_targets, gcp_persistent_disk_targets
+
+
+def test_azure_managed_disk_targets_are_metadata_only_and_eligible() -> None:
+    targets = azure_managed_disk_targets(
+        [
+            {
+                "id": "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/disks/os-disk",
+                "name": "os-disk",
+                "location": "eastus",
+                "disk_size_gb": 128,
+                "encryption_type": "EncryptionAtRestWithCustomerKey",
+            }
+        ],
+        subscription_id="sub-1",
+    )
+
+    assert targets == [
+        {
+            "provider": "azure",
+            "target_type": "managed_disk",
+            "target_id": "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/disks/os-disk",
+            "name": "os-disk",
+            "account_id": "sub-1",
+            "location": "eastus",
+            "size_gb": 128,
+            "encryption": "EncryptionAtRestWithCustomerKey",
+            "status": "eligible",
+            "execution": "not_started",
+            "requires_snapshot_role": True,
+        }
+    ]
+
+
+def test_gcp_persistent_disk_targets_are_metadata_only_and_eligible() -> None:
+    targets = gcp_persistent_disk_targets(
+        [
+            {
+                "id": "1234567890",
+                "name": "web-disk",
+                "location": "us-central1-a",
+                "size_gb": 50,
+                "encrypted": True,
+            }
+        ],
+        project_id="proj-1",
+    )
+
+    assert targets == [
+        {
+            "provider": "gcp",
+            "target_type": "persistent_disk",
+            "target_id": "1234567890",
+            "name": "web-disk",
+            "account_id": "proj-1",
+            "location": "us-central1-a",
+            "size_gb": 50,
+            "encryption": "customer-managed",
+            "status": "eligible",
+            "execution": "not_started",
+            "requires_snapshot_role": True,
+        }
+    ]


### PR DESCRIPTION
## Summary
- Adds a provider-neutral side-scan target contract for disk-like workload assets.
- Emits Azure Managed Disk and GCP Persistent Disk side_scan_targets from existing read-only inventory metadata.
- Corrects docs to distinguish AWS EBS side-scan execution from Azure/GCP target discovery.

## Validation
- uv run ruff check src/agent_bom/cloud/side_scan_targets.py src/agent_bom/cloud/azure_inventory.py src/agent_bom/cloud/gcp_inventory.py tests/test_cloud_side_scan_targets.py tests/test_cloud_gcp_inventory.py tests/test_azure_parallel_discovery.py
- uv run ruff format --check src/agent_bom/cloud/side_scan_targets.py tests/test_cloud_side_scan_targets.py
- uv run mypy src/agent_bom/cloud/side_scan_targets.py src/agent_bom/cloud/azure_inventory.py src/agent_bom/cloud/gcp_inventory.py
- uv run pytest tests/test_cloud_side_scan_targets.py tests/test_cloud_gcp_inventory.py::test_inventory_enumerates_estate_breadth tests/test_azure_parallel_discovery.py::test_discovery_runs_concurrently -q
- uv run python scripts/check_release_consistency.py

Progresses #3351