### PR TITLE
feat(api): finding lifecycle L3+L4 — resolve reconcile and current-state reads (#3465)

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -131,6 +131,12 @@
             "description": "Observation timestamp from scan completion; defaults to ingest time when omitted.",
             "title": "Observed At"
           },
+          "reconcile_absent": {
+            "default": false,
+            "description": "When true, mark open findings in the same source scope that are absent from this batch as resolved at observed_at.",
+            "title": "Reconcile Absent",
+            "type": "boolean"
+          },
           "schema_version": {
             "default": "v1",
             "maxLength": 32,

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -93,6 +93,12 @@ components:
           description: Observation timestamp from scan completion; defaults to ingest
             time when omitted.
           title: Observed At
+        reconcile_absent:
+          default: false
+          description: When true, mark open findings in the same source scope that
+            are absent from this batch as resolved at observed_at.
+          title: Reconcile Absent
+          type: boolean
         schema_version:
           default: v1
           maxLength: 32

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -370,9 +370,7 @@ def _ensure_current_lifecycle_sqlite(conn: sqlite3.Connection) -> None:
 
 def _migrate_lifecycle_observations_l2_sqlite(conn: sqlite3.Connection) -> None:
     """Upgrade L1 observation rows (PK on observed_at) to L2 (PK on scan_id)."""
-    rows = conn.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='hub_findings_current_observations'"
-    ).fetchall()
+    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='hub_findings_current_observations'").fetchall()
     if not rows:
         return
     cols = {row[1] for row in conn.execute("PRAGMA table_info(hub_findings_current_observations)").fetchall()}
@@ -642,11 +640,11 @@ def _postgres_current_order_clause(sort: str) -> str:
     return _sqlite_current_order_clause(sort)
 
 
-def _current_page_sort_key(sort: str) -> Callable[[dict[str, Any]], tuple[float, str, str]]:
+def _current_page_sort_key(sort: str) -> Callable[[dict[str, Any]], tuple[Any, str, str]]:
     """Sort key for in-memory current-state pages (descending primary signal)."""
     normalized = sort if sort in _LIST_PAGE_SORTS else "effective_reach"
 
-    def _key(row: dict[str, Any]) -> tuple[float, str, str]:
+    def _key(row: dict[str, Any]) -> tuple[Any, str, str]:
         if normalized == "ordinal":
             primary = 0.0
             tie = str(row.get("last_seen") or "")
@@ -680,9 +678,7 @@ def _filter_current_rows(
         rows = [r for r in rows if str(r.get("severity") or (r.get("payload") or {}).get("severity", "")).lower() == sev]
     if scan_id is not None:
         rows = [
-            r
-            for r in rows
-            if str((r.get("payload") or {}).get("batch_id") or (r.get("payload") or {}).get("scan_id") or "") == scan_id
+            r for r in rows if str((r.get("payload") or {}).get("batch_id") or (r.get("payload") or {}).get("scan_id") or "") == scan_id
         ]
     return rows
 
@@ -1116,10 +1112,7 @@ class SQLiteComplianceHubStore:
             where.append("severity_rank = ?")
             params.append(severity_policy_rank(severity))
         if scan_id is not None:
-            where.append(
-                "(CAST(json_extract(payload, '$.batch_id') AS TEXT) = ?"
-                " OR CAST(json_extract(payload, '$.scan_id') AS TEXT) = ?)"
-            )
+            where.append("(CAST(json_extract(payload, '$.batch_id') AS TEXT) = ? OR CAST(json_extract(payload, '$.scan_id') AS TEXT) = ?)")
             params.extend([scan_id, scan_id])
         where_sql = " AND ".join(where)
 
@@ -1187,7 +1180,7 @@ class SQLiteComplianceHubStore:
             f"""
             UPDATE hub_findings_current
             SET status = 'resolved', resolved_at = ?, updated_at = ?
-            WHERE {' AND '.join(where)}
+            WHERE {" AND ".join(where)}
             """,  # nosec B608
             params,
         )

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -640,26 +640,22 @@ def _postgres_current_order_clause(sort: str) -> str:
     return _sqlite_current_order_clause(sort)
 
 
