### PR TITLE
chore(repo): hygiene + session cookie Secure default (#3475)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv/
 .pytest_cache/
 .demo-bin/
 agent-bom-report.json
+gateway-baseline-policy.json
 agent-bom.cdx.json
 agent-bom-badge.json
 agent-bom-diagram.mmd
@@ -34,6 +35,7 @@ ui/out/
 ui/.next/
 .coverage
 .claude/worktrees/
+.codex/
 AUDIT_*.md
 ui/.claude/
 # macOS / iCloud duplicate conflict files — keep them out of git even if they

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -364,6 +364,10 @@ def _session_cookie_secure(request: Request) -> bool:
         return True
     if raw in {"0", "false", "no", "off"}:
         return False
+    from agent_bom.api.middleware import _production_or_clustered_control_plane
+
+    if _production_or_clustered_control_plane():
+        return True
     trusted_proxy = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH", "").strip().lower() in {"1", "true", "yes", "on"}
     forwarded_proto = request.headers.get("x-forwarded-proto", "").split(",", 1)[0].strip().lower() if trusted_proxy else ""
     return request.url.scheme == "https" or forwarded_proto == "https"

--- a/tests/test_api_hardening.py
+++ b/tests/test_api_hardening.py
@@ -228,6 +228,52 @@ def test_browser_session_cookies_use_strict_samesite(monkeypatch):
     assert any(CSRF_COOKIE_NAME in value for value in set_cookie_values)
 
 
+def test_browser_session_cookie_secure_defaults_on_in_production(monkeypatch):
+    from agent_bom.api.routes import enterprise
+
+    monkeypatch.setenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY", "test-browser-session-signing-key")
+    monkeypatch.setenv("AGENT_BOM_ENV", "production")
+    monkeypatch.delenv("AGENT_BOM_SESSION_COOKIE_SECURE", raising=False)
+    request = SimpleNamespace(headers={}, url=SimpleNamespace(scheme="http"))
+    response = Response()
+
+    enterprise._set_browser_session_cookie(
+        response,
+        request,
+        subject="dashboard-user",
+        role="admin",
+        tenant_id="tenant-alpha",
+        auth_method="browser_session_static_api_key",
+    )
+
+    set_cookie_values = [value.decode("latin-1") for key, value in response.raw_headers if key.lower() == b"set-cookie"]
+    assert all("Secure" in value for value in set_cookie_values)
+
+
+def test_browser_session_cookie_secure_off_on_local_http(monkeypatch):
+    from agent_bom.api.routes import enterprise
+
+    monkeypatch.setenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY", "test-browser-session-signing-key")
+    monkeypatch.delenv("AGENT_BOM_ENV", raising=False)
+    monkeypatch.delenv("AGENT_BOM_DEPLOYMENT_ENV", raising=False)
+    monkeypatch.delenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_SESSION_COOKIE_SECURE", raising=False)
+    request = SimpleNamespace(headers={}, url=SimpleNamespace(scheme="http"))
+    response = Response()
+
+    enterprise._set_browser_session_cookie(
+        response,
+        request,
+        subject="dashboard-user",
+        role="admin",
+        tenant_id="tenant-alpha",
+        auth_method="browser_session_static_api_key",
+    )
+
+    set_cookie_values = [value.decode("latin-1") for key, value in response.raw_headers if key.lower() == b"set-cookie"]
+    assert all("Secure" not in value for value in set_cookie_values)
+
+
 def test_browser_session_requires_persistent_key_when_clustered(monkeypatch):
     monkeypatch.delenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY", raising=False)
     monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "2")


### PR DESCRIPTION
## Summary
- `.gitignore`: `.codex/` worktrees and `gateway-baseline-policy.json` (CLI/quickstart local output).
- **#3475**: default `Secure` on browser session cookies when `AGENT_BOM_ENV=production` or clustered control plane, even behind TLS-terminated ingress without `AGENT_BOM_TRUST_PROXY_AUTH`. Explicit `AGENT_BOM_SESSION_COOKIE_SECURE=0` still opts out.

## Verification
- `uv run pytest tests/test_api_hardening.py::test_browser_session_cookie_secure_defaults_on_in_production tests/test_api_hardening.py::test_browser_session_cookie_secure_off_on_local_http -q`

Closes #3475.


Made with [Cursor](https://cursor.com)