### PR TITLE
fix(ci): stabilize large-graph-overview E2E search drilldown

### DIFF
--- a/ui/e2e/large-graph-overview.spec.ts
+++ b/ui/e2e/large-graph-overview.spec.ts
@@ -158,6 +158,17 @@ async function routeLargeGraphPage(page: Page) {
       body: JSON.stringify({ critical: 0, high: 621, medium: 0, low: 0, total: 621, kev: 0, compound_issues: 0 }),
     });
   });
+  await page.route("**/v1/posture", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        score: 72,
+        grade: "C",
+        findings: { critical: 0, high: 621, medium: 0, low: 0, total: 621 },
+        last_scan_at: createdAt,
+      }),
+    });
+  });
   await page.route("**/v1/graph/snapshots?**", async (route) => {
     await route.fulfill({
       contentType: "application/json",
@@ -172,7 +183,7 @@ async function routeLargeGraphPage(page: Page) {
       body: JSON.stringify({ nodes_added: [], nodes_removed: [], nodes_changed: [], edges_added: [], edges_removed: [] }),
     });
   });
-  await page.route("**/v1/graph/search?**", async (route) => {
+  await page.route("**/v1/graph/search**", async (route) => {
     await route.fulfill({
       contentType: "application/json",
       body: JSON.stringify({
@@ -273,6 +284,7 @@ async function expectSigmaCanvases(page: Page) {
 }
 
 test("large graph overview renders above threshold and search drills back into React Flow", async ({ page }, testInfo: TestInfo) => {
+  test.setTimeout(60_000);
   await routeLargeGraphPage(page);
 
   await page.goto("/graph?vulnOnly=0&severity=&depth=3&pageSize=500&layers=agent,package", {
@@ -286,9 +298,15 @@ test("large graph overview renders above threshold and search drills back into R
   await expectCanvasHasPixels(page);
   await page.screenshot({ path: testInfo.outputPath("large-graph-overview.png"), fullPage: true });
 
+  const searchButton = page.getByRole("button", { name: "Search", exact: true });
+  await expect(searchButton).toBeEnabled({ timeout: 15_000 });
+
   await page.getByPlaceholder("Search nodes, tags, severities, or attributes").fill("large-package-42");
-  await page.getByRole("button", { name: "Search", exact: true }).click();
-  await page.getByRole("button", { name: "large-package-42" }).click();
+  await searchButton.click();
+
+  const resultButton = page.getByRole("button", { name: "large-package-42" });
+  await expect(resultButton).toBeVisible({ timeout: 15_000 });
+  await resultButton.click();
 
   await expect(page.getByText("Root-centered investigation:")).toBeVisible();
   await expect(page.getByRole("heading", { name: "large-package-42" })).toBeVisible();


### PR DESCRIPTION
## Summary
- Mock `/v1/posture` alongside posture counts so the Next.js proxy does not stall on `ECONNREFUSED :8422` during graph E2E.
- Broaden graph search route matching and wait for Search enablement plus visible search results before drill-in.
- Raise the canvas-heavy spec timeout to 60s so UI Validate does not fail at 30s on main.

## Context
Fixes **#3410** (`UI Validate` failure on `large-graph-overview.spec.ts` search drilldown timeout).

## Test plan
- [ ] CI `UI Validate` / `npm run test:e2e -- e2e/large-graph-overview.spec.ts`

Made with [Cursor](https://cursor.com)