### PR TITLE
feat(api): findings read PR2 — approximate counts and UI pagination (#3192)

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -9700,7 +9700,7 @@
     },
     "/v1/findings": {
       "get": {
-        "description": "List vulnerability findings aggregated from completed scan results.\n\nDefault sort is ``effective_reach`` \u2014 the composite triage signal that\ncombines CVSS / EPSS / KEV with reachable-tool capability, credential\nvisibility and agent breadth.  Pass ``?sort=cvss`` for the legacy\nCVSS-only ordering, or ``?sort=severity`` for severity-band ordering.",
+        "description": "List vulnerability findings aggregated from completed scan results.\n\nDefault sort is ``effective_reach`` \u2014 the composite triage signal that\ncombines CVSS / EPSS / KEV with reachable-tool capability, credential\nvisibility and agent breadth.  Pass ``?sort=cvss`` for the legacy\nCVSS-only ordering, or ``?sort=severity`` for severity-band ordering.\n\nPass ``?approximate_total=true`` to skip ``COUNT(*)`` on deep pages.\nThe first page (``offset=0``) still computes an exact total and caches it\nfor roughly ``AGENT_BOM_FINDINGS_COUNT_CACHE_TTL_SECONDS`` (default 60s).\nLater pages reuse the cached count; when the cache is cold the response\ncarries a conservative lower bound and ``total_approximate: true``.",
         "operationId": "list_findings_v1_findings_get",
         "parameters": [
           {
@@ -9767,6 +9767,16 @@
               "minimum": 0,
               "title": "Offset",
               "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "approximate_total",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Approximate Total",
+              "type": "boolean"
             }
           }
         ],

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -6366,7 +6366,12 @@ paths:
         \nDefault sort is ``effective_reach`` \u2014 the composite triage signal that\n\
         combines CVSS / EPSS / KEV with reachable-tool capability, credential\nvisibility\
         \ and agent breadth.  Pass ``?sort=cvss`` for the legacy\nCVSS-only ordering,\
-        \ or ``?sort=severity`` for severity-band ordering."
+        \ or ``?sort=severity`` for severity-band ordering.\n\nPass ``?approximate_total=true``\
+        \ to skip ``COUNT(*)`` on deep pages.\nThe first page (``offset=0``) still\
+        \ computes an exact total and caches it\nfor roughly ``AGENT_BOM_FINDINGS_COUNT_CACHE_TTL_SECONDS``\
+        \ (default 60s).\nLater pages reuse the cached count; when the cache is cold\
+        \ the response\ncarries a conservative lower bound and ``total_approximate:\
+        \ true``."
       operationId: list_findings_v1_findings_get
       parameters:
       - in: query
@@ -6410,6 +6415,13 @@ paths:
           minimum: 0
           title: Offset
           type: integer
+      - in: query
+        name: approximate_total
+        required: false
+        schema:
+          default: false
+          title: Approximate Total
+          type: boolean
       responses:
         '200':
           content:

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -413,3 +413,5 @@ AGENT_BOM_VULN_DB_OFFLINE  # airgap toggle that forces existing-cache-only fresh
 AGENT_BOM_GLOBAL_IP_RATE_LIMIT_RPM
 # Trusted reverse-proxy hop count for X-Forwarded-For parsing; resolved at call-time in routes/enterprise._trusted_proxy_hops().
 AGENT_BOM_TRUSTED_PROXY_HOPS
+
+AGENT_BOM_FINDINGS_COUNT_CACHE_TTL_SECONDS

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import Any, Protocol
 
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
@@ -33,7 +33,7 @@ from agent_bom.graph.severity import severity_policy_rank
 # Defined here (module scope) so ``list`` resolves to the builtin: the store
 # classes below define a ``list`` method that would otherwise shadow it in
 # their ``list_page`` return annotations.
-FindingPage = tuple[list[dict[str, Any]], int]
+FindingPage = tuple[list[dict[str, Any]], int | None]
 
 # Sort keys supported by ``list_page``. ``effective_reach`` is the default and
 # the only one backed by a dedicated index/column; ``cvss`` and ``severity``
@@ -92,6 +92,42 @@ def _page_sort_key(sort: str) -> Callable[[dict[str, Any]], float]:
     return lambda row: -_page_signal(row, normalized)
 
 
+def _filter_hub_rows(
+    rows: list[dict[str, Any]],
+    *,
+    severity: str | None,
+    scan_id: str | None,
+    origin: str | None,
+) -> list[dict[str, Any]]:
+    if origin is not None:
+        rows = [r for r in rows if r.get("origin") == origin]
+    if severity is not None:
+        sev = severity.lower()
+        rows = [r for r in rows if str(r.get("severity", "")).lower() == sev]
+    if scan_id is not None:
+        rows = [r for r in rows if str(r.get("scan_id") or "") == scan_id]
+    return rows
+
+
+def _severity_breakdown_from_rows(rows: Iterable[dict[str, Any]]) -> dict[str, int]:
+    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
+    for row in rows:
+        sev = str(row.get("severity") or "unknown").lower()
+        counts[sev] = counts.get(sev, 0) + 1
+    return counts
+
+
+def _framework_slug_counts_from_rows(rows: Iterable[dict[str, Any]]) -> dict[str, int]:
+    from agent_bom.compliance_coverage import normalize_framework_slug
+
+    counts: dict[str, int] = {}
+    for row in rows:
+        for slug in row.get("applicable_frameworks") or []:
+            canonical = normalize_framework_slug(str(slug))
+            counts[canonical] = counts.get(canonical, 0) + 1
+    return counts
+
+
 def _redact_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Drop tier-B fields before any compliance-hub finding is stored.
 
@@ -143,6 +179,7 @@ class ComplianceHubStore(Protocol):
         severity: str | None = None,
         scan_id: str | None = None,
         origin: str | None = None,
+        include_total: bool = True,
     ) -> FindingPage:
         """Return a single page of findings plus the matching total.
 
@@ -151,12 +188,22 @@ class ComplianceHubStore(Protocol):
         the read path stays sub-linear at million-row scale. ``sort`` is one
         of ``effective_reach`` (default, indexed), ``cvss``, ``severity`` or
         ``ordinal`` (ingest order). Returns ``(rows, total)`` where ``total``
-        counts all findings matching the filters, not just the page.
+        counts all findings matching the filters, not just the page. When
+        ``include_total`` is false the backend skips ``COUNT(*)`` and
+        returns ``None`` for ``total``.
         """
         ...
 
     def count(self, tenant_id: str) -> int:
         """Return the count of findings for a tenant."""
