### PR TITLE
fix(hardening): severity unification and cosign/MCP audit fixes (#3242)

### DIFF
--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -28,13 +28,12 @@ from collections.abc import Callable
 from typing import Any, Protocol
 
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
+from agent_bom.graph.severity import severity_policy_rank
 
 # Defined here (module scope) so ``list`` resolves to the builtin: the store
 # classes below define a ``list`` method that would otherwise shadow it in
 # their ``list_page`` return annotations.
 FindingPage = tuple[list[dict[str, Any]], int]
-
-_SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1}
 
 # Sort keys supported by ``list_page``. ``effective_reach`` is the default and
 # the only one backed by a dedicated index/column; ``cvss`` and ``severity``
@@ -43,7 +42,7 @@ _LIST_PAGE_SORTS = ("effective_reach", "cvss", "severity", "ordinal")
 
 
 def _severity_rank(payload: dict[str, Any]) -> int:
-    return _SEVERITY_RANK.get(str(payload.get("severity", "")).lower(), 0)
+    return severity_policy_rank(str(payload.get("severity", "")))
 
 
 def _cvss_value(payload: dict[str, Any]) -> float:

--- a/src/agent_bom/cli/_agent_mode.py
+++ b/src/agent_bom/cli/_agent_mode.py
@@ -9,6 +9,8 @@ import sys
 from copy import deepcopy
 from typing import Any
 
+from agent_bom.graph.severity import severity_policy_rank
+
 # Keys whose value is credential material and must never appear in the
 # machine-readable envelope, which automation callers routinely capture and log.
 # Matched on the key name only, as a whole token, so reference labels and entity
@@ -41,8 +43,6 @@ def _redact_sensitive(value: Any, *, key_is_sensitive: bool = False) -> Any:
         return _REDACTED
     return value
 
-
-from agent_bom.graph.severity import severity_policy_rank
 
 AGENT_MODE_ENV_VAR = "AGENT_BOM_AGENT_MODE"
 AGENT_MODE_SCHEMA_VERSION = "1"

--- a/src/agent_bom/cli/_agent_mode.py
+++ b/src/agent_bom/cli/_agent_mode.py
@@ -42,14 +42,14 @@ def _redact_sensitive(value: Any, *, key_is_sensitive: bool = False) -> Any:
     return value
 
 
+from agent_bom.graph.severity import severity_policy_rank
+
 AGENT_MODE_ENV_VAR = "AGENT_BOM_AGENT_MODE"
 AGENT_MODE_SCHEMA_VERSION = "1"
 
 # Number of top-ranked findings / exposure paths kept in the summarized scan
 # payload that agent mode emits by default.
 SCAN_SUMMARY_TOP_N = 10
-
-_SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1, "unknown": 0}
 
 
 def agent_mode_requested(argv: list[str] | None = None) -> bool:
@@ -157,7 +157,7 @@ def _risk_sort_key(item: Any) -> tuple[float, int]:
     except (TypeError, ValueError):
         score = 0.0
     severity = str(item.get("effective_severity") or item.get("severity") or "unknown").lower()
-    return (score, _SEVERITY_RANK.get(severity, 0))
+    return (score, severity_policy_rank(severity))
 
 
 def _compact_finding(item: dict[str, Any]) -> dict[str, Any]:

--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -1539,14 +1539,9 @@ def _derive_findings(report: GovernanceReport) -> list[GovernanceFinding]:
     findings.extend(_find_agent_usage_anomalies(report))
 
     # Sort by severity
-    severity_order = {
-        GovernanceSeverity.CRITICAL: 0,
-        GovernanceSeverity.HIGH: 1,
-        GovernanceSeverity.MEDIUM: 2,
-        GovernanceSeverity.LOW: 3,
-        GovernanceSeverity.INFO: 4,
-    }
-    findings.sort(key=lambda f: severity_order.get(f.severity, 99))
+    from agent_bom.graph.severity import severity_worst_first_rank
+
+    findings.sort(key=lambda f: severity_worst_first_rank(f.severity.value if hasattr(f.severity, "value") else str(f.severity)))
 
     return findings
 

