### PR TITLE
feat(api): async findings report export jobs

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,8 +53,8 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 243 |
-| `docs/openapi/v1.json` | component schemas | 63 |
+| `docs/openapi/v1.json` | paths | 246 |
+| `docs/openapi/v1.json` | component schemas | 65 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -2491,6 +2491,49 @@
         "title": "PushPayload",
         "type": "object"
       },
+      "ReportFormat": {
+        "description": "Supported async report artifact formats.",
+        "enum": [
+          "ndjson"
+        ],
+        "title": "ReportFormat",
+        "type": "string"
+      },
+      "ReportJobRequest": {
+        "additionalProperties": false,
+        "description": "Request body for ``POST /v1/reports``.",
+        "properties": {
+          "format": {
+            "$ref": "#/components/schemas/ReportFormat",
+            "default": "ndjson"
+          },
+          "severity": {
+            "anyOf": [
+              {
+                "maxLength": 32,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Severity"
+          },
+          "sort": {
+            "default": "effective_reach",
+            "enum": [
+              "effective_reach",
+              "cvss",
+              "severity",
+              "ordinal"
+            ],
+            "title": "Sort",
+            "type": "string"
+          }
+        },
+        "title": "ReportJobRequest",
+        "type": "object"
+      },
       "RotateKeyRequest": {
         "additionalProperties": false,
         "properties": {
@@ -18496,6 +18539,147 @@
         "summary": "Get Registry Server",
         "tags": [
           "registry"
+        ]
+      }
+    },
+    "/v1/reports": {
+      "post": {
+        "description": "Enqueue an async findings export (gzipped NDJSON) instead of a synchronous body.",
+        "operationId": "create_report_job_v1_reports_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReportJobRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Create Report Job V1 Reports Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Report Job",
+        "tags": [
+          "reports"
+        ]
+      }
+    },
+    "/v1/reports/{job_id}": {
+      "get": {
+        "description": "Return async report job status and download URL when complete.",
+        "operationId": "get_report_job_v1_reports__job_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Report Job V1 Reports  Job Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Report Job",
+        "tags": [
+          "reports"
+        ]
+      }
+    },
+    "/v1/reports/{job_id}/download": {
+      "get": {
+        "description": "Download a completed report artifact using the job-scoped token.",
+        "operationId": "download_report_artifact_v1_reports__job_id__download_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "token",
+            "required": true,
+            "schema": {
+              "maxLength": 256,
+              "minLength": 8,
+              "title": "Token",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Download Report Artifact",
+        "tags": [
+          "reports"
         ]
       }
     },

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -1676,6 +1676,36 @@ components:
           type: array
       title: PushPayload
       type: object
+    ReportFormat:
+      description: Supported async report artifact formats.
+      enum:
+      - ndjson
+      title: ReportFormat
+      type: string
+    ReportJobRequest:
+      additionalProperties: false
+      description: Request body for ``POST /v1/reports``.
+      properties:
+        format:
+          $ref: '#/components/schemas/ReportFormat'
+          default: ndjson
+        severity:
+          anyOf:
+          - maxLength: 32
+            type: string
+          - type: 'null'
+          title: Severity
+        sort:
+          default: effective_reach
+          enum:
+          - effective_reach
+          - cvss
+          - severity
+          - ordinal
+          title: Sort
+          type: string
+      title: ReportJobRequest
+      type: object
     RotateKeyRequest:
       additionalProperties: false
       properties:
@@ -12015,6 +12045,98 @@ paths:
       summary: Get Registry Server
       tags:
       - registry
+  /v1/reports:
+    post:
+      description: Enqueue an async findings export (gzipped NDJSON) instead of a
+        synchronous body.
+      operationId: create_report_job_v1_reports_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReportJobRequest'
+        required: true
+      responses:
+        '202':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Create Report Job V1 Reports Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Create Report Job
+      tags:
+      - reports
+  /v1/reports/{job_id}:
+    get:
+      description: Return async report job status and download URL when complete.
+      operationId: get_report_job_v1_reports__job_id__get
+      parameters:
+      - in: path
+        name: job_id
+        required: true
+        schema:
+          title: Job Id
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Report Job V1 Reports  Job Id  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Report Job
+      tags:
+      - reports
+  /v1/reports/{job_id}/download:
+    get:
+      description: Download a completed report artifact using the job-scoped token.
+      operationId: download_report_artifact_v1_reports__job_id__download_get
+      parameters:
+      - in: path
+        name: job_id
+        required: true
+        schema:
+          title: Job Id
+          type: string
+      - in: query
+        name: token
+        required: true
+        schema:
+          maxLength: 256
+          minLength: 8
+          title: Token
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema: {}
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Download Report Artifact
+      tags:
+      - reports
   /v1/results/push:
     post:
       description: 'Receive pushed scan results from a CLI instance.

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -208,6 +208,11 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_RATE_LIMIT_KEY_MAX_AGE_DAYS` | `int` | `90` | — |
 | `AGENT_BOM_RATE_LIMIT_KEY_ROTATION_DAYS` | `int` | `30` | Operators rotate AGENT_BOM_RATE_LIMIT_KEY periodically and record the rotation timestamp in AGENT_BOM_RATE_LIMIT_KEY_LAST_ROTATED (ISO-8601 with timezone). The control plane warns when the configured key age approaches the rotation interval |
 
+## Report export artifacts
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_REPORT_ARTIFACT_DIR` | `str` | `''` | Async findings report exports are written to a local artifact directory and downloaded through job-scoped tokens. Empty string means use the per-user default ~/.agent-bom/report-artifacts. The worker re-reads the env var at runtime so tests |
+
 ## Runtime → graph incident feedback
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/docs/schemas/v1/ReportJob.json
+++ b/docs/schemas/v1/ReportJob.json
@@ -1,0 +1,142 @@
+{
+  "$defs": {
+    "JobStatus": {
+      "enum": [
+        "pending",
+        "running",
+        "done",
+        "failed",
+        "cancelled"
+      ],
+      "title": "JobStatus",
+      "type": "string"
+    },
+    "ReportFormat": {
+      "description": "Supported async report artifact formats.",
+      "enum": [
+        "ndjson"
+      ],
+      "title": "ReportFormat",
+      "type": "string"
+    }
+  },
+  "description": "Async findings export job backed by streamed hub reads.",
+  "properties": {
+    "byte_count": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Byte Count"
+    },
+    "completed_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Completed At"
+    },
+    "created_at": {
+      "title": "Created At",
+      "type": "string"
+    },
+    "download_token": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Download Token"
+    },
+    "error": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Error"
+    },
+    "format": {
+      "$ref": "#/$defs/ReportFormat",
+      "default": "ndjson"
+    },
+    "job_id": {
+      "title": "Job Id",
+      "type": "string"
+    },
+    "row_count": {
+      "anyOf": [
+        {
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Row Count"
+    },
+    "severity": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Severity"
+    },
+    "sort": {
+      "default": "effective_reach",
+      "title": "Sort",
+      "type": "string"
+    },
+    "started_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Started At"
+    },
+    "status": {
+      "$ref": "#/$defs/JobStatus",
+      "default": "pending"
+    },
+    "tenant_id": {
+      "default": "default",
+      "title": "Tenant Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "job_id",
+    "created_at"
+  ],
+  "title": "ReportJob",
+  "type": "object"
+}

