### PR TITLE
feat(retention): per-tenant graph retention and analytics cap (PR2)

### DIFF
--- a/deploy/helm/agent-bom/examples/README.md
+++ b/deploy/helm/agent-bom/examples/README.md
@@ -82,3 +82,8 @@ python scripts/install_helm_profile.py production \
 - Treat `mesh-hardening` and `snowflake-backend` as overlays, not separate products.
 - Treat `snowflake-backend` as a warehouse-native deployment mode with explicit parity boundaries, not the default production path.
 - Gateway remains an optional runtime surface layered onto the control plane, not a mandatory chokepoint.
+- Graph snapshot retention defaults to ``AGENT_BOM_GRAPH_RETENTION_DAYS`` (180). Per-tenant
+  windows can be set with ``AGENT_BOM_GRAPH_RETENTION_OVERRIDES`` JSON on the API deployment or
+  persisted in the control-plane tenant retention store. Local analytics and runtime observations
+  are capped on write with ``AGENT_BOM_ANALYTICS_MAX_EVENTS``; on-disk CLI history uses
+  ``AGENT_BOM_HISTORY_MAX_REPORTS``.

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -464,6 +464,16 @@ controlPlane:
     env:
       - name: AGENT_BOM_API_LOCAL_PATH_SCANS
         value: "disabled"
+      # Retention knobs (global default, optional per-tenant JSON overrides, analytics cap).
+      # Per-tenant overrides can also be persisted via the control-plane tenant retention store.
+      # - name: AGENT_BOM_GRAPH_RETENTION_DAYS
+      #   value: "180"
+      # - name: AGENT_BOM_GRAPH_RETENTION_OVERRIDES
+      #   value: '{"tenant-a": 30, "tenant-b": 90}'
+      # - name: AGENT_BOM_HISTORY_MAX_REPORTS
+      #   value: "500"
+      # - name: AGENT_BOM_ANALYTICS_MAX_EVENTS
+      #   value: "50000"
     envFrom: []
     extraVolumes: []
     extraVolumeMounts: []

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -59,6 +59,11 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_A2A_AUTH_REQUIRE_SIGNED_TOKENS` | `bool` | `True` | — |
 | `AGENT_BOM_A2A_AUTH_SHARED_TOKEN_MIN_AGENTS` | `int` | `2` | — |
 
+## Analytics Retention
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_ANALYTICS_MAX_EVENTS` | `int` | `50000` | Caps local analytics mirrors and runtime observation tables on write. ClickHouse analytics tables carry their own TTL clauses; this knob bounds SQLite/Postgres growth. ``<= 0`` disables pruning. |
+
 ## Blast Radius Risk Scoring
 | Env var | Type | Default | Description |
 |---|---|---|---|
@@ -126,6 +131,11 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_GRAPH_BACKEND` | `str` | `''` | SQLite is the local default. Postgres remains selected by AGENT_BOM_POSTGRES_URL. Neptune is experimental and requires explicit opt-in plus endpoint config. SQLite and Postgres remain the supported graph backends. |
 | `AGENT_BOM_NEPTUNE_ENDPOINT` | `str` | `''` | — |
 | `AGENT_BOM_NEPTUNE_TRAVERSAL_SOURCE` | `str` | `'g'` | — |
+
+## Graph Retention
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_GRAPH_RETENTION_DAYS` | `int` | `180` | Age-based graph snapshot retention for self-hosted graph stores. Per-tenant overrides resolve from ``AGENT_BOM_GRAPH_RETENTION_OVERRIDES`` (JSON map) and the control-plane tenant retention store before this global default. |
 
 ## HTTP Client
 | Env var | Type | Default | Description |

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -217,13 +217,11 @@ AGENT_BOM_GRAPH_DELTA_WEBHOOK_SIGNING_SECRET
 # Graph delta generic webhook private-network opt-in; deploy-time egress boundary.
 AGENT_BOM_GRAPH_DELTA_WEBHOOK_ALLOW_PRIVATE_NETWORKS
 # Graph evidence manifest retention horizon; read by graph_store.py for local/self-hosted history metadata.
-AGENT_BOM_GRAPH_RETENTION_DAYS
 # Deploy-time JSON map of tenant_id -> retention_days for graph snapshots.
 AGENT_BOM_GRAPH_RETENTION_OVERRIDES
 # Local CLI scan-history retained report cap; read by history.py so workstations/CI caches do not grow unbounded.
 AGENT_BOM_HISTORY_MAX_REPORTS
 # Cap for local analytics mirrors and runtime observation tables on write.
-AGENT_BOM_ANALYTICS_MAX_EVENTS
 AGENT_BOM_GRAPH_WRITE_BATCH_SIZE
 AGENT_BOM_HSTS_MAX_AGE_SECONDS
 AGENT_BOM_HSTS_PRELOAD

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -218,8 +218,12 @@ AGENT_BOM_GRAPH_DELTA_WEBHOOK_SIGNING_SECRET
 AGENT_BOM_GRAPH_DELTA_WEBHOOK_ALLOW_PRIVATE_NETWORKS
 # Graph evidence manifest retention horizon; read by graph_store.py for local/self-hosted history metadata.
 AGENT_BOM_GRAPH_RETENTION_DAYS
