### PR TITLE
refactor(output): Markdown/HTML exposure paths via Finding (#2918 PR-2)

### DIFF
--- a/src/agent_bom/output/exposure_path.py
+++ b/src/agent_bom/output/exposure_path.py
@@ -124,26 +124,33 @@ def exposure_path_for_finding(
     return {key: value for key, value in path.items() if value is not None}
 
 
-def exposure_path_for_blast_radius(br: BlastRadius, *, rank: int | None = None) -> dict[str, Any]:
-    """Return a bounded, report-safe ExposurePath view for a blast-radius item.
-
-    Legacy adapter: projects through the unified Finding model so file-based
-    formatters can converge on one canonical exposure-path builder.
-    """
-    from agent_bom.finding import blast_radius_to_finding
-
-    path = exposure_path_for_finding(
-        blast_radius_to_finding(br),
-        rank=rank,
-        provenance_source="blast_radius_output",
-    )
+def _blast_exposure_path_id(br: BlastRadius) -> str:
     vuln = br.vulnerability
     package = br.package
     package_name_value = _display_package_name(package.name, package.version)
-    path["id"] = "blast:" + ":".join(
+    return "blast:" + ":".join(
         _slug(part) for part in [vuln.id, package.ecosystem, package_name_value, package.version or "unknown"]
     )
+
+
+def exposure_path_for_report_finding(
+    finding: Finding,
+    *,
+    br: BlastRadius | None = None,
+    rank: int | None = None,
+) -> dict[str, Any]:
+    """Project a unified Finding to a legacy-compatible ExposurePath payload."""
+    path = exposure_path_for_finding(finding, rank=rank, provenance_source="blast_radius_output")
+    if br is not None:
+        path["id"] = _blast_exposure_path_id(br)
     return path
+
+
+def exposure_path_for_blast_radius(br: BlastRadius, *, rank: int | None = None) -> dict[str, Any]:
+    """Return a bounded, report-safe ExposurePath view for a blast-radius item."""
+    from agent_bom.finding import blast_radius_to_finding
+
+    return exposure_path_for_report_finding(blast_radius_to_finding(br), br=br, rank=rank)
 
 
 def _chain_token(hop: str) -> str:

--- a/src/agent_bom/output/finding_views.py
+++ b/src/agent_bom/output/finding_views.py
@@ -81,3 +81,14 @@ def has_high_or_critical(finding: Finding) -> bool:
 
 def is_medium(finding: Finding) -> bool:
     return severity_value(finding) == "medium"
+
+
+def ranked_cve_findings(
+    report: AIBOMReport,
+    blast_radii: list[BlastRadius] | None = None,
+    *,
+    limit: int = 10,
+) -> list[Finding]:
+    """Return top CVE findings by unified risk score for exposure-path views."""
+    findings = cve_findings(report, blast_radii)
+    return sorted(findings, key=lambda finding: float(finding.risk_score or 0.0), reverse=True)[:limit]

--- a/src/agent_bom/output/html.py
+++ b/src/agent_bom/output/html.py
@@ -25,7 +25,8 @@ from typing import TYPE_CHECKING, Any
 
 from agent_bom.finding import FindingType
 from agent_bom.graph.severity import severity_policy_rank
-from agent_bom.output.exposure_path import exposure_path_brief
+from agent_bom.output.exposure_path import exposure_path_brief_for_finding
+from agent_bom.output.finding_views import ranked_cve_findings
 from agent_bom.security import sanitize_launch_command, sanitize_path_label
 
 if TYPE_CHECKING:
@@ -378,13 +379,14 @@ def _blast_table(blast_radii: list["BlastRadius"]) -> str:
     )
 
 
-def _exposure_path_section(blast_radii: list["BlastRadius"]) -> str:
-    if not blast_radii:
+def _exposure_path_section(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
+    findings = ranked_cve_findings(report, blast_radii)
+    if not findings:
         return ""
     cards = []
-    for rank, br in enumerate(sorted(blast_radii, key=lambda b: b.risk_score, reverse=True)[:10], 1):
-        brief = exposure_path_brief(br, rank=rank)
-        sev = br.vulnerability.severity.value.lower()
+    for rank, finding in enumerate(findings, 1):
+        brief = exposure_path_brief_for_finding(finding, rank=rank)
+        sev = str(finding.effective_severity() or finding.severity or "unknown").lower()
         color = _SEV_COLOR.get(sev, "#6b7280")
         cards.append(
             '<div class="exposure-path-card">'
@@ -1430,7 +1432,7 @@ def to_html(
             f'<sup style="font-size:.65rem;color:#475569;margin-left:6px;font-weight:400">'
             f"ranked investigation briefs from blast-radius evidence"
             f"</sup></div>"
-            f'<div class="panel exposure-paths">{_exposure_path_section(blast_radii)}</div>'
+            f'<div class="panel exposure-paths">{_exposure_path_section(report, blast_radii)}</div>'
             f"</section>"
             f'<section id="blast">'
             f'<div class="sec-title">&#x1f4a5; Blast Radius'

--- a/src/agent_bom/output/markdown.py
+++ b/src/agent_bom/output/markdown.py
@@ -9,7 +9,8 @@ from agent_bom.compliance_utils import framework_qualified_blast_radius_tags
 from agent_bom.finding import Finding, FindingType
 from agent_bom.graph.severity import severity_policy_rank
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
-from agent_bom.output.exposure_path import exposure_path_brief
+from agent_bom.output.exposure_path import exposure_path_brief_for_finding
+from agent_bom.output.finding_views import ranked_cve_findings
 
 
 def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> str:
@@ -113,7 +114,7 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
 
         lines.append("")
 
-        lines.extend(_exposure_path_section(brs))
+        lines.extend(_exposure_path_section(report, brs))
 
     # Critical/High details
     critical_high = [br for br in brs if br.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH)]
@@ -235,9 +236,10 @@ def _compliance_tags_text(br: BlastRadius) -> str:
     return ", ".join(framework_qualified_blast_radius_tags(br))
 
 
-def _exposure_path_section(brs: list[BlastRadius]) -> list[str]:
-    """Render the top blast-radius findings as investigation-first paths."""
-    if not brs:
+def _exposure_path_section(report: AIBOMReport, blast_radii: list[BlastRadius]) -> list[str]:
+    """Render the top CVE findings as investigation-first exposure paths."""
+    findings = ranked_cve_findings(report, blast_radii)
+    if not findings:
         return []
 
     lines = [
@@ -246,8 +248,8 @@ def _exposure_path_section(brs: list[BlastRadius]) -> list[str]:
         "| Rank | Risk | Severity | Path | Proof | Fix |",
         "|------|------|----------|------|-------|-----|",
     ]
-    for rank, br in enumerate(sorted(brs, key=lambda b: b.risk_score, reverse=True)[:10], 1):
-        brief = exposure_path_brief(br, rank=rank)
+    for rank, finding in enumerate(findings, 1):
+        brief = exposure_path_brief_for_finding(finding, rank=rank)
         lines.append(
             f"| #{brief['rank']} | {brief['risk']} | {brief['severity']} | {_md_cell(brief['path'])} | "
             f"{_md_cell(brief['proof'])} | {_md_cell(brief['fix'])} |"


### PR DESCRIPTION
## Summary
- Add `ranked_cve_findings()` and `exposure_path_for_report_finding()` helpers for formatter migration.
- Migrate Markdown and HTML exposure-path sections to `exposure_path_brief_for_finding()` with no direct `BlastRadius` usage in those sections.

## Verification
- `uv run pytest tests/test_output_formats.py -q -k exposure_path`
- `uv run pytest tests/test_exposure_path_finding.py -q`
- `uv run ruff check src/agent_bom/output/markdown.py src/agent_bom/output/html.py src/agent_bom/output/finding_views.py src/agent_bom/output/exposure_path.py`

## Notes
- Part of **#2918** PR-2. SARIF/JSON exposure blocks follow in PR-3.

Made with [Cursor](https://cursor.com)