### PR TITLE
fix(api): idempotent finding ingest (P0) (#3242)

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -19353,7 +19353,7 @@
     },
     "/v1/scan": {
       "post": {
-        "description": "Start a scan. Returns immediately with a job_id.\nPoll GET /v1/scan/{job_id} for results, or stream via /v1/scan/{job_id}/stream.",
+        "description": "Start a scan. Returns immediately with a job_id.\nPoll GET /v1/scan/{job_id} for results, or stream via /v1/scan/{job_id}/stream.\n\nRetry-safe: repeating the request with the same ``Idempotency-Key`` header\nreturns the first job instead of minting a new job_id per attempt; reusing\nthe key with a different body is a 409 conflict.",
         "operationId": "create_scan_v1_scan_post",
         "requestBody": {
           "content": {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -12525,7 +12525,14 @@ paths:
     post:
       description: 'Start a scan. Returns immediately with a job_id.
 
-        Poll GET /v1/scan/{job_id} for results, or stream via /v1/scan/{job_id}/stream.'
+        Poll GET /v1/scan/{job_id} for results, or stream via /v1/scan/{job_id}/stream.
+
+
+        Retry-safe: repeating the request with the same ``Idempotency-Key`` header
+
+        returns the first job instead of minting a new job_id per attempt; reusing
+
+        the key with a different body is a 409 conflict.'
       operationId: create_scan_v1_scan_post
       requestBody:
         content:

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -220,13 +220,26 @@ class InMemoryComplianceHubStore:
 
     def __init__(self) -> None:
         self._by_tenant: dict[str, list[dict[str, Any]]] = {}
+        # Maps finding_id -> ingest-order slot so a resend of the same
+        # (tenant_id, finding_id) refreshes its row in place instead of
+        # appending a duplicate (idempotent ingest, mirrors the SQL backends).
+        self._slots: dict[str, dict[str, int]] = {}
         self._lock = threading.Lock()
 
     def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
         clean = _redact_findings(findings)
         with self._lock:
             bucket = self._by_tenant.setdefault(tenant_id, [])
-            bucket.extend(clean)
+            slots = self._slots.setdefault(tenant_id, {})
+            for payload in clean:
+                finding_id = str(payload.get("id") or "")
+                if finding_id and finding_id in slots:
+                    # Refresh payload, keep original ingest position.
+                    bucket[slots[finding_id]] = payload
+                    continue
+                if finding_id:
+                    slots[finding_id] = len(bucket)
+                bucket.append(payload)
             total = len(bucket)
         if clean:
             from agent_bom.api.findings_count_cache import invalidate_tenant
@@ -280,6 +293,7 @@ class InMemoryComplianceHubStore:
         with self._lock:
             removed = len(self._by_tenant.get(tenant_id, []))
             self._by_tenant[tenant_id] = []
+            self._slots[tenant_id] = {}
         if removed:
             from agent_bom.api.findings_count_cache import invalidate_tenant
 
@@ -382,11 +396,12 @@ class SQLiteComplianceHubStore:
                 severity TEXT NOT NULL DEFAULT '',
                 severity_rank INTEGER NOT NULL DEFAULT 0,
                 cvss_score REAL NOT NULL DEFAULT 0,
-                PRIMARY KEY (tenant_id, finding_id, ordinal)
+                PRIMARY KEY (tenant_id, finding_id)
             )
             """
         )
         self._migrate_columns()
+        self._migrate_primary_key()
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_order ON compliance_hub_findings(tenant_id, ordinal)")
         self._ensure_scale_indexes()
         self._conn.commit()
@@ -425,6 +440,57 @@ class SQLiteComplianceHubStore:
                 "UPDATE compliance_hub_findings SET cvss_score = "
                 "CAST(COALESCE(json_extract(payload, '$.cvss_score'), 0) AS REAL) WHERE cvss_score = 0"
             )
+
+    def _migrate_primary_key(self) -> None:
+        """Collapse the primary key to ``(tenant_id, finding_id)`` (idempotent).
+
+        Pre-idempotency tables keyed on ``(tenant_id, finding_id, ordinal)`` so
+        every resend of the same finding minted a new row. SQLite cannot ALTER a
+        primary key in place, so we rebuild: dedup existing duplicates keeping
+        the lowest ordinal (the original ingest), then swap in the new-schema
+        table. A no-op when the table already carries the collapsed key.
+        """
+        pk_cols = [row[1] for row in self._conn.execute("PRAGMA table_info(compliance_hub_findings)").fetchall() if row[5]]
+        if "ordinal" not in pk_cols:
+            return  # already migrated to (tenant_id, finding_id)
+
+        self._conn.execute(
+            """
+            CREATE TABLE compliance_hub_findings_v2 (
+                tenant_id TEXT NOT NULL,
+                finding_id TEXT NOT NULL,
+                ingested_at TEXT NOT NULL,
+                source TEXT NOT NULL,
+                applicable_frameworks_csv TEXT NOT NULL DEFAULT '',
+                payload TEXT NOT NULL,
+                ordinal INTEGER NOT NULL,
+                effective_reach_score REAL NOT NULL DEFAULT 0,
+                origin TEXT NOT NULL DEFAULT '',
+                severity TEXT NOT NULL DEFAULT '',
+                severity_rank INTEGER NOT NULL DEFAULT 0,
+                cvss_score REAL NOT NULL DEFAULT 0,
+                PRIMARY KEY (tenant_id, finding_id)
+            )
+            """
+        )
+        # Keep the lowest-ordinal row for each (tenant_id, finding_id) so the
+        # rebuild is deterministic and preserves the original ingest order.
+        self._conn.execute(
+            """
+            INSERT INTO compliance_hub_findings_v2
+                (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload,
+                 ordinal, effective_reach_score, origin, severity, severity_rank, cvss_score)
+            SELECT f.tenant_id, f.finding_id, f.ingested_at, f.source, f.applicable_frameworks_csv,
+                   f.payload, f.ordinal, f.effective_reach_score, f.origin, f.severity, f.severity_rank, f.cvss_score
+            FROM compliance_hub_findings f
+            WHERE f.ordinal = (
+                SELECT MIN(s.ordinal) FROM compliance_hub_findings s
+                WHERE s.tenant_id = f.tenant_id AND s.finding_id = f.finding_id
+            )
+            """
+        )
+        self._conn.execute("DROP TABLE compliance_hub_findings")
+        self._conn.execute("ALTER TABLE compliance_hub_findings_v2 RENAME TO compliance_hub_findings")
 
     def _ensure_scale_indexes(self) -> None:
         """Install origin-aware read indexes, replacing the pre-origin index.
@@ -484,12 +550,25 @@ class SQLiteComplianceHubStore:
                     _cvss_value(payload),
                 )
             )
+        # Idempotent ingest: a repeat of the same (tenant_id, finding_id)
+        # refreshes the stored payload/metadata in place and keeps the original
+        # ``ordinal`` (ingest order) instead of appending a duplicate row.
         self._conn.executemany(
             """
-            INSERT OR REPLACE INTO compliance_hub_findings
+            INSERT INTO compliance_hub_findings
                 (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload,
                  ordinal, effective_reach_score, origin, severity, severity_rank, cvss_score)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(tenant_id, finding_id) DO UPDATE SET
+                ingested_at = excluded.ingested_at,
+                source = excluded.source,
+                applicable_frameworks_csv = excluded.applicable_frameworks_csv,
+                payload = excluded.payload,
+                effective_reach_score = excluded.effective_reach_score,
+                origin = excluded.origin,
+                severity = excluded.severity,
+                severity_rank = excluded.severity_rank,
+                cvss_score = excluded.cvss_score
             """,
             rows,
         )

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -50,7 +50,7 @@ class PostgresComplianceHubStore:
                     severity TEXT NOT NULL DEFAULT '',
                     severity_rank INTEGER NOT NULL DEFAULT 0,
                     cvss_score DOUBLE PRECISION NOT NULL DEFAULT 0,
-                    PRIMARY KEY (tenant_id, finding_id, ordinal)
+                    PRIMARY KEY (tenant_id, finding_id)
                 )
                 """
             )
@@ -60,6 +60,7 @@ class PostgresComplianceHubStore:
             conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN IF NOT EXISTS origin TEXT NOT NULL DEFAULT ''")
             # Backfill origin from the stored payload for pre-migration rows.
             conn.execute("UPDATE compliance_hub_findings SET origin = COALESCE(payload->>'origin', '') WHERE origin = ''")
+            # Materialise severity/cvss sort keys so filtered severity/cvss
             # Materialise severity/cvss sort keys so filtered severity/cvss
             # sorts ride a composite index rather than a payload-expression
             # sort (#3192). Backfill extracts from payload for legacy rows.
@@ -75,6 +76,7 @@ class PostgresComplianceHubStore:
             conn.execute(
                 "UPDATE compliance_hub_findings SET cvss_score = COALESCE((payload->>'cvss_score')::float8, 0) WHERE cvss_score = 0"
             )
+            self._migrate_primary_key(conn)
             conn.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_order ON compliance_hub_findings(tenant_id, ordinal)")
             conn.execute("DROP INDEX IF EXISTS idx_hub_findings_tenant_reach")
             # Backs the default effective_reach sort scoped by origin: an
@@ -100,6 +102,50 @@ class PostgresComplianceHubStore:
             _ensure_tenant_rls(conn, "compliance_hub_findings", "tenant_id")
             conn.commit()
 
+    @staticmethod
+    def _migrate_primary_key(conn: Any) -> None:
+        """Collapse the primary key to ``(tenant_id, finding_id)`` (idempotent).
+
+        Pre-idempotency deployments keyed on ``(tenant_id, finding_id, ordinal)``
+        so every resend of the same finding appended a fresh row. Dedup existing
+        duplicates (keep the lowest ordinal), then swap the primary key. Guarded
+        so it is a no-op once the collapsed key is in place.
+        """
+        # Drop duplicates ahead of the unique key, keeping the original ingest.
+        conn.execute(
+            """
+            DELETE FROM compliance_hub_findings a
+            USING compliance_hub_findings b
+            WHERE a.tenant_id = b.tenant_id
+              AND a.finding_id = b.finding_id
+              AND a.ordinal > b.ordinal
+            """
+        )
+        conn.execute(
+            """
+            DO $$
+            DECLARE
+                pk_cols text;
+                pk_name text;
+            BEGIN
+                SELECT string_agg(a.attname, ',' ORDER BY array_position(c.conkey, a.attnum)), c.conname
+                  INTO pk_cols, pk_name
+                  FROM pg_constraint c
+                  JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+                 WHERE c.conrelid = 'compliance_hub_findings'::regclass
+                   AND c.contype = 'p'
+                 GROUP BY c.conname;
+                IF pk_cols IS DISTINCT FROM 'tenant_id,finding_id' THEN
+                    IF pk_name IS NOT NULL THEN
+                        EXECUTE 'ALTER TABLE compliance_hub_findings DROP CONSTRAINT ' || quote_ident(pk_name);
+                    END IF;
+                    ALTER TABLE compliance_hub_findings
+                        ADD CONSTRAINT compliance_hub_findings_pkey PRIMARY KEY (tenant_id, finding_id);
+                END IF;
+            END$$;
+            """
+        )
+
     def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
         findings = _redact_findings(findings)
         if not findings:
@@ -107,12 +153,25 @@ class PostgresComplianceHubStore:
         now = _now_utc_iso()
         with _tenant_connection(self._pool) as conn:
             for payload in findings:
+                # Idempotent ingest: a resend of the same (tenant_id, finding_id)
+                # refreshes payload/metadata and keeps the original ``ordinal``
+                # (the BIGSERIAL default only advances on genuine inserts).
                 conn.execute(
                     """
                     INSERT INTO compliance_hub_findings
                         (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload,
                          effective_reach_score, origin, severity, severity_rank, cvss_score)
                     VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s, %s)
