### PR TITLE
feat(enrich): bundle KEV and EPSS into offline vuln-DB layer

### DIFF
--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -128,11 +128,11 @@ OSV/GHSA calls. The preload path is:
 |---|---|---|
 | 1. Sync on a connected bastion | `agent-bom db update` | Produces `~/.agent-bom/db/vulns.db` (~50 MB first run) |
 | 2. Verify freshness | `agent-bom db status` | Confirm OSV/Alpine/Debian/EPSS/KEV rows and sync timestamps |
-| 3. Bundle for transfer | `scripts/release/bundle-vuln-db.sh dist/airgap` | Writes `dist/airgap/vulns.db` + `sha256sums-vulns.db.txt` |
-| 4. Import on disconnected host | `sha256sum -c sha256sums-vulns.db.txt` then copy `vulns.db` | Mount or copy to the runtime DB path |
-| 5. Point runtime at the cache | `AGENT_BOM_DB_PATH=/var/lib/agent-bom/vulns.db` | Same path in Docker, Helm, or bare-metal installs |
+| 3. Bundle for transfer | `scripts/release/bundle-vuln-db.sh dist/airgap` | Writes `vulns.db`, `known_exploited_vulnerabilities.json`, `epss_scores-current.csv.gz`, and `sha256sums.txt` |
+| 4. Import on disconnected host | `cd dist/airgap && sha256sum -c sha256sums.txt` then copy the bundle directory | Mount or copy to the runtime DB path (same directory for sidecar KEV/EPSS feeds) |
+| 5. Point runtime at the cache | `AGENT_BOM_DB_PATH=/var/lib/agent-bom/vulns.db` | Sidecar feeds resolve from the DB parent dir, or set `AGENT_BOM_VULN_DB_BUNDLE_DIR` explicitly |
 | 6. Disable network refresh | `AGENT_BOM_VULN_DB_OFFLINE=1` or CLI `--offline` | Scans use the bundled cache only; rerun step 1–4 on a schedule |
-| 7. Smoke scan | `agent-bom agents --offline /workspace` | Expect `Vuln data: … local cache (offline — network skipped)` |
+| 7. Smoke scan | `agent-bom agents --offline /workspace` | Expect `Vuln data: … local cache (offline — network skipped)` and KEV/EPSS enrichment from the bundle |
 
 Docker pilot compose already wires `AGENT_BOM_DB_PATH` to a named volume —
 preload by copying `vulns.db` into that volume before the first scan. Helm
@@ -144,6 +144,19 @@ Image import for disconnected registries remains in
 [`site-docs/deployment/airgapped-image-bundle.md`](../site-docs/deployment/airgapped-image-bundle.md);
 combine that image bundle with the `vulns.db` bundle above for full offline
 scanning.
+
+Verify the air-gap vuln-DB bundle on a connected bastion before transfer:
+
+```bash
+scripts/release/bundle-vuln-db.sh dist/airgap
+cd dist/airgap
+sha256sum -c sha256sums.txt
+AGENT_BOM_DB_PATH="$PWD/vulns.db" AGENT_BOM_VULN_DB_OFFLINE=1 \
+  uv run pytest -q tests/test_enrichment_cache.py::test_offline_kev_loads_from_bundled_path
+```
+
+On the disconnected host, mount the whole `dist/airgap` directory (not only
+`vulns.db`) so KEV/EPSS sidecar feeds resolve next to the DB path.
 
 ## Inspect scanner accuracy evidence
 

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -410,6 +410,7 @@ AGENT_BOM_VERSION
 AGENT_BOM_VISUAL_LEAK_TIMEOUT_SECONDS
 AGENT_BOM_VULN_DB_MAX_AGE_HOURS  # runtime override for vuln-cache staleness threshold (hours, default 24); re-read at scan time so tests can monkeypatch; read in vuln_freshness.py
 AGENT_BOM_VULN_DB_OFFLINE  # airgap toggle that forces existing-cache-only freshness with no network refresh; mirrors --offline for non-CLI callers; read in vuln_freshness.py
