### PR TITLE
feat(export): delta-stream connector for SIEM and data-lake sinks

### DIFF
--- a/docs/OCSF_BOUNDARY.md
+++ b/docs/OCSF_BOUNDARY.md
@@ -27,10 +27,11 @@ wire-protocol for SIEM interop**, not agent-bom's internal data model.
    AWS-→-OCSF-→-internal double hop. OCSF only appears on the way out to
    a SIEM.
 4. **OCSF emission is one-way, at the wire boundary.** Translators live
-   in `siem/ocsf.py` (SIEM push, Detection Finding, `class_uid=2004`)
-   and `output/ocsf.py` (MCP tool output, Security Finding,
-   `class_uid=2001`). Runtime alerts are the only source currently
-   translated; CIS / skills / CVE findings stay in internal JSON today.
+   in `siem/ocsf.py` (SIEM push, Detection Finding, `class_uid=2004`),
+   `siem/delta_stream.py` (finding delta-stream projection), and
+   `output/ocsf.py` (MCP tool output, Security Finding, `class_uid=2001`).
+   Runtime alerts and finding-delta export batches are translated at the
+   boundary; CIS / skills / CVE findings stay in internal JSON otherwise.
 
 ## What is allowed to depend on OCSF
 

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -189,6 +189,13 @@ so they cannot regress silently, but they are not part of this reference.
 ## PostgreSQL Control Plane Tuning
 | Env var | Type | Default | Description |
 |---|---|---|---|
