### PR TITLE
fix(api,http): bound ScanRequest list elements and jitter sync retries

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -2742,6 +2742,7 @@
         "properties": {
           "agent_projects": {
             "items": {
+              "maxLength": 4096,
               "type": "string"
             },
             "title": "Agent Projects",
@@ -2754,6 +2755,7 @@
           },
           "connectors": {
             "items": {
+              "maxLength": 128,
               "type": "string"
             },
             "title": "Connectors",
@@ -2792,6 +2794,7 @@
           },
           "exclude_agents": {
             "items": {
+              "maxLength": 256,
               "type": "string"
             },
             "title": "Exclude Agents",
@@ -2799,6 +2802,7 @@
           },
           "exclude_servers": {
             "items": {
+              "maxLength": 256,
               "type": "string"
             },
             "title": "Exclude Servers",
@@ -2806,6 +2810,7 @@
           },
           "filesystem_paths": {
             "items": {
+              "maxLength": 4096,
               "type": "string"
             },
             "title": "Filesystem Paths",
@@ -2819,6 +2824,7 @@
           "gha_path": {
             "anyOf": [
               {
+                "maxLength": 4096,
                 "type": "string"
               },
               {
@@ -2829,6 +2835,7 @@
           },
           "images": {
             "items": {
+              "maxLength": 512,
               "type": "string"
             },
             "title": "Images",
@@ -2837,6 +2844,7 @@
           "inventory": {
             "anyOf": [
               {
+                "maxLength": 4096,
                 "type": "string"
               },
               {
@@ -2847,6 +2855,7 @@
           },
           "jupyter_dirs": {
             "items": {
+              "maxLength": 4096,
               "type": "string"
             },
             "title": "Jupyter Dirs",
@@ -2892,6 +2901,7 @@
           "sbom": {
             "anyOf": [
               {
+                "maxLength": 4096,
                 "type": "string"
               },
               {
@@ -2902,6 +2912,7 @@
           },
           "scope_agents": {
             "items": {
+              "maxLength": 256,
               "type": "string"
             },
             "title": "Scope Agents",
@@ -2909,6 +2920,7 @@
           },
           "scope_servers": {
             "items": {
+              "maxLength": 256,
               "type": "string"
             },
             "title": "Scope Servers",
@@ -2916,6 +2928,7 @@
           },
           "tf_dirs": {
             "items": {
+              "maxLength": 4096,
               "type": "string"
             },
             "title": "Tf Dirs",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -1814,6 +1814,7 @@ components:
       properties:
         agent_projects:
           items:
+            maxLength: 4096
             type: string
           title: Agent Projects
           type: array
@@ -1823,6 +1824,7 @@ components:
           type: boolean
         connectors:
           items:
+            maxLength: 128
             type: string
           title: Connectors
           type: array
@@ -1849,16 +1851,19 @@ components:
           type: boolean
         exclude_agents:
           items:
+            maxLength: 256
             type: string
           title: Exclude Agents
           type: array
         exclude_servers:
           items:
+            maxLength: 256
             type: string
           title: Exclude Servers
           type: array
         filesystem_paths:
           items:
+            maxLength: 4096
             type: string
           title: Filesystem Paths
           type: array
@@ -1868,21 +1873,25 @@ components:
           type: string
         gha_path:
           anyOf:
-          - type: string
+          - maxLength: 4096
+            type: string
           - type: 'null'
           title: Gha Path
         images:
           items:
+            maxLength: 512
             type: string
           title: Images
           type: array
         inventory:
           anyOf:
-          - type: string
+          - maxLength: 4096
+            type: string
           - type: 'null'
           title: Inventory
         jupyter_dirs:
           items:
+            maxLength: 4096
             type: string
           title: Jupyter Dirs
           type: array
@@ -1910,21 +1919,25 @@ components:
           type: boolean
         sbom:
           anyOf:
-          - type: string
+          - maxLength: 4096
+            type: string
           - type: 'null'
           title: Sbom
         scope_agents:
           items:
+            maxLength: 256
             type: string
           title: Scope Agents
           type: array
         scope_servers:
           items:
+            maxLength: 256
             type: string
           title: Scope Servers
           type: array
         tf_dirs:
           items:
+            maxLength: 4096
             type: string
           title: Tf Dirs
           type: array

--- a/docs/schemas/v1/ScanJob.json
+++ b/docs/schemas/v1/ScanJob.json
@@ -17,6 +17,7 @@
       "properties": {
         "agent_projects": {
           "items": {
+            "maxLength": 4096,
             "type": "string"
           },
           "title": "Agent Projects",
@@ -29,6 +30,7 @@
         },
         "connectors": {
           "items": {
+            "maxLength": 128,
             "type": "string"
           },
           "title": "Connectors",
@@ -68,6 +70,7 @@
         },
         "exclude_agents": {
           "items": {
+            "maxLength": 256,
             "type": "string"
           },
           "title": "Exclude Agents",
@@ -75,6 +78,7 @@
         },
         "exclude_servers": {
           "items": {
+            "maxLength": 256,
             "type": "string"
           },
           "title": "Exclude Servers",
@@ -82,6 +86,7 @@
         },
         "filesystem_paths": {
           "items": {
+            "maxLength": 4096,
             "type": "string"
           },
           "title": "Filesystem Paths",
@@ -95,6 +100,7 @@
         "gha_path": {
           "anyOf": [
             {
+              "maxLength": 4096,
               "type": "string"
             },
             {
@@ -106,6 +112,7 @@
         },
         "images": {
           "items": {
+            "maxLength": 512,
             "type": "string"
           },
           "title": "Images",
@@ -114,6 +121,7 @@
         "inventory": {
           "anyOf": [
             {
+              "maxLength": 4096,
               "type": "string"
             },
             {
@@ -125,6 +133,7 @@
         },
         "jupyter_dirs": {
           "items": {
+            "maxLength": 4096,
             "type": "string"
           },
           "title": "Jupyter Dirs",
@@ -172,6 +181,7 @@
         "sbom": {
           "anyOf": [
             {
+              "maxLength": 4096,
               "type": "string"
             },
             {
@@ -183,6 +193,7 @@
         },
         "scope_agents": {
           "items": {
+            "maxLength": 256,
             "type": "string"
           },
           "title": "Scope Agents",
@@ -190,6 +201,7 @@
         },
         "scope_servers": {
           "items": {
+            "maxLength": 256,
             "type": "string"
           },
           "title": "Scope Servers",
@@ -197,6 +209,7 @@
         },
         "tf_dirs": {
           "items": {
+            "maxLength": 4096,
             "type": "string"
           },
           "title": "Tf Dirs",

--- a/docs/schemas/v1/ScanRequest.json
+++ b/docs/schemas/v1/ScanRequest.json
@@ -4,6 +4,7 @@
   "properties": {
     "agent_projects": {
       "items": {
+        "maxLength": 4096,
         "type": "string"
       },
       "title": "Agent Projects",
@@ -16,6 +17,7 @@
     },
     "connectors": {
       "items": {
+        "maxLength": 128,
         "type": "string"
       },
       "title": "Connectors",
@@ -55,6 +57,7 @@
     },
     "exclude_agents": {
       "items": {
+        "maxLength": 256,
         "type": "string"
       },
       "title": "Exclude Agents",
@@ -62,6 +65,7 @@
     },
     "exclude_servers": {
       "items": {
+        "maxLength": 256,
         "type": "string"
       },
       "title": "Exclude Servers",
@@ -69,6 +73,7 @@
     },
     "filesystem_paths": {
       "items": {
+        "maxLength": 4096,
         "type": "string"
       },
       "title": "Filesystem Paths",
@@ -82,6 +87,7 @@
     "gha_path": {
       "anyOf": [
         {
+          "maxLength": 4096,
           "type": "string"
         },
         {
@@ -93,6 +99,7 @@
     },
     "images": {
       "items": {
+        "maxLength": 512,
         "type": "string"
       },
       "title": "Images",
@@ -101,6 +108,7 @@
     "inventory": {
       "anyOf": [
         {
+          "maxLength": 4096,
           "type": "string"
         },
         {
@@ -112,6 +120,7 @@
     },
     "jupyter_dirs": {
       "items": {
+        "maxLength": 4096,
         "type": "string"
       },
       "title": "Jupyter Dirs",
@@ -159,6 +168,7 @@
     "sbom": {
       "anyOf": [
         {
+          "maxLength": 4096,
           "type": "string"
         },
         {
@@ -170,6 +180,7 @@
     },
     "scope_agents": {
       "items": {
+        "maxLength": 256,
         "type": "string"
       },
       "title": "Scope Agents",
@@ -177,6 +188,7 @@
     },
     "scope_servers": {
       "items": {
+        "maxLength": 256,
         "type": "string"
       },
       "title": "Scope Servers",
@@ -184,6 +196,7 @@
     },
     "tf_dirs": {
       "items": {
+        "maxLength": 4096,
         "type": "string"
       },
       "title": "Tf Dirs",

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from enum import Enum
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
 
@@ -44,6 +44,17 @@ _BATCH_LIST_TARGET_FIELDS = (
 )
 _BATCH_SINGLE_TARGET_FIELDS = ("inventory", "gha_path", "sbom")
 
+_SCAN_PATH_MAX_LENGTH = 4096
+_SCAN_IMAGE_REF_MAX_LENGTH = 512
+_SCAN_CONNECTOR_MAX_LENGTH = 128
+_SCAN_GLOB_MAX_LENGTH = 256
+
+ScanPathEntry = Annotated[str, Field(max_length=_SCAN_PATH_MAX_LENGTH)]
+ScanImageRef = Annotated[str, Field(max_length=_SCAN_IMAGE_REF_MAX_LENGTH)]
+ScanConnectorName = Annotated[str, Field(max_length=_SCAN_CONNECTOR_MAX_LENGTH)]
+ScanGlobPattern = Annotated[str, Field(max_length=_SCAN_GLOB_MAX_LENGTH)]
+ScanSinglePath = Annotated[str, Field(max_length=_SCAN_PATH_MAX_LENGTH)]
+
 
 class _BoundedProgress(list[str]):
     """List that keeps only the latest configured API progress events."""
@@ -68,10 +79,10 @@ class ScanRequest(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    inventory: str | None = None
+    inventory: ScanSinglePath | None = None
     """Path to agents.json inventory file."""
 
-    images: list[str] = Field(default_factory=list)
+    images: list[ScanImageRef] = Field(default_factory=list)
     """Docker image references to scan (e.g. ['myapp:latest', 'redis:7'])."""
 
     k8s: bool = False
@@ -80,19 +91,19 @@ class ScanRequest(BaseModel):
     k8s_namespace: str | None = None
     """Kubernetes namespace (None = all)."""
 
-    tf_dirs: list[str] = Field(default_factory=list)
+    tf_dirs: list[ScanPathEntry] = Field(default_factory=list)
     """Terraform directories to scan."""
 
-    gha_path: str | None = None
+    gha_path: ScanSinglePath | None = None
     """Path to a Git repo to scan GitHub Actions workflows."""
 
-    agent_projects: list[str] = Field(default_factory=list)
+    agent_projects: list[ScanPathEntry] = Field(default_factory=list)
     """Python project directories using AI agent frameworks."""
 
-    jupyter_dirs: list[str] = Field(default_factory=list)
+    jupyter_dirs: list[ScanPathEntry] = Field(default_factory=list)
     """Directories to scan for Jupyter notebooks (.ipynb) with AI library usage."""
 
-    sbom: str | None = None
+    sbom: ScanSinglePath | None = None
     """Path to an existing CycloneDX / SPDX SBOM file."""
 
     enrich: bool = False
@@ -113,10 +124,10 @@ class ScanRequest(BaseModel):
     db_sources: str | None = None
     """Comma-separated vulnerability DB sources to refresh when auto_update_db is enabled."""
 
-    connectors: list[str] = Field(default_factory=list)
+    connectors: list[ScanConnectorName] = Field(default_factory=list)
     """SaaS connectors to discover from (e.g. ['jira', 'servicenow', 'slack'])."""
 
-    filesystem_paths: list[str] = Field(default_factory=list)
+    filesystem_paths: list[ScanPathEntry] = Field(default_factory=list)
     """Filesystem directories or tar archives to scan via Syft."""
 
     format: str = "json"
@@ -128,16 +139,16 @@ class ScanRequest(BaseModel):
     dynamic_max_depth: int = 4
     """Max directory depth for dynamic discovery."""
 
-    scope_agents: list[str] = Field(default_factory=list)
+    scope_agents: list[ScanGlobPattern] = Field(default_factory=list)
     """Filter discovered agents by name (glob patterns, e.g. ['claude-*', 'cursor'])."""
 
-    scope_servers: list[str] = Field(default_factory=list)
+    scope_servers: list[ScanGlobPattern] = Field(default_factory=list)
     """Filter discovered MCP servers by name (glob patterns)."""
 
-    exclude_agents: list[str] = Field(default_factory=list)
+    exclude_agents: list[ScanGlobPattern] = Field(default_factory=list)
     """Exclude agents matching these name patterns."""
 
-    exclude_servers: list[str] = Field(default_factory=list)
+    exclude_servers: list[ScanGlobPattern] = Field(default_factory=list)
     """Exclude MCP servers matching these name patterns."""
 
     min_severity: str | None = None

--- a/src/agent_bom/http_client.py
+++ b/src/agent_bom/http_client.py
@@ -391,15 +391,16 @@ def sync_request_with_retry(
                 wait = backoff
 
             if attempt < max_retries:
+                jittered_wait = _jittered_wait(wait)
                 logger.info(
                     "HTTP %d from %s — retry %d/%d in %.1fs",
                     response.status_code,
                     log_url,
                     attempt + 1,
                     max_retries,
-                    wait,
+                    jittered_wait,
                 )
-                time.sleep(wait)
+                time.sleep(jittered_wait)
                 backoff = min(backoff * 2, MAX_BACKOFF)
             else:
                 logger.warning(
@@ -412,14 +413,15 @@ def sync_request_with_retry(
 
         except httpx.TimeoutException:
             if attempt < max_retries:
+                jittered_wait = _jittered_wait(backoff)
                 logger.info(
                     "Timeout on %s — retry %d/%d in %.1fs",
                     log_url,
                     attempt + 1,
                     max_retries,
-                    backoff,
+                    jittered_wait,
                 )
-                time.sleep(backoff)
+                time.sleep(jittered_wait)
                 backoff = min(backoff * 2, MAX_BACKOFF)
             else:
                 logger.warning("Timeout on %s — exhausted %d retries", log_url, max_retries)
@@ -428,15 +430,16 @@ def sync_request_with_retry(
         except httpx.HTTPError as e:
             safe_err = _sanitize_for_log(e)
             if attempt < max_retries:
+                jittered_wait = _jittered_wait(backoff)
                 logger.info(
                     "HTTP error on %s: %s — retry %d/%d in %.1fs",
                     log_url,
                     safe_err,
                     attempt + 1,
                     max_retries,
-                    backoff,
+                    jittered_wait,
                 )
-                time.sleep(backoff)
+                time.sleep(jittered_wait)
                 backoff = min(backoff * 2, MAX_BACKOFF)
             else:
                 logger.warning("HTTP error on %s: %s — exhausted %d retries", log_url, safe_err, max_retries)

--- a/tests/test_api_scan_batches.py
+++ b/tests/test_api_scan_batches.py
@@ -236,6 +236,22 @@ def test_scan_request_accepts_at_batch_target_cap():
     assert len(req.images) == API_MAX_BATCH_SCAN_TARGETS
 
 
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    [
+        ("images", "x" * 513),
+        ("tf_dirs", "x" * 4097),
+        ("connectors", "x" * 129),
+        ("scope_agents", "x" * 257),
+    ],
+)
+def test_scan_request_rejects_oversized_list_elements(field_name, value):
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        ScanRequest(**{field_name: [value]})
+
+
 def test_scan_over_batch_target_cap_returns_422_not_500(monkeypatch):
     """model_validator ValueError must serialize in the 422 envelope (#3474)."""
     from starlette.testclient import TestClient

--- a/tests/test_http_client_cov.py
+++ b/tests/test_http_client_cov.py
@@ -221,3 +221,25 @@ def test_sync_github_advisory_429_fails_fast_without_retry(monkeypatch):
     assert result.status_code == 429
     assert client.request.call_count == 1
     sleep.assert_not_called()
+
+
+def test_sync_retry_wait_uses_jitter(monkeypatch):
+    mock_503 = MagicMock()
+    mock_503.status_code = 503
+    mock_503.headers = {}
+    mock_200 = MagicMock()
+    mock_200.status_code = 200
+    client = MagicMock()
+    client.request.side_effect = [mock_503, mock_200]
+    sleep_calls: list[float] = []
+
+    def _fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr("agent_bom.http_client.random.uniform", lambda lo, hi: 0.05)
+    monkeypatch.setattr("agent_bom.http_client.time.sleep", _fake_sleep)
+
+    result = sync_request_with_retry(client, "GET", "https://example.com/data", max_retries=2)
+
+    assert result.status_code == 200
+    assert sleep_calls == [1.05]


### PR DESCRIPTION
## Summary
- Adds per-element `max_length` constraints on `ScanRequest` list and path fields so pathological payloads fail validation instead of fanning out into scan jobs.
- Applies `_jittered_wait` to sync HTTP retry sleeps (status/timeout/transport errors), matching the async client behavior.

Closes #3491
Closes #3492

## Verification
- `uv run pytest tests/test_api_scan_batches.py::test_scan_request_rejects_oversized_list_elements -q`
- `uv run pytest tests/test_http_client_cov.py::test_sync_retry_wait_uses_jitter -q`


Made with [Cursor](https://cursor.com)