-def _current_page_sort_key(sort: str) -> Callable[[dict[str, Any]], tuple[Any, str, str]]:
+def _current_page_sort_key(sort: str) -> Callable[[dict[str, Any]], tuple[float | str, str, str]]:
     """Sort key for in-memory current-state pages (descending primary signal)."""
     normalized = sort if sort in _LIST_PAGE_SORTS else "effective_reach"
 
-    def _key(row: dict[str, Any]) -> tuple[Any, str, str]:
+    def _key(row: dict[str, Any]) -> tuple[float | str, str, str]:
+        tie = str(row.get("last_seen") or "")
+        canonical = str(row.get("canonical_id") or "")
         if normalized == "ordinal":
-            primary = 0.0
-            tie = str(row.get("last_seen") or "")
-        elif normalized == "cvss":
+            return (tie, canonical, "")
+        if normalized == "cvss":
             primary = float(row.get("cvss_score") or 0.0)
-            tie = str(row.get("last_seen") or "")
         elif normalized == "severity":
             primary = float(row.get("severity_rank") or 0)
-            tie = str(row.get("last_seen") or "")
         else:
             primary = float(row.get("effective_reach_score") or 0.0)
-            tie = str(row.get("last_seen") or "")
-        if normalized == "ordinal":
-            return (tie, str(row.get("canonical_id") or ""), "")
-        return (-primary, tie, str(row.get("canonical_id") or ""))
+        return (-primary, tie, canonical)
 
     return _key
 

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -227,6 +227,32 @@ class ComplianceHubStore(Protocol):
         """Return one current-state lifecycle row for tests and diagnostics."""
         ...
 
