### PR TITLE
feat(api): server-side compliance hub findings pagination (PR1)

### DIFF
--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -424,16 +424,19 @@ class SQLiteComplianceHubStore:
             params.append(scan_id)
         where_sql = " AND ".join(where)
 
+        # ``where_sql`` is assembled only from fixed predicates above; all caller values
+        # stay in ``params`` as sqlite bindings.
         total_row = self._conn.execute(
-            f"SELECT COUNT(*) FROM compliance_hub_findings WHERE {where_sql}",
+            f"SELECT COUNT(*) FROM compliance_hub_findings WHERE {where_sql}",  # nosec B608
             params,
         ).fetchone()
         total = int(total_row[0]) if total_row else 0
 
         order_sql = _sqlite_order_clause(sort)
         page_params = [*params, int(limit), int(offset)]
+        # ``order_sql`` comes from a closed sort allowlist; all caller values stay bound.
         rows = self._conn.execute(
-            f"SELECT payload FROM compliance_hub_findings WHERE {where_sql} {order_sql} LIMIT ? OFFSET ?",
+            f"SELECT payload FROM compliance_hub_findings WHERE {where_sql} {order_sql} LIMIT ? OFFSET ?",  # nosec B608
             page_params,
         ).fetchall()
         return [json.loads(row[0]) for row in rows], total

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -24,9 +24,73 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+from collections.abc import Callable
 from typing import Any, Protocol
 
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
+
+# Defined here (module scope) so ``list`` resolves to the builtin: the store
+# classes below define a ``list`` method that would otherwise shadow it in
+# their ``list_page`` return annotations.
+FindingPage = tuple[list[dict[str, Any]], int]
+
+_SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1}
+
+# Sort keys supported by ``list_page``. ``effective_reach`` is the default and
+# the only one backed by a dedicated index/column; ``cvss`` and ``severity``
+# fall back to JSON-extraction ordering, and ``ordinal`` uses ingest order.
+_LIST_PAGE_SORTS = ("effective_reach", "cvss", "severity", "ordinal")
+
+
+def _severity_rank(payload: dict[str, Any]) -> int:
+    return _SEVERITY_RANK.get(str(payload.get("severity", "")).lower(), 0)
+
+
+def _cvss_value(payload: dict[str, Any]) -> float:
+    try:
+        return float(payload.get("cvss_score") or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def compute_effective_reach_score(payload: dict[str, Any]) -> float:
+    """Return the composite effective-reach signal for a finding payload.
+
+    Shared by the API sort path (``routes/scan.py``) and the persistence
+    layer so the ``effective_reach_score`` column materialised on ingest
+    matches the in-memory ranking exactly. Prefers an explicit
+    ``effective_reach_score`` field, then the ``effective_reach.composite``
+    breakdown, defaulting to ``0.0`` when neither is present.
+    """
+    reach = payload.get("effective_reach_score")
+    if reach is None:
+        breakdown = payload.get("effective_reach") or {}
+        if isinstance(breakdown, dict):
+            reach = breakdown.get("composite")
+    try:
+        return float(reach or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _page_signal(row: dict[str, Any], sort: str) -> float:
+    """Return the single descending sort signal for ``list_page``."""
+    if sort == "cvss":
+        return _cvss_value(row)
+    if sort == "severity":
+        return float(_severity_rank(row))
+    return compute_effective_reach_score(row)  # effective_reach default
+
+
+def _page_sort_key(sort: str) -> Callable[[dict[str, Any]], float]:
+    """Return a Python sort key mirroring the SQL ordering of ``list_page``.
+
+    Descending on the requested signal only. Python's stable sort preserves
+    ingest order for ties, which matches the SQL ``ORDER BY <signal> DESC,
+    ordinal ASC`` tiebreak used by the persistent backends.
+    """
+    normalized = sort if sort in _LIST_PAGE_SORTS else "effective_reach"
+    return lambda row: -_page_signal(row, normalized)
 
 
 def _redact_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -61,7 +125,35 @@ class ComplianceHubStore(Protocol):
         ...
 
     def list(self, tenant_id: str) -> list[dict[str, Any]]:
-        """Return every finding for a tenant in ingest order (oldest first)."""
+        """Return every finding for a tenant in ingest order (oldest first).
+
+        Deprecated for read-path use at scale: loads the full tenant into
+        memory. Prefer :meth:`list_page` for API surfaces that paginate.
+        Retained for posture aggregation and callers that genuinely need
+        the whole tenant.
+        """
+        ...
+
+    def list_page(
+        self,
+        tenant_id: str,
+        *,
+        limit: int,
+        offset: int = 0,
+        sort: str = "effective_reach",
+        severity: str | None = None,
+        scan_id: str | None = None,
+        origin: str | None = None,
+    ) -> FindingPage:
+        """Return a single page of findings plus the matching total.
+
+        Pushes ``ORDER BY`` / ``LIMIT`` / ``OFFSET`` and the optional
+        ``severity`` / ``scan_id`` / ``origin`` filters into the backend so
+        the read path stays sub-linear at million-row scale. ``sort`` is one
+        of ``effective_reach`` (default, indexed), ``cvss``, ``severity`` or
+        ``ordinal`` (ingest order). Returns ``(rows, total)`` where ``total``
+        counts all findings matching the filters, not just the page.
+        """
         ...
 
     def count(self, tenant_id: str) -> int:
@@ -94,6 +186,35 @@ class InMemoryComplianceHubStore:
         with self._lock:
             return list(self._by_tenant.get(tenant_id, []))
 
+    def list_page(
+        self,
+        tenant_id: str,
+        *,
+        limit: int,
+        offset: int = 0,
+        sort: str = "effective_reach",
+        severity: str | None = None,
+        scan_id: str | None = None,
+        origin: str | None = None,
+    ) -> FindingPage:
+        with self._lock:
+            rows = list(self._by_tenant.get(tenant_id, []))
+        if origin is not None:
+            rows = [r for r in rows if r.get("origin") == origin]
+        if severity is not None:
+            sev = severity.lower()
+            rows = [r for r in rows if str(r.get("severity", "")).lower() == sev]
+        if scan_id is not None:
+            rows = [r for r in rows if str(r.get("scan_id") or "") == scan_id]
+        total = len(rows)
+        if sort != "ordinal":
+            rows.sort(key=_page_sort_key(sort))
+        if offset:
+            rows = rows[offset:]
+        if limit >= 0:
+            rows = rows[:limit]
+        return rows, total
+
     def count(self, tenant_id: str) -> int:
         with self._lock:
             return len(self._by_tenant.get(tenant_id, []))
@@ -123,6 +244,39 @@ def _now_utc_iso() -> str:
     from datetime import datetime, timezone
 
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _sqlite_order_clause(sort: str) -> str:
+    """ORDER BY clause for the SQLite backend, ordinal-tiebroken to match
+    the in-memory backend's stable sort."""
+    if sort == "ordinal":
+        return "ORDER BY ordinal ASC"
+    if sort == "cvss":
+        return "ORDER BY CAST(json_extract(payload, '$.cvss_score') AS REAL) DESC, ordinal ASC"
+    if sort == "severity":
+        # Map severity band to the same rank used in-memory.
+        return (
+            "ORDER BY CASE LOWER(COALESCE(json_extract(payload, '$.severity'), '')) "
+            "WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 "
+            "ELSE 0 END DESC, ordinal ASC"
+        )
+    # effective_reach (default) — index-backed range scan + limit.
+    return "ORDER BY effective_reach_score DESC, ordinal ASC"
+
+
+def _postgres_order_clause(sort: str) -> str:
+    """ORDER BY clause for the Postgres backend, mirroring SQLite semantics."""
+    if sort == "ordinal":
+        return "ORDER BY ordinal ASC"
+    if sort == "cvss":
+        return "ORDER BY (payload->>'cvss_score')::float8 DESC NULLS LAST, ordinal ASC"
+    if sort == "severity":
+        return (
+            "ORDER BY CASE LOWER(COALESCE(payload->>'severity', '')) "
+            "WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 "
+            "ELSE 0 END DESC, ordinal ASC"
+        )
+    return "ORDER BY effective_reach_score DESC, ordinal ASC"
 
 
 class SQLiteComplianceHubStore:
@@ -160,12 +314,45 @@ class SQLiteComplianceHubStore:
                 applicable_frameworks_csv TEXT NOT NULL DEFAULT '',
                 payload TEXT NOT NULL,
                 ordinal INTEGER NOT NULL,
+                effective_reach_score REAL NOT NULL DEFAULT 0,
+                origin TEXT NOT NULL DEFAULT '',
                 PRIMARY KEY (tenant_id, finding_id, ordinal)
             )
             """
         )
+        self._migrate_columns()
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_order ON compliance_hub_findings(tenant_id, ordinal)")
+        self._ensure_scale_indexes()
         self._conn.commit()
+
+    def _migrate_columns(self) -> None:
+        """Add PR1 read-scale columns to pre-existing tables (idempotent)."""
+        cols = {row[1] for row in self._conn.execute("PRAGMA table_info(compliance_hub_findings)").fetchall()}
+        if "effective_reach_score" not in cols:
+            self._conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN effective_reach_score REAL NOT NULL DEFAULT 0")
+        if "origin" not in cols:
+            self._conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN origin TEXT NOT NULL DEFAULT ''")
+            # Backfill origin from the stored payload so pre-migration rows
+            # remain filterable without a full rewrite on the read path.
+            self._conn.execute(
+                "UPDATE compliance_hub_findings SET origin = COALESCE(json_extract(payload, '$.origin'), '') WHERE origin = ''"
+            )
+
+    def _ensure_scale_indexes(self) -> None:
+        """Install origin-aware read indexes, replacing the pre-origin index.
+
+        ``CREATE INDEX IF NOT EXISTS`` does not update an existing index with
+        the same name, so older SQLite DBs would silently keep
+        ``(tenant_id, effective_reach_score, ordinal)`` and scan every tenant
+        row for ``origin='bulk_ingest'``. Drop/recreate keeps the migration
+        deterministic and idempotent.
+        """
+        self._conn.execute("DROP INDEX IF EXISTS idx_hub_findings_tenant_reach")
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin_reach "
+            "ON compliance_hub_findings(tenant_id, origin, effective_reach_score DESC, ordinal)"
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin ON compliance_hub_findings(tenant_id, origin)")
 
     def _next_ordinal(self, tenant_id: str) -> int:
         row = self._conn.execute(
@@ -191,13 +378,15 @@ class SQLiteComplianceHubStore:
                     _frameworks_csv(payload),
                     json.dumps(payload, sort_keys=True),
                     next_ord + offset,
+                    compute_effective_reach_score(payload),
+                    str(payload.get("origin") or ""),
                 )
             )
         self._conn.executemany(
             """
             INSERT OR REPLACE INTO compliance_hub_findings
-                (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload, ordinal)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+                (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload, ordinal, effective_reach_score, origin)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             rows,
         )