+                    ON CONFLICT (tenant_id, finding_id) DO UPDATE SET
+                        ingested_at = EXCLUDED.ingested_at,
+                        source = EXCLUDED.source,
+                        applicable_frameworks_csv = EXCLUDED.applicable_frameworks_csv,
+                        payload = EXCLUDED.payload,
+                        effective_reach_score = EXCLUDED.effective_reach_score,
+                        origin = EXCLUDED.origin,
+                        severity = EXCLUDED.severity,
+                        severity_rank = EXCLUDED.severity_rank,
+                        cvss_score = EXCLUDED.cvss_score
                     """,
                     (
                         tenant_id,

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -38,6 +38,7 @@ from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from werkzeug.security import safe_join
 
+from agent_bom.api.idempotency_store import IdempotencyConflictError, idempotency_request_fingerprint
 from agent_bom.api.models import (
     BrowserExtensionsRequest,
     DatasetCardsRequest,
@@ -53,6 +54,7 @@ from agent_bom.api.pipeline import _now, submit_scan_job
 from agent_bom.api.scan_batches import child_request_for_target, refresh_batch_parent, scan_request_targets
 from agent_bom.api.scan_job_reconciliation import reconcile_scan_jobs_active
 from agent_bom.api.stores import (
+    _get_idempotency_store,
     _get_store,
     _job_lock,
     _jobs_get,
@@ -62,7 +64,9 @@ from agent_bom.api.stores import (
 )
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.api.tenant_quota import enforce_active_scan_quota, enforce_retained_jobs_quota, tenant_quota_guard
+from agent_bom.canonical_ids import canonical_finding_id
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
+from agent_bom.security import sanitize_error
 
 router = APIRouter()
 _logger = logging.getLogger(__name__)
@@ -218,6 +222,13 @@ def _dataclass_to_dict(obj: object) -> object:
     return obj
 
 
+def _request_header(request: Request, key: str) -> str:
+    headers = getattr(request, "headers", None)
+    if headers is None:
+        return ""
+    return str(headers.get(key, "") or "")
+
+
 def _tenant_id(request: Request) -> str:
     return require_request_tenant_id(request)
 
@@ -268,9 +279,29 @@ def _bulk_ingested_findings_for_tenant(tenant_id: str) -> list[dict[str, Any]]:
     return [item for item in get_compliance_hub_store().list(tenant_id) if isinstance(item, dict) and item.get("origin") == "bulk_ingest"]
 
 
+def _derive_bulk_finding_id(row: dict[str, Any], *, source: str) -> str:
+    """Return a deterministic identity key for a bulk finding lacking an ``id``.
+
+    Idempotency requires the identity key to be a pure function of finding
+    content — never the per-attempt ``batch_id`` or wall clock. We fold in the
+    stable discriminators (source, rule/vuln, location, package) via the shared
+    ``uuid5`` canonicaliser so a resent identical batch collapses onto the same
+    rows instead of appending duplicates.
+    """
+    raw_asset = row.get("asset")
+    asset = raw_asset if isinstance(raw_asset, dict) else {}
+    rule = row.get("vulnerability_id") or row.get("cve_id") or row.get("rule_id") or row.get("title") or ""
+    location = row.get("location") or row.get("file_path") or asset.get("location") or ""
+    package = row.get("package") or row.get("package_name") or asset.get("name") or asset.get("identifier") or ""
+    return canonical_finding_id(source, str(rule), str(location), str(package))
+
+
 def _normalized_bulk_finding(row: dict[str, Any], *, source: str, batch_id: str, ordinal: int) -> dict[str, Any]:
     payload = dict(row)
-    payload.setdefault("id", f"{batch_id}:{ordinal}")
+    client_id = row.get("id")
+    # Client-stable ids win; otherwise derive a content-deterministic id so
+    # resends collapse (idempotent) rather than mint a fresh batch_id:ordinal.
+    payload["id"] = str(client_id) if client_id else _derive_bulk_finding_id(row, source=source)
     payload.setdefault("source", source)
     payload.setdefault("severity", "unknown")
     payload["origin"] = "bulk_ingest"
@@ -777,12 +808,49 @@ def enqueue_scan_job(
 async def create_scan(request: Request, body: ScanRequest) -> ScanJob:
     """Start a scan. Returns immediately with a job_id.
     Poll GET /v1/scan/{job_id} for results, or stream via /v1/scan/{job_id}/stream.
