### PR TITLE
feat(sdk): expose finding lifecycle ingest on control-plane clients

### DIFF
--- a/sdks/go/client.go
+++ b/sdks/go/client.go
@@ -146,22 +146,34 @@ func (c *Client) ListFindings(ctx context.Context, query FindingQuery) (JSON, er
 
 // IngestFindingsRequest posts normalized findings directly into the control plane.
 type IngestFindingsRequest struct {
-	Findings      []JSON
-	Source        string
-	SchemaVersion string
-	Metadata      JSON
-	TenantID      string
+	Findings         []JSON
+	Source           string
+	SchemaVersion    string
+	Metadata         JSON
+	TenantID         string
+	ObservedAt       string
+	ReconcileAbsent  bool
+	IdempotencyKey   string
 }
 
 // IngestFindings posts normalized findings directly into the control plane.
 func (c *Client) IngestFindings(ctx context.Context, req IngestFindingsRequest) (JSON, error) {
-	return c.request(ctx, http.MethodPost, "/v1/findings/bulk", nil, compact(JSON{
+	body := compact(JSON{
 		"findings":       req.Findings,
 		"source":         req.Source,
 		"schema_version": req.SchemaVersion,
 		"metadata":       req.Metadata,
 		"tenant_id":      firstNonEmpty(req.TenantID, c.tenantID),
-	}))
+		"observed_at":    req.ObservedAt,
+	})
+	if req.ReconcileAbsent {
+		body["reconcile_absent"] = true
+	}
+	extra := map[string]string{}
+	if req.IdempotencyKey != "" {
+		extra["Idempotency-Key"] = req.IdempotencyKey
+	}
+	return c.request(ctx, http.MethodPost, "/v1/findings/bulk", nil, body, extra)
 }
 
 // DatasetVersionRequest registers one dataset version artifact.
@@ -407,7 +419,7 @@ func (c *Client) IntelSources(ctx context.Context) (JSON, error) {
 	return c.request(ctx, http.MethodGet, "/v1/intel/sources", nil, nil)
 }
 
-func (c *Client) request(ctx context.Context, method string, path string, values url.Values, body JSON) (JSON, error) {
+func (c *Client) request(ctx context.Context, method string, path string, values url.Values, body JSON, extraHeaders ...map[string]string) (JSON, error) {
 	endpoint := c.url(path)
 	if len(values) > 0 {
 		endpoint += "?" + values.Encode()
@@ -441,6 +453,11 @@ func (c *Client) request(ctx context.Context, method string, path string, values
 	}
 	if c.tenantID != "" {
 		request.Header.Set("X-Agent-Bom-Tenant-ID", c.tenantID)
+	}
+	if len(extraHeaders) > 0 {
+		for key, value := range extraHeaders[0] {
+			request.Header.Set(key, value)
+		}
 	}
 
 	response, err := c.httpClient.Do(request)

--- a/sdks/typescript-client/src/index.ts
+++ b/sdks/typescript-client/src/index.ts
@@ -71,6 +71,9 @@ export interface BulkFindingIngestRequest {
   schemaVersion?: string;
   metadata?: Record<string, JsonValue>;
   tenantId?: string;
+  observedAt?: string;
+  reconcileAbsent?: boolean;
+  idempotencyKey?: string;
 }
 
 export interface DatasetVersionCreateRequest {
@@ -108,6 +111,8 @@ export interface BulkFindingIngestResponse {
   tenant_total: number;
   tenant_id: string;
   source: string;
+  observed_at?: string;
+  reconciled?: number;
   warnings?: string[];
   [key: string]: JsonValue | undefined;
 }
@@ -296,13 +301,24 @@ export class AgentBomClient {
   ingestFindings(
     request: BulkFindingIngestRequest,
   ): Promise<BulkFindingIngestResponse> {
-    return this.request<BulkFindingIngestResponse>("POST", "/v1/findings/bulk", {
-      findings: request.findings,
-      source: request.source,
-      schema_version: request.schemaVersion,
-      metadata: request.metadata,
-      tenant_id: request.tenantId ?? this.tenantId,
-    });
+    const extraHeaders: Record<string, string> = {};
+    if (request.idempotencyKey) {
+      extraHeaders["Idempotency-Key"] = request.idempotencyKey;
+    }
+    return this.request<BulkFindingIngestResponse>(
+      "POST",
+      "/v1/findings/bulk",
+      {
+        findings: request.findings,
+        source: request.source,
+        schema_version: request.schemaVersion,
+        metadata: request.metadata,
+        tenant_id: request.tenantId ?? this.tenantId,
+        observed_at: request.observedAt,
+        reconcile_absent: request.reconcileAbsent,
+      },
+      extraHeaders,
+    );
   }
 
   registerDatasetVersion(
@@ -507,10 +523,11 @@ export class AgentBomClient {
     method: string,
     path: string,
     body?: Record<string, JsonValue | undefined>,
+    extraHeaders: Record<string, string> = {},
   ): Promise<T> {
     const init: RequestInit = {
       method,
-      headers: this.headers(body !== undefined),
+      headers: { ...this.headers(body !== undefined), ...extraHeaders },
     };
     if (body !== undefined) {
       init.body = JSON.stringify(stripUndefined(body));

--- a/sdks/typescript-client/tests/client.test.js
+++ b/sdks/typescript-client/tests/client.test.js
@@ -104,6 +104,47 @@ test("posts normalized bulk findings", async () => {
   });
 });
 
+test("posts bulk findings with lifecycle fields and idempotency header", async () => {
+  let payload;
+  let headers;
+  const client = new AgentBomClient({
+    baseUrl: "https://agent-bom.example.com",
+    tenantId: "tenant-d",
+    fetch: async (_url, init) => {
+      payload = JSON.parse(init.body);
+      headers = init.headers;
+      return jsonResponse({
+        schema_version: "v1",
+        batch_id: "batch-1",
+        ingested: 1,
+        tenant_total: 1,
+        tenant_id: "tenant-d",
+        source: "agent-runtime",
+        observed_at: "2026-07-08T12:00:00Z",
+        reconciled: 2,
+      });
+    },
+  });
+
+  const response = await client.ingestFindings({
+    source: "agent-runtime",
+    findings: [{ id: "finding-1", severity: "high" }],
+    observedAt: "2026-07-08T12:00:00Z",
+    reconcileAbsent: true,
+    idempotencyKey: "scan-batch-42",
+  });
+
+  assert.equal(response.reconciled, 2);
+  assert.equal(headers["Idempotency-Key"], "scan-batch-42");
+  assert.deepEqual(payload, {
+    findings: [{ id: "finding-1", severity: "high" }],
+    source: "agent-runtime",
+    tenant_id: "tenant-d",
+    observed_at: "2026-07-08T12:00:00Z",
+    reconcile_absent: true,
+  });
+});
+
 test("registers dataset versions", async () => {
   let seenUrl = "";
   let payload;

--- a/src/agent_bom/client.py
+++ b/src/agent_bom/client.py
@@ -230,8 +230,15 @@ class AgentBomClient:
         schema_version: str | None = None,
         metadata: Mapping[str, JsonValue] | None = None,
         tenant_id: str | None = None,
+        observed_at: str | None = None,
+        reconcile_absent: bool = False,
+        idempotency_key: str | None = None,
     ) -> JsonObject:
         """Post normalized findings directly into the control plane."""
+
+        extra_headers: dict[str, str] = {}
+        if idempotency_key:
+            extra_headers["Idempotency-Key"] = idempotency_key
 
         return self._request(
             "POST",
@@ -243,8 +250,11 @@ class AgentBomClient:
                     "schema_version": schema_version,
                     "metadata": dict(metadata) if metadata is not None else None,
                     "tenant_id": tenant_id or self.tenant_id,
+                    "observed_at": observed_at,
+                    "reconcile_absent": reconcile_absent or None,
                 }
             ),
+            extra_headers=extra_headers or None,
         )
 
     def register_dataset_version(
@@ -489,8 +499,12 @@ class AgentBomClient:
         *,
         params: Mapping[str, QueryValue] | None = None,
         json: Mapping[str, JsonValue] | None = None,
+        extra_headers: Mapping[str, str] | None = None,
     ) -> JsonObject:
-        response = self._client.request(method, self._url(path), params=params, json=json, headers=self._headers(json is not None))
+        headers = self._headers(json is not None)
+        if extra_headers:
+            headers.update(extra_headers)
+        response = self._client.request(method, self._url(path), params=params, json=json, headers=headers)
         text = response.text
         if response.status_code < 200 or response.status_code >= 300:
             raise AgentBomApiError(

--- a/tests/test_python_client.py
+++ b/tests/test_python_client.py
@@ -191,6 +191,37 @@ def test_client_accepts_positional_findings_payload() -> None:
     }
 
 
+def test_client_ingest_findings_lifecycle_fields() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content.decode("utf-8"))
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(201, json={"ingested": 1, "reconciled": 1})
+
+    client = _client(handler)
+
+    result = client.ingest_findings(
+        [{"id": "finding-1", "severity": "high"}],
+        source="sdk-test",
+        observed_at="2026-07-08T12:00:00Z",
+        reconcile_absent=True,
+        idempotency_key="scan-batch-42",
+    )
+
+    assert result["reconciled"] == 1
+    headers = captured["headers"]
+    assert isinstance(headers, dict)
+    assert headers["idempotency-key"] == "scan-batch-42"
+    assert captured["body"] == {
+        "findings": [{"id": "finding-1", "severity": "high"}],
+        "source": "sdk-test",
+        "tenant_id": "tenant-a",
+        "observed_at": "2026-07-08T12:00:00Z",
+        "reconcile_absent": True,
+    }
+
+
 def test_client_rejects_ambiguous_auth() -> None:
     with pytest.raises(ValueError, match="either api_key or bearer_token"):
         AgentBomClient(base_url="https://agent-bom.example.com", api_key="a", bearer_token="b")


### PR DESCRIPTION
## Summary
- Python `AgentBomClient.ingest_findings()` accepts `observed_at`, `reconcile_absent`, and `idempotency_key`.
- TypeScript `ingestFindings()` accepts `observedAt`, `reconcileAbsent`, and `idempotencyKey` (sends `Idempotency-Key` header).
- Go `IngestFindingsRequest` adds matching fields.

Part of #3482 (headless lifecycle parity). Pairs with #3481 API L3+L4.

## Verification
- `uv run pytest tests/test_python_client.py -q`
- `cd sdks/typescript-client && npm run build && npm test`
- `cd sdks/go && go test ./...`