### PR TITLE
docs(hosted): clarify current editions and hosted POC boundaries

### DIFF
--- a/docs/DEPLOY_PLATFORM.md
+++ b/docs/DEPLOY_PLATFORM.md
@@ -115,13 +115,15 @@ feed its `helm_values_hint` output into your values file.
 
 ---
 
-## Tier 3 — Hosted / SaaS (you run the control plane)
+## Tier 3 — Operator-hosted / gated POC
 
-The hosted tier is the same control plane chart, operated centrally, with
-customers connecting read-only across the control-plane / collector seam:
+The operator-hosted tier is the same control plane chart, operated centrally,
+with invited customers connecting read-only across the control-plane /
+collector seam:
 
 1. **You run the control plane** — deploy the chart (Tier 2) in your account,
-   multi-tenant, behind your ingress and identity provider.
+   behind your ingress and identity provider. For customer-0 and design
+   partners, keep access invite-only with operator-minted tenants and keys.
 2. **Customers connect read-only** — each customer applies a connect module
    (`deploy/terraform/connect-aws`, `connect-azure`, `connect-gcp`,
    `connect-snowflake`) that mints a read-only role trusting your hosted
@@ -143,12 +145,12 @@ customers connecting read-only across the control-plane / collector seam:
 This is the same primitive used by `create_aws_connect_role` in the EKS module,
 just pointed at a hosted scanner instead of a local one.
 
-For a gated customer-0 URL, start with the smaller hosted POC runbook instead
-of presenting a generally available SaaS product:
+Start with the smaller hosted POC runbook for invite-only hosted evaluations:
 [`HOSTED_POC.md`](HOSTED_POC.md). The recommended first proof is one AWS VM
-behind HTTPS with `deploy/docker-compose.hosted-poc.yml` layered on top of the
-platform compose so Caddy is the only public listener. The Snowflake Native App
-lane remains the enterprise customer-owned install path.
+behind HTTPS with
+`deploy/docker-compose.hosted-poc.yml` layered on top of the platform compose
+so Caddy is the only public listener. The Snowflake Native App lane remains an
+enterprise customer-owned install path.
 
 ---
 
@@ -160,7 +162,7 @@ lane remains the enterprise customer-owned install path.
 | Single team / air-gapped VM | 1 — Docker Compose (or `docker-compose.platform.yml`) |
 | Production on AWS, one command | 2A — `platform-eks` Terraform |
 | Production on an existing/any cluster | 2B — Helm |
-| Multi-tenant, you operate it for others | 3 — Hosted + connect roles |
+| Invite-only hosted design partner or customer-0 | 3 — Operator-hosted + connect roles |
 | Gated customer-0 demo link | [`HOSTED_POC.md`](HOSTED_POC.md) |
 
 ## Related

--- a/site-docs/architecture/hosted-product-spec.md
+++ b/site-docs/architecture/hosted-product-spec.md
@@ -1,8 +1,8 @@
 # Hosted Product Control-Plane Spec
 
-This is the next implementation spec for making `agent-bom` feel like one
-coherent hosted product instead of a collection of good but partially separate
-surfaces.
+This spec tracks the hosted control-plane shape for `agent-bom`: one coherent
+product surface across sources, jobs, schedules, evidence, graph, runtime
+policy, and reports.
 
 The product rule stays simple:
 
@@ -98,10 +98,13 @@ product surface.
 | Auth / audit | `/v1/auth/*`, `/v1/audit*`, `/v1/exceptions*` |
 | Findings / posture / graph | `/v1/assets*`, `/v1/graph*`, `/v1/compliance*`, `/v1/posture*`, `/v1/governance*` |
 
-## New API surface to add next
+## Source and credential API surface
 
-The control plane is still missing a first-class source registry. That should
-be the next backend slice.
+The control plane now has first-class source and credential-reference routes.
+They are tenant-scoped and RBAC-gated, and should remain the canonical backend
+for the Connections and Sources product surfaces. The remaining work is
+productization: customer-0 bootstrap, hosted smoke tests, connection validation
+clarity, and source-to-evidence provenance.
 
 ### `Source` registry routes
 
@@ -115,7 +118,7 @@ be the next backend slice.
 | `POST /v1/sources/{source_id}/test` | validate credentials and connectivity |
 | `POST /v1/sources/{source_id}/run` | trigger a job now |
 | `GET /v1/sources/{source_id}/jobs` | show source-linked job history |
-| `GET /v1/sources/{source_id}/evidence` | show evidence and provenance linked to the source |
+| `GET /v1/sources/{source_id}/evidence` | show evidence and provenance linked to the source, where evidence indexing is enabled |
 
 ### Credential reference routes
 
@@ -179,26 +182,23 @@ These rules should be enforced in both the API and background execution paths.
 - audit events are emitted for create, update, run, toggle, delete, export, allow, and block actions
 - gateway and proxy events carry tenant context, source identity, and trace correlation
 
-## Rollout order for the next PRs
+## Remaining hosted-product rollout
 
-This should land as alignment work, not surface-area sprawl.
+The core source and credential route layer has landed. The next work should be
+alignment and hosted-readiness work, not unrelated surface-area sprawl.
 
-1. **Source registry backend**  
-   Add `sources`, `credential_refs`, and source-linked job metadata.
-2. **Real Sources control-plane UI**  
-   Replace brochure content with source list, health, status, and run actions.
-3. **Schedule CRUD in UI**  
-   Make recurring runs editable from the product, not only via API.
+1. **Customer-0 bootstrap**
+   Provide an operator script or runbook path that creates one tenant-bound
+   admin/API key without requiring an already-authenticated browser session.
+2. **Hosted POC smoke**
+   Test login, connect, scan, scan detail, findings, graph, compliance export,
+   and audit export against the hosted compose profile.
+3. **Connection test clarity**
+   Keep "test and scan" clear in the UI, or add a standalone connection
+   validation route for roles and warehouse credentials.
 4. **Source / job / evidence linkage**  
-   Add provenance views so every finding can be traced to a source and job.
-5. **Auth / RBAC / tenant enforcement pass**  
-   Confirm every source, job, schedule, and evidence route is tenant-scoped and role-gated.
-6. **Credential reference model**  
-   Support customer-managed secrets and role references without leaking secret material into the UI.
-7. **Audit trail views**  
-   Add source and job-level audit visibility in the product.
-8. **Multi-tenant isolation hardening**  
-   Make tenant ownership explicit in DB access paths, worker claims, exports, and UI filters.
+   Continue tightening provenance views so every finding can be traced to a
+   source and job.
 
 ## Short implementation rule
 


### PR DESCRIPTION
## Summary
- reframes hosted docs around current/live editions: OSS, self-hosted platform, and operator-hosted gated POC
- points hosted evaluations to the shipped HOSTED_POC runbook and current source/credential API surface
- removes public future-plan language from the deployment/spec docs

## Validation
- git diff --check
- pre-commit run --files docs/DEPLOY_PLATFORM.md site-docs/architecture/hosted-product-spec.md

Closes #3246