+| `AGENT_BOM_DELTA_STREAM_AUTH_SCHEME` | `str` | `''` | — |
+| `AGENT_BOM_DELTA_STREAM_AUTH_TOKEN` | `str` | `''` | — |
+| `AGENT_BOM_DELTA_STREAM_DESTINATION_ID` | `str` | `'delta-stream-default'` | — |
+| `AGENT_BOM_DELTA_STREAM_ENABLED` | `bool` | `False` | Finding delta-stream export to SIEM / data-lake sinks (#3514). |
+| `AGENT_BOM_DELTA_STREAM_FORMAT` | `str` | `'ndjson'` | — |
+| `AGENT_BOM_DELTA_STREAM_SIGNING_SECRET` | `str` | `''` | — |
+| `AGENT_BOM_DELTA_STREAM_URL` | `str` | `''` | — |
 | `AGENT_BOM_HUB_REFERENCE_NORMALIZE` | `bool` | `True` | Compliance hub reference-table normalization (#3513). When enabled, repeated CVE/framework blobs are stored once per tenant and ledger rows keep join keys. Set to 0 to disable new extractions (reads still hydrate existing refs). |
 | `AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS` | `int` | `5` | — |
 | `AGENT_BOM_POSTGRES_GRAPH_SEARCH_TIMEOUT_MS` | `int` | `3000` | — |
@@ -208,17 +215,6 @@ so they cannot regress silently, but they are not part of this reference.
 |---|---|---|---|
 | `AGENT_BOM_RATE_LIMIT_KEY_MAX_AGE_DAYS` | `int` | `90` | — |
 | `AGENT_BOM_RATE_LIMIT_KEY_ROTATION_DAYS` | `int` | `30` | Operators rotate AGENT_BOM_RATE_LIMIT_KEY periodically and record the rotation timestamp in AGENT_BOM_RATE_LIMIT_KEY_LAST_ROTATED (ISO-8601 with timezone). The control plane warns when the configured key age approaches the rotation interval |
-
-## Delta stream export (SIEM / data lake)
-| Env var | Type | Default | Description |
-|---|---|---|---|
-| `AGENT_BOM_DELTA_STREAM_ENABLED` | `bool` | `False` | Enable finding delta export on hub ingest (#3514). When enabled, each bulk/compliance ingest emits **new**, **changed**, and **resolved** events since the last watermark via the hardened delivery client. |
-| `AGENT_BOM_DELTA_STREAM_URL` | `str` | `''` | HTTPS webhook or object-store pre-signed URL target for delta batches. Required when delta export is enabled (unless tests inject an in-memory sink). |
-| `AGENT_BOM_DELTA_STREAM_DESTINATION_ID` | `str` | `'delta-stream-default'` | Stable destination id for delivery logs, DLQ routing, and per-tenant watermarks. |
-| `AGENT_BOM_DELTA_STREAM_FORMAT` | `str` | `'ndjson'` | Payload shape: `ndjson` (canonical finding_delta.v1 events) or `ocsf` (OCSF Detection Finding projection). |
-| `AGENT_BOM_DELTA_STREAM_AUTH_SCHEME` | `str` | `''` | Optional Authorization scheme forwarded to the delivery client (e.g. `Bearer`). |
-| `AGENT_BOM_DELTA_STREAM_AUTH_TOKEN` | `str` | `''` | Optional bearer/API token for the delta-stream destination. |
-| `AGENT_BOM_DELTA_STREAM_SIGNING_SECRET` | `str` | `''` | Optional HMAC signing secret for webhook verification at the sink. |
 
 ## Report export artifacts
 | Env var | Type | Default | Description |

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -209,6 +209,17 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_RATE_LIMIT_KEY_MAX_AGE_DAYS` | `int` | `90` | — |
 | `AGENT_BOM_RATE_LIMIT_KEY_ROTATION_DAYS` | `int` | `30` | Operators rotate AGENT_BOM_RATE_LIMIT_KEY periodically and record the rotation timestamp in AGENT_BOM_RATE_LIMIT_KEY_LAST_ROTATED (ISO-8601 with timezone). The control plane warns when the configured key age approaches the rotation interval |
 
+## Delta stream export (SIEM / data lake)
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_DELTA_STREAM_ENABLED` | `bool` | `False` | Enable finding delta export on hub ingest (#3514). When enabled, each bulk/compliance ingest emits **new**, **changed**, and **resolved** events since the last watermark via the hardened delivery client. |
+| `AGENT_BOM_DELTA_STREAM_URL` | `str` | `''` | HTTPS webhook or object-store pre-signed URL target for delta batches. Required when delta export is enabled (unless tests inject an in-memory sink). |
+| `AGENT_BOM_DELTA_STREAM_DESTINATION_ID` | `str` | `'delta-stream-default'` | Stable destination id for delivery logs, DLQ routing, and per-tenant watermarks. |
+| `AGENT_BOM_DELTA_STREAM_FORMAT` | `str` | `'ndjson'` | Payload shape: `ndjson` (canonical finding_delta.v1 events) or `ocsf` (OCSF Detection Finding projection). |
+| `AGENT_BOM_DELTA_STREAM_AUTH_SCHEME` | `str` | `''` | Optional Authorization scheme forwarded to the delivery client (e.g. `Bearer`). |
+| `AGENT_BOM_DELTA_STREAM_AUTH_TOKEN` | `str` | `''` | Optional bearer/API token for the delta-stream destination. |
+| `AGENT_BOM_DELTA_STREAM_SIGNING_SECRET` | `str` | `''` | Optional HMAC signing secret for webhook verification at the sink. |
+
 ## Report export artifacts
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/site-docs/deployment/siem-integration.md
+++ b/site-docs/deployment/siem-integration.md
@@ -143,3 +143,38 @@ This avoids lock-in in both directions:
 
 - customers are not forced into OCSF to use the product
 - customers who want OCSF still get a clean interoperability path
+
+## Finding delta-stream export (control plane)
+
+When the compliance hub ingests findings (`POST /v1/findings/bulk` or
+compliance format ingest), operators can push **only what changed** to a SIEM
+or data-lake sink instead of re-listing the full hub on every poll.
+
+Enable on the control plane:
+
+```bash
+export AGENT_BOM_DELTA_STREAM_ENABLED=1
+export AGENT_BOM_DELTA_STREAM_URL=https://siem.example.com/hooks/agent-bom-deltas
+export AGENT_BOM_DELTA_STREAM_FORMAT=ndjson   # or ocsf
+export AGENT_BOM_DELTA_STREAM_AUTH_SCHEME=Bearer
+export AGENT_BOM_DELTA_STREAM_AUTH_TOKEN="$SIEM_TOKEN"
+```
+
+Each ingest batch emits a delta payload with:
+
+- `new` — canonical id first seen in current state for the ingest source
+- `changed` — severity, CVSS, reach score, or status materially changed
+- `resolved` — open finding absent from a reconcile-absent batch
+
+Watermarks are stored per `(tenant_id, destination_id)` so retries and
+multi-replica control planes do not double-send the same batch. Delivery rides
+the hardened `agent_bom.delivery` client (retries, DLQ, circuit breaker,
+idempotency keys).
+
+First command → artifact → next step:
+
+1. Enable the env vars above and restart the control plane.
+2. POST a bulk ingest with `reconcile_absent: true` when you want resolved events.
+3. Inspect delivery logs / your sink for `finding_delta_batch` payloads tagged
+   with `batch_id` and `observed_at`.
+4. See `docs/operations/ENV_VARS.md` for the full variable reference.

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -1869,9 +1869,11 @@ async def ingest_compliance_findings(request: Request) -> dict:
     tenant_id = _tenant_id(request)
     store = get_compliance_hub_store()
     from agent_bom.api.finding_lifecycle import collect_present_canonical_ids, normalize_observed_at
+    from agent_bom.delta_stream import capture_hub_snapshots, emit_hub_finding_deltas_if_enabled, resolved_canonical_ids
 
     observed_at = normalize_observed_at(body.get("observed_at"))
     batch_id = str(uuid.uuid4())
+    prior_snapshots = capture_hub_snapshots(store, tenant_id, source=fmt)
     new_total = store.add(tenant_id, payloads)
     store.upsert_current_batch(
         tenant_id,
@@ -1881,14 +1883,26 @@ async def ingest_compliance_findings(request: Request) -> dict:
         source=fmt,
     )
     reconciled = 0
+    resolved_ids: set[str] = set()
     if body.get("reconcile_absent"):
         present = collect_present_canonical_ids(payloads, source=fmt)
+        resolved_ids = resolved_canonical_ids(prior_snapshots, present)
         reconciled = store.reconcile_current_absent(
             tenant_id,
             present_canonical_ids=present,
             observed_at=observed_at,
             scope_source=fmt,
         )
+    delta_results = emit_hub_finding_deltas_if_enabled(
+        tenant_id=tenant_id,
+        hub_store=store,
+        prior=prior_snapshots,
+        batch_findings=payloads,
+        resolved_canonical_ids=resolved_ids,
+        observed_at=observed_at,
+        batch_id=batch_id,
+        source=fmt,
+    )
 
     framework_counts: dict[str, int] = {}
     for payload in payloads:
@@ -1904,6 +1918,13 @@ async def ingest_compliance_findings(request: Request) -> dict:
     }
     if body.get("reconcile_absent"):
         response["reconciled"] = reconciled
+    if delta_results:
+        delivered = sum(
+            1
+            for result in delta_results
+            if (result.get("status") == "delivered" if isinstance(result, dict) else getattr(result, "delivered", False))
+        )
+        response["delta_stream"] = {"emitted_batches": len(delta_results), "delivered": delivered}
     return response
 
 

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1456,6 +1456,9 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
 
     observed_at = normalize_observed_at(body.observed_at or body.metadata.get("observed_at"))
     hub_store = get_compliance_hub_store()
+    from agent_bom.delta_stream import capture_hub_snapshots, emit_hub_finding_deltas_if_enabled, resolved_canonical_ids
+
+    prior_snapshots = capture_hub_snapshots(hub_store, tenant_id, source=body.source)
     new_total = hub_store.add(tenant_id, payloads)
     hub_store.upsert_current_batch(
         tenant_id,
@@ -1465,14 +1468,26 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
         source=body.source,
     )
     reconciled = 0
+    resolved_ids: set[str] = set()
     if body.reconcile_absent:
         present = collect_present_canonical_ids(payloads, source=body.source)
+        resolved_ids = resolved_canonical_ids(prior_snapshots, present)
         reconciled = hub_store.reconcile_current_absent(
             tenant_id,
             present_canonical_ids=present,
             observed_at=observed_at,
             scope_source=body.source,
         )
+    delta_results = emit_hub_finding_deltas_if_enabled(
+        tenant_id=tenant_id,
+        hub_store=hub_store,
+        prior=prior_snapshots,
+        batch_findings=payloads,
+        resolved_canonical_ids=resolved_ids,
+        observed_at=observed_at,
+        batch_id=batch_id,
+        source=body.source,
+    )
     warnings = ["tenant_id in body ignored; request tenant scope is authoritative"] if ignored_body_tenant else []
     response = {
         "schema_version": "v1",
@@ -1486,6 +1501,13 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
     }
     if body.reconcile_absent:
         response["reconciled"] = reconciled
+    if delta_results:
+        delivered = sum(
+            1
+            for result in delta_results
+            if (result.get("status") == "delivered" if isinstance(result, dict) else getattr(result, "delivered", False))
+        )
+        response["delta_stream"] = {"emitted_batches": len(delta_results), "delivered": delivered}
     if idem_key:
         _get_idempotency_store().put(
             "/v1/findings/bulk",

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -387,6 +387,15 @@ POSTGRES_GRAPH_SEARCH_TIMEOUT_MS = _int("AGENT_BOM_POSTGRES_GRAPH_SEARCH_TIMEOUT
 # Set to 0 to disable new extractions (reads still hydrate existing refs).
 HUB_REFERENCE_NORMALIZE = _bool("AGENT_BOM_HUB_REFERENCE_NORMALIZE", True)
 
+# Finding delta-stream export to SIEM / data-lake sinks (#3514).
+DELTA_STREAM_ENABLED = _bool("AGENT_BOM_DELTA_STREAM_ENABLED", False)
+DELTA_STREAM_URL = _str("AGENT_BOM_DELTA_STREAM_URL", "")
+DELTA_STREAM_DESTINATION_ID = _str("AGENT_BOM_DELTA_STREAM_DESTINATION_ID", "delta-stream-default")
+DELTA_STREAM_FORMAT = _str("AGENT_BOM_DELTA_STREAM_FORMAT", "ndjson")
+DELTA_STREAM_AUTH_SCHEME = _str("AGENT_BOM_DELTA_STREAM_AUTH_SCHEME", "")
+DELTA_STREAM_AUTH_TOKEN = _str("AGENT_BOM_DELTA_STREAM_AUTH_TOKEN", "")
+DELTA_STREAM_SIGNING_SECRET = _str("AGENT_BOM_DELTA_STREAM_SIGNING_SECRET", "")
+
 
 # ── Rate-limit fingerprint key rotation policy ──────────────────────────
 # Operators rotate AGENT_BOM_RATE_LIMIT_KEY periodically and record the

--- a/src/agent_bom/delta_stream.py
+++ b/src/agent_bom/delta_stream.py
@@ -1,0 +1,470 @@
+"""Finding delta-stream connector for SIEM and data-lake sinks (#3514).
+
+Emits **new**, **resolved**, and **changed** hub finding events since the last
+watermark using the hardened :mod:`agent_bom.delivery` client (retries, DLQ,
+circuit breaker, idempotency). Full snapshot re-list is not required on the
+read path — deltas are computed from current-state before/after a batch ingest
+plus optional reconcile-absent semantics.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal, Protocol, runtime_checkable
+
+from agent_bom.api.finding_lifecycle import resolve_canonical_id
+from agent_bom.delivery import Delivery, DeliveryClient, Destination, get_delivery_client
+from agent_bom.security import sanitize_sensitive_payload
+
+logger = logging.getLogger(__name__)
+
+DeltaEventKind = Literal["new", "resolved", "changed"]
+DeltaFormat = Literal["ndjson", "ocsf"]
+
+
+class DeltaStreamError(RuntimeError):
+    """Raised for invalid connector configuration."""
+
+
+@dataclass(frozen=True)
+class FindingSnapshot:
+    canonical_id: str
+    severity: str
+    severity_rank: int
+    cvss_score: float
+    effective_reach_score: float
+    status: str
+    finding: dict[str, Any]
+
+    @classmethod
+    def from_finding(cls, finding: dict[str, Any], *, source: str = "") -> FindingSnapshot:
+        canonical = str(finding.get("canonical_id") or resolve_canonical_id(finding, source=source))
+        return cls(
+            canonical_id=canonical,
+            severity=str(finding.get("severity") or "unknown").lower(),
+            severity_rank=int(finding.get("severity_rank") or 0),
+            cvss_score=float(finding.get("cvss_score") or 0.0),
+            effective_reach_score=float(finding.get("effective_reach_score") or 0.0),
+            status=str(finding.get("status") or "open"),
+            finding=dict(finding),
+        )
+
+    def material_fields_changed(self, other: FindingSnapshot) -> bool:
+        return (
+            self.severity != other.severity
+            or self.severity_rank != other.severity_rank
+            or self.cvss_score != other.cvss_score
+            or self.effective_reach_score != other.effective_reach_score
+            or self.status != other.status
+        )
+
+
+@dataclass(frozen=True)
+class FindingDeltaEvent:
+    kind: DeltaEventKind
+    tenant_id: str
+    canonical_id: str
+    observed_at: str
+    batch_id: str
+    source: str
+    finding: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": "finding_delta.v1",
+            "tenant_id": self.tenant_id,
+            "event_type": self.kind,
+            "canonical_id": self.canonical_id,
+            "observed_at": self.observed_at,
+            "batch_id": self.batch_id,
+            "source": self.source,
+            "finding": sanitize_sensitive_payload(self.finding),
+        }
+
+
+@dataclass(frozen=True)
+class DeltaStreamDestination:
+    destination_id: str
+    url: str
+    format: DeltaFormat = "ndjson"
+    kind: str = "delta_stream"
+    auth_scheme: str = ""
+    auth_token: str = ""
+    signing_secret: str = ""
+
+    def to_delivery_destination(self) -> Destination:
+        return Destination(
+            destination_id=self.destination_id,
+            url=self.url,
+            kind=self.kind,
+            auth_scheme=self.auth_scheme,
+            auth_token=self.auth_token,
+            signing_secret=self.signing_secret,
+        )
+
+
+@dataclass(frozen=True)
+class DeltaWatermark:
+    observed_at: str
+    batch_id: str
+    updated_at: str
+
+
+@dataclass
+class InMemoryDeltaSink:
+    """Test double that captures emitted delta batches without HTTP."""
+
+    batches: list[dict[str, Any]] = field(default_factory=list)
+
+    def record(self, payload: dict[str, Any]) -> None:
+        self.batches.append(payload)
+
+
+class DeltaStreamStore:
+    """SQLite watermark ledger per (tenant, destination)."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS delta_stream_watermarks (
+                    tenant_id TEXT NOT NULL,
+                    destination_id TEXT NOT NULL,
+                    observed_at TEXT NOT NULL,
+                    batch_id TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (tenant_id, destination_id)
+                )
+                """
+            )
+
+    def get_watermark(self, tenant_id: str, destination_id: str) -> DeltaWatermark | None:
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT observed_at, batch_id, updated_at
+                FROM delta_stream_watermarks
+                WHERE tenant_id = ? AND destination_id = ?
+                """,
+                (tenant_id, destination_id),
+            ).fetchone()
+        if row is None:
+            return None
+        return DeltaWatermark(
+            observed_at=str(row["observed_at"]),
+            batch_id=str(row["batch_id"]),
+            updated_at=str(row["updated_at"]),
+        )
+
+    def set_watermark(self, tenant_id: str, destination_id: str, *, observed_at: str, batch_id: str) -> None:
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO delta_stream_watermarks (tenant_id, destination_id, observed_at, batch_id, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(tenant_id, destination_id) DO UPDATE SET
+                    observed_at = excluded.observed_at,
+                    batch_id = excluded.batch_id,
+                    updated_at = excluded.updated_at
+                """,
+                (tenant_id, destination_id, observed_at, batch_id, now),
+            )
+
+
+def default_delta_stream_store_path() -> Path:
+    from agent_bom.delivery import default_delivery_store_path
+
+    return default_delivery_store_path().with_name("delta_stream.db")
+
+
+def compute_finding_deltas(
+    *,
+    tenant_id: str,
+    prior: dict[str, FindingSnapshot],
+    batch_findings: list[dict[str, Any]],
+    resolved_canonical_ids: set[str],
+    observed_at: str,
+    batch_id: str,
+    source: str,
+) -> list[FindingDeltaEvent]:
+    """Return new / changed / resolved delta events for one ingest batch."""
+    events: list[FindingDeltaEvent] = []
+    seen: set[str] = set()
+
+    for finding in batch_findings:
+        snap = FindingSnapshot.from_finding(finding, source=source)
+        seen.add(snap.canonical_id)
+        prior_row = prior.get(snap.canonical_id)
+        if prior_row is None:
+            events.append(
+                FindingDeltaEvent(
+                    kind="new",
+                    tenant_id=tenant_id,
+                    canonical_id=snap.canonical_id,
+                    observed_at=observed_at,
+                    batch_id=batch_id,
+                    source=source,
+                    finding=snap.finding,
+                )
+            )
+            continue
+        merged = dict(prior_row.finding)
+        merged.update(snap.finding)
+        merged_snap = FindingSnapshot.from_finding(merged, source=source)
+        if prior_row.material_fields_changed(merged_snap):
+            events.append(
+                FindingDeltaEvent(
+                    kind="changed",
+                    tenant_id=tenant_id,
+                    canonical_id=snap.canonical_id,
+                    observed_at=observed_at,
+                    batch_id=batch_id,
+                    source=source,
+                    finding=merged,
+                )
+            )
+
+    for canonical_id in sorted(resolved_canonical_ids):
+        if canonical_id in seen:
+            continue
+        prior_row = prior.get(canonical_id)
+        if prior_row is None:
+            continue
+        resolved_finding = dict(prior_row.finding)
+        resolved_finding["status"] = "resolved"
+        resolved_finding["canonical_id"] = canonical_id
+        events.append(
+            FindingDeltaEvent(
+                kind="resolved",
+                tenant_id=tenant_id,
+                canonical_id=canonical_id,
+                observed_at=observed_at,
+                batch_id=batch_id,
+                source=source,
+                finding=resolved_finding,
+            )
+        )
+
+    return events
+
+
+def capture_hub_snapshots(store: Any, tenant_id: str, *, source: str) -> dict[str, FindingSnapshot]:
+    """Walk current-state findings for a tenant/source into diff snapshots."""
+    snapshots: dict[str, FindingSnapshot] = {}
+    list_page = getattr(store, "list_current_page", None)
+    if not callable(list_page):
+        return snapshots
+    cursor: str | None = None
+    while True:
+        page, _total, next_cursor = list_page(
+            tenant_id,
+            limit=500,
+            origin=None,
+            cursor=cursor,
+            include_total=cursor is None,
+        )
+        for row in page:
+            if str(row.get("source") or "") != source:
+                continue
+            if str(row.get("status") or "open") not in ("open", "reopened"):
+                continue
+            snap = FindingSnapshot.from_finding(row, source=source)
+            snapshots[snap.canonical_id] = snap
+        if not next_cursor:
+            break
+        cursor = next_cursor
+    return snapshots
+
+
+def resolved_canonical_ids(prior: dict[str, FindingSnapshot], present: set[str]) -> set[str]:
+    return {cid for cid in prior if cid not in present}
+
+
+def _format_delta_payload(events: list[FindingDeltaEvent], *, fmt: DeltaFormat) -> dict[str, Any]:
+    raw_events = [event.to_dict() for event in events]
+    if fmt == "ocsf":
+        from agent_bom.siem.ocsf import to_ocsf_detection_finding
+
+        ocsf_events = []
+        for event in raw_events:
+            raw_finding = event.get("finding")
+            finding = raw_finding if isinstance(raw_finding, dict) else {}
+            alert = {
+                "severity": finding.get("severity", "medium"),
+                "message": finding.get("title") or finding.get("id") or event.get("canonical_id"),
+                "detector": f"finding_delta_{event.get('event_type', 'new')}",
+                "details": event,
+            }
+            ocsf_events.append(to_ocsf_detection_finding(alert))
+        return {"format": "ocsf", "events": ocsf_events}
+    return {"format": "ndjson", "events": raw_events}
+
+
+@runtime_checkable
+class DeltaStreamConnector(Protocol):
+    def emit_batch(
+        self,
+        tenant_id: str,
+        events: list[FindingDeltaEvent],
+        *,
+        observed_at: str,
+        batch_id: str,
+    ) -> list[Any]: ...
+
+
+class DeliveryDeltaStreamConnector:
+    """Deliver delta batches via :class:`DeliveryClient`."""
+
+    def __init__(
+        self,
+        destination: DeltaStreamDestination,
+        *,
+        delivery_client: DeliveryClient | None = None,
+        watermark_store: DeltaStreamStore | None = None,
+        memory_sink: InMemoryDeltaSink | None = None,
+    ) -> None:
+        if not destination.url.strip() and memory_sink is None:
+            raise DeltaStreamError("delta stream destination url is required unless using InMemoryDeltaSink")
+        self.destination = destination
+        self._client = None if memory_sink is not None else (delivery_client or get_delivery_client())
+        self._watermarks = watermark_store or DeltaStreamStore(default_delta_stream_store_path())
+        self._sink = memory_sink
+
+    def emit_batch(
+        self,
+        tenant_id: str,
+        events: list[FindingDeltaEvent],
+        *,
+        observed_at: str,
+        batch_id: str,
+    ) -> list[Any]:
+        if not events:
+            return []
+        payload = _format_delta_payload(events, fmt=self.destination.format)
+        payload["tenant_id"] = tenant_id
+        payload["batch_id"] = batch_id
+        payload["observed_at"] = observed_at
+        payload["event_count"] = len(events)
+        if self._sink is not None:
+            self._sink.record(payload)
+            self._watermarks.set_watermark(
+                tenant_id,
+                self.destination.destination_id,
+                observed_at=observed_at,
+                batch_id=batch_id,
+            )
+            return [{"status": "delivered", "sink": "memory"}]
+
+        delivery = Delivery(
+            destination_id=self.destination.destination_id,
+            payload=payload,
+            event_type="finding_delta_batch",
+            idempotency_key=f"{tenant_id}:{batch_id}:{self.destination.destination_id}",
+        )
+        if self._client is None:
+            raise DeltaStreamError("delivery client unavailable")
+        result = self._client.deliver(self.destination.to_delivery_destination(), delivery)
+        if result.delivered:
+            self._watermarks.set_watermark(
+                tenant_id,
+                self.destination.destination_id,
+                observed_at=observed_at,
+                batch_id=batch_id,
+            )
+        return [result]
+
+
+def load_delta_stream_destination() -> DeltaStreamDestination | None:
+    from agent_bom.config import (
+        DELTA_STREAM_AUTH_SCHEME,
+        DELTA_STREAM_AUTH_TOKEN,
+        DELTA_STREAM_DESTINATION_ID,
+        DELTA_STREAM_ENABLED,
+        DELTA_STREAM_FORMAT,
+        DELTA_STREAM_SIGNING_SECRET,
+        DELTA_STREAM_URL,
+    )
+
+    if not DELTA_STREAM_ENABLED:
+        return None
+    if not DELTA_STREAM_URL.strip():
+        logger.warning("AGENT_BOM_DELTA_STREAM_ENABLED=1 but AGENT_BOM_DELTA_STREAM_URL is empty; skipping delta export")
+        return None
+    fmt: DeltaFormat = "ocsf" if DELTA_STREAM_FORMAT.strip().lower() == "ocsf" else "ndjson"
+    return DeltaStreamDestination(
+        destination_id=DELTA_STREAM_DESTINATION_ID or "delta-stream-default",
+        url=DELTA_STREAM_URL.strip(),
+        format=fmt,
+        auth_scheme=DELTA_STREAM_AUTH_SCHEME,
+        auth_token=DELTA_STREAM_AUTH_TOKEN,
+        signing_secret=DELTA_STREAM_SIGNING_SECRET,
+    )
+
+
+def emit_hub_finding_deltas_if_enabled(
+    *,
+    tenant_id: str,
+    hub_store: Any,
+    prior: dict[str, FindingSnapshot],
+    batch_findings: list[dict[str, Any]],
+    resolved_canonical_ids: set[str],
+    observed_at: str,
+    batch_id: str,
+    source: str,
+    connector: DeltaStreamConnector | None = None,
+) -> list[Any]:
+    """Compute and emit hub finding deltas when delta-stream export is enabled."""
+    destination = load_delta_stream_destination()
+    if destination is None and connector is None:
+        return []
+    events = compute_finding_deltas(
+        tenant_id=tenant_id,
+        prior=prior,
+        batch_findings=batch_findings,
+        resolved_canonical_ids=resolved_canonical_ids,
+        observed_at=observed_at,
+        batch_id=batch_id,
+        source=source,
+    )
+    if not events:
+        return []
+    active = connector or DeliveryDeltaStreamConnector(destination)  # type: ignore[arg-type]
+    return active.emit_batch(tenant_id, events, observed_at=observed_at, batch_id=batch_id)
+
+
+__all__ = [
+    "DeltaEventKind",
+    "DeltaFormat",
+    "DeltaStreamDestination",
+    "DeltaStreamError",
+    "DeltaStreamStore",
+    "DeltaWatermark",
+    "DeliveryDeltaStreamConnector",
+    "FindingDeltaEvent",
+    "FindingSnapshot",
+    "InMemoryDeltaSink",
+    "capture_hub_snapshots",
+    "compute_finding_deltas",
+    "default_delta_stream_store_path",
+    "emit_hub_finding_deltas_if_enabled",
+    "load_delta_stream_destination",
+    "resolved_canonical_ids",
+]

--- a/src/agent_bom/delta_stream.py
+++ b/src/agent_bom/delta_stream.py
@@ -301,20 +301,9 @@ def resolved_canonical_ids(prior: dict[str, FindingSnapshot], present: set[str])
 def _format_delta_payload(events: list[FindingDeltaEvent], *, fmt: DeltaFormat) -> dict[str, Any]:
     raw_events = [event.to_dict() for event in events]
     if fmt == "ocsf":
-        from agent_bom.siem.ocsf import to_ocsf_detection_finding
+        from agent_bom.siem.delta_stream import delta_events_to_ocsf
 
-        ocsf_events = []
-        for event in raw_events:
-            raw_finding = event.get("finding")
-            finding = raw_finding if isinstance(raw_finding, dict) else {}
-            alert = {
-                "severity": finding.get("severity", "medium"),
-                "message": finding.get("title") or finding.get("id") or event.get("canonical_id"),
-                "detector": f"finding_delta_{event.get('event_type', 'new')}",
-                "details": event,
-            }
-            ocsf_events.append(to_ocsf_detection_finding(alert))
-        return {"format": "ocsf", "events": ocsf_events}
+        return {"format": "ocsf", "events": delta_events_to_ocsf(raw_events)}
     return {"format": "ndjson", "events": raw_events}
 
 

--- a/src/agent_bom/siem/delta_stream.py
+++ b/src/agent_bom/siem/delta_stream.py
@@ -1,0 +1,24 @@
+"""SIEM wire-format projection for finding delta-stream batches."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_bom.siem.ocsf import to_ocsf_detection_finding
+
+
+def delta_events_to_ocsf(raw_events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Project canonical finding-delta events to OCSF Detection Findings."""
+
+    ocsf_events: list[dict[str, Any]] = []
+    for event in raw_events:
+        raw_finding = event.get("finding")
+        finding = raw_finding if isinstance(raw_finding, dict) else {}
+        alert = {
+            "severity": finding.get("severity", "medium"),
+            "message": finding.get("title") or finding.get("id") or event.get("canonical_id"),
+            "detector": f"finding_delta_{event.get('event_type', 'new')}",
+            "details": event,
+        }
+        ocsf_events.append(to_ocsf_detection_finding(alert))
+    return ocsf_events

--- a/tests/test_delta_stream.py
+++ b/tests/test_delta_stream.py
@@ -1,0 +1,171 @@
+"""Tests for finding delta-stream export (#3514)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore, reset_compliance_hub_store, set_compliance_hub_store
+from agent_bom.api.finding_lifecycle import collect_present_canonical_ids, normalize_observed_at
+from agent_bom.delta_stream import (
+    DeliveryDeltaStreamConnector,
+    DeltaStreamDestination,
+    DeltaStreamStore,
+    FindingSnapshot,
+    InMemoryDeltaSink,
+    capture_hub_snapshots,
+    compute_finding_deltas,
+    emit_hub_finding_deltas_if_enabled,
+    resolved_canonical_ids,
+)
+
+
+def _finding(
+    finding_id: str,
+    *,
+    severity: str = "medium",
+    cvss_score: float = 5.0,
+    status: str = "open",
+    source: str = "test-source",
+) -> dict:
+    return {
+        "id": finding_id,
+        "title": f"Finding {finding_id}",
+        "severity": severity,
+        "cvss_score": cvss_score,
+        "status": status,
+        "source": source,
+        "origin": "bulk_ingest",
+    }
+
+
+def test_compute_finding_deltas_new_changed_resolved() -> None:
+    prior = {
+        "existing-open": FindingSnapshot.from_finding(_finding("existing-open"), source="src"),
+        "will-resolve": FindingSnapshot.from_finding(_finding("will-resolve"), source="src"),
+    }
+    batch = [
+        _finding("brand-new", severity="high"),
+        _finding("existing-open", severity="critical", cvss_score=9.1),
+    ]
+    events = compute_finding_deltas(
+        tenant_id="tenant-1",
+        prior=prior,
+        batch_findings=batch,
+        resolved_canonical_ids={"will-resolve"},
+        observed_at="2026-07-04T12:00:00Z",
+        batch_id="batch-2",
+        source="src",
+    )
+    kinds = {event.kind for event in events}
+    assert kinds == {"new", "changed", "resolved"}
+    by_kind = {event.kind: event for event in events}
+    assert by_kind["new"].canonical_id.endswith("brand-new")
+    assert by_kind["changed"].finding["severity"] == "critical"
+    assert by_kind["resolved"].finding["status"] == "resolved"
+
+
+def test_resolved_canonical_ids_from_prior_present() -> None:
+    prior = {"a": FindingSnapshot.from_finding(_finding("a"), source="s"), "b": FindingSnapshot.from_finding(_finding("b"), source="s")}
+    assert resolved_canonical_ids(prior, {"a"}) == {"b"}
+
+
+def test_delivery_delta_stream_connector_memory_sink(tmp_path: Path) -> None:
+    sink = InMemoryDeltaSink()
+    store = DeltaStreamStore(tmp_path / "delta_stream.db")
+    connector = DeliveryDeltaStreamConnector(
+        DeltaStreamDestination(destination_id="test", url="", format="ndjson"),
+        watermark_store=store,
+        memory_sink=sink,
+    )
+    results = connector.emit_batch(
+        "tenant-1",
+        compute_finding_deltas(
+            tenant_id="tenant-1",
+            prior={},
+            batch_findings=[_finding("one")],
+            resolved_canonical_ids=set(),
+            observed_at="2026-07-04T12:00:00Z",
+            batch_id="batch-1",
+            source="src",
+        ),
+        observed_at="2026-07-04T12:00:00Z",
+        batch_id="batch-1",
+    )
+    assert results == [{"status": "delivered", "sink": "memory"}]
+    assert len(sink.batches) == 1
+    batch = sink.batches[0]
+    assert batch["event_count"] == 1
+    assert batch["events"][0]["event_type"] == "new"
+    watermark = store.get_watermark("tenant-1", "test")
+    assert watermark is not None
+    assert watermark.batch_id == "batch-1"
+
+
+def test_hub_ingest_emits_new_changed_resolved_via_memory_sink(tmp_path: Path) -> None:
+    reset_compliance_hub_store()
+    hub = InMemoryComplianceHubStore()
+    set_compliance_hub_store(hub)
+
+    tenant_id = f"delta-{uuid4().hex}"
+    source = "agent-runtime"
+    observed_at = normalize_observed_at(None)
+    sink = InMemoryDeltaSink()
+    watermark_store = DeltaStreamStore(tmp_path / "delta_stream.db")
+    connector = DeliveryDeltaStreamConnector(
+        DeltaStreamDestination(destination_id="mem", url="", format="ndjson"),
+        watermark_store=watermark_store,
+        memory_sink=sink,
+    )
+
+    batch1 = [
+        _finding("finding-a", severity="medium", source=source),
+        _finding("finding-b", severity="low", source=source),
+    ]
+    prior1 = capture_hub_snapshots(hub, tenant_id, source=source)
+    hub.upsert_current_batch(tenant_id, batch1, observed_at=observed_at, batch_id="batch-1", source=source)
+    emit_hub_finding_deltas_if_enabled(
+        tenant_id=tenant_id,
+        hub_store=hub,
+        prior=prior1,
+        batch_findings=batch1,
+        resolved_canonical_ids=set(),
+        observed_at=observed_at,
+        batch_id="batch-1",
+        source=source,
+        connector=connector,
+    )
+
+    batch2 = [
+        _finding("finding-a", severity="critical", cvss_score=9.8, source=source),
+        _finding("finding-c", severity="high", source=source),
+    ]
+    prior2 = capture_hub_snapshots(hub, tenant_id, source=source)
+    present = collect_present_canonical_ids(batch2, source=source)
+    resolved_ids = resolved_canonical_ids(prior2, present)
+    hub.upsert_current_batch(tenant_id, batch2, observed_at=observed_at, batch_id="batch-2", source=source)
+    hub.reconcile_current_absent(
+        tenant_id,
+        present_canonical_ids=present,
+        observed_at=observed_at,
+        scope_source=source,
+    )
+    emit_hub_finding_deltas_if_enabled(
+        tenant_id=tenant_id,
+        hub_store=hub,
+        prior=prior2,
+        batch_findings=batch2,
+        resolved_canonical_ids=resolved_ids,
+        observed_at=observed_at,
+        batch_id="batch-2",
+        source=source,
+        connector=connector,
+    )
+
+    assert len(sink.batches) == 2
+    first_kinds = {event["event_type"] for event in sink.batches[0]["events"]}
+    assert first_kinds == {"new"}
+    second_kinds = {event["event_type"] for event in sink.batches[1]["events"]}
+    assert second_kinds == {"changed", "new", "resolved"}
+
+    reset_compliance_hub_store()

--- a/tests/test_ocsf_boundary.py
+++ b/tests/test_ocsf_boundary.py
@@ -33,6 +33,7 @@ _ALLOWED_OCSF_CONSUMERS = {
     "siem/sentinel.py",
     "siem/chronicle.py",
     "siem/security_lake.py",
+    "siem/delta_stream.py",
     # output/ocsf.py is the MCP tool's OCSF serializer.
     "output/ocsf.py",
 }


### PR DESCRIPTION
## Summary
- Add `agent_bom.delta_stream` with watermark ledger, delta computation (new/changed/resolved), and delivery via the hardened outbound client.
- Wire delta export into `POST /v1/findings/bulk` and compliance format ingest when `AGENT_BOM_DELTA_STREAM_ENABLED=1`.
- Document env vars and SIEM first-command path; integration test uses in-memory sink.

Closes #3514

## Test plan
- [x] `uv run pytest tests/test_delta_stream.py -q`
- [x] `uv run ruff check src/agent_bom/delta_stream.py src/agent_bom/config.py src/agent_bom/api/routes/scan.py src/agent_bom/api/routes/compliance.py tests/test_delta_stream.py`
- [x] `uv run mypy src/agent_bom/delta_stream.py`