### PR TITLE
fix(ci): clear UI lint errors from #3412 merge

### DIFF
--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -605,7 +605,7 @@ function VulnsPage() {
           setVulns(collectGraphVulns(graph));
           setFindingsTotal(graph.nodes.filter((node) => graphNodeKind(node) === "vulnerability").length);
           return;
-        } catch (graphError) {
+        } catch {
           const selectedJob = await api.getScan(paramScan);
           setVulns(collectVulns([selectedJob]));
           setFindingsTotal(collectVulns([selectedJob]).length);

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -12,7 +12,6 @@ import {
   Activity,
   GitBranch,
   Shield,
-  Lock,
   Users,
   Network,
   Waypoints,


### PR DESCRIPTION
## Summary
- Fix `@typescript-eslint/no-unused-vars` in `ui/app/vulns/page.tsx` (unused `graphError` catch binding).
- Remove unused `Lock` import from `ui/components/nav.tsx` after Runtime nav consolidation.

## Verification
- `cd ui && npm run lint`

## Notes
- Unblocks `UI Validate` on `main` after #3412 merged with a lint failure.

Made with [Cursor](https://cursor.com)