### PR TITLE
feat(ui): interactive blast-radius overlay on the lineage graph

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -14,7 +14,7 @@ import {
   type Node,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { AlertTriangle, Loader2, Route, ShieldAlert } from "lucide-react";
+import { AlertTriangle, Loader2, Radar, Route, ShieldAlert } from "lucide-react";
 
 import { AttackPathCard } from "@/components/attack-path-card";
 import { GraphEvaluationSummary } from "@/components/graph-evaluation-summary";
@@ -595,6 +595,21 @@ function queryResponseToGraphResponse(
  * page would have to thread the LOD band through props or duplicate
  * `<ReactFlow>` ancestry.
  */
+/**
+ * Blast-radius overlay state (audit/#3192). Populated from `/v1/graph/impact`
+ * (reverse-BFS "what depends on this node"), it drives an on-canvas highlight of
+ * every impacted node + edge so operators can see the real downstream cost of a
+ * finding instead of only a count in the side panel.
+ */
+type BlastRadiusState = {
+  rootId: string;
+  rootLabel: string;
+  nodeIds: Set<string>;
+  countsByType: Record<string, number>;
+  affectedCount: number;
+  maxDepthReached: number;
+};
+
 export default function GraphPageClient() {
   return (
     <ReactFlowProvider>
@@ -633,6 +648,9 @@ function GraphPageInner() {
   const [reachabilityError, setReachabilityError] = useState<string | null>(
     null,
   );
+  const [blastRadius, setBlastRadius] = useState<BlastRadiusState | null>(null);
+  const [loadingBlast, setLoadingBlast] = useState(false);
+  const [blastError, setBlastError] = useState<string | null>(null);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [pinnedFocusId, setPinnedFocusId] = useState<string | null>(null);
   const [expandedClusterIds, setExpandedClusterIds] = useState<Set<string>>(
@@ -1137,6 +1155,22 @@ function GraphPageInner() {
 
   const lineageLayoutNodes = layoutNodes as Node<LineageNodeData>[];
   const displayNodes = useMemo<Node<LineageNodeData>[]>(() => {
+    if (blastRadius) {
+      return lineageLayoutNodes.map((node) => {
+        const inBlast = blastRadius.nodeIds.has(node.id);
+        const isRoot = node.id === blastRadius.rootId;
+        return {
+          ...node,
+          className: composeFocusClass(node.className, isRoot, !inBlast),
+          data: {
+            ...node.data,
+            renderBand: effectiveLodBand,
+            dimmed: !inBlast,
+            highlighted: inBlast,
+          },
+        };
+      });
+    }
     if (attackPathNodeIds) {
       return lineageLayoutNodes
         .filter((node) => attackPathNodeIds.has(node.id))
@@ -1205,6 +1239,7 @@ function GraphPageInner() {
     attackPathNodeIds,
     attackPathNodeOrder,
     reachabilitySummary,
+    blastRadius,
     activeFocusId,
     effectiveLodBand,
   ]);
@@ -1263,6 +1298,32 @@ function GraphPageInner() {
           };
         });
     }
+    if (blastRadius) {
+      return layoutEdges.map((edge): Edge => {
+        const inBlast =
+          blastRadius.nodeIds.has(edge.source) &&
+          blastRadius.nodeIds.has(edge.target);
+        return {
+          ...edge,
+          animated: captureMode ? false : Boolean(inBlast || edge.animated),
+          style: {
+            ...edge.style,
+            opacity: inBlast ? 0.95 : 0.06,
+            strokeWidth: inBlast
+              ? Math.max(
+                  typeof edge.style?.strokeWidth === "number"
+                    ? edge.style.strokeWidth
+                    : 2,
+                  3,
+                )
+              : 1,
+            ...(inBlast
+              ? { filter: "drop-shadow(0 0 6px rgba(139,92,246,0.55))" }
+              : {}),
+          },
+        };
+      });
+    }
     if (reachabilitySummary) {
       return layoutEdges.map((edge): Edge => {
         const inReach =
@@ -1300,6 +1361,7 @@ function GraphPageInner() {
     localNeighborhoodIds,
     attackPathEdgeKeys,
     reachabilitySummary,
+    blastRadius,
     graphLayoutKind,
     captureMode,
   ]);
@@ -1585,7 +1647,50 @@ function GraphPageInner() {
     setAutoPathDismissed(false);
     setReachabilitySummary(null);
     setReachabilityError(null);
+    setBlastRadius(null);
+    setBlastError(null);
   }, []);
+
+  const clearBlastRadius = useCallback(() => {
+    setBlastRadius(null);
+    setBlastError(null);
+  }, []);
+
+  const loadBlastRadius = useCallback(
+    async (nodeId: string, nodeLabel: string) => {
+      if (!nodeId) return;
+      // Blast radius takes over the canvas; drop any competing overlays so the
+      // impacted set is the only thing highlighted.
+      setSelectedAttackPathKey(null);
+      setReachabilitySummary(null);
+      setReachabilityError(null);
+      setLoadingBlast(true);
+      setBlastError(null);
+      try {
+        const impact = await api.getGraphImpact(
+          nodeId,
+          selectedScanId || undefined,
+          4,
+        );
+        setBlastRadius({
+          rootId: impact.node_id,
+          rootLabel: nodeLabel || impact.node_id,
+          nodeIds: new Set<string>([impact.node_id, ...impact.affected_nodes]),
+          countsByType: impact.affected_by_type,
+          affectedCount: impact.affected_count,
+          maxDepthReached: impact.max_depth_reached,
+        });
+      } catch (e) {
+        setBlastRadius(null);
+        setBlastError(
+          e instanceof Error ? e.message : "Failed to compute blast radius",
+        );
+      } finally {
+        setLoadingBlast(false);
+      }
+    },
+    [selectedScanId],
+  );
 
   const pageStart =
     graphData && graphData.pagination.total > 0
@@ -1874,6 +1979,15 @@ function GraphPageInner() {
                 setReachabilitySummary(null);
                 setReachabilityError(null);
               }}
+            />
+          )}
+
+          {(blastRadius || loadingBlast || blastError) && (
+            <BlastRadiusPanel
+              summary={blastRadius}
+              loading={loadingBlast}
+              error={blastError}
+              onClear={clearBlastRadius}
             />
           )}
 
@@ -2328,6 +2442,8 @@ function GraphPageInner() {
                 setPinnedFocusId(null);
                 setReachabilitySummary(null);
                 setReachabilityError(null);
+                setBlastRadius(null);
+                setBlastError(null);
               }}
             >
               <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
@@ -2357,6 +2473,17 @@ function GraphPageInner() {
                 setSelectedNode(null);
                 setSelectedNodeId(null);
               }}
+              blastRadiusActive={blastRadius?.rootId === selectedNodeId}
+              blastRadiusLoading={loadingBlast}
+              onShowBlastRadius={
+                selectedNodeId
+                  ? () =>
+                      void loadBlastRadius(
+                        selectedNodeId,
+                        selectedNode.label ?? selectedNodeId,
+                      )
+                  : undefined
+              }
             />
           )}
         </div>
