### PR TITLE
feat(api): keyset cursor pagination for hub current-state findings

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -9731,7 +9731,7 @@
     },
     "/v1/findings": {
       "get": {
-        "description": "List vulnerability findings aggregated from completed scan results.\n\nDefault sort is ``effective_reach`` \u2014 the composite triage signal that\ncombines CVSS / EPSS / KEV with reachable-tool capability, credential\nvisibility and agent breadth.  Pass ``?sort=cvss`` for the legacy\nCVSS-only ordering, or ``?sort=severity`` for severity-band ordering.\n\nPass ``?approximate_total=true`` to skip ``COUNT(*)`` on deep pages.\nThe first page (``offset=0``) still computes an exact total and caches it\nfor roughly ``AGENT_BOM_FINDINGS_COUNT_CACHE_TTL_SECONDS`` (default 60s).\nLater pages reuse the cached count; when the cache is cold the response\ncarries a conservative lower bound and ``total_approximate: true``.",
+        "description": "List vulnerability findings aggregated from completed scan results.\n\nDefault sort is ``effective_reach`` \u2014 the composite triage signal that\ncombines CVSS / EPSS / KEV with reachable-tool capability, credential\nvisibility and agent breadth.  Pass ``?sort=cvss`` for the legacy\nCVSS-only ordering, or ``?sort=severity`` for severity-band ordering.\n\nPass ``?approximate_total=true`` to skip ``COUNT(*)`` on deep pages.\nThe first page (``offset=0``) still computes an exact total and caches it\nfor roughly ``AGENT_BOM_FINDINGS_COUNT_CACHE_TTL_SECONDS`` (default 60s).\nLater pages reuse the cached count; when the cache is cold the response\ncarries a conservative lower bound and ``total_approximate: true``.\n\nPass ``?cursor=`` with the ``next_cursor`` from a prior response for\nkeyset pagination through bulk-ingested hub findings (avoids deep\n``OFFSET`` cost). ``cursor`` and non-zero ``offset`` cannot be combined.",
         "operationId": "list_findings_v1_findings_get",
         "parameters": [
           {
@@ -9798,6 +9798,23 @@
               "minimum": 0,
               "title": "Offset",
               "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 512,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
             }
           },
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -6397,7 +6397,9 @@ paths:
         \ computes an exact total and caches it\nfor roughly ``AGENT_BOM_FINDINGS_COUNT_CACHE_TTL_SECONDS``\
         \ (default 60s).\nLater pages reuse the cached count; when the cache is cold\
         \ the response\ncarries a conservative lower bound and ``total_approximate:\
-        \ true``."
+        \ true``.\n\nPass ``?cursor=`` with the ``next_cursor`` from a prior response\
+        \ for\nkeyset pagination through bulk-ingested hub findings (avoids deep\n\
+        ``OFFSET`` cost). ``cursor`` and non-zero ``offset`` cannot be combined."
       operationId: list_findings_v1_findings_get
       parameters:
       - in: query
@@ -6441,6 +6443,15 @@ paths:
           minimum: 0
           title: Offset
           type: integer
+      - in: query
+        name: cursor
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 512
+            type: string
+          - type: 'null'
+          title: Cursor
       - in: query
         name: approximate_total
         required: false

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -27,6 +27,12 @@ import threading
 from collections.abc import Callable, Iterable, Sequence
 from typing import Any, Protocol
 
+from agent_bom.api.finding_cursor import (
+    cursor_from_current_row,
+    decode_finding_cursor,
+    row_is_after_cursor,
+    sqlite_keyset_clause,
+)
 from agent_bom.api.hub_current_payload import (
     batch_ledger_payloads,
     current_state_overlay,
@@ -40,6 +46,7 @@ from agent_bom.graph.severity import severity_policy_rank
 # classes below define a ``list`` method that would otherwise shadow it in
 # their ``list_page`` return annotations.
 FindingPage = tuple[list[dict[str, Any]], int | None]
+FindingCursorPage = tuple[list[dict[str, Any]], int | None, str | None]
 _HubFindingRows = list[dict[str, Any]]
 
 # Sort keys supported by ``list_page``. ``effective_reach`` (default),
@@ -245,7 +252,8 @@ class ComplianceHubStore(Protocol):
         scan_id: str | None = None,
         origin: str | None = None,
         include_total: bool = True,
-    ) -> FindingPage:
+        cursor: str | None = None,
+    ) -> FindingCursorPage:
         """Return a page from ``hub_findings_current`` with lifecycle fields merged."""
         ...
 
@@ -690,20 +698,45 @@ class InMemoryComplianceHubStore:
         scan_id: str | None = None,
         origin: str | None = None,
         include_total: bool = True,
-    ) -> FindingPage:
+        cursor: str | None = None,
+    ) -> FindingCursorPage:
         from agent_bom.api.finding_lifecycle import enriched_finding_payload
 
