### PR TITLE
docs(audit): add sanitized 2026-07-03 ledger with issue mapping

### DIFF
--- a/docs/audits/AUDIT-2026-07-03.md
+++ b/docs/audits/AUDIT-2026-07-03.md
@@ -1,0 +1,115 @@
+# agent-bom v0.92.0 — Audit ledger (2026-07-03)
+
+**Scope:** Multi-wave audit 2026-07-02 → 2026-07-03. Live verification against post-fix commits.
+**Baseline:** `main @ 689deea2a` (lifecycle L2). **Product version:** 0.92.0.
+**Policy:** Canonical model is product truth; OCSF is export/interop only (`docs/OCSF_BOUNDARY.md`). No vendor parity claims in this doc.
+
+---
+
+## §A. Scores (1–10, post-wave)
+
+| Dimension | Score | Note |
+|---|---|---|
+| CLI / scanner | 9 · 8 | ~15 scan surfaces; offline SCA; IaC → SARIF+enrichment |
+| MCP / runtime / gateway | 9 · 7 | proxy blocks; firewall; skills injection detect |
+| API surface | 8 | 242 paths; envelope + correlation_id |
+| Ingestion bulk/compliance/scan/SBOM | 8.5 | idempotent; UUIDv5 identity; finding lifecycle L1+L2 |
+| **Ingestion OCSF path** | **3** | P0 event-loop DoS — #3485 |
+| Enterprise auth | 8.5 | RBAC, SCIM, SAML, audit chain |
+| Scale reads | 8 | ~39 ms @500k (was O(n)); no partitioning yet (#3463) |
+| Cost / efficiency | 6 | gzip + at-rest compression open — #3486 |
+| Interop formats | 8.5 | SARIF/CycloneDX/SPDX/OpenVEX/OCSF export paths |
+
+---
+
+## §B. Master issue ledger
+
+### Fixed & live-verified (19 items)
+
+| # | Finding | PR / issue |
+|---|---|---|
+| 1 | P0 finding ingest not idempotent | ON CONFLICT upsert |
+| 2 | P1 O(n) findings read | #3442 — ~39 ms @500k |
+| 3 | P1 filtered severity/cvss sort | #3461 — ~28 ms @500k |
+| 4 | P1 retention not enforced | #3441, #3453 |
+| 5 | P1 scan Idempotency-Key | #3462 |
+| 6 | P1 batch cap 500→422 | #3477 |
+| 7 | P1 SQLite tenant fail-open | sentinel fix |
+| 8 | P2 skills CI exit 0 | #3449 |
+| 9 | P2 secret scanner FP | #3447 |
+| 10 | P2 /health rate-limit exempt | #3464 family |
+| 11 | P2 cloud retry bypass | http_client routing |
+| 12 | P2 Alembic manual | #3433 Helm hook |
+| 13 | P3 batch scan fan-out cap | API_MAX_BATCH_SCAN_TARGETS |
+| 14 | P3 sdks/python stale version | #3438 |
+| 15 | P3 pci-dss slug | #3439 |
+| 16 | P3 session Secure default | #3475 / #3479 |
+| 17 | P3 SBOM/air-gap/KEV+EPSS offline | #3451, #3466 |
+| 18 | Finding lifecycle L1+L2 | #3470, #3480 |
+| 19 | P3 SAML RelayState cluster | #3478 |
+
+### Open (A–T) → GitHub issues
+
+| ID | Priority | Finding | GitHub |
+|---|---|---|---|
+| **A** | P0 | `/v1/ocsf/ingest` event-loop DoS | **#3485** |
+| **B** | quick win | No HTTP response gzip | **#3486** (with C) |
+| **C** | quick win | No at-rest payload compression | **#3486** (with B) |
+| **D** | P1 | Payload stored twice (ledger + current-state) | **#3487** |
+| **E** | P1 | Lifecycle L3 resolve-reconcile | **#3465** / PR **#3481** |
+| **F** | P1 | Lifecycle L4 read unification | **#3465** / PR **#3481** |
+| **G** | P2 | Driver `run()` / `failure_mode` not enforced | **#3488** |
+| **H** | P2 | Rate-limit fixed vs sliding (Postgres) | **#3489** |
+| **I** | P2 | Compliance ingest over-tags frameworks | **#3490** |
+| **J** | P2 | ClickHouse analytics dedup | **#3484** |
+| **K** | P2 | `ScanRequest` list fields lack `max_length` | **#3491** |
+| **L** | P2 | Sync retry no jitter | **#3492** |
+| **M** | P2 | nebius/lambda/runpod raw `requests` | **#3493** |
+| **N** | P3 | NetworkPolicy API egress 0.0.0.0/0:443 | **#3494** |
+| **O** | P3 | No table partitioning | **#3463** |
+| **P** | P3 | Batch parent empty graph exports | **#3495** |
+| **Q** | P3 | Stale Alembic docs | **#3496** |
+| **R** | P3 | Finding encryption prerequisite (document) | **#3497** |
+| **S** | P3 | OCSF product attribution on ingest | **#3498** |
+| **T** | scope | Multi-language reachability; data-lake interop | **#3499** |
+
+**Related (not in A–T):** headless lifecycle SDK/MCP/UI glue — **#3482** (SDK fields shipped #3483).
+
+---
+
+## §C. OCSF vs canonical (interop)
+
+| Layer | Model |
+|---|---|
+| Scan, hub, lifecycle, API, UI | **Canonical** `Finding` + `ContextGraph` |
+| Graph node labels | Derived OCSF UIDs (`graph/ocsf.py`) |
+| SIEM / syslog export | OCSF projection (`siem/ocsf.py`, `output/ocsf.py`) |
+| ClickHouse analytics | **Canonical rows** — not OCSF storage (#3484) |
+| `/v1/ocsf/ingest` | Interop **ingress** — must not block event loop (#3485) |
+
+---
+
+## §D. Prioritized backlog
+
+1. **P0** — #3485 (OCSF DoS)
+2. **Quick wins** — #3486 (gzip + zstd)
+3. **P1** — #3487 (dedup storage); #3481 → closes #3465 (L3+L4)
+4. **P2** — #3488–#3493, #3484, #3482
+5. **P3 / scope** — #3494–#3499, #3463
+
+---
+
+## §E. Cost / efficiency (measured)
+
+| Metric | Value |
+|---|---|
+| Bytes/finding on disk | ~2,645 B |
+| Payload gzip-9 / zstd-19 | ~15× / ~20× |
+| `/v1/findings?limit=500` egress | ~319 KB uncompressed; ~23 KB gzipped |
+| Read latency | ~38 ms / 500 rows over 50k |
+
+**Wins:** #3486 (egress + storage), #3487 (dedup), #3485 (unblock OCSF path).
+
+---
+
+_Sanitized from consolidated audit dossier 2026-07-03. Vendor parity sections omitted per repo policy. Update this ledger when PRs merge._


### PR DESCRIPTION
## Summary
- Add `docs/audits/AUDIT-2026-07-03.md` — sanitized master ledger (§B A–T) with links to filed GitHub issues.
- Omits vendor parity / competitive comparison sections per repo policy.
- Maps open items to #3485–#3499, existing #3463/#3465/#3482/#3484, and in-flight #3481.

## Notes
- Scratchpad dossier remains ephemeral; this is the durable Cursor handoff surface.

## Test plan
- [ ] `git diff --check`

Made with [Cursor](https://cursor.com)