@@ -2510,6 +2637,86 @@ function ReachabilityDrillInPanel({
             )}
           </div>
         </div>
+      )}
+    </div>
+  );
+}
+
+function BlastRadiusPanel({
+  summary,
+  loading,
+  error,
+  onClear,
+}: {
+  summary: BlastRadiusState | null;
+  loading: boolean;
+  error: string | null;
+  onClear: () => void;
+}) {
+  return (
+    <div className="mt-3 rounded-2xl border border-violet-500/30 bg-violet-500/10 p-3 text-xs text-violet-100">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-start gap-2">
+          <Radar className="mt-0.5 h-4 w-4 text-violet-300" />
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.24em] text-violet-300">
+              Blast radius
+            </p>
+            <p className="mt-1 text-sm font-medium text-violet-50">
+              {summary
+                ? `${summary.affectedCount} asset${summary.affectedCount === 1 ? "" : "s"} impacted if ${summary.rootLabel} is compromised`
+                : "Computing blast radius"}
+            </p>
+            {summary && (
+              <p className="mt-1 text-[11px] text-violet-200/80">
+                Reverse-dependency reach · up to {summary.maxDepthReached} hop
+                {summary.maxDepthReached === 1 ? "" : "s"}
+              </p>
+            )}
+            {error && (
+              <p className="mt-1 text-[11px] text-amber-200">{error}</p>
+            )}
+            {loading && (
+              <p className="mt-1 flex items-center gap-1 text-[11px] text-violet-200">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Tracing downstream dependents
+              </p>
+            )}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClear}
+          className="rounded-lg border border-violet-400/30 bg-violet-950/60 px-2.5 py-1 text-violet-100 transition hover:border-violet-300"
+        >
+          Clear blast radius
+        </button>
+      </div>
+
+      {summary && Object.keys(summary.countsByType).length > 0 && (
+        <div className="mt-3 rounded-xl border border-violet-400/20 bg-zinc-950/45 p-2">
+          <p className="text-[10px] uppercase tracking-[0.2em] text-violet-300">
+            Impacted by type
+          </p>
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {Object.entries(summary.countsByType)
+              .sort((left, right) => right[1] - left[1])
+              .map(([type, count]) => (
+                <span
+                  key={type}
+                  className="rounded border border-violet-400/20 bg-violet-950/60 px-1.5 py-0.5 text-[10px] text-violet-100"
+                >
+                  {prettifyReachabilityType(type)}: {count}
+                </span>
+              ))}
+          </div>
+        </div>
+      )}
+
+      {summary && summary.affectedCount === 0 && (
+        <p className="mt-2 text-zinc-400">
+          Nothing downstream depends on this node in the current snapshot.
+        </p>
       )}
     </div>
   );