--- a/docs/schemas/v1/ReportJobRequest.json
+++ b/docs/schemas/v1/ReportJobRequest.json
@@ -1,0 +1,46 @@
+{
+  "$defs": {
+    "ReportFormat": {
+      "description": "Supported async report artifact formats.",
+      "enum": [
+        "ndjson"
+      ],
+      "title": "ReportFormat",
+      "type": "string"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Request body for ``POST /v1/reports``.",
+  "properties": {
+    "format": {
+      "$ref": "#/$defs/ReportFormat",
+      "default": "ndjson"
+    },
+    "severity": {
+      "anyOf": [
+        {
+          "maxLength": 32,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Severity"
+    },
+    "sort": {
+      "default": "effective_reach",
+      "enum": [
+        "effective_reach",
+        "cvss",
+        "severity",
+        "ordinal"
+      ],
+      "title": "Sort",
+      "type": "string"
+    }
+  },
+  "title": "ReportJobRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/index.json
+++ b/docs/schemas/v1/index.json
@@ -162,6 +162,16 @@
       "schema": "PushPayload.json"
     },
     {
+      "doc": "Async findings export job backed by streamed hub reads.",
+      "name": "ReportJob",
+      "schema": "ReportJob.json"
+    },
+    {
+      "doc": "Request body for ``POST /v1/reports``.",
+      "name": "ReportJobRequest",
+      "schema": "ReportJobRequest.json"
+    },
+    {
       "doc": "",
       "name": "RotateKeyRequest",
       "schema": "RotateKeyRequest.json"

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -833,6 +833,8 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("POST", "/v1/exceptions", "analyst"),
         ("POST", "/v1/findings/jira", "analyst"),
         ("POST", "/v1/findings/bulk", "analyst"),
+        ("POST", "/v1/reports", "analyst"),
+        ("GET", "/v1/reports/", "analyst"),
         ("POST", "/v1/findings/false-positive", "analyst"),
         ("POST", "/v1/findings/feedback", "analyst"),
         ("DELETE", "/v1/findings/false-positive/", "analyst"),

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -212,6 +212,42 @@ class ScanJob(BaseModel):
         return sanitized if isinstance(sanitized, list) else []
 
 
+class ReportFormat(str, Enum):
+    """Supported async report artifact formats."""
+
+    NDJSON = "ndjson"
+
+
+class ReportJobRequest(BaseModel):
+    """Request body for ``POST /v1/reports``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    format: ReportFormat = ReportFormat.NDJSON
+    sort: Literal["effective_reach", "cvss", "severity", "ordinal"] = "effective_reach"
+    severity: str | None = Field(default=None, max_length=32)
+
+
+class ReportJob(BaseModel):
+    """Async findings export job backed by streamed hub reads."""
+
+    job_id: str
+    tenant_id: str = "default"
+    status: JobStatus = JobStatus.PENDING
+    format: ReportFormat = ReportFormat.NDJSON
+    sort: str = "effective_reach"
+    severity: str | None = None
+    created_at: str
+    started_at: str | None = None
+    completed_at: str | None = None
+    row_count: int | None = None
+    byte_count: int | None = None
+    download_token: str | None = None
+    error: str | None = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
 # ─── Meta Models ───────────────────────────────────────────────────────────
 
 

--- a/src/agent_bom/api/report_job_store.py
+++ b/src/agent_bom/api/report_job_store.py
@@ -1,0 +1,63 @@
+"""In-memory persistence for async report export jobs."""
+
+from __future__ import annotations
+
+import threading
+from typing import Protocol
+
+from agent_bom.api.models import ReportJob
+
+
+class ReportJobStore(Protocol):
+    def put(self, job: ReportJob) -> None: ...
+    def get(self, job_id: str, tenant_id: str) -> ReportJob | None: ...
+    def update(self, job: ReportJob) -> None: ...
+
+
+class InMemoryReportJobStore:
+    """Thread-safe report job store for single-replica pilots."""
+
+    def __init__(self) -> None:
+        self._jobs: dict[str, ReportJob] = {}
+        self._lock = threading.Lock()
+
+    def put(self, job: ReportJob) -> None:
+        with self._lock:
+            self._jobs[job.job_id] = job
+
+    def get(self, job_id: str, tenant_id: str) -> ReportJob | None:
+        with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None or job.tenant_id != tenant_id:
+                return None
+            return job.model_copy(deep=True)
+
+    def update(self, job: ReportJob) -> None:
+        self.put(job)
+
+    def list_for_tenant(self, tenant_id: str) -> list[ReportJob]:
+        with self._lock:
+            return [job.model_copy(deep=True) for job in self._jobs.values() if job.tenant_id == tenant_id]
+
+
+_store: InMemoryReportJobStore | None = None
+_store_lock = threading.Lock()
+
+
+def get_report_job_store() -> InMemoryReportJobStore:
+    global _store
+    if _store is None:
+        with _store_lock:
+            if _store is None:
+                _store = InMemoryReportJobStore()
+    return _store
+
+
+def set_report_job_store(store: InMemoryReportJobStore) -> None:
+    global _store
+    _store = store
+
+
+def reset_report_job_store() -> None:
+    global _store
+    _store = None

--- a/src/agent_bom/api/report_worker.py
+++ b/src/agent_bom/api/report_worker.py
@@ -1,0 +1,138 @@
+"""Background worker for async findings report exports."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+import os
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+
+from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+from agent_bom.api.models import JobStatus, ReportJob
+from agent_bom.api.pipeline import get_executor
+from agent_bom.api.report_job_store import get_report_job_store
+from agent_bom.security import sanitize_error, sanitize_text
+
+_logger = logging.getLogger(__name__)
+
+_PAGE_SIZE = 500
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def report_artifact_root() -> Path:
+    raw = (os.environ.get("AGENT_BOM_REPORT_ARTIFACT_DIR") or "").strip()
+    if raw:
+        return Path(raw)
+    return Path.home() / ".agent-bom" / "report-artifacts"
+
+
+def _artifact_path(tenant_id: str, job_id: str) -> Path:
+    safe_tenant = tenant_id.replace("/", "_").replace("\\", "_") or "default"
+    return report_artifact_root() / safe_tenant / f"{job_id}.ndjson.gz"
+
+
+def submit_report_job(job_id: str, tenant_id: str) -> None:
+    """Queue a report export on the shared scan worker pool."""
+    get_executor().submit(_run_report_job_sync, job_id, tenant_id)
+
+
+def _run_report_job_sync(job_id: str, tenant_id: str) -> None:
+    store = get_report_job_store()
+    job = store.get(job_id, tenant_id)
+    if job is None:
+        return
+    job.status = JobStatus.RUNNING
+    job.started_at = _now_iso()
+    store.update(job)
+
+    try:
+        row_count, byte_count, download_token = _write_findings_artifact(job)
+    except Exception as exc:  # noqa: BLE001
+        safe = sanitize_error(exc)
+        _logger.warning("Report job %s failed: %s", job_id, sanitize_text(safe))
+        failed = store.get(job_id, tenant_id)
+        if failed is None:
+            return
+        failed.status = JobStatus.FAILED
+        failed.completed_at = _now_iso()
+        failed.error = safe
+        store.update(failed)
+        try:
+            from agent_bom.api.audit_log import log_action
+
+            log_action(
+                "report.export_failed",
+                actor="system",
+                tenant_id=tenant_id,
+                details={"job_id": job_id, "error": safe},
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        return
+
+    done = store.get(job_id, tenant_id)
+    if done is None:
+        return
+    done.status = JobStatus.DONE
+    done.completed_at = _now_iso()
+    done.row_count = row_count
+    done.byte_count = byte_count
+    done.download_token = download_token
+    store.update(done)
+    try:
+        from agent_bom.api.audit_log import log_action
+
+        log_action(
+            "report.export_completed",
+            actor="system",
+            tenant_id=tenant_id,
+            details={"job_id": job_id, "row_count": row_count, "byte_count": byte_count, "format": done.format.value},
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _write_findings_artifact(job: ReportJob) -> tuple[int, int, str]:
+    hub = get_compliance_hub_store()
+    list_page = getattr(hub, "list_current_page", None)
+    if not callable(list_page):
+        raise RuntimeError("Compliance hub store does not support current-state finding exports")
+
+    path = _artifact_path(job.tenant_id, job.job_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    row_count = 0
+    cursor: str | None = None
+    with gzip.open(path, "wt", encoding="utf-8") as handle:
+        while True:
+            page, _total, next_cursor = list_page(
+                job.tenant_id,
+                limit=_PAGE_SIZE,
+                sort=job.sort,
+                severity=job.severity,
+                include_total=cursor is None,
+                cursor=cursor,
+            )
+            for row in page:
+                handle.write(json.dumps(row, separators=(",", ":"), ensure_ascii=True))
+                handle.write("\n")
+                row_count += 1
+            if not next_cursor:
+                break
+            cursor = next_cursor
+
+    byte_count = path.stat().st_size
+    return row_count, byte_count, secrets.token_urlsafe(32)
+
+
+def resolve_report_artifact(job: ReportJob) -> Path | None:
+    if job.status != JobStatus.DONE:
+        return None
+    path = _artifact_path(job.tenant_id, job.job_id)
+    return path if path.is_file() else None

--- a/src/agent_bom/api/routes/reports.py
+++ b/src/agent_bom/api/routes/reports.py
@@ -1,0 +1,80 @@
+"""Async findings report export routes."""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import FileResponse
+
+from agent_bom.api.models import JobStatus, ReportJob, ReportJobRequest
+from agent_bom.api.pipeline import _now
+from agent_bom.api.report_job_store import get_report_job_store
+from agent_bom.api.report_worker import resolve_report_artifact, submit_report_job
+from agent_bom.api.tenancy import require_request_tenant_id
+
+router = APIRouter()
+
+
+def _tenant_id(request: Request) -> str:
+    return require_request_tenant_id(request)
+
+
+def _job_payload(job: ReportJob, *, request: Request) -> dict:
+    payload = job.model_dump(mode="json")
+    if job.status == JobStatus.DONE and job.download_token:
+        payload["download_url"] = str(request.url_for("download_report_artifact", job_id=job.job_id)) + f"?token={job.download_token}"
+    payload.pop("download_token", None)
+    return payload
+
+
+@router.post("/v1/reports", tags=["reports"], status_code=202)
+async def create_report_job(request: Request, body: ReportJobRequest) -> dict:
+    """Enqueue an async findings export (gzipped NDJSON) instead of a synchronous body."""
+    tenant_id = _tenant_id(request)
+    job = ReportJob(
+        job_id=str(uuid.uuid4()),
+        tenant_id=tenant_id,
+        status=JobStatus.PENDING,
+        format=body.format,
+        sort=body.sort,
+        severity=body.severity,
+        created_at=_now(),
+    )
+    get_report_job_store().put(job)
+    submit_report_job(job.job_id, tenant_id)
+    return _job_payload(job, request=request)
+
+
+@router.get("/v1/reports/{job_id}", tags=["reports"])
+async def get_report_job(request: Request, job_id: str) -> dict:
+    """Return async report job status and download URL when complete."""
+    tenant_id = _tenant_id(request)
+    job = get_report_job_store().get(job_id, tenant_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Report job not found")
+    return _job_payload(job, request=request)
+
+
+@router.get("/v1/reports/{job_id}/download", tags=["reports"], name="download_report_artifact")
+async def download_report_artifact(
+    request: Request,
+    job_id: str,
+    token: Annotated[str, Query(min_length=8, max_length=256)],
+) -> FileResponse:
+    """Download a completed report artifact using the job-scoped token."""
+    tenant_id = _tenant_id(request)
+    job = get_report_job_store().get(job_id, tenant_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Report job not found")
+    if job.status != JobStatus.DONE or not job.download_token:
+        raise HTTPException(status_code=409, detail="Report artifact is not ready")
+    if not secrets.compare_digest(job.download_token, token):
+        raise HTTPException(status_code=403, detail="Invalid download token")
+    path = resolve_report_artifact(job)
+    if path is None:
+        raise HTTPException(status_code=410, detail="Report artifact is unavailable")
+    filename = f"findings-{job_id[:8]}.ndjson.gz"
+    return FileResponse(path, media_type="application/gzip", filename=filename)

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -846,6 +846,7 @@ from agent_bom.api.routes.plugins import router as _plugins_router  # noqa: E402
 from agent_bom.api.routes.posture_streaming import router as _posture_streaming_router  # noqa: E402
 from agent_bom.api.routes.privacy import router as _privacy_router  # noqa: E402
 from agent_bom.api.routes.proxy import router as _proxy_router  # noqa: E402
+from agent_bom.api.routes.reports import router as _reports_router  # noqa: E402
 from agent_bom.api.routes.runtime_blueprints import router as _runtime_blueprints_router  # noqa: E402
 from agent_bom.api.routes.scan import router as _scan_router  # noqa: E402
 from agent_bom.api.routes.schedules import router as _schedules_router  # noqa: E402
@@ -880,6 +881,7 @@ app.include_router(_plugins_router)
 app.include_router(_posture_streaming_router)
 app.include_router(_privacy_router)
 app.include_router(_proxy_router)
+app.include_router(_reports_router)
 app.include_router(_runtime_blueprints_router)
 app.include_router(_scan_router)
 app.include_router(_schedules_router)

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -406,6 +406,14 @@ RATE_LIMIT_KEY_LAST_ROTATED = (os.environ.get("AGENT_BOM_RATE_LIMIT_KEY_LAST_ROT
 RUNTIME_FEEDBACK_PATH = _str("AGENT_BOM_RUNTIME_FEEDBACK_PATH", "")
 
 
+# ── Report export artifacts ──────────────────────────────────────────────
+# Async findings report exports are written to a local artifact directory and
+# downloaded through job-scoped tokens. Empty string means use the per-user
+# default ~/.agent-bom/report-artifacts. The worker re-reads the env var at
+# runtime so tests and short-lived self-hosted processes can override it safely.
+REPORT_ARTIFACT_DIR = _str("AGENT_BOM_REPORT_ARTIFACT_DIR", "")
+
+
 # ── Agent-to-Agent (A2A) auth posture ────────────────────────────────────
 # Governance thresholds for the A2A auth posture evaluator
 # (agent_bom.a2a_auth_posture). agent-bom does not broker A2A auth; it scans

--- a/tests/test_report_jobs.py
+++ b/tests/test_report_jobs.py
@@ -1,0 +1,110 @@
+"""Tests for async findings report export jobs."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import time
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import SQLiteComplianceHubStore, reset_compliance_hub_store, set_compliance_hub_store
+from agent_bom.api.report_job_store import reset_report_job_store
+from agent_bom.api.report_worker import _run_report_job_sync
+from agent_bom.api.server import app
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+@pytest.fixture(autouse=True)
+def _reset_stores():
+    reset_compliance_hub_store()
+    reset_report_job_store()
+    yield
+    reset_compliance_hub_store()
+    reset_report_job_store()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _trusted_proxy_env():
+    enable_trusted_proxy_env()
+    yield
+    disable_trusted_proxy_env()
+
+
+def _client(tenant: str = "tenant-alpha") -> TestClient:
+    client = TestClient(app)
+    client.headers.update(proxy_headers(role="analyst", tenant=tenant))
+    return client
+
+
+def _seed_hub(tmp_path: Path, tenant_id: str, count: int = 3) -> None:
+    store = SQLiteComplianceHubStore(str(tmp_path / "hub.db"))
+    set_compliance_hub_store(store)
+    observed_at = "2026-07-04T00:00:00Z"
+    for idx in range(count):
+        store.upsert_current_batch(
+            tenant_id,
+            [
+                {
+                    "id": f"{tenant_id}:finding-{idx}",
+                    "canonical_id": f"{tenant_id}:finding-{idx}",
+                    "title": f"Finding {idx}",
+                    "severity": "high",
+                    "effective_reach_score": float(count - idx),
+                }
+            ],
+            observed_at=observed_at,
+            batch_id=f"batch-{idx}",
+            source="test",
+        )
+
+
+def test_report_job_streams_findings_to_gzip_artifact(monkeypatch, tmp_path: Path) -> None:
+    tenant_id = f"report-{uuid4().hex}"
+    monkeypatch.setenv("AGENT_BOM_REPORT_ARTIFACT_DIR", str(tmp_path))
+    monkeypatch.setattr("agent_bom.api.routes.reports.submit_report_job", _run_report_job_sync)
+    _seed_hub(tmp_path, tenant_id, count=4)
+    client = _client(tenant=tenant_id)
+
+    created = client.post("/v1/reports", json={"format": "ndjson", "sort": "effective_reach"})
+    assert created.status_code == 202, created.text
+    job_id = created.json()["job_id"]
+
+    deadline = time.time() + 5
+    body = {}
+    while time.time() < deadline:
+        polled = client.get(f"/v1/reports/{job_id}")
+        assert polled.status_code == 200
+        body = polled.json()
+        if body["status"] == "done":
+            break
+        time.sleep(0.05)
+    assert body["status"] == "done"
+    assert body["row_count"] == 4
+    assert body["byte_count"] > 0
+    assert "download_url" in body
+
+    download_url = body["download_url"]
+    assert "/download?token=" in download_url
+    downloaded = client.get(download_url)
+    assert downloaded.status_code == 200
+    rows = [json.loads(line) for line in gzip.decompress(downloaded.content).decode().splitlines() if line.strip()]
+    assert len(rows) == 4
+    assert rows[0]["canonical_id"] == f"{tenant_id}:finding-0"
+    assert rows[-1]["id"] == f"{tenant_id}:finding-3"
+
+
+def test_report_job_is_tenant_scoped(tmp_path: Path) -> None:
+    tenant_a = f"report-a-{uuid4().hex}"
+    tenant_b = f"report-b-{uuid4().hex}"
+    _seed_hub(tmp_path, tenant_a, count=1)
+    client_a = _client(tenant=tenant_a)
+    client_b = _client(tenant=tenant_b)
+
+    created = client_a.post("/v1/reports", json={})
+    assert created.status_code == 202
+    job_id = created.json()["job_id"]
+    assert client_b.get(f"/v1/reports/{job_id}").status_code == 404


### PR DESCRIPTION
## Summary
- Add `POST /v1/reports` (202), `GET /v1/reports/{id}`, and token-scoped `GET /v1/reports/{id}/download` for async gzipped NDJSON findings exports.
- Stream `hub_findings_current` via keyset pagination into `AGENT_BOM_REPORT_ARTIFACT_DIR`; analyst RBAC on report routes.
- Foundation only: in-memory job store + local filesystem artifacts (no S3/GCS yet).

Related: #3512

## Verification
- `.venv/bin/pytest tests/test_report_jobs.py -q`
- `.venv/bin/ruff check` on touched API files
- `.venv/bin/mypy` on report store/worker/routes
- `python scripts/export_openapi.py --check`


Made with [Cursor](https://cursor.com)