### PR TITLE
fix(compliance): normalize pci-dss slug alias and SAML install hint (#3439)

### DIFF
--- a/docs/TENANT_RESOLUTION.md
+++ b/docs/TENANT_RESOLUTION.md
@@ -16,7 +16,7 @@ Source of truth: authenticated identity at the request boundary.
 | API key (RBAC) | `KeyStore.verify(raw_key).tenant_id` — bound at key-create time |
 | OIDC bearer | `AGENT_BOM_OIDC_TENANT_CLAIM` (default `tenant_id`) extracted from the JWT |
 | OIDC tenant providers | The matching tenant from `AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON` issuer match |
-| SAML | `Tenant ID` SAML attribute from the assertion |
+| SAML | `Tenant ID` SAML attribute from the assertion (requires `pip install 'agent-bom[saml]'`) |
 | Trusted proxy | `X-Agent-Bom-Tenant-ID` header — only honoured when `AGENT_BOM_TRUST_PROXY_AUTH_SECRET` matches |
 | SCIM | `AGENT_BOM_SCIM_TENANT_ID` for the legacy single token, or `AGENT_BOM_SCIM_BEARER_TOKENS_JSON` for per-tenant bearer tokens (server-side, never from request payload) |
 

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -869,12 +869,14 @@ async def get_compliance_narrative_by_framework(request: Request, framework: str
     Returns the same structure as GET /v1/compliance/narrative but scoped
     to a single framework's controls.
     """
+    from agent_bom.compliance_coverage import normalize_framework_slug
     from agent_bom.output.compliance_narrative import (
         ALL_FRAMEWORK_SLUGS,
         generate_compliance_narrative,
     )
 
-    if framework.lower() not in ALL_FRAMEWORK_SLUGS:
+    canonical = normalize_framework_slug(framework)
+    if canonical not in ALL_FRAMEWORK_SLUGS:
         raise HTTPException(
             status_code=400,
             detail=(f"Unknown framework '{framework}'. Supported: {', '.join(ALL_FRAMEWORK_SLUGS)}"),
@@ -890,7 +892,7 @@ async def get_compliance_narrative_by_framework(request: Request, framework: str
             "generated_at": "",
         }
 
-    narrative: ComplianceNarrative = generate_compliance_narrative(report, framework=framework.lower())
+    narrative: ComplianceNarrative = generate_compliance_narrative(report, framework=canonical)
     return _narrative_to_dict(narrative)
 
 
@@ -998,11 +1000,12 @@ async def get_compliance_by_framework(request: Request, framework: str) -> dict:
 
     full = await get_compliance(request)
 
-    from agent_bom.compliance_coverage import framework_output_key_by_slug
+    from agent_bom.compliance_coverage import framework_output_key_by_slug, normalize_framework_slug
 
     framework_map = framework_output_key_by_slug()
 
-    key = framework_map.get(framework.lower())
+    canonical = normalize_framework_slug(framework)
+    key = framework_map.get(canonical)
     if not key:
         supported = [*framework_map.keys(), "aisvs"]
         raise HTTPException(
@@ -1822,6 +1825,7 @@ async def ingest_compliance_findings(request: Request) -> dict:
     from pathlib import Path
 
     from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+    from agent_bom.compliance_coverage import normalize_framework_slug
     from agent_bom.compliance_hub_ingest import ingest_findings
 
     body = await request.json()
@@ -1857,6 +1861,12 @@ async def ingest_compliance_findings(request: Request) -> dict:
         )
 
     payloads = [f.to_dict() for f in findings]
+    for payload in payloads:
+        frameworks = payload.get("applicable_frameworks")
+        if isinstance(frameworks, list):
+            payload["applicable_frameworks"] = [
+                normalize_framework_slug(str(slug)) for slug in frameworks if slug
+            ]
     tenant_id = _tenant_id(request)
     store = get_compliance_hub_store()
     new_total = store.add(tenant_id, payloads)
@@ -1905,7 +1915,7 @@ async def get_hub_posture(request: Request) -> dict:
     single posture story across every entry point.
     """
     from agent_bom.api.compliance_hub_store import get_compliance_hub_store
-    from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS
+    from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS, normalize_framework_slug
 
     tenant_id = _tenant_id(request)
     hub_findings = get_compliance_hub_store().list(tenant_id)
@@ -1937,7 +1947,8 @@ async def get_hub_posture(request: Request) -> dict:
         sev = (f.get("severity") or "unknown").lower()
         hub_severity_counts[sev] = hub_severity_counts.get(sev, 0) + 1
         for slug in f.get("applicable_frameworks") or []:
-            hub_framework_counts[slug] = hub_framework_counts.get(slug, 0) + 1
+            canonical = normalize_framework_slug(str(slug))
+            hub_framework_counts[canonical] = hub_framework_counts.get(canonical, 0) + 1
 
     combined: dict[str, int] = {}
     for slug, count in native_framework_counts.items():

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -995,8 +995,13 @@ async def delete_key(request: Request, key_id: str) -> None:
 @router.get("/v1/auth/saml/metadata", tags=["enterprise"])
 async def saml_metadata() -> PlainTextResponse:
     """Return SP metadata XML for enterprise IdP configuration."""
-    from agent_bom.api.saml import SAMLConfig, SAMLError
+    from agent_bom.api.saml import SAML_INSTALL_HINT, SAMLConfig, SAMLError, saml_runtime_available
 
+    if not saml_runtime_available():
+        raise HTTPException(
+            status_code=503,
+            detail=f"SAML SSO requires the optional [saml] extra. Install with: {SAML_INSTALL_HINT}",
+        )
     try:
         metadata = SAMLConfig.from_env().metadata_xml()
     except SAMLError as exc:
@@ -1020,8 +1025,13 @@ async def saml_login(req: SAMLLoginRequest) -> dict:
     """Verify a SAML assertion and return a short-lived API key."""
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.auth import Role, create_api_key, get_key_store
-    from agent_bom.api.saml import SAMLConfig, SAMLError
+    from agent_bom.api.saml import SAML_INSTALL_HINT, SAMLConfig, SAMLError, saml_runtime_available
 
+    if not saml_runtime_available():
+        raise HTTPException(
+            status_code=503,
+            detail=f"SAML SSO requires the optional [saml] extra. Install with: {SAML_INSTALL_HINT}",
+        )
     try:
         _consume_saml_relay_state(req.relay_state)
         cfg = SAMLConfig.from_env()

--- a/src/agent_bom/api/saml.py
+++ b/src/agent_bom/api/saml.py
@@ -38,6 +38,19 @@ class SAMLError(Exception):
     """Raised when SAML configuration or assertion verification fails."""
 
 
+SAML_INSTALL_HINT = "pip install 'agent-bom[saml]'"
+
+
+def saml_runtime_available() -> bool:
+    """Return True when the optional ``[saml]`` extra (python3-saml) is installed."""
+    try:
+        import onelogin.saml2.auth  # noqa: F401
+        import onelogin.saml2.settings  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 def _env_flag(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes"}
 
@@ -50,11 +63,8 @@ def _optional_env_flag(name: str) -> bool | None:
 
 
 def _check_saml_support() -> None:
-    try:
-        import onelogin.saml2.auth  # noqa: F401
-        import onelogin.saml2.settings  # noqa: F401
-    except ImportError as exc:
-        raise SAMLError("SAML support requires python3-saml: pip install 'agent-bom[saml]'") from exc
+    if not saml_runtime_available():
+        raise SAMLError(f"SAML SSO requires the optional [saml] extra. Install with: {SAML_INSTALL_HINT}")
 
 
 def _normalize_saml_attributes(attributes: dict[str, Any]) -> dict[str, Any]:
@@ -271,19 +281,32 @@ class SAMLConfig:
 def describe_saml_posture() -> dict[str, object]:
     """Return operator-facing SAML posture for auth policy surfaces."""
     config = SAMLConfig.from_env()
-    if not config.enabled:
+    common: dict[str, object] = {
+        "supported": True,
+        "runtime_available": saml_runtime_available(),
+        "install_hint": SAML_INSTALL_HINT,
+        "metadata_endpoint": "/v1/auth/saml/metadata",
+        "role_attribute": config.role_attribute,
+        "tenant_attribute": config.tenant_attribute,
+        "require_role_attribute": config.require_role_attribute,
+        "require_tenant_attribute": config.require_tenant_attribute,
+        "allow_default_tenant": config.allow_default_tenant,
+        "session_ttl_seconds": config.session_ttl_seconds,
+    }
+    if not common["runtime_available"]:
         return {
-            "supported": True,
+            **common,
             "configured": False,
-            "metadata_endpoint": "/v1/auth/saml/metadata",
             "acs_path": None,
             "idp_host": None,
-            "role_attribute": config.role_attribute,
-            "tenant_attribute": config.tenant_attribute,
-            "require_role_attribute": config.require_role_attribute,
-            "require_tenant_attribute": config.require_tenant_attribute,
-            "allow_default_tenant": config.allow_default_tenant,
-            "session_ttl_seconds": config.session_ttl_seconds,
+            "message": f"SAML SSO requires the optional [saml] extra. Install with: {SAML_INSTALL_HINT}",
+        }
+    if not config.enabled:
+        return {
+            **common,
+            "configured": False,
+            "acs_path": None,
+            "idp_host": None,
             "message": (
                 "SAML assertion exchange is not configured. When enabled, agent-bom verifies the IdP assertion and mints "
                 "a short-lived session API key for the UI."
@@ -292,16 +315,9 @@ def describe_saml_posture() -> dict[str, object]:
 
     acs = urlparse(config.sp_acs_url)
     return {
-        "supported": True,
+        **common,
         "configured": True,
-        "metadata_endpoint": "/v1/auth/saml/metadata",
         "acs_path": acs.path or "/v1/auth/saml/login",
         "idp_host": urlparse(config.idp_sso_url).netloc or config.idp_sso_url,
-        "role_attribute": config.role_attribute,
-        "tenant_attribute": config.tenant_attribute,
-        "require_role_attribute": config.require_role_attribute,
-        "require_tenant_attribute": config.require_tenant_attribute,
-        "allow_default_tenant": config.allow_default_tenant,
-        "session_ttl_seconds": config.session_ttl_seconds,
         "message": "SAML assertion exchange is enabled and mints short-lived session API keys after IdP verification.",
     }

--- a/src/agent_bom/compliance_coverage.py
+++ b/src/agent_bom/compliance_coverage.py
@@ -274,6 +274,20 @@ TAG_MAPPED_FRAMEWORKS: tuple[ComplianceFrameworkMetadata, ...] = (
     ),
 )
 
+# Canonical hyphenated slugs (``TAG_MAPPED_FRAMEWORKS``) vs legacy ingest aliases.
+FRAMEWORK_SLUG_ALIASES: dict[str, str] = {
+    "mitre-attack": "attack",
+    "mitre_attack": "attack",
+    "pci_dss": "pci-dss",
+}
+
+
+def normalize_framework_slug(slug: str) -> str:
+    """Normalize API/ingest framework slugs to canonical hyphenated form."""
+    normalized = slug.strip().lower().replace("_", "-")
+    return FRAMEWORK_SLUG_ALIASES.get(normalized, normalized)
+
+
 AISVS_BENCHMARK = ComplianceBenchmarkMetadata(
     family="OWASP",
     framework="AISVS v1.0",

--- a/src/agent_bom/compliance_hub.py
+++ b/src/agent_bom/compliance_hub.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from agent_bom.compliance_coverage import normalize_framework_slug
 from agent_bom.finding import FindingSource, FindingType
 
 if TYPE_CHECKING:
@@ -219,7 +220,14 @@ def apply_hub_classification(finding: "Finding", *, include_gov: bool = False) -
         finding_type=finding.finding_type,
         include_gov=include_gov,
     )
-    seen = set(finding.applicable_frameworks)
+    seen: set[str] = set()
+    normalized_frameworks: list[str] = []
+    for slug in finding.applicable_frameworks:
+        canonical = normalize_framework_slug(str(slug))
+        if canonical not in seen:
+            seen.add(canonical)
+            normalized_frameworks.append(canonical)
+    finding.applicable_frameworks = normalized_frameworks
     for slug in selected:
         if slug not in seen:
             finding.applicable_frameworks.append(slug)

--- a/src/agent_bom/output/compliance_narrative.py
+++ b/src/agent_bom/output/compliance_narrative.py
@@ -32,6 +32,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport
 
+from agent_bom.compliance_coverage import FRAMEWORK_SLUG_ALIASES, normalize_framework_slug
+
 # ─── Catalogue lookups ────────────────────────────────────────────────────────
 # Imported lazily where needed to keep top-level import cost low.
 
@@ -77,16 +79,7 @@ def _all_framework_slugs() -> list[str]:
 
 
 ALL_FRAMEWORK_SLUGS: list[str] = _all_framework_slugs()
-FRAMEWORK_SLUG_ALIASES: dict[str, str] = {
-    "mitre-attack": "attack",
-    "mitre_attack": "attack",
-}
 ACCEPTED_FRAMEWORK_SLUGS: list[str] = [*ALL_FRAMEWORK_SLUGS, *FRAMEWORK_SLUG_ALIASES]
-
-
-def normalize_framework_slug(slug: str) -> str:
-    normalized = slug.strip().lower()
-    return FRAMEWORK_SLUG_ALIASES.get(normalized, normalized)
 
 
 # ─── Dataclasses ─────────────────────────────────────────────────────────────

--- a/tests/test_api_operator_policy.py
+++ b/tests/test_api_operator_policy.py
@@ -721,6 +721,7 @@ def test_auth_policy_reports_identity_provider_posture(monkeypatch: pytest.Monke
     monkeypatch.setenv("AGENT_BOM_SAML_SP_ENTITY_ID", "https://agent-bom.example.com/saml/metadata")
     monkeypatch.setenv("AGENT_BOM_SAML_SP_ACS_URL", "https://agent-bom.example.com/v1/auth/saml/login")
     monkeypatch.setenv("AGENT_BOM_SAML_SESSION_TTL_SECONDS", "1800")
+    monkeypatch.setattr("agent_bom.api.saml.saml_runtime_available", lambda: True)
 
     client = TestClient(app)
     body = client.get("/v1/auth/policy").json()

--- a/tests/test_api_saml.py
+++ b/tests/test_api_saml.py
@@ -9,7 +9,14 @@ from fastapi import HTTPException
 from agent_bom.api.auth import KeyStore, get_key_store, set_key_store
 from agent_bom.api.models import SAMLLoginRequest
 from agent_bom.api.routes import enterprise
-from agent_bom.api.saml import SAMLConfig, SAMLError, saml_attributes_to_role, saml_attributes_to_tenant
+from agent_bom.api.saml import (
+    SAML_INSTALL_HINT,
+    SAMLConfig,
+    SAMLError,
+    describe_saml_posture,
+    saml_attributes_to_role,
+    saml_attributes_to_tenant,
+)
 from agent_bom.api.shared_auth_state import reset_auth_state_for_tests
 
 
@@ -305,3 +312,36 @@ async def test_saml_login_rejects_invalid_assertion(isolated_key_store, monkeypa
 
     assert error.value.status_code == 401
     assert error.value.detail == "bad saml"
+
+
+def test_describe_saml_posture_reports_missing_extra(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("agent_bom.api.saml.saml_runtime_available", lambda: False)
+
+    posture = describe_saml_posture()
+
+    assert posture["runtime_available"] is False
+    assert posture["install_hint"] == SAML_INSTALL_HINT
+    assert posture["configured"] is False
+    assert SAML_INSTALL_HINT in str(posture["message"])
+
+
+@pytest.mark.asyncio
+async def test_saml_metadata_returns_install_hint_when_extra_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("agent_bom.api.saml.saml_runtime_available", lambda: False)
+
+    with pytest.raises(HTTPException) as error:
+        await enterprise.saml_metadata()
+
+    assert error.value.status_code == 503
+    assert SAML_INSTALL_HINT in error.value.detail
+
+
+@pytest.mark.asyncio
+async def test_saml_login_returns_install_hint_when_extra_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("agent_bom.api.saml.saml_runtime_available", lambda: False)
+
+    with pytest.raises(HTTPException) as error:
+        await enterprise.saml_login(SAMLLoginRequest(saml_response="assertion", relay_state="nonce"))
+
+    assert error.value.status_code == 503
+    assert SAML_INSTALL_HINT in error.value.detail

--- a/tests/test_api_saml.py
+++ b/tests/test_api_saml.py
@@ -74,6 +74,12 @@ def isolated_key_store():
         reset_auth_state_for_tests()
 
 
+@pytest.fixture
+def saml_runtime_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Route tests mock SAMLConfig; opt in to the optional [saml] extra gate."""
+    monkeypatch.setattr("agent_bom.api.saml.saml_runtime_available", lambda: True)
+
+
 def test_saml_config_disabled_when_env_missing():
     with patch.dict(os.environ, {}, clear=True):
         cfg = SAMLConfig.from_env()
@@ -178,7 +184,7 @@ def test_saml_verify_rejects_reserved_tenant_attribute():
 
 
 @pytest.mark.asyncio
-async def test_saml_metadata_route_returns_xml(monkeypatch):
+async def test_saml_metadata_route_returns_xml(monkeypatch, saml_runtime_enabled):
     monkeypatch.setattr("agent_bom.api.saml.SAMLConfig.metadata_xml", lambda self: "<EntityDescriptor />")
 
     response = await enterprise.saml_metadata()
@@ -188,7 +194,7 @@ async def test_saml_metadata_route_returns_xml(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_saml_login_mints_short_lived_api_key(isolated_key_store, monkeypatch):
+async def test_saml_login_mints_short_lived_api_key(isolated_key_store, monkeypatch, saml_runtime_enabled):
     relay = await enterprise.saml_relay_state()
     monkeypatch.setattr(
         "agent_bom.api.saml.SAMLConfig.verify_response",
@@ -215,7 +221,7 @@ async def test_saml_login_mints_short_lived_api_key(isolated_key_store, monkeypa
 
 
 @pytest.mark.asyncio
-async def test_saml_login_rejects_missing_relay_state_by_default(isolated_key_store, monkeypatch):
+async def test_saml_login_rejects_missing_relay_state_by_default(isolated_key_store, monkeypatch, saml_runtime_enabled):
     monkeypatch.setattr(
         "agent_bom.api.saml.SAMLConfig.verify_response",
         lambda self, saml_response, relay_state=None: None,
@@ -229,7 +235,7 @@ async def test_saml_login_rejects_missing_relay_state_by_default(isolated_key_st
 
 
 @pytest.mark.asyncio
-async def test_saml_login_rejects_unissued_relay_state(isolated_key_store, monkeypatch):
+async def test_saml_login_rejects_unissued_relay_state(isolated_key_store, monkeypatch, saml_runtime_enabled):
     monkeypatch.setattr(
         "agent_bom.api.saml.SAMLConfig.verify_response",
         lambda self, saml_response, relay_state=None: None,
@@ -243,7 +249,7 @@ async def test_saml_login_rejects_unissued_relay_state(isolated_key_store, monke
 
 
 @pytest.mark.asyncio
-async def test_saml_relay_state_is_one_time(isolated_key_store, monkeypatch):
+async def test_saml_relay_state_is_one_time(isolated_key_store, monkeypatch, saml_runtime_enabled):
     relay = await enterprise.saml_relay_state()
 
     monkeypatch.setattr(
@@ -270,7 +276,7 @@ async def test_saml_relay_state_is_one_time(isolated_key_store, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_saml_login_rejects_replayed_assertion_with_fresh_relay(isolated_key_store, monkeypatch):
+async def test_saml_login_rejects_replayed_assertion_with_fresh_relay(isolated_key_store, monkeypatch, saml_runtime_enabled):
     first_relay = await enterprise.saml_relay_state()
     second_relay = await enterprise.saml_relay_state()
 
@@ -299,7 +305,7 @@ async def test_saml_login_rejects_replayed_assertion_with_fresh_relay(isolated_k
 
 
 @pytest.mark.asyncio
-async def test_saml_login_rejects_invalid_assertion(isolated_key_store, monkeypatch):
+async def test_saml_login_rejects_invalid_assertion(isolated_key_store, monkeypatch, saml_runtime_enabled):
     relay = await enterprise.saml_relay_state()
 
     def _raise_bad_saml(self, saml_response, relay_state=None):

--- a/tests/test_compliance_coverage.py
+++ b/tests/test_compliance_coverage.py
@@ -12,6 +12,7 @@ from agent_bom.compliance_coverage import (
     TAG_MAPPED_FRAMEWORKS,
     framework_output_key_by_slug,
     framework_report_labels_by_slug,
+    normalize_framework_slug,
     render_compliance_coverage_table,
 )
 
@@ -51,6 +52,12 @@ def test_api_framework_maps_are_derived_from_metadata() -> None:
     assert output_map == {metadata.slug: metadata.output_key for metadata in TAG_MAPPED_FRAMEWORKS}
     assert report_map == {metadata.slug: (metadata.output_key, metadata.report_label) for metadata in TAG_MAPPED_FRAMEWORKS}
     assert output_map["pci-dss"] == "pci_dss"
+
+
+def test_normalize_framework_slug_accepts_pci_dss_aliases() -> None:
+    assert normalize_framework_slug("pci-dss") == "pci-dss"
+    assert normalize_framework_slug("pci_dss") == "pci-dss"
+    assert normalize_framework_slug("PCI_DSS") == "pci-dss"
 
 
 def test_aisvs_coverage_uses_benchmark_registry() -> None:

--- a/tests/test_compliance_hub_api.py
+++ b/tests/test_compliance_hub_api.py
@@ -255,6 +255,26 @@ def test_hub_posture_with_no_findings_returns_zeros():
     assert body["framework_counts"]["hub"] == {}
 
 
+def test_hub_posture_normalizes_pci_dss_framework_slug():
+    """Regression (#3439): hub ingest/posture must count pci_dss under pci-dss."""
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+    get_compliance_hub_store().add(
+        "tenant-alpha",
+        [
+            {
+                "id": "pci-finding-1",
+                "severity": "high",
+                "applicable_frameworks": ["pci_dss"],
+            }
+        ],
+    )
+    body = _client().get("/v1/compliance/hub/posture").json()
+    hub_counts = body["framework_counts"]["hub"]
+    assert hub_counts.get("pci-dss") == 1
+    assert "pci_dss" not in hub_counts
+
+
 def test_hub_posture_native_counts_aggregate_all_15_frameworks():
     """Regression: posture endpoint must aggregate every framework in
     TAG_MAPPED_FRAMEWORKS, not just an inline subset. Previously the


### PR DESCRIPTION
## Summary
- Add `normalize_framework_slug()` in `compliance_coverage.py` so `pci_dss` / `pci-dss` resolve to the canonical `pci-dss` slug at API, ingest, hub classification, and posture aggregation boundaries.
- SAML routes and `describe_saml_posture()` now report `runtime_available` / `install_hint` and return HTTP 503 with `pip install 'agent-bom[saml]'` when the optional extra is missing.
- Document the SAML extra requirement on SSO setup in `docs/TENANT_RESOLUTION.md`.

Fixes #3439

## Test plan
- [x] `uv run ruff check` on touched source + test files
- [x] `uv run pytest -q tests/test_compliance_coverage.py tests/test_compliance_hub_api.py::test_hub_posture_normalizes_pci_dss_framework_slug tests/test_api_saml.py::test_describe_saml_posture_reports_missing_extra tests/test_api_saml.py::test_saml_metadata_returns_install_hint_when_extra_missing tests/test_api_saml.py::test_saml_login_returns_install_hint_when_extra_missing tests/test_api_operator_policy.py::test_auth_policy_reports_identity_provider_posture tests/test_api_data_p1_batch_v0867.py`

Made with [Cursor](https://cursor.com)