### PR TITLE
docs(deploy): audit Alembic, encryption prerequisite, ClickHouse positioning

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -311,6 +311,12 @@ spec:
 
 For the maintained Helm chart in `deploy/helm/agent-bom/`, the runtime monitor DaemonSet now includes liveness, readiness, and startup probes by default when enabled, can optionally expose a Prometheus Operator `ServiceMonitor` for `/metrics`, can optionally create an `Ingress` and `PodDisruptionBudget` for the monitor service, and ships with an explicit `NetworkPolicy` egress baseline for DNS plus outbound web traffic instead of `allow-all` egress.
 
+Postgres schema migrations for the control plane run automatically on Helm
+`pre-install` / `pre-upgrade` when `controlPlane.migrations.enabled` is true
+(the default). Operators do not run Alembic manually before routine chart
+upgrades; see [`DEPLOY_PLATFORM.md`](DEPLOY_PLATFORM.md) and
+[`site-docs/deployment/control-plane-helm.md`](../site-docs/deployment/control-plane-helm.md).
+
 ---
 
 ## ❄️ Snowflake Integration

--- a/docs/DEPLOY_PLATFORM.md
+++ b/docs/DEPLOY_PLATFORM.md
@@ -113,6 +113,13 @@ EKS, AKS, GKE, BYO-Postgres, SQLite pilots, collector-only workloads, and more.
 On AWS you can still run `aws/baseline` on its own for RDS/IRSA/S3/Secrets and
 feed its `helm_values_hint` output into your values file.
 
+**Schema migrations:** for Helm installs against Postgres, the chart's
+`pre-install,pre-upgrade` hook runs Alembic automatically
+(`controlPlane.migrations.enabled`, on by default). A normal `helm upgrade`
+does not require a manual `alembic upgrade head`. See
+[Control-Plane Helm — migration contract](../site-docs/deployment/control-plane-helm.md)
+for the one-time `init.sql` stamp path and the non-Helm override.
+
 ---
 
 ## Tier 3 — Operator-hosted / gated POC

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -346,6 +346,10 @@ as prerequisites before ingesting real findings:
 - **In transit** — TLS is always verified on outbound calls; terminate ingress
   TLS and prefer the delegated mTLS posture below for the proxy/gateway seam.
 