--- a/ui/components/lineage-detail.tsx
+++ b/ui/components/lineage-detail.tsx
@@ -15,7 +15,9 @@ import {
   Hourglass,
   KeyRound,
   Lock,
+  Loader2,
   Package,
+  Radar,
   Server,
   ShieldAlert,
   ShieldOff,
@@ -144,9 +146,15 @@ const TYPE_BORDER: Record<LineageNodeData["nodeType"], string> = {
 export function LineageDetailPanel({
   data,
   onClose,
+  onShowBlastRadius,
+  blastRadiusActive = false,
+  blastRadiusLoading = false,
 }: {
   data: LineageNodeData;
   onClose: () => void;
+  onShowBlastRadius?: (() => void) | undefined;
+  blastRadiusActive?: boolean;
+  blastRadiusLoading?: boolean;
 }) {
   const Icon = TYPE_ICON[data.nodeType];
   const osvUrl =
@@ -541,6 +549,27 @@ export function LineageDetailPanel({
               <Row label="Impact depth" value={data.maxImpactDepth} />
             )}
           </div>
+        )}
+
+        {onShowBlastRadius && (
+          <button
+            type="button"
+            onClick={onShowBlastRadius}
+            disabled={blastRadiusLoading}
+            aria-pressed={blastRadiusActive}
+            className={`flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition disabled:cursor-not-allowed disabled:opacity-60 ${
+              blastRadiusActive
+                ? "border-violet-400/50 bg-violet-500/20 text-violet-100"
+                : "border-violet-500/30 bg-violet-500/10 text-violet-200 hover:border-violet-400/60 hover:bg-violet-500/20"
+            }`}
+          >
+            {blastRadiusLoading ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Radar className="h-3.5 w-3.5" />
+            )}
+            {blastRadiusActive ? "Blast radius shown" : "Show blast radius"}
+          </button>
         )}
 
         {data.impactByType && Object.keys(data.impactByType).length > 0 && (

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   GraphQueryRequest,
   GraphQueryResponse,
   GraphNodeDetailResponse,
+  GraphImpactResponse,
   GraphSearchResponse,
   GraphSemanticClustersResponse,
   GraphAgentsResponse,
@@ -706,6 +707,15 @@ export const api = {
     if (scanId) params.set("scan_id", scanId);
     const qs = params.toString();
     return get<GraphNodeDetailResponse>(`/v1/graph/node/${encodeURIComponent(nodeId)}${qs ? `?${qs}` : ""}`);
+  },
+
+  /** Compute the blast radius (reverse-BFS impact) of a node */
+  getGraphImpact: (nodeId: string, scanId?: string, maxDepth?: number) => {
+    const params = new URLSearchParams();
+    params.set("node", nodeId);
+    if (scanId) params.set("scan_id", scanId);
+    if (maxDepth != null) params.set("max_depth", String(maxDepth));
+    return get<GraphImpactResponse>(`/v1/graph/impact?${params.toString()}`);
   },
 
   /** Connect to SSE stream for real-time progress */

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -176,6 +176,47 @@ describe('api.listJobs', () => {
   })
 })
 
