### PR TITLE
feat(helm): Alembic pre-upgrade hook; chore(sdks): bump Python SDK (#3433, #3438)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,9 @@ RUN apk add --no-cache build-base ca-certificates git libffi-dev linux-headers \
 
 COPY pyproject.toml README.md PYPI_README.md LICENSE ./
 COPY src/ ./src/
+COPY deploy/supabase/postgres/ ./deploy/supabase/postgres/
 
-RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake]"
+RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake,postgres]"
 
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.6-alpine3.23@sha256:02da11a8d221ca167aa07de20b3cd7104c1f01227f4b02b1fa13cf6517280a81
@@ -48,6 +49,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0"
 # Copy only installed packages from builder (no compiler toolchain or git)
 COPY --from=builder /install /usr/local
 COPY --from=builder /app/LICENSE /app/LICENSE
+COPY --from=builder /app/deploy/supabase/postgres /opt/agent-bom/deploy/supabase/postgres
 
 RUN apk add --no-cache ca-certificates libffi libgcc libstdc++ \
     && apk upgrade --no-cache --available \

--- a/deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
@@ -1,5 +1,8 @@
 controlPlane:
   enabled: true
+  migrations:
+    postgres:
+      enabled: false
   api:
     replicas: 1
     envFrom:

--- a/deploy/helm/agent-bom/templates/NOTES.txt
+++ b/deploy/helm/agent-bom/templates/NOTES.txt
@@ -1,3 +1,24 @@
+{{- if not .Values.controlPlane.enabled }}
+================================================================================
+  SCANNER-ONLY DEPLOYMENT (controlPlane.enabled=false)
+================================================================================
+
+This release deploys ONLY the scheduled Kubernetes scanner CronJob and its
+supporting RBAC. The REST API, dashboard, gateway, proxy, firewall, MCP server,
+and Postgres-backed control plane are NOT included.
+
+To deploy the full self-hosted platform, upgrade with:
+
+  helm upgrade {{ .Release.Name }} {{ .Chart.Name }} \
+    --namespace {{ .Release.Namespace }} \
+    --reuse-values \
+    --set controlPlane.enabled=true
+
+See deploy/helm/agent-bom/README.md and site-docs/deployment/control-plane-helm.md
+for production profiles, Postgres provisioning, and ingress guidance.
+
+================================================================================
+{{- else }}
 Enterprise pilot notes:
 
 - The chart does not provision Postgres. Production profiles expect an
@@ -6,16 +27,27 @@ Enterprise pilot notes:
   `deploy/helm/agent-bom/examples/postgres-secret.example.yaml` for the
   Kubernetes Secret shape and `site-docs/deployment/postgres-provisioning.md`
   for the ownership contract.
+{{- if .Values.controlPlane.migrations.postgres.enabled }}
+- Postgres migrations run automatically via a Helm pre-install/pre-upgrade hook
+  (`alembic -c deploy/supabase/postgres/alembic.ini upgrade head`). A failed
+  migration fails the release loudly — inspect the hook Job
+  `{{ include "agent-bom.name" . }}-postgres-migrate` before retrying.
+- For existing databases bootstrapped from `init.sql`, stamp the baseline once
+  before the first hooked upgrade:
+  `alembic -c deploy/supabase/postgres/alembic.ini stamp 20260416_01`.
+{{- else }}
+- SQLite pilot mode skips the Alembic migration hook. Do not use SQLite for
+  multi-replica production control planes.
+{{- end }}
 - Set `AGENT_BOM_AUDIT_HMAC_KEY` in the control-plane secret.
 - Production and multi-replica control planes fail closed when `AGENT_BOM_AUDIT_HMAC_KEY` is missing.
   Keep `AGENT_BOM_REQUIRE_AUDIT_HMAC=1` set for explicit policy evidence.
 - Use Postgres for the pilot control plane; SQLite is not the multi-replica path.
 - Prefer internal ingress / VPN-only exposure for the API and UI.
-- Run Alembic before first multi-replica rollout: `alembic -c deploy/supabase/postgres/alembic.ini upgrade head`.
-- For existing databases bootstrapped from `init.sql`, stamp the baseline first: `alembic -c deploy/supabase/postgres/alembic.ini stamp 20260416_01`.
 - Label the namespace with Pod Security Admission restricted mode before applying sidecars:
   `kubectl label namespace {{ .Release.Namespace }} pod-security.kubernetes.io/enforce=restricted pod-security.kubernetes.io/audit=restricted pod-security.kubernetes.io/warn=restricted --overwrite`
 - The focused EKS pilot values lock ingress down; adjust `networkPolicy.ingress` if your ingress controller does not run in `ingress-nginx`.
 - For production operator defaults, start from `deploy/helm/agent-bom/examples/eks-production-values.yaml`.
 - `sidecarInjection.enabled=true` requires cert-manager because the chart packages
   the webhook TLS certificate and CA injection path.
+{{- end }}