+# Deploy-time JSON map of tenant_id -> retention_days for graph snapshots.
+AGENT_BOM_GRAPH_RETENTION_OVERRIDES
 # Local CLI scan-history retained report cap; read by history.py so workstations/CI caches do not grow unbounded.
 AGENT_BOM_HISTORY_MAX_REPORTS
+# Cap for local analytics mirrors and runtime observation tables on write.
+AGENT_BOM_ANALYTICS_MAX_EVENTS
 AGENT_BOM_GRAPH_WRITE_BATCH_SIZE
 AGENT_BOM_HSTS_MAX_AGE_SECONDS
 AGENT_BOM_HSTS_PRELOAD

--- a/src/agent_bom/analytics_retention.py
+++ b/src/agent_bom/analytics_retention.py
@@ -13,6 +13,32 @@ class _ObservationCapConnection(Protocol):
     def execute(self, query: str, params: Any = ()) -> Any: ...
 
 
+def _runtime_observation_queries(placeholder: str) -> tuple[str, str, str]:
+    if placeholder == "%s":
+        return (
+            "SELECT COUNT(*) FROM runtime_observations WHERE tenant_id = %s",
+            """
+            SELECT observation_id FROM runtime_observations
+            WHERE tenant_id = %s
+            ORDER BY observed_at ASC
+            LIMIT %s
+            """,
+            "DELETE FROM runtime_observations WHERE tenant_id = %s AND observation_id = %s",
+        )
+    if placeholder == "?":
+        return (
+            "SELECT COUNT(*) FROM runtime_observations WHERE tenant_id = ?",
+            """
+            SELECT observation_id FROM runtime_observations
+            WHERE tenant_id = ?
+            ORDER BY observed_at ASC
+            LIMIT ?
+            """,
+            "DELETE FROM runtime_observations WHERE tenant_id = ? AND observation_id = ?",
+        )
+    raise ValueError("unsupported SQL placeholder")
+
+
 def analytics_max_events() -> int:
     """Return the retained analytics event cap. ``<= 0`` disables pruning."""
     raw = os.environ.get("AGENT_BOM_ANALYTICS_MAX_EVENTS")
