### PR TITLE
refactor(ui): split vulns page and sync filters to URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ permissions:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ Run `agent-bom db update` before `--offline` image or package scans. Guided path
 **Cloud (read-only).** Four connectors — AWS, Azure, GCP, Snowflake — are
 opt-in, agentless, and default-off. No secret values are read or stored.
 `agent-bom connect <provider>` prints the grant template and enable flag without
-network I/O until you opt in.
+network I/O until you opt in. Full intake map:
+[docs/DATA_SOURCES.md](docs/DATA_SOURCES.md)
 
 | Cloud | Enable | Scan |
 |---|---|---|

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -1,0 +1,75 @@
+# Data sources — mechanism and permission map
+
+One-page map from the README intake diagram to the **actual connect path**,
+**permission boundary**, and **first command**. agent-bom is **read-only by
+default** across every lane: no secret values stored, no writes to customer
+environments unless an operator explicitly opts into a documented exception
+(AWS side-scan snapshot lifecycle).
+
+## How intake works (four modes)
+
+| Mode | When to use | Permission model |
+|---|---|---|
+| **Direct scan** | Local repo, CI job, MCP config on disk, image tarball, IaC tree, SBOM file | Reads files/processes the operator already controls; see [PERMISSIONS.md](PERMISSIONS.md) |
+| **Read-only cloud role** | AWS, Azure, GCP, Snowflake estate inventory | Customer-managed IAM/RBAC/key-pair; agent-bom assumes or uses creds at scan time only |
+| **API push / ingest** | Fleet sync, scan report upload, findings bulk, OCSF traces | Control-plane API key / OIDC / SAML; tenant-scoped write to *your* agent-bom instance |
+| **Optional in-env collector** | Endpoint fleet timer, Helm scan CronJob, proxy/gateway sidecar | Deployed in customer boundary; pushes metadata/evidence to control plane |
+
+Deep architecture: [site-docs/architecture/data-ingestion-and-security.md](../site-docs/architecture/data-ingestion-and-security.md) ·
+cloud grants: [CLOUD_CONNECT.md](CLOUD_CONNECT.md)
+
+## Diagram tile → mechanism
+
+| Source | Mechanism | Enable / first command | Permission boundary |
+|---|---|---|---|
+| **Repo** | Direct scan (filesystem + lockfiles) | `agent-bom agents -p .` | Local read-only; no network unless enrichment enabled |
+| **CI** | Direct scan in pipeline + optional push | `uses: msaad00/agent-bom@v…` or `agent-bom agents … --push-url …/v1/results/push` | CI runner filesystem; push uses API key to *your* control plane |
+| **MCP** | Config discovery + optional live introspection | `agent-bom agents -p .` or `agent-bom mcp introspect` | Reads MCP configs; no credential values |
+| **Image** | Container image scanner driver | `agent-bom image <ref>` | Local daemon/registry/tarball read |
+| **IaC** | Terraform/K8s/Helm scanner drivers | `agent-bom iac -p .` | Local/IaC tree read-only |
+| **SBOM** | SBOM import driver | `agent-bom sbom ingest <file>` | Parses supplied artifact only |
+| **Model** | Model advisory / Hugging Face paths | `agent-bom agents --huggingface` (etc.) | Token read from env at runtime; never stored |
+| **AWS** | Read-only IAM role (`SecurityAudit` + optional `ViewOnlyAccess`) | `agent-bom connect aws` → `AGENT_BOM_AWS_INVENTORY=1` → `agent-bom cloud aws` | [connect-aws](../deploy/terraform/connect-aws/README.md); STS `AssumeRole` + `ExternalId` for org fan-out |
+| **Azure** | `Reader` + `Security Reader` | `agent-bom connect azure` → `AGENT_BOM_AZURE_INVENTORY=1` → `agent-bom cloud azure` | [connect-azure](../deploy/terraform/connect-azure/README.md); `DefaultAzureCredential` chain |
+| **GCP** | `roles/viewer` + `roles/iam.securityReviewer` | `agent-bom connect gcp` → `AGENT_BOM_GCP_INVENTORY=1` → `agent-bom cloud gcp` | [connect-gcp](../deploy/terraform/connect-gcp/README.md); ADC / SA key JSON |
+| **Snowflake** | `ABOM_READONLY` role; key-pair JWT or browser SSO | `pip install 'agent-bom[snowflake]'` → `agent-bom connect snowflake` → `agent-bom agents --snowflake` | [connect-snowflake](../deploy/terraform/connect-snowflake/README.md); Python connector auth — no `snowsql` session required |
+
+### Snowflake quick path
+
+```bash
+pip install 'agent-bom[snowflake]'
+# One-time (ACCOUNTADMIN): deploy ABOM_READONLY grant — see scripts/provision/snowflake_readonly.sql
+export SNOWFLAKE_ACCOUNT=xy12345
+export SNOWFLAKE_USER=AGENT_BOM
+export SNOWFLAKE_WAREHOUSE=COMPUTE_WH
+# Default: browser SSO (externalbrowser). CI: SNOWFLAKE_AUTHENTICATOR=snowflake_jwt + SNOWFLAKE_PRIVATE_KEY_PATH
+agent-bom agents --snowflake
+```
+
+## Control-plane ingest API (push evidence)
+
+| Route | Purpose | CLI / client |
+|---|---|---|
+| `POST /v1/fleet/sync` | Endpoint inventory sync | `agent-bom agents --push-url …/v1/fleet/sync` |
+| `POST /v1/results/push` | Full scan report → ScanJob | `agent-bom agents … --push-url …/v1/results/push` |
+| `POST /v1/findings/bulk` | Normalized findings batch | API / integrations |
+| `POST /v1/ocsf/ingest` | OCSF security events | SIEM / observability hooks |
+| `POST /v1/sources` + `POST /v1/sources/{id}/run` | Registered connector/source registry | Dashboard **Scan → Sources** |
+
+Hosted source kinds (`scan.*`, `connector.*`, `ingest.*`, `runtime.*`) are defined in `src/agent_bom/api/models.py` (`SourceKind`).
+
+## Optional deploy-in-target collectors
+
+| Collector | Role |
+|---|---|
+| Endpoint fleet timer / plist | Periodic `agent-bom agents` + `POST /v1/fleet/sync` |
+| Helm scanner CronJob | In-cluster scheduled scan (`deploy/helm/agent-bom` values) |
+| Proxy / gateway sidecar | Runtime audit + policy enforcement |
+| AWS side-scan | **Opt-in** snapshot lifecycle (non-read-only exception); see `deploy/terraform/connect-aws-sidescan/` |
+
+## Related docs
+
+- [PRODUCT_MAP.md](PRODUCT_MAP.md) — lanes and surfaces
+- [FIRST_RUN.md](FIRST_RUN.md) — local first scan
+- [DEPLOY_PLATFORM.md](DEPLOY_PLATFORM.md) — self-host the control plane
+- [MCP_SERVER.md](MCP_SERVER.md) — agent tool intake (`ingest_external_scan`)

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ material. The index below groups the canonical docs by audience.
 - [`../PROJECT_STRUCTURE.md`](../PROJECT_STRUCTURE.md) — repo map: where everything lives, which trees are canonical
 - [`ARCHITECTURE.md`](ARCHITECTURE.md) — layered stack, data flow, scan pipeline, blast radius, compliance tagging (mermaid)
 - [`CLI_MAP.md`](CLI_MAP.md) — all 50 top-level commands grouped by domain + intentional aliases
+- [`DATA_SOURCES.md`](DATA_SOURCES.md) — intake diagram → mechanism → permission boundary
 
 ## Security engineers (scan · gate · export)
 

