### PR TITLE
fix(scan): reduce secret FP on OAuth token minting assignments (#3437)

### DIFF
--- a/src/agent_bom/runtime/patterns.py
+++ b/src/agent_bom/runtime/patterns.py
@@ -58,6 +58,28 @@ CREDENTIAL_PATTERNS: list[tuple[str, re.Pattern]] = [
     ("PagerDuty API Key", re.compile(r"\b[A-Za-z0-9+/]{20}-us\b")),
 ]
 
+# A hardcoded secret is a literal — a quoted string or a bare token. Source
+# code frequently *derives* a secret-named variable from a function or method
+# call instead (``access_token = self.signing_key.sign(claims)`` mints an OAuth
+# token; it is not an exposed credential). This regex distinguishes an
+# assignment whose value is a function/method call from a literal secret so
+# file scanners can suppress those false positives. It matches
+# ``<secret-name> = <ident-chain>(`` where the value is an (optionally awaited)
+# identifier/attribute chain that is immediately called — never a quoted or
+# bare literal.
+CODE_CALL_ASSIGNMENT = re.compile(
+    r"""(?ix)
+    \b(?:secret|token|password|passwd|pwd|apikey|api[_-]?key|
+       access[_-]?key|access[_-]?token|refresh[_-]?token|session[_-]?secret|
+       client[_-]?secret|auth[_-]?token|credential|private[_-]?key|
+       bearer|signing[_-]?key)\w*
+    \s* [=:] \s*
+    (?:await\s+|new\s+)?
+    [A-Za-z_][\w.]*          # identifier / attribute chain (self.signing_key.sign)
+    \s* \(                   # ...immediately called → an expression, not a literal
+    """
+)
+
 # ─── PII patterns ────────────────────────────────────────────────────────────
 
 # Personal Identifiable Information patterns for detection and redaction

--- a/src/agent_bom/secret_scanner.py
+++ b/src/agent_bom/secret_scanner.py
@@ -27,7 +27,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from agent_bom.runtime.patterns import CREDENTIAL_PATTERNS, PII_PATTERNS
+from agent_bom.runtime.patterns import CODE_CALL_ASSIGNMENT, CREDENTIAL_PATTERNS, PII_PATTERNS
 
 # ── Config ───────────────────────────────────────────────────────────────────
 
@@ -316,7 +316,19 @@ def _scan_file(file_path: Path, rel_path: str, *, detect_entropy: bool = False) 
 
         # Credential patterns (CRITICAL)
         for name, pattern in CREDENTIAL_PATTERNS:
-            if pattern.search(line):
+            match = pattern.search(line)
+            if match:
+                # A secret-named variable assigned to a function/method call
+                # (e.g. OAuth token minting:
+                # `access_token = self.signing_key.sign(claims)`) is derived
+                # code, not a hardcoded literal. The generic patterns capture
+                # the value as an identifier/attribute chain; if it is
+                # immediately called, suppress the false positive. A real
+                # literal passed as a call argument (e.g. `k = load("AKIA...")`)
+                # still matches on the literal itself, whose match is not
+                # call-shaped here, so it is preserved.
+                if line[match.end() :].lstrip().startswith("(") and CODE_CALL_ASSIGNMENT.search(line):
+                    break
                 findings.append(
                     SecretFinding(
                         file_path=rel_path,

--- a/tests/test_secret_scanner.py
+++ b/tests/test_secret_scanner.py
@@ -80,6 +80,39 @@ def test_scan_secrets_keeps_ipv4_pii_in_code_config_and_secret_contexts(tmp_path
     }
 
 
+def test_scan_secrets_ignores_oauth_token_minting_assignments(tmp_path: Path):
+    # Regression for #3437: minting a token from a method call is not a
+    # hardcoded credential and must not raise a CRITICAL finding.
+    (tmp_path / "oauth_as.py").write_text(
+        "def issue(self, claims):\n"
+        "    access_token = self.signing_key.sign(claims)\n"
+        "    refresh_token = self.signing_key.sign(refresh_claims)\n"
+        "    api_key = build_api_key(user)\n"
+        "    return access_token\n",
+        encoding="utf-8",
+    )
+
+    result = scan_secrets(tmp_path)
+
+    assert result.critical_count == 0
+    assert not any(finding.category == "credential" for finding in result.findings)
+
+
+def test_scan_secrets_still_flags_literal_token_passed_to_a_call(tmp_path: Path):
+    # The call-assignment suppression must not hide a real literal secret that
+    # merely happens to be passed as a function argument.
+    (tmp_path / "loader.py").write_text(
+        'aws_key = load("AKIAIOSFODNN7EXAMPLE")\n',
+        encoding="utf-8",
+    )
+
+    result = scan_secrets(tmp_path)
+
+    assert any(
+        finding.secret_type == "AWS Access Key" and finding.severity == "critical" for finding in result.findings
+    )
+
+
 def test_scan_secrets_warns_on_non_directory(tmp_path: Path):
     target = tmp_path / "not-a-dir.txt"
     target.write_text("hello", encoding="utf-8")


### PR DESCRIPTION
## Summary
- Secret scanner flagged `access_token = self.signing_key.sign(claims)` in `src/agent_bom/api/oauth_as.py` as a CRITICAL credential exposure. The "Generic API Key" pattern captured the assigned attribute chain (`self.signing_key.sign`) as a literal token — this is OAuth token minting, not a hardcoded secret.
- Add `CODE_CALL_ASSIGNMENT` to the runtime pattern library (`runtime/patterns.py`) to distinguish a secret-named variable assigned to a function/method call from a literal secret.
- Suppress the credential finding only when the matched value is immediately called (`<ident-chain>(`); a real literal passed as a call argument (e.g. `load("AKIA...")`) is still flagged.

## Verification
- `uv run pytest tests/test_secret_scanner.py -q` → 6 passed (2 new regression tests).
- `uv run ruff check src/agent_bom/secret_scanner.py src/agent_bom/runtime/patterns.py tests/test_secret_scanner.py` → clean.
- Scanned a copy of `oauth_as.py`: `critical_count == 0`, no `credential` findings (previously 1 CRITICAL "Generic API Key").

## Notes
- Discriminator is positional: it only suppresses the specific credential match whose value is the call target, so a hardcoded literal appearing elsewhere on the same line is preserved.

Fixes #3437

Made with [Cursor](https://cursor.com)