### PR TITLE
fix(hardening): Role enum, Grafana creds, ecosystem claims, HOSTS rollup (#3242)

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -101,7 +101,7 @@ helm upgrade --install agent-bom deploy/helm/agent-bom \
 
 - **Agents + MCP** — MCP clients, servers, tools, transports, trust posture
 - **Skills + instructions** — `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.windsurfrules`, `skills/*`
-- **Package risk** — supply-chain scanning across common application and OS package ecosystems with OSV/GHSA enrichment and blast radius; Hex/Pub are advisory ecosystem identifiers today, not native lockfile parsers
+- **Package risk** — supply-chain scanning across 15 package ecosystems (including `mix.lock` / `pubspec.lock` for Hex and Pub) with OSV/GHSA enrichment and blast radius
 - **AI models + datasets** — malicious-model detection via safe pickle-opcode disassembly (no execution), model/dataset cards, and target-scoped PII/PHI dataset-file scanning
 - **Container images + IaC** — native OCI parsing plus Dockerfile, Terraform, CloudFormation, Helm, and Kubernetes coverage
 - **Cloud estate** — read-only, gated asset inventory across AWS/Azure/GCP plus AI/GPU posture and CIS benchmarks

--- a/site-docs/api/parsers.md
+++ b/site-docs/api/parsers.md
@@ -1,6 +1,6 @@
 # Parsers
 
-Package parsers for lockfiles across ecosystems (Python, Node.js, Go, Rust, Java, .NET, Ruby, C/C++).
+Package parsers for lockfiles across ecosystems (Python, Node.js, Go, Rust, Java, .NET, Ruby, Elixir/Erlang Hex, Dart/Flutter Pub, C/C++, and OS packages).
 
 ::: agent_bom.parsers
     options:

--- a/src/agent_bom/graph/rollup.py
+++ b/src/agent_bom/graph/rollup.py
@@ -30,6 +30,15 @@ from agent_bom.graph.types import EntityType, RelationshipType
 # Severity buckets reported in every roll-up histogram, worst → least.
 _SEVERITY_ORDER: tuple[str, ...] = SEVERITY_BUCKETS_WORST_FIRST
 
+# Estate containment edges: org/account/resource trees use CONTAINS; cloud
+# account→resource lineage may be HOSTS-only on legacy graphs.
+_CONTAINMENT_RELS: frozenset[str] = frozenset({RelationshipType.CONTAINS.value})
+
+# HOSTS is operational hosting (provider→agent, etc.); only account→cloud_resource
+# HOSTS edges participate in estate roll-up alongside CONTAINS.
+_HOSTS_CONTAINMENT_SOURCES: frozenset[str] = frozenset({EntityType.ACCOUNT.value})
+_HOSTS_CONTAINMENT_TARGETS: frozenset[str] = frozenset({EntityType.CLOUD_RESOURCE.value})
+
 # Container entity types form the readable top-level scaffold of the estate.
 # A node of one of these types is a candidate roll-up container; everything else
 # is a leaf that aggregates into its nearest container ancestor.
@@ -173,16 +182,33 @@ class RollupFilters:
         return True
 
 
-def _contains_children(graph: UnifiedGraph) -> dict[str, list[str]]:
-    """Map container_id -> sorted direct CONTAINS children (deterministic).
+def _edge_is_containment(graph: UnifiedGraph, edge: Any) -> bool:
+    rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
+    if rel in _CONTAINMENT_RELS:
+        return True
+    if rel != RelationshipType.HOSTS.value:
+        return False
+    source = graph.nodes.get(edge.source)
+    target = graph.nodes.get(edge.target)
+    if source is None or target is None:
+        return False
+    return (
+        _node_type_value(source) in _HOSTS_CONTAINMENT_SOURCES
+        and _node_type_value(target) in _HOSTS_CONTAINMENT_TARGETS
+    )
 
+
+def _contains_children(graph: UnifiedGraph) -> dict[str, list[str]]:
+    """Map container_id -> sorted direct containment children (deterministic).
+
+    Walks ``CONTAINS`` and account→``CLOUD_RESOURCE`` ``HOSTS`` edges so cloud
+    resources roll up under their account even when only ``HOSTS`` is present.
     Self-loops are ignored. Children are de-duplicated and sorted by id so the
     output is stable across runs regardless of edge insertion order.
     """
     children: dict[str, set[str]] = defaultdict(set)
     for edge in graph.edges:
-        rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
-        if rel != RelationshipType.CONTAINS.value:
+        if not _edge_is_containment(graph, edge):
             continue
         if edge.source == edge.target:
             continue

--- a/tests/test_graph_rollup.py
+++ b/tests/test_graph_rollup.py
@@ -27,6 +27,10 @@ def _contains(graph: UnifiedGraph, parent: str, child: str) -> None:
     graph.add_edge(UnifiedEdge(source=parent, target=child, relationship=RelationshipType.CONTAINS))
 
 
+def _hosts(graph: UnifiedGraph, parent: str, child: str) -> None:
+    graph.add_edge(UnifiedEdge(source=parent, target=child, relationship=RelationshipType.HOSTS))
+
+
 def _deep_estate() -> UnifiedGraph:
     """org -> account -> app -> {server, server} -> {package(crit), package(low)}."""
     g = UnifiedGraph(scan_id="estate-scan", tenant_id="default")
@@ -83,6 +87,29 @@ def _large_estate(accounts: int = 10, apps: int = 10, pkgs: int = 12) -> Unified
 
 
 # ── Roll-up ──────────────────────────────────────────────────────────────
+
+
+def test_rollup_treats_hosts_as_containment_for_cloud_account_resources() -> None:
+    """Legacy or HOSTS-only account→resource edges must roll up like CONTAINS."""
+    g = UnifiedGraph(scan_id="hosts-scan", tenant_id="default")
+    g.add_node(UnifiedNode(id="account:aws:1", entity_type=EntityType.ACCOUNT, label="prod"))
+    g.add_node(
+        UnifiedNode(
+            id="cloud_resource:aws:s3:bucket",
+            entity_type=EntityType.CLOUD_RESOURCE,
+            label="public-bucket",
+            severity="high",
+        )
+    )
+    _hosts(g, "account:aws:1", "cloud_resource:aws:s3:bucket")
+
+    view = rollup_view(g)
+    assert view["summary"]["top_level_count"] == 1
+    top = view["top_level"][0]
+    assert top["id"] == "account:aws:1"
+    assert top["aggregate"]["descendant_count"] == 1
+    assert top["aggregate"]["by_type"]["cloud_resource"] == 1
+    assert top["aggregate"]["worst_severity"] == "high"
 
 
 def test_rollup_collapses_deep_contains_tree_with_aggregate_counts() -> None:


### PR DESCRIPTION
## Summary
- **Role enum** — already on `main` via #3279 (`api/auth.py` imports `rbac.Role`; `tests/test_auth.py::test_api_auth_uses_central_role_rank` guards regression).
- **Grafana compose** — already on `main` via #3282 (`GRAFANA_ADMIN_*` required from env; Grafana bound to `127.0.0.1:3001`).
- **Hex/Pub ecosystem claims** — remove stale PYPI copy denying lockfile parsers; parsers ship in `beam_parsers.py` with `tests/test_beam_parsers.py`. Update `site-docs/api/parsers.md` ecosystem list.
- **HOSTS roll-up** — treat account→`cloud_resource` `HOSTS` as containment in `graph/rollup.py` when `CONTAINS` is absent; regression in `tests/test_graph_rollup.py`.

Partial close-out of #3242. Deferred (separate issues): severity enum unification, cosign pinning, SAML replay, MCP audit actor.

## Verification
- `uv run pytest tests/test_graph_rollup.py tests/test_graph_builder.py -k "rollup or cloud_resource_rolls" -q`
- `uv run ruff check src/agent_bom/graph/rollup.py tests/test_graph_rollup.py`


Made with [Cursor](https://cursor.com)