### PR TITLE
fix(api): gate external compliance frameworks and lock OCSF product attribution

### DIFF
--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -201,6 +201,8 @@ def _normalize_ocsf_event(event: dict, *, tenant_id: str) -> dict:
         product = source_meta.get("product")
         if isinstance(product, dict):
             source_id = str(product.get("name", "")).strip()
+            if not source_id:
+                source_id = str(product.get("vendor_name", "")).strip()
         if not source_id:
             source_id = str(source_meta.get("log_name", "")).strip()
         metadata_uid = str(source_meta.get("uid", "")).strip()

--- a/src/agent_bom/compliance_hub.py
+++ b/src/agent_bom/compliance_hub.py
@@ -102,6 +102,17 @@ _CLOUD_POSTURE_FRAMEWORKS: tuple[str, ...] = (
     FRAMEWORK_NIST_800_53,
 )
 
+# External SARIF/CSV/JSON imports without AI asset signals should not inherit
+# the full AI framework set — those slugs are added via asset_type / finding_type
+# refinements (agent, mcp_server, INJECTION, etc.).
+_EXTERNAL_BASELINE: tuple[str, ...] = (
+    FRAMEWORK_NIST_CSF,
+    FRAMEWORK_SOC2,
+    FRAMEWORK_ISO_27001,
+    FRAMEWORK_CIS,
+    FRAMEWORK_PCI_DSS,
+)
+
 
 # ─── Source → framework selection table (the source of truth) ───────────────
 # Issue #1044 specifies this mapping. Each source carries a baseline list of
@@ -135,7 +146,7 @@ _SOURCE_BASELINE: dict[FindingSource, tuple[str, ...]] = {
         FRAMEWORK_CIS,
         FRAMEWORK_SOC2,
     ),
-    FindingSource.EXTERNAL: ALL_FRAMEWORKS,
+    FindingSource.EXTERNAL: _EXTERNAL_BASELINE,
 }
 
 

--- a/src/agent_bom/compliance_hub_ingest.py
+++ b/src/agent_bom/compliance_hub_ingest.py
@@ -399,7 +399,10 @@ def ingest_csv_findings(path: str | Path) -> list[Finding]:
         description = _resolve_csv_field(row, _CSV_DEFAULT_MAPPING["description"])
         asset_name = _resolve_csv_field(row, _CSV_DEFAULT_MAPPING["asset_name"]) or title or cve_id
 
