### PR TITLE
docs(deploy): auto-migration hook, finding encryption prereq, ClickHouse OSS+Cloud

### DIFF
--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -320,6 +320,35 @@ Production deployments must keep cryptographic keys separated by purpose:
 
 Do not reuse the API key or audit HMAC key as a rate-limit, browser-session, or proxy-attestation secret. Set `AGENT_BOM_TRUST_PROXY_AUTH_ISSUER` when the upstream proxy can inject a stable issuer identifier; the API will then reject trusted-proxy requests from any other issuer.
 
+#### Finding and scan payload encryption at rest (deployment prerequisite)
+
+Finding, scan, and graph payloads are **not** application-layer encrypted. This
+is by design: confidentiality at rest is delegated to the storage layer so the
+control plane stays operable across SQLite, Postgres/RDS, and object storage
+without managing a payload-encryption key or breaking search, indexing, and
+graph queries. Selected fields still get app-layer protection — API tokens are
+stored as SHA-256 hashes, the audit chain is HMAC-signed, browser sessions are
+signed, and stored cloud-connection secrets use envelope encryption — but the
+finding bodies themselves rely on encryption-at-rest from the backend.
+
+For any buyer with a data-classification or regulatory requirement, treat these
+as prerequisites before ingesting real findings:
+
+- **Database at rest** — enable encryption on the Postgres/RDS instance (e.g. RDS
+  storage encryption with a customer-managed KMS key) or the underlying volume
+  (LUKS/EBS encryption) that backs SQLite.
+- **Object storage at rest** — enable bucket/default encryption (SSE-KMS or
+  equivalent) for any S3/GCS/Azure Blob destinations used for exports, backups,
+  or air-gapped DB snapshots.
+- **Access controls** — keep the database and object storage private to the VPC,
+  enforce least-privilege IAM/DB roles, and rely on tenant `FORCE ROW LEVEL
+  SECURITY` (Postgres) for multi-tenant isolation.
+- **In transit** — TLS is always verified on outbound calls; terminate ingress
+  TLS and prefer the delegated mTLS posture below for the proxy/gateway seam.
+
+If a threat model requires application-layer (pre-storage) encryption of finding
+payloads, that is not provided today; scope it explicitly rather than assuming it.
+
 ### Proxy-to-control-plane mTLS posture
 
 The recommended production pattern is delegated mTLS: terminate TLS and verify

--- a/docs/ENTERPRISE_OPERATIONS_EVIDENCE.md
+++ b/docs/ENTERPRISE_OPERATIONS_EVIDENCE.md
@@ -89,9 +89,10 @@ topology, and disaster-recovery approval process.
 | Rollback action | `helm rollback`, database restore if schema changes require it, restart API/UI/gateway workers |
 | Post-rollback | repeated smoke test, audit export, incident record, root-cause link |
 
-For long-lived Postgres control planes, run migrations explicitly and keep the
-pre-upgrade backup URI in the change ticket. Do not treat image rollback as a
-database rollback when schema changes were applied.
+For long-lived Postgres control planes, Helm applies migrations automatically
+via the chart's `pre-install,pre-upgrade` hook (`controlPlane.migrations.enabled`,
+on by default). Keep the pre-upgrade backup URI in the change ticket. Do not
+treat image rollback as a database rollback when schema changes were applied.
 
 ## Air-Gap Evidence
 

--- a/docs/VISUAL_LANGUAGE.md
+++ b/docs/VISUAL_LANGUAGE.md
@@ -104,3 +104,52 @@ If the diagram is going to be referenced by an enterprise buyer's procurement
 deck, ship SVG. If it's going to drift faster than the next release, ship
 Mermaid. If a junior engineer would type it into a terminal, ship ASCII inside
 a fenced code block.