+    def list_current_page(
+        self,
+        tenant_id: str,
+        *,
+        limit: int,
+        offset: int = 0,
+        sort: str = "effective_reach",
+        severity: str | None = None,
+        scan_id: str | None = None,
+        origin: str | None = None,
+        include_total: bool = True,
+    ) -> FindingPage:
+        """Return a page from ``hub_findings_current`` with lifecycle fields merged."""
+        ...
+
+    def reconcile_current_absent(
+        self,
+        tenant_id: str,
+        *,
+        present_canonical_ids: set[str],
+        observed_at: str,
+        scope_source: str | None = None,
+    ) -> int:
+        """Mark open findings absent from a scan batch as resolved at ``observed_at``."""
+        ...
+
 
 def _upsert_current_finding_sqlite(
     conn: sqlite3.Connection,
@@ -507,6 +533,59 @@ class InMemoryComplianceHubStore:
             row = self._current.get(tenant_id, {}).get(canonical_id)
             return dict(row) if row else None
 
+    def list_current_page(
+        self,
+        tenant_id: str,
+        *,
+        limit: int,
+        offset: int = 0,
+        sort: str = "effective_reach",
+        severity: str | None = None,
+        scan_id: str | None = None,
+        origin: str | None = None,
+        include_total: bool = True,
+    ) -> FindingPage:
+        from agent_bom.api.finding_lifecycle import enriched_finding_payload
+
+        with self._lock:
+            rows = list(self._current.get(tenant_id, {}).values())
+        rows = _filter_current_rows(rows, severity=severity, scan_id=scan_id, origin=origin)
+        total = len(rows) if include_total else None
+        rows.sort(key=_current_page_sort_key(sort))
+        if offset:
+            rows = rows[offset:]
+        if limit >= 0:
+            rows = rows[:limit]
+        return [enriched_finding_payload(row) for row in rows], total
+
+    def reconcile_current_absent(
+        self,
+        tenant_id: str,
+        *,
+        present_canonical_ids: set[str],
+        observed_at: str,
+        scope_source: str | None = None,
+    ) -> int:
+        now = _now_utc_iso()
+        updated = 0
+        with self._lock:
+            current = self._current.setdefault(tenant_id, {})
+            for canonical_id, row in list(current.items()):
+                if str(row.get("status") or "") not in ("open", "reopened"):
+                    continue
+                if canonical_id in present_canonical_ids:
+                    continue
+                payload = row.get("payload") or {}
+                if scope_source is not None and str(payload.get("source") or "") != scope_source:
+                    continue
+                merged = dict(row)
+                merged["status"] = "resolved"
+                merged["resolved_at"] = observed_at
+                merged["updated_at"] = now
+                current[canonical_id] = merged
+                updated += 1
+        return updated
+
 
 # ─── SQLite backend ─────────────────────────────────────────────────────────
 
@@ -545,6 +624,67 @@ def _sqlite_order_clause(sort: str) -> str:
         return "ORDER BY severity_rank DESC, ordinal ASC"
     # effective_reach (default) — index-backed range scan + limit.
     return "ORDER BY effective_reach_score DESC, ordinal ASC"
+
+
+def _sqlite_current_order_clause(sort: str) -> str:
+    """ORDER BY for ``hub_findings_current`` (no ingest ``ordinal`` column)."""
+    if sort == "ordinal":
+        return "ORDER BY last_seen ASC, canonical_id ASC"
+    if sort == "cvss":
+        return "ORDER BY cvss_score DESC, last_seen DESC, canonical_id ASC"
+    if sort == "severity":
+        return "ORDER BY severity_rank DESC, last_seen DESC, canonical_id ASC"
+    return "ORDER BY effective_reach_score DESC, last_seen DESC, canonical_id ASC"
+
+
+def _postgres_current_order_clause(sort: str) -> str:
+    """Postgres ORDER BY for ``hub_findings_current``."""
+    return _sqlite_current_order_clause(sort)
+
+
+def _current_page_sort_key(sort: str) -> Callable[[dict[str, Any]], tuple[float, str, str]]:
+    """Sort key for in-memory current-state pages (descending primary signal)."""
+    normalized = sort if sort in _LIST_PAGE_SORTS else "effective_reach"
+
+    def _key(row: dict[str, Any]) -> tuple[float, str, str]:
+        if normalized == "ordinal":
+            primary = 0.0
+            tie = str(row.get("last_seen") or "")
+        elif normalized == "cvss":
+            primary = float(row.get("cvss_score") or 0.0)
+            tie = str(row.get("last_seen") or "")
+        elif normalized == "severity":
+            primary = float(row.get("severity_rank") or 0)
+            tie = str(row.get("last_seen") or "")
+        else:
+            primary = float(row.get("effective_reach_score") or 0.0)
+            tie = str(row.get("last_seen") or "")
+        if normalized == "ordinal":
+            return (tie, str(row.get("canonical_id") or ""), "")
+        return (-primary, tie, str(row.get("canonical_id") or ""))
+
+    return _key
+
+
+def _filter_current_rows(
+    rows: list[dict[str, Any]],
+    *,
+    severity: str | None,
+    scan_id: str | None,
+    origin: str | None,
+) -> list[dict[str, Any]]:
+    if origin is not None:
+        rows = [r for r in rows if (r.get("payload") or {}).get("origin") == origin]
+    if severity is not None:
+        sev = severity.lower()
+        rows = [r for r in rows if str(r.get("severity") or (r.get("payload") or {}).get("severity", "")).lower() == sev]
+    if scan_id is not None:
+        rows = [
+            r
+            for r in rows
+            if str((r.get("payload") or {}).get("batch_id") or (r.get("payload") or {}).get("scan_id") or "") == scan_id
+        ]
+    return rows
 
 
 def _postgres_order_clause(sort: str) -> str:
@@ -952,6 +1092,107 @@ class SQLiteComplianceHubStore:
             "updated_at": row[11],
             "payload": json.loads(row[12]),
         }