+The published site mirror of this prerequisite lives in
+[Enterprise MCP / Endpoint Pilot — Security properties](../site-docs/deployment/enterprise-pilot.md#security-properties)
+and [Own-Infra EKS](../site-docs/deployment/own-infra-eks.md#finding-and-scan-payload-encryption-at-rest).
+
 If a threat model requires application-layer (pre-storage) encryption of finding
 payloads, that is not provided today; scope it explicitly rather than assuming it.
 

--- a/site-docs/deployment/backend-parity.md
+++ b/site-docs/deployment/backend-parity.md
@@ -16,6 +16,13 @@ The product contract is:
 - `Snowflake`: warehouse-native and governance-oriented backend where parity is explicitly implemented
 - `Neptune`: design-only enterprise graph-store candidate; not wired today
 
+**ClickHouse hosting and data shape:** analytics uses the OSS ClickHouse server
+in your VPC/Kubernetes cluster, or optionally **ClickHouse Cloud** — neither is
+required for the control plane. The sink stores **canonical product rows**
+(findings, runtime events, posture snapshots), not raw OCSF events; OCSF remains
+an export projection at the SIEM boundary (`docs/OCSF_BOUNDARY.md`). See
+[Backend and Security-Lake Strategy](backend-and-security-lakes.md).
+
 This page documents what is wired today, not what might exist as a class on disk.
 
 ## Current API Backend Matrix

--- a/site-docs/deployment/data-retention.md
+++ b/site-docs/deployment/data-retention.md
@@ -23,7 +23,7 @@ This page defines the recommended retention model for a self-hosted deployment.
 |---|---|---|---|---|
 | Control-plane state | tenants, policies, schedules, API keys, source registry, fleet state, graph state | `Postgres` / `Supabase` | keep current state + short operational history | transactional truth, not a data lake |
 | Scan jobs and results | submitted scans, summaries, attached result payloads | `Postgres` / `Supabase` | 14-90 days in the control plane | enough for operator review without turning the API DB into an archive |
-| Runtime operational evidence | proxy audit ingest, traces, OCSF ingest, gateway activity | `Postgres` for recent operational views, optional `ClickHouse` for longer history | 7-30 days in control plane, 30-365+ days in analytics | recent ops stay fast; history moves to analytics |
+| Runtime operational evidence | proxy audit ingest, traces, OCSF ingest, gateway activity | `Postgres` for recent operational views, optional `ClickHouse` for longer history (canonical analytics rows — OCSF is normalized on ingest, not stored as OCSF in ClickHouse) | 7-30 days in control plane, 30-365+ days in analytics | recent ops stay fast; history moves to analytics |
 | Compliance evidence | signed evidence bundles, exported reports, review packets | `S3` or customer archive store | match framework policy | this is evidence, not dashboard cache |
 | Security-lake / warehouse mirrors | analytics projections, governance joins, long-range history | `ClickHouse`, `Snowflake`, future `Databricks` target | customer-defined | lake and warehouse retention should be explicit and owned by the operator |
 
@@ -126,7 +126,7 @@ data deletion.
 For the self-hosted EKS shape, the practical answer is:
 
 - keep the packaged control plane on `Postgres`
-- use `ClickHouse` only if retained runtime or trend analytics becomes heavy
+- use `ClickHouse` only if retained runtime or trend analytics becomes heavy (OSS self-hosted in your cluster/VPC, or optional ClickHouse Cloud — not a managed prerequisite)
 - archive signed evidence bundles and longer-lived exports to `S3`
 - mirror to `Snowflake` when governance or warehouse-native joins matter
 

--- a/site-docs/deployment/enterprise-pilot.md
+++ b/site-docs/deployment/enterprise-pilot.md
@@ -58,7 +58,7 @@ This pilot page stays focused on the narrower pilot contract:
 | Proxy audit push | Yes | SOC sees blocks and warnings centrally |
 | Same-origin UI | Yes | One ingress, one internal control plane |
 | Postgres | Yes | Primary transactional backend for multi-replica pilots |
-| ClickHouse | Optional | Bring it in once pilot event volume justifies it |
+| ClickHouse | Optional | OSS server in your VPC or optional ClickHouse Cloud; canonical analytics rows only (not OCSF storage). Bring it in once pilot event volume justifies it |
 | Snowflake backend | No | Not part of the focused pilot contract |
 | Managed endpoint agent | No | Still roadmap, not current product contract |
 | MDM integration | No | Still roadmap |
@@ -74,12 +74,21 @@ This pilot page stays focused on the narrower pilot contract:
 - the EKS pilot path assumes Pod Security Admission `restricted`
 - focused pilot values lock ingress down instead of leaving it wide open
 
+Finding, scan, and graph payloads are **not** application-layer encrypted.
+Confidentiality at rest is delegated to Postgres/RDS volume encryption, optional
+object-store encryption for exports/backups, and tenant RLS — not to an
+in-control-plane payload cipher. API tokens are hashed, audit chains are
+HMAC-signed, and cloud-connection secrets use envelope encryption; finding
+bodies rely on your storage encryption. See
+[`docs/ENTERPRISE_DEPLOYMENT.md`](https://github.com/msaad00/agent-bom/blob/main/docs/ENTERPRISE_DEPLOYMENT.md#finding-and-scan-payload-encryption-at-rest-deployment-prerequisite)
+for the full buyer checklist.
+
 ## Scale properties
 
 - API is horizontally scalable behind Postgres-backed state
 - scheduler leader election uses Postgres advisory locking
 - endpoint fleet is batch-driven and scales to pilot size without a managed agent
-- ClickHouse is available when pilot volume grows beyond what Postgres should carry for analytics
+- ClickHouse is available when pilot volume grows beyond what Postgres should carry for analytics (OSS self-hosted or optional ClickHouse Cloud; see [Backend and Security-Lake Strategy](backend-and-security-lakes.md))
 - sidecar proxy rollout stays workload-by-workload instead of forcing universal inline routing
 
 For concrete sizing, autoscaling, and load-test guidance, use

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -381,6 +381,18 @@ To manage migrations with external tooling instead, disable the hook
 alembic -c deploy/supabase/postgres/alembic.ini upgrade head
 ```
 
+## Finding and scan payload encryption at rest
+
+Finding, scan, and graph payloads are **not** application-layer encrypted in
+the control plane. This is intentional: search, indexing, and graph queries
+stay operable across SQLite and Postgres without a product-managed payload key.
+Treat **database volume encryption** (RDS/KMS, LUKS/EBS), **encrypted
+export/backup buckets**, **VPC-private access**, and **Postgres RLS** as
+deployment prerequisites before ingesting production findings. Selected fields
+still get app-layer protection (hashed API tokens, HMAC audit chain, signed
+sessions, envelope-encrypted cloud-connection secrets). Full buyer checklist:
+[`docs/ENTERPRISE_DEPLOYMENT.md`](https://github.com/msaad00/agent-bom/blob/main/docs/ENTERPRISE_DEPLOYMENT.md#finding-and-scan-payload-encryption-at-rest-deployment-prerequisite).
+
 ## What You Still Own
 
 This is a real self-hosted packaging path, but not every enterprise primitive


### PR DESCRIPTION
## Summary
- **#3496** — State explicitly that Helm runs Alembic on `pre-install`/`pre-upgrade`; no manual step for routine upgrades (`DEPLOY_PLATFORM.md`, `DEPLOYMENT.md`; site paths already documented).
- **#3497** — Surface finding/scan payload encryption-at-rest prerequisites in published site docs (`enterprise-pilot.md`, `own-infra-eks.md`) with cross-links to `ENTERPRISE_DEPLOYMENT.md`.
- **ClickHouse positioning (audit §C)** — Clarify OSS self-hosted vs optional ClickHouse Cloud and that analytics sinks store canonical product rows, not OCSF (`backend-parity.md`, `data-retention.md`, pilot scope table).

Related: #3496
Related: #3497

## Test plan
- [x] Stale-command search: no docs claim manual Alembic is required before Helm upgrades without the hook override context
- [x] `git diff --check`


Made with [Cursor](https://cursor.com)