+
+## Layered session / enforcement flows (compact TB)
+
+Use this pattern when explaining **who can do what, where it is enforced, and
+what gets persisted** — auth scopes, scan push, OCSF ingest, MCP tool calls,
+Helm upgrade hooks, fleet sync. The goal matches a readable chat or doc card:
+**nothing too wide to pan, nothing so tall it needs endless scroll.**
+
+### Layout rules
+
+1. **Direction `TB` only** — three stacked bands, not `LR` meshes.
+2. **Three bands max:** `Who / sources` → `Where enforced` → `What persisted`.
+3. **≤3 nodes per band** — overflow becomes a bullet list under the diagram.
+4. **One enforcement spine** — a single vertical chain through the middle band
+   (`require_scope` → route → store), not parallel crossing edges.
+5. **Narrow subgraph titles** — short labels (`Who can push`, `Enforced at`,
+   `Lands in`), not paragraph subtitles inside nodes.
+6. **Repo and docs only** — these diagrams belong in README, `docs/`, and
+   `site-docs/`; the dashboard stays operator chrome (no floating workflow
+   banners on graph canvases).
+
+### Template
+
+```mermaid
+flowchart TB
+    subgraph Who["Who can push evidence"]
+        CLI["CLI scan + --push-url"]
+        CI["GitHub Action upload"]
+        Fleet["In-cluster collector"]
+    end
+
+    subgraph Enforced["Where it is enforced"]
+        Auth["API key · tenant RBAC"]
+        Route["POST /v1/scan · ScanPipeline"]
+    end
+
+    subgraph Lands["What lands"]
+        Store["Postgres: job · findings · graph snapshot"]
+    end
+
+    CLI --> Auth
+    CI --> Auth
+    Fleet --> Auth
+    Auth --> Route --> Store
+```
+
+Ship one compact diagram per workflow page; link to code paths in prose below
+the fence. Regenerate wide `flowchart LR` inventory diagrams only when the
+buyer deck needs the full estate map — use compact TB for session truth.

--- a/site-docs/architecture/how-agent-bom-works.md
+++ b/site-docs/architecture/how-agent-bom-works.md
@@ -75,6 +75,35 @@ flowchart LR
     H --> M
 ```
 
+### Scan push session (compact)
+
+Who can send scan evidence, where the API enforces it, and what lands in the
+control-plane store. See `src/agent_bom/api/routes/scan.py` and
+`ScanPipeline` for the code path.
+
+```mermaid
+flowchart TB
+    subgraph Who["Who can push a scan"]
+        CLI["CLI · agent-bom agents --push-url"]
+        CI["GitHub Action · artifact upload"]
+        Coll["Collector · in-cluster push"]
+    end
+
+    subgraph Enforced["Where it is enforced"]
+        Auth["API key · tenant RBAC · quotas"]
+        Pipe["POST /v1/scan · ScanPipeline"]
+    end
+
+    subgraph Lands["What lands"]
+        PG["Postgres: job · findings · graph snapshot"]
+    end
+
+    CLI --> Auth
+    CI --> Auth
+    Coll --> Auth
+    Auth --> Pipe --> PG
+```
+
 ## What comes in
 
 `agent-bom` supports four intake modes.

--- a/site-docs/deployment/backend-and-security-lakes.md
+++ b/site-docs/deployment/backend-and-security-lakes.md
@@ -17,6 +17,18 @@ The backend strategy should stay simple:
 
 This page explains how those stores fit together in a self-hosted deployment.
 
+### Hosting model per tier
+
+The self-hosted story does not depend on a managed cloud warehouse. `Postgres`
+and `ClickHouse` both ship open-source servers you can run inside your own VPC,
+Kubernetes cluster, or bare metal — the `deploy/` compose and Helm paths target
+exactly these OSS builds. `ClickHouse` also offers a managed **ClickHouse Cloud**
+service; that hosted option is optional — many deployments run the OSS server
+self-hosted. `Snowflake` is warehouse SaaS only — choose it when
+warehouse-native governance is the goal, not as a prerequisite for analytics
+scale-out. A typical fully self-hostable stack is `Postgres` + OSS `ClickHouse`
++ optional `S3`-compatible object storage.
+
 ## The product contract
 
 `agent-bom` should not require operators to choose between:

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -272,9 +272,15 @@ You still own:
 
 - keep `controlPlane.api.replicas` and `controlPlane.ui.replicas` at `2+`
 - use `Postgres`, not SQLite
-- run Alembic for long-lived Postgres control planes:
-  - `alembic -c deploy/supabase/postgres/alembic.ini upgrade head`
-  - existing `init.sql` databases should be stamped once with `20260416_01`
+- database migrations run automatically: the chart ships a `pre-install,pre-upgrade`
+  Helm hook (`controlPlane.migrations.enabled`, on by default) that runs
+  `alembic -c deploy/supabase/postgres/alembic.ini upgrade head` before the new
+  API pods roll. No manual Alembic step is required for Helm upgrades.
+  - databases first bootstrapped from `init.sql` should be stamped once with the
+    baseline so the auto-hook has a revision to upgrade from:
+    `alembic -c deploy/supabase/postgres/alembic.ini stamp 20260416_01`
+  - to manage migrations yourself (non-Helm or external DB tooling), set
+    `controlPlane.migrations.enabled=false` and run `upgrade head` in your pipeline
 - enable the control-plane HPAs before higher-volume rollout
 - use anti-affinity and a control-plane `PriorityClass` when you expect node pressure
 - enable topology spread when you run multi-AZ EKS

--- a/site-docs/deployment/eks-mcp-pilot.md
+++ b/site-docs/deployment/eks-mcp-pilot.md
@@ -105,8 +105,7 @@ That gives the team a clean story:
 
 ## Required platform hardening
 
-Before calling this pilot production-like, apply the namespace labels and run
-the control-plane migrations explicitly:
+Before calling this pilot production-like, apply the namespace labels:
 
 ```bash
 kubectl label namespace agent-bom \
