### PR TITLE
perf(analytics): ClickHouse sink dedup for canonical rows

### DIFF
--- a/deploy/supabase/clickhouse/init.sql
+++ b/deploy/supabase/clickhouse/init.sql
@@ -11,11 +11,13 @@ CREATE TABLE IF NOT EXISTS agent_bom.control_plane_schema_versions (
 ) ENGINE = ReplacingMergeTree(updated_at)
 ORDER BY component;
 
--- 1. Vulnerability scan results (append-only)
+-- 1. Vulnerability scan results (idempotent via finding_key)
 CREATE TABLE IF NOT EXISTS agent_bom.vulnerability_scans (
     scan_id String,
     scan_timestamp DateTime DEFAULT now(),
     tenant_id String DEFAULT 'default',
+    finding_key String DEFAULT '',
+    updated_at DateTime DEFAULT now(),
     package_name String,
     package_version String,
     ecosystem LowCardinality(String),
@@ -27,14 +29,15 @@ CREATE TABLE IF NOT EXISTS agent_bom.vulnerability_scans (
     agent_name String,
     environment LowCardinality(String),
     cmmc_tags Array(String)
-) ENGINE = MergeTree()
-ORDER BY (scan_timestamp, severity, agent_name)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (tenant_id, scan_id, finding_key)
 PARTITION BY toYYYYMM(scan_timestamp);
 
--- 2. Runtime protection events (append-only)
+-- 2. Runtime protection events (idempotent via event_id)
 CREATE TABLE IF NOT EXISTS agent_bom.runtime_events (
     event_id String,
     event_timestamp DateTime DEFAULT now(),
+    updated_at DateTime DEFAULT now(),
     tenant_id String DEFAULT 'default',
     event_type LowCardinality(String),
     detector LowCardinality(String),
@@ -46,8 +49,8 @@ CREATE TABLE IF NOT EXISTS agent_bom.runtime_events (
     trace_id String DEFAULT '',
     request_id String DEFAULT '',
     source_id String DEFAULT ''
-) ENGINE = ReplacingMergeTree()
-ORDER BY (event_timestamp, event_type, agent_name, event_id)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (tenant_id, event_id)
 PARTITION BY toYYYYMM(event_timestamp);
 
 -- 3. Posture scores (periodic snapshots)
@@ -67,11 +70,12 @@ ORDER BY (measured_at, agent_name)
 PARTITION BY toYYYYMM(measured_at)
 TTL measured_at + INTERVAL 2 YEAR;
 
--- 4. Scan metadata (one row per scan run)
+-- 4. Scan metadata (one row per scan run; idempotent on scan_id)
 CREATE TABLE IF NOT EXISTS agent_bom.scan_metadata (
     scan_id String,
     scan_timestamp DateTime DEFAULT now(),
     tenant_id String DEFAULT 'default',
+    updated_at DateTime DEFAULT now(),
     agent_count UInt32,
     package_count UInt32,
     vuln_count UInt32,
@@ -82,8 +86,8 @@ CREATE TABLE IF NOT EXISTS agent_bom.scan_metadata (
     source LowCardinality(String),
     aisvs_score Float32 DEFAULT 0.0,
     has_runtime_correlation UInt8 DEFAULT 0
-) ENGINE = MergeTree()
-ORDER BY (scan_timestamp, scan_id)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (tenant_id, scan_id)
 PARTITION BY toYYYYMM(scan_timestamp)
 TTL scan_timestamp + INTERVAL 2 YEAR;
 
@@ -109,14 +113,16 @@ CREATE TABLE IF NOT EXISTS agent_bom.compliance_controls (
     measured_at DateTime DEFAULT now(),
     scan_id String,
     tenant_id String DEFAULT 'default',
+    control_key String DEFAULT '',
+    updated_at DateTime DEFAULT now(),
     framework LowCardinality(String),
     control_id String,
     control_name String,
     status LowCardinality(String),
     finding_count UInt32,
     score Float32
-) ENGINE = MergeTree()
-ORDER BY (measured_at, framework, control_id)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (tenant_id, scan_id, control_key)
 PARTITION BY toYYYYMM(measured_at)
 TTL measured_at + INTERVAL 2 YEAR;
 
@@ -124,6 +130,7 @@ TTL measured_at + INTERVAL 2 YEAR;
 CREATE TABLE IF NOT EXISTS agent_bom.audit_events (
     event_timestamp DateTime DEFAULT now(),
     entry_id String,
+    updated_at DateTime DEFAULT now(),
     action LowCardinality(String),
     actor String,
     resource String,
@@ -131,8 +138,8 @@ CREATE TABLE IF NOT EXISTS agent_bom.audit_events (
     session_id String DEFAULT '',
     trace_id String DEFAULT '',
     request_id String DEFAULT ''
-) ENGINE = MergeTree()
-ORDER BY (event_timestamp, tenant_id, action)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (tenant_id, entry_id)
 PARTITION BY toYYYYMM(event_timestamp)
 TTL event_timestamp + INTERVAL 2 YEAR;
 
@@ -141,6 +148,8 @@ CREATE TABLE IF NOT EXISTS agent_bom.cis_benchmark_checks (
     measured_at DateTime DEFAULT now(),
     scan_id String,
     tenant_id String DEFAULT 'default',
+    check_key String DEFAULT '',
+    updated_at DateTime DEFAULT now(),
     cloud LowCardinality(String),
     check_id String,
     title String,
@@ -156,19 +165,19 @@ CREATE TABLE IF NOT EXISTS agent_bom.cis_benchmark_checks (
     priority UInt8,
     guardrails Array(String),
     requires_human_review UInt8
-) ENGINE = MergeTree()
-ORDER BY (measured_at, tenant_id, cloud, status, priority, check_id)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (tenant_id, scan_id, check_key)
 PARTITION BY toYYYYMM(measured_at)
 TTL measured_at + INTERVAL 2 YEAR;
 
 -- Forward-compatible migrations for deployments created from older init.sql
 -- revisions. These mirror the runtime ClickHouse client migrations.
 --
--- Note: runtime_events now uses ReplacingMergeTree ORDER BY (..., event_id) so
--- retried OCSF/runtime events collapse instead of double-counting. ClickHouse
--- cannot ALTER a table's engine in place; deployments whose runtime_events
--- predates this revision keep the append-only MergeTree until the table is
--- recreated. New deployments get dedup automatically.
+-- Note: ReplacingMergeTree dedup keys apply on fresh CREATE TABLE above.
+-- ClickHouse cannot ALTER a table's engine or ORDER BY in place; deployments
+-- whose analytics tables predate this revision keep append-only MergeTree until
+-- the table is recreated. New deployments get idempotent sink semantics
+-- automatically. OCSF remains an export projection only — see docs/OCSF_BOUNDARY.md.
 ALTER TABLE agent_bom.vulnerability_scans ADD COLUMN IF NOT EXISTS tenant_id String DEFAULT 'default';
 ALTER TABLE agent_bom.runtime_events ADD COLUMN IF NOT EXISTS tenant_id String DEFAULT 'default';
 ALTER TABLE agent_bom.runtime_events ADD COLUMN IF NOT EXISTS session_id String DEFAULT '';
@@ -183,5 +192,14 @@ ALTER TABLE agent_bom.audit_events ADD COLUMN IF NOT EXISTS trace_id String DEFA
 ALTER TABLE agent_bom.audit_events ADD COLUMN IF NOT EXISTS request_id String DEFAULT '';
 ALTER TABLE agent_bom.cis_benchmark_checks ADD COLUMN IF NOT EXISTS tenant_id String DEFAULT 'default';
 ALTER TABLE agent_bom.cis_benchmark_checks ADD COLUMN IF NOT EXISTS remediation String DEFAULT '{}';
+ALTER TABLE agent_bom.vulnerability_scans ADD COLUMN IF NOT EXISTS finding_key String DEFAULT '';
+ALTER TABLE agent_bom.vulnerability_scans ADD COLUMN IF NOT EXISTS updated_at DateTime DEFAULT now();
+ALTER TABLE agent_bom.runtime_events ADD COLUMN IF NOT EXISTS updated_at DateTime DEFAULT now();
+ALTER TABLE agent_bom.scan_metadata ADD COLUMN IF NOT EXISTS updated_at DateTime DEFAULT now();
+ALTER TABLE agent_bom.compliance_controls ADD COLUMN IF NOT EXISTS control_key String DEFAULT '';
+ALTER TABLE agent_bom.compliance_controls ADD COLUMN IF NOT EXISTS updated_at DateTime DEFAULT now();
+ALTER TABLE agent_bom.audit_events ADD COLUMN IF NOT EXISTS updated_at DateTime DEFAULT now();
+ALTER TABLE agent_bom.cis_benchmark_checks ADD COLUMN IF NOT EXISTS check_key String DEFAULT '';
+ALTER TABLE agent_bom.cis_benchmark_checks ADD COLUMN IF NOT EXISTS updated_at DateTime DEFAULT now();
 
 INSERT INTO agent_bom.control_plane_schema_versions (component, version) VALUES ('analytics', 1);

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -309,8 +309,9 @@ list/put plus session-scoped `app.current_tenant` for RLS.
 
 ### ClickHouse — `src/agent_bom/cloud/clickhouse.py`
 
-OLAP-only. Append-only analytics for trends, runtime events, posture.
-This is not a transactional control-plane replacement.
+OLAP-only. Canonical analytics rows for trends, runtime events, posture.
+Idempotent sink semantics via `ReplacingMergeTree` dedup keys on fresh
+deployments (#3484); not a transactional control-plane replacement.
 
 | Table | Source dataclass | tenant_id |
 |---|---|---|

--- a/docs/OCSF_BOUNDARY.md
+++ b/docs/OCSF_BOUNDARY.md
@@ -72,6 +72,19 @@ These are legitimate follow-ups if and when a SIEM / XDR / Security
 Lake integration needs them. Until then they are speculative work and
 should stay off the roadmap.
 
+## ClickHouse analytics persistence
+
+ClickHouse stores **canonical product rows** built by
+`analytics_contract.py` and `clickhouse_store.py` — scan findings,
+runtime events, posture snapshots, and compliance measurements. OCSF is
+not written to ClickHouse directly; SIEM export remains a separate
+projection at the wire boundary (see above).
+
+Buffered flushes and scan retries derive stable dedup keys
+(`finding_key`, `event_id`, `entry_id`, etc.) so repeated inserts of
+the same canonical row collapse under `ReplacingMergeTree` instead of
+inflating trend queries (#3484).
+
 ## Why keep OCSF at all
 
 AWS Security Lake, Google Chronicle, and Microsoft Sentinel all

--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -547,7 +547,7 @@ class ClickHouseAnalyticsStore:
         if tenant_id is not None:
             where += f" AND tenant_id = '{_escape(tenant_id)}'"
         query = (
-            f"SELECT toDate(scan_timestamp) AS day, severity, "
+            f"SELECT toDate(scan_timestamp) AS day, severity, "  # nosec B608
             f"uniqExact(if(finding_key != '', finding_key, "
             f"concat(tenant_id, ':', scan_id, ':', agent_name, ':', cve_id, ':', package_name, ':', package_version))) AS cnt "
             f"FROM vulnerability_scans WHERE {where} "
@@ -561,7 +561,7 @@ class ClickHouseAnalyticsStore:
         if tenant_id is not None:
             where += f" AND tenant_id = '{_escape(tenant_id)}'"
         query = (
-            f"SELECT cve_id, "
+            f"SELECT cve_id, "  # nosec B608
             f"uniqExact(if(finding_key != '', finding_key, "
             f"concat(tenant_id, ':', scan_id, ':', agent_name, ':', cve_id, ':', package_name, ':', package_version))) AS cnt, "
             f"max(cvss_score) AS max_cvss "
@@ -597,7 +597,7 @@ class ClickHouseAnalyticsStore:
         if tenant_id is not None:
             where += f" AND tenant_id = '{_escape(tenant_id)}'"
         query = (
-            f"SELECT event_type, severity, uniqExact(event_id) AS cnt "
+            f"SELECT event_type, severity, uniqExact(event_id) AS cnt "  # nosec B608
             f"FROM runtime_events "
             f"WHERE {where} "
             f"GROUP BY event_type, severity ORDER BY cnt DESC"

--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -62,6 +62,17 @@ def _deterministic_event_id(*parts: Any) -> str:
     return canonical_id("analytics_event", *parts)
 
 
+def _deterministic_row_key(kind: str, *parts: Any) -> str:
+    """Return a stable dedup key for canonical analytics rows (#3484)."""
+    from agent_bom.canonical_ids import canonical_id
+
+    return canonical_id(f"analytics_{kind}", *parts)
+
+
+def _insert_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
 # ------------------------------------------------------------------
 # Protocol
 # ------------------------------------------------------------------
@@ -317,6 +328,16 @@ class ClickHouseAnalyticsStore:
             {
                 "scan_id": scan_id,
                 "tenant_id": str(v.get("tenant_id") or tenant_id or "default"),
+                "finding_key": _deterministic_row_key(
+                    "finding",
+                    str(v.get("tenant_id") or tenant_id or "default"),
+                    scan_id,
+                    agent_name,
+                    v.get("cve_id", v.get("id", "")),
+                    _split_package(v)[0],
+                    _split_package(v)[1],
+                ),
+                "updated_at": _insert_timestamp(),
                 "package_name": _split_package(v)[0],
                 "package_version": _split_package(v)[1],
                 "ecosystem": v.get("ecosystem", ""),
@@ -364,6 +385,7 @@ class ClickHouseAnalyticsStore:
         return {
             "event_id": event_id,
             "event_timestamp": event_timestamp,
+            "updated_at": _insert_timestamp(),
             "tenant_id": resolved_tenant,
             "event_type": event_type,
             "detector": detector,
@@ -393,6 +415,7 @@ class ClickHouseAnalyticsStore:
         return {
             "tenant_id": str(snapshot.get("tenant_id") or tenant_id or "default"),
             "agent_name": agent_name,
+            "updated_at": _insert_timestamp(),
             "total_packages": int(snapshot.get("total_packages", 0)),
             "critical_vulns": int(snapshot.get("critical", 0)),
             "high_vulns": int(snapshot.get("high", 0)),
@@ -431,12 +454,18 @@ class ClickHouseAnalyticsStore:
             self._client.insert_json("cis_benchmark_checks", rows)
 
     def _compliance_row(self, control: dict, *, tenant_id: str = "default") -> dict[str, Any]:
+        resolved_tenant = str(control.get("tenant_id") or tenant_id or "default")
+        scan_id = control.get("scan_id", "")
+        framework = control.get("framework", "")
+        control_id = control.get("control_id", "")
         return {
             "measured_at": control.get("measured_at"),
-            "scan_id": control.get("scan_id", ""),
-            "tenant_id": str(control.get("tenant_id") or tenant_id or "default"),
-            "framework": control.get("framework", ""),
-            "control_id": control.get("control_id", ""),
+            "scan_id": scan_id,
+            "tenant_id": resolved_tenant,
+            "control_key": _deterministic_row_key("control", resolved_tenant, scan_id, framework, control_id),
+            "updated_at": _insert_timestamp(),
+            "framework": framework,
+            "control_id": control_id,
             "control_name": control.get("control_name", ""),
             "status": control.get("status", "unknown"),
             "finding_count": int(control.get("finding_count", 0)),
@@ -444,12 +473,18 @@ class ClickHouseAnalyticsStore:
         }
 
     def _cis_check_row(self, check: dict, *, tenant_id: str = "default") -> dict[str, Any]:
+        resolved_tenant = str(check.get("tenant_id") or tenant_id or "default")
+        scan_id = check.get("scan_id", "")
+        cloud = check.get("cloud", "")
+        check_id = check.get("check_id", "")
         return {
             "measured_at": _coerce_clickhouse_timestamp(check.get("measured_at")),
-            "scan_id": check.get("scan_id", ""),
-            "tenant_id": str(check.get("tenant_id") or tenant_id or "default"),
-            "cloud": check.get("cloud", ""),
-            "check_id": check.get("check_id", ""),
+            "scan_id": scan_id,
+            "tenant_id": resolved_tenant,
+            "check_key": _deterministic_row_key("cis_check", resolved_tenant, scan_id, cloud, check_id),
+            "updated_at": _insert_timestamp(),
+            "cloud": cloud,
+            "check_id": check_id,
             "title": check.get("title", ""),
             "status": check.get("status", "unknown"),
             "severity": check.get("severity", "unknown"),
@@ -469,13 +504,28 @@ class ClickHouseAnalyticsStore:
         self._client.insert_json("audit_events", [self._audit_row(event)])
 
     def _audit_row(self, event: dict) -> dict[str, Any]:
+        tenant_id = str(event.get("tenant_id", "default"))
+        event_timestamp = _coerce_clickhouse_timestamp(event.get("event_timestamp") or event.get("timestamp"))
+        entry_id = str(event.get("entry_id") or "").strip()
+        if not entry_id:
+            entry_id = _deterministic_event_id(
+                tenant_id,
+                event.get("action", ""),
+                event.get("actor", ""),
+                event.get("resource", ""),
+                str(event_timestamp or ""),
+                str(event.get("session_id", "") or ""),
+                str(event.get("trace_id", "") or ""),
+                str(event.get("request_id", "") or ""),
+            )
         return {
-            "event_timestamp": _coerce_clickhouse_timestamp(event.get("event_timestamp") or event.get("timestamp")),
-            "entry_id": event.get("entry_id", str(uuid.uuid4())),
+            "event_timestamp": event_timestamp,
+            "entry_id": entry_id,
+            "updated_at": _insert_timestamp(),
             "action": event.get("action", ""),
             "actor": event.get("actor", ""),
             "resource": event.get("resource", ""),
-            "tenant_id": event.get("tenant_id", "default"),
+            "tenant_id": tenant_id,
             "session_id": str(event.get("session_id", "") or ""),
             "trace_id": str(event.get("trace_id", "") or ""),
             "request_id": str(event.get("request_id", "") or ""),
@@ -497,7 +547,9 @@ class ClickHouseAnalyticsStore:
         if tenant_id is not None:
             where += f" AND tenant_id = '{_escape(tenant_id)}'"
         query = (
-            f"SELECT toDate(scan_timestamp) AS day, severity, count() AS cnt "  # nosec B608
+            f"SELECT toDate(scan_timestamp) AS day, severity, "
+            f"uniqExact(if(finding_key != '', finding_key, "
+            f"concat(tenant_id, ':', scan_id, ':', agent_name, ':', cve_id, ':', package_name, ':', package_version))) AS cnt "
             f"FROM vulnerability_scans WHERE {where} "
             f"GROUP BY day, severity ORDER BY day"
         )
@@ -509,7 +561,10 @@ class ClickHouseAnalyticsStore:
         if tenant_id is not None:
             where += f" AND tenant_id = '{_escape(tenant_id)}'"
         query = (
-            f"SELECT cve_id, count() AS cnt, max(cvss_score) AS max_cvss "  # nosec B608
+            f"SELECT cve_id, "
+            f"uniqExact(if(finding_key != '', finding_key, "
+            f"concat(tenant_id, ':', scan_id, ':', agent_name, ':', cve_id, ':', package_name, ':', package_version))) AS cnt, "
+            f"max(cvss_score) AS max_cvss "
             f"FROM vulnerability_scans WHERE {where} "
             f"GROUP BY cve_id ORDER BY cnt DESC LIMIT {int(limit)}"
         )
@@ -542,7 +597,7 @@ class ClickHouseAnalyticsStore:
         if tenant_id is not None:
             where += f" AND tenant_id = '{_escape(tenant_id)}'"
         query = (
-            f"SELECT event_type, severity, count() AS cnt "  # nosec B608
+            f"SELECT event_type, severity, uniqExact(event_id) AS cnt "
             f"FROM runtime_events "
             f"WHERE {where} "
             f"GROUP BY event_type, severity ORDER BY cnt DESC"
@@ -664,9 +719,12 @@ class ClickHouseAnalyticsStore:
         )
 
     def _metadata_row(self, metadata: dict, *, tenant_id: str = "default") -> dict[str, Any]:
+        resolved_tenant = str(metadata.get("tenant_id") or tenant_id or "default")
+        scan_id = metadata.get("scan_id", str(uuid.uuid4()))
         return {
-            "scan_id": metadata.get("scan_id", str(uuid.uuid4())),
-            "tenant_id": str(metadata.get("tenant_id") or tenant_id or "default"),
+            "scan_id": scan_id,
+            "tenant_id": resolved_tenant,
+            "updated_at": _insert_timestamp(),
             "agent_count": int(metadata.get("agent_count", 0)),
             "package_count": int(metadata.get("package_count", 0)),
             "vuln_count": int(metadata.get("vuln_count", 0)),
@@ -898,7 +956,9 @@ class BufferedAnalyticsStore:
             if audit_rows:
                 self._store._client.insert_json("audit_events", audit_rows)
         except Exception:
-            logger.warning("Buffered ClickHouse flush failed", exc_info=True)
+            logger.warning("Buffered ClickHouse flush failed; re-queuing batch", exc_info=True)
+            for item in drained:
+                self._queue.put(item)
 
     @property
     def flush_interval(self) -> float:

--- a/src/agent_bom/cloud/clickhouse.py
+++ b/src/agent_bom/cloud/clickhouse.py
@@ -139,12 +139,14 @@ CREATE TABLE IF NOT EXISTS control_plane_schema_versions (
     updated_at DateTime DEFAULT now()
 ) ENGINE = ReplacingMergeTree(updated_at)
 ORDER BY component""",
-    # 1. Vulnerability scan results (append-only)
+    # 1. Vulnerability scan results (idempotent via finding_key)
     """\
 CREATE TABLE IF NOT EXISTS vulnerability_scans (
     scan_id String,
     scan_timestamp DateTime DEFAULT now(),
     tenant_id String DEFAULT 'default',
+    finding_key String DEFAULT '',
+    updated_at DateTime DEFAULT now(),
     package_name String,
     package_version String,
     ecosystem LowCardinality(String),
@@ -156,14 +158,15 @@ CREATE TABLE IF NOT EXISTS vulnerability_scans (
     agent_name String,
     environment LowCardinality(String),
     cmmc_tags Array(String)
-) ENGINE = MergeTree()
-ORDER BY (scan_timestamp, severity, agent_name)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (tenant_id, scan_id, finding_key)
 PARTITION BY toYYYYMM(scan_timestamp)""",
     # 2. Runtime protection events (append-only)
     """\
 CREATE TABLE IF NOT EXISTS runtime_events (
     event_id String,
     event_timestamp DateTime DEFAULT now(),
+    updated_at DateTime DEFAULT now(),
     tenant_id String DEFAULT 'default',
     event_type LowCardinality(String),
     detector LowCardinality(String),
@@ -175,8 +178,8 @@ CREATE TABLE IF NOT EXISTS runtime_events (
     trace_id String DEFAULT '',
     request_id String DEFAULT '',
     source_id String DEFAULT ''
-) ENGINE = ReplacingMergeTree()
-ORDER BY (event_timestamp, event_type, agent_name, event_id)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (tenant_id, event_id)
 PARTITION BY toYYYYMM(event_timestamp)""",
     # 3. Posture scores (periodic snapshots)
     """\
@@ -195,12 +198,13 @@ CREATE TABLE IF NOT EXISTS posture_scores (
 ORDER BY (measured_at, agent_name)
 PARTITION BY toYYYYMM(measured_at)
 TTL measured_at + INTERVAL 2 YEAR""",
-    # 4. Scan metadata (one row per scan run)
+    # 4. Scan metadata (one row per scan run; idempotent on scan_id)
     """\
 CREATE TABLE IF NOT EXISTS scan_metadata (
     scan_id String,
     scan_timestamp DateTime DEFAULT now(),
     tenant_id String DEFAULT 'default',
+    updated_at DateTime DEFAULT now(),
     agent_count UInt32,
     package_count UInt32,
     vuln_count UInt32,
@@ -211,8 +215,8 @@ CREATE TABLE IF NOT EXISTS scan_metadata (
     source LowCardinality(String),
     aisvs_score Float32 DEFAULT 0.0,
     has_runtime_correlation UInt8 DEFAULT 0
-) ENGINE = MergeTree()
-ORDER BY (scan_timestamp, scan_id)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (tenant_id, scan_id)
 PARTITION BY toYYYYMM(scan_timestamp)
 TTL scan_timestamp + INTERVAL 2 YEAR""",
     # 5. Fleet agent snapshots (trust/lifecycle over time)
@@ -238,14 +242,16 @@ CREATE TABLE IF NOT EXISTS compliance_controls (
     measured_at DateTime DEFAULT now(),
     scan_id String,
     tenant_id String DEFAULT 'default',
+    control_key String DEFAULT '',
+    updated_at DateTime DEFAULT now(),
     framework LowCardinality(String),
     control_id String,
     control_name String,
     status LowCardinality(String),
     finding_count UInt32,
     score Float32
-) ENGINE = MergeTree()
-ORDER BY (measured_at, framework, control_id)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (tenant_id, scan_id, control_key)
 PARTITION BY toYYYYMM(measured_at)
 TTL measured_at + INTERVAL 2 YEAR""",
     # 7. Audit events for trend/forensics dashboards
@@ -253,6 +259,7 @@ TTL measured_at + INTERVAL 2 YEAR""",
 CREATE TABLE IF NOT EXISTS audit_events (
     event_timestamp DateTime DEFAULT now(),
     entry_id String,
+    updated_at DateTime DEFAULT now(),
     action LowCardinality(String),
     actor String,
     resource String,
@@ -260,8 +267,8 @@ CREATE TABLE IF NOT EXISTS audit_events (
     session_id String DEFAULT '',
     trace_id String DEFAULT '',
     request_id String DEFAULT ''
-) ENGINE = MergeTree()
-ORDER BY (event_timestamp, tenant_id, action)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (tenant_id, entry_id)
 PARTITION BY toYYYYMM(event_timestamp)
 TTL event_timestamp + INTERVAL 2 YEAR""",
     # 8. CIS benchmark check observations with remediation fields indexed
@@ -270,6 +277,8 @@ CREATE TABLE IF NOT EXISTS cis_benchmark_checks (
     measured_at DateTime DEFAULT now(),
     scan_id String,
     tenant_id String DEFAULT 'default',
+    check_key String DEFAULT '',
+    updated_at DateTime DEFAULT now(),
     cloud LowCardinality(String),
     check_id String,
     title String,
@@ -285,8 +294,8 @@ CREATE TABLE IF NOT EXISTS cis_benchmark_checks (
     priority UInt8,
     guardrails Array(String),
     requires_human_review UInt8
-) ENGINE = MergeTree()
-ORDER BY (measured_at, tenant_id, cloud, status, priority, check_id)
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (tenant_id, scan_id, check_key)
 PARTITION BY toYYYYMM(measured_at)
 TTL measured_at + INTERVAL 2 YEAR""",
 ]
@@ -311,4 +320,15 @@ _TABLE_MIGRATIONS: list[str] = [
     "ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS request_id String DEFAULT ''",
     "ALTER TABLE cis_benchmark_checks ADD COLUMN IF NOT EXISTS tenant_id String DEFAULT 'default'",
     "ALTER TABLE cis_benchmark_checks ADD COLUMN IF NOT EXISTS remediation String DEFAULT '{}'",
+    # #3484 — idempotent sink keys for canonical analytics rows (new columns only;
+    # engine/ORDER BY changes apply on fresh CREATE TABLE above).
+    "ALTER TABLE vulnerability_scans ADD COLUMN IF NOT EXISTS finding_key String DEFAULT ''",
+    "ALTER TABLE vulnerability_scans ADD COLUMN IF NOT EXISTS updated_at DateTime DEFAULT now()",
+    "ALTER TABLE runtime_events ADD COLUMN IF NOT EXISTS updated_at DateTime DEFAULT now()",
+    "ALTER TABLE scan_metadata ADD COLUMN IF NOT EXISTS updated_at DateTime DEFAULT now()",
+    "ALTER TABLE compliance_controls ADD COLUMN IF NOT EXISTS control_key String DEFAULT ''",
+    "ALTER TABLE compliance_controls ADD COLUMN IF NOT EXISTS updated_at DateTime DEFAULT now()",
+    "ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS updated_at DateTime DEFAULT now()",
+    "ALTER TABLE cis_benchmark_checks ADD COLUMN IF NOT EXISTS check_key String DEFAULT ''",
+    "ALTER TABLE cis_benchmark_checks ADD COLUMN IF NOT EXISTS updated_at DateTime DEFAULT now()",
 ]

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -498,6 +498,85 @@ class TestClickHouseAnalyticsStore:
         assert audit_row["trace_id"] == "trace-1"
         assert audit_row["request_id"] == "req-1"
 
+    def test_scan_finding_key_stable_on_retry(self):
+        from agent_bom.api.clickhouse_store import ClickHouseAnalyticsStore
+
+        rows: list[dict] = []
+
+        class _Client:
+            def ensure_tables(self):
+                return None
+
+            def insert_json(self, table, batch):
+                rows.extend(batch)
+
+        vuln = {
+            "package": "requests@2.33.0",
+            "ecosystem": "pypi",
+            "cve_id": "CVE-2026-0001",
+            "severity": "high",
+        }
+        with patch("agent_bom.cloud.clickhouse.ClickHouseClient", return_value=_Client()):
+            store = ClickHouseAnalyticsStore(url="http://localhost:8123")
+            store.record_scan("scan-dedup", "agent-1", [vuln], tenant_id="tenant-alpha")
+            store.record_scan("scan-dedup", "agent-1", [vuln], tenant_id="tenant-alpha")
+
+        assert len(rows) == 2
+        assert rows[0]["finding_key"]
+        assert rows[0]["finding_key"] == rows[1]["finding_key"]
+        assert rows[0]["updated_at"]
+
+    def test_audit_row_derives_deterministic_entry_id(self):
+        from agent_bom.api.clickhouse_store import ClickHouseAnalyticsStore
+
+        rows: list[dict] = []
+
+        class _Client:
+            def ensure_tables(self):
+                return None
+
+            def insert_json(self, table, batch):
+                rows.extend(batch)
+
+        event = {
+            "action": "auth.key_created",
+            "actor": "system",
+            "resource": "api_key",
+            "timestamp": "2026-04-20T12:00:02Z",
+            "tenant_id": "tenant-alpha",
+        }
+        with patch("agent_bom.cloud.clickhouse.ClickHouseClient", return_value=_Client()):
+            store = ClickHouseAnalyticsStore(url="http://localhost:8123")
+            store.record_audit_event(dict(event))
+            store.record_audit_event(dict(event))
+
+        assert len(rows) == 2
+        assert rows[0]["entry_id"] == rows[1]["entry_id"]
+
+    def test_buffered_flush_requeues_on_insert_failure(self):
+        from agent_bom.api.clickhouse_store import BufferedAnalyticsStore, ClickHouseAnalyticsStore
+
+        attempts = {"count": 0}
+
+        class _Client:
+            def ensure_tables(self):
+                return None
+
+            def insert_json(self, table, rows):
+                attempts["count"] += 1
+                if attempts["count"] == 1:
+                    raise RuntimeError("transient clickhouse outage")
+
+        with patch("agent_bom.cloud.clickhouse.ClickHouseClient", return_value=_Client()):
+            store = ClickHouseAnalyticsStore(url="http://localhost:8123")
+            buffered = BufferedAnalyticsStore(store, max_batch=10, flush_interval=60.0)
+            buffered.record_event({"event_type": "tool_blocked", "severity": "high", "event_id": "evt-retry-1"})
+            buffered._flush_pending()
+            assert attempts["count"] == 1
+            buffered._flush_pending()
+            assert attempts["count"] == 2
+            buffered.close()
+
 
 def test_clickhouse_escape_strips_control_chars_and_quotes():
     from agent_bom.api.clickhouse_store import _escape


### PR DESCRIPTION
## Summary
- Add stable dedup keys (`finding_key`, `control_key`, `check_key`, deterministic `entry_id`) on canonical analytics rows and `ReplacingMergeTree(updated_at)` DDL for fresh deployments.
- Trend queries use `uniqExact` on dedup keys so retried scan/runtime flushes do not inflate counts before background merges.
- `BufferedAnalyticsStore` re-queues drained batches on transient insert failure; documents OCSF vs ClickHouse boundary.

Related: #3484

## Verification
- `.venv/bin/pytest tests/test_clickhouse.py tests/test_clickhouse_tenant_isolation.py -q`
- `.venv/bin/ruff check` on touched files
- `.venv/bin/mypy` on `clickhouse_store.py` and `cloud/clickhouse.py`

## Notes
- Engine/ORDER BY changes apply on new `CREATE TABLE`; existing clusters pick up new columns via ALTER only (documented in `init.sql`).


Made with [Cursor](https://cursor.com)