### PR TITLE
feat(api): expression-indexed severity/cvss finding sorts (#3192)

### DIFF
--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -36,9 +36,10 @@ FindingPage = tuple[list[dict[str, Any]], int]
 
 _SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1}
 
-# Sort keys supported by ``list_page``. ``effective_reach`` is the default and
-# the only one backed by a dedicated index/column; ``cvss`` and ``severity``
-# fall back to JSON-extraction ordering, and ``ordinal`` uses ingest order.
+# Sort keys supported by ``list_page``. ``effective_reach`` (default),
+# ``cvss`` and ``severity`` are each backed by a materialised column +
+# composite ``(tenant_id, origin, <col> DESC, ordinal)`` index; ``ordinal``
+# uses ingest order.
 _LIST_PAGE_SORTS = ("effective_reach", "cvss", "severity", "ordinal")
 
 
@@ -248,34 +249,36 @@ def _now_utc_iso() -> str:
 
 def _sqlite_order_clause(sort: str) -> str:
     """ORDER BY clause for the SQLite backend, ordinal-tiebroken to match
-    the in-memory backend's stable sort."""
+    the in-memory backend's stable sort.
+
+    ``cvss``/``severity`` order by the materialised ``cvss_score`` /
+    ``severity_rank`` columns (not ``json_extract``) so the composite
+    ``(tenant_id, origin, <col> DESC, ordinal)`` indexes back the sort with
+    an ordered range scan instead of a temp-B-tree filesort (#3192).
+    """
     if sort == "ordinal":
         return "ORDER BY ordinal ASC"
     if sort == "cvss":
-        return "ORDER BY CAST(json_extract(payload, '$.cvss_score') AS REAL) DESC, ordinal ASC"
+        return "ORDER BY cvss_score DESC, ordinal ASC"
     if sort == "severity":
-        # Map severity band to the same rank used in-memory.
-        return (
-            "ORDER BY CASE LOWER(COALESCE(json_extract(payload, '$.severity'), '')) "
-            "WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 "
-            "ELSE 0 END DESC, ordinal ASC"
-        )
+        return "ORDER BY severity_rank DESC, ordinal ASC"
     # effective_reach (default) — index-backed range scan + limit.
     return "ORDER BY effective_reach_score DESC, ordinal ASC"
 
 
 def _postgres_order_clause(sort: str) -> str:
-    """ORDER BY clause for the Postgres backend, mirroring SQLite semantics."""
+    """ORDER BY clause for the Postgres backend, mirroring SQLite semantics.
+
+    ``cvss``/``severity`` order by the materialised ``cvss_score`` /
+    ``severity_rank`` columns backed by the composite
+    ``(tenant_id, origin, <col> DESC, ordinal)`` indexes (#3192).
+    """
     if sort == "ordinal":
         return "ORDER BY ordinal ASC"
     if sort == "cvss":
-        return "ORDER BY (payload->>'cvss_score')::float8 DESC NULLS LAST, ordinal ASC"
+        return "ORDER BY cvss_score DESC, ordinal ASC"
     if sort == "severity":
-        return (
-            "ORDER BY CASE LOWER(COALESCE(payload->>'severity', '')) "
-            "WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 "
-            "ELSE 0 END DESC, ordinal ASC"
-        )
+        return "ORDER BY severity_rank DESC, ordinal ASC"
     return "ORDER BY effective_reach_score DESC, ordinal ASC"
 
 
@@ -316,6 +319,9 @@ class SQLiteComplianceHubStore:
                 ordinal INTEGER NOT NULL,
                 effective_reach_score REAL NOT NULL DEFAULT 0,
                 origin TEXT NOT NULL DEFAULT '',
+                severity TEXT NOT NULL DEFAULT '',
+                severity_rank INTEGER NOT NULL DEFAULT 0,
+                cvss_score REAL NOT NULL DEFAULT 0,
                 PRIMARY KEY (tenant_id, finding_id, ordinal)
             )
             """
@@ -337,6 +343,28 @@ class SQLiteComplianceHubStore:
             self._conn.execute(
                 "UPDATE compliance_hub_findings SET origin = COALESCE(json_extract(payload, '$.origin'), '') WHERE origin = ''"
             )
+        # Materialise severity/cvss sort keys so the filtered severity/cvss
+        # sorts ride a composite index instead of a json_extract filesort
+        # (#3192). Backfill extracts from the stored payload for legacy rows.
+        if "severity" not in cols:
+            self._conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN severity TEXT NOT NULL DEFAULT ''")
+            self._conn.execute(
+                "UPDATE compliance_hub_findings SET severity = COALESCE(json_extract(payload, '$.severity'), '') WHERE severity = ''"
+            )
+        if "severity_rank" not in cols:
+            self._conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN severity_rank INTEGER NOT NULL DEFAULT 0")
+            self._conn.execute(
+                "UPDATE compliance_hub_findings SET severity_rank = CASE "
+                "LOWER(COALESCE(json_extract(payload, '$.severity'), '')) "
+                "WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 "
+                "ELSE 0 END WHERE severity_rank = 0"
+            )
+        if "cvss_score" not in cols:
+            self._conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN cvss_score REAL NOT NULL DEFAULT 0")
+            self._conn.execute(
+                "UPDATE compliance_hub_findings SET cvss_score = "
+                "CAST(COALESCE(json_extract(payload, '$.cvss_score'), 0) AS REAL) WHERE cvss_score = 0"
+            )
 
     def _ensure_scale_indexes(self) -> None:
         """Install origin-aware read indexes, replacing the pre-origin index.
@@ -353,6 +381,17 @@ class SQLiteComplianceHubStore:
             "ON compliance_hub_findings(tenant_id, origin, effective_reach_score DESC, ordinal)"
         )
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin ON compliance_hub_findings(tenant_id, origin)")
+        # Back the filtered severity/cvss sorts with ordered composite indexes
+        # so ORDER BY rides an index range scan (no temp B-tree filesort) — the
+        # numeric severity_rank keeps critical>high>medium>low ordering (#3192).
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin_severity "
+            "ON compliance_hub_findings(tenant_id, origin, severity_rank DESC, ordinal)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin_cvss "
+            "ON compliance_hub_findings(tenant_id, origin, cvss_score DESC, ordinal)"
+        )
 
     def _next_ordinal(self, tenant_id: str) -> int:
         row = self._conn.execute(
@@ -380,13 +419,17 @@ class SQLiteComplianceHubStore:
                     next_ord + offset,
                     compute_effective_reach_score(payload),
                     str(payload.get("origin") or ""),
+                    str(payload.get("severity") or ""),
+                    _severity_rank(payload),
+                    _cvss_value(payload),
                 )
             )
         self._conn.executemany(
             """
             INSERT OR REPLACE INTO compliance_hub_findings
-                (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload, ordinal, effective_reach_score, origin)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload,
+                 ordinal, effective_reach_score, origin, severity, severity_rank, cvss_score)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             rows,
         )

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -13,10 +13,12 @@ from typing import Any
 
 from agent_bom.api.compliance_hub_store import (
     FindingPage,
+    _cvss_value,
     _frameworks_csv,
     _now_utc_iso,
     _postgres_order_clause,
     _redact_findings,
+    _severity_rank,
     compute_effective_reach_score,
 )
 from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
