### PR TITLE
feat(api,ui): overview graph drill and estate correlation API

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 242 |
+| `docs/openapi/v1.json` | paths | 243 |
 | `docs/openapi/v1.json` | component schemas | 63 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -9280,6 +9280,108 @@
         ]
       }
     },
+    "/v1/estate/correlations": {
+      "get": {
+        "description": "Return local\u2194cloud agent correlation matches for a completed scan.",
+        "operationId": "get_estate_correlations_v1_estate_correlations_get",
+        "parameters": [
+          {
+            "description": "Scan job ID; latest completed scan if omitted",
+            "in": "query",
+            "name": "scan_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scan job ID; latest completed scan if omitted",
+              "title": "Scan Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Estate Correlations V1 Estate Correlations Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Estate Correlations",
+        "tags": [
+          "estate"
+        ]
+      }
+    },
     "/v1/evaluations": {
       "get": {
         "operationId": "list_evaluation_runs_v1_evaluations_get",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -6094,6 +6094,64 @@ paths:
       summary: Check Entitlement
       tags:
       - enterprise
+  /v1/estate/correlations:
+    get:
+      description: "Return local\u2194cloud agent correlation matches for a completed\
+        \ scan."
+      operationId: get_estate_correlations_v1_estate_correlations_get
+      parameters:
+      - description: Scan job ID; latest completed scan if omitted
+        in: query
+        name: scan_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Scan job ID; latest completed scan if omitted
+          title: Scan Id
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Estate Correlations V1 Estate Correlations Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Estate Correlations
+      tags:
+      - estate
   /v1/evaluations:
     get:
       operationId: list_evaluation_runs_v1_evaluations_get

--- a/src/agent_bom/api/routes/estate.py
+++ b/src/agent_bom/api/routes/estate.py
@@ -1,0 +1,90 @@
+"""Estate correlation read API — cross-environment agent matches from scan evidence.
+
+Surfaces the same ``correlate_cross_environment`` matcher the graph builder uses
+when emitting ``CORRELATES_WITH`` / ``POSSIBLY_CORRELATES_WITH`` edges, without
+requiring a full graph load.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, cast
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from agent_bom.api.models import JobStatus
+from agent_bom.api.stores import _get_store
+from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.cross_env_correlation import CorrelationConfidence, correlate_cross_environment
+from agent_bom.rbac import require_authenticated_permission
+
+router = APIRouter(dependencies=[cast(Any, require_authenticated_permission("read"))])
+
+
+def _tenant_id(request: Request) -> str:
+    return require_request_tenant_id(request)
+
+
+def _latest_done_job(tenant_id: str, *, scan_id: str | None = None) -> Any | None:
+    jobs = _get_store().list_all(tenant_id=tenant_id)
+    if scan_id:
+        for job in jobs:
+            if job.job_id == scan_id and job.status == JobStatus.DONE and job.result:
+                return job
+        return None
+    for job in jobs:
+        if job.status == JobStatus.DONE and job.result:
+            return job
+    return None
+
+
+def _match_payload(match: Any) -> dict[str, Any]:
+    payload = asdict(match)
+    confidence = payload.pop("confidence", None)
+    if isinstance(confidence, CorrelationConfidence):
+        payload["confidence"] = confidence.value
+    elif hasattr(confidence, "value"):
+        payload["confidence"] = confidence.value
+    payload["matched_signals"] = list(payload.get("matched_signals") or ())
+    return payload
+
+
+@router.get("/v1/estate/correlations", tags=["estate"])
+async def get_estate_correlations(
+    request: Request,
+    scan_id: str | None = Query(None, description="Scan job ID; latest completed scan if omitted"),
+) -> dict[str, Any]:
+    """Return local↔cloud agent correlation matches for a completed scan."""
+    tenant_id = _tenant_id(request)
+    job = _latest_done_job(tenant_id, scan_id=scan_id)
+    if job is None:
+        if scan_id:
+            raise HTTPException(status_code=404, detail=f"Completed scan '{scan_id}' not found")
+        return {
+            "schema_version": "estate.correlations.v1",
+            "tenant_id": tenant_id,
+            "scan_id": None,
+            "count": 0,
+            "high_confidence_count": 0,
+            "low_confidence_count": 0,
+            "matches": [],
+        }
+
+    agents = job.result.get("agents") if isinstance(job.result, dict) else None
+    if not isinstance(agents, list):
+        agents = []
+
+    result = correlate_cross_environment(agents)
+    matches = [_match_payload(match) for match in result.matches]
+    high = len(result.by_confidence(CorrelationConfidence.HIGH))
+    low = len(result.by_confidence(CorrelationConfidence.LOW))
+
+    return {
+        "schema_version": "estate.correlations.v1",
+        "tenant_id": tenant_id,
+        "scan_id": job.job_id,
+        "count": len(matches),
+        "high_confidence_count": high,
+        "low_confidence_count": low,
+        "matches": matches,
+    }

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any, cast
+from urllib.parse import urlencode
 
 from fastapi import APIRouter, Request
 
@@ -39,6 +40,35 @@ def _tenant_id(request: Request) -> str:
 
 def _empty_severity() -> dict[str, int]:
     return {key: 0 for key in _SEVERITY_KEYS}
+
+
+def _graph_drill_href(
+    *,
+    rollup: bool = True,
+    severity: str | None = None,
+    relationships: str | None = None,
+    layers: str | None = None,
+) -> str:
+    """Build a /graph deep-link for overview domain tiles."""
+    params: dict[str, str] = {}
+    if rollup:
+        params["rollup"] = "1"
+    if severity:
+        params["severity"] = severity
+    if relationships:
+        params["relationships"] = relationships
+    if layers:
+        params["layers"] = layers
+    query = urlencode(params)
+    return f"/graph?{query}" if query else "/graph"
+
+
+def _cloud_graph_href(severity: dict[str, int]) -> str:
+    if severity["critical"] > 0:
+        return _graph_drill_href(severity="critical")
+    if severity["high"] > 0:
+        return _graph_drill_href(severity="high")
+    return _graph_drill_href()
 
 
 def _severity_from_summary(
@@ -334,6 +364,7 @@ async def get_overview(request: Request) -> dict[str, Any]:
         "cloud": {
             "label": "Cloud / CNAPP",
             "href": "/findings",
+            "graph_href": _cloud_graph_href(scan["severity"]),
             "metric": scan["unique_cves"],
             "metric_label": "open CVEs",
             "status": _status_for(scan["severity"]["critical"], scan["severity"]["high"]),
@@ -347,6 +378,7 @@ async def get_overview(request: Request) -> dict[str, Any]:
         "runtime": {
             "label": "Runtime",
             "href": "/gateway",
+            "graph_href": _graph_drill_href(relationships="runtime"),
             "metric": runtime["active_surfaces"],
             "metric_label": "active surfaces",
             "status": "ok" if runtime["active_surfaces"] > 0 else "idle",
@@ -363,6 +395,7 @@ async def get_overview(request: Request) -> dict[str, Any]:
         "identity": {
             "label": "NHI / Identity",
             "href": "/identity",
+            "graph_href": _graph_drill_href(layers="agent,user,role,policy", relationships="governance"),
             "metric": identity["managed_identities"] + identity["fleet_agents"],
             "metric_label": "identities + agents",
             "status": _identity_status(identity),

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -830,6 +830,7 @@ from agent_bom.api.routes.datasets import router as _datasets_router  # noqa: E4
 from agent_bom.api.routes.discovery import router as _discovery_router  # noqa: E402
 from agent_bom.api.routes.enterprise import router as _enterprise_router  # noqa: E402
 from agent_bom.api.routes.entitlements import router as _entitlements_router  # noqa: E402
+from agent_bom.api.routes.estate import router as _estate_router  # noqa: E402
 from agent_bom.api.routes.evaluations import router as _evaluations_router  # noqa: E402
 from agent_bom.api.routes.fleet import router as _fleet_router  # noqa: E402
 from agent_bom.api.routes.frameworks import router as _frameworks_router  # noqa: E402
@@ -862,6 +863,7 @@ app.include_router(_credentials_router)
 app.include_router(_datasets_router)
 app.include_router(_discovery_router)
 app.include_router(_entitlements_router)
+app.include_router(_estate_router)
 app.include_router(_enterprise_router)
 app.include_router(_fleet_router)
 app.include_router(_evaluations_router)

--- a/tests/test_estate_correlations.py
+++ b/tests/test_estate_correlations.py
@@ -1,0 +1,115 @@
+"""Tests for GET /v1/estate/correlations."""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import JobStatus, _get_store, app
+from agent_bom.api.store import InMemoryJobStore
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+_AUTH_HEADERS = proxy_headers(tenant="default")
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+def _clear_jobs() -> None:
+    from agent_bom.api.server import set_job_store
+
+    set_job_store(InMemoryJobStore())
+
+
+def _add_agents_job(*, job_id: str = "scan-estate", agents: list[dict]) -> None:
+    from agent_bom.api.server import ScanJob, ScanRequest
+
+    job = ScanJob(
+        job_id=job_id,
+        tenant_id="default",
+        created_at="2026-07-04T10:00:00Z",
+        request=ScanRequest(),
+    )
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-07-04T10:05:00Z"
+    job.result = {"agents": agents}
+    _get_store().put(job)
+
+
+def test_estate_correlations_empty_without_scans() -> None:
+    _clear_jobs()
+    client = TestClient(app)
+    resp = client.get("/v1/estate/correlations", headers=_AUTH_HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["schema_version"] == "estate.correlations.v1"
+    assert data["count"] == 0
+    assert data["matches"] == []
+
+
+def test_estate_correlations_returns_bedrock_match() -> None:
+    _clear_jobs()
+    model = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    arn = "arn:aws:bedrock:us-east-1:111122223333:agent/AGENTID01"
+    _add_agents_job(
+        agents=[
+            {
+                "name": "cursor-dev",
+                "agent_type": "cursor",
+                "config_path": "/home/dev/.cursor/mcp.json",
+                "version": "0.42.0",
+                "metadata": {},
+                "mcp_servers": [
+                    {
+                        "name": "bedrock-mcp",
+                        "env": {
+                            "AWS_ACCOUNT_ID": "111122223333",
+                            "AWS_REGION": "us-east-1",
+                            "BEDROCK_MODEL_ID": model,
+                        },
+                    }
+                ],
+            },
+            {
+                "name": "bedrock:prod-agent",
+                "agent_type": "custom",
+                "config_path": arn,
+                "source": "aws-bedrock",
+                "version": model,
+                "metadata": {
+                    "cloud_origin": {
+                        "provider": "aws",
+                        "service": "bedrock",
+                        "resource_type": "agent",
+                        "resource_id": arn,
+                        "resource_name": "prod-agent",
+                        "location": "us-east-1",
+                        "scope": {"account_id": "111122223333"},
+                    }
+                },
+                "mcp_servers": [],
+            },
+        ],
+    )
+    client = TestClient(app)
+    resp = client.get("/v1/estate/correlations", headers=_AUTH_HEADERS)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["scan_id"] == "scan-estate"
+    assert data["count"] >= 1
+    assert data["high_confidence_count"] >= 1
+    match = data["matches"][0]
+    assert match["local_agent_name"] == "cursor-dev"
+    assert match["cloud_provider"] == "aws"
+    assert match["confidence"] == "high"
+
+
+def test_estate_correlations_unknown_scan_is_404() -> None:
+    _clear_jobs()
+    client = TestClient(app)
+    resp = client.get("/v1/estate/correlations?scan_id=missing", headers=_AUTH_HEADERS)
+    assert resp.status_code == 404

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -74,6 +74,8 @@ def test_overview_empty_shape() -> None:
     for domain in data["domains"].values():
         assert {"label", "href", "metric", "metric_label", "status", "detail"} <= set(domain)
         assert domain["href"].startswith("/")
+        if "graph_href" in domain:
+            assert str(domain["graph_href"]).startswith("/graph")
 
 
 def test_overview_aggregates_findings() -> None:

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -701,6 +701,10 @@ function GraphPageInner() {
         )
       : null,
   );
+  const requestedRollupRef = useRef<boolean>(
+    typeof window !== "undefined" &&
+      new URLSearchParams(window.location.search).get("rollup") === "1",
+  );
   const firstScanSelectionRef = useRef(true);
   // Last URL the filter→URL sync effect wrote, used to break an infinite
   // router.replace loop (see the sync effect below for the full rationale).
@@ -952,7 +956,8 @@ function GraphPageInner() {
     0;
 
   const rollupEligible =
-    estateNodeCount >= LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD &&
+    (estateNodeCount >= LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD ||
+      requestedRollupRef.current) &&
     !investigationMode &&
     !selectedAttackPath &&
     !reachabilitySummary &&

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -756,7 +756,7 @@ function ScorecardStrip({
             return (
               <Link
                 key={domain.href}
-                href={domain.href}
+                href={domain.graph_href ?? domain.href}
                 className="flex items-center justify-between gap-2 rounded-xl border border-zinc-800 bg-zinc-950/70 px-3 py-2.5 transition-colors hover:border-zinc-600"
               >
                 <div className="min-w-0">

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2111,6 +2111,7 @@ export type OverviewDomainStatus = "ok" | "warn" | "critical" | "idle";
 export interface OverviewDomain {
   label: string;
   href: string;
+  graph_href?: string | undefined;
   metric: number;
   metric_label: string;
   status: OverviewDomainStatus;


### PR DESCRIPTION
## Summary
- Add optional `graph_href` on `/v1/overview` domain tiles (cloud, runtime, identity) so the home scorecard drills into `/graph` with rollup/severity/layer context.
- Honor `?rollup=1` on the graph page to open estate rollup navigation without waiting for the large-graph threshold.
- Add `GET /v1/estate/correlations` — read-only cross-environment agent matches from completed scans (same matcher as graph `CORRELATES_WITH` edges).
- Regenerate `docs/openapi/v1.{json,yaml}` (fixes Version Alignment CI).

## Related
- #3521 — tracking issue for this Phase 1b slice
- #3192 — graph excellence (drillable / rollup navigation)
- #3510 / #3515 — overview tile wiring (merged)

## Test plan
- [x] `pytest tests/test_estate_correlations.py tests/test_overview.py -q` (8 passed)
- [x] `ruff check` + `mypy src/agent_bom/api/routes/estate.py`
- [x] `python scripts/export_openapi.py --check`
- [x] `cd ui && npm run typecheck`
- [ ] Home domain tiles open graph rollup with severity filter when critical/high findings exist
- [ ] `GET /v1/estate/correlations` returns Bedrock triplet matches on a scan with local + cloud agents