### PR TITLE
feat(api): finding lifecycle L2 — occurrence log keyed on scan_id (#3465)

### DIFF
--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -234,6 +234,7 @@ def _upsert_current_finding_sqlite(
     tenant_id: str,
     payload: dict[str, Any],
     observed_at: str,
+    scan_id: str,
     source: str,
 ) -> None:
     from agent_bom.api.finding_lifecycle import (
@@ -249,10 +250,10 @@ def _upsert_current_finding_sqlite(
     inserted = conn.execute(
         """
         INSERT OR IGNORE INTO hub_findings_current_observations
-            (tenant_id, canonical_id, observed_at)
-        VALUES (?, ?, ?)
+            (tenant_id, canonical_id, scan_id, observed_at)
+        VALUES (?, ?, ?, ?)
         """,
-        (tenant_id, canonical, observed_at),
+        (tenant_id, canonical, scan_id, observed_at),
     ).rowcount
     if not inserted:
         return
@@ -338,6 +339,39 @@ def _ensure_current_lifecycle_sqlite(conn: sqlite3.Connection) -> None:
     from agent_bom.api.finding_lifecycle import _CURRENT_LIFECYCLE_SQLITE_DDL
 
     conn.executescript(_CURRENT_LIFECYCLE_SQLITE_DDL)
+    _migrate_lifecycle_observations_l2_sqlite(conn)
+
+
+def _migrate_lifecycle_observations_l2_sqlite(conn: sqlite3.Connection) -> None:
+    """Upgrade L1 observation rows (PK on observed_at) to L2 (PK on scan_id)."""
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='hub_findings_current_observations'"
+    ).fetchall()
+    if not rows:
+        return
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(hub_findings_current_observations)").fetchall()}
+    if "scan_id" in cols:
+        return
+    conn.execute("ALTER TABLE hub_findings_current_observations RENAME TO hub_findings_current_observations_l1")
+    conn.execute(
+        """
+        CREATE TABLE hub_findings_current_observations (
+            tenant_id TEXT NOT NULL,
+            canonical_id TEXT NOT NULL,
+            scan_id TEXT NOT NULL,
+            observed_at TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, canonical_id, scan_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO hub_findings_current_observations (tenant_id, canonical_id, scan_id, observed_at)
+        SELECT tenant_id, canonical_id, observed_at, observed_at
+        FROM hub_findings_current_observations_l1
+        """
+    )
+    conn.execute("DROP TABLE hub_findings_current_observations_l1")
 
 
 # ─── In-memory backend ──────────────────────────────────────────────────────
@@ -454,7 +488,7 @@ class InMemoryComplianceHubStore:
             observations = self._current_observations.setdefault(tenant_id, set())
             for payload in clean:
                 canonical = resolve_canonical_id(payload, source=source)
-                obs_key = (canonical, observed_at)
+                obs_key = (canonical, batch_id)
                 if obs_key in observations:
                     continue
                 observations.add(obs_key)
@@ -885,6 +919,7 @@ class SQLiteComplianceHubStore:
                 tenant_id=tenant_id,
                 payload=payload,
                 observed_at=observed_at,
+                scan_id=batch_id,
                 source=source,
             )
         self._conn.commit()

--- a/src/agent_bom/api/finding_lifecycle.py
+++ b/src/agent_bom/api/finding_lifecycle.py
@@ -1,9 +1,9 @@
-"""Monotone current-state merge for hub findings (#3465 L1).
+"""Monotone current-state merge for hub findings (#3465).
 
 One row per ``(tenant_id, canonical_id)`` with ``first_seen`` / ``last_seen``
-driven by ``observed_at``. Duplicate observations — same canonical id and
-``observed_at`` — are no-ops for lifecycle fields; ``scan_count`` advances only
-when a new observation timestamp is recorded (L2 will gate on occurrence log).
+driven by ``observed_at``. The occurrence log dedups on
+``(tenant_id, canonical_id, scan_id)``; ``scan_count`` advances only when a new
+scan sighting inserts into the log (L2).
 """
 
 from __future__ import annotations
@@ -163,8 +163,9 @@ CREATE TABLE IF NOT EXISTS hub_findings_current (
 CREATE TABLE IF NOT EXISTS hub_findings_current_observations (
     tenant_id TEXT NOT NULL,
     canonical_id TEXT NOT NULL,
+    scan_id TEXT NOT NULL,
     observed_at TEXT NOT NULL,
-    PRIMARY KEY (tenant_id, canonical_id, observed_at)
+    PRIMARY KEY (tenant_id, canonical_id, scan_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_last_seen
@@ -194,8 +195,9 @@ CREATE TABLE IF NOT EXISTS hub_findings_current (
 CREATE TABLE IF NOT EXISTS hub_findings_current_observations (
     tenant_id TEXT NOT NULL,
     canonical_id TEXT NOT NULL,
+    scan_id TEXT NOT NULL,
     observed_at TEXT NOT NULL,
-    PRIMARY KEY (tenant_id, canonical_id, observed_at)
+    PRIMARY KEY (tenant_id, canonical_id, scan_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_last_seen

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -26,6 +26,46 @@ from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _g
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
 
+def _migrate_lifecycle_observations_l2_postgres(conn: Any) -> None:
+    """Upgrade L1 observation rows (PK on observed_at) to L2 (PK on scan_id)."""
+    conn.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = current_schema()
+                  AND table_name = 'hub_findings_current_observations'
+            ) THEN
+                RETURN;
+            END IF;
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema()
+                  AND table_name = 'hub_findings_current_observations'
+                  AND column_name = 'scan_id'
+            ) THEN
+                RETURN;
+            END IF;
+            ALTER TABLE hub_findings_current_observations
+                RENAME TO hub_findings_current_observations_l1;
+            CREATE TABLE hub_findings_current_observations (
+                tenant_id TEXT NOT NULL,
+                canonical_id TEXT NOT NULL,
+                scan_id TEXT NOT NULL,
+                observed_at TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, canonical_id, scan_id)
+            );
+            INSERT INTO hub_findings_current_observations
+                (tenant_id, canonical_id, scan_id, observed_at)
+            SELECT tenant_id, canonical_id, observed_at, observed_at
+            FROM hub_findings_current_observations_l1;
+            DROP TABLE hub_findings_current_observations_l1;
+        END $$;
+        """
+    )
+
+
 class PostgresComplianceHubStore:
     """Shared hub store backing multi-replica self-hosted deployments."""
 
@@ -108,6 +148,7 @@ class PostgresComplianceHubStore:
             from agent_bom.api.finding_lifecycle import _CURRENT_LIFECYCLE_POSTGRES_DDL
 
             conn.execute(_CURRENT_LIFECYCLE_POSTGRES_DDL)
+            _migrate_lifecycle_observations_l2_postgres(conn)
             _ensure_tenant_rls(conn, "hub_findings_current", "tenant_id")
             _ensure_tenant_rls(conn, "hub_findings_current_observations", "tenant_id")
             conn.commit()
@@ -350,11 +391,11 @@ class PostgresComplianceHubStore:
                 inserted = conn.execute(
                     """
                     INSERT INTO hub_findings_current_observations
-                        (tenant_id, canonical_id, observed_at)
-                    VALUES (%s, %s, %s)
+                        (tenant_id, canonical_id, scan_id, observed_at)
+                    VALUES (%s, %s, %s, %s)
                     ON CONFLICT DO NOTHING
                     """,
-                    (tenant_id, canonical, observed_at),
+                    (tenant_id, canonical, batch_id, observed_at),
                 ).rowcount
                 if not inserted:
                     continue

--- a/tests/test_finding_lifecycle.py
+++ b/tests/test_finding_lifecycle.py
@@ -1,4 +1,4 @@
-"""Monotone current-state finding lifecycle (#3465 L1)."""
+"""Monotone current-state finding lifecycle (#3465 L1–L2)."""
 
 from __future__ import annotations
 
@@ -58,26 +58,31 @@ def test_monotone_merge_timestamps(hub_store) -> None:
     assert row["scan_count"] == 1
     assert row["status"] == "open"
 
-    hub_store.upsert_current_batch(tenant, [finding], observed_at=MON, batch_id="batch-mon-2")
+    hub_store.upsert_current_batch(tenant, [finding], observed_at=MON, batch_id="batch-mon-1")
     retry = hub_store.get_current(tenant, canonical)
     assert retry is not None
     assert retry["first_seen"] == MON
     assert retry["last_seen"] == MON
     assert retry["scan_count"] == 1
 
+    hub_store.upsert_current_batch(tenant, [finding], observed_at=MON, batch_id="batch-mon-2")
+    same_day_rescan = hub_store.get_current(tenant, canonical)
+    assert same_day_rescan is not None
+    assert same_day_rescan["scan_count"] == 2
+
     hub_store.upsert_current_batch(tenant, [finding], observed_at=TUE, batch_id="batch-tue-1")
     advanced = hub_store.get_current(tenant, canonical)
     assert advanced is not None
     assert advanced["first_seen"] == MON
     assert advanced["last_seen"] == TUE
-    assert advanced["scan_count"] == 2
+    assert advanced["scan_count"] == 3
 
-    hub_store.upsert_current_batch(tenant, [finding], observed_at=TUE, batch_id="batch-tue-2")
+    hub_store.upsert_current_batch(tenant, [finding], observed_at=TUE, batch_id="batch-tue-1")
     retry_tue = hub_store.get_current(tenant, canonical)
     assert retry_tue is not None
     assert retry_tue["first_seen"] == MON
     assert retry_tue["last_seen"] == TUE
-    assert retry_tue["scan_count"] == 2
+    assert retry_tue["scan_count"] == 3
 
 
 def test_bulk_ingest_carries_observed_at() -> None:


### PR DESCRIPTION
## Summary
- Occurrence log PK is now `(tenant_id, canonical_id, scan_id)` with `observed_at` stored for timeline.
- `scan_count` bumps only when a new `scan_id` inserts into the log (retry same batch → no-op).
- Idempotent migration from L1 `(tenant_id, canonical_id, observed_at)` schema on SQLite + Postgres.

## Verification
- `uv run pytest tests/test_finding_lifecycle.py -q`

Part of #3465 (L2). L3 resolve reconcile and L4 read unification remain.


Made with [Cursor](https://cursor.com)