### PR TITLE
refactor(api): hub reference-table normalization

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -328,6 +328,21 @@ Every `query_*` method on the analytics store accepts `tenant_id` and
 injects a `WHERE tenant_id = '<scope>'` predicate. Absent `tenant_id`
 is deliberately cross-tenant and reserved for admin surfaces.
 
+### Hub reference tables — `hub_cve_intel`, `hub_framework_refs`
+
+Compliance hub ledger rows can store join keys (`intel_ref`,
+`framework_ref`) instead of repeating CVE enrichment and framework tag
+maps on every finding (#3513). Reference blobs live in tenant-scoped
+tables; list/current read paths hydrate before API responses.
+
+| Control | Purpose |
+|---|---|
+| `AGENT_BOM_HUB_REFERENCE_NORMALIZE=1` (default) | Extract shared blobs on ingest |
+| `AGENT_BOM_HUB_REFERENCE_NORMALIZE=0` | Rollback: stop new extractions; reads still hydrate existing refs |
+
+Legacy inline payloads continue to work without migration. SQLite and
+Postgres profiles create reference tables on store init.
+
 ### Snowflake — `src/agent_bom/api/snowflake_store.py`
 
 Warehouse-native deployment for governance-heavy customers. Today it

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -189,6 +189,7 @@ so they cannot regress silently, but they are not part of this reference.
 ## PostgreSQL Control Plane Tuning
 | Env var | Type | Default | Description |
 |---|---|---|---|
+| `AGENT_BOM_HUB_REFERENCE_NORMALIZE` | `bool` | `True` | Compliance hub reference-table normalization (#3513). When enabled, repeated CVE/framework blobs are stored once per tenant and ledger rows keep join keys. Set to 0 to disable new extractions (reads still hydrate existing refs). |
 | `AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS` | `int` | `5` | — |
 | `AGENT_BOM_POSTGRES_GRAPH_SEARCH_TIMEOUT_MS` | `int` | `3000` | — |
 | `AGENT_BOM_POSTGRES_POOL_MAX_SIZE` | `int` | `20` | — |

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -152,7 +152,8 @@ def _framework_slug_counts_from_rows(rows: Iterable[dict[str, Any]]) -> dict[str
 
 def _redact_finding(payload: dict[str, Any]) -> dict[str, Any]:
     """Redact one hub finding payload for persistence."""
-    clean = redact_for_persistence(payload, EvidenceTier.SAFE_TO_STORE)
+    redacted = redact_for_persistence(payload, EvidenceTier.SAFE_TO_STORE)
+    clean: dict[str, Any] = redacted if isinstance(redacted, dict) else {}
     if "id" not in clean and "id" in payload:
         clean["id"] = str(payload["id"])
     if "source" not in clean and "source" in payload:

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -618,6 +618,7 @@ class InMemoryComplianceHubStore:
     def framework_slug_counts(self, tenant_id: str) -> dict[str, int]:
         with self._lock:
             rows = list(self._by_tenant.get(tenant_id, []))
+        rows = hydrate_finding_payloads_memory(tenant_id, rows)
         return _framework_slug_counts_from_rows(rows)
 
     def count(self, tenant_id: str) -> int:
@@ -1082,6 +1083,7 @@ class SQLiteComplianceHubStore:
         for offset, original in enumerate(findings):
             if not isinstance(original, dict):
                 continue
+            frameworks_csv = _frameworks_csv(original)
             slim = persist_finding_references_sqlite(self._conn, tenant_id, original)
             payload = _redact_finding(slim)
             rows.append(
@@ -1090,7 +1092,7 @@ class SQLiteComplianceHubStore:
                     str(payload.get("id") or f"hub-{next_ord + offset}"),
                     now,
                     str(payload.get("source") or ""),
-                    _frameworks_csv(payload),
+                    frameworks_csv,
                     encode_hub_payload(payload),
                     next_ord + offset,
                     compute_effective_reach_score(payload),

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -39,6 +39,13 @@ from agent_bom.api.hub_current_payload import (
     resolve_ledger_finding_id,
 )
 from agent_bom.api.hub_payload_codec import decode_hub_payload, encode_hub_payload
+from agent_bom.api.hub_reference_store import (
+    ensure_sqlite_reference_tables,
+    hydrate_finding_payloads_memory,
+    hydrate_finding_payloads_sqlite,
+    normalize_finding_payload_for_store,
+    persist_finding_references_sqlite,
+)
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.graph.severity import severity_policy_rank
 
@@ -143,6 +150,19 @@ def _framework_slug_counts_from_rows(rows: Iterable[dict[str, Any]]) -> dict[str
     return counts
 
 
+def _redact_finding(payload: dict[str, Any]) -> dict[str, Any]:
+    """Redact one hub finding payload for persistence."""
+    clean = redact_for_persistence(payload, EvidenceTier.SAFE_TO_STORE)
+    if "id" not in clean and "id" in payload:
+        clean["id"] = str(payload["id"])
+    if "source" not in clean and "source" in payload:
+        clean["source"] = str(payload["source"])
+    for key in ("origin", "batch_id", "bulk_ordinal", "intel_ref", "framework_ref"):
+        if key not in clean and key in payload:
+            clean[key] = payload[key]
+    return clean
+
+
 def _redact_findings(findings: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
     """Drop tier-B fields before any compliance-hub finding is stored.
 
@@ -153,17 +173,7 @@ def _redact_findings(findings: Iterable[dict[str, Any]]) -> list[dict[str, Any]]
     for payload in findings:
         if not isinstance(payload, dict):
             continue
-        clean = redact_for_persistence(payload, EvidenceTier.SAFE_TO_STORE)
-        # Preserve identity fields the store keys on, even if the redactor
-        # didn't recognise them by exact name (e.g. legacy "id" alias).
-        if "id" not in clean and "id" in payload:
-            clean["id"] = str(payload["id"])
-        if "source" not in clean and "source" in payload:
-            clean["source"] = str(payload["source"])
-        for key in ("origin", "batch_id", "bulk_ordinal"):
-            if key not in clean and key in payload:
-                clean[key] = payload[key]
-        redacted.append(clean)
+        redacted.append(_redact_finding(payload))
     return redacted
 
 
@@ -285,7 +295,12 @@ def _fetch_ledger_payloads_sqlite(
         """,  # nosec B608
         (tenant_id, *finding_ids),
     ).fetchall()
-    return {str(row[0]): decode_hub_payload(row[1]) for row in rows}
+    if not rows:
+        return {}
+    ordered_ids = [str(row[0]) for row in rows]
+    payloads = [decode_hub_payload(row[1]) for row in rows]
+    hydrated = hydrate_finding_payloads_sqlite(conn, tenant_id, payloads)
+    return dict(zip(ordered_ids, hydrated))
 
 
 def _sqlite_current_row_from_db(row: tuple[Any, ...], *, has_ledger_col: bool) -> dict[str, Any]:
@@ -542,21 +557,24 @@ class InMemoryComplianceHubStore:
         self._lock = threading.Lock()
 
     def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
-        clean = _redact_findings(findings)
         with self._lock:
             bucket = self._by_tenant.setdefault(tenant_id, [])
             slots = self._slots.setdefault(tenant_id, {})
-            for payload in clean:
-                finding_id = str(payload.get("id") or "")
+            for payload in findings:
+                if not isinstance(payload, dict):
+                    continue
+                slim = normalize_finding_payload_for_store(tenant_id, payload)
+                stored = _redact_finding(slim)
+                finding_id = str(stored.get("id") or "")
                 if finding_id and finding_id in slots:
                     # Refresh payload, keep original ingest position.
-                    bucket[slots[finding_id]] = payload
+                    bucket[slots[finding_id]] = stored
                     continue
                 if finding_id:
                     slots[finding_id] = len(bucket)
-                bucket.append(payload)
+                bucket.append(stored)
             total = len(bucket)
-        if clean:
+        if findings:
             from agent_bom.api.findings_count_cache import invalidate_tenant
 
             invalidate_tenant(tenant_id)
@@ -564,7 +582,8 @@ class InMemoryComplianceHubStore:
 
     def list(self, tenant_id: str) -> list[dict[str, Any]]:
         with self._lock:
-            return list(self._by_tenant.get(tenant_id, []))
+            rows = list(self._by_tenant.get(tenant_id, []))
+        return hydrate_finding_payloads_memory(tenant_id, rows)
 
     def list_page(
         self,
@@ -588,7 +607,7 @@ class InMemoryComplianceHubStore:
             rows = rows[offset:]
         if limit >= 0:
             rows = rows[:limit]
-        return rows, total
+        return hydrate_finding_payloads_memory(tenant_id, rows), total
 
     def severity_breakdown(self, tenant_id: str) -> dict[str, int]:
         with self._lock:
@@ -664,7 +683,7 @@ class InMemoryComplianceHubStore:
         for finding_id in finding_ids:
             idx = slots.get(finding_id)
             if idx is not None and 0 <= idx < len(bucket):
-                out[finding_id] = dict(bucket[idx])
+                out[finding_id] = hydrate_finding_payloads_memory(tenant_id, [bucket[idx]])[0]
         return out
 
     def _hydrate_current_rows(self, tenant_id: str, rows: _HubFindingRows) -> _HubFindingRows:
@@ -926,6 +945,7 @@ class SQLiteComplianceHubStore:
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_order ON compliance_hub_findings(tenant_id, ordinal)")
         self._ensure_scale_indexes()
         _ensure_current_lifecycle_sqlite(self._conn)
+        ensure_sqlite_reference_tables(self._conn)
         self._conn.commit()
 
     def _migrate_columns(self) -> None:
@@ -1053,13 +1073,16 @@ class SQLiteComplianceHubStore:
         return int(row[0]) + 1 if row else 1
 
     def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
-        findings = _redact_findings(findings)
         if not findings:
             return self.count(tenant_id)
         now = _now_utc_iso()
         next_ord = self._next_ordinal(tenant_id)
         rows = []
-        for offset, payload in enumerate(findings):
+        for offset, original in enumerate(findings):
+            if not isinstance(original, dict):
+                continue
+            slim = persist_finding_references_sqlite(self._conn, tenant_id, original)
+            payload = _redact_finding(slim)
             rows.append(
                 (
                     tenant_id,
@@ -1110,7 +1133,8 @@ class SQLiteComplianceHubStore:
             "SELECT payload FROM compliance_hub_findings WHERE tenant_id = ? ORDER BY ordinal ASC",
             (tenant_id,),
         ).fetchall()
-        return [decode_hub_payload(row[0]) for row in rows]
+        payloads = [decode_hub_payload(row[0]) for row in rows]
+        return hydrate_finding_payloads_sqlite(self._conn, tenant_id, payloads)
 
     def list_page(
         self,
@@ -1156,7 +1180,8 @@ class SQLiteComplianceHubStore:
             f"SELECT payload FROM compliance_hub_findings WHERE {where_sql} {order_sql} LIMIT ? OFFSET ?",  # nosec B608
             page_params,
         ).fetchall()
-        return [decode_hub_payload(row[0]) for row in rows], total
+        payloads = [decode_hub_payload(row[0]) for row in rows]
+        return hydrate_finding_payloads_sqlite(self._conn, tenant_id, payloads), total
 
     def severity_breakdown(self, tenant_id: str) -> dict[str, int]:
         rows = self._conn.execute(

--- a/src/agent_bom/api/hub_reference_payload.py
+++ b/src/agent_bom/api/hub_reference_payload.py
@@ -1,0 +1,150 @@
+"""Reference-table normalization for hub finding payloads (#3513).
+
+Repeated CVE/CVSS/EPSS enrichment and framework tag maps are stored once per
+tenant in reference tables. Finding ledger rows keep join keys
+(``intel_ref``, ``framework_ref``) plus sort/filter scalars.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from agent_bom.canonical_ids import canonical_id
+
+# Enrichment blobs keyed by CVE id (tenant-scoped table).
+_CVE_INTEL_KEYS: tuple[str, ...] = (
+    "summary",
+    "references",
+    "advisory_sources",
+    "primary_advisory_source",
+    "cvss_vector",
+    "cvss_v3_vector",
+    "cvss_v4_vector",
+    "epss_percentile",
+    "cisa_kev",
+    "is_kev",
+    "kev_date",
+    "kev_added_date",
+    "nvd_url",
+    "ghsa_id",
+    "osv_id",
+    "ghsa_severity",
+    "nvd_published",
+)
+
+# Framework tag arrays stored once per unique tag bundle.
+_FRAMEWORK_TAG_KEYS: tuple[str, ...] = (
+    "owasp_tags",
+    "atlas_tags",
+    "nist_ai_rmf_tags",
+    "owasp_mcp_tags",
+    "owasp_agentic_tags",
+    "eu_ai_act_tags",
+    "nist_csf_tags",
+    "iso_27001_tags",
+    "soc2_tags",
+    "cis_tags",
+    "cmmc_tags",
+    "compliance_tags",
+    "applicable_frameworks",
+)
+
+_REF_MARKER_KEYS = ("intel_ref", "framework_ref")
+
+
+def resolve_cve_id(payload: Mapping[str, Any]) -> str:
+    for key in ("cve_id", "vulnerability_id", "id"):
+        raw = payload.get(key)
+        if raw and str(raw).upper().startswith("CVE-"):
+            return str(raw).upper()
+    return ""
+
+
+def framework_ref_key(payload: Mapping[str, Any]) -> str:
+    bundle: dict[str, Any] = {}
+    for key in _FRAMEWORK_TAG_KEYS:
+        value = payload.get(key)
+        if value:
+            bundle[key] = value
+    if not bundle:
+        return ""
+    fingerprint = json.dumps(bundle, sort_keys=True, separators=(",", ":"), default=str)
+    return canonical_id("hub_framework_ref", fingerprint)
+
+
+def extract_reference_blobs(payload: Mapping[str, Any]) -> tuple[dict[str, Any], dict[str, Any] | None, dict[str, Any] | None]:
+    """Split a finding payload into a slim row plus optional reference blobs."""
+    slim = dict(payload)
+    cve_id = resolve_cve_id(payload)
+    intel_blob: dict[str, Any] | None = None
+    if cve_id:
+        intel_blob = {}
+        for key in _CVE_INTEL_KEYS:
+            if key in slim:
+                intel_blob[key] = slim.pop(key)
+        if not intel_blob:
+            intel_blob = None
+        else:
+            slim["intel_ref"] = cve_id
+
+    framework_blob: dict[str, Any] | None = None
+    fw_ref = framework_ref_key(payload)
+    if fw_ref:
+        framework_blob = {}
+        for key in _FRAMEWORK_TAG_KEYS:
+            if key in slim:
+                framework_blob[key] = slim.pop(key)
+        if framework_blob:
+            slim["framework_ref"] = fw_ref
+        else:
+            framework_blob = None
+            fw_ref = ""
+
+    return slim, intel_blob, framework_blob
+
+
+def is_reference_backed_payload(payload: Mapping[str, Any]) -> bool:
+    return any(payload.get(key) for key in _REF_MARKER_KEYS)
+
+
+def hydrate_reference_payload(
+    payload: Mapping[str, Any],
+    *,
+    cve_intel: Mapping[str, dict[str, Any]],
+    framework_refs: Mapping[str, dict[str, Any]],
+) -> dict[str, Any]:
+    """Merge reference blobs back into a stored finding payload."""
+    if not is_reference_backed_payload(payload):
+        return dict(payload)
+
+    merged = dict(payload)
+    intel_ref = str(merged.pop("intel_ref", "") or "")
+    if intel_ref:
+        blob = cve_intel.get(intel_ref)
+        if blob:
+            for key, value in blob.items():
+                merged.setdefault(key, value)
+
+    framework_ref = str(merged.pop("framework_ref", "") or "")
+    if framework_ref:
+        blob = framework_refs.get(framework_ref)
+        if blob:
+            for key, value in blob.items():
+                merged.setdefault(key, value)
+
+    return merged
+
+
+def batch_reference_keys(payloads: Iterable[Mapping[str, Any]]) -> tuple[set[str], set[str]]:
+    cve_ids: set[str] = set()
+    framework_refs: set[str] = set()
+    for payload in payloads:
+        intel_ref = str(payload.get("intel_ref") or "")
+        if intel_ref:
+            cve_ids.add(intel_ref)
+        framework_ref = str(payload.get("framework_ref") or "")
+        if framework_ref:
+            framework_refs.add(framework_ref)
+    return cve_ids, framework_refs

--- a/src/agent_bom/api/hub_reference_store.py
+++ b/src/agent_bom/api/hub_reference_store.py
@@ -1,0 +1,289 @@
+"""Persistence helpers for hub reference tables (#3513)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+from agent_bom.api.hub_payload_codec import decode_hub_payload, encode_hub_payload
+from agent_bom.api.hub_reference_payload import (
+    batch_reference_keys,
+    extract_reference_blobs,
+    hydrate_reference_payload,
+    resolve_cve_id,
+)
+from agent_bom.config import HUB_REFERENCE_NORMALIZE
+
+_HUB_CVE_INTEL_DDL = """
+CREATE TABLE IF NOT EXISTS hub_cve_intel (
+    tenant_id TEXT NOT NULL,
+    cve_id TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, cve_id)
+)
+"""
+
+_HUB_FRAMEWORK_REFS_DDL = """
+CREATE TABLE IF NOT EXISTS hub_framework_refs (
+    tenant_id TEXT NOT NULL,
+    framework_ref TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, framework_ref)
+)
+"""
+
+_MEMORY_CVE_INTEL: dict[tuple[str, str], dict[str, Any]] = {}
+_MEMORY_FRAMEWORK_REFS: dict[tuple[str, str], dict[str, Any]] = {}
+_MEMORY_LOCK = threading.Lock()
+
+
+def reset_in_memory_hub_references() -> None:
+    with _MEMORY_LOCK:
+        _MEMORY_CVE_INTEL.clear()
+        _MEMORY_FRAMEWORK_REFS.clear()
+
+
+def ensure_sqlite_reference_tables(conn: sqlite3.Connection) -> None:
+    conn.execute(_HUB_CVE_INTEL_DDL)
+    conn.execute(_HUB_FRAMEWORK_REFS_DDL)
+
+
+def ensure_postgres_reference_tables(conn: Any) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS hub_cve_intel (
+            tenant_id TEXT NOT NULL,
+            cve_id TEXT NOT NULL,
+            payload JSONB NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, cve_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS hub_framework_refs (
+            tenant_id TEXT NOT NULL,
+            framework_ref TEXT NOT NULL,
+            payload JSONB NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, framework_ref)
+        )
+        """
+    )
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def normalize_finding_payload_for_store(tenant_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Extract shared reference blobs and return the slim ledger payload."""
+    if not HUB_REFERENCE_NORMALIZE:
+        return dict(payload)
+    slim, intel_blob, framework_blob = extract_reference_blobs(payload)
+    if intel_blob:
+        cve_id = resolve_cve_id(payload)
+        if cve_id:
+            _upsert_cve_intel_memory(tenant_id, cve_id, intel_blob)
+    if framework_blob:
+        fw_ref = str(slim.get("framework_ref") or "")
+        if fw_ref:
+            _upsert_framework_ref_memory(tenant_id, fw_ref, framework_blob)
+    return slim
+
+
+def persist_finding_references_sqlite(conn: sqlite3.Connection, tenant_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    if not HUB_REFERENCE_NORMALIZE:
+        return dict(payload)
+    ensure_sqlite_reference_tables(conn)
+    slim, intel_blob, framework_blob = extract_reference_blobs(payload)
+    now = _now_iso()
+    if intel_blob:
+        cve_id = resolve_cve_id(payload)
+        if cve_id:
+            conn.execute(
+                """
+                INSERT INTO hub_cve_intel (tenant_id, cve_id, payload, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(tenant_id, cve_id) DO UPDATE SET
+                    payload = excluded.payload,
+                    updated_at = excluded.updated_at
+                """,
+                (tenant_id, cve_id, encode_hub_payload(intel_blob), now),
+            )
+    if framework_blob:
+        fw_ref = str(slim.get("framework_ref") or "")
+        if fw_ref:
+            conn.execute(
+                """
+                INSERT INTO hub_framework_refs (tenant_id, framework_ref, payload, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(tenant_id, framework_ref) DO UPDATE SET
+                    payload = excluded.payload,
+                    updated_at = excluded.updated_at
+                """,
+                (tenant_id, fw_ref, encode_hub_payload(framework_blob), now),
+            )
+    return slim
+
+
+def persist_finding_references_postgres(conn: Any, tenant_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    if not HUB_REFERENCE_NORMALIZE:
+        return dict(payload)
+    ensure_postgres_reference_tables(conn)
+    slim, intel_blob, framework_blob = extract_reference_blobs(payload)
+    now = _now_iso()
+    if intel_blob:
+        cve_id = resolve_cve_id(payload)
+        if cve_id:
+            conn.execute(
+                """
+                INSERT INTO hub_cve_intel (tenant_id, cve_id, payload, updated_at)
+                VALUES (%s, %s, %s::jsonb, %s)
+                ON CONFLICT (tenant_id, cve_id) DO UPDATE SET
+                    payload = EXCLUDED.payload,
+                    updated_at = EXCLUDED.updated_at
+                """,
+                (tenant_id, cve_id, json.dumps(intel_blob, sort_keys=True), now),
+            )
+    if framework_blob:
+        fw_ref = str(slim.get("framework_ref") or "")
+        if fw_ref:
+            conn.execute(
+                """
+                INSERT INTO hub_framework_refs (tenant_id, framework_ref, payload, updated_at)
+                VALUES (%s, %s, %s::jsonb, %s)
+                ON CONFLICT (tenant_id, framework_ref) DO UPDATE SET
+                    payload = EXCLUDED.payload,
+                    updated_at = EXCLUDED.updated_at
+                """,
+                (tenant_id, fw_ref, json.dumps(framework_blob, sort_keys=True), now),
+            )
+    return slim
+
+
+def _upsert_cve_intel_memory(tenant_id: str, cve_id: str, blob: dict[str, Any]) -> None:
+    with _MEMORY_LOCK:
+        _MEMORY_CVE_INTEL[(tenant_id, cve_id)] = dict(blob)
+
+
+def _upsert_framework_ref_memory(tenant_id: str, framework_ref: str, blob: dict[str, Any]) -> None:
+    with _MEMORY_LOCK:
+        _MEMORY_FRAMEWORK_REFS[(tenant_id, framework_ref)] = dict(blob)
+
+
+def _fetch_cve_intel_memory(tenant_id: str, cve_ids: Sequence[str]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    with _MEMORY_LOCK:
+        for cve_id in cve_ids:
+            blob = _MEMORY_CVE_INTEL.get((tenant_id, cve_id))
+            if blob:
+                out[cve_id] = dict(blob)
+    return out
+
+
+def _fetch_framework_refs_memory(tenant_id: str, refs: Sequence[str]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    with _MEMORY_LOCK:
+        for ref in refs:
+            blob = _MEMORY_FRAMEWORK_REFS.get((tenant_id, ref))
+            if blob:
+                out[ref] = dict(blob)
+    return out
+
+
+def _fetch_cve_intel_sqlite(conn: sqlite3.Connection, tenant_id: str, cve_ids: Sequence[str]) -> dict[str, dict[str, Any]]:
+    if not cve_ids:
+        return {}
+    placeholders = ",".join("?" * len(cve_ids))
+    rows = conn.execute(
+        f"SELECT cve_id, payload FROM hub_cve_intel WHERE tenant_id = ? AND cve_id IN ({placeholders})",  # nosec B608
+        (tenant_id, *cve_ids),
+    ).fetchall()
+    return {str(row[0]): decode_hub_payload(row[1]) for row in rows}
+
+
+def _fetch_framework_refs_sqlite(conn: sqlite3.Connection, tenant_id: str, refs: Sequence[str]) -> dict[str, dict[str, Any]]:
+    if not refs:
+        return {}
+    placeholders = ",".join("?" * len(refs))
+    rows = conn.execute(
+        f"SELECT framework_ref, payload FROM hub_framework_refs WHERE tenant_id = ? AND framework_ref IN ({placeholders})",  # nosec B608
+        (tenant_id, *refs),
+    ).fetchall()
+    return {str(row[0]): decode_hub_payload(row[1]) for row in rows}
+
+
+def _fetch_cve_intel_postgres(conn: Any, tenant_id: str, cve_ids: Sequence[str]) -> dict[str, dict[str, Any]]:
+    if not cve_ids:
+        return {}
+    rows = conn.execute(
+        "SELECT cve_id, payload FROM hub_cve_intel WHERE tenant_id = %s AND cve_id = ANY(%s)",
+        (tenant_id, list(cve_ids)),
+    ).fetchall()
+    out: dict[str, dict[str, Any]] = {}
+    for cve_id, raw in rows:
+        out[str(cve_id)] = decode_hub_payload(raw)
+    return out
+
+
+def _fetch_framework_refs_postgres(conn: Any, tenant_id: str, refs: Sequence[str]) -> dict[str, dict[str, Any]]:
+    if not refs:
+        return {}
+    rows = conn.execute(
+        "SELECT framework_ref, payload FROM hub_framework_refs WHERE tenant_id = %s AND framework_ref = ANY(%s)",
+        (tenant_id, list(refs)),
+    ).fetchall()
+    out: dict[str, dict[str, Any]] = {}
+    for framework_ref, raw in rows:
+        out[str(framework_ref)] = decode_hub_payload(raw)
+    return out
+
+
+def hydrate_finding_payload_memory(tenant_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    cve_ids, framework_refs = batch_reference_keys([payload])
+    return hydrate_reference_payload(
+        payload,
+        cve_intel=_fetch_cve_intel_memory(tenant_id, sorted(cve_ids)),
+        framework_refs=_fetch_framework_refs_memory(tenant_id, sorted(framework_refs)),
+    )
+
+
+def hydrate_finding_payloads_memory(tenant_id: str, payloads: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    items = list(payloads)
+    cve_ids, framework_refs = batch_reference_keys(items)
+    cve_map = _fetch_cve_intel_memory(tenant_id, sorted(cve_ids))
+    fw_map = _fetch_framework_refs_memory(tenant_id, sorted(framework_refs))
+    return [hydrate_reference_payload(item, cve_intel=cve_map, framework_refs=fw_map) for item in items]
+
+
+def hydrate_finding_payloads_sqlite(
+    conn: sqlite3.Connection,
+    tenant_id: str,
+    payloads: Iterable[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    items = list(payloads)
+    cve_ids, framework_refs = batch_reference_keys(items)
+    cve_map = _fetch_cve_intel_sqlite(conn, tenant_id, sorted(cve_ids))
+    fw_map = _fetch_framework_refs_sqlite(conn, tenant_id, sorted(framework_refs))
+    return [hydrate_reference_payload(item, cve_intel=cve_map, framework_refs=fw_map) for item in items]
+
+
+def hydrate_finding_payloads_postgres(
+    conn: Any,
+    tenant_id: str,
+    payloads: Iterable[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    items = list(payloads)
+    cve_ids, framework_refs = batch_reference_keys(items)
+    cve_map = _fetch_cve_intel_postgres(conn, tenant_id, sorted(cve_ids))
+    fw_map = _fetch_framework_refs_postgres(conn, tenant_id, sorted(framework_refs))
+    return [hydrate_reference_payload(item, cve_intel=cve_map, framework_refs=fw_map) for item in items]

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -321,6 +321,7 @@ class PostgresComplianceHubStore:
             for original in findings:
                 if not isinstance(original, dict):
                     continue
+                frameworks_csv = _frameworks_csv(original)
                 slim = persist_finding_references_postgres(conn, tenant_id, original)
                 payload = _redact_finding(slim)
                 # Idempotent ingest: a resend of the same (tenant_id, finding_id)
@@ -348,7 +349,7 @@ class PostgresComplianceHubStore:
                         str(payload.get("id") or f"hub-{now}-{id(original)}"),
                         now,
                         str(payload.get("source") or ""),
-                        _frameworks_csv(payload),
+                        frameworks_csv,
                         encode_hub_payload(payload),
                         compute_effective_reach_score(payload),
                         str(payload.get("origin") or ""),

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -19,6 +19,7 @@ from agent_bom.api.compliance_hub_store import (
     _now_utc_iso,
     _postgres_current_order_clause,
     _postgres_order_clause,
+    _redact_finding,
     _redact_findings,
     _severity_rank,
     compute_effective_reach_score,
@@ -34,6 +35,11 @@ from agent_bom.api.hub_current_payload import (
     resolve_ledger_finding_id,
 )
 from agent_bom.api.hub_payload_codec import decode_hub_payload, encode_hub_payload
+from agent_bom.api.hub_reference_store import (
+    ensure_postgres_reference_tables,
+    hydrate_finding_payloads_postgres,
+    persist_finding_references_postgres,
+)
 from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
@@ -111,10 +117,12 @@ def _fetch_ledger_payloads_postgres(
         """,
         (tenant_id, list(finding_ids)),
     ).fetchall()
-    out: dict[str, dict[str, Any]] = {}
-    for finding_id, raw_payload in rows:
-        out[str(finding_id)] = decode_hub_payload(raw_payload)
-    return out
+    if not rows:
+        return {}
+    ordered_ids = [str(finding_id) for finding_id, _raw in rows]
+    payloads = [decode_hub_payload(raw) for _finding_id, raw in rows]
+    hydrated = hydrate_finding_payloads_postgres(conn, tenant_id, payloads)
+    return dict(zip(ordered_ids, hydrated))
 
 
 def _postgres_current_row_from_db(row: tuple[Any, ...], *, has_ledger_col: bool) -> dict[str, Any]:
@@ -256,6 +264,9 @@ class PostgresComplianceHubStore:
             _migrate_current_ledger_ref_postgres(conn)
             _ensure_tenant_rls(conn, "hub_findings_current", "tenant_id")
             _ensure_tenant_rls(conn, "hub_findings_current_observations", "tenant_id")
+            ensure_postgres_reference_tables(conn)
+            _ensure_tenant_rls(conn, "hub_cve_intel", "tenant_id")
+            _ensure_tenant_rls(conn, "hub_framework_refs", "tenant_id")
             conn.commit()
 
     @staticmethod
@@ -303,12 +314,15 @@ class PostgresComplianceHubStore:
         )
 
     def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
-        findings = _redact_findings(findings)
         if not findings:
             return self.count(tenant_id)
         now = _now_utc_iso()
         with _tenant_connection(self._pool) as conn:
-            for payload in findings:
+            for original in findings:
+                if not isinstance(original, dict):
+                    continue
+                slim = persist_finding_references_postgres(conn, tenant_id, original)
+                payload = _redact_finding(slim)
                 # Idempotent ingest: a resend of the same (tenant_id, finding_id)
                 # refreshes payload/metadata and keeps the original ``ordinal``
                 # (the BIGSERIAL default only advances on genuine inserts).
@@ -331,7 +345,7 @@ class PostgresComplianceHubStore:
                     """,
                     (
                         tenant_id,
-                        str(payload.get("id") or f"hub-{now}-{id(payload)}"),
+                        str(payload.get("id") or f"hub-{now}-{id(original)}"),
                         now,
                         str(payload.get("source") or ""),
                         _frameworks_csv(payload),
@@ -352,11 +366,8 @@ class PostgresComplianceHubStore:
                 "SELECT payload FROM compliance_hub_findings WHERE tenant_id = %s ORDER BY ordinal ASC",
                 (tenant_id,),
             ).fetchall()
-        out: list[dict[str, Any]] = []
-        for row in rows:
-            raw = row[0]
-            out.append(decode_hub_payload(raw))
-        return out
+            payloads = [decode_hub_payload(row[0]) for row in rows]
+            return hydrate_finding_payloads_postgres(conn, tenant_id, payloads)
 
     def list_page(
         self,
@@ -403,10 +414,8 @@ class PostgresComplianceHubStore:
                 f"SELECT payload FROM compliance_hub_findings WHERE {where_sql} {order_sql} LIMIT %s OFFSET %s",  # nosec B608
                 (*params, int(limit), int(offset)),
             ).fetchall()
-        out: list[dict[str, Any]] = []
-        for row in rows:
-            raw = row[0]
-            out.append(decode_hub_payload(raw))
+            payloads = [decode_hub_payload(row[0]) for row in rows]
+            out = hydrate_finding_payloads_postgres(conn, tenant_id, payloads)
         return out, total
 
     def severity_breakdown(self, tenant_id: str) -> dict[str, int]:

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -382,6 +382,11 @@ POSTGRES_CONNECT_TIMEOUT_SECONDS = _int("AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECO
 POSTGRES_STATEMENT_TIMEOUT_MS = _int("AGENT_BOM_POSTGRES_STATEMENT_TIMEOUT_MS", 15_000)
 POSTGRES_GRAPH_SEARCH_TIMEOUT_MS = _int("AGENT_BOM_POSTGRES_GRAPH_SEARCH_TIMEOUT_MS", 3_000)
 
+# Compliance hub reference-table normalization (#3513). When enabled, repeated
+# CVE/framework blobs are stored once per tenant and ledger rows keep join keys.
+# Set to 0 to disable new extractions (reads still hydrate existing refs).
+HUB_REFERENCE_NORMALIZE = _bool("AGENT_BOM_HUB_REFERENCE_NORMALIZE", True)
+
 
 # ── Rate-limit fingerprint key rotation policy ──────────────────────────
 # Operators rotate AGENT_BOM_RATE_LIMIT_KEY periodically and record the

--- a/tests/test_hub_reference_normalization.py
+++ b/tests/test_hub_reference_normalization.py
@@ -1,0 +1,115 @@
+"""Reference-table normalization for hub finding payloads (#3513)."""
+
+from __future__ import annotations
+
+import json
+from uuid import uuid4
+
+import pytest
+
+from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore, SQLiteComplianceHubStore
+from agent_bom.api.hub_payload_codec import encode_hub_payload
+from agent_bom.api.hub_reference_payload import extract_reference_blobs, hydrate_reference_payload
+from agent_bom.api.hub_reference_store import reset_in_memory_hub_references
+
+
+@pytest.fixture(autouse=True)
+def _reset_memory_refs():
+    reset_in_memory_hub_references()
+    yield
+    reset_in_memory_hub_references()
+
+
+def _shared_intel_finding(finding_id: str, *, cve_id: str = "CVE-2026-3513") -> dict:
+    return {
+        "id": finding_id,
+        "title": f"Finding {finding_id}",
+        "severity": "high",
+        "cvss_score": 8.8,
+        "epss_score": 0.42,
+        "cve_id": cve_id,
+        "vulnerability_id": cve_id,
+        "summary": "Shared CVE enrichment blob " + ("x" * 400),
+        "references": [f"https://nvd.nist.gov/vuln/detail/{cve_id}"],
+        "advisory_sources": ["osv", "ghsa", "nvd"],
+        "cvss_vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "owasp_tags": ["LLM01", "LLM02"],
+        "nist_csf_tags": ["ID.AM-1"],
+        "compliance_tags": ["LLM01"],
+        "origin": "bulk_ingest",
+        "source": "test",
+        "batch_id": "batch-ref",
+    }
+
+
+def test_extract_and_hydrate_reference_blobs_roundtrip() -> None:
+    finding = _shared_intel_finding("f-1")
+    slim, intel_blob, framework_blob = extract_reference_blobs(finding)
+    assert slim["intel_ref"] == "CVE-2026-3513"
+    assert slim["framework_ref"]
+    assert "summary" not in slim
+    assert "owasp_tags" not in slim
+    assert intel_blob is not None
+    assert framework_blob is not None
+
+    restored = hydrate_reference_payload(
+        slim,
+        cve_intel={"CVE-2026-3513": intel_blob},
+        framework_refs={slim["framework_ref"]: framework_blob},
+    )
+    assert restored["summary"] == finding["summary"]
+    assert restored["owasp_tags"] == finding["owasp_tags"]
+    assert restored["cvss_score"] == finding["cvss_score"]
+
+
+@pytest.mark.parametrize("store_factory", ["memory", "sqlite"])
+def test_hub_list_returns_hydrated_user_visible_fields(store_factory: str, tmp_path) -> None:
+    if store_factory == "memory":
+        store = InMemoryComplianceHubStore()
+    else:
+        store = SQLiteComplianceHubStore(str(tmp_path / "refs.db"))
+
+    tenant = f"ref-{uuid4().hex}"
+    findings = [_shared_intel_finding(f"f-{idx}") for idx in range(5)]
+    store.add(tenant, findings)
+
+    listed = store.list(tenant)
+    assert len(listed) == 5
+    for item, original in zip(listed, findings):
+        assert item["summary"] == original["summary"]
+        assert item["owasp_tags"] == original["owasp_tags"]
+        assert item["cvss_score"] == original["cvss_score"]
+
+    if store_factory == "sqlite":
+        row = store._conn.execute(
+            "SELECT payload FROM compliance_hub_findings WHERE tenant_id = ? LIMIT 1",
+            (tenant,),
+        ).fetchone()
+        assert row is not None
+        stored = json.loads(row[0])
+        assert stored.get("intel_ref") == "CVE-2026-3513"
+        assert "summary" not in stored
+
+
+def test_reference_normalization_reduces_ledger_bytes_at_scale(tmp_path) -> None:
+    store = SQLiteComplianceHubStore(str(tmp_path / "scale.db"))
+    tenant = f"scale-{uuid4().hex}"
+    count = 1000
+    findings = [_shared_intel_finding(f"scale-{idx}") for idx in range(count)]
+    store.add(tenant, findings)
+
+    inline_bytes = sum(len(encode_hub_payload(f)) for f in findings)
+    rows = store._conn.execute(
+        "SELECT payload FROM compliance_hub_findings WHERE tenant_id = ?",
+        (tenant,),
+    ).fetchall()
+    stored_bytes = sum(len(row[0]) for row in rows)
+    intel_rows = store._conn.execute(
+        "SELECT payload FROM hub_cve_intel WHERE tenant_id = ?",
+        (tenant,),
+    ).fetchall()
+    ref_bytes = sum(len(row[0]) for row in intel_rows)
+
+    assert stored_bytes < inline_bytes * 0.65
+    assert ref_bytes < inline_bytes * 0.02
+    assert stored_bytes + ref_bytes < inline_bytes * 0.7


### PR DESCRIPTION
## Summary
- Add `hub_cve_intel` and `hub_framework_refs` tables (SQLite + Postgres) with extract/hydrate helpers for repeated CVE/framework blobs.
- Hub ingest stores slim ledger rows with `intel_ref` / `framework_ref`; list and ledger hydration restore user-visible fields.
- `AGENT_BOM_HUB_REFERENCE_NORMALIZE=0` disables new extractions (rollback); legacy inline payloads unchanged.

Related: #3513

## Verification
- `.venv/bin/pytest tests/test_hub_reference_normalization.py tests/test_hub_payload_dedup.py -q`
- `.venv/bin/ruff check` on touched files
- `.venv/bin/mypy` on reference payload/store modules

## Notes
- Reference extraction runs before tier-A redaction so enrichment blobs are captured.
- 1k-finding size budget test shows ~35%+ ledger byte reduction when sharing one CVE intel row.


Made with [Cursor](https://cursor.com)