+describe('api.getGraphImpact', () => {
+  it('requests the blast-radius endpoint with node, scan, and depth', async () => {
+    const payload = {
+      node_id: 'server:github-mcp',
+      affected_nodes: ['agent:coder', 'tool:read_file'],
+      affected_by_type: { agent: 1, tool: 1 },
+      affected_count: 2,
+      max_depth_reached: 2,
+    }
+    const fetchMock = mockFetch(payload)
+    global.fetch = fetchMock
+
+    const result = await api.getGraphImpact('server:github-mcp', 'scan-1', 4)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/v1/graph/impact?node=server%3Agithub-mcp&scan_id=scan-1&max_depth=4',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+    expect(result.affected_count).toBe(2)
+    expect(result.affected_nodes).toContain('agent:coder')
+  })
+
+  it('omits optional params when not provided', async () => {
+    const fetchMock = mockFetch({
+      node_id: 'n1',
+      affected_nodes: [],
+      affected_by_type: {},
+      affected_count: 0,
+      max_depth_reached: 0,
+    })
+    global.fetch = fetchMock
+
+    await api.getGraphImpact('n1')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/v1/graph/impact?node=n1',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+  })
+})
+
 describe('api.getScan', () => {
   it('returns expected shape', async () => {
     const payload = {


### PR DESCRIPTION
## Summary
- Wires the already-shipped `/v1/graph/impact` (reverse-BFS blast radius) endpoint into the lineage graph canvas — turning the side-panel "affected nodes" count into an interactive, on-canvas overlay.
- Click a node → **Show blast radius**: impacted nodes + connecting edges are highlighted (violet) and everything else is dimmed, so operators see the real downstream cost of a finding, not just a number.
- Adds a blast-radius banner (affected count, max hop depth, impact-by-type) and clears via the banner, an empty-pane click, or the investigation reset.

This is incremental drill-down hardening on the existing React Flow + `UnifiedGraph` stack — no new backend, no engine swap. It reuses the same highlight/dim pattern as the reachability drill-in.

## Changes
- `ui/lib/api.ts` — `api.getGraphImpact(node, scanId?, maxDepth?)` for `/v1/graph/impact`.
- `ui/app/graph/graph-page-client.tsx` — `BlastRadiusState`, `loadBlastRadius`, node/edge highlight branches, banner, and clear wiring.
- `ui/components/lineage-detail.tsx` — "Show blast radius" trigger with loading/active states.
- `ui/tests/api.test.ts` — coverage for the new client (URL params + omitted optionals).

## Verification
- `npm run typecheck`, `eslint` (changed files), `npm run build` — clean.
- `vitest run` api + graph suites — 55 passing (incl. 2 new `getGraphImpact` tests).
- Playwright light + dark screenshots against mocked impact data: the vulnerable package's 5 dependents (2 servers, 2 agents, 1 cloud resource) highlight while the unrelated tool node dims; detail panel shows "Blast radius shown" + impact-by-type.

## Notes
- Refs #3192 (graph excellence epic — drillable/dynamic). Epic stays open; this lands the interactive blast-radius slice.
- Graph canvas background remains dark in both themes by existing design; chrome/panels adapt to theme.

Made with [Cursor](https://cursor.com)