+
+    def list_current_page(
+        self,
+        tenant_id: str,
+        *,
+        limit: int,
+        offset: int = 0,
+        sort: str = "effective_reach",
+        severity: str | None = None,
+        scan_id: str | None = None,
+        origin: str | None = None,
+        include_total: bool = True,
+    ) -> FindingPage:
+        from agent_bom.api.finding_lifecycle import enriched_finding_payload
+
+        where = ["tenant_id = ?"]
+        params: list[Any] = [tenant_id]
+        if origin is not None:
+            where.append("json_extract(payload, '$.origin') = ?")
+            params.append(origin)
+        if severity is not None:
+            where.append("severity_rank = ?")
+            params.append(severity_policy_rank(severity))
+        if scan_id is not None:
+            where.append(
+                "(CAST(json_extract(payload, '$.batch_id') AS TEXT) = ?"
+                " OR CAST(json_extract(payload, '$.scan_id') AS TEXT) = ?)"
+            )
+            params.extend([scan_id, scan_id])
+        where_sql = " AND ".join(where)
+
+        total: int | None
+        if include_total:
+            total_row = self._conn.execute(
+                f"SELECT COUNT(*) FROM hub_findings_current WHERE {where_sql}",  # nosec B608
+                params,
+            ).fetchone()
+            total = int(total_row[0]) if total_row else 0
+        else:
+            total = None
+
+        order_sql = _sqlite_current_order_clause(sort)
+        page_params = [*params, int(limit), int(offset)]
+        rows = self._conn.execute(
+            f"""
+            SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
+                   cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+                   updated_at, payload
+            FROM hub_findings_current
+            WHERE {where_sql} {order_sql} LIMIT ? OFFSET ?
+            """,  # nosec B608
+            page_params,
+        ).fetchall()
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            current_row = {
+                "canonical_id": row[0],
+                "first_seen": row[1],
+                "last_seen": row[2],
+                "status": row[3],
+                "severity": row[4],
+                "severity_rank": row[5],
+                "cvss_score": row[6],
+                "effective_reach_score": row[7],
+                "scan_count": row[8],
+                "resolved_at": row[9],
+                "reopened_at": row[10],
+                "updated_at": row[11],
+                "payload": json.loads(row[12]),
+            }
+            out.append(enriched_finding_payload(current_row))
+        return out, total
+
+    def reconcile_current_absent(
+        self,
+        tenant_id: str,
+        *,
+        present_canonical_ids: set[str],
+        observed_at: str,
+        scope_source: str | None = None,
+    ) -> int:
+        now = _now_utc_iso()
+        where = ["tenant_id = ?", "status IN ('open', 'reopened')"]
+        params: list[Any] = [observed_at, now, tenant_id]
+        if scope_source is not None:
+            where.append("json_extract(payload, '$.source') = ?")
+            params.append(scope_source)
+        if present_canonical_ids:
+            placeholders = ",".join("?" * len(present_canonical_ids))
+            where.append(f"canonical_id NOT IN ({placeholders})")
+            params.extend(sorted(present_canonical_ids))
+        cur = self._conn.execute(
+            f"""
+            UPDATE hub_findings_current
+            SET status = 'resolved', resolved_at = ?, updated_at = ?
+            WHERE {' AND '.join(where)}
+            """,  # nosec B608
+            params,
+        )
+        self._conn.commit()
+        return int(cur.rowcount or 0)
 
 
 # ─── Module-level access (set/reset wired in stores.py) ──────────────────────

--- a/src/agent_bom/api/finding_lifecycle.py
+++ b/src/agent_bom/api/finding_lifecycle.py
@@ -8,6 +8,7 @@ scan sighting inserts into the log (L2).
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Any
 