@@ -114,17 +113,23 @@ kubectl label namespace agent-bom \
   pod-security.kubernetes.io/audit=restricted \
   pod-security.kubernetes.io/warn=restricted \
   --overwrite
-
-alembic -c deploy/supabase/postgres/alembic.ini upgrade head
 ```
+
+Control-plane migrations run automatically. The chart's
+`pre-install,pre-upgrade` Helm hook (`controlPlane.migrations.enabled`, on by
+default) runs `alembic upgrade head` before the new API pods roll, so no manual
+migration step is required for `helm upgrade`.
 
 If the database was already bootstrapped from
 [deploy/supabase/postgres/init.sql](https://github.com/msaad00/agent-bom/blob/main/deploy/supabase/postgres/init.sql),
-stamp the baseline once before future upgrades:
+stamp the baseline once so the auto-hook has a revision to upgrade from:
 
 ```bash
 alembic -c deploy/supabase/postgres/alembic.ini stamp 20260416_01
 ```
+
+To manage migrations with your own tooling, disable the hook with
+`controlPlane.migrations.enabled=false` and run `upgrade head` in your pipeline.
 
 The focused pilot values also set `networkPolicy.restrictIngress=true` and only
 allow ingress from:

--- a/site-docs/deployment/enterprise-pilot.md
+++ b/site-docs/deployment/enterprise-pilot.md
@@ -87,27 +87,31 @@ For concrete sizing, autoscaling, and load-test guidance, use
 
 ## Required rollout steps
 
-1. Run Postgres migrations.
-2. Install the Helm control plane with the focused pilot values.
-3. Label the namespace for Pod Security Admission `restricted`.
-4. Start endpoint fleet scan-and-push on employee workstations.
-5. Add proxy sidecars only to the MCP workloads you want inline enforcement on.
+1. Install the Helm control plane with the focused pilot values (Postgres
+   migrations run automatically via the chart's pre-upgrade hook).
+2. Label the namespace for Pod Security Admission `restricted`.
+3. Start endpoint fleet scan-and-push on employee workstations.
+4. Add proxy sidecars only to the MCP workloads you want inline enforcement on.
 
 ## Migration contract
 
-Long-lived control-plane databases now have an Alembic baseline:
-
-```bash
-alembic -c deploy/supabase/postgres/alembic.ini upgrade head
-```
+Long-lived control-plane databases have an Alembic baseline, and the Helm chart
+applies migrations automatically: the `pre-install,pre-upgrade` hook
+(`controlPlane.migrations.enabled`, on by default) runs `alembic upgrade head`
+before the new API pods roll. A `helm upgrade` needs no manual migration step.
 
 If a database was already initialized from
 [deploy/supabase/postgres/init.sql](https://github.com/msaad00/agent-bom/blob/main/deploy/supabase/postgres/init.sql),
-stamp it once before future changes:
+stamp it once so the auto-hook has a revision to upgrade from:
 
 ```bash
 alembic -c deploy/supabase/postgres/alembic.ini stamp 20260416_01
 ```
 
-Use `init.sql` for disposable bootstrap paths and local compose; use Alembic as
-the authoritative migration path for long-lived enterprise control planes.
+Use `init.sql` for disposable bootstrap paths and local compose. For non-Helm or
+externally managed databases, disable the hook with
+`controlPlane.migrations.enabled=false` and run `upgrade head` yourself:
+
+```bash
+alembic -c deploy/supabase/postgres/alembic.ini upgrade head
+```

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -330,7 +330,9 @@ The rollout order should normally be:
 ## Recommended Production Defaults
 
 - use Postgres, not SQLite, for the control plane
-- use Alembic for long-lived Postgres-backed deployments
+- migrations are applied automatically by the chart's pre-upgrade Helm hook
+  (`controlPlane.migrations.enabled`, on by default) for long-lived
+  Postgres-backed deployments
 - keep the proxy and API internal to your VPC unless exposure is intentional
 - attach discovery jobs to IRSA instead of static cloud keys
 - keep discovery roles read-only unless a specific workflow truly requires write access
@@ -360,17 +362,23 @@ That split is what makes the deployment:
 - **manageable**: each surface can roll out on its own lifecycle
 - **accurate**: one shared graph and policy model keeps outputs consistent across surfaces
 
-Run database migrations explicitly:
-
-```bash
-alembic -c deploy/supabase/postgres/alembic.ini upgrade head
-```
+Database migrations run automatically. The Helm chart's `pre-install,pre-upgrade`
+hook (`controlPlane.migrations.enabled`, on by default) runs `alembic upgrade
+head` before the new API pods roll, so `helm upgrade` needs no manual migration
+step.
 
 If the database was previously bootstrapped from `init.sql`, stamp the baseline
-once before future upgrades:
+once so the auto-hook has a revision to upgrade from:
 
 ```bash
 alembic -c deploy/supabase/postgres/alembic.ini stamp 20260416_01
+```
+
+To manage migrations with external tooling instead, disable the hook
+(`controlPlane.migrations.enabled=false`) and run it yourself:
+
+```bash
+alembic -c deploy/supabase/postgres/alembic.ini upgrade head
 ```
 
 ## What You Still Own


### PR DESCRIPTION
## Summary
- **Closes #3496** — Helm runs `alembic upgrade head` via `pre-install,pre-upgrade` hook by default; manual migration only when `controlPlane.migrations.enabled=false` or for init.sql stamp baseline.
- **Closes #3497** — finding/scan payloads are not app-layer encrypted; enterprise buyers need DB/object-store encryption at rest documented in `docs/ENTERPRISE_DEPLOYMENT.md`.
- **ClickHouse positioning** — OSS self-hosted and ClickHouse Cloud (hosted) are both valid; Snowflake remains SaaS-only.
- **Refs #3506** — compact layered workflow diagram pattern in `VISUAL_LANGUAGE.md` + scan-push exemplar in `how-agent-bom-works.md`.

## Verification
- `git diff --check`
- stale manual-migration phrasing search clean on updated deploy paths