### PR TITLE
refactor(output): Finding-native exposure path projection (#2918)

### DIFF
--- a/src/agent_bom/output/exposure_path.py
+++ b/src/agent_bom/output/exposure_path.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from agent_bom.models import BlastRadius
+
+if TYPE_CHECKING:
+    from agent_bom.finding import Finding
 
 
 def _display_package_name(name: str, version: str | None) -> str:
@@ -23,82 +26,124 @@ def _display_package_name(name: str, version: str | None) -> str:
     return name
 
 
-def exposure_path_for_blast_radius(br: BlastRadius, *, rank: int | None = None) -> dict[str, Any]:
-    """Return a bounded, report-safe ExposurePath view for a blast-radius item.
+def exposure_path_for_finding(
+    finding: Finding,
+    *,
+    rank: int | None = None,
+    provenance_source: str = "finding_output",
+) -> dict[str, Any]:
+    """Return a bounded, report-safe ExposurePath view for a unified Finding."""
 
-    The API graph endpoints produce richer graph-native ExposurePath payloads.
-    File-based reports start from ``BlastRadius``, so this projection preserves
-    the same investigation shape without claiming graph persistence or live path
-    replay was involved.
-    """
+    from agent_bom.output.finding_views import package_ecosystem, package_name, package_version
 
-    vuln = br.vulnerability
-    package = br.package
-    package_name = _display_package_name(package.name, package.version)
-    package_ref = f"pkg:{package.ecosystem}:{package_name}@{package.version or 'unknown'}"
-    finding_ref = f"finding:{vuln.id}"
-    source_ref = _source_ref(br)
+    pkg_name = package_name(finding)
+    pkg_version = package_version(finding)
+    ecosystem = package_ecosystem(finding)
+    display_name = _display_package_name(pkg_name, pkg_version or None)
+    package_ref = f"pkg:{ecosystem}:{display_name}@{pkg_version or 'unknown'}"
+    vuln_id = finding.cve_id or finding.title or finding.asset.name
+    finding_ref = f"finding:{vuln_id}"
+    source_ref = _source_ref_for_finding(finding, display_name, pkg_version, ecosystem)
     target_ref = finding_ref
+    server_refs = _server_refs_for_finding(finding)
+    tool_refs = _tool_refs_for_finding(finding)
+    credential_refs = _credential_refs_for_finding(finding)
     nodes = _ordered_unique(
         [
             source_ref,
-            *_server_refs(br)[:3],
+            *server_refs[:3],
             package_ref,
             target_ref,
-            *_tool_refs(br)[:3],
-            *_credential_refs(br)[:3],
+            *tool_refs[:3],
+            *credential_refs[:3],
         ]
     )
-    relationships = _relationships(br, source_ref, package_ref, finding_ref)
-    fix = f"Upgrade {package_name} to {vuln.fixed_version}" if vuln.fixed_version else "No upstream fix recorded; monitor advisory source"
-    proof_bits = []
-    if br.affected_agents:
-        proof_bits.append(f"{len(br.affected_agents)} affected agent(s)")
-    if br.affected_servers:
-        proof_bits.append(f"{len(br.affected_servers)} affected server(s)")
-    if br.exposed_tools:
-        proof_bits.append(f"{len(br.exposed_tools)} reachable tool(s)")
-    if br.exposed_credentials:
-        proof_bits.append(f"{len(br.exposed_credentials)} exposed credential reference(s)")
-    if vuln.is_kev:
+    relationships = _relationships_for_finding(
+        finding,
+        source_ref,
+        package_ref,
+        finding_ref,
+        server_refs,
+        tool_refs,
+        credential_refs,
+    )
+    fix = (
+        f"Upgrade {display_name} to {finding.fixed_version}"
+        if finding.fixed_version
+        else "No upstream fix recorded; monitor advisory source"
+    )
+    proof_bits: list[str] = []
+    if finding.affected_agents:
+        proof_bits.append(f"{len(finding.affected_agents)} affected agent(s)")
+    if finding.affected_servers:
+        proof_bits.append(f"{len(finding.affected_servers)} affected server(s)")
+    if finding.exposed_tools:
+        proof_bits.append(f"{len(finding.exposed_tools)} reachable tool(s)")
+    if finding.exposed_credentials:
+        proof_bits.append(f"{len(finding.exposed_credentials)} exposed credential reference(s)")
+    if finding.is_kev:
         proof_bits.append("CISA KEV")
-    if vuln.epss_score is not None:
-        proof_bits.append(f"EPSS {vuln.epss_score:.4f}")
+    if finding.epss_score is not None:
+        proof_bits.append(f"EPSS {finding.epss_score:.4f}")
 
-    path_id_parts = [vuln.id, package.ecosystem, package_name, package.version or "unknown"]
+    reachability = finding.reachability or "unknown"
+    severity = str(finding.effective_severity() or finding.severity or "unknown")
+    path_id_parts = [vuln_id, ecosystem, display_name, pkg_version or "unknown"]
     path: dict[str, Any] = {
-        "id": "blast:" + ":".join(_slug(part) for part in path_id_parts),
+        "id": "finding:" + ":".join(_slug(part) for part in path_id_parts),
         "rank": rank,
-        "label": f"{package_name}@{package.version or '?'} -> {vuln.id}",
-        "summary": br.attack_vector_summary
-        or br.ai_risk_context
-        or f"{vuln.id} affects {package_name}@{package.version or '?'} with {br.reachability} reachability.",
-        "riskScore": round(br.risk_score, 2),
-        "severity": vuln.severity.value,
+        "label": f"{display_name}@{pkg_version or '?'} -> {vuln_id}",
+        "summary": finding.attack_vector_summary
+        or finding.ai_risk_context
+        or f"{vuln_id} affects {display_name}@{pkg_version or '?'} with {reachability} reachability.",
+        "riskScore": round(float(finding.risk_score or 0.0), 2),
+        "severity": severity,
         "source": source_ref,
         "target": target_ref,
         "hops": nodes,
         "relationships": relationships,
         "nodeIds": nodes,
         "edgeIds": [rel["id"] for rel in relationships],
-        "findings": [vuln.id],
-        "affectedAgents": [_agent_label(agent) for agent in br.affected_agents[:10]],
-        "affectedServers": [_server_label(server) for server in br.affected_servers[:10]],
-        "reachableTools": [tool.name for tool in br.exposed_tools[:10]],
-        "exposedCredentials": list(br.exposed_credentials[:10]),
+        "findings": [vuln_id],
+        "affectedAgents": list(finding.affected_agents[:10]),
+        "affectedServers": list(finding.affected_servers[:10]),
+        "reachableTools": list(finding.exposed_tools[:10]),
+        "exposedCredentials": list(finding.exposed_credentials[:10]),
         "dependencyContext": {
-            "package": package_name,
-            "version": package.version,
-            "ecosystem": package.ecosystem,
-            "direct": package.is_direct,
-            "dependencyDepth": package.dependency_depth,
-            "reachabilityEvidence": package.reachability_evidence,
+            "package": display_name,
+            "version": pkg_version,
+            "ecosystem": ecosystem,
+            "direct": finding.evidence.get("package_is_direct"),
+            "dependencyDepth": finding.evidence.get("package_dependency_depth"),
+            "reachabilityEvidence": finding.evidence.get("package_reachability_evidence"),
         },
         "fix": fix,
         "evidence": proof_bits,
-        "provenance": {"source": "blast_radius_output", "graphPersistence": False},
+        "provenance": {"source": provenance_source, "graphPersistence": False},
     }
     return {key: value for key, value in path.items() if value is not None}
+
+
+def exposure_path_for_blast_radius(br: BlastRadius, *, rank: int | None = None) -> dict[str, Any]:
+    """Return a bounded, report-safe ExposurePath view for a blast-radius item.
+
+    Legacy adapter: projects through the unified Finding model so file-based
+    formatters can converge on one canonical exposure-path builder.
+    """
+    from agent_bom.finding import blast_radius_to_finding
+
+    path = exposure_path_for_finding(
+        blast_radius_to_finding(br),
+        rank=rank,
+        provenance_source="blast_radius_output",
+    )
+    vuln = br.vulnerability
+    package = br.package
+    package_name_value = _display_package_name(package.name, package.version)
+    path["id"] = "blast:" + ":".join(
+        _slug(part) for part in [vuln.id, package.ecosystem, package_name_value, package.version or "unknown"]
+    )
+    return path
 
 
 def _chain_token(hop: str) -> str:
@@ -108,13 +153,7 @@ def _chain_token(hop: str) -> str:
 
 
 def exposure_path_chain(path: dict[str, Any], *, include_tool: bool = True) -> str:
-    """Render the primary trust spine of an ExposurePath as a one-line chain.
-
-    Produces ``agent → server → package@version → finding → tool`` from the
-    already-computed ``hops``/``target`` projection. The chain is the
-    differentiating wedge (agent → MCP server → package → CVE → tool); the wider
-    reachable-tool/credential set is summarised separately via blast counts.
-    """
+    """Render the primary trust spine of an ExposurePath as a one-line chain."""
 
     hops = [hop for hop in (path.get("hops") or []) if hop]
     if not hops:
@@ -142,20 +181,29 @@ def exposure_path_blast_summary(path: dict[str, Any]) -> str:
     return f"{creds} cred(s), {tools} tool(s) reachable"
 
 
-def exposure_path_brief(br: BlastRadius, *, rank: int) -> dict[str, str]:
+def exposure_path_brief_for_finding(finding: Finding, *, rank: int) -> dict[str, str]:
     """Return compact strings for Markdown/HTML investigation summaries."""
 
-    path = exposure_path_for_blast_radius(br, rank=rank)
+    path = exposure_path_for_finding(finding, rank=rank)
     proof = ", ".join(str(item) for item in path.get("evidence", [])) or "Package finding"
+    severity = str(finding.effective_severity() or finding.severity or "unknown").upper()
     return {
         "rank": str(rank),
-        "risk": f"{br.risk_score:.1f}",
-        "severity": br.vulnerability.severity.value.upper(),
+        "risk": f"{float(finding.risk_score or 0.0):.1f}",
+        "severity": severity,
         "path": str(path["label"]),
         "why": str(path["summary"]),
         "proof": proof,
         "fix": str(path["fix"]),
     }
+
+
+def exposure_path_brief(br: BlastRadius, *, rank: int) -> dict[str, str]:
+    """Return compact strings for Markdown/HTML investigation summaries."""
+
+    from agent_bom.finding import blast_radius_to_finding
+
+    return exposure_path_brief_for_finding(blast_radius_to_finding(br), rank=rank)
 
 
 def _agent_label(agent: Any) -> str:
@@ -174,16 +222,41 @@ def _source_ref(br: BlastRadius) -> str:
     return f"pkg:{br.package.ecosystem}:{_display_package_name(br.package.name, br.package.version)}@{br.package.version or 'unknown'}"
 
 
+def _source_ref_for_finding(
+    finding: Finding,
+    package_name_value: str,
+    package_version_value: str,
+    ecosystem: str,
+) -> str:
+    if finding.affected_agents:
+        return f"agent:{finding.affected_agents[0]}"
+    if finding.affected_servers:
+        return f"server:{finding.affected_servers[0]}"
+    return f"pkg:{ecosystem}:{package_name_value}@{package_version_value or 'unknown'}"
+
+
 def _server_refs(br: BlastRadius) -> list[str]:
     return [f"server:{_server_label(server)}" for server in br.affected_servers]
+
+
+def _server_refs_for_finding(finding: Finding) -> list[str]:
+    return [f"server:{server}" for server in finding.affected_servers]
 
 
 def _tool_refs(br: BlastRadius) -> list[str]:
     return [f"tool:{tool.name}" for tool in br.exposed_tools]
 
 
+def _tool_refs_for_finding(finding: Finding) -> list[str]:
+    return [f"tool:{tool}" for tool in finding.exposed_tools]
+
+
 def _credential_refs(br: BlastRadius) -> list[str]:
     return [f"credential:{name}" for name in br.exposed_credentials]
+
+
+def _credential_refs_for_finding(finding: Finding) -> list[str]:
+    return [f"credential:{name}" for name in finding.exposed_credentials]
 
 
 def _relationships(br: BlastRadius, source_ref: str, package_ref: str, finding_ref: str) -> list[dict[str, str]]:
@@ -201,6 +274,33 @@ def _relationships(br: BlastRadius, source_ref: str, package_ref: str, finding_r
     for tool_ref in _tool_refs(br)[:3]:
         add("provides_tool", source_ref, tool_ref)
     for credential_ref in _credential_refs(br)[:3]:
+        add("exposes_credential", source_ref, credential_ref)
+    return rels
+
+
+def _relationships_for_finding(
+    finding: Finding,
+    source_ref: str,
+    package_ref: str,
+    finding_ref: str,
+    server_refs: list[str],
+    tool_refs: list[str],
+    credential_refs: list[str],
+) -> list[dict[str, str]]:
+    rels: list[dict[str, str]] = []
+
+    def add(rel_type: str, source: str, target: str) -> None:
+        rels.append({"id": f"{source}->{rel_type}->{target}", "type": rel_type, "source": source, "target": target})
+
+    for server_ref in server_refs[:3]:
+        add("uses", source_ref, server_ref)
+        add("depends_on", server_ref, package_ref)
+    if not finding.affected_servers:
+        add("depends_on", source_ref, package_ref)
+    add("vulnerable_to", package_ref, finding_ref)
+    for tool_ref in tool_refs[:3]:
+        add("provides_tool", source_ref, tool_ref)
+    for credential_ref in credential_refs[:3]:
         add("exposes_credential", source_ref, credential_ref)
     return rels
 

--- a/tests/test_exposure_path_finding.py
+++ b/tests/test_exposure_path_finding.py
@@ -1,0 +1,76 @@
+"""ExposurePath parity tests for unified Finding migration (#2918)."""
+
+from __future__ import annotations
+
+from agent_bom.finding import blast_radius_to_finding
+from agent_bom.models import Agent, AgentStatus, AgentType, BlastRadius, MCPServer, MCPTool, Package, Severity, TransportType, Vulnerability
+from agent_bom.output.exposure_path import exposure_path_for_blast_radius, exposure_path_for_finding
+
+
+def _pkg(name: str = "lodash", version: str = "4.17.20", ecosystem: str = "npm") -> Package:
+    return Package(name=name, version=version, ecosystem=ecosystem)
+
+
+def _vuln(vuln_id: str = "CVE-2024-0001") -> Vulnerability:
+    return Vulnerability(
+        id=vuln_id,
+        summary="Test vulnerability",
+        severity=Severity.CRITICAL,
+        cvss_score=9.8,
+        fixed_version="4.17.21",
+    )
+
+
+def _server(name: str = "prod-mcp", tools: list[MCPTool] | None = None) -> MCPServer:
+    return MCPServer(name=name, command="npx srv", transport=TransportType.STDIO, tools=tools or [])
+
+
+def _agent(name: str = "prod-agent", servers: list[MCPServer] | None = None) -> Agent:
+    return Agent(
+        name=name,
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/test.json",
+        mcp_servers=servers or [],
+        status=AgentStatus.CONFIGURED,
+    )
+
+
+def _blast_radius() -> BlastRadius:
+    tool = MCPTool(name="deploy", description="Deploy workloads")
+    server = _server(tools=[tool])
+    agent = _agent(servers=[server])
+    br = BlastRadius(
+        package=_pkg(),
+        vulnerability=_vuln(),
+        affected_agents=[agent],
+        affected_servers=[server],
+        exposed_credentials=["AWS_SECRET_ACCESS_KEY"],
+        exposed_tools=[tool],
+    )
+    br.risk_score = 9.4
+    br.attack_vector_summary = "Agent reaches vulnerable MCP package."
+    return br
+
+
+def test_exposure_path_for_finding_matches_blast_radius_projection() -> None:
+    br = _blast_radius()
+    legacy = exposure_path_for_blast_radius(br, rank=1)
+    finding = blast_radius_to_finding(br)
+    projected = exposure_path_for_finding(finding, rank=1, provenance_source="blast_radius_output")
+
+    assert projected["label"] == legacy["label"]
+    assert projected["summary"] == legacy["summary"]
+    assert projected["riskScore"] == legacy["riskScore"]
+    assert projected["affectedAgents"] == legacy["affectedAgents"]
+    assert projected["affectedServers"] == legacy["affectedServers"]
+    assert projected["reachableTools"] == legacy["reachableTools"]
+    assert projected["exposedCredentials"] == legacy["exposedCredentials"]
+    assert projected["relationships"] == legacy["relationships"]
+    assert projected["provenance"] == legacy["provenance"]
+
+
+def test_exposure_path_for_blast_radius_keeps_legacy_id_prefix() -> None:
+    br = _blast_radius()
+    path = exposure_path_for_blast_radius(br, rank=2)
+    assert path["id"].startswith("blast:")
+    assert path["rank"] == 2


### PR DESCRIPTION
## Summary
- Add `exposure_path_for_finding()` and `exposure_path_brief_for_finding()` as the canonical ExposurePath builders for file-based reports.
- Keep `exposure_path_for_blast_radius()` as a legacy adapter that projects through `blast_radius_to_finding()` while preserving the `blast:` id prefix and provenance source.
- Add parity regression tests to prevent field drift during formatter migration.

## Verification
- `uv run pytest tests/test_exposure_path_finding.py -q`
- `uv run pytest tests/test_output_formats.py -q -k exposure_path`
- `uv run ruff check src/agent_bom/output/exposure_path.py tests/test_exposure_path_finding.py`

## Notes
- Foundation PR for **#2918**; follow-ups can migrate Markdown/HTML/SARIF formatters to call the Finding-native helpers directly.

