### PR TITLE
fix(docs): keep extension contract link mkdocs-strict safe

### DIFF
--- a/site-docs/api/extensions.md
+++ b/site-docs/api/extensions.md
@@ -25,7 +25,7 @@ returns built-ins plus trusted entry-point extensions when enabled.
 Three further opt-in groups — `agent_bom.mcp_tools`,
 `agent_bom.advisory_sources`, and `agent_bom.runtime_emitters` — plus the full
 author contract, capability model, and runnable examples are documented in
-[`docs/PLUGIN_ENTRYPOINTS.md`](../../docs/PLUGIN_ENTRYPOINTS.md).
+[`docs/PLUGIN_ENTRYPOINTS.md`](https://github.com/msaad00/agent-bom/blob/main/docs/PLUGIN_ENTRYPOINTS.md).
 
 ## Inventory Parser Example
 


### PR DESCRIPTION
Summary
- replaces the site-docs relative link to docs/PLUGIN_ENTRYPOINTS.md with a source link that MkDocs strict mode can resolve
- fixes the docs build failure seen in the v0.92.0 release run

Validation
- uv tool run --from mkdocs==1.6.1 --with mkdocs-material==9.7.5 --with mkdocstrings==1.0.3 --with mkdocstrings-python==2.0.3 mkdocs build --strict
- git diff --check