+AGENT_BOM_VULN_DB_BUNDLE_DIR  # optional override for the air-gap KEV/EPSS sidecar feed directory; defaults to the parent of AGENT_BOM_DB_PATH; read in enrichment.py
 
 # Coarse per-IP rate-limit ceiling override; resolved at call-time with bounds-checking in middleware.global_ip_rate_limit_rpm().
 AGENT_BOM_GLOBAL_IP_RATE_LIMIT_RPM

--- a/scripts/release/bundle-vuln-db.sh
+++ b/scripts/release/bundle-vuln-db.sh
@@ -6,13 +6,19 @@
 # Next artifact:
 #   scripts/release/bundle-vuln-db.sh dist/airgap
 # Next step on the disconnected host:
-#   verify sha256sums.txt, copy vulns.db to the runtime path, set
+#   verify sha256sums.txt, copy the bundle to the runtime path, set
 #   AGENT_BOM_DB_PATH and AGENT_BOM_VULN_DB_OFFLINE=1 — see
 #   docs/ENTERPRISE_DEPLOYMENT.md and docs/RELEASE_VERIFICATION.md.
 set -euo pipefail
 
 SOURCE="${AGENT_BOM_DB_SOURCE:-${HOME}/.agent-bom/db/vulns.db}"
 OUTPUT_DIR="${1:-dist/airgap}"
+
+KEV_URL="${AGENT_BOM_KEV_FEED_URL:-https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json}"
+EPSS_URL="${AGENT_BOM_EPSS_FEED_URL:-https://epss.empiricalsecurity.com/epss_scores-current.csv.gz}"
+
+KEV_FILE="known_exploited_vulnerabilities.json"
+EPSS_FILE="epss_scores-current.csv.gz"
 
 if [[ ! -f "$SOURCE" ]]; then
   echo "error: vulnerability DB not found at ${SOURCE}" >&2
@@ -24,6 +30,12 @@ mkdir -p "$OUTPUT_DIR"
 DEST="$OUTPUT_DIR/vulns.db"
 cp "$SOURCE" "$DEST"
 
+echo "Downloading CISA KEV catalog …"
+curl -fsSL "$KEV_URL" -o "$OUTPUT_DIR/$KEV_FILE"
+
+echo "Downloading FIRST EPSS bulk export …"
+curl -fsSL "$EPSS_URL" -o "$OUTPUT_DIR/$EPSS_FILE"
+
 if command -v agent-bom >/dev/null 2>&1; then
   agent-bom db status --path "$DEST"
 elif command -v uv >/dev/null 2>&1 && [[ -f pyproject.toml ]]; then
@@ -34,6 +46,7 @@ fi
 
 (
   cd "$OUTPUT_DIR"
+  sha256sum vulns.db "$KEV_FILE" "$EPSS_FILE" > sha256sums.txt
   sha256sum vulns.db > sha256sums-vulns.db.txt
 )
-echo "Wrote ${DEST} and ${OUTPUT_DIR}/sha256sums-vulns.db.txt"
+echo "Wrote ${DEST}, ${OUTPUT_DIR}/${KEV_FILE}, ${OUTPUT_DIR}/${EPSS_FILE}, and ${OUTPUT_DIR}/sha256sums.txt"

--- a/src/agent_bom/enrichment.py
+++ b/src/agent_bom/enrichment.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import csv
 import errno
+import gzip
+import io
 import json
 import logging
 import os
@@ -43,6 +46,11 @@ _logger = logging.getLogger(__name__)
 NVD_API_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
 EPSS_API_URL = "https://api.first.org/data/v1/epss"
 CISA_KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+