@@ -45,6 +47,9 @@ class PostgresComplianceHubStore:
                     ordinal BIGSERIAL NOT NULL,
                     effective_reach_score DOUBLE PRECISION NOT NULL DEFAULT 0,
                     origin TEXT NOT NULL DEFAULT '',
+                    severity TEXT NOT NULL DEFAULT '',
+                    severity_rank INTEGER NOT NULL DEFAULT 0,
+                    cvss_score DOUBLE PRECISION NOT NULL DEFAULT 0,
                     PRIMARY KEY (tenant_id, finding_id, ordinal)
                 )
                 """
@@ -55,6 +60,21 @@ class PostgresComplianceHubStore:
             conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN IF NOT EXISTS origin TEXT NOT NULL DEFAULT ''")
             # Backfill origin from the stored payload for pre-migration rows.
             conn.execute("UPDATE compliance_hub_findings SET origin = COALESCE(payload->>'origin', '') WHERE origin = ''")
+            # Materialise severity/cvss sort keys so filtered severity/cvss
+            # sorts ride a composite index rather than a payload-expression
+            # sort (#3192). Backfill extracts from payload for legacy rows.
+            conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN IF NOT EXISTS severity TEXT NOT NULL DEFAULT ''")
+            conn.execute("UPDATE compliance_hub_findings SET severity = COALESCE(payload->>'severity', '') WHERE severity = ''")
+            conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN IF NOT EXISTS severity_rank INTEGER NOT NULL DEFAULT 0")
+            conn.execute(
+                "UPDATE compliance_hub_findings SET severity_rank = CASE LOWER(COALESCE(payload->>'severity', '')) "
+                "WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 "
+                "ELSE 0 END WHERE severity_rank = 0"
+            )
+            conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN IF NOT EXISTS cvss_score DOUBLE PRECISION NOT NULL DEFAULT 0")
+            conn.execute(
+                "UPDATE compliance_hub_findings SET cvss_score = COALESCE((payload->>'cvss_score')::float8, 0) WHERE cvss_score = 0"
+            )
             conn.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_order ON compliance_hub_findings(tenant_id, ordinal)")
             conn.execute("DROP INDEX IF EXISTS idx_hub_findings_tenant_reach")
             # Backs the default effective_reach sort scoped by origin: an
@@ -66,6 +86,17 @@ class PostgresComplianceHubStore:
                 "ON compliance_hub_findings(tenant_id, origin, effective_reach_score DESC, ordinal)"
             )
             conn.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin ON compliance_hub_findings(tenant_id, origin)")
+            # Back the filtered severity/cvss sorts with ordered composite
+            # indexes so ORDER BY is an index range scan, not a sort of the
+            # whole tenant — severity_rank preserves band ordering (#3192).
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin_severity "
+                "ON compliance_hub_findings(tenant_id, origin, severity_rank DESC, ordinal)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin_cvss "
+                "ON compliance_hub_findings(tenant_id, origin, cvss_score DESC, ordinal)"
+            )
             _ensure_tenant_rls(conn, "compliance_hub_findings", "tenant_id")
             conn.commit()
 
@@ -79,8 +110,9 @@ class PostgresComplianceHubStore:
                 conn.execute(
                     """
                     INSERT INTO compliance_hub_findings
