### PR TITLE
feat(release): SBOM release asset, image scan gate, air-gap vuln-DB docs (#3436)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -587,13 +587,17 @@ jobs:
           subject-digest: ${{ steps.build-ui-image.outputs.digest }}
           push-to-registry: true
 
-  published-image-self-scan:
-    name: Self-scan published image
+  published-image-scan-gate:
+    name: Published image scan gate
     needs: docker-publish
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: read
+      security-events: write
+    env:
+      # Repository variable override, e.g. CRITICAL or CRITICAL,HIGH,MEDIUM
+      RELEASE_IMAGE_SCAN_FAIL_SEVERITIES: ${{ vars.RELEASE_IMAGE_SCAN_FAIL_SEVERITIES != '' && vars.RELEASE_IMAGE_SCAN_FAIL_SEVERITIES || 'CRITICAL,HIGH' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -610,14 +614,66 @@ jobs:
       - name: Pull published API image
         run: docker pull agentbom/agent-bom:${{ steps.meta.outputs.version }}
 
-      - name: Scan published API image with agent-bom
+      - name: Install Trivy
+        run: |
+          set -euo pipefail
+          TRIVY_VERSION="0.72.0"
+          TRIVY_SHA256="bbb64b9695866ce4a7a8f5c9592002c5961cab378577fa3f8a040df362b9b2ea"
+          TRIVY_ARCHIVE="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          curl -fsSL -o "/tmp/${TRIVY_ARCHIVE}" \
+            "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${TRIVY_ARCHIVE}"
+          echo "${TRIVY_SHA256}  /tmp/${TRIVY_ARCHIVE}" | sha256sum -c -
+          tar -xzf "/tmp/${TRIVY_ARCHIVE}" -C /tmp trivy
+          sudo install -m 0755 /tmp/trivy /usr/local/bin/trivy
+          trivy --version
+
+      - name: Trivy scan gate (published image)
+        # Cross-check the Docker Hub image after push. Severity threshold is
+        # configurable via the RELEASE_IMAGE_SCAN_FAIL_SEVERITIES repository
+        # variable (default CRITICAL,HIGH). Unfixable OS/package CVEs listed in
+        # .image-scan-ignore are excluded from the gate.
+        run: |
+          set -euo pipefail
+          IMAGE="agentbom/agent-bom:${{ steps.meta.outputs.version }}"
+          trivy image "$IMAGE" \
+            --severity "${RELEASE_IMAGE_SCAN_FAIL_SEVERITIES}" \
+            --ignore-unfixed \
+            --ignorefile .image-scan-ignore \
+            --exit-code 1 \
+            --format table
+          trivy image "$IMAGE" \
+            --severity "${RELEASE_IMAGE_SCAN_FAIL_SEVERITIES}" \
+            --ignore-unfixed \
+            --ignorefile .image-scan-ignore \
+            --format json \
+            -o trivy-published-image.json
+          trivy image "$IMAGE" \
+            --severity "${RELEASE_IMAGE_SCAN_FAIL_SEVERITIES}" \
+            --ignore-unfixed \
+            --ignorefile .image-scan-ignore \
+            --format sarif \
+            -o trivy-published-image.sarif
+
+      - name: Upload Trivy SARIF to GitHub Security tab
+        if: always() && hashFiles('trivy-published-image.sarif') != ''
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: trivy-published-image.sarif
+          category: release-published-image-trivy
+
+      - name: Scan published API image with agent-bom (evidence)
         run: uv run agent-bom image agentbom/agent-bom:${{ steps.meta.outputs.version }} --format json --output published-image-self-scan.json
 
-      - name: Upload published image self-scan artifact
+      - name: Upload published image scan artifacts
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: published-image-self-scan
-          path: published-image-self-scan.json
+          name: published-image-scan
+          path: |
+            trivy-published-image.json
+            trivy-published-image.sarif
+            published-image-self-scan.json
+          if-no-files-found: warn
 
   helm-publish:
     name: Publish Helm chart to OCI
@@ -1001,9 +1057,10 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    # Keep the post-publish image self-scan running, but do not let a slow
-    # registry scan delay minting the GitHub Release after artifacts are out.
-    needs: [pypi-publish, docker-publish, docker-publish-ui, sign, provenance, sbom, helm-publish]
+    # Block the GitHub Release until the published-image Trivy gate passes.
+    # PyPI/Docker Hub artifacts may already be live; the gate still prevents
+    # minting signed release assets when the pushed image crosses the threshold.
+    needs: [pypi-publish, docker-publish, docker-publish-ui, sign, provenance, sbom, helm-publish, published-image-scan-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/deploy/helm/agent-bom/examples/airgap-vuln-db-values.yaml
+++ b/deploy/helm/agent-bom/examples/airgap-vuln-db-values.yaml
@@ -1,0 +1,40 @@
+# Air-gapped control plane: mount a pre-synced vulns.db and disable network refresh.
+#
+# 1. On a connected bastion: agent-bom db update
+# 2. Bundle: scripts/release/bundle-vuln-db.sh dist/airgap
+# 3. Create a Secret or PVC with dist/airgap/vulns.db on the disconnected cluster
+# 4. helm install/upgrade with -f deploy/helm/agent-bom/examples/airgap-vuln-db-values.yaml
+#
+# See docs/ENTERPRISE_DEPLOYMENT.md and docs/RELEASE_VERIFICATION.md.
+
+controlPlane:
+  enabled: true
+  api:
+    env:
+      - name: AGENT_BOM_DB_PATH
+        value: /var/lib/agent-bom/vulns.db
+      - name: AGENT_BOM_VULN_DB_OFFLINE
+        value: "1"
+    extraVolumes:
+      - name: vuln-db
+        secret:
+          secretName: agent-bom-vuln-db
+    extraVolumeMounts:
+      - name: vuln-db
+        mountPath: /var/lib/agent-bom
+        readOnly: true
+
+scanner:
+  env:
+    - name: AGENT_BOM_DB_PATH
+      value: /var/lib/agent-bom/vulns.db
+    - name: AGENT_BOM_VULN_DB_OFFLINE
+      value: "1"
+  extraVolumes:
+    - name: vuln-db
+      secret:
+        secretName: agent-bom-vuln-db
+  extraVolumeMounts:
+    - name: vuln-db
+      mountPath: /var/lib/agent-bom
+      readOnly: true

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -508,6 +508,26 @@ Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base i
 - Air-gapped environments with a pre-synced local vulnerability DB.
 - Reproducible image scans across developer laptops and build runners.
 
+#### Air-gapped vulnerability database preload
+
+Disconnected estates need a **transferred `vulns.db`** plus offline runtime
+flags. The product does not phone home for advisories when
+`AGENT_BOM_VULN_DB_OFFLINE=1` or `--offline` is set; it reads whatever cache
+you mount at `AGENT_BOM_DB_PATH` (default `~/.agent-bom/db/vulns.db`).
+
+| Step | First command → artifact | Next step |
+|---|---|---|
+| Sync (connected bastion) | `agent-bom db update` → `~/.agent-bom/db/vulns.db` | `agent-bom db status` to confirm source freshness |
+| Bundle | `scripts/release/bundle-vuln-db.sh dist/airgap` → `vulns.db` + checksum | Transfer through your approved file path |
+| Docker runtime | `docker run -v /path/to/vulns.db:/var/lib/agent-bom/vulns.db:ro -e AGENT_BOM_DB_PATH=/var/lib/agent-bom/vulns.db -e AGENT_BOM_VULN_DB_OFFLINE=1 …` | `agent-bom agents --offline /workspace` smoke |
+| Helm control plane | `kubectl create secret generic agent-bom-vuln-db --from-file=vulns.db=dist/airgap/vulns.db` then `-f deploy/helm/agent-bom/examples/airgap-vuln-db-values.yaml` | Roll API + scanner pods; rescans use the mounted cache only |
+| Refresh cadence | Repeat sync + bundle on a connected host | Replace the mounted `vulns.db` on your maintenance window |
+
+`deploy/docker-compose.pilot.yml` already sets `AGENT_BOM_DB_PATH` on the API
+service volume — seed that volume with a pre-synced `vulns.db` before bringing
+the stack up. Image import for disconnected registries is documented in
+[`site-docs/deployment/airgapped-image-bundle.md`](../site-docs/deployment/airgapped-image-bundle.md).
+
 ## Output Integration
 
 | Target | Command | Format |

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -95,6 +95,56 @@ You can also run `agent-bom` against that SBOM directly:
 agent-bom sbom agent-bom-sbom.cdx.json -f json
 ```
 
+## Release CI image scan gate
+
+After `agentbom/agent-bom:<tag>` is pushed to Docker Hub, release CI pulls the
+published image and runs a Trivy gate before minting the GitHub Release:
+
+| Step | Tool | Default policy |
+|---|---|---|
+| Pre-publish candidate | `agent-bom image` in `container-gate` | fail on fixable `MEDIUM+`, `.image-scan-ignore` allowlist |
+| Post-publish registry image | Trivy in `published-image-scan-gate` | fail on `CRITICAL,HIGH`, `--ignore-unfixed`, same allowlist |
+
+Override the published-image threshold with the repository variable
+`RELEASE_IMAGE_SCAN_FAIL_SEVERITIES` (comma-separated Trivy severities, e.g.
+`CRITICAL` or `CRITICAL,HIGH,MEDIUM`).
+
+Local dry-run against a release candidate image:
+
+```bash
+docker build -t agent-bom:release-test .
+trivy image --severity CRITICAL,HIGH --ignore-unfixed --ignorefile .image-scan-ignore agent-bom:release-test
+```
+
+Trivy SARIF from the release job is uploaded to the GitHub Security tab under
+category `release-published-image-trivy`.
+
+## Air-gap vulnerability database preload
+
+Air-gapped scans use a **pre-synced local SQLite cache** (`vulns.db`), not live
+OSV/GHSA calls. The preload path is:
+
+| Step | Command / artifact | Next step |
+|---|---|---|
+| 1. Sync on a connected bastion | `agent-bom db update` | Produces `~/.agent-bom/db/vulns.db` (~50 MB first run) |
+| 2. Verify freshness | `agent-bom db status` | Confirm OSV/Alpine/Debian/EPSS/KEV rows and sync timestamps |
+| 3. Bundle for transfer | `scripts/release/bundle-vuln-db.sh dist/airgap` | Writes `dist/airgap/vulns.db` + `sha256sums-vulns.db.txt` |
+| 4. Import on disconnected host | `sha256sum -c sha256sums-vulns.db.txt` then copy `vulns.db` | Mount or copy to the runtime DB path |
+| 5. Point runtime at the cache | `AGENT_BOM_DB_PATH=/var/lib/agent-bom/vulns.db` | Same path in Docker, Helm, or bare-metal installs |
+| 6. Disable network refresh | `AGENT_BOM_VULN_DB_OFFLINE=1` or CLI `--offline` | Scans use the bundled cache only; rerun step 1–4 on a schedule |
+| 7. Smoke scan | `agent-bom agents --offline /workspace` | Expect `Vuln data: … local cache (offline — network skipped)` |
+
+Docker pilot compose already wires `AGENT_BOM_DB_PATH` to a named volume —
+preload by copying `vulns.db` into that volume before the first scan. Helm
+operators can start from
+`deploy/helm/agent-bom/examples/airgap-vuln-db-values.yaml` (Secret-mounted
+`vulns.db` + offline env flags).
+
+Image import for disconnected registries remains in
+[`site-docs/deployment/airgapped-image-bundle.md`](../site-docs/deployment/airgapped-image-bundle.md);
+combine that image bundle with the `vulns.db` bundle above for full offline
+scanning.
+
 ## Inspect scanner accuracy evidence
 
 Release candidates also carry a checked-in scanner accuracy baseline:
@@ -124,6 +174,8 @@ pytest tests/test_graph_schema_ui_parity.py tests/test_graph_edge_counts.py test
 - the distribution artifacts were signed by GitHub Actions OIDC via Sigstore
 - the build provenance is available as SLSA attestations
 - the release includes a self-SBOM that can be inspected or rescanned later
+- the published Docker image passed a Trivy gate at the configured severity threshold before the GitHub Release was minted
+- air-gapped operators can preload `vulns.db`, mount it at `AGENT_BOM_DB_PATH`, and run with `AGENT_BOM_VULN_DB_OFFLINE=1`
 - scanner accuracy claims are backed by a versioned local evidence artifact
 - graph readability/trust claims are linked to deterministic, checked-in proof
 

--- a/scripts/release/bundle-vuln-db.sh
+++ b/scripts/release/bundle-vuln-db.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Bundle a pre-synced agent-bom vulnerability database for air-gapped import.
+#
+# First command (connected bastion):
+#   agent-bom db update
+# Next artifact:
+#   scripts/release/bundle-vuln-db.sh dist/airgap
+# Next step on the disconnected host:
+#   verify sha256sums.txt, copy vulns.db to the runtime path, set
+#   AGENT_BOM_DB_PATH and AGENT_BOM_VULN_DB_OFFLINE=1 — see
+#   docs/ENTERPRISE_DEPLOYMENT.md and docs/RELEASE_VERIFICATION.md.
+set -euo pipefail
+
+SOURCE="${AGENT_BOM_DB_SOURCE:-${HOME}/.agent-bom/db/vulns.db}"
+OUTPUT_DIR="${1:-dist/airgap}"
+
+if [[ ! -f "$SOURCE" ]]; then
+  echo "error: vulnerability DB not found at ${SOURCE}" >&2
+  echo "Run 'agent-bom db update' on a connected host first." >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+DEST="$OUTPUT_DIR/vulns.db"
+cp "$SOURCE" "$DEST"
+
+if command -v agent-bom >/dev/null 2>&1; then
+  agent-bom db status --path "$DEST"
+elif command -v uv >/dev/null 2>&1 && [[ -f pyproject.toml ]]; then
+  uv run agent-bom db status --path "$DEST"
+else
+  echo "Bundled ${DEST} ($(wc -c <"$DEST" | tr -d ' ') bytes)"
+fi
+
+(
+  cd "$OUTPUT_DIR"
+  sha256sum vulns.db > sha256sums-vulns.db.txt
+)
+echo "Wrote ${DEST} and ${OUTPUT_DIR}/sha256sums-vulns.db.txt"


### PR DESCRIPTION
## Summary
- Add a Trivy post-publish gate on `agentbom/agent-bom:<tag>` (default fail on `CRITICAL,HIGH`, override via `RELEASE_IMAGE_SCAN_FAIL_SEVERITIES`) and block GitHub Release minting until it passes; keep agent-bom scan evidence and upload Trivy SARIF.
- Document the air-gap `vulns.db` preload path in `docs/RELEASE_VERIFICATION.md` and `docs/ENTERPRISE_DEPLOYMENT.md` (first command → artifact → next step).
- Ship minimal scaffolds: `scripts/release/bundle-vuln-db.sh` and `deploy/helm/agent-bom/examples/airgap-vuln-db-values.yaml` wiring `AGENT_BOM_DB_PATH` + `AGENT_BOM_VULN_DB_OFFLINE`.
- CycloneDX SBOM release asset upload was already present in `release.yml`; docs now call out the image gate and offline DB path explicitly.

Fixes #3436

## Test plan
- [x] `uv run python scripts/lint_release_workflow.py .github/workflows/release.yml`
- [x] `helm template agent-bom deploy/helm/agent-bom -f deploy/helm/agent-bom/examples/airgap-vuln-db-values.yaml --set controlPlane.enabled=true`
- [ ] Full release workflow runs on next tag (Trivy gate + SBOM asset upload)


Made with [Cursor](https://cursor.com)