### PR TITLE
fix(scan): skip unreachable Go checksum lookups

### DIFF
--- a/src/agent_bom/parsers/compiled_parsers.py
+++ b/src/agent_bom/parsers/compiled_parsers.py
@@ -19,6 +19,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+import httpx
+
 from agent_bom.models import MCPServer, Package
 
 logger = logging.getLogger(__name__)
@@ -125,7 +127,7 @@ def verify_go_checksums(
             from agent_bom.http_client import fetch_bytes
 
             body = fetch_bytes(lookup_url, timeout=timeout).decode("utf-8", errors="replace")
-        except (OSError, ValueError, ConnectionError) as exc:
+        except (OSError, ValueError, ConnectionError, RuntimeError, httpx.HTTPError) as exc:
             logger.warning(
                 "go.sum verification skipped for %s — checksum DB unreachable: %s",
                 key,

--- a/tests/test_go_integrity.py
+++ b/tests/test_go_integrity.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import textwrap
 from unittest.mock import patch
 
+import httpx
 import pytest
 
 from agent_bom.parsers.compiled_parsers import (
@@ -192,6 +193,21 @@ class TestVerifyGoChecksumsNetworkFailure:
         modules = [("github.com/gin-gonic/gin", "v1.9.1")]
 
         with patch("agent_bom.http_client.fetch_bytes", side_effect=OSError("timeout")):
+            result = verify_go_checksums(go_sum, modules)
+
+        assert "github.com/gin-gonic/gin@v1.9.1" not in result
+
+    def test_http_status_error_returns_gracefully(self, tmp_path):
+        go_sum = tmp_path / "go.sum"
+        go_sum.write_text(GO_SUM_CONTENT)
+        modules = [("github.com/gin-gonic/gin", "v1.9.1")]
+        request = httpx.Request("GET", "https://sum.golang.org/lookup/github.com/gin-gonic/gin@v1.9.1")
+        response = httpx.Response(400, request=request)
+
+        with patch(
+            "agent_bom.http_client.fetch_bytes",
+            side_effect=httpx.HTTPStatusError("bad checksum lookup", request=request, response=response),
+        ):
             result = verify_go_checksums(go_sum, modules)
 
         assert "github.com/gin-gonic/gin@v1.9.1" not in result


### PR DESCRIPTION
Summary
- treats checksum DB HTTP failures and offline-mode blocks as optional Go checksum verification misses instead of aborting scans
- keeps checksum matches/verdicts unchanged when the checksum DB is reachable
- adds a regression for httpx HTTPStatusError from sum.golang.org lookups

Public repo proof
- Before: a Go-heavy public repo scan aborted on a sum.golang.org 400 response.
- After: the same repo scan completed and emitted inventory/findings/blast-radius output.

Validation
- uv run pytest tests/test_go_integrity.py::TestVerifyGoChecksumsNetworkFailure -q
- uv run ruff check src/agent_bom/parsers/compiled_parsers.py tests/test_go_integrity.py
- uv run ruff format --check src/agent_bom/parsers/compiled_parsers.py tests/test_go_integrity.py