+        normalized_sort = sort if sort in _LIST_PAGE_SORTS else "effective_reach"
         with self._lock:
             rows = list(self._current.get(tenant_id, {}).values())
         rows = _filter_current_rows(rows, severity=severity, scan_id=scan_id, origin=origin)
         total = len(rows) if include_total else None
-        rows.sort(key=_current_page_sort_key(sort))
-        if offset:
+        rows.sort(key=_current_page_sort_key(normalized_sort))
+        if cursor:
+            primary, last_seen, canonical_id = decode_finding_cursor(cursor, expected_sort=normalized_sort)
+            rows = [
+                row
+                for row in rows
+                if row_is_after_cursor(
+                    row,
+                    sort=normalized_sort,
+                    primary=primary,
+                    last_seen=last_seen,
+                    canonical_id=canonical_id,
+                )
+            ]
+        elif offset:
             rows = rows[offset:]
-        if limit >= 0:
-            rows = rows[:limit]
+        page_limit = max(0, int(limit))
+        fetch_limit = page_limit + 1 if page_limit >= 0 else page_limit
+        if page_limit >= 0:
+            chunk = rows[:fetch_limit]
+            has_more = len(chunk) > page_limit
+            rows = chunk[:page_limit]
+        else:
+            has_more = False
         rows = self._hydrate_current_rows(tenant_id, [dict(row) for row in rows])
-        return [enriched_finding_payload(row) for row in rows], total
+        enriched = [enriched_finding_payload(row) for row in rows]
+        next_cursor = None
+        if has_more and rows:
+            next_cursor = cursor_from_current_row(rows[-1], sort=normalized_sort)
+        return enriched, total, next_cursor
 
     def reconcile_current_absent(
         self,
@@ -1234,9 +1267,11 @@ class SQLiteComplianceHubStore:
         scan_id: str | None = None,
         origin: str | None = None,
         include_total: bool = True,
-    ) -> FindingPage:
+        cursor: str | None = None,
+    ) -> FindingCursorPage:
         from agent_bom.api.finding_lifecycle import enriched_finding_payload
 
+        normalized_sort = sort if sort in _LIST_PAGE_SORTS else "effective_reach"
         where = ["tenant_id = ?"]
         params: list[Any] = [tenant_id]
         if origin is not None:
@@ -1248,10 +1283,14 @@ class SQLiteComplianceHubStore:
         if scan_id is not None:
             where.append("(CAST(json_extract(payload, '$.batch_id') AS TEXT) = ? OR CAST(json_extract(payload, '$.scan_id') AS TEXT) = ?)")
             params.extend([scan_id, scan_id])
+        if cursor:
+            keyset_sql, keyset_params = sqlite_keyset_clause(normalized_sort, cursor)
+            where.append(keyset_sql.removeprefix(" AND "))
+            params.extend(keyset_params)
         where_sql = " AND ".join(where)
 
         total: int | None
