### PR TITLE
fix(api): batch cap returns 422 and index filtered severity+cvss reads (#3474)

### DIFF
--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -518,6 +518,10 @@ class SQLiteComplianceHubStore:
             "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin_cvss "
             "ON compliance_hub_findings(tenant_id, origin, cvss_score DESC, ordinal)"
         )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin_severity_cvss "
+            "ON compliance_hub_findings(tenant_id, origin, severity_rank, cvss_score DESC, ordinal)"
+        )
 
     def _next_ordinal(self, tenant_id: str) -> int:
         row = self._conn.execute(
@@ -604,8 +608,8 @@ class SQLiteComplianceHubStore:
             where.append("origin = ?")
             params.append(origin)
         if severity is not None:
-            where.append("LOWER(json_extract(payload, '$.severity')) = ?")
-            params.append(severity.lower())
+            where.append("severity_rank = ?")
+            params.append(severity_policy_rank(severity))
         if scan_id is not None:
             where.append("CAST(json_extract(payload, '$.scan_id') AS TEXT) = ?")
             params.append(scan_id)

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1903,6 +1903,24 @@ def _error_message_for(status_code: int, detail: object) -> str:
     }.get(status_code, "Request failed")
 
 
+def _json_safe_validation_errors(errors: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Make Pydantic validation errors JSON-serializable.
+
+    ``model_validator`` failures embed a live ``ValueError`` in ``ctx['error']``;
+    serializing that verbatim blows up the 422 envelope and surfaces as 500.
+    """
+    safe: list[dict[str, object]] = []
+    for err in errors:
+        item = dict(err)
+        ctx = item.get("ctx")
+        if isinstance(ctx, dict):
+            item["ctx"] = {
+                key: str(value) if isinstance(value, BaseException) else value for key, value in ctx.items()
+            }
+        safe.append(item)
+    return safe
+
+
 def _build_error_envelope(
     *,
     status_code: int,
@@ -1962,7 +1980,7 @@ def install_error_envelope(application: object) -> None:
     async def validation_exception_handler(request: StarletteRequest, exc: RequestValidationError):
         return _build_error_envelope(
             status_code=422,
-            detail=exc.errors(),
+            detail=_json_safe_validation_errors(exc.errors()),
             correlation_id=_correlation_id(request),
         )
 

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -99,6 +99,10 @@ class PostgresComplianceHubStore:
                 "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin_cvss "
                 "ON compliance_hub_findings(tenant_id, origin, cvss_score DESC, ordinal)"
             )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin_severity_cvss "
+                "ON compliance_hub_findings(tenant_id, origin, severity_rank, cvss_score DESC, ordinal)"
+            )
             _ensure_tenant_rls(conn, "compliance_hub_findings", "tenant_id")
             conn.commit()
 
@@ -220,8 +224,10 @@ class PostgresComplianceHubStore:
             where.append("origin = %s")
             params.append(origin)
         if severity is not None:
-            where.append("LOWER(payload->>'severity') = %s")
-            params.append(severity.lower())
+            from agent_bom.graph.severity import severity_policy_rank
+
+            where.append("severity_rank = %s")
+            params.append(severity_policy_rank(severity))
         if scan_id is not None:
             where.append("payload->>'scan_id' = %s")
             params.append(scan_id)

--- a/tests/test_api_data_p1_batch_v0867.py
+++ b/tests/test_api_data_p1_batch_v0867.py
@@ -129,6 +129,26 @@ def test_p1_18_error_envelope_for_validation(fresh_client):
     assert body["error"]["correlation_id"]
 
 
+def test_p1_18_validation_envelope_serializes_model_validator_value_error(fresh_client):
+    """Scan batch cap uses a model_validator ValueError; ctx must stringify."""
+    from agent_bom.config import API_MAX_BATCH_SCAN_TARGETS
+
+    resp = fresh_client.post(
+        "/v1/scan",
+        json={
+            "images": [f"repo/img-{idx}:latest" for idx in range(API_MAX_BATCH_SCAN_TARGETS + 1)],
+            "offline": True,
+            "no_scan": True,
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    body = resp.json()
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    details = body["error"]["details"]
+    assert isinstance(details, list)
+    assert any("maximum is" in str(item.get("msg", "")) for item in details)
+
+
 def test_p1_18_correlation_id_round_trips(fresh_client):
     requested = "test-corr-id-1234"
     resp = fresh_client.get("/v1/jobs/missing-job", headers={"x-request-id": requested})

--- a/tests/test_api_scan_batches.py
+++ b/tests/test_api_scan_batches.py
@@ -234,3 +234,28 @@ def test_scan_request_accepts_at_batch_target_cap():
 
     req = ScanRequest(images=[f"repo/img-{idx}:latest" for idx in range(API_MAX_BATCH_SCAN_TARGETS)])
     assert len(req.images) == API_MAX_BATCH_SCAN_TARGETS
+
+
+def test_scan_over_batch_target_cap_returns_422_not_500(monkeypatch):
+    """model_validator ValueError must serialize in the 422 envelope (#3474)."""
+    from starlette.testclient import TestClient
+
+    from agent_bom.api.server import app
+    from agent_bom.config import API_MAX_BATCH_SCAN_TARGETS
+    from tests.auth_helpers import enable_trusted_proxy_env, proxy_headers
+
+    enable_trusted_proxy_env()
+    monkeypatch.setattr(scan_routes, "submit_scan_job", lambda job: None)
+    _reset_store()
+
+    client = TestClient(app)
+    body = {
+        "images": [f"repo/img-{idx}:latest" for idx in range(API_MAX_BATCH_SCAN_TARGETS + 1)],
+        "offline": True,
+        "no_scan": True,
+    }
+    resp = client.post("/v1/scan", json=body, headers=proxy_headers(role="analyst"))
+    assert resp.status_code == 422, resp.text
+    payload = resp.json()
+    assert payload["error"]["code"] == "VALIDATION_ERROR"
+    assert "maximum is" in str(payload.get("detail") or payload["error"].get("details"))

--- a/tests/test_compliance_hub_store_pagination.py
+++ b/tests/test_compliance_hub_store_pagination.py
@@ -184,6 +184,27 @@ def test_sqlite_cvss_sort_uses_index(tmp_path) -> None:
     assert "SCAN compliance_hub_findings" not in text, text
 
 
+def test_sqlite_severity_filter_cvss_sort_uses_index(tmp_path) -> None:
+    """severity=critical&sort=cvss must use the severity_rank+cvss composite
+    index instead of json_extract on payload (#3192)."""
+    from agent_bom.graph.severity import severity_policy_rank
+
+    store = SQLiteComplianceHubStore(str(tmp_path / "hub.db"))
+    tenant = "tenant-plan"
+    store.add(tenant, [_finding(i) for i in range(200)])
+    plan = store._conn.execute(  # noqa: SLF001 - inspecting query plan in-test
+        "EXPLAIN QUERY PLAN SELECT payload FROM compliance_hub_findings "
+        "WHERE tenant_id = ? AND origin = ? AND severity_rank = ? "
+        "ORDER BY cvss_score DESC, ordinal LIMIT 10 OFFSET 0",
+        (tenant, "bulk_ingest", severity_policy_rank("critical")),
+    ).fetchall()
+    text = " ".join(str(row[-1]) for row in plan)
+    assert "USING" in text and "INDEX" in text and "severity" in text and "cvss" in text, text
+    assert "json_extract" not in text, text
+    assert "USE TEMP B-TREE FOR ORDER BY" not in text, text
+    assert "SCAN compliance_hub_findings" not in text, text
+
+
 def test_sqlite_migration_backfills_sort_columns(tmp_path) -> None:
     """A pre-#3192 table (no severity/cvss columns) must be migrated in place:
     the columns are added and backfilled from the stored payload so legacy rows


### PR DESCRIPTION
## Summary
- Stringify Pydantic `model_validator` `ValueError` in the 422 error envelope so `POST /v1/scan` over `API_MAX_BATCH_SCAN_TARGETS` returns 422 instead of 500.
- Push severity filters through `severity_rank` (materialized column) and add `(tenant_id, origin, severity_rank, cvss_score DESC, ordinal)` index for `severity=critical&sort=cvss` reads.

## Verification
- `uv run pytest tests/test_api_scan_batches.py::test_scan_over_batch_target_cap_returns_422_not_500 -q`
- `uv run pytest tests/test_api_data_p1_batch_v0867.py::test_p1_18_validation_envelope_serializes_model_validator_value_error -q`
- `uv run pytest tests/test_compliance_hub_store_pagination.py::test_sqlite_severity_filter_cvss_sort_uses_index -q`

Closes #3474.


Made with [Cursor](https://cursor.com)