### PR TITLE
feat(api): finding lifecycle L1 — monotone current-state merge (#3465)

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -119,6 +119,18 @@
             "title": "Metadata",
             "type": "object"
           },
+          "observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Observation timestamp from scan completion; defaults to ingest time when omitted.",
+            "title": "Observed At"
+          },
           "schema_version": {
             "default": "v1",
             "maxLength": 32,

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -86,6 +86,13 @@ components:
           additionalProperties: true
           title: Metadata
           type: object
+        observed_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Observation timestamp from scan completion; defaults to ingest
+            time when omitted.
+          title: Observed At
         schema_version:
           default: v1
           maxLength: 32

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -211,6 +211,134 @@ class ComplianceHubStore(Protocol):
         """Remove all findings for a tenant. Returns the number removed."""
         ...
 
+    def upsert_current_batch(
+        self,
+        tenant_id: str,
+        findings: list[dict[str, Any]],
+        *,
+        observed_at: str,
+        batch_id: str,
+        source: str = "",
+    ) -> None:
+        """Merge findings into the current-state lifecycle table (#3465 L1)."""
+        ...
+
+    def get_current(self, tenant_id: str, canonical_id: str) -> dict[str, Any] | None:
+        """Return one current-state lifecycle row for tests and diagnostics."""
+        ...
+
+
+def _upsert_current_finding_sqlite(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    payload: dict[str, Any],
+    observed_at: str,
+    source: str,
+) -> None:
+    from agent_bom.api.finding_lifecycle import (
+        apply_observation_to_current,
+        lifecycle_metrics,
+        resolve_canonical_id,
+    )
+
+    canonical = resolve_canonical_id(payload, source=source)
+    metrics = lifecycle_metrics(payload)
+    now = _now_utc_iso()
+    payload_json = json.dumps(payload, sort_keys=True)
+    inserted = conn.execute(
+        """
+        INSERT OR IGNORE INTO hub_findings_current_observations
+            (tenant_id, canonical_id, observed_at)
+        VALUES (?, ?, ?)
+        """,
+        (tenant_id, canonical, observed_at),
+    ).rowcount
+    if not inserted:
+        return
+
+    existing_row = conn.execute(
+        """
+        SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
+               cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+               updated_at, payload
+        FROM hub_findings_current
+        WHERE tenant_id = ? AND canonical_id = ?
+        """,
+        (tenant_id, canonical),
+    ).fetchone()
+    existing: dict[str, Any] | None
+    if existing_row is None:
+        existing = None
+    else:
+        existing = {
+            "canonical_id": existing_row[0],
+            "first_seen": existing_row[1],
+            "last_seen": existing_row[2],
+            "status": existing_row[3],
+            "severity": existing_row[4],
+            "severity_rank": existing_row[5],
+            "cvss_score": existing_row[6],
+            "effective_reach_score": existing_row[7],
+            "scan_count": existing_row[8],
+            "resolved_at": existing_row[9],
+            "reopened_at": existing_row[10],
+            "updated_at": existing_row[11],
+            "payload": json.loads(existing_row[12]),
+        }
+    merged = apply_observation_to_current(
+        existing,
+        canonical_id=canonical,
+        observed_at=observed_at,
+        metrics=metrics,
+        payload=payload,
+        updated_at=now,
+    )
+    conn.execute(
+        """
+        INSERT INTO hub_findings_current
+            (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
+             cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+             updated_at, payload)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(tenant_id, canonical_id) DO UPDATE SET
+            first_seen = MIN(hub_findings_current.first_seen, excluded.first_seen),
+            last_seen = MAX(hub_findings_current.last_seen, excluded.last_seen),
+            status = excluded.status,
+            severity = excluded.severity,
+            severity_rank = excluded.severity_rank,
+            cvss_score = excluded.cvss_score,
+            effective_reach_score = excluded.effective_reach_score,
+            scan_count = excluded.scan_count,
+            resolved_at = excluded.resolved_at,
+            reopened_at = excluded.reopened_at,
+            updated_at = excluded.updated_at,
+            payload = excluded.payload
+        """,
+        (
+            tenant_id,
+            canonical,
+            merged["first_seen"],
+            merged["last_seen"],
+            merged["status"],
+            merged["severity"],
+            merged["severity_rank"],
+            merged["cvss_score"],
+            merged["effective_reach_score"],
+            merged["scan_count"],
+            merged["resolved_at"],
+            merged["reopened_at"],
+            merged["updated_at"],
+            payload_json,
+        ),
+    )
+
+
+def _ensure_current_lifecycle_sqlite(conn: sqlite3.Connection) -> None:
+    from agent_bom.api.finding_lifecycle import _CURRENT_LIFECYCLE_SQLITE_DDL
+
+    conn.executescript(_CURRENT_LIFECYCLE_SQLITE_DDL)
+
 
 # ─── In-memory backend ──────────────────────────────────────────────────────
 
@@ -224,6 +352,8 @@ class InMemoryComplianceHubStore:
         # (tenant_id, finding_id) refreshes its row in place instead of
         # appending a duplicate (idempotent ingest, mirrors the SQL backends).
         self._slots: dict[str, dict[str, int]] = {}
+        self._current: dict[str, dict[str, dict[str, Any]]] = {}
+        self._current_observations: dict[str, set[tuple[str, str]]] = {}
         self._lock = threading.Lock()
 
     def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
@@ -294,11 +424,54 @@ class InMemoryComplianceHubStore:
             removed = len(self._by_tenant.get(tenant_id, []))
             self._by_tenant[tenant_id] = []
             self._slots[tenant_id] = {}
+            self._current.pop(tenant_id, None)
+            self._current_observations.pop(tenant_id, None)
         if removed:
             from agent_bom.api.findings_count_cache import invalidate_tenant
 
             invalidate_tenant(tenant_id)
         return removed
+
+    def upsert_current_batch(
+        self,
+        tenant_id: str,
+        findings: list[dict[str, Any]],
+        *,
+        observed_at: str,
+        batch_id: str,
+        source: str = "",
+    ) -> None:
+        from agent_bom.api.finding_lifecycle import (
+            apply_observation_to_current,
+            lifecycle_metrics,
+            resolve_canonical_id,
+        )
+
+        clean = _redact_findings(findings)
+        now = _now_utc_iso()
+        with self._lock:
+            current = self._current.setdefault(tenant_id, {})
+            observations = self._current_observations.setdefault(tenant_id, set())
+            for payload in clean:
+                canonical = resolve_canonical_id(payload, source=source)
+                obs_key = (canonical, observed_at)
+                if obs_key in observations:
+                    continue
+                observations.add(obs_key)
+                merged = apply_observation_to_current(
+                    current.get(canonical),
+                    canonical_id=canonical,
+                    observed_at=observed_at,
+                    metrics=lifecycle_metrics(payload),
+                    payload=payload,
+                    updated_at=now,
+                )
+                current[canonical] = merged
+
+    def get_current(self, tenant_id: str, canonical_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._current.get(tenant_id, {}).get(canonical_id)
+            return dict(row) if row else None
 
 
 # ─── SQLite backend ─────────────────────────────────────────────────────────
@@ -404,6 +577,7 @@ class SQLiteComplianceHubStore:
         self._migrate_primary_key()
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_order ON compliance_hub_findings(tenant_id, ordinal)")
         self._ensure_scale_indexes()
+        _ensure_current_lifecycle_sqlite(self._conn)
         self._conn.commit()
 
     def _migrate_columns(self) -> None:
@@ -679,6 +853,8 @@ class SQLiteComplianceHubStore:
             "DELETE FROM compliance_hub_findings WHERE tenant_id = ?",
             (tenant_id,),
         )
+        self._conn.execute("DELETE FROM hub_findings_current WHERE tenant_id = ?", (tenant_id,))
+        self._conn.execute("DELETE FROM hub_findings_current_observations WHERE tenant_id = ?", (tenant_id,))
         self._conn.commit()
         removed = cur.rowcount or 0
         if removed:
@@ -686,6 +862,57 @@ class SQLiteComplianceHubStore:
 
             invalidate_tenant(tenant_id)
         return removed
+
+    def upsert_current_batch(
+        self,
+        tenant_id: str,
+        findings: list[dict[str, Any]],
+        *,
+        observed_at: str,
+        batch_id: str,
+        source: str = "",
+    ) -> None:
+        clean = _redact_findings(findings)
+        if not clean:
+            return
+        for payload in clean:
+            _upsert_current_finding_sqlite(
+                self._conn,
+                tenant_id=tenant_id,
+                payload=payload,
+                observed_at=observed_at,
+                source=source,
+            )
+        self._conn.commit()
+
+    def get_current(self, tenant_id: str, canonical_id: str) -> dict[str, Any] | None:
+        row = self._conn.execute(
+            """
+            SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
+                   cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+                   updated_at, payload
+            FROM hub_findings_current
+            WHERE tenant_id = ? AND canonical_id = ?
+            """,
+            (tenant_id, canonical_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "canonical_id": row[0],
+            "first_seen": row[1],
+            "last_seen": row[2],
+            "status": row[3],
+            "severity": row[4],
+            "severity_rank": row[5],
+            "cvss_score": row[6],
+            "effective_reach_score": row[7],
+            "scan_count": row[8],
+            "resolved_at": row[9],
+            "reopened_at": row[10],
+            "updated_at": row[11],
+            "payload": json.loads(row[12]),
+        }
 
 
 # ─── Module-level access (set/reset wired in stores.py) ──────────────────────

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any, Protocol
 
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
@@ -129,7 +129,7 @@ def _framework_slug_counts_from_rows(rows: Iterable[dict[str, Any]]) -> dict[str
     return counts
 
 
-def _redact_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _redact_findings(findings: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
     """Drop tier-B fields before any compliance-hub finding is stored.
 
     The hub is a tier-A sink — findings are exported, queried by auditors,
@@ -214,7 +214,7 @@ class ComplianceHubStore(Protocol):
     def upsert_current_batch(
         self,
         tenant_id: str,
-        findings: list[dict[str, Any]],
+        findings: Sequence[dict[str, Any]],
         *,
         observed_at: str,
         batch_id: str,
@@ -435,7 +435,7 @@ class InMemoryComplianceHubStore:
     def upsert_current_batch(
         self,
         tenant_id: str,
-        findings: list[dict[str, Any]],
+        findings: Sequence[dict[str, Any]],
         *,
         observed_at: str,
         batch_id: str,
@@ -866,7 +866,7 @@ class SQLiteComplianceHubStore:
     def upsert_current_batch(
         self,
         tenant_id: str,
-        findings: list[dict[str, Any]],
+        findings: Sequence[dict[str, Any]],
         *,
         observed_at: str,
         batch_id: str,

--- a/src/agent_bom/api/finding_lifecycle.py
+++ b/src/agent_bom/api/finding_lifecycle.py
@@ -1,0 +1,203 @@
+"""Monotone current-state merge for hub findings (#3465 L1).
+
+One row per ``(tenant_id, canonical_id)`` with ``first_seen`` / ``last_seen``
+driven by ``observed_at``. Duplicate observations — same canonical id and
+``observed_at`` — are no-ops for lifecycle fields; ``scan_count`` advances only
+when a new observation timestamp is recorded (L2 will gate on occurrence log).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from agent_bom.api.compliance_hub_store import _severity_rank, compute_effective_reach_score
+from agent_bom.canonical_ids import canonical_finding_id, canonical_id
+
+FindingLifecycleMetrics = dict[str, Any]
+
+
+def normalize_observed_at(value: str | datetime | None) -> str:
+    """Return a UTC ISO-8601 timestamp suitable for monotone comparisons."""
+    if value is None or value == "":
+        return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    if isinstance(value, datetime):
+        dt = value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+        return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    text = str(value).strip()
+    if text.endswith("Z"):
+        return text
+    if "+" in text[10:] or text.endswith("+00:00"):
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            return parsed.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        except ValueError:
+            return text
+    return text
+
+
+def resolve_canonical_id(payload: dict[str, Any], *, source: str = "") -> str:
+    """Return the stable canonical id for a hub finding payload."""
+    explicit = payload.get("canonical_id") or payload.get("id")
+    if explicit:
+        return str(explicit)
+
+    raw_asset = payload.get("asset")
+    asset = raw_asset if isinstance(raw_asset, dict) else {}
+    asset_stable = asset.get("stable_id") or asset.get("canonical_id")
+    if not asset_stable:
+        asset_type = str(asset.get("asset_type") or "external")
+        identifier = asset.get("identifier") or f"{asset.get('name', '')}:{asset.get('location') or ''}"
+        asset_stable = canonical_id(asset_type, identifier)
+
+    rule = (
+        payload.get("vulnerability_id")
+        or payload.get("cve_id")
+        or payload.get("rule_id")
+        or payload.get("title")
+        or ""
+    )
+    location = payload.get("location") or payload.get("file_path") or asset.get("location") or ""
+    package = payload.get("package") or payload.get("package_name") or asset.get("name") or asset.get("identifier") or ""
+    pkg_version = str(payload.get("package_version") or "")
+    if source and not payload.get("asset"):
+        return canonical_finding_id(source, str(rule), str(location), str(package))
+    return canonical_finding_id(str(asset_stable), str(rule), str(package), pkg_version, str(location))
+
+
+def lifecycle_metrics(payload: dict[str, Any]) -> FindingLifecycleMetrics:
+    """Extract denormalised lifecycle columns from a finding payload."""
+    severity = str(payload.get("severity") or "unknown").lower()
+    cvss_raw = payload.get("cvss_score")
+    cvss_score: float | None
+    try:
+        cvss_score = float(cvss_raw) if cvss_raw is not None else None
+    except (TypeError, ValueError):
+        cvss_score = None
+    return {
+        "severity": severity,
+        "severity_rank": _severity_rank(payload),
+        "cvss_score": cvss_score,
+        "effective_reach_score": compute_effective_reach_score(payload),
+    }
+
+
+def merge_status_on_observation(existing_status: str | None, *, is_new_row: bool) -> str:
+    """Apply reopen semantics when a resolved finding is observed again."""
+    if is_new_row or not existing_status:
+        return "open"
+    if existing_status == "resolved":
+        return "reopened"
+    return existing_status
+
+
+def apply_observation_to_current(
+    existing: dict[str, Any] | None,
+    *,
+    canonical_id: str,
+    observed_at: str,
+    metrics: FindingLifecycleMetrics,
+    payload: dict[str, Any],
+    updated_at: str,
+) -> dict[str, Any]:
+    """Return the merged current-state row after a new observation timestamp."""
+    if existing is None:
+        return {
+            "canonical_id": canonical_id,
+            "first_seen": observed_at,
+            "last_seen": observed_at,
+            "status": "open",
+            "severity": metrics["severity"],
+            "severity_rank": metrics["severity_rank"],
+            "cvss_score": metrics["cvss_score"],
+            "effective_reach_score": metrics["effective_reach_score"],
+            "scan_count": 1,
+            "resolved_at": None,
+            "reopened_at": None,
+            "updated_at": updated_at,
+            "payload": payload,
+        }
+
+    prior_status = str(existing.get("status") or "open")
+    first_seen = observed_at if observed_at < str(existing["first_seen"]) else str(existing["first_seen"])
+    last_seen = observed_at if observed_at > str(existing["last_seen"]) else str(existing["last_seen"])
+    reopened_at = existing.get("reopened_at")
+    if prior_status == "resolved":
+        reopened_at = observed_at
+    return {
+        "canonical_id": canonical_id,
+        "first_seen": first_seen,
+        "last_seen": last_seen,
+        "status": merge_status_on_observation(prior_status, is_new_row=False),
+        "severity": metrics["severity"],
+        "severity_rank": metrics["severity_rank"],
+        "cvss_score": metrics["cvss_score"],
+        "effective_reach_score": metrics["effective_reach_score"],
+        "scan_count": int(existing.get("scan_count") or 0) + 1,
+        "resolved_at": existing.get("resolved_at"),
+        "reopened_at": reopened_at,
+        "updated_at": updated_at,
+        "payload": payload,
+    }
+
+
+_CURRENT_LIFECYCLE_SQLITE_DDL = """
+CREATE TABLE IF NOT EXISTS hub_findings_current (
+    tenant_id TEXT NOT NULL,
+    canonical_id TEXT NOT NULL,
+    first_seen TEXT NOT NULL,
+    last_seen TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'open',
+    severity TEXT NOT NULL DEFAULT '',
+    severity_rank INTEGER NOT NULL DEFAULT 0,
+    cvss_score REAL,
+    effective_reach_score REAL NOT NULL DEFAULT 0,
+    scan_count INTEGER NOT NULL DEFAULT 1,
+    resolved_at TEXT,
+    reopened_at TEXT,
+    updated_at TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, canonical_id)
+);
+
+CREATE TABLE IF NOT EXISTS hub_findings_current_observations (
+    tenant_id TEXT NOT NULL,
+    canonical_id TEXT NOT NULL,
+    observed_at TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, canonical_id, observed_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_last_seen
+    ON hub_findings_current(tenant_id, last_seen DESC);
+"""
+
+
+_CURRENT_LIFECYCLE_POSTGRES_DDL = """
+CREATE TABLE IF NOT EXISTS hub_findings_current (
+    tenant_id TEXT NOT NULL,
+    canonical_id TEXT NOT NULL,
+    first_seen TEXT NOT NULL,
+    last_seen TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'open',
+    severity TEXT NOT NULL DEFAULT '',
+    severity_rank INTEGER NOT NULL DEFAULT 0,
+    cvss_score DOUBLE PRECISION,
+    effective_reach_score DOUBLE PRECISION NOT NULL DEFAULT 0,
+    scan_count INTEGER NOT NULL DEFAULT 1,
+    resolved_at TEXT,
+    reopened_at TEXT,
+    updated_at TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    PRIMARY KEY (tenant_id, canonical_id)
+);
+
+CREATE TABLE IF NOT EXISTS hub_findings_current_observations (
+    tenant_id TEXT NOT NULL,
+    canonical_id TEXT NOT NULL,
+    observed_at TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, canonical_id, observed_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_last_seen
+    ON hub_findings_current(tenant_id, last_seen DESC);
+"""

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -9,6 +9,7 @@ share ingested findings across replicas.
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from typing import Any
 
 from agent_bom.api.compliance_hub_store import (
@@ -320,7 +321,7 @@ class PostgresComplianceHubStore:
     def upsert_current_batch(
         self,
         tenant_id: str,
-        findings: list[dict[str, Any]],
+        findings: Sequence[dict[str, Any]],
         *,
         observed_at: str,
         batch_id: str,

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -100,6 +100,11 @@ class PostgresComplianceHubStore:
                 "ON compliance_hub_findings(tenant_id, origin, cvss_score DESC, ordinal)"
             )
             _ensure_tenant_rls(conn, "compliance_hub_findings", "tenant_id")
+            from agent_bom.api.finding_lifecycle import _CURRENT_LIFECYCLE_POSTGRES_DDL
+
+            conn.execute(_CURRENT_LIFECYCLE_POSTGRES_DDL)
+            _ensure_tenant_rls(conn, "hub_findings_current", "tenant_id")
+            _ensure_tenant_rls(conn, "hub_findings_current_observations", "tenant_id")
             conn.commit()
 
     @staticmethod
@@ -302,6 +307,8 @@ class PostgresComplianceHubStore:
                 "DELETE FROM compliance_hub_findings WHERE tenant_id = %s",
                 (tenant_id,),
             )
+            conn.execute("DELETE FROM hub_findings_current WHERE tenant_id = %s", (tenant_id,))
+            conn.execute("DELETE FROM hub_findings_current_observations WHERE tenant_id = %s", (tenant_id,))
             conn.commit()
         removed = cur.rowcount or 0
         if removed:
@@ -309,3 +316,146 @@ class PostgresComplianceHubStore:
 
             invalidate_tenant(tenant_id)
         return removed
+
+    def upsert_current_batch(
+        self,
+        tenant_id: str,
+        findings: list[dict[str, Any]],
+        *,
+        observed_at: str,
+        batch_id: str,
+        source: str = "",
+    ) -> None:
+        from agent_bom.api.finding_lifecycle import (
+            apply_observation_to_current,
+            lifecycle_metrics,
+            resolve_canonical_id,
+        )
+
+        clean = _redact_findings(findings)
+        if not clean:
+            return
+        now = _now_utc_iso()
+        with _tenant_connection(self._pool) as conn:
+            for payload in clean:
+                canonical = resolve_canonical_id(payload, source=source)
+                metrics = lifecycle_metrics(payload)
+                inserted = conn.execute(
+                    """
+                    INSERT INTO hub_findings_current_observations
+                        (tenant_id, canonical_id, observed_at)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT DO NOTHING
+                    """,
+                    (tenant_id, canonical, observed_at),
+                ).rowcount
+                if not inserted:
+                    continue
+                existing_row = conn.execute(
+                    """
+                    SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
+                           cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+                           updated_at, payload
+                    FROM hub_findings_current
+                    WHERE tenant_id = %s AND canonical_id = %s
+                    """,
+                    (tenant_id, canonical),
+                ).fetchone()
+                existing: dict[str, Any] | None
+                if existing_row is None:
+                    existing = None
+                else:
+                    raw_payload = existing_row[12]
+                    existing = {
+                        "canonical_id": existing_row[0],
+                        "first_seen": existing_row[1],
+                        "last_seen": existing_row[2],
+                        "status": existing_row[3],
+                        "severity": existing_row[4],
+                        "severity_rank": existing_row[5],
+                        "cvss_score": existing_row[6],
+                        "effective_reach_score": existing_row[7],
+                        "scan_count": existing_row[8],
+                        "resolved_at": existing_row[9],
+                        "reopened_at": existing_row[10],
+                        "updated_at": existing_row[11],
+                        "payload": raw_payload if isinstance(raw_payload, dict) else json.loads(raw_payload),
+                    }
+                merged = apply_observation_to_current(
+                    existing,
+                    canonical_id=canonical,
+                    observed_at=observed_at,
+                    metrics=metrics,
+                    payload=payload,
+                    updated_at=now,
+                )
+                conn.execute(
+                    """
+                    INSERT INTO hub_findings_current
+                        (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
+                         cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+                         updated_at, payload)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb)
+                    ON CONFLICT (tenant_id, canonical_id) DO UPDATE SET
+                        first_seen = LEAST(hub_findings_current.first_seen, EXCLUDED.first_seen),
+                        last_seen = GREATEST(hub_findings_current.last_seen, EXCLUDED.last_seen),
+                        status = EXCLUDED.status,
+                        severity = EXCLUDED.severity,
+                        severity_rank = EXCLUDED.severity_rank,
+                        cvss_score = EXCLUDED.cvss_score,
+                        effective_reach_score = EXCLUDED.effective_reach_score,
+                        scan_count = EXCLUDED.scan_count,
+                        resolved_at = EXCLUDED.resolved_at,
+                        reopened_at = EXCLUDED.reopened_at,
+                        updated_at = EXCLUDED.updated_at,
+                        payload = EXCLUDED.payload
+                    """,
+                    (
+                        tenant_id,
+                        canonical,
+                        merged["first_seen"],
+                        merged["last_seen"],
+                        merged["status"],
+                        merged["severity"],
+                        merged["severity_rank"],
+                        merged["cvss_score"],
+                        merged["effective_reach_score"],
+                        merged["scan_count"],
+                        merged["resolved_at"],
+                        merged["reopened_at"],
+                        merged["updated_at"],
+                        json.dumps(merged["payload"], sort_keys=True),
+                    ),
+                )
+            conn.commit()
+
+    def get_current(self, tenant_id: str, canonical_id: str) -> dict[str, Any] | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                """
+                SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
+                       cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+                       updated_at, payload
+                FROM hub_findings_current
+                WHERE tenant_id = %s AND canonical_id = %s
+                """,
+                (tenant_id, canonical_id),
+            ).fetchone()
+        if row is None:
+            return None
+        raw_payload = row[12]
+        return {
+            "canonical_id": row[0],
+            "first_seen": row[1],
+            "last_seen": row[2],
+            "status": row[3],
+            "severity": row[4],
+            "severity_rank": row[5],
+            "cvss_score": row[6],
+            "effective_reach_score": row[7],
+            "scan_count": row[8],
+            "resolved_at": row[9],
+            "reopened_at": row[10],
+            "updated_at": row[11],
+            "payload": raw_payload if isinstance(raw_payload, dict) else json.loads(raw_payload),
+        }

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -20,6 +20,7 @@ import json
 import logging
 import os
 import secrets
+import uuid
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast
 
@@ -1867,7 +1868,18 @@ async def ingest_compliance_findings(request: Request) -> dict:
             payload["applicable_frameworks"] = [normalize_framework_slug(str(slug)) for slug in frameworks if slug]
     tenant_id = _tenant_id(request)
     store = get_compliance_hub_store()
+    from agent_bom.api.finding_lifecycle import normalize_observed_at
+
+    observed_at = normalize_observed_at(body.get("observed_at"))
+    batch_id = str(uuid.uuid4())
     new_total = store.add(tenant_id, payloads)
+    store.upsert_current_batch(
+        tenant_id,
+        payloads,
+        observed_at=observed_at,
+        batch_id=batch_id,
+        source=fmt,
+    )
 
     framework_counts: dict[str, int] = {}
     for payload in payloads:
@@ -1878,6 +1890,7 @@ async def ingest_compliance_findings(request: Request) -> dict:
         "ingested": len(payloads),
         "tenant_total": new_total,
         "format": fmt,
+        "observed_at": observed_at,
         "framework_hits": dict(sorted(framework_counts.items())),
     }
 

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -255,6 +255,10 @@ class BulkFindingsRequest(BaseModel):
     schema_version: str = Field(default="v1", min_length=1, max_length=32)
     metadata: dict[str, Any] = Field(default_factory=dict)
     tenant_id: str | None = Field(default=None, description="Deprecated compatibility field; request tenant scope is authoritative.")
+    observed_at: str | None = Field(
+        default=None,
+        description="Observation timestamp from scan completion; defaults to ingest time when omitted.",
+    )
 
     @field_validator("findings")
     @classmethod
@@ -1419,7 +1423,18 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
     payloads = [
         _normalized_bulk_finding(row, source=body.source, batch_id=batch_id, ordinal=idx) for idx, row in enumerate(body.findings, start=1)
     ]
-    new_total = get_compliance_hub_store().add(tenant_id, payloads)
+    from agent_bom.api.finding_lifecycle import normalize_observed_at
+
+    observed_at = normalize_observed_at(body.observed_at or body.metadata.get("observed_at"))
+    hub_store = get_compliance_hub_store()
+    new_total = hub_store.add(tenant_id, payloads)
+    hub_store.upsert_current_batch(
+        tenant_id,
+        payloads,
+        observed_at=observed_at,
+        batch_id=batch_id,
+        source=body.source,
+    )
     warnings = ["tenant_id in body ignored; request tenant scope is authoritative"] if ignored_body_tenant else []
     response = {
         "schema_version": "v1",
@@ -1428,6 +1443,7 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
         "tenant_total": new_total,
         "tenant_id": tenant_id,
         "source": body.source,
+        "observed_at": observed_at,
         "warnings": warnings,
     }
     if idem_key:

--- a/tests/test_finding_lifecycle.py
+++ b/tests/test_finding_lifecycle.py
@@ -1,0 +1,148 @@
+"""Monotone current-state finding lifecycle (#3465 L1)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from agent_bom.api.compliance_hub_store import (
+    InMemoryComplianceHubStore,
+    SQLiteComplianceHubStore,
+    reset_compliance_hub_store,
+    set_compliance_hub_store,
+)
+from agent_bom.api.finding_lifecycle import resolve_canonical_id
+from agent_bom.api.server import app
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+MON = "2026-07-07T12:00:00Z"
+TUE = "2026-07-08T12:00:00Z"
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+def hub_store(request: pytest.FixtureRequest, tmp_path):
+    if request.param == "memory":
+        return InMemoryComplianceHubStore()
+    return SQLiteComplianceHubStore(str(tmp_path / "lifecycle.db"))
+
+
+def _sample_finding() -> dict:
+    return {
+        "id": "finding-lifecycle-1",
+        "title": "Reachable secret in MCP tool",
+        "severity": "high",
+        "source": "agent-runtime",
+        "origin": "bulk_ingest",
+    }
+
+
+def test_monotone_merge_timestamps(hub_store) -> None:
+    tenant = f"lifecycle-{uuid4().hex}"
+    finding = _sample_finding()
+    canonical = resolve_canonical_id(finding)
+
+    hub_store.upsert_current_batch(tenant, [finding], observed_at=MON, batch_id="batch-mon-1")
+    row = hub_store.get_current(tenant, canonical)
+    assert row is not None
+    assert row["first_seen"] == MON
+    assert row["last_seen"] == MON
+    assert row["scan_count"] == 1
+    assert row["status"] == "open"
+
+    hub_store.upsert_current_batch(tenant, [finding], observed_at=MON, batch_id="batch-mon-2")
+    retry = hub_store.get_current(tenant, canonical)
+    assert retry is not None
+    assert retry["first_seen"] == MON
+    assert retry["last_seen"] == MON
+    assert retry["scan_count"] == 1
+
+    hub_store.upsert_current_batch(tenant, [finding], observed_at=TUE, batch_id="batch-tue-1")
+    advanced = hub_store.get_current(tenant, canonical)
+    assert advanced is not None
+    assert advanced["first_seen"] == MON
+    assert advanced["last_seen"] == TUE
+    assert advanced["scan_count"] == 2
+
+    hub_store.upsert_current_batch(tenant, [finding], observed_at=TUE, batch_id="batch-tue-2")
+    retry_tue = hub_store.get_current(tenant, canonical)
+    assert retry_tue is not None
+    assert retry_tue["first_seen"] == MON
+    assert retry_tue["last_seen"] == TUE
+    assert retry_tue["scan_count"] == 2
+
+
+def test_bulk_ingest_carries_observed_at() -> None:
+    from starlette.testclient import TestClient
+
+    tenant = f"bulk-observed-{uuid4().hex}"
+    store = InMemoryComplianceHubStore()
+    set_compliance_hub_store(store)
+    client = TestClient(app)
+    client.headers.update(proxy_headers(role="analyst", tenant=tenant))
+
+    resp = client.post(
+        "/v1/findings/bulk",
+        json={
+            "source": "agent-runtime",
+            "observed_at": MON,
+            "findings": [_sample_finding()],
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["observed_at"] == MON
+
+    canonical = resolve_canonical_id(_sample_finding())
+    row = store.get_current(tenant, canonical)
+    assert row is not None
+    assert row["first_seen"] == MON
+    assert row["last_seen"] == MON
+
+    reset_compliance_hub_store()
+
+
+def _mark_resolved(store, tenant: str, canonical: str, resolved_at: str) -> None:
+    if isinstance(store, InMemoryComplianceHubStore):
+        row = store.get_current(tenant, canonical)
+        assert row is not None
+        row = dict(row)
+        row["status"] = "resolved"
+        row["resolved_at"] = resolved_at
+        store._current[tenant][canonical] = row
+        return
+    row = store.get_current(tenant, canonical)
+    assert row is not None
+    store._conn.execute(
+        """
+        UPDATE hub_findings_current
+        SET status = 'resolved', resolved_at = ?
+        WHERE tenant_id = ? AND canonical_id = ?
+        """,
+        (resolved_at, tenant, canonical),
+    )
+    store._conn.commit()
+
+
+def test_reopen_on_resolved_observation(hub_store) -> None:
+    tenant = f"reopen-{uuid4().hex}"
+    finding = _sample_finding()
+    canonical = resolve_canonical_id(finding)
+
+    hub_store.upsert_current_batch(tenant, [finding], observed_at=MON, batch_id="batch-mon")
+    _mark_resolved(hub_store, tenant, canonical, MON)
+
+    hub_store.upsert_current_batch(tenant, [finding], observed_at=TUE, batch_id="batch-tue")
+    reopened = hub_store.get_current(tenant, canonical)
+    assert reopened is not None
+    assert reopened["status"] == "reopened"
+    assert reopened["reopened_at"] == TUE
+    assert reopened["last_seen"] == TUE


### PR DESCRIPTION
## Summary
- Add `hub_findings_current` + `hub_findings_current_observations` tables with monotone merge (`first_seen=LEAST`, `last_seen=GREATEST`, severity latest-wins, reopen on resolved).
- Wire `/v1/findings/bulk` and `/v1/compliance/ingest` to carry `observed_at` and upsert current-state alongside existing `compliance_hub_findings` ledger.
- Deduplicate retries on `(tenant_id, canonical_id, observed_at)` so `scan_count` advances only for new observation timestamps (L2 occurrence log follows).

## Test plan
- [x] `uv run pytest tests/test_finding_lifecycle.py -q`
- [x] `uv run pytest tests/test_findings_bulk_api.py tests/test_ingest_idempotency.py -q`
- [x] `uv run ruff check` on touched files


Made with [Cursor](https://cursor.com)