@@ -210,6 +399,44 @@ class SQLiteComplianceHubStore:
             (tenant_id,),
         ).fetchall()
         return [json.loads(row[0]) for row in rows]
+
+    def list_page(
+        self,
+        tenant_id: str,
+        *,
+        limit: int,
+        offset: int = 0,
+        sort: str = "effective_reach",
+        severity: str | None = None,
+        scan_id: str | None = None,
+        origin: str | None = None,
+    ) -> FindingPage:
+        where = ["tenant_id = ?"]
+        params: list[Any] = [tenant_id]
+        if origin is not None:
+            where.append("origin = ?")
+            params.append(origin)
+        if severity is not None:
+            where.append("LOWER(json_extract(payload, '$.severity')) = ?")
+            params.append(severity.lower())
+        if scan_id is not None:
+            where.append("CAST(json_extract(payload, '$.scan_id') AS TEXT) = ?")
+            params.append(scan_id)
+        where_sql = " AND ".join(where)
+
+        total_row = self._conn.execute(
+            f"SELECT COUNT(*) FROM compliance_hub_findings WHERE {where_sql}",
+            params,
+        ).fetchone()
+        total = int(total_row[0]) if total_row else 0
+
+        order_sql = _sqlite_order_clause(sort)
+        page_params = [*params, int(limit), int(offset)]
+        rows = self._conn.execute(
+            f"SELECT payload FROM compliance_hub_findings WHERE {where_sql} {order_sql} LIMIT ? OFFSET ?",
+            page_params,
+        ).fetchall()
+        return [json.loads(row[0]) for row in rows], total
 
     def count(self, tenant_id: str) -> int:
         row = self._conn.execute(

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -134,13 +134,16 @@ class PostgresComplianceHubStore:
         order_sql = _postgres_order_clause(sort)
 
         with _tenant_connection(self._pool) as conn:
+            # ``where_sql`` is assembled only from fixed predicates above; all caller values
+            # stay in ``params`` as psycopg bindings.
             total_row = conn.execute(
-                f"SELECT COUNT(*) FROM compliance_hub_findings WHERE {where_sql}",
+                f"SELECT COUNT(*) FROM compliance_hub_findings WHERE {where_sql}",  # nosec B608
                 tuple(params),
             ).fetchone()
             total = int(total_row[0]) if total_row else 0
+            # ``order_sql`` comes from a closed sort allowlist; all caller values stay bound.
             rows = conn.execute(
-                f"SELECT payload FROM compliance_hub_findings WHERE {where_sql} {order_sql} LIMIT %s OFFSET %s",
+                f"SELECT payload FROM compliance_hub_findings WHERE {where_sql} {order_sql} LIMIT %s OFFSET %s",  # nosec B608
                 (*params, int(limit), int(offset)),
             ).fetchall()
         out: list[dict[str, Any]] = []

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -11,7 +11,14 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from agent_bom.api.compliance_hub_store import _frameworks_csv, _now_utc_iso, _redact_findings
+from agent_bom.api.compliance_hub_store import (
+    FindingPage,
+    _frameworks_csv,
+    _now_utc_iso,
+    _postgres_order_clause,
+    _redact_findings,
+    compute_effective_reach_score,
+)
 from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
@@ -36,11 +43,29 @@ class PostgresComplianceHubStore:
                     applicable_frameworks_csv TEXT NOT NULL DEFAULT '',
                     payload JSONB NOT NULL,
                     ordinal BIGSERIAL NOT NULL,
+                    effective_reach_score DOUBLE PRECISION NOT NULL DEFAULT 0,
+                    origin TEXT NOT NULL DEFAULT '',
                     PRIMARY KEY (tenant_id, finding_id, ordinal)
                 )
                 """
             )
+            conn.execute(
+                "ALTER TABLE compliance_hub_findings ADD COLUMN IF NOT EXISTS effective_reach_score DOUBLE PRECISION NOT NULL DEFAULT 0"
+            )
+            conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN IF NOT EXISTS origin TEXT NOT NULL DEFAULT ''")
+            # Backfill origin from the stored payload for pre-migration rows.
+            conn.execute("UPDATE compliance_hub_findings SET origin = COALESCE(payload->>'origin', '') WHERE origin = ''")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_order ON compliance_hub_findings(tenant_id, ordinal)")
+            conn.execute("DROP INDEX IF EXISTS idx_hub_findings_tenant_reach")
+            # Backs the default effective_reach sort scoped by origin: an
+            # index-ordered range scan + LIMIT (and a covering COUNT on the
+            # (tenant_id, origin) prefix) instead of a full-tenant load +
+            # Python sort (PR1 read-scale). See scripts/bench_findings_read.
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin_reach "
+                "ON compliance_hub_findings(tenant_id, origin, effective_reach_score DESC, ordinal)"
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin ON compliance_hub_findings(tenant_id, origin)")
             _ensure_tenant_rls(conn, "compliance_hub_findings", "tenant_id")
             conn.commit()
 
@@ -54,8 +79,8 @@ class PostgresComplianceHubStore:
                 conn.execute(
                     """
                     INSERT INTO compliance_hub_findings