--- a/deploy/helm/agent-bom/templates/controlplane-alembic-migration-job.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-alembic-migration-job.yaml
@@ -1,0 +1,65 @@
+{{- if and .Values.controlPlane.enabled .Values.controlPlane.migrations.enabled .Values.controlPlane.migrations.postgres.enabled }}
+{{- $migrations := .Values.controlPlane.migrations }}
+{{- $envFrom := $migrations.envFrom }}
+{{- if not $envFrom }}
+{{- $envFrom = .Values.controlPlane.api.envFrom }}
+{{- end }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "agent-bom.name" . }}-postgres-migrate
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "agent-bom.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres-migration
+  annotations:
+    helm.sh/hook: {{ $migrations.hooks | quote }}
+    helm.sh/hook-weight: {{ $migrations.hookWeight | quote }}
+    helm.sh/hook-delete-policy: {{ $migrations.deletePolicy | quote }}
+spec:
+  ttlSecondsAfterFinished: {{ $migrations.ttlSecondsAfterFinished }}
+  backoffLimit: {{ $migrations.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "agent-bom.labels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres-migration
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: alembic
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          workingDir: {{ $migrations.workingDir | quote }}
+          command:
+            - alembic
+            - -c
+            - {{ $migrations.alembicConfig | quote }}
+            - upgrade
+            - head
+          env:
+            {{- with $migrations.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml $migrations.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/deploy/helm/agent-bom/templates/cronjob.yaml
+++ b/deploy/helm/agent-bom/templates/cronjob.yaml
@@ -9,6 +9,12 @@ metadata:
   labels:
     {{- include "agent-bom.labels" . | nindent 4 }}
     app.kubernetes.io/component: scanner
+  {{- if not .Values.controlPlane.enabled }}
+  annotations:
+    agent-bom.io/scanner-only-warning: >-
+      controlPlane.enabled=false — only the scanner CronJob is deployed.
+      Enable the API/UI/gateway with --set controlPlane.enabled=true.
+  {{- end }}
 spec:
   schedule: {{ .Values.scanner.schedule | quote }}
   concurrencyPolicy: Forbid

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -583,6 +583,27 @@ controlPlane:
       creationPolicy: Owner
     data: []
     secrets: []
+  migrations:
+    enabled: true
+    postgres:
+      enabled: true
+    hooks: pre-upgrade,pre-install
+    hookWeight: "-10"
+    deletePolicy: before-hook-creation,hook-succeeded
+    backoffLimit: 0
+    ttlSecondsAfterFinished: 600
+    alembicConfig: deploy/supabase/postgres/alembic.ini
+    workingDir: /opt/agent-bom
+    env: []
+    # When empty, the hook inherits controlPlane.api.envFrom (Postgres URL secret).
+    envFrom: []
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
   backup:
     enabled: false
     schedule: "0 3 * * *"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,12 @@ graph = [
     "scipy>=1.13",
 ]
 pdf = []
-postgres = ["psycopg[binary]>=3.1", "psycopg-pool>=3.1"]
+postgres = [
+    "psycopg[binary]>=3.1",
+    "psycopg-pool>=3.1",
+    "alembic>=1.13",
+    "sqlalchemy>=2.0",
+]
 watch = ["watchdog>=4.0"]
 runtime = [
     "psutil>=5.9",  # Process + container discovery (--include-processes)

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agent-bom-sdk"
-version = "0.90.0"
+version = "0.92.0"
 description = "Thin Python alias that re-exports the packaged agent-bom control-plane client."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -583,6 +583,7 @@ def _job_summary_payload(job: ScanJob) -> dict[str, Any]:
 
     result = job.result if isinstance(job.result, dict) else {}
     summary = result.get("summary") if isinstance(result.get("summary"), dict) else None
+    aggregation = result.get("aggregation") if isinstance(result.get("aggregation"), dict) else None
     scan_run = result.get("scan_run") if isinstance(result.get("scan_run"), dict) else None
     generated_at = result.get("generated_at") or (scan_run or {}).get("generated_at")
     scan_timestamp = result.get("scan_timestamp") or generated_at
@@ -603,6 +604,7 @@ def _job_summary_payload(job: ScanJob) -> dict[str, Any]:
         "completed_at": job.completed_at,
         "request": request_payload if isinstance(request_payload, dict) else {},
         "summary": summary,
+        "aggregation": aggregation,
         "scan_timestamp": scan_timestamp,
         "generated_at": generated_at,
         "scan_run": scan_run,
@@ -1165,6 +1167,12 @@ async def list_findings(
     for job in _completed_jobs_for_tenant(tenant_id):
         if scan_id and job.job_id != scan_id:
             continue
+        # Batch parents aggregate their children's evidence; skip them in the
+        # global roll-up so findings are not double-counted against the children
+        # that already contribute. When a caller targets the parent by scan_id
+        # they get the aggregated union instead.
+        if job.child_job_ids and job.job_id != scan_id:
+            continue
         scan_findings.extend(_iter_scan_findings(job))
     if severity:
         normalized = severity.lower()
@@ -1274,6 +1282,10 @@ async def list_inventory(
     agents: list[dict[str, Any]] = []
     jobs: list[dict[str, str]] = []
     for job in _completed_jobs_for_tenant(tenant_id):
+        # Skip batch parents: their aggregated agents duplicate the children
+        # that already contribute to the inventory roll-up.
+        if job.child_job_ids:
+            continue
         result = job.result or {}
         job_agents = [item for item in result.get("agents", []) or [] if isinstance(item, dict)]
         if not job_agents:

--- a/src/agent_bom/api/scan_batches.py
+++ b/src/agent_bom/api/scan_batches.py
@@ -17,6 +17,11 @@ BATCH_LIST_TARGET_FIELDS = (
 )
 BATCH_SINGLE_TARGET_FIELDS = ("inventory", "gha_path", "sbom")
 
+# Parent-only metadata computed by the batch roll-up. These keys are never
+# copied up from child results so aggregation cannot clobber the parent's own
+# batch bookkeeping.
+_PARENT_METADATA_RESULT_KEYS = frozenset({"batch", "summary", "aggregation"})
+
 
 def scan_request_targets(request: ScanRequest) -> list[dict[str, Any]]:
     """Return explicit top-level scan targets that can be fanned out."""
@@ -73,6 +78,39 @@ def child_request_for_target(request: ScanRequest, target: dict[str, Any]) -> Sc
             payload["k8s_namespace"] = value.get("namespace")
 
     return ScanRequest.model_validate(payload)
+
+
+def _aggregate_child_results(children: list[ScanJob]) -> tuple[dict[str, list[Any]], list[str]]:
+    """Merge graph/finding evidence from completed children onto the parent.
+
+    Batch parents historically exposed only per-child roll-up rows, so reading
+    the parent ``job_id`` for graph exports or findings returned empty because
+    the top-level ``agents`` / ``findings`` / ``blast_radius`` fields the read
+    endpoints consume lived on the child results only. This concatenates every
+    top-level *list* field (agents, packages, findings, blast_radius, cloud
+    inventory, …) from successful children into a single parent result so the
+    existing scan read paths surface the union of child evidence.
+
+    Returns the aggregated field map and the child job ids that contributed
+    evidence (used for the explicit aggregation status block).
+    """
+
+    aggregated: dict[str, list[Any]] = {}
+    contributing: list[str] = []
+    for child in children:
+        result = child.result if isinstance(child.result, dict) else None
+        if child.status != JobStatus.DONE or not result:
+            continue
+        contributed = False
+        for key, value in result.items():
+            if key in _PARENT_METADATA_RESULT_KEYS:
+                continue
+            if isinstance(value, list) and value:
+                aggregated.setdefault(key, []).extend(value)
+                contributed = True
+        if contributed:
+            contributing.append(child.job_id)
+    return aggregated, contributing
 
 
 def refresh_batch_parent(parent_job_id: str, *, tenant_id: str | None = None) -> ScanJob | None:
@@ -143,7 +181,30 @@ def refresh_batch_parent(parent_job_id: str, *, tenant_id: str | None = None) ->
         "pending_targets": status_counts[JobStatus.PENDING.value],
         "children": sorted(child_rows, key=lambda row: row.get("target_index") or 0),
     }
-    result = {"batch": batch, "summary": batch}
+
+    aggregated_fields, contributing_children = _aggregate_child_results(children)
+    succeeded = status_counts[JobStatus.DONE.value]
+    if succeeded == total and total > 0:
+        aggregation_status = "complete"
+    elif succeeded > 0:
+        aggregation_status = "partial"
+    elif terminal < total:
+        aggregation_status = "pending"
+    else:
+        aggregation_status = "empty"
+    aggregation = {
+        "status": aggregation_status,
+        "child_job_ids": list(parent.child_job_ids),
+        "contributing_child_job_ids": contributing_children,
+        "target_count": total,
+        "succeeded_targets": succeeded,
+        "aggregated_counts": {key: len(value) for key, value in aggregated_fields.items()},
+    }
+
+    result: dict[str, Any] = dict(aggregated_fields)
+    result["batch"] = batch
+    result["summary"] = batch
+    result["aggregation"] = aggregation
 
     with _job_lock(parent.job_id):
         parent.status = next_status

--- a/src/agent_bom/deploy_profiles.py
+++ b/src/agent_bom/deploy_profiles.py
@@ -31,6 +31,10 @@ def helm_validation_profiles(repo_root: Path) -> list[HelmValidationProfile]:
     examples = helm_example_dir(repo_root)
     return [
         HelmValidationProfile(
+            name="scanner-only",
+            description="Default scanner-only render (controlPlane.enabled=false).",
+        ),
+        HelmValidationProfile(
             name="sqlite-pilot",
             description="Single-node SQLite demo control plane for fast packaged pilots.",
             values_files=(examples / "eks-control-plane-sqlite-pilot-values.yaml",),

--- a/tests/test_api_scan_batches.py
+++ b/tests/test_api_scan_batches.py
@@ -86,6 +86,121 @@ def test_batch_parent_rolls_up_child_results_without_failing_partial_batch(monke
     assert batch["children"][1]["error"] == "image scan failed"
 
 
+def _child_report(image: str, cve: str) -> dict:
+    """Minimal scan-result JSON shaped like a real single-target child scan."""
+    return {
+        "agents": [
+            {
+                "name": image,
+                "type": "custom",
+                "source": "local",
+                "mcp_servers": [
+                    {
+                        "name": f"{image}-server",
+                        "command": "python",
+                        "packages": [
+                            {
+                                "name": "demo-lib",
+                                "version": "1.0.0",
+                                "ecosystem": "pypi",
+                                "vulnerabilities": [{"id": cve, "severity": "critical", "cvss_score": 9.8}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        "findings": [{"id": cve, "vulnerability_id": cve, "package": "demo-lib", "severity": "critical"}],
+        "blast_radius": [{"vulnerability_id": cve, "package": "demo-lib", "severity": "critical", "risk_score": 9.0}],
+        "summary": {"total_agents": 1},
+    }
+
+
+def test_batch_parent_aggregates_child_graph_and_findings(monkeypatch):
+    """Parent read path surfaces the union of child graph/findings (#3435)."""
+    store = _reset_store()
+    monkeypatch.setattr(scan_routes, "submit_scan_job", lambda job: None)
+    parent = scan_routes.enqueue_scan_job(
+        tenant_id="tenant-a",
+        triggered_by="api-test",
+        request_body=ScanRequest(images=["repo/a:latest", "repo/b:latest"], no_scan=True),
+    )
+
+    reports = {
+        parent.child_job_ids[0]: _child_report("repo/a:latest", "CVE-A"),
+        parent.child_job_ids[1]: _child_report("repo/b:latest", "CVE-B"),
+    }
+    for index, (child_id, report) in enumerate(reports.items(), start=1):
+        child = store.get(child_id, tenant_id="tenant-a")
+        assert child is not None
+        child.status = JobStatus.DONE
+        child.completed_at = f"2026-06-24T00:00:0{index}+00:00"
+        child.result = report
+        store.put(child)
+
+    refreshed = scan_routes.refresh_batch_parent(parent.job_id, tenant_id="tenant-a")
+    assert refreshed is not None
+    assert refreshed.status == JobStatus.DONE
+
+    aggregation = refreshed.result["aggregation"]
+    assert aggregation["status"] == "complete"
+    assert set(aggregation["child_job_ids"]) == set(parent.child_job_ids)
+    assert set(aggregation["contributing_child_job_ids"]) == set(parent.child_job_ids)
+    assert aggregation["aggregated_counts"]["agents"] == 2
+
+    # Parent result carries the union of child evidence for read endpoints.
+    assert len(refreshed.result["agents"]) == 2
+    assert {row["vulnerability_id"] for row in refreshed.result["findings"]} == {"CVE-A", "CVE-B"}
+    # Parent batch bookkeeping is preserved alongside the aggregated fields.
+    assert refreshed.result["batch"]["succeeded_targets"] == 2
+
+    # Acceptance criterion: parent graph export is non-empty.
+    graph = scan_routes._graph_export_response(refreshed.result, format="json", mermaid_limit=80)
+    assert isinstance(graph, dict)
+    assert graph["nodes"], "expected non-empty aggregated graph export for batch parent"
+    node_labels = {node["label"] for node in graph["nodes"]}
+    assert {"CVE-A", "CVE-B"} <= node_labels
+
+    # Findings read path over the parent surfaces both children's vulns.
+    parent_findings = scan_routes._iter_scan_findings(refreshed)
+    assert {"CVE-A", "CVE-B"} <= {row.get("vulnerability_id") for row in parent_findings}
+
+
+def test_batch_parent_partial_aggregation_reports_status(monkeypatch):
+    """A partially-complete batch exposes explicit aggregation status + child IDs."""
+    store = _reset_store()
+    monkeypatch.setattr(scan_routes, "submit_scan_job", lambda job: None)
+    parent = scan_routes.enqueue_scan_job(
+        tenant_id="tenant-a",
+        triggered_by="api-test",
+        request_body=ScanRequest(images=["repo/a:latest", "repo/b:latest"], no_scan=True),
+    )
+
+    child_ok = store.get(parent.child_job_ids[0], tenant_id="tenant-a")
+    child_failed = store.get(parent.child_job_ids[1], tenant_id="tenant-a")
+    assert child_ok is not None and child_failed is not None
+
+    child_ok.status = JobStatus.DONE
+    child_ok.completed_at = "2026-06-24T00:00:01+00:00"
+    child_ok.result = _child_report("repo/a:latest", "CVE-A")
+    store.put(child_ok)
+
+    child_failed.status = JobStatus.FAILED
+    child_failed.completed_at = "2026-06-24T00:00:02+00:00"
+    child_failed.error = "image scan failed"
+    store.put(child_failed)
+
+    refreshed = scan_routes.refresh_batch_parent(parent.job_id, tenant_id="tenant-a")
+    assert refreshed is not None
+    aggregation = refreshed.result["aggregation"]
+    assert aggregation["status"] == "partial"
+    assert aggregation["succeeded_targets"] == 1
+    assert set(aggregation["child_job_ids"]) == set(parent.child_job_ids)
+    assert aggregation["contributing_child_job_ids"] == [child_ok.job_id]
+    # Only the successful child's evidence is aggregated.
+    assert {row["vulnerability_id"] for row in refreshed.result["findings"]} == {"CVE-A"}
+
+
 def test_single_target_scan_request_keeps_single_job_shape(monkeypatch):
     _reset_store()
     submitted: list[str] = []

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -739,3 +739,38 @@ def test_pilot_and_production_values_narrow_ingress_to_controller_pods_and_ports
         assert source["namespaceSelector"]["matchLabels"]["kubernetes.io/metadata.name"] == "ingress-nginx"
         assert source["podSelector"]["matchLabels"]["app.kubernetes.io/component"] == "controller"
         assert ports == {3000, 8422}
+
+
+def test_helm_migrations_defaults():
+    """Postgres migrations hook ships enabled for control-plane Postgres profiles."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    migrations = doc["controlPlane"]["migrations"]
+    assert migrations["enabled"] is True
+    assert migrations["postgres"]["enabled"] is True
+    assert migrations["backoffLimit"] == 0
+    assert migrations["hooks"] == "pre-upgrade,pre-install"
+    assert migrations["alembicConfig"] == "deploy/supabase/postgres/alembic.ini"
+
+
+def test_alembic_migration_hook_template():
+    """Postgres migrations should run as a fail-loud Helm pre-upgrade hook."""
+    template = (HELM_DIR / "templates" / "controlplane-alembic-migration-job.yaml").read_text()
+    assert "controlPlane.migrations.postgres.enabled" in template
+    assert 'helm.sh/hook: {{ $migrations.hooks | quote }}' in template
+    assert "alembic" in template
+    assert "upgrade" in template
+    assert "head" in template
+    assert "backoffLimit: {{ $migrations.backoffLimit }}" in template
+
+
+def test_scanner_only_cronjob_warning_annotation():
+    """Scanner-only renders should surface an install-time warning annotation."""
+    template = (HELM_DIR / "templates" / "cronjob.yaml").read_text()
+    assert "agent-bom.io/scanner-only-warning" in template
+    assert "controlPlane.enabled=true" in template
+
+
+def test_sqlite_pilot_disables_postgres_migration_hook():
+    """SQLite pilot should not render the Alembic migration hook."""
+    doc = yaml.safe_load((HELM_DIR / "examples" / "eks-control-plane-sqlite-pilot-values.yaml").read_text())
+    assert doc["controlPlane"]["migrations"]["postgres"]["enabled"] is False

--- a/tests/test_deploy_profiles.py
+++ b/tests/test_deploy_profiles.py
@@ -14,6 +14,7 @@ def test_helm_validation_profiles_reference_existing_chart_assets():
     assert chart_dir.exists()
     profiles = helm_validation_profiles(repo_root)
     assert [profile.name for profile in profiles] == [
+        "scanner-only",
         "sqlite-pilot",
         "focused-pilot",
         "focused-pilot-byo-postgres",

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -555,9 +555,9 @@ def test_dockerfiles_support_proxy_and_ca_contract():
 
 
 def test_primary_api_image_includes_snowflake_extra_for_snowflake_backend():
-    """The default API image must contain the Snowflake connector for the Snowflake Helm profile."""
+    """The default API image must contain Snowflake and Postgres extras for Helm profiles."""
     content = (ROOT / "Dockerfile").read_text()
-    assert 'pip install --no-cache-dir --prefix=/install ".[api,snowflake]"' in content
+    assert 'pip install --no-cache-dir --prefix=/install ".[api,snowflake,postgres]"' in content
 
 
 def test_runtime_dockerfile_builds_from_repo_source():

--- a/uv.lock
+++ b/uv.lock
@@ -55,6 +55,7 @@ ai-enrich = [
     { name = "litellm" },
 ]
 all = [
+    { name = "alembic" },
     { name = "azure-ai-projects" },
     { name = "azure-containerregistry" },
     { name = "azure-identity" },
@@ -128,6 +129,7 @@ all = [
     { name = "six" },
     { name = "smithery" },
     { name = "snowflake-connector-python" },
+    { name = "sqlalchemy" },
     { name = "sse-starlette" },
     { name = "streamlit" },
     { name = "uvicorn", extra = ["standard"] },
@@ -251,6 +253,7 @@ dev = [
     { name = "types-toml" },
 ]
 dev-all = [
+    { name = "alembic" },
     { name = "bandit" },
     { name = "fastapi" },
     { name = "mcp" },
@@ -270,6 +273,7 @@ dev-all = [
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "smithery" },
+    { name = "sqlalchemy" },
     { name = "sse-starlette" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
@@ -327,8 +331,10 @@ otel = [
     { name = "protobuf" },
 ]
 postgres = [
+    { name = "alembic" },
     { name = "psycopg", extra = ["binary"] },
     { name = "psycopg-pool" },
+    { name = "sqlalchemy" },
 ]
 runtime = [
     { name = "cryptography" },
@@ -387,6 +393,7 @@ requires-dist = [
     { name = "agent-bom", extras = ["visual"], marker = "extra == 'all'" },
     { name = "agent-bom", extras = ["wandb"], marker = "extra == 'cloud'" },
     { name = "agent-bom", extras = ["watch"], marker = "extra == 'all'" },
+    { name = "alembic", marker = "extra == 'postgres'", specifier = ">=1.13" },
     { name = "azure-ai-projects", marker = "extra == 'azure'", specifier = ">=1.0" },
     { name = "azure-containerregistry", marker = "extra == 'azure'", specifier = ">=1.2" },
     { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.15" },
@@ -484,6 +491,7 @@ requires-dist = [
     { name = "six", marker = "extra == 'azure'", specifier = ">=1.17.0" },
     { name = "smithery", marker = "extra == 'mcp-server'", specifier = ">=0.4" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.6" },
+    { name = "sqlalchemy", marker = "extra == 'postgres'", specifier = ">=2.0" },
     { name = "sse-starlette", marker = "extra == 'api'", specifier = ">=2.1" },
     { name = "streamlit", marker = "extra == 'dashboard'", specifier = ">=1.55.0" },
     { name = "toml", specifier = ">=0.10" },
@@ -636,6 +644,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "alembic"
+version = "1.18.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/cc/ac0bed8e562e7407fe55c3ba85a4dce86e6dbd8730887bd1e406a6c5c18a/alembic-1.18.5.tar.gz", hash = "sha256:1554982221dd17e9a749b53902407578eb305e453f71999e8c7f0a48389fff8e", size = 2060480, upload-time = "2026-06-25T15:20:54.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/78/5fe6dc3a3a5b2f5a2a4faef8bfe336d5fa049a38884ab3172e0098160c01/alembic-1.18.5-py3-none-any.whl", hash = "sha256:06d8ba9d04558022f5395e9317de03d270f3dced49cee01f89fe7a13c26f14bc", size = 264664, upload-time = "2026-06-25T15:20:56.673Z" },
 ]
 
 [[package]]
@@ -2379,6 +2401,69 @@ grpc = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/58/5404031044f55afad7aad1aff8be3f22b1bed03e237cfeabbc7e5c8cfde0/greenlet-3.5.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:aca9b4ce85b152b5524ef7d88170efdff80dc0032aa8b75f9aaf7f3479ea95b4", size = 287424, upload-time = "2026-06-26T18:20:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/bf/1c65e9b94a54d547068fa5b5a8a06f221f3316b48908e08668d29c77cb50/greenlet-3.5.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f71be4920368fe1fabeeaa53d1e3548337e2b223d9565f8ad5e392a75ba23fc", size = 606523, upload-time = "2026-06-26T19:07:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/b66baacc95775ad511287acb0137b95574a9ce5491902372b7564799d790/greenlet-3.5.3-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d77e67f65f98449e3fb83f795b5d0a8437aead2f874ca89c96576caf4be3af6", size = 618315, upload-time = "2026-06-26T19:10:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2b/28ed29463522fdbe4c15b1f63922041626a7478316b34ab4adda3f0a4aba/greenlet-3.5.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8540f1e6205bd13ca0ce685581037219ca54a1b41a0a15d228c6c9b8ad5903d7", size = 617381, upload-time = "2026-06-26T18:32:16.077Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7b/ad04e9d1337fc04965dc9fc616b6a72cb65a24b800a014c011ec812f5489/greenlet-3.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7ef56fe650f50575bf843acde967b9c567687f3c22340941a899b7bc56e956a8", size = 1577771, upload-time = "2026-06-26T19:09:01.537Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/33/6c87ab7ba663f70ca21f3022aad1ffe56d3f3e0521e836c2415e13abcc3c/greenlet-3.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5121af01cf911e70056c00d4b46d5e9b5d1415550038573d744138bacb59e6b8", size = 1644048, upload-time = "2026-06-26T18:31:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/35/f0d8ee998b422cf8693b270f098e55d8d4ec8006b061b333f54f177d28d9/greenlet-3.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:0f41e4a05a3c0cb31b17023eff28dd111e1d16bf7d7d00406cd7df23f31398a7", size = 239137, upload-time = "2026-06-26T18:23:21.664Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/96/b9820295576ef18c9edc404f10e260ae7215ceaf3781a54b720ed2627862/greenlet-3.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:ec6f1af59f6b5f3fc9678e2ea062d8377d22ac644f7844cb7a292910cf12ff44", size = 237630, upload-time = "2026-06-26T18:24:00.281Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
+    { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/6fea0e3d6600f785069481ee637e09378dd4118acdfd38ad88ae2db31c98/greenlet-3.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:c4e7b79d83805475f0102008843f6eb45fd3bb0b2e88c774adab5fbaab27117d", size = 238211, upload-time = "2026-06-26T18:22:37.671Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7e/220a7f5824a64a60443fc03b39dfac4ea63a7fb6d481efa27eafa928e7f4/greenlet-3.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:dc133a1569ee667b2a6ef56ce551084aeefd87a5acbc4736d336d1e2edc6cfc4", size = 238141, upload-time = "2026-06-26T18:22:48.507Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/93/43e116ee114b28737ba7e12952a0d4e2f55944d0f84e42bc91ba7192a3c9/greenlet-3.5.3-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:fd2e02fa07485778536a036222d616ab957b1d533f36b3ed98ce725d9c9d3117", size = 288202, upload-time = "2026-06-26T18:23:49.604Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2f/146d218299046a43d1f029fd544b3d110d0f175a09c715c7e8da4a4a345d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df0a0628d1597eb0897b62f55d1343f772405fd25f3b2a796c76874b0c2e22e8", size = 654096, upload-time = "2026-06-26T19:07:12.71Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cc/04738cafb3f45fa991ea44f9de94c47dcec964f5a972300988a6751f49d9/greenlet-3.5.3-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ebd933a6adabc298bab47731a130fe6bfb888bd934eee37810f151159544540d", size = 666304, upload-time = "2026-06-26T19:10:09.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/aa/4e0dad5e605c270c784ab911c43da6adb136ccd4d81180f763ca429a723d/greenlet-3.5.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b9d501b40e80b70e32323c799dd9b420a5577a9601469d362ae1ffb690f3a7c", size = 663635, upload-time = "2026-06-26T18:32:20.802Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/13efdbea246fe3d3b735e191fec08fb50809f53cd2383ebe123d0809e44b/greenlet-3.5.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a1fad1d11e7d6aab184107baa8e4ece11ccba3ec9599cd7efa5ff4d70d43256a", size = 1621252, upload-time = "2026-06-26T19:09:05.647Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/22/c0a336ae4a1410fd5f5121098e5bfbf1865f64c5ef80b4b5412886c4a332/greenlet-3.5.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fad5aec764399f1b5cc347ad250a59660f20c8f8888ea6bae1f93b769cce1154", size = 1684824, upload-time = "2026-06-26T18:31:47.738Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/94/91aec0030bea75c4b3244251d0de60a1f3432d1ecb53ab6c437fb5c3ba61/greenlet-3.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:7669aa24cf2a1041d6f7899575b494a3ab4cf68bfcc8609b1dc0be7272db835e", size = 240754, upload-time = "2026-06-26T18:22:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/06/68d0983e79e02138f64b4d303c500c27ddb48e5e77f3debb80888a921eae/greenlet-3.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:5b4807c4082c9d1b6d9eed56fcd041863e37f2228106eef24c30ca096e238605", size = 239549, upload-time = "2026-06-26T18:22:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/91/95/3e161213d7f1d378d15aa9e792093e9bfe01844680d04b7fd6e0107c9098/greenlet-3.5.3-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:271a8ea7c1024e8a0d7dd2be66dd66dda8a07193f41a17b9e924f7600f5b62be", size = 296389, upload-time = "2026-06-26T18:22:20.657Z" },
+    { url = "https://files.pythonhosted.org/packages/00/92/715c44721abe2b4d1ae9abde4179411868a5bff312479f54e105d372f131/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19131729ae0ddc3c2e1ef85e650169b5e37ee32e400f215f78b94d7b0d567310", size = 653382, upload-time = "2026-06-26T19:07:14.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/83/37a10372a1090a6624cca8e74c12df1a36c2dc36429ed0255b7fb1aeee23/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8", size = 659401, upload-time = "2026-06-26T19:10:10.876Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e2/d1509cad4207da559cc42986ecdd8fc67ad0d1bba2bf03023c467fd5e0f3/greenlet-3.5.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e81fa194a1d20967877bdf9c7794db2bc99063e5be36aee710c08f04c5bb087f", size = 656969, upload-time = "2026-06-26T18:32:22.272Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7d/eaf70de20aadca3a5884aec58362861c64ce45e7b277f47ed026926a3b89/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:55cf4d777485d43110e47133cbba6d74a8885a87ec1227ef0267f9ee80c5aa21", size = 1617822, upload-time = "2026-06-26T19:09:06.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f9/414d38fc400ae4350d4185eaad1827676f7cf5287b9136e0ed1cbbe20a7f/greenlet-3.5.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da", size = 1677983, upload-time = "2026-06-26T18:31:49.396Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/15/7edb977e08f9bff702fe42d6c902702786ff6b9694058b4e6a2a6ac90e57/greenlet-3.5.3-cp314-cp314t-win_amd64.whl", hash = "sha256:efc6bd60ea02e085862c74a3ef64b147ffc6f1a5ea7d9f26e7a939943f68c1e3", size = 243626, upload-time = "2026-06-26T18:24:41.485Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/93928dce91e6b3598b5e779e8d1fd6576a504640c58e78627077f6a7a91a/greenlet-3.5.3-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:ea03f2f04367845d6b58eeed276e1e56e51f0b97d8ad5a88a7d20a91dc9056cc", size = 288860, upload-time = "2026-06-26T18:22:48.07Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ca/69db42d447a1378043e2c8f19c09cbbd1263371505053c496b49066d3d16/greenlet-3.5.3-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78dbef602fda6d97d957eb7937f70c9ce9e9527330347f8f6b6f9e554a9e7a47", size = 659747, upload-time = "2026-06-26T19:07:15.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/0b/af7ac2ef8dd41e3da1a40dda6305c23b9a03e13ba975ec916357b50f8575/greenlet-3.5.3-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f73857adb8fee13fa56c172bd11262f888c0c648f9fea113e777bb2c7904a81", size = 670419, upload-time = "2026-06-26T19:10:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/51/1e/1d51640cacbfc455dbe9f9a9f594c49e4e244f63b9971a2f4764e46cc53d/greenlet-3.5.3-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:232fec92e823addaf02d9472cf7381e24a1d046a6ced1103c5caa4c21b9dfc1d", size = 668787, upload-time = "2026-06-26T18:32:24.298Z" },
+    { url = "https://files.pythonhosted.org/packages/21/66/4030d5b0b5894500023f003bb054d9bb354dfbd1e186c3a296759172f5f5/greenlet-3.5.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:2421c3564da9429d5586d46ca31ebb26516b5498a802cf65c041a8e8a8980d34", size = 1626305, upload-time = "2026-06-26T19:09:08.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/50/5221371c7550108dfa3c378debc41d032aa9c78e89abb01d8011cfc93289/greenlet-3.5.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:e0f0d160f0b2e558e6c75f7930967183255dc9735e5f5b8cae58ee09c9576d8b", size = 1688631, upload-time = "2026-06-26T18:31:51.278Z" },
+    { url = "https://files.pythonhosted.org/packages/68/5d/00d469daae3c65d2bf620b10eee82eb022127d483c6bc8c69fae6f3fbf17/greenlet-3.5.3-cp315-cp315-win_amd64.whl", hash = "sha256:dd99329bbc15ca78dcc583dba05d0b1b0bae01ab6c2174989f5aaee3e41ac930", size = 241027, upload-time = "2026-06-26T18:22:38.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/e8/883785b44c5780ed71e83d3e4437e710470be17a2e181e8b601e2da0dc4a/greenlet-3.5.3-cp315-cp315-win_arm64.whl", hash = "sha256:499fef2acede88c1864a57bb586b4bf533c81e1b82df7ab93451cdb47dfec227", size = 240085, upload-time = "2026-06-26T18:23:54.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/da/4f4a8450962fad137c1c8981a3f1b8919d06c829993d4d476f9c525d5173/greenlet-3.5.3-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:176bc16a721fa5fc294d70b87b4dfa5fbdd251b3da5d5372735ecef9bd7d6d0c", size = 297221, upload-time = "2026-06-26T18:23:27.176Z" },
+    { url = "https://files.pythonhosted.org/packages/57/66/b3bfae3e220a9b63ea539a0eea681800c69ab1aada757eae8789f183e7ce/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:629b614d2b786e89c50440e246f33eea78f58a962d0bdbbcc809e6d13605903f", size = 657221, upload-time = "2026-06-26T19:07:16.973Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/81/b6d4d73a709684fc77e7fa034d7c2fe82cffa9fc920fadcaa659c2626213/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b2e857ae16f5f72142edf75f9f176fe7526ba19a2841df1420516f83831c9f2", size = 663226, upload-time = "2026-06-26T19:10:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/07/e210b02b589f16e74ff48b730690e4a34ffe984219fce4f3c1a0e7ec8545/greenlet-3.5.3-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e515757e2e36bcbf1fad09a46e1557e8b1ae1797d4b44d09da7deed88ad28608", size = 660802, upload-time = "2026-06-26T18:32:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/2e/5303eb3fa06bca089060f479707182a93e360683bc252acf846c3090d34e/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:b363d46ed1ea431825fdb01471bb024fc08399bad1572a616e853c7684415adb", size = 1622157, upload-time = "2026-06-26T19:09:09.527Z" },
+    { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/0d/ca7d15afbdc397e3401134c9e1800d51d12b829661786187a4ad08fe484f/greenlet-3.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:b7068bd09f761f3f5b4d214c2bed063186b2a86148c740b3873e3f56d79bac31", size = 242586, upload-time = "2026-06-26T18:23:37.93Z" },
+]
+
+[[package]]
 name = "griffelib"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3010,6 +3095,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/fb/8ab3845fe046ba4cbf74536bcf6801a774b7caf4350de1c5d37f1f0a9e90/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6f0ce10945fab9c4c06ce14e22af9059d1a87493a9af4501a5b0b9187e21cf2", size = 4250945, upload-time = "2026-05-18T19:20:47.385Z" },
     { url = "https://files.pythonhosted.org/packages/68/1b/7553ab136894374ffae8851ec06f98f511cd8e66246e41b6be059d0a7289/lxml-6.1.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8844cd288697c6425c9beba919302241e3278871dc6519515e72b04e987abcf", size = 4401664, upload-time = "2026-05-18T19:20:50.489Z" },
     { url = "https://files.pythonhosted.org/packages/db/a4/441aee36c6f6b249823d20fd91f9be9ab89d7c5a8ae542a4a4ca6d342d56/lxml-6.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ed21202aec73cda4d55d1ce57b389aadb90ffb044e6cd1080b8347efe1b1ec84", size = 3508989, upload-time = "2026-05-18T19:18:38.158Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -5366,6 +5463,54 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/f1/a7a892f18d4d224e6b26f706531eafccc41e37594d37d304786969ee13cb/sqlalchemy-2.0.51.tar.gz", hash = "sha256:804dccd8a4a6242c4e30ad961e540e18a588f6527202f2d6791b01845d59fdc9", size = 9912201, upload-time = "2026-06-15T15:41:20.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/69/a67c69e5f28fc9c99d6f7bd60bd50e91f2fed2423e3b30fb228fa00e51f3/sqlalchemy-2.0.51-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1aa10c0daee6705294d181daadaa793221e1a59ed55000a3fab1d42b088ce4ba", size = 2161838, upload-time = "2026-06-15T16:05:17.144Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a4/c8c22b8438bddc0a030157c6ec0f6ef97b3c38effa444bdab2a27af04090/sqlalchemy-2.0.51-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5b2ed6d828f1f09bd812861f4f59ca3bc3803f9df871f4555187f0faf018604", size = 3319402, upload-time = "2026-06-15T16:10:40.002Z" },
+    { url = "https://files.pythonhosted.org/packages/90/54/44012d32fd77d991256d2ff793ba3807c51d40cb27a85b4796224f6744df/sqlalchemy-2.0.51-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:436728ce18a80f6951a1e11cc6112c2ede9faf20766f1a26195a7c441ca12dbd", size = 3319675, upload-time = "2026-06-15T16:12:25.658Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a5/de0592acaf5906cd7430874392d6f7e8b4a7c8437610953ee2d1501c0b44/sqlalchemy-2.0.51-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dc261707bf5739aea8a541593f3cc1d463c2701fb05fbcbba0ce031b69a21260", size = 3270777, upload-time = "2026-06-15T16:10:42.125Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/14/a44c90739c780b362238e4ac3cb19dd0ca40d13e6ddc5daa112166ddab4f/sqlalchemy-2.0.51-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a6d26094615306d116dd5e4a51b0304c99dd2356fc569eed6922a80a6bd3b265", size = 3293940, upload-time = "2026-06-15T16:12:27.156Z" },
+    { url = "https://files.pythonhosted.org/packages/65/eb/fbd0f206a330e66f8c602a99c37c4e731f107faed62954b41b01f16dd9d9/sqlalchemy-2.0.51-cp311-cp311-win32.whl", hash = "sha256:ca8435d13829b92f4a97362d91975154a4015db3a2634154e1754e9a915e6b86", size = 2121183, upload-time = "2026-06-15T16:13:29.905Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fd/005bf80f3cf6e5c62b5dd68616280f51cd012c60840fa74781b3ed7b1623/sqlalchemy-2.0.51-cp311-cp311-win_amd64.whl", hash = "sha256:4a011ea4510683319ce4ed274b56ee05194b39b6da9d09ca7a39388f0fa84dcc", size = 2145796, upload-time = "2026-06-15T16:13:31.283Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/70/e868bc5412acd101a8280f25c95f10eeae0771c4eb806b02491142810ee8/sqlalchemy-2.0.51-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d78702b26ba1c18b2d0fb2ea940ba7f17a9581b42e8361ff93920ebbee1235a", size = 2160291, upload-time = "2026-06-15T16:08:48.918Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1c/71ee0f8a6b9d7316a1ccd30430b4c62b6c2e36adc96017a4e3a72dce49d6/sqlalchemy-2.0.51-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:581921d849d6e6f994d560389192955e80e2950e18fcdfe2ccea863e01158e6e", size = 3343835, upload-time = "2026-06-15T16:19:42.613Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/7c/7ab9f9aadc5944fdd06612484ed7918fe376ad871a5f50404dc1536e0194/sqlalchemy-2.0.51-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d21ce524ab86c23046e992a5b81cb54c21079c6df6e78b8fc77d77cac70a6b9", size = 3358470, upload-time = "2026-06-15T16:26:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7d/ff77169fee6186de145a7f2b87006c39638391130abbab2b1f63ac6ea583/sqlalchemy-2.0.51-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c5d98a2709840027f5a347c3af0a7c3d5f6c1ff93af2ca1c54494e23cba8f389", size = 3289874, upload-time = "2026-06-15T16:19:45.212Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/3b/6c505903710d781b55bc3141ee34a062bf9745a6b5bc7333305b9ed63b33/sqlalchemy-2.0.51-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1181256e0f16479691b5616d36375dc2620ad8332b25978763c3d206ad3f3f1d", size = 3321692, upload-time = "2026-06-15T16:26:39.747Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b7/c5ffe50aa2f4d947c9250e1519d939260329a07fe6272edfccd784b3d007/sqlalchemy-2.0.51-cp312-cp312-win32.whl", hash = "sha256:9f380393be5abeb6815f68fd39271b95127173511b6706b0a630a9995d53f8f5", size = 2119674, upload-time = "2026-06-15T16:23:09.543Z" },
+    { url = "https://files.pythonhosted.org/packages/25/dc/46a65916af68a06ef6b972c6050ba4c8f97070fe3fb33097d34229d9bef6/sqlalchemy-2.0.51-cp312-cp312-win_amd64.whl", hash = "sha256:2cf39aabdf48e87c1c2c2ed6d20d33ffa0733b3071ce9c5f66357947dd009080", size = 2146670, upload-time = "2026-06-15T16:23:11.048Z" },
+    { url = "https://files.pythonhosted.org/packages/54/fe/a210d52fd1a90ecfae8a78e9d8b27e18d733d60818a8bf250ff690b75120/sqlalchemy-2.0.51-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c2056838b6685b72fdb36c99996cf862753461a62f2e84f4196371d3b2d6a07", size = 2157184, upload-time = "2026-06-15T16:08:50.374Z" },
+    { url = "https://files.pythonhosted.org/packages/17/6b/2dce8369b199cb855110e056032f94a9f66dacc2237d3d39c115a86eac56/sqlalchemy-2.0.51-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:483b11bd46bf35fc14c52faf338b04300c9e6ce554bce9b11be85bfec3bc3195", size = 3284735, upload-time = "2026-06-15T16:19:46.934Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ff/dbc495b8a14da840faffb353857a72d4190113cac33727906fb997047f0f/sqlalchemy-2.0.51-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1bed1ee8b01da6088210aa9412023326fb98a599ba502e6118308601dcbef77f", size = 3302756, upload-time = "2026-06-15T16:26:41.336Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/d5/fde8f4dddcf518ee15ab35a7c6a28acc32c8ba548d1d2aa451f96e6dbb0b/sqlalchemy-2.0.51-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:72ca54c952107ba5cd58854b67a5a6268631289d21651a1235396f3b98b47400", size = 3232055, upload-time = "2026-06-15T16:19:49.286Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d1/43d3a0ac955a58601c24fa23038b1c55ee3a1ec02c0f96ebb1eae2bcf614/sqlalchemy-2.0.51-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b3e693d15533a45cd5906f0589f9c35090bef6ef45bf1e8195c424aa0ae06a8d", size = 3269850, upload-time = "2026-06-15T16:26:43.017Z" },
+    { url = "https://files.pythonhosted.org/packages/94/df/de669c7054cd47c4439ac34b1b2ee8b804a794791fbb10720e997a2c87c7/sqlalchemy-2.0.51-cp313-cp313-win32.whl", hash = "sha256:b93ab07b5292dbe7e6b8da89475275e7042744283921344b56105f3eeb0f828b", size = 2117721, upload-time = "2026-06-15T16:23:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8a/403c51d064196bae20a0bc2476577f83a3f8dd299719a97417086b7f2ec5/sqlalchemy-2.0.51-cp313-cp313-win_amd64.whl", hash = "sha256:0f053118c30e53161857a953e4de667d90e274980dccbe5dd3829bbbeece72a5", size = 2143615, upload-time = "2026-06-15T16:23:13.906Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/49/a739be2e1d02a96a658eb71ab45d921c874249252358ad24a5bffdd02525/sqlalchemy-2.0.51-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6ea306caaae6bd5afd0a46050003c88f6bf33227377a49298c498c3cb88ff491", size = 2158999, upload-time = "2026-06-15T16:08:51.759Z" },
+    { url = "https://files.pythonhosted.org/packages/23/6b/2e0e38cf75c8780eca78d9b2e78164f8bcfd70125e5caa588ff5cbb9c9f4/sqlalchemy-2.0.51-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c45a496d6bc05dec41dcd4c3a2b183723f47473255c159cd80b503c8f246424d", size = 3282539, upload-time = "2026-06-15T16:19:51.065Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a1/e77854cb5336fd37dc3c6ae3b71de242c98caac5725120be0b526b31cbd0/sqlalchemy-2.0.51-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4004ada0aafe8ae1991b2cd1d99c6d9146126e123bd6f883c260d974aa012e54", size = 3287545, upload-time = "2026-06-15T16:26:44.735Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ab/9e17272fd4dac8df3b83c4fbe52b998a1c9d89a843c8c35ff29b74ff7364/sqlalchemy-2.0.51-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0f6bcad487aee1c638d707235682fc96f741de00663619881ab235400d03289e", size = 3230929, upload-time = "2026-06-15T16:19:52.625Z" },
+    { url = "https://files.pythonhosted.org/packages/02/3c/52f408ea701781caee975606beccc48845f2aee8711ac29843d612c0306c/sqlalchemy-2.0.51-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:39a76529db6305693d8d4affa58ad5b5e2e18edd62daea628b29b97930b3513d", size = 3252888, upload-time = "2026-06-15T16:26:46.454Z" },
+    { url = "https://files.pythonhosted.org/packages/24/16/3efd2ee6bc4ca4693a30a1dd17a91b606cae15d517d2a4746611d9b73ce8/sqlalchemy-2.0.51-cp314-cp314-win32.whl", hash = "sha256:08a204d8b5638717c26a24df18fcf40af45a6b22e35b70b1d62f0113c2e278e8", size = 2120551, upload-time = "2026-06-15T16:23:15.629Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/78/55b12e70f45bccc40d9e483925c065027b3b98ea4cbbdf6f8c2546feaf6c/sqlalchemy-2.0.51-cp314-cp314-win_amd64.whl", hash = "sha256:96747bfbadb055466e5b46d572618170046b45ce5a4879167f50d70a5319a499", size = 2146318, upload-time = "2026-06-15T16:23:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/21/db/a9574ed40fed418924b1b1a3e54f47ee3963053b3d3d325a0d36b41f2c08/sqlalchemy-2.0.51-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e5ea1a213be1fcd5e49d9904c3b9939211ded90bc2a64e93f4c01963474285de", size = 2178920, upload-time = "2026-06-15T15:59:56.285Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/90/a1bb5c7cbba76b7bc1fbd586d0a5479a7bc9c27b4a8298f22ec9423b2bb3/sqlalchemy-2.0.51-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7c6b36ed71f41942bdcd2ad2522be46bfce09d5705be5640ecf19bbc7660e4b7", size = 3566534, upload-time = "2026-06-15T15:58:35.024Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4b/481f1fed30e0e9e8dd24aecbb49f29eb57fe7657ece5cf06ee9b84bb97d8/sqlalchemy-2.0.51-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0c2c62877097e1a0db401fba5cb4debee33265e5b2a55c4ccb489c02c53b4f72", size = 3535844, upload-time = "2026-06-15T16:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/02/71/0aa64aeda645510af0a43f7d9ee70932f0d1dc4263aed34c50ee891d9df3/sqlalchemy-2.0.51-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0378d055e9e8cd6ce4d8dff683bdd3d7d413533c4ee51d67a2b1e0f9eacc0f23", size = 3475355, upload-time = "2026-06-15T15:58:36.592Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/6061db32316446135a3abae5f308d144ab988a34234726042da3e58b1c63/sqlalchemy-2.0.51-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6e46fc36029eff666391e0531e5387b62ce6c4f1d8e50b3fb3099eaca1b42522", size = 3486591, upload-time = "2026-06-15T16:02:45.346Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c9/f14fdf71bb8957e0c7e39db69bbdf12b5c80f4ef775fdfa127bf4e0d6760/sqlalchemy-2.0.51-cp314-cp314t-win32.whl", hash = "sha256:9161cfc9efce70d1715f47d6ff40f79c6778c00d53be4fbc09d70301e4b83ba7", size = 2151313, upload-time = "2026-06-15T16:03:39.127Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c6/673e618e6f4f297e126d9b56ea2f6478708f6c1af4e3223835c22e2c3697/sqlalchemy-2.0.51-cp314-cp314t-win_amd64.whl", hash = "sha256:159bb6ba32059f57ad7375a8f50d844dd2f19d14954ecf820cd33e20debd46b2", size = 2186280, upload-time = "2026-06-15T16:03:40.569Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/22/dbf013a12ec759e54a34a119e9e217435b3f71b2dd5c61a7ade0a25dae87/sqlalchemy-2.0.51-py3-none-any.whl", hash = "sha256:bb024d8b621d0be75f4f44ecc7c950450026e76d66dc8f791bb5331d7fed59d5", size = 1944334, upload-time = "2026-06-15T16:09:22.418Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add a fail-loud Helm pre-install/pre-upgrade Job that runs `alembic upgrade head` when the control plane and Postgres migrations are enabled; SQLite pilot disables the hook.
- Surface scanner-only default warnings in `NOTES.txt` and on the scanner CronJob annotation, plus a `scanner-only` Helm validation profile.
- Bump `agent-bom-sdk` to `0.92.0`, add Alembic/SQLAlchemy to the `postgres` extra, and ship migration assets in the runtime image.

Fixes #3433
Fixes #3438

## Test plan
- [x] `python3 scripts/validate_helm_profiles.py --profile scanner-only --profile focused-pilot-byo-postgres`
- [x] `helm template agent-bom-scanner-only deploy/helm/agent-bom | grep -c postgres-migrate` → `0`
- [x] `helm template agent-bom-postgres deploy/helm/agent-bom -f deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml -f deploy/helm/agent-bom/examples/byo-postgres-values.yaml | grep -c postgres-migrate` → `1`
- [x] `uv run pytest tests/test_deploy_profiles.py tests/test_deploy_manifests.py::test_helm_migrations_defaults tests/test_deploy_manifests.py::test_alembic_migration_hook_template tests/test_deploy_manifests.py::test_scanner_only_cronjob_warning_annotation tests/test_deploy_manifests.py::test_sqlite_pilot_disables_postgres_migration_hook -q`
- [x] `python3 scripts/check_release_consistency.py`


Made with [Cursor](https://cursor.com)