@@ -171,6 +172,32 @@ CREATE TABLE IF NOT EXISTS hub_findings_current_observations (
 CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_last_seen
     ON hub_findings_current(tenant_id, last_seen DESC);
 """
+
+
+def collect_present_canonical_ids(
+    findings: Sequence[dict[str, Any]],
+    *,
+    source: str = "",
+) -> set[str]:
+    """Return canonical ids observed in a scan batch for resolve-reconcile."""
+    return {resolve_canonical_id(payload, source=source) for payload in findings}
+
+
+def enriched_finding_payload(current_row: dict[str, Any]) -> dict[str, Any]:
+    """Merge lifecycle fields from a current-state row into the API payload."""
+    payload = dict(current_row.get("payload") or {})
+    payload["status"] = current_row.get("status")
+    payload["first_seen"] = current_row.get("first_seen")
+    payload["last_seen"] = current_row.get("last_seen")
+    payload["scan_count"] = current_row.get("scan_count")
+    canonical = current_row.get("canonical_id")
+    if canonical:
+        payload["canonical_id"] = canonical
+    if current_row.get("resolved_at"):
+        payload["resolved_at"] = current_row["resolved_at"]
+    if current_row.get("reopened_at"):
+        payload["reopened_at"] = current_row["reopened_at"]
+    return payload
 
 
 _CURRENT_LIFECYCLE_POSTGRES_DDL = """

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -17,6 +17,7 @@ from agent_bom.api.compliance_hub_store import (
     _cvss_value,
     _frameworks_csv,
     _now_utc_iso,
+    _postgres_current_order_clause,
     _postgres_order_clause,
     _redact_findings,
     _severity_rank,
@@ -507,3 +508,103 @@ class PostgresComplianceHubStore:
             "updated_at": row[11],
             "payload": raw_payload if isinstance(raw_payload, dict) else json.loads(raw_payload),
         }
+
+    def list_current_page(
+        self,
+        tenant_id: str,
+        *,
+        limit: int,
+        offset: int = 0,
+        sort: str = "effective_reach",
+        severity: str | None = None,
+        scan_id: str | None = None,
+        origin: str | None = None,
+        include_total: bool = True,
+    ) -> FindingPage:
+        from agent_bom.api.finding_lifecycle import enriched_finding_payload
+        from agent_bom.graph.severity import severity_policy_rank
+
+        where = ["tenant_id = %s"]
+        params: list[Any] = [tenant_id]
+        if origin is not None:
+            where.append("payload->>'origin' = %s")
+            params.append(origin)
+        if severity is not None:
+            where.append("severity_rank = %s")
+            params.append(severity_policy_rank(severity))
+        if scan_id is not None:
+            where.append("(payload->>'batch_id' = %s OR payload->>'scan_id' = %s)")
+            params.extend([scan_id, scan_id])
+        where_sql = " AND ".join(where)
+        order_sql = _postgres_current_order_clause(sort)
+
+        with _tenant_connection(self._pool) as conn:
+            total: int | None
+            if include_total:
+                total_row = conn.execute(
+                    f"SELECT COUNT(*) FROM hub_findings_current WHERE {where_sql}",  # nosec B608
+                    tuple(params),
+                ).fetchone()
+                total = int(total_row[0]) if total_row else 0
+            else:
+                total = None
+            rows = conn.execute(
+                f"""
+                SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
+                       cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+                       updated_at, payload
+                FROM hub_findings_current
+                WHERE {where_sql} {order_sql} LIMIT %s OFFSET %s
+                """,  # nosec B608
+                (*params, int(limit), int(offset)),
+            ).fetchall()
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            raw_payload = row[12]
+            current_row = {
+                "canonical_id": row[0],
+                "first_seen": row[1],
+                "last_seen": row[2],
+                "status": row[3],
+                "severity": row[4],
+                "severity_rank": row[5],
+                "cvss_score": row[6],
+                "effective_reach_score": row[7],
+                "scan_count": row[8],
+                "resolved_at": row[9],
+                "reopened_at": row[10],
+                "updated_at": row[11],
+                "payload": raw_payload if isinstance(raw_payload, dict) else json.loads(raw_payload),
+            }
+            out.append(enriched_finding_payload(current_row))
+        return out, total
+
+    def reconcile_current_absent(
+        self,
+        tenant_id: str,
+        *,
+        present_canonical_ids: set[str],
+        observed_at: str,
+        scope_source: str | None = None,
+    ) -> int:
+        now = _now_utc_iso()
+        where = ["tenant_id = %s", "status IN ('open', 'reopened')"]
+        params: list[Any] = [observed_at, now, tenant_id]
+        if scope_source is not None:
+            where.append("payload->>'source' = %s")
+            params.append(scope_source)
+        if present_canonical_ids:
+            placeholders = ",".join("%s" for _ in present_canonical_ids)
+            where.append(f"canonical_id NOT IN ({placeholders})")
+            params.extend(sorted(present_canonical_ids))
+        with _tenant_connection(self._pool) as conn:
+            cur = conn.execute(
+                f"""
+                UPDATE hub_findings_current
+                SET status = 'resolved', resolved_at = %s, updated_at = %s
+                WHERE {' AND '.join(where)}
+                """,  # nosec B608
+                tuple(params),
+            )
+            conn.commit()
+        return int(cur.rowcount or 0)

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -1868,7 +1868,7 @@ async def ingest_compliance_findings(request: Request) -> dict:
             payload["applicable_frameworks"] = [normalize_framework_slug(str(slug)) for slug in frameworks if slug]
     tenant_id = _tenant_id(request)
     store = get_compliance_hub_store()
-    from agent_bom.api.finding_lifecycle import normalize_observed_at
+    from agent_bom.api.finding_lifecycle import collect_present_canonical_ids, normalize_observed_at
 
     observed_at = normalize_observed_at(body.get("observed_at"))
     batch_id = str(uuid.uuid4())
@@ -1880,19 +1880,31 @@ async def ingest_compliance_findings(request: Request) -> dict:
         batch_id=batch_id,
         source=fmt,
     )
