### PR TITLE
docs(readme): tighten front door for skimmable onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,38 +30,22 @@
 
 ## What It Is
 
-`agent-bom` scans AI infrastructure across local projects, agent fleets, cloud
-estates (AWS, Azure, GCP, Snowflake), registries, IaC, SBOMs, models, datasets,
-and runtime. It builds one evidence graph of agents, MCP servers, tools,
-packages, credential references, non-human identities, data systems, and exposed
-resources. Every source converges into a unified `Finding` model and a unified
-`ContextGraph`, so blast radius, multi-hop exposure paths, and exposure scoring
-all read from the same evidence.
+`agent-bom` is a read-only scanner and self-hosted control plane for local
+projects, agent fleets, MCP runtimes, and cloud estates (AWS, Azure, GCP,
+Snowflake). Every source converges into one `Finding` model and one
+`ContextGraph` — the unified evidence graph used by CLI, API, UI, MCP, reports,
+and gateway decisions.
 
-`ContextGraph` is the product name for that unified evidence graph across CLI,
-API, UI, MCP, reports, and gateway decisions.
+Blast radius is the core idea: a vulnerable package is linked to the MCP server
+that loads it, the tools it exposes, reachable credential references, and the
+agents that can call it — not just a CVE row.
 
-<details>
-<summary><strong>Recent accuracy upgrades</strong></summary>
+Coverage depth, scanner accuracy tiers, and honest boundaries:
+[AI infrastructure scanning](docs/AI_INFRASTRUCTURE_SCANNING.md) ·
+[scanner accuracy baseline](docs/SCANNER_ACCURACY_BASELINE.md) ·
+[product boundaries](docs/PRODUCT_BOUNDARIES.md)
 
-- **Canonical CVE IDs** — `ALPINE-CVE-*` / `DEBIAN-CVE-*` are mapped to `CVE-*` for cross-tool parity.
-- **Match-confidence tiers** on every finding: `distro_confirmed` > `osv_range` > `osv_ecosystem` > `unfixed_distro` > `nvd_cpe_candidate`.
-- **NVD incremental sync** + **NVD CPE candidate matching** (opt-in via `AGENT_BOM_ENABLE_CPE_MATCH`) for non-ecosystem / OS / vendor software the OSV and distro feeds miss.
-- **Parallel OSV** batches with bounded concurrency.
-
-**Accuracy model.** Distro-confirmed findings match or exceed Trivy on published
-benchmarks (e.g. alpine 3.14.2). The optional `nvd_cpe_candidate` tier is
-review-grade and **off by default** — it widens long-tail coverage without
-inflating confirmed counts. No Trivy/Grype/Syft subprocess is required.
-
-**NVD key model.** CVE/CPE enrichment ships in the distributed vuln database
-(built server-side with an org key), so end users — and MCP/agent callers — do
-**not** supply an NVD key. `NVD_API_KEY` is an optional self-host/freshness knob,
-never a per-user requirement.
-</details>
-
-<details>
-<summary><strong>Who it's for</strong></summary>
+## Who It's For
 
 <p align="center">
   <picture>
@@ -69,20 +53,20 @@ never a per-user requirement.
     <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/persona-value-light.svg" alt="agent-bom value by persona: developers (CLI/CI), security teams (API/dashboard), and automation (MCP tools)" width="980" />
   </picture>
 </p>
-</details>
 
-The product goal is interoperability for humans and agents: developers get a
-CLI/CI scanner, security teams get an API and dashboard, automation gets MCP
-tools and typed schemas, and runtime controls can enforce the same evidence when
-the operator chooses to enable them. Snowflake is one supported connector and
-deployment lane; it is not the product center.
+Developers get CLI/CI gates. Security teams get API, dashboard, and graph
+evidence. Automation gets MCP tools and typed schemas. Runtime controls can
+enforce the same evidence when enabled. Snowflake is a supported connector lane,
+not the product center.
+
+MCP server mode advertises 70 MCP tools, 6 resources, and 8 workflow prompts.
+Registry metadata is tracked through the committed Smithery manifest and Glama
+listing; install and liveness checks live in the integration docs.
 
 ## How It Works
 
-`agent-bom` is a read-only collection and evidence engine first: it discovers
-assets, matches and enriches risk signals, normalizes everything into one graph,
-then serves the same evidence through CLI, CI, API, UI, MCP, reports, and
-runtime controls.
+Read-only intake, scan and enrichment, one evidence graph, then the same model
+through CLI, CI, API, UI, MCP, exports, and optional runtime policy.
 
 <p align="center">
   <picture>
