### PR TITLE
fix(cloud,helm): http_client GPU connectors + scoped API NetworkPolicy

### DIFF
--- a/deploy/helm/agent-bom/templates/networkpolicy.yaml
+++ b/deploy/helm/agent-bom/templates/networkpolicy.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.networkPolicy.enabled }}
+{{- $egress := .Values.networkPolicy.egress | default list }}
+{{- $additionalEgress := .Values.networkPolicy.additionalEgress | default list }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -31,6 +33,9 @@ spec:
         - protocol: TCP
           port: 53
     {{- end }}
+    {{- with $egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- if .Values.networkPolicy.allowWeb }}
     - to:
         - ipBlock:
@@ -41,7 +46,7 @@ spec:
           port: {{ . }}
         {{- end }}
     {{- end }}
-    {{- with .Values.networkPolicy.additionalEgress }}
+    {{- with $additionalEgress }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -717,10 +717,14 @@ networkPolicy:
   restrictIngress: true
   ingress: []
   allowDns: true
-  allowWeb: true
+  # Kubernetes NetworkPolicy cannot portably express FQDNs from upstream URLs.
+  # Translate Postgres, ClickHouse, IdP/OIDC, and cloud API endpoints into
+  # ipBlock/pod/namespace selectors via egress/additionalEgress below.
+  allowWeb: false
   webPorts:
     - 80
     - 443
+  egress: []
   additionalEgress: []
 
 pdb:

--- a/src/agent_bom/cloud/lambda_labs.py
+++ b/src/agent_bom/cloud/lambda_labs.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 
+from agent_bom import http_client
 from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
@@ -37,13 +38,13 @@ _GPU_FAMILIES: dict[str, str] = {
 
 
 def _lambda_get(path: str, api_key: str) -> dict | list:
-    try:
-        import requests
-    except ImportError as exc:
-        raise CloudDiscoveryError("requests is required for Lambda Labs discovery. Install with: pip install requests") from exc
-
-    headers = {"Authorization": f"Bearer {api_key}"}
-    resp = requests.get(f"{_API_BASE}{path}", headers=headers, timeout=_API_TIMEOUT)
+    resp = http_client.sync_get(
+        f"{_API_BASE}{path}",
+        timeout=_API_TIMEOUT,
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    if resp is None:
+        raise CloudDiscoveryError("Lambda Labs: request failed after retries")
     if resp.status_code == 401:
         raise CloudDiscoveryError("Lambda Labs: invalid API key (HTTP 401)")
     resp.raise_for_status()
@@ -62,11 +63,6 @@ def discover(
     Returns:
         (agents, warnings) tuple.
     """
-    try:
-        import requests  # noqa: F401
-    except ImportError:
-        return [], ["Lambda Labs discovery requires 'requests'. Install with: pip install requests"]
-
     resolved_key = api_key or os.environ.get("LAMBDA_API_KEY", "")
     if not resolved_key:
         return [], ["LAMBDA_API_KEY not set. Provide --lambda-api-key or set the LAMBDA_API_KEY env var."]

--- a/src/agent_bom/cloud/nebius.py
+++ b/src/agent_bom/cloud/nebius.py
@@ -1,11 +1,8 @@
 """Nebius cloud discovery — GPU cloud AI workloads, AI Studio, compute instances, and InfiniBand training.
 
-Requires ``requests``.  Install with::
-
-    pip install 'agent-bom[nebius]'
-
 Authentication uses Nebius credentials (NEBIUS_API_KEY + NEBIUS_PROJECT_ID env vars).
-Nebius does not have an official Python SDK, so all API calls use REST via requests.
+Nebius does not have an official Python SDK, so all API calls use REST via the shared
+``http_client`` (retry, timeout, SSRF guards).
 """
 
 from __future__ import annotations
@@ -16,6 +13,7 @@ import os
 import shutil
 import subprocess
 
+from agent_bom import http_client
 from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
@@ -32,10 +30,14 @@ _API_TIMEOUT = 15
 
 def _nebius_get(url: str, api_key: str, params: dict | None = None) -> dict:
     """Make an authenticated GET request to a Nebius REST API endpoint."""
-    import requests
-
-    headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
-    resp = requests.get(url, headers=headers, params=params, timeout=_API_TIMEOUT)
+    resp = http_client.sync_get(
+        url,
+        timeout=_API_TIMEOUT,
+        headers={"Authorization": f"Bearer {api_key}", "Accept": "application/json"},
+        params=params,
+    )
+    if resp is None:
+        raise CloudDiscoveryError("Nebius: request failed after retries")
     resp.raise_for_status()
     return resp.json()
 
@@ -52,26 +54,33 @@ def _nebius_get_all(url: str, api_key: str, items_key: str, params: dict | None 
         items_key: Top-level key containing the list (e.g. ``"models"``, ``"instances"``).
         params: Additional query parameters.
     """
-    import requests
-
-    headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
     all_items: list = []
     page_params = dict(params or {})
     _max_pages = 50  # safety cap — prevents infinite loops on malformed responses
 
-    for _ in range(_max_pages):
-        resp = requests.get(url, headers=headers, params=page_params, timeout=_API_TIMEOUT)
-        resp.raise_for_status()
-        data = resp.json()
+    with http_client.create_sync_client(timeout=_API_TIMEOUT) as client:
+        headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+        for _ in range(_max_pages):
+            resp = http_client.sync_request_with_retry(
+                client,
+                "GET",
+                url,
+                headers=headers,
+                params=page_params,
+            )
+            if resp is None:
+                raise CloudDiscoveryError("Nebius: request failed after retries")
+            resp.raise_for_status()
+            data = resp.json()
 
-        # Nebius API uses both "models"/"instances" keys and a generic "data" fallback
-        items = data.get(items_key, data.get("data", []))
-        all_items.extend(items if isinstance(items, list) else [])
+            # Nebius API uses both "models"/"instances" keys and a generic "data" fallback
+            items = data.get(items_key, data.get("data", []))
+            all_items.extend(items if isinstance(items, list) else [])
 
-        next_token = data.get("nextPageToken") or data.get("next_page_token", "")
-        if not next_token:
-            break
-        page_params["pageToken"] = next_token
+            next_token = data.get("nextPageToken") or data.get("next_page_token", "")
+            if not next_token:
+                break
+            page_params["pageToken"] = next_token
 
     return all_items
 
@@ -89,13 +98,8 @@ def discover(
         (agents, warnings) — discovered agents and non-fatal warnings.
 
     Raises:
-        CloudDiscoveryError: if ``requests`` is not installed.
+        CloudDiscoveryError: on unrecoverable API errors.
     """
-    try:
-        import requests  # noqa: F401
-    except ImportError:
-        raise CloudDiscoveryError("requests is required for Nebius discovery. Install with: pip install 'agent-bom[nebius]'")
-
     agents: list[Agent] = []
     warnings: list[str] = []
 

--- a/src/agent_bom/cloud/runpod.py
+++ b/src/agent_bom/cloud/runpod.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import os
 
+from agent_bom import http_client
 from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 
@@ -60,13 +61,16 @@ query {
 
 
 def _graphql(query: str, api_key: str) -> dict:
-    try:
-        import requests
-    except ImportError as exc:
-        raise CloudDiscoveryError("requests is required for RunPod discovery. Install with: pip install requests") from exc
-
-    headers = {"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"}
-    resp = requests.post(_GRAPHQL_URL, json={"query": query}, headers=headers, timeout=_API_TIMEOUT)
+    with http_client.create_sync_client(timeout=_API_TIMEOUT) as client:
+        resp = http_client.sync_request_with_retry(
+            client,
+            "POST",
+            _GRAPHQL_URL,
+            json={"query": query},
+            headers={"Content-Type": "application/json", "Authorization": f"Bearer {api_key}"},
+        )
+    if resp is None:
+        raise CloudDiscoveryError("RunPod: request failed after retries")
     if resp.status_code == 401:
         raise CloudDiscoveryError("RunPod: invalid API key (HTTP 401)")
     resp.raise_for_status()
@@ -88,11 +92,6 @@ def discover(
     Returns:
         (agents, warnings) tuple.
     """
-    try:
-        import requests  # noqa: F401
-    except ImportError:
-        return [], ["RunPod discovery requires 'requests'. Install with: pip install requests"]
-
     resolved_key = api_key or os.environ.get("RUNPOD_API_KEY", "")
     if not resolved_key:
         return [], ["RUNPOD_API_KEY not set. Provide --runpod-api-key or set the RUNPOD_API_KEY env var."]

--- a/src/agent_bom/http_client.py
+++ b/src/agent_bom/http_client.py
@@ -448,10 +448,15 @@ def sync_request_with_retry(
     return None
 
 
-def sync_get(url: str, timeout: float | None = None, headers: dict | None = None) -> httpx.Response | None:
+def sync_get(
+    url: str,
+    timeout: float | None = None,
+    headers: dict | None = None,
+    params: dict | None = None,
+) -> httpx.Response | None:
     """Convenience: single GET request with retry. Manages its own client."""
     with create_sync_client(timeout=timeout) as client:
-        return sync_request_with_retry(client, "GET", url, headers=headers or {})
+        return sync_request_with_retry(client, "GET", url, headers=headers or {}, params=params or {})
 
 
 def fetch_bytes(url: str, *, timeout: float = 30, headers: dict | None = None) -> bytes:

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -1243,21 +1243,6 @@ def test_aws_eks_reuses_k8s():
 # ─── Nebius Provider Tests ──────────────────────────────────────────────────
 
 
-def test_nebius_missing_requests():
-    """Helpful error when requests is not installed."""
-    with patch.dict(sys.modules, {"requests": None}):
-        import agent_bom.cloud.nebius as nb_mod
-
-        try:
-            importlib.reload(nb_mod)
-        except Exception:
-            pass
-        with pytest.raises(CloudDiscoveryError, match="requests is required"):
-            from agent_bom.cloud.nebius import discover
-
-            discover()
-
-
 def test_nebius_ai_studio_discovery():
     """Nebius AI Studio models are discovered as agents."""
     from agent_bom.cloud.nebius import discover
@@ -1272,7 +1257,7 @@ def test_nebius_ai_studio_discovery():
     }
     mock_response.raise_for_status = MagicMock()
 
-    with patch("requests.get", return_value=mock_response):
+    with patch("agent_bom.http_client.sync_request_with_retry", return_value=mock_response):
         agents, warnings = discover(api_key="fake-key", project_id="proj-123")
 
     ai_agents = [a for a in agents if a.source == "nebius-ai-studio"]
@@ -1291,9 +1276,10 @@ def test_nebius_gpu_instance_discovery():
     mock_response = MagicMock()
     mock_response.raise_for_status = MagicMock()
 
-    def side_effect(url, **kwargs):
+    def side_effect(client, method, url, **kwargs):
         resp = MagicMock()
         resp.raise_for_status = MagicMock()
+        resp.status_code = 200
         if "compute.api" in url:
             resp.json.return_value = {
                 "instances": [
@@ -1319,7 +1305,7 @@ def test_nebius_gpu_instance_discovery():
             resp.json.return_value = {}
         return resp
 
-    with patch("requests.get", side_effect=side_effect):
+    with patch("agent_bom.http_client.sync_request_with_retry", side_effect=side_effect):
         agents, warnings = discover(api_key="fake-key", project_id="proj-123")
 
     gpu_agents = [a for a in agents if a.source == "nebius-gpu"]

--- a/tests/test_cloud_nebius.py
+++ b/tests/test_cloud_nebius.py
@@ -28,7 +28,7 @@ def test_nebius_get_success():
     mock_resp.json.return_value = {"data": [1, 2, 3]}
     mock_resp.status_code = 200
 
-    with patch("requests.get", return_value=mock_resp):
+    with patch("agent_bom.http_client.sync_get", return_value=mock_resp):
         result = _nebius_get("https://api.example.com/v1/test", "api-key-123")
         assert result == {"data": [1, 2, 3]}
 
@@ -36,21 +36,6 @@ def test_nebius_get_success():
 # ---------------------------------------------------------------------------
 # discover (top level)
 # ---------------------------------------------------------------------------
-
-
-def test_discover_no_requests():
-    import builtins
-
-    original = builtins.__import__
-
-    def mock_import(name, *args, **kwargs):
-        if name == "requests":
-            raise ImportError("mocked")
-        return original(name, *args, **kwargs)
-
-    with patch("builtins.__import__", side_effect=mock_import):
-        with pytest.raises(CloudDiscoveryError, match="requests"):
-            discover()
 
 
 def test_discover_no_api_key():
@@ -115,15 +100,16 @@ def test_ai_studio_success():
     mock_resp = MagicMock()
     mock_resp.json.return_value = {"models": [{"id": "m1", "name": "llama-70b", "version": "1.0", "status": "ACTIVE"}]}
     mock_resp.status_code = 200
+    mock_resp.raise_for_status = MagicMock()
 
-    with patch("requests.get", return_value=mock_resp):
+    with patch("agent_bom.http_client.sync_request_with_retry", return_value=mock_resp):
         agents, warnings = _discover_ai_studio("key", "proj")
         assert len(agents) == 1
         assert "llama-70b" in agents[0].name
 
 
 def test_ai_studio_error():
-    with patch("requests.get", side_effect=RuntimeError("network error")):
+    with patch("agent_bom.http_client.sync_request_with_retry", side_effect=RuntimeError("network error")):
         agents, warnings = _discover_ai_studio("key", "proj")
         assert len(agents) == 0
         assert len(warnings) == 1
@@ -149,8 +135,9 @@ def test_gpu_instances_found():
         ]
     }
     mock_resp.status_code = 200
+    mock_resp.raise_for_status = MagicMock()
 
-    with patch("requests.get", return_value=mock_resp):
+    with patch("agent_bom.http_client.sync_request_with_retry", return_value=mock_resp):
         agents, warnings = _discover_gpu_instances("key", "proj")
         assert len(agents) == 1
         assert "gpu-node-1" in agents[0].name
@@ -172,8 +159,9 @@ def test_gpu_instances_non_gpu_filtered():
         ]
     }
     mock_resp.status_code = 200
+    mock_resp.raise_for_status = MagicMock()
 
-    with patch("requests.get", return_value=mock_resp):
+    with patch("agent_bom.http_client.sync_request_with_retry", return_value=mock_resp):
         agents, warnings = _discover_gpu_instances("key", "proj")
         assert len(agents) == 0
 
@@ -251,8 +239,9 @@ def test_container_services_with_image():
     mock_resp = MagicMock()
     mock_resp.json.return_value = {"containers": [{"id": "c1", "name": "web-svc", "image": "nginx:latest"}]}
     mock_resp.status_code = 200
+    mock_resp.raise_for_status = MagicMock()
 
-    with patch("requests.get", return_value=mock_resp):
+    with patch("agent_bom.http_client.sync_request_with_retry", return_value=mock_resp):
         agents, warnings = _discover_container_services("key", "proj")
         assert len(agents) == 1
 
@@ -261,14 +250,15 @@ def test_container_services_no_image():
     mock_resp = MagicMock()
     mock_resp.json.return_value = {"containers": [{"id": "c1", "name": "svc-no-img", "image": ""}]}
     mock_resp.status_code = 200
+    mock_resp.raise_for_status = MagicMock()
 
-    with patch("requests.get", return_value=mock_resp):
+    with patch("agent_bom.http_client.sync_request_with_retry", return_value=mock_resp):
         agents, warnings = _discover_container_services("key", "proj")
         assert len(agents) == 1  # Still created, just with UNKNOWN transport
 
 
 def test_container_services_error():
-    with patch("requests.get", side_effect=RuntimeError("fail")):
+    with patch("agent_bom.http_client.sync_request_with_retry", side_effect=RuntimeError("fail")):
         agents, warnings = _discover_container_services("key", "proj")
         assert len(agents) == 0
         assert len(warnings) == 1

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -557,8 +557,9 @@ def test_helm_network_policy_defaults_are_explicit():
     assert policy["enabled"] is True
     assert policy["restrictIngress"] is True
     assert policy["allowDns"] is True
-    assert policy["allowWeb"] is True
+    assert policy["allowWeb"] is False
     assert policy["webPorts"] == [80, 443]
+    assert policy["egress"] == []
     assert policy["additionalEgress"] == []
 
 

--- a/tests/test_iac_helm.py
+++ b/tests/test_iac_helm.py
@@ -859,6 +859,7 @@ class TestAgentBomHelmChartDefaults:
         assert "kind: NetworkPolicy" in network_policy
         assert ".Values.networkPolicy.enabled" in network_policy
         assert ".Values.networkPolicy.allowDns" in network_policy
+        assert ".Values.networkPolicy.egress" in network_policy
         assert ".Values.networkPolicy.allowWeb" in network_policy
         assert ".Values.networkPolicy.additionalEgress" in network_policy
         assert "cidr: 0.0.0.0/0" in network_policy


### PR DESCRIPTION
## Summary
- Route Nebius, Lambda Labs, and RunPod discovery through shared `http_client` (retry, timeout, SSRF guards) instead of raw `requests`.
- Tighten API-tier Helm NetworkPolicy: default `allowWeb: false`, add structured `egress` list (gateway-style); operators declare Postgres/ClickHouse/IdP/cloud endpoints via `egress` / `additionalEgress`.

Related: #3493 #3494

## Verification
- `.venv/bin/ruff check src/agent_bom/cloud/nebius.py src/agent_bom/cloud/lambda_labs.py src/agent_bom/cloud/runpod.py src/agent_bom/http_client.py`
- `.venv/bin/mypy src/agent_bom/cloud/nebius.py src/agent_bom/cloud/lambda_labs.py src/agent_bom/cloud/runpod.py src/agent_bom/http_client.py`
- `.venv/bin/pytest tests/test_cloud_nebius.py tests/test_cloud.py::test_nebius_ai_studio_discovery tests/test_cloud.py::test_nebius_gpu_instance_discovery tests/test_deploy_manifests.py::test_helm_network_policy_defaults_are_explicit -q`
- `helm template agent-bom deploy/helm/agent-bom --set networkPolicy.enabled=true`


Made with [Cursor](https://cursor.com)