### PR TITLE
perf(graph): cap governance payloads

### DIFF
--- a/docs/decisions/008-pluggable-neptune-graph-backend.md
+++ b/docs/decisions/008-pluggable-neptune-graph-backend.md
@@ -31,10 +31,11 @@ API persistence boundary.
 
 The adapter design is:
 
-- **Configuration:** opt in with a backend selector such as
-  `AGENT_BOM_GRAPH_BACKEND=neptune` plus endpoint, AWS auth mode, region, TLS,
-  and optional IAM role settings. Missing config must fail startup for the
-  Neptune backend rather than falling back silently to another tenant's store.
+- **Configuration:** opt in with `AGENT_BOM_GRAPH_BACKEND=neptune`,
+  `AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH=1`, endpoint, AWS auth mode, region,
+  TLS, and optional IAM role settings. Missing experimental opt-in or endpoint
+  config must fail startup for the Neptune backend rather than falling back
+  silently to another tenant's store.
 - **Dependency boundary:** keep AWS/Gremlin dependencies in an optional extra.
   Base installs, CLI scans, SQLite, and Postgres deployments must not import
   those packages at module import time.
@@ -75,7 +76,7 @@ The adapter design is:
 ## Migration Strategy
 
 1. Add a `NeptuneGraphStore` skeleton behind an optional import boundary and
-   feature flag.
+   `AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH=1` feature flag.
 2. Add mocked adapter contract tests that exercise the full
    `GraphStoreProtocol` surface without requiring AWS.
 3. Add a local serializer that exports a `UnifiedGraph` into the exact
@@ -97,5 +98,6 @@ The adapter design is:
   not a shipped managed graph backend.
 - **Trade-off:** Search may need a separate indexed text service at very large
   scale; that is outside the first adapter.
-- **Boundary:** This ADR does not add Neptune code, Gremlin/openCypher public
-  query endpoints, WebGL rendering, or production latency claims.
+- **Boundary:** The first code path remains experimental and fail-closed. This
+  ADR does not add Gremlin/openCypher public query endpoints, WebGL rendering, or
+  production latency claims.

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -13104,6 +13104,34 @@
               "title": "Limit",
               "type": "integer"
             }