@@ -92,28 +76,19 @@ runtime controls.
 </p>
 
 <details>
-<summary><b>Control-plane architecture — sources, backend, API, MCP, UI, and consumers</b></summary>
+<summary><b>Control-plane architecture</b></summary>
 
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-light.svg" alt="agent-bom architecture showing sources, scan engine, unified model, control plane, and consumers" width="980" />
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-light.svg" alt="agent-bom layered control-plane architecture" width="980" />
   </picture>
 </p>
 
 </details>
 
 <details>
-<summary><b>Scan pipeline — discover, match, enrich, evaluate, normalize, report</b></summary>
-
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/scan-pipeline-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/scan-pipeline-light.svg" alt="agent-bom scan pipeline from discovery through vulnerability matching, enrichment, analysis, reporting, and enforcement" width="980" />
-  </picture>
-</p>
-
-</details>
+<summary><b>Blast radius drilldown</b></summary>
 
 <p align="center">
   <picture>
@@ -126,207 +101,71 @@ runtime controls.
 package -> vulnerability finding -> MCP server -> tools + credential refs -> agent
 ```
 
-Blast radius is the core idea: a vulnerable package is not just a CVE row — it
-is linked to the MCP server that loads it, the tools that server exposes, the
-credential environment names in reach, and the agents that can call it.
-
-## What It Scans
-
-| Domain | Coverage |
-|---|---|
-| Supply chain | Package and OS risk across npm, PyPI, Maven, Go, Cargo, NuGet, Composer, RubyGems, conda, Swift, Hex, Pub, apk, deb, and rpm, with OSV/GHSA/NVD enrichment, opt-in review-grade NVD CPE candidate matching for non-ecosystem software, transitive resolution, and dependency-confusion detection |
-| Agents + MCP | MCP clients, servers, tools, transports, and trust posture with live introspection across 29 first-class client types |
-| AI models + datasets | Malicious-model detection via safe pickle-opcode disassembly (no deserialization), model/dataset cards, and target-scoped PII/PHI dataset-file scanning |
-| Cloud estate | Read-only, gated asset inventory and CIS posture across AWS, Azure, GCP, and Snowflake, plus AI/GPU provider posture |
-| Identity (NHI) | Non-human identity discovery (Okta/Entra, gated), credential-expiry posture, and access-review recertification |
-| LLM cost | Spend forecasting, budget runway, chargeback/allocation, and seasonal-aware spend-anomaly detection |
-| Containers + IaC | OCI images, Dockerfile, Terraform, CloudFormation, Helm, and Kubernetes; registry sweeps across ECR/ACR/GAR and opt-in agentless AWS EBS disk side-scan (scoped snapshot lifecycle) |
-| Secrets + runtime | Secret detection, MCP proxy/gateway, A2A and MCP auth-posture checks, inline firewall enforcement, and redaction |
-| Compliance | Mapped governance frameworks plus ZIP evidence bundles for auditors |
-
-CIS misconfigurations and graph toxic-combinations converge into the same
-`Finding` stream and exit-code gate as package vulnerabilities, so a real
-exposure can fail a pipeline. The graph adds correlation overlays on the same
-base: AppSec findings organized around their application, LLM cost fused onto
-the resources that incur it, read-only cloud audit-trail activity as behavioral
-edges, and an estate-scale `CONTAINS` roll-up with drill-down so large clouds
-stay readable.
-
-### Current Coverage Boundaries
-
-agent-bom is strongest today as a read-only CSPM/CIS, vuln/SCA, compliance,
-runtime-policy, and graph-posture product. Connected account scans can run on a
-schedule, so new or removed assets are picked up at the next scan and graph
-history can show appeared/removed evidence. For cloud posture, opt-in event
-consumers can also drain AWS CloudTrail/EventBridge→SQS, Azure Activity
-Log/Event Grid→Storage Queue, and GCP Cloud Asset/Audit Log→Pub/Sub to re-check
-the affected resource class between scheduled scans. That is change-triggered
-posture re-evaluation, not a full runtime CDR product.
-
-For DSPM, Snowflake has the deepest current support because agent-bom can read
-warehouse metadata, grants, tags, lineage, and governance activity visible to
-the configured role. AWS S3 and GCP Cloud Storage also have opt-in bounded
-content-sampling lanes for classifier-backed PII/PHI/PCI/secrets evidence; they
-store only redacted classification counts, never raw object bytes. Other cloud data-store
-sensitivity is posture and metadata based until broader provider DLP/Macie
-wrapping, database/warehouse sampling, and object/table/column-level access
-mapping land. Snowflake is therefore a strong optional lane for
-Snowflake-heavy customers, not the required data plane for the product.
-
-## Product Map
-
-Use this map when you are deciding where to start. Every lane writes into the
-same `Finding` and `ContextGraph` model; the difference is the entry point,
-credential boundary, and operator surface.
-
-| Need | Surface | First action | Auth / data boundary | Main artifact |
-|---|---|---|---|---|
-| Scan a repo, image, or local agent config | CLI / CI | `agent-bom agents -p .` | local files only unless an opt-in connector is enabled | JSON, SARIF, SBOM, HTML |
-| Connect cloud and selected data-estate evidence | Cloud and warehouse connectors | `agent-bom connect aws` then `agent-bom cloud scan` | read-only provider credentials; no secret values read or stored | cloud assets, CIS findings, Snowflake governance evidence, graph edges |
-| Review posture as a team | API + dashboard | `pip install 'agent-bom[ui]' && agent-bom serve` | API key/OIDC/SAML/SCIM where configured; tenant-scoped state | findings, graph, audit, compliance |
-| Give agents security tools | MCP server | `agent-bom mcp server` | read-mostly tools; Shield writes require admin role, scope, and audit reason | strict MCP tool responses |
-| Govern runtime tool calls | Proxy / gateway | configure proxy or gateway policy | inline policy checks; redacted, auditable decisions | allow/warn/block audit trail |
-| Package evidence for security and audit | Reports / exports | `agent-bom agents -p . -f html -o report.html` | caller-controlled export path | SARIF, CycloneDX, SPDX, OCSF, compliance bundle |
-
-See [docs/PRODUCT_MAP.md](docs/PRODUCT_MAP.md) for the longer workflow map,
-including backend choices, auth modes, and where each capability lives in the
-CLI, API, MCP server, dashboard, and deployment docs.
-
-## How Data Gets In
-
-Today, agent-bom ingests through read-only pulls and explicit pushes, not
-Snowpipe or a required streaming bus.
-
-| Ingest lane | Current mechanism | Typical sources | Cadence |
-|---|---|---|---|
-| Read-only cloud / warehouse connectors | Assumable role, managed identity, ADC, or Snowflake key-pair; SDK/SQL `list`/`get`/`SELECT` calls only | AWS, Azure, GCP, Snowflake | on demand or scheduled polling |
-| Direct scans | CLI/API scan job over local or submitted targets | repo, image, IaC, SBOM, MCP config, model, dataset | per command or job |
-| Artifact import | Operator-provided standard evidence | CycloneDX, SPDX, SARIF, scanner JSON, OCSF-like evidence | per import |
-| Runtime / gateway events | Authenticated API ingest from configured runtimes | MCP/tool-call auth, DLP decisions, LLM spans, proxy audit | event push |
-
-Scheduled connectors re-run with the stored tenant-scoped connection and detect
-new, changed, and removed assets at the next cadence through graph history and
-diff evidence. Snowpipe/Streams are a future Snowflake-native option for
-near-real-time telemetry landing in customer-owned Snowflake tables; they are
-not required for the hosted demo, self-hosted platform, CLI, or current
-Snowflake connector.
-
-<details>
-<summary><b>Product proof — dashboard, graph, and identity surfaces</b></summary>
-
-Captured from the packaged UI with bundled demo scan data and seeded
-control-plane records — synthetic data where needed, but the real scan, graph,
-fleet, identity, audit, and gateway routes.
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png" alt="agent-bom risk overview dashboard with posture score, findings, and attack path summary" width="900" />
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-paths-live.png" alt="agent-bom risk overview attack paths with exposure KPIs" width="900" />
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-live.png" alt="agent-bom agent mesh graph showing agent, MCP server, package, tool, credential reference, and finding path" width="900" />
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/security-graph-live.png" alt="agent-bom security graph with attack-path queue, graph evidence export, and remediation handoff" width="900" />
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/lineage-graph-live.png" alt="agent-bom lineage topology across environment, identity, MCP, package, credential, model, dataset, and finding nodes" width="900" />
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/context-map-live.png" alt="agent-bom agent-scoped context map with reachable MCP servers and lateral movement side panel" width="900" />
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dependency-map-live.png" alt="agent-bom supply chain dependency map with scan pipeline counts and package risk distribution" width="900" />
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/gateway-policies-live.png" alt="agent-bom runtime gateway policy posture with baseline policy, rules, and bound agents" width="900" />
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/fleet-state-live.png" alt="agent-bom fleet state with lifecycle distribution, owner metadata, environment label, and discovery state" width="900" />
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/identity-audit-live.png" alt="agent-bom identity audit log with HMAC integrity counters and agent identity issue, rotate, and revoke events" width="900" />
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/remediation-live.png" alt="agent-bom fix-first remediation table with prioritized packages and framework context" width="900" />
-</p>
-
-Capture rules and the full manifest live in [docs/CAPTURE.md](docs/CAPTURE.md)
-and [docs/images/product-screenshots.json](docs/images/product-screenshots.json).
-
 </details>
+
+## Start Here
+
+Every lane writes into the same `Finding` and `ContextGraph` model. Pick the
+entry point that matches your role; see [docs/PRODUCT_MAP.md](docs/PRODUCT_MAP.md)
+for ingest lanes, auth boundaries, and surface detail.
+
+| Need | Surface | First action | Main artifact |
+|---|---|---|---|
+| Scan a repo, image, or local agent config | CLI / CI | `agent-bom agents -p .` | JSON, SARIF, SBOM, HTML |
+| Connect cloud and data-estate evidence | Cloud connectors | `agent-bom connect aws` then `agent-bom cloud scan` | assets, CIS findings, graph edges |
+| Review posture as a team | API + dashboard | `pip install 'agent-bom[ui]' && agent-bom serve` | findings, graph, audit, compliance |
+| Give agents security tools | MCP server | `agent-bom mcp server` | strict MCP tool responses |
+| Govern runtime tool calls | Proxy / gateway | configure proxy or gateway policy | allow/warn/block audit trail |
+| Package evidence for audit | Reports / exports | `agent-bom agents -p . -f html -o report.html` | SARIF, CycloneDX, SPDX, OCSF, compliance bundle |
+
+| Goal | Command |
+|---|---|
+| Multi-hop exposure paths | `agent-bom graph` |
+| LLM cost forecast | `agent-bom cost forecast` |
+| Non-human identity posture | `agent-bom identity credential-expiry` |
+| Advisory remediation plan | `agent-bom remediate -p .` |
+| Gated-capability readiness | `agent-bom capabilities` |
+| CI gate | `uses: msaad00/agent-bom@v0.91.0` |
+
+Full command map: [docs/CLI_MAP.md](docs/CLI_MAP.md) · role routing:
+[docs/START_HERE.md](docs/START_HERE.md) · repo layout:
+[PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md)
 
 ## First Run
 
 ```bash
 pip install agent-bom
 agent-bom db update                      # populate ~/.agent-bom vuln DB before --offline scans