-                        (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload, effective_reach_score, origin)
-                    VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s)
+                        (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload,
+                         effective_reach_score, origin, severity, severity_rank, cvss_score)
+                    VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s, %s)
                     """,
                     (
                         tenant_id,
@@ -91,6 +123,9 @@ class PostgresComplianceHubStore:
                         json.dumps(payload, sort_keys=True),
                         compute_effective_reach_score(payload),
                         str(payload.get("origin") or ""),
+                        str(payload.get("severity") or ""),
+                        _severity_rank(payload),
+                        _cvss_value(payload),
                     ),
                 )
             conn.commit()

--- a/tests/test_compliance_hub_store_pagination.py
+++ b/tests/test_compliance_hub_store_pagination.py
@@ -13,6 +13,8 @@ backend shares the same helpers and SQL shape but requires a live database
 
 from __future__ import annotations
 
+import json
+import sqlite3
 from typing import Any
 
 import pytest
@@ -22,6 +24,8 @@ from agent_bom.api.compliance_hub_store import (
     SQLiteComplianceHubStore,
     compute_effective_reach_score,
 )
+
+_SEVERITY_RANK = {"critical": 4, "high": 3, "medium": 2, "low": 1}
 
 _SEEDED = 1200
 
@@ -117,6 +121,93 @@ def test_list_page_cvss_sort_is_descending(seeded_store) -> None:
     rows, _ = store.list_page(tenant, limit=15, offset=0, sort="cvss")
     scores = [float(r.get("cvss_score") or 0.0) for r in rows]
     assert scores == sorted(scores, reverse=True)
+
+
+def test_list_page_severity_sort_is_rank_descending(seeded_store) -> None:
+    """Severity sort must order by band rank (critical>high>medium>low), not
+    the alphabetical text — the numeric ``severity_rank`` column preserves this
+    after the move off ``json_extract`` (#3192)."""
+    store, tenant = seeded_store
+    rows, _ = store.list_page(tenant, limit=40, offset=0, sort="severity")
+    ranks = [_SEVERITY_RANK.get(str(r.get("severity", "")).lower(), 0) for r in rows]
+    assert ranks == sorted(ranks, reverse=True), "severity sort must be rank DESC"
+    # The seed spreads all four bands; the top page must start at critical.
+    assert rows[0]["severity"] == "critical"
+
+
+def test_sqlite_severity_sort_uses_index(tmp_path) -> None:
+    """Filtered severity sort must ride the composite severity index, not a
+    temp-B-tree filesort over json_extract (#3192)."""
+    store = SQLiteComplianceHubStore(str(tmp_path / "hub.db"))
+    tenant = "tenant-plan"
+    store.add(tenant, [_finding(i) for i in range(200)])
+    plan = store._conn.execute(  # noqa: SLF001 - inspecting query plan in-test
+        "EXPLAIN QUERY PLAN SELECT payload FROM compliance_hub_findings "
+        "WHERE tenant_id = ? AND origin = ? ORDER BY severity_rank DESC, ordinal LIMIT 10 OFFSET 0",
+        (tenant, "bulk_ingest"),
+    ).fetchall()
+    text = " ".join(str(row[-1]) for row in plan)
+    assert "USING" in text and "INDEX" in text and "severity" in text, text
+    assert "USE TEMP B-TREE FOR ORDER BY" not in text, text
+    assert "SCAN compliance_hub_findings" not in text, text
+
+
+def test_sqlite_cvss_sort_uses_index(tmp_path) -> None:
+    """Filtered cvss sort must ride the composite cvss index, not a
+    temp-B-tree filesort over json_extract (#3192)."""
+    store = SQLiteComplianceHubStore(str(tmp_path / "hub.db"))
+    tenant = "tenant-plan"
+    store.add(tenant, [_finding(i) for i in range(200)])
+    plan = store._conn.execute(  # noqa: SLF001 - inspecting query plan in-test
+        "EXPLAIN QUERY PLAN SELECT payload FROM compliance_hub_findings "
+        "WHERE tenant_id = ? AND origin = ? ORDER BY cvss_score DESC, ordinal LIMIT 10 OFFSET 0",
+        (tenant, "bulk_ingest"),
+    ).fetchall()
+    text = " ".join(str(row[-1]) for row in plan)
+    assert "USING" in text and "INDEX" in text and "cvss" in text, text
+    assert "USE TEMP B-TREE FOR ORDER BY" not in text, text
+    assert "SCAN compliance_hub_findings" not in text, text
+
+
+def test_sqlite_migration_backfills_sort_columns(tmp_path) -> None:
+    """A pre-#3192 table (no severity/cvss columns) must be migrated in place:
+    the columns are added and backfilled from the stored payload so legacy rows
+    sort correctly without a rewrite."""
+    db_path = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE compliance_hub_findings (
+            tenant_id TEXT NOT NULL,
+            finding_id TEXT NOT NULL,
+            ingested_at TEXT NOT NULL,
+            source TEXT NOT NULL,
+            applicable_frameworks_csv TEXT NOT NULL DEFAULT '',
+            payload TEXT NOT NULL,
+            ordinal INTEGER NOT NULL,
+            PRIMARY KEY (tenant_id, finding_id, ordinal)
+        )
+        """
+    )
+    payload = {"id": "legacy-1", "severity": "critical", "cvss_score": 9.8, "origin": "bulk_ingest"}
+    conn.execute(
+        "INSERT INTO compliance_hub_findings (tenant_id, finding_id, ingested_at, source, payload, ordinal) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("tenant-legacy", "legacy-1", "2026-01-01T00:00:00Z", "sarif", json.dumps(payload), 1),
+    )
+    conn.commit()
+    conn.close()
+
+    # Re-opening through the store must migrate + backfill the new columns.
+    store = SQLiteComplianceHubStore(db_path)
+    row = store._conn.execute(  # noqa: SLF001 - verifying backfilled columns
+        "SELECT severity, severity_rank, cvss_score FROM compliance_hub_findings WHERE finding_id = ?",
+        ("legacy-1",),
+    ).fetchone()
+    assert row == ("critical", 4, 9.8)
+
+    rows, _ = store.list_page("tenant-legacy", limit=5, sort="severity")
+    assert rows[0]["id"] == "legacy-1"
 
 
 def test_sqlite_effective_reach_sort_uses_index(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Promote `severity`, `severity_rank`, and `cvss_score` to real columns on `compliance_hub_findings` in both the SQLite and Postgres hub stores. Values are populated on the `add()` write path (column writes only — PK/ingest identity untouched) and legacy rows are backfilled from the stored payload via idempotent bootstrap migration.
- Point the `cvss`/`severity` branches of `list_page()` `ORDER BY` at the materialised columns (numeric `severity_rank` keeps critical>high>medium>low ordering) instead of `json_extract`, and add composite `(tenant_id, origin, <col> DESC, ordinal)` indexes so the filtered sorts ride an index range scan.
- Default `effective_reach` sort, count paths, and existing indexes are unchanged.

## Problem
PR1 (#3442) indexed the default `effective_reach` sort, but severity/cvss filtered sorts still degraded (52 → 230 → 422 ms at 50k→500k) because `list_page()` ordered by `json_extract(payload,'$.severity')` / `'$.cvss_score'` with no expression index, forcing a temp-B-tree filesort.

## EXPLAIN before/after (SQLite, `WHERE tenant_id=? AND origin=?`, LIMIT 50)
```
severity BEFORE: SEARCH ... USING INDEX idx_hub_findings_tenant_origin | USE TEMP B-TREE FOR ORDER BY
severity AFTER : SEARCH ... USING INDEX idx_hub_findings_tenant_origin_severity   (no temp B-tree)
cvss     BEFORE: SEARCH ... USING INDEX idx_hub_findings_tenant_origin | USE TEMP B-TREE FOR ORDER BY
cvss     AFTER : SEARCH ... USING INDEX idx_hub_findings_tenant_origin_cvss       (no temp B-tree)
```

## Bench delta (200k rows, limit=50, median)
| sort | before (json_extract filesort) | after (indexed) |
|---|---|---|
| severity | 90.1 ms | 0.014 ms |
| cvss | 79.0 ms | 0.014 ms |

## Verification
- `uv run ruff check` + `uv run mypy` clean on touched files.
- `uv run pytest tests/test_compliance_hub_store_pagination.py` — 21 passed (new EXPLAIN QUERY PLAN assertions for severity/cvss index usage + no temp B-tree/SCAN; rank-descending correctness; legacy backfill migration).
- `uv run pytest tests/test_findings_read_scale.py` — 1 passed.

## Notes
- Scoped to read/`list_page` + schema columns + indexes only, to avoid conflict with concurrent work on the `add()` PK/ingest-identity idempotency.
- Backfill migrations are idempotent (`ADD COLUMN IF NOT EXISTS` / column-presence guards + guarded `UPDATE`s) and run in the existing bootstrap path.

Made with [Cursor](https://cursor.com)