### PR TITLE
fix(api): restore overview tiles from compact scans and add current-state sort indexes

### DIFF
--- a/docs/audits/AUDIT-2026-07-03.md
+++ b/docs/audits/AUDIT-2026-07-03.md
@@ -1,7 +1,7 @@
 # agent-bom v0.92.0 — Audit ledger (2026-07-03)
 
 **Scope:** Multi-wave audit 2026-07-02 → 2026-07-03. Live verification against post-fix commits.
-**Baseline:** `main @ 689deea2a` (lifecycle L2). **Product version:** 0.92.0.
+**Baseline:** `main @ 62388b25a` (v0.92.0, post–graph rollup UI merge). **Product version:** 0.92.0.
 **Policy:** Canonical model is product truth; OCSF is export/interop only (`docs/OCSF_BOUNDARY.md`). No vendor parity claims in this doc.
 
 ---
@@ -60,20 +60,32 @@
 | **F** | P1 | Lifecycle L4 read unification | **#3465** / PR **#3481** |
 | **G** | P2 | Driver `run()` / `failure_mode` not enforced | **#3488** |
 | **H** | P2 | Rate-limit fixed vs sliding (Postgres) | **#3489** |
-| **I** | P2 | Compliance ingest over-tags frameworks | **#3490** |
+| **I** | P2 | Compliance ingest over-tags frameworks | **#3490** → PR **#3509** |
 | **J** | P2 | ClickHouse analytics dedup | **#3484** |
-| **K** | P2 | `ScanRequest` list fields lack `max_length` | **#3491** |
-| **L** | P2 | Sync retry no jitter | **#3492** |
+| **K** | P2 | `ScanRequest` list fields lack `max_length` | **#3491** → PR **#3508** |
+| **L** | P2 | Sync retry no jitter | **#3492** → PR **#3508** |
 | **M** | P2 | nebius/lambda/runpod raw `requests` | **#3493** |
 | **N** | P3 | NetworkPolicy API egress 0.0.0.0/0:443 | **#3494** |
 | **O** | P3 | No table partitioning | **#3463** |
 | **P** | P3 | Batch parent empty graph exports | **#3495** |
 | **Q** | P3 | Stale Alembic docs | **#3496** |
 | **R** | P3 | Finding encryption prerequisite (document) | **#3497** |
-| **S** | P3 | OCSF product attribution on ingest | **#3498** |
+| **S** | P3 | OCSF product attribution on ingest | **#3498** → PR **#3509** |
 | **T** | scope | Multi-language reachability; data-lake interop | **#3499** |
 
 **Related (not in A–T):** headless lifecycle SDK/MCP/UI glue — **#3482** (SDK fields shipped #3483).