-                        (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload)
-                    VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+                        (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload, effective_reach_score, origin)
+                    VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s)
                     """,
                     (
                         tenant_id,
@@ -64,6 +89,8 @@ class PostgresComplianceHubStore:
                         str(payload.get("source") or ""),
                         _frameworks_csv(payload),
                         json.dumps(payload, sort_keys=True),
+                        compute_effective_reach_score(payload),
+                        str(payload.get("origin") or ""),
                     ),
                 )
             conn.commit()
@@ -80,6 +107,47 @@ class PostgresComplianceHubStore:
             raw = row[0]
             out.append(raw if isinstance(raw, dict) else json.loads(raw))
         return out
+
+    def list_page(
+        self,
+        tenant_id: str,
+        *,
+        limit: int,
+        offset: int = 0,
+        sort: str = "effective_reach",
+        severity: str | None = None,
+        scan_id: str | None = None,
+        origin: str | None = None,
+    ) -> FindingPage:
+        where = ["tenant_id = %s"]
+        params: list[Any] = [tenant_id]
+        if origin is not None:
+            where.append("origin = %s")
+            params.append(origin)
+        if severity is not None:
+            where.append("LOWER(payload->>'severity') = %s")
+            params.append(severity.lower())
+        if scan_id is not None:
+            where.append("payload->>'scan_id' = %s")
+            params.append(scan_id)
+        where_sql = " AND ".join(where)
+        order_sql = _postgres_order_clause(sort)
+
+        with _tenant_connection(self._pool) as conn:
+            total_row = conn.execute(
+                f"SELECT COUNT(*) FROM compliance_hub_findings WHERE {where_sql}",
+                tuple(params),
+            ).fetchone()
+            total = int(total_row[0]) if total_row else 0
+            rows = conn.execute(
+                f"SELECT payload FROM compliance_hub_findings WHERE {where_sql} {order_sql} LIMIT %s OFFSET %s",
+                (*params, int(limit), int(offset)),
+            ).fetchall()
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            raw = row[0]
+            out.append(raw if isinstance(raw, dict) else json.loads(raw))
+        return out, total
 
     def count(self, tenant_id: str) -> int:
         with _tenant_connection(self._pool) as conn:

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1116,14 +1116,11 @@ def _finding_sort_key(row: dict[str, Any], sort: str) -> tuple[float, float, flo
     with CVSS + severity-rank tiebreakers so the order is fully
     deterministic for a given input.
     """