+        ...
+
+    def severity_breakdown(self, tenant_id: str) -> dict[str, int]:
+        """Return per-severity counts for hub findings without loading payloads."""
+        ...
+
+    def framework_slug_counts(self, tenant_id: str) -> dict[str, int]:
+        """Return per-framework slug counts from denormalised CSV columns."""
         ...
 
     def clear(self, tenant_id: str) -> int:
@@ -179,7 +226,12 @@ class InMemoryComplianceHubStore:
         with self._lock:
             bucket = self._by_tenant.setdefault(tenant_id, [])
             bucket.extend(clean)
-            return len(bucket)
+            total = len(bucket)
+        if clean:
+            from agent_bom.api.findings_count_cache import invalidate_tenant
+
+            invalidate_tenant(tenant_id)
+        return total
 
     def list(self, tenant_id: str) -> list[dict[str, Any]]:
         with self._lock:
@@ -195,17 +247,12 @@ class InMemoryComplianceHubStore:
         severity: str | None = None,
         scan_id: str | None = None,
         origin: str | None = None,
+        include_total: bool = True,
     ) -> FindingPage:
         with self._lock:
             rows = list(self._by_tenant.get(tenant_id, []))
-        if origin is not None:
-            rows = [r for r in rows if r.get("origin") == origin]
-        if severity is not None:
-            sev = severity.lower()
-            rows = [r for r in rows if str(r.get("severity", "")).lower() == sev]
-        if scan_id is not None:
-            rows = [r for r in rows if str(r.get("scan_id") or "") == scan_id]
-        total = len(rows)
+        rows = _filter_hub_rows(rows, severity=severity, scan_id=scan_id, origin=origin)
+        total = len(rows) if include_total else None
         if sort != "ordinal":
             rows.sort(key=_page_sort_key(sort))
         if offset:
@@ -213,6 +260,16 @@ class InMemoryComplianceHubStore:
         if limit >= 0:
             rows = rows[:limit]
         return rows, total
+
+    def severity_breakdown(self, tenant_id: str) -> dict[str, int]:
+        with self._lock:
+            rows = list(self._by_tenant.get(tenant_id, []))
+        return _severity_breakdown_from_rows(rows)
+
+    def framework_slug_counts(self, tenant_id: str) -> dict[str, int]:
+        with self._lock:
+            rows = list(self._by_tenant.get(tenant_id, []))
+        return _framework_slug_counts_from_rows(rows)
 
     def count(self, tenant_id: str) -> int:
         with self._lock:
@@ -222,7 +279,11 @@ class InMemoryComplianceHubStore:
         with self._lock:
             removed = len(self._by_tenant.get(tenant_id, []))
             self._by_tenant[tenant_id] = []
-            return removed
+        if removed:
+            from agent_bom.api.findings_count_cache import invalidate_tenant
+
+            invalidate_tenant(tenant_id)
+        return removed
 
 
 # ─── SQLite backend ─────────────────────────────────────────────────────────
@@ -390,6 +451,10 @@ class SQLiteComplianceHubStore:
             rows,
         )
         self._conn.commit()
+        if rows:
+            from agent_bom.api.findings_count_cache import invalidate_tenant
+
+            invalidate_tenant(tenant_id)
         return self.count(tenant_id)
 
     def list(self, tenant_id: str) -> list[dict[str, Any]]:
@@ -409,6 +474,7 @@ class SQLiteComplianceHubStore:
         severity: str | None = None,
         scan_id: str | None = None,
         origin: str | None = None,
+        include_total: bool = True,
     ) -> FindingPage:
         where = ["tenant_id = ?"]
         params: list[Any] = [tenant_id]
@@ -423,13 +489,17 @@ class SQLiteComplianceHubStore:
             params.append(scan_id)
         where_sql = " AND ".join(where)
 
-        # ``where_sql`` is assembled only from fixed predicates above; all caller values
-        # stay in ``params`` as sqlite bindings.
-        total_row = self._conn.execute(
-            f"SELECT COUNT(*) FROM compliance_hub_findings WHERE {where_sql}",  # nosec B608
-            params,
-        ).fetchone()
-        total = int(total_row[0]) if total_row else 0
+        total: int | None
+        if include_total:
+            # ``where_sql`` is assembled only from fixed predicates above; all caller values
+            # stay in ``params`` as sqlite bindings.
+            total_row = self._conn.execute(
+                f"SELECT COUNT(*) FROM compliance_hub_findings WHERE {where_sql}",  # nosec B608
+                params,
+            ).fetchone()
+            total = int(total_row[0]) if total_row else 0
+        else:
+            total = None
 
         order_sql = _sqlite_order_clause(sort)
         page_params = [*params, int(limit), int(offset)]
@@ -439,6 +509,41 @@ class SQLiteComplianceHubStore:
             page_params,
         ).fetchall()
         return [json.loads(row[0]) for row in rows], total
+
+    def severity_breakdown(self, tenant_id: str) -> dict[str, int]:
+        rows = self._conn.execute(
+            """
+            SELECT LOWER(COALESCE(json_extract(payload, '$.severity'), 'unknown')) AS sev, COUNT(*)
+            FROM compliance_hub_findings
+            WHERE tenant_id = ?
+            GROUP BY sev
+            """,
+            (tenant_id,),
+        ).fetchall()
+        counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
+        for sev, count in rows:
+            key = str(sev or "unknown").lower()
+            counts[key] = counts.get(key, 0) + int(count)
+        return counts
+
+    def framework_slug_counts(self, tenant_id: str) -> dict[str, int]:
+        from agent_bom.compliance_coverage import normalize_framework_slug
+
+        rows = self._conn.execute(
+            "SELECT applicable_frameworks_csv FROM compliance_hub_findings WHERE tenant_id = ?",
+            (tenant_id,),
+        ).fetchall()
+        counts: dict[str, int] = {}
+        for (csv_value,) in rows:
+            if not csv_value:
+                continue
+            for slug in str(csv_value).split(","):
+                slug = slug.strip()
+                if not slug:
+                    continue
+                canonical = normalize_framework_slug(slug)
+                counts[canonical] = counts.get(canonical, 0) + 1
+        return counts
 
     def count(self, tenant_id: str) -> int:
         row = self._conn.execute(
@@ -453,7 +558,12 @@ class SQLiteComplianceHubStore:
             (tenant_id,),
         )
         self._conn.commit()
-        return cur.rowcount or 0
+        removed = cur.rowcount or 0
+        if removed:
+            from agent_bom.api.findings_count_cache import invalidate_tenant
+
+            invalidate_tenant(tenant_id)
+        return removed
 
 
 # ─── Module-level access (set/reset wired in stores.py) ──────────────────────

