### PR TITLE
feat(hosted): close customer-zero readiness loop

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 241 |
+| `docs/openapi/v1.json` | paths | 242 |
 | `docs/openapi/v1.json` | component schemas | 63 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/HOSTED_POC.md
+++ b/docs/HOSTED_POC.md
@@ -1,10 +1,8 @@
 # Hosted POC Runbook
 
 This runbook is for a gated customer-0 deployment: a live URL that shows how
-agent-bom works, lets a small set of users connect read-only accounts, and
-proves the product loop before a managed cloud edition is offered.
-
-It is not a claim that public `agent-bom Cloud` is generally available.
+agent-bom works, lets a small set of invited users connect read-only accounts,
+and proves the product loop with operator-controlled access.
 
 ## Recommended path
 
@@ -24,7 +22,6 @@ is ready.
 |---|---|---|
 | Public demo link | AWS VM + Caddy + platform compose | Fastest custom URL, simple TLS, works for any tester |
 | Customer-owned warehouse install | Snowflake Native App | Runs inside the customer's Snowflake account with Snowflake auth and SPCS |
-| Later managed product | Hosted chart + connect roles | Same control plane, stricter tenant onboarding and quotas |
 
 ## Customer-0 AWS VM
 
@@ -137,14 +134,52 @@ python scripts/deploy/hosted_poc_preflight.py --write-postgres-secret
 
 The preflight fails closed when required secrets are missing, the browser API
 URL is still localhost, CORS is wildcarded, unauthenticated API mode is enabled,
-API/UI ports bind publicly, or the composed stack would mount placeholder
-secrets. Run it again after any `.env`, DNS, or compose change.
+API/UI ports bind publicly, required secrets are reused, audit integrity is
+allowed to fall back to an ephemeral key, or the composed stack would mount
+placeholder secrets. Run it again after any `.env`, DNS, or compose change.
+
+Mint the first invited admin key from inside the API container so the key record
+lands in the same persistent store used by the API:
+
+```bash
+docker compose \
+  -f deploy/docker-compose.platform.yml \
+  -f deploy/docker-compose.hosted-poc.yml \
+  exec api \
+  python scripts/deploy/mint_hosted_admin_key.py \
+    --tenant-id customer-0 \
+    --name customer-0-admin \
+    --raw-key-file /tmp/customer0-admin.key
+```
+
+The JSON response includes key metadata only. The raw key is written once to the
+private `0600` file passed with `--raw-key-file`; store that value in your
+password manager, then delete or move the file into your secret store. Do not
+commit it or paste it into docs, screenshots, tickets, or chat transcripts.
+
+Run the hosted smoke before inviting anyone:
+
+```bash
+AGENT_BOM_SMOKE_URL="https://demo.agent-bom.com" \
+AGENT_BOM_SMOKE_API_KEY="<raw admin key>" \
+scripts/deploy/hosted_poc_smoke.sh
+```
+
+After at least one cloud/Snowflake connection is stored, verify the broker path
+without launching a full scan:
+
+```bash
+AGENT_BOM_SMOKE_URL="https://demo.agent-bom.com" \
+AGENT_BOM_SMOKE_API_KEY="<raw admin key>" \
+AGENT_BOM_SMOKE_CONNECTION_ID="<connection id>" \
+scripts/deploy/hosted_poc_smoke.sh
+```
 
 ### Production auth checklist
 
-For the gated POC, users are invited manually. Do not enable public signup until
-tenant lifecycle, abuse controls, quotas, billing, and self-service credential
-rotation exist.
+For the gated POC, users are invited manually and access is revoked manually.
+Keep the surface operator-controlled; this profile is not a public registration
+flow.
 
 Before sharing the link, verify:
 
@@ -274,7 +309,7 @@ If this succeeds, the account can run the Native App containers.
 
 ## What to avoid
 
-- Do not present the AWS demo as generally available managed SaaS.
+- Do not present the AWS demo as anything beyond an invite-only hosted POC.
 - Do not ask testers for long-lived cloud keys when assumable roles work.
 - Do not enable unauthenticated API access.
 - Do not publish Grafana, observability, or development compose profiles.

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -6488,6 +6488,99 @@
         ]
       }
     },
