### PR TITLE
fix(reliability): tenant fail-closed, cloud retry, health rate-exempt, batch cap

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -27,6 +27,7 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_ALLOW_UNAUTHENTICATED_API` | `bool` | `False` | — |
 | `AGENT_BOM_API_JOB_TTL` | `int` | `3600` | — |
 | `AGENT_BOM_API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT` | `int` | `API_MAX_CONCURRENT_JOBS` | — |
+| `AGENT_BOM_API_MAX_BATCH_SCAN_TARGETS` | `int` | `100` | Per-request fan-out ceiling: a single POST /v1/scan expands one batchable target field per child job, so an uncapped request could enqueue unbounded work bounded only by the tenant active-scan quota churn. Reject over-cap requests at valida |
 | `AGENT_BOM_API_MAX_FLEET_AGENTS_PER_TENANT` | `int` | `1000` | — |
 | `AGENT_BOM_API_MAX_JOBS` | `int` | `10` | Used by api/server.py for the REST API job queue.  10 concurrent scan jobs prevents resource exhaustion on shared hosts. 1-hour TTL auto-cleans completed jobs.  200 in-memory ceiling triggers LRU eviction for long-running API instances. |
 | `AGENT_BOM_API_MAX_JOB_PROGRESS_EVENTS` | `int` | `500` | — |

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1420,6 +1420,22 @@ def _validate_rate_limit(name: str, value: int, *, max_rpm: int) -> int:
 class RateLimitMiddleware(BaseHTTPMiddleware):
     """Tenant-aware sliding window rate limiter with bounded memory."""
 
+    # Health/readiness/liveness probes must never self-throttle: orchestrators
+    # (k8s, ELB, uptime monitors) hit these on short intervals and a probe storm
+    # would otherwise consume the per-tenant/IP read budget and 429 the probes.
+    # These stay behind the OUTERMOST GlobalRateLimitMiddleware flood cap, so an
+    # anonymous flood is still bounded pre-auth — this only removes the finer
+    # per-tenant/IP read limiter for liveness endpoints.
+    _HEALTH_EXEMPT_PATHS = frozenset(
+        {
+            "/health",
+            "/healthz",
+            "/livez",
+            "/readyz",
+            "/ping",
+        }
+    )
+
     def __init__(
         self,
         app: ASGIApp,
@@ -1473,6 +1489,9 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: StarletteRequest, call_next):
         if self._is_dashboard_static_asset(request.url.path, request.method):
+            return await call_next(request)
+
+        if request.url.path in self._HEALTH_EXEMPT_PATHS:
             return await call_next(request)
 
         now = time.time()

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -6,7 +6,9 @@ from collections.abc import Iterable
 from enum import Enum
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
+
+from agent_bom.config import API_MAX_BATCH_SCAN_TARGETS
 
 # ─── Enums ─────────────────────────────────────────────────────────────────
 
@@ -28,6 +30,19 @@ class StepStatus(str, Enum):
 
 
 # ─── Scan Models ───────────────────────────────────────────────────────────
+
+# Fields that fan out one child scan job per element when a request carries more
+# than one explicit target. Mirrors scan_batches.BATCH_*_TARGET_FIELDS (kept
+# local to avoid a models -> scan_batches import cycle).
+_BATCH_LIST_TARGET_FIELDS = (
+    "images",
+    "tf_dirs",
+    "agent_projects",
+    "jupyter_dirs",
+    "connectors",
+    "filesystem_paths",
+)
+_BATCH_SINGLE_TARGET_FIELDS = ("inventory", "gha_path", "sbom")
 
 
 class _BoundedProgress(list[str]):
@@ -127,6 +142,17 @@ class ScanRequest(BaseModel):
 
     min_severity: str | None = None
     """Minimum severity to include in results (low/medium/high/critical)."""
+
+    @model_validator(mode="after")
+    def _enforce_batch_target_cap(self) -> "ScanRequest":
+        """Bound per-request fan-out so one request cannot enqueue unbounded work."""
+        total = sum(len(getattr(self, name)) for name in _BATCH_LIST_TARGET_FIELDS)
+        total += sum(1 for name in _BATCH_SINGLE_TARGET_FIELDS if getattr(self, name))
+        if self.k8s:
+            total += 1
+        if total > API_MAX_BATCH_SCAN_TARGETS:
+            raise ValueError(f"scan request expands to {total} targets; maximum is {API_MAX_BATCH_SCAN_TARGETS} per request")
+        return self
 
 
 class ScanJob(BaseModel):

--- a/src/agent_bom/api/postgres_store.py
+++ b/src/agent_bom/api/postgres_store.py
@@ -39,6 +39,7 @@ from agent_bom.api.postgres_policy import (  # noqa: F401
 )
 from agent_bom.api.postgres_tenant_quota import PostgresTenantQuotaStore  # noqa: F401
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
+from agent_bom.api.store import _require_tenant_scope
 
 _JOB_TTL_SECONDS = 3600
 
@@ -233,9 +234,10 @@ class PostgresJobStore:
             self._replace_cis_checks(conn, job)
             conn.commit()
 
-    def get(self, job_id: str, tenant_id: str | None = None):
+    def get(self, job_id: str, tenant_id: str | None = None, *, all_tenants: bool = False):
         from .server import ScanJob
 
+        _require_tenant_scope(tenant_id, all_tenants, "PostgresJobStore.get()")
         with _tenant_connection(self._pool) as conn:
             if tenant_id is None:
                 row = conn.execute("SELECT data FROM scan_jobs WHERE job_id = %s", (job_id,)).fetchone()
@@ -249,7 +251,8 @@ class PostgresJobStore:
             raw = row[0] if isinstance(row[0], str) else json.dumps(row[0])
             return ScanJob.model_validate_json(raw)
 
-    def delete(self, job_id: str, tenant_id: str | None = None) -> bool:
+    def delete(self, job_id: str, tenant_id: str | None = None, *, all_tenants: bool = False) -> bool:
+        _require_tenant_scope(tenant_id, all_tenants, "PostgresJobStore.delete()")
         with _tenant_connection(self._pool) as conn:
             if tenant_id is None:
                 cursor = conn.execute("DELETE FROM scan_jobs WHERE job_id = %s", (job_id,))
@@ -261,26 +264,31 @@ class PostgresJobStore:
             conn.commit()
             return cursor.rowcount > 0
 
-    def list_all(self, tenant_id: str | None = None) -> list:
+    def list_all(self, tenant_id: str | None = None, *, all_tenants: bool = False) -> list:
         from .server import ScanJob
 
-        if tenant_id is None:
-            raise ValueError("tenant_id is required for PostgresJobStore.list_all()")
+        _require_tenant_scope(tenant_id, all_tenants, "PostgresJobStore.list_all()")
 
         with _tenant_connection(self._pool) as conn:
-            rows = conn.execute(
-                "SELECT data FROM scan_jobs WHERE team_id = %s ORDER BY created_at DESC",
-                (tenant_id,),
-            ).fetchall()
+            if tenant_id is None:
+                rows = conn.execute("SELECT data FROM scan_jobs ORDER BY created_at DESC").fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT data FROM scan_jobs WHERE team_id = %s ORDER BY created_at DESC",
+                    (tenant_id,),
+                ).fetchall()
             return [ScanJob.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
 
     def list_summary(
         self,
         tenant_id: str | None = None,
         *,
+        all_tenants: bool = False,
         limit: int | None = None,
         offset: int = 0,
     ) -> list[dict]:
+        _require_tenant_scope(tenant_id, all_tenants, "PostgresJobStore.list_summary()")
+
         def _json_column(row: tuple, index: int, default: str, expected_type: type) -> object:
             if len(row) <= index:
                 return json.loads(default)

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1096,7 +1096,7 @@ async def list_jobs(
             # asks for details and the job is not already in memory.
             try:
                 get_job = getattr(store, "get", None)
-                full_job = get_job(item["job_id"]) if callable(get_job) else None
+                full_job = get_job(item["job_id"], tenant_id=tenant_id) if callable(get_job) else None
             except Exception:
                 full_job = None
             enriched.append(_job_summary_payload(full_job) if isinstance(full_job, ScanJob) else item)

--- a/src/agent_bom/api/scan_job_reconciliation.py
+++ b/src/agent_bom/api/scan_job_reconciliation.py
@@ -15,7 +15,13 @@ def is_active_scan_job(job: ScanJob) -> bool:
 
 
 def active_scan_job_count(store: Any, tenant_id: str | None = None) -> int:
-    return sum(1 for job in store.list_all(tenant_id=tenant_id) if is_active_scan_job(job))
+    # A missing tenant means "count active jobs across every tenant" for the
+    # global gauge — an explicit cross-tenant reconciliation, not a leak.
+    if tenant_id is None:
+        jobs = store.list_all(all_tenants=True)
+    else:
+        jobs = store.list_all(tenant_id=tenant_id)
+    return sum(1 for job in jobs if is_active_scan_job(job))
 
 
 def reconcile_scan_jobs_active(store: Any, tenant_id: str | None = None) -> int:
@@ -46,7 +52,7 @@ def fail_stale_active_scan_jobs(
     """Mark active jobs older than timeout_seconds as failed."""
     current = now or datetime.now(timezone.utc)
     failed = 0
-    for job in store.list_all():
+    for job in store.list_all(all_tenants=True):
         if not is_active_scan_job(job):
             continue
         created = _parse_created_at(job)
@@ -75,7 +81,7 @@ def fail_orphaned_active_scan_jobs(
     """
     now = datetime.now(timezone.utc)
     failed = 0
-    for job in store.list_all():
+    for job in store.list_all(all_tenants=True):
         if not is_active_scan_job(job):
             continue
         job.status = JobStatus.FAILED

--- a/src/agent_bom/api/store.py
+++ b/src/agent_bom/api/store.py
@@ -21,17 +21,31 @@ from .server import JobStatus, ScanJob
 _JOB_TTL_SECONDS = 3600  # 1 hour
 
 
+def _require_tenant_scope(tenant_id: str | None, all_tenants: bool, method: str) -> None:
+    """Fail closed when a request-path read/write omits a tenant scope.
+
+    A bare ``tenant_id=None`` used to mean "match every tenant" for the
+    SQLite/in-memory stores, which silently leaks cross-tenant rows on
+    request-serving paths. Cross-tenant access must now be explicit: legitimate
+    background reconciliation passes ``all_tenants=True``; anything else with a
+    missing tenant is rejected.
+    """
+    if tenant_id is None and not all_tenants:
+        raise ValueError(f"{method} requires a tenant_id; pass all_tenants=True for background reconciliation")
+
+
 class JobStore(Protocol):
     """Protocol for scan job persistence."""
 
     def put(self, job: ScanJob) -> None: ...
-    def get(self, job_id: str, tenant_id: str | None = None) -> ScanJob | None: ...
-    def delete(self, job_id: str, tenant_id: str | None = None) -> bool: ...
-    def list_all(self, tenant_id: str | None = None) -> list[ScanJob]: ...
+    def get(self, job_id: str, tenant_id: str | None = None, *, all_tenants: bool = False) -> ScanJob | None: ...
+    def delete(self, job_id: str, tenant_id: str | None = None, *, all_tenants: bool = False) -> bool: ...
+    def list_all(self, tenant_id: str | None = None, *, all_tenants: bool = False) -> list[ScanJob]: ...
     def list_summary(
         self,
         tenant_id: str | None = None,
         *,
+        all_tenants: bool = False,
         limit: int | None = None,
         offset: int = 0,
     ) -> list[dict]: ...
@@ -65,7 +79,8 @@ class InMemoryJobStore:
         for jid, _job in completed[: len(self._jobs) - self._max_retained_jobs]:
             self._jobs.pop(jid, None)
 
-    def get(self, job_id: str, tenant_id: str | None = None) -> ScanJob | None:
+    def get(self, job_id: str, tenant_id: str | None = None, *, all_tenants: bool = False) -> ScanJob | None:
+        _require_tenant_scope(tenant_id, all_tenants, "InMemoryJobStore.get()")
         with self._lock:
             job = self._jobs.get(job_id)
             if job is None:
@@ -74,7 +89,8 @@ class InMemoryJobStore:
                 return None
             return job
 
-    def delete(self, job_id: str, tenant_id: str | None = None) -> bool:
+    def delete(self, job_id: str, tenant_id: str | None = None, *, all_tenants: bool = False) -> bool:
+        _require_tenant_scope(tenant_id, all_tenants, "InMemoryJobStore.delete()")
         with self._lock:
             job = self._jobs.get(job_id)
             if job is None:
@@ -83,9 +99,9 @@ class InMemoryJobStore:
                 return False
             del self._jobs[job_id]
             return True
-            return False
 
-    def list_all(self, tenant_id: str | None = None) -> list[ScanJob]:
+    def list_all(self, tenant_id: str | None = None, *, all_tenants: bool = False) -> list[ScanJob]:
+        _require_tenant_scope(tenant_id, all_tenants, "InMemoryJobStore.list_all()")
         with self._lock:
             jobs = list(self._jobs.values())
             if tenant_id is None:
@@ -96,9 +112,11 @@ class InMemoryJobStore:
         self,
         tenant_id: str | None = None,
         *,
+        all_tenants: bool = False,
         limit: int | None = None,
         offset: int = 0,
     ) -> list[dict]:
+        _require_tenant_scope(tenant_id, all_tenants, "InMemoryJobStore.list_summary()")
         with self._lock:
             rows = [
                 {
@@ -282,7 +300,8 @@ class SQLiteJobStore:
             self._shrink_connection_memory()
             self._close_thread_connection()
 
-    def get(self, job_id: str, tenant_id: str | None = None) -> ScanJob | None:
+    def get(self, job_id: str, tenant_id: str | None = None, *, all_tenants: bool = False) -> ScanJob | None:
+        _require_tenant_scope(tenant_id, all_tenants, "SQLiteJobStore.get()")
         try:
             if tenant_id is None:
                 row = self._conn.execute("SELECT data FROM jobs WHERE job_id = ?", (job_id,)).fetchone()
@@ -298,7 +317,8 @@ class SQLiteJobStore:
             self._shrink_connection_memory()
             self._close_thread_connection()
 
-    def delete(self, job_id: str, tenant_id: str | None = None) -> bool:
+    def delete(self, job_id: str, tenant_id: str | None = None, *, all_tenants: bool = False) -> bool:
+        _require_tenant_scope(tenant_id, all_tenants, "SQLiteJobStore.delete()")
         try:
             if tenant_id is None:
                 cursor = self._conn.execute("DELETE FROM jobs WHERE job_id = ?", (job_id,))
@@ -313,7 +333,8 @@ class SQLiteJobStore:
             self._shrink_connection_memory()
             self._close_thread_connection()
 
-    def list_all(self, tenant_id: str | None = None) -> list[ScanJob]:
+    def list_all(self, tenant_id: str | None = None, *, all_tenants: bool = False) -> list[ScanJob]:
+        _require_tenant_scope(tenant_id, all_tenants, "SQLiteJobStore.list_all()")
         try:
             if tenant_id is None:
                 rows = self._conn.execute("SELECT data FROM jobs ORDER BY created_at DESC").fetchall()
@@ -331,9 +352,11 @@ class SQLiteJobStore:
         self,
         tenant_id: str | None = None,
         *,
+        all_tenants: bool = False,
         limit: int | None = None,
         offset: int = 0,
     ) -> list[dict]:
+        _require_tenant_scope(tenant_id, all_tenants, "SQLiteJobStore.list_summary()")
         try:
             base_sql = """SELECT job_id, tenant_id, status, created_at, completed_at, triggered_by, schedule_id,
                                  batch_id, parent_job_id, child_job_ids, target, target_index, target_count

--- a/src/agent_bom/cloud/container_sbom.py
+++ b/src/agent_bom/cloud/container_sbom.py
@@ -17,6 +17,12 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import lru_cache
+from typing import TYPE_CHECKING
+
+from agent_bom import http_client
+
+if TYPE_CHECKING:
+    import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -134,68 +140,53 @@ def _parse_image_ref(image_ref: str) -> tuple[str, str, str, str]:
     return registry, org, repo, tag
 
 
+def _registry_get(url: str, *, headers: dict | None = None, params: dict | None = None) -> httpx.Response | None:
+    """Resilient GET for registry metadata.
+
+    Routes through the shared resilient client so Docker Hub calls get the same
+    retry/backoff, 429 Retry-After handling, and per-host circuit breaker as the
+    OSV/NVD paths. Best-effort: returns ``None`` on any failure (offline mode,
+    exhausted retries, network error) so callers fall back gracefully.
+    """
+    try:
+        with http_client.create_sync_client(timeout=_API_TIMEOUT) as client:
+            return http_client.sync_request_with_retry(client, "GET", url, headers=headers or {}, params=params or {})
+    except Exception:  # noqa: BLE001
+        return None
+
+
 def _dockerhub_token(org: str, repo: str) -> str | None:
     """Fetch an anonymous Docker Hub pull token for public images."""
-    try:
-        import requests
-    except ImportError:
-        return None
-    try:
-        resp = requests.get(
-            _DOCKERHUB_TOKEN_URL,
-            params={"service": "registry.docker.io", "scope": f"repository:{org}/{repo}:pull"},
-            timeout=_API_TIMEOUT,
-        )
-        if resp.status_code == 200:
-            return resp.json().get("token")
-    except Exception:  # noqa: BLE001
-        pass
+    resp = _registry_get(
+        _DOCKERHUB_TOKEN_URL,
+        params={"service": "registry.docker.io", "scope": f"repository:{org}/{repo}:pull"},
+    )
+    if resp is not None and resp.status_code == 200:
+        return resp.json().get("token")
     return None
 
 
 def _fetch_manifest(org: str, repo: str, tag: str, token: str) -> dict | None:
     """Fetch the image manifest from Docker Hub registry API v2."""
-    try:
-        import requests
-    except ImportError:
-        return None
     headers = {
         "Authorization": f"Bearer {token}",
         "Accept": ("application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json"),
     }
-    try:
-        resp = requests.get(
-            f"{_DOCKERHUB_REGISTRY_URL}/{org}/{repo}/manifests/{tag}",
-            headers=headers,
-            timeout=_API_TIMEOUT,
-        )
-        if resp.status_code == 200:
-            return {"manifest": resp.json(), "digest": resp.headers.get("Docker-Content-Digest")}
-    except Exception:  # noqa: BLE001
-        pass
+    resp = _registry_get(f"{_DOCKERHUB_REGISTRY_URL}/{org}/{repo}/manifests/{tag}", headers=headers)
+    if resp is not None and resp.status_code == 200:
+        return {"manifest": resp.json(), "digest": resp.headers.get("Docker-Content-Digest")}
     return None
 
 
 def _fetch_config(org: str, repo: str, config_digest: str, token: str) -> dict | None:
     """Fetch the image config blob (contains OS, arch, creation time, labels)."""
-    try:
-        import requests
-    except ImportError:
-        return None
     headers = {
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.docker.container.image.v1+json",
     }
-    try:
-        resp = requests.get(
-            f"{_DOCKERHUB_REGISTRY_URL}/{org}/{repo}/blobs/{config_digest}",
-            headers=headers,
-            timeout=_API_TIMEOUT,
-        )
-        if resp.status_code == 200:
-            return resp.json()
-    except Exception:  # noqa: BLE001
-        pass
+    resp = _registry_get(f"{_DOCKERHUB_REGISTRY_URL}/{org}/{repo}/blobs/{config_digest}", headers=headers)
+    if resp is not None and resp.status_code == 200:
+        return resp.json()
     return None
 
 

--- a/src/agent_bom/cloud/crusoe.py
+++ b/src/agent_bom/cloud/crusoe.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 
+from agent_bom import http_client
 from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
@@ -24,16 +25,16 @@ _API_TIMEOUT = 15
 
 
 def _crusoe_get(path: str, api_key: str) -> dict | list:
-    try:
-        import requests
-    except ImportError as exc:
-        raise CloudDiscoveryError("requests is required for Crusoe discovery. Install with: pip install requests") from exc
-
-    resp = requests.get(
+    # Route through the shared resilient client so Crusoe calls get the same
+    # retry/backoff, 429 Retry-After handling, and per-host circuit breaker as
+    # the OSV/NVD paths instead of a raw one-shot request.
+    resp = http_client.sync_get(
         f"{_API_BASE}{path}",
-        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
         timeout=_API_TIMEOUT,
+        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
     )
+    if resp is None:
+        raise CloudDiscoveryError("Crusoe: request failed after retries")
     if resp.status_code == 401:
         raise CloudDiscoveryError("Crusoe: invalid API key (HTTP 401)")
     resp.raise_for_status()
@@ -54,11 +55,6 @@ def discover(
     Returns:
         (agents, warnings) tuple.
     """
-    try:
-        import requests  # noqa: F401
-    except ImportError:
-        return [], ["Crusoe discovery requires 'requests'. Install with: pip install requests"]
-
     resolved_key = api_key or os.environ.get("CRUSOE_API_KEY", "")
     resolved_project = project_id or os.environ.get("CRUSOE_PROJECT_ID", "")
 

--- a/src/agent_bom/cloud/vastai.py
+++ b/src/agent_bom/cloud/vastai.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 
+from agent_bom import http_client
 from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
@@ -24,16 +25,16 @@ _API_TIMEOUT = 15
 
 
 def _vast_get(path: str, api_key: str) -> dict | list:
-    try:
-        import requests
-    except ImportError as exc:
-        raise CloudDiscoveryError("requests is required for Vast.ai discovery. Install with: pip install requests") from exc
-
-    resp = requests.get(
+    # Route through the shared resilient client so Vast.ai calls get the same
+    # retry/backoff, 429 Retry-After handling, and per-host circuit breaker as
+    # the OSV/NVD paths instead of a raw one-shot request.
+    resp = http_client.sync_get(
         f"{_API_BASE}{path}",
-        headers={"Authorization": f"Bearer {api_key}"},
         timeout=_API_TIMEOUT,
+        headers={"Authorization": f"Bearer {api_key}"},
     )
+    if resp is None:
+        raise CloudDiscoveryError("Vast.ai: request failed after retries")
     if resp.status_code == 401:
         raise CloudDiscoveryError("Vast.ai: invalid API key (HTTP 401)")
     resp.raise_for_status()
@@ -52,11 +53,6 @@ def discover(
     Returns:
         (agents, warnings) tuple.
     """
-    try:
-        import requests  # noqa: F401
-    except ImportError:
-        return [], ["Vast.ai discovery requires 'requests'. Install with: pip install requests"]
-
     resolved_key = api_key or os.environ.get("VASTAI_API_KEY", "")
     if not resolved_key:
         return [], ["VASTAI_API_KEY not set. Provide --vastai-api-key or set the VASTAI_API_KEY env var."]

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -355,6 +355,11 @@ API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT = _int("AGENT_BOM_API_MAX_ACTIVE_SCAN_JOBS_P
 API_MAX_RETAINED_JOBS_PER_TENANT = _int("AGENT_BOM_API_MAX_RETAINED_JOBS_PER_TENANT", 500)
 API_MAX_FLEET_AGENTS_PER_TENANT = _int("AGENT_BOM_API_MAX_FLEET_AGENTS_PER_TENANT", 1_000)
 API_MAX_SCHEDULES_PER_TENANT = _int("AGENT_BOM_API_MAX_SCHEDULES_PER_TENANT", 100)
+# Per-request fan-out ceiling: a single POST /v1/scan expands one batchable
+# target field per child job, so an uncapped request could enqueue unbounded
+# work bounded only by the tenant active-scan quota churn. Reject over-cap
+# requests at validation time (HTTP 422).
+API_MAX_BATCH_SCAN_TARGETS = _int("AGENT_BOM_API_MAX_BATCH_SCAN_TARGETS", 100)
 API_ALLOW_UNAUTHENTICATED = _bool("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", False)
 # Slowloris throughput floor (audit-5 PR-C): minimum sustained body
 # bytes/second once a request body crosses the warmup threshold inside

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -533,7 +533,7 @@ def test_get_scan_redacts_result_findings_replay_only_fields():
         "package_version": "10.0.0",
         "severity": "high",
     }
-    assert store.get("job-finding-redaction").result["findings"][0]["description"] == "Copied workspace details"
+    assert store.get("job-finding-redaction", all_tenants=True).result["findings"][0]["description"] == "Copied workspace details"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_scan_batches.py
+++ b/tests/test_api_scan_batches.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from agent_bom.api.models import JobStatus, ScanRequest
 from agent_bom.api.routes import scan as scan_routes
 from agent_bom.api.store import InMemoryJobStore
@@ -216,3 +218,19 @@ def test_single_target_scan_request_keeps_single_job_shape(monkeypatch):
     assert job.parent_job_id is None
     assert job.child_job_ids == []
     assert submitted == [job.job_id]
+
+
+def test_scan_request_rejects_over_batch_target_cap():
+    from pydantic import ValidationError
+
+    from agent_bom.config import API_MAX_BATCH_SCAN_TARGETS
+
+    with pytest.raises(ValidationError, match="maximum is"):
+        ScanRequest(images=[f"repo/img-{idx}:latest" for idx in range(API_MAX_BATCH_SCAN_TARGETS + 1)])
+
+
+def test_scan_request_accepts_at_batch_target_cap():
+    from agent_bom.config import API_MAX_BATCH_SCAN_TARGETS
+
+    req = ScanRequest(images=[f"repo/img-{idx}:latest" for idx in range(API_MAX_BATCH_SCAN_TARGETS)])
+    assert len(req.images) == API_MAX_BATCH_SCAN_TARGETS

--- a/tests/test_api_store.py
+++ b/tests/test_api_store.py
@@ -30,34 +30,34 @@ def test_in_memory_put_and_get():
     store = InMemoryJobStore()
     job = _make_job()
     store.put(job)
-    assert store.get("test-123") is not None
-    assert store.get("test-123").job_id == "test-123"
+    assert store.get("test-123", all_tenants=True) is not None
+    assert store.get("test-123", all_tenants=True).job_id == "test-123"
 
 
 def test_in_memory_get_missing():
     store = InMemoryJobStore()
-    assert store.get("nonexistent") is None
+    assert store.get("nonexistent", all_tenants=True) is None
 
 
 def test_in_memory_delete():
     store = InMemoryJobStore()
     store.put(_make_job())
-    assert store.delete("test-123") is True
-    assert store.get("test-123") is None
-    assert store.delete("test-123") is False
+    assert store.delete("test-123", all_tenants=True) is True
+    assert store.get("test-123", all_tenants=True) is None
+    assert store.delete("test-123", all_tenants=True) is False
 
 
 def test_in_memory_list_all():
     store = InMemoryJobStore()
     store.put(_make_job("j1"))
     store.put(_make_job("j2"))
-    assert len(store.list_all()) == 2
+    assert len(store.list_all(all_tenants=True)) == 2
 
 
 def test_in_memory_list_summary():
     store = InMemoryJobStore()
     store.put(_make_job("j1"))
-    summary = store.list_summary()
+    summary = store.list_summary(all_tenants=True)
     assert len(summary) == 1
     assert summary[0]["job_id"] == "j1"
     assert "status" in summary[0]
@@ -69,8 +69,8 @@ def test_in_memory_cleanup():
     store.put(_make_job("j2", status=JobStatus.RUNNING))
     removed = store.cleanup_expired(ttl_seconds=1)
     assert removed == 1
-    assert store.get("j1") is None
-    assert store.get("j2") is not None
+    assert store.get("j1", all_tenants=True) is None
+    assert store.get("j2", all_tenants=True) is not None
 
 
 def test_in_memory_retention_evicts_oldest_completed_jobs():
@@ -83,9 +83,9 @@ def test_in_memory_retention_evicts_oldest_completed_jobs():
     store.put(running)
     store.put(new)
 
-    assert store.get("old") is None
-    assert store.get("running") is not None
-    assert store.get("new") is not None
+    assert store.get("old", all_tenants=True) is None
+    assert store.get("running", all_tenants=True) is not None
+    assert store.get("new", all_tenants=True) is not None
 
 
 def test_completed_scan_refreshes_bounded_hot_cache(monkeypatch):
@@ -109,11 +109,11 @@ def test_completed_scan_refreshes_bounded_hot_cache(monkeypatch):
     for job in jobs:
         _run_scan_sync(job)
 
-    assert len(store.list_all()) == 3
+    assert len(store.list_all(all_tenants=True)) == 3
     assert len(stores._jobs) == 3
     assert sorted(stores._jobs) == ["job-2", "job-3", "job-4"]
     assert all(stores._jobs_is_compacted(job) for job in stores._jobs.values())
-    assert all(store.get(job_id).result for job_id in ["job-2", "job-3", "job-4"])
+    assert all(store.get(job_id, all_tenants=True).result for job_id in ["job-2", "job-3", "job-4"])
 
 
 def test_scan_memory_release_is_best_effort(monkeypatch):
@@ -187,11 +187,11 @@ def test_compacted_hot_cache_job_hydrates_full_scan_response(monkeypatch):
 
     cached = stores._jobs["full-job"]
     assert stores._jobs_is_compacted(cached)
-    assert cached.result != store.get("full-job").result
+    assert cached.result != store.get("full-job", all_tenants=True).result
 
     request = SimpleNamespace(state=SimpleNamespace(tenant_id="default"))
     hydrated = _job_for_request(request, "full-job")
-    assert hydrated.result == store.get("full-job").result
+    assert hydrated.result == store.get("full-job", all_tenants=True).result
 
 
 def test_scan_job_progress_is_bounded(monkeypatch):
@@ -215,7 +215,7 @@ def test_sqlite_put_and_get():
         job = _make_job()
         store.put(job)
 
-        retrieved = store.get("test-123")
+        retrieved = store.get("test-123", all_tenants=True)
         assert retrieved is not None
         assert retrieved.job_id == "test-123"
         assert retrieved.status == JobStatus.PENDING
@@ -241,7 +241,7 @@ def test_sqlite_get_missing():
         db_path = f.name
     try:
         store = SQLiteJobStore(db_path=db_path)
-        assert store.get("nonexistent") is None
+        assert store.get("nonexistent", all_tenants=True) is None
     finally:
         Path(db_path).unlink(missing_ok=True)
 
@@ -259,10 +259,10 @@ def test_sqlite_upsert():
         job.completed_at = "2026-02-23T13:00:00+00:00"
         store.put(job)
 
-        retrieved = store.get("test-123")
+        retrieved = store.get("test-123", all_tenants=True)
         assert retrieved.status == JobStatus.DONE
         assert retrieved.completed_at == "2026-02-23T13:00:00+00:00"
-        assert len(store.list_all()) == 1
+        assert len(store.list_all(all_tenants=True)) == 1
     finally:
         Path(db_path).unlink(missing_ok=True)
 
@@ -273,9 +273,9 @@ def test_sqlite_delete():
     try:
         store = SQLiteJobStore(db_path=db_path)
         store.put(_make_job())
-        assert store.delete("test-123") is True
-        assert store.get("test-123") is None
-        assert store.delete("test-123") is False
+        assert store.delete("test-123", all_tenants=True) is True
+        assert store.get("test-123", all_tenants=True) is None
+        assert store.delete("test-123", all_tenants=True) is False
     finally:
         Path(db_path).unlink(missing_ok=True)
 
@@ -287,7 +287,7 @@ def test_sqlite_list_all():
         store = SQLiteJobStore(db_path=db_path)
         store.put(_make_job("j1"))
         store.put(_make_job("j2"))
-        jobs = store.list_all()
+        jobs = store.list_all(all_tenants=True)
         assert len(jobs) == 2
         ids = {j.job_id for j in jobs}
         assert ids == {"j1", "j2"}
@@ -303,7 +303,7 @@ def test_sqlite_list_summary():
         for idx in range(3):
             store.put(_make_job(f"j{idx}", triggered_by="api-user"))
         assert store.count_summary() == 3
-        summary = store.list_summary(limit=2, offset=1)
+        summary = store.list_summary(all_tenants=True, limit=2, offset=1)
         assert len(summary) == 2
         assert summary[0]["job_id"] == "j1"
         assert summary[0]["triggered_by"] == "api-user"
@@ -328,7 +328,7 @@ def test_sqlite_list_summary_includes_scan_batch_metadata():
         )
         store.put(job)
 
-        summary = store.list_summary()
+        summary = store.list_summary(all_tenants=True)
 
         assert summary[0]["batch_id"] == "batch-1"
         assert summary[0]["parent_job_id"] == "parent-1"
@@ -353,7 +353,7 @@ def test_sqlite_list_summary_does_not_hydrate_full_result(monkeypatch):
             raise AssertionError("list_summary should not deserialize full job data")
 
         monkeypatch.setattr(store, "_deserialize", fail_deserialize)
-        summary = store.list_summary()
+        summary = store.list_summary(all_tenants=True)
         assert summary[0]["job_id"] == "j1"
         assert summary[0]["triggered_by"] == "api-user"
     finally:
@@ -371,9 +371,9 @@ def test_sqlite_cleanup_expired():
 
         removed = store.cleanup_expired(ttl_seconds=1)
         assert removed == 2
-        assert store.get("j1") is None
-        assert store.get("j2") is not None
-        assert store.get("j3") is None
+        assert store.get("j1", all_tenants=True) is None
+        assert store.get("j2", all_tenants=True) is not None
+        assert store.get("j3", all_tenants=True) is None
     finally:
         Path(db_path).unlink(missing_ok=True)
 
@@ -388,7 +388,7 @@ def test_sqlite_persistence_across_instances():
 
         # Create new store instance pointing to same DB
         store2 = SQLiteJobStore(db_path=db_path)
-        retrieved = store2.get("persistent-job")
+        retrieved = store2.get("persistent-job", all_tenants=True)
         assert retrieved is not None
         assert retrieved.job_id == "persistent-job"
         assert retrieved.status == JobStatus.DONE
@@ -411,9 +411,76 @@ def test_sqlite_preserves_result_data():
         job.progress = ["Starting scan...", "Found 1 agent", "Scan complete."]
         store.put(job)
 
-        retrieved = store.get("test-123")
+        retrieved = store.get("test-123", all_tenants=True)
         assert retrieved.result["agents"][0]["name"] == "test-agent"
         assert len(retrieved.result["vulnerabilities"]) == 1
         assert retrieved.progress == ["Starting scan...", "Found 1 agent", "Scan complete."]
+    finally:
+        Path(db_path).unlink(missing_ok=True)
+
+
+# ── Tenant isolation guard (fail-closed on None tenant_id) ───────────────────
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["get", "delete", "list_all", "list_summary"],
+)
+def test_in_memory_rejects_none_tenant_without_opt_in(method: str):
+    store = InMemoryJobStore()
+    store.put(_make_job("j1", tenant_id="tenant-a"))
+    store.put(_make_job("j2", tenant_id="tenant-b"))
+
+    fn = getattr(store, method)
+    if method in ("get", "delete"):
+        with pytest.raises(ValueError, match="requires a tenant_id"):
+            fn("j1")
+    else:
+        with pytest.raises(ValueError, match="requires a tenant_id"):
+            fn()
+
+
+def test_in_memory_all_tenants_opt_in_returns_cross_tenant():
+    store = InMemoryJobStore()
+    store.put(_make_job("j1", tenant_id="tenant-a"))
+    store.put(_make_job("j2", tenant_id="tenant-b"))
+
+    assert len(store.list_all(all_tenants=True)) == 2
+    assert store.get("j1", all_tenants=True).tenant_id == "tenant-a"
+    assert store.get("j2", all_tenants=True).tenant_id == "tenant-b"
+
+
+def test_in_memory_tenant_scoped_read_isolates():
+    store = InMemoryJobStore()
+    store.put(_make_job("j1", tenant_id="tenant-a"))
+    store.put(_make_job("j2", tenant_id="tenant-b"))
+
+    assert store.get("j1", tenant_id="tenant-a") is not None
+    assert store.get("j1", tenant_id="tenant-b") is None
+    assert len(store.list_all(tenant_id="tenant-a")) == 1
+
+
+def test_sqlite_rejects_none_tenant_without_opt_in():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        store = SQLiteJobStore(db_path=db_path)
+        store.put(_make_job("j1", tenant_id="tenant-a"))
+
+        with pytest.raises(ValueError, match="requires a tenant_id"):
+            store.list_all()
+    finally:
+        Path(db_path).unlink(missing_ok=True)
+
+
+def test_sqlite_all_tenants_opt_in_returns_cross_tenant():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        store = SQLiteJobStore(db_path=db_path)
+        store.put(_make_job("j1", tenant_id="tenant-a"))
+        store.put(_make_job("j2", tenant_id="tenant-b"))
+
+        assert len(store.list_all(all_tenants=True)) == 2
     finally:
         Path(db_path).unlink(missing_ok=True)

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -542,11 +542,13 @@ async def test_pushed_results_enforce_retained_job_quota(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_list_jobs_is_summary_first_and_opt_in_for_hydration():
+    _jobs.clear()
+
     class _Store:
         def __init__(self) -> None:
             self.get_calls = 0
 
-        def list_summary(self, tenant_id: str | None = None) -> list[dict]:
+        def list_summary(self, tenant_id: str | None = None, **_kwargs) -> list[dict]:
             assert tenant_id == "tenant-alpha"
             return [
                 {
@@ -559,7 +561,8 @@ async def test_list_jobs_is_summary_first_and_opt_in_for_hydration():
                 }
             ]
 
-        def get(self, job_id: str) -> ScanJob | None:
+        def get(self, job_id: str, tenant_id: str | None = None) -> ScanJob | None:
+            assert tenant_id == "tenant-alpha"
             self.get_calls += 1
             return ScanJob(
                 job_id=job_id,

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -365,7 +365,7 @@ async def test_create_scan_and_push_stamp_request_tenant(monkeypatch):
             posture_scorecard={"overall_score": 82},
         ),
     )
-    pushed_job = store.get(pushed["job_id"])
+    pushed_job = store.get(pushed["job_id"], all_tenants=True)
     assert pushed_job is not None
     assert pushed_job.tenant_id == "tenant-alpha"
     assert pushed_job.triggered_by == "analyst@example.com:source-a"
@@ -435,7 +435,7 @@ async def test_receive_push_normalizes_report_contract_and_persists_graph(tmp_pa
         ),
     )
 
-    pushed_job = store.get(pushed["job_id"])
+    pushed_job = store.get(pushed["job_id"], all_tenants=True)
     assert pushed_job is not None
     assert pushed_job.result["scan_id"] == pushed["job_id"]
     assert pushed_job.result["blast_radius"][0]["vulnerability_id"] == "CVE-2026-0001"

--- a/tests/test_cloud_http_resilience.py
+++ b/tests/test_cloud_http_resilience.py
@@ -1,0 +1,61 @@
+"""Tests that cloud provider HTTP calls route through the resilient client."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from agent_bom.cloud.base import CloudDiscoveryError
+
+
+def test_crusoe_get_retries_via_resilient_client():
+    from agent_bom.cloud import crusoe
+
+    ok = httpx.Response(200, json={"items": []}, request=httpx.Request("GET", "https://example.com"))
+
+    with patch("agent_bom.cloud.crusoe.http_client.sync_get", return_value=ok) as mock_get:
+        result = crusoe._crusoe_get("/compute/vms", "test-key")
+
+    mock_get.assert_called_once()
+    assert result == {"items": []}
+
+
+def test_crusoe_get_raises_on_exhausted_retries():
+    from agent_bom.cloud import crusoe
+
+    with patch("agent_bom.cloud.crusoe.http_client.sync_get", return_value=None):
+        with pytest.raises(CloudDiscoveryError, match="failed after retries"):
+            crusoe._crusoe_get("/compute/vms", "test-key")
+
+
+def test_vast_get_retries_via_resilient_client():
+    from agent_bom.cloud import vastai
+
+    ok = httpx.Response(200, json={"instances": []}, request=httpx.Request("GET", "https://example.com"))
+
+    with patch("agent_bom.cloud.vastai.http_client.sync_get", return_value=ok) as mock_get:
+        result = vastai._vast_get("/instances/?owner=me", "test-key")
+
+    mock_get.assert_called_once()
+    assert result == {"instances": []}
+
+
+def test_container_sbom_registry_get_uses_resilient_client():
+    from agent_bom.cloud import container_sbom
+
+    ok = httpx.Response(200, json={"token": "abc"}, request=httpx.Request("GET", "https://example.com"))
+
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("agent_bom.cloud.container_sbom.http_client.create_sync_client", return_value=mock_client),
+        patch("agent_bom.cloud.container_sbom.http_client.sync_request_with_retry", return_value=ok) as mock_retry,
+    ):
+        token = container_sbom._dockerhub_token("library", "ubuntu")
+
+    mock_retry.assert_called_once()
+    assert token == "abc"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2593,7 +2593,7 @@ def test_api_skill_audit_endpoint():
         assert len(body["findings"]) == 1
         assert body["findings"][0]["category"] == "shell_access"
     finally:
-        _get_store().delete("skill-audit-test")
+        _get_store().delete("skill-audit-test", all_tenants=True)
 
 
 def test_api_skill_audit_empty():
@@ -2620,7 +2620,7 @@ def test_api_skill_audit_empty():
         assert body["passed"] is True
         assert body["findings"] == []
     finally:
-        _get_store().delete("no-skill-audit-test")
+        _get_store().delete("no-skill-audit-test", all_tenants=True)
 
 
 # ── Resilient HTTP client tests ──────────────────────────────────────

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -352,7 +352,7 @@ def test_job_store_put_get(mock_pool):
         job.model_dump_json(),
     )
 
-    retrieved = store.get("j-1")
+    retrieved = store.get("j-1", all_tenants=True)
     assert retrieved is not None
     assert retrieved.job_id == "j-1"
 
@@ -384,7 +384,7 @@ def test_job_store_get_nonexistent(mock_pool):
     from agent_bom.api.postgres_store import PostgresJobStore
 
     store = PostgresJobStore(pool=mock_pool)
-    assert store.get("nonexistent") is None
+    assert store.get("nonexistent", all_tenants=True) is None
 
 
 def test_job_store_delete(mock_pool):
@@ -392,14 +392,14 @@ def test_job_store_delete(mock_pool):
 
     store = PostgresJobStore(pool=mock_pool)
     mock_pool._conn._store.setdefault("scan_jobs", {})["j-1"] = ("j-1", "done", "", None, "{}")
-    assert store.delete("j-1") is True
+    assert store.delete("j-1", all_tenants=True) is True
 
 
 def test_job_store_delete_nonexistent(mock_pool):
     from agent_bom.api.postgres_store import PostgresJobStore
 
     store = PostgresJobStore(pool=mock_pool)
-    assert store.delete("nonexistent") is False
+    assert store.delete("nonexistent", all_tenants=True) is False
 
 
 def test_job_store_list_summary(mock_pool):
@@ -407,7 +407,7 @@ def test_job_store_list_summary(mock_pool):
 
     store = PostgresJobStore(pool=mock_pool)
     # list_summary returns dicts from column-based query
-    result = store.list_summary()
+    result = store.list_summary(all_tenants=True)
     assert isinstance(result, list)
 
 
@@ -415,7 +415,7 @@ def test_job_store_list_all_requires_tenant_id(mock_pool):
     from agent_bom.api.postgres_store import PostgresJobStore
 
     store = PostgresJobStore(pool=mock_pool)
-    with pytest.raises(ValueError, match="tenant_id is required"):
+    with pytest.raises(ValueError, match="requires a tenant_id"):
         store.list_all()
 
 
@@ -433,7 +433,7 @@ def test_job_store_list_summary_includes_tenant(mock_pool):
         "sched-alpha",
         "{}",
     )
-    result = store.list_summary()
+    result = store.list_summary(all_tenants=True)
     assert result[0]["tenant_id"] == "tenant-alpha"
     assert result[0]["triggered_by"] == "scheduler"
     assert result[0]["schedule_id"] == "sched-alpha"

--- a/tests/test_rate_limit_headers.py
+++ b/tests/test_rate_limit_headers.py
@@ -1,5 +1,6 @@
 """Tests for rate-limit, version, and request tracing headers."""
 
+import pytest
 from starlette.applications import Starlette
 from starlette.responses import JSONResponse as StarletteJSONResponse
 from starlette.routing import Route
@@ -17,6 +18,10 @@ def _make_app(scan_rpm: int = 10, read_rpm: int = 20):
         routes=[
             Route("/v1/data", dummy),
             Route("/health", dummy),
+            Route("/healthz", dummy),
+            Route("/livez", dummy),
+            Route("/readyz", dummy),
+            Route("/ping", dummy),
             Route("/_next/static/app.js", dummy),
             Route("/missing.js", dummy),
         ]
@@ -237,3 +242,14 @@ def test_non_dashboard_suffix_paths_still_consume_read_rate_limit():
     assert first.status_code == 200
     assert first.headers["x-ratelimit-limit"] == "1"
     assert second.status_code == 429
+
+
+@pytest.mark.parametrize("path", ["/health", "/healthz", "/livez", "/readyz", "/ping"])
+def test_health_probe_paths_exempt_from_read_rate_limit(path: str):
+    """Health/readiness/liveness probes must not self-throttle under probe storms."""
+    client = TestClient(_make_app(read_rpm=1))
+
+    for _ in range(5):
+        resp = client.get(path)
+        assert resp.status_code == 200
+        assert "x-ratelimit-limit" not in resp.headers

--- a/tests/test_scan_jobs_active_gauge.py
+++ b/tests/test_scan_jobs_active_gauge.py
@@ -114,9 +114,9 @@ def test_fail_stale_active_jobs_then_reconcile_clears_leaked_gauge() -> None:
     )
 
     assert failed == 2
-    assert store.get("old-pending").status == JobStatus.FAILED
-    assert store.get("old-running").status == JobStatus.FAILED
-    assert store.get("fresh-running").status == JobStatus.RUNNING
+    assert store.get("old-pending", all_tenants=True).status == JobStatus.FAILED
+    assert store.get("old-running", all_tenants=True).status == JobStatus.FAILED
+    assert store.get("fresh-running", all_tenants=True).status == JobStatus.RUNNING
     assert reconcile_scan_jobs_active(store) == 1
     assert metrics.scan_jobs_active() == 1
 
@@ -128,8 +128,8 @@ def test_startup_orphan_cleanup_fails_active_jobs() -> None:
     store.put(_job("done", JobStatus.DONE))
 
     assert fail_orphaned_active_scan_jobs(store) == 2
-    assert store.get("orphan-pending").status == JobStatus.FAILED
-    assert store.get("orphan-running").status == JobStatus.FAILED
-    assert store.get("done").status == JobStatus.DONE
+    assert store.get("orphan-pending", all_tenants=True).status == JobStatus.FAILED
+    assert store.get("orphan-running", all_tenants=True).status == JobStatus.FAILED
+    assert store.get("done", all_tenants=True).status == JobStatus.DONE
     assert reconcile_scan_jobs_active(store) == 0
     assert metrics.scan_jobs_active() == 0


### PR DESCRIPTION
## Summary

- **Tenant isolation (P1):** SQLite/in-memory `JobStore` read paths (`get`, `delete`, `list_all`, `list_summary`) now **fail closed** when `tenant_id is None` — raises `ValueError` instead of returning all tenants. Background reconciliation (`fail_stale_active_scan_jobs`, `fail_orphaned_active_scan_jobs`, global active gauge) opts in explicitly via `all_tenants=True`. Postgres store aligned to the same contract.
- **Cloud HTTP resilience (P2):** Crusoe, Vast.ai, and container SBOM registry calls route through `http_client.sync_get` / `sync_request_with_retry` (retry/backoff, 429 Retry-After, per-host circuit breaker) instead of raw `requests.get`.
- **Health probe rate-limit exemption (P2):** `/health`, `/healthz`, `/livez`, `/readyz`, `/ping` bypass the per-tenant/IP **read** rate limiter so probe storms do not self-throttle. The outermost `GlobalRateLimitMiddleware` pre-auth flood cap remains in force.
- **Batch fan-out cap (P2):** `ScanRequest` model validator rejects requests expanding to more than `API_MAX_BATCH_SCAN_TARGETS` (default 100) explicit targets → HTTP 422.

**Fail-open / fail-closed notes:**
| Surface | Before | After |
|---|---|---|
| Job store read with `tenant_id=None` | Fail **open** (all tenants) on SQLite/in-memory | Fail **closed** (`ValueError`); reconciliation uses `all_tenants=True` |
| `/health` under read rate limiter | Throttled like any GET | **Exempt** from read limiter; global IP flood cap still applies |
| Cloud provider HTTP | No retry on 429/5xx | Retries via shared resilient client; breaker opens on sustained 429s |

**Deferred:** Declarative DB partitioning — design tracked in #3463 (not implemented here).

## Verification

```bash
uv run ruff check src/agent_bom/api/store.py src/agent_bom/api/postgres_store.py \
  src/agent_bom/api/scan_job_reconciliation.py src/agent_bom/api/models.py \
  src/agent_bom/api/middleware.py src/agent_bom/cloud/crusoe.py \
  src/agent_bom/cloud/vastai.py src/agent_bom/cloud/container_sbom.py src/agent_bom/config.py
uv run mypy src/agent_bom/api/store.py src/agent_bom/api/postgres_store.py \
  src/agent_bom/api/scan_job_reconciliation.py src/agent_bom/api/models.py \
  src/agent_bom/api/middleware.py src/agent_bom/cloud/crusoe.py \
  src/agent_bom/cloud/vastai.py src/agent_bom/cloud/container_sbom.py
uv run pytest tests/test_api_store.py tests/test_scan_jobs_active_gauge.py \
  tests/test_api_endpoints.py tests/test_rate_limit_headers.py \
  tests/test_api_scan_batches.py tests/test_cloud_http_resilience.py -q
```

107 targeted tests passed; ruff + mypy clean on changed sources.

## Notes

- Existing store unit tests updated to pass `all_tenants=True` or explicit `tenant_id` — reflects the new contract.
- `test_api_tenant_isolation.py::test_create_scan_and_push_stamp_request_tenant` fails on `list_jobs` summary hydration on `origin/main` (pre-existing; unrelated to store guard).

Made with [Cursor](https://cursor.com)