### PR TITLE
feat(scanners): runtime-enforce driver run() and failure_mode

### DIFF
--- a/src/agent_bom/orchestration.py
+++ b/src/agent_bom/orchestration.py
@@ -6,8 +6,9 @@ stage pulled from the scanner, enricher, and matcher registries.
 
 This is a READ MODEL only. It does NOT execute anything and does NOT replace the
 existing execution path (`ScanPipeline` / `_run_scan_sync` in
-``agent_bom.api.pipeline``), which remains the de-facto orchestrator. A later PR
-in this series will execute against this model; importing it changes no behavior.
+``agent_bom.api.pipeline``), which remains the de-facto orchestrator. Scanner
+driver execution for registry-backed ``run_attr`` dispatch lives in
+``agent_bom.scanners.executor`` and honors each driver's ``failure_mode``.
 
 The ``graph`` and ``findings`` stages exist in the real pipeline but have no
 component registry yet, so they are surfaced as ordered, non-registry-backed

--- a/src/agent_bom/scanners/executor.py
+++ b/src/agent_bom/scanners/executor.py
@@ -1,0 +1,216 @@
+"""Runtime dispatch for registered scanner drivers.
+
+Registry metadata declares ``run_attr`` and ``failure_mode`` for each driver.
+This module resolves the callable on the declared module and executes it while
+honoring the configured failure semantics.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from agent_bom.scanners.base import (
+    ScannerExecutionState,
+    ScannerFailureMode,
+    ScannerRegistration,
+    ScannerRunTelemetry,
+)
+from agent_bom.scanners.registry import get_scanner_registration
+from agent_bom.security import sanitize_error
+
+_logger = logging.getLogger(__name__)
+
+
+class ScannerDriverError(RuntimeError):
+    """Raised when a driver with ``fail_closed`` failure mode errors."""
+
+    def __init__(self, scanner: str, message: str) -> None:
+        self.scanner = scanner
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class ScannerDriverRunResult:
+    """Outcome of one scanner-driver execution attempt."""
+
+    registration: ScannerRegistration
+    telemetry: ScannerRunTelemetry
+    payload: dict[str, Any] | None = None
+
+
+def _resolve_runner(registration: ScannerRegistration) -> Callable[..., Any]:
+    module = importlib.import_module(registration.module)
+    run_attr = registration.run_attr or "run"
+    runner = getattr(module, run_attr, None)
+    if runner is None or not callable(runner):
+        raise AttributeError(f"{registration.module} has no callable {run_attr}")
+    return runner
+
+
+def _telemetry(
+    registration: ScannerRegistration,
+    *,
+    status: str,
+    duration_ms: float,
+    warnings: list[str] | None = None,
+    findings_emitted: int = 0,
+) -> ScannerRunTelemetry:
+    return ScannerRunTelemetry(
+        scanner=registration.name,
+        status=status,
+        duration_ms=duration_ms,
+        warnings=list(warnings or []),
+        findings_emitted=findings_emitted,
+    )
+
+
+def _coerce_payload(raw: Any) -> dict[str, Any] | None:
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        return raw
+    return {"result": raw}
+
+
+def _count_findings(payload: dict[str, Any] | None) -> int:
+    if not payload:
+        return 0
+    for key in ("findings", "findings_emitted", "finding_count"):
+        value = payload.get(key)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, list):
+            return len(value)
+    return 0
+
+
+def run_scanner_driver(
+    name: str,
+    *,
+    allow_planned: bool = False,
+    **kwargs: Any,
+) -> ScannerDriverRunResult:
+    """Execute one registered scanner driver and honor its failure semantics."""
+
+    registration = get_scanner_registration(name)
+    if registration.execution_state is ScannerExecutionState.PLANNED and not allow_planned:
+        return _handle_unavailable(
+            registration,
+            reason=f"scanner driver {registration.name} is planned but not executable",
+            duration_ms=0.0,
+        )
+
+    started = time.perf_counter()
+    try:
+        runner = _resolve_runner(registration)
+    except Exception as exc:  # noqa: BLE001
+        return _handle_unavailable(
+            registration,
+            reason=sanitize_error(exc),
+            duration_ms=(time.perf_counter() - started) * 1000.0,
+            exc=exc,
+        )
+
+    try:
+        payload = _coerce_payload(runner(**kwargs))
+    except Exception as exc:  # noqa: BLE001
+        return _handle_failure(
+            registration,
+            reason=sanitize_error(exc),
+            duration_ms=(time.perf_counter() - started) * 1000.0,
+            exc=exc,
+        )
+
+    duration_ms = (time.perf_counter() - started) * 1000.0
+    findings = _count_findings(payload)
+    return ScannerDriverRunResult(
+        registration=registration,
+        telemetry=_telemetry(
+            registration,
+            status="ok",
+            duration_ms=duration_ms,
+            findings_emitted=findings,
+        ),
+        payload=payload,
+    )
+
+
+def _handle_unavailable(
+    registration: ScannerRegistration,
+    *,
+    reason: str,
+    duration_ms: float,
+    exc: Exception | None = None,
+) -> ScannerDriverRunResult:
+    mode = registration.failure_mode
+    if mode is ScannerFailureMode.FAIL_CLOSED:
+        message = f"Scanner driver {registration.name} unavailable: {reason}"
+        _logger.error(message)
+        raise ScannerDriverError(registration.name, message) from exc
+    if mode is ScannerFailureMode.SKIP_WHEN_UNAVAILABLE:
+        _logger.info("Skipping unavailable scanner driver %s: %s", registration.name, reason)
+        return ScannerDriverRunResult(
+            registration=registration,
+            telemetry=_telemetry(
+                registration,
+                status="skipped",
+                duration_ms=duration_ms,
+                warnings=[reason],
+            ),
+        )
+    _logger.warning("Scanner driver %s unavailable; continuing: %s", registration.name, reason)
+    return ScannerDriverRunResult(
+        registration=registration,
+        telemetry=_telemetry(
+            registration,
+            status="warning",
+            duration_ms=duration_ms,
+            warnings=[reason],
+        ),
+    )
+
+
+def _handle_failure(
+    registration: ScannerRegistration,
+    *,
+    reason: str,
+    duration_ms: float,
+    exc: Exception | None = None,
+) -> ScannerDriverRunResult:
+    mode = registration.failure_mode
+    if mode is ScannerFailureMode.FAIL_CLOSED:
+        message = f"Scanner driver {registration.name} failed: {reason}"
+        _logger.error(message)
+        raise ScannerDriverError(registration.name, message) from exc
+    if mode is ScannerFailureMode.SKIP_WHEN_UNAVAILABLE:
+        _logger.info("Skipping failed scanner driver %s: %s", registration.name, reason)
+        return ScannerDriverRunResult(
+            registration=registration,
+            telemetry=_telemetry(
+                registration,
+                status="skipped",
+                duration_ms=duration_ms,
+                warnings=[reason],
+            ),
+        )
+    _logger.warning("Scanner driver %s failed; continuing: %s", registration.name, reason)
+    return ScannerDriverRunResult(
+        registration=registration,
+        telemetry=_telemetry(
+            registration,
+            status="warning",
+            duration_ms=duration_ms,
+            warnings=[reason],
+        ),
+    )
+
+
+__all__ = [
+    "ScannerDriverError",
+    "ScannerDriverRunResult",
+    "run_scanner_driver",
+]

--- a/tests/test_scanner_driver_executor.py
+++ b/tests/test_scanner_driver_executor.py
@@ -1,0 +1,135 @@
+"""Tests for scanner driver runtime dispatch."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from agent_bom.extensions import ExtensionCapabilities
+from agent_bom.scanners.base import ScannerExecutionState, ScannerFailureMode, ScannerPhase, ScannerRegistration
+from agent_bom.scanners.executor import ScannerDriverError, run_scanner_driver
+
+
+@pytest.fixture(autouse=True)
+def reset_scanner_registry(monkeypatch):
+    import agent_bom.scanners.registry as scanner_registry
+    from agent_bom.extensions import ENTRYPOINTS_ENABLED_ENV
+
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    scanner_registry._reset_scanner_registry_for_tests()
+    yield
+    scanner_registry._reset_scanner_registry_for_tests()
+    scanner_registry.list_registered_scanners()
+
+
+def _register_test_driver(
+    *,
+    name: str = "test-driver",
+    module: str = "agent_bom.tests.fake_executor_driver",
+    run_attr: str = "run",
+    failure_mode: ScannerFailureMode = ScannerFailureMode.WARN_AND_CONTINUE,
+    execution_state: ScannerExecutionState = ScannerExecutionState.ACTIVE,
+) -> None:
+    from agent_bom.scanners.registry import register_scanner
+
+    register_scanner(
+        ScannerRegistration(
+            name=name,
+            module=module,
+            source="test",
+            phase=ScannerPhase.SCANNING,
+            execution_state=execution_state,
+            failure_mode=failure_mode,
+            run_attr=run_attr,
+            input_types=("filesystem_path",),
+            output_types=("findings",),
+            finding_types=("test",),
+            capabilities=ExtensionCapabilities(scan_modes=("local",)),
+            summary="test driver",
+        )
+    )
+
+
+def test_run_scanner_driver_invokes_declared_run_attr(monkeypatch):
+    module_name = "agent_bom.tests.fake_executor_driver"
+    calls: list[dict] = []
+
+    fake_module = types.ModuleType(module_name)
+    fake_module.run = lambda **kwargs: calls.append(kwargs) or {"findings": [{"id": "f-1"}]}
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+    _register_test_driver()
+
+    result = run_scanner_driver("test-driver", path="/tmp/demo")
+
+    assert calls == [{"path": "/tmp/demo"}]
+    assert result.telemetry.status == "ok"
+    assert result.telemetry.findings_emitted == 1
+    assert result.payload == {"findings": [{"id": "f-1"}]}
+
+
+def test_fail_closed_surfaces_as_scan_failure(monkeypatch):
+    module_name = "agent_bom.tests.fake_executor_driver_fail"
+    fake_module = types.ModuleType(module_name)
+
+    def _boom(**_kwargs):
+        raise RuntimeError("scanner exploded")
+
+    fake_module.scan = _boom
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+    _register_test_driver(
+        module=module_name,
+        run_attr="scan",
+        failure_mode=ScannerFailureMode.FAIL_CLOSED,
+    )
+
+    with pytest.raises(ScannerDriverError, match="test-driver failed"):
+        run_scanner_driver("test-driver")
+
+
+def test_warn_and_continue_returns_warning_instead_of_raising(monkeypatch):
+    module_name = "agent_bom.tests.fake_executor_driver_warn"
+    fake_module = types.ModuleType(module_name)
+    fake_module.run = lambda **_kwargs: (_ for _ in ()).throw(ValueError("soft failure"))
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+    _register_test_driver(module=module_name, failure_mode=ScannerFailureMode.WARN_AND_CONTINUE)
+
+    result = run_scanner_driver("test-driver")
+
+    assert result.telemetry.status == "warning"
+    assert result.telemetry.warnings
+    assert result.payload is None
+
+
+def test_skip_when_unavailable_skips_missing_runner(monkeypatch):
+    module_name = "agent_bom.tests.fake_executor_driver_missing"
+    fake_module = types.ModuleType(module_name)
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+    _register_test_driver(
+        module=module_name,
+        run_attr="missing_callable",
+        failure_mode=ScannerFailureMode.SKIP_WHEN_UNAVAILABLE,
+    )
+
+    result = run_scanner_driver("test-driver")
+
+    assert result.telemetry.status == "skipped"
+    assert "missing_callable" in result.telemetry.warnings[0]
+
+
+def test_planned_driver_is_not_executable_by_default(monkeypatch):
+    module_name = "agent_bom.tests.fake_executor_driver_planned"
+    fake_module = types.ModuleType(module_name)
+    fake_module.run = lambda **_kwargs: {"findings": []}
+    monkeypatch.setitem(sys.modules, module_name, fake_module)
+    _register_test_driver(
+        module=module_name,
+        execution_state=ScannerExecutionState.PLANNED,
+        failure_mode=ScannerFailureMode.SKIP_WHEN_UNAVAILABLE,
+    )
+
+    result = run_scanner_driver("test-driver")
+
+    assert result.telemetry.status == "skipped"
+    assert "planned" in result.telemetry.warnings[0].lower()


### PR DESCRIPTION
## Summary
- Add `agent_bom.scanners.executor.run_scanner_driver()` to resolve each registration's `run_attr` callable and execute it with telemetry.
- Honor `failure_mode`: `fail_closed` raises `ScannerDriverError`, `warn_and_continue` returns warning telemetry, `skip_when_unavailable` skips missing/planned drivers without aborting the scan.
- Planned drivers remain non-executable unless explicitly opted in.

Related: #3488

## Verification
- `.venv/bin/ruff check src/agent_bom/scanners/executor.py tests/test_scanner_driver_executor.py`
- `.venv/bin/mypy src/agent_bom/scanners/executor.py`
- `.venv/bin/pytest tests/test_scanner_driver_executor.py tests/test_orchestration.py tests/test_scanner_driver_registry.py -q`


Made with [Cursor](https://cursor.com)