+          },
+          {
+            "description": "Max governance edges to return",
+            "in": "query",
+            "name": "edge_limit",
+            "required": false,
+            "schema": {
+              "default": 5000,
+              "description": "Max governance edges to return",
+              "maximum": 25000,
+              "minimum": 1,
+              "title": "Edge Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max governance attack paths to embed",
+            "in": "query",
+            "name": "attack_path_limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "description": "Max governance attack paths to embed",
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Attack Path Limit",
+              "type": "integer"
+            }
           }
         ],
         "responses": {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -8569,6 +8569,28 @@ paths:
           minimum: 1
           title: Limit
           type: integer
+      - description: Max governance edges to return
+        in: query
+        name: edge_limit
+        required: false
+        schema:
+          default: 5000
+          description: Max governance edges to return
+          maximum: 25000
+          minimum: 1
+          title: Edge Limit
+          type: integer
+      - description: Max governance attack paths to embed
+        in: query
+        name: attack_path_limit
+        required: false
+        schema:
+          default: 100
+          description: Max governance attack paths to embed
+          maximum: 1000
+          minimum: 1
+          title: Attack Path Limit
+          type: integer
       responses:
         '200':
           content:

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -122,7 +122,8 @@ so they cannot regress silently, but they are not part of this reference.
 ## Graph Backend Selection
 | Env var | Type | Default | Description |
 |---|---|---|---|
-| `AGENT_BOM_GRAPH_BACKEND` | `str` | `''` | SQLite is the local default. Postgres remains selected by AGENT_BOM_POSTGRES_URL. Neptune is an explicit enterprise lane and must fail closed without endpoint configuration so deployments do not silently fall back to a different graph. |
+| `AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH` | `bool` | `False` | — |
+| `AGENT_BOM_GRAPH_BACKEND` | `str` | `''` | SQLite is the local default. Postgres remains selected by AGENT_BOM_POSTGRES_URL. Neptune is experimental and requires explicit opt-in plus endpoint config. SQLite and Postgres remain the supported graph backends. |
 | `AGENT_BOM_NEPTUNE_ENDPOINT` | `str` | `''` | — |
 | `AGENT_BOM_NEPTUNE_TRAVERSAL_SOURCE` | `str` | `'g'` | — |
 

--- a/docs/perf/graph-api-postgres-benchmark.md
+++ b/docs/perf/graph-api-postgres-benchmark.md
@@ -34,11 +34,12 @@ plans, and Postgres p50/p95/p99 query-family timings on a deterministic
 synthetic estate.
 
 These artifacts do not claim Snowflake behavior, browser timing, managed
-operator deployment timing, or production SLOs. The current measured ceiling is
-the checked-in Docker Postgres estate with 10,479 nodes, 11,242 edges, and 291
-materialized attack paths. 100k+ and 1M-node Postgres claims are not yet
-measured; they remain the next #3353 work item. Measured local CPU graph timings
-remain in [`p95-p99-graph-query.md`](p95-p99-graph-query.md).
+operator deployment timing, managed graph-backend timing, or production SLOs.
+The current measured ceiling is the checked-in Docker Postgres estate with
+10,479 nodes, 11,242 edges, and 291 materialized attack paths. 100k+ and
+1M-node Postgres claims are not yet measured; they remain follow-on scale work.
+Measured local CPU graph timings remain in
+[`p95-p99-graph-query.md`](p95-p99-graph-query.md).
 
 ## Scope
 
@@ -59,6 +60,8 @@ Covered by the checked-in evidence:
   digest, and bounded traversal
 - retained graph history and redaction-aware evidence-manifest API/CLI surfaces
   backed by the same tenant-scoped snapshot store
+- fail-closed backend selection for experimental Neptune so unmeasured managed
+  graph paths cannot be selected accidentally
 
 Excluded from these local artifacts:
 
@@ -66,6 +69,7 @@ Excluded from these local artifacts:
 - Snowflake or managed-operator deployment timings
 - browser/UI interaction timing
 - 50k / 100k / 1M edge Postgres runs
+- Amazon Neptune or other managed graph backend latency
 - six-month hosted lake retention jobs, audit-chain bundle persistence,
   compliance bundle persistence, and legal-hold/deletion workflows
 

--- a/src/agent_bom/api/neptune_graph.py
+++ b/src/agent_bom/api/neptune_graph.py
@@ -1,9 +1,10 @@
 """Amazon Neptune graph store adapter.
 
 The adapter is intentionally optional: importing agent-bom must not require
-Gremlin, AWS credentials, or a reachable Neptune cluster. Production callers
-select it explicitly through ``AGENT_BOM_GRAPH_BACKEND=neptune`` and an
-endpoint; tests can inject a small Gremlin-compatible client.
+Gremlin, AWS credentials, or a reachable Neptune cluster. Operators select it
+explicitly through ``AGENT_BOM_GRAPH_BACKEND=neptune``,
+``AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH=1``, and an endpoint; tests can inject a
+small Gremlin-compatible client.
 """
 
 from __future__ import annotations
@@ -34,6 +35,25 @@ class GremlinClientProtocol(Protocol):
     def submit(self, query: str, bindings: dict[str, Any] | None = None) -> Any: ...
 
 
+def neptune_graph_backend_enabled() -> bool:
+    """Return whether the experimental Neptune backend may be selected."""
+    return os.environ.get("AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def require_neptune_graph_backend_enabled() -> None:
+    """Fail closed unless an operator explicitly opts into the experimental backend."""
+    if not neptune_graph_backend_enabled():
+        raise NeptuneGraphStoreConfigError(
+            "AGENT_BOM_GRAPH_BACKEND=neptune is experimental and requires "
+            "AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH=1; use SQLite/Postgres for supported graph scale."
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class NeptuneGraphConfig:
     """Connection settings for a Neptune Gremlin endpoint."""
@@ -43,6 +63,7 @@ class NeptuneGraphConfig:
 
     @classmethod
     def from_env(cls) -> "NeptuneGraphConfig":
+        require_neptune_graph_backend_enabled()
         endpoint = os.environ.get("AGENT_BOM_NEPTUNE_ENDPOINT", "").strip()
         if not endpoint:
             raise NeptuneGraphStoreConfigError(

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -62,6 +62,8 @@ _GRAPH_QUERY_DEFAULT_BUDGET = {
     "timeout_ms": 2500,
 }
 _FILTERED_GRAPH_ATTACK_PATH_LIMIT = 100
+_GOVERNANCE_EDGE_LIMIT = 5_000
+_GOVERNANCE_ATTACK_PATH_LIMIT = 100
 
 _SEMANTIC_LAYER_LABELS = {
     GraphSemanticLayer.USER.value: "User",
@@ -1198,9 +1200,7 @@ def _filtered_graph_response(graph: UnifiedGraph, *, offset: int, limit: int) ->
     off_page_hops = {hop for p in kept_paths for hop in p.hops} - paged_ids
     nodes_by_id = {n.id: n for n in paged_nodes}
     nodes_by_id.update({hop: graph.nodes[hop] for hop in off_page_hops if hop in graph.nodes})
-    attack_paths = [
-        _serialize_attack_path(p, graph.edges, nodes_by_id=nodes_by_id, scan_id=graph.scan_id) for p in kept_paths
-    ]
+    attack_paths = [_serialize_attack_path(p, graph.edges, nodes_by_id=nodes_by_id, scan_id=graph.scan_id) for p in kept_paths]
     interaction_risks = [
         r.to_dict() for r in graph.interaction_risks if r.agents and all(f"agent:{agent_name}" in paged_ids for agent_name in r.agents)
     ]
@@ -1292,6 +1292,63 @@ def _serialize_attack_path_queue(
         "interaction_risks": [],
         "stats": stats,
         "pagination": _page_meta(total, offset, limit),
+    }
+
+
+def _governance_graph_payload(
+    graph: UnifiedGraph,
+    *,
+    tenant_id: str,
+    overlay_stats: dict[str, Any],
+    node_limit: int,
+    edge_limit: int,
+    attack_path_limit: int,
+) -> dict[str, Any]:
+    governance_types = {
+        EntityType.MANAGED_IDENTITY,
+        EntityType.ACCESS_GRANT,
+        EntityType.ACCESS_POLICY,
+        EntityType.DRIFT_INCIDENT,
+    }
+    governance_ids = {node.id for node in graph.nodes.values() if node.entity_type in governance_types}
+    keep_edges = [e for e in graph.edges if e.source in governance_ids or e.target in governance_ids]
+    keep_ids = set(governance_ids)
+    for edge in keep_edges:
+        keep_ids.add(edge.source)
+        keep_ids.add(edge.target)
+    nodes = [graph.nodes[nid].to_dict() for nid in keep_ids if nid in graph.nodes][:node_limit]
+    node_id_window = {n["id"] for n in nodes}
+    candidate_edges = [e for e in keep_edges if e.source in node_id_window and e.target in node_id_window]
+    edges = candidate_edges[:edge_limit]
+
+    matching_paths = [p for p in _derived_attack_paths(graph) if p.hops and any(hop in governance_ids for hop in p.hops)]
+    attack_paths = [
+        _serialize_attack_path(p, keep_edges, nodes_by_id=graph.nodes, scan_id=graph.scan_id) for p in matching_paths[:attack_path_limit]
+    ]
+    counts: dict[str, int] = {}
+    for node in graph.nodes.values():
+        if node.entity_type in governance_types:
+            counts[node.entity_type.value] = counts.get(node.entity_type.value, 0) + 1
+    return {
+        "scan_id": graph.scan_id,
+        "tenant_id": tenant_id,
+        "created_at": graph.created_at,
+        "nodes": nodes,
+        "edges": [e.to_dict() for e in edges],
+        "attack_paths": attack_paths,
+        "overlay": overlay_stats,
+        "governance_counts": counts,
+        "stats": {"node_count": len(nodes), "edge_count": len(edges)},
+        "edge_pagination": {
+            "total": len(candidate_edges),
+            "limit": edge_limit,
+            "has_more": len(candidate_edges) > edge_limit,
+        },
+        "attack_path_pagination": {
+            "total": len(matching_paths),
+            "limit": attack_path_limit,
+            "has_more": len(matching_paths) > attack_path_limit,
+        },
     }
 
 
@@ -1730,6 +1787,13 @@ async def get_graph_governance(
     request: Request,
     scan_id: Optional[str] = Query(None, description="Scan ID"),
     limit: int = Query(2000, ge=1, le=10000, description="Max nodes to return"),
+    edge_limit: int = Query(_GOVERNANCE_EDGE_LIMIT, ge=1, le=25_000, description="Max governance edges to return"),
+    attack_path_limit: int = Query(
+        _GOVERNANCE_ATTACK_PATH_LIMIT,
+        ge=1,
+        le=1000,
+        description="Max governance attack paths to embed",
+    ),
 ) -> dict:
     """Return the agent-identity governance subgraph projected onto the inventory.
 
@@ -1746,45 +1810,15 @@ async def get_graph_governance(
     graph_store = _get_graph_store_or_503()
     graph = await _graph_store_call(graph_store.load_graph, scan_id=scan_id or "", tenant_id=tenant)
     overlay_stats = apply_governance_overlay(graph, tenant_id=tenant)
-
-    governance_types = {
-        EntityType.MANAGED_IDENTITY,
-        EntityType.ACCESS_GRANT,
-        EntityType.ACCESS_POLICY,
-        EntityType.DRIFT_INCIDENT,
-    }
-    governance_ids = {node.id for node in graph.nodes.values() if node.entity_type in governance_types}
-    # Keep governance nodes plus the inventory nodes they touch (one hop) so the
-    # subgraph is self-contained and renderable.
-    keep_edges = [e for e in graph.edges if e.source in governance_ids or e.target in governance_ids]
-    keep_ids = set(governance_ids)
-    for edge in keep_edges:
-        keep_ids.add(edge.source)
-        keep_ids.add(edge.target)
-    nodes = [graph.nodes[nid].to_dict() for nid in keep_ids if nid in graph.nodes][:limit]
-    node_id_window = {n["id"] for n in nodes}
-    edges = [e.to_dict() for e in keep_edges if e.source in node_id_window and e.target in node_id_window]
-
-    derived = [
-        _serialize_attack_path(p, keep_edges, nodes_by_id=graph.nodes, scan_id=graph.scan_id)
-        for p in _derived_attack_paths(graph)
-        if p.hops and any(hop in governance_ids for hop in p.hops)
-    ]
-    counts: dict[str, int] = {}
-    for node in graph.nodes.values():
-        if node.entity_type in governance_types:
-            counts[node.entity_type.value] = counts.get(node.entity_type.value, 0) + 1
-    return {
-        "scan_id": graph.scan_id,
-        "tenant_id": tenant,
-        "created_at": graph.created_at,
-        "nodes": nodes,
-        "edges": edges,
-        "attack_paths": derived,
-        "overlay": overlay_stats,
-        "governance_counts": counts,
-        "stats": {"node_count": len(nodes), "edge_count": len(edges)},
-    }
+    return await _graph_compute_call(
+        _governance_graph_payload,
+        graph,
+        tenant_id=tenant,
+        overlay_stats=overlay_stats,
+        node_limit=limit,
+        edge_limit=edge_limit,
+        attack_path_limit=attack_path_limit,
+    )
 
 
 @router.get("/v1/graph/nhi/governance", tags=["graph"])
@@ -2188,8 +2222,7 @@ async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
         )
         nodes_by_id = {**filtered_graph.nodes, **{node.id: node for node in backfilled_nodes}}
         attack_paths = [
-            _serialize_attack_path(ap, filtered_graph.edges, nodes_by_id=nodes_by_id, scan_id=filtered_graph.scan_id)
-            for ap in root_paths
+            _serialize_attack_path(ap, filtered_graph.edges, nodes_by_id=nodes_by_id, scan_id=filtered_graph.scan_id) for ap in root_paths
         ]
 
     return {

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -248,10 +248,11 @@ LOCAL_ANALYTICS_DB = _str("AGENT_BOM_LOCAL_ANALYTICS_DB", "")
 
 # ── Graph Backend Selection ───────────────────────────────────────────────
 # SQLite is the local default. Postgres remains selected by AGENT_BOM_POSTGRES_URL.
-# Neptune is an explicit enterprise lane and must fail closed without endpoint
-# configuration so deployments do not silently fall back to a different graph.
+# Neptune is experimental and requires explicit opt-in plus endpoint config.
+# SQLite and Postgres remain the supported graph backends.
 
 GRAPH_BACKEND = _str("AGENT_BOM_GRAPH_BACKEND", "")
+EXPERIMENTAL_NEPTUNE_GRAPH = _bool("AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH", False)
 NEPTUNE_ENDPOINT = _str("AGENT_BOM_NEPTUNE_ENDPOINT", "")
 NEPTUNE_TRAVERSAL_SOURCE = _str("AGENT_BOM_NEPTUNE_TRAVERSAL_SOURCE", "g")
 

--- a/tests/test_graph_governance_overlay.py
+++ b/tests/test_graph_governance_overlay.py
@@ -11,7 +11,9 @@ from agent_bom.api.agent_identity_store import (
     issue_jit_grant,
 )
 from agent_bom.api.drift_incident_store import DriftIncident
-from agent_bom.graph.container import UnifiedGraph
+from agent_bom.api.routes.graph import _governance_graph_payload
+from agent_bom.graph.container import AttackPath, UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.governance_overlay import apply_governance_overlay
 from agent_bom.graph.node import UnifiedNode
 from agent_bom.graph.types import EntityType, RelationshipType
@@ -158,3 +160,43 @@ def test_governance_endpoint_returns_overlay_subgraph(tmp_path):
     finally:
         set_graph_store(original_graph)
         set_agent_identity_store(None)
+
+
+def test_governance_payload_caps_edges_and_attack_paths_for_large_graphs():
+    graph = UnifiedGraph(scan_id="gov-large", tenant_id="default")
+    graph.add_node(
+        UnifiedNode(
+            id="managed_identity:svc",
+            entity_type=EntityType.MANAGED_IDENTITY,
+            label="svc",
+        )
+    )
+    for index in range(8):
+        tool_id = f"tool:srv:tool-{index}"
+        graph.add_node(UnifiedNode(id=tool_id, entity_type=EntityType.TOOL, label=f"tool-{index}"))
+        graph.add_edge(UnifiedEdge(source="managed_identity:svc", target=tool_id, relationship=RelationshipType.CAN_ACCESS))
+        graph.attack_paths.append(
+            AttackPath(
+                source="managed_identity:svc",
+                target=tool_id,
+                hops=["managed_identity:svc", tool_id],
+                edges=["can_access"],
+                composite_risk=7.0,
+                summary=f"governance path {index}",
+            )
+        )
+
+    payload = _governance_graph_payload(
+        graph,
+        tenant_id="default",
+        overlay_stats={"nodes_added": 0},
+        node_limit=20,
+        edge_limit=3,
+        attack_path_limit=2,
+    )
+
+    assert len(payload["edges"]) == 3
+    assert payload["edge_pagination"] == {"total": 8, "limit": 3, "has_more": True}
+    assert len(payload["attack_paths"]) == 2
+    assert payload["attack_path_pagination"] == {"total": 8, "limit": 2, "has_more": True}
+    assert payload["stats"]["edge_count"] == 3

--- a/tests/test_neptune_graph_store.py
+++ b/tests/test_neptune_graph_store.py
@@ -109,6 +109,20 @@ def test_neptune_backend_selection_is_explicit_and_fail_closed(monkeypatch: pyte
     previous = api_stores._graph_store
     api_stores._graph_store = None
     monkeypatch.setenv("AGENT_BOM_GRAPH_BACKEND", "neptune")
+    monkeypatch.delenv("AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH", raising=False)
+    monkeypatch.delenv("AGENT_BOM_NEPTUNE_ENDPOINT", raising=False)
+    try:
+        with pytest.raises(NeptuneGraphStoreConfigError, match="AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH"):
+            api_stores._get_graph_store()
+    finally:
+        api_stores._graph_store = previous
+
+
+def test_neptune_backend_selection_requires_endpoint_after_experimental_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    previous = api_stores._graph_store
+    api_stores._graph_store = None
+    monkeypatch.setenv("AGENT_BOM_GRAPH_BACKEND", "neptune")
+    monkeypatch.setenv("AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH", "1")
     monkeypatch.delenv("AGENT_BOM_NEPTUNE_ENDPOINT", raising=False)
     try:
         with pytest.raises(NeptuneGraphStoreConfigError, match="AGENT_BOM_NEPTUNE_ENDPOINT"):
@@ -122,6 +136,7 @@ def test_neptune_backend_selection_accepts_injected_client(monkeypatch: pytest.M
     api_stores._graph_store = None
     fake_client = FakeGremlinClient()
     monkeypatch.setenv("AGENT_BOM_GRAPH_BACKEND", "neptune")
+    monkeypatch.setenv("AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH", "1")
     monkeypatch.setenv("AGENT_BOM_NEPTUNE_ENDPOINT", "wss://neptune.example:8182/gremlin")
     monkeypatch.setattr("agent_bom.api.neptune_graph._client_from_config", lambda _config: fake_client)
     try:


### PR DESCRIPTION
Summary
- caps /v1/graph/governance embedded edge and attack-path payloads for large estates
- returns edge_pagination and attack_path_pagination so callers can see truncation and drill into focused graph endpoints
- moves governance serialization off the event loop through the existing graph compute wrapper
- gates the experimental Neptune backend behind AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH=1 so the supported scale path remains SQLite/Postgres unless explicitly opted in

Validation
- pre-commit run --files docs/decisions/008-pluggable-neptune-graph-backend.md docs/operations/ENV_VARS.md docs/perf/graph-api-postgres-benchmark.md src/agent_bom/api/neptune_graph.py src/agent_bom/config.py src/agent_bom/mcp_tools/scanning.py tests/test_neptune_graph_store.py
- uv run pytest tests/test_neptune_graph_store.py tests/test_graph_governance_overlay.py tests/test_graph_filtered_attack_paths_paging.py -q
- uv run ruff check src/agent_bom/api/neptune_graph.py src/agent_bom/config.py src/agent_bom/mcp_tools/scanning.py tests/test_neptune_graph_store.py
- uv run ruff format --check src/agent_bom/api/neptune_graph.py src/agent_bom/config.py src/agent_bom/mcp_tools/scanning.py tests/test_neptune_graph_store.py
- uv run python scripts/generate_env_var_reference.py --check
- uv run python scripts/check_release_consistency.py

Closes #3353