+
+### New gaps filed (Fable consolidated audit, no duplication)
+
+| Priority | Finding | GitHub | Distinct from |
+|---|---|---|---|
+| **P1** | Dashboard `/v1/overview` reads compacted-away `posture_scorecard` / `blast_radius` → N/A + zero CVE tiles | **#3510** | #3482 / #3468 (UI/demo), not compression |
+| **P1** | `hub_findings_current` missing sort indexes + no keyset pagination | **#3511** | #3463 (ledger partition), #3486/#3487 (bytes) |
+| **P2** | Async report jobs → object storage + signed URLs | **#3512** | #3499 (lake/BI columnar), #3486 (sync gzip) |
+| **P2** | Reference-table normalization (CVE/CVSS/EPSS shared once) | **#3513** | #3487 (2× copy), #3486 (compress repeated blobs) |
+| **P2** | Delta-stream connector (new/resolved/changed only) | **#3514** | #3512 (bulk export), #3484 (CH dedup) |
+
+**Cross-cutting (tracked on #3242):** RBAC middleware/decorator drift; air-gap PyPI check; compose home mount; offline custom-DB warning surfacing; README reachability wording.
 
 ---
 
@@ -91,11 +103,35 @@
 
 ## §D. Prioritized backlog
 
+### Phased sequence (consolidated, issue-linked)
+
+| Phase | Focus | Issues |
+|---|---|---|
+| **1 — acute (days)** | First-impression dashboard + sorted read floor + wire/disk quick wins | **#3510** → **#3511** → **#3486** → **#3487** (unblocked) |
+| **2 — export ergonomics** | Never return multi-GB synchronous bodies | **#3512** |
+| **3 — structural** | Millions cheap by design, not just compressed | **#3513** + keyset cursors (in **#3511**) |
+| **4 — distribution** | Lake, analytics, partitions, deltas | **#3514**, **#3499**, **#3484**, **#3463** |
+
+### Legacy priority list (A–T)
+
 1. **P0** — #3485 (OCSF DoS)
 2. **Quick wins** — #3486 (gzip + zstd)
-3. **P1** — #3487 (dedup storage); #3481 → closes #3465 (L3+L4)
-4. **P2** — #3488–#3493, #3484, #3482
+3. **P1** — #3510 (overview wiring); #3511 (current-state indexes/keyset); #3487 (dedup storage); #3481 → closes #3465 (L3+L4, merged)
+4. **P2** — #3512–#3514; #3488–#3493; #3484; #3482
 5. **P3 / scope** — #3494–#3499, #3463
+
+### Backlog alignment (no real duplication)
+
+| Recommendation | Issue | Note |
+|---|---|---|
+| HTTP response gzip | #3486 (B) | `GZipMiddleware(minimum_size=500)` — ship in Phase 1 |
+| zstd at-rest payloads | #3486 (C) | PG TOAST &lt;2KB may not fire; still worth column compress |
+| De-dup double-store | #3487 | Unblocked; depends merged |
+| Unbounded-table partitioning | #3463 | Ledger `compliance_hub_findings`; not current-state sort |
+| ClickHouse sink dedup | #3484 | ReplacingMergeTree version key |
+| Columnar / data-lake export | #3499 | Parquet/Iceberg + reachability — not operator report jobs |
+| Headless lifecycle parity | #3482 | UI columns + bulk ingest |
+| Graph readability / rollup | #3192 | UI drill; ties to read-path **#3511** |
 
 ---
 
@@ -108,7 +144,40 @@
 | `/v1/findings?limit=500` egress | ~319 KB uncompressed; ~23 KB gzipped |
 | Read latency | ~38 ms / 500 rows over 50k |
 
-**Wins:** #3486 (egress + storage), #3487 (dedup), #3485 (unblock OCSF path).
+**Wins:** #3486 (egress + storage), #3487 (dedup), #3485 (unblock OCSF path), **#3510** (dashboard truth), **#3511** (sorted read floor).
+
+---
+
+## §F. Fable consolidated audit — validated wiring gaps (`main @ 62388b25a`)
+
+Hands-on re-validation (clean install, API scan, MCP/proxy/gateway, UI build, read-path probe). **No functional defects** on MCP surface (70 tools / 6 resources / 8 prompts confirmed).
+
+### Dashboard posture bug — **confirmed in code**
+
+| Symptom | Cause |
+|---|---|
+| Posture **N/A**, score **0**, CVE tiles **0** on `/v1/overview` | `_compact_terminal_job` drops `posture_scorecard` and `blast_radius`; `overview.py` still reads them |
+| Scan detail shows real grade/score/vulns | Full result exists before compaction / in persistent paths |
+| Estate map counts correct | Discovery layer unaffected |
+
+**Fix:** wire `_posture_snapshot` / `_scan_rollup` to retained `summary` (+ minimal scorecard rehydrate). Tracked **#3510**.
+
+### Read-path regression — **confirmed in code**
+
+`hub_findings_current` DDL only defines `idx_hub_findings_current_tenant_last_seen`. Default `effective_reach` sort cannot use a covering index. Tracked **#3511** (indexes + keyset cursors). Distinct from **#3463**.
+
+### MCP / tools / skills — live OK
+
+Strict-arg rejection, `check flask@2.0.0`, skills scan, proxy audit JSONL + HMAC, gateway init/serve — all exercised; no blockers filed.
+
+### Make-it-true overclaims (wire, don't delete)
+
+| Claim | Action |
+|---|---|
+| CWE-aware reachability (README) | Precise wording or ship call-graph path (**#3499**) |
+| Air-gap | Skip/opt-out PyPI background check (**#3242**) |
+| Compose persistence | Mount `~/.agent-bom` for `abom` user (**#3242**) |
+| Dashboard posture | **#3510** |
 
 ---
 

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -362,9 +362,13 @@ def _upsert_current_finding_sqlite(
 
 
 def _ensure_current_lifecycle_sqlite(conn: sqlite3.Connection) -> None:
-    from agent_bom.api.finding_lifecycle import _CURRENT_LIFECYCLE_SQLITE_DDL
+    from agent_bom.api.finding_lifecycle import (
+        _CURRENT_LIFECYCLE_SORT_INDEXES_SQLITE,
+        _CURRENT_LIFECYCLE_SQLITE_DDL,
+    )
 
     conn.executescript(_CURRENT_LIFECYCLE_SQLITE_DDL)
+    conn.executescript(_CURRENT_LIFECYCLE_SORT_INDEXES_SQLITE)
     _migrate_lifecycle_observations_l2_sqlite(conn)
 
 

--- a/src/agent_bom/api/finding_lifecycle.py
+++ b/src/agent_bom/api/finding_lifecycle.py
@@ -173,6 +173,15 @@ CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_last_seen
     ON hub_findings_current(tenant_id, last_seen DESC);
 """
 
+_CURRENT_LIFECYCLE_SORT_INDEXES_SQLITE = """
+CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_reach
+    ON hub_findings_current(tenant_id, effective_reach_score DESC, last_seen DESC, canonical_id ASC);
+CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_cvss
+    ON hub_findings_current(tenant_id, cvss_score DESC, last_seen DESC, canonical_id ASC);
+CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_severity
+    ON hub_findings_current(tenant_id, severity_rank DESC, last_seen DESC, canonical_id ASC);
+"""
+
 
 def collect_present_canonical_ids(
     findings: Sequence[dict[str, Any]],
@@ -229,4 +238,10 @@ CREATE TABLE IF NOT EXISTS hub_findings_current_observations (
 
 CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_last_seen
     ON hub_findings_current(tenant_id, last_seen DESC);
+CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_reach
+    ON hub_findings_current(tenant_id, effective_reach_score DESC, last_seen DESC, canonical_id ASC);
+CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_cvss
+    ON hub_findings_current(tenant_id, cvss_score DESC, last_seen DESC, canonical_id ASC);
+CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_severity
+    ON hub_findings_current(tenant_id, severity_rank DESC, last_seen DESC, canonical_id ASC);
 """

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -41,12 +41,94 @@ def _empty_severity() -> dict[str, int]:
     return {key: 0 for key in _SEVERITY_KEYS}
 
 
-def _scan_rollup(jobs: list[Any]) -> dict[str, Any]:
-    """Aggregate severity counts, sources, scans, and top-risk findings.
+def _severity_from_summary(
+    summary: dict[str, Any],
+    finding_summary: dict[str, Any] | None = None,
+) -> dict[str, int]:
+    """Rebuild severity histogram from compact scan ``summary`` metadata."""
+    severity = _empty_severity()
+    by_sev = (finding_summary or {}).get("by_severity") or {}
+    if isinstance(by_sev, dict) and by_sev:
+        for key in _SEVERITY_KEYS:
+            severity[key] = int(by_sev.get(key) or 0)
+        return severity
+    severity["critical"] = int(
+        summary.get("critical_unified_findings") or summary.get("critical_findings") or 0
+    )
+    severity["high"] = int(summary.get("high_unified_findings") or 0)
+    total = int(summary.get("total_vulnerabilities") or summary.get("total_findings") or 0)
+    remainder = max(0, total - severity["critical"] - severity["high"])
+    if remainder:
+        severity["medium"] = remainder
+    return severity
 
-    Drives the Cloud/CNAPP, Ops, and top-risks strip from the same scan-job
-    store the dashboard and ``/v1/posture/counts`` already read.
-    """
+
+def _rollup_from_blast_radius(blast_radius: list[dict[str, Any]]) -> dict[str, Any]:
+    severity = _empty_severity()
+    kev = 0
+    credential_exposed = 0
+    seen_ids: set[str] = set()
+    top_risks: list[dict[str, Any]] = []
+
+    for b in blast_radius:
+        vid = b.get("vulnerability_id", "")
+        if vid and vid in seen_ids:
+            continue
+        if vid:
+            seen_ids.add(vid)
+        sev = (b.get("severity") or "").lower()
+        if sev in severity:
+            severity[sev] += 1
+        is_kev = bool(b.get("cisa_kev") or b.get("is_kev"))
+        if is_kev:
+            kev += 1
+        creds = b.get("exposed_credentials") or []
+        if creds:
+            credential_exposed += 1
+        risk = b.get("risk_score")
+        if risk is None:
+            risk = (b.get("blast_score") or 0) / 10
+        top_risks.append(
+            {
+                "vulnerability_id": vid,
+                "package": b.get("package"),
+                "severity": sev or "low",
+                "risk_score": round(float(risk or 0), 1),
+                "is_kev": is_kev,
+                "cvss_score": b.get("cvss_score"),
+                "epss_score": b.get("epss_score"),
+                "affected_agents": list(b.get("affected_agents") or []),
+            }
+        )
+
+    top_risks.sort(key=lambda r: r["risk_score"], reverse=True)
+    return {
+        "severity": severity,
+        "kev": kev,
+        "credential_exposed": credential_exposed,
+        "unique_cves": len(seen_ids),
+        "top_risks": top_risks[:10],
+    }
+
+
+def _rollup_from_summary(result: dict[str, Any]) -> dict[str, Any]:
+    summary = cast(dict[str, Any], result.get("summary") or {})
+    finding_summary = cast(dict[str, Any], result.get("finding_summary") or {})
+    severity = _severity_from_summary(summary, finding_summary)
+    total_vulns = int(summary.get("total_vulnerabilities") or summary.get("total_findings") or 0)
+    unique_cves = total_vulns if total_vulns else sum(severity.values())
+    return {
+        "severity": severity,
+        "kev": 0,
+        "credential_exposed": 0,
+        "unique_cves": unique_cves,
+        "unique_packages": int(summary.get("unique_packages") or summary.get("total_packages") or 0),
+        "top_risks": [],
+    }
+
+
+def _scan_rollup(jobs: list[Any]) -> dict[str, Any]:
+    """Aggregate severity counts, sources, scans, and top-risk findings."""
     severity = _empty_severity()
     sources: set[str] = set()
     scan_count = 0
@@ -55,8 +137,8 @@ def _scan_rollup(jobs: list[Any]) -> dict[str, Any]:
     running_count = 0
     kev = 0
     credential_exposed = 0
-    seen_ids: set[str] = set()
-    unique_packages: set[str] = set()
+    unique_cves = 0
+    unique_packages = 0
     top_risks: list[dict[str, Any]] = []
     latest_scan_at: str | None = None
 
@@ -81,44 +163,30 @@ def _scan_rollup(jobs: list[Any]) -> dict[str, Any]:
             if src:
                 sources.add(str(src))
 
-        for agent in result.get("agents", []) or []:
-            for server in agent.get("mcp_servers", []) or []:
-                for pkg in server.get("packages", []) or []:
-                    name = pkg.get("name")
-                    version = pkg.get("version")
-                    if name:
-                        unique_packages.add(f"{name}@{version}")
-
-        for b in result.get("blast_radius", []) or []:
-            vid = b.get("vulnerability_id", "")
-            if vid and vid in seen_ids:
-                continue
-            if vid:
-                seen_ids.add(vid)
-            sev = (b.get("severity") or "").lower()
-            if sev in severity:
-                severity[sev] += 1
-            is_kev = bool(b.get("cisa_kev") or b.get("is_kev"))
-            if is_kev:
-                kev += 1
-            creds = b.get("exposed_credentials") or []
-            if creds:
-                credential_exposed += 1
-            risk = b.get("risk_score")
-            if risk is None:
-                risk = (b.get("blast_score") or 0) / 10
-            top_risks.append(
-                {
-                    "vulnerability_id": vid,
-                    "package": b.get("package"),
-                    "severity": sev or "low",
-                    "risk_score": round(float(risk or 0), 1),
-                    "is_kev": is_kev,
-                    "cvss_score": b.get("cvss_score"),
-                    "epss_score": b.get("epss_score"),
-                    "affected_agents": list(b.get("affected_agents") or []),
-                }
-            )
+        blast_radius = result.get("blast_radius") or []
+        if blast_radius:
+            partial = _rollup_from_blast_radius(cast(list[dict[str, Any]], blast_radius))
+            for key in _SEVERITY_KEYS:
+                severity[key] += partial["severity"][key]
+            kev += partial["kev"]
+            credential_exposed += partial["credential_exposed"]
+            unique_cves += partial["unique_cves"]
+            top_risks.extend(partial["top_risks"])
+            for agent in result.get("agents", []) or []:
+                for server in agent.get("mcp_servers", []) or []:
+                    for pkg in server.get("packages", []) or []:
+                        name = pkg.get("name")
+                        if name:
+                            unique_packages += 1
+        else:
+            partial = _rollup_from_summary(result)
+            for key in _SEVERITY_KEYS:
+                severity[key] += partial["severity"][key]
+            kev += partial["kev"]
+            credential_exposed += partial["credential_exposed"]
+            unique_cves += partial["unique_cves"]
+            unique_packages = max(unique_packages, partial["unique_packages"])
+            top_risks.extend(partial["top_risks"])
 
     top_risks.sort(key=lambda r: r["risk_score"], reverse=True)
 
@@ -131,8 +199,8 @@ def _scan_rollup(jobs: list[Any]) -> dict[str, Any]:
         "running_count": running_count,
         "kev": kev,
         "credential_exposed": credential_exposed,
-        "unique_cves": len(seen_ids),
-        "unique_packages": len(unique_packages),
+        "unique_cves": unique_cves,
+        "unique_packages": unique_packages,
         "top_risks": top_risks[:10],
         "latest_scan_at": latest_scan_at,
     }
@@ -143,12 +211,31 @@ def _posture_snapshot(jobs: list[Any]) -> dict[str, Any]:
     for job in jobs:
         if job.status != JobStatus.DONE or not job.result:
             continue
-        scorecard = cast(dict[str, Any], job.result).get("posture_scorecard")
-        if scorecard:
+        result = cast(dict[str, Any], job.result)
+        scorecard = result.get("posture_scorecard")
+        if isinstance(scorecard, dict) and scorecard:
             return {
                 "grade": scorecard.get("grade", "N/A"),
                 "score": scorecard.get("score", 0),
                 "summary": scorecard.get("summary", ""),
+            }
+        summary = result.get("summary")
+        if isinstance(summary, dict) and (
+            summary.get("total_vulnerabilities") or summary.get("total_findings")
+        ):
+            from agent_bom.posture import _score_to_grade
+
+            critical = int(
+                summary.get("critical_unified_findings") or summary.get("critical_findings") or 0
+            )
+            high = int(summary.get("high_unified_findings") or 0)
+            total = int(summary.get("total_vulnerabilities") or summary.get("total_findings") or 0)
+            penalty = min(100.0, critical * 12.0 + high * 6.0 + max(0, total - critical - high) * 1.5)
+            score = max(0.0, round(100.0 - penalty, 1))
+            return {
+                "grade": _score_to_grade(score),
+                "score": score,
+                "summary": f"{total} finding(s) from latest completed scan",
             }
         break
     return {"grade": "N/A", "score": 0, "summary": "No completed scans available"}

--- a/src/agent_bom/api/stores.py
+++ b/src/agent_bom/api/stores.py
@@ -80,6 +80,14 @@ def _compact_terminal_job(job: ScanJob) -> ScanJob:
                 compact_result[key] = job.result[key]
         if "scan_timestamp" not in compact_result and "generated_at" in compact_result:
             compact_result["scan_timestamp"] = compact_result["generated_at"]
+        scorecard = job.result.get("posture_scorecard")
+        if isinstance(scorecard, dict):
+            compact_result["posture_scorecard"] = {
+                key: scorecard[key] for key in ("grade", "score", "summary") if key in scorecard
+            }
+        scan_sources = job.result.get("scan_sources")
+        if isinstance(scan_sources, list):
+            compact_result["scan_sources"] = scan_sources
     return job.model_copy(update={"result": compact_result})
 
 

--- a/tests/test_finding_lifecycle.py
+++ b/tests/test_finding_lifecycle.py
@@ -235,6 +235,20 @@ def test_list_current_page_enriches_lifecycle_fields(hub_store) -> None:
     assert rows[0]["scan_count"] == 1
 
 
+@pytest.mark.parametrize("hub_store", ["sqlite"], indirect=True)
+def test_hub_findings_current_sort_indexes_exist(hub_store) -> None:
+    conn = hub_store._conn
+    index_names = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='hub_findings_current'"
+        ).fetchall()
+    }
+    assert "idx_hub_findings_current_tenant_reach" in index_names
+    assert "idx_hub_findings_current_tenant_cvss" in index_names
+    assert "idx_hub_findings_current_tenant_severity" in index_names
+
+
 def test_bulk_reconcile_absent_api() -> None:
     from starlette.testclient import TestClient
 

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -123,6 +123,56 @@ def test_overview_aggregates_findings() -> None:
     assert len(data["top_risks"]) == 2
 
 
+def test_overview_reads_compacted_scan_summary() -> None:
+    """Hot-cache compaction must not zero out posture/CVE tiles on /v1/overview."""
+    from agent_bom.api.server import ScanJob, ScanRequest
+    from agent_bom.api.stores import _compact_terminal_job
+
+    _clear_jobs()
+    job = ScanJob(
+        job_id="compact-job",
+        tenant_id="default",
+        created_at="2026-02-22T10:00:00Z",
+        request=ScanRequest(),
+    )
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-02-22T10:05:00Z"
+    job.result = {
+        "summary": {
+            "total_vulnerabilities": 87,
+            "critical_unified_findings": 3,
+            "high_unified_findings": 12,
+            "unique_packages": 9,
+        },
+        "posture_scorecard": {
+            "grade": "F",
+            "score": 42.0,
+            "summary": "Poor posture",
+            "dimensions": {},
+        },
+        "scan_sources": ["agent_discovery"],
+        "blast_radius": [
+            {
+                "vulnerability_id": "CVE-IGNORED",
+                "severity": "critical",
+                "risk_score": 10,
+            }
+        ],
+    }
+    _get_store().put(_compact_terminal_job(job))
+
+    client = TestClient(app)
+    resp = client.get("/v1/overview", headers=_AUTH_HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["posture"]["grade"] == "F"
+    assert data["posture"]["score"] == 42.0
+    assert data["headline"]["critical"] == 3
+    assert data["headline"]["high"] == 12
+    assert data["domains"]["cloud"]["metric"] == 87
+
+
 def test_overview_requires_auth() -> None:
     """Endpoint is read-only but still behind the standard viewer gate."""
     _clear_jobs()


### PR DESCRIPTION
## Summary
- **#3510:** Retain minimal `posture_scorecard` / `scan_sources` in hot-cache compaction and teach `/v1/overview` to roll up from `summary` when blast-radius detail is absent — fixes N/A posture and zero CVE tiles on compacted jobs.
- **#3511:** Add `hub_findings_current` tenant sort indexes (`effective_reach_score`, `cvss_score`, `severity_rank`) for SQLite + Postgres; backfill on SQLite lifecycle migration.
- Audit ledger updated with Phase 1 roadmap and Fable validation notes.

## Test plan
- [x] `uv run pytest tests/test_overview.py tests/test_finding_lifecycle.py -q` (18 passed)
- [ ] `test_overview_reads_compacted_scan_summary` — posture `F`/42.0, headline critical=3/high=12, cloud metric=87
- [ ] `test_hub_findings_current_sort_indexes_exist` — reach/cvss/severity indexes present on SQLite store

## Notes
- Keyset cursor pagination for `list_current_page` / `/v1/findings` remains a follow-up within **#3511** (indexes land first).

Related: #3510, #3511