--- a/src/agent_bom/compliance_hub_ingest.py
+++ b/src/agent_bom/compliance_hub_ingest.py
@@ -27,6 +27,7 @@ from typing import Any, Iterable
 
 from agent_bom.compliance_hub import apply_hub_classification
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+from agent_bom.graph.severity import normalize_severity
 
 # SARIF level → severity. SARIF only defines four levels; we map none/note
 # down to "info" so they don't masquerade as low-severity bugs.
@@ -357,17 +358,17 @@ def _resolve_csv_field(row: dict[str, str], candidates: tuple[str, ...]) -> str:
 
 def _normalise_csv_severity(value: str) -> str:
     lowered = value.lower().strip()
-    if lowered in ("critical", "crit"):
-        return "critical"
-    if lowered in ("high", "h"):
-        return "high"
-    if lowered in ("medium", "med", "moderate", "m"):
-        return "medium"
-    if lowered in ("low", "l"):
-        return "low"
-    if lowered in ("info", "informational", "note"):
-        return "info"
-    return lowered or "unknown"
+    aliases = {
+        "crit": "critical",
+        "h": "high",
+        "med": "medium",
+        "moderate": "medium",
+        "m": "medium",
+        "l": "low",
+        "note": "info",
+        "informational": "info",
+    }
+    return normalize_severity(aliases.get(lowered, lowered) if lowered else None)
 
 
 def ingest_csv_findings(path: str | Path) -> list[Finding]:

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -304,6 +304,10 @@ class Finding:
         from agent_bom.graph.severity import normalize_severity
 
         self.severity = normalize_severity(self.severity)