+    reconciled = 0
+    if body.get("reconcile_absent"):
+        present = collect_present_canonical_ids(payloads, source=fmt)
+        reconciled = store.reconcile_current_absent(
+            tenant_id,
+            present_canonical_ids=present,
+            observed_at=observed_at,
+            scope_source=fmt,
+        )
 
     framework_counts: dict[str, int] = {}
     for payload in payloads:
         for slug in payload.get("applicable_frameworks") or []:
             framework_counts[slug] = framework_counts.get(slug, 0) + 1
 
-    return {
+    response = {
         "ingested": len(payloads),
         "tenant_total": new_total,
         "format": fmt,
         "observed_at": observed_at,
         "framework_hits": dict(sorted(framework_counts.items())),
     }
+    if body.get("reconcile_absent"):
+        response["reconciled"] = reconciled
+    return response
 
 
 @router.get("/v1/compliance/hub/findings", tags=["compliance"])

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -259,6 +259,13 @@ class BulkFindingsRequest(BaseModel):
         default=None,
         description="Observation timestamp from scan completion; defaults to ingest time when omitted.",
     )
+    reconcile_absent: bool = Field(
+        default=False,
+        description=(
+            "When true, mark open findings in the same source scope that are absent "
+            "from this batch as resolved at observed_at."
+        ),
+    )
 
     @field_validator("findings")
     @classmethod