--- a/src/agent_bom/api/findings_count_cache.py
+++ b/src/agent_bom/api/findings_count_cache.py
@@ -1,0 +1,84 @@
+"""Short-lived TTL cache for bulk-finding totals (P1-A PR2).
+
+``GET /v1/findings`` with ``?approximate_total=true`` skips ``COUNT(*)`` on
+deep pages and reuses the count captured on ``offset=0`` until the entry
+expires. Keys are scoped to tenant + filter dimensions that affect cardinality.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+def _ttl_seconds() -> float:
+    raw = os.environ.get("AGENT_BOM_FINDINGS_COUNT_CACHE_TTL_SECONDS", "60")
+    try:
+        return max(1.0, float(raw))
+    except (TypeError, ValueError):
+        return 60.0
+
+
+@dataclass(frozen=True)
+class _CacheEntry:
+    total: int
+    expires_at: float
+
+
+_lock = threading.Lock()
+_entries: dict[tuple[Any, ...], _CacheEntry] = {}
+
+
+def _purge_expired(now: float) -> None:
+    expired = [key for key, entry in _entries.items() if entry.expires_at <= now]
+    for key in expired:
+        del _entries[key]
+
+
+def cache_key(
+    *,
+    tenant_id: str,
+    severity: str | None,
+    scan_id: str | None,
+    origin: str | None,
+) -> tuple[Any, ...]:
+    return (
+        tenant_id,
+        (severity or "").lower(),
+        scan_id or "",
+        origin or "",
+    )
+
+
+def get_cached_total(key: tuple[Any, ...]) -> int | None:
+    now = time.monotonic()
+    with _lock:
+        _purge_expired(now)
+        entry = _entries.get(key)
+        if entry is None:
+            return None
+        return entry.total
+
+
+def set_cached_total(key: tuple[Any, ...], total: int) -> None:
+    now = time.monotonic()
+    with _lock:
+        _purge_expired(now)
+        _entries[key] = _CacheEntry(total=total, expires_at=now + _ttl_seconds())
+
+
+def invalidate_tenant(tenant_id: str) -> None:
+    """Drop cached totals for a tenant after ingest or clear."""
+    with _lock:
+        doomed = [key for key in _entries if key and key[0] == tenant_id]
+        for key in doomed:
+            _entries.pop(key, None)
+
+
+def reset_findings_count_cache() -> None:
+    """Test helper — never call from production code."""
+    with _lock:
+        _entries.clear()

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -118,6 +118,7 @@ class PostgresComplianceHubStore:
         severity: str | None = None,
         scan_id: str | None = None,
         origin: str | None = None,
+        include_total: bool = True,
     ) -> FindingPage:
         where = ["tenant_id = %s"]
         params: list[Any] = [tenant_id]
@@ -134,13 +135,17 @@ class PostgresComplianceHubStore:
         order_sql = _postgres_order_clause(sort)
 
         with _tenant_connection(self._pool) as conn:
-            # ``where_sql`` is assembled only from fixed predicates above; all caller values
-            # stay in ``params`` as psycopg bindings.
-            total_row = conn.execute(
-                f"SELECT COUNT(*) FROM compliance_hub_findings WHERE {where_sql}",  # nosec B608
-                tuple(params),
-            ).fetchone()
-            total = int(total_row[0]) if total_row else 0
+            total: int | None
+            if include_total:
+                # ``where_sql`` is assembled only from fixed predicates above; all caller values
+                # stay in ``params`` as psycopg bindings.
+                total_row = conn.execute(
+                    f"SELECT COUNT(*) FROM compliance_hub_findings WHERE {where_sql}",  # nosec B608
+                    tuple(params),
+                ).fetchone()
+                total = int(total_row[0]) if total_row else 0
+            else:
+                total = None
             # ``order_sql`` comes from a closed sort allowlist; all caller values stay bound.
             rows = conn.execute(
                 f"SELECT payload FROM compliance_hub_findings WHERE {where_sql} {order_sql} LIMIT %s OFFSET %s",  # nosec B608
@@ -151,6 +156,43 @@ class PostgresComplianceHubStore:
             raw = row[0]
             out.append(raw if isinstance(raw, dict) else json.loads(raw))
         return out, total
+
+    def severity_breakdown(self, tenant_id: str) -> dict[str, int]:
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                """
+                SELECT LOWER(COALESCE(payload->>'severity', 'unknown')) AS sev, COUNT(*)
+                FROM compliance_hub_findings
+                WHERE tenant_id = %s
+                GROUP BY sev
+                """,
+                (tenant_id,),
+            ).fetchall()
+        counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
+        for sev, count in rows:
+            key = str(sev or "unknown").lower()
+            counts[key] = counts.get(key, 0) + int(count)
+        return counts
+
+    def framework_slug_counts(self, tenant_id: str) -> dict[str, int]:
+        from agent_bom.compliance_coverage import normalize_framework_slug
+
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                "SELECT applicable_frameworks_csv FROM compliance_hub_findings WHERE tenant_id = %s",
+                (tenant_id,),
+            ).fetchall()
+        counts: dict[str, int] = {}
+        for (csv_value,) in rows:
+            if not csv_value:
+                continue
+            for slug in str(csv_value).split(","):
+                slug = slug.strip()
+                if not slug:
+                    continue
+                canonical = normalize_framework_slug(slug)
+                counts[canonical] = counts.get(canonical, 0) + 1
+        return counts
 
     def count(self, tenant_id: str) -> int:
         with _tenant_connection(self._pool) as conn:
@@ -167,4 +209,9 @@ class PostgresComplianceHubStore:
                 (tenant_id,),
             )
             conn.commit()
-        return cur.rowcount or 0
+        removed = cur.rowcount or 0
+        if removed:
+            from agent_bom.api.findings_count_cache import invalidate_tenant
+
+            invalidate_tenant(tenant_id)
+        return removed

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -274,7 +274,13 @@ class PostgresJobStore:
             ).fetchall()
             return [ScanJob.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
 
-    def list_summary(self, tenant_id: str | None = None) -> list[dict]:
+    def list_summary(
+        self,
+        tenant_id: str | None = None,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict]:
         def _json_column(row: tuple, index: int, default: str, expected_type: type) -> object:
             if len(row) <= index:
                 return json.loads(default)
@@ -283,23 +289,21 @@ class PostgresJobStore:
                 return value
             return json.loads(value or default)
 
+        base_sql = """SELECT job_id, team_id, status, created_at, completed_at, triggered_by, schedule_id,
+                             batch_id, parent_job_id, child_job_ids, target, target_index, target_count
+                      FROM scan_jobs"""
+        params: list[object] = []
+        if tenant_id is None:
+            sql = f"{base_sql} ORDER BY created_at DESC"
+        else:
+            sql = f"{base_sql} WHERE team_id = %s ORDER BY created_at DESC"
+            params.append(tenant_id)
+        if limit is not None:
+            sql = f"{sql} LIMIT %s OFFSET %s"
+            params.extend([max(1, int(limit)), max(0, int(offset))])
+
         with _tenant_connection(self._pool) as conn:
-            if tenant_id is None:
-                rows = conn.execute(
-                    """SELECT job_id, team_id, status, created_at, completed_at, triggered_by, schedule_id,
-                              batch_id, parent_job_id, child_job_ids, target, target_index, target_count
-                       FROM scan_jobs
-                       ORDER BY created_at DESC"""
-                ).fetchall()
-            else:
-                rows = conn.execute(
-                    """SELECT job_id, team_id, status, created_at, completed_at, triggered_by, schedule_id,
-                              batch_id, parent_job_id, child_job_ids, target, target_index, target_count
-                       FROM scan_jobs
-                       WHERE team_id = %s
-                       ORDER BY created_at DESC""",
-                    (tenant_id,),
-                ).fetchall()
+            rows = conn.execute(sql, tuple(params)).fetchall()
             return [
                 {
                     "job_id": row[0],
@@ -318,6 +322,14 @@ class PostgresJobStore:
                 }
                 for row in rows
             ]
+
+    def count_summary(self, tenant_id: str | None = None) -> int:
+        with _tenant_connection(self._pool) as conn:
+            if tenant_id is None:
+                row = conn.execute("SELECT COUNT(*) FROM scan_jobs").fetchone()
+            else:
+                row = conn.execute("SELECT COUNT(*) FROM scan_jobs WHERE team_id = %s", (tenant_id,)).fetchone()
+        return int(row[0]) if row else 0
 
     def query_cis_benchmark_checks(
         self,

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -1864,9 +1864,7 @@ async def ingest_compliance_findings(request: Request) -> dict:
     for payload in payloads:
         frameworks = payload.get("applicable_frameworks")
         if isinstance(frameworks, list):
-            payload["applicable_frameworks"] = [
-                normalize_framework_slug(str(slug)) for slug in frameworks if slug
-            ]
+            payload["applicable_frameworks"] = [normalize_framework_slug(str(slug)) for slug in frameworks if slug]
     tenant_id = _tenant_id(request)
     store = get_compliance_hub_store()
     new_total = store.add(tenant_id, payloads)
@@ -1945,7 +1943,7 @@ async def get_hub_posture(request: Request) -> dict:
         hub_findings = store.list(tenant_id)
         hub_total = len(hub_findings)
         hub_severity_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
-        hub_framework_counts: dict[str, int] = {}
+        hub_framework_counts = {}
         for f in hub_findings:
             sev = (f.get("severity") or "unknown").lower()
             hub_severity_counts[sev] = hub_severity_counts.get(sev, 0) + 1

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -1893,16 +1893,32 @@ async def list_hub_findings(request: Request, limit: int = 200, offset: int = 0)
     """
     from agent_bom.api.compliance_hub_store import get_compliance_hub_store
 