+        if self.vendor_severity is not None:
+            self.vendor_severity = normalize_severity(self.vendor_severity)
+        if self.cvss_severity is not None:
+            self.cvss_severity = normalize_severity(self.cvss_severity)
         self.controls = _dedupe_control_tags(
             [
                 *(tag if isinstance(tag, ControlTag) else ControlTag.from_dict(tag) for tag in self.controls),

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -301,6 +301,9 @@ class Finding:
 
     def __post_init__(self) -> None:
         """Compute stable ID from finding content if not explicitly set."""
+        from agent_bom.graph.severity import normalize_severity
+
+        self.severity = normalize_severity(self.severity)
         self.controls = _dedupe_control_tags(
             [
                 *(tag if isinstance(tag, ControlTag) else ControlTag.from_dict(tag) for tag in self.controls),
@@ -645,7 +648,7 @@ def secret_dict_to_finding(secret: dict) -> "Finding":
     line = raw_line if isinstance(raw_line, int) else sanitize_text(raw_line, max_len=40) if raw_line is not None else None
     secret_type = sanitize_text(secret.get("type", "secret") or "secret", max_len=120)
     category = sanitize_text(secret.get("category", "secret") or "secret", max_len=120)
-    severity = sanitize_text(secret.get("severity", "medium") or "medium", max_len=40).upper()
+    severity = sanitize_text(secret.get("severity", "medium") or "medium", max_len=40)
     loc = f"{file_path}:{line}" if line else file_path
     return Finding(
         finding_type=FindingType.CREDENTIAL_EXPOSURE,
@@ -686,7 +689,7 @@ def cloud_cis_check_to_finding(check: dict, provider: str) -> "Finding":
 
     check_id = sanitize_text(str(check.get("check_id", "") or "unknown"), max_len=40)
     title = sanitize_text(str(check.get("title", "") or check_id), max_len=300)
-    severity = sanitize_text(str(check.get("severity", "medium") or "medium"), max_len=40).upper()
+    severity = sanitize_text(str(check.get("severity", "medium") or "medium"), max_len=40)
     evidence_text = sanitize_text(str(check.get("evidence", "") or ""), max_len=600)
     recommendation = sanitize_text(str(check.get("recommendation", "") or ""), max_len=600)
     resource_ids = [sanitize_text(str(r), max_len=300) for r in (check.get("resource_ids") or []) if str(r).strip()]
@@ -738,7 +741,7 @@ def snowflake_governance_finding_to_finding(finding: dict, account: str) -> "Fin
     from agent_bom.security import sanitize_text
 
     category = sanitize_text(str(finding.get("category", "") or "access"), max_len=60)
-    severity = sanitize_text(str(finding.get("severity", "medium") or "medium"), max_len=40).upper()
+    severity = sanitize_text(str(finding.get("severity", "medium") or "medium"), max_len=40)
     title = sanitize_text(str(finding.get("title", "") or category), max_len=300)
     description = sanitize_text(str(finding.get("description", "") or ""), max_len=600)
     agent_or_role = sanitize_text(str(finding.get("agent_or_role", "") or ""), max_len=300)

--- a/src/agent_bom/graph/severity.py
+++ b/src/agent_bom/graph/severity.py
@@ -133,6 +133,11 @@ def severity_at_or_above(candidate: str | None, threshold: str | None) -> bool:
     return severity_policy_rank(candidate) >= severity_policy_rank(threshold)
 
 
+def severity_worst_first_rank(sev: str | None) -> int:
+    """Ascending sort rank where more severe findings sort earlier."""
+    return -severity_policy_rank(sev)
+
+
 def severity_to_ocsf(sev: str) -> int:
     """Convert severity string to OCSF severity_id."""
     return SEVERITY_TO_OCSF.get(sev.lower() if sev else "", OCSFSeverity.UNKNOWN)

--- a/src/agent_bom/guard.py
+++ b/src/agent_bom/guard.py
@@ -28,19 +28,13 @@ import sys
 from dataclasses import dataclass, field
 from typing import Optional
 
+from agent_bom.graph.severity import severity_policy_rank
+
 logger = logging.getLogger(__name__)
 
 # Patterns to extract package names from pip/npm install args
 _PIP_SPEC_RE = re.compile(r"^([A-Za-z0-9_][A-Za-z0-9._-]*)(?:[=<>!~\[].*)?$")
 _NPM_SPEC_RE = re.compile(r"^(@?[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)?)(?:@.*)?$")
-_SEVERITY_RANK = {
-    "unknown": 0,
-    "none": 0,
-    "low": 1,
-    "medium": 2,
-    "high": 3,
-    "critical": 4,
-}
 
 # pip/npm flags that take a value argument (so we skip the next token)
 _PIP_VALUE_FLAGS = frozenset(
@@ -162,13 +156,13 @@ async def _check_package(name: str, ecosystem: str, min_severity: str = "high", 
 
     cve_list = []
     blocked = False
-    min_rank = _SEVERITY_RANK.get(min_severity, _SEVERITY_RANK["high"])
+    min_rank = severity_policy_rank(min_severity)
     for v in getattr(pkg_entry, "vulnerabilities", []):
         severity = _severity_value(getattr(v, "severity", "unknown"))
         cve_id = getattr(v, "id", "unknown")
         is_kev = bool(getattr(v, "is_kev", False))
         cve_list.append({"id": cve_id, "severity": severity, "is_kev": is_kev})
-        if _SEVERITY_RANK.get(severity, 0) >= min_rank or (block_kev and is_kev):
+        if severity_policy_rank(severity) >= min_rank or (block_kev and is_kev):
             blocked = True
 
     return {

--- a/src/agent_bom/hardware_evidence.py
+++ b/src/agent_bom/hardware_evidence.py
@@ -69,6 +69,7 @@ from typing import Any
 
 from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
 from agent_bom.graph.node import stable_node_id
+from agent_bom.graph.severity import normalize_severity
 
 SCHEMA_VERSION = "agent-bom.hardware-evidence/v1"
 _SUPPORTED_SCHEMAS = frozenset({SCHEMA_VERSION})
@@ -80,7 +81,6 @@ RESOURCE_KIND_FIRMWARE = "firmware"
 RESOURCE_KIND_GPU = "gpu"
 
 _DATA_SOURCE = "hardware-attestation-ingest"
-_VALID_SEVERITIES = frozenset({"critical", "high", "medium", "low", "info", "unknown"})
 
 
 class HardwareEvidenceError(ValueError):
@@ -148,8 +148,7 @@ def _attestation_tags(attestation: dict[str, Any]) -> tuple[list[str], dict[str,
 
 
 def _normalize_severity(raw: Any) -> str:
-    value = _str(raw).lower()
-    return value if value in _VALID_SEVERITIES else "unknown"
+    return normalize_severity(_str(raw))
 
 
 def build_hardware_graph(

--- a/src/agent_bom/iac/__init__.py
+++ b/src/agent_bom/iac/__init__.py
@@ -180,7 +180,7 @@ def scan_iac_with_context(
 
     findings: list[IaCFinding] = []
     files_matched: dict[str, int] = defaultdict(int)
-    severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+    from agent_bom.graph.severity import severity_worst_first_rank
 
     walk_root = root_path.parent if explicit_file else root_path
     walk_paths = [root_path] if explicit_file else sorted(root_path.rglob("*"))
@@ -249,7 +249,7 @@ def scan_iac_with_context(
         if not finding.atlas_techniques:
             finding.atlas_techniques = get_atlas_techniques(finding.rule_id, message=finding.message)
 
-    findings.sort(key=lambda f: (severity_order.get(f.severity, 9), f.file_path, f.line_number))
+    findings.sort(key=lambda f: (severity_worst_first_rank(f.severity), f.file_path, f.line_number))
 
     # Build verdict table — one entry per canonical scanner ID.
     verdicts: list[ScannerVerdict] = []

--- a/src/agent_bom/output/compliance_narrative.py
+++ b/src/agent_bom/output/compliance_narrative.py
@@ -138,7 +138,9 @@ class ComplianceNarrative:
 
 
 def _severity_order(sev: str) -> int:
-    return {"critical": 0, "high": 1, "medium": 2, "low": 3}.get(sev.lower(), 4)
+    from agent_bom.graph.severity import severity_worst_first_rank
+
+    return severity_worst_first_rank(sev)
 
 
 def _control_status(sev_breakdown: dict[str, int]) -> str:

--- a/tests/test_cloud_cis_convergence.py
+++ b/tests/test_cloud_cis_convergence.py
@@ -55,7 +55,7 @@ def test_cis_fails_become_findings_across_providers() -> None:
     assert by_title["CIS 1.7: Root used"].attack_tags == ["T1078"]
     assert "CIS-1.7" in by_title["CIS 1.7: Root used"].compliance_tags
     az = by_title["CIS 3.2: Storage open"]
-    assert az.severity == "CRITICAL"
+    assert az.severity == "critical"
     assert az.asset.identifier == "/sub/x/sa/foo"
 
 

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -212,7 +212,7 @@ def test_finding_effective_severity_vendor_wins():
         vendor_severity="HIGH",
         cvss_severity="LOW",
     )
-    assert finding.effective_severity() == "HIGH"
+    assert finding.effective_severity() == "high"
 
 
 def test_finding_effective_severity_cvss_fallback():
@@ -224,7 +224,7 @@ def test_finding_effective_severity_cvss_fallback():
         vendor_severity=None,
         cvss_severity="LOW",
     )
-    assert finding.effective_severity() == "LOW"
+    assert finding.effective_severity() == "low"
 
 
 def test_finding_effective_severity_base_fallback():
@@ -234,7 +234,7 @@ def test_finding_effective_severity_base_fallback():
         asset=Asset(name="pkg", asset_type="package"),
         severity="HIGH",
     )
-    assert finding.effective_severity() == "HIGH"
+    assert finding.effective_severity() == "high"
 
 
 def test_finding_all_compliance_tags_deduplicates():

--- a/tests/test_graph_severity.py
+++ b/tests/test_graph_severity.py
@@ -1,0 +1,45 @@
+"""Regression tests for the unified severity system."""
+
+from __future__ import annotations
+
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+from agent_bom.graph.severity import (
+    SEVERITY_POLICY_ORDER,
+    normalize_severity,
+    severity_at_or_above,
+    severity_policy_rank,
+    severity_worst_first_rank,
+)
+
+
+def test_normalize_severity_lowercases_and_maps_informational():
+    assert normalize_severity("CRITICAL") == "critical"
+    assert normalize_severity(" High ") == "high"
+    assert normalize_severity("INFORMATIONAL") == "info"
+    assert normalize_severity("bogus") == "unknown"
+    assert normalize_severity(None) == "unknown"
+
+
+def test_policy_order_unknown_below_none():
+    assert SEVERITY_POLICY_ORDER["UNKNOWN"] < SEVERITY_POLICY_ORDER["NONE"]
+    assert severity_policy_rank("unknown") < severity_policy_rank("none")
+    assert severity_at_or_above("none", "unknown") is True
+    assert severity_at_or_above("unknown", "none") is False
+
+
+def test_worst_first_rank_sorts_critical_before_low():
+    assert severity_worst_first_rank("critical") < severity_worst_first_rank("high")
+    assert severity_worst_first_rank("high") < severity_worst_first_rank("medium")
+    assert severity_worst_first_rank("medium") < severity_worst_first_rank("low")
+    assert severity_worst_first_rank("low") < severity_worst_first_rank("unknown")
+
+
+def test_finding_normalizes_severity_at_ingest():
+    finding = Finding(
+        finding_type=FindingType.CREDENTIAL_EXPOSURE,
+        source=FindingSource.SECRET_SCAN,
+        asset=Asset(name="config.py", asset_type="file"),
+        severity="CRITICAL",
+        title="Hardcoded credential",
+    )
+    assert finding.severity == "critical"

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from agent_bom.integrity import (
+    _DEFAULT_COSIGN_CERTIFICATE_IDENTITY_REGEXP,
+    _DEFAULT_COSIGN_CERTIFICATE_OIDC_ISSUER,
+    _try_cosign_verify,
     check_npm_provenance,
     check_pypi_provenance,
+    verify_instruction_file,
     verify_npm_integrity,
     verify_package_integrity,
     verify_pypi_integrity,
@@ -235,3 +240,63 @@ def test_check_pypi_provenance_partial_release_is_not_verified():
     assert result["status"] == "partial"
     assert result["attestation_count"] == 1
     assert result["missing_files"] == ["pkg-1.0.0.tar.gz"]
+
+
+# ---------------------------------------------------------------------------
+# Cosign defaults + no-cosign fallback
+# ---------------------------------------------------------------------------
+
+
+def test_cosign_defaults_pin_release_workflow_identity():
+    assert _DEFAULT_COSIGN_CERTIFICATE_IDENTITY_REGEXP == (
+        r"https://github\.com/msaad00/agent-bom/\.github/workflows/release\.yml@.*"
+    )
+    assert _DEFAULT_COSIGN_CERTIFICATE_OIDC_ISSUER == "https://token.actions.githubusercontent.com"
+
+
+def test_instruction_file_digest_match_without_cosign_is_not_verified(tmp_path):
+    from agent_bom.integrity import _compute_sha256
+
+    f = tmp_path / "SKILL.md"
+    f.write_text("# Skill file content", encoding="utf-8")
+    sha = _compute_sha256(f)
+    bundle_data = {
+        "dsseEnvelope": {
+            "payload": __import__("base64").b64encode(
+                json.dumps({"subject": [{"digest": {"sha256": sha}}]}).encode("utf-8")
+            ).decode("ascii")
+        }
+    }
+    (tmp_path / "SKILL.md.sigstore").write_text(json.dumps(bundle_data), encoding="utf-8")
+
+    with patch("agent_bom.integrity._try_cosign_verify", return_value=False):
+        result = verify_instruction_file(f)
+
+    assert result.bundle_valid is True
+    assert result.verified is False
+    assert result.reason == "cosign_verification_failed"
+
+
+def test_try_cosign_verify_uses_release_identity_by_default(tmp_path, monkeypatch):
+    f = tmp_path / "SKILL.md"
+    f.write_text("# Signed skill", encoding="utf-8")
+    bundle = tmp_path / "SKILL.md.sigstore"
+    bundle.write_text("{}", encoding="utf-8")
+    calls: list[list[str]] = []
+
+    class _Proc:
+        returncode = 0
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd)
+        return _Proc()
+
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/local/bin/cosign" if name == "cosign" else None)
+    monkeypatch.setattr("subprocess.run", _run)
+    monkeypatch.delenv("AGENT_BOM_COSIGN_CERTIFICATE_IDENTITY_REGEXP", raising=False)
+    monkeypatch.delenv("AGENT_BOM_COSIGN_CERTIFICATE_OIDC_ISSUER", raising=False)
+
+    assert _try_cosign_verify(f, bundle) is True
+    cmd = calls[0]
+    assert cmd[cmd.index("--certificate-identity-regexp") + 1] == _DEFAULT_COSIGN_CERTIFICATE_IDENTITY_REGEXP
+    assert cmd[cmd.index("--certificate-oidc-issuer") + 1] == _DEFAULT_COSIGN_CERTIFICATE_OIDC_ISSUER

--- a/tests/test_secret_findings_in_stream.py
+++ b/tests/test_secret_findings_in_stream.py
@@ -17,7 +17,7 @@ def test_secret_dict_to_finding_redacted_no_value():
     f = secret_dict_to_finding(_SECRET)
     assert f.finding_type == FindingType.CREDENTIAL_EXPOSURE
     assert f.source == FindingSource.SECRET_SCAN
-    assert f.severity == "CRITICAL"
+    assert f.severity == "critical"
     assert f.asset.location == "config/app.py"
     # The redacted preview is carried; no raw secret bytes anywhere.
     blob = str(f.to_dict())

--- a/tests/test_snowflake_governance_activity_wiring.py
+++ b/tests/test_snowflake_governance_activity_wiring.py
@@ -185,7 +185,7 @@ def test_governance_findings_reach_to_findings() -> None:
     findings = report.to_findings()
     gov = [f for f in findings if f.source == FindingSource.CLOUD_CIS and "governance" in f.title.lower()]
     assert len(gov) == 1
-    assert gov[0].severity == "HIGH"
+    assert gov[0].severity == "high"
 
 
 # ── Activity: summary onto account, NO per-query explosion ─────────────────


### PR DESCRIPTION
## Summary
- Centralize divergent severity ordering on `graph.severity` (`normalize_severity`, `severity_policy_rank`, new `severity_worst_first_rank`) across IaC, Snowflake governance, compliance hub store, guard, agent mode, and compliance narrative sorting.
- Normalize `Finding.severity` to canonical lowercase at ingest (`Finding.__post_init__`, hub CSV ingest, hardware evidence) and align dependent tests.
- Confirm cosign defaults already pin release-workflow identity; add `tests/test_integrity.py` coverage for pinned defaults and the fail-closed no-cosign fallback.

Partial residual for #3242. Already on main (skipped): duplicate Role enum (#3279), Grafana admin creds (#3282), Hex/Pub docs / HOSTS rollup (#3450).

## Deferred
- **MCP audit actor (C):** already implemented on main via `_authenticated_actor` from MCP request metadata (`mcp_server_runtime.execute_tool_async`, shield/identity write paths); no additional diff needed in this PR.
- **SAML replay (D):** deferred — needs a durable jti/nonce store.

## Test plan
- [x] `uv run pytest tests/test_graph_severity.py tests/test_integrity.py tests/test_secret_findings_in_stream.py tests/test_focused_security_gates.py tests/test_compliance_hub_ingest.py tests/test_policy_engine.py tests/test_cli_common.py -q` (126 passed)
- [x] `uv run ruff check` on touched source files


Made with [Cursor](https://cursor.com)