-agent-bom quickstart --run --offline    # write sample, scan, seed gateway policy, populate the cockpit
-agent-bom agents -p . -f html -o agent-bom-report.html   # a real local scan
+agent-bom quickstart --run --offline    # sample scan, gateway policy seed, dashboard data
+agent-bom agents -p . -f html -o agent-bom-report.html
 ```
 
-Offline image and package scans require a populated local vulnerability database.
-Run `agent-bom db update` (or allow the first online scan to warm the cache)
-before `agent-bom image --offline`, `agent-bom agents --offline`, or CI jobs
-that pass `--offline`.
-
-The demo uses bundled advisory-backed OSV/GHSA ranges against intentionally
-vulnerable sample packages, producing graph-ready inventory without touching
-your source tree. See [docs/FIRST_RUN.md](docs/FIRST_RUN.md) for the guided path
-from CLI output to the dashboard, and [docs/CAPTURE.md](docs/CAPTURE.md) to
-reproduce the dashboard screenshots from a clean local control-plane store.
+Run `agent-bom db update` before `--offline` image or package scans. Guided path:
+[docs/FIRST_RUN.md](docs/FIRST_RUN.md) · UI screenshots:
+[docs/CAPTURE.md](docs/CAPTURE.md)
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif" alt="agent-bom terminal demo" width="820" />
 </p>
 
-## Start Here
+## Cloud, Deploy, Trust
 
-| Goal | Command |
-|---|---|
-| Local agent and MCP inventory | `agent-bom agents` |
-| Repo and lockfile scan | `agent-bom agents -p .` |
-| Connect a cloud (read-only) | `agent-bom connect aws` |
-| Cloud estate scan | `agent-bom cloud scan` |
-| Multi-hop exposure paths | `agent-bom graph` |
-| Report (HTML/SARIF/SBOM) | `agent-bom agents -p . -f html -o report.html` |
-| LLM cost forecast | `agent-bom cost forecast` |
-| Non-human identity posture | `agent-bom identity credential-expiry` |
-| Advisory remediation plan | `agent-bom remediate -p .` |
-| Gated-capability readiness | `agent-bom capabilities` |
-| CI gate | `uses: msaad00/agent-bom@v0.91.0` |
-| Local API and dashboard | `pip install 'agent-bom[ui]' && agent-bom serve` |
+**Cloud (read-only).** Four connectors — AWS, Azure, GCP, Snowflake — are
+opt-in, agentless, and default-off. No secret values are read or stored.
+`agent-bom connect <provider>` prints the grant template and enable flag without
+network I/O until you opt in.
 
-The base wheel is the scanner and CLI path; optional runtime surfaces fail fast
-with install hints when their extras are missing.
-[PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md) is the repo map,
-[docs/START_HERE.md](docs/START_HERE.md) routes by role, and
-[docs/CLI_MAP.md](docs/CLI_MAP.md) groups every command by domain.
+| Cloud | Enable | Scan |
+|---|---|---|
+| AWS | `AGENT_BOM_AWS_INVENTORY=1` | `agent-bom cloud aws` |
+| Azure | `AGENT_BOM_AZURE_INVENTORY=1` | `agent-bom cloud azure` |
+| GCP | `AGENT_BOM_GCP_INVENTORY=1` | `agent-bom cloud gcp` |
+| Snowflake | key-pair role | `agent-bom agents --snowflake` |
 
-## Connect a Cloud (Read-Only Auth)
+Setup and grants: [docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md)
 
-`agent-bom` reads four clouds — **AWS, Azure, GCP, and Snowflake** — through one
-connection model. Every connector is **read-only, agentless, and keyless** by
-default: only control-plane `list`/`get` (or `SHOW`/`SELECT`) APIs, no writes, no
-secret values, and no data leaves your account. Each connector is opt-in and
-default-off behind a per-provider env flag; with the flag unset, agent-bom does
-zero cloud network I/O. `agent-bom connect aws | azure | gcp | snowflake` prints
-the exact read-only grant, the opt-in env var, and whether local credentials are
-detectable — without any network I/O until you opt in.
-
-| Cloud | Read-only grant | Keyless / token auth | Enable | Scan |
-|---|---|---|---|---|
-| AWS | `SecurityAudit` managed policy | profile / SSO / instance role (boto3 chain) | `AGENT_BOM_AWS_INVENTORY=1` | `agent-bom cloud aws` |
-| Azure | `Reader` (+ `Security Reader`) | `az login` / managed identity / cert SP | `AGENT_BOM_AZURE_INVENTORY=1` | `agent-bom cloud azure` |
-| GCP | impersonated read-only service account | ADC / `gcloud` / workload identity | `AGENT_BOM_GCP_INVENTORY=1` | `agent-bom cloud gcp` |
-| Snowflake | `ABOM_READONLY` role + key-pair user | RSA key-pair JWT (no password) | — | `agent-bom agents --snowflake` |
-
-```bash
-# AWS — attach SecurityAudit to the principal, then:
-export AGENT_BOM_AWS_INVENTORY=1
-export AWS_PROFILE=<readonly-profile>
-agent-bom cloud aws --cis
-
-# Run every configured cloud at once (read-only, auto-detects what is connected):
-agent-bom cloud scan --fail-on-severity high
-```
-
-AWS, Azure, GCP, and Snowflake setup, the full grant templates, per-cloud permission
-catalogs, and the "why read-only is enough" rationale live in
-[docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md). agent-bom is one interoperable
-scanner and control plane: it reads inventory and posture, normalizes it into
-one graph, serves humans and agents from the same evidence, and emits findings;
-it never writes, never reads secret contents, and never moves data out of your
-account unless you explicitly configure an export destination.
-
-## Deploy In Your Boundary
-
-`agent-bom` is built for customer-controlled deployment across four lanes of one
-product: the OSS CLI, the self-hosted API/UI platform, a gated hosted POC you
-operate, and an optional Snowflake-native deployment for Snowflake-heavy
-customers. A managed public SaaS control plane is roadmap work gated on
-self-serve signup, tenant lifecycle, quotas, billing, and abuse controls.
+**Deploy in your boundary.** OSS CLI, self-hosted API/UI, gated hosted POC, or
+optional Snowflake-native lane — no managed public SaaS in this repo yet.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
@@ -334,55 +173,26 @@ docker compose -f docker-compose.pilot.yml up -d
 # Dashboard -> http://localhost:3000
 ```
 