--- a/src/agent_bom/cli/_grouped_help.py
+++ b/src/agent_bom/cli/_grouped_help.py
@@ -33,7 +33,21 @@ COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
         ),
         (
             "Governance",
-            ["policy", "trust", "fleet", "cost", "identity", "serve", "api", "schedule", "remediate", "teardown", "findings", "attest", "audit-drain-dlq"],
+            [
+                "policy",
+                "trust",
+                "fleet",
+                "cost",
+                "identity",
+                "serve",
+                "api",
+                "schedule",
+                "remediate",
+                "teardown",
+                "findings",
+                "attest",
+                "audit-drain-dlq",
+            ],
         ),
         (
             "Database",

--- a/src/agent_bom/cli/_grouped_help.py
+++ b/src/agent_bom/cli/_grouped_help.py
@@ -13,15 +13,15 @@ COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
     [
         (
             "Get started",
-            ["connect", "agents", "graph", "report", "up"],
+            ["connect", "agents", "graph", "report", "up", "quickstart", "capabilities", "doctor", "samples"],
         ),
         (
             "Scanning",
-            ["skills", "image", "fs", "iac", "sbom", "ingest", "cloud", "check", "verify", "secrets", "code"],
+            ["skills", "image", "fs", "iac", "sbom", "ingest", "cloud", "check", "verify", "secrets", "code", "manifest", "scanners"],
         ),
         (
             "Runtime",
-            ["proxy", "watch", "audit"],
+            ["proxy", "watch", "audit", "gateway", "firewall", "proxy-bootstrap", "sidecar-injector"],
         ),
         (
             "MCP",
@@ -33,7 +33,7 @@ COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
         ),
         (
             "Governance",
-            ["policy", "trust", "fleet", "cost", "identity", "serve", "api", "schedule", "remediate", "teardown"],
+            ["policy", "trust", "fleet", "cost", "identity", "serve", "api", "schedule", "remediate", "teardown", "findings", "attest", "audit-drain-dlq"],
         ),
         (
             "Database",
@@ -41,7 +41,7 @@ COMMAND_CATEGORIES: OrderedDict[str, list[str]] = OrderedDict(
         ),
         (
             "Utilities",
-            ["upgrade", "completions"],
+            ["upgrade", "completions", "plugins", "profiles", "interactive", "graph-evidence"],
         ),
     ]
 )

--- a/tests/test_access_review.py
+++ b/tests/test_access_review.py
@@ -81,11 +81,15 @@ def test_create_campaign_sets_due_date(store):
 def test_lifecycle_create_decide_complete(store):
     campaign, items = create_campaign_from_discovery(store, tenant_id="t1", name="recert", discovered=_DISCOVERED, now=NOW)
     # First decision moves the campaign to in_progress.
-    _, c1 = record_decision(store, tenant_id="t1", item_id=items[0].item_id, decision=DECISION_ATTEST, decided_by="alice")
+    _, c1 = record_decision(
+        store, tenant_id="t1", item_id=items[0].item_id, decision=DECISION_ATTEST, decided_by="alice", now=NOW
+    )
     assert c1.status == STATUS_IN_PROGRESS
     assert c1.decided_count == 1
     # Deciding the last item completes it.
-    _, c2 = record_decision(store, tenant_id="t1", item_id=items[1].item_id, decision=DECISION_REVOKE, decided_by="alice")
+    _, c2 = record_decision(
+        store, tenant_id="t1", item_id=items[1].item_id, decision=DECISION_REVOKE, decided_by="alice", now=NOW
+    )
     assert c2.status == STATUS_COMPLETED
     assert c2.decided_count == 2
     assert c2.completed_at

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -1888,6 +1888,7 @@ function GraphPageInner() {
                   <button
                     key={result.id}
                     type="button"
+                    data-testid={`graph-search-result-${result.id}`}
                     onClick={() => void focusSearchResult(result)}
                     className="rounded-xl border border-zinc-800 bg-zinc-900/80 px-3 py-2 text-left transition hover:border-zinc-600 hover:bg-zinc-900"
                   >

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -1,15 +1,12 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useState, useMemo, type ReactNode } from "react";
-import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { Suspense, useCallback, useEffect, useState, useMemo, type ElementType } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   api,
   Vulnerability,
   ScanJob,
   ScanResult,
-  severityColor,
-  severityDot,
   JobListItem,
   RemediationItem,
   UnifiedFinding,
@@ -19,12 +16,23 @@ import {
   type UnifiedGraphResponse,
 } from "@/lib/api";
 import { ApiOfflineState } from "@/components/api-offline-state";
+import { FindingDrawer } from "@/components/finding-drawer";
+import { FindingsQueueTable } from "@/components/findings-queue";
 import { PaginationBar } from "@/components/pagination-bar";
 import { PageEmptyState, PageLoadingState } from "@/components/states/page-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
 import { FIRST_SCAN_ACTIONS } from "@/lib/empty-state-actions";
+import {
+  type EnrichedVuln,
+  type GroupKey,
+  type RemediationSummary,
+  type ScanScope,
+  type SeverityFilter,
+  type SortKey,
+  uniqueStrings,
+} from "@/lib/findings-view";
 import { severityRank } from "@/lib/severity";
-import { Bug, Download, ExternalLink, ChevronDown, ChevronRight, ChevronUp, Layers, Loader2, Package, Server, ShieldOff, Radar, FileSearch, ShieldAlert, ClipboardCheck, X } from "lucide-react";
+import { Bug, Download, Layers, Loader2, Package, Server, ClipboardCheck } from "lucide-react";
 
 function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
   if (err instanceof ApiAuthError) return "auth";
@@ -40,72 +48,7 @@ function downloadJson(data: unknown, filename: string) {
   URL.revokeObjectURL(url);
 }
 
-interface EnrichedVuln extends Vulnerability {
-  packages: string[];
-  agents: string[];
-  sources: string[]; // scan source labels (e.g., "python:3.11-slim", "claude-desktop")
-  affected_servers: string[];
-  exposed_credentials: string[];
-  reachable_tools: string[];
-  references: string[];
-  advisory_sources: string[];
-  attack_vector_summary?: string | undefined;
-  impact_category?: string | undefined;
-  risk_score?: number | undefined;
-  remediation_items: RemediationSummary[];
-  /** Graph-walk reachability surfaced from the unified-graph dependency
-   *  reach engine. Mirrors `BlastRadius.graph_reachable` on the API. */
-  graph_reachable?: boolean | null | undefined;
-  graph_min_hop_distance?: number | null | undefined;
-}
 
-function ReachabilityBadge({
-  reachable,
-  hops,
-}: {
-  reachable: boolean | null | undefined;
-  hops: number | null | undefined;
-}) {
-  if (reachable === true) {
-    const hopLabel = typeof hops === "number" && hops > 0 ? ` · ${hops} hop${hops === 1 ? "" : "s"}` : "";
-    return (
-      <span
-        title="An agent's USES/DEPENDS_ON closure reaches this package"
-        className="text-xs font-mono bg-amber-950 border border-amber-800 text-amber-300 rounded px-1.5 py-0.5"
-      >
-        Reachable{hopLabel}
-      </span>
-    );
-  }
-  if (reachable === false) {
-    return (
-      <span
-        title="Package is in inventory but no agent traversal reaches it"
-        className="text-xs font-mono bg-zinc-900 border border-zinc-700 text-zinc-500 rounded px-1.5 py-0.5"
-      >
-        Unreachable
-      </span>
-    );
-  }
-  return null;
-}
-
-interface RemediationSummary {
-  package: string;
-  ecosystem: string;
-  current_version: string;
-  fixed_version: string | null;
-  action?: string | undefined;
-  command?: string | null | undefined;
-  verify_command?: string | null | undefined;
-  references: string[];
-  risk_narrative: string;
-}
-
-type SeverityFilter = "all" | "critical" | "high" | "medium" | "low";
-type SortKey = "severity" | "cvss" | "epss" | "id";
-type GroupKey = "none" | "package" | "agent" | "severity";
-type ScanScope = "latest" | "all";
 
 function serverFindingsSort(sortKey: SortKey): string {
   if (sortKey === "cvss") return "cvss";
@@ -113,17 +56,6 @@ function serverFindingsSort(sortKey: SortKey): string {
   return "effective_reach";
 }
 
-function CisaKevBadge() {
-  return (
-    <span className="text-xs font-mono bg-red-950 border border-red-800 text-red-400 rounded px-1.5 py-0.5">
-      KEV
-    </span>
-  );
-}
-
-function uniqueStrings(items: Array<string | null | undefined>) {
-  return [...new Set(items.filter((item): item is string => Boolean(item && item.trim())).map((item) => item.trim()))];
-}
 
 function toRemediationSummary(item: RemediationItem): RemediationSummary {
   return {
@@ -286,34 +218,6 @@ function collectUnifiedFindings(findings: UnifiedFinding[]): EnrichedVuln[] {
   });
 }
 
-function SortButton({
-  label,
-  field,
-  current,
-  dir,
-  onClick,
-}: {
-  label: string;
-  field: SortKey;
-  current: SortKey;
-  dir: "asc" | "desc";
-  onClick: (f: SortKey) => void;
-}) {
-  const active = current === field;
-  return (
-    <button
-      onClick={() => onClick(field)}
-      className={`flex items-center gap-0.5 text-xs font-medium uppercase tracking-wide transition-colors ${
-        active ? "text-zinc-200" : "text-zinc-500 hover:text-zinc-300"
-      }`}
-    >
-      {label}
-      {active ? (
-        dir === "desc" ? <ChevronDown className="w-3 h-3" /> : <ChevronUp className="w-3 h-3" />
-      ) : null}
-    </button>
-  );
-}
 
 export default function VulnsPageWrapper() {
   return (
@@ -330,9 +234,15 @@ export default function VulnsPageWrapper() {
 
 function VulnsPage() {
   const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
   const paramSeverity = searchParams.get("severity");
   const paramCve = searchParams.get("cve");
   const paramAgent = searchParams.get("agent");
+  const paramQuery = searchParams.get("q");
+  const paramScope = searchParams.get("scope");
+  const paramGroup = searchParams.get("group");
+  const paramPage = searchParams.get("page");
   const paramScan = searchParams.get("scan") ?? searchParams.get("scan_id");
 
   const [jobs, setJobs] = useState<JobListItem[]>([]);
@@ -343,7 +253,7 @@ function VulnsPage() {
   // Per #2199 splash-kind sweep: track auth/forbidden/network so the splash
   // matches the actual cause instead of always reading as a connect failure.
   const [errorKind, setErrorKind] = useState<"network" | "auth" | "forbidden">("network");
-  const [scope, setScope] = useState<ScanScope>("latest");
+  const [scope, setScope] = useState<ScanScope>(paramScope === "all" ? "all" : "latest");
   const [filter, setFilter] = useState<SeverityFilter>(
     paramSeverity && ["critical", "high", "medium", "low"].includes(paramSeverity)
       ? (paramSeverity as SeverityFilter)
@@ -351,15 +261,20 @@ function VulnsPage() {
   );
   const [sortKey, setSortKey] = useState<SortKey>("severity");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
-  const [search, setSearch] = useState(paramCve ?? paramAgent ?? "");
-  const [groupBy, setGroupBy] = useState<GroupKey>("none");
+  const [search, setSearch] = useState(paramQuery ?? paramCve ?? paramAgent ?? "");
+  const [groupBy, setGroupBy] = useState<GroupKey>(
+    paramGroup === "package" || paramGroup === "agent" || paramGroup === "severity" ? paramGroup : "none",
+  );
   const [suppressed, setSuppressed] = useState<Set<string>>(new Set());
   const [triageRows, setTriageRows] = useState<FindingTriageItem[]>([]);
   const [triageError, setTriageError] = useState("");
   const [triageBusyKey, setTriageBusyKey] = useState<string | null>(null);
   const [vexExporting, setVexExporting] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(paramCve ?? null);
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useState(() => {
+    const parsed = Number(paramPage ?? "1");
+    return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 1;
+  });
   const [findingsTotal, setFindingsTotal] = useState(0);
   const PAGE_SIZE = 25;
   const useServerPaging = groupBy === "none" && !search.trim();
@@ -377,12 +292,39 @@ function VulnsPage() {
   }, [paramSeverity]);
 
   useEffect(() => {
-    setSearch(paramCve ?? paramAgent ?? "");
-  }, [paramCve, paramAgent]);
+    setSearch(paramQuery ?? paramCve ?? paramAgent ?? "");
+  }, [paramQuery, paramCve, paramAgent]);
+
+  useEffect(() => {
+    setScope(paramScope === "all" ? "all" : "latest");
+  }, [paramScope]);
+
+  useEffect(() => {
+    setGroupBy(
+      paramGroup === "package" || paramGroup === "agent" || paramGroup === "severity" ? paramGroup : "none",
+    );
+  }, [paramGroup]);
+
+  useEffect(() => {
+    const parsed = Number(paramPage ?? "1");
+    setPage(Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 1);
+  }, [paramPage]);
 
   useEffect(() => {
     if (paramCve) setSelectedId(paramCve);
   }, [paramCve]);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (filter !== "all") params.set("severity", filter);
+    if (search.trim()) params.set("q", search.trim());
+    if (scope !== "latest") params.set("scope", scope);
+    if (groupBy !== "none") params.set("group", groupBy);
+    if (page > 1) params.set("page", String(page));
+    if (paramScan) params.set("scan", paramScan);
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }, [filter, search, scope, groupBy, page, paramScan, pathname, router]);
 
   const collectVulns = useCallback((fullJobs: ScanJob[]) => {
     const vulnMap = new Map<string, EnrichedVuln>();
@@ -786,7 +728,7 @@ function VulnsPage() {
     { key: "low",      label: `Low${useServerPaging ? "" : ` (${counts.low})`}`,           color: "text-blue-400" },
   ];
 
-  const GROUP_OPTIONS: { key: GroupKey; label: string; icon: React.ElementType }[] = [
+  const GROUP_OPTIONS: { key: GroupKey; label: string; icon: ElementType }[] = [
     { key: "none", label: "Flat", icon: Layers },
     { key: "severity", label: "Severity", icon: Bug },
     { key: "package", label: "Package", icon: Package },
@@ -982,7 +924,7 @@ function VulnsPage() {
                         {groupVulns.length}
                       </span>
                     </div>
-                    <VulnTable
+                    <FindingsQueueTable
                       vulns={visibleGroupVulns}
                       sortKey={sortKey}
                       sortDir={sortDir}
@@ -1004,7 +946,7 @@ function VulnsPage() {
               })}
             </div>
           ) : (
-            <VulnTable
+            <FindingsQueueTable
               vulns={paged}
               sortKey={sortKey}
               sortDir={sortDir}
@@ -1048,547 +990,3 @@ function VulnsPage() {
   );
 }
 
-function VulnTable({
-  vulns,
-  sortKey,
-  sortDir,
-  handleSort,
-  suppressed,
-  onMarkFP,
-  selectedId,
-  onSelect,
-}: {
-  vulns: EnrichedVuln[];
-  sortKey: SortKey;
-  sortDir: "asc" | "desc";
-  handleSort: (f: SortKey) => void;
-  suppressed: Set<string>;
-  onMarkFP: (vulnId: string, packageName: string) => void;
-  selectedId: string | null;
-  onSelect: (vulnId: string | null) => void;
-}) {
-  return (
-    <div className="border border-zinc-800 rounded-xl overflow-hidden overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead className="bg-zinc-900 border-b border-zinc-800">
-          <tr>
-            <th className="text-left px-4 py-3">
-              <SortButton label="CVE" field="id" current={sortKey} dir={sortDir} onClick={handleSort} />
-            </th>
-            <th className="text-left px-4 py-3">
-              <SortButton label="Severity" field="severity" current={sortKey} dir={sortDir} onClick={handleSort} />
-            </th>
-            <th className="text-left px-4 py-3">
-              <SortButton label="CVSS" field="cvss" current={sortKey} dir={sortDir} onClick={handleSort} />
-            </th>
-            <th className="text-left px-4 py-3">
-              <SortButton label="EPSS" field="epss" current={sortKey} dir={sortDir} onClick={handleSort} />
-            </th>
-            <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Packages</th>
-            <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Agents</th>
-            <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Fix</th>
-            <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Actions</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-zinc-800 bg-zinc-950">
-          {vulns?.map((v) => {
-            const isSelected = selectedId === v.id;
-            return (
-              <tr
-                key={v.id}
-                className={`cursor-pointer transition-colors ${isSelected ? "bg-zinc-900/90 ring-1 ring-inset ring-emerald-900/60" : "hover:bg-zinc-900"}`}
-                onClick={() => onSelect(v.id)}
-              >
-                <td className="px-4 py-3">
-                  <div className="flex items-start gap-2">
-                    <button
-                      type="button"
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onSelect(v.id);
-                      }}
-                      className="mt-0.5 rounded p-0.5 text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-300"
-                      aria-label={`Open details for ${v.id}`}
-                    >
-                      <ChevronRight className="h-3.5 w-3.5" />
-                    </button>
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${severityDot(v.severity)}`} />
-                          <button
-                            type="button"
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              onSelect(v.id);
-                            }}
-                            className="font-mono text-xs text-zinc-200 transition-colors hover:text-emerald-400"
-                          >
-                            {v.id}
-                          </button>
-                          <a
-                            href={`https://osv.dev/vulnerability/${v.id}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            onClick={(event) => event.stopPropagation()}
-                            className="inline-flex items-center gap-1 rounded-full border border-zinc-700 px-2 py-0.5 text-[11px] font-medium text-zinc-400 transition-colors hover:border-zinc-600 hover:text-zinc-200"
-                          >
-                            OSV
-                            <ExternalLink className="h-3 w-3" />
-                          </a>
-                          {(v.is_kev ?? v.cisa_kev) && <CisaKevBadge />}
-                          <ReachabilityBadge
-                            reachable={v.graph_reachable}
-                            hops={v.graph_min_hop_distance}
-                          />
-                        </div>
-                        {(v.summary ?? v.description) && (
-                          <p className="text-xs text-zinc-600 mt-0.5 ml-3.5 line-clamp-1 max-w-xs">
-                            {v.summary ?? v.description}
-                          </p>
-                        )}
-                      </div>
-                    </div>
-                  </td>
-                <td className="px-4 py-3">
-                    <span className={`text-xs font-medium px-2 py-0.5 rounded border ${severityColor(v.severity)}`}>
-                      {v.severity}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-xs font-mono text-zinc-400">
-                    {renderScoreValue(v.cvss_score, "CVSS not published by the current advisory")}
-                  </td>
-                  <td className="px-4 py-3 text-xs font-mono text-zinc-400">
-                    {renderPercentValue(v.epss_score, "EPSS not available for this advisory")}
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex flex-wrap gap-1">
-                      {v.packages.slice(0, 3).map((p) => (
-                        <span key={p} className="text-xs font-mono bg-zinc-800 border border-zinc-700 rounded px-1.5 py-0.5 text-zinc-400">
-                          {p}
-                        </span>
-                      ))}
-                      {v.packages.length > 3 && (
-                        <span className="text-xs text-zinc-600">+{v.packages.length - 3}</span>
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 text-xs text-zinc-500">
-                    {v.agents.slice(0, 2).join(", ")}
-                    {v.agents.length > 2 && <span className="text-zinc-600"> +{v.agents.length - 2}</span>}
-                  </td>
-                  <td className="px-4 py-3 text-xs font-mono text-emerald-500">
-                    {v.fixed_version ?? "N/A"}
-                  </td>
-                  <td className="px-4 py-3">
-                    {suppressed.has(v.id) ? (
-                      <span className="text-xs font-medium px-2 py-0.5 rounded border bg-zinc-800 border-zinc-700 text-zinc-400">
-                        Suppressed
-                      </span>
-                    ) : (
-                      <button
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          onMarkFP(v.id, v.packages[0] ?? "");
-                        }}
-                        className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-zinc-700 hover:bg-zinc-600 text-zinc-300 transition-colors"
-                      >
-                        <ShieldOff className="w-3 h-3" />
-                        Mark FP
-                      </button>
-                    )}
-                  </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-
-      {vulns.length === 0 && (
-        <div className="px-4 py-8 text-center text-zinc-600 text-sm">
-          No vulnerabilities match your filters.
-        </div>
-      )}
-    </div>
-  );
-}
-
-function FindingDrawer({
-  vuln,
-  triage,
-  triageBusy,
-  onTriageDecision,
-  onClose,
-}: {
-  vuln: EnrichedVuln;
-  triage: FindingTriageItem | undefined;
-  triageBusy: boolean;
-  onTriageDecision: (
-    vuln: EnrichedVuln,
-    decision: FindingTriageDecision,
-    justification?: FindingTriageJustification,
-  ) => void;
-  onClose: () => void;
-}) {
-  return (
-    <div className="fixed inset-0 z-50 flex justify-end bg-black/45 backdrop-blur-sm" role="dialog" aria-modal="true" aria-label={`Finding details for ${vuln.id}`}>
-      <button type="button" className="absolute inset-0 cursor-default" aria-label="Close finding details" onClick={onClose} />
-      <aside className="relative h-full w-full max-w-3xl overflow-y-auto border-l border-zinc-800 bg-zinc-950 p-5 shadow-2xl">
-        <div className="mb-4 flex items-start justify-between gap-4 border-b border-zinc-800 pb-4">
-          <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">Evidence drawer</p>
-            <h2 className="mt-1 break-all font-mono text-lg font-semibold text-zinc-100">{vuln.id}</h2>
-            <p className="mt-1 text-sm text-zinc-500">
-              Reachability, impacted packages, agent exposure, remediation, and VEX decisioning.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-lg border border-zinc-800 bg-zinc-900 p-2 text-zinc-400 transition-colors hover:border-zinc-700 hover:text-zinc-100"
-            aria-label="Close finding drawer"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        </div>
-        <VulnDetailPanel
-          vuln={vuln}
-          triage={triage}
-          triageBusy={triageBusy}
-          onTriageDecision={onTriageDecision}
-        />
-      </aside>
-    </div>
-  );
-}
-
-function renderScoreValue(value: number | undefined, missingLabel: string) {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value.toFixed(1);
-  }
-  return (
-    <span className="rounded bg-zinc-900 px-1.5 py-0.5 text-zinc-500" title={missingLabel}>
-      N/A
-    </span>
-  );
-}
-
-function renderPercentValue(value: number | undefined, missingLabel: string) {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return `${(value * 100).toFixed(1)}%`;
-  }
-  return (
-    <span className="rounded bg-zinc-900 px-1.5 py-0.5 text-zinc-500" title={missingLabel}>
-      N/A
-    </span>
-  );
-}
-
-function VulnDetailPanel({
-  vuln,
-  triage,
-  triageBusy,
-  onTriageDecision,
-}: {
-  vuln: EnrichedVuln;
-  triage: FindingTriageItem | undefined;
-  triageBusy: boolean;
-  onTriageDecision: (
-    vuln: EnrichedVuln,
-    decision: FindingTriageDecision,
-    justification?: FindingTriageJustification,
-  ) => void;
-}) {
-  const summary = vuln.attack_vector_summary ?? vuln.summary ?? vuln.description ?? "No advisory summary available.";
-  const cweMatches = summary.match(/CWE-\d+/gi) ?? [];
-  const published = vuln.published_at ?? vuln.published ?? vuln.nvd_published;
-  const modified = vuln.modified_at;
-  const references = uniqueStrings(vuln.references).slice(0, 6);
-  const fixCandidates = vuln.remediation_items.filter((item) => item.fixed_version || item.command || item.verify_command);
-  const investigationSources = uniqueStrings([
-    ...vuln.sources,
-    ...vuln.advisory_sources,
-  ]);
-
-  return (
-    <div className="ml-6 rounded-xl border border-zinc-800 bg-zinc-900/50 p-4">
-      <div className="grid gap-4 xl:grid-cols-[1.3fr_1fr]">
-        <div className="space-y-4">
-          <div>
-            <h4 className="text-xs font-medium uppercase tracking-wide text-zinc-500">Attack summary</h4>
-            <p className="mt-2 text-sm leading-6 text-zinc-300">{summary}</p>
-            {cweMatches.length > 0 && (
-              <div className="mt-2 flex flex-wrap gap-1">
-                {[...new Set(cweMatches)].map((cwe) => (
-                  <span key={cwe} className="rounded border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-xs font-mono text-zinc-400">
-                    {cwe}
-                  </span>
-                ))}
-              </div>
-            )}
-          </div>
-          <div className="grid gap-3 md:grid-cols-3">
-            <DetailStat label="Severity" value={vuln.severity} accent={severityColor(vuln.severity)} />
-            <DetailStat label="CVSS" value={typeof vuln.cvss_score === "number" ? vuln.cvss_score.toFixed(1) : "Not published"} />
-            <DetailStat label="EPSS" value={typeof vuln.epss_score === "number" ? `${(vuln.epss_score * 100).toFixed(1)}%` : "Not available"} />
-          </div>
-          <div className="grid gap-3 md:grid-cols-2">
-            <ContextCard
-              icon={Radar}
-              title="Asset and reach context"
-              items={[
-                `${vuln.packages.length} package${vuln.packages.length === 1 ? "" : "s"}`,
-                `${vuln.agents.length} agent${vuln.agents.length === 1 ? "" : "s"}`,
-                `${vuln.affected_servers.length} server${vuln.affected_servers.length === 1 ? "" : "s"}`,
-                vuln.risk_score ? `Risk score ${vuln.risk_score.toFixed(1)}` : null,
-                vuln.impact_category ? `Impact ${vuln.impact_category}` : null,
-              ]}
-              detail={
-                <>
-                  <TagList label="Packages" values={vuln.packages} mono />
-                  <TagList label="Agents" values={vuln.agents} />
-                  <TagList label="Servers" values={vuln.affected_servers} />
-                </>
-              }
-            />
-            <ContextCard
-              icon={ShieldAlert}
-              title="Exposure at risk"
-              items={[
-                `${vuln.exposed_credentials.length} credential${vuln.exposed_credentials.length === 1 ? "" : "s"} exposed`,
-                `${vuln.reachable_tools.length} reachable tool${vuln.reachable_tools.length === 1 ? "" : "s"}`,
-              ]}
-              detail={
-                <>
-                  <TagList label="Credentials" values={vuln.exposed_credentials} mono />
-                  <TagList label="Tools" values={vuln.reachable_tools} mono />
-                </>
-              }
-            />
-          </div>
-        </div>
-
-        <div className="space-y-4">
-          <div className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
-            <h4 className="text-xs font-medium uppercase tracking-wide text-zinc-500">Fix context</h4>
-            <div className="mt-3 space-y-2 text-sm text-zinc-300">
-              <div><span className="text-zinc-500">Fix:</span> {vuln.fixed_version ?? "No published fix"}</div>
-              {published && <div><span className="text-zinc-500">Published:</span> {new Date(published).toLocaleDateString()}</div>}
-              {modified && <div><span className="text-zinc-500">Modified:</span> {new Date(modified).toLocaleDateString()}</div>}
-              {typeof vuln.confidence === "number" && <div><span className="text-zinc-500">Confidence:</span> {(vuln.confidence * 100).toFixed(0)}%</div>}
-              {vuln.severity_source && <div><span className="text-zinc-500">Severity source:</span> {vuln.severity_source}</div>}
-            </div>
-            {fixCandidates.length > 0 && (
-              <div className="mt-4 space-y-3">
-                {fixCandidates.slice(0, 2).map((item) => (
-                  <div key={`${item.package}:${item.current_version}`} className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-3">
-                    <div className="flex items-center justify-between gap-2">
-                      <span className="text-xs font-medium text-zinc-200">{item.package}</span>
-                      <span className="text-[11px] font-mono text-emerald-400">
-                        {item.current_version} → {item.fixed_version ?? "monitor"}
-                      </span>
-                    </div>
-                    {item.action && <p className="mt-2 text-xs text-zinc-400">{item.action}</p>}
-                    {item.command && <CodeLine label="Apply" value={item.command} />}
-                    {item.verify_command && <CodeLine label="Verify" value={item.verify_command} />}
-                  </div>
-                ))}
-              </div>
-            )}
-            {vuln.remediation_items[0]?.risk_narrative && (
-              <p className="mt-3 text-xs leading-5 text-zinc-400">{vuln.remediation_items[0].risk_narrative}</p>
-            )}
-          </div>
-          <div className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
-            <h4 className="text-xs font-medium uppercase tracking-wide text-zinc-500">Investigation sources</h4>
-            <div className="mt-3 space-y-3">
-              <TagList label="Signals" values={investigationSources} />
-              <TagList label="Aliases" values={vuln.aliases ?? []} mono />
-              {references.length > 0 && (
-                <div className="space-y-2">
-                  <div className="text-[11px] font-medium uppercase tracking-wide text-zinc-500">Advisories</div>
-                  <div className="flex flex-col gap-2">
-                    {references.map((ref) => (
-                      <a
-                        key={ref}
-                        href={ref}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex items-center gap-2 rounded-lg border border-zinc-800 bg-zinc-900/70 px-3 py-2 text-xs text-zinc-300 transition-colors hover:border-zinc-700 hover:text-zinc-100"
-                      >
-                        <FileSearch className="h-3.5 w-3.5 text-zinc-500" />
-                        <span className="truncate">{ref}</span>
-                        <ExternalLink className="ml-auto h-3 w-3 shrink-0" />
-                      </a>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          </div>
-          <div className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <h4 className="text-xs font-medium uppercase tracking-wide text-zinc-500">Review queue</h4>
-                <p className="mt-2 text-xs leading-5 text-zinc-400">
-                  Record analyst disposition for this package finding. Not affected decisions require an OpenVEX justification and become eligible for signed VEX export.
-                </p>
-              </div>
-              {triage && (
-                <span className="rounded-full border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-[11px] font-medium text-zinc-300">
-                  {triage.queue_state}
-                </span>
-              )}
-            </div>
-            {triage ? (
-              <div className="mt-3 grid gap-2 text-xs text-zinc-400 sm:grid-cols-2">
-                <div><span className="text-zinc-500">Decision:</span> {triage.decision}</div>
-                <div><span className="text-zinc-500">Assignee:</span> {triage.assignee || "unassigned"}</div>
-                {triage.justification && <div className="sm:col-span-2"><span className="text-zinc-500">Justification:</span> {triage.justification}</div>}
-                {triage.decision_reason && <div className="sm:col-span-2"><span className="text-zinc-500">Reason:</span> {triage.decision_reason}</div>}
-              </div>
-            ) : (
-              <p className="mt-3 text-xs text-zinc-500">No triage item recorded for this finding/package pair.</p>
-            )}
-            <div className="mt-4 flex flex-wrap gap-2">
-              <TriageButton
-                label="Investigate"
-                busy={triageBusy}
-                disabled={Boolean(triage)}
-                onClick={() => onTriageDecision(vuln, "under_investigation")}
-              />
-              <TriageButton
-                label="Affected"
-                busy={triageBusy}
-                onClick={() => onTriageDecision(vuln, "affected")}
-              />
-              <TriageButton
-                label="Not affected"
-                busy={triageBusy}
-                tone="green"
-                onClick={() => onTriageDecision(vuln, "not_affected", "vulnerable_code_not_in_execute_path")}
-              />
-            </div>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <a
-              href={`https://osv.dev/vulnerability/${vuln.id}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-300 transition-colors hover:border-zinc-600 hover:text-zinc-100"
-            >
-              Open on OSV
-              <ExternalLink className="h-3 w-3" />
-            </a>
-            <Link
-              href={`/vulns?cve=${vuln.id}`}
-              className="inline-flex items-center gap-1 rounded-lg border border-emerald-800 bg-emerald-950/40 px-3 py-1.5 text-xs font-medium text-emerald-300 transition-colors hover:bg-emerald-950/70"
-            >
-              Keep this CVE scoped
-            </Link>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function TriageButton({
-  label,
-  busy,
-  disabled = false,
-  tone = "zinc",
-  onClick,
-}: {
-  label: string;
-  busy: boolean;
-  disabled?: boolean;
-  tone?: "zinc" | "green";
-  onClick: () => void;
-}) {
-  const classes =
-    tone === "green"
-      ? "border-emerald-800 bg-emerald-950/40 text-emerald-300 hover:bg-emerald-950/70"
-      : "border-zinc-700 bg-zinc-900 text-zinc-300 hover:border-zinc-600 hover:text-zinc-100";
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={busy || disabled}
-      className={`inline-flex items-center gap-1 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${classes}`}
-    >
-      {busy && <Loader2 className="h-3 w-3 animate-spin" />}
-      {label}
-    </button>
-  );
-}
-
-function DetailStat({ label, value, accent }: { label: string; value: string; accent?: string }) {
-  return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
-      <div className="text-[11px] font-medium uppercase tracking-wide text-zinc-500">{label}</div>
-      <div className={`mt-2 text-sm font-medium text-zinc-100 ${accent ?? ""}`}>{value}</div>
-    </div>
-  );
-}
-
-function ContextCard({
-  icon: Icon,
-  title,
-  items,
-  detail,
-}: {
-  icon: typeof Radar;
-  title: string;
-  items: Array<string | null | undefined>;
-  detail: ReactNode;
-}) {
-  const visibleItems = items.filter(Boolean) as string[];
-  return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
-      <div className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-wide text-zinc-500">
-        <Icon className="h-3.5 w-3.5" />
-        {title}
-      </div>
-      {visibleItems.length > 0 && (
-        <ul className="mt-3 space-y-1 text-xs text-zinc-300">
-          {visibleItems.map((item) => (
-            <li key={item}>{item}</li>
-          ))}
-        </ul>
-      )}
-      <div className="mt-3 space-y-2">{detail}</div>
-    </div>
-  );
-}
-
-function TagList({ label, values, mono = false }: { label: string; values: string[]; mono?: boolean }) {
-  if (values.length === 0) {
-    return null;
-  }
-  return (
-    <div className="space-y-2">
-      <div className="text-[11px] font-medium uppercase tracking-wide text-zinc-500">{label}</div>
-      <div className="flex flex-wrap gap-1.5">
-        {values.map((value) => (
-          <span
-            key={`${label}:${value}`}
-            className={`rounded border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-xs text-zinc-300 ${mono ? "font-mono" : ""}`}
-          >
-            {value}
-          </span>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function CodeLine({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="mt-2">
-      <div className="text-[11px] font-medium uppercase tracking-wide text-zinc-500">{label}</div>
-      <code className="mt-1 block overflow-x-auto rounded bg-black/30 px-2 py-1.5 text-[11px] text-emerald-300">
-        {value}
-      </code>
-    </div>
-  );
-}

--- a/ui/components/finding-drawer.tsx
+++ b/ui/components/finding-drawer.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { ExternalLink, FileSearch, Loader2, Radar, ShieldAlert, X } from "lucide-react";
+
+import { severityColor, type FindingTriageDecision, type FindingTriageItem, type FindingTriageJustification } from "@/lib/api";
+import { type EnrichedVuln, uniqueStrings } from "@/lib/findings-view";
+
+export function FindingDrawer({
+  vuln,
+  triage,
+  triageBusy,
+  onTriageDecision,
+  onClose,
+}: {
+  vuln: EnrichedVuln;
+  triage: FindingTriageItem | undefined;
+  triageBusy: boolean;
+  onTriageDecision: (
+    vuln: EnrichedVuln,
+    decision: FindingTriageDecision,
+    justification?: FindingTriageJustification,
+  ) => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end bg-black/45 backdrop-blur-sm" role="dialog" aria-modal="true" aria-label={`Finding details for ${vuln.id}`}>
+      <button type="button" className="absolute inset-0 cursor-default" aria-label="Close finding details" onClick={onClose} />
+      <aside className="relative h-full w-full max-w-3xl overflow-y-auto border-l border-zinc-800 bg-zinc-950 p-5 shadow-2xl">
+        <div className="mb-4 flex items-start justify-between gap-4 border-b border-zinc-800 pb-4">
+          <div className="min-w-0">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">Evidence drawer</p>
+            <h2 className="mt-1 break-all font-mono text-lg font-semibold text-zinc-100">{vuln.id}</h2>
+            <p className="mt-1 text-sm text-zinc-500">
+              Reachability, impacted packages, agent exposure, remediation, and VEX decisioning.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-zinc-800 bg-zinc-900 p-2 text-zinc-400 transition-colors hover:border-zinc-700 hover:text-zinc-100"
+            aria-label="Close finding drawer"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <VulnDetailPanel
+          vuln={vuln}
+          triage={triage}
+          triageBusy={triageBusy}
+          onTriageDecision={onTriageDecision}
+        />
+      </aside>
+    </div>
+  );
+}
+
+function VulnDetailPanel({
+  vuln,
+  triage,
+  triageBusy,
+  onTriageDecision,
+}: {
+  vuln: EnrichedVuln;
+  triage: FindingTriageItem | undefined;
+  triageBusy: boolean;
+  onTriageDecision: (
+    vuln: EnrichedVuln,
+    decision: FindingTriageDecision,
+    justification?: FindingTriageJustification,
+  ) => void;
+}) {
+  const summary = vuln.attack_vector_summary ?? vuln.summary ?? vuln.description ?? "No advisory summary available.";
+  const cweMatches = summary.match(/CWE-\d+/gi) ?? [];
+  const published = vuln.published_at ?? vuln.published ?? vuln.nvd_published;
+  const modified = vuln.modified_at;
+  const references = uniqueStrings(vuln.references).slice(0, 6);
+  const fixCandidates = vuln.remediation_items.filter((item) => item.fixed_version || item.command || item.verify_command);
+  const investigationSources = uniqueStrings([
+    ...vuln.sources,
+    ...vuln.advisory_sources,
+  ]);
+
+  return (
+    <div className="ml-6 rounded-xl border border-zinc-800 bg-zinc-900/50 p-4">
+      <div className="grid gap-4 xl:grid-cols-[1.3fr_1fr]">
+        <div className="space-y-4">
+          <div>
+            <h4 className="text-xs font-medium uppercase tracking-wide text-zinc-500">Attack summary</h4>
+            <p className="mt-2 text-sm leading-6 text-zinc-300">{summary}</p>
+            {cweMatches.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1">
+                {[...new Set(cweMatches)].map((cwe) => (
+                  <span key={cwe} className="rounded border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-xs font-mono text-zinc-400">
+                    {cwe}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="grid gap-3 md:grid-cols-3">
+            <DetailStat label="Severity" value={vuln.severity} accent={severityColor(vuln.severity)} />
+            <DetailStat label="CVSS" value={typeof vuln.cvss_score === "number" ? vuln.cvss_score.toFixed(1) : "Not published"} />
+            <DetailStat label="EPSS" value={typeof vuln.epss_score === "number" ? `${(vuln.epss_score * 100).toFixed(1)}%` : "Not available"} />
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <ContextCard
+              icon={Radar}
+              title="Asset and reach context"
+              items={[
+                `${vuln.packages.length} package${vuln.packages.length === 1 ? "" : "s"}`,
+                `${vuln.agents.length} agent${vuln.agents.length === 1 ? "" : "s"}`,
+                `${vuln.affected_servers.length} server${vuln.affected_servers.length === 1 ? "" : "s"}`,
+                vuln.risk_score ? `Risk score ${vuln.risk_score.toFixed(1)}` : null,
+                vuln.impact_category ? `Impact ${vuln.impact_category}` : null,
+              ]}
+              detail={
+                <>
+                  <TagList label="Packages" values={vuln.packages} mono />
+                  <TagList label="Agents" values={vuln.agents} />
+                  <TagList label="Servers" values={vuln.affected_servers} />
+                </>
+              }
+            />
+            <ContextCard
+              icon={ShieldAlert}
+              title="Exposure at risk"
+              items={[
+                `${vuln.exposed_credentials.length} credential${vuln.exposed_credentials.length === 1 ? "" : "s"} exposed`,
+                `${vuln.reachable_tools.length} reachable tool${vuln.reachable_tools.length === 1 ? "" : "s"}`,
+              ]}
+              detail={
+                <>
+                  <TagList label="Credentials" values={vuln.exposed_credentials} mono />
+                  <TagList label="Tools" values={vuln.reachable_tools} mono />
+                </>
+              }
+            />
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
+            <h4 className="text-xs font-medium uppercase tracking-wide text-zinc-500">Fix context</h4>
+            <div className="mt-3 space-y-2 text-sm text-zinc-300">
+              <div><span className="text-zinc-500">Fix:</span> {vuln.fixed_version ?? "No published fix"}</div>
+              {published && <div><span className="text-zinc-500">Published:</span> {new Date(published).toLocaleDateString()}</div>}
+              {modified && <div><span className="text-zinc-500">Modified:</span> {new Date(modified).toLocaleDateString()}</div>}
+              {typeof vuln.confidence === "number" && <div><span className="text-zinc-500">Confidence:</span> {(vuln.confidence * 100).toFixed(0)}%</div>}
+              {vuln.severity_source && <div><span className="text-zinc-500">Severity source:</span> {vuln.severity_source}</div>}
+            </div>
+            {fixCandidates.length > 0 && (
+              <div className="mt-4 space-y-3">
+                {fixCandidates.slice(0, 2).map((item) => (
+                  <div key={`${item.package}:${item.current_version}`} className="rounded-lg border border-zinc-800 bg-zinc-900/70 p-3">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-xs font-medium text-zinc-200">{item.package}</span>
+                      <span className="text-[11px] font-mono text-emerald-400">
+                        {item.current_version} → {item.fixed_version ?? "monitor"}
+                      </span>
+                    </div>
+                    {item.action && <p className="mt-2 text-xs text-zinc-400">{item.action}</p>}
+                    {item.command && <CodeLine label="Apply" value={item.command} />}
+                    {item.verify_command && <CodeLine label="Verify" value={item.verify_command} />}
+                  </div>
+                ))}
+              </div>
+            )}
+            {vuln.remediation_items[0]?.risk_narrative && (
+              <p className="mt-3 text-xs leading-5 text-zinc-400">{vuln.remediation_items[0].risk_narrative}</p>
+            )}
+          </div>
+          <div className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
+            <h4 className="text-xs font-medium uppercase tracking-wide text-zinc-500">Investigation sources</h4>
+            <div className="mt-3 space-y-3">
+              <TagList label="Signals" values={investigationSources} />
+              <TagList label="Aliases" values={vuln.aliases ?? []} mono />
+              {references.length > 0 && (
+                <div className="space-y-2">
+                  <div className="text-[11px] font-medium uppercase tracking-wide text-zinc-500">Advisories</div>
+                  <div className="flex flex-col gap-2">
+                    {references.map((ref) => (
+                      <a
+                        key={ref}
+                        href={ref}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-2 rounded-lg border border-zinc-800 bg-zinc-900/70 px-3 py-2 text-xs text-zinc-300 transition-colors hover:border-zinc-700 hover:text-zinc-100"
+                      >
+                        <FileSearch className="h-3.5 w-3.5 text-zinc-500" />
+                        <span className="truncate">{ref}</span>
+                        <ExternalLink className="ml-auto h-3 w-3 shrink-0" />
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h4 className="text-xs font-medium uppercase tracking-wide text-zinc-500">Review queue</h4>
+                <p className="mt-2 text-xs leading-5 text-zinc-400">
+                  Record analyst disposition for this package finding. Not affected decisions require an OpenVEX justification and become eligible for signed VEX export.
+                </p>
+              </div>
+              {triage && (
+                <span className="rounded-full border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-[11px] font-medium text-zinc-300">
+                  {triage.queue_state}
+                </span>
+              )}
+            </div>
+            {triage ? (
+              <div className="mt-3 grid gap-2 text-xs text-zinc-400 sm:grid-cols-2">
+                <div><span className="text-zinc-500">Decision:</span> {triage.decision}</div>
+                <div><span className="text-zinc-500">Assignee:</span> {triage.assignee || "unassigned"}</div>
+                {triage.justification && <div className="sm:col-span-2"><span className="text-zinc-500">Justification:</span> {triage.justification}</div>}
+                {triage.decision_reason && <div className="sm:col-span-2"><span className="text-zinc-500">Reason:</span> {triage.decision_reason}</div>}
+              </div>
+            ) : (
+              <p className="mt-3 text-xs text-zinc-500">No triage item recorded for this finding/package pair.</p>
+            )}
+            <div className="mt-4 flex flex-wrap gap-2">
+              <TriageButton
+                label="Investigate"
+                busy={triageBusy}
+                disabled={Boolean(triage)}
+                onClick={() => onTriageDecision(vuln, "under_investigation")}
+              />
+              <TriageButton
+                label="Affected"
+                busy={triageBusy}
+                onClick={() => onTriageDecision(vuln, "affected")}
+              />
+              <TriageButton
+                label="Not affected"
+                busy={triageBusy}
+                tone="green"
+                onClick={() => onTriageDecision(vuln, "not_affected", "vulnerable_code_not_in_execute_path")}
+              />
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <a
+              href={`https://osv.dev/vulnerability/${vuln.id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 rounded-lg border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-300 transition-colors hover:border-zinc-600 hover:text-zinc-100"
+            >
+              Open on OSV
+              <ExternalLink className="h-3 w-3" />
+            </a>
+            <Link
+              href={`/vulns?cve=${vuln.id}`}
+              className="inline-flex items-center gap-1 rounded-lg border border-emerald-800 bg-emerald-950/40 px-3 py-1.5 text-xs font-medium text-emerald-300 transition-colors hover:bg-emerald-950/70"
+            >
+              Keep this CVE scoped
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TriageButton({
+  label,
+  busy,
+  disabled = false,
+  tone = "zinc",
+  onClick,
+}: {
+  label: string;
+  busy: boolean;
+  disabled?: boolean;
+  tone?: "zinc" | "green";
+  onClick: () => void;
+}) {
+  const classes =
+    tone === "green"
+      ? "border-emerald-800 bg-emerald-950/40 text-emerald-300 hover:bg-emerald-950/70"
+      : "border-zinc-700 bg-zinc-900 text-zinc-300 hover:border-zinc-600 hover:text-zinc-100";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={busy || disabled}
+      className={`inline-flex items-center gap-1 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${classes}`}
+    >
+      {busy && <Loader2 className="h-3 w-3 animate-spin" />}
+      {label}
+    </button>
+  );
+}
+
+function DetailStat({ label, value, accent }: { label: string; value: string; accent?: string }) {
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-zinc-500">{label}</div>
+      <div className={`mt-2 text-sm font-medium text-zinc-100 ${accent ?? ""}`}>{value}</div>
+    </div>
+  );
+}
+
+function ContextCard({
+  icon: Icon,
+  title,
+  items,
+  detail,
+}: {
+  icon: typeof Radar;
+  title: string;
+  items: Array<string | null | undefined>;
+  detail: ReactNode;
+}) {
+  const visibleItems = items.filter(Boolean) as string[];
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
+      <div className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-wide text-zinc-500">
+        <Icon className="h-3.5 w-3.5" />
+        {title}
+      </div>
+      {visibleItems.length > 0 && (
+        <ul className="mt-3 space-y-1 text-xs text-zinc-300">
+          {visibleItems.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ul>
+      )}
+      <div className="mt-3 space-y-2">{detail}</div>
+    </div>
+  );
+}
+
+function TagList({ label, values, mono = false }: { label: string; values: string[]; mono?: boolean }) {
+  if (values.length === 0) {
+    return null;
+  }
+  return (
+    <div className="space-y-2">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-zinc-500">{label}</div>
+      <div className="flex flex-wrap gap-1.5">
+        {values.map((value) => (
+          <span
+            key={`${label}:${value}`}
+            className={`rounded border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-xs text-zinc-300 ${mono ? "font-mono" : ""}`}
+          >
+            {value}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CodeLine({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="mt-2">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-zinc-500">{label}</div>
+      <code className="mt-1 block overflow-x-auto rounded bg-black/30 px-2 py-1.5 text-[11px] text-emerald-300">
+        {value}
+      </code>
+    </div>
+  );
+}

--- a/ui/components/findings-queue.tsx
+++ b/ui/components/findings-queue.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { ChevronDown, ChevronRight, ChevronUp, ExternalLink, ShieldOff } from "lucide-react";
+
+import { severityColor, severityDot } from "@/lib/api";
+import type { EnrichedVuln, SortKey } from "@/lib/findings-view";
+
+function ReachabilityBadge({
+  reachable,
+  hops,
+}: {
+  reachable: boolean | null | undefined;
+  hops: number | null | undefined;
+}) {
+  if (reachable === true) {
+    const hopLabel = typeof hops === "number" && hops > 0 ? ` · ${hops} hop${hops === 1 ? "" : "s"}` : "";
+    return (
+      <span
+        title="An agent's USES/DEPENDS_ON closure reaches this package"
+        className="text-xs font-mono bg-amber-950 border border-amber-800 text-amber-300 rounded px-1.5 py-0.5"
+      >
+        Reachable{hopLabel}
+      </span>
+    );
+  }
+  if (reachable === false) {
+    return (
+      <span
+        title="Package is in inventory but no agent traversal reaches it"
+        className="text-xs font-mono bg-zinc-900 border border-zinc-700 text-zinc-500 rounded px-1.5 py-0.5"
+      >
+        Unreachable
+      </span>
+    );
+  }
+  return null;
+}
+
+function CisaKevBadge() {
+  return (
+    <span className="text-xs font-mono bg-red-950 border border-red-800 text-red-400 rounded px-1.5 py-0.5">
+      KEV
+    </span>
+  );
+}
+
+function SortButton({
+  label,
+  field,
+  current,
+  dir,
+  onClick,
+}: {
+  label: string;
+  field: SortKey;
+  current: SortKey;
+  dir: "asc" | "desc";
+  onClick: (f: SortKey) => void;
+}) {
+  const active = current === field;
+  return (
+    <button
+      onClick={() => onClick(field)}
+      className={`flex items-center gap-0.5 text-xs font-medium uppercase tracking-wide transition-colors ${
+        active ? "text-zinc-200" : "text-zinc-500 hover:text-zinc-300"
+      }`}
+    >
+      {label}
+      {active ? (
+        dir === "desc" ? <ChevronDown className="w-3 h-3" /> : <ChevronUp className="w-3 h-3" />
+      ) : null}
+    </button>
+  );
+}
+
+function renderScoreValue(value: number | undefined, missingLabel: string) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value.toFixed(1);
+  }
+  return (
+    <span className="rounded bg-zinc-900 px-1.5 py-0.5 text-zinc-500" title={missingLabel}>
+      N/A
+    </span>
+  );
+}
+
+function renderPercentValue(value: number | undefined, missingLabel: string) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return `${(value * 100).toFixed(1)}%`;
+  }
+  return (
+    <span className="rounded bg-zinc-900 px-1.5 py-0.5 text-zinc-500" title={missingLabel}>
+      N/A
+    </span>
+  );
+}
+
+export function FindingsQueueTable({
+  vulns,
+  sortKey,
+  sortDir,
+  handleSort,
+  suppressed,
+  onMarkFP,
+  selectedId,
+  onSelect,
+}: {
+  vulns: EnrichedVuln[];
+  sortKey: SortKey;
+  sortDir: "asc" | "desc";
+  handleSort: (f: SortKey) => void;
+  suppressed: Set<string>;
+  onMarkFP: (vulnId: string, packageName: string) => void;
+  selectedId: string | null;
+  onSelect: (vulnId: string | null) => void;
+}) {
+  return (
+    <div className="border border-zinc-800 rounded-xl overflow-hidden overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="bg-zinc-900 border-b border-zinc-800">
+          <tr>
+            <th className="text-left px-4 py-3">
+              <SortButton label="CVE" field="id" current={sortKey} dir={sortDir} onClick={handleSort} />
+            </th>
+            <th className="text-left px-4 py-3">
+              <SortButton label="Severity" field="severity" current={sortKey} dir={sortDir} onClick={handleSort} />
+            </th>
+            <th className="text-left px-4 py-3">
+              <SortButton label="CVSS" field="cvss" current={sortKey} dir={sortDir} onClick={handleSort} />
+            </th>
+            <th className="text-left px-4 py-3">
+              <SortButton label="EPSS" field="epss" current={sortKey} dir={sortDir} onClick={handleSort} />
+            </th>
+            <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Packages</th>
+            <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Agents</th>
+            <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Fix</th>
+            <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Actions</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-zinc-800 bg-zinc-950">
+          {vulns?.map((v) => {
+            const isSelected = selectedId === v.id;
+            return (
+              <tr
+                key={v.id}
+                className={`cursor-pointer transition-colors ${isSelected ? "bg-zinc-900/90 ring-1 ring-inset ring-emerald-900/60" : "hover:bg-zinc-900"}`}
+                onClick={() => onSelect(v.id)}
+              >
+                <td className="px-4 py-3">
+                  <div className="flex items-start gap-2">
+                    <button
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onSelect(v.id);
+                      }}
+                      className="mt-0.5 rounded p-0.5 text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-300"
+                      aria-label={`Open details for ${v.id}`}
+                    >
+                      <ChevronRight className="h-3.5 w-3.5" />
+                    </button>
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${severityDot(v.severity)}`} />
+                          <button
+                            type="button"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              onSelect(v.id);
+                            }}
+                            className="font-mono text-xs text-zinc-200 transition-colors hover:text-emerald-400"
+                          >
+                            {v.id}
+                          </button>
+                          <a
+                            href={`https://osv.dev/vulnerability/${v.id}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            onClick={(event) => event.stopPropagation()}
+                            className="inline-flex items-center gap-1 rounded-full border border-zinc-700 px-2 py-0.5 text-[11px] font-medium text-zinc-400 transition-colors hover:border-zinc-600 hover:text-zinc-200"
+                          >
+                            OSV
+                            <ExternalLink className="h-3 w-3" />
+                          </a>
+                          {(v.is_kev ?? v.cisa_kev) && <CisaKevBadge />}
+                          <ReachabilityBadge
+                            reachable={v.graph_reachable}
+                            hops={v.graph_min_hop_distance}
+                          />
+                        </div>
+                        {(v.summary ?? v.description) && (
+                          <p className="text-xs text-zinc-600 mt-0.5 ml-3.5 line-clamp-1 max-w-xs">
+                            {v.summary ?? v.description}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </td>
+                <td className="px-4 py-3">
+                    <span className={`text-xs font-medium px-2 py-0.5 rounded border ${severityColor(v.severity)}`}>
+                      {v.severity}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-xs font-mono text-zinc-400">
+                    {renderScoreValue(v.cvss_score, "CVSS not published by the current advisory")}
+                  </td>
+                  <td className="px-4 py-3 text-xs font-mono text-zinc-400">
+                    {renderPercentValue(v.epss_score, "EPSS not available for this advisory")}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-1">
+                      {v.packages.slice(0, 3).map((p) => (
+                        <span key={p} className="text-xs font-mono bg-zinc-800 border border-zinc-700 rounded px-1.5 py-0.5 text-zinc-400">
+                          {p}
+                        </span>
+                      ))}
+                      {v.packages.length > 3 && (
+                        <span className="text-xs text-zinc-600">+{v.packages.length - 3}</span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-xs text-zinc-500">
+                    {v.agents.slice(0, 2).join(", ")}
+                    {v.agents.length > 2 && <span className="text-zinc-600"> +{v.agents.length - 2}</span>}
+                  </td>
+                  <td className="px-4 py-3 text-xs font-mono text-emerald-500">
+                    {v.fixed_version ?? "N/A"}
+                  </td>
+                  <td className="px-4 py-3">
+                    {suppressed.has(v.id) ? (
+                      <span className="text-xs font-medium px-2 py-0.5 rounded border bg-zinc-800 border-zinc-700 text-zinc-400">
+                        Suppressed
+                      </span>
+                    ) : (
+                      <button
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onMarkFP(v.id, v.packages[0] ?? "");
+                        }}
+                        className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-zinc-700 hover:bg-zinc-600 text-zinc-300 transition-colors"
+                      >
+                        <ShieldOff className="w-3 h-3" />
+                        Mark FP
+                      </button>
+                    )}
+                  </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+
+      {vulns.length === 0 && (
+        <div className="px-4 py-8 text-center text-zinc-600 text-sm">
+          No vulnerabilities match your filters.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/e2e/large-graph-overview.spec.ts
+++ b/ui/e2e/large-graph-overview.spec.ts
@@ -169,7 +169,7 @@ async function routeLargeGraphPage(page: Page) {
       }),
     });
   });
-  await page.route("**/v1/graph/snapshots?**", async (route) => {
+  await page.route("**/v1/graph/snapshots**", async (route) => {
     await route.fulfill({
       contentType: "application/json",
       body: JSON.stringify([
@@ -302,9 +302,14 @@ test("large graph overview renders above threshold and search drills back into R
   await expect(searchButton).toBeEnabled({ timeout: 15_000 });
 
   await page.getByPlaceholder("Search nodes, tags, severities, or attributes").fill("large-package-42");
+  const searchResponse = page.waitForResponse(
+    (response) => response.url().includes("/v1/graph/search") && response.ok(),
+    { timeout: 15_000 },
+  );
   await searchButton.click();
+  await searchResponse;
 
-  const resultButton = page.getByRole("button", { name: "large-package-42" });
+  const resultButton = page.getByTestId("graph-search-result-pkg:42");
   await expect(resultButton).toBeVisible({ timeout: 15_000 });
   await resultButton.click();
 

--- a/ui/lib/findings-view.ts
+++ b/ui/lib/findings-view.ts
@@ -1,0 +1,39 @@
+import type { Vulnerability } from "@/lib/api";
+
+export interface EnrichedVuln extends Vulnerability {
+  packages: string[];
+  agents: string[];
+  sources: string[];
+  affected_servers: string[];
+  exposed_credentials: string[];
+  reachable_tools: string[];
+  references: string[];
+  advisory_sources: string[];
+  attack_vector_summary?: string | undefined;
+  impact_category?: string | undefined;
+  risk_score?: number | undefined;
+  remediation_items: RemediationSummary[];
+  graph_reachable?: boolean | null | undefined;
+  graph_min_hop_distance?: number | null | undefined;
+}
+
+export interface RemediationSummary {
+  package: string;
+  ecosystem: string;
+  current_version: string;
+  fixed_version: string | null;
+  action?: string | undefined;
+  command?: string | null | undefined;
+  verify_command?: string | null | undefined;
+  references: string[];
+  risk_narrative: string;
+}
+
+export type SeverityFilter = "all" | "critical" | "high" | "medium" | "low";
+export type SortKey = "severity" | "cvss" | "epss" | "id";
+export type GroupKey = "none" | "package" | "agent" | "severity";
+export type ScanScope = "latest" | "all";
+
+export function uniqueStrings(items: Array<string | null | undefined>) {
+  return [...new Set(items.filter((item): item is string => Boolean(item && item.trim())).map((item) => item.trim()))];
+}

--- a/ui/tests/vulns-page.test.tsx
+++ b/ui/tests/vulns-page.test.tsx
@@ -17,6 +17,8 @@ const { apiMock } = vi.hoisted(() => ({
 
 vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: vi.fn() }),
+  usePathname: () => "/vulns",
 }));
 
 vi.mock("next/link", () => ({


### PR DESCRIPTION
## Summary
- Extract `FindingsQueueTable` and `FindingDrawer` from `/vulns` into dedicated components with shared types in `ui/lib/findings-view.ts`.
- Sync severity, search, scope, group, and page filters to URL query params for shareable/bookmarkable views.
- Extend `vulns-page` test mocks for `useRouter` / `usePathname`.

## Verification
- `cd ui && npm run lint -- app/vulns/page.tsx components/finding-drawer.tsx components/findings-queue.tsx lib/findings-view.ts tests/vulns-page.test.tsx`
- `cd ui && npm run typecheck`
- `cd ui && npm run test:run -- vulns-page.test.tsx`
- `cd ui && npm run test:e2e -- e2e/large-graph-overview.spec.ts --project=chromium`