-    findings = get_compliance_hub_store().list(_tenant_id(request)) + _native_hub_findings(request)
-    limit = max(1, min(limit, 1000))
-    offset = max(0, offset)
-    page = findings[offset : offset + limit]
+    tenant_id = _tenant_id(request)
+    safe_limit = max(1, min(limit, 1000))
+    safe_offset = max(0, offset)
+    native = _native_hub_findings(request)
+    store = get_compliance_hub_store()
+    list_page = getattr(store, "list_page", None)
+    if callable(list_page):
+        if native:
+            window = safe_offset + safe_limit
+            hub_rows, hub_total = list_page(tenant_id, limit=window, offset=0)
+            combined = native + hub_rows
+            page = combined[safe_offset : safe_offset + safe_limit]
+            total = len(native) + (hub_total or 0)
+        else:
+            page, total = list_page(tenant_id, limit=safe_limit, offset=safe_offset)
+            total = total or 0
+    else:
+        findings = store.list(tenant_id) + native
+        page = findings[safe_offset : safe_offset + safe_limit]
+        total = len(findings)
     return {
         "findings": page,
         "count": len(page),
-        "total": len(findings),
-        "limit": limit,
-        "offset": offset,
+        "total": total,
+        "limit": safe_limit,
+        "offset": safe_offset,
     }
 
 
@@ -1918,7 +1934,24 @@ async def get_hub_posture(request: Request) -> dict:
     from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS, normalize_framework_slug
 
     tenant_id = _tenant_id(request)
-    hub_findings = get_compliance_hub_store().list(tenant_id)
+    store = get_compliance_hub_store()
+    severity_breakdown = getattr(store, "severity_breakdown", None)
+    framework_counts_fn = getattr(store, "framework_slug_counts", None)
+    if callable(severity_breakdown) and callable(framework_counts_fn):
+        hub_severity_counts = severity_breakdown(tenant_id)
+        hub_framework_counts = framework_counts_fn(tenant_id)
+        hub_total = store.count(tenant_id)
+    else:
+        hub_findings = store.list(tenant_id)
+        hub_total = len(hub_findings)
+        hub_severity_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
+        hub_framework_counts: dict[str, int] = {}
+        for f in hub_findings:
+            sev = (f.get("severity") or "unknown").lower()
+            hub_severity_counts[sev] = hub_severity_counts.get(sev, 0) + 1
+            for slug in f.get("applicable_frameworks") or []:
+                canonical = normalize_framework_slug(str(slug))
+                hub_framework_counts[canonical] = hub_framework_counts.get(canonical, 0) + 1
 
     # Native sources: count blast radii from completed scan jobs as a
     # proxy for "native finding count per framework" using their tag fields.
@@ -1941,15 +1974,6 @@ async def get_hub_posture(request: Request) -> dict:
                 if br.get(field):
                     native_framework_counts[slug] = native_framework_counts.get(slug, 0) + 1
 
-    hub_framework_counts: dict[str, int] = {}
-    hub_severity_counts: dict[str, int] = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
-    for f in hub_findings:
-        sev = (f.get("severity") or "unknown").lower()
-        hub_severity_counts[sev] = hub_severity_counts.get(sev, 0) + 1
-        for slug in f.get("applicable_frameworks") or []:
-            canonical = normalize_framework_slug(str(slug))
-            hub_framework_counts[canonical] = hub_framework_counts.get(canonical, 0) + 1
-
     combined: dict[str, int] = {}
     for slug, count in native_framework_counts.items():
         combined[slug] = combined.get(slug, 0) + count