+    "/v1/cloud/connections/{connection_id}/test": {
+      "post": {
+        "description": "Validate a stored connection's brokered read-only credential.\n\nThis is the pre-scan button for hosted POCs and self-hosted onboarding. It is\ntenant-scoped, uses the same RBAC gate as scans, and never runs inventory/CIS\nor writes findings. On success the connection becomes ``active``; on failure\nit becomes ``error`` with sanitized status detail.",
+        "operationId": "test_connection_v1_cloud_connections__connection_id__test_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connection_id",
+            "required": true,
+            "schema": {
+              "title": "Connection Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Test Connection V1 Cloud Connections  Connection Id  Test Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Test Connection",
+        "tags": [
+          "cloud-connections"
+        ]
+      }
+    },
     "/v1/cloud/{provider}/cis-benchmark": {
       "get": {
         "description": "Run the CIS Foundations benchmark for a cloud provider over REST.\n\nCalls the same provider ``run_benchmark`` functions the CLI and MCP\n``cis_benchmark`` tool use and returns the report's canonical ``to_dict()``\nshape unchanged, so REST / CLI / MCP report the same checks and counts.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -4268,6 +4268,70 @@ paths:
       summary: Scan Connection
       tags:
       - cloud-connections
+  /v1/cloud/connections/{connection_id}/test:
+    post:
+      description: 'Validate a stored connection''s brokered read-only credential.
+
+
+        This is the pre-scan button for hosted POCs and self-hosted onboarding. It
+        is
+
+        tenant-scoped, uses the same RBAC gate as scans, and never runs inventory/CIS
+
+        or writes findings. On success the connection becomes ``active``; on failure
+
+        it becomes ``error`` with sanitized status detail.'
+      operationId: test_connection_v1_cloud_connections__connection_id__test_post
+      parameters:
+      - in: path
+        name: connection_id
+        required: true
+        schema:
+          title: Connection Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Test Connection V1 Cloud Connections  Connection Id  Test
+                  Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Test Connection
+      tags:
+      - cloud-connections
   /v1/cloud/{provider}/cis-benchmark:
     get:
       description: 'Run the CIS Foundations benchmark for a cloud provider over REST.

--- a/scripts/deploy/hosted_poc_preflight.py
+++ b/scripts/deploy/hosted_poc_preflight.py
@@ -30,6 +30,14 @@ REQUIRED_ENV = (
 SECRET_MIN_LENGTH = 32
 LOCAL_HOSTS = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
 TRUTHY = {"1", "true", "yes", "on"}
+UNIQUE_SECRET_ENV = (
+    "POSTGRES_PASSWORD",
+    "POSTGRES_APP_PASSWORD",
+    "AGENT_BOM_API_KEY",
+    "AGENT_BOM_AUDIT_HMAC_KEY",
+    "AGENT_BOM_BROWSER_SESSION_SIGNING_KEY",
+    "AGENT_BOM_CONNECTIONS_KEY",
+)
 
 
 def _repo_root() -> Path:
@@ -64,6 +72,19 @@ def _validate_fernet_key(errors: list[str]) -> None:
         return
     if len(decoded) != 32:
         _fail(errors, "AGENT_BOM_CONNECTIONS_KEY must decode to 32 bytes")
+
+
+def _validate_secret_uniqueness(errors: list[str]) -> None:
+    seen: dict[str, str] = {}
+    for name in UNIQUE_SECRET_ENV:
+        value = os.environ.get(name, "")
+        if not value:
+            continue
+        previous = seen.get(value)
+        if previous:
+            _fail(errors, f"{name} must not reuse the same secret value as {previous}")
+            continue
+        seen[value] = name
 
 
 def _validate_public_url(errors: list[str]) -> str:
@@ -108,6 +129,10 @@ def _validate_auth_and_bindings(errors: list[str]) -> None:
     if os.environ.get("AGENT_BOM_SESSION_COOKIE_SECURE", "1").strip().lower() in {"0", "false", "no", "off"}:
         _fail(errors, "AGENT_BOM_SESSION_COOKIE_SECURE must stay enabled")
 
+    ephemeral_audit = os.environ.get("AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC", "")
+    if ephemeral_audit.strip().lower() in TRUTHY:
+        _fail(errors, "AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC must be unset or false")
+
 
 def _write_postgres_secret(root: Path, *, force: bool) -> None:
     secret_path = root / "deploy" / "secrets" / "postgres_password"
@@ -148,7 +173,7 @@ def _validate_compose_config(errors: list[str], rendered: str) -> None:
     for needle, message in forbidden.items():
         if needle in rendered:
             _fail(errors, message)
-    if "AGENT_BOM_SESSION_COOKIE_SECURE=1" not in rendered and "AGENT_BOM_SESSION_COOKIE_SECURE: \"1\"" not in rendered:
+    if "AGENT_BOM_SESSION_COOKIE_SECURE=1" not in rendered and 'AGENT_BOM_SESSION_COOKIE_SECURE: "1"' not in rendered:
         _fail(errors, "compose output must set AGENT_BOM_SESSION_COOKIE_SECURE=1")
 
 
@@ -156,6 +181,7 @@ def run_preflight(root: Path, *, skip_compose: bool, write_secret: bool, force: 
     errors: list[str] = []
     _validate_secret_lengths(errors)
     _validate_fernet_key(errors)
+    _validate_secret_uniqueness(errors)
     public_url = _validate_public_url(errors)
     _validate_cors(errors, public_url)
     _validate_auth_and_bindings(errors)

--- a/scripts/deploy/hosted_poc_smoke.sh
+++ b/scripts/deploy/hosted_poc_smoke.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_url="${AGENT_BOM_SMOKE_URL:-${NEXT_PUBLIC_API_URL:-}}"
+api_key="${AGENT_BOM_SMOKE_API_KEY:-${AGENT_BOM_API_KEY:-}}"
+
+if [[ -z "${base_url}" ]]; then
+  echo "AGENT_BOM_SMOKE_URL or NEXT_PUBLIC_API_URL is required" >&2
+  exit 1
+fi
+if [[ -z "${api_key}" ]]; then
+  echo "AGENT_BOM_SMOKE_API_KEY or AGENT_BOM_API_KEY is required" >&2
+  exit 1
+fi
+
+base_url="${base_url%/}"
+
+request() {
+  local method="$1"
+  local path="$2"
+  curl -fsS \
+    -X "${method}" \
+    -H "Authorization: Bearer ${api_key}" \
+    -H "Content-Type: application/json" \
+    "${base_url}${path}" >/dev/null
+}
+
+curl -fsS "${base_url}/health" >/dev/null
+request GET /v1/auth/me
+request GET /v1/overview
+request GET /v1/jobs
+request GET /v1/graph/snapshots
+request GET /v1/compliance
+request GET /v1/audit/integrity
+
+if [[ -n "${AGENT_BOM_SMOKE_CONNECTION_ID:-}" ]]; then
+  encoded_connection_id="${AGENT_BOM_SMOKE_CONNECTION_ID}"
+  request POST "/v1/cloud/connections/${encoded_connection_id}/test"
+  if [[ "${AGENT_BOM_SMOKE_RUN_CONNECTION_SCAN:-0}" =~ ^(1|true|yes|on)$ ]]; then
+    request POST "/v1/cloud/connections/${encoded_connection_id}/scan"
+  fi
+fi
+
+echo "Hosted POC smoke passed for ${base_url}"

--- a/scripts/deploy/mint_hosted_admin_key.py
+++ b/scripts/deploy/mint_hosted_admin_key.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Mint the first hosted POC admin API key.
+
+The raw key is written once to a local 0600 file, never logged. The stored
+record is written through the same API key store used by the API process, so
+hosted deployments should run this inside the API container with
+``AGENT_BOM_POSTGRES_URL`` configured.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from agent_bom.api.auth import Role, create_api_key, get_key_store
+
+DEFAULT_RAW_KEY_FILE = Path("/tmp/agent-bom-customer0-admin.key")
+
+
+@dataclass(frozen=True)
+class MintedAdminKey:
+    """One-time key material plus non-secret metadata for operator output."""
+
+    raw_key: str
+    metadata: dict[str, Any]
+
+
+def mint_admin_key(
+    *,
+    tenant_id: str,
+    name: str,
+    expires_at: str | None = None,
+    scopes: list[str] | None = None,
+    allow_inmemory: bool = False,
+) -> MintedAdminKey:
+    """Create and persist one admin key for an invite-only hosted POC."""
+
+    if not os.environ.get("AGENT_BOM_POSTGRES_URL") and not allow_inmemory:
+        raise RuntimeError("AGENT_BOM_POSTGRES_URL must be set for hosted admin bootstrap; use --allow-inmemory only for local tests.")
+    raw_key, record = create_api_key(
+        name=name,
+        role=Role.ADMIN,
+        expires_at=expires_at,
+        scopes=scopes or ["*"],
+        tenant_id=tenant_id,
+    )
+    get_key_store().add(record)
+    return MintedAdminKey(
+        raw_key=raw_key,
+        metadata={
+            "key_id": record.key_id,
+            "key_prefix": record.key_prefix,
+            "name": record.name,
+            "role": record.role.value,
+            "tenant_id": record.tenant_id,
+            "expires_at": record.expires_at,
+            "scopes": record.scopes,
+        },
+    )
+
+
+def write_raw_key_file(path: Path, raw_key: str, *, force: bool = False) -> Path:
+    """Write the one-time raw API key to a private file without logging it."""
+
+    path = path.expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT
+    flags |= os.O_TRUNC if force else os.O_EXCL
+    try:
+        fd = os.open(path, flags, 0o600)
+    except FileExistsError as exc:
+        raise RuntimeError(f"raw key file already exists: {path}") from exc
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(raw_key)
+        handle.write("\n")
+    path.chmod(0o600)
+    return path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Mint an initial hosted POC admin API key")
+    parser.add_argument("--tenant-id", default="customer-0", help="tenant id for the invited POC account")
+    parser.add_argument("--name", default="customer-0-admin", help="display name stored for the key")
+    parser.add_argument("--expires-at", default=None, help="optional ISO-8601 expiration")
+    parser.add_argument("--scope", action="append", dest="scopes", help="scope to add; defaults to '*'")
+    parser.add_argument("--allow-inmemory", action="store_true", help="allow local in-memory bootstrap for tests only")
+    parser.add_argument(
+        "--raw-key-file",
+        type=Path,
+        default=DEFAULT_RAW_KEY_FILE,
+        help="private 0600 file that receives the one-time raw API key",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite --raw-key-file if it already exists",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        minted = mint_admin_key(
+            tenant_id=args.tenant_id,
+            name=args.name,
+            expires_at=args.expires_at,
+            scopes=args.scopes,
+            allow_inmemory=args.allow_inmemory,
+        )
+        raw_key_file = write_raw_key_file(args.raw_key_file, minted.raw_key, force=args.force)
+        public_payload = {**minted.metadata, "raw_key_file": str(raw_key_file)}
+    except Exception as exc:  # noqa: BLE001 - CLI entrypoint returns a clean failure
+        if isinstance(exc, RuntimeError) and str(exc).startswith("raw key file already exists:"):
+            print(f"failed to mint hosted admin key: {exc}", file=sys.stderr)
+        else:
+            print("failed to mint hosted admin key; check server logs and bootstrap configuration", file=sys.stderr)
+        return 1
+    print(json.dumps(public_payload, indent=2, sort_keys=True))
+    print(f"raw API key written once to {raw_key_file} with mode 0600", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -17,6 +17,7 @@ Endpoints:
     GET    /v1/cloud/connections          list this tenant's connections
     GET    /v1/cloud/connections/{id}     one connection (non-secret metadata)
     DELETE /v1/cloud/connections/{id}     remove a connection
+    POST   /v1/cloud/connections/{id}/test  validate brokered read-only auth
     POST   /v1/cloud/connections/{id}/scan  launch a read-only scan via the broker
 
 The ``/scan`` endpoint brokers the stored connection into a short-lived read-only
@@ -390,6 +391,24 @@ def _scan_audit_metadata(note: str) -> dict[str, Any]:
     return {"read_only": True, "writes_performed": False, "note": note}
 
 
+def _test_connection_broker(record: CloudConnectionRecord) -> None:
+    """Validate that the broker can materialize read-only credentials.
+
+    This deliberately does not run inventory, CIS, or persistence. It only proves
+    that the encrypted connection secret can be decrypted and exchanged for the
+    provider credential/session the scan path will later use.
+    """
+
+    from agent_bom.cloud.connection_broker import broker_session
+
+    brokered = broker_session(record, session_name=f"agent-bom-test-{record.id[:8]}")
+    if (record.provider or "").strip().lower() == "snowflake":
+        try:
+            brokered.close()
+        except Exception:  # noqa: BLE001 - close best-effort; never mask broker success
+            _logger.debug("Snowflake broker connection close failed for test connection %s", record.id)
+
+
 def _run_aws_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> dict[str, Any]:
     """Broker the connection into a read-only session and run inventory + CIS.
 
@@ -596,6 +615,61 @@ def _run_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> dict[
     return runner(record, tenant_id)
 
 
+@router.post("/v1/cloud/connections/{connection_id}/test")
+async def test_connection(request: Request, connection_id: str, _role: Any = _SCAN_DEP) -> dict[str, Any]:
+    """Validate a stored connection's brokered read-only credential.
+
+    This is the pre-scan button for hosted POCs and self-hosted onboarding. It is
+    tenant-scoped, uses the same RBAC gate as scans, and never runs inventory/CIS
+    or writes findings. On success the connection becomes ``active``; on failure
+    it becomes ``error`` with sanitized status detail.
+    """
+
+    record = _require_connection(request, connection_id)
+    tenant_id = record.tenant_id
+    actor = _actor(request)
+
+    if (record.provider or "").strip().lower() not in _SCAN_RUNNERS:
+        raise HTTPException(status_code=400, detail=f"Unsupported provider '{record.provider}'.")
+
+    try:
+        _test_connection_broker(record)
+    except Exception as exc:  # noqa: BLE001 - broker failure
+        detail = sanitize_error(exc, generic=True)
+        _mark_connection(record, status=STATUS_ERROR, status_detail=detail)
+        _logger.exception("Cloud connection test failed for connection %s", record.id)
+        log_action(
+            "cloud_connection.test",
+            actor=actor,
+            resource=f"cloud-connection/{record.id}",
+            tenant_id=tenant_id,
+            provider=record.provider,
+            outcome="failure",
+        )
+        raise HTTPException(status_code=502, detail="Cloud connection test failed; see server logs.") from exc
+
+    _mark_connection(record, status=STATUS_ACTIVE, status_detail="")
+    log_action(
+        "cloud_connection.test",
+        actor=actor,
+        resource=f"cloud-connection/{record.id}",
+        tenant_id=tenant_id,
+        provider=record.provider,
+        outcome="success",
+    )
+    return {
+        "schema_version": "cloud.connections.test.v1",
+        "connection_id": record.id,
+        "tenant_id": tenant_id,
+        "provider": record.provider,
+        "status": "ok",
+        "audit_metadata": _scan_audit_metadata(
+            "Connection test brokered a read-only credential only; no inventory, CIS, findings, or resource writes ran."
+        ),
+        "connection": record.to_public_dict(),
+    }
+
+
 @router.post("/v1/cloud/connections/{connection_id}/scan")
 async def scan_connection(request: Request, connection_id: str, _role: Any = _SCAN_DEP) -> dict[str, Any]:
     """Launch a read-only cloud scan for a stored connection via the broker.
@@ -620,7 +694,7 @@ async def scan_connection(request: Request, connection_id: str, _role: Any = _SC
     except Exception as exc:  # noqa: BLE001 - broker / discovery / persistence failure
         # Persist an error status with a sanitized, secret-free detail. Full
         # diagnostics go to the server log only; the client gets a generic message.
-        detail = sanitize_error(exc)
+        detail = sanitize_error(exc, generic=True)
         _mark_connection(record, status=STATUS_ERROR, status_detail=detail)
         _logger.exception("Cloud connection scan failed for connection %s", record.id)
         log_action(

--- a/tests/test_cloud_connections.py
+++ b/tests/test_cloud_connections.py
@@ -1205,6 +1205,74 @@ def test_scan_missing_connection_404(monkeypatch: pytest.MonkeyPatch) -> None:
     assert resp.status_code == 404
 
 
+def test_connection_test_brokers_without_scan_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.api.store import InMemoryJobStore
+    from agent_bom.api.stores import _get_store, set_job_store
+    from agent_bom.cloud import connection_broker
+
+    calls: dict[str, Any] = {}
+    set_job_store(InMemoryJobStore())
+
+    def _fake_broker(record: CloudConnectionRecord, **kwargs: Any) -> Any:
+        calls["broker_record_id"] = record.id
+        calls["session_name"] = kwargs.get("session_name")
+        return _BROKER_SESSION_SENTINEL
+
+    monkeypatch.setattr(connection_broker, "broker_session", _fake_broker)
+    client = TestClient(_app())
+    cid = _seed_connection("tenant-alpha")
+
+    resp = client.post(f"/v1/cloud/connections/{cid}/test", headers=_proxy_headers(tenant="tenant-alpha"))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schema_version"] == "cloud.connections.test.v1"
+    assert body["provider"] == "aws"
+    assert body["status"] == "ok"
+    assert "scan_id" not in body
+    assert calls["broker_record_id"] == cid
+    assert str(calls["session_name"]).startswith("agent-bom-test-")
+
+    assert _get_store().list_all("tenant-alpha") == []
+    fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
+    assert fetched["status"] == "active"
+    assert fetched["last_scan_at"] is None
+    assert fetched["last_scan_id"] is None
+    assert "super-secret-external-id" not in str(body)
+
+
+def test_connection_test_failure_marks_error_without_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.cloud import connection_broker
+
+    def _fake_broker(record: CloudConnectionRecord, **kwargs: Any) -> Any:
+        raise connection_broker.ConnectionBrokerError("failed for super-secret-external-id")
+
+    monkeypatch.setattr(connection_broker, "broker_session", _fake_broker)
+    cid = _seed_connection("tenant-alpha")
+    client = TestClient(_app())
+
+    resp = client.post(f"/v1/cloud/connections/{cid}/test", headers=_proxy_headers(tenant="tenant-alpha"))
+
+    assert resp.status_code == 502
+    assert "super-secret-external-id" not in str(resp.json())
+    fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers(tenant="tenant-alpha")).json()
+    assert fetched["status"] == "error"
+    assert "super-secret-external-id" not in fetched["status_detail"]
+    assert fetched["last_scan_id"] is None
+
+
+def test_connection_test_is_tenant_scoped(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.cloud import connection_broker
+
+    monkeypatch.setattr(connection_broker, "broker_session", lambda record, **kwargs: _BROKER_SESSION_SENTINEL)
+    cid = _seed_connection("tenant-alpha")
+    client = TestClient(_app())
+
+    resp = client.post(f"/v1/cloud/connections/{cid}/test", headers=_proxy_headers(tenant="tenant-beta"))
+
+    assert resp.status_code == 404
+
+
 class _FakeProviderCIS:
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/tests/test_hosted_admin_key_bootstrap.py
+++ b/tests/test_hosted_admin_key_bootstrap.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from agent_bom.api.auth import KeyStore, get_key_store, set_key_store
+from scripts.deploy.mint_hosted_admin_key import main, mint_admin_key, write_raw_key_file
+
+
+@pytest.fixture(autouse=True)
+def isolated_key_store(monkeypatch: pytest.MonkeyPatch):
+    original = get_key_store()
+    store = KeyStore()
+    set_key_store(store)
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+    try:
+        yield store
+    finally:
+        set_key_store(original)
+
+
+def test_mint_hosted_admin_key_persists_admin_record(isolated_key_store: KeyStore) -> None:
+    payload = mint_admin_key(
+        tenant_id="customer-0",
+        name="customer-0-admin",
+        allow_inmemory=True,
+    )
+
+    verified = isolated_key_store.verify(payload.raw_key)
+    assert verified is not None
+    assert verified.role.value == "admin"
+    assert verified.tenant_id == "customer-0"
+    assert verified.scopes == ["*"]
+    assert payload.raw_key != payload.metadata["key_prefix"]
+
+
+def test_mint_hosted_admin_key_requires_persistent_store_without_test_escape() -> None:
+    with pytest.raises(RuntimeError, match="AGENT_BOM_POSTGRES_URL"):
+        mint_admin_key(tenant_id="customer-0", name="customer-0-admin")
+
+
+def test_cli_writes_one_time_raw_key_to_private_file(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    raw_key_file = tmp_path / "customer0-admin.key"
+
+    assert (
+        main(
+            [
+                "--tenant-id",
+                "tenant-a",
+                "--name",
+                "admin",
+                "--allow-inmemory",
+                "--raw-key-file",
+                str(raw_key_file),
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tenant_id"] == "tenant-a"
+    assert payload["role"] == "admin"
+    assert "raw_key" not in payload
+    assert payload["raw_key_file"] == str(raw_key_file)
+    raw_key = raw_key_file.read_text(encoding="utf-8").strip()
+    assert raw_key.startswith("abom_")
+    assert stat.S_IMODE(raw_key_file.stat().st_mode) == 0o600
+    assert os.environ.get("AGENT_BOM_POSTGRES_URL") is None
+
+
+def test_cli_refuses_to_overwrite_raw_key_file(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    raw_key_file = tmp_path / "customer0-admin.key"
+    raw_key_file.write_text("existing\n", encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "--tenant-id",
+                "tenant-a",
+                "--name",
+                "admin",
+                "--allow-inmemory",
+                "--raw-key-file",
+                str(raw_key_file),
+            ]
+        )
+        == 1
+    )
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "raw key file already exists" in captured.err
+    assert raw_key_file.read_text(encoding="utf-8") == "existing\n"
+
+
+def test_write_raw_key_file_force_overwrites_private_file(tmp_path: Path) -> None:
+    raw_key_file = tmp_path / "customer0-admin.key"
+    raw_key_file.write_text("existing\n", encoding="utf-8")
+
+    write_raw_key_file(raw_key_file, "abom_new-key", force=True)
+
+    assert raw_key_file.read_text(encoding="utf-8") == "abom_new-key\n"
+    assert stat.S_IMODE(raw_key_file.stat().st_mode) == 0o600

--- a/tests/test_hosted_poc_preflight.py
+++ b/tests/test_hosted_poc_preflight.py
@@ -86,6 +86,22 @@ def test_preflight_rejects_bad_connections_key(monkeypatch: pytest.MonkeyPatch, 
     assert any("Fernet key" in error or "32 bytes" in error for error in errors)
 
 
+def test_preflight_rejects_reused_secret_values(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("POSTGRES_APP_PASSWORD", VALID_ENV["POSTGRES_PASSWORD"])
+
+    errors = run_preflight(tmp_path, skip_compose=True, write_secret=False, force=False)
+
+    assert any("POSTGRES_APP_PASSWORD must not reuse" in error for error in errors)
+
+
+def test_preflight_rejects_ephemeral_audit_hmac(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC", "1")
+
+    errors = run_preflight(tmp_path, skip_compose=True, write_secret=False, force=False)
+
+    assert "AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC must be unset or false" in errors
+
+
 def test_preflight_can_write_postgres_secret(tmp_path: Path) -> None:
     errors = run_preflight(tmp_path, skip_compose=True, write_secret=True, force=False)
 

--- a/tests/test_hosted_poc_smoke.py
+++ b/tests/test_hosted_poc_smoke.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path("scripts/deploy/hosted_poc_smoke.sh")
+
+
+def test_hosted_poc_smoke_requires_url_and_key() -> None:
+    env = os.environ.copy()
+    for name in ("AGENT_BOM_SMOKE_URL", "NEXT_PUBLIC_API_URL", "AGENT_BOM_SMOKE_API_KEY", "AGENT_BOM_API_KEY"):
+        env.pop(name, None)
+
+    result = subprocess.run(["bash", str(SCRIPT)], check=False, capture_output=True, text=True, env=env)
+
+    assert result.returncode == 1
+    assert "AGENT_BOM_SMOKE_URL" in result.stderr
+
+
+def test_hosted_poc_smoke_hits_core_customer_zero_surfaces(tmp_path: Path) -> None:
+    calls = tmp_path / "curl-calls.txt"
+    fake_curl = tmp_path / "curl"
+    fake_curl.write_text(
+        '#!/usr/bin/env bash\nprintf \'%s\\n\' "$*" >> "$CURL_CALLS"\nexit 0\n',
+        encoding="utf-8",
+    )
+    fake_curl.chmod(0o755)
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{tmp_path}:{env['PATH']}",
+            "CURL_CALLS": str(calls),
+            "AGENT_BOM_SMOKE_URL": "https://demo.agent-bom.com",
+            "AGENT_BOM_SMOKE_API_KEY": "abom_test",
+            "AGENT_BOM_SMOKE_CONNECTION_ID": "conn-123",
+            "AGENT_BOM_SMOKE_RUN_CONNECTION_SCAN": "1",
+        }
+    )
+
+    result = subprocess.run(["bash", str(SCRIPT)], check=False, capture_output=True, text=True, env=env)
+
+    assert result.returncode == 0
+    output = calls.read_text(encoding="utf-8")
+    for path in (
+        "/health",
+        "/v1/auth/me",
+        "/v1/overview",
+        "/v1/jobs",
+        "/v1/graph/snapshots",
+        "/v1/compliance",
+        "/v1/audit/integrity",
+        "/v1/cloud/connections/conn-123/test",
+        "/v1/cloud/connections/conn-123/scan",
+    ):
+        assert path in output

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -37,6 +37,7 @@ import {
   api,
   type CloudConnectionRecord,
   type CloudConnectionCreateRequest,
+  type CloudConnectionTestResponse,
   type CloudConnectionScanResponse,
 } from "@/lib/api";
 import { useAuthState } from "@/components/auth-provider";
@@ -54,11 +55,10 @@ import { vendorLogo } from "@/lib/vendor-logos";
 // (non-secret provider params). `permissions` / `cli` mirror the real
 // `agent-bom connect <provider>` onboarding (src/agent_bom/cli/_entry_points.py).
 //
-// `readiness` reflects connection_store.py's documented Phase A nuance: AWS is
-// broker-enabled and live; Azure/GCP/Snowflake accept the connect flow and store
-// the connection, with brokering still maturing ("Brokering planned").
+// `readiness` reflects the API's broker-enabled scan runners for AWS, Azure,
+// GCP, and Snowflake.
 
-type ProviderReadiness = "live" | "planned";
+type ProviderReadiness = "live";
 
 interface ProviderField {
   key: string;
@@ -123,7 +123,7 @@ const PROVIDER_OPTIONS: ProviderOption[] = [
     tagline: "Read-only Reader credential",
     permissions: "Reader-role service principal (read-only)",
     cli: "agent-bom connect azure",
-    readiness: "planned",
+    readiness: "live",
     roleField: {
       key: "role_ref",
       label: "Client ID (app registration)",
@@ -164,7 +164,7 @@ const PROVIDER_OPTIONS: ProviderOption[] = [
     tagline: "Read-only service account",
     permissions: "roles/viewer service account (read-only)",
     cli: "agent-bom connect gcp",
-    readiness: "planned",
+    readiness: "live",
     roleField: {
       key: "role_ref",
       label: "Service account email",
@@ -200,7 +200,7 @@ const PROVIDER_OPTIONS: ProviderOption[] = [
     tagline: "Read-only key-pair connection",
     permissions: "Read-only governance role (key-pair auth)",
     cli: "agent-bom connect snowflake",
-    readiness: "planned",
+    readiness: "live",
     roleField: {
       key: "role_ref",
       label: "Account",
@@ -273,7 +273,7 @@ function eventMode(connection: CloudConnectionRecord): {
   }
   if (connection.scan_interval_minutes) {
     return {
-      label: "Polling fallback",
+      label: "Scheduled scan",
       detail: `Every ${connection.scan_interval_minutes} min`,
       tone: "border-amber-900/60 bg-amber-950/30 text-amber-200",
     };
@@ -356,21 +356,10 @@ function ProviderLogo({
 }
 
 function ReadinessBadge({ readiness }: { readiness: ProviderReadiness }) {
-  if (readiness === "live") {
-    return (
-      <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-900/60 bg-emerald-950/30 px-2.5 py-0.5 text-[11px] font-medium text-emerald-300">
-        <CheckCircle2 className="h-3 w-3" />
-        Live
-      </span>
-    );
-  }
   return (
-    <span
-      className="inline-flex items-center gap-1.5 rounded-full border border-sky-900/60 bg-sky-950/30 px-2.5 py-0.5 text-[11px] font-medium text-sky-300"
-      title="The connect flow stores this connection; broker-side scanning is still maturing in Phase A."
-    >
-      <Clock className="h-3 w-3" />
-      Brokering planned
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-900/60 bg-emerald-950/30 px-2.5 py-0.5 text-[11px] font-medium text-emerald-300">
+      <CheckCircle2 className="h-3 w-3" />
+      {readiness === "live" ? "Live" : "Live"}
     </span>
   );
 }
@@ -437,6 +426,9 @@ export default function ConnectionsPage() {
     Record<string, CloudConnectionScanResponse>
   >({});
   const [scanErrors, setScanErrors] = useState<Record<string, string>>({});
+  const [testResults, setTestResults] = useState<
+    Record<string, CloudConnectionTestResponse>
+  >({});
   const [scheduleErrors, setScheduleErrors] = useState<Record<string, string>>(
     {},
   );
@@ -491,6 +483,29 @@ export default function ConnectionsPage() {
       await refresh();
     } catch (err) {
       const detail = err instanceof Error ? err.message : "Scan failed.";
+      setScanErrors((prev) => ({ ...prev, [connection.id]: detail }));
+      await refresh();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleTest(connection: CloudConnectionRecord) {
+    setBusyId(connection.id);
+    setMessage(null);
+    setScanErrors((prev) => {
+      const next = { ...prev };
+      delete next[connection.id];
+      return next;
+    });
+    try {
+      const result = await api.testCloudConnection(connection.id);
+      setTestResults((prev) => ({ ...prev, [connection.id]: result }));
+      setMessage(`${connection.display_name} read-only credential verified.`);
+      await refresh();
+    } catch (err) {
+      const detail =
+        err instanceof Error ? err.message : "Connection test failed.";
       setScanErrors((prev) => ({ ...prev, [connection.id]: detail }));
       await refresh();
     } finally {
@@ -738,6 +753,7 @@ export default function ConnectionsPage() {
                         canManage={canManage}
                         scannable={scannable}
                         result={result}
+                        testResult={testResults[connection.id]}
                         scanError={scanError}
                         scheduleError={scheduleErrors[connection.id]}
                         statusDetail={
@@ -745,6 +761,7 @@ export default function ConnectionsPage() {
                             ? connection.status_detail
                             : ""
                         }
+                        onTest={() => void handleTest(connection)}
                         onScan={() => void handleScan(connection)}
                         onScheduleChange={(value) =>
                           void handleScheduleChange(connection, value)
@@ -886,9 +903,11 @@ function FragmentRow({
   canManage,
   scannable,
   result,
+  testResult,
   scanError,
   scheduleError,
   statusDetail,
+  onTest,
   onScan,
   onScheduleChange,
   onDelete,
@@ -898,9 +917,11 @@ function FragmentRow({
   canManage: boolean;
   scannable: boolean;
   result: CloudConnectionScanResponse | undefined;
+  testResult: CloudConnectionTestResponse | undefined;
   scanError: string | undefined;
   scheduleError: string | undefined;
   statusDetail: string;
+  onTest: () => void;
   onScan: () => void;
   onScheduleChange: (value: string) => void;
   onDelete: () => void;
@@ -908,7 +929,12 @@ function FragmentRow({
   const handoffScanId = result?.scan_id ?? connection.last_scan_id;
   const mode = eventMode(connection);
   const showDetail = Boolean(
-    result || handoffScanId || scanError || scheduleError || statusDetail,
+    result ||
+      testResult ||
+      handoffScanId ||
+      scanError ||
+      scheduleError ||
+      statusDetail,
   );
   return (
     <>
@@ -986,17 +1012,30 @@ function FragmentRow({
         <td className="px-4 py-3">
           <div className="flex justify-end gap-2">
             <button
+              onClick={onTest}
+              disabled={isBusy || !canManage || !scannable}
+              title={
+                scannable
+                  ? "Verify the stored read-only credential without running inventory"
+                  : "Testing for this provider is unavailable"
+              }
+              className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-800/70 bg-emerald-950/20 px-3 py-1.5 text-xs font-medium text-emerald-200 transition hover:border-emerald-600 hover:bg-emerald-950/40 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              {isBusy ? "Working…" : "Test"}
+            </button>
+            <button
               onClick={onScan}
               disabled={isBusy || !canManage || !scannable}
               title={
                 scannable
-                  ? "Validate credentials and run a read-only scan"
+                  ? "Run a read-only inventory and CIS scan"
                   : "Scanning for this provider is unavailable"
               }
               className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <ShieldCheck className="h-3.5 w-3.5" />
-              {isBusy ? "Scanning…" : "Test and scan"}
+              {isBusy ? "Working…" : "Run scan"}
             </button>
             <button
               onClick={onDelete}
@@ -1014,6 +1053,12 @@ function FragmentRow({
         <tr className="border-b border-[color:var(--border-subtle)] last:border-b-0 bg-[color:var(--surface-elevated)]/40">
           <td colSpan={7} className="px-4 pb-4 pt-0">
             {result ? <ScanResultPanel result={result} /> : null}
+            {!result && testResult ? (
+              <div className="rounded-xl border border-emerald-900/60 bg-emerald-950/20 p-3 text-xs text-emerald-200">
+                Read-only credential verified. No inventory, CIS, findings, or
+                resource writes ran.
+              </div>
+            ) : null}
             {!result && handoffScanId ? (
               <ScanHandoffLinks scanId={handoffScanId} />
             ) : null}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2700,6 +2700,21 @@ export interface CloudConnectionScanCis {
   pass_rate: number | null;
 }
 
+/** Response from `POST /v1/cloud/connections/{id}/test`; no scan is created. */
+export interface CloudConnectionTestResponse {
+  schema_version: string;
+  connection_id: string;
+  tenant_id: string;
+  provider: string;
+  status: "ok" | string;
+  audit_metadata: {
+    read_only: boolean;
+    writes_performed: boolean;
+    note: string;
+  };
+  connection: CloudConnectionRecord;
+}
+
 /** Response from `POST /v1/cloud/connections/{id}/scan` (AWS, Azure, GCP, Snowflake). */
 export interface CloudConnectionScanResponse {
   schema_version: string;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -106,6 +106,7 @@ import type {
   CloudConnectionsResponse,
   CloudConnectionCreateRequest,
   CloudConnectionUpdateRequest,
+  CloudConnectionTestResponse,
   CloudConnectionScanResponse
 } from "./api-types";
 export type {
@@ -295,6 +296,7 @@ export type {
   CloudConnectionUpdateRequest,
   CloudConnectionScanInventory,
   CloudConnectionScanCis,
+  CloudConnectionTestResponse,
   CloudConnectionScanResponse,
 } from "./api-types";
 export type { MitreAtlasCatalogMetadata } from "./api-types";
@@ -1038,7 +1040,10 @@ export const api = {
     patch<CloudConnectionRecord>(`/v1/cloud/connections/${encodeURIComponent(id)}`, body),
   /** Delete a connection owned by this tenant. */
   deleteCloudConnection: (id: string) => del(`/v1/cloud/connections/${encodeURIComponent(id)}`),
-  /** Launch a read-only scan via the credential broker (AWS today). */
+  /** Validate the stored read-only credential without running inventory/CIS. */
+  testCloudConnection: (id: string) =>
+    post<CloudConnectionTestResponse>(`/v1/cloud/connections/${encodeURIComponent(id)}/test`, {}),
+  /** Launch a read-only scan via the credential broker (AWS, Azure, GCP, Snowflake). */
   scanCloudConnection: (id: string) =>
     post<CloudConnectionScanResponse>(`/v1/cloud/connections/${encodeURIComponent(id)}/scan`, {}),
 

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -10,6 +10,7 @@ const { apiMock } = vi.hoisted(() => ({
     createCloudConnection: vi.fn(),
     updateCloudConnection: vi.fn(),
     deleteCloudConnection: vi.fn(),
+    testCloudConnection: vi.fn(),
     scanCloudConnection: vi.fn(),
   },
 }));
@@ -252,7 +253,7 @@ describe("ConnectionsPage", () => {
       expect(screen.getByText("Production account")).toBeInTheDocument(),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Test and scan" }));
+    fireEvent.click(screen.getByRole("button", { name: "Run scan" }));
 
     await waitFor(() =>
       expect(apiMock.scanCloudConnection).toHaveBeenCalledWith("conn-1"),
@@ -277,6 +278,49 @@ describe("ConnectionsPage", () => {
       "href",
       "/graph?scan_id=abcdef12-3456-7890-abcd-ef1234567890",
     );
+  });
+
+  it("tests a brokered credential without launching a scan", async () => {
+    apiMock.listCloudConnections.mockResolvedValue({
+      schema_version: "cloud.connections.v1",
+      tenant_id: "tenant-acme",
+      connections: [CREATED_RECORD],
+      count: 1,
+    });
+    apiMock.testCloudConnection.mockResolvedValue({
+      schema_version: "cloud.connections.test.v1",
+      connection_id: "conn-1",
+      tenant_id: "tenant-acme",
+      provider: "aws",
+      status: "ok",
+      audit_metadata: {
+        read_only: true,
+        writes_performed: false,
+        note: "Connection test brokered a read-only credential only.",
+      },
+      connection: { ...CREATED_RECORD, status: "active" },
+    });
+
+    render(<ConnectionsPage />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Production account")).toBeInTheDocument(),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Test" }));
+
+    await waitFor(() =>
+      expect(apiMock.testCloudConnection).toHaveBeenCalledWith("conn-1"),
+    );
+    expect(apiMock.scanCloudConnection).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(
+        screen.getByText("Production account read-only credential verified."),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByText(/No inventory, CIS, findings, or resource writes ran/),
+    ).toBeInTheDocument();
   });
 
   it("shows durable handoff links from the persisted last scan id after reload", async () => {
@@ -342,7 +386,7 @@ describe("ConnectionsPage", () => {
 
     expect(screen.getByText("Event-driven")).toBeInTheDocument();
     expect(screen.getByText(/Last event/)).toBeInTheDocument();
-    expect(screen.queryByText("Polling fallback")).toBeNull();
+    expect(screen.queryByText("Scheduled scan")).toBeNull();
   });
 
   it("updates the recurring scan schedule without exposing secrets", async () => {


### PR DESCRIPTION
Summary
- Adds a hosted admin bootstrap script and hosted POC smoke script for the customer-0 path.
- Hardens hosted preflight against reused secrets and ephemeral audit-HMAC fallback.
- Adds a broker-only cloud connection test endpoint that verifies credentials without running inventory/CIS or creating scan evidence.
- Updates the Connections UI to show AWS/Azure/GCP/Snowflake as live brokered connectors, with separate Test and Run scan actions.
- Refreshes HOSTED_POC.md to describe the current invite-only hosted POC only, not future public self-serve plans.

Validation
- `uv run ruff check scripts/deploy/mint_hosted_admin_key.py scripts/deploy/hosted_poc_preflight.py src/agent_bom/api/routes/cloud_connections.py tests/test_hosted_admin_key_bootstrap.py tests/test_hosted_poc_preflight.py tests/test_hosted_poc_smoke.py tests/test_cloud_connections.py`
- `uv run ruff format --check scripts/deploy/mint_hosted_admin_key.py scripts/deploy/hosted_poc_preflight.py src/agent_bom/api/routes/cloud_connections.py tests/test_hosted_admin_key_bootstrap.py tests/test_hosted_poc_preflight.py tests/test_hosted_poc_smoke.py tests/test_cloud_connections.py`
- `uv run mypy src/agent_bom/api/routes/cloud_connections.py --ignore-missing-imports --disable-error-code import-untyped`
- `uv run pytest tests/test_hosted_admin_key_bootstrap.py tests/test_hosted_poc_preflight.py tests/test_hosted_poc_smoke.py tests/test_cloud_connections.py -q`
- `cd ui && npm run lint -- app/connections/page.tsx tests/connections-page.test.tsx lib/api.ts lib/api-types.ts`
- `cd ui && npm run typecheck`
- `cd ui && npm run test:run -- connections-page.test.tsx`
- `uv run python scripts/check_release_consistency.py`
- `git diff --check`

Closes #3247
