### PR TITLE
refactor(api): deduplicate current-state hub payloads via ledger refs

### DIFF
--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -27,6 +27,12 @@ import threading
 from collections.abc import Callable, Iterable, Sequence
 from typing import Any, Protocol
 
+from agent_bom.api.hub_current_payload import (
+    batch_ledger_payloads,
+    current_state_overlay,
+    hydrate_current_payload,
+    resolve_ledger_finding_id,
+)
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.graph.severity import severity_policy_rank
 
@@ -34,6 +40,7 @@ from agent_bom.graph.severity import severity_policy_rank
 # classes below define a ``list`` method that would otherwise shadow it in
 # their ``list_page`` return annotations.
 FindingPage = tuple[list[dict[str, Any]], int | None]
+_HubFindingRows = list[dict[str, Any]]
 
 # Sort keys supported by ``list_page``. ``effective_reach`` (default),
 # ``cvss`` and ``severity`` are each backed by a materialised column +
@@ -254,6 +261,46 @@ class ComplianceHubStore(Protocol):
         ...
 
 
+def _fetch_ledger_payloads_sqlite(
+    conn: sqlite3.Connection,
+    tenant_id: str,
+    finding_ids: Sequence[str],
+) -> dict[str, dict[str, Any]]:
+    if not finding_ids:
+        return {}
+    placeholders = ",".join("?" * len(finding_ids))
+    rows = conn.execute(
+        f"""
+        SELECT finding_id, payload
+        FROM compliance_hub_findings
+        WHERE tenant_id = ? AND finding_id IN ({placeholders})
+        """,  # nosec B608
+        (tenant_id, *finding_ids),
+    ).fetchall()
+    return {str(row[0]): json.loads(row[1]) for row in rows}
+
+
+def _sqlite_current_row_from_db(row: tuple[Any, ...], *, has_ledger_col: bool) -> dict[str, Any]:
+    current_row = {
+        "canonical_id": row[0],
+        "first_seen": row[1],
+        "last_seen": row[2],
+        "status": row[3],
+        "severity": row[4],
+        "severity_rank": row[5],
+        "cvss_score": row[6],
+        "effective_reach_score": row[7],
+        "scan_count": row[8],
+        "resolved_at": row[9],
+        "reopened_at": row[10],
+        "updated_at": row[11],
+        "payload": json.loads(row[12]),
+    }
+    if has_ledger_col:
+        current_row["ledger_finding_id"] = row[13]
+    return current_row
+
+
 def _upsert_current_finding_sqlite(
     conn: sqlite3.Connection,
     *,
@@ -272,7 +319,9 @@ def _upsert_current_finding_sqlite(
     canonical = resolve_canonical_id(payload, source=source)
     metrics = lifecycle_metrics(payload)
     now = _now_utc_iso()
-    payload_json = json.dumps(payload, sort_keys=True)
+    ledger_finding_id = resolve_ledger_finding_id(payload, canonical_id=canonical)
+    overlay = current_state_overlay(payload) if ledger_finding_id else dict(payload)
+    payload_json = json.dumps(overlay, sort_keys=True)
     inserted = conn.execute(
         """
         INSERT OR IGNORE INTO hub_findings_current_observations
@@ -284,35 +333,30 @@ def _upsert_current_finding_sqlite(
     if not inserted:
         return
 
+    has_ledger_col = _hub_findings_current_has_ledger_col(conn)
+    payload_select = "payload, ledger_finding_id" if has_ledger_col else "payload"
     existing_row = conn.execute(
-        """
+        f"""
         SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
                cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-               updated_at, payload
+               updated_at, {payload_select}
         FROM hub_findings_current
         WHERE tenant_id = ? AND canonical_id = ?
-        """,
+        """,  # nosec B608
         (tenant_id, canonical),
     ).fetchone()
     existing: dict[str, Any] | None
     if existing_row is None:
         existing = None
     else:
-        existing = {
-            "canonical_id": existing_row[0],
-            "first_seen": existing_row[1],
-            "last_seen": existing_row[2],
-            "status": existing_row[3],
-            "severity": existing_row[4],
-            "severity_rank": existing_row[5],
-            "cvss_score": existing_row[6],
-            "effective_reach_score": existing_row[7],
-            "scan_count": existing_row[8],
-            "resolved_at": existing_row[9],
-            "reopened_at": existing_row[10],
-            "updated_at": existing_row[11],
-            "payload": json.loads(existing_row[12]),
-        }
+        existing = _sqlite_current_row_from_db(existing_row, has_ledger_col=has_ledger_col)
+        if has_ledger_col:
+            ledger_map = _fetch_ledger_payloads_sqlite(
+                conn,
+                tenant_id,
+                [str(existing.get("ledger_finding_id") or "")],
+            )
+            existing["payload"] = hydrate_current_payload(existing, ledger_payloads=ledger_map)
     merged = apply_observation_to_current(
         existing,
         canonical_id=canonical,
@@ -321,44 +365,114 @@ def _upsert_current_finding_sqlite(
         payload=payload,
         updated_at=now,
     )
-    conn.execute(
-        """
-        INSERT INTO hub_findings_current
-            (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
-             cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-             updated_at, payload)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(tenant_id, canonical_id) DO UPDATE SET
-            first_seen = MIN(hub_findings_current.first_seen, excluded.first_seen),
-            last_seen = MAX(hub_findings_current.last_seen, excluded.last_seen),
-            status = excluded.status,
-            severity = excluded.severity,
-            severity_rank = excluded.severity_rank,
-            cvss_score = excluded.cvss_score,
-            effective_reach_score = excluded.effective_reach_score,
-            scan_count = excluded.scan_count,
-            resolved_at = excluded.resolved_at,
-            reopened_at = excluded.reopened_at,
-            updated_at = excluded.updated_at,
-            payload = excluded.payload
-        """,
-        (
-            tenant_id,
-            canonical,
-            merged["first_seen"],
-            merged["last_seen"],
-            merged["status"],
-            merged["severity"],
-            merged["severity_rank"],
-            merged["cvss_score"],
-            merged["effective_reach_score"],
-            merged["scan_count"],
-            merged["resolved_at"],
-            merged["reopened_at"],
-            merged["updated_at"],
-            payload_json,
-        ),
+    if has_ledger_col:
+        conn.execute(
+            """
+            INSERT INTO hub_findings_current
+                (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
+                 cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+                 updated_at, payload, ledger_finding_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(tenant_id, canonical_id) DO UPDATE SET
+                first_seen = MIN(hub_findings_current.first_seen, excluded.first_seen),
+                last_seen = MAX(hub_findings_current.last_seen, excluded.last_seen),
+                status = excluded.status,
+                severity = excluded.severity,
+                severity_rank = excluded.severity_rank,
+                cvss_score = excluded.cvss_score,
+                effective_reach_score = excluded.effective_reach_score,
+                scan_count = excluded.scan_count,
+                resolved_at = excluded.resolved_at,
+                reopened_at = excluded.reopened_at,
+                updated_at = excluded.updated_at,
+                payload = excluded.payload,
+                ledger_finding_id = excluded.ledger_finding_id
+            """,
+            (
+                tenant_id,
+                canonical,
+                merged["first_seen"],
+                merged["last_seen"],
+                merged["status"],
+                merged["severity"],
+                merged["severity_rank"],
+                merged["cvss_score"],
+                merged["effective_reach_score"],
+                merged["scan_count"],
+                merged["resolved_at"],
+                merged["reopened_at"],
+                merged["updated_at"],
+                payload_json,
+                ledger_finding_id or None,
+            ),
+        )
+    else:
+        conn.execute(
+            """
+            INSERT INTO hub_findings_current
+                (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
+                 cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+                 updated_at, payload)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(tenant_id, canonical_id) DO UPDATE SET
+                first_seen = MIN(hub_findings_current.first_seen, excluded.first_seen),
+                last_seen = MAX(hub_findings_current.last_seen, excluded.last_seen),
+                status = excluded.status,
+                severity = excluded.severity,
+                severity_rank = excluded.severity_rank,
+                cvss_score = excluded.cvss_score,
+                effective_reach_score = excluded.effective_reach_score,
+                scan_count = excluded.scan_count,
+                resolved_at = excluded.resolved_at,
+                reopened_at = excluded.reopened_at,
+                updated_at = excluded.updated_at,
+                payload = excluded.payload
+            """,
+            (
+                tenant_id,
+                canonical,
+                merged["first_seen"],
+                merged["last_seen"],
+                merged["status"],
+                merged["severity"],
+                merged["severity_rank"],
+                merged["cvss_score"],
+                merged["effective_reach_score"],
+                merged["scan_count"],
+                merged["resolved_at"],
+                merged["reopened_at"],
+                merged["updated_at"],
+                payload_json,
+            ),
+        )
+
+
+def _hydrate_sqlite_current_rows(
+    conn: sqlite3.Connection,
+    tenant_id: str,
+    current_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    ledger_map = batch_ledger_payloads(
+        lambda ids: _fetch_ledger_payloads_sqlite(conn, tenant_id, ids),
+        [str(row.get("ledger_finding_id") or "") for row in current_rows],
     )
+    hydrated: list[dict[str, Any]] = []
+    for row in current_rows:
+        hydrated_row = dict(row)
+        hydrated_row["payload"] = hydrate_current_payload(row, ledger_payloads=ledger_map)
+        hydrated.append(hydrated_row)
+    return hydrated
+
+
+def _hub_findings_current_has_ledger_col(conn: sqlite3.Connection) -> bool:
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(hub_findings_current)").fetchall()}
+    return "ledger_finding_id" in cols
+
+
+def _migrate_current_ledger_ref_sqlite(conn: sqlite3.Connection) -> None:
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(hub_findings_current)").fetchall()}
+    if "ledger_finding_id" not in cols:
+        conn.execute("ALTER TABLE hub_findings_current ADD COLUMN ledger_finding_id TEXT")
 
 
 def _ensure_current_lifecycle_sqlite(conn: sqlite3.Connection) -> None:
@@ -366,6 +480,7 @@ def _ensure_current_lifecycle_sqlite(conn: sqlite3.Connection) -> None:
 
     conn.executescript(_CURRENT_LIFECYCLE_SQLITE_DDL)
     _migrate_lifecycle_observations_l2_sqlite(conn)
+    _migrate_current_ledger_ref_sqlite(conn)
 
 
 def _migrate_lifecycle_observations_l2_sqlite(conn: sqlite3.Connection) -> None:
@@ -524,12 +639,41 @@ class InMemoryComplianceHubStore:
                     payload=payload,
                     updated_at=now,
                 )
+                finding_id = resolve_ledger_finding_id(payload, canonical_id=canonical)
+                if finding_id:
+                    merged["ledger_finding_id"] = finding_id
+                    merged["payload"] = current_state_overlay(payload)
                 current[canonical] = merged
+
+    def _ledger_payload_map(self, tenant_id: str, finding_ids: Sequence[str]) -> dict[str, dict[str, Any]]:
+        slots = self._slots.get(tenant_id, {})
+        bucket = self._by_tenant.get(tenant_id, [])
+        out: dict[str, dict[str, Any]] = {}
+        for finding_id in finding_ids:
+            idx = slots.get(finding_id)
+            if idx is not None and 0 <= idx < len(bucket):
+                out[finding_id] = dict(bucket[idx])
+        return out
+
+    def _hydrate_current_rows(self, tenant_id: str, rows: _HubFindingRows) -> _HubFindingRows:
+        ledger_map = batch_ledger_payloads(
+            lambda ids: self._ledger_payload_map(tenant_id, ids),
+            [str(row.get("ledger_finding_id") or "") for row in rows],
+        )
+        hydrated: list[dict[str, Any]] = []
+        for row in rows:
+            hydrated_row = dict(row)
+            hydrated_row["payload"] = hydrate_current_payload(row, ledger_payloads=ledger_map)
+            hydrated.append(hydrated_row)
+        return hydrated
 
     def get_current(self, tenant_id: str, canonical_id: str) -> dict[str, Any] | None:
         with self._lock:
             row = self._current.get(tenant_id, {}).get(canonical_id)
-            return dict(row) if row else None
+            if not row:
+                return None
+            hydrated = self._hydrate_current_rows(tenant_id, [dict(row)])
+            return hydrated[0]
 
     def list_current_page(
         self,
@@ -554,6 +698,7 @@ class InMemoryComplianceHubStore:
             rows = rows[offset:]
         if limit >= 0:
             rows = rows[:limit]
+        rows = self._hydrate_current_rows(tenant_id, [dict(row) for row in rows])
         return [enriched_finding_payload(row) for row in rows], total
 
     def reconcile_current_absent(
@@ -1057,33 +1202,22 @@ class SQLiteComplianceHubStore:
         self._conn.commit()
 
     def get_current(self, tenant_id: str, canonical_id: str) -> dict[str, Any] | None:
+        has_ledger_col = _hub_findings_current_has_ledger_col(self._conn)
+        payload_select = "payload, ledger_finding_id" if has_ledger_col else "payload"
         row = self._conn.execute(
-            """
+            f"""
             SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
                    cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-                   updated_at, payload
+                   updated_at, {payload_select}
             FROM hub_findings_current
             WHERE tenant_id = ? AND canonical_id = ?
-            """,
+            """,  # nosec B608
             (tenant_id, canonical_id),
         ).fetchone()
         if row is None:
             return None
-        return {
-            "canonical_id": row[0],
-            "first_seen": row[1],
-            "last_seen": row[2],
-            "status": row[3],
-            "severity": row[4],
-            "severity_rank": row[5],
-            "cvss_score": row[6],
-            "effective_reach_score": row[7],
-            "scan_count": row[8],
-            "resolved_at": row[9],
-            "reopened_at": row[10],
-            "updated_at": row[11],
-            "payload": json.loads(row[12]),
-        }
+        current_row = _sqlite_current_row_from_db(row, has_ledger_col=has_ledger_col)
+        return _hydrate_sqlite_current_rows(self._conn, tenant_id, [current_row])[0]
 
     def list_current_page(
         self,
@@ -1124,33 +1258,22 @@ class SQLiteComplianceHubStore:
 
         order_sql = _sqlite_current_order_clause(sort)
         page_params = [*params, int(limit), int(offset)]
+        has_ledger_col = _hub_findings_current_has_ledger_col(self._conn)
+        payload_select = "payload, ledger_finding_id" if has_ledger_col else "payload"
         rows = self._conn.execute(
             f"""
             SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
                    cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-                   updated_at, payload
+                   updated_at, {payload_select}
             FROM hub_findings_current
             WHERE {where_sql} {order_sql} LIMIT ? OFFSET ?
             """,  # nosec B608
             page_params,
         ).fetchall()
+        current_rows = [_sqlite_current_row_from_db(row, has_ledger_col=has_ledger_col) for row in rows]
+        hydrated_rows = _hydrate_sqlite_current_rows(self._conn, tenant_id, current_rows)
         out: list[dict[str, Any]] = []
-        for row in rows:
-            current_row = {
-                "canonical_id": row[0],
-                "first_seen": row[1],
-                "last_seen": row[2],
-                "status": row[3],
-                "severity": row[4],
-                "severity_rank": row[5],
-                "cvss_score": row[6],
-                "effective_reach_score": row[7],
-                "scan_count": row[8],
-                "resolved_at": row[9],
-                "reopened_at": row[10],
-                "updated_at": row[11],
-                "payload": json.loads(row[12]),
-            }
+        for current_row in hydrated_rows:
             out.append(enriched_finding_payload(current_row))
         return out, total
 

--- a/src/agent_bom/api/finding_lifecycle.py
+++ b/src/agent_bom/api/finding_lifecycle.py
@@ -158,6 +158,7 @@ CREATE TABLE IF NOT EXISTS hub_findings_current (
     reopened_at TEXT,
     updated_at TEXT NOT NULL,
     payload TEXT NOT NULL,
+    ledger_finding_id TEXT,
     PRIMARY KEY (tenant_id, canonical_id)
 );
 
@@ -216,6 +217,7 @@ CREATE TABLE IF NOT EXISTS hub_findings_current (
     reopened_at TEXT,
     updated_at TEXT NOT NULL,
     payload JSONB NOT NULL,
+    ledger_finding_id TEXT,
     PRIMARY KEY (tenant_id, canonical_id)
 );
 

--- a/src/agent_bom/api/hub_current_payload.py
+++ b/src/agent_bom/api/hub_current_payload.py
@@ -1,0 +1,55 @@
+"""Current-state finding payload overlay + ledger hydration (#3487)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import Any
+
+_OVERLAY_KEYS = ("origin", "batch_id", "scan_id", "source", "id", "canonical_id")
+
+
+def resolve_ledger_finding_id(payload: Mapping[str, Any], *, canonical_id: str = "") -> str:
+    """Return the ledger ``finding_id`` key for a hub finding payload."""
+    explicit = payload.get("id") or payload.get("canonical_id") or canonical_id
+    return str(explicit) if explicit else ""
+
+
+def current_state_overlay(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Persist only filter/sort helper fields in current-state rows."""
+    return {key: payload[key] for key in _OVERLAY_KEYS if key in payload and payload[key] is not None}
+
+
+def is_overlay_only_payload(payload: Mapping[str, Any]) -> bool:
+    if not payload:
+        return True
+    return set(payload.keys()).issubset(set(_OVERLAY_KEYS))
+
+
+def hydrate_current_payload(
+    row: Mapping[str, Any],
+    *,
+    ledger_payloads: Mapping[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Merge a current-state overlay with the canonical ledger payload."""
+    overlay = dict(row.get("payload") or {})
+    if not is_overlay_only_payload(overlay):
+        return overlay
+    finding_id = str(row.get("ledger_finding_id") or overlay.get("id") or "")
+    if finding_id:
+        base = ledger_payloads.get(finding_id)
+        if base:
+            merged = dict(base)
+            merged.update(overlay)
+            return merged
+    return overlay
+
+
+def batch_ledger_payloads(
+    fetch: Callable[[Sequence[str]], Mapping[str, dict[str, Any]]],
+    finding_ids: Iterable[str],
+) -> dict[str, dict[str, Any]]:
+    """Deduplicate finding ids before a ledger lookup."""
+    unique = sorted({fid for fid in finding_ids if fid})
+    if not unique:
+        return {}
+    return dict(fetch(unique))

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -23,6 +23,12 @@ from agent_bom.api.compliance_hub_store import (
     _severity_rank,
     compute_effective_reach_score,
 )
+from agent_bom.api.hub_current_payload import (
+    batch_ledger_payloads,
+    current_state_overlay,
+    hydrate_current_payload,
+    resolve_ledger_finding_id,
+)
 from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
@@ -65,6 +71,98 @@ def _migrate_lifecycle_observations_l2_postgres(conn: Any) -> None:
         END $$;
         """
     )
+
+
+def _migrate_current_ledger_ref_postgres(conn: Any) -> None:
+    conn.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = current_schema()
+                  AND table_name = 'hub_findings_current'
+                  AND column_name = 'ledger_finding_id'
+            ) THEN
+                ALTER TABLE hub_findings_current ADD COLUMN ledger_finding_id TEXT;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def _fetch_ledger_payloads_postgres(
+    conn: Any,
+    tenant_id: str,
+    finding_ids: Sequence[str],
+) -> dict[str, dict[str, Any]]:
+    if not finding_ids:
+        return {}
+    rows = conn.execute(
+        """
+        SELECT finding_id, payload
+        FROM compliance_hub_findings
+        WHERE tenant_id = %s AND finding_id = ANY(%s)
+        """,
+        (tenant_id, list(finding_ids)),
+    ).fetchall()
+    out: dict[str, dict[str, Any]] = {}
+    for finding_id, raw_payload in rows:
+        out[str(finding_id)] = raw_payload if isinstance(raw_payload, dict) else json.loads(raw_payload)
+    return out
+
+
+def _postgres_current_row_from_db(row: tuple[Any, ...], *, has_ledger_col: bool) -> dict[str, Any]:
+    raw_payload = row[12]
+    current_row = {
+        "canonical_id": row[0],
+        "first_seen": row[1],
+        "last_seen": row[2],
+        "status": row[3],
+        "severity": row[4],
+        "severity_rank": row[5],
+        "cvss_score": row[6],
+        "effective_reach_score": row[7],
+        "scan_count": row[8],
+        "resolved_at": row[9],
+        "reopened_at": row[10],
+        "updated_at": row[11],
+        "payload": raw_payload if isinstance(raw_payload, dict) else json.loads(raw_payload),
+    }
+    if has_ledger_col:
+        current_row["ledger_finding_id"] = row[13]
+    return current_row
+
+
+def _hydrate_postgres_current_rows(
+    conn: Any,
+    tenant_id: str,
+    current_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    ledger_map = batch_ledger_payloads(
+        lambda ids: _fetch_ledger_payloads_postgres(conn, tenant_id, ids),
+        [str(row.get("ledger_finding_id") or "") for row in current_rows],
+    )
+    hydrated: list[dict[str, Any]] = []
+    for row in current_rows:
+        hydrated_row = dict(row)
+        hydrated_row["payload"] = hydrate_current_payload(row, ledger_payloads=ledger_map)
+        hydrated.append(hydrated_row)
+    return hydrated
+
+
+def _postgres_current_has_ledger_col(conn: Any) -> bool:
+    row = conn.execute(
+        """
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = 'hub_findings_current'
+          AND column_name = 'ledger_finding_id'
+        LIMIT 1
+        """
+    ).fetchone()
+    return row is not None
 
 
 class PostgresComplianceHubStore:
@@ -150,6 +248,7 @@ class PostgresComplianceHubStore:
 
             conn.execute(_CURRENT_LIFECYCLE_POSTGRES_DDL)
             _migrate_lifecycle_observations_l2_postgres(conn)
+            _migrate_current_ledger_ref_postgres(conn)
             _ensure_tenant_rls(conn, "hub_findings_current", "tenant_id")
             _ensure_tenant_rls(conn, "hub_findings_current_observations", "tenant_id")
             conn.commit()
@@ -389,6 +488,8 @@ class PostgresComplianceHubStore:
             for payload in clean:
                 canonical = resolve_canonical_id(payload, source=source)
                 metrics = lifecycle_metrics(payload)
+                ledger_finding_id = resolve_ledger_finding_id(payload, canonical_id=canonical)
+                overlay = current_state_overlay(payload) if ledger_finding_id else dict(payload)
                 inserted = conn.execute(
                     """
                     INSERT INTO hub_findings_current_observations
@@ -400,36 +501,24 @@ class PostgresComplianceHubStore:
                 ).rowcount
                 if not inserted:
                     continue
+                has_ledger_col = _postgres_current_has_ledger_col(conn)
+                payload_select = "payload, ledger_finding_id" if has_ledger_col else "payload"
                 existing_row = conn.execute(
-                    """
+                    f"""
                     SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
                            cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-                           updated_at, payload
+                           updated_at, {payload_select}
                     FROM hub_findings_current
                     WHERE tenant_id = %s AND canonical_id = %s
-                    """,
+                    """,  # nosec B608
                     (tenant_id, canonical),
                 ).fetchone()
                 existing: dict[str, Any] | None
                 if existing_row is None:
                     existing = None
                 else:
-                    raw_payload = existing_row[12]
-                    existing = {
-                        "canonical_id": existing_row[0],
-                        "first_seen": existing_row[1],
-                        "last_seen": existing_row[2],
-                        "status": existing_row[3],
-                        "severity": existing_row[4],
-                        "severity_rank": existing_row[5],
-                        "cvss_score": existing_row[6],
-                        "effective_reach_score": existing_row[7],
-                        "scan_count": existing_row[8],
-                        "resolved_at": existing_row[9],
-                        "reopened_at": existing_row[10],
-                        "updated_at": existing_row[11],
-                        "payload": raw_payload if isinstance(raw_payload, dict) else json.loads(raw_payload),
-                    }
+                    existing = _postgres_current_row_from_db(existing_row, has_ledger_col=has_ledger_col)
+                    existing = _hydrate_postgres_current_rows(conn, tenant_id, [existing])[0]
                 merged = apply_observation_to_current(
                     existing,
                     canonical_id=canonical,
@@ -438,76 +527,106 @@ class PostgresComplianceHubStore:
                     payload=payload,
                     updated_at=now,
                 )
-                conn.execute(
-                    """
-                    INSERT INTO hub_findings_current
-                        (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
-                         cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-                         updated_at, payload)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb)
-                    ON CONFLICT (tenant_id, canonical_id) DO UPDATE SET
-                        first_seen = LEAST(hub_findings_current.first_seen, EXCLUDED.first_seen),
-                        last_seen = GREATEST(hub_findings_current.last_seen, EXCLUDED.last_seen),
-                        status = EXCLUDED.status,
-                        severity = EXCLUDED.severity,
-                        severity_rank = EXCLUDED.severity_rank,
-                        cvss_score = EXCLUDED.cvss_score,
-                        effective_reach_score = EXCLUDED.effective_reach_score,
-                        scan_count = EXCLUDED.scan_count,
-                        resolved_at = EXCLUDED.resolved_at,
-                        reopened_at = EXCLUDED.reopened_at,
-                        updated_at = EXCLUDED.updated_at,
-                        payload = EXCLUDED.payload
-                    """,
-                    (
-                        tenant_id,
-                        canonical,
-                        merged["first_seen"],
-                        merged["last_seen"],
-                        merged["status"],
-                        merged["severity"],
-                        merged["severity_rank"],
-                        merged["cvss_score"],
-                        merged["effective_reach_score"],
-                        merged["scan_count"],
-                        merged["resolved_at"],
-                        merged["reopened_at"],
-                        merged["updated_at"],
-                        json.dumps(merged["payload"], sort_keys=True),
-                    ),
-                )
+                if has_ledger_col:
+                    conn.execute(
+                        """
+                        INSERT INTO hub_findings_current
+                            (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
+                             cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+                             updated_at, payload, ledger_finding_id)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s)
+                        ON CONFLICT (tenant_id, canonical_id) DO UPDATE SET
+                            first_seen = LEAST(hub_findings_current.first_seen, EXCLUDED.first_seen),
+                            last_seen = GREATEST(hub_findings_current.last_seen, EXCLUDED.last_seen),
+                            status = EXCLUDED.status,
+                            severity = EXCLUDED.severity,
+                            severity_rank = EXCLUDED.severity_rank,
+                            cvss_score = EXCLUDED.cvss_score,
+                            effective_reach_score = EXCLUDED.effective_reach_score,
+                            scan_count = EXCLUDED.scan_count,
+                            resolved_at = EXCLUDED.resolved_at,
+                            reopened_at = EXCLUDED.reopened_at,
+                            updated_at = EXCLUDED.updated_at,
+                            payload = EXCLUDED.payload,
+                            ledger_finding_id = EXCLUDED.ledger_finding_id
+                        """,
+                        (
+                            tenant_id,
+                            canonical,
+                            merged["first_seen"],
+                            merged["last_seen"],
+                            merged["status"],
+                            merged["severity"],
+                            merged["severity_rank"],
+                            merged["cvss_score"],
+                            merged["effective_reach_score"],
+                            merged["scan_count"],
+                            merged["resolved_at"],
+                            merged["reopened_at"],
+                            merged["updated_at"],
+                            json.dumps(overlay, sort_keys=True),
+                            ledger_finding_id or None,
+                        ),
+                    )
+                else:
+                    conn.execute(
+                        """
+                        INSERT INTO hub_findings_current
+                            (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
+                             cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+                             updated_at, payload)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb)
+                        ON CONFLICT (tenant_id, canonical_id) DO UPDATE SET
+                            first_seen = LEAST(hub_findings_current.first_seen, EXCLUDED.first_seen),
+                            last_seen = GREATEST(hub_findings_current.last_seen, EXCLUDED.last_seen),
+                            status = EXCLUDED.status,
+                            severity = EXCLUDED.severity,
+                            severity_rank = EXCLUDED.severity_rank,
+                            cvss_score = EXCLUDED.cvss_score,
+                            effective_reach_score = EXCLUDED.effective_reach_score,
+                            scan_count = EXCLUDED.scan_count,
+                            resolved_at = EXCLUDED.resolved_at,
+                            reopened_at = EXCLUDED.reopened_at,
+                            updated_at = EXCLUDED.updated_at,
+                            payload = EXCLUDED.payload
+                        """,
+                        (
+                            tenant_id,
+                            canonical,
+                            merged["first_seen"],
+                            merged["last_seen"],
+                            merged["status"],
+                            merged["severity"],
+                            merged["severity_rank"],
+                            merged["cvss_score"],
+                            merged["effective_reach_score"],
+                            merged["scan_count"],
+                            merged["resolved_at"],
+                            merged["reopened_at"],
+                            merged["updated_at"],
+                            json.dumps(overlay, sort_keys=True),
+                        ),
+                    )
             conn.commit()
 
     def get_current(self, tenant_id: str, canonical_id: str) -> dict[str, Any] | None:
         with _tenant_connection(self._pool) as conn:
+            has_ledger_col = _postgres_current_has_ledger_col(conn)
+            payload_select = "payload, ledger_finding_id" if has_ledger_col else "payload"
             row = conn.execute(
-                """
+                f"""
                 SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
                        cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-                       updated_at, payload
+                       updated_at, {payload_select}
                 FROM hub_findings_current
                 WHERE tenant_id = %s AND canonical_id = %s
-                """,
+                """,  # nosec B608
                 (tenant_id, canonical_id),
             ).fetchone()
-        if row is None:
-            return None
-        raw_payload = row[12]
-        return {
-            "canonical_id": row[0],
-            "first_seen": row[1],
-            "last_seen": row[2],
-            "status": row[3],
-            "severity": row[4],
-            "severity_rank": row[5],
-            "cvss_score": row[6],
-            "effective_reach_score": row[7],
-            "scan_count": row[8],
-            "resolved_at": row[9],
-            "reopened_at": row[10],
-            "updated_at": row[11],
-            "payload": raw_payload if isinstance(raw_payload, dict) else json.loads(raw_payload),
-        }
+            if row is None:
+                return None
+            current_row = _postgres_current_row_from_db(row, has_ledger_col=has_ledger_col)
+            return _hydrate_postgres_current_rows(conn, tenant_id, [current_row])[0]
 
     def list_current_page(
         self,
@@ -548,34 +667,22 @@ class PostgresComplianceHubStore:
                 total = int(total_row[0]) if total_row else 0
             else:
                 total = None
+            has_ledger_col = _postgres_current_has_ledger_col(conn)
+            payload_select = "payload, ledger_finding_id" if has_ledger_col else "payload"
             rows = conn.execute(
                 f"""
                 SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
                        cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-                       updated_at, payload
+                       updated_at, {payload_select}
                 FROM hub_findings_current
                 WHERE {where_sql} {order_sql} LIMIT %s OFFSET %s
                 """,  # nosec B608
                 (*params, int(limit), int(offset)),
             ).fetchall()
+            current_rows = [_postgres_current_row_from_db(row, has_ledger_col=has_ledger_col) for row in rows]
+            hydrated_rows = _hydrate_postgres_current_rows(conn, tenant_id, current_rows)
         out: list[dict[str, Any]] = []
-        for row in rows:
-            raw_payload = row[12]
-            current_row = {
-                "canonical_id": row[0],
-                "first_seen": row[1],
-                "last_seen": row[2],
-                "status": row[3],
-                "severity": row[4],
-                "severity_rank": row[5],
-                "cvss_score": row[6],
-                "effective_reach_score": row[7],
-                "scan_count": row[8],
-                "resolved_at": row[9],
-                "reopened_at": row[10],
-                "updated_at": row[11],
-                "payload": raw_payload if isinstance(raw_payload, dict) else json.loads(raw_payload),
-            }
+        for current_row in hydrated_rows:
             out.append(enriched_finding_payload(current_row))
         return out, total
 

--- a/tests/test_hub_payload_dedup.py
+++ b/tests/test_hub_payload_dedup.py
@@ -1,0 +1,79 @@
+"""Regression tests for current-state payload dedup (#3487)."""
+
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+
+from agent_bom.api.compliance_hub_store import (
+    InMemoryComplianceHubStore,
+    SQLiteComplianceHubStore,
+)
+from agent_bom.api.finding_lifecycle import resolve_canonical_id
+
+
+def _large_finding(finding_id: str) -> dict:
+    return {
+        "id": finding_id,
+        "title": "Reachable secret in MCP tool",
+        "severity": "high",
+        "source": "agent-runtime",
+        "origin": "bulk_ingest",
+        "batch_id": "batch-dedup",
+        "description": "x" * 1200,
+        "evidence": {"blob": "y" * 800},
+    }
+
+
+@pytest.mark.parametrize("store_factory", ["memory", "sqlite"])
+def test_current_state_stores_overlay_and_hydrates_from_ledger(
+    store_factory: str,
+    tmp_path,
+) -> None:
+    if store_factory == "memory":
+        store = InMemoryComplianceHubStore()
+    else:
+        store = SQLiteComplianceHubStore(str(tmp_path / "dedup.db"))
+
+    tenant = f"dedup-{uuid4().hex}"
+    finding = _large_finding("finding-dedup-1")
+    store.add(tenant, [finding])
+    store.upsert_current_batch(
+        tenant,
+        [finding],
+        observed_at="2026-07-04T00:00:00Z",
+        batch_id="batch-dedup",
+        source="agent-runtime",
+    )
+
+    canonical = resolve_canonical_id(finding, source="agent-runtime")
+    current = store.get_current(tenant, canonical)
+    assert current is not None
+    assert current["payload"]["title"] == finding["title"]
+
+    if store_factory == "sqlite":
+        row = store._conn.execute(
+            """
+            SELECT payload, ledger_finding_id
+            FROM hub_findings_current
+            WHERE tenant_id = ? AND canonical_id = ?
+            """,
+            (tenant, canonical),
+        ).fetchone()
+        assert row is not None
+        assert row[1] == finding["id"]
+        overlay = json.loads(row[0])
+        assert "description" not in overlay
+        assert overlay["origin"] == "bulk_ingest"
+        ledger_payload = store._conn.execute(
+            "SELECT payload FROM compliance_hub_findings WHERE tenant_id = ? AND finding_id = ?",
+            (tenant, finding["id"]),
+        ).fetchone()[0]
+        assert len(row[0]) < len(ledger_payload)
+
+    listed, total = store.list_current_page(tenant, limit=10)
+    assert total == 1
+    assert listed[0]["title"] == finding["title"]
+    assert listed[0]["severity"] == finding["severity"]


### PR DESCRIPTION
## Summary
- Current-state rows keep filter overlay fields plus `ledger_finding_id` instead of copying the full finding payload.
- Reads (`get_current`, `list_current_page`) batch-hydrate from `compliance_hub_findings` for SQLite, Postgres, and in-memory stores.
- Idempotent migration adds `ledger_finding_id` to existing `hub_findings_current` tables.

## Test plan
- [x] `uv run pytest tests/test_hub_payload_dedup.py tests/test_finding_lifecycle.py -q` (14 passed)
- [ ] SQLite row overlay bytes < ledger payload bytes for the same finding
- [ ] `/v1/findings` list still returns full finding bodies after bulk ingest

Related: #3487