### PR TITLE
feat(ui): findings paging, auth fail-closed, unified runtime

### DIFF
--- a/ui/app/runtime/page.tsx
+++ b/ui/app/runtime/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Loader2, Lock, Shield } from "lucide-react";
+
+import ProxyDashboard from "@/app/proxy/page";
+import GatewayPage from "@/app/gateway/page";
+
+type RuntimeTab = "proxy" | "gateway";
+
+const TABS: { key: RuntimeTab; label: string; icon: typeof Shield; description: string }[] = [
+  {
+    key: "proxy",
+    label: "Proxy",
+    icon: Shield,
+    description: "Live MCP proxy telemetry, alerts, and tool-call enforcement evidence.",
+  },
+  {
+    key: "gateway",
+    label: "Gateway",
+    icon: Lock,
+    description: "Gateway policy, fused live feed, audit trail, and evaluate sandbox.",
+  },
+];
+
+function RuntimeTabs() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const tab: RuntimeTab = searchParams.get("tab") === "gateway" ? "gateway" : "proxy";
+  const active = TABS.find((item) => item.key === tab) ?? TABS[0]!;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 border-b border-zinc-800 pb-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-zinc-100">Runtime</h1>
+          <p className="mt-1 max-w-3xl text-sm text-zinc-400">
+            One enforcement surface for MCP proxy telemetry and gateway policy. Switch tabs to review live
+            activity, alerts, rollout posture, and audit evidence without hopping between nav entries.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {TABS.map((item) => {
+            const Icon = item.icon;
+            const selected = item.key === tab;
+            return (
+              <button
+                key={item.key}
+                type="button"
+                onClick={() => router.replace(`/runtime?tab=${item.key}`)}
+                className={`inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium transition-colors ${
+                  selected
+                    ? "border-emerald-700 bg-emerald-950/40 text-emerald-200"
+                    : "border-zinc-800 bg-zinc-950 text-zinc-400 hover:border-zinc-700 hover:text-zinc-200"
+                }`}
+              >
+                <Icon className="h-4 w-4" />
+                {item.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <p className="text-xs text-zinc-500">{active.description}</p>
+
+      {tab === "proxy" ? <ProxyDashboard /> : <GatewayPage />}
+    </div>
+  );
+}
+
+export default function RuntimePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-[40vh] items-center justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-zinc-500" />
+        </div>
+      }
+    >
+      <RuntimeTabs />
+    </Suspense>
+  );
+}

