### PR TITLE
perf(graph): cap filtered graph attack paths

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -61,6 +61,7 @@ _GRAPH_QUERY_DEFAULT_BUDGET = {
     "max_edges": 10_000,
     "timeout_ms": 2500,
 }
+_FILTERED_GRAPH_ATTACK_PATH_LIMIT = 100
 
 _SEMANTIC_LAYER_LABELS = {
     GraphSemanticLayer.USER.value: "User",
@@ -1192,7 +1193,8 @@ def _filtered_graph_response(graph: UnifiedGraph, *, offset: int, limit: int) ->
     paged_nodes, pagination = _paginate(all_nodes, offset, limit)
     paged_ids = {n.id for n in paged_nodes}
     paged_edges = [e for e in graph.edges if e.source in paged_ids and e.target in paged_ids]
-    kept_paths = [p for p in _derived_attack_paths(graph) if p.hops and p.hops[0] in paged_ids]
+    matching_paths = [p for p in _derived_attack_paths(graph) if p.hops and p.hops[0] in paged_ids]
+    kept_paths = matching_paths[:_FILTERED_GRAPH_ATTACK_PATH_LIMIT]
     off_page_hops = {hop for p in kept_paths for hop in p.hops} - paged_ids
     nodes_by_id = {n.id: n for n in paged_nodes}
     nodes_by_id.update({hop: graph.nodes[hop] for hop in off_page_hops if hop in graph.nodes})
@@ -1213,6 +1215,11 @@ def _filtered_graph_response(graph: UnifiedGraph, *, offset: int, limit: int) ->
         "interaction_risks": interaction_risks,
         "stats": stats,
         "pagination": pagination,
+        "attack_path_pagination": {
+            "total": len(matching_paths),
+            "limit": _FILTERED_GRAPH_ATTACK_PATH_LIMIT,
+            "has_more": len(matching_paths) > _FILTERED_GRAPH_ATTACK_PATH_LIMIT,
+        },
     }
 
 

--- a/tests/test_graph_filtered_attack_paths_paging.py
+++ b/tests/test_graph_filtered_attack_paths_paging.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from agent_bom.api.routes.graph import _filtered_graph_response
-from agent_bom.graph.container import UnifiedGraph
+from agent_bom.api.routes.graph import _FILTERED_GRAPH_ATTACK_PATH_LIMIT, _filtered_graph_response
+from agent_bom.graph.container import AttackPath, UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import UnifiedNode
 from agent_bom.graph.types import EntityType, RelationshipType
@@ -20,9 +20,7 @@ def _graph_larger_than_page(filler: int) -> UnifiedGraph:
     # The rest of the kill-chain is inserted last, so it falls on a later page.
     g.add_node(UnifiedNode(id="server:fs", entity_type=EntityType.SERVER, label="fs"))
     g.add_node(UnifiedNode(id="pkg:express", entity_type=EntityType.PACKAGE, label="express"))
-    g.add_node(
-        UnifiedNode(id="vuln:CVE-1", entity_type=EntityType.VULNERABILITY, label="CVE-1", severity="critical", risk_score=9.0)
-    )
+    g.add_node(UnifiedNode(id="vuln:CVE-1", entity_type=EntityType.VULNERABILITY, label="CVE-1", severity="critical", risk_score=9.0))
     g.add_edge(UnifiedEdge(source="agent:a", target="server:fs", relationship=RelationshipType.USES))
     g.add_edge(UnifiedEdge(source="server:fs", target="pkg:express", relationship=RelationshipType.DEPENDS_ON))
     g.add_edge(UnifiedEdge(source="pkg:express", target="vuln:CVE-1", relationship=RelationshipType.VULNERABLE_TO))
@@ -51,3 +49,31 @@ def test_filtered_response_keeps_paths_spanning_pages_with_resolved_labels():
     assert exposure_hops["vuln:CVE-1"]["role"] != "unknown"
     assert exposure_hops["server:fs"]["label"] == "fs"
     assert exposure_hops["server:fs"]["role"] != "unknown"
+
+
+def test_filtered_response_caps_embedded_attack_paths_for_large_pages():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+    for i in range(_FILTERED_GRAPH_ATTACK_PATH_LIMIT + 20):
+        vuln_id = f"vuln:CVE-{i}"
+        g.add_node(UnifiedNode(id=vuln_id, entity_type=EntityType.VULNERABILITY, label=f"CVE-{i}", severity="critical"))
+        g.attack_paths.append(
+            AttackPath(
+                source="agent:a",
+                target=vuln_id,
+                hops=["agent:a", vuln_id],
+                edges=["vulnerable_to"],
+                composite_risk=90.0 - (i * 0.01),
+                summary=f"path {i}",
+                vuln_ids=[f"CVE-{i}"],
+            )
+        )
+
+    response = _filtered_graph_response(g, offset=0, limit=1)
+
+    assert len(response["attack_paths"]) == _FILTERED_GRAPH_ATTACK_PATH_LIMIT
+    assert response["attack_path_pagination"] == {
+        "total": _FILTERED_GRAPH_ATTACK_PATH_LIMIT + 20,
+        "limit": _FILTERED_GRAPH_ATTACK_PATH_LIMIT,
+        "has_more": True,
+    }


### PR DESCRIPTION
## Summary
- Caps embedded attack paths in filtered /v1/graph responses so node-windowed graph calls cannot serialize an unbounded path payload.
- Adds attack_path_pagination metadata pointing callers to the dedicated attack-path queue when more paths exist.
- Keeps /v1/graph/attack-paths as the full paged attack-path source of truth.

## Validation
- uv run ruff check src/agent_bom/api/routes/graph.py tests/test_graph_filtered_attack_paths_paging.py
- uv run ruff format --check tests/test_graph_filtered_attack_paths_paging.py
- uv run pytest tests/test_graph_filtered_attack_paths_paging.py -q
- uv run python scripts/check_release_consistency.py

Progresses #3353