@@ -314,6 +321,20 @@ def _normalized_bulk_finding(row: dict[str, Any], *, source: str, batch_id: str,
     return payload
 
 
+_LIFECYCLE_RESPONSE_KEYS = (
+    "origin",
+    "batch_id",
+    "bulk_ordinal",
+    "status",
+    "first_seen",
+    "last_seen",
+    "resolved_at",
+    "reopened_at",
+    "scan_count",
+    "canonical_id",
+)
+
+
 def _redact_finding_page(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     redacted = redact_for_persistence(rows, EvidenceTier.SAFE_TO_STORE)
     if not isinstance(redacted, list):
@@ -322,7 +343,7 @@ def _redact_finding_page(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for clean, raw in zip(redacted, rows):
         if not isinstance(clean, dict):
             continue
-        for key in ("origin", "batch_id", "bulk_ordinal"):
+        for key in _LIFECYCLE_RESPONSE_KEYS:
             if key not in clean and key in raw:
                 clean[key] = raw[key]
         page.append(clean)
@@ -1298,14 +1319,14 @@ async def list_findings(
     scan_findings.sort(key=lambda row: _finding_sort_key(row, sort_key))
 
     store = get_compliance_hub_store()
-    list_page = getattr(store, "list_page", None)
+    bulk_list = getattr(store, "list_current_page", None) or getattr(store, "list_page", None)
     total_approximate = False
-    if callable(list_page):
+    if callable(bulk_list):
         if scan_findings:
             # Bounded merge: pull at most (offset + limit) top bulk rows, merge
             # with the in-memory scan findings, then slice the requested page.
             window = offset + limit
-            bulk_page, bulk_total = list_page(
+            bulk_page, bulk_total = bulk_list(
                 tenant_id,
                 limit=window,
                 offset=0,
@@ -1330,7 +1351,7 @@ async def list_findings(
             )
             total = None if resolved_bulk is None else len(scan_findings) + resolved_bulk
         else:
-            page_rows, bulk_total = list_page(
+            page_rows, bulk_total = bulk_list(
                 tenant_id,
                 limit=limit,
                 offset=offset,
@@ -1423,7 +1444,7 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
     payloads = [
         _normalized_bulk_finding(row, source=body.source, batch_id=batch_id, ordinal=idx) for idx, row in enumerate(body.findings, start=1)
     ]
-    from agent_bom.api.finding_lifecycle import normalize_observed_at
+    from agent_bom.api.finding_lifecycle import collect_present_canonical_ids, normalize_observed_at
 
     observed_at = normalize_observed_at(body.observed_at or body.metadata.get("observed_at"))
     hub_store = get_compliance_hub_store()
@@ -1435,6 +1456,15 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
         batch_id=batch_id,
         source=body.source,
     )
+    reconciled = 0
+    if body.reconcile_absent:
+        present = collect_present_canonical_ids(payloads, source=body.source)
+        reconciled = hub_store.reconcile_current_absent(
+            tenant_id,
+            present_canonical_ids=present,
+            observed_at=observed_at,
+            scope_source=body.source,
+        )
     warnings = ["tenant_id in body ignored; request tenant scope is authoritative"] if ignored_body_tenant else []
     response = {
         "schema_version": "v1",
@@ -1446,6 +1476,8 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
         "observed_at": observed_at,
         "warnings": warnings,
     }
+    if body.reconcile_absent:
+        response["reconciled"] = reconciled
     if idem_key:
         _get_idempotency_store().put(
             "/v1/findings/bulk",

--- a/tests/test_finding_lifecycle.py
+++ b/tests/test_finding_lifecycle.py
@@ -1,4 +1,4 @@
-"""Monotone current-state finding lifecycle (#3465 L1–L2)."""
+"""Monotone current-state finding lifecycle (#3465 L1–L4)."""
 
 from __future__ import annotations
 
@@ -151,3 +151,122 @@ def test_reopen_on_resolved_observation(hub_store) -> None:
     assert reopened["status"] == "reopened"
     assert reopened["reopened_at"] == TUE
     assert reopened["last_seen"] == TUE
+
+
+def _finding_with_id(finding_id: str) -> dict:
+    payload = _sample_finding()
+    payload["id"] = finding_id
+    return payload
+
+
+def test_reconcile_absent_resolves_open_not_in_batch(hub_store) -> None:
+    tenant = f"reconcile-{uuid4().hex}"
+    kept = _finding_with_id("finding-kept")
+    dropped = _finding_with_id("finding-dropped")
+    kept_canonical = resolve_canonical_id(kept)
+    dropped_canonical = resolve_canonical_id(dropped)
+
+    hub_store.upsert_current_batch(
+        tenant,
+        [kept, dropped],
+        observed_at=MON,
+        batch_id="batch-initial",
+        source="agent-runtime",
+    )
+    hub_store.reconcile_current_absent(
+        tenant,
+        present_canonical_ids={kept_canonical},
+        observed_at=TUE,
+        scope_source="agent-runtime",
+    )
+
+    kept_row = hub_store.get_current(tenant, kept_canonical)
+    dropped_row = hub_store.get_current(tenant, dropped_canonical)
+    assert kept_row is not None
+    assert dropped_row is not None
+    assert kept_row["status"] == "open"
+    assert dropped_row["status"] == "resolved"
+    assert dropped_row["resolved_at"] == TUE
+
+    # Idempotent: a second reconcile at the same observed_at is a no-op.
+    again = hub_store.reconcile_current_absent(
+        tenant,
+        present_canonical_ids={kept_canonical},
+        observed_at=TUE,
+        scope_source="agent-runtime",
+    )
+    assert again == 0
+
+
+def test_reconcile_absent_scoped_by_source(hub_store) -> None:
+    tenant = f"reconcile-scope-{uuid4().hex}"
+    runtime = _finding_with_id("finding-runtime")
+    runtime["source"] = "agent-runtime"
+    other = _finding_with_id("finding-other")
+    other["source"] = "external-scanner"
+
+    hub_store.upsert_current_batch(tenant, [runtime, other], observed_at=MON, batch_id="batch-a")
+    hub_store.reconcile_current_absent(
+        tenant,
+        present_canonical_ids=set(),
+        observed_at=TUE,
+        scope_source="agent-runtime",
+    )
+
+    runtime_row = hub_store.get_current(tenant, resolve_canonical_id(runtime))
+    other_row = hub_store.get_current(tenant, resolve_canonical_id(other))
+    assert runtime_row is not None
+    assert other_row is not None
+    assert runtime_row["status"] == "resolved"
+    assert other_row["status"] == "open"
+
+
+def test_list_current_page_enriches_lifecycle_fields(hub_store) -> None:
+    tenant = f"list-current-{uuid4().hex}"
+    finding = _sample_finding()
+    hub_store.upsert_current_batch(tenant, [finding], observed_at=MON, batch_id="batch-list")
+
+    rows, total = hub_store.list_current_page(tenant, limit=10, offset=0, origin="bulk_ingest")
+    assert total == 1
+    assert len(rows) == 1
+    assert rows[0]["first_seen"] == MON
+    assert rows[0]["last_seen"] == MON
+    assert rows[0]["status"] == "open"
+    assert rows[0]["scan_count"] == 1
+
+
+def test_bulk_reconcile_absent_api() -> None:
+    from starlette.testclient import TestClient
+
+    tenant = f"bulk-reconcile-{uuid4().hex}"
+    store = InMemoryComplianceHubStore()
+    set_compliance_hub_store(store)
+    client = TestClient(app)
+    client.headers.update(proxy_headers(role="analyst", tenant=tenant))
+
+    kept = _finding_with_id("finding-kept-api")
+    dropped = _finding_with_id("finding-dropped-api")
+    client.post(
+        "/v1/findings/bulk",
+        json={"source": "agent-runtime", "observed_at": MON, "findings": [kept, dropped]},
+    )
+
+    resp = client.post(
+        "/v1/findings/bulk",
+        json={
+            "source": "agent-runtime",
+            "observed_at": TUE,
+            "reconcile_absent": True,
+            "findings": [kept],
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["reconciled"] == 1
+
+    listed = client.get("/v1/findings", params={"limit": 50}).json()
+    by_id = {item["id"]: item for item in listed["findings"]}
+    assert by_id["finding-kept-api"]["status"] == "open"
+    assert by_id["finding-dropped-api"]["status"] == "resolved"
+    assert by_id["finding-dropped-api"]["resolved_at"] == TUE
+
+    reset_compliance_hub_store()

--- a/tests/test_findings_read_scale.py
+++ b/tests/test_findings_read_scale.py
@@ -56,7 +56,15 @@ def test_findings_list_page_under_500ms_at_2k_rows() -> None:
     batch_id = f"batch-{uuid.uuid4().hex}"
     store = InMemoryComplianceHubStore()
     set_compliance_hub_store(store)
-    store.add(tenant_id, _synthetic_findings(_FINDINGS_COUNT, batch_id=batch_id))
+    findings = _synthetic_findings(_FINDINGS_COUNT, batch_id=batch_id)
+    store.add(tenant_id, findings)
+    store.upsert_current_batch(
+        tenant_id,
+        findings,
+        observed_at="2026-07-03T12:00:00Z",
+        batch_id=batch_id,
+        source="test_findings_read_scale",
+    )
 
     client = TestClient(app)
     headers = proxy_headers(role="viewer", tenant=tenant_id)
@@ -82,7 +90,15 @@ def test_findings_approximate_total_skips_count_on_deep_page() -> None:
     batch_id = f"batch-{uuid.uuid4().hex}"
     store = InMemoryComplianceHubStore()
     set_compliance_hub_store(store)
-    store.add(tenant_id, _synthetic_findings(_FINDINGS_COUNT, batch_id=batch_id))
+    findings = _synthetic_findings(_FINDINGS_COUNT, batch_id=batch_id)
+    store.add(tenant_id, findings)
+    store.upsert_current_batch(
+        tenant_id,
+        findings,
+        observed_at="2026-07-03T12:00:00Z",
+        batch_id=batch_id,
+        source="test_findings_read_scale",
+    )
 
     client = TestClient(app)
     headers = proxy_headers(role="viewer", tenant=tenant_id)


### PR DESCRIPTION
## Summary
- **L3 resolve reconcile**: optional `reconcile_absent` on `/v1/findings/bulk` and `/v1/compliance/ingest` marks open findings in the same `source` scope absent from the batch as `resolved` at `observed_at` (idempotent per observation).
- **L4 read unification**: `GET /v1/findings` bulk slice reads `hub_findings_current` via `list_current_page`, returning merged lifecycle fields (`status`, `first_seen`, `last_seen`, `resolved_at`, `scan_count`, …).

Closes #3465

## Verification
- `uv run pytest tests/test_finding_lifecycle.py tests/test_findings_bulk_api.py tests/test_compliance_hub_store_pagination.py tests/test_findings_read_scale.py -q`
- `uv run ruff check` on touched modules

## Notes
- Reconcile is opt-in (`reconcile_absent: false` default) so partial/delta ingests do not auto-resolve the tenant.