### PR TITLE
fix(auth): cluster-safe SAML RelayState nonce store (#3476)

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -13,6 +13,7 @@ import sys
 import threading
 import time
 import uuid
+from collections.abc import Sequence
 from functools import lru_cache
 from typing import TYPE_CHECKING, cast
 
@@ -1903,7 +1904,7 @@ def _error_message_for(status_code: int, detail: object) -> str:
     }.get(status_code, "Request failed")
 
 
-def _json_safe_validation_errors(errors: list[dict[str, object]]) -> list[dict[str, object]]:
+def _json_safe_validation_errors(errors: Sequence[object]) -> list[dict[str, object]]:
     """Make Pydantic validation errors JSON-serializable.
 
     ``model_validator`` failures embed a live ``ValueError`` in ``ctx['error']``;
@@ -1911,12 +1912,13 @@ def _json_safe_validation_errors(errors: list[dict[str, object]]) -> list[dict[s
     """
     safe: list[dict[str, object]] = []
     for err in errors:
+        if not isinstance(err, dict):
+            safe.append({"error": str(err)})
+            continue
         item = dict(err)
         ctx = item.get("ctx")
         if isinstance(ctx, dict):
-            item["ctx"] = {
-                key: str(value) if isinstance(value, BaseException) else value for key, value in ctx.items()
-            }
+            item["ctx"] = {key: str(value) if isinstance(value, BaseException) else value for key, value in ctx.items()}
         safe.append(item)
     return safe
 

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -34,7 +34,6 @@ import json
 import logging
 import os
 import secrets
-import threading
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -80,8 +79,6 @@ class AuditExportVerifyRequest(BaseModel):
     signature: str = Field(..., min_length=64, max_length=128, description="X-Agent-Bom-Audit-Export-Signature value")
 
 
-_SAML_RELAY_STATES: dict[str, float] = {}
-_SAML_RELAY_LOCK = threading.Lock()
 _FEEDBACK_PREFIX = "[finding_feedback:"
 _TRIAGE_PREFIX = "[finding_triage]"
 _LEGACY_FALSE_POSITIVE_PREFIX = "[false_positive]"