-        finding_type = FindingType.CVE if cve_id and cve_id.upper().startswith(("CVE-", "GHSA-")) else FindingType.SAST
+        if cve_id and cve_id.upper().startswith(("CVE-", "GHSA-")):
+            finding_type = FindingType.CVE
+        else:
+            finding_type = _pick_finding_type(title, [], description or title)
         asset_type = "package" if finding_type == FindingType.CVE else "file"
 
         finding = Finding(

--- a/tests/test_compliance_hub.py
+++ b/tests/test_compliance_hub.py
@@ -158,14 +158,24 @@ def test_cis_fail_pulls_in_cis_even_when_source_does_not() -> None:
 # ─── External imports — auto-detect / catch-all ─────────────────────────────
 
 
-def test_external_source_selects_every_framework() -> None:
-    """SARIF / CycloneDX / CSV imports may carry findings whose source
-    can't be inferred. The hub returns every framework so the importer
-    can prune based on actual finding metadata in PR B."""
+def test_external_source_avoids_ai_frameworks_by_default() -> None:
+    """Generic external imports (SARIF/CSV) should not inherit AI-only slugs
+    unless asset_type or finding_type signals warrant them."""
     selected = set(select_frameworks(FindingSource.EXTERNAL))
-    expected = {meta.slug for meta in TAG_MAPPED_FRAMEWORKS} - {"aisvs"}  # benchmark slug, not tag-mapped
-    missing = expected - selected
-    assert not missing, f"EXTERNAL must offer every tag-mapped framework; missing {sorted(missing)}"
+    assert FRAMEWORK_OWASP_LLM not in selected
+    assert FRAMEWORK_OWASP_MCP not in selected
+    assert FRAMEWORK_OWASP_AGENTIC not in selected
+    assert FRAMEWORK_ATLAS not in selected
+    assert FRAMEWORK_EU_AI_ACT not in selected
+    assert FRAMEWORK_NIST_CSF in selected
+    assert FRAMEWORK_SOC2 in selected
+
+
+def test_external_source_adds_ai_frameworks_for_agent_assets() -> None:
+    selected = set(select_frameworks(FindingSource.EXTERNAL, asset_type="agent"))
+    assert FRAMEWORK_OWASP_LLM in selected
+    assert FRAMEWORK_OWASP_MCP in selected
+    assert FRAMEWORK_ATLAS in selected
 
 
 # ─── Government overlay — opt-in ─────────────────────────────────────────────

--- a/tests/test_compliance_hub_ingest.py
+++ b/tests/test_compliance_hub_ingest.py
@@ -368,8 +368,8 @@ def test_cyclonedx_no_vulnerabilities_section_returns_empty(tmp_path: Path):
 
 
 def test_csv_findings_with_cve_classified_as_supply_chain(tmp_path: Path):
-    """Row with a CVE id -> CVE finding, EXTERNAL source. EXTERNAL pulls
-    every framework, but the asset_type=package keeps things sensible."""
+    """Row with a CVE id -> CVE finding, EXTERNAL source. Package CVEs
+    should not inherit AI-only framework slugs by default."""
     target = tmp_path / "vulns.csv"
     target.write_text(
         "Title,Severity,Description,File,CVE\n"
@@ -383,6 +383,8 @@ def test_csv_findings_with_cve_classified_as_supply_chain(tmp_path: Path):
     assert cve_finding.cve_id == "CVE-2021-23337"
     assert cve_finding.finding_type == FindingType.CVE
     assert cve_finding.severity == "high"
+    assert FRAMEWORK_OWASP_MCP not in cve_finding.applicable_frameworks
+    assert FRAMEWORK_OWASP_LLM not in cve_finding.applicable_frameworks
     sast_finding = next(f for f in findings if not f.cve_id)
     assert sast_finding.finding_type == FindingType.SAST
     assert sast_finding.asset.location == "src/app.py"

--- a/tests/test_runtime_event_store.py
+++ b/tests/test_runtime_event_store.py
@@ -174,6 +174,37 @@ async def test_ocsf_idless_event_dedups_across_retries():
     assert observations["count"] == 1
 
 
+@pytest.mark.asyncio
+async def test_ocsf_ingest_surfaces_product_attribution_in_sources():
+    req = _request("tenant-alpha")
+    payload = {
+        "events": [
+            {
+                "class_uid": 4001,
+                "class_name": "Network Activity",
+                "severity": "Low",
+                "time": 1_746_033_601_000,
+                "message": "Outbound MCP request observed",
+                "metadata": {"product": {"name": "datadog", "vendor_name": "Datadog"}},
+            }
+        ]
+    }
+
+    class _Analytics:
+        def record_events(self, events, *, tenant_id: str = "default"):
+            return None
+
+    with patch("agent_bom.api.routes.observability._get_analytics_store", return_value=_Analytics()):
+        response = await observability_routes.ingest_ocsf(req, payload)
+
+    assert response["sources"] == ["datadog"]
+    normalized = observability_routes._normalize_ocsf_event(
+        payload["events"][0],
+        tenant_id="tenant-alpha",
+    )
+    assert normalized["source_id"] == "datadog"
+
+
 def test_sqlite_runtime_event_store_batch_persists_in_one_transaction(tmp_path):
     store = SQLiteRuntimeEventStore(str(tmp_path / "runtime-batch.db"))
     from agent_bom.api.runtime_event_store import RuntimeObservationRecord


### PR DESCRIPTION
## Summary
- Narrows `FindingSource.EXTERNAL` hub baseline to general enterprise/supply-chain frameworks; AI slugs are added only via asset_type (`agent`, `mcp_server`, …) or finding_type refinements (`INJECTION`, etc.).
- Adds OCSF ingest regression coverage for `metadata.product` → `source_id` / response `sources`, with `vendor_name` fallback when `name` is absent.

Closes #3490
Closes #3498

## Verification
- `uv run pytest tests/test_compliance_hub.py tests/test_compliance_hub_ingest.py::test_csv_findings_with_cve_classified_as_supply_chain tests/test_compliance_hub_cross_format.py tests/test_runtime_event_store.py::test_ocsf_ingest_surfaces_product_attribution_in_sources -q`


Made with [Cursor](https://cursor.com)