+
+    Retry-safe: repeating the request with the same ``Idempotency-Key`` header
+    returns the first job instead of minting a new job_id per attempt; reusing
+    the key with a different body is a 409 conflict.
     """
-    return enqueue_scan_job(
-        tenant_id=_tenant_id(request),
+    tenant_id = _tenant_id(request)
+    idem_key = _request_header(request, "Idempotency-Key")
+    idem_source = _request_header(request, "X-Agent-Bom-Source-Id") or "scan"
+    request_hash = idempotency_request_fingerprint(body)
+    if idem_key:
+        try:
+            cached = _get_idempotency_store().get(
+                "/v1/scan",
+                tenant_id,
+                idem_source,
+                idem_key,
+                request_hash=request_hash,
+            )
+        except IdempotencyConflictError as exc:
+            raise HTTPException(status_code=409, detail=sanitize_error(exc)) from exc
+        if cached is not None:
+            cached_job_id = str(cached.get("job_id") or "")
+            existing = _jobs_get(cached_job_id) if cached_job_id else None
+            if existing is None and cached_job_id:
+                existing = _get_store().get(cached_job_id, tenant_id=tenant_id)
+            if existing is not None:
+                return _job_response_payload(existing)
+
+    job = enqueue_scan_job(
+        tenant_id=tenant_id,
         triggered_by=_triggered_by(request),
         request_body=body,
     )
+    if idem_key:
+        _get_idempotency_store().put(
+            "/v1/scan",
+            tenant_id,
+            idem_source,
+            idem_key,
+            {"job_id": job.job_id},
+            request_hash=request_hash,
+        )
+    return job
 
 
 @router.get("/v1/scan/drivers", tags=["scan"])
@@ -1324,13 +1392,36 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
 
     tenant_id = _tenant_id(request)
     ignored_body_tenant = bool(body.tenant_id and body.tenant_id != tenant_id)
+
+    # Batch-level replay safety: an identical retry under the same
+    # Idempotency-Key returns the first cached response (same batch_id and
+    # counts); a reused key with a different body is a 409 conflict. This is
+    # additive to the row-level (tenant_id, finding_id) collapse below.
+    idem_key = _request_header(request, "Idempotency-Key")
+    idem_source = _request_header(request, "X-Agent-Bom-Source-Id") or "bulk-ingest"
+    request_hash = idempotency_request_fingerprint(body)
+    if idem_key:
+        try:
+            cached = _get_idempotency_store().get(
+                "/v1/findings/bulk",
+                tenant_id,
+                idem_source,
+                idem_key,
+                request_hash=request_hash,
+            )
+        except IdempotencyConflictError as exc:
+            raise HTTPException(status_code=409, detail=sanitize_error(exc)) from exc
+        if cached is not None:
+            cached["idempotent_replay"] = True
+            return cached
+
     batch_id = str(uuid.uuid4())
     payloads = [
         _normalized_bulk_finding(row, source=body.source, batch_id=batch_id, ordinal=idx) for idx, row in enumerate(body.findings, start=1)
     ]
     new_total = get_compliance_hub_store().add(tenant_id, payloads)
     warnings = ["tenant_id in body ignored; request tenant scope is authoritative"] if ignored_body_tenant else []
-    return {
+    response = {
         "schema_version": "v1",
         "batch_id": batch_id,
         "ingested": len(payloads),
@@ -1339,6 +1430,16 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
         "source": body.source,
         "warnings": warnings,
     }
+    if idem_key:
+        _get_idempotency_store().put(
+            "/v1/findings/bulk",
+            tenant_id,
+            idem_source,
+            idem_key,
+            response,
+            request_hash=request_hash,
+        )
+    return response
 
 
 @router.get("/v1/inventory", tags=["scan"])

--- a/tests/test_ingest_idempotency.py
+++ b/tests/test_ingest_idempotency.py
@@ -1,0 +1,271 @@
+"""P0 regression: finding ingest must be idempotent (#3242).
+
+Resending an identical batch of findings — same stable ids, or the same
+content without client ids, or the same body under one ``Idempotency-Key`` —
+must not inflate a tenant's total. Before the fix, the compliance-hub PK was
+``(tenant_id, finding_id, ordinal)`` with ``ordinal = MAX(ordinal)+1`` and the
+bulk route minted a fresh ``batch_id``/``id`` per attempt, so three identical
+sends yielded 100 -> 200 -> 300.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from uuid import uuid4
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import (
+    InMemoryComplianceHubStore,
+    SQLiteComplianceHubStore,
+    reset_compliance_hub_store,
+)
+from agent_bom.api.server import app
+from agent_bom.api.stores import set_idempotency_store
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+def setup_function() -> None:
+    from agent_bom.api.server import set_job_store
+    from agent_bom.api.store import InMemoryJobStore
+
+    reset_compliance_hub_store()
+    set_idempotency_store(None)
+    set_job_store(InMemoryJobStore())
+
+
+def teardown_function() -> None:
+    from agent_bom.api.server import set_job_store
+    from agent_bom.api.store import InMemoryJobStore
+
+    reset_compliance_hub_store()
+    set_idempotency_store(None)
+    set_job_store(InMemoryJobStore())
+
+
+def _client(tenant: str, role: str = "analyst") -> TestClient:
+    client = TestClient(app)
+    client.headers.update(proxy_headers(role=role, tenant=tenant))
+    return client
+
+
+def _batch(count: int = 100, *, with_id: bool = True) -> list[dict]:
+    rows: list[dict] = []
+    for i in range(count):
+        row = {
+            "title": f"finding {i}",
+            "severity": "high",
+            "vulnerability_id": f"CVE-2026-{i:04d}",
+            "package": f"pkg-{i}",
+            "location": f"/app/{i}.py",
+        }
+        if with_id:
+            row["id"] = f"stable-{i:03d}"
+        rows.append(row)
+    return rows
+
+
+# ─── Bulk ingest ─────────────────────────────────────────────────────────────
+
+
+def test_bulk_ingest_idempotent_with_stable_ids() -> None:
+    tenant = f"idem-bulk-{uuid4().hex}"
+    client = _client(tenant)
+    findings = _batch(100, with_id=True)
+    totals = []
+    for _ in range(3):
+        resp = client.post("/v1/findings/bulk", json={"source": "agent", "findings": findings})
+        assert resp.status_code == 201, resp.text
+        totals.append(resp.json()["tenant_total"])
+    assert totals == [100, 100, 100]
+
+
+def test_bulk_ingest_idempotent_without_client_ids() -> None:
+    """No client id -> content-derived deterministic id -> resend collapses."""
+    tenant = f"idem-bulk-noid-{uuid4().hex}"
+    client = _client(tenant)
+    findings = _batch(100, with_id=False)
+    totals = []
+    for _ in range(3):
+        resp = client.post("/v1/findings/bulk", json={"source": "agent", "findings": findings})
+        assert resp.status_code == 201, resp.text
+        totals.append(resp.json()["tenant_total"])
+    assert totals == [100, 100, 100]
+
+
+def test_bulk_ingest_new_findings_still_append() -> None:
+    tenant = f"idem-bulk-append-{uuid4().hex}"
+    client = _client(tenant)
+    first = client.post("/v1/findings/bulk", json={"source": "agent", "findings": _batch(100)})
+    assert first.json()["tenant_total"] == 100
+    extra = [{"id": f"extra-{i}", "severity": "low", "title": f"e{i}"} for i in range(10)]
+    second = client.post("/v1/findings/bulk", json={"source": "agent", "findings": extra})
+    assert second.json()["tenant_total"] == 110
+
+
+def test_bulk_ingest_idempotency_key_replays_cached_response() -> None:
+    tenant = f"idem-bulk-key-{uuid4().hex}"
+    client = _client(tenant)
+    findings = _batch(100)
+    headers = {"Idempotency-Key": "batch-key-1"}
+    first = client.post("/v1/findings/bulk", json={"source": "agent", "findings": findings}, headers=headers)
+    second = client.post("/v1/findings/bulk", json={"source": "agent", "findings": findings}, headers=headers)
+    assert first.status_code == 201 and second.status_code == 201
+    assert first.json()["batch_id"] == second.json()["batch_id"]
+    assert second.json()["idempotent_replay"] is True
+    assert second.json()["tenant_total"] == 100
+
+
+def test_bulk_ingest_idempotency_key_conflict_on_different_body() -> None:
+    tenant = f"idem-bulk-conflict-{uuid4().hex}"
+    client = _client(tenant)
+    headers = {"Idempotency-Key": "batch-key-2"}
+    first = client.post("/v1/findings/bulk", json={"source": "agent", "findings": _batch(100)}, headers=headers)
+    assert first.status_code == 201
+    conflicting = client.post(
+        "/v1/findings/bulk",
+        json={"source": "agent", "findings": [{"id": "different", "severity": "low"}]},
+        headers=headers,
+    )
+    assert conflicting.status_code == 409, conflicting.text
+
+
+# ─── Compliance ingest ───────────────────────────────────────────────────────
+
+
+def _sarif(count: int = 5) -> str:
+    return json.dumps(
+        {
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "external-secrets",
+                            "rules": [{"id": f"SECRET-{i}", "properties": {"tags": ["secret", "CWE-798"]}} for i in range(count)],
+                        }
+                    },
+                    "results": [
+                        {
+                            "ruleId": f"SECRET-{i}",
+                            "level": "error",
+                            "message": {"text": f"issue {i}"},
+                            "locations": [{"physicalLocation": {"artifactLocation": {"uri": f"app/{i}.py"}}}],
+                            "properties": {"security-severity": "9.5"},
+                        }
+                        for i in range(count)
+                    ],
+                }
+            ],
+        }
+    )
+
+
+def test_compliance_ingest_idempotent_on_resend() -> None:
+    tenant = f"idem-compliance-{uuid4().hex}"
+    client = _client(tenant, role="admin")
+    content = _sarif(5)
+    totals = []
+    for _ in range(3):
+        resp = client.post("/v1/compliance/ingest", json={"format": "sarif", "content": content})
+        assert resp.status_code == 201, resp.text
+        totals.append(resp.json()["tenant_total"])
+    assert totals == [5, 5, 5]
+
+
+# ─── Scan job replay ─────────────────────────────────────────────────────────
+
+
+def test_scan_idempotency_key_returns_same_job() -> None:
+    tenant = f"idem-scan-{uuid4().hex}"
+    client = _client(tenant, role="admin")
+    headers = {"Idempotency-Key": "scan-key-1"}
+    first = client.post("/v1/scan", json={}, headers=headers)
+    second = client.post("/v1/scan", json={}, headers=headers)
+    assert first.status_code == 202, first.text
+    assert second.status_code == 202, second.text
+    assert first.json()["job_id"] == second.json()["job_id"]
+
+
+def test_scan_idempotency_key_conflict_on_different_body() -> None:
+    tenant = f"idem-scan-conflict-{uuid4().hex}"
+    client = _client(tenant, role="admin")
+    headers = {"Idempotency-Key": "scan-key-2"}
+    first = client.post("/v1/scan", json={}, headers=headers)
+    assert first.status_code == 202
+    conflicting = client.post("/v1/scan", json={"images": ["alpine:latest"]}, headers=headers)
+    assert conflicting.status_code == 409, conflicting.text
+
+
+# ─── Store-level backends ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("kind", ["memory", "sqlite"])
+def test_store_add_is_idempotent_on_finding_id(kind: str, tmp_path) -> None:
+    store = InMemoryComplianceHubStore() if kind == "memory" else SQLiteComplianceHubStore(str(tmp_path / "hub.db"))
+    tenant = "tenant-store"
+    findings = [{"id": f"f-{i}", "severity": "high", "origin": "bulk_ingest"} for i in range(100)]
+    assert store.add(tenant, findings) == 100
+    assert store.add(tenant, findings) == 100
+    assert store.add(tenant, findings) == 100
+    # Resend refreshes payload in place; ordinal (ingest order) is preserved.
+    rows, total = store.list_page(tenant, limit=5, offset=0, sort="ordinal")
+    assert total == 100
+    assert [r["id"] for r in rows] == [f"f-{i}" for i in range(5)]
+
+
+def test_sqlite_migrates_ordinal_primary_key_and_dedups(tmp_path) -> None:
+    """A pre-idempotency table (PK includes ordinal, with dup finding rows)
+    must rebuild to PK (tenant_id, finding_id), keeping the lowest ordinal."""
+    db_path = tmp_path / "hub.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE compliance_hub_findings (
+                tenant_id TEXT NOT NULL,
+                finding_id TEXT NOT NULL,
+                ingested_at TEXT NOT NULL,
+                source TEXT NOT NULL,
+                applicable_frameworks_csv TEXT NOT NULL DEFAULT '',
+                payload TEXT NOT NULL,
+                ordinal INTEGER NOT NULL,
+                effective_reach_score REAL NOT NULL DEFAULT 0,
+                origin TEXT NOT NULL DEFAULT '',
+                PRIMARY KEY (tenant_id, finding_id, ordinal)
+            )
+            """
+        )
+        # Same finding_id ingested twice (ordinals 1 and 2) — a legacy duplicate.
+        conn.executemany(
+            "INSERT INTO compliance_hub_findings (tenant_id, finding_id, ingested_at, source, payload, ordinal) VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                ("t", "dup", "2026-01-01T00:00:00Z", "s", json.dumps({"id": "dup", "v": 1}), 1),
+                ("t", "dup", "2026-01-02T00:00:00Z", "s", json.dumps({"id": "dup", "v": 2}), 2),
+                ("t", "solo", "2026-01-03T00:00:00Z", "s", json.dumps({"id": "solo"}), 3),
+            ],
+        )
+        conn.commit()
+
+    store = SQLiteComplianceHubStore(str(db_path))
+    assert store.count("t") == 2  # dup collapsed to one row
+
+    pk_cols = [row[1] for row in store._conn.execute("PRAGMA table_info(compliance_hub_findings)").fetchall() if row[5]]  # noqa: SLF001
+    assert pk_cols == ["tenant_id", "finding_id"]
+
+    # Lowest ordinal (the original) is retained for the deduped finding.
+    kept = store._conn.execute("SELECT ordinal FROM compliance_hub_findings WHERE finding_id = 'dup'").fetchone()  # noqa: SLF001
+    assert kept[0] == 1
+
+    # Re-opening the migrated DB is a no-op (idempotent migration).
+    SQLiteComplianceHubStore(str(db_path))
+    assert store.count("t") == 2


### PR DESCRIPTION
## Summary
- **Deterministic finding id**: `_normalized_bulk_finding` (bulk route) derives a content-based id (`source + rule/vuln + location + package` via the shared `canonical_finding_id`/`uuid5` helper) when the client omits a stable `id`, instead of falling back to `{batch_id}:{ordinal}`. `batch_id` is metadata only. Compliance ingest already emits content-derived `Finding` ids.
- **Collapse on resend**: the compliance-hub stores now key on `(tenant_id, finding_id)` and use `INSERT ... ON CONFLICT DO UPDATE` (SQLite, Postgres, in-memory), refreshing payload/metadata while keeping the original `ordinal` as ingest order. Idempotent migrations dedup existing duplicates (lowest ordinal wins) then rebuild (SQLite table swap) / re-key (`DROP CONSTRAINT` + `ADD PRIMARY KEY`, Postgres) the primary key.
- **Idempotency-Key**: `/v1/findings/bulk` and `/v1/scan` honor an `Idempotency-Key` header via the existing `idempotency_store`. Same key + same body replays the cached response (and the first `job_id` for `/v1/scan`); same key + different body returns `409`.

## Live evidence (TestClient)
Before:
```
bulk (stable ids):   100 -> 200 -> 300
bulk (derived ids):  100 -> 200 -> 300
compliance/ingest:     5 ->  10 ->  15
```
After:
```
bulk (stable ids):   100 -> 100 -> 100
bulk (derived ids):  100 -> 100 -> 100
compliance/ingest:     5 ->   5 ->   5
```

## Files changed
- `src/agent_bom/api/routes/scan.py` — deterministic bulk id + Idempotency-Key on `/v1/findings/bulk` and `/v1/scan`
- `src/agent_bom/api/compliance_hub_store.py` — in-memory + SQLite collapse, PK migration
- `src/agent_bom/api/postgres_compliance_hub.py` — Postgres collapse, PK migration
- `tests/test_ingest_idempotency.py` — new regression coverage (fails without fix)

## Migration approach
- **SQLite**: `_migrate_primary_key` detects `ordinal` still in the PK, creates a `_v2` table keyed on `(tenant_id, finding_id)`, copies the lowest-ordinal row per finding (dedup), drops the old table, and renames. No-op once collapsed. Read-scale indexes are re-created afterward.
- **Postgres**: dedup via `DELETE ... USING` keeping the min ordinal, then a guarded `DO $$` block that drops the existing primary key and adds `(tenant_id, finding_id)` only when the current PK differs. Idempotent.

## Verification
```
uv run pytest tests/test_ingest_idempotency.py tests/test_findings_bulk_api.py \
  tests/test_compliance_hub_store_pagination.py tests/test_findings_read_scale.py \
  tests/test_compliance_hub_api.py tests/test_compliance_hub.py \
  tests/test_compliance_hub_ingest.py tests/test_compliance_hub_cross_format.py \
  tests/test_api_store.py tests/test_evidence_policy.py
# 175 passed
uv run pytest tests/test_api_scan_batches.py tests/test_scan_contract.py \
  tests/test_scan_jobs_active_gauge.py tests/test_rescan.py  # 27 passed
uv run ruff check <touched>        # clean
uv run mypy <touched src modules>  # clean
uv run python scripts/check_exception_sanitization.py  # clean
```

## Notes
- Preserves `list_page`/effective-reach ordering and existing indexes.
- Fail behavior: row-level `(tenant_id, finding_id)` collapse is the durable idempotency guarantee; the `Idempotency-Key` layer is additive batch-replay safety. `409` on key reuse with a divergent body via `sanitize_error` (no raw exception bodies).

Made with [Cursor](https://cursor.com)