@@ -168,22 +165,22 @@ def _saml_idp_initiated_allowed() -> bool:
     return os.environ.get("AGENT_BOM_SAML_ALLOW_IDP_INITIATED", "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _saml_relay_nonce(relay_state: str) -> str:
+    return f"saml-relay:{_relay_state_digest(relay_state)}"
+
+
 def _new_saml_relay_state() -> tuple[str, str]:
-    # Sweep expired entries on issue too, not only on consume — otherwise
-    # an attacker who issues many relay-state nonces but never completes
-    # the SAML round trip can grow the in-memory map unbounded. The
-    # cleanup is O(n) on the active set, which is small in practice
-    # (single-tenant pilot or reverse-proxy SSO; broader deployments
-    # should pin this map in shared storage).
-    relay_state = secrets.token_urlsafe(32)
-    now_monotonic = time.monotonic()
-    expires_at = now_monotonic + _saml_relay_ttl_seconds()
-    with _SAML_RELAY_LOCK:
-        expired = [key for key, exp in _SAML_RELAY_STATES.items() if exp < now_monotonic]
-        for key in expired:
-            _SAML_RELAY_STATES.pop(key, None)
-        _SAML_RELAY_STATES[_relay_state_digest(relay_state)] = expires_at
-    return relay_state, (datetime.now(timezone.utc) + timedelta(seconds=_saml_relay_ttl_seconds())).isoformat()
+    from agent_bom.api.shared_auth_state import get_auth_state
+
+    backend = get_auth_state()
+    ttl = _saml_relay_ttl_seconds()
+    now = int(time.time())
+    expires_at = now + ttl
+    for _ in range(3):
+        relay_state = secrets.token_urlsafe(32)
+        if backend.register_one_time_nonce(_saml_relay_nonce(relay_state), expires_at, now=now):
+            return relay_state, (datetime.now(timezone.utc) + timedelta(seconds=ttl)).isoformat()
+    raise HTTPException(status_code=503, detail="SAML relay_state issuance unavailable")
 
 
 def _consume_saml_relay_state(relay_state: str | None) -> None:
@@ -191,14 +188,11 @@ def _consume_saml_relay_state(relay_state: str | None) -> None:
         if _saml_idp_initiated_allowed():
             return
         raise HTTPException(status_code=401, detail="SAML relay_state required")
-    now = time.monotonic()
-    digest = _relay_state_digest(relay_state)
-    with _SAML_RELAY_LOCK:
-        expired = [key for key, expires_at in _SAML_RELAY_STATES.items() if expires_at < now]
-        for key in expired:
-            _SAML_RELAY_STATES.pop(key, None)
-        expires_at = _SAML_RELAY_STATES.pop(digest, None)
-    if expires_at is None or expires_at < now:
+    from agent_bom.api.shared_auth_state import get_auth_state
+
+    backend = get_auth_state()
+    now = int(time.time())
+    if not backend.redeem_one_time_nonce(_saml_relay_nonce(relay_state), now=now):
         raise HTTPException(status_code=401, detail="Invalid or expired SAML relay_state")
 
 

--- a/src/agent_bom/api/shared_auth_state.py
+++ b/src/agent_bom/api/shared_auth_state.py
@@ -28,6 +28,10 @@ The contract is:
 - ``is_nonce_revoked(nonce, now=None) -> bool`` — fast lookup.
 - ``consume_nonce_once(nonce, expires_at, now=None) -> bool`` — atomically
   mark a nonce as consumed and return ``False`` when it was already live.
+- ``register_one_time_nonce(nonce, expires_at, now=None) -> bool`` — register
+  a nonce for later single redemption (SAML RelayState issuance).
+- ``redeem_one_time_nonce(nonce, now=None) -> bool`` — atomically redeem a
+  previously registered nonce; return ``False`` when missing or expired.
 - ``cleanup_expired(now=None) -> int`` — best-effort sweep of stale
   rows; called opportunistically by route handlers. Returns the count
   of rows removed for observability.
@@ -85,12 +89,13 @@ _UPSERT_REVOKED_SQL = (
 )
 _DELETE_EXPIRED_NONCE_SQL = "DELETE FROM revoked_session_nonces WHERE nonce = %s AND expires_at <= TO_TIMESTAMP(%s)"
 _CONSUME_REVOKED_SQL = (
-    "INSERT INTO revoked_session_nonces (nonce, expires_at)"
-    " VALUES (%s, TO_TIMESTAMP(%s))"
-    " ON CONFLICT (nonce) DO NOTHING"
-    " RETURNING 1"
+    "INSERT INTO revoked_session_nonces (nonce, expires_at) VALUES (%s, TO_TIMESTAMP(%s)) ON CONFLICT (nonce) DO NOTHING RETURNING 1"
 )
 _CHECK_REVOKED_SQL = "SELECT 1 FROM revoked_session_nonces WHERE nonce = %s AND expires_at > TO_TIMESTAMP(%s)"
+_REGISTER_NONCE_SQL = (
+    "INSERT INTO revoked_session_nonces (nonce, expires_at) VALUES (%s, TO_TIMESTAMP(%s)) ON CONFLICT (nonce) DO NOTHING RETURNING 1"
+)
+_REDEEM_NONCE_SQL = "DELETE FROM revoked_session_nonces WHERE nonce = %s AND expires_at > TO_TIMESTAMP(%s) RETURNING 1"
 _DELETE_OLD_ATTEMPTS_SWEEP_SQL = "DELETE FROM auth_session_attempts WHERE attempted_at < NOW() - INTERVAL '24 hours'"
 _DELETE_EXPIRED_REVOKED_SQL = "DELETE FROM revoked_session_nonces WHERE expires_at <= NOW()"
 
@@ -112,6 +117,14 @@ class AuthStateBackend(Protocol):
 
     def consume_nonce_once(self, nonce: str, expires_at: int, now: int | None = None) -> bool:
         """Atomically mark ``nonce`` consumed. Return ``True`` only for the first live consumer."""
+        ...
+
+    def register_one_time_nonce(self, nonce: str, expires_at: int, now: int | None = None) -> bool:
+        """Register ``nonce`` for later single redemption. Return ``False`` when already live."""
+        ...
+
+    def redeem_one_time_nonce(self, nonce: str, now: int | None = None) -> bool:
+        """Atomically redeem a registered nonce. Return ``False`` when missing or expired."""
         ...
 
     def cleanup_expired(self, now: int | None = None) -> int:
@@ -178,6 +191,31 @@ class InMemoryAuthState:
             if nonce in self._revoked:
                 return False
             self._revoked[nonce] = expires_at
+            return True
+
+    def register_one_time_nonce(self, nonce: str, expires_at: int, now: int | None = None) -> bool:
+        if not nonce:
+            return False
+        moment = int(time.time()) if now is None else int(now)
+        with self._lock:
+            stale = [k for k, exp in self._revoked.items() if exp <= moment]
+            for k in stale:
+                self._revoked.pop(k, None)
+            if nonce in self._revoked:
+                return False
+            self._revoked[nonce] = expires_at
+            return True
+
+    def redeem_one_time_nonce(self, nonce: str, now: int | None = None) -> bool:
+        if not nonce:
+            return False
+        moment = int(time.time()) if now is None else int(now)
+        with self._lock:
+            expires_at = self._revoked.get(nonce)
+            if expires_at is None or expires_at <= moment:
+                self._revoked.pop(nonce, None)
+                return False
+            self._revoked.pop(nonce, None)
             return True
 
     def cleanup_expired(self, now: int | None = None) -> int:
@@ -319,6 +357,47 @@ class PostgresAuthState:
         except Exception as exc:  # noqa: BLE001
             self._warn_fallback("consume_nonce_once", exc)
             return self._fallback.consume_nonce_once(nonce, expires_at, now)
+
+    def register_one_time_nonce(self, nonce: str, expires_at: int, now: int | None = None) -> bool:
+        if not nonce:
+            return False
+        if not self._ensure_schema():
+            return self._fallback.register_one_time_nonce(nonce, expires_at, now)
+        try:
+            from agent_bom.api.postgres_common import _get_pool
+
+            pool = _get_pool()
+            moment = int(time.time()) if now is None else int(now)
+            with pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(_DELETE_EXPIRED_NONCE_SQL, (nonce, moment))
+                    cur.execute(_REGISTER_NONCE_SQL, (nonce, int(expires_at)))
+                    row = cur.fetchone()
+                conn.commit()
+            return row is not None
+        except Exception as exc:  # noqa: BLE001
+            self._warn_fallback("register_one_time_nonce", exc)
+            return self._fallback.register_one_time_nonce(nonce, expires_at, now)
+
+    def redeem_one_time_nonce(self, nonce: str, now: int | None = None) -> bool:
+        if not nonce:
+            return False
+        if not self._ensure_schema():
+            return self._fallback.redeem_one_time_nonce(nonce, now)
+        try:
+            from agent_bom.api.postgres_common import _get_pool
+
+            pool = _get_pool()
+            moment = int(time.time()) if now is None else int(now)
+            with pool.connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(_REDEEM_NONCE_SQL, (nonce, moment))
+                    row = cur.fetchone()
+                conn.commit()
+            return row is not None
+        except Exception as exc:  # noqa: BLE001
+            self._warn_fallback("redeem_one_time_nonce", exc)
+            return self._fallback.redeem_one_time_nonce(nonce, now)
 
     def cleanup_expired(self, now: int | None = None) -> int:
         if not self._ensure_schema():

--- a/tests/test_api_saml.py
+++ b/tests/test_api_saml.py
@@ -276,6 +276,33 @@ async def test_saml_relay_state_is_one_time(isolated_key_store, monkeypatch, sam
 
 
 @pytest.mark.asyncio
+async def test_saml_relay_state_redeems_from_shared_auth_backend(isolated_key_store, monkeypatch, saml_runtime_enabled):
+    from agent_bom.api.shared_auth_state import InMemoryAuthState
+
+    shared = InMemoryAuthState()
+    monkeypatch.setattr("agent_bom.api.shared_auth_state.get_auth_state", lambda: shared)
+    relay = await enterprise.saml_relay_state()
+
+    monkeypatch.setattr(
+        "agent_bom.api.saml.SAMLConfig.verify_response",
+        lambda self, saml_response, relay_state=None: type(
+            "Assertion",
+            (),
+            {
+                "subject": "alice@example.com",
+                "attributes": {"agent_bom_role": "admin", "tenant_id": "tenant-alpha"},
+                "role": "admin",
+                "tenant_id": "tenant-alpha",
+                "session_index": "session-1",
+            },
+        )(),
+    )
+
+    response = await enterprise.saml_login(SAMLLoginRequest(saml_response="assertion", relay_state=relay["relay_state"]))
+    assert response["tenant_id"] == "tenant-alpha"
+
+
+@pytest.mark.asyncio
 async def test_saml_login_rejects_replayed_assertion_with_fresh_relay(isolated_key_store, monkeypatch, saml_runtime_enabled):
     first_relay = await enterprise.saml_relay_state()
     second_relay = await enterprise.saml_relay_state()

--- a/tests/test_shared_auth_state.py
+++ b/tests/test_shared_auth_state.py
@@ -134,6 +134,27 @@ class TestInMemoryRevocation:
         assert backend.is_nonce_revoked("saml-response:shared") is True
 
 
+class TestInMemoryOneTimeNonce:
+    def test_register_and_redeem_once(self) -> None:
+        backend = InMemoryAuthState()
+        expires_at = int(time.time()) + 300
+        assert backend.register_one_time_nonce("saml-relay:abc", expires_at) is True
+        assert backend.redeem_one_time_nonce("saml-relay:abc") is True
+        assert backend.redeem_one_time_nonce("saml-relay:abc") is False
+
+    def test_register_rejects_duplicate_live_nonce(self) -> None:
+        backend = InMemoryAuthState()
+        expires_at = int(time.time()) + 300
+        assert backend.register_one_time_nonce("saml-relay:abc", expires_at) is True
+        assert backend.register_one_time_nonce("saml-relay:abc", expires_at) is False
+
+    def test_redeem_expired_nonce_fails(self) -> None:
+        backend = InMemoryAuthState()
+        past = int(time.time()) - 1
+        assert backend.register_one_time_nonce("saml-relay:expired", past) is True
+        assert backend.redeem_one_time_nonce("saml-relay:expired") is False
+
+
 class TestInMemoryCleanup:
     def test_cleanup_keeps_live_revocations_and_drops_expired(self) -> None:
         backend = InMemoryAuthState()


### PR DESCRIPTION
## Summary
- Replace process-local `_SAML_RELAY_STATES` with `register_one_time_nonce` / `redeem_one_time_nonce` on the shared auth-state backend (same store as SAML response replay guards).
- SAML CSRF protection now works across API replicas when `AGENT_BOM_POSTGRES_URL` is set.

## Verification
- `uv run pytest tests/test_shared_auth_state.py::TestInMemoryOneTimeNonce -q`
- `uv run pytest tests/test_api_saml.py -q`

Closes #3476.


Made with [Cursor](https://cursor.com)