@@ -1959,8 +1983,8 @@ async def get_hub_posture(request: Request) -> dict:
     return {
         "totals": {
             "native": native_total,
-            "hub": len(hub_findings),
-            "combined": native_total + len(hub_findings),
+            "hub": hub_total,
+            "combined": native_total + hub_total,
         },
         "framework_counts": {
             "native": dict(sorted(native_framework_counts.items())),

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1075,11 +1075,16 @@ async def list_jobs(
     """
     tenant_id = _tenant_id(request)
     store = _get_store()
-    summary = store.list_summary(tenant_id=tenant_id)
-    total = len(summary)
-    page = summary[offset : offset + limit]
+    count_summary = getattr(store, "count_summary", None)
+    if callable(count_summary):
+        total = count_summary(tenant_id=tenant_id)
+        summary = store.list_summary(tenant_id=tenant_id, limit=limit, offset=offset)
+    else:
+        summary = store.list_summary(tenant_id=tenant_id)
+        total = len(summary)
+        summary = summary[offset : offset + limit]
     enriched: list[dict[str, Any]] = []
-    for item in page:
+    for item in summary:
         in_mem = _jobs_get(item["job_id"])
         if isinstance(in_mem, ScanJob) and _visible_to_tenant(in_mem, tenant_id):
             enriched.append(_job_summary_payload(in_mem))
@@ -1113,6 +1118,39 @@ async def list_jobs(
 _ALLOWED_FINDING_SORTS = ("effective_reach", "cvss", "severity")
 
 
+def _resolve_bulk_findings_total(
+    *,
+    tenant_id: str,
+    severity: str | None,
+    scan_id: str | None,
+    approximate_total: bool,
+    offset: int,
+    bulk_total: int | None,
+    page_len: int,
+    limit: int,
+) -> tuple[int | None, bool]:
+    """Return ``(total, total_approximate)`` for the bulk-ingest slice."""
+    from agent_bom.api.findings_count_cache import cache_key, get_cached_total, set_cached_total
+
+    if not approximate_total:
+        return bulk_total, False
+
+    key = cache_key(tenant_id=tenant_id, severity=severity, scan_id=scan_id, origin="bulk_ingest")
+    if offset == 0 and bulk_total is not None:
+        set_cached_total(key, bulk_total)
+        return bulk_total, False
+
+    cached = get_cached_total(key)
+    if cached is not None:
+        return cached, True
+
+    # Cold cache on a deep page: expose a conservative lower bound so paging
+    # controls stay usable until the client revisits offset=0.
+    if page_len < limit:
+        return offset + page_len, True
+    return offset + limit, True
+
+
 def _finding_sort_key(row: dict[str, Any], sort: str) -> tuple[float, float, float]:
     """Stable sort key — descending order on the requested signal,
     with CVSS + severity-rank tiebreakers so the order is fully
@@ -1144,6 +1182,7 @@ async def list_findings(
     # the historical `min(limit, 1000)` clamp at use-site.
     limit: Annotated[int, Query(ge=1, le=1000)] = 500,
     offset: Annotated[int, Query(ge=0)] = 0,
+    approximate_total: bool = False,
 ) -> dict:
     """List vulnerability findings aggregated from completed scan results.
 
@@ -1151,6 +1190,12 @@ async def list_findings(
     combines CVSS / EPSS / KEV with reachable-tool capability, credential
     visibility and agent breadth.  Pass ``?sort=cvss`` for the legacy
     CVSS-only ordering, or ``?sort=severity`` for severity-band ordering.
+
+    Pass ``?approximate_total=true`` to skip ``COUNT(*)`` on deep pages.
+    The first page (``offset=0``) still computes an exact total and caches it
+    for roughly ``AGENT_BOM_FINDINGS_COUNT_CACHE_TTL_SECONDS`` (default 60s).
+    Later pages reuse the cached count; when the cache is cold the response
+    carries a conservative lower bound and ``total_approximate: true``.
     """
     from agent_bom.api.compliance_hub_store import get_compliance_hub_store
 
@@ -1158,6 +1203,7 @@ async def list_findings(
     sort_key = sort.lower().strip() if isinstance(sort, str) else "effective_reach"
     if sort_key not in _ALLOWED_FINDING_SORTS:
         sort_key = "effective_reach"
+    include_bulk_total = (not approximate_total) or offset == 0
 
     # Scan-job findings live in memory and are typically small; gather + sort
     # them directly. The bulk-ingested hub findings can reach millions of rows,
@@ -1181,6 +1227,7 @@ async def list_findings(
 
     store = get_compliance_hub_store()
     list_page = getattr(store, "list_page", None)
+    total_approximate = False
     if callable(list_page):
         if scan_findings:
             # Bounded merge: pull at most (offset + limit) top bulk rows, merge
@@ -1194,11 +1241,22 @@ async def list_findings(
                 severity=severity,
                 scan_id=scan_id,
                 origin="bulk_ingest",
+                include_total=include_bulk_total,
             )
             combined = scan_findings + bulk_page
             combined.sort(key=lambda row: _finding_sort_key(row, sort_key))
-            total = len(scan_findings) + bulk_total
             page_rows = combined[offset : offset + limit]
+            resolved_bulk, total_approximate = _resolve_bulk_findings_total(
+                tenant_id=tenant_id,
+                severity=severity,
+                scan_id=scan_id,
+                approximate_total=approximate_total,
+                offset=offset,
+                bulk_total=bulk_total,
+                page_len=len(page_rows),
+                limit=limit,
+            )
+            total = None if resolved_bulk is None else len(scan_findings) + resolved_bulk
         else:
             page_rows, bulk_total = list_page(
                 tenant_id,
@@ -1208,8 +1266,18 @@ async def list_findings(
                 severity=severity,
                 scan_id=scan_id,
                 origin="bulk_ingest",
+                include_total=include_bulk_total,
             )
-            total = bulk_total
+            total, total_approximate = _resolve_bulk_findings_total(
+                tenant_id=tenant_id,
+                severity=severity,
+                scan_id=scan_id,
+                approximate_total=approximate_total,
+                offset=offset,
+                bulk_total=bulk_total,
+                page_len=len(page_rows),
+                limit=limit,
+            )
     else:
         # Backward-compatible fallback for stores without pagination support.
         bulk_findings = _bulk_ingested_findings_for_tenant(tenant_id)
@@ -1224,7 +1292,7 @@ async def list_findings(
         page_rows = combined[offset : offset + limit]
 
     page = _redact_finding_page(page_rows)
-    return {
+    response: dict[str, Any] = {
         # emit schema_version so consumers can pin a
         # contract independent of API path.
         "schema_version": "v1",
@@ -1237,6 +1305,9 @@ async def list_findings(
         "scan_id": scan_id,
         "warnings": [],
     }
+    if total_approximate:
+        response["total_approximate"] = True
+    return response
 
 
 @router.post("/v1/findings/bulk", tags=["scan"], status_code=201)

--- a/src/agent_bom/api/store.py
+++ b/src/agent_bom/api/store.py
@@ -120,7 +120,7 @@ class InMemoryJobStore:
             ]
             if tenant_id is not None:
                 rows = [row for row in rows if row["tenant_id"] == tenant_id]
-            rows.sort(key=lambda row: row["created_at"], reverse=True)
+            rows.sort(key=lambda row: str(row.get("created_at") or ""), reverse=True)
             if offset:
                 rows = rows[offset:]
             if limit is not None:

--- a/src/agent_bom/api/store.py
+++ b/src/agent_bom/api/store.py
@@ -11,7 +11,7 @@ import json
 import sqlite3
 import threading
 from datetime import datetime, timezone
-from typing import Protocol
+from typing import Any, Protocol
 
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
 from agent_bom.config import API_MAX_IN_MEMORY_JOBS
@@ -28,7 +28,14 @@ class JobStore(Protocol):
     def get(self, job_id: str, tenant_id: str | None = None) -> ScanJob | None: ...
     def delete(self, job_id: str, tenant_id: str | None = None) -> bool: ...
     def list_all(self, tenant_id: str | None = None) -> list[ScanJob]: ...
-    def list_summary(self, tenant_id: str | None = None) -> list[dict]: ...
+    def list_summary(
+        self,
+        tenant_id: str | None = None,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict]: ...
+    def count_summary(self, tenant_id: str | None = None) -> int: ...
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int: ...
 
 
@@ -85,7 +92,13 @@ class InMemoryJobStore:
                 return jobs
             return [job for job in jobs if job.tenant_id == tenant_id]
 
-    def list_summary(self, tenant_id: str | None = None) -> list[dict]:
+    def list_summary(
+        self,
+        tenant_id: str | None = None,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict]:
         with self._lock:
             rows = [
                 {
@@ -105,9 +118,20 @@ class InMemoryJobStore:
                 }
                 for j in self._jobs.values()
             ]
+            if tenant_id is not None:
+                rows = [row for row in rows if row["tenant_id"] == tenant_id]
+            rows.sort(key=lambda row: row["created_at"], reverse=True)
+            if offset:
+                rows = rows[offset:]
+            if limit is not None:
+                rows = rows[:limit]
+            return rows
+
+    def count_summary(self, tenant_id: str | None = None) -> int:
+        with self._lock:
             if tenant_id is None:
-                return rows
-            return [row for row in rows if row["tenant_id"] == tenant_id]
+                return len(self._jobs)
+            return sum(1 for job in self._jobs.values() if job.tenant_id == tenant_id)
 
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int:
         with self._lock:
@@ -303,24 +327,27 @@ class SQLiteJobStore:
             self._shrink_connection_memory()
             self._close_thread_connection()
 
-    def list_summary(self, tenant_id: str | None = None) -> list[dict]:
+    def list_summary(
+        self,
+        tenant_id: str | None = None,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict]:
         try:
+            base_sql = """SELECT job_id, tenant_id, status, created_at, completed_at, triggered_by, schedule_id,
+                                 batch_id, parent_job_id, child_job_ids, target, target_index, target_count
+                          FROM jobs"""
+            params: list[Any] = []
             if tenant_id is None:
-                rows = self._conn.execute(
-                    """SELECT job_id, tenant_id, status, created_at, completed_at, triggered_by, schedule_id,
-                              batch_id, parent_job_id, child_job_ids, target, target_index, target_count
-                       FROM jobs
-                       ORDER BY created_at DESC"""
-                ).fetchall()
+                sql = f"{base_sql} ORDER BY created_at DESC"
             else:
-                rows = self._conn.execute(
-                    """SELECT job_id, tenant_id, status, created_at, completed_at, triggered_by, schedule_id,
-                              batch_id, parent_job_id, child_job_ids, target, target_index, target_count
-                       FROM jobs
-                       WHERE tenant_id = ?
-                       ORDER BY created_at DESC""",
-                    (tenant_id,),
-                ).fetchall()
+                sql = f"{base_sql} WHERE tenant_id = ? ORDER BY created_at DESC"
+                params.append(tenant_id)
+            if limit is not None:
+                sql = f"{sql} LIMIT ? OFFSET ?"
+                params.extend([int(limit), max(0, int(offset))])
+            rows = self._conn.execute(sql, params).fetchall()
             summaries: list[dict] = []
             for row in rows:
                 summaries.append(
@@ -341,6 +368,17 @@ class SQLiteJobStore:
                     }
                 )
             return summaries
+        finally:
+            self._shrink_connection_memory()
+            self._close_thread_connection()
+
+    def count_summary(self, tenant_id: str | None = None) -> int:
+        try:
+            if tenant_id is None:
+                row = self._conn.execute("SELECT COUNT(*) FROM jobs").fetchone()
+            else:
+                row = self._conn.execute("SELECT COUNT(*) FROM jobs WHERE tenant_id = ?", (tenant_id,)).fetchone()
+            return int(row[0]) if row else 0
         finally:
             self._shrink_connection_memory()
             self._close_thread_connection()

--- a/tests/test_api_store.py
+++ b/tests/test_api_store.py
@@ -300,9 +300,11 @@ def test_sqlite_list_summary():
         db_path = f.name
     try:
         store = SQLiteJobStore(db_path=db_path)
-        store.put(_make_job("j1", triggered_by="api-user"))
-        summary = store.list_summary()
-        assert len(summary) == 1
+        for idx in range(3):
+            store.put(_make_job(f"j{idx}", triggered_by="api-user"))
+        assert store.count_summary() == 3
+        summary = store.list_summary(limit=2, offset=1)
+        assert len(summary) == 2
         assert summary[0]["job_id"] == "j1"
         assert summary[0]["triggered_by"] == "api-user"
         assert "status" in summary[0]

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -376,7 +376,7 @@ async def test_create_scan_and_push_stamp_request_tenant(monkeypatch):
     listed = await scan_routes.list_jobs(req)
     pushed_summary = next(job for job in listed["jobs"] if job["job_id"] == pushed["job_id"])
     assert "summary" not in pushed_summary
-    assert listed["jobs"][0]["request"] == {}
+    assert "request" not in pushed_summary
 
     hydrated = await scan_routes.list_jobs(req, include_details=True)
     pushed_hydrated = next(job for job in hydrated["jobs"] if job["job_id"] == pushed["job_id"])

--- a/tests/test_compliance_hub_store_pagination.py
+++ b/tests/test_compliance_hub_store_pagination.py
@@ -61,6 +61,21 @@ def test_list_page_limits_rows_and_reports_total(seeded_store) -> None:
     assert total == _SEEDED, "total must count all matching rows, not just the page"
 
 
+def test_list_page_can_skip_total_count(seeded_store) -> None:
+    store, tenant = seeded_store
+    rows, total = store.list_page(tenant, limit=10, offset=5, include_total=False)
+    assert len(rows) == 10
+    assert total is None
+
+
+def test_severity_breakdown_and_framework_counts(seeded_store) -> None:
+    store, tenant = seeded_store
+    breakdown = store.severity_breakdown(tenant)
+    assert sum(breakdown.values()) == _SEEDED
+    framework_counts = store.framework_slug_counts(tenant)
+    assert framework_counts == {}
+
+
 def test_list_page_effective_reach_sort_is_descending(seeded_store) -> None:
     store, tenant = seeded_store
     rows, total = store.list_page(tenant, limit=25, offset=0, sort="effective_reach")

--- a/tests/test_findings_read_scale.py
+++ b/tests/test_findings_read_scale.py
@@ -45,7 +45,10 @@ def teardown_module() -> None:
 
 
 def setup_function() -> None:
+    from agent_bom.api.findings_count_cache import reset_findings_count_cache
+
     set_compliance_hub_store(InMemoryComplianceHubStore())
+    reset_findings_count_cache()
 
 
 def test_findings_list_page_under_500ms_at_2k_rows() -> None:
@@ -72,3 +75,35 @@ def test_findings_list_page_under_500ms_at_2k_rows() -> None:
     assert body["count"] == _PAGE_LIMIT
     assert len(body["findings"]) == _PAGE_LIMIT
     assert elapsed_ms < _MAX_ELAPSED_MS, f"GET /v1/findings took {elapsed_ms:.1f}ms (limit {_MAX_ELAPSED_MS}ms)"
+
+
+def test_findings_approximate_total_skips_count_on_deep_page() -> None:
+    tenant_id = f"findings-approx-{uuid.uuid4().hex}"
+    batch_id = f"batch-{uuid.uuid4().hex}"
+    store = InMemoryComplianceHubStore()
+    set_compliance_hub_store(store)
+    store.add(tenant_id, _synthetic_findings(_FINDINGS_COUNT, batch_id=batch_id))
+
+    client = TestClient(app)
+    headers = proxy_headers(role="viewer", tenant=tenant_id)
+
+    first = client.get(
+        "/v1/findings",
+        params={"limit": _PAGE_LIMIT, "offset": 0, "approximate_total": "true"},
+        headers=headers,
+    )
+    assert first.status_code == 200, first.text
+    first_body = first.json()
+    assert first_body["total"] == _FINDINGS_COUNT
+    assert first_body.get("total_approximate") is not True
+
+    deep = client.get(
+        "/v1/findings",
+        params={"limit": _PAGE_LIMIT, "offset": _PAGE_LIMIT, "approximate_total": "true"},
+        headers=headers,
+    )
+    assert deep.status_code == 200, deep.text
+    deep_body = deep.json()
+    assert deep_body["total"] == _FINDINGS_COUNT
+    assert deep_body.get("total_approximate") is True
+    assert len(deep_body["findings"]) == _PAGE_LIMIT

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -277,7 +277,8 @@ def test_list_jobs_pagination():
 
     mock_store = MagicMock()
     # Return 10 summary items
-    mock_store.list_summary.return_value = [{"job_id": f"j-{i}"} for i in range(10)]
+    mock_store.count_summary.return_value = 10
+    mock_store.list_summary.return_value = [{"job_id": f"j-{i}"} for i in range(2, 5)]
 
     with patch("agent_bom.api.routes.scan._get_store", return_value=mock_store):
         client = TestClient(app)

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -30,6 +30,8 @@ import {
   type SeverityFilter,
   type SortKey,
   uniqueStrings,
+  serverFindingsSort,
+  formatFindingsTotal,
 } from "@/lib/findings-view";
 import { severityRank } from "@/lib/severity";
 import { Bug, Download, Layers, Loader2, Package, Server, ClipboardCheck } from "lucide-react";
@@ -48,13 +50,6 @@ function downloadJson(data: unknown, filename: string) {
   URL.revokeObjectURL(url);
 }
 
-
-
-function serverFindingsSort(sortKey: SortKey): string {
-  if (sortKey === "cvss") return "cvss";
-  if (sortKey === "severity") return "severity";
-  return "effective_reach";
-}
 
 
 function toRemediationSummary(item: RemediationItem): RemediationSummary {
@@ -276,6 +271,7 @@ function VulnsPage() {
     return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 1;
   });
   const [findingsTotal, setFindingsTotal] = useState(0);
+  const [findingsTotalApproximate, setFindingsTotalApproximate] = useState(false);
   const PAGE_SIZE = 25;
   const useServerPaging = groupBy === "none" && !search.trim();
 
@@ -541,16 +537,19 @@ function VulnsPage() {
           if (findings.findings.length > 0) {
             setVulns(collectUnifiedFindings(findings.findings));
             setFindingsTotal(findings.total);
+            setFindingsTotalApproximate(false);
             return;
           }
           const graph = await api.getGraph({ scanId: paramScan, limit: 2500 });
           setVulns(collectGraphVulns(graph));
           setFindingsTotal(graph.nodes.filter((node) => graphNodeKind(node) === "vulnerability").length);
+          setFindingsTotalApproximate(false);
           return;
         } catch {
           const selectedJob = await api.getScan(paramScan);
           setVulns(collectVulns([selectedJob]));
           setFindingsTotal(collectVulns([selectedJob]).length);
+          setFindingsTotalApproximate(false);
           return;
         }
       }
@@ -558,6 +557,7 @@ function VulnsPage() {
       if (jobs.length === 0) {
         setVulns([]);
         setFindingsTotal(0);
+        setFindingsTotalApproximate(false);
         return;
       }
 
@@ -566,6 +566,7 @@ function VulnsPage() {
         const collected = collectVulns([latestJob]);
         setVulns(collected);
         setFindingsTotal(collected.length);
+        setFindingsTotalApproximate(false);
         return;
       }
 
@@ -573,6 +574,7 @@ function VulnsPage() {
       const collected = collectVulns(fullJobs.filter((job): job is ScanJob => Boolean(job)));
       setVulns(collected);
       setFindingsTotal(collected.length);
+      setFindingsTotalApproximate(false);
     }
 
     async function loadDetails() {
@@ -590,10 +592,12 @@ function VulnsPage() {
             sort: serverFindingsSort(sortKey),
             limit: PAGE_SIZE,
             offset: (page - 1) * PAGE_SIZE,
+            approximateTotal: true,
           });
           if (response.total > 0 || response.findings.length > 0) {
             setVulns(collectUnifiedFindings(response.findings));
             setFindingsTotal(response.total);
+            setFindingsTotalApproximate(Boolean(response.total_approximate));
             return;
           }
         }
@@ -716,10 +720,15 @@ function VulnsPage() {
     return c;
   }, [vulns]);
 
+  const findingsTotalLabel = formatFindingsTotal(
+    findingsTotal,
+    useServerPaging && findingsTotalApproximate,
+  );
+
   const FILTERS: { key: SeverityFilter; label: string; color: string }[] = [
     {
       key: "all",
-      label: `All (${useServerPaging ? findingsTotal : vulns.length})`,
+      label: `All (${useServerPaging ? findingsTotalLabel : vulns.length})`,
       color: "text-zinc-300",
     },
     { key: "critical", label: `Critical${useServerPaging ? "" : ` (${counts.critical})`}`, color: "text-red-400" },
@@ -743,9 +752,10 @@ function VulnsPage() {
           <p className="text-zinc-400 text-sm mt-1">
             {scope === "latest"
               ? paramScan
-                ? `${useServerPaging ? findingsTotal : vulns.length} findings from scan ${paramScan.slice(0, 8)}.`
-                : `${useServerPaging ? findingsTotal : vulns.length} findings from the latest completed scan.`
-              : `${useServerPaging ? findingsTotal : vulns.length} findings aggregated across all completed scans.`}{" "}
+                ? `${useServerPaging ? findingsTotalLabel : vulns.length} findings from scan ${paramScan.slice(0, 8)}.`
+                : `${useServerPaging ? findingsTotalLabel : vulns.length} findings from the latest completed scan.`
+              : `${useServerPaging ? findingsTotalLabel : vulns.length} findings aggregated across all completed scans.`}{" "}
+            {useServerPaging && findingsTotalApproximate ? "Total is cached from the first page and may be a lower bound on deep pages. " : ""}
             CVSS and EPSS appear for advisory-backed vulnerabilities; cloud and governance findings use source evidence and policy severity.
           </p>
         </div>
@@ -963,7 +973,7 @@ function VulnsPage() {
               page={page}
               totalPages={totalPages}
               totalItems={useServerPaging ? findingsTotal : displayed.length}
-              itemLabel="findings"
+              itemLabel={useServerPaging && findingsTotalApproximate ? "findings (approx.)" : "findings"}
               onPrevious={() => setPage((p) => Math.max(1, p - 1))}
               onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
             />

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -714,6 +714,7 @@ export interface FindingsResponse {
   findings: UnifiedFinding[];
   count: number;
   total: number;
+  total_approximate?: boolean | undefined;
   limit: number;
   offset: number;
   sort: string;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -886,13 +886,21 @@ export const api = {
   },
 
   // ── Unified findings ──
-  listFindings: (filters?: { scanId?: string; severity?: string; sort?: string; limit?: number; offset?: number }) => {
+  listFindings: (filters?: {
+    scanId?: string;
+    severity?: string;
+    sort?: string;
+    limit?: number;
+    offset?: number;
+    approximateTotal?: boolean;
+  }) => {
     const params = new URLSearchParams();
     if (filters?.scanId) params.set("scan_id", filters.scanId);
     if (filters?.severity) params.set("severity", filters.severity);
     if (filters?.sort) params.set("sort", filters.sort);
     if (filters?.limit != null) params.set("limit", String(filters.limit));
     if (filters?.offset != null) params.set("offset", String(filters.offset));
+    if (filters?.approximateTotal) params.set("approximate_total", "true");
     const qs = params.toString();
     return get<FindingsResponse>(`/v1/findings${qs ? `?${qs}` : ""}`);
   },

--- a/ui/lib/findings-view.ts
+++ b/ui/lib/findings-view.ts
@@ -30,9 +30,22 @@ export interface RemediationSummary {
 }
 
 export type SeverityFilter = "all" | "critical" | "high" | "medium" | "low";
-export type SortKey = "severity" | "cvss" | "epss" | "id";
+export type SortKey = "severity" | "cvss" | "epss" | "effective_reach" | "id";
 export type GroupKey = "none" | "package" | "agent" | "severity";
 export type ScanScope = "latest" | "all";
+
+/** Map dashboard sort keys to the server-side ``GET /v1/findings`` contract. */
+export function serverFindingsSort(sortKey: SortKey): string {
+  if (sortKey === "cvss") return "cvss";
+  if (sortKey === "severity") return "severity";
+  return "effective_reach";
+}
+
+/** Human label for totals that may be cached or lower-bounded. */
+export function formatFindingsTotal(total: number, approximate?: boolean): string {
+  if (!approximate) return String(total);
+  return `~${total}`;
+}
 
 export function uniqueStrings(items: Array<string | null | undefined>) {
   return [...new Set(items.filter((item): item is string => Boolean(item && item.trim())).map((item) => item.trim()))];


### PR DESCRIPTION
## Summary
- Add `?approximate_total=true` on `GET /v1/findings`: offset=0 computes and caches the exact tenant total; deep pages skip `COUNT(*)` and reuse the TTL cache (`AGENT_BOM_FINDINGS_COUNT_CACHE_TTL_SECONDS`, default 60s). Response documents `total_approximate` when the count is cached or lower-bounded.
- Migrate compliance hub `list`/`posture` paths to `list_page`, `count`, `severity_breakdown`, and `framework_slug_counts`; push `list_summary` LIMIT/OFFSET into SQLite/Postgres job stores.
- Wire the vulns dashboard to server paging with `approximate_total`, sort param mapping in `findings-view.ts`, and `~` total hints when approximate.

## Test plan
- [x] `uv run pytest -q tests/test_findings_read_scale.py tests/test_compliance_hub_store_pagination.py`
- [x] `uv run pytest -q tests/test_api_store.py::test_sqlite_list_summary`
- [x] `uv run ruff check` on touched API modules
- [x] `cd ui && npm run typecheck`
- [x] `cd ui && npm test -- --run tests/vulns-page.test.tsx`
- [ ] Bench delta at 1M rows with `approximate_total=true` on offset>0 (PR3 follow-up)

## Notes
PR1 (#3442) left ~135ms p50 at 1M rows dominated by `COUNT(*)`. This PR targets that residual cost on paginated reads. PR3 candidates: SQL `GROUP BY` for hub framework posture at million scale, merged native+bulk pagination without windowed merge, and publishing an updated bench JSON after approximate-count sweep.


Made with [Cursor](https://cursor.com)