-The pilot compose profile is a single-workstation evaluator: API and UI ports
-bind to `127.0.0.1`, CORS is scoped to local UI origins, and no-auth is enabled
-only for that loopback boundary. Use `docker-compose.platform.yml` or
-`docs/HOSTED_POC.md` before sharing a link with anyone else.
+Pilot compose binds to `127.0.0.1` with loopback CORS only. Use
+`docker-compose.platform.yml` or [docs/HOSTED_POC.md](docs/HOSTED_POC.md) before
+sharing a link.
 
-- [Deploy anywhere guide](docs/DEPLOY_PLATFORM.md) — laptop, your Kubernetes, or hosted control plane
-- [Helm chart](deploy/helm/agent-bom) and [one-apply EKS platform module](deploy/terraform/platform-eks)
-- [Docker Hub image](https://hub.docker.com/r/agentbom/agent-bom)
-- [CloudFormation one-click](deploy/cloudformation) — a read-only `cloud aws` scan via CodeBuild, no local credentials handed to agent-bom
+- [Deploy anywhere](docs/DEPLOY_PLATFORM.md) · [Helm](deploy/helm/agent-bom) ·
+  [EKS module](deploy/terraform/platform-eks) ·
+  [Docker Hub](https://hub.docker.com/r/agentbom/agent-bom) ·
+  [CloudFormation one-click](deploy/cloudformation)
 
-There is no managed cloud offering in this repository; lane boundaries are
-documented in [docs/PRODUCT_BOUNDARIES.md](docs/PRODUCT_BOUNDARIES.md).
+**Trust.**
 
-## Trust Model
+- Read-only discovery by default; no mandatory telemetry.
+- Credential values redacted; env names preserved for explainable exposure paths.
+- Exports: JSON, SARIF, CycloneDX, SPDX, OCSF, Markdown, HTML, compliance bundles.
+- Tenant scope, auth boundaries, and audit evidence on API/runtime paths.
 
-- Read-only discovery by default for cloud and local inventory.
-- No mandatory telemetry.
-- Credential values are redacted; credential environment names are preserved as
-  evidence so exposure paths stay explainable.
-- Findings export as JSON, SARIF, CycloneDX, SPDX, OCSF, Markdown, HTML, and
-  compliance evidence bundles.
-- API and runtime paths are designed for tenant scope, auth boundaries, and
-  audit evidence; OpenAPI artifacts are committed for client contract checks.
-
-References: [Threat model](docs/THREAT_MODEL.md) ·
-[Pentest readiness](docs/PENTEST_READINESS.md) ·
+[Threat model](docs/THREAT_MODEL.md) · [Pentest readiness](docs/PENTEST_READINESS.md) ·
 [Python client](docs/PYTHON_API.md) · [Go client](sdks/go/README.md) ·
-[Release verification](docs/RELEASE_VERIFICATION.md)
-
-## Surfaces
-
-| Surface | Primary user | Current boundary |
-|---|---|---|
-| CLI / CI | developers and release gates | local scans, SARIF/SBOM/HTML/JSON, deterministic exit codes |
-| REST API | control-plane integrations | scans, bulk findings, dataset versions, evaluation runs, graph evidence, audit, runtime summaries |
-| MCP tools | agents and assistants | strict arguments, read-mostly security queries, exposure paths, deploy decisions, audited Shield actions |
-| Dashboard | security teams and operators | inventory, findings, graph cockpit, compliance, evidence, runtime posture |
-| Runtime proxy/gateway | runtime operators | scoped MCP traffic inspection, policy decisions, redacted audit evidence |
-| Python / TypeScript clients | services and agent runtimes | typed helpers for stable REST endpoints |
-
-MCP server mode advertises 70 MCP tools, 6 resources, and 8 workflow prompts.
-Most tools are read-only; Shield and identity write actions fail closed unless
-the MCP request is authenticated with `AGENT_BOM_MCP_OPERATOR_TOKEN` and the
-tool call includes the matching admin role, write scope, and audit reason. CLI
-scan commands run local scan pipelines today and share lower
-scanner and discovery libraries with the API, but they are not API wrappers yet.
-MCP registry presence is tracked through the committed Smithery manifest and
-other registry metadata; install and liveness checks live in the integration
-docs, not this front door.
+[Release verification](docs/RELEASE_VERIFICATION.md) ·
+[MCP security model](docs/MCP_SECURITY_MODEL.md)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -32,18 +32,41 @@
 
 `agent-bom` is a read-only scanner and self-hosted control plane for local
 projects, agent fleets, MCP runtimes, and cloud estates (AWS, Azure, GCP,
-Snowflake). Every source converges into one `Finding` model and one
-`ContextGraph` — the unified evidence graph used by CLI, API, UI, MCP, reports,
-and gateway decisions.
+Snowflake).
+
+**ContextGraph** is agent-bom's unified evidence graph across CLI, API, UI, MCP
+tools, reports, and gateway decisions. Findings, assets, packages, cloud
+resources, identities, agents, MCP servers, credentials, and runtime decisions
+all normalize into that graph so posture, blast radius, and enforcement read
+from the same evidence.
 
 Blast radius is the core idea: a vulnerable package is linked to the MCP server
 that loads it, the tools it exposes, reachable credential references, and the
 agents that can call it — not just a CVE row.
 
-Coverage depth, scanner accuracy tiers, and honest boundaries:
+Coverage depth and honest boundaries:
 [AI infrastructure scanning](docs/AI_INFRASTRUCTURE_SCANNING.md) ·
-[scanner accuracy baseline](docs/SCANNER_ACCURACY_BASELINE.md) ·
 [product boundaries](docs/PRODUCT_BOUNDARIES.md)
+
+## Accuracy Model
+
+agent-bom normalizes advisory and distro evidence into canonical CVE findings
+with match-confidence tiers:
+
+`distro_confirmed` > `osv_range` > `osv_ecosystem` > `unfixed_distro` > `nvd_cpe_candidate`
+
+Distro-confirmed findings are treated as confirmed. Optional NVD CPE candidate
+matching widens long-tail OS/vendor software coverage, but remains review-grade
+and off by default.
+
+**NVD key model.** End users do not need an NVD API key. CVE/CPE enrichment
+ships through the distributed vulnerability database. `NVD_API_KEY` is only an
+optional self-hosted freshness knob for operators rebuilding or refreshing the
+database.
+
+Matching mechanics and release evidence:
+[vulnerability matching](docs/VULNERABILITY_MATCHING.md) ·
+[scanner accuracy baseline](docs/SCANNER_ACCURACY_BASELINE.md)
 
 ## Who It's For
 

--- a/docs/SCANNER_ACCURACY_BASELINE.md
+++ b/docs/SCANNER_ACCURACY_BASELINE.md
@@ -2,6 +2,9 @@
 
 This file defines what `agent-bom` can prove before a release and what remains a roadmap item.
 
+For match-confidence tiers, canonical CVE mapping, and NVD key boundaries, see
+[VULNERABILITY_MATCHING.md](VULNERABILITY_MATCHING.md).
+
 The machine-readable release artifact is [`accuracy-baseline.json`](accuracy-baseline.json). It is generated with:
 
 ```bash

--- a/docs/VULNERABILITY_MATCHING.md
+++ b/docs/VULNERABILITY_MATCHING.md
@@ -1,0 +1,74 @@
+# Vulnerability matching
+
+This document explains how `agent-bom` normalizes scanner evidence into
+canonical CVE findings, assigns match-confidence tiers, and uses NVD data
+without requiring every end user to supply an API key.
+
+For release gates and what the project can prove before tagging, see
+[SCANNER_ACCURACY_BASELINE.md](SCANNER_ACCURACY_BASELINE.md).
+
+## Canonical CVE identity
+
+Distro-scoped advisory IDs such as `ALPINE-CVE-*` and `DEBIAN-CVE-*` are mapped
+to canonical `CVE-*` IDs where the pattern allows. That keeps SARIF, SBOM, and
+dashboard exports aligned with other tools that key on CVE.
+
+## Match-confidence tiers
+
+Every package vulnerability finding carries a `match_confidence_tier`. Tiers are
+ordered strongest to weakest:
+
+| Tier | Meaning |
+|---|---|
+| `distro_confirmed` | Distro security feed confirms the package/version is affected |
+| `osv_range` | OSV affected-version range matches the installed version |
+| `osv_ecosystem` | OSV ecosystem match without a precise version range |
+| `unfixed_distro` | Distro documents the issue but no fixed package is available yet |
+| `nvd_cpe_candidate` | NVD CPE applicability suggests a match; review-grade only |
+
+Distro-confirmed findings are treated as confirmed for gates and posture counts.
+The `nvd_cpe_candidate` tier is intentionally lower confidence: CPE product names
+do not always equal package names, so these matches are opt-in and surfaced for
+analyst review rather than silently promoted to confirmed counts.
+
+Enable CPE candidate matching with `AGENT_BOM_ENABLE_CPE_MATCH=1` (default off).
+
+## NVD enrichment and keys
+
+**End users and MCP callers do not need an NVD API key.** The distributed
+vulnerability database ships with OSV, GHSA, distro, EPSS, KEV, and NVD-derived
+fields populated during `agent-bom db update` / server-side sync.
+
+`NVD_API_KEY` is an **operator-only** knob when rebuilding or refreshing the
+local database: it raises NVD API rate limits during incremental sync and is
+sent only to `services.nvd.nist.gov`. It is never required for CLI scans, MCP
+tool calls, or dashboard review against the bundled cache.
+
+NVD incremental sync pulls CVSS, CWE, and CPE applicability into the local DB on
+a checkpointed schedule. A failed sync window is retried; it is not skipped
+silently.
+
+## Scanner mechanics
+
+- **Parallel OSV batches** — bounded concurrency (`AGENT_BOM_SCANNER_OSV_BATCH_CONCURRENCY`, default `3`) with pipeline-wide 429 backoff for large inventories.
+- **Sparse/EOL distro fallback** — when distro secdb coverage is thin, OSV range matching can still surface affected packages on end-of-life images.
+- **No external scanner subprocess** — the native vulnerability path does not require Trivy, Grype, or Syft. External scanner JSON (Trivy, Grype, Syft) can still be ingested for blast-radius fusion when operators already have those artifacts.
+
+## Benchmarks and parity claims
+
+Distro-confirmed findings are benchmark-grade on published image corpora (for
+example alpine `3.14.2` in release notes). Optional `nvd_cpe_candidate`
+matching widens long-tail OS and vendor software that OSV and distro feeds miss;
+it does not inflate confirmed counts because the tier stays review-grade and off
+by default.
+
+Machine-readable release evidence lives in
+[`accuracy-baseline.json`](accuracy-baseline.json). Regenerate with:
+
+```bash
+uv run python scripts/generate_accuracy_baseline.py --check
+```
+
+Network regression tests (including live scanner parity checks when the `trivy`
+binary is available) run under `tests/test_online_scan_validation.py` and
+`tests/test_accuracy_baseline.py`.


### PR DESCRIPTION
## Summary
- Cut README from ~394 to ~203 lines: short What It Is, visible personas, hero how-it-works diagram, collapsed architecture + blast-radius details.
- Merge Product Map and Start Here into one scannable section; combine cloud, deploy, and trust into a single late section.
- Remove duplicated essays (accuracy tiers, coverage boundaries, ingest lanes, surfaces table, scan-pipeline diagram, 11-screenshot gallery) and link to `docs/SCANNER_ACCURACY_BASELINE.md`, `docs/PRODUCT_BOUNDARIES.md`, `docs/PRODUCT_MAP.md`, `docs/CLOUD_CONNECT.md`, and `docs/CAPTURE.md` instead.
- Preserve required storefront markers (demo gif, MCP 70/6/8 counts, Smithery manifest, v0.91.0 action pin).

## Test plan
- [x] `uv run python scripts/check_release_consistency.py`
- [x] `uv run pytest tests/test_public_docs_cli_alignment.py -q`
- [x] `uv run pytest tests/test_stats_alignment.py::TestMarkdownStats::test_no_stale_tool_count -q`

Made with [Cursor](https://cursor.com)