### PR TITLE
fix(ui): dock graph lens switcher — stop overlaying the canvas

### DIFF
--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -523,8 +523,11 @@ export default function ContextPage() {
       {/* Main area: graph + sidebar */}
       <div className="flex-1 flex overflow-hidden">
         {/* Graph */}
-        <div className="flex-1 relative">
-          <GraphLensSwitcher variant="floating" />
+        <div className="flex-1 flex flex-col min-h-0">
+          <div className="mb-2 shrink-0 px-1">
+            <GraphLensSwitcher variant="compact" />
+          </div>
+          <div className="relative min-h-0 flex-1">
           {detailLoading && graphData && (
             <GraphRefreshOverlay label="Updating context graph" />
           )}
@@ -584,6 +587,7 @@ export default function ContextPage() {
               onClose={() => setSelectedNode(null)}
             />
           )}
+          </div>
         </div>
 
         {/* Lateral movement sidebar */}

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -2362,8 +2362,11 @@ function GraphPageInner() {
       </div>
 
       <div className="flex-1 flex relative min-h-[68vh]">
-        <div className="flex-1 relative min-h-[60vh]">
-          <GraphLensSwitcher variant="floating" />
+        <div className="flex-1 relative min-h-[60vh] flex flex-col">
+          <div className="mb-2 shrink-0 px-1">
+            <GraphLensSwitcher variant="compact" />
+          </div>
+          <div className="relative min-h-0 flex-1">
           {loadingGraph && !graphData ? (
             <GraphPanelSkeleton
               title="Loading graph window"
@@ -2486,6 +2489,7 @@ function GraphPageInner() {
               }
             />
           )}
+          </div>
         </div>
       </div>
     </div>

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -551,8 +551,11 @@ export default function MeshPage() {
       />
 
       {/* Graph */}
-      <div className="flex-1 relative">
-        <GraphLensSwitcher variant="floating" />
+      <div className="flex-1 flex flex-col min-h-0">
+        <div className="mb-2 shrink-0 px-1">
+          <GraphLensSwitcher variant="compact" />
+        </div>
+        <div className="relative min-h-0 flex-1">
         {detailLoading && activeResult && (
           <GraphRefreshOverlay label="Updating agent mesh" />
         )}
@@ -607,6 +610,7 @@ export default function MeshPage() {
             onClose={() => setSelectedNode(null)}
           />
         )}
+        </div>
       </div>
     </div>
   );

--- a/ui/components/graph-lens-switcher.tsx
+++ b/ui/components/graph-lens-switcher.tsx
@@ -47,7 +47,7 @@ const GRAPH_LENSES: GraphLens[] = [
 ];
 
 interface GraphLensSwitcherProps {
-  variant?: "inline" | "floating";
+  variant?: "inline" | "floating" | "compact";
 }
 
 export function GraphLensSwitcher({
@@ -74,21 +74,30 @@ export function GraphLensSwitcher({
       className={
         variant === "floating"
           ? "pointer-events-auto flex min-w-0 flex-wrap items-center justify-between gap-2 rounded-2xl border border-zinc-700/80 bg-zinc-950/85 px-3 py-2 shadow-2xl shadow-black/40 backdrop-blur"
-          : "flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3"
+          : variant === "compact"
+            ? "flex flex-wrap items-center justify-between gap-2 rounded-xl border border-zinc-800 bg-zinc-950/80 px-3 py-2"
+            : "flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3"
       }
     >
-      <div className="min-w-0">
-        <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-[color:var(--text-tertiary)]">
-          {variant === "floating" ? "Security Graph Lens" : "Security Graph"}
+      {variant !== "compact" && (
+        <div className="min-w-0">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-[color:var(--text-tertiary)]">
+            {variant === "floating" ? "Security Graph Lens" : "Security Graph"}
+          </p>
+          <p
+            className={`mt-0.5 text-xs text-[color:var(--text-secondary)] ${
+              variant === "floating" ? "hidden sm:block" : ""
+            }`}
+          >
+            One graph, multiple lenses — switch how you read the same estate.
+          </p>
+        </div>
+      )}
+      {variant === "compact" && (
+        <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-zinc-500">
+          Lens
         </p>
-        <p
-          className={`mt-0.5 text-xs text-[color:var(--text-secondary)] ${
-            variant === "floating" ? "hidden sm:block" : ""
-          }`}
-        >
-          One graph, multiple lenses — switch how you read the same estate.
-        </p>
-      </div>
+      )}
       <InsightLayerToggle layers={layers} onToggle={onToggle} />
     </div>
   );

--- a/ui/tests/graph-lens-switcher.test.tsx
+++ b/ui/tests/graph-lens-switcher.test.tsx
@@ -16,6 +16,15 @@ describe("GraphLensSwitcher", () => {
     push.mockClear();
   });
 
+  it("renders the compact lens bar without overlay marketing copy", () => {
+    render(<GraphLensSwitcher variant="compact" />);
+
+    expect(screen.queryByTestId("graph-lens-floating-bar")).not.toBeInTheDocument();
+    expect(screen.queryByText("Security Graph Lens")).not.toBeInTheDocument();
+    expect(screen.getByText("Lens")).toBeInTheDocument();
+    expect(screen.getByText("Lineage")).toBeInTheDocument();
+  });
+
   it("renders the floating lens bar for full-canvas graph pages", () => {
     render(<GraphLensSwitcher variant="floating" />);
 


### PR DESCRIPTION
## Summary
- Replaces the floating "Security Graph Lens" bar (absolute top-center over React Flow nodes) with a compact in-flow lens row above the canvas on lineage, mesh, and context pages.
- Removes marketing subtitle from the compact variant — operator chrome stays functional, not promotional.

Follow-up to #3502 / Refs #3192.

## Verification
- `npm run typecheck`
- `vitest run tests/graph-lens-switcher.test.tsx` (4 passing)

Made with [Cursor](https://cursor.com)