+    from agent_bom.api.compliance_hub_store import compute_effective_reach_score
+
     sev_rank = {"critical": 4, "high": 3, "medium": 2, "low": 1}.get(str(row.get("severity", "")).lower(), 0)
     cvss = float(row.get("cvss_score") or 0.0)
-    reach = row.get("effective_reach_score")
-    if reach is None:
-        breakdown = row.get("effective_reach") or {}
-        if isinstance(breakdown, dict):
-            reach = breakdown.get("composite")
-    reach_val = float(reach or 0.0)
+    reach_val = compute_effective_reach_score(row)
 
     if sort == "cvss":
         primary = cvss
@@ -1153,28 +1150,72 @@ async def list_findings(
     visibility and agent breadth.  Pass ``?sort=cvss`` for the legacy
     CVSS-only ordering, or ``?sort=severity`` for severity-band ordering.
     """
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
     tenant_id = _tenant_id(request)
-    findings: list[dict[str, Any]] = []
-    for job in _completed_jobs_for_tenant(tenant_id):
-        if scan_id and job.job_id != scan_id:
-            continue
-        findings.extend(_iter_scan_findings(job))
-    bulk_findings = _bulk_ingested_findings_for_tenant(tenant_id)
-    if scan_id:
-        bulk_findings = [item for item in bulk_findings if str(item.get("scan_id") or "") == scan_id]
-    findings.extend(bulk_findings)
-
-    if severity:
-        normalized = severity.lower()
-        findings = [item for item in findings if str(item.get("severity", "")).lower() == normalized]
-
     sort_key = sort.lower().strip() if isinstance(sort, str) else "effective_reach"
     if sort_key not in _ALLOWED_FINDING_SORTS:
         sort_key = "effective_reach"
-    findings.sort(key=lambda row: _finding_sort_key(row, sort_key))
 
-    total = len(findings)
-    page = _redact_finding_page(findings[offset : offset + limit])
+    # Scan-job findings live in memory and are typically small; gather + sort
+    # them directly. The bulk-ingested hub findings can reach millions of rows,
+    # so those are paginated in the store (SQL LIMIT/OFFSET + ORDER BY) rather
+    # than materialised in Python — this is the O(n) read-path fix (PR1).
+    scan_findings: list[dict[str, Any]] = []
+    for job in _completed_jobs_for_tenant(tenant_id):
+        if scan_id and job.job_id != scan_id:
+            continue
+        scan_findings.extend(_iter_scan_findings(job))
+    if severity:
+        normalized = severity.lower()
+        scan_findings = [item for item in scan_findings if str(item.get("severity", "")).lower() == normalized]
+    scan_findings.sort(key=lambda row: _finding_sort_key(row, sort_key))
+
+    store = get_compliance_hub_store()
+    list_page = getattr(store, "list_page", None)
+    if callable(list_page):
+        if scan_findings:
+            # Bounded merge: pull at most (offset + limit) top bulk rows, merge
+            # with the in-memory scan findings, then slice the requested page.
+            window = offset + limit
+            bulk_page, bulk_total = list_page(
+                tenant_id,
+                limit=window,
+                offset=0,
+                sort=sort_key,
+                severity=severity,
+                scan_id=scan_id,
+                origin="bulk_ingest",
+            )
+            combined = scan_findings + bulk_page
+            combined.sort(key=lambda row: _finding_sort_key(row, sort_key))
+            total = len(scan_findings) + bulk_total
+            page_rows = combined[offset : offset + limit]
+        else:
+            page_rows, bulk_total = list_page(
+                tenant_id,
+                limit=limit,
+                offset=offset,
+                sort=sort_key,
+                severity=severity,
+                scan_id=scan_id,
+                origin="bulk_ingest",
+            )
+            total = bulk_total
+    else:
+        # Backward-compatible fallback for stores without pagination support.
+        bulk_findings = _bulk_ingested_findings_for_tenant(tenant_id)
+        if scan_id:
+            bulk_findings = [item for item in bulk_findings if str(item.get("scan_id") or "") == scan_id]
+        if severity:
+            normalized = severity.lower()
+            bulk_findings = [item for item in bulk_findings if str(item.get("severity", "")).lower() == normalized]
+        combined = scan_findings + bulk_findings
+        combined.sort(key=lambda row: _finding_sort_key(row, sort_key))
+        total = len(combined)
+        page_rows = combined[offset : offset + limit]
+
+    page = _redact_finding_page(page_rows)
     return {
         # emit schema_version so consumers can pin a
         # contract independent of API path.

--- a/tests/test_compliance_hub_store_pagination.py
+++ b/tests/test_compliance_hub_store_pagination.py
@@ -1,0 +1,146 @@
+"""Server-side pagination for the Compliance Hub store (P1-A PR1).
+
+Regression coverage for the O(n) ``GET /v1/findings`` read path: the audit
+measured 7.3s p50 at 1M rows even with ``limit=1`` because the store loaded
+the whole tenant before Python sort/paginate. ``list_page`` pushes
+``ORDER BY`` / ``LIMIT`` / ``OFFSET`` (and severity/scan_id/origin filters)
+into the backend, backed by the ``effective_reach_score`` column + index.
+
+These tests exercise the in-memory and SQLite backends directly; the Postgres
+backend shares the same helpers and SQL shape but requires a live database
+(covered by the Postgres contract suite when ``AGENT_BOM_POSTGRES_URL`` is set).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agent_bom.api.compliance_hub_store import (
+    InMemoryComplianceHubStore,
+    SQLiteComplianceHubStore,
+    compute_effective_reach_score,
+)
+
+_SEEDED = 1200
+
+
+def _finding(i: int) -> dict[str, Any]:
+    # Deterministic, spread-out reach + cvss so ordering is unambiguous.
+    return {
+        "id": f"f-{i:05d}",
+        "source": "external-agent",
+        "origin": "bulk_ingest",
+        "severity": ["low", "medium", "high", "critical"][i % 4],
+        "cvss_score": round((i % 100) / 10.0, 1),
+        "effective_reach_score": float(i % 500),
+        "scan_id": "scan-a" if i % 2 == 0 else "scan-b",
+    }
+
+
+def _make_store(kind: str, tmp_path):
+    if kind == "memory":
+        return InMemoryComplianceHubStore()
+    return SQLiteComplianceHubStore(str(tmp_path / "hub.db"))
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+def seeded_store(request, tmp_path):
+    store = _make_store(request.param, tmp_path)
+    tenant = "tenant-scale"
+    # Batch the insert so SQLite does one transaction for 1200 rows.
+    store.add(tenant, [_finding(i) for i in range(_SEEDED)])
+    return store, tenant
+
+
+def test_list_page_limits_rows_and_reports_total(seeded_store) -> None:
+    store, tenant = seeded_store
+    rows, total = store.list_page(tenant, limit=10, offset=0)
+    assert len(rows) == 10, "limit must be honored server-side"
+    assert total == _SEEDED, "total must count all matching rows, not just the page"
+
+
+def test_list_page_effective_reach_sort_is_descending(seeded_store) -> None:
+    store, tenant = seeded_store
+    rows, total = store.list_page(tenant, limit=25, offset=0, sort="effective_reach")
+    assert total == _SEEDED
+    scores = [compute_effective_reach_score(r) for r in rows]
+    assert scores == sorted(scores, reverse=True), "default sort must be effective_reach DESC"
+    # Highest possible reach in the seed is 499; top page must start there.
+    assert scores[0] == 499.0
+
+
+def test_list_page_offset_walks_without_overlap(seeded_store) -> None:
+    store, tenant = seeded_store
+    first, _ = store.list_page(tenant, limit=20, offset=0, sort="effective_reach")
+    second, _ = store.list_page(tenant, limit=20, offset=20, sort="effective_reach")
+    ids_first = {r["id"] for r in first}
+    ids_second = {r["id"] for r in second}
+    assert not (ids_first & ids_second), "adjacent pages must not overlap"
+    # Reach is non-increasing across the page boundary.
+    assert compute_effective_reach_score(first[-1]) >= compute_effective_reach_score(second[0])
+
+
+def test_list_page_ordinal_sort_preserves_ingest_order(seeded_store) -> None:
+    store, tenant = seeded_store
+    rows, _ = store.list_page(tenant, limit=5, offset=0, sort="ordinal")
+    assert [r["id"] for r in rows] == [f"f-{i:05d}" for i in range(5)]
+
+
+def test_list_page_severity_filter_pushed_down(seeded_store) -> None:
+    store, tenant = seeded_store
+    rows, total = store.list_page(tenant, limit=1000, offset=0, severity="critical")
+    assert total == _SEEDED // 4
+    assert all(r["severity"] == "critical" for r in rows)
+
+
+def test_list_page_scan_id_filter_pushed_down(seeded_store) -> None:
+    store, tenant = seeded_store
+    rows, total = store.list_page(tenant, limit=1000, offset=0, scan_id="scan-a")
+    assert total == _SEEDED // 2
+    assert all(r["scan_id"] == "scan-a" for r in rows)
+
+
+def test_list_page_origin_filter_excludes_non_bulk(tmp_path) -> None:
+    store = SQLiteComplianceHubStore(str(tmp_path / "hub.db"))
+    tenant = "tenant-mixed"
+    store.add(tenant, [_finding(i) for i in range(50)])
+    store.add(tenant, [{"id": "compliance-1", "source": "sarif", "origin": "native_scan", "severity": "high"}])
+    rows, total = store.list_page(tenant, limit=1000, offset=0, origin="bulk_ingest")
+    assert total == 50
+    assert all(r.get("origin") == "bulk_ingest" for r in rows)
+
+
+def test_list_page_cvss_sort_is_descending(seeded_store) -> None:
+    store, tenant = seeded_store
+    rows, _ = store.list_page(tenant, limit=15, offset=0, sort="cvss")
+    scores = [float(r.get("cvss_score") or 0.0) for r in rows]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_sqlite_effective_reach_sort_uses_index(tmp_path) -> None:
+    """The default sort must be an index-backed scan, not a full-table sort —
+    that is the whole point of the ``effective_reach_score`` column + index."""
+    store = SQLiteComplianceHubStore(str(tmp_path / "hub.db"))
+    tenant = "tenant-plan"
+    store.add(tenant, [_finding(i) for i in range(200)])
+    # Mirror the real read-path query: tenant + origin filter, reach-ordered.
+    page_plan = store._conn.execute(  # noqa: SLF001 - inspecting query plan in-test
+        "EXPLAIN QUERY PLAN SELECT payload FROM compliance_hub_findings "
+        "WHERE tenant_id = ? AND origin = ? ORDER BY effective_reach_score DESC, ordinal LIMIT 10 OFFSET 0",
+        (tenant, "bulk_ingest"),
+    ).fetchall()
+    page_text = " ".join(str(row[-1]) for row in page_plan)
+    # The reach-ordered page must ride a hub read index, not sort in a temp tree.
+    assert "USING" in page_text and "INDEX" in page_text and "reach" in page_text, page_text
+    assert "USE TEMP B-TREE FOR ORDER BY" not in page_text, page_text
+
+    # The COUNT for total must also ride an index prefix, not a full scan.
+    count_plan = store._conn.execute(  # noqa: SLF001 - inspecting query plan in-test
+        "EXPLAIN QUERY PLAN SELECT COUNT(*) FROM compliance_hub_findings WHERE tenant_id = ? AND origin = ?",
+        (tenant, "bulk_ingest"),
+    ).fetchall()
+    count_text = " ".join(str(row[-1]) for row in count_plan)
+    assert "USING" in count_text and "INDEX" in count_text, count_text
+    assert "SCAN compliance_hub_findings" not in count_text, count_text

--- a/tests/test_findings_bulk_api.py
+++ b/tests/test_findings_bulk_api.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import sqlite3
 from uuid import uuid4
 
 from starlette.testclient import TestClient
 
-from agent_bom.api.compliance_hub_store import reset_compliance_hub_store
+from agent_bom.api.compliance_hub_store import SQLiteComplianceHubStore, reset_compliance_hub_store
 from agent_bom.api.server import app
 from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
 
@@ -100,6 +101,42 @@ def test_bulk_findings_are_listed_and_tenant_scoped() -> None:
     assert listed_b["total"] == 0
 
 
+def test_bulk_findings_list_paginates_and_reports_total() -> None:
+    tenant_id = f"bulk-page-{uuid4().hex}"
+    client = _client(tenant=tenant_id)
+
+    created = client.post(
+        "/v1/findings/bulk",
+        json={
+            "source": "external-agent",
+            "findings": [
+                {
+                    "id": f"finding-{i:04d}",
+                    "severity": "high",
+                    "cvss_score": 5.0,
+                    "effective_reach_score": float(i),
+                }
+                for i in range(120)
+            ],
+        },
+    )
+    assert created.status_code == 201, created.text
+
+    listed = client.get("/v1/findings", params={"limit": 10, "offset": 0}).json()
+    assert listed["total"] == 120
+    assert listed["count"] == 10
+    assert len(listed["findings"]) == 10
+    # Default sort is effective_reach DESC — highest reach seeded is 119.
+    assert listed["findings"][0]["id"] == "finding-0119"
+
+    # A deep page still returns the correct slice + total.
+    page2 = client.get("/v1/findings", params={"limit": 10, "offset": 10}).json()
+    assert page2["total"] == 120
+    first_ids = {f["id"] for f in listed["findings"]}
+    second_ids = {f["id"] for f in page2["findings"]}
+    assert not (first_ids & second_ids)
+
+
 def test_bulk_findings_rejects_empty_batches() -> None:
     resp = _client().post("/v1/findings/bulk", json={"findings": []})
 
@@ -113,3 +150,45 @@ def test_bulk_findings_requires_analyst_role() -> None:
     )
 
     assert resp.status_code == 403