-        if include_total:
+        if include_total and not cursor:
             total_row = self._conn.execute(
                 f"SELECT COUNT(*) FROM hub_findings_current WHERE {where_sql}",  # nosec B608
                 params,
@@ -1260,8 +1299,15 @@ class SQLiteComplianceHubStore:
         else:
             total = None
 
-        order_sql = _sqlite_current_order_clause(sort)
-        page_params = [*params, int(limit), int(offset)]
+        order_sql = _sqlite_current_order_clause(normalized_sort)
+        page_limit = max(0, int(limit))
+        fetch_limit = page_limit + 1 if page_limit >= 0 else page_limit
+        if cursor:
+            page_params = [*params, fetch_limit]
+            limit_sql = "LIMIT ?"
+        else:
+            page_params = [*params, fetch_limit, int(offset)]
+            limit_sql = "LIMIT ? OFFSET ?"
         has_ledger_col = _hub_findings_current_has_ledger_col(self._conn)
         payload_select = "payload, ledger_finding_id" if has_ledger_col else "payload"
         rows = self._conn.execute(
@@ -1270,16 +1316,22 @@ class SQLiteComplianceHubStore:
                    cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
                    updated_at, {payload_select}
             FROM hub_findings_current
-            WHERE {where_sql} {order_sql} LIMIT ? OFFSET ?
+            WHERE {where_sql} {order_sql} {limit_sql}
             """,  # nosec B608
             page_params,
         ).fetchall()
         current_rows = [_sqlite_current_row_from_db(row, has_ledger_col=has_ledger_col) for row in rows]
+        has_more = page_limit >= 0 and len(current_rows) > page_limit
+        if has_more:
+            current_rows = current_rows[:page_limit]
         hydrated_rows = _hydrate_sqlite_current_rows(self._conn, tenant_id, current_rows)
         out: list[dict[str, Any]] = []
         for current_row in hydrated_rows:
             out.append(enriched_finding_payload(current_row))
-        return out, total
+        next_cursor = None
+        if has_more and hydrated_rows:
+            next_cursor = cursor_from_current_row(hydrated_rows[-1], sort=normalized_sort)
+        return out, total, next_cursor
 
     def reconcile_current_absent(
         self,

--- a/src/agent_bom/api/finding_cursor.py
+++ b/src/agent_bom/api/finding_cursor.py
@@ -1,0 +1,116 @@
+"""Opaque keyset cursors for ``hub_findings_current`` sorted reads."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+_ALLOWED_SORTS = frozenset({"effective_reach", "cvss", "severity", "ordinal"})
+
+
+def encode_finding_cursor(
+    *,
+    sort: str,
+    primary: float,
+    last_seen: str,
+    canonical_id: str,
+) -> str:
+    payload = {
+        "sort": sort if sort in _ALLOWED_SORTS else "effective_reach",
+        "primary": primary,
+        "last_seen": last_seen,
+        "canonical_id": canonical_id,
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def decode_finding_cursor(cursor: str, *, expected_sort: str) -> tuple[float, str, str]:
+    try:
+        padded = cursor + "=" * (-len(cursor) % 4)
+        raw = base64.urlsafe_b64decode(padded.encode()).decode()
+        payload = json.loads(raw)
+        if not isinstance(payload, dict):
+            raise ValueError
+        sort = str(payload.get("sort") or "")
+        if sort != expected_sort:
+            raise ValueError("Cursor sort mismatch")
+        return float(payload.get("primary") or 0.0), str(payload.get("last_seen") or ""), str(payload.get("canonical_id") or "")
+    except Exception as exc:
+        raise ValueError("Invalid findings cursor") from exc
+
+
+def cursor_from_current_row(row: dict[str, Any], *, sort: str) -> str:
+    normalized = sort if sort in _ALLOWED_SORTS else "effective_reach"
+    if normalized == "ordinal":
+        primary = 0.0
+    elif normalized == "cvss":
+        primary = float(row.get("cvss_score") or 0.0)
+    elif normalized == "severity":
+        primary = float(row.get("severity_rank") or 0.0)
+    else:
+        primary = float(row.get("effective_reach_score") or 0.0)
+    return encode_finding_cursor(
+        sort=normalized,
+        primary=primary,
+        last_seen=str(row.get("last_seen") or ""),
+        canonical_id=str(row.get("canonical_id") or ""),
+    )
+
+
+def sqlite_keyset_clause(sort: str, cursor: str) -> tuple[str, list[Any]]:
+    """Return extra WHERE SQL + params for keyset pagination after ``cursor``."""
+    normalized = sort if sort in _ALLOWED_SORTS else "effective_reach"
+    primary, last_seen, canonical_id = decode_finding_cursor(cursor, expected_sort=normalized)
+    if normalized == "ordinal":
+        return (
+            " AND (last_seen > ? OR (last_seen = ? AND canonical_id > ?))",
+            [last_seen, last_seen, canonical_id],
+        )
+    if normalized == "cvss":
+        col = "cvss_score"
+    elif normalized == "severity":
+        col = "severity_rank"
+    else:
+        col = "effective_reach_score"
+    return (
+        f" AND ({col} < ? OR ({col} = ? AND (last_seen < ? OR (last_seen = ? AND canonical_id > ?))))",
+        [primary, primary, last_seen, last_seen, canonical_id],
+    )
+
+
+def postgres_keyset_clause(sort: str, cursor: str) -> tuple[str, list[Any]]:
+    clause, params = sqlite_keyset_clause(sort, cursor)
+    return clause.replace("?", "%s"), params
+
+
+def row_is_after_cursor(
+    row: dict[str, Any],
+    *,
+    sort: str,
+    primary: float,
+    last_seen: str,
+    canonical_id: str,
+) -> bool:
+    """Return True when ``row`` sorts strictly after the cursor tuple."""
+    normalized = sort if sort in _ALLOWED_SORTS else "effective_reach"
+    row_last = str(row.get("last_seen") or "")
+    row_canonical = str(row.get("canonical_id") or "")
+    if normalized == "ordinal":
+        return (row_last, row_canonical) > (last_seen, canonical_id)
+    if normalized == "cvss":
+        row_primary = float(row.get("cvss_score") or 0.0)
+    elif normalized == "severity":
+        row_primary = float(row.get("severity_rank") or 0.0)
+    else:
+        row_primary = float(row.get("effective_reach_score") or 0.0)
+    if row_primary < primary:
+        return True
+    if row_primary > primary:
+        return False
+    if row_last < last_seen:
+        return True
+    if row_last > last_seen:
+        return False
+    return row_canonical > canonical_id

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from agent_bom.api.compliance_hub_store import (
+    FindingCursorPage,
     FindingPage,
     _cvss_value,
     _frameworks_csv,
@@ -22,6 +23,10 @@ from agent_bom.api.compliance_hub_store import (
     _redact_findings,
     _severity_rank,
     compute_effective_reach_score,
+)
+from agent_bom.api.finding_cursor import (
+    cursor_from_current_row,
+    postgres_keyset_clause,
 )
 from agent_bom.api.hub_current_payload import (
     batch_ledger_payloads,
@@ -639,10 +644,12 @@ class PostgresComplianceHubStore:
         scan_id: str | None = None,
         origin: str | None = None,
         include_total: bool = True,
-    ) -> FindingPage:
+        cursor: str | None = None,
+    ) -> FindingCursorPage:
         from agent_bom.api.finding_lifecycle import enriched_finding_payload
         from agent_bom.graph.severity import severity_policy_rank
 
+        normalized_sort = sort if sort in ("effective_reach", "cvss", "severity", "ordinal") else "effective_reach"
         where = ["tenant_id = %s"]
         params: list[Any] = [tenant_id]
         if origin is not None:
@@ -654,12 +661,18 @@ class PostgresComplianceHubStore:
         if scan_id is not None:
             where.append("(payload->>'batch_id' = %s OR payload->>'scan_id' = %s)")
             params.extend([scan_id, scan_id])
+        if cursor:
+            keyset_sql, keyset_params = postgres_keyset_clause(normalized_sort, cursor)
+            where.append(keyset_sql.removeprefix(" AND "))
+            params.extend(keyset_params)
         where_sql = " AND ".join(where)
-        order_sql = _postgres_current_order_clause(sort)
+        order_sql = _postgres_current_order_clause(normalized_sort)
+        page_limit = max(0, int(limit))
+        fetch_limit = page_limit + 1 if page_limit >= 0 else page_limit
 
         with _tenant_connection(self._pool) as conn:
             total: int | None
-            if include_total:
+            if include_total and not cursor:
                 total_row = conn.execute(
                     f"SELECT COUNT(*) FROM hub_findings_current WHERE {where_sql}",  # nosec B608
                     tuple(params),
@@ -669,22 +682,34 @@ class PostgresComplianceHubStore:
                 total = None
             has_ledger_col = _postgres_current_has_ledger_col(conn)
             payload_select = "payload, ledger_finding_id" if has_ledger_col else "payload"
+            if cursor:
+                query_params: tuple[Any, ...] = (*params, fetch_limit)
+                limit_sql = "LIMIT %s"
+            else:
+                query_params = (*params, fetch_limit, int(offset))
+                limit_sql = "LIMIT %s OFFSET %s"
             rows = conn.execute(
                 f"""
                 SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
                        cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
                        updated_at, {payload_select}
                 FROM hub_findings_current
-                WHERE {where_sql} {order_sql} LIMIT %s OFFSET %s
+                WHERE {where_sql} {order_sql} {limit_sql}
                 """,  # nosec B608
-                (*params, int(limit), int(offset)),
+                query_params,
             ).fetchall()
             current_rows = [_postgres_current_row_from_db(row, has_ledger_col=has_ledger_col) for row in rows]
+            has_more = page_limit >= 0 and len(current_rows) > page_limit
+            if has_more:
+                current_rows = current_rows[:page_limit]
             hydrated_rows = _hydrate_postgres_current_rows(conn, tenant_id, current_rows)
         out: list[dict[str, Any]] = []
         for current_row in hydrated_rows:
             out.append(enriched_finding_payload(current_row))
-        return out, total
+        next_cursor = None
+        if has_more and hydrated_rows:
+            next_cursor = cursor_from_current_row(hydrated_rows[-1], sort=normalized_sort)
+        return out, total, next_cursor
 
     def reconcile_current_absent(
         self,
@@ -709,7 +734,7 @@ class PostgresComplianceHubStore:
                 f"""
                 UPDATE hub_findings_current
                 SET status = 'resolved', resolved_at = %s, updated_at = %s
-                WHERE {' AND '.join(where)}
+                WHERE {" AND ".join(where)}
                 """,  # nosec B608
                 tuple(params),
             )

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -261,10 +261,7 @@ class BulkFindingsRequest(BaseModel):
     )
     reconcile_absent: bool = Field(
         default=False,
-        description=(
-            "When true, mark open findings in the same source scope that are absent "
-            "from this batch as resolved at observed_at."
-        ),
+        description=("When true, mark open findings in the same source scope that are absent from this batch as resolved at observed_at."),
     )
 
     @field_validator("findings")
@@ -1271,10 +1268,9 @@ async def list_findings(
     severity: str | None = None,
     scan_id: Annotated[str | None, Query(max_length=128)] = None,
     sort: str = "effective_reach",
-    # enforce limit cap server-side instead of trusting
-    # the historical `min(limit, 1000)` clamp at use-site.
     limit: Annotated[int, Query(ge=1, le=1000)] = 500,
     offset: Annotated[int, Query(ge=0)] = 0,
+    cursor: Annotated[str | None, Query(max_length=512)] = None,
     approximate_total: bool = False,
 ) -> dict:
     """List vulnerability findings aggregated from completed scan results.
@@ -1289,27 +1285,31 @@ async def list_findings(
     for roughly ``AGENT_BOM_FINDINGS_COUNT_CACHE_TTL_SECONDS`` (default 60s).
     Later pages reuse the cached count; when the cache is cold the response
     carries a conservative lower bound and ``total_approximate: true``.
+
+    Pass ``?cursor=`` with the ``next_cursor`` from a prior response for
+    keyset pagination through bulk-ingested hub findings (avoids deep
+    ``OFFSET`` cost). ``cursor`` and non-zero ``offset`` cannot be combined.
     """
     from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+    from agent_bom.api.finding_cursor import decode_finding_cursor
 
     tenant_id = _tenant_id(request)
     sort_key = sort.lower().strip() if isinstance(sort, str) else "effective_reach"
     if sort_key not in _ALLOWED_FINDING_SORTS:
         sort_key = "effective_reach"
-    include_bulk_total = (not approximate_total) or offset == 0
+    if cursor and offset:
+        raise HTTPException(status_code=400, detail="cursor and offset are mutually exclusive")
+    if cursor:
+        try:
+            decode_finding_cursor(cursor, expected_sort=sort_key)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
+    include_bulk_total = (not approximate_total and not cursor) or (offset == 0 and not cursor)
 
-    # Scan-job findings live in memory and are typically small; gather + sort
-    # them directly. The bulk-ingested hub findings can reach millions of rows,
-    # so those are paginated in the store (SQL LIMIT/OFFSET + ORDER BY) rather
-    # than materialised in Python — this is the O(n) read-path fix (PR1).
     scan_findings: list[dict[str, Any]] = []
     for job in _completed_jobs_for_tenant(tenant_id):
         if scan_id and job.job_id != scan_id:
             continue
-        # Batch parents aggregate their children's evidence; skip them in the
-        # global roll-up so findings are not double-counted against the children
-        # that already contribute. When a caller targets the parent by scan_id
-        # they get the aggregated union instead.
         if job.child_job_ids and job.job_id != scan_id:
             continue
         scan_findings.extend(_iter_scan_findings(job))
@@ -1321,12 +1321,14 @@ async def list_findings(
     store = get_compliance_hub_store()
     bulk_list = getattr(store, "list_current_page", None) or getattr(store, "list_page", None)
     total_approximate = False
+    next_cursor: str | None = None
+    warnings: list[str] = []
+    if cursor and scan_findings:
+        warnings.append("cursor pagination applies to bulk-ingested findings only; in-memory scan findings appear on the first page")
     if callable(bulk_list):
-        if scan_findings:
-            # Bounded merge: pull at most (offset + limit) top bulk rows, merge
-            # with the in-memory scan findings, then slice the requested page.
+        if scan_findings and not cursor:
             window = offset + limit
-            bulk_page, bulk_total = bulk_list(
+            bulk_result = bulk_list(
                 tenant_id,
                 limit=window,
                 offset=0,
@@ -1336,6 +1338,8 @@ async def list_findings(
                 origin="bulk_ingest",
                 include_total=include_bulk_total,
             )
+            bulk_page = bulk_result[0]
+            bulk_total = bulk_result[1]
             combined = scan_findings + bulk_page
             combined.sort(key=lambda row: _finding_sort_key(row, sort_key))
             page_rows = combined[offset : offset + limit]
@@ -1351,28 +1355,31 @@ async def list_findings(
             )
             total = None if resolved_bulk is None else len(scan_findings) + resolved_bulk
         else:
-            page_rows, bulk_total = bulk_list(
+            bulk_result = bulk_list(
                 tenant_id,
                 limit=limit,
-                offset=offset,
+                offset=0 if cursor else offset,
                 sort=sort_key,
                 severity=severity,
                 scan_id=scan_id,
                 origin="bulk_ingest",
                 include_total=include_bulk_total,
+                cursor=cursor,
             )
+            page_rows = bulk_result[0]
+            bulk_total = bulk_result[1]
+            next_cursor = bulk_result[2] if len(bulk_result) > 2 else None
             total, total_approximate = _resolve_bulk_findings_total(
                 tenant_id=tenant_id,
                 severity=severity,
                 scan_id=scan_id,
                 approximate_total=approximate_total,
-                offset=offset,
+                offset=0 if cursor else offset,
                 bulk_total=bulk_total,
                 page_len=len(page_rows),
                 limit=limit,
             )
     else:
-        # Backward-compatible fallback for stores without pagination support.
         bulk_findings = _bulk_ingested_findings_for_tenant(tenant_id)
         if scan_id:
             bulk_findings = [item for item in bulk_findings if str(item.get("scan_id") or "") == scan_id]
@@ -1386,17 +1393,18 @@ async def list_findings(
 
     page = _redact_finding_page(page_rows)
     response: dict[str, Any] = {
-        # emit schema_version so consumers can pin a
-        # contract independent of API path.
         "schema_version": "v1",
         "findings": page,
         "count": len(page),
         "total": total,
         "limit": limit,
-        "offset": offset,
+        "offset": 0 if cursor else offset,
         "sort": sort_key,
         "scan_id": scan_id,
-        "warnings": [],
+        "cursor": cursor or "",
+        "next_cursor": next_cursor or "",
+        "has_more": bool(next_cursor),
+        "warnings": warnings,
     }
     if total_approximate:
         response["total_approximate"] = True

--- a/tests/test_finding_cursor.py
+++ b/tests/test_finding_cursor.py
@@ -1,0 +1,141 @@
+"""Keyset cursor pagination for hub current-state findings (#3511)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import SQLiteComplianceHubStore, set_compliance_hub_store
+from agent_bom.api.finding_cursor import decode_finding_cursor, encode_finding_cursor
+from agent_bom.api.server import app
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+def test_finding_cursor_round_trip() -> None:
+    token = encode_finding_cursor(
+        sort="effective_reach",
+        primary=88.5,
+        last_seen="2026-07-04T00:00:00Z",
+        canonical_id="finding-abc",
+    )
+    primary, last_seen, canonical_id = decode_finding_cursor(token, expected_sort="effective_reach")
+    assert primary == 88.5
+    assert last_seen == "2026-07-04T00:00:00Z"
+    assert canonical_id == "finding-abc"
+
+
+def test_sqlite_list_current_page_keyset_walk() -> None:
+    import tempfile
+
+    tenant = f"keyset-{uuid4().hex}"
+    with tempfile.TemporaryDirectory() as tmp:
+        store = SQLiteComplianceHubStore(f"{tmp}/keyset.db")
+        findings = []
+        for idx in range(1, 8):
+            findings.append(
+                {
+                    "id": f"finding-{idx}",
+                    "title": f"Finding {idx}",
+                    "severity": "high" if idx % 2 else "medium",
+                    "effective_reach_score": float(idx),
+                    "origin": "bulk_ingest",
+                    "source": "test",
+                    "batch_id": "batch-keyset",
+                }
+            )
+        store.add(tenant, findings)
+        store.upsert_current_batch(
+            tenant,
+            findings,
+            observed_at="2026-07-04T00:00:00Z",
+            batch_id="batch-keyset",
+            source="test",
+        )
+
+        page1, total, next_cursor = store.list_current_page(tenant, limit=3, origin="bulk_ingest")
+        assert total == 7
+        assert len(page1) == 3
+        assert next_cursor
+        assert page1[0]["effective_reach_score"] >= page1[1]["effective_reach_score"]
+
+        page2, _, next_cursor2 = store.list_current_page(
+            tenant,
+            limit=3,
+            origin="bulk_ingest",
+            cursor=next_cursor,
+            include_total=False,
+        )
+        assert len(page2) == 3
+        assert {row["id"] for row in page1}.isdisjoint({row["id"] for row in page2})
+
+        page3, _, next_cursor3 = store.list_current_page(
+            tenant,
+            limit=3,
+            origin="bulk_ingest",
+            cursor=next_cursor2,
+            include_total=False,
+        )
+        assert len(page3) == 1
+        assert next_cursor3 is None
+
+
+def test_findings_api_keyset_pagination() -> None:
+    from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore
+
+    tenant = f"api-keyset-{uuid4().hex}"
+    store = InMemoryComplianceHubStore()
+    set_compliance_hub_store(store)
+    findings = [
+        {
+            "id": f"bulk-{idx}",
+            "title": f"Bulk {idx}",
+            "severity": "high",
+            "effective_reach_score": float(idx),
+            "origin": "bulk_ingest",
+            "source": "test",
+            "batch_id": "batch-api",
+        }
+        for idx in range(1, 6)
+    ]
+    store.add(tenant, findings)
+    store.upsert_current_batch(
+        tenant,
+        findings,
+        observed_at="2026-07-04T00:00:00Z",
+        batch_id="batch-api",
+        source="test",
+    )
+
+    client = TestClient(app)
+    headers = proxy_headers(tenant=tenant)
+    first = client.get("/v1/findings?limit=2", headers=headers)
+    assert first.status_code == 200
+    body = first.json()
+    assert body["count"] == 2
+    assert body["has_more"] is True
+    assert body["next_cursor"]
+
+    second = client.get(
+        f"/v1/findings?limit=2&cursor={body['next_cursor']}",
+        headers=headers,
+    )
+    assert second.status_code == 200
+    body2 = second.json()
+    assert body2["count"] == 2
+    assert {row["id"] for row in body["findings"]}.isdisjoint({row["id"] for row in body2["findings"]})
+
+
+def test_findings_api_rejects_cursor_with_offset() -> None:
+    client = TestClient(app)
+    headers = proxy_headers(tenant="default")
+    resp = client.get("/v1/findings?limit=2&offset=1&cursor=abc", headers=headers)
+    assert resp.status_code == 400

--- a/tests/test_finding_lifecycle.py
+++ b/tests/test_finding_lifecycle.py
@@ -226,7 +226,7 @@ def test_list_current_page_enriches_lifecycle_fields(hub_store) -> None:
     finding = _sample_finding()
     hub_store.upsert_current_batch(tenant, [finding], observed_at=MON, batch_id="batch-list")
 
-    rows, total = hub_store.list_current_page(tenant, limit=10, offset=0, origin="bulk_ingest")
+    rows, total, _next = hub_store.list_current_page(tenant, limit=10, offset=0, origin="bulk_ingest")
     assert total == 1
     assert len(rows) == 1
     assert rows[0]["first_seen"] == MON

--- a/tests/test_hub_payload_dedup.py
+++ b/tests/test_hub_payload_dedup.py
@@ -73,7 +73,7 @@ def test_current_state_stores_overlay_and_hydrates_from_ledger(
         ).fetchone()[0]
         assert len(row[0]) < len(ledger_payload)
 
-    listed, total = store.list_current_page(tenant, limit=10)
+    listed, total, _next = store.list_current_page(tenant, limit=10)
     assert total == 1
     assert listed[0]["title"] == finding["title"]
     assert listed[0]["severity"] == finding["severity"]


### PR DESCRIPTION
## Summary
- Add opaque keyset cursors to `list_current_page` for SQLite, Postgres, and in-memory hub stores (effective_reach / cvss / severity / ordinal sorts).
- Expose `cursor`, `next_cursor`, and `has_more` on `GET /v1/findings`; reject `cursor` + non-zero `offset` together.
- Deep pages skip `COUNT(*)` unless the first offset page requests totals.

## Test plan
- [x] `uv run ruff check src/`
- [x] `uv run mypy src/agent_bom/api/finding_cursor.py src/agent_bom/api/compliance_hub_store.py`
- [x] `uv run pytest tests/test_finding_cursor.py tests/test_finding_lifecycle.py tests/test_findings_read_scale.py -q` (19 passed)

Related: #3511