### PR TITLE
feat(ui): wire estate roll-up navigation for large graphs

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -14,7 +14,7 @@ import {
   type Node,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
-import { AlertTriangle, Loader2, Radar, Route, ShieldAlert } from "lucide-react";
+import { AlertTriangle, Layers, Loader2, Radar, Route, ShieldAlert } from "lucide-react";
 
 import { AttackPathCard } from "@/components/attack-path-card";
 import { GraphEvaluationSummary } from "@/components/graph-evaluation-summary";
@@ -95,6 +95,8 @@ import {
   type GraphSnapshot,
   type UnifiedGraphResponse,
 } from "@/lib/api";
+import type { GraphRollupResponse } from "@/lib/api-types";
+import { buildRollupFlowGraph } from "@/lib/graph-rollup-view";
 import { buildUnifiedFlowGraph } from "@/lib/unified-graph-flow";
 import {
   LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD,
@@ -610,6 +612,11 @@ type BlastRadiusState = {
   maxDepthReached: number;
 };
 
+type RollupBreadcrumb = {
+  id: string;
+  label: string;
+};
+
 export default function GraphPageClient() {
   return (
     <ReactFlowProvider>
@@ -651,6 +658,11 @@ function GraphPageInner() {
   const [blastRadius, setBlastRadius] = useState<BlastRadiusState | null>(null);
   const [loadingBlast, setLoadingBlast] = useState(false);
   const [blastError, setBlastError] = useState<string | null>(null);
+  const [rollupView, setRollupView] = useState<GraphRollupResponse | null>(null);
+  const [rollupStack, setRollupStack] = useState<RollupBreadcrumb[]>([]);
+  const [rollupDismissed, setRollupDismissed] = useState(false);
+  const [loadingRollup, setLoadingRollup] = useState(false);
+  const [rollupError, setRollupError] = useState<string | null>(null);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [pinnedFocusId, setPinnedFocusId] = useState<string | null>(null);
   const [expandedClusterIds, setExpandedClusterIds] = useState<Set<string>>(
@@ -758,6 +770,10 @@ function GraphPageInner() {
     setInvestigationMode(null);
     setReachabilitySummary(null);
     setReachabilityError(null);
+    setRollupView(null);
+    setRollupStack([]);
+    setRollupDismissed(false);
+    setRollupError(null);
     if (firstScanSelectionRef.current) {
       firstScanSelectionRef.current = false;
       if (seededFromUrlRef.current) {
@@ -929,7 +945,78 @@ function GraphPageInner() {
     }
   }, [attackPaths, selectedAttackPathKey]);
 
+  const estateNodeCount =
+    activeSnapshot?.node_count ??
+    rollupView?.summary.total_nodes ??
+    graphData?.nodes.length ??
+    0;
+
+  const rollupEligible =
+    estateNodeCount >= LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD &&
+    !investigationMode &&
+    !selectedAttackPath &&
+    !reachabilitySummary &&
+    !blastRadius;
+
+  const rollupNavigationActive =
+    rollupEligible && !rollupDismissed && rollupView !== null;
+
+  useEffect(() => {
+    if (!selectedScanId || !rollupEligible || rollupDismissed) {
+      return;
+    }
+
+    let cancelled = false;
+    setLoadingRollup(true);
+    setRollupError(null);
+    const drillNode = rollupStack.at(-1)?.id;
+
+    api
+      .getGraphRollup(selectedScanId, {
+        ...(drillNode ? { node: drillNode } : {}),
+        ...(filters.severity ? { minSeverity: filters.severity } : {}),
+      })
+      .then((result) => {
+        if (cancelled) return;
+        setRollupView(result);
+        setRollupError(null);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setRollupError(e.message);
+        setRollupView(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingRollup(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    selectedScanId,
+    rollupEligible,
+    rollupDismissed,
+    rollupStack,
+    filters.severity,
+  ]);
+
   const flow = useMemo(() => {
+    if (rollupNavigationActive && rollupView) {
+      const items =
+        rollupView.mode === "drilldown"
+          ? (rollupView.children ?? [])
+          : (rollupView.top_level ?? []);
+      const rollupFlow = buildRollupFlowGraph(items);
+      return {
+        nodes: rollupFlow.nodes,
+        edges: rollupFlow.edges,
+        agentNames: [] as string[],
+        legend: [] as ReturnType<typeof buildUnifiedFlowGraph>["legend"],
+        summary: null as
+          null | ReturnType<typeof buildUnifiedFlowGraph>["summary"],
+      };
+    }
     if (!graphData) {
       return {
         nodes: [],
@@ -941,7 +1028,12 @@ function GraphPageInner() {
       };
     }
     return buildUnifiedFlowGraph(graphData, filters);
-  }, [graphData, filters]);
+  }, [
+    graphData,
+    filters,
+    rollupNavigationActive,
+    rollupView,
+  ]);
 
   useEffect(() => {
     if (initializedFocus || flow.agentNames.length === 0) return;
@@ -1029,12 +1121,33 @@ function GraphPageInner() {
       : EXPANDED_AGGREGATION_THRESHOLD;
 
   const aggregated = useMemo(
-    () =>
-      aggregateSiblings(flow.nodes, flow.edges, {
+    () => {
+      if (rollupNavigationActive) {
+        return {
+          nodes: flow.nodes,
+          edges: flow.edges,
+          clusters: new Map<
+            string,
+            {
+              parentId: string;
+              childType: LineageNodeType;
+              members: string[];
+            }
+          >(),
+        };
+      }
+      return aggregateSiblings(flow.nodes, flow.edges, {
         thresholdN: aggregationThreshold,
         expandedClusterIds: expandedClusterIds,
-      }),
-    [flow.nodes, flow.edges, aggregationThreshold, expandedClusterIds],
+      });
+    },
+    [
+      flow.nodes,
+      flow.edges,
+      aggregationThreshold,
+      expandedClusterIds,
+      rollupNavigationActive,
+    ],
   );
   const aggregatedClusterNodes = useMemo(
     () =>
@@ -1154,9 +1267,12 @@ function GraphPageInner() {
   });
 
   const lineageLayoutNodes = layoutNodes as Node<LineageNodeData>[];
+  const canvasLayoutNodes = rollupNavigationActive
+    ? (aggregated.nodes as Node<LineageNodeData>[])
+    : lineageLayoutNodes;
   const displayNodes = useMemo<Node<LineageNodeData>[]>(() => {
     if (blastRadius) {
-      return lineageLayoutNodes.map((node) => {
+      return canvasLayoutNodes.map((node) => {
         const inBlast = blastRadius.nodeIds.has(node.id);
         const isRoot = node.id === blastRadius.rootId;
         return {
@@ -1172,7 +1288,7 @@ function GraphPageInner() {
       });
     }
     if (attackPathNodeIds) {
-      return lineageLayoutNodes
+      return canvasLayoutNodes
         .filter((node) => attackPathNodeIds.has(node.id))
         .map((node) => {
           const inPath = attackPathNodeIds.has(node.id);
@@ -1194,7 +1310,7 @@ function GraphPageInner() {
         });
     }
     if (reachabilitySummary) {
-      return lineageLayoutNodes.map((node) => {
+      return canvasLayoutNodes.map((node) => {
         const inReach = reachabilitySummary.nodeIds.has(node.id);
         const isRoot = node.id === reachabilitySummary.rootId;
         return {
@@ -1210,7 +1326,7 @@ function GraphPageInner() {
       });
     }
     if (!localNeighborhoodIds) {
-      return lineageLayoutNodes.map((node) => ({
+      return canvasLayoutNodes.map((node) => ({
         ...node,
         data: {
           ...node.data,
@@ -1218,7 +1334,7 @@ function GraphPageInner() {
         },
       }));
     }
-    return lineageLayoutNodes.map((node) => {
+    return canvasLayoutNodes.map((node) => {
       const isFocused = node.id === activeFocusId;
       const isConnected = localNeighborhoodIds.has(node.id);
       const dimmed = !isConnected;
@@ -1234,7 +1350,7 @@ function GraphPageInner() {
       };
     });
   }, [
-    lineageLayoutNodes,
+    canvasLayoutNodes,
     localNeighborhoodIds,
     attackPathNodeIds,
     attackPathNodeOrder,
@@ -1245,7 +1361,9 @@ function GraphPageInner() {
   ]);
 
   const compressedGroupCount = aggregatedClusterNodes.length;
-  const sourceNodeCount = graphData?.nodes.length ?? flow.nodes.length;
+  const sourceNodeCount = rollupNavigationActive
+    ? (rollupView?.summary.total_nodes ?? estateNodeCount)
+    : (graphData?.nodes.length ?? flow.nodes.length);
   const renderedNodeCount = displayNodes.length;
 
   const displayEdges = useMemo(() => {
@@ -1425,6 +1543,7 @@ function GraphPageInner() {
     captureMode,
     selectedAttackPath: Boolean(selectedAttackPath),
     reachabilityActive: Boolean(reachabilitySummary),
+    rollupActive: rollupNavigationActive,
     graphOnlyFindings,
     webglEnabled: webglGraphEnabled,
   });
@@ -1443,36 +1562,46 @@ function GraphPageInner() {
     [displayNodes],
   );
 
-  const onNodeClick = useCallback((_event: React.MouseEvent, node: Node) => {
-    // Cluster-pill click → restore the absorbed siblings in place. We
-    // never open the detail panel for a synthetic cluster node.
-    if (isClusterPillNode(node as Node<LineageNodeData>)) {
-      const id = node.id;
-      setExpandedClusterIds((current) => {
-        const next = new Set(current);
-        next.add(id);
-        return next;
-      });
-      return;
-    }
+  const onNodeClick = useCallback(
+    (_event: React.MouseEvent, node: Node) => {
+      // Cluster-pill click → restore the absorbed siblings in place. We
+      // never open the detail panel for a synthetic cluster node.
+      if (isClusterPillNode(node as Node<LineageNodeData>)) {
+        const id = node.id;
+        setExpandedClusterIds((current) => {
+          const next = new Set(current);
+          next.add(id);
+          return next;
+        });
+        return;
+      }
 
-    const data = node.data as LineageNodeData;
-    setSelectedNode({
-      ...data,
-      attributes: {
-        ...(data.attributes ?? {}),
-        node_id: node.id,
-      },
-    });
-    setSelectedNodeId(node.id);
-    setSelectedAttackPathKey(null);
-    setAutoPathDismissed(true);
-    // Click pin (#2257): toggle a "pinned focus" on the clicked node.
-    // Re-clicking the same node clears the pin. Hover state is reset
-    // because the pin replaces hover as the focus source.
-    setPinnedFocusId((current) => (current === node.id ? null : node.id));
-    setHoveredNodeId(null);
-  }, []);
+      const data = node.data as LineageNodeData;
+      if (rollupNavigationActive && data.attributes?.rollup_has_children === true) {
+        setRollupStack((current) => {
+          if (current.at(-1)?.id === node.id) return current;
+          return [...current, { id: node.id, label: data.label }];
+        });
+      }
+
+      setSelectedNode({
+        ...data,
+        attributes: {
+          ...(data.attributes ?? {}),
+          node_id: node.id,
+        },
+      });
+      setSelectedNodeId(node.id);
+      setSelectedAttackPathKey(null);
+      setAutoPathDismissed(true);
+      // Click pin (#2257): toggle a "pinned focus" on the clicked node.
+      // Re-clicking the same node clears the pin. Hover state is reset
+      // because the pin replaces hover as the focus source.
+      setPinnedFocusId((current) => (current === node.id ? null : node.id));
+      setHoveredNodeId(null);
+    },
+    [rollupNavigationActive],
+  );
 
   const onLargeGraphNodeSelect = useCallback(
     (nodeId: string) => {
@@ -1654,6 +1783,20 @@ function GraphPageInner() {
   const clearBlastRadius = useCallback(() => {
     setBlastRadius(null);
     setBlastError(null);
+  }, []);
+
+  const dismissRollup = useCallback(() => {
+    setRollupDismissed(true);
+    setRollupStack([]);
+    setRollupError(null);
+  }, []);
+
+  const navigateRollupBreadcrumb = useCallback((index: number) => {
+    setRollupStack((current) => current.slice(0, index + 1));
+  }, []);
+
+  const resetRollupToRoot = useCallback(() => {
+    setRollupStack([]);
   }, []);
 
   const loadBlastRadius = useCallback(
@@ -1990,6 +2133,21 @@ function GraphPageInner() {
               onClear={clearBlastRadius}
             />
           )}
+
+          {(rollupEligible || loadingRollup || rollupError) &&
+            !rollupDismissed && (
+              <RollupNavigationPanel
+                summary={rollupView}
+                estateNodeCount={estateNodeCount}
+                breadcrumbs={rollupStack}
+                loading={loadingRollup}
+                error={rollupError}
+                active={rollupNavigationActive}
+                onDismiss={dismissRollup}
+                onReset={resetRollupToRoot}
+                onBreadcrumb={navigateRollupBreadcrumb}
+              />
+            )}
 
           {searchResults.length > 0 && (
             <div className="mt-2 rounded-2xl border border-zinc-800 bg-zinc-950/90 p-2">
@@ -2721,6 +2879,102 @@ function BlastRadiusPanel({
         <p className="mt-2 text-zinc-400">
           Nothing downstream depends on this node in the current snapshot.
         </p>
+      )}
+    </div>
+  );
+}
+
+function RollupNavigationPanel({
+  summary,
+  estateNodeCount,
+  breadcrumbs,
+  loading,
+  error,
+  active,
+  onDismiss,
+  onReset,
+  onBreadcrumb,
+}: {
+  summary: GraphRollupResponse | null;
+  estateNodeCount: number;
+  breadcrumbs: RollupBreadcrumb[];
+  loading: boolean;
+  error: string | null;
+  active: boolean;
+  onDismiss: () => void;
+  onReset: () => void;
+  onBreadcrumb: (index: number) => void;
+}) {
+  const visibleCount =
+    summary?.mode === "drilldown"
+      ? (summary.children?.length ?? 0)
+      : (summary?.top_level?.length ?? 0);
+
+  return (
+    <div className="mt-3 rounded-2xl border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs text-emerald-100">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex items-start gap-2">
+          <Layers className="mt-0.5 h-4 w-4 text-emerald-300" />
+          <div>
+            <p className="text-[10px] uppercase tracking-[0.24em] text-emerald-300">
+              Estate roll-up
+            </p>
+            <p className="mt-1 text-sm font-medium text-emerald-50">
+              {active
+                ? `${visibleCount} container${visibleCount === 1 ? "" : "s"} at this level · ${estateNodeCount} nodes in snapshot`
+                : `Large estate (${estateNodeCount} nodes) — loading roll-up view`}
+            </p>
+            {active && (
+              <p className="mt-1 text-[11px] text-emerald-200/80">
+                Click a container with descendants to drill down one CONTAINS
+                level. Severity filters apply to rolled-up aggregates.
+              </p>
+            )}
+            {error && (
+              <p className="mt-1 text-[11px] text-amber-200">{error}</p>
+            )}
+            {loading && (
+              <p className="mt-1 flex items-center gap-1 text-[11px] text-emerald-200">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Collapsing containment hierarchy
+              </p>
+            )}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="rounded-lg border border-emerald-400/30 bg-emerald-950/60 px-2.5 py-1 text-emerald-100 transition hover:border-emerald-300"
+        >
+          Show full graph
+        </button>
+      </div>
+
+      {breadcrumbs.length > 0 && (
+        <nav
+          aria-label="Roll-up breadcrumb"
+          className="mt-3 flex flex-wrap items-center gap-1 text-[11px] text-emerald-100"
+        >
+          <button
+            type="button"
+            onClick={onReset}
+            className="rounded border border-emerald-400/20 bg-emerald-950/50 px-2 py-0.5 transition hover:border-emerald-300"
+          >
+            Estate root
+          </button>
+          {breadcrumbs.map((crumb, index) => (
+            <span key={crumb.id} className="flex items-center gap-1">
+              <span className="text-emerald-400/70">/</span>
+              <button
+                type="button"
+                onClick={() => onBreadcrumb(index)}
+                className="max-w-[12rem] truncate rounded border border-emerald-400/20 bg-emerald-950/50 px-2 py-0.5 transition hover:border-emerald-300"
+              >
+                {crumb.label}
+              </button>
+            </span>
+          ))}
+        </nav>
       )}
     </div>
   );

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -300,6 +300,56 @@ export interface GraphNodeDetailResponse {
   impact: GraphImpactResponse;
 }
 
+export interface GraphRollupAggregate {
+  descendant_count: number;
+  by_type: Record<string, number>;
+  severity_counts: Record<string, number>;
+  worst_severity: string;
+  worst_severity_rank: number;
+  internet_exposed: boolean;
+  toxic_combo: boolean;
+  exposed_count: number;
+  toxic_count: number;
+}
+
+export interface GraphRollupContainer {
+  id: string;
+  label: string;
+  entity_type: string;
+  severity: string;
+  is_container: boolean;
+  has_children: boolean;
+  direct_child_count: number;
+  aggregate: GraphRollupAggregate;
+}
+
+export interface GraphRollupSummary {
+  total_nodes?: number;
+  total_edges?: number;
+  top_level_count?: number;
+  container_count?: number;
+  orphan_count?: number;
+  direct_child_count?: number;
+  returned_child_count?: number;
+}
+
+export interface GraphRollupResponse {
+  scan_id: string;
+  tenant_id: string;
+  created_at: string;
+  mode: "rollup" | "drilldown" | "attack_path";
+  filters: Record<string, unknown>;
+  top_level?: GraphRollupContainer[];
+  children?: GraphRollupContainer[];
+  node?: {
+    id: string;
+    label: string;
+    entity_type: string;
+    severity: string;
+  } | null;
+  summary: GraphRollupSummary;
+}
+
 export interface GraphSearchResponse {
   query: string;
   results: UnifiedNode[];

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -17,6 +17,7 @@ import type {
   GraphQueryResponse,
   GraphNodeDetailResponse,
   GraphImpactResponse,
+  GraphRollupResponse,
   GraphSearchResponse,
   GraphSemanticClustersResponse,
   GraphAgentsResponse,
@@ -716,6 +717,28 @@ export const api = {
     if (scanId) params.set("scan_id", scanId);
     if (maxDepth != null) params.set("max_depth", String(maxDepth));
     return get<GraphImpactResponse>(`/v1/graph/impact?${params.toString()}`);
+  },
+
+  /** Estate-scale CONTAINS roll-up with optional one-level drill-down */
+  getGraphRollup: (
+    scanId?: string,
+    options?: {
+      node?: string;
+      minSeverity?: string;
+      exposed?: boolean;
+      toxic?: boolean;
+      mode?: "rollup" | "attack_path";
+    },
+  ) => {
+    const params = new URLSearchParams();
+    if (scanId) params.set("scan_id", scanId);
+    if (options?.node) params.set("node", options.node);
+    if (options?.minSeverity) params.set("min_severity", options.minSeverity);
+    if (options?.exposed) params.set("exposed", "true");
+    if (options?.toxic) params.set("toxic", "true");
+    if (options?.mode) params.set("mode", options.mode);
+    const qs = params.toString();
+    return get<GraphRollupResponse>(`/v1/graph/rollup${qs ? `?${qs}` : ""}`);
   },
 
   /** Connect to SSE stream for real-time progress */

--- a/ui/lib/graph-renderer-switch.ts
+++ b/ui/lib/graph-renderer-switch.ts
@@ -11,6 +11,7 @@ export interface GraphRendererDecisionInput {
   captureMode?: boolean | undefined;
   selectedAttackPath?: boolean | undefined;
   reachabilityActive?: boolean | undefined;
+  rollupActive?: boolean | undefined;
   graphOnlyFindings?: boolean | undefined;
   webglEnabled?: boolean | undefined;
 }
@@ -28,6 +29,7 @@ export function decideGraphRenderer({
   captureMode = false,
   selectedAttackPath = false,
   reachabilityActive = false,
+  rollupActive = false,
   graphOnlyFindings = false,
   webglEnabled = false,
 }: GraphRendererDecisionInput): GraphRendererDecision {
@@ -51,6 +53,14 @@ export function decideGraphRenderer({
     return {
       kind: "react-flow",
       reason: "reachability-drill-in",
+      interactive: true,
+      supportsInvestigation: true,
+    };
+  }
+  if (rollupActive) {
+    return {
+      kind: "react-flow",
+      reason: "estate-rollup-navigation",
       interactive: true,
       supportsInvestigation: true,
     };

--- a/ui/lib/graph-rollup-view.ts
+++ b/ui/lib/graph-rollup-view.ts
@@ -1,0 +1,152 @@
+import type { Edge, Node } from "@xyflow/react";
+
+import type { LineageNodeData, LineageNodeType } from "@/components/lineage-nodes";
+import type { GraphRollupContainer } from "@/lib/api-types";
+
+const ROLLUP_ENTITY_TO_NODE_TYPE: Record<string, LineageNodeType> = {
+  provider: "provider",
+  org: "org",
+  account: "account",
+  user: "user",
+  group: "group",
+  role: "role",
+  policy: "policy",
+  service_account: "serviceAccount",
+  service_principal: "servicePrincipal",
+  federated_identity: "federatedIdentity",
+  environment: "environment",
+  fleet: "fleet",
+  cluster: "cluster",
+  application: "container",
+  server: "server",
+  package: "package",
+  tool: "tool",
+  credential: "credential",
+  vulnerability: "vulnerability",
+  misconfiguration: "misconfiguration",
+  model: "model",
+  dataset: "dataset",
+  container: "container",
+  cloud_resource: "cloudResource",
+  managed_identity: "managedIdentity",
+  access_grant: "accessGrant",
+  access_policy: "accessPolicy",
+  drift_incident: "driftIncident",
+  data_store: "dataStore",
+  directory: "directory",
+  source_file: "sourceFile",
+  config_file: "configFile",
+  agent: "agent",
+};
+
+const FLOW_NODE_TYPES: Record<LineageNodeType, string> = {
+  provider: "providerNode",
+  agent: "agentNode",
+  org: "providerNode",
+  account: "providerNode",
+  user: "userNode",
+  group: "groupNode",
+  role: "credentialNode",
+  policy: "credentialNode",
+  serviceAccount: "serviceAccountNode",
+  servicePrincipal: "serviceAccountNode",
+  federatedIdentity: "serviceAccountNode",
+  environment: "environmentNode",
+  fleet: "fleetNode",
+  cluster: "clusterNode",
+  server: "serverNode",
+  sharedServer: "sharedServerNode",
+  package: "packageNode",
+  vulnerability: "vulnNode",
+  credential: "credentialNode",
+  tool: "toolNode",
+  model: "modelNode",
+  dataset: "datasetNode",
+  container: "containerNode",
+  cloudResource: "cloudResourceNode",
+  misconfiguration: "misconfigNode",
+  managedIdentity: "managedIdentityNode",
+  accessGrant: "accessGrantNode",
+  accessPolicy: "accessPolicyNode",
+  driftIncident: "driftIncidentNode",
+  dataStore: "dataStoreNode",
+  directory: "containerNode",
+  sourceFile: "packageNode",
+  configFile: "packageNode",
+};
+
+const DEFAULT_COLUMNS = 3;
+const NODE_WIDTH = 268;
+const NODE_HEIGHT = 112;
+
+export function rollupEntityToNodeType(entityType: string): LineageNodeType {
+  return ROLLUP_ENTITY_TO_NODE_TYPE[entityType] ?? "cloudResource";
+}
+
+export function rollupContainerSubtitle(container: GraphRollupContainer): string {
+  const parts: string[] = [];
+  const descendants = container.aggregate.descendant_count;
+  if (descendants > 0) {
+    parts.push(
+      `${descendants} descendant${descendants === 1 ? "" : "s"}`,
+    );
+  } else if (container.direct_child_count > 0) {
+    parts.push(
+      `${container.direct_child_count} direct child${container.direct_child_count === 1 ? "" : "ren"}`,
+    );
+  }
+  if (container.aggregate.worst_severity && container.aggregate.worst_severity !== "none") {
+    parts.push(`worst ${container.aggregate.worst_severity}`);
+  }
+  if (container.aggregate.internet_exposed) {
+    parts.push("internet exposed");
+  }
+  if (container.aggregate.toxic_combo) {
+    parts.push("toxic combo");
+  }
+  if (container.has_children) {
+    parts.push("click to drill down");
+  }
+  return parts.join(" · ");
+}
+
+function rollupContainerToNodeData(
+  container: GraphRollupContainer,
+): LineageNodeData {
+  const nodeType = rollupEntityToNodeType(container.entity_type);
+  return {
+    label: container.label,
+    nodeType,
+    entityType: container.entity_type,
+    severity: container.severity || container.aggregate.worst_severity || undefined,
+    description: rollupContainerSubtitle(container),
+    attributes: {
+      node_id: container.id,
+      rollup_has_children: container.has_children,
+      rollup_is_container: container.is_container,
+      rollup_descendant_count: container.aggregate.descendant_count,
+    },
+    highlighted: container.aggregate.worst_severity_rank >= 4,
+    isCritical: container.aggregate.worst_severity === "critical",
+  };
+}
+
+export function buildRollupFlowGraph(
+  containers: GraphRollupContainer[],
+  options?: { columns?: number },
+): { nodes: Node<LineageNodeData>[]; edges: Edge[] } {
+  const columns = Math.max(1, options?.columns ?? DEFAULT_COLUMNS);
+  const nodes: Node<LineageNodeData>[] = containers.map((container, index) => {
+    const nodeType = rollupEntityToNodeType(container.entity_type);
+    const col = index % columns;
+    const row = Math.floor(index / columns);
+    return {
+      id: container.id,
+      type: FLOW_NODE_TYPES[nodeType],
+      position: { x: col * NODE_WIDTH, y: row * NODE_HEIGHT },
+      data: rollupContainerToNodeData(container),
+      ...(container.has_children ? { className: "cursor-pointer" } : {}),
+    };
+  });
+  return { nodes, edges: [] };
+}

--- a/ui/tests/api.test.ts
+++ b/ui/tests/api.test.ts
@@ -217,6 +217,56 @@ describe('api.getGraphImpact', () => {
   })
 })
 
+describe('api.getGraphRollup', () => {
+  it('requests the estate roll-up endpoint with scan and drill params', async () => {
+    const payload = {
+      scan_id: 'scan-1',
+      tenant_id: 'default',
+      created_at: '2026-01-01T00:00:00Z',
+      mode: 'drilldown',
+      filters: {},
+      children: [],
+      summary: { direct_child_count: 2, returned_child_count: 2 },
+    }
+    const fetchMock = mockFetch(payload)
+    global.fetch = fetchMock
+
+    const result = await api.getGraphRollup('scan-1', {
+      node: 'account:prod',
+      minSeverity: 'high',
+      exposed: true,
+      toxic: true,
+      mode: 'attack_path',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/v1/graph/rollup?scan_id=scan-1&node=account%3Aprod&min_severity=high&exposed=true&toxic=true&mode=attack_path',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+    expect(result.mode).toBe('drilldown')
+  })
+
+  it('omits optional params when not provided', async () => {
+    const fetchMock = mockFetch({
+      scan_id: 'scan-1',
+      tenant_id: 'default',
+      created_at: '2026-01-01T00:00:00Z',
+      mode: 'rollup',
+      filters: {},
+      top_level: [],
+      summary: { top_level_count: 0 },
+    })
+    global.fetch = fetchMock
+
+    await api.getGraphRollup()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/v1/graph/rollup',
+      expect.objectContaining({ credentials: 'include' }),
+    )
+  })
+})
+
 describe('api.getScan', () => {
   it('returns expected shape', async () => {
     const payload = {

--- a/ui/tests/graph-renderer-switch.test.ts
+++ b/ui/tests/graph-renderer-switch.test.ts
@@ -28,6 +28,11 @@ describe("graph renderer switch", () => {
       reason: "reachability-drill-in",
       supportsInvestigation: true,
     });
+    expect(decideGraphRenderer({ ...broadGraph, rollupActive: true })).toMatchObject({
+      kind: "react-flow",
+      reason: "estate-rollup-navigation",
+      supportsInvestigation: true,
+    });
     expect(decideGraphRenderer({ ...broadGraph, graphOnlyFindings: true })).toMatchObject({
       kind: "react-flow",
       reason: "findings-only-fallback",

--- a/ui/tests/graph-rollup-view.test.ts
+++ b/ui/tests/graph-rollup-view.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import type { GraphRollupContainer } from "@/lib/api-types";
+import {
+  buildRollupFlowGraph,
+  rollupContainerSubtitle,
+  rollupEntityToNodeType,
+} from "@/lib/graph-rollup-view";
+
+function sampleContainer(
+  overrides: Partial<GraphRollupContainer> = {},
+): GraphRollupContainer {
+  return {
+    id: "account:prod",
+    label: "prod",
+    entity_type: "account",
+    severity: "",
+    is_container: true,
+    has_children: true,
+    direct_child_count: 2,
+    aggregate: {
+      descendant_count: 42,
+      by_type: { server: 2, package: 40 },
+      severity_counts: { critical: 1, low: 39 },
+      worst_severity: "critical",
+      worst_severity_rank: 5,
+      internet_exposed: true,
+      toxic_combo: false,
+      exposed_count: 1,
+      toxic_count: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe("rollupEntityToNodeType", () => {
+  it("maps estate entity types to lineage node types", () => {
+    expect(rollupEntityToNodeType("account")).toBe("account");
+    expect(rollupEntityToNodeType("application")).toBe("container");
+    expect(rollupEntityToNodeType("unknown_type")).toBe("cloudResource");
+  });
+});
+
+describe("rollupContainerSubtitle", () => {
+  it("summarizes descendants, severity, exposure, and drill hint", () => {
+    const subtitle = rollupContainerSubtitle(sampleContainer());
+    expect(subtitle).toContain("42 descendants");
+    expect(subtitle).toContain("worst critical");
+    expect(subtitle).toContain("internet exposed");
+    expect(subtitle).toContain("click to drill down");
+  });
+});
+
+describe("buildRollupFlowGraph", () => {
+  it("lays out containers on a grid with rollup metadata", () => {
+    const { nodes, edges } = buildRollupFlowGraph([
+      sampleContainer(),
+      sampleContainer({
+        id: "account:dev",
+        label: "dev",
+        has_children: false,
+        aggregate: {
+          ...sampleContainer().aggregate,
+          descendant_count: 3,
+          worst_severity: "low",
+          worst_severity_rank: 1,
+          internet_exposed: false,
+        },
+      }),
+    ]);
+
+    expect(edges).toHaveLength(0);
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0]?.id).toBe("account:prod");
+    expect(nodes[0]?.position).toEqual({ x: 0, y: 0 });
+    expect(nodes[1]?.position).toEqual({ x: 268, y: 0 });
+    expect(nodes[0]?.data.attributes?.rollup_has_children).toBe(true);
+    expect(nodes[0]?.data.description).toContain("click to drill down");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `api.getGraphRollup()` and `buildRollupFlowGraph()` to consume `/v1/graph/rollup` + drill-down responses.
- Auto-enables roll-up navigation on snapshots with ≥200 nodes (same threshold as large-graph overview), with breadcrumb drill-down, severity filter pass-through, and **Show full graph** dismiss.
- Forces React Flow for roll-up mode so large estates stay interactive instead of falling through to the overview/WebGL renderer.

Refs #3192

## Verification
- `npm run typecheck`
- `npm test -- --run tests/graph-rollup-view.test.ts tests/graph-renderer-switch.test.ts tests/api.test.ts`


Made with [Cursor](https://cursor.com)