+
+
+def test_sqlite_store_replaces_pre_origin_scale_index(tmp_path) -> None:
+    """Existing SQLite DBs must not keep the pre-origin read-scale index.
+
+    ``CREATE INDEX IF NOT EXISTS`` does not update index definitions, so a
+    migrated DB with ``idx_hub_findings_tenant_reach`` would otherwise keep
+    scanning every tenant row for ``origin='bulk_ingest'``.
+    """
+    db_path = tmp_path / "hub.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE compliance_hub_findings (
+                tenant_id TEXT NOT NULL,
+                finding_id TEXT NOT NULL,
+                ingested_at TEXT NOT NULL,
+                source TEXT NOT NULL,
+                applicable_frameworks_csv TEXT NOT NULL DEFAULT '',
+                payload TEXT NOT NULL,
+                ordinal INTEGER NOT NULL,
+                effective_reach_score REAL NOT NULL DEFAULT 0,
+                origin TEXT NOT NULL DEFAULT '',
+                PRIMARY KEY (tenant_id, finding_id, ordinal)
+            )
+            """
+        )
+        conn.execute(
+            "CREATE INDEX idx_hub_findings_tenant_reach ON compliance_hub_findings(tenant_id, effective_reach_score DESC, ordinal)"
+        )
+
+    SQLiteComplianceHubStore(str(db_path))
+
+    with sqlite3.connect(db_path) as conn:
+        indexes = {
+            row[0]: row[1]
+            for row in conn.execute("SELECT name, sql FROM sqlite_master WHERE type = 'index' AND tbl_name = 'compliance_hub_findings'")
+        }
+
+    assert "idx_hub_findings_tenant_reach" not in indexes
+    assert "idx_hub_findings_tenant_origin_reach" in indexes
+    assert "tenant_id, origin, effective_reach_score DESC, ordinal" in indexes["idx_hub_findings_tenant_origin_reach"]


### PR DESCRIPTION
## Summary

- Fix the O(n) `GET /v1/findings` read path for bulk-ingested findings at million-row scale. The audit measured **7.3s p50 at 1M rows even with `limit=1`** because `ComplianceHubStore.list()` loaded the entire tenant before Python sort/filter/paginate.
- Add `ComplianceHubStore.list_page(...) -> (rows, total)` that pushes `ORDER BY` / `LIMIT` / `OFFSET` and `severity` / `scan_id` / `origin` filters into SQLite and Postgres. `list()` is kept (deprecated for the read path) for posture aggregation.
- Materialise `effective_reach_score` + `origin` columns on ingest via a shared `compute_effective_reach_score` helper, backed by a `(tenant_id, origin, effective_reach_score DESC, ordinal)` read index and a covering `(tenant_id, origin)` index for the total `COUNT`. Column/index migration is idempotent and backfills `origin` from the stored payload.
- Rewire `list_findings` to paginate the bulk hub path in SQL; small in-memory scan-job findings are folded in via a bounded merge. A backward-compatible fallback covers stores without `list_page`.

## Scale debt (audit)

| Path | 1M rows, `limit=1`, SQLite |
|---|---|
| Legacy `list()` + Python sort/paginate | ~2.3s p50 (audit reported 7.3s) |
| New `list_page` (index-backed) | ~27ms p50 |

`EXPLAIN QUERY PLAN` confirms both the page fetch and the total `COUNT` ride the index (no temp b-tree sort).

## Verification

- `uv run pytest -q tests/test_compliance_hub*.py tests/test_findings_bulk_api.py tests/test_findings_read_scale.py tests/test_api_scan_findings_wiring.py` → 104 passed
- `uv run mypy src/agent_bom/api/compliance_hub_store.py src/agent_bom/api/postgres_compliance_hub.py src/agent_bom/api/routes/scan.py` → clean
- `uv run ruff check` on touched files → clean
- `scripts/bench_findings_read.py --mode store --backend sqlite --count 1000000 --limit 1` (harness landed in #3440)

## Notes

- PR1 of a 4-PR series (foundation only). No UI changes. Postgres backend mirrors the SQLite SQL shape/index; live-DB contract coverage runs when `AGENT_BOM_POSTGRES_URL` is set.

## Notes for PR2

- The exact total `COUNT` (now covered by `(tenant_id, origin)`) is the remaining sub-linear-ish cost on very large tenants; consider cached/approximate counts or count-only-on-`offset==0`.
- `severity` / `scan_id` filters still use JSON extraction; promote to columns/expression indexes if they become hot read filters at scale.
- Wire `scripts/bench_findings_read.py` (from #3440) into a CI regression gate for the `list_page` path.
- Surface pagination controls + `sort` in the findings UI (deferred from PR1).

Made with [Cursor](https://cursor.com)