+# Air-gap bundle filenames (written by scripts/release/bundle-vuln-db.sh).
+_BUNDLE_KEV_FILENAME = "known_exploited_vulnerabilities.json"
+_BUNDLE_EPSS_FILENAME = "epss_scores-current.csv.gz"
+_offline_bundle_epss_loaded = False
 
 
 def _state_dir() -> Path:
@@ -105,6 +113,125 @@ def _record_enrichment_backpressure(exc: BackpressureRejectedError) -> None:
     except Exception as warning_exc:  # pragma: no cover - defensive against import cycles
         _logger.debug("Failed to record enrichment backpressure scan warning: %s", warning_exc)
     _logger.warning("External enrichment skipped by adaptive backpressure: %s", message)
+
+
+def _offline_enrichment_enabled(*, offline: bool = False) -> bool:
+    """True when scan-time or env offline flags disable network enrichment."""
+    if offline:
+        return True
+    from agent_bom.vuln_freshness import offline_env
+
+    return offline_env()
+
+
+def _vuln_db_bundle_dir() -> Path | None:
+    """Resolve the air-gap bundle directory for KEV/EPSS sidecar feeds."""
+    explicit = os.environ.get("AGENT_BOM_VULN_DB_BUNDLE_DIR", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    raw_db = os.environ.get("AGENT_BOM_DB_PATH", "").strip()
+    if raw_db:
+        return Path(raw_db).expanduser().parent
+    return None
+
+
+def _parse_kev_feed(data: dict) -> dict:
+    """Normalize a CISA KEV JSON feed into the enrichment cache shape."""
+    kev_dict: dict[str, dict] = {}
+    for vuln in data.get("vulnerabilities", []):
+        cve_id = vuln.get("cveID")
+        if cve_id:
+            kev_dict[cve_id] = {
+                "date_added": vuln.get("dateAdded"),
+                "due_date": vuln.get("dueDate"),
+                "short_description": vuln.get("shortDescription"),
+                "required_action": vuln.get("requiredAction"),
+                "vendor_project": vuln.get("vendorProject"),
+                "product": vuln.get("product"),
+            }
+    return kev_dict
+
+
+def _load_bundled_kev_catalog() -> dict:
+    """Load CISA KEV from the air-gap bundle when present."""
+    bundle_dir = _vuln_db_bundle_dir()
+    if bundle_dir is None:
+        return {}
+    path = bundle_dir / _BUNDLE_KEV_FILENAME
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+        if not isinstance(data, dict):
+            return {}
+        kev_dict = _parse_kev_feed(data)
+        if kev_dict:
+            record_enrichment_source("cisa_kev", "cache")
+        return kev_dict
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        _logger.warning("Failed to load bundled KEV catalog from %s: %s", path, exc)
+        return {}
+
+
+def _load_bundled_epss_catalog() -> dict[str, dict]:
+    """Load the full EPSS CSV export from the air-gap bundle when present."""
+    global _offline_bundle_epss_loaded  # noqa: PLW0603
+
+    bundle_dir = _vuln_db_bundle_dir()
+    if bundle_dir is None:
+        return {}
+    path = bundle_dir / _BUNDLE_EPSS_FILENAME
+    if not path.exists():
+        return {}
+
+    try:
+        raw = path.read_bytes()
+        try:
+            content = gzip.decompress(raw).decode("utf-8")
+        except OSError:
+            content = raw.decode("utf-8")
+        cached_at = path.stat().st_mtime
+        scores: dict[str, dict] = {}
+        lines = content.splitlines(keepends=True)
+        clean_content = "".join(line for line in lines if not line.startswith("#"))
+        reader = csv.DictReader(io.StringIO(clean_content))
+        for row in reader:
+            cve_id = (row.get("cve") or "").strip()
+            prob_str = (row.get("epss") or "").strip()
+            pct_str = (row.get("percentile") or "").strip()
+            if not cve_id or not prob_str:
+                continue
+            try:
+                prob = float(prob_str)
+                pct = float(pct_str) if pct_str else None
+            except ValueError:
+                continue
+            if not (0.0 <= prob <= 1.0):
+                continue
+            if pct is not None and not (0.0 <= pct <= 100.0):
+                pct = None
+            scores[cve_id] = {
+                "score": prob,
+                "percentile": pct,
+                "date": row.get("date"),
+                "_cached_at": cached_at,
+            }
+        if scores:
+            _epss_file_cache.update(scores)
+            _offline_bundle_epss_loaded = True
+            record_enrichment_source("epss", "cache")
+        return scores
+    except OSError as exc:
+        _logger.warning("Failed to load bundled EPSS catalog from %s: %s", path, exc)
+        return {}
+
+
+def _ensure_offline_bundle_epss_loaded() -> None:
+    """Load bundled EPSS once per process when offline enrichment is active."""
+    global _offline_bundle_epss_loaded  # noqa: PLW0603
+    if _offline_bundle_epss_loaded:
+        return
+    _load_bundled_epss_catalog()
 
 
 def _evict_oldest(cache: dict[str, dict], max_entries: int) -> None:
@@ -183,11 +310,13 @@ def _save_enrichment_cache() -> None:
                 _logger.warning("Failed to persist %s enrichment cache to disk: %s", name, exc)
 
 
-def _cached_epss_scores(cve_ids: list[str], *, allow_stale: bool = False) -> dict[str, dict]:
+def _cached_epss_scores(cve_ids: list[str], *, allow_stale: bool = False, offline: bool = False) -> dict[str, dict]:
     """Return EPSS entries already present in the local cache."""
     if not cve_ids:
         return {}
     _load_enrichment_cache()
+    if _offline_enrichment_enabled(offline=offline):
+        _ensure_offline_bundle_epss_loaded()
     raw_cache = dict(_epss_file_cache)
     if allow_stale:
         cache_file = _ENRICHMENT_CACHE_DIR / "epss_cache.json"
@@ -233,7 +362,7 @@ def enrichment_cache_age_hours(now: Optional[datetime] = None) -> Optional[int]:
     return int(age_seconds // 3600)
 
 
-def _cached_kev_catalog(*, allow_stale: bool = False) -> dict:
+def _cached_kev_catalog(*, allow_stale: bool = False, offline: bool = False) -> dict:
     """Return the persisted KEV catalog without making network requests."""
     global _kev_cache, _kev_cache_time
     if _kev_cache and _kev_cache_time:
@@ -242,19 +371,25 @@ def _cached_kev_catalog(*, allow_stale: bool = False) -> dict:
             record_enrichment_source("cisa_kev", "cache")
             return _kev_cache
 
-    if not _KEV_CACHE_FILE.exists():
-        return {}
-    try:
-        disk_data = json.loads(_KEV_CACHE_FILE.read_text())
-        cached_at = disk_data.get("_cached_at", 0)
-        data = disk_data.get("data") or {}
-        if data and (allow_stale or (time.time() - cached_at) < _KEV_CACHE_TTL_SECONDS):
-            _kev_cache = data
-            _kev_cache_time = datetime.fromtimestamp(cached_at, tz=timezone.utc)
-            record_enrichment_source("cisa_kev", "cache")
-            return data
-    except (OSError, json.JSONDecodeError, ValueError) as exc:
-        _logger.warning("Failed to load KEV disk cache: %s", exc)
+    if _KEV_CACHE_FILE.exists():
+        try:
+            disk_data = json.loads(_KEV_CACHE_FILE.read_text())
+            cached_at = disk_data.get("_cached_at", 0)
+            data = disk_data.get("data") or {}
+            if data and (allow_stale or (time.time() - cached_at) < _KEV_CACHE_TTL_SECONDS):
+                _kev_cache = data
+                _kev_cache_time = datetime.fromtimestamp(cached_at, tz=timezone.utc)
+                record_enrichment_source("cisa_kev", "cache")
+                return data
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            _logger.warning("Failed to load KEV disk cache: %s", exc)
+
+    if _offline_enrichment_enabled(offline=offline):
+        bundled = _load_bundled_kev_catalog()
+        if bundled:
+            _kev_cache = bundled
+            _kev_cache_time = datetime.now(timezone.utc)
+            return bundled
     return {}
 
 
@@ -462,19 +597,9 @@ async def fetch_cisa_kev_catalog(client: httpx.AsyncClient) -> dict:
     if response and response.status_code == 200:
         try:
             data = response.json()
-            kev_dict = {}
-
-            for vuln in data.get("vulnerabilities", []):
-                cve_id = vuln.get("cveID")
-                if cve_id:
-                    kev_dict[cve_id] = {
-                        "date_added": vuln.get("dateAdded"),
-                        "due_date": vuln.get("dueDate"),
-                        "short_description": vuln.get("shortDescription"),
-                        "required_action": vuln.get("requiredAction"),
-                        "vendor_project": vuln.get("vendorProject"),
-                        "product": vuln.get("product"),
-                    }
+            if not isinstance(data, dict):
+                raise ValueError(f"unexpected payload type: {type(data).__name__}")
+            kev_dict = _parse_kev_feed(data)
 
             _kev_cache = kev_dict
             _kev_cache_time = datetime.now(timezone.utc)
@@ -581,12 +706,13 @@ async def enrich_vulnerabilities(
     console.print(f"\n[bold blue]🔬 Enriching {len(cve_ids)} CVE(s) with external data...[/bold blue]\n")
 
     enriched_count = 0
+    offline_enrichment = offline or _offline_enrichment_enabled()
 
     async with create_client(timeout=30.0) as client:
         # ── Parallel enrichment: EPSS + KEV + NVD run concurrently ──
         # EPSS and KEV are single-call fetches. NVD needs CWE pre-check
         # (local, no network) then batched fetch. All three are independent.
-        if offline:
+        if offline_enrichment:
             console.print("  [cyan]→[/cyan] Joining EPSS + KEV from local offline caches...")
         else:
             console.print("  [cyan]→[/cyan] Fetching EPSS + KEV + NVD in parallel...")
@@ -594,20 +720,20 @@ async def enrich_vulnerabilities(
         async def _fetch_epss() -> dict:
             if not enable_epss:
                 return {}
-            if offline:
-                return _cached_epss_scores(cve_ids, allow_stale=True)
+            if offline_enrichment:
+                return _cached_epss_scores(cve_ids, allow_stale=True, offline=True)
             data = await fetch_epss_scores(cve_ids, client)
             return data or {}
 
         async def _fetch_kev() -> dict:
             if not enable_kev:
                 return {}
-            if offline:
-                return _cached_kev_catalog(allow_stale=True)
+            if offline_enrichment:
+                return _cached_kev_catalog(allow_stale=True, offline=True)
             return await fetch_cisa_kev_catalog(client)
 
         async def _fetch_nvd() -> tuple[dict[str, dict], int, int]:
-            if offline or not enable_nvd or not cve_ids:
+            if offline_enrichment or not enable_nvd or not cve_ids:
                 return {}, 0, 0
             # Build set of CVE IDs that already have CWE data (local check)
             cves_with_cwes: set[str] = set()

--- a/tests/test_enrichment_cache.py
+++ b/tests/test_enrichment_cache.py
@@ -21,6 +21,7 @@ def _reset_enrichment_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(enrichment, "_KEV_CACHE_FILE", tmp_path / "kev_cache.json")
     monkeypatch.setattr(enrichment, "_kev_cache", None)
     monkeypatch.setattr(enrichment, "_kev_cache_time", None)
+    monkeypatch.setattr(enrichment, "_offline_bundle_epss_loaded", False)
 
 
 class TestNVDCache:
@@ -152,3 +153,66 @@ async def test_offline_enrichment_joins_epss_and_kev_caches(tmp_path, monkeypatc
     assert vuln.is_kev is True
     assert vuln.kev_date_added == "2026-05-01"
     assert vuln.kev_due_date == "2026-05-22"
+
+
+def test_offline_kev_loads_from_bundled_path(tmp_path, monkeypatch):
+    bundle_dir = tmp_path / "airgap"
+    bundle_dir.mkdir()
+    (bundle_dir / "vulns.db").write_bytes(b"sqlite-placeholder")
+    (bundle_dir / "known_exploited_vulnerabilities.json").write_text(
+        json.dumps(
+            {
+                "vulnerabilities": [
+                    {
+                        "cveID": "CVE-2025-4242",
+                        "dateAdded": "2026-06-01",
+                        "dueDate": "2026-06-22",
+                        "shortDescription": "bundled kev entry",
+                    }
+                ]
+            }
+        )
+    )
+
+    monkeypatch.setenv("AGENT_BOM_VULN_DB_OFFLINE", "1")
+    monkeypatch.setenv("AGENT_BOM_DB_PATH", str(bundle_dir / "vulns.db"))
+
+    catalog = enrichment._cached_kev_catalog(allow_stale=True, offline=True)
+
+    assert catalog["CVE-2025-4242"]["date_added"] == "2026-06-01"
+    assert catalog["CVE-2025-4242"]["due_date"] == "2026-06-22"
+
+
+@pytest.mark.asyncio
+async def test_offline_enrichment_uses_bundled_kev_without_state_cache(tmp_path, monkeypatch):
+    bundle_dir = tmp_path / "airgap"
+    bundle_dir.mkdir()
+    (bundle_dir / "vulns.db").write_bytes(b"sqlite-placeholder")
+    (bundle_dir / "known_exploited_vulnerabilities.json").write_text(
+        json.dumps(
+            {
+                "vulnerabilities": [
+                    {
+                        "cveID": "CVE-2025-7777",
+                        "dateAdded": "2026-06-10",
+                        "dueDate": "2026-07-01",
+                    }
+                ]
+            }
+        )
+    )
+
+    monkeypatch.setenv("AGENT_BOM_VULN_DB_OFFLINE", "1")
+    monkeypatch.setenv("AGENT_BOM_DB_PATH", str(bundle_dir / "vulns.db"))
+
+    async def _no_network(*_args, **_kwargs):
+        raise AssertionError("offline bundled KEV must not perform network requests")
+
+    monkeypatch.setattr(enrichment, "request_with_retry", _no_network)
+
+    vuln = Vulnerability(id="CVE-2025-7777", summary="bundled kev", severity=Severity.HIGH)
+    enriched = await enrichment.enrich_vulnerabilities([vuln])
+
+    assert enriched == 1
+    assert vuln.is_kev is True
+    assert vuln.kev_date_added == "2026-06-10"


### PR DESCRIPTION
## Summary
- Extend `scripts/release/bundle-vuln-db.sh` to download CISA KEV JSON and FIRST EPSS CSV.gz alongside `vulns.db`, with a combined `sha256sums.txt` in `dist/airgap/`.
- Wire offline enrichment to read bundled KEV/EPSS sidecar feeds when `AGENT_BOM_VULN_DB_OFFLINE=1` (or `--offline`), resolving the bundle directory from `AGENT_BOM_VULN_DB_BUNDLE_DIR` or the parent of `AGENT_BOM_DB_PATH`.
- Document air-gap bundle verification in `docs/RELEASE_VERIFICATION.md`.

## Test plan
- [x] `uv run pytest -q tests/test_enrichment_cache.py::test_offline_kev_loads_from_bundled_path`
- [x] `uv run pytest -q tests/test_enrichment_cache.py`
- [x] `uv run ruff check src/agent_bom/enrichment.py tests/test_enrichment_cache.py`


Made with [Cursor](https://cursor.com)