### PR TITLE
fix(api): CVSS keyset pagination and report export truncation

### DIFF
--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -28,6 +28,7 @@ from typing import Any, Protocol
 
 from agent_bom.api.finding_cursor import (
     cursor_from_current_row,
+    cvss_sort_value,
     decode_finding_cursor,
     row_is_after_cursor,
     sqlite_keyset_clause,
@@ -493,6 +494,7 @@ def _ensure_current_lifecycle_sqlite(conn: sqlite3.Connection) -> None:
     conn.executescript(_CURRENT_LIFECYCLE_SORT_INDEXES_SQLITE)
     _migrate_lifecycle_observations_l2_sqlite(conn)
     _migrate_current_ledger_ref_sqlite(conn)
+    conn.execute("UPDATE hub_findings_current SET cvss_score = 0 WHERE cvss_score IS NULL")
 
 
 def _migrate_lifecycle_observations_l2_sqlite(conn: sqlite3.Connection) -> None:
@@ -811,7 +813,7 @@ def _sqlite_current_order_clause(sort: str) -> str:
     if sort == "ordinal":
         return "ORDER BY last_seen ASC, canonical_id ASC"
     if sort == "cvss":
-        return "ORDER BY cvss_score DESC, last_seen DESC, canonical_id ASC"
+        return "ORDER BY COALESCE(cvss_score, 0) DESC, last_seen DESC, canonical_id ASC"
     if sort == "severity":
         return "ORDER BY severity_rank DESC, last_seen DESC, canonical_id ASC"
     return "ORDER BY effective_reach_score DESC, last_seen DESC, canonical_id ASC"
@@ -832,7 +834,7 @@ def _current_page_sort_key(sort: str) -> Callable[[dict[str, Any]], tuple[float 
         if normalized == "ordinal":
             return (tie, canonical, "")
         if normalized == "cvss":
-            primary = float(row.get("cvss_score") or 0.0)
+            primary = cvss_sort_value(row.get("cvss_score"))
         elif normalized == "severity":
             primary = float(row.get("severity_rank") or 0)
         else:

--- a/src/agent_bom/api/finding_cursor.py
+++ b/src/agent_bom/api/finding_cursor.py
@@ -8,6 +8,19 @@ from typing import Any
 
 _ALLOWED_SORTS = frozenset({"effective_reach", "cvss", "severity", "ordinal"})
 
+# Legacy rows may have NULL ``cvss_score``; treat as 0 for DESC keyset walks so
+# SQL comparisons stay three-valued-logic safe (#3511 / audit 2026-07-04).
+_CVSS_NULL_SORT_VALUE = 0.0
+
+
+def cvss_sort_value(raw: Any) -> float:
+    if raw is None:
+        return _CVSS_NULL_SORT_VALUE
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return _CVSS_NULL_SORT_VALUE
+
 
 def encode_finding_cursor(
     *,
@@ -46,7 +59,7 @@ def cursor_from_current_row(row: dict[str, Any], *, sort: str) -> str:
     if normalized == "ordinal":
         primary = 0.0
     elif normalized == "cvss":
-        primary = float(row.get("cvss_score") or 0.0)
+        primary = cvss_sort_value(row.get("cvss_score"))
     elif normalized == "severity":
         primary = float(row.get("severity_rank") or 0.0)
     else:
@@ -59,6 +72,10 @@ def cursor_from_current_row(row: dict[str, Any], *, sort: str) -> str:
     )
 
 
+def _cvss_keyset_expr() -> str:
+    return "COALESCE(cvss_score, 0)"
+
+
 def sqlite_keyset_clause(sort: str, cursor: str) -> tuple[str, list[Any]]:
     """Return extra WHERE SQL + params for keyset pagination after ``cursor``."""
     normalized = sort if sort in _ALLOWED_SORTS else "effective_reach"
@@ -69,7 +86,7 @@ def sqlite_keyset_clause(sort: str, cursor: str) -> tuple[str, list[Any]]:
             [last_seen, last_seen, canonical_id],
         )
     if normalized == "cvss":
-        col = "cvss_score"
+        col = _cvss_keyset_expr()
     elif normalized == "severity":
         col = "severity_rank"
     else:
@@ -100,7 +117,7 @@ def row_is_after_cursor(
     if normalized == "ordinal":
         return (row_last, row_canonical) > (last_seen, canonical_id)
     if normalized == "cvss":
-        row_primary = float(row.get("cvss_score") or 0.0)
+        row_primary = cvss_sort_value(row.get("cvss_score"))
     elif normalized == "severity":
         row_primary = float(row.get("severity_rank") or 0.0)
     else:

--- a/src/agent_bom/api/finding_lifecycle.py
+++ b/src/agent_bom/api/finding_lifecycle.py
@@ -12,7 +12,7 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Any
 
-from agent_bom.api.compliance_hub_store import _severity_rank, compute_effective_reach_score
+from agent_bom.api.compliance_hub_store import _cvss_value, _severity_rank, compute_effective_reach_score
 from agent_bom.canonical_ids import canonical_finding_id, canonical_id
 
 FindingLifecycleMetrics = dict[str, Any]
@@ -69,16 +69,10 @@ def resolve_canonical_id(payload: dict[str, Any], *, source: str = "") -> str:
 def lifecycle_metrics(payload: dict[str, Any]) -> FindingLifecycleMetrics:
     """Extract denormalised lifecycle columns from a finding payload."""
     severity = str(payload.get("severity") or "unknown").lower()
-    cvss_raw = payload.get("cvss_score")
-    cvss_score: float | None
-    try:
-        cvss_score = float(cvss_raw) if cvss_raw is not None else None
-    except (TypeError, ValueError):
-        cvss_score = None
     return {
         "severity": severity,
         "severity_rank": _severity_rank(payload),
-        "cvss_score": cvss_score,
+        "cvss_score": _cvss_value(payload),
         "effective_reach_score": compute_effective_reach_score(payload),
     }
 

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -254,6 +254,7 @@ class PostgresComplianceHubStore:
             conn.execute(_CURRENT_LIFECYCLE_POSTGRES_DDL)
             _migrate_lifecycle_observations_l2_postgres(conn)
             _migrate_current_ledger_ref_postgres(conn)
+            conn.execute("UPDATE hub_findings_current SET cvss_score = 0 WHERE cvss_score IS NULL")
             _ensure_tenant_rls(conn, "hub_findings_current", "tenant_id")
             _ensure_tenant_rls(conn, "hub_findings_current_observations", "tenant_id")
             conn.commit()

--- a/tests/test_finding_cursor.py
+++ b/tests/test_finding_cursor.py
@@ -134,6 +134,70 @@ def test_findings_api_keyset_pagination() -> None:
     assert {row["id"] for row in body["findings"]}.isdisjoint({row["id"] for row in body2["findings"]})
 
 
+def test_sqlite_cvss_keyset_walks_all_rows_without_cvss_column_populated() -> None:
+    """NULL/omitted cvss_score must not truncate CVSS-sorted cursor walks."""
+    import tempfile
+
+    tenant = f"cvss-keyset-{uuid4().hex}"
+    count = 25
+    with tempfile.TemporaryDirectory() as tmp:
+        store = SQLiteComplianceHubStore(f"{tmp}/cvss-keyset.db")
+        findings = [
+            {
+                "id": f"finding-{idx}",
+                "title": f"Finding {idx}",
+                "severity": "high",
+                "effective_reach_score": float(idx),
+                "origin": "bulk_ingest",
+                "source": "test",
+                "batch_id": "batch-cvss-keyset",
+            }
+            for idx in range(count)
+        ]
+        store.add(tenant, findings)
+        store.upsert_current_batch(
+            tenant,
+            findings,
+            observed_at="2026-07-04T00:00:00Z",
+            batch_id="batch-cvss-keyset",
+            source="test",
+        )
+
+        null_rows = store._conn.execute(
+            "SELECT COUNT(*) FROM hub_findings_current WHERE tenant_id = ? AND cvss_score IS NULL",
+            (tenant,),
+        ).fetchone()[0]
+        assert null_rows == 0
+
+        seen: set[str] = set()
+        cursor: str | None = None
+        while True:
+            page, total, next_cursor = store.list_current_page(
+                tenant,
+                limit=5,
+                sort="cvss",
+                origin="bulk_ingest",
+                cursor=cursor,
+                include_total=cursor is None,
+            )
+            if cursor is None:
+                assert total == count
+            for row in page:
+                seen.add(str(row["id"]))
+            if not next_cursor:
+                break
+            cursor = next_cursor
+
+        assert len(seen) == count
+
+
+def test_lifecycle_metrics_defaults_cvss_score_to_zero() -> None:
+    from agent_bom.api.finding_lifecycle import lifecycle_metrics
+
+    metrics = lifecycle_metrics({"severity": "high"})
+    assert metrics["cvss_score"] == 0.0
+
+
 def test_findings_api_rejects_cursor_with_offset() -> None:
     client = TestClient(app)
     headers = proxy_headers(tenant="default")


### PR DESCRIPTION
## Summary
- Default `cvss_score` to `0.0` in `lifecycle_metrics` so bulk upsert materialises the column on every current-state row.
- Backfill `hub_findings_current` NULL cvss scores on store init (SQLite + Postgres).
- CVSS keyset cursors and ORDER BY use `COALESCE(cvss_score, 0)` so NULL legacy rows no longer halt pagination after page 1.

Fixes silent truncation in `GET /v1/findings?sort=cvss` and `POST /v1/reports` with CVSS sort (audit 2026-07-04).

Related: #3529

## Verification
- `.venv/bin/pytest tests/test_finding_cursor.py tests/test_report_jobs.py tests/test_finding_lifecycle.py -q`
- `.venv/bin/ruff check` on touched files
- `.venv/bin/mypy` on `finding_cursor.py` and `finding_lifecycle.py`


Made with [Cursor](https://cursor.com)