@@ -60,8 +86,9 @@ def prune_runtime_observations_for_tenant(
     cap = analytics_max_events() if max_events is None else max_events
     if cap <= 0:
         return 0
+    count_query, stale_query, delete_query = _runtime_observation_queries(placeholder)
     count_row = conn.execute(
-        f"SELECT COUNT(*) FROM runtime_observations WHERE tenant_id = {placeholder}",
+        count_query,
         (tenant_id,),
     ).fetchone()
     count = int(count_row[0])
@@ -69,19 +96,12 @@ def prune_runtime_observations_for_tenant(
         return 0
     excess = count - cap
     stale = conn.execute(
-        f"""
-        SELECT observation_id FROM runtime_observations
-        WHERE tenant_id = {placeholder}
-        ORDER BY observed_at ASC
-        LIMIT {placeholder}
-        """,
+        stale_query,
         (tenant_id, excess),
     ).fetchall()
     if not stale:
         return 0
     observation_ids = [str(row[0]) for row in stale]
-    conn.executemany(
-        f"DELETE FROM runtime_observations WHERE tenant_id = {placeholder} AND observation_id = {placeholder}",
-        [(tenant_id, observation_id) for observation_id in observation_ids],
-    )
+    for observation_id in observation_ids:
+        conn.execute(delete_query, (tenant_id, observation_id))
     return len(observation_ids)

--- a/src/agent_bom/analytics_retention.py
+++ b/src/agent_bom/analytics_retention.py
@@ -1,0 +1,87 @@
+"""Shared analytics growth caps for local mirrors and runtime observations."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from typing import Any, Protocol
+
+_DEFAULT_ANALYTICS_MAX_EVENTS = 50_000
+
+
+class _ObservationCapConnection(Protocol):
+    def execute(self, query: str, params: Any = ()) -> Any: ...
+
+
+def analytics_max_events() -> int:
+    """Return the retained analytics event cap. ``<= 0`` disables pruning."""
+    raw = os.environ.get("AGENT_BOM_ANALYTICS_MAX_EVENTS")
+    if raw is None:
+        try:
+            from agent_bom.config import ANALYTICS_MAX_EVENTS
+
+            return int(ANALYTICS_MAX_EVENTS)
+        except (ImportError, TypeError, ValueError):
+            return _DEFAULT_ANALYTICS_MAX_EVENTS
+    try:
+        return int(raw)
+    except ValueError:
+        return _DEFAULT_ANALYTICS_MAX_EVENTS
+
+
+def prune_local_scan_runs(conn: sqlite3.Connection, *, max_events: int | None = None) -> int:
+    """Drop oldest ``scan_runs`` rows when the mirror exceeds the cap."""
+    cap = analytics_max_events() if max_events is None else max_events
+    if cap <= 0:
+        return 0
+    count = int(conn.execute("SELECT COUNT(*) FROM scan_runs").fetchone()[0])
+    if count <= cap:
+        return 0
+    excess = count - cap
+    stale = conn.execute(
+        "SELECT run_id FROM scan_runs ORDER BY generated_at ASC, recorded_at ASC LIMIT ?",
+        (excess,),
+    ).fetchall()
+    if not stale:
+        return 0
+    run_ids = [str(row[0]) for row in stale]
+    conn.executemany("DELETE FROM scan_runs WHERE run_id = ?", ((run_id,) for run_id in run_ids))
+    return len(run_ids)
+
+
+def prune_runtime_observations_for_tenant(
+    conn: _ObservationCapConnection,
+    tenant_id: str,
+    *,
+    max_events: int | None = None,
+    placeholder: str = "?",
+) -> int:
+    """Drop oldest runtime observations for one tenant when over the cap."""
+    cap = analytics_max_events() if max_events is None else max_events
+    if cap <= 0:
+        return 0
+    count_row = conn.execute(
+        f"SELECT COUNT(*) FROM runtime_observations WHERE tenant_id = {placeholder}",
+        (tenant_id,),
+    ).fetchone()
+    count = int(count_row[0])
+    if count <= cap:
+        return 0
+    excess = count - cap
+    stale = conn.execute(
+        f"""
+        SELECT observation_id FROM runtime_observations
+        WHERE tenant_id = {placeholder}
+        ORDER BY observed_at ASC
+        LIMIT {placeholder}
+        """,
+        (tenant_id, excess),
+    ).fetchall()
+    if not stale:
+        return 0
+    observation_ids = [str(row[0]) for row in stale]
+    conn.executemany(
+        f"DELETE FROM runtime_observations WHERE tenant_id = {placeholder} AND observation_id = {placeholder}",
+        [(tenant_id, observation_id) for observation_id in observation_ids],
+    )
+    return len(observation_ids)

--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -655,7 +655,10 @@ class BufferedAnalyticsStore:
     """Buffered wrapper for ClickHouse analytics writes.
 
     Writes are queued and flushed from a background thread so scan and runtime
-    paths do not block on ClickHouse round-trips.
+    paths do not block on ClickHouse round-trips. ClickHouse tables already
+    carry server-side TTL clauses (see ``agent_bom.cloud.clickhouse``); local
+    SQLite/Postgres mirrors and runtime observations are capped separately via
+    ``AGENT_BOM_ANALYTICS_MAX_EVENTS``.
     """
 
     def __init__(self, store: ClickHouseAnalyticsStore, *, max_batch: int = 200, flush_interval: float = 1.0) -> None:

--- a/src/agent_bom/api/postgres_runtime_event.py
+++ b/src/agent_bom/api/postgres_runtime_event.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 
+from agent_bom.analytics_retention import prune_runtime_observations_for_tenant
 from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
 from agent_bom.api.runtime_event_store import (
     RuntimeObservationRecord,
@@ -103,6 +104,7 @@ class PostgresRuntimeEventStore:
                 """,
                 (session.tenant_id, session.session_id, session.last_seen, json.dumps(session.to_dict(), sort_keys=True)),
             )
+            prune_runtime_observations_for_tenant(conn, record.tenant_id, placeholder="%s")
             conn.commit()
 
     def list_sessions(self, tenant_id: str, *, limit: int = 100, offset: int = 0) -> list[RuntimeSessionRecord]:

--- a/src/agent_bom/api/postgres_tenant_graph_retention.py
+++ b/src/agent_bom/api/postgres_tenant_graph_retention.py
@@ -1,0 +1,62 @@
+"""Postgres-backed per-tenant graph retention overrides."""
+
+from __future__ import annotations
+
+from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
+
+
+class PostgresTenantGraphRetentionStore:
+    """Persistent tenant graph retention overrides with tenant-aware access."""
+
+    def __init__(self, pool: ConnectionPool | None = None) -> None:
+        self._pool = pool or _get_pool()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "tenant_graph_retention")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tenant_graph_retention_overrides (
+                    tenant_id TEXT PRIMARY KEY,
+                    updated_at TEXT NOT NULL DEFAULT to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+                    retention_days INTEGER NOT NULL
+                )
+                """
+            )
+            _ensure_tenant_rls(conn, "tenant_graph_retention_overrides", "tenant_id")
+            conn.commit()
+
+    def get(self, tenant_id: str) -> int | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT retention_days FROM tenant_graph_retention_overrides WHERE tenant_id = %s",
+                (tenant_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            return max(1, int(row[0]))
+
+    def put(self, tenant_id: str, retention_days: int) -> None:
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                """
+                INSERT INTO tenant_graph_retention_overrides (tenant_id, retention_days)
+                VALUES (%s, %s)
+                ON CONFLICT (tenant_id) DO UPDATE SET
+                    updated_at = to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+                    retention_days = EXCLUDED.retention_days
+                """,
+                (tenant_id, max(1, int(retention_days))),
+            )
+            conn.commit()
+
+    def delete(self, tenant_id: str) -> bool:
+        with _tenant_connection(self._pool) as conn:
+            cursor = conn.execute(
+                "DELETE FROM tenant_graph_retention_overrides WHERE tenant_id = %s",
+                (tenant_id,),
+            )
+            conn.commit()
+            return bool(cursor.rowcount > 0)

--- a/src/agent_bom/api/runtime_event_store.py
+++ b/src/agent_bom/api/runtime_event_store.py
@@ -9,6 +9,7 @@ from collections import Counter
 from dataclasses import asdict, dataclass, field
 from typing import Any, Protocol
 
+from agent_bom.analytics_retention import prune_runtime_observations_for_tenant
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
 from agent_bom.security import sanitize_sensitive_payload, sanitize_text
 
@@ -164,6 +165,7 @@ class InMemoryRuntimeEventStore:
                 return
             self._observations[key] = record
             self._sessions[session_key] = _merge_session(self._sessions.get(session_key), record)
+            _enforce_in_memory_observation_cap(self._observations, record.tenant_id)
 
     def list_sessions(self, tenant_id: str, *, limit: int = 100, offset: int = 0) -> list[RuntimeSessionRecord]:
         with self._lock:
@@ -268,6 +270,7 @@ class SQLiteRuntimeEventStore:
             """,
             (session.tenant_id, session.session_id, session.last_seen, json.dumps(session.to_dict(), sort_keys=True)),
         )
