### PR TITLE
fix(api/scim): group PATCH, deprovision keys, SCIM error envelopes

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1968,6 +1968,20 @@ def install_error_envelope(application: object) -> None:
         return getattr(request.state, "request_id", "") or request.headers.get("x-request-id") or str(uuid.uuid4())
 
     async def http_exception_handler(request: StarletteRequest, exc: HTTPException):
+        if request.url.path.startswith("/scim/"):
+            from agent_bom.api.scim import scim_error_body
+
+            correlation_id = _correlation_id(request)
+            detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+            payload = scim_error_body(status_code=exc.status_code, detail=detail)
+            response_headers = dict(getattr(exc, "headers", None) or {})
+            response_headers.setdefault("X-Request-ID", correlation_id)
+            return JSONResponse(
+                status_code=exc.status_code,
+                content=payload,
+                media_type="application/scim+json",
+                headers=response_headers,
+            )
         return _build_error_envelope(
             status_code=exc.status_code,
             detail=exc.detail,

--- a/src/agent_bom/api/routes/scim.py
+++ b/src/agent_bom/api/routes/scim.py
@@ -31,6 +31,7 @@ _FILTER_RE = re.compile(r'^\s*(userName|displayName|externalId|id)\s+eq\s+"([^"]
 # accepts an optional quoted form so SCIM clients that always quote literals
 # still work.
 _ACTIVE_FILTER_RE = re.compile(r'^\s*active\s+eq\s+"?(true|false)"?\s*$', re.IGNORECASE)
+_MEMBER_FILTER_RE = re.compile(r'^members\[value\s+eq\s+"([^"]{1,512})"\]\s*$', re.IGNORECASE)
 
 
 def _tenant_id(request: Request) -> str:
@@ -95,7 +96,7 @@ def _user_from_payload(tenant_id: str, body: dict[str, Any], *, existing: SCIMUs
         external_id = existing.external_id
     return SCIMUser(
         tenant_id=tenant_id,
-        user_id=existing.user_id if existing else str(body.get("id") or uuid.uuid4()),
+        user_id=existing.user_id if existing else str(uuid.uuid4()),
         external_id=external_id,
         user_name=user_name,
         display_name=display_name,
@@ -121,7 +122,7 @@ def _group_from_payload(tenant_id: str, body: dict[str, Any], *, existing: SCIMG
         external_id = existing.external_id
     return SCIMGroup(
         tenant_id=tenant_id,
-        group_id=existing.group_id if existing else str(body.get("id") or uuid.uuid4()),
+        group_id=existing.group_id if existing else str(uuid.uuid4()),
         external_id=external_id,
         display_name=display_name,
         members=[entry for entry in members if isinstance(entry, dict)],
@@ -226,6 +227,50 @@ def _apply_user_patch(user: SCIMUser, body: dict[str, Any]) -> SCIMUser:
     return user
 
 
+def _member_value(entry: dict[str, Any]) -> str:
+    return str(entry.get("value") or "").strip()
+
+
+def _dedupe_members(members: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    deduped: list[dict[str, Any]] = []
+    for entry in members:
+        if not isinstance(entry, dict):
+            continue
+        key = _member_value(entry)
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        deduped.append(entry)
+    return deduped
+
+
+def _parse_member_filter_path(path: str) -> str | None:
+    match = _MEMBER_FILTER_RE.match(path.strip())
+    return match.group(1) if match else None
+
+
+def _member_entries_from_value(value: object) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [entry for entry in value if isinstance(entry, dict)]
+    if isinstance(value, dict):
+        return [value]
+    return []
+
+
+def _maybe_revoke_scim_credentials(user: SCIMUser, *, previously_active: bool) -> None:
+    if previously_active and not user.active:
+        from agent_bom.api.scim import revoke_credentials_for_scim_user
+
+        revoke_credentials_for_scim_user(user.tenant_id, user)
+
+
+def _save_scim_user(store: Any, user: SCIMUser, *, previously_active: bool) -> SCIMUser:
+    saved = store.put_user(user)
+    _maybe_revoke_scim_credentials(saved, previously_active=previously_active)
+    return saved
+
+
 def _apply_group_patch(group: SCIMGroup, body: dict[str, Any]) -> SCIMGroup:
     operations = body.get("Operations", [])
     if not isinstance(operations, list):
@@ -238,17 +283,26 @@ def _apply_group_patch(group: SCIMGroup, body: dict[str, Any]) -> SCIMGroup:
         value = operation.get("value")
         if op not in {"add", "replace", "remove"}:
             raise HTTPException(status_code=400, detail="Only add, replace, and remove patch operations are supported")
-        if op == "remove" and path.startswith("members"):
-            group.members = []
-        elif path == "displayName":
+        member_id = _parse_member_filter_path(path)
+        if op == "remove":
+            if member_id is not None:
+                group.members = [entry for entry in group.members if _member_value(entry) != member_id]
+                continue
+            if path == "members" or path.startswith("members"):
+                group.members = []
+                continue
+        if op == "add" and path == "members":
+            group.members = _dedupe_members([*group.members, *_member_entries_from_value(value)])
+            continue
+        if path == "displayName":
             group.display_name = str(value or "").strip()
         elif path == "members" and isinstance(value, list):
-            group.members = [entry for entry in value if isinstance(entry, dict)]
+            group.members = _dedupe_members([entry for entry in value if isinstance(entry, dict)])
         elif isinstance(value, dict) and not path:
             if "displayName" in value:
                 group.display_name = str(value["displayName"]).strip()
             if "members" in value and isinstance(value["members"], list):
-                group.members = [entry for entry in value["members"] if isinstance(entry, dict)]
+                group.members = _dedupe_members([entry for entry in value["members"] if isinstance(entry, dict)])
         else:
             raise HTTPException(status_code=400, detail="Unsupported group patch path")
     if not group.display_name:
@@ -258,11 +312,10 @@ def _apply_group_patch(group: SCIMGroup, body: dict[str, Any]) -> SCIMGroup:
 
 
 def _scim_error_response(exc: HTTPException) -> dict[str, Any]:
-    return {
-        "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
-        "status": str(exc.status_code),
-        "detail": str(exc.detail),
-    }
+    from agent_bom.api.scim import scim_error_body
+
+    detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+    return scim_error_body(status_code=exc.status_code, detail=detail)
 
 
 def _bulk_status(
@@ -343,16 +396,20 @@ def _bulk_modify_user(request: Request, method: str, user_id: str | None, body: 
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
     if method == "PATCH":
-        saved = store.put_user(_apply_user_patch(user, body))
+        previously_active = user.active
+        saved = _save_scim_user(store, _apply_user_patch(user, body), previously_active=previously_active)
         action = "scim.user_patched"
     elif method == "PUT":
-        saved = store.put_user(_user_from_payload(tenant_id, body, existing=user))
+        previously_active = user.active
+        saved = _save_scim_user(store, _user_from_payload(tenant_id, body, existing=user), previously_active=previously_active)
         action = "scim.user_replaced"
     elif method == "DELETE":
+        previously_active = user.active
         deactivated = store.deactivate_user(tenant_id, user_id)
         if deactivated is None:
             raise HTTPException(status_code=404, detail="User not found")
         saved = deactivated
+        _maybe_revoke_scim_credentials(saved, previously_active=previously_active)
         action = "scim.user_deactivated"
     else:
         raise HTTPException(status_code=400, detail="Unsupported SCIM bulk method")
@@ -607,7 +664,8 @@ async def patch_user(request: Request, user_id: str, body: dict[str, Any]) -> di
     user = store.get_user(tenant_id, user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
-    saved = store.put_user(_apply_user_patch(user, body))
+    previously_active = user.active
+    saved = _save_scim_user(store, _apply_user_patch(user, body), previously_active=previously_active)
     log_action(
         "scim.user_patched",
         actor=_actor(request),
@@ -626,7 +684,8 @@ async def replace_user(request: Request, user_id: str, body: dict[str, Any]) -> 
     existing = store.get_user(tenant_id, user_id)
     if existing is None:
         raise HTTPException(status_code=404, detail="User not found")
-    saved = store.put_user(_user_from_payload(tenant_id, body, existing=existing))
+    previously_active = existing.active
+    saved = _save_scim_user(store, _user_from_payload(tenant_id, body, existing=existing), previously_active=previously_active)
     log_action(
         "scim.user_replaced",
         actor=_actor(request),
@@ -641,9 +700,15 @@ async def replace_user(request: Request, user_id: str, body: dict[str, Any]) -> 
 async def delete_user(request: Request, user_id: str) -> Response:
     _require_scim(request)
     tenant_id = _tenant_id(request)
-    user = _get_scim_store().deactivate_user(tenant_id, user_id)
+    store = _get_scim_store()
+    existing = store.get_user(tenant_id, user_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    previously_active = existing.active
+    user = store.deactivate_user(tenant_id, user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
+    _maybe_revoke_scim_credentials(user, previously_active=previously_active)
     log_action(
         "scim.user_deactivated",
         actor=_actor(request),

--- a/src/agent_bom/api/scim.py
+++ b/src/agent_bom/api/scim.py
@@ -334,9 +334,9 @@ def describe_scim_posture() -> dict[str, object]:
         "auth_authority": "api_key_oidc_saml_trusted_proxy_with_scim_role_overlay",
         "runtime_auth_enforced": configured,
         "deprovisioning_boundary": (
-            "SCIM deactivate/delete updates provisioned lifecycle state and constrains runtime OIDC, SAML, "
-            "browser, and trusted reverse-proxy roles when the authenticated subject matches a tenant-local SCIM user. "
-            "Long-lived service API keys remain governed by API-key lifecycle controls."
+            "SCIM deactivate/delete updates provisioned lifecycle state, constrains runtime OIDC, SAML, "
+            "browser, and trusted reverse-proxy roles when the authenticated subject matches a tenant-local "
+            "SCIM user, and revokes API keys whose name matches the SCIM userName, id, or externalId."
         ),
         "groups_required": groups_required,
         "verified_idp_templates": [
@@ -381,3 +381,41 @@ def describe_scim_posture() -> dict[str, object]:
             )
         ),
     }
+
+
+SCIM_ERROR_SCHEMA = "urn:ietf:params:scim:api:messages:2.0:Error"
+
+
+def scim_error_body(*, status_code: int, detail: str) -> dict[str, Any]:
+    """RFC 7644 Error response body for non-bulk SCIM failures."""
+    return {
+        "schemas": [SCIM_ERROR_SCHEMA],
+        "status": str(status_code),
+        "detail": detail,
+    }
+
+
+def revoke_credentials_for_scim_user(tenant_id: str, user: Any) -> int:
+    """Revoke tenant API keys whose display name matches a deprovisioned SCIM user."""
+    from agent_bom.api.audit_log import log_action
+    from agent_bom.api.auth import get_key_store
+
+    store = get_key_store()
+    subjects = {str(user.user_name), str(user.user_id)}
+    external_id = getattr(user, "external_id", None)
+    if external_id:
+        subjects.add(str(external_id))
+    subjects_lower = {entry.lower() for entry in subjects if entry}
+    revoked = 0
+    for key in store.list_keys(tenant_id):
+        if key.name in subjects or key.name.lower() in subjects_lower:
+            store.remove(key.key_id)
+            revoked += 1
+            log_action(
+                "scim.api_key_revoked",
+                actor="scim-provisioner",
+                resource=f"key/{key.key_id}",
+                tenant_id=tenant_id,
+                user_name=user.user_name,
+            )
+    return revoked

--- a/tests/test_api_scim_lifecycle.py
+++ b/tests/test_api_scim_lifecycle.py
@@ -231,6 +231,23 @@ def test_scim_per_tenant_bearer_mapping_binds_tokens_to_server_side_tenants(monk
     assert [resource["id"] for resource in alpha_list.json()["Resources"]] == [alpha_user["id"]]
     assert [resource["id"] for resource in beta_list.json()["Resources"]] == [beta_user["id"]]
     assert client.get(f"/scim/v2/Users/{alpha_user['id']}", headers=_headers("beta-scim-secret")).status_code == 404
+    assert (
+        client.patch(
+            f"/scim/v2/Users/{alpha_user['id']}",
+            headers=_headers("beta-scim-secret"),
+            json={"Operations": [{"op": "replace", "path": "active", "value": False}]},
+        ).status_code
+        == 404
+    )
+    assert client.delete(f"/scim/v2/Users/{alpha_user['id']}", headers=_headers("beta-scim-secret")).status_code == 404
+    assert (
+        client.put(
+            f"/scim/v2/Users/{alpha_user['id']}",
+            headers=_headers("beta-scim-secret"),
+            json={"userName": "hijack@example.com", "displayName": "Hijack"},
+        ).status_code
+        == 404
+    )
 
     posture = describe_scim_posture()
     assert posture["token_binding_mode"] == "multi_tenant"
@@ -401,6 +418,55 @@ def test_scim_user_lifecycle_accepts_common_idp_payloads(
     assert listed.json()["totalResults"] == 1
 
 
+def test_scim_group_member_add_and_remove_are_incremental(scim_client: TestClient) -> None:
+    user_a = scim_client.post(
+        "/scim/v2/Users",
+        headers=_headers(),
+        json={"userName": "member-a@example.com", "externalId": "member-a"},
+    ).json()
+    user_b = scim_client.post(
+        "/scim/v2/Users",
+        headers=_headers(),
+        json={"userName": "member-b@example.com", "externalId": "member-b"},
+    ).json()
+    user_c = scim_client.post(
+        "/scim/v2/Users",
+        headers=_headers(),
+        json={"userName": "member-c@example.com", "externalId": "member-c"},
+    ).json()
+    created = scim_client.post(
+        "/scim/v2/Groups",
+        headers=_headers(),
+        json={
+            "displayName": "Incremental Group",
+            "members": [
+                {"value": user_a["id"], "display": "member-a@example.com"},
+                {"value": user_b["id"], "display": "member-b@example.com"},
+            ],
+        },
+    )
+    assert created.status_code == 201
+    group_id = created.json()["id"]
+
+    added = scim_client.patch(
+        f"/scim/v2/Groups/{group_id}",
+        headers=_headers(),
+        json={"Operations": [{"op": "add", "path": "members", "value": [{"value": user_c["id"]}]}]},
+    )
+    assert added.status_code == 200
+    member_ids = {entry["value"] for entry in added.json()["members"]}
+    assert member_ids == {user_a["id"], user_b["id"], user_c["id"]}
+
+    removed = scim_client.patch(
+        f"/scim/v2/Groups/{group_id}",
+        headers=_headers(),
+        json={"Operations": [{"op": "remove", "path": f'members[value eq "{user_a["id"]}"]'}]},
+    )
+    assert removed.status_code == 200
+    member_ids = {entry["value"] for entry in removed.json()["members"]}
+    assert member_ids == {user_b["id"], user_c["id"]}
+
+
 def test_scim_group_lifecycle_accepts_common_idp_members(scim_client: TestClient) -> None:
     user = scim_client.post(
         "/scim/v2/Users",
@@ -428,6 +494,64 @@ def test_scim_group_lifecycle_accepts_common_idp_members(scim_client: TestClient
     )
     assert patched.status_code == 200
     assert patched.json()["members"] == []
+
+
+def test_scim_create_ignores_client_supplied_id(scim_client: TestClient) -> None:
+    victim = scim_client.post(
+        "/scim/v2/Users",
+        headers=_headers(),
+        json={"userName": "victim@example.com", "displayName": "Victim"},
+    ).json()
+    attacker = scim_client.post(
+        "/scim/v2/Users",
+        headers=_headers(),
+        json={"userName": "attacker@example.com", "id": victim["id"], "displayName": "Attacker"},
+    )
+    assert attacker.status_code == 201
+    assert attacker.json()["id"] != victim["id"]
+    fetched = scim_client.get(f"/scim/v2/Users/{victim['id']}", headers=_headers()).json()
+    assert fetched["userName"] == "victim@example.com"
+
+
+def test_scim_errors_use_scim_envelope(scim_client: TestClient) -> None:
+    response = scim_client.post("/scim/v2/Users", headers=_headers(), json={"displayName": "Missing userName"})
+    assert response.status_code == 400
+    assert response.headers["content-type"].startswith("application/scim+json")
+    body = response.json()
+    assert body["schemas"] == ["urn:ietf:params:scim:api:messages:2.0:Error"]
+    assert body["status"] == "400"
+    assert body["detail"] == "userName is required"
+
+
+def test_scim_deactivate_revokes_matching_api_key(scim_client: TestClient) -> None:
+    from agent_bom.api.auth import KeyStore, Role, create_api_key, get_key_store, set_key_store
+
+    store = KeyStore()
+    set_key_store(store)
+    raw_key, record = create_api_key(name="alice@example.com", role=Role.VIEWER, tenant_id="tenant-alpha")
+    store.add(record)
+
+    created = scim_client.post(
+        "/scim/v2/Users",
+        headers=_headers(),
+        json={"userName": "alice@example.com", "displayName": "Alice"},
+    )
+    assert created.status_code == 201
+    user_id = created.json()["id"]
+
+    patched = scim_client.patch(
+        f"/scim/v2/Users/{user_id}",
+        headers=_headers(),
+        json={"Operations": [{"op": "replace", "path": "active", "value": False}]},
+    )
+    assert patched.status_code == 200
+
+    revoked = get_key_store().get(record.key_id)
+    assert revoked is not None
+    assert revoked.is_revoked()
+    api_client = TestClient(app)
+    api_client.headers.update({"Authorization": f"Bearer {raw_key}", "X-Tenant-ID": "tenant-alpha"})
+    assert api_client.get("/v1/auth/me").status_code == 401
 
 
 def test_scim_bulk_create_patch_and_delete_users_and_groups(scim_client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- **#3533** — Group `PatchOp` `add` appends members; filtered `remove` drops one member only (Okta/Entra Push Groups).
- **#3534** — Server assigns UUID on create; client `id` no longer overwrites existing users.
- **#3535** — SCIM deactivate/delete revokes tenant API keys whose name matches userName/id/externalId.
- **#3536** — `/scim/*` HTTP errors return RFC 7644 Error schema with `application/scim+json`.
- **#3538** — Regression tests: cross-tenant PATCH/PUT/DELETE, incremental group membership, error envelope, key revoke.

Closed #3539 (audit-only doc PR) in favor of making the surface real.

## Test plan
- [x] `uv run pytest tests/test_api_scim_lifecycle.py -q` (21 passed)
- [x] `uv run ruff check src/agent_bom/api/routes/scim.py src/agent_bom/api/scim.py src/agent_bom/api/middleware.py tests/test_api_scim_lifecycle.py`


Made with [Cursor](https://cursor.com)