### PR TITLE
refactor(output): migrate compact and console formatters to Finding (#2918)

### DIFF
--- a/src/agent_bom/output/compact.py
+++ b/src/agent_bom/output/compact.py
@@ -76,16 +76,26 @@ def _page_window(total: int, limit: int, page: int) -> tuple[int, int, int]:
     return safe_page, start, end
 
 
-def _forward_fix_version(br: object) -> str | None:
+def _forward_fix_version(finding) -> str | None:
     """Return a fix version only when it is a forward upgrade for this package."""
-    fixed = getattr(getattr(br, "vulnerability", None), "fixed_version", None)
-    if not fixed:
-        return None
-    package = getattr(br, "package", None)
-    current = str(getattr(package, "version", "") or "")
+    from agent_bom.finding import Finding
+    from agent_bom.output.finding_views import package_ecosystem, package_version
+
+    if isinstance(finding, Finding):
+        fixed = finding.fixed_version
+        if not fixed:
+            return None
+        current = package_version(finding)
+        ecosystem = package_ecosystem(finding)
+    else:
+        fixed = getattr(getattr(finding, "vulnerability", None), "fixed_version", None)
+        if not fixed:
+            return None
+        package = getattr(finding, "package", None)
+        current = str(getattr(package, "version", "") or "")
+        ecosystem = str(getattr(package, "ecosystem", "") or "")
     if current in ("", "unknown", "latest"):
         return str(fixed)
-    ecosystem = str(getattr(package, "ecosystem", "") or "")
     try:
         from agent_bom.version_utils import compare_version_order
 
@@ -144,13 +154,13 @@ def print_compact_summary(report: AIBOMReport, *, verbose: bool = False) -> None
 
     from agent_bom.finding import FindingType
     from agent_bom.output import _sev_badge, console
+    from agent_bom.output.finding_views import active_cve_findings, finding_severity
     from agent_bom.posture import compute_posture_scorecard
-    from agent_bom.vex import active_blast_radii
 
     sev_counts: Counter[str] = Counter()
-    active_findings = active_blast_radii(report.blast_radii)
-    for br in active_findings:
-        sev_counts[br.vulnerability.severity.value.upper()] += 1
+    active_findings = active_cve_findings(report)
+    for finding in active_findings:
+        sev_counts[finding_severity(finding).value.upper()] += 1
     policy_findings = [finding for finding in report.to_findings() if finding.finding_type != FindingType.CVE]
     for finding in policy_findings:
         sev_counts[str(finding.severity).upper()] += 1
@@ -190,7 +200,7 @@ def print_compact_summary(report: AIBOMReport, *, verbose: bool = False) -> None
     if coverage_incomplete:
         posture = "[bold black on yellow] PARTIAL COVERAGE [/bold black on yellow]"
         border_style = "yellow"
-    elif report.total_vulnerabilities == 0 and not policy_findings:
+    elif report.total_vulnerabilities == 0 and not active_findings and not policy_findings:
         posture = "[bold white on green] CLEAN [/bold white on green]"
         border_style = "green"
     else:
@@ -372,21 +382,29 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
     scan types without agent context (image, check, iac, CI/CD).
     """
     from agent_bom.output import _sev_badge, console
-    from agent_bom.vex import active_blast_radii
+    from agent_bom.output.finding_views import (
+        active_cve_findings,
+        cve_findings,
+        exploit_likelihood_value,
+        finding_severity,
+        is_actionable_finding,
+        is_package_direct,
+        package_name,
+        package_version,
+    )
 
-    if not report.blast_radii:
-        return
-
-    # Filter: show actionable findings by default, count the rest
-    active_findings = active_blast_radii(report.blast_radii)
+    active_findings = active_cve_findings(report)
     if not active_findings:
         return
-    priority = [br for br in active_findings if br.is_actionable]
+
+    priority = [finding for finding in active_findings if is_actionable_finding(finding)]
     rest_count = len(active_findings) - len(priority)
     if fixable_only:
-        priority = [br for br in priority if _forward_fix_version(br)]
+        priority = [finding for finding in priority if _forward_fix_version(finding)]
     if not priority:
-        display_list = [br for br in active_findings if _forward_fix_version(br)] if fixable_only else active_findings
+        display_list = (
+            [finding for finding in active_findings if _forward_fix_version(finding)] if fixable_only else active_findings
+        )
     else:
         display_list = priority
     total = len(display_list)
@@ -394,7 +412,9 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
     shown = display_list[start:end]
 
     # Detect if we have blast radius context (agents/servers/credentials)
-    has_blast_context = any(br.affected_agents and (br.affected_servers or br.exposed_credentials) for br in shown)
+    has_blast_context = any(
+        finding.affected_agents and (finding.affected_servers or finding.exposed_credentials) for finding in shown
+    )
 
     console.print()
     shown_n = len(shown)
@@ -426,14 +446,11 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
     table.add_column("EPSS", justify="center", no_wrap=True)
     table.add_column("Fix", ratio=1)
 
-    for br in shown:
-        forward_fix = _forward_fix_version(br)
+    for finding in shown:
+        forward_fix = _forward_fix_version(finding)
         fix = f"[green]{forward_fix}[/green]" if forward_fix else "[dim]no fix[/dim]"
-        # Exploit-likelihood (issue #486) — KEV wins; elevated EPSS-only
-        # levels still surface a muted hint so the operator knows why
-        # the row is flagged even when it's not in CISA KEV.
-        _exploit_level = br.vulnerability.exploit_likelihood
-        if br.vulnerability.is_kev:
+        _exploit_level = exploit_likelihood_value(finding)
+        if finding.is_kev:
             kev = " [red bold]KEV[/red bold]"
         elif _exploit_level == "likely_exploited":
             kev = " [#e67e22 bold]EXPL[/#e67e22 bold]"
@@ -443,18 +460,21 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
             kev = ""
 
         epss_display = "[dim]—[/dim]"
-        if br.vulnerability.epss_score is not None:
-            epss_pct = int(br.vulnerability.epss_score * 100)
+        if finding.epss_score is not None:
+            epss_pct = int(finding.epss_score * 100)
             epss_style = "red bold" if epss_pct >= 70 else "yellow" if epss_pct >= 30 else "dim"
             epss_display = f"[{epss_style}]{epss_pct}%[/{epss_style}]"
 
-        pkg_display = f"{br.package.name}@{br.package.version}" + ("" if br.package.is_direct else " [dim]T[/dim]")
+        pkg_display = (
+            f"{package_name(finding)}@{package_version(finding)}"
+            + ("" if is_package_direct(finding) else " [dim]T[/dim]")
+        )
+        vuln_id = finding.cve_id or finding.id
 
         if has_blast_context:
-            # Build single-line blast chain: agent → server → credential
-            agent_names = [a.name for a in br.affected_agents]
-            cred_names = list(br.exposed_credentials)
-            server_names = [s.name for s in br.affected_servers] if br.affected_servers else []
+            agent_names = list(finding.affected_agents)
+            cred_names = list(finding.exposed_credentials)
+            server_names = list(finding.affected_servers)
             chain_parts: list[str] = []
             if agent_names:
                 name = agent_names[0][:16]
@@ -471,8 +491,8 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
                     chain_parts[-1] += f"+{len(cred_names) - 1}"
             blast_display = " → ".join(chain_parts) if chain_parts else "[dim]—[/dim]"
             table.add_row(
-                _sev_badge(br.vulnerability.severity),
-                f"{br.vulnerability.id}{kev}",
+                _sev_badge(finding_severity(finding)),
+                f"{vuln_id}{kev}",
                 pkg_display,
                 blast_display,
                 epss_display,
@@ -480,8 +500,8 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
             )
         else:
             table.add_row(
-                _sev_badge(br.vulnerability.severity),
-                f"{br.vulnerability.id}{kev}",
+                _sev_badge(finding_severity(finding)),
+                f"{vuln_id}{kev}",
                 pkg_display,
                 epss_display,
                 fix,
@@ -508,42 +528,44 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
         console.print(f"  [dim]+ {' · '.join(parts)} — {' · '.join(nav_hints)}[/dim]")
 
     # Critical details section — show description and blast chain for CRIT/HIGH only
-    critical_findings = [br for br in shown if br.vulnerability.severity in (Severity.CRITICAL, Severity.HIGH)]
+    critical_findings = [finding for finding in shown if finding_severity(finding) in (Severity.CRITICAL, Severity.HIGH)]
     if critical_findings:
         console.print()
         console.print(Rule(lane_title("analyze", "Critical Details"), style="dim"))
         sev_style_map = {Severity.CRITICAL: "red bold", Severity.HIGH: "#e67e22 bold"}
-        for br in critical_findings[:5]:
-            style = sev_style_map.get(br.vulnerability.severity, "white")
-            summary = br.vulnerability.summary or ""
+        for finding in critical_findings[:5]:
+            sev = finding_severity(finding)
+            style = sev_style_map.get(sev, "white")
+            summary = finding.description or ""
             if len(summary) > 80:
                 summary = summary[:77] + "..."
-            sev_label = br.vulnerability.severity.value.upper()
-            pkg_ref = f"{br.package.name}@{br.package.version}"
-            console.print(f"\n  [{style}]{br.vulnerability.id}[/{style}] · {pkg_ref} · [{style}]{sev_label}[/{style}]")
+            sev_label = sev.value.upper()
+            pkg_ref = f"{package_name(finding)}@{package_version(finding)}"
+            vuln_id = finding.cve_id or finding.id
+            console.print(f"\n  [{style}]{vuln_id}[/{style}] · {pkg_ref} · [{style}]{sev_label}[/{style}]")
             if summary:
                 console.print(f"  {summary}")
-            forward_fix = _forward_fix_version(br)
+            forward_fix = _forward_fix_version(finding)
             if forward_fix:
                 console.print(f"  Fix: [green]upgrade to ≥ {forward_fix}[/green]")
-            if has_blast_context and (br.affected_agents or br.exposed_credentials):
-                agent_str = ", ".join(a.name for a in br.affected_agents[:3])
-                cred_str = ", ".join(br.exposed_credentials[:3])
+            if has_blast_context and (finding.affected_agents or finding.exposed_credentials):
+                agent_str = ", ".join(finding.affected_agents[:3])
+                cred_str = ", ".join(finding.exposed_credentials[:3])
                 blast_parts = []
                 if agent_str:
                     blast_parts.append(agent_str)
-                if br.affected_servers:
-                    blast_parts.append(", ".join(s.name for s in br.affected_servers[:2]))
+                if finding.affected_servers:
+                    blast_parts.append(", ".join(finding.affected_servers[:2]))
                 if cred_str:
                     blast_parts.append(f"[yellow]{cred_str}[/yellow]")
                 if blast_parts:
                     console.print(f"  Blast: {' → '.join(blast_parts)}")
 
-    # Status bar
     console.print()
-    fixable = sum(1 for br in report.blast_radii if _forward_fix_version(br))
-    kev_count = sum(1 for br in report.blast_radii if br.vulnerability.is_kev)
-    unknown_sev = sum(1 for br in report.blast_radii if br.vulnerability.severity == Severity.NONE)
+    all_cve = cve_findings(report)
+    fixable = sum(1 for finding in all_cve if _forward_fix_version(finding))
+    kev_count = sum(1 for finding in all_cve if finding.is_kev)
+    unknown_sev = sum(1 for finding in all_cve if finding_severity(finding) == Severity.NONE)
     hints = ["[dim]--verbose[/dim] full details", "[dim]-f html[/dim] interactive report"]
     if page < total_pages:
         hints.insert(0, f"[dim]--page {page + 1}[/dim] next findings")
@@ -551,7 +573,7 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
         hints.insert(0, f"[green]{fixable} fixable[/green]")
     if kev_count:
         hints.insert(0, f"[red]{kev_count} KEV[/red]")
-    if unknown_sev > 0 and unknown_sev == len(report.blast_radii):
+    if unknown_sev > 0 and unknown_sev == len(all_cve):
         hints.insert(0, "[yellow]--enrich[/yellow] for severity scores")
     console.print(Rule(style="dim"))
     console.print(f"  {' · '.join(hints)}")
@@ -560,11 +582,13 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
 def print_compact_remediation(report: AIBOMReport, limit: int = 5, page: int = 1) -> None:
     """Top N remediation items, one-liner each."""
     from agent_bom.output import build_remediation_plan, console
+    from agent_bom.output.finding_views import cve_findings
 
-    if not report.blast_radii:
+    cve_rows = cve_findings(report)
+    if not cve_rows:
         return
 
-    plan = build_remediation_plan(report.blast_radii)
+    plan = build_remediation_plan(cve_rows)
     fixable = [p for p in plan if p["fix"]]
     if not fixable:
         return

--- a/src/agent_bom/output/console_render.py
+++ b/src/agent_bom/output/console_render.py
@@ -10,6 +10,17 @@ from rich.tree import Tree
 
 from agent_bom.models import AgentStatus, AIBOMReport, BlastRadius, Severity
 from agent_bom.output.compact import _coverage_bar, _pct
+from agent_bom.output.finding_views import (
+    active_cve_findings,
+    cve_findings,
+    finding_references,
+    finding_severity,
+    is_actionable_finding,
+    is_package_malicious,
+    package_ecosystem,
+    package_name,
+    package_version,
+)
 from agent_bom.security import sanitize_command_args
 
 console = Console()
@@ -306,15 +317,13 @@ def print_posture_summary(report: AIBOMReport) -> None:
 
     # Vulnerability severity breakdown (excluding VEX-suppressed)
     from agent_bom.finding import FindingType
-    from agent_bom.vex import is_vex_suppressed
 
     sev_counts: Counter[str] = Counter()
-    vex_suppressed_count = 0
-    for br in report.blast_radii:
-        if is_vex_suppressed(br.vulnerability):
-            vex_suppressed_count += 1
-        else:
-            sev_counts[br.vulnerability.severity.value.upper()] += 1
+    all_cve = cve_findings(report)
+    active_findings = active_cve_findings(report)
+    vex_suppressed_count = len(all_cve) - len(active_findings)
+    for finding in active_findings:
+        sev_counts[finding_severity(finding).value.upper()] += 1
 
     # Non-CVE policy/security findings (cloud CIS FAILs, MCP blocklist, toxic
     # combinations, governance) drive the headline too. A cloud scan with HIGH
@@ -421,19 +430,18 @@ def print_posture_summary(report: AIBOMReport) -> None:
             lines.append(f"    [yellow]{cred}[/yellow]  [dim]({loc_str})[/dim]")
 
     # Top impacted packages (when vulns exist)
-    if report.blast_radii:
+    if cve_findings(report):
         lines.append("")
         lines.append("  [bold]Top Impacted Packages[/bold]")
         # Group vulns by package
         pkg_vulns: dict[str, dict] = {}
-        for br in report.blast_radii:
-            key = f"{br.package.name}@{br.package.version}"
+        for finding in all_cve:
+            key = f"{package_name(finding)}@{package_version(finding)}"
             if key not in pkg_vulns:
-                pkg_vulns[key] = {"eco": br.package.ecosystem, "sevs": Counter(), "agents": set(), "kev": False}
-            pkg_vulns[key]["sevs"][br.vulnerability.severity.value.upper()] += 1
-            for a in br.affected_agents:
-                pkg_vulns[key]["agents"].add(a.name)
-            if br.vulnerability.is_kev:
+                pkg_vulns[key] = {"eco": package_ecosystem(finding), "sevs": Counter(), "agents": set(), "kev": False}
+            pkg_vulns[key]["sevs"][finding_severity(finding).value.upper()] += 1
+            pkg_vulns[key]["agents"].update(finding.affected_agents)
+            if finding.is_kev:
                 pkg_vulns[key]["kev"] = True
 
         # Sort by total vuln count descending
@@ -578,7 +586,8 @@ def print_agent_tree(report: AIBOMReport) -> None:
 
 def print_blast_radius(report: AIBOMReport, fixable_only: bool = False) -> None:
     """Print blast radius analysis for vulnerabilities."""
-    if not report.blast_radii:
+    all_cve = cve_findings(report)
+    if not all_cve:
         return
 
     _console().print()
@@ -597,41 +606,42 @@ def print_blast_radius(report: AIBOMReport, fixable_only: bool = False) -> None:
 
     # Filter to actionable findings only — UNKNOWN severity transitive
     # deps with no creds/tools are noise. Users see all with --verbose.
-    actionable = [br for br in report.blast_radii if br.is_actionable]
+    actionable = [finding for finding in all_cve if is_actionable_finding(finding)]
     # --fixable-only: keep only entries that have a fix available
     if fixable_only:
-        actionable = [br for br in actionable if br.vulnerability.fixed_version]
+        actionable = [finding for finding in actionable if finding.fixed_version]
     if not actionable:
         _console().print("  [green]✓ No actionable findings (all transitive/low-severity noise).[/green]")
-        if len(report.blast_radii) > 0:
-            _console().print(f"  [dim]{len(report.blast_radii)} low-priority findings hidden. Use --verbose to see all.[/dim]")
+        if len(all_cve) > 0:
+            _console().print(f"  [dim]{len(all_cve)} low-priority findings hidden. Use --verbose to see all.[/dim]")
         return
 
-    for br in actionable[:25]:  # Top 25 actionable
-        sev_style = SEVERITY_TEXT.get(br.vulnerability.severity, "white")
-        if br.vulnerability.fixed_version:
-            fix = f"[green]✓ {br.vulnerability.fixed_version}[/green]"
+    for finding in actionable[:25]:  # Top 25 actionable
+        sev = finding_severity(finding)
+        sev_style = SEVERITY_TEXT.get(sev, "white")
+        if finding.fixed_version:
+            fix = f"[green]✓ {finding.fixed_version}[/green]"
         else:
             fix = "[red dim]No fix[/red dim]"
 
         # EPSS score display
         epss_display = "—"
-        if br.vulnerability.epss_score is not None:
-            epss_pct = int(br.vulnerability.epss_score * 100)
+        if finding.epss_score is not None:
+            epss_pct = int(finding.epss_score * 100)
             epss_style = "red bold" if epss_pct >= 70 else "yellow" if epss_pct >= 30 else "dim"
             epss_display = f"[{epss_style}]{epss_pct}%[/{epss_style}]"
 
         # KEV indicator
-        kev_display = "[red bold]🔥[/red bold]" if br.vulnerability.is_kev else "—"
+        kev_display = "[red bold]🔥[/red bold]" if finding.is_kev else "—"
 
         # Malicious package indicator
-        if br.package.is_malicious:
+        if is_package_malicious(finding):
             kev_display += " [red bold]☠[/red bold]"
 
         # Blast column: agents/creds compact
         blast_parts = []
-        n_agents = len(br.affected_agents)
-        n_creds = len(br.exposed_credentials)
+        n_agents = len(finding.affected_agents)
+        n_creds = len(finding.exposed_credentials)
         if n_agents:
             blast_parts.append(f"{n_agents}A")
         if n_creds:
@@ -639,60 +649,61 @@ def print_blast_radius(report: AIBOMReport, fixable_only: bool = False) -> None:
         blast_display = "/".join(blast_parts) if blast_parts else "—"
 
         # Vulnerability: ID + package on two lines
-        vuln_display = f"{br.vulnerability.id}\n[dim]{br.package.name}@{br.package.version}[/dim]"
+        vuln_id = finding.cve_id or finding.id
+        vuln_display = f"{vuln_id}\n[dim]{package_name(finding)}@{package_version(finding)}[/dim]"
 
         # Threats column: actual framework tag IDs per finding
         threat_lines = []
-        if br.owasp_tags:
-            tags = sorted(br.owasp_tags)[:3]
-            extra = f" +{len(br.owasp_tags) - 3}" if len(br.owasp_tags) > 3 else ""
+        if finding.owasp_tags:
+            tags = sorted(finding.owasp_tags)[:3]
+            extra = f" +{len(finding.owasp_tags) - 3}" if len(finding.owasp_tags) > 3 else ""
             threat_lines.append(f"[purple]{' '.join(tags)}{extra}[/purple]")
-        if br.atlas_tags:
-            tags = sorted(br.atlas_tags)[:3]
-            extra = f" +{len(br.atlas_tags) - 3}" if len(br.atlas_tags) > 3 else ""
+        if finding.atlas_tags:
+            tags = sorted(finding.atlas_tags)[:3]
+            extra = f" +{len(finding.atlas_tags) - 3}" if len(finding.atlas_tags) > 3 else ""
             threat_lines.append(f"[cyan]{' '.join(tags)}{extra}[/cyan]")
-        if getattr(br, "attack_tags", None):
-            tags = sorted(br.attack_tags)[:3]
-            extra = f" +{len(br.attack_tags) - 3}" if len(br.attack_tags) > 3 else ""
+        if finding.attack_tags:
+            tags = sorted(finding.attack_tags)[:3]
+            extra = f" +{len(finding.attack_tags) - 3}" if len(finding.attack_tags) > 3 else ""
             threat_lines.append(f"[red]{' '.join(tags)}{extra}[/red]")
-        if br.nist_ai_rmf_tags:
-            tags = sorted(br.nist_ai_rmf_tags)[:3]
-            extra = f" +{len(br.nist_ai_rmf_tags) - 3}" if len(br.nist_ai_rmf_tags) > 3 else ""
+        if finding.nist_ai_rmf_tags:
+            tags = sorted(finding.nist_ai_rmf_tags)[:3]
+            extra = f" +{len(finding.nist_ai_rmf_tags) - 3}" if len(finding.nist_ai_rmf_tags) > 3 else ""
             threat_lines.append(f"[green]{' '.join(tags)}{extra}[/green]")
-        if br.owasp_mcp_tags:
-            tags = sorted(br.owasp_mcp_tags)[:3]
-            extra = f" +{len(br.owasp_mcp_tags) - 3}" if len(br.owasp_mcp_tags) > 3 else ""
+        if finding.owasp_mcp_tags:
+            tags = sorted(finding.owasp_mcp_tags)[:3]
+            extra = f" +{len(finding.owasp_mcp_tags) - 3}" if len(finding.owasp_mcp_tags) > 3 else ""
             threat_lines.append(f"[yellow]{' '.join(tags)}{extra}[/yellow]")
-        if br.owasp_agentic_tags:
-            tags = sorted(br.owasp_agentic_tags)[:3]
-            extra = f" +{len(br.owasp_agentic_tags) - 3}" if len(br.owasp_agentic_tags) > 3 else ""
+        if finding.owasp_agentic_tags:
+            tags = sorted(finding.owasp_agentic_tags)[:3]
+            extra = f" +{len(finding.owasp_agentic_tags) - 3}" if len(finding.owasp_agentic_tags) > 3 else ""
             threat_lines.append(f"[magenta]{' '.join(tags)}{extra}[/magenta]")
-        if br.eu_ai_act_tags:
-            tags = sorted(br.eu_ai_act_tags)[:3]
-            extra = f" +{len(br.eu_ai_act_tags) - 3}" if len(br.eu_ai_act_tags) > 3 else ""
+        if finding.eu_ai_act_tags:
+            tags = sorted(finding.eu_ai_act_tags)[:3]
+            extra = f" +{len(finding.eu_ai_act_tags) - 3}" if len(finding.eu_ai_act_tags) > 3 else ""
             threat_lines.append(f"[blue]{' '.join(tags)}{extra}[/blue]")
-        if br.nist_csf_tags:
-            tags = sorted(br.nist_csf_tags)[:3]
-            extra = f" +{len(br.nist_csf_tags) - 3}" if len(br.nist_csf_tags) > 3 else ""
+        if finding.nist_csf_tags:
+            tags = sorted(finding.nist_csf_tags)[:3]
+            extra = f" +{len(finding.nist_csf_tags) - 3}" if len(finding.nist_csf_tags) > 3 else ""
             threat_lines.append(f"[bright_green]{' '.join(tags)}{extra}[/bright_green]")
-        if br.iso_27001_tags:
-            tags = sorted(br.iso_27001_tags)[:3]
-            extra = f" +{len(br.iso_27001_tags) - 3}" if len(br.iso_27001_tags) > 3 else ""
+        if finding.iso_27001_tags:
+            tags = sorted(finding.iso_27001_tags)[:3]
+            extra = f" +{len(finding.iso_27001_tags) - 3}" if len(finding.iso_27001_tags) > 3 else ""
             threat_lines.append(f"[bright_cyan]{' '.join(tags)}{extra}[/bright_cyan]")
-        if br.soc2_tags:
-            tags = sorted(br.soc2_tags)[:3]
-            extra = f" +{len(br.soc2_tags) - 3}" if len(br.soc2_tags) > 3 else ""
+        if finding.soc2_tags:
+            tags = sorted(finding.soc2_tags)[:3]
+            extra = f" +{len(finding.soc2_tags) - 3}" if len(finding.soc2_tags) > 3 else ""
             threat_lines.append(f"[bright_yellow]{' '.join(tags)}{extra}[/bright_yellow]")
-        if br.cis_tags:
-            tags = sorted(br.cis_tags)[:3]
-            extra = f" +{len(br.cis_tags) - 3}" if len(br.cis_tags) > 3 else ""
+        if finding.cis_tags:
+            tags = sorted(finding.cis_tags)[:3]
+            extra = f" +{len(finding.cis_tags) - 3}" if len(finding.cis_tags) > 3 else ""
             threat_lines.append(f"[bright_magenta]{' '.join(tags)}{extra}[/bright_magenta]")
         threats_display = "\n".join(threat_lines) if threat_lines else "—"
 
         table.add_row(
-            f"[{sev_style}]{br.risk_score:.1f}[/{sev_style}]",
+            f"[{sev_style}]{finding.risk_score:.1f}[/{sev_style}]",
             vuln_display,
-            _sev_badge(br.vulnerability.severity),
+            _sev_badge(sev),
             epss_display,
             kev_display,
             blast_display,
@@ -702,19 +713,20 @@ def print_blast_radius(report: AIBOMReport, fixable_only: bool = False) -> None:
 
     _console().print(table)
 
-    if len(report.blast_radii) > 25:
-        _console().print(f"\n  [dim]...and {len(report.blast_radii) - 25} more findings. Use --output to export full report.[/dim]")
+    if len(all_cve) > 25:
+        _console().print(f"\n  [dim]...and {len(all_cve) - 25} more findings. Use --output to export full report.[/dim]")
 
     # Verification sources — one link per unique CVE
     seen_ids: set[str] = set()
     sources: list[tuple[str, str]] = []
-    for br in report.blast_radii:
-        vid = br.vulnerability.id
+    for finding in all_cve:
+        vid = finding.cve_id or finding.id
         if vid in seen_ids:
             continue
         seen_ids.add(vid)
-        if br.vulnerability.references:
-            sources.append((vid, br.vulnerability.references[0]))
+        refs = finding_references(finding)
+        if refs:
+            sources.append((vid, refs[0]))
         elif vid.startswith("CVE-"):
             sources.append((vid, f"https://osv.dev/vulnerability/{vid}"))
         elif vid.startswith("GHSA-"):
@@ -729,7 +741,8 @@ def print_blast_radius(report: AIBOMReport, fixable_only: bool = False) -> None:
 
 def print_attack_flow_tree(report: AIBOMReport) -> None:
     """Print per-CVE blast radius chains as Rich Trees."""
-    if not report.blast_radii:
+    all_cve = cve_findings(report)
+    if not all_cve:
         return
 
     _console().print()
@@ -743,59 +756,60 @@ def print_attack_flow_tree(report: AIBOMReport) -> None:
         Severity.LOW: "dim",
     }
 
-    for br in sorted(report.blast_radii, key=lambda b: b.risk_score, reverse=True)[:15]:
-        sev = br.vulnerability.severity
+    for finding in sorted(all_cve, key=lambda item: item.risk_score, reverse=True)[:15]:
+        sev = finding_severity(finding)
         sev_style = severity_styles.get(sev, "white")
+        vuln_id = finding.cve_id or finding.id
 
         # Root: CVE line
-        root_parts = [f"[{sev_style}]{br.vulnerability.id}[/{sev_style}]"]
+        root_parts = [f"[{sev_style}]{vuln_id}[/{sev_style}]"]
         root_parts.append(f"[{sev_style}]\\[{sev.value}][/{sev_style}]")
-        if br.vulnerability.cvss_score is not None:
-            root_parts.append(f"CVSS {br.vulnerability.cvss_score:.1f}")
-        if br.vulnerability.epss_score is not None:
-            pct = int(br.vulnerability.epss_score * 100)
+        if finding.cvss_score is not None:
+            root_parts.append(f"CVSS {finding.cvss_score:.1f}")
+        if finding.epss_score is not None:
+            pct = int(finding.epss_score * 100)
             root_parts.append(f"EPSS {pct}%")
-        if br.vulnerability.is_kev:
+        if finding.is_kev:
             root_parts.append("[red bold]🔥 KEV[/red bold]")
 
         cve_tree = Tree(" · ".join(root_parts))
 
         # Package node
-        pkg_label = f"{br.package.name}@{br.package.version} ({br.package.ecosystem})"
+        pkg_label = f"{package_name(finding)}@{package_version(finding)} ({package_ecosystem(finding)})"
         pkg_branch = cve_tree.add(f"[dim]{pkg_label}[/dim]")
 
         # Server branches
-        for server in br.affected_servers:
-            srv_branch = pkg_branch.add(f"\U0001f50c [bold cyan]{server.name}[/bold cyan] [dim](MCP Server)[/dim]")
+        for server_name in finding.affected_servers:
+            srv_branch = pkg_branch.add(f"\U0001f50c [bold cyan]{server_name}[/bold cyan] [dim](MCP Server)[/dim]")
 
             # Agents
-            for agent in br.affected_agents:
-                srv_branch.add(f"\U0001f916 [green]{agent.name}[/green] [dim](Agent)[/dim]")
+            for agent_name in finding.affected_agents:
+                srv_branch.add(f"\U0001f916 [green]{agent_name}[/green] [dim](Agent)[/dim]")
 
             # Credentials
-            for cred in br.exposed_credentials:
+            for cred in finding.exposed_credentials:
                 srv_branch.add(f"[yellow]🔑 {cred}[/yellow]")
 
             # Tools (compact, max 5 per line)
-            if br.exposed_tools:
-                tool_names = [t.name for t in br.exposed_tools[:5]]
-                extra = f" +{len(br.exposed_tools) - 5}" if len(br.exposed_tools) > 5 else ""
+            if finding.exposed_tools:
+                tool_names = finding.exposed_tools[:5]
+                extra = f" +{len(finding.exposed_tools) - 5}" if len(finding.exposed_tools) > 5 else ""
                 srv_branch.add(f"[dim]🔧 {', '.join(tool_names)}{extra}[/dim]")
 
         # If no servers, still show agents/creds/tools under package
-        if not br.affected_servers:
-            for agent in br.affected_agents:
-                pkg_branch.add(f"\U0001f916 [green]{agent.name}[/green] [dim](Agent)[/dim]")
-            for cred in br.exposed_credentials:
+        if not finding.affected_servers:
+            for agent_name in finding.affected_agents:
+                pkg_branch.add(f"\U0001f916 [green]{agent_name}[/green] [dim](Agent)[/dim]")
+            for cred in finding.exposed_credentials:
                 pkg_branch.add(f"[yellow]🔑 {cred}[/yellow]")
-            if br.exposed_tools:
-                tool_names = [t.name for t in br.exposed_tools[:5]]
-                extra = f" +{len(br.exposed_tools) - 5}" if len(br.exposed_tools) > 5 else ""
+            if finding.exposed_tools:
+                tool_names = finding.exposed_tools[:5]
+                extra = f" +{len(finding.exposed_tools) - 5}" if len(finding.exposed_tools) > 5 else ""
                 pkg_branch.add(f"[dim]🔧 {', '.join(tool_names)}{extra}[/dim]")
 
         _console().print(cve_tree)
 
-    remaining = len(report.blast_radii) - 15
+    remaining = len(all_cve) - 15
     if remaining > 0:
         _console().print(f"\n  [dim]...and {remaining} more findings. Use --output to export full report.[/dim]")
     _console().print()
@@ -810,7 +824,7 @@ def print_threat_frameworks(report: AIBOMReport) -> None:
     from agent_bom.nist_ai_rmf import NIST_AI_RMF
     from agent_bom.owasp import OWASP_LLM_TOP10
 
-    if not report.blast_radii:
+    if not cve_findings(report):
         return
 
     # Aggregate tag counts
@@ -825,28 +839,28 @@ def print_threat_frameworks(report: AIBOMReport) -> None:
     iso_27001_counts: Counter[str] = Counter()
     soc2_counts: Counter[str] = Counter()
     cis_counts: Counter[str] = Counter()
-    for br in report.blast_radii:
-        for tag in br.owasp_tags:
+    for finding in cve_findings(report):
+        for tag in finding.owasp_tags:
             owasp_counts[tag] += 1
-        for tag in br.atlas_tags:
+        for tag in finding.atlas_tags:
             atlas_counts[tag] += 1
-        for tag in getattr(br, "attack_tags", []):
+        for tag in finding.attack_tags:
             attack_counts[tag] += 1
-        for tag in br.nist_ai_rmf_tags:
+        for tag in finding.nist_ai_rmf_tags:
             nist_counts[tag] += 1
-        for tag in br.owasp_mcp_tags:
+        for tag in finding.owasp_mcp_tags:
             owasp_mcp_counts[tag] += 1
-        for tag in br.owasp_agentic_tags:
+        for tag in finding.owasp_agentic_tags:
             owasp_agentic_counts[tag] += 1
-        for tag in br.eu_ai_act_tags:
+        for tag in finding.eu_ai_act_tags:
             eu_ai_act_counts[tag] += 1
-        for tag in br.nist_csf_tags:
+        for tag in finding.nist_csf_tags:
             nist_csf_counts[tag] += 1
-        for tag in br.iso_27001_tags:
+        for tag in finding.iso_27001_tags:
             iso_27001_counts[tag] += 1
-        for tag in br.soc2_tags:
+        for tag in finding.soc2_tags:
             soc2_counts[tag] += 1
-        for tag in br.cis_tags:
+        for tag in finding.cis_tags:
             cis_counts[tag] += 1
 
     if (
@@ -1104,15 +1118,27 @@ def print_threat_frameworks(report: AIBOMReport) -> None:
 # ─── Remediation Plan ───────────────────────────────────────────────────────
 
 
-def build_remediation_plan(blast_radii: list[BlastRadius]) -> list[dict]:
-    """Group blast radii into a prioritized remediation plan.
+def build_remediation_plan(blast_radii: list[BlastRadius] | list) -> list[dict]:
+    """Group CVE findings into a prioritized remediation plan.
+
+    Accepts legacy ``BlastRadius`` rows or unified ``Finding`` CVE rows. When
+    passed BlastRadius objects, they are projected through ``blast_radius_to_finding``
+    before grouping.
 
     Returns items sorted by grouped blast-radius risk: each item = one upgrade action that clears
     N vulns across M agents and frees exposed credentials.
     """
     from collections import defaultdict
 
+    from agent_bom.finding import Finding, blast_radius_to_finding
     from agent_bom.remediation_commands import build_fix_command, build_verify_command
+
+    if not blast_radii:
+        return []
+    if isinstance(blast_radii[0], Finding):
+        findings: list[Finding] = list(blast_radii)
+    else:
+        findings = [blast_radius_to_finding(br) for br in blast_radii]
 
     groups: dict[tuple, dict] = defaultdict(
         lambda: {
@@ -1177,52 +1203,56 @@ def build_remediation_plan(blast_radii: list[BlastRadius]) -> list[dict]:
             detail = ", ".join(reasons[:-1]) + f", and {reasons[-1]}"
         return f"Prioritized as {group['priority']} because {detail}."
 
-    for br in blast_radii:
-        key = (br.package.name, br.package.ecosystem, br.package.version)
+    for finding in findings:
+        pkg_name = package_name(finding)
+        ecosystem = package_ecosystem(finding)
+        current = package_version(finding)
+        key = (pkg_name, ecosystem, current)
         g = groups[key]
-        g["package"] = br.package.name
-        g["ecosystem"] = br.package.ecosystem
-        g["current"] = br.package.version
+        g["package"] = pkg_name
+        g["ecosystem"] = ecosystem
+        g["current"] = current
         # Only accept fixed_version values that are real forward upgrades for
         # the package ecosystem; this avoids downgrade/canary suggestions from
         # multi-branch or pre-release advisories.
-        fv = br.vulnerability.fixed_version
+        fv = finding.fixed_version
         if fv:
             from agent_bom.version_utils import compare_versions, is_prerelease_version
 
-            if is_prerelease_version(fv, br.package.ecosystem):
+            if is_prerelease_version(fv, ecosystem):
                 g["suppressed_prerelease_fixes"].add(fv)
-            elif compare_versions(br.package.version, fv, br.package.ecosystem):
-                if g["fix"] is None or compare_versions(g["fix"], fv, br.package.ecosystem):
+            elif compare_versions(current, fv, ecosystem):
+                if g["fix"] is None or compare_versions(g["fix"], fv, ecosystem):
                     g["fix"] = fv
-        g["vulns"].append(br.vulnerability.id)
-        for a in br.affected_agents:
-            g["agents"].add(a.name)
-        g["creds"].update(br.exposed_credentials)
-        g["tools"].update(t.name for t in br.exposed_tools)
-        g["owasp"].update(br.owasp_tags)
-        g["atlas"].update(br.atlas_tags)
-        g["nist"].update(br.nist_ai_rmf_tags)
-        g["owasp_mcp"].update(br.owasp_mcp_tags)
-        g["owasp_agentic"].update(br.owasp_agentic_tags)
-        g["eu_ai_act"].update(br.eu_ai_act_tags)
-        g["nist_csf"].update(br.nist_csf_tags)
-        g["iso_27001"].update(br.iso_27001_tags)
-        g["soc2"].update(br.soc2_tags)
-        g["cis"].update(br.cis_tags)
-        for ref in br.vulnerability.references:
+        vuln_id = finding.cve_id or finding.id
+        g["vulns"].append(vuln_id)
+        g["agents"].update(finding.affected_agents)
+        g["creds"].update(finding.exposed_credentials)
+        g["tools"].update(finding.exposed_tools)
+        g["owasp"].update(finding.owasp_tags)
+        g["atlas"].update(finding.atlas_tags)
+        g["nist"].update(finding.nist_ai_rmf_tags)
+        g["owasp_mcp"].update(finding.owasp_mcp_tags)
+        g["owasp_agentic"].update(finding.owasp_agentic_tags)
+        g["eu_ai_act"].update(finding.eu_ai_act_tags)
+        g["nist_csf"].update(finding.nist_csf_tags)
+        g["iso_27001"].update(finding.iso_27001_tags)
+        g["soc2"].update(finding.soc2_tags)
+        g["cis"].update(finding.cis_tags)
+        for ref in finding_references(finding):
             g["references"].add(ref)
-        if severity_order.get(br.vulnerability.severity, 0) > severity_order.get(g["max_severity"], 0):
-            g["max_severity"] = br.vulnerability.severity
-        if br.vulnerability.severity == Severity.CRITICAL:
+        sev = finding_severity(finding)
+        if severity_order.get(sev, 0) > severity_order.get(g["max_severity"], 0):
+            g["max_severity"] = sev
+        if sev == Severity.CRITICAL:
             g["critical_count"] += 1
-        elif br.vulnerability.severity == Severity.HIGH:
+        elif sev == Severity.HIGH:
             g["high_count"] += 1
-        if br.vulnerability.is_kev:
+        if finding.is_kev:
             g["has_kev"] = True
-        if br.ai_risk_context:
+        if finding.ai_risk_context:
             g["ai_risk"] = True
-        g["max_risk_score"] = max(g["max_risk_score"], br.risk_score)
+        g["max_risk_score"] = max(g["max_risk_score"], finding.risk_score)
 
     plan = []
     for g in groups.values():
@@ -1305,10 +1335,11 @@ def build_remediation_plan(blast_radii: list[BlastRadius]) -> list[dict]:
 
 def print_remediation_plan(report: AIBOMReport) -> None:
     """Print a prioritized remediation plan with named assets and risk narrative."""
-    if not report.blast_radii:
+    all_cve = cve_findings(report)
+    if not all_cve:
         return
 
-    plan = build_remediation_plan(report.blast_radii)
+    plan = build_remediation_plan(all_cve)
     fixable = [p for p in plan if p["fix"]]
     unfixable = [p for p in plan if not p["fix"]]
 
@@ -1316,9 +1347,9 @@ def print_remediation_plan(report: AIBOMReport) -> None:
     total_agents = report.total_agents or 1
     all_creds: set[str] = set()
     all_tools: set[str] = set()
-    for br in report.blast_radii:
-        all_creds.update(br.exposed_credentials)
-        all_tools.update(t.name for t in br.exposed_tools)
+    for finding in all_cve:
+        all_creds.update(finding.exposed_credentials)
+        all_tools.update(finding.exposed_tools)
     total_creds = len(all_creds) or 1
     total_tools = len(all_tools) or 1
 
@@ -1608,10 +1639,10 @@ def print_export_hint(report: AIBOMReport) -> None:
     iso_27001_hit: set[str] = set()
     soc2_hit: set[str] = set()
     cis_hit: set[str] = set()
-    for br in report.blast_radii:
+    for br in cve_findings(report):
         owasp_hit.update(br.owasp_tags)
         atlas_hit.update(br.atlas_tags)
-        attack_hit.update(getattr(br, "attack_tags", []))
+        attack_hit.update(br.attack_tags)
         nist_hit.update(br.nist_ai_rmf_tags)
         owasp_mcp_hit.update(br.owasp_mcp_tags)
         owasp_agentic_hit.update(br.owasp_agentic_tags)
@@ -1641,7 +1672,7 @@ def print_export_hint(report: AIBOMReport) -> None:
     soc2_total = len(_SOC2_TSC)
     cis_total = len(_CIS_CONTROLS)
 
-    if report.blast_radii:
+    if cve_findings(report):
         lines.append("[bold]AI Threat Framework Coverage[/bold]")
         lines.append("")
 
@@ -1934,12 +1965,13 @@ def print_policy_results(policy_result: dict) -> None:
 
 def print_severity_chart(report: AIBOMReport) -> None:
     """Print an ASCII severity distribution bar chart."""
-    if not report.blast_radii:
+    all_cve = cve_findings(report)
+    if not all_cve:
         return
 
     counts: dict[str, int] = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0}
-    for br in report.blast_radii:
-        sev = br.vulnerability.severity.value.upper()
+    for finding in all_cve:
+        sev = finding_severity(finding).value.upper()
         if sev in counts:
             counts[sev] += 1
 

--- a/src/agent_bom/output/console_render.py
+++ b/src/agent_bom/output/console_render.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from rich.console import Console
 from rich.panel import Panel
 from rich.rule import Rule
 from rich.table import Table
 from rich.tree import Tree
 
-from agent_bom.models import AgentStatus, AIBOMReport, BlastRadius, Severity
+from agent_bom.models import AgentStatus, AIBOMReport, Severity
 from agent_bom.output.compact import _coverage_bar, _pct
 from agent_bom.output.finding_views import (
     active_cve_findings,
@@ -1118,7 +1120,7 @@ def print_threat_frameworks(report: AIBOMReport) -> None:
 # ─── Remediation Plan ───────────────────────────────────────────────────────
 
 
-def build_remediation_plan(blast_radii: list[BlastRadius] | list) -> list[dict]:
+def build_remediation_plan(blast_radii: Sequence[object]) -> list[dict]:
     """Group CVE findings into a prioritized remediation plan.
 
     Accepts legacy ``BlastRadius`` rows or unified ``Finding`` CVE rows. When
@@ -1130,15 +1132,105 @@ def build_remediation_plan(blast_radii: list[BlastRadius] | list) -> list[dict]:
     """
     from collections import defaultdict
 
-    from agent_bom.finding import Finding, blast_radius_to_finding
+    from agent_bom.finding import Asset, Finding, FindingSource, FindingType, blast_radius_to_finding
     from agent_bom.remediation_commands import build_fix_command, build_verify_command
 
     if not blast_radii:
         return []
-    if isinstance(blast_radii[0], Finding):
-        findings: list[Finding] = list(blast_radii)
-    else:
-        findings = [blast_radius_to_finding(br) for br in blast_radii]
+
+    def _is_mock_value(value: object) -> bool:
+        return type(value).__module__ == "unittest.mock"
+
+    def _attr(obj: object, name: str, default: object = None) -> object:
+        return getattr(obj, name, default)
+
+    def _text(value: object, default: str = "") -> str:
+        if value is None or _is_mock_value(value):
+            return default
+        raw = getattr(value, "value", value)
+        if raw is None or _is_mock_value(raw):
+            return default
+        return str(raw)
+
+    def _names(values: object) -> list[str]:
+        if not values or _is_mock_value(values):
+            return []
+        names: list[str] = []
+        iterable = values if isinstance(values, list | tuple | set) else []
+        for item in iterable:
+            name = _text(_attr(item, "name", item))
+            if name:
+                names.append(name)
+        return names
+
+    def _list_text(values: object) -> list[str]:
+        if not values or _is_mock_value(values):
+            return []
+        if not isinstance(values, list | tuple | set):
+            return []
+        return [_text(item) for item in values if _text(item)]
+
+    def _float(value: object, default: float = 0.0) -> float:
+        if value is None or _is_mock_value(value):
+            return default
+        try:
+            return float(str(value))
+        except (TypeError, ValueError):
+            return default
+
+    def _blast_radius_like_to_finding(item: object) -> Finding:
+        if isinstance(item, Finding):
+            return item
+        try:
+            return blast_radius_to_finding(item)
+        except TypeError:
+            # Some legacy CLI tests and plugin adapters still pass BlastRadius-like
+            # objects instead of the dataclass. Keep remediation tolerant while the
+            # formatter migration converges on the unified Finding stream.
+            vuln = _attr(item, "vulnerability")
+            pkg = _attr(item, "package")
+            package = _text(_attr(pkg, "name"), "unknown-package")
+            version = _text(_attr(pkg, "version"))
+            ecosystem = _text(_attr(pkg, "ecosystem"))
+            vuln_id = _text(_attr(vuln, "id"), "UNKNOWN")
+            severity = _text(_attr(vuln, "severity"), "unknown").lower()
+            fixed_version = _text(_attr(vuln, "fixed_version")) or None
+            references = _list_text(_attr(vuln, "references", []))
+            identifier = f"pkg:{ecosystem}/{package}@{version}" if ecosystem and package and version else None
+            return Finding(
+                finding_type=FindingType.CVE,
+                source=FindingSource.SBOM,
+                asset=Asset(name=package, asset_type="package", identifier=identifier),
+                severity=severity,
+                title=f"{vuln_id} in {package}",
+                cve_id=vuln_id,
+                fixed_version=fixed_version,
+                is_kev=bool(_attr(vuln, "is_kev", False)),
+                evidence={
+                    "package_name": package,
+                    "package_version": version,
+                    "ecosystem": ecosystem,
+                    "references": references,
+                },
+                affected_agents=_names(_attr(item, "affected_agents", [])),
+                affected_servers=_names(_attr(item, "affected_servers", [])),
+                exposed_credentials=_list_text(_attr(item, "exposed_credentials", [])),
+                exposed_tools=_list_text(_attr(item, "exposed_tools", [])),
+                owasp_tags=_list_text(_attr(item, "owasp_tags", [])),
+                atlas_tags=_list_text(_attr(item, "atlas_tags", [])),
+                nist_ai_rmf_tags=_list_text(_attr(item, "nist_ai_rmf_tags", [])),
+                owasp_mcp_tags=_list_text(_attr(item, "owasp_mcp_tags", [])),
+                owasp_agentic_tags=_list_text(_attr(item, "owasp_agentic_tags", [])),
+                eu_ai_act_tags=_list_text(_attr(item, "eu_ai_act_tags", [])),
+                nist_csf_tags=_list_text(_attr(item, "nist_csf_tags", [])),
+                iso_27001_tags=_list_text(_attr(item, "iso_27001_tags", [])),
+                soc2_tags=_list_text(_attr(item, "soc2_tags", [])),
+                cis_tags=_list_text(_attr(item, "cis_tags", [])),
+                risk_score=_float(_attr(item, "risk_score", 0.0)),
+                ai_risk_context=_text(_attr(item, "ai_risk_context")) or None,
+            )
+
+    findings = [_blast_radius_like_to_finding(item) for item in blast_radii]
 
     groups: dict[tuple, dict] = defaultdict(
         lambda: {
@@ -1335,7 +1427,10 @@ def build_remediation_plan(blast_radii: list[BlastRadius] | list) -> list[dict]:
 
 def print_remediation_plan(report: AIBOMReport) -> None:
     """Print a prioritized remediation plan with named assets and risk narrative."""
-    all_cve = cve_findings(report)
+    try:
+        all_cve: Sequence[object] = cve_findings(report)
+    except TypeError:
+        all_cve = list(getattr(report, "blast_radii", []) or [])
     if not all_cve:
         return
 
@@ -1348,8 +1443,8 @@ def print_remediation_plan(report: AIBOMReport) -> None:
     all_creds: set[str] = set()
     all_tools: set[str] = set()
     for finding in all_cve:
-        all_creds.update(finding.exposed_credentials)
-        all_tools.update(finding.exposed_tools)
+        all_creds.update(getattr(finding, "exposed_credentials", []) or [])
+        all_tools.update(getattr(finding, "exposed_tools", []) or [])
     total_creds = len(all_creds) or 1
     total_tools = len(all_tools) or 1
 

--- a/src/agent_bom/output/finding_views.py
+++ b/src/agent_bom/output/finding_views.py
@@ -16,6 +16,16 @@ def cve_findings(report: AIBOMReport, blast_radii: list[BlastRadius] | None = No
     return [finding for finding in report.to_findings() if finding.finding_type == FindingType.CVE]
 
 
+def active_cve_findings(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> list[Finding]:
+    """Return CVE findings that remain active after VEX suppression."""
+    from agent_bom.vex import active_blast_radii
+
+    source = blast_radii if blast_radii is not None else report.blast_radii
+    if source:
+        return cve_findings(report, active_blast_radii(source))
+    return [finding for finding in cve_findings(report) if not finding.suppressed]
+
+
 def nested_vulnerabilities(report: AIBOMReport) -> list[Any]:
     """Return package vulnerabilities from the legacy inventory tree."""
     vulns: list[Any] = []
@@ -64,6 +74,66 @@ def package_ecosystem(finding: Finding) -> str:
 
 def severity_value(finding: Finding) -> str:
     return str(finding.effective_severity() or finding.severity or "unknown").lower()
+
+
+def finding_severity(finding: Finding) -> Severity:
+    """Map a unified finding to the legacy Severity enum for console badges."""
+    raw = severity_value(finding)
+    if raw == "none":
+        return Severity.NONE
+    try:
+        return Severity(raw)
+    except ValueError:
+        return Severity.UNKNOWN
+
+
+def is_package_direct(finding: Finding) -> bool:
+    return bool(evidence(finding, "package_is_direct", False))
+
+
+def is_package_malicious(finding: Finding) -> bool:
+    return bool(evidence(finding, "package_is_malicious", False))
+
+
+def is_actionable_finding(finding: Finding) -> bool:
+    """Return whether a CVE finding should surface in default actionable views."""
+    if finding.is_actionable is not None:
+        return bool(finding.is_actionable)
+    if finding.suppressed:
+        return False
+    if finding.is_kev:
+        return True
+    if severity_value(finding) in {"critical", "high"}:
+        return True
+    if finding.exposed_credentials or finding.exposed_tools:
+        return True
+    if is_package_direct(finding) or is_package_malicious(finding):
+        return True
+    return False
+
+
+def exploit_likelihood_value(finding: Finding) -> str:
+    """Graded exploit-likelihood signal derived from unified finding enrichment."""
+    from agent_bom.config import EPSS_ACTIVE_EXPLOITATION_THRESHOLD
+
+    if finding.is_kev:
+        return "actively_exploited"
+    epss = finding.epss_score
+    percentile = evidence(finding, "epss_percentile", None)
+    if epss is not None and epss >= EPSS_ACTIVE_EXPLOITATION_THRESHOLD:
+        return "likely_exploited"
+    if percentile is not None and percentile >= 95:
+        return "likely_exploited"
+    if percentile is not None and percentile >= 80:
+        return "public_exploit"
+    return "theoretical"
+
+
+def finding_references(finding: Finding) -> list[str]:
+    refs = evidence(finding, "references", [])
+    if isinstance(refs, list):
+        return [str(ref) for ref in refs if ref]
+    return []
 
 
 def severity_counts(findings: list[Finding]) -> dict[str, int]:

--- a/tests/test_console_finding_migration.py
+++ b/tests/test_console_finding_migration.py
@@ -1,0 +1,172 @@
+"""Regression tests for compact/console formatters on unified Finding (#2918 PR1)."""
+
+from __future__ import annotations
+
+import re
+from io import StringIO
+
+from rich.console import Console
+
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType, blast_radius_to_finding
+from agent_bom.models import (
+    Agent,
+    AgentStatus,
+    AgentType,
+    AIBOMReport,
+    BlastRadius,
+    MCPServer,
+    Package,
+    Severity,
+    TransportType,
+    Vulnerability,
+)
+from agent_bom.output import (
+    build_remediation_plan,
+    print_blast_radius,
+    print_compact_blast_radius,
+    print_compact_remediation,
+    print_compact_summary,
+    print_severity_chart,
+)
+from agent_bom.output.finding_views import active_cve_findings, cve_findings
+
+
+def _capture(fn, *args, **kwargs) -> str:
+    buf = StringIO()
+    con = Console(file=buf, width=120, force_terminal=True, no_color=True)
+    import agent_bom.output as out_mod
+
+    orig = out_mod.console
+    out_mod.console = con
+    try:
+        fn(*args, **kwargs)
+    finally:
+        out_mod.console = orig
+    return buf.getvalue()
+
+
+def _plain(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _cve_finding(**overrides) -> Finding:
+    base = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(name="lodash", asset_type="package", identifier="pkg:npm/lodash@4.17.20"),
+        severity="critical",
+        title="CVE-2024-0001: lodash@4.17.20",
+        description="Prototype pollution in lodash",
+        cve_id="CVE-2024-0001",
+        fixed_version="4.17.21",
+        is_kev=True,
+        epss_score=0.82,
+        risk_score=9.1,
+        is_actionable=True,
+        affected_agents=["prod-agent"],
+        affected_servers=["prod-mcp"],
+        exposed_credentials=["GITHUB_TOKEN"],
+        evidence={
+            "package_name": "lodash",
+            "package_version": "4.17.20",
+            "ecosystem": "npm",
+            "package_is_direct": True,
+        },
+    )
+    for key, value in overrides.items():
+        setattr(base, key, value)
+    return base
+
+
+def test_cve_findings_from_unified_stream_without_blast_radii():
+    finding = _cve_finding()
+    report = AIBOMReport(agents=[], findings=[finding])
+
+    rows = cve_findings(report)
+
+    assert len(rows) == 1
+    assert rows[0].cve_id == "CVE-2024-0001"
+    assert rows[0].affected_agents == ["prod-agent"]
+
+
+def test_active_cve_findings_matches_blast_radius_projection():
+    vuln = Vulnerability(id="CVE-2024-0002", summary="x", severity=Severity.HIGH, fixed_version="2.0.0")
+    pkg = Package(name="axios", version="0.21.0", ecosystem="npm", vulnerabilities=[vuln])
+    server = MCPServer(name="srv", command="npx", transport=TransportType.STDIO, packages=[pkg])
+    agent = Agent(
+        name="agent",
+        agent_type=AgentType.CURSOR,
+        config_path="/tmp/cursor.json",
+        mcp_servers=[server],
+        status=AgentStatus.CONFIGURED,
+    )
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_agents=[agent],
+        affected_servers=[server],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+    report = AIBOMReport(agents=[agent], blast_radii=[br])
+
+    projected = active_cve_findings(report)
+    legacy = [blast_radius_to_finding(item) for item in report.blast_radii]
+
+    assert len(projected) == 1
+    assert projected[0].cve_id == legacy[0].cve_id
+    assert projected[0].affected_agents == legacy[0].affected_agents
+
+
+def test_compact_summary_renders_from_unified_findings():
+    report = AIBOMReport(agents=[], findings=[_cve_finding()])
+    output = _plain(_capture(print_compact_summary, report))
+
+    assert "CRIT" in output
+    assert "CLEAN" not in output
+
+
+def test_compact_blast_radius_renders_from_unified_findings():
+    report = AIBOMReport(agents=[], findings=[_cve_finding()])
+    output = _plain(_capture(print_compact_blast_radius, report, limit=5))
+
+    assert "CVE-2024-0001" in output
+    assert "lodash" in output
+    assert "4.17" in output
+    assert "KEV" in output
+    assert "prod-agent" in output
+
+
+def test_compact_remediation_renders_from_unified_findings():
+    report = AIBOMReport(agents=[], findings=[_cve_finding()])
+    output = _plain(_capture(print_compact_remediation, report))
+
+    assert "Fix First" in output
+    assert "lodash" in output
+    assert "4.17.21" in output
+
+
+def test_console_blast_radius_renders_from_unified_findings():
+    report = AIBOMReport(agents=[], findings=[_cve_finding()])
+    output = _plain(_capture(print_blast_radius, report))
+
+    assert "CVE-2024-0001" in output
+    assert "lodash" in output
+    assert "4.17" in output
+
+
+def test_build_remediation_plan_accepts_findings():
+    finding = _cve_finding()
+    plan = build_remediation_plan([finding])
+
+    assert len(plan) == 1
+    assert plan[0]["package"] == "lodash"
+    assert plan[0]["fix"] == "4.17.21"
+
+
+def test_severity_chart_from_unified_findings():
+    report = AIBOMReport(agents=[], findings=[_cve_finding()])
+    output = _plain(_capture(print_severity_chart, report))
+
+    assert "CRITICAL" in output
+    assert "1 (" in output


### PR DESCRIPTION
## Summary
- Migrate `compact.py` and `console_render.py` CVE rendering paths to consume unified `Finding` rows via `cve_findings()` / `active_cve_findings()` and shared `finding_views` helpers (same pattern as csv/junit/prometheus).
- Extend `finding_views.py` with severity/actionability/exploit-likelihood helpers; keep `blast_radius_to_finding` as the read-only legacy adapter.
- Add `tests/test_console_finding_migration.py` regression coverage for findings-only reports (no `blast_radii`).

Partial fix for #2918 — PR2 will migrate the remaining output formatters.

## Verification
- `uv run pytest tests/test_*compact* tests/test_*console* -q` → 33 passed (compact/console); broader `tests/test_cli*` has unrelated sandbox/env failures in this workspace
- `uv run ruff check src/agent_bom/output/compact.py src/agent_bom/output/console_render.py src/agent_bom/output/finding_views.py tests/test_console_finding_migration.py`

## PR2 remaining formatters (still iterate `blast_radii`)
- `json_fmt.py`
- `html.py`
- `markdown.py`
- `sarif.py`
- `compliance_export.py`
- `compliance_narrative.py`
- `mermaid.py`
- `svg.py`
- `graph.py`
- `pdf.py`


Made with [Cursor](https://cursor.com)