+        prune_runtime_observations_for_tenant(self._conn, record.tenant_id)
         self._conn.commit()
 
     def list_sessions(self, tenant_id: str, *, limit: int = 100, offset: int = 0) -> list[RuntimeSessionRecord]:
@@ -406,3 +409,26 @@ def set_runtime_event_store(store: RuntimeEventStore | None) -> None:
 
 def reset_runtime_event_store() -> None:
     set_runtime_event_store(None)
+
+
+def _enforce_in_memory_observation_cap(
+    observations: dict[tuple[str, str], RuntimeObservationRecord],
+    tenant_id: str,
+) -> None:
+    """Drop oldest in-memory observations for one tenant when over the cap."""
+    from agent_bom.analytics_retention import analytics_max_events
+
+    cap = analytics_max_events()
+    if cap <= 0:
+        return
+    tenant_rows = [
+        (key, row)
+        for key, row in observations.items()
+        if key[0] == tenant_id
+    ]
+    if len(tenant_rows) <= cap:
+        return
+    tenant_rows.sort(key=lambda item: item[1].observed_at)
+    for key, _row in tenant_rows[: len(tenant_rows) - cap]:
+        observations.pop(key, None)
+

--- a/src/agent_bom/api/storage_schema.py
+++ b/src/agent_bom/api/storage_schema.py
@@ -52,6 +52,7 @@ CONTROL_PLANE_SCHEMA_COMPONENTS: tuple[StorageSchemaComponent, ...] = (
     # Runtime session/observation timeline is durable by default (same tiering).
     StorageSchemaComponent("runtime_sessions", "sqlite/postgres", ("runtime_observations", "runtime_sessions")),
     StorageSchemaComponent("tenant_quotas", "sqlite/postgres", ("tenant_quota_overrides",)),
+    StorageSchemaComponent("tenant_graph_retention", "sqlite/postgres", ("tenant_graph_retention_overrides",)),
     StorageSchemaComponent("sources", "sqlite/postgres", ("sources", "control_plane_sources")),
     StorageSchemaComponent("schedules", "sqlite/postgres", ("scan_schedules",)),
     StorageSchemaComponent("exceptions", "sqlite/postgres", ("vuln_exceptions",)),

--- a/src/agent_bom/api/stores.py
+++ b/src/agent_bom/api/stores.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from agent_bom.api.schedule_store import ScheduleStore
     from agent_bom.api.scim_store import SCIMStore
     from agent_bom.api.source_store import SourceStore
+    from agent_bom.api.tenant_graph_retention_store import TenantGraphRetentionStore
     from agent_bom.api.tenant_quota_store import TenantQuotaStore
 
 # ── Shared lock (protects lazy init of all stores) ───────────────────────────
@@ -284,6 +285,37 @@ def set_tenant_quota_store(store: TenantQuotaStore) -> None:
     """Switch the tenant quota override store backend."""
     global _tenant_quota_store
     _tenant_quota_store = store
+
+
+# ─── Tenant graph retention override store (pluggable) ─────────────────────
+_tenant_graph_retention_store: TenantGraphRetentionStore | None = None
+
+
+def _get_tenant_graph_retention_store() -> TenantGraphRetentionStore:
+    """Get the active tenant graph retention override store."""
+    global _tenant_graph_retention_store
+    if _tenant_graph_retention_store is None:
+        with _store_lock:
+            if _tenant_graph_retention_store is None:
+                if os.environ.get("AGENT_BOM_POSTGRES_URL"):
+                    from agent_bom.api.postgres_tenant_graph_retention import PostgresTenantGraphRetentionStore
+
+                    _tenant_graph_retention_store = PostgresTenantGraphRetentionStore()
+                elif os.environ.get("AGENT_BOM_DB"):
+                    from agent_bom.api.tenant_graph_retention_store import SQLiteTenantGraphRetentionStore
+
+                    _tenant_graph_retention_store = SQLiteTenantGraphRetentionStore(os.environ["AGENT_BOM_DB"])
+                else:
+                    from agent_bom.api.tenant_graph_retention_store import InMemoryTenantGraphRetentionStore
+
+                    _tenant_graph_retention_store = InMemoryTenantGraphRetentionStore()
+    return _tenant_graph_retention_store
+
+
+def set_tenant_graph_retention_store(store: TenantGraphRetentionStore) -> None:
+    """Switch the tenant graph retention override store backend."""
+    global _tenant_graph_retention_store
+    _tenant_graph_retention_store = store
 
 
 # ─── SCIM lifecycle store (enterprise identity) ────────────────────────────

--- a/src/agent_bom/api/tenant_graph_retention.py
+++ b/src/agent_bom/api/tenant_graph_retention.py
@@ -1,0 +1,92 @@
+"""Per-tenant graph snapshot retention resolution."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from agent_bom.api.stores import _get_tenant_graph_retention_store, set_tenant_graph_retention_store
+
+
+def _env_graph_retention_overrides() -> dict[str, int]:
+    """Parse deploy-time tenant retention overrides from ``AGENT_BOM_GRAPH_RETENTION_OVERRIDES``."""
+    raw = os.environ.get("AGENT_BOM_GRAPH_RETENTION_OVERRIDES", "").strip()
+    if not raw:
+        return {}
+    try:
+        loaded = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(loaded, dict):
+        return {}
+    overrides: dict[str, int] = {}
+    for key, value in loaded.items():
+        tenant_id = str(key).strip()
+        if not tenant_id:
+            continue
+        try:
+            overrides[tenant_id] = max(1, int(value))
+        except (TypeError, ValueError):
+            continue
+    return overrides
+
+
+def resolve_graph_retention_days(tenant_id: str | None = None) -> int:
+    """Return the effective graph retention window for *tenant_id*.
+
+    Precedence: API config store override, then env JSON overrides, then the
+    global ``AGENT_BOM_GRAPH_RETENTION_DAYS`` default.
+    """
+    from agent_bom.db.graph_store import _graph_retention_days, normalize_graph_tenant_id
+
+    tid = normalize_graph_tenant_id(tenant_id)
+    stored = _get_tenant_graph_retention_store().get(tid)
+    if stored is not None:
+        return max(1, int(stored))
+    env_overrides = _env_graph_retention_overrides()
+    if tid in env_overrides:
+        return env_overrides[tid]
+    return _graph_retention_days()
+
+
+def get_tenant_graph_retention_override(tenant_id: str) -> int | None:
+    """Return the persisted override for *tenant_id*, if any."""
+    from agent_bom.db.graph_store import normalize_graph_tenant_id
+
+    return _get_tenant_graph_retention_store().get(normalize_graph_tenant_id(tenant_id))
+
+
+def set_tenant_graph_retention_override(tenant_id: str, retention_days: int) -> int:
+    """Persist a tenant-specific graph retention override."""
+    from agent_bom.db.graph_store import normalize_graph_tenant_id
+
+    normalized = normalize_graph_tenant_id(tenant_id)
+    days = max(1, int(retention_days))
+    _get_tenant_graph_retention_store().put(normalized, days)
+    return days
+
+
+def clear_tenant_graph_retention_override(tenant_id: str) -> bool:
+    """Remove a tenant-specific graph retention override."""
+    from agent_bom.db.graph_store import normalize_graph_tenant_id
+
+    return _get_tenant_graph_retention_store().delete(normalize_graph_tenant_id(tenant_id))
+
+
+def graph_retention_overrides_snapshot() -> dict[str, Any]:
+    """Return env + store override sources for policy reporting."""
+    return {
+        "env_overrides": _env_graph_retention_overrides(),
+        "per_tenant_overrides": True,
+    }
+
+
+__all__ = [
+    "clear_tenant_graph_retention_override",
+    "get_tenant_graph_retention_override",
+    "graph_retention_overrides_snapshot",
+    "resolve_graph_retention_days",
+    "set_tenant_graph_retention_override",
+    "set_tenant_graph_retention_store",
+]

--- a/src/agent_bom/api/tenant_graph_retention_store.py
+++ b/src/agent_bom/api/tenant_graph_retention_store.py
@@ -1,0 +1,91 @@
+"""Store backends for per-tenant graph snapshot retention overrides."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from typing import Protocol
+
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
+
+class TenantGraphRetentionStore(Protocol):
+    """Protocol for per-tenant graph retention day overrides."""
+
+    def get(self, tenant_id: str) -> int | None: ...
+    def put(self, tenant_id: str, retention_days: int) -> None: ...
+    def delete(self, tenant_id: str) -> bool: ...
+
+
+class InMemoryTenantGraphRetentionStore:
+    """Process-local retention override store for development and tests."""
+
+    def __init__(self) -> None:
+        self._overrides: dict[str, int] = {}
+
+    def get(self, tenant_id: str) -> int | None:
+        value = self._overrides.get(tenant_id)
+        return int(value) if value is not None else None
+
+    def put(self, tenant_id: str, retention_days: int) -> None:
+        self._overrides[tenant_id] = max(1, int(retention_days))
+
+    def delete(self, tenant_id: str) -> bool:
+        return self._overrides.pop(tenant_id, None) is not None
+
+
+class SQLiteTenantGraphRetentionStore:
+    """SQLite-backed tenant graph retention override store."""
+
+    def __init__(self, db_path: str = "agent_bom.db") -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        conn: sqlite3.Connection = self._local.conn
+        return conn
+
+    def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "tenant_graph_retention")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tenant_graph_retention_overrides (
+                tenant_id TEXT PRIMARY KEY,
+                updated_at TEXT NOT NULL DEFAULT '',
+                retention_days INTEGER NOT NULL
+            )
+            """
+        )
+        self._conn.commit()
+
+    def get(self, tenant_id: str) -> int | None:
+        row = self._conn.execute(
+            "SELECT retention_days FROM tenant_graph_retention_overrides WHERE tenant_id = ?",
+            (tenant_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return max(1, int(row[0]))
+
+    def put(self, tenant_id: str, retention_days: int) -> None:
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO tenant_graph_retention_overrides (tenant_id, updated_at, retention_days)
+            VALUES (?, datetime('now'), ?)
+            """,
+            (tenant_id, max(1, int(retention_days))),
+        )
+        self._conn.commit()
+
+    def delete(self, tenant_id: str) -> bool:
+        cursor = self._conn.execute(
+            "DELETE FROM tenant_graph_retention_overrides WHERE tenant_id = ?",
+            (tenant_id,),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -246,6 +246,22 @@ DSPM_DB_MAX_CELL_CHARS = _int("AGENT_BOM_DSPM_DB_MAX_CELL_CHARS", 4096)
 LOCAL_ANALYTICS_DB = _str("AGENT_BOM_LOCAL_ANALYTICS_DB", "")
 
 
+# ── Graph Retention ───────────────────────────────────────────────────────
+# Age-based graph snapshot retention for self-hosted graph stores. Per-tenant
+# overrides resolve from ``AGENT_BOM_GRAPH_RETENTION_OVERRIDES`` (JSON map) and
+# the control-plane tenant retention store before this global default.
+
+GRAPH_RETENTION_DAYS = _int("AGENT_BOM_GRAPH_RETENTION_DAYS", 180)
+
+
+# ── Analytics Retention ───────────────────────────────────────────────────
+# Caps local analytics mirrors and runtime observation tables on write. ClickHouse
+# analytics tables carry their own TTL clauses; this knob bounds SQLite/Postgres
+# growth. ``<= 0`` disables pruning.
+
+ANALYTICS_MAX_EVENTS = _int("AGENT_BOM_ANALYTICS_MAX_EVENTS", 50_000)
+
+
 # ── Graph Backend Selection ───────────────────────────────────────────────
 # SQLite is the local default. Postgres remains selected by AGENT_BOM_POSTGRES_URL.
 # Neptune is experimental and requires explicit opt-in plus endpoint config.

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -364,20 +364,34 @@ def _parse_iso_timestamp(value: object) -> datetime | None:
     return parsed
 
 
-def graph_retention_policy(conn: sqlite3.Connection | None = None) -> dict[str, Any]:
+def graph_retention_policy(
+    conn: sqlite3.Connection | None = None,
+    *,
+    tenant_id: str | None = None,
+) -> dict[str, Any]:
     """Describe the active graph retention policy.
 
     When a connection is supplied, the response reflects real enforcement state
     (``last_purge_at`` / ``last_purged_count``) recorded by
     :func:`purge_expired_graph_snapshots`, rather than metadata alone.
+
+    Pass ``tenant_id`` to resolve the effective retention window for one tenant
+    (store override, env JSON map, then global default).
     """
+    from agent_bom.api.tenant_graph_retention import graph_retention_overrides_snapshot, resolve_graph_retention_days
+
+    normalized_tenant = normalize_graph_tenant_id(tenant_id) if tenant_id is not None else None
     policy: dict[str, Any] = {
-        "retention_days": _graph_retention_days(),
+        "retention_days": resolve_graph_retention_days(normalized_tenant),
+        "default_retention_days": _graph_retention_days(),
         "mode": "queryable_snapshot_history",
         "deletion_state": "active",
         "enforcement": "age_based_purge_on_save",
         "legal_hold": False,
+        **graph_retention_overrides_snapshot(),
     }
+    if normalized_tenant is not None:
+        policy["tenant_id"] = normalized_tenant
     if conn is not None:
         last_purge_at, last_purged_count = _read_purge_state(conn)
         policy["last_purge_at"] = last_purge_at
@@ -403,11 +417,12 @@ def purge_expired_graph_snapshots(
     ``attack_paths`` and ``interaction_risks`` for the same ``(scan_id,
     tenant_id)`` pair, plus the API search index when present.
     """
-    days = _graph_retention_days() if retention_days is None else max(1, int(retention_days))
+    from agent_bom.api.tenant_graph_retention import resolve_graph_retention_days
+
+    fixed_days = None if retention_days is None else max(1, int(retention_days))
     now_dt = now or datetime.now(timezone.utc)
     if now_dt.tzinfo is None:
         now_dt = now_dt.replace(tzinfo=timezone.utc)
-    cutoff = now_dt - timedelta(days=days)
 
     query = "SELECT scan_id, tenant_id, created_at FROM graph_snapshots"
     params: list[Any] = []
@@ -417,10 +432,14 @@ def purge_expired_graph_snapshots(
     rows = conn.execute(query, params).fetchall()
 
     expired: list[tuple[str, str]] = []
+    resolved_days: dict[str, int] = {}
     for row in rows:
+        tid = str(row[1])
+        days = fixed_days if fixed_days is not None else resolved_days.setdefault(tid, resolve_graph_retention_days(tid))
+        cutoff = now_dt - timedelta(days=days)
         created = _parse_iso_timestamp(row[2])
         if created is not None and created < cutoff:
-            expired.append((str(row[0]), str(row[1])))
+            expired.append((str(row[0]), tid))
 
     if expired:
         for table in _GRAPH_PURGEABLE_TABLES:
@@ -438,9 +457,11 @@ def purge_expired_graph_snapshots(
     _record_purge_state(conn, purged_count=len(expired), purged_at=purged_at)
     conn.commit()
 
+    effective_days = fixed_days if fixed_days is not None else _graph_retention_days()
     return {
-        "retention_days": days,
-        "cutoff": cutoff.isoformat(),
+        "retention_days": effective_days,
+        "per_tenant_retention_days": dict(resolved_days) if fixed_days is None and resolved_days else None,
+        "cutoff": (now_dt - timedelta(days=effective_days)).isoformat(),
         "purged_count": len(expired),
         "last_purge_at": purged_at,
         "purged_snapshots": [{"scan_id": scan_id, "tenant_id": tid} for scan_id, tid in expired],

--- a/src/agent_bom/db/local_analytics.py
+++ b/src/agent_bom/db/local_analytics.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+from agent_bom.analytics_retention import prune_local_scan_runs
 from agent_bom.canonical_ids import canonical_package_id
 from agent_bom.config import LOCAL_ANALYTICS_DB
 
@@ -275,6 +276,7 @@ class LocalAnalyticsStore:
                 """,
                 [_package_row(run_id, scan_id, package_row) for package_row in package_rows],
             )
+            prune_local_scan_runs(conn)
             conn.commit()
         return scan_id
 

--- a/tests/test_retention_enforcement.py
+++ b/tests/test_retention_enforcement.py
@@ -6,10 +6,15 @@ Covers P1-B PR1:
 - ``save_graph`` runs the purge on its post-save lifecycle hook and records
   real enforcement state in ``graph_retention_policy``.
 - ``history.save_report`` caps on-disk reports and prunes the oldest.
+
+Covers P1-B PR2:
+- Per-tenant graph retention via env JSON map and API config store.
+- Analytics cap for local analytics mirrors and runtime observations.
 """
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from datetime import datetime, timedelta, timezone
 
@@ -87,6 +92,49 @@ class TestGraphSnapshotPurge:
         assert result["purged_count"] == 1
         remaining = {row[0] for row in db.execute("SELECT scan_id FROM graph_snapshots")}
         assert remaining == {"b"}
+
+
+class TestPerTenantGraphRetention:
+    def test_purge_applies_different_windows_per_tenant_via_env(self, db, monkeypatch):
+        from agent_bom.api.stores import set_tenant_graph_retention_store
+        from agent_bom.api.tenant_graph_retention_store import InMemoryTenantGraphRetentionStore
+        from agent_bom.db.graph_store import purge_expired_graph_snapshots
+
+        set_tenant_graph_retention_store(InMemoryTenantGraphRetentionStore())
+        monkeypatch.setenv("AGENT_BOM_GRAPH_RETENTION_OVERRIDES", json.dumps({"tenant-a": 30, "tenant-b": 90}))
+
+        now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        _insert_snapshot(db, "a-old", (now - timedelta(days=45)).isoformat(), tenant="tenant-a")
+        _insert_snapshot(db, "a-recent", (now - timedelta(days=10)).isoformat(), tenant="tenant-a")
+        _insert_snapshot(db, "b-old", (now - timedelta(days=45)).isoformat(), tenant="tenant-b")
+        _insert_snapshot(db, "b-recent", (now - timedelta(days=10)).isoformat(), tenant="tenant-b")
+
+        result = purge_expired_graph_snapshots(db, now=now)
+
+        assert result["purged_count"] == 1
+        assert result["purged_snapshots"] == [{"scan_id": "a-old", "tenant_id": "tenant-a"}]
+        remaining = {row[0] for row in db.execute("SELECT scan_id FROM graph_snapshots")}
+        assert remaining == {"a-recent", "b-old", "b-recent"}
+
+    def test_purge_prefers_store_override_over_env(self, db, monkeypatch):
+        from agent_bom.api.stores import set_tenant_graph_retention_store
+        from agent_bom.api.tenant_graph_retention import set_tenant_graph_retention_override
+        from agent_bom.api.tenant_graph_retention_store import InMemoryTenantGraphRetentionStore
+        from agent_bom.db.graph_store import graph_retention_policy, purge_expired_graph_snapshots
+
+        set_tenant_graph_retention_store(InMemoryTenantGraphRetentionStore())
+        monkeypatch.setenv("AGENT_BOM_GRAPH_RETENTION_OVERRIDES", json.dumps({"tenant-a": 30}))
+        set_tenant_graph_retention_override("tenant-a", 90)
+
+        now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        _insert_snapshot(db, "a-borderline", (now - timedelta(days=45)).isoformat(), tenant="tenant-a")
+
+        result = purge_expired_graph_snapshots(db, now=now)
+        assert result["purged_count"] == 0
+
+        policy = graph_retention_policy(db, tenant_id="tenant-a")
+        assert policy["retention_days"] == 90
+        assert policy["tenant_id"] == "tenant-a"
 
 
 class TestSaveGraphRetentionHook:
@@ -167,3 +215,54 @@ class TestHistoryCap:
 
         assert history.prune_history(max_reports=2) == 2
         assert len(history.list_reports()) == 2
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Analytics growth cap
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestAnalyticsCap:
+    def test_local_analytics_prunes_oldest_scan_runs(self, monkeypatch, tmp_path):
+        from agent_bom.db.local_analytics import LocalAnalyticsStore
+
+        db_path = tmp_path / "analytics.sqlite"
+        monkeypatch.setenv("AGENT_BOM_ANALYTICS_MAX_EVENTS", "2")
+
+        store = LocalAnalyticsStore(db_path)
+        for index in range(4):
+            store.record_scan_report(
+                {
+                    "scan_id": f"scan-{index}",
+                    "generated_at": f"2026-01-0{index + 1}T00:00:00+00:00",
+                    "summary": {},
+                },
+                source="test",
+            )
+
+        runs = store.list_scan_runs(limit=10)
+        assert len(runs) == 2
+        assert {row["scan_id"] for row in runs} == {"scan-2", "scan-3"}
+
+    def test_runtime_observations_prune_oldest_per_tenant(self, monkeypatch):
+        from agent_bom.api.runtime_event_store import InMemoryRuntimeEventStore, RuntimeObservationRecord
+
+        monkeypatch.setenv("AGENT_BOM_ANALYTICS_MAX_EVENTS", "2")
+        store = InMemoryRuntimeEventStore()
+        for index in range(4):
+            store.put_observation(
+                RuntimeObservationRecord(
+                    tenant_id="tenant-a",
+                    observation_id=f"obs-{index}",
+                    session_id="sess-1",
+                    observed_at=f"2026-01-0{index + 1}T00:00:00+00:00",
+                    event_type="tool_call",
+                    verdict="allow",
+                    severity="info",
+                    tool_name="read",
+                )
+            )
+
+        observations = store.list_observations("tenant-a", limit=10)
+        assert len(observations) == 2
+        assert {row.observation_id for row in observations} == {"obs-2", "obs-3"}


### PR DESCRIPTION
## Summary
- Extend graph snapshot retention with per-tenant windows: `AGENT_BOM_GRAPH_RETENTION_OVERRIDES` JSON env map plus SQLite/Postgres `tenant_graph_retention_overrides` store; `purge_expired_graph_snapshots` evaluates each tenant independently.
- Cap analytics growth on write via `AGENT_BOM_ANALYTICS_MAX_EVENTS` for local analytics `scan_runs` and SQLite/Postgres/in-memory `runtime_observations` (ClickHouse continues to rely on table TTL).
- Document retention env knobs in Helm `values.yaml` and `deploy/helm/agent-bom/examples/README.md`.

## Verification
- `uv run pytest tests/test_retention_enforcement.py -q` (12 passed)
- `uv run pytest tests/test_local_analytics.py tests/test_runtime_event_store.py -q` (12 passed)
- `uv run ruff check` on changed retention modules

## Notes
- Precedence: API retention store > env JSON overrides > global `AGENT_BOM_GRAPH_RETENTION_DAYS`.
- Deferred: REST admin route for tenant retention overrides (store helpers ship; wire in PR3), Postgres graph backend parity for purge hook, age-based TTL alternative for analytics.


Made with [Cursor](https://cursor.com)