### PR TITLE
fix(ui): hide duplicate headers on unified runtime tabs

### DIFF
--- a/ui/app/gateway/page.tsx
+++ b/ui/app/gateway/page.tsx
@@ -36,6 +36,7 @@ import {
   Activity,
 } from "lucide-react";
 import { GatewayFeedPanel } from "./GatewayFeedPanel";
+import { useRuntimeEmbedded } from "@/components/runtime-embed-context";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -55,6 +56,7 @@ const RUNTIME_COLORS: Record<GatewayPolicyRuntimeSummary["rollout_mode"], string
 // ─── Page ───────────────────────────────────────────────────────────────────
 
 export default function GatewayPage() {
+  const embedded = useRuntimeEmbedded();
   const [policies, setPolicies] = useState<GatewayPolicy[]>([]);
   const [stats, setStats] = useState<GatewayStatsResponse | null>(null);
   const [audit, setAudit] = useState<PolicyAuditEntry[]>([]);
@@ -151,7 +153,7 @@ export default function GatewayPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
+      {!embedded ? (
       <div className="flex items-start justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight flex items-center gap-2">
@@ -170,6 +172,7 @@ export default function GatewayPage() {
           Create Policy
         </button>
       </div>
+      ) : null}
 
       {/* Stats */}
       {stats && (

--- a/ui/app/proxy/page.tsx
+++ b/ui/app/proxy/page.tsx
@@ -21,6 +21,7 @@ import {
   Pie,
   Cell,
 } from "recharts";
+import { useRuntimeEmbedded } from "@/components/runtime-embed-context";
 import {
   Shield,
   Activity,
@@ -64,6 +65,7 @@ interface LiveMetrics {
 // ─── Page ────────────────────────────────────────────────────────────────────
 
 export default function ProxyDashboard() {
+  const embedded = useRuntimeEmbedded();
   const [status, setStatus] = useState<ProxyStatusResponse | null>(null);
   const [alerts, setAlerts] = useState<ProxyAlert[]>([]);
   const [live, setLive] = useState<LiveMetrics | null>(null);
@@ -183,7 +185,7 @@ export default function ProxyDashboard() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
+      {!embedded ? (
       <div className="flex items-start justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight flex items-center gap-2">
@@ -217,6 +219,7 @@ export default function ProxyDashboard() {
           </button>
         </div>
       </div>
+      ) : null}
 
       {/* Loading */}
       {loading && (

--- a/ui/app/runtime/page.tsx
+++ b/ui/app/runtime/page.tsx
@@ -6,6 +6,7 @@ import { Loader2, Lock, Shield } from "lucide-react";
 
 import ProxyDashboard from "@/app/proxy/page";
 import GatewayPage from "@/app/gateway/page";
+import { RuntimeEmbedProvider } from "@/components/runtime-embed-context";
 
 type RuntimeTab = "proxy" | "gateway";
 
@@ -65,7 +66,9 @@ function RuntimeTabs() {
 
       <p className="text-xs text-zinc-500">{active.description}</p>
 
-      {tab === "proxy" ? <ProxyDashboard /> : <GatewayPage />}
+      <RuntimeEmbedProvider>
+        {tab === "proxy" ? <ProxyDashboard /> : <GatewayPage />}
+      </RuntimeEmbedProvider>
     </div>
   );
 }

--- a/ui/components/runtime-embed-context.tsx
+++ b/ui/components/runtime-embed-context.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+const RuntimeEmbedContext = createContext(false);
+
+export function RuntimeEmbedProvider({ children }: { children: React.ReactNode }) {
+  return <RuntimeEmbedContext.Provider value>{children}</RuntimeEmbedContext.Provider>;
+}
+
+export function useRuntimeEmbedded(): boolean {
+  return useContext(RuntimeEmbedContext);
+}

--- a/ui/tests/runtime-page.test.tsx
+++ b/ui/tests/runtime-page.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import RuntimePage from "@/app/runtime/page";
+
+const { proxyMock, gatewayMock } = vi.hoisted(() => ({
+  proxyMock: vi.fn(() => <div>proxy surface</div>),
+  gatewayMock: vi.fn(() => <div>gateway surface</div>),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams("tab=proxy"),
+}));
+
+vi.mock("@/app/proxy/page", () => ({
+  default: () => proxyMock(),
+}));
+
+vi.mock("@/app/gateway/page", () => ({
+  default: () => gatewayMock(),
+}));
+
+describe("RuntimePage", () => {
+  beforeEach(() => {
+    proxyMock.mockClear();
+    gatewayMock.mockClear();
+  });
+
+  it("renders the unified runtime shell with embedded proxy content", async () => {
+    render(<RuntimePage />);
+
+    expect(await screen.findByRole("heading", { name: "Runtime" })).toBeInTheDocument();
+    expect(screen.getByText("proxy surface")).toBeInTheDocument();
+    expect(proxyMock).toHaveBeenCalled();
+    expect(gatewayMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `RuntimeEmbedProvider` so `/runtime` can embed proxy and gateway dashboards without duplicate H1 chrome.
- Suppress standalone proxy/gateway headers when the embed context is active.
- Add a runtime page smoke test.

## Verification
- `cd ui && npm run lint`
- `cd ui && npm run typecheck`
- `cd ui && npm run test:run -- runtime-page.test.tsx gateway-page.test.tsx`

## Notes
- Follow-up polish for #3412 unified runtime page.

Made with [Cursor](https://cursor.com)