--- a/ui/app/sources/page.tsx
+++ b/ui/app/sources/page.tsx
@@ -171,14 +171,14 @@ const OPERATING_SURFACES = [
   },
   {
     title: "Runtime proxy and alerts",
-    href: "/proxy",
+    href: "/runtime?tab=proxy",
     summary: "Live runtime enforcement, detector alerts, drift protection, and audit review for MCP and tool-call activity.",
     status: "Runtime",
     icon: Radio,
   },
   {
     title: "Gateway and policy enforcement",
-    href: "/gateway",
+    href: "/runtime?tab=gateway",
     summary: "Policy evaluation and enforcement for high-impact tool usage and approval workflows.",
     status: "Protect",
     icon: Shield,

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -107,6 +107,12 @@ type SortKey = "severity" | "cvss" | "epss" | "id";
 type GroupKey = "none" | "package" | "agent" | "severity";
 type ScanScope = "latest" | "all";
 
+function serverFindingsSort(sortKey: SortKey): string {
+  if (sortKey === "cvss") return "cvss";
+  if (sortKey === "severity") return "severity";
+  return "effective_reach";
+}
+
 function CisaKevBadge() {
   return (
     <span className="text-xs font-mono bg-red-950 border border-red-800 text-red-400 rounded px-1.5 py-0.5">
@@ -354,7 +360,9 @@ function VulnsPage() {
   const [vexExporting, setVexExporting] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(paramCve ?? null);
   const [page, setPage] = useState(1);
+  const [findingsTotal, setFindingsTotal] = useState(0);
   const PAGE_SIZE = 25;
+  const useServerPaging = groupBy === "none" && !search.trim();
 
   // URL-as-source-of-truth: when the query string changes (link, back/forward),
   // re-sync the derived filter state so the view matches the address bar instead
@@ -584,54 +592,71 @@ function VulnsPage() {
   }, [refreshTriage]);
 
   useEffect(() => {
-    async function loadDetails() {
-      if (loading) return;
+    async function loadLegacyFindings() {
       if (paramScan) {
-        setDetailLoading(true);
-        setError("");
         try {
           const findings = await api.listFindings({ scanId: paramScan, limit: 1000 });
           if (findings.findings.length > 0) {
             setVulns(collectUnifiedFindings(findings.findings));
+            setFindingsTotal(findings.total);
             return;
           }
           const graph = await api.getGraph({ scanId: paramScan, limit: 2500 });
           setVulns(collectGraphVulns(graph));
+          setFindingsTotal(graph.nodes.filter((node) => graphNodeKind(node) === "vulnerability").length);
+          return;
         } catch (graphError) {
-          try {
-            const selectedJob = await api.getScan(paramScan);
-            setVulns(collectVulns([selectedJob]));
-          } catch (jobError) {
-            setError(
-              jobError instanceof Error
-                ? jobError.message
-                : graphError instanceof Error
-                  ? graphError.message
-                  : "Failed to load selected scan",
-            );
-            setErrorKind(_classifyApiErrorKind(jobError));
-          }
-        } finally {
-          setDetailLoading(false);
+          const selectedJob = await api.getScan(paramScan);
+          setVulns(collectVulns([selectedJob]));
+          setFindingsTotal(collectVulns([selectedJob]).length);
+          return;
         }
-        return;
       }
+
       if (jobs.length === 0) {
         setVulns([]);
-        setDetailLoading(false);
+        setFindingsTotal(0);
         return;
       }
+
+      if (scope === "latest") {
+        const latestJob = await api.getScan(jobs[0]!.job_id);
+        const collected = collectVulns([latestJob]);
+        setVulns(collected);
+        setFindingsTotal(collected.length);
+        return;
+      }
+
+      const fullJobs = await Promise.all(jobs.map((job) => api.getScan(job.job_id).catch(() => null)));
+      const collected = collectVulns(fullJobs.filter((job): job is ScanJob => Boolean(job)));
+      setVulns(collected);
+      setFindingsTotal(collected.length);
+    }
+
+    async function loadDetails() {
+      if (loading) return;
 
       setDetailLoading(true);
       setError("");
       try {
-        if (scope === "latest") {
-          const latestJob = await api.getScan(jobs[0]!.job_id);
-          setVulns(collectVulns([latestJob]));
-        } else {
-          const fullJobs = await Promise.all(jobs.map((job) => api.getScan(job.job_id).catch(() => null)));
-          setVulns(collectVulns(fullJobs.filter((job): job is ScanJob => Boolean(job))));
+        if (useServerPaging) {
+          const scanId =
+            paramScan ?? (scope === "latest" && jobs[0] ? jobs[0].job_id : undefined);
+          const response = await api.listFindings({
+            ...(scanId ? { scanId } : {}),
+            ...(filter !== "all" ? { severity: filter } : {}),
+            sort: serverFindingsSort(sortKey),
+            limit: PAGE_SIZE,
+            offset: (page - 1) * PAGE_SIZE,
+          });
+          if (response.total > 0 || response.findings.length > 0) {
+            setVulns(collectUnifiedFindings(response.findings));
+            setFindingsTotal(response.total);
+            return;
+          }
         }
+
+        await loadLegacyFindings();
       } catch (e: unknown) {
         setError(e instanceof Error ? e.message : "Failed to load");
         setErrorKind(_classifyApiErrorKind(e));
@@ -641,7 +666,17 @@ function VulnsPage() {
     }
 
     void loadDetails();
-  }, [jobs, scope, loading, collectVulns, paramScan]);
+  }, [
+    jobs,
+    scope,
+    loading,
+    collectVulns,
+    paramScan,
+    useServerPaging,
+    page,
+    filter,
+    sortKey,
+  ]);
 
   function handleSort(field: SortKey) {
     if (sortKey === field) {
@@ -653,6 +688,9 @@ function VulnsPage() {
   }
 
   const displayed = useMemo(() => {
+    if (useServerPaging) {
+      return vulns;
+    }
     let list = vulns;
     if (filter !== "all") {
       list = list.filter((v) => v.severity.toLowerCase() === filter);
@@ -681,13 +719,17 @@ function VulnsPage() {
       return sortDir === "desc" ? -diff : diff;
     });
     return list;
-  }, [vulns, filter, search, sortKey, sortDir]);
+  }, [vulns, filter, search, sortKey, sortDir, useServerPaging]);
 
   // Reset page when filters change
-  useEffect(() => { setPage(1); }, [filter, search, sortKey, sortDir]);
+  useEffect(() => { setPage(1); }, [filter, search, sortKey, sortDir, groupBy, scope, paramScan]);
 
-  const totalPages = Math.max(1, Math.ceil(displayed.length / PAGE_SIZE));
-  const paged = displayed.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+  const totalPages = useServerPaging
+    ? Math.max(1, Math.ceil(findingsTotal / PAGE_SIZE))
+    : Math.max(1, Math.ceil(displayed.length / PAGE_SIZE));
+  const paged = useServerPaging
+    ? displayed
+    : displayed.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
   const selectedVuln = useMemo(
     () => displayed.find((vuln) => vuln.id === selectedId) ?? vulns.find((vuln) => vuln.id === selectedId) ?? null,
     [displayed, selectedId, vulns],
@@ -733,11 +775,15 @@ function VulnsPage() {
   }, [vulns]);
 
   const FILTERS: { key: SeverityFilter; label: string; color: string }[] = [
-    { key: "all",      label: `All (${vulns.length})`,          color: "text-zinc-300" },
-    { key: "critical", label: `Critical (${counts.critical})`,  color: "text-red-400" },
-    { key: "high",     label: `High (${counts.high})`,          color: "text-orange-400" },
-    { key: "medium",   label: `Medium (${counts.medium})`,      color: "text-yellow-400" },
-    { key: "low",      label: `Low (${counts.low})`,            color: "text-blue-400" },
+    {
+      key: "all",
+      label: `All (${useServerPaging ? findingsTotal : vulns.length})`,
+      color: "text-zinc-300",
+    },
+    { key: "critical", label: `Critical${useServerPaging ? "" : ` (${counts.critical})`}`, color: "text-red-400" },
+    { key: "high",     label: `High${useServerPaging ? "" : ` (${counts.high})`}`,         color: "text-orange-400" },
+    { key: "medium",   label: `Medium${useServerPaging ? "" : ` (${counts.medium})`}`,     color: "text-yellow-400" },
+    { key: "low",      label: `Low${useServerPaging ? "" : ` (${counts.low})`}`,           color: "text-blue-400" },
   ];
 
   const GROUP_OPTIONS: { key: GroupKey; label: string; icon: React.ElementType }[] = [
@@ -755,9 +801,9 @@ function VulnsPage() {
           <p className="text-zinc-400 text-sm mt-1">
             {scope === "latest"
               ? paramScan
-                ? `${vulns.length} findings from scan ${paramScan.slice(0, 8)}.`
-                : `${vulns.length} findings from the latest completed scan.`
-              : `${vulns.length} findings aggregated across all completed scans.`}{" "}
+                ? `${useServerPaging ? findingsTotal : vulns.length} findings from scan ${paramScan.slice(0, 8)}.`
+                : `${useServerPaging ? findingsTotal : vulns.length} findings from the latest completed scan.`
+              : `${useServerPaging ? findingsTotal : vulns.length} findings aggregated across all completed scans.`}{" "}
             CVSS and EPSS appear for advisory-backed vulnerabilities; cloud and governance findings use source evidence and policy severity.
           </p>
         </div>
@@ -974,7 +1020,8 @@ function VulnsPage() {
             <PaginationBar
               page={page}
               totalPages={totalPages}
-              totalItems={displayed.length}
+              totalItems={useServerPaging ? findingsTotal : displayed.length}
+              itemLabel="findings"
               onPrevious={() => setPage((p) => Math.max(1, p - 1))}
               onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
             />

--- a/ui/components/auth-gate.tsx
+++ b/ui/components/auth-gate.tsx
@@ -46,7 +46,28 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   }
 
   if (error && isApiReachabilityFailure(error)) {
-    return <>{children}</>;
+    return (
+      <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-10">
+        <div className="w-full max-w-xl rounded-3xl border border-amber-900/50 bg-amber-950/20 p-8 text-center shadow-2xl shadow-black/20">
+          <ShieldCheck className="mx-auto mb-4 h-8 w-8 text-amber-300" />
+          <h1 className="text-xl font-semibold tracking-tight text-zinc-100">Control plane unreachable</h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-400">
+            Authentication could not be verified because the API is offline or returned a server error. The dashboard
+            stays locked until session discovery succeeds.
+          </p>
+          <p className="mt-2 text-xs text-zinc-500">
+            {userFacingApiErrorMessage(error, "Failed to load auth session")}
+          </p>
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            className="mt-6 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-zinc-950 transition hover:bg-emerald-400"
+          >
+            Retry connection
+          </button>
+        </div>
+      </div>
+    );
   }
 
   if (!error || isAuthFailure(error)) {

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -130,8 +130,7 @@ const NAV_GROUPS: NavGroup[] = [
     icon: Shield,
     accent: "#f778ba", // pink — enforcement layer
     links: [
-      { href: "/proxy", label: "Proxy", icon: Shield, capability: "runtime.ingest" },
-      { href: "/gateway", label: "Gateway", icon: Lock, capability: "policy.manage" },
+      { href: "/runtime", label: "Runtime", icon: Shield },
     ],
   },
   // Govern is split into three tight, single-purpose groups instead of one

--- a/ui/components/posture-grade.tsx
+++ b/ui/components/posture-grade.tsx
@@ -47,7 +47,7 @@ export function postureDimensionHref(key: string, label: string) {
   if (text.includes("credential") || text.includes("tool")) return "/mesh";
   if (text.includes("agent") || text.includes("server")) return "/agents";
   if (text.includes("trust") || text.includes("framework") || text.includes("compliance")) return "/compliance";
-  if (text.includes("runtime") || text.includes("proxy") || text.includes("watch")) return "/proxy";
+  if (text.includes("runtime") || text.includes("proxy") || text.includes("watch")) return "/runtime?tab=proxy";
   return "/graph";
 }
 

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -414,7 +414,7 @@ export function recommendedInteractionRiskActions(risk: InteractionRiskLike): In
   } else {
     actions.push({
       label: "Inspect runtime controls",
-      href: "/proxy",
+      href: "/runtime?tab=proxy",
     });
   }
 

--- a/ui/lib/deployment-context.ts
+++ b/ui/lib/deployment-context.ts
@@ -113,7 +113,7 @@ const SURFACE_DEFINITIONS: Record<DeploymentSurface, DeploymentSurfaceDefinition
   },
   proxy: {
     label: "Proxy",
-    navHref: "/proxy",
+    navHref: "/runtime?tab=proxy",
     isAvailable: (counts) => bool(counts?.has_proxy),
     requirement: "Runtime proxy audit or detector telemetry",
     command: "agent-bom proxy --help",
@@ -127,7 +127,7 @@ const SURFACE_DEFINITIONS: Record<DeploymentSurface, DeploymentSurfaceDefinition
   },
   gateway: {
     label: "Gateway",
-    navHref: "/gateway",
+    navHref: "/runtime?tab=gateway",
     isAvailable: (counts) => bool(counts?.has_gateway),
     requirement: "Gateway policy usage or managed runtime policy state",
     command: "helm upgrade --install agent-bom deploy/helm/agent-bom --set gateway.enabled=true",
@@ -170,7 +170,10 @@ const SURFACE_DEFINITIONS: Record<DeploymentSurface, DeploymentSurfaceDefinition
 };
 
 export function deploymentSurfaceForHref(href: string): DeploymentSurface | null {
-  const normalized = href === "/vulns" ? "/findings" : href;
+  const normalized = href === "/vulns" ? "/findings" : href.split("?")[0] ?? href;
+  if (normalized === "/proxy") return "proxy";
+  if (normalized === "/gateway") return "gateway";
+  if (normalized === "/runtime") return null;
   const match = Object.entries(SURFACE_DEFINITIONS).find(([, definition]) => definition.navHref === normalized);
   return (match?.[0] as DeploymentSurface | undefined) ?? null;
 }
@@ -185,6 +188,10 @@ export function isDeploymentSurfaceAvailable(
 
 export function isNavLinkVisible(href: string, counts: PostureCountsResponse | null): boolean {
   if (!hasDeploymentSignals(counts)) return true;
+  const baseHref = href.split("?")[0] ?? href;
+  if (baseHref === "/runtime") {
+    return Boolean(counts?.has_proxy || counts?.has_gateway);
+  }
   const surface = deploymentSurfaceForHref(href);
   if (!surface) return true;
   return isDeploymentSurfaceAvailable(surface, counts);

--- a/ui/tests/auth-gate.test.tsx
+++ b/ui/tests/auth-gate.test.tsx
@@ -91,7 +91,7 @@ describe("AuthGate", () => {
     expect(unlock).toBeEnabled();
   });
 
-  it("lets pages render their own offline state when auth discovery gets a server error", async () => {
+  it("blocks protected content when auth discovery gets a server error", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 500,
@@ -109,6 +109,8 @@ describe("AuthGate", () => {
       </AuthProvider>,
     );
 
-    await waitFor(() => expect(screen.getByText("page-level offline state")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Control plane unreachable")).toBeInTheDocument());
+    expect(screen.queryByText("page-level offline state")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry connection" })).toBeInTheDocument();
   });
 });

--- a/ui/tests/deployment-context.test.ts
+++ b/ui/tests/deployment-context.test.ts
@@ -71,8 +71,8 @@ describe("deployment-context helpers", () => {
       has_traces: true,
       scan_count: 3,
     });
-    expect(isNavLinkVisible("/gateway", counts)).toBe(true);
-    expect(isNavLinkVisible("/proxy", counts)).toBe(true);
+    expect(isNavLinkVisible("/runtime", counts)).toBe(true);
+    expect(isNavLinkVisible("/runtime?tab=proxy", counts)).toBe(true);
     expect(isNavLinkVisible("/audit", counts)).toBe(true);
   });
 

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -232,7 +232,7 @@ describe('Nav', () => {
       Discover: ['/', '/agents', '/fleet', '/registry'],
       Scan: ['/sources', '/scan', '/jobs', '/findings'],
       Analyze: ['/security-graph'],
-      Protect: ['/proxy', '/gateway'],
+      Protect: ['/runtime'],
       Compliance: ['/compliance', '/governance', '/audit'],
       Operations: ['/identity', '/cost', '/drift', '/activity'],
       Remediation: ['/remediation', '/traces'],
@@ -264,7 +264,7 @@ describe('Nav', () => {
 
     expect(screen.getAllByRole('link', { name: /dashboard/i }).length).toBeGreaterThan(0)
     expect(screen.getAllByRole('link', { name: /new scan/i }).length).toBeGreaterThan(0)
-    expect(screen.getAllByRole('link', { name: /proxy/i }).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('link', { name: /runtime/i }).length).toBeGreaterThan(0)
     expect(screen.getAllByRole('link', { name: /remediation/i }).length).toBeGreaterThan(0)
   })
 
@@ -336,7 +336,7 @@ describe('Nav', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /protect/i }))
     await waitFor(() => {
-      expect(screen.getAllByRole('link', { name: /^gateway$/i }).some((link) => link.getAttribute('href') === '/gateway')).toBe(true)
+      expect(screen.getAllByRole('link', { name: /^runtime$/i }).some((link) => link.getAttribute('href') === '/runtime')).toBe(true)
     })
 
     fireEvent.click(screen.getByRole('button', { name: /remediation/i }))

--- a/ui/tests/posture-grade.test.tsx
+++ b/ui/tests/posture-grade.test.tsx
@@ -12,7 +12,7 @@ describe("posture-grade helpers", () => {
   it("maps dimension labels to evidence destinations", () => {
     expect(postureDimensionHref("vulnerability_exposure", "Vulnerability Exposure")).toBe("/findings");
     expect(postureDimensionHref("credential_reach", "Credential Reach")).toBe("/mesh");
-    expect(postureDimensionHref("runtime_watch", "Runtime Watch")).toBe("/proxy");
+    expect(postureDimensionHref("runtime_watch", "Runtime Watch")).toBe("/runtime?tab=proxy");
   });
 
   it("returns readable drilldown hints", () => {

--- a/ui/tests/vulns-page.test.tsx
+++ b/ui/tests/vulns-page.test.tsx
@@ -8,6 +8,7 @@ const { apiMock } = vi.hoisted(() => ({
   apiMock: {
     listJobs: vi.fn(),
     getScan: vi.fn(),
+    listFindings: vi.fn(),
     listFindingTriage: vi.fn(),
     createException: vi.fn(),
     exportFindingTriageVex: vi.fn(),
@@ -89,6 +90,7 @@ describe("VulnsPage", () => {
   beforeEach(() => {
     apiMock.listJobs.mockReset();
     apiMock.getScan.mockReset();
+    apiMock.listFindings.mockReset();
     apiMock.listFindingTriage.mockReset();
     apiMock.createException.mockReset();
     apiMock.exportFindingTriageVex.mockReset();
@@ -103,6 +105,7 @@ describe("VulnsPage", () => {
       ],
     });
     apiMock.getScan.mockResolvedValue(scanJob());
+    apiMock.listFindings.mockResolvedValue({ findings: [], total: 0 });
     apiMock.listFindingTriage.mockResolvedValue({ triage: [] });
   });
 


### PR DESCRIPTION
## Summary
- Wire the flat findings queue to server-side `GET /v1/findings` paging (`limit`/`offset`/`total`) when `groupBy=none` and search is empty, with legacy scan/graph fallback when the API returns no rows.
- Fail closed in `AuthGate` when `/v1/auth/me` fails with network or server errors instead of rendering protected dashboard surfaces without a verified session.
- Add `/runtime` with Proxy and Gateway tabs, consolidate Protect nav to a single Runtime entry, and point deep links at `/runtime?tab=proxy|gateway`. `/proxy` and `/gateway` routes remain for bookmarks.

## Verification
- `cd ui && npm run typecheck`
- `cd ui && npm run test:run -- vulns-page.test.tsx auth-gate.test.tsx nav.test.tsx deployment-context.test.ts posture-grade.test.tsx`

## Notes
- Does not close **#2918** (formatter convergence on unified Finding) or the longer epics (**#3192**, **#3175**, **#3242**).

Made with [Cursor](https://cursor.com)