### PR TITLE
fix(api): harden OCSF ingest — cap/offload (A) + deterministic event IDs & ClickHouse dedup (J)

### DIFF
--- a/deploy/supabase/clickhouse/init.sql
+++ b/deploy/supabase/clickhouse/init.sql
@@ -46,8 +46,8 @@ CREATE TABLE IF NOT EXISTS agent_bom.runtime_events (
     trace_id String DEFAULT '',
     request_id String DEFAULT '',
     source_id String DEFAULT ''
-) ENGINE = MergeTree()
-ORDER BY (event_timestamp, event_type, agent_name)
+) ENGINE = ReplacingMergeTree()
+ORDER BY (event_timestamp, event_type, agent_name, event_id)
 PARTITION BY toYYYYMM(event_timestamp);
 
 -- 3. Posture scores (periodic snapshots)
@@ -163,6 +163,12 @@ TTL measured_at + INTERVAL 2 YEAR;
 
 -- Forward-compatible migrations for deployments created from older init.sql
 -- revisions. These mirror the runtime ClickHouse client migrations.
+--
+-- Note: runtime_events now uses ReplacingMergeTree ORDER BY (..., event_id) so
+-- retried OCSF/runtime events collapse instead of double-counting. ClickHouse
+-- cannot ALTER a table's engine in place; deployments whose runtime_events
+-- predates this revision keep the append-only MergeTree until the table is
+-- recreated. New deployments get dedup automatically.
 ALTER TABLE agent_bom.vulnerability_scans ADD COLUMN IF NOT EXISTS tenant_id String DEFAULT 'default';
 ALTER TABLE agent_bom.runtime_events ADD COLUMN IF NOT EXISTS tenant_id String DEFAULT 'default';
 ALTER TABLE agent_bom.runtime_events ADD COLUMN IF NOT EXISTS session_id String DEFAULT '';

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -32,6 +32,7 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_API_MAX_JOBS` | `int` | `10` | Used by api/server.py for the REST API job queue.  10 concurrent scan jobs prevents resource exhaustion on shared hosts. 1-hour TTL auto-cleans completed jobs.  200 in-memory ceiling triggers LRU eviction for long-running API instances. |
 | `AGENT_BOM_API_MAX_JOB_PROGRESS_EVENTS` | `int` | `500` | — |
 | `AGENT_BOM_API_MAX_MEMORY_JOBS` | `int` | `200` | — |
+| `AGENT_BOM_API_MAX_OCSF_INGEST_EVENTS` | `int` | `1000` | — |
 | `AGENT_BOM_API_MAX_RETAINED_JOBS_PER_TENANT` | `int` | `500` | — |
 | `AGENT_BOM_API_MAX_SCHEDULES_PER_TENANT` | `int` | `100` | — |
 | `AGENT_BOM_API_SCAN_CLAIM_POLL_SECONDS` | `int` | `3` | — |

--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -50,6 +50,18 @@ def _coerce_clickhouse_timestamp(value: Any) -> str | None:
     return dt.strftime("%Y-%m-%d %H:%M:%S")
 
 
+def _deterministic_event_id(*parts: Any) -> str:
+    """Return a stable content-derived event id for id-less analytics events.
+
+    Mirrors the runtime observation store fallback so an event retried without
+    a caller-supplied id collapses under ``runtime_events`` ReplacingMergeTree
+    dedup instead of appending a new row each time (audit item J).
+    """
+    from agent_bom.canonical_ids import canonical_id
+
+    return canonical_id("analytics_event", *parts)
+
+
 # ------------------------------------------------------------------
 # Protocol
 # ------------------------------------------------------------------
@@ -329,15 +341,35 @@ class ClickHouseAnalyticsStore:
             self._client.insert_json("runtime_events", rows)
 
     def _event_row(self, event: dict, *, tenant_id: str = "default") -> dict[str, Any]:
+        resolved_tenant = str(event.get("tenant_id") or tenant_id or "default")
+        event_timestamp = _coerce_clickhouse_timestamp(event.get("event_timestamp") or event.get("timestamp") or event.get("ts"))
+        event_type = event.get("event_type", event.get("type", ""))
+        detector = event.get("detector", "")
+        tool_name = event.get("tool_name", event.get("tool", ""))
+        message = event.get("message", "")
+        event_id = str(event.get("event_id") or "").strip()
+        if not event_id:
+            # Deterministic content-derived ID so retries collapse under the
+            # runtime_events ReplacingMergeTree instead of double-counting on a
+            # fresh uuid4 (audit item J).
+            event_id = _deterministic_event_id(
+                resolved_tenant,
+                str(event.get("source_id") or ""),
+                str(event_timestamp or ""),
+                event_type,
+                detector,
+                tool_name,
+                message,
+            )
         return {
-            "event_id": event.get("event_id", str(uuid.uuid4())),
-            "event_timestamp": _coerce_clickhouse_timestamp(event.get("event_timestamp") or event.get("timestamp") or event.get("ts")),
-            "tenant_id": str(event.get("tenant_id") or tenant_id or "default"),
-            "event_type": event.get("event_type", event.get("type", "")),
-            "detector": event.get("detector", ""),
+            "event_id": event_id,
+            "event_timestamp": event_timestamp,
+            "tenant_id": resolved_tenant,
+            "event_type": event_type,
+            "detector": detector,
             "severity": event.get("severity", "INFO"),
-            "tool_name": event.get("tool_name", event.get("tool", "")),
-            "message": event.get("message", ""),
+            "tool_name": tool_name,
+            "message": message,
             "agent_name": event.get("agent_name", ""),
             "session_id": str(event.get("session_id", "") or ""),
             "trace_id": str(event.get("trace_id", "") or ""),

--- a/src/agent_bom/api/postgres_runtime_event.py
+++ b/src/agent_bom/api/postgres_runtime_event.py
@@ -88,7 +88,7 @@ class PostgresRuntimeEventStore:
                 chunk = observation_ids[offset : offset + _BATCH_LOOKUP_CHUNK]
                 placeholders = ",".join("%s" for _ in chunk)
                 rows = conn.execute(
-                    f"SELECT observation_id FROM runtime_observations WHERE tenant_id = %s AND observation_id IN ({placeholders})",
+                    f"SELECT observation_id FROM runtime_observations WHERE tenant_id = %s AND observation_id IN ({placeholders})",  # nosec B608
                     (tenant_id, *chunk),
                 ).fetchall()
                 existing_ids.update(row[0] for row in rows)
@@ -101,7 +101,7 @@ class PostgresRuntimeEventStore:
                 chunk = session_ids[offset : offset + _BATCH_LOOKUP_CHUNK]
                 placeholders = ",".join("%s" for _ in chunk)
                 rows = conn.execute(
-                    f"SELECT session_id, data FROM runtime_sessions WHERE tenant_id = %s AND session_id IN ({placeholders})",
+                    f"SELECT session_id, data FROM runtime_sessions WHERE tenant_id = %s AND session_id IN ({placeholders})",  # nosec B608
                     (tenant_id, *chunk),
                 ).fetchall()
                 for session_id, data in rows:

--- a/src/agent_bom/api/postgres_runtime_event.py
+++ b/src/agent_bom/api/postgres_runtime_event.py
@@ -19,9 +19,11 @@ import json
 from agent_bom.analytics_retention import prune_runtime_observations_for_tenant
 from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
 from agent_bom.api.runtime_event_store import (
+    _BATCH_LOOKUP_CHUNK,
     RuntimeObservationRecord,
     RuntimeSessionRecord,
-    _merge_session,
+    _dedupe_observation_records,
+    _merge_sessions_for_batch,
     _observation_from_json,
     _session_from_json,
 )
@@ -72,40 +74,75 @@ class PostgresRuntimeEventStore:
             conn.commit()
 
     def put_observation(self, record: RuntimeObservationRecord) -> None:
+        self.put_observations_batch([record])
+
+    def put_observations_batch(self, records: list[RuntimeObservationRecord]) -> int:
+        unique_records = _dedupe_observation_records(records)
+        if not unique_records:
+            return 0
+        tenant_id = unique_records[0].tenant_id
         with _tenant_connection(self._pool) as conn:
-            existing = conn.execute(
-                "SELECT 1 FROM runtime_observations WHERE tenant_id = %s AND observation_id = %s",
-                (record.tenant_id, record.observation_id),
-            ).fetchone()
-            if existing:
-                return
-            session = _merge_session(self.get_session(record.tenant_id, record.session_id), record)
-            conn.execute(
-                """
+            existing_ids: set[str] = set()
+            observation_ids = [record.observation_id for record in unique_records]
+            for offset in range(0, len(observation_ids), _BATCH_LOOKUP_CHUNK):
+                chunk = observation_ids[offset : offset + _BATCH_LOOKUP_CHUNK]
+                placeholders = ",".join("%s" for _ in chunk)
+                rows = conn.execute(
+                    f"SELECT observation_id FROM runtime_observations WHERE tenant_id = %s AND observation_id IN ({placeholders})",
+                    (tenant_id, *chunk),
+                ).fetchall()
+                existing_ids.update(row[0] for row in rows)
+            new_records = [record for record in unique_records if record.observation_id not in existing_ids]
+            if not new_records:
+                return 0
+            session_ids = sorted({record.session_id for record in new_records})
+            existing_sessions: dict[str, RuntimeSessionRecord] = {}
+            for offset in range(0, len(session_ids), _BATCH_LOOKUP_CHUNK):
+                chunk = session_ids[offset : offset + _BATCH_LOOKUP_CHUNK]
+                placeholders = ",".join("%s" for _ in chunk)
+                rows = conn.execute(
+                    f"SELECT session_id, data FROM runtime_sessions WHERE tenant_id = %s AND session_id IN ({placeholders})",
+                    (tenant_id, *chunk),
+                ).fetchall()
+                for session_id, data in rows:
+                    existing_sessions[session_id] = _session_from_json(data)
+            merged_sessions = _merge_sessions_for_batch(existing_sessions, new_records)
+            observation_sql = """
                 INSERT INTO runtime_observations (tenant_id, observation_id, session_id, observed_at, data)
                 VALUES (%s, %s, %s, %s, %s)
                 ON CONFLICT (tenant_id, observation_id) DO NOTHING
-                """,
-                (
-                    record.tenant_id,
-                    record.observation_id,
-                    record.session_id,
-                    record.observed_at,
-                    json.dumps(record.to_dict(), sort_keys=True),
-                ),
-            )
-            conn.execute(
-                """
+            """
+            for record in new_records:
+                conn.execute(
+                    observation_sql,
+                    (
+                        record.tenant_id,
+                        record.observation_id,
+                        record.session_id,
+                        record.observed_at,
+                        json.dumps(record.to_dict(), sort_keys=True),
+                    ),
+                )
+            session_sql = """
                 INSERT INTO runtime_sessions (tenant_id, session_id, last_seen, data)
                 VALUES (%s, %s, %s, %s)
                 ON CONFLICT (tenant_id, session_id) DO UPDATE SET
                     last_seen = EXCLUDED.last_seen,
                     data = EXCLUDED.data
-                """,
-                (session.tenant_id, session.session_id, session.last_seen, json.dumps(session.to_dict(), sort_keys=True)),
-            )
-            prune_runtime_observations_for_tenant(conn, record.tenant_id, placeholder="%s")
+            """
+            for session in merged_sessions.values():
+                conn.execute(
+                    session_sql,
+                    (
+                        session.tenant_id,
+                        session.session_id,
+                        session.last_seen,
+                        json.dumps(session.to_dict(), sort_keys=True),
+                    ),
+                )
+            prune_runtime_observations_for_tenant(conn, tenant_id, placeholder="%s")
             conn.commit()
+            return len(new_records)
 
     def list_sessions(self, tenant_id: str, *, limit: int = 100, offset: int = 0) -> list[RuntimeSessionRecord]:
         with _tenant_connection(self._pool) as conn:

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -28,6 +28,7 @@ from agent_bom.api.runtime_event_store import (
 from agent_bom.api.stores import _get_analytics_store, _get_fleet_store, _get_store
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.api.tenant_quota import enforce_retained_jobs_quota, tenant_quota_guard
+from agent_bom.canonical_ids import canonical_id
 from agent_bom.config import API_MAX_OCSF_INGEST_EVENTS
 from agent_bom.graph.severity import ocsf_to_severity
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
@@ -208,22 +209,41 @@ def _normalize_ocsf_event(event: dict, *, tenant_id: str) -> dict:
     if isinstance(finding_info, dict):
         event_id = str(finding_info.get("uid", "")).strip()
     if not event_id:
-        event_id = metadata_uid or str(uuid.uuid4())
+        event_id = metadata_uid
     severity = str(event.get("severity", "")).strip().lower()
     if not severity:
         try:
             severity = ocsf_to_severity(int(event.get("severity_id", 0)))
         except Exception:
             severity = "unknown"
+    event_timestamp = _ocsf_timestamp(event.get("time") or event.get("start_time") or event.get("event_time"))
+    detector = _ocsf_finding_detector(event)
+    tool_name = _resource_name(event)
+    message = _ocsf_finding_message(event)
+    if not event_id:
+        # Deterministic content-derived ID so retries of an id-less OCSF event
+        # collapse on the runtime observation PK (tenant_id, observation_id)
+        # instead of leaking a fresh uuid4 per ingest (audit item J).
+        event_id = canonical_id(
+            "ocsf_event",
+            tenant_id,
+            source_id,
+            event_timestamp,
+            class_uid,
+            class_name,
+            detector,
+            tool_name,
+            message,
+        )
     normalized = {
         "event_id": event_id,
-        "event_timestamp": _ocsf_timestamp(event.get("time") or event.get("start_time") or event.get("event_time")),
+        "event_timestamp": event_timestamp,
         "tenant_id": tenant_id,
         "event_type": f"ocsf_{class_slug}",
-        "detector": _ocsf_finding_detector(event),
+        "detector": detector,
         "severity": severity or "unknown",
-        "tool_name": _resource_name(event),
-        "message": _ocsf_finding_message(event),
+        "tool_name": tool_name,
+        "message": message,
         "agent_name": "",
         "session_id": "",
         "trace_id": "",
@@ -257,7 +277,20 @@ def _event_session_id(payload: dict[str, Any]) -> str:
 
 def _runtime_observation_from_event(event: dict[str, Any], *, tenant_id: str, source: str = "api") -> RuntimeObservationRecord:
     observed_at = str(event.get("event_timestamp") or event.get("observed_at") or event.get("timestamp") or _now())
-    event_id = str(event.get("event_id") or event.get("observation_id") or "").strip() or str(uuid.uuid4())
+    event_id = str(event.get("event_id") or event.get("observation_id") or "").strip()
+    if not event_id:
+        # Deterministic content-derived ID so a retried id-less runtime event
+        # dedups on the observation PK instead of leaking uuid4 (audit item J).
+        event_id = canonical_id(
+            "runtime_event",
+            tenant_id,
+            event.get("source_id") or event.get("source") or source,
+            event.get("session_id") or event.get("trace_id") or event.get("request_id") or "",
+            observed_at,
+            event.get("event_type") or event.get("type") or "runtime_event",
+            event.get("tool_name") or event.get("tool") or "",
+            event.get("message") or event.get("reason") or event.get("decision") or "",
+        )
     summary: dict[str, Any] = {}
     for key in ("message", "reason", "decision", "risk", "policy", "blocked"):
         if key in event:

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -8,6 +8,7 @@ Endpoints:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from collections import defaultdict
@@ -27,6 +28,7 @@ from agent_bom.api.runtime_event_store import (
 from agent_bom.api.stores import _get_analytics_store, _get_fleet_store, _get_store
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.api.tenant_quota import enforce_retained_jobs_quota, tenant_quota_guard
+from agent_bom.config import API_MAX_OCSF_INGEST_EVENTS
 from agent_bom.graph.severity import ocsf_to_severity
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.rbac import require_authenticated_permission
@@ -282,12 +284,20 @@ def _runtime_observation_from_event(event: dict[str, Any], *, tenant_id: str, so
 
 
 def _persist_runtime_observations(events: list[dict[str, Any]], *, tenant_id: str, source: str = "api") -> int:
+    if not events:
+        return 0
     store = get_runtime_event_store()
-    count = 0
-    for event in events:
-        store.put_observation(_runtime_observation_from_event(event, tenant_id=tenant_id, source=source))
-        count += 1
-    return count
+    records = [_runtime_observation_from_event(event, tenant_id=tenant_id, source=source) for event in events]
+    return store.put_observations_batch(records)
+
+
+def _finish_ocsf_ingest(normalized_events: list[dict[str, Any]], *, tenant_id: str) -> None:
+    try:
+        if normalized_events:
+            _get_analytics_store().record_events(normalized_events, tenant_id=tenant_id)
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("OCSF analytics ingest skipped: %s", sanitize_text(exc))
+    _persist_runtime_observations(normalized_events, tenant_id=tenant_id, source="ocsf")
 
 
 # OTel attribute keys carrying the chargeback/showback allocation (#2925).
@@ -542,17 +552,18 @@ async def ingest_ocsf(request: Request, body: dict | list[dict]) -> dict:
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
 
+    if len(ocsf_events) > API_MAX_OCSF_INGEST_EVENTS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"OCSF ingest accepts at most {API_MAX_OCSF_INGEST_EVENTS} events per request",
+        )
+
     normalized_events = [_normalize_ocsf_event(event, tenant_id=tenant_id) for event in ocsf_events]
     class_counts: dict[str, int] = defaultdict(int)
     for event in normalized_events:
         class_counts[str(event.get("ocsf_class_uid", "unknown"))] += 1
 
-    try:
-        if normalized_events:
-            _get_analytics_store().record_events(normalized_events, tenant_id=tenant_id)
-    except Exception as exc:  # noqa: BLE001
-        _logger.warning("OCSF analytics ingest skipped: %s", sanitize_text(exc))
-    _persist_runtime_observations(normalized_events, tenant_id=tenant_id, source="ocsf")
+    await asyncio.to_thread(_finish_ocsf_ingest, normalized_events, tenant_id=tenant_id)
 
     source_ids = sorted({str(event.get("source_id", "")).strip() for event in normalized_events if str(event.get("source_id", "")).strip()})
     log_action(

--- a/src/agent_bom/api/runtime_event_store.py
+++ b/src/agent_bom/api/runtime_event_store.py
@@ -192,11 +192,7 @@ class InMemoryRuntimeEventStore:
         if not unique_records:
             return 0
         with self._lock:
-            new_records = [
-                record
-                for record in unique_records
-                if (record.tenant_id, record.observation_id) not in self._observations
-            ]
+            new_records = [record for record in unique_records if (record.tenant_id, record.observation_id) not in self._observations]
             if not new_records:
                 return 0
             existing_sessions: dict[str, RuntimeSessionRecord] = {
@@ -511,14 +507,9 @@ def _enforce_in_memory_observation_cap(
     cap = analytics_max_events()
     if cap <= 0:
         return
-    tenant_rows = [
-        (key, row)
-        for key, row in observations.items()
-        if key[0] == tenant_id
-    ]
+    tenant_rows = [(key, row) for key, row in observations.items() if key[0] == tenant_id]
     if len(tenant_rows) <= cap:
         return
     tenant_rows.sort(key=lambda item: item[1].observed_at)
     for key, _row in tenant_rows[: len(tenant_rows) - cap]:
         observations.pop(key, None)
-

--- a/src/agent_bom/api/runtime_event_store.py
+++ b/src/agent_bom/api/runtime_event_store.py
@@ -303,7 +303,7 @@ class SQLiteRuntimeEventStore:
             chunk = observation_ids[offset : offset + _BATCH_LOOKUP_CHUNK]
             placeholders = ",".join("?" * len(chunk))
             rows = conn.execute(
-                f"SELECT observation_id FROM runtime_observations WHERE tenant_id = ? AND observation_id IN ({placeholders})",
+                f"SELECT observation_id FROM runtime_observations WHERE tenant_id = ? AND observation_id IN ({placeholders})",  # nosec B608
                 (tenant_id, *chunk),
             ).fetchall()
             existing_ids.update(row[0] for row in rows)
@@ -316,7 +316,7 @@ class SQLiteRuntimeEventStore:
             chunk = session_ids[offset : offset + _BATCH_LOOKUP_CHUNK]
             placeholders = ",".join("?" * len(chunk))
             rows = conn.execute(
-                f"SELECT session_id, data FROM runtime_sessions WHERE tenant_id = ? AND session_id IN ({placeholders})",
+                f"SELECT session_id, data FROM runtime_sessions WHERE tenant_id = ? AND session_id IN ({placeholders})",  # nosec B608
                 (tenant_id, *chunk),
             ).fetchall()
             for session_id, data in rows:

--- a/src/agent_bom/api/runtime_event_store.py
+++ b/src/agent_bom/api/runtime_event_store.py
@@ -79,8 +79,35 @@ class RuntimeSessionRecord:
         return asdict(self)
 
 
+_BATCH_LOOKUP_CHUNK = 500
+
+
+def _dedupe_observation_records(records: list[RuntimeObservationRecord]) -> list[RuntimeObservationRecord]:
+    seen: set[tuple[str, str]] = set()
+    unique: list[RuntimeObservationRecord] = []
+    for record in records:
+        key = (record.tenant_id, record.observation_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(record)
+    return unique
+
+
+def _merge_sessions_for_batch(
+    existing_sessions: dict[str, RuntimeSessionRecord],
+    new_records: list[RuntimeObservationRecord],
+) -> dict[str, RuntimeSessionRecord]:
+    sessions = dict(existing_sessions)
+    for record in new_records:
+        sessions[record.session_id] = _merge_session(sessions.get(record.session_id), record)
+    return sessions
+
+
 class RuntimeEventStore(Protocol):
     def put_observation(self, record: RuntimeObservationRecord) -> None: ...
+
+    def put_observations_batch(self, records: list[RuntimeObservationRecord]) -> int: ...
 
     def list_sessions(self, tenant_id: str, *, limit: int = 100, offset: int = 0) -> list[RuntimeSessionRecord]: ...
 
@@ -158,14 +185,33 @@ class InMemoryRuntimeEventStore:
         :class:`agent_bom.storage.base.TenantScopedStore` contract."""
 
     def put_observation(self, record: RuntimeObservationRecord) -> None:
-        key = (record.tenant_id, record.observation_id)
-        session_key = (record.tenant_id, record.session_id)
+        self.put_observations_batch([record])
+
+    def put_observations_batch(self, records: list[RuntimeObservationRecord]) -> int:
+        unique_records = _dedupe_observation_records(records)
+        if not unique_records:
+            return 0
         with self._lock:
-            if key in self._observations:
-                return
-            self._observations[key] = record
-            self._sessions[session_key] = _merge_session(self._sessions.get(session_key), record)
-            _enforce_in_memory_observation_cap(self._observations, record.tenant_id)
+            new_records = [
+                record
+                for record in unique_records
+                if (record.tenant_id, record.observation_id) not in self._observations
+            ]
+            if not new_records:
+                return 0
+            existing_sessions: dict[str, RuntimeSessionRecord] = {
+                record.session_id: session
+                for record in new_records
+                if (session := self._sessions.get((record.tenant_id, record.session_id))) is not None
+            }
+            merged_sessions = _merge_sessions_for_batch(existing_sessions, new_records)
+            for record in new_records:
+                self._observations[(record.tenant_id, record.observation_id)] = record
+            for session_id, session in merged_sessions.items():
+                self._sessions[(session.tenant_id, session_id)] = session
+            for tenant_id in {record.tenant_id for record in new_records}:
+                _enforce_in_memory_observation_cap(self._observations, tenant_id)
+            return len(new_records)
 
     def list_sessions(self, tenant_id: str, *, limit: int = 100, offset: int = 0) -> list[RuntimeSessionRecord]:
         with self._lock:
@@ -247,31 +293,75 @@ class SQLiteRuntimeEventStore:
         self._conn.commit()
 
     def put_observation(self, record: RuntimeObservationRecord) -> None:
-        existing = self._conn.execute(
-            "SELECT 1 FROM runtime_observations WHERE tenant_id = ? AND observation_id = ?",
-            (record.tenant_id, record.observation_id),
-        ).fetchone()
-        if existing:
-            return
-        session = _merge_session(self.get_session(record.tenant_id, record.session_id), record)
-        self._conn.execute(
+        self.put_observations_batch([record])
+
+    def put_observations_batch(self, records: list[RuntimeObservationRecord]) -> int:
+        unique_records = _dedupe_observation_records(records)
+        if not unique_records:
+            return 0
+        tenant_id = unique_records[0].tenant_id
+        conn = self._conn
+        existing_ids: set[str] = set()
+        observation_ids = [record.observation_id for record in unique_records]
+        for offset in range(0, len(observation_ids), _BATCH_LOOKUP_CHUNK):
+            chunk = observation_ids[offset : offset + _BATCH_LOOKUP_CHUNK]
+            placeholders = ",".join("?" * len(chunk))
+            rows = conn.execute(
+                f"SELECT observation_id FROM runtime_observations WHERE tenant_id = ? AND observation_id IN ({placeholders})",
+                (tenant_id, *chunk),
+            ).fetchall()
+            existing_ids.update(row[0] for row in rows)
+        new_records = [record for record in unique_records if record.observation_id not in existing_ids]
+        if not new_records:
+            return 0
+        session_ids = sorted({record.session_id for record in new_records})
+        existing_sessions: dict[str, RuntimeSessionRecord] = {}
+        for offset in range(0, len(session_ids), _BATCH_LOOKUP_CHUNK):
+            chunk = session_ids[offset : offset + _BATCH_LOOKUP_CHUNK]
+            placeholders = ",".join("?" * len(chunk))
+            rows = conn.execute(
+                f"SELECT session_id, data FROM runtime_sessions WHERE tenant_id = ? AND session_id IN ({placeholders})",
+                (tenant_id, *chunk),
+            ).fetchall()
+            for session_id, data in rows:
+                existing_sessions[session_id] = _session_from_json(data)
+        merged_sessions = _merge_sessions_for_batch(existing_sessions, new_records)
+        conn.executemany(
             """
             INSERT INTO runtime_observations
                 (tenant_id, observation_id, session_id, observed_at, data)
             VALUES (?, ?, ?, ?, ?)
             """,
-            (record.tenant_id, record.observation_id, record.session_id, record.observed_at, json.dumps(record.to_dict(), sort_keys=True)),
+            [
+                (
+                    record.tenant_id,
+                    record.observation_id,
+                    record.session_id,
+                    record.observed_at,
+                    json.dumps(record.to_dict(), sort_keys=True),
+                )
+                for record in new_records
+            ],
         )
-        self._conn.execute(
+        conn.executemany(
             """
             INSERT OR REPLACE INTO runtime_sessions
                 (tenant_id, session_id, last_seen, data)
             VALUES (?, ?, ?, ?)
             """,
-            (session.tenant_id, session.session_id, session.last_seen, json.dumps(session.to_dict(), sort_keys=True)),
+            [
+                (
+                    session.tenant_id,
+                    session.session_id,
+                    session.last_seen,
+                    json.dumps(session.to_dict(), sort_keys=True),
+                )
+                for session in merged_sessions.values()
+            ],
         )
-        prune_runtime_observations_for_tenant(self._conn, record.tenant_id)
-        self._conn.commit()
+        prune_runtime_observations_for_tenant(conn, tenant_id)
+        conn.commit()
+        return len(new_records)
 
     def list_sessions(self, tenant_id: str, *, limit: int = 100, offset: int = 0) -> list[RuntimeSessionRecord]:
         rows = self._conn.execute(

--- a/src/agent_bom/cloud/clickhouse.py
+++ b/src/agent_bom/cloud/clickhouse.py
@@ -175,8 +175,8 @@ CREATE TABLE IF NOT EXISTS runtime_events (
     trace_id String DEFAULT '',
     request_id String DEFAULT '',
     source_id String DEFAULT ''
-) ENGINE = MergeTree()
-ORDER BY (event_timestamp, event_type, agent_name)
+) ENGINE = ReplacingMergeTree()
+ORDER BY (event_timestamp, event_type, agent_name, event_id)
 PARTITION BY toYYYYMM(event_timestamp)""",
     # 3. Posture scores (periodic snapshots)
     """\

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -360,6 +360,7 @@ API_MAX_SCHEDULES_PER_TENANT = _int("AGENT_BOM_API_MAX_SCHEDULES_PER_TENANT", 10
 # work bounded only by the tenant active-scan quota churn. Reject over-cap
 # requests at validation time (HTTP 422).
 API_MAX_BATCH_SCAN_TARGETS = _int("AGENT_BOM_API_MAX_BATCH_SCAN_TARGETS", 100)
+API_MAX_OCSF_INGEST_EVENTS = _int("AGENT_BOM_API_MAX_OCSF_INGEST_EVENTS", 1_000)
 API_ALLOW_UNAUTHENTICATED = _bool("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", False)
 # Slowloris throughput floor (audit-5 PR-C): minimum sustained body
 # bytes/second once a request body crosses the warmup threshold inside

--- a/tests/test_api_tenant_isolation.py
+++ b/tests/test_api_tenant_isolation.py
@@ -1104,6 +1104,59 @@ async def test_ocsf_ingest_rejects_non_event_payload():
 
 
 @pytest.mark.asyncio
+async def test_ocsf_ingest_rejects_over_cap(monkeypatch):
+    monkeypatch.setattr("agent_bom.api.routes.observability.API_MAX_OCSF_INGEST_EVENTS", 2)
+    req = _request("tenant-alpha")
+    payload = {
+        "events": [
+            {"class_uid": 1, "class_name": "Detection Finding", "time": 1_746_033_600_000},
+            {"class_uid": 2, "class_name": "Network Activity", "time": 1_746_033_601_000},
+            {"class_uid": 3, "class_name": "Process Activity", "time": 1_746_033_602_000},
+        ]
+    }
+
+    with pytest.raises(HTTPException) as exc:
+        await observability_routes.ingest_ocsf(req, payload)
+
+    assert exc.value.status_code == 422
+    assert "at most 2 events" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_ocsf_ingest_offloads_sync_persistence(monkeypatch):
+    req = _request("tenant-alpha")
+    offloaded: list[str] = []
+
+    async def _fake_to_thread(fn, /, *args, **kwargs):
+        offloaded.append(fn.__name__)
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr("agent_bom.api.routes.observability.asyncio.to_thread", _fake_to_thread)
+
+    class _Analytics:
+        def record_events(self, events, *, tenant_id: str = "default"):
+            return None
+
+    payload = {
+        "events": [
+            {
+                "class_uid": 2004,
+                "class_name": "Detection Finding",
+                "severity_id": 2,
+                "time": 1_746_033_600_000,
+                "finding_info": {"uid": "finding-offload"},
+            }
+        ]
+    }
+
+    with patch("agent_bom.api.routes.observability._get_analytics_store", return_value=_Analytics()):
+        result = await observability_routes.ingest_ocsf(req, payload)
+
+    assert result["ingested"] == 1
+    assert offloaded == ["_finish_ocsf_ingest"]
+
+
+@pytest.mark.asyncio
 async def test_posture_counts_include_deployment_context_by_tenant():
     job_store = InMemoryJobStore()
     fleet_store = InMemoryFleetStore()

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -424,6 +424,34 @@ class TestClickHouseAnalyticsStore:
         assert len(inserted["rows"]) == 2
         assert inserted["rows"][0]["event_type"] == "vulnerable_tool_call"
 
+    def test_event_row_derives_deterministic_id_for_idless_events(self):
+        from agent_bom.api.clickhouse_store import ClickHouseAnalyticsStore
+
+        rows: list[dict] = []
+
+        class _Client:
+            def ensure_tables(self):
+                return None
+
+            def insert_json(self, table, batch):
+                rows.extend(batch)
+
+        event = {
+            "event_type": "ocsf_network_activity",
+            "severity": "low",
+            "tool_name": "proxy-relay",
+            "message": "Outbound MCP request observed",
+            "source_id": "datadog",
+            "event_timestamp": "2026-04-20T12:00:01Z",
+        }
+        with patch("agent_bom.cloud.clickhouse.ClickHouseClient", return_value=_Client()):
+            store = ClickHouseAnalyticsStore(url="http://localhost:8123")
+            store.record_event(dict(event), tenant_id="tenant-alpha")
+            store.record_event(dict(event), tenant_id="tenant-alpha")
+
+        assert rows[0]["event_id"]
+        assert rows[0]["event_id"] == rows[1]["event_id"]
+
     def test_audit_and_runtime_rows_preserve_correlation_fields(self):
         from agent_bom.api.clickhouse_store import ClickHouseAnalyticsStore
 

--- a/tests/test_runtime_event_store.py
+++ b/tests/test_runtime_event_store.py
@@ -110,6 +110,29 @@ async def test_runtime_observation_queries_are_tenant_scoped_and_paginated():
     assert exc.value.status_code == 404
 
 
+def test_sqlite_runtime_event_store_batch_persists_in_one_transaction(tmp_path):
+    store = SQLiteRuntimeEventStore(str(tmp_path / "runtime-batch.db"))
+    from agent_bom.api.runtime_event_store import RuntimeObservationRecord
+
+    records = [
+        RuntimeObservationRecord(
+            tenant_id="tenant-alpha",
+            observation_id=f"evt-{index}",
+            session_id="sess-1",
+            observed_at=f"2026-01-01T00:00:{index:02d}Z",
+            event_type="tool_call",
+            verdict="allowed",
+            tool_name="search",
+        )
+        for index in range(25)
+    ]
+    assert store.put_observations_batch(records) == 25
+    session = store.get_session("tenant-alpha", "sess-1")
+    assert session is not None
+    assert session.observation_count == 25
+    assert store.put_observations_batch(records) == 0
+
+
 def test_sqlite_runtime_event_store_persists_session_summaries(tmp_path):
     store = SQLiteRuntimeEventStore(str(tmp_path / "runtime.db"))
     set_runtime_event_store(store)

--- a/tests/test_runtime_event_store.py
+++ b/tests/test_runtime_event_store.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from fastapi import HTTPException
@@ -108,6 +109,69 @@ async def test_runtime_observation_queries_are_tenant_scoped_and_paginated():
     with pytest.raises(HTTPException) as exc:
         await observability_routes.list_runtime_session_observations(alpha, "sess-beta")
     assert exc.value.status_code == 404
+
+
+def test_normalize_ocsf_event_idless_id_is_deterministic():
+    event = {
+        "class_uid": 4001,
+        "class_name": "Network Activity",
+        "severity": "Low",
+        "time": 1_746_033_601_000,
+        "message": "Outbound MCP request observed",
+        "resources": [{"name": "proxy-relay"}],
+        "metadata": {"product": {"name": "datadog"}},
+    }
+    first = observability_routes._normalize_ocsf_event(dict(event), tenant_id="tenant-alpha")
+    second = observability_routes._normalize_ocsf_event(dict(event), tenant_id="tenant-alpha")
+    other_tenant = observability_routes._normalize_ocsf_event(dict(event), tenant_id="tenant-beta")
+
+    assert first["event_id"]
+    assert first["event_id"] == second["event_id"]
+    assert first["event_id"] != other_tenant["event_id"]
+
+
+def test_runtime_observation_idless_id_is_deterministic():
+    event = {
+        "session_id": "sess-1",
+        "observed_at": "2026-01-01T00:00:00Z",
+        "event_type": "tool_call",
+        "tool_name": "read_file",
+        "message": "flagged",
+    }
+    first = observability_routes._runtime_observation_from_event(dict(event), tenant_id="tenant-alpha")
+    second = observability_routes._runtime_observation_from_event(dict(event), tenant_id="tenant-alpha")
+
+    assert first.observation_id
+    assert first.observation_id == second.observation_id
+
+
+@pytest.mark.asyncio
+async def test_ocsf_idless_event_dedups_across_retries():
+    req = _request("tenant-alpha")
+    payload = {
+        "events": [
+            {
+                "class_uid": 4001,
+                "class_name": "Network Activity",
+                "severity": "Low",
+                "time": 1_746_033_601_000,
+                "message": "Outbound MCP request observed",
+                "resources": [{"name": "proxy-relay"}],
+                "metadata": {"product": {"name": "datadog"}},
+            }
+        ]
+    }
+
+    class _Analytics:
+        def record_events(self, events, *, tenant_id: str = "default"):
+            return None
+
+    with patch("agent_bom.api.routes.observability._get_analytics_store", return_value=_Analytics()):
+        await observability_routes.ingest_ocsf(req, payload)
+        await observability_routes.ingest_ocsf(req, payload)
+
+    observations = await observability_routes.list_runtime_observations(req)
+    assert observations["count"] == 1
 
 
 def test_sqlite_runtime_event_store_batch_persists_in_one_transaction(tmp_path):


### PR DESCRIPTION
## Summary
Two paired fixes on the OCSF/runtime ingest path (audit items A and J):

**A — event-loop DoS (Closes #3485)**
- Reject OCSF payloads over `AGENT_BOM_API_MAX_OCSF_INGEST_EVENTS` (default 1000) with `422`.
- Batch runtime observation persistence via `put_observations_batch` (single transaction; per-backend in-memory / SQLite `executemany` / Postgres).
- Offload analytics + runtime writes with `asyncio.to_thread` so `/v1/ocsf/ingest` no longer blocks the event loop.

**J — OCSF/runtime dedup split-brain (Refs #3484)**
- Id-less OCSF and runtime events previously fell back to `uuid4()` per ingest, so retries duplicated on the observation PK and double-counted in the append-only ClickHouse sink.
- Derive a deterministic content-addressed UUIDv5 (`canonical_id`) when the caller supplies no `event_id` — retries now collapse on `(tenant_id, observation_id)`.
- Switch ClickHouse `runtime_events` to `ReplacingMergeTree ORDER BY (..., event_id)` so the analytics sink collapses retries too; `_event_row` derives the same deterministic id.
- Existing `runtime_events` tables keep MergeTree (ClickHouse can't ALTER engine in place); documented in `init.sql`. New deployments get dedup automatically.

## Verification
- `uv run pytest -q tests/test_runtime_event_store.py tests/test_clickhouse.py tests/test_clickhouse_tenant_isolation.py tests/test_api_tenant_isolation.py` -> 92 passed
- `uv run ruff check` + `uv run mypy` on touched modules -> clean
- New tests: OCSF cap `422`, thread offload, SQLite batch txn, deterministic OCSF/runtime id, id-less OCSF retry dedup, ClickHouse deterministic `_event_row` id.

## Notes
- #3484 remains open for scan-analytics-row dedup + buffered-writer retry contract test (out of scope here).