### PR TITLE
feat(api): S3 report export artifacts with presigned URLs

### DIFF
--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -474,6 +474,13 @@ controlPlane:
       #   value: "500"
       # - name: AGENT_BOM_ANALYTICS_MAX_EVENTS
       #   value: "50000"
+      # Async findings exports: upload completed artifacts to customer S3 (IRSA recommended).
+      # - name: AGENT_BOM_REPORT_S3_BUCKET
+      #   value: "my-org-agent-bom-reports"
+      # - name: AGENT_BOM_REPORT_S3_PREFIX
+      #   value: "report-artifacts"
+      # - name: AGENT_BOM_REPORT_S3_PRESIGN_SECONDS
+      #   value: "3600"
     envFrom: []
     extraVolumes: []
     extraVolumeMounts: []

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -219,12 +219,12 @@ so they cannot regress silently, but they are not part of this reference.
 ## Report export artifacts
 | Env var | Type | Default | Description |
 |---|---|---|---|
+| `AGENT_BOM_API_MAX_ACTIVE_REPORT_JOBS_PER_TENANT` | `int` | `5` | — |
 | `AGENT_BOM_REPORT_ARTIFACT_DIR` | `str` | `''` | Async findings report exports are written to a local artifact directory and downloaded through job-scoped tokens. Empty string means use the per-user default ~/.agent-bom/report-artifacts. The worker re-reads the env var at runtime so tests |
-| `AGENT_BOM_REPORT_S3_BUCKET` | `str` | `''` | When set, completed report exports upload to this S3 bucket and job status returns a presigned GET URL. Requires boto3 (`pip install 'agent-bom[aws]'`). Credentials follow the standard AWS SDK chain (IRSA, instance profile, env keys). |
-| `AGENT_BOM_REPORT_S3_PREFIX` | `str` | `report-artifacts` | Object key prefix for S3 report artifacts (`{prefix}/{tenant}/{job_id}.ndjson.gz`). |
-| `AGENT_BOM_REPORT_S3_REGION` | `str` | `''` | Optional AWS region for the S3 client. Empty uses the SDK default resolution chain. |
-| `AGENT_BOM_REPORT_S3_PRESIGN_SECONDS` | `int` | `3600` | Lifetime of presigned GET URLs returned on completed report jobs. |
-| `AGENT_BOM_API_MAX_ACTIVE_REPORT_JOBS_PER_TENANT` | `int` | `5` | Maximum concurrent pending or running async report export jobs per tenant. `0` disables the cap. |
+| `AGENT_BOM_REPORT_S3_BUCKET` | `str` | `''` | When REPORT_S3_BUCKET is set, completed exports are uploaded to customer S3 and job status returns a presigned GET URL. Credentials follow the standard AWS SDK chain (IRSA, instance profile, env keys). Requires boto3 (``[aws]`` extra). |
+| `AGENT_BOM_REPORT_S3_PREFIX` | `str` | `'report-artifacts'` | — |
+| `AGENT_BOM_REPORT_S3_PRESIGN_SECONDS` | `int` | `3600` | — |
+| `AGENT_BOM_REPORT_S3_REGION` | `str` | `''` | — |
 
 ## Runtime → graph incident feedback
 | Env var | Type | Default | Description |

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -220,6 +220,11 @@ so they cannot regress silently, but they are not part of this reference.
 | Env var | Type | Default | Description |
 |---|---|---|---|
 | `AGENT_BOM_REPORT_ARTIFACT_DIR` | `str` | `''` | Async findings report exports are written to a local artifact directory and downloaded through job-scoped tokens. Empty string means use the per-user default ~/.agent-bom/report-artifacts. The worker re-reads the env var at runtime so tests |
+| `AGENT_BOM_REPORT_S3_BUCKET` | `str` | `''` | When set, completed report exports upload to this S3 bucket and job status returns a presigned GET URL. Requires boto3 (`pip install 'agent-bom[aws]'`). Credentials follow the standard AWS SDK chain (IRSA, instance profile, env keys). |
+| `AGENT_BOM_REPORT_S3_PREFIX` | `str` | `report-artifacts` | Object key prefix for S3 report artifacts (`{prefix}/{tenant}/{job_id}.ndjson.gz`). |
+| `AGENT_BOM_REPORT_S3_REGION` | `str` | `''` | Optional AWS region for the S3 client. Empty uses the SDK default resolution chain. |
+| `AGENT_BOM_REPORT_S3_PRESIGN_SECONDS` | `int` | `3600` | Lifetime of presigned GET URLs returned on completed report jobs. |
+| `AGENT_BOM_API_MAX_ACTIVE_REPORT_JOBS_PER_TENANT` | `int` | `5` | Maximum concurrent pending or running async report export jobs per tenant. `0` disables the cap. |
 
 ## Runtime → graph incident feedback
 | Env var | Type | Default | Description |

--- a/docs/schemas/v1/ReportJob.json
+++ b/docs/schemas/v1/ReportJob.json
@@ -22,6 +22,34 @@
   },
   "description": "Async findings export job backed by streamed hub reads.",
   "properties": {
+    "artifact_backend": {
+      "anyOf": [
+        {
+          "enum": [
+            "local",
+            "s3"
+          ],
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Artifact Backend"
+    },
+    "artifact_uri": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Artifact Uri"
+    },
     "byte_count": {
       "anyOf": [
         {
@@ -81,6 +109,18 @@
     "job_id": {
       "title": "Job Id",
       "type": "string"
+    },
+    "presigned_download_url": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Presigned Download Url"
     },
     "row_count": {
       "anyOf": [

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -243,6 +243,9 @@ class ReportJob(BaseModel):
     row_count: int | None = None
     byte_count: int | None = None
     download_token: str | None = None
+    artifact_backend: Literal["local", "s3"] | None = None
+    artifact_uri: str | None = None
+    presigned_download_url: str | None = None
     error: str | None = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/src/agent_bom/api/report_artifact_store.py
+++ b/src/agent_bom/api/report_artifact_store.py
@@ -1,0 +1,100 @@
+"""Report artifact storage backends: local filesystem and S3 (#3512)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+_logger = logging.getLogger(__name__)
+
+ReportArtifactBackend = Literal["local", "s3"]
+
+
+@dataclass(frozen=True)
+class PublishedReportArtifact:
+    backend: ReportArtifactBackend
+    artifact_uri: str
+    presigned_download_url: str | None
+    local_path: Path | None
+
+
+def _env_str(name: str, default: str = "") -> str:
+    return (os.environ.get(name) or default).strip()
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or not str(raw).strip():
+        return default
+    return int(raw)
+
+
+def _safe_segment(value: str) -> str:
+    return value.replace("/", "_").replace("\\", "_") or "default"
+
+
+def report_artifact_backend() -> ReportArtifactBackend:
+    if _env_str("AGENT_BOM_REPORT_S3_BUCKET"):
+        return "s3"
+    return "local"
+
+
+def s3_object_key(tenant_id: str, job_id: str) -> str:
+    prefix = _env_str("AGENT_BOM_REPORT_S3_PREFIX", "report-artifacts").strip("/")
+    tenant = _safe_segment(tenant_id)
+    name = f"{job_id}.ndjson.gz"
+    return f"{prefix}/{tenant}/{name}" if prefix else f"{tenant}/{name}"
+
+
+def publish_report_artifact(local_path: Path, *, tenant_id: str, job_id: str) -> PublishedReportArtifact:
+    """Publish a completed gzip artifact to the configured backend."""
+    backend = report_artifact_backend()
+    if backend == "local":
+        return PublishedReportArtifact(
+            backend="local",
+            artifact_uri=str(local_path),
+            presigned_download_url=None,
+            local_path=local_path,
+        )
+    return _publish_s3(local_path, tenant_id=tenant_id, job_id=job_id)
+
+
+def _publish_s3(local_path: Path, *, tenant_id: str, job_id: str) -> PublishedReportArtifact:
+    bucket = _env_str("AGENT_BOM_REPORT_S3_BUCKET")
+    if not bucket:
+        raise RuntimeError("AGENT_BOM_REPORT_S3_BUCKET is required for S3 report artifacts")
+
+    try:
+        import boto3
+    except ImportError as exc:  # pragma: no cover - optional extra
+        raise RuntimeError("S3 report artifacts require boto3; install with: pip install 'agent-bom[aws]'") from exc
+
+    key = s3_object_key(tenant_id, job_id)
+    region = _env_str("AGENT_BOM_REPORT_S3_REGION")
+    client_kwargs: dict[str, str] = {}
+    if region:
+        client_kwargs["region_name"] = region
+    client = boto3.client("s3", **client_kwargs)
+    client.upload_file(
+        str(local_path),
+        bucket,
+        key,
+        ExtraArgs={"ContentType": "application/gzip", "ServerSideEncryption": "AES256"},
+    )
+    presign_seconds = max(60, _env_int("AGENT_BOM_REPORT_S3_PRESIGN_SECONDS", 3_600))
+    presigned = client.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": bucket, "Key": key},
+        ExpiresIn=presign_seconds,
+    )
+    uri = f"s3://{bucket}/{key}"
+    _logger.info("Published report artifact for job %s to %s", job_id, uri)
+    return PublishedReportArtifact(
+        backend="s3",
+        artifact_uri=uri,
+        presigned_download_url=presigned,
+        local_path=local_path,
+    )

--- a/src/agent_bom/api/report_worker.py
+++ b/src/agent_bom/api/report_worker.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from agent_bom.api.compliance_hub_store import get_compliance_hub_store
 from agent_bom.api.models import JobStatus, ReportJob
 from agent_bom.api.pipeline import get_executor
+from agent_bom.api.report_artifact_store import publish_report_artifact
 from agent_bom.api.report_job_store import get_report_job_store
 from agent_bom.security import sanitize_error, sanitize_text
 
@@ -52,7 +53,8 @@ def _run_report_job_sync(job_id: str, tenant_id: str) -> None:
     store.update(job)
 
     try:
-        row_count, byte_count, download_token = _write_findings_artifact(job)
+        row_count, byte_count, download_token, artifact_path = _write_findings_artifact(job)
+        published = publish_report_artifact(artifact_path, tenant_id=tenant_id, job_id=job_id)
     except Exception as exc:  # noqa: BLE001
         safe = sanitize_error(exc)
         _logger.warning("Report job %s failed: %s", job_id, sanitize_text(safe))
@@ -84,6 +86,9 @@ def _run_report_job_sync(job_id: str, tenant_id: str) -> None:
     done.row_count = row_count
     done.byte_count = byte_count
     done.download_token = download_token
+    done.artifact_backend = published.backend
+    done.artifact_uri = published.artifact_uri
+    done.presigned_download_url = published.presigned_download_url
     store.update(done)
     try:
         from agent_bom.api.audit_log import log_action
@@ -92,13 +97,20 @@ def _run_report_job_sync(job_id: str, tenant_id: str) -> None:
             "report.export_completed",
             actor="system",
             tenant_id=tenant_id,
-            details={"job_id": job_id, "row_count": row_count, "byte_count": byte_count, "format": done.format.value},
+            details={
+                "job_id": job_id,
+                "row_count": row_count,
+                "byte_count": byte_count,
+                "format": done.format.value,
+                "artifact_backend": published.backend,
+                "artifact_uri": published.artifact_uri,
+            },
         )
     except Exception:  # noqa: BLE001
         pass
 
 
-def _write_findings_artifact(job: ReportJob) -> tuple[int, int, str]:
+def _write_findings_artifact(job: ReportJob) -> tuple[int, int, str, Path]:
     hub = get_compliance_hub_store()
     list_page = getattr(hub, "list_current_page", None)
     if not callable(list_page):
@@ -128,7 +140,7 @@ def _write_findings_artifact(job: ReportJob) -> tuple[int, int, str]:
             cursor = next_cursor
 
     byte_count = path.stat().st_size
-    return row_count, byte_count, secrets.token_urlsafe(32)
+    return row_count, byte_count, secrets.token_urlsafe(32), path
 
 
 def resolve_report_artifact(job: ReportJob) -> Path | None:

--- a/src/agent_bom/api/routes/reports.py
+++ b/src/agent_bom/api/routes/reports.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import secrets
 import uuid
 from typing import Annotated
@@ -14,6 +15,7 @@ from agent_bom.api.pipeline import _now
 from agent_bom.api.report_job_store import get_report_job_store
 from agent_bom.api.report_worker import resolve_report_artifact, submit_report_job
 from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.config import API_MAX_ACTIVE_REPORT_JOBS_PER_TENANT
 
 router = APIRouter()
 
@@ -24,16 +26,44 @@ def _tenant_id(request: Request) -> str:
 
 def _job_payload(job: ReportJob, *, request: Request) -> dict:
     payload = job.model_dump(mode="json")
-    if job.status == JobStatus.DONE and job.download_token:
-        payload["download_url"] = str(request.url_for("download_report_artifact", job_id=job.job_id)) + f"?token={job.download_token}"
+    if job.status == JobStatus.DONE:
+        if job.presigned_download_url:
+            payload["download_url"] = job.presigned_download_url
+        elif job.download_token:
+            payload["download_url"] = str(request.url_for("download_report_artifact", job_id=job.job_id)) + f"?token={job.download_token}"
     payload.pop("download_token", None)
+    payload.pop("presigned_download_url", None)
     return payload
+
+
+def _active_report_jobs_limit() -> int:
+    raw = os.environ.get("AGENT_BOM_API_MAX_ACTIVE_REPORT_JOBS_PER_TENANT")
+    if raw is not None and str(raw).strip():
+        return int(raw)
+    return API_MAX_ACTIVE_REPORT_JOBS_PER_TENANT
+
+
+def _enforce_active_report_quota(tenant_id: str) -> None:
+    limit = _active_report_jobs_limit()
+    if limit <= 0:
+        return
+    active = sum(
+        1
+        for job in get_report_job_store().list_for_tenant(tenant_id)
+        if job.status in (JobStatus.PENDING, JobStatus.RUNNING)
+    )
+    if active >= limit:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Active report export limit reached ({limit} pending or running jobs)",
+        )
 
 
 @router.post("/v1/reports", tags=["reports"], status_code=202)
 async def create_report_job(request: Request, body: ReportJobRequest) -> dict:
     """Enqueue an async findings export (gzipped NDJSON) instead of a synchronous body."""
     tenant_id = _tenant_id(request)
+    _enforce_active_report_quota(tenant_id)
     job = ReportJob(
         job_id=str(uuid.uuid4()),
         tenant_id=tenant_id,

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -426,6 +426,14 @@ RUNTIME_FEEDBACK_PATH = _str("AGENT_BOM_RUNTIME_FEEDBACK_PATH", "")
 # default ~/.agent-bom/report-artifacts. The worker re-reads the env var at
 # runtime so tests and short-lived self-hosted processes can override it safely.
 REPORT_ARTIFACT_DIR = _str("AGENT_BOM_REPORT_ARTIFACT_DIR", "")
+# When REPORT_S3_BUCKET is set, completed exports are uploaded to customer S3
+# and job status returns a presigned GET URL. Credentials follow the standard
+# AWS SDK chain (IRSA, instance profile, env keys). Requires boto3 (``[aws]`` extra).
+REPORT_S3_BUCKET = _str("AGENT_BOM_REPORT_S3_BUCKET", "")
+REPORT_S3_PREFIX = _str("AGENT_BOM_REPORT_S3_PREFIX", "report-artifacts")
+REPORT_S3_REGION = _str("AGENT_BOM_REPORT_S3_REGION", "")
+REPORT_S3_PRESIGN_SECONDS = _int("AGENT_BOM_REPORT_S3_PRESIGN_SECONDS", 3_600)
+API_MAX_ACTIVE_REPORT_JOBS_PER_TENANT = _int("AGENT_BOM_API_MAX_ACTIVE_REPORT_JOBS_PER_TENANT", 5)
 
 
 # ── Agent-to-Agent (A2A) auth posture ────────────────────────────────────

--- a/tests/test_report_artifact_store.py
+++ b/tests/test_report_artifact_store.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -84,6 +85,14 @@ def test_publish_s3_requires_boto3(tmp_path: Path, monkeypatch) -> None:
     artifact = tmp_path / "job.ndjson.gz"
     artifact.write_bytes(b"payload")
     monkeypatch.delitem(sys.modules, "boto3", raising=False)
+    real_import = builtins.__import__
+
+    def _blocked_import(name: str, *args, **kwargs):
+        if name == "boto3":
+            raise ImportError("blocked boto3 for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
 
     with pytest.raises(RuntimeError, match="boto3"):
         publish_report_artifact(artifact, tenant_id="tenant-a", job_id="job-1")

--- a/tests/test_report_artifact_store.py
+++ b/tests/test_report_artifact_store.py
@@ -1,0 +1,89 @@
+"""Tests for report artifact S3 publishing (#3512)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_bom.api.report_artifact_store import (
+    PublishedReportArtifact,
+    publish_report_artifact,
+    report_artifact_backend,
+    s3_object_key,
+)
+
+
+def test_report_artifact_backend_defaults_local(monkeypatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_REPORT_S3_BUCKET", raising=False)
+    assert report_artifact_backend() == "local"
+
+
+def test_report_artifact_backend_selects_s3_when_bucket_set(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_REPORT_S3_BUCKET", "customer-reports")
+    assert report_artifact_backend() == "s3"
+
+
+def test_s3_object_key_includes_prefix_and_tenant(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_REPORT_S3_PREFIX", "exports")
+    key = s3_object_key("tenant/a", "job-123")
+    assert key == "exports/tenant_a/job-123.ndjson.gz"
+
+
+def test_publish_local_artifact(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_REPORT_S3_BUCKET", raising=False)
+    artifact = tmp_path / "job.ndjson.gz"
+    artifact.write_bytes(b"payload")
+
+    published = publish_report_artifact(artifact, tenant_id="tenant-a", job_id="job-1")
+
+    assert published == PublishedReportArtifact(
+        backend="local",
+        artifact_uri=str(artifact),
+        presigned_download_url=None,
+        local_path=artifact,
+    )
+
+
+def test_publish_s3_artifact_uploads_and_presigns(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_REPORT_S3_BUCKET", "customer-reports")
+    monkeypatch.setenv("AGENT_BOM_REPORT_S3_PREFIX", "report-artifacts")
+    monkeypatch.setenv("AGENT_BOM_REPORT_S3_REGION", "us-east-1")
+    monkeypatch.setenv("AGENT_BOM_REPORT_S3_PRESIGN_SECONDS", "7200")
+    artifact = tmp_path / "job.ndjson.gz"
+    artifact.write_bytes(b"payload")
+
+    mock_client = MagicMock()
+    mock_client.generate_presigned_url.return_value = "https://s3.example/presigned"
+    fake_boto3 = MagicMock()
+    fake_boto3.client.return_value = mock_client
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+    published = publish_report_artifact(artifact, tenant_id="tenant-a", job_id="job-1")
+
+    fake_boto3.client.assert_called_once_with("s3", region_name="us-east-1")
+    mock_client.upload_file.assert_called_once()
+    upload_args = mock_client.upload_file.call_args
+    assert upload_args[0][0] == str(artifact)
+    assert upload_args[0][1] == "customer-reports"
+    assert upload_args[0][2] == "report-artifacts/tenant-a/job-1.ndjson.gz"
+    mock_client.generate_presigned_url.assert_called_once_with(
+        "get_object",
+        Params={"Bucket": "customer-reports", "Key": "report-artifacts/tenant-a/job-1.ndjson.gz"},
+        ExpiresIn=7200,
+    )
+    assert published.backend == "s3"
+    assert published.artifact_uri == "s3://customer-reports/report-artifacts/tenant-a/job-1.ndjson.gz"
+    assert published.presigned_download_url == "https://s3.example/presigned"
+
+
+def test_publish_s3_requires_boto3(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_REPORT_S3_BUCKET", "customer-reports")
+    artifact = tmp_path / "job.ndjson.gz"
+    artifact.write_bytes(b"payload")
+    monkeypatch.delitem(sys.modules, "boto3", raising=False)
+
+    with pytest.raises(RuntimeError, match="boto3"):
+        publish_report_artifact(artifact, tenant_id="tenant-a", job_id="job-1")

--- a/tests/test_report_jobs.py
+++ b/tests/test_report_jobs.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import gzip
 import json
+import sys
 import time
 from pathlib import Path
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
@@ -108,3 +110,54 @@ def test_report_job_is_tenant_scoped(tmp_path: Path) -> None:
     assert created.status_code == 202
     job_id = created.json()["job_id"]
     assert client_b.get(f"/v1/reports/{job_id}").status_code == 404
+
+
+def test_report_job_returns_s3_presigned_url(monkeypatch, tmp_path: Path) -> None:
+    tenant_id = f"report-s3-{uuid4().hex}"
+    monkeypatch.setenv("AGENT_BOM_REPORT_ARTIFACT_DIR", str(tmp_path))
+    monkeypatch.setenv("AGENT_BOM_REPORT_S3_BUCKET", "customer-reports")
+    monkeypatch.setattr("agent_bom.api.routes.reports.submit_report_job", _run_report_job_sync)
+
+    mock_client = MagicMock()
+    mock_client.generate_presigned_url.return_value = "https://s3.example/presigned"
+    fake_boto3 = MagicMock()
+    fake_boto3.client.return_value = mock_client
+    monkeypatch.setitem(sys.modules, "boto3", fake_boto3)
+
+    _seed_hub(tmp_path, tenant_id, count=2)
+    client = _client(tenant=tenant_id)
+
+    created = client.post("/v1/reports", json={"format": "ndjson"})
+    assert created.status_code == 202
+    job_id = created.json()["job_id"]
+
+    deadline = time.time() + 5
+    body = {}
+    while time.time() < deadline:
+        polled = client.get(f"/v1/reports/{job_id}")
+        assert polled.status_code == 200
+        body = polled.json()
+        if body["status"] == "done":
+            break
+        time.sleep(0.05)
+
+    assert body["status"] == "done"
+    assert body["artifact_backend"] == "s3"
+    assert body["artifact_uri"].startswith("s3://customer-reports/")
+    assert body["download_url"] == "https://s3.example/presigned"
+    mock_client.upload_file.assert_called_once()
+
+
+def test_report_job_active_quota(monkeypatch, tmp_path: Path) -> None:
+    tenant_id = f"report-quota-{uuid4().hex}"
+    monkeypatch.setenv("AGENT_BOM_API_MAX_ACTIVE_REPORT_JOBS_PER_TENANT", "1")
+    monkeypatch.setattr("agent_bom.api.routes.reports.submit_report_job", lambda *_args, **_kwargs: None)
+    _seed_hub(tmp_path, tenant_id, count=1)
+    client = _client(tenant=tenant_id)
+
+    first = client.post("/v1/reports", json={})
+    assert first.status_code == 202
+
+    second = client.post("/v1/reports", json={})
+    assert second.status_code == 429
+    assert "limit" in second.json()["detail"].lower()


### PR DESCRIPTION
## Summary
- When `AGENT_BOM_REPORT_S3_BUCKET` is set, completed async report jobs upload gzipped NDJSON to customer S3 and return a presigned GET URL plus `artifact_uri` / `artifact_backend` on the job payload.
- Local token download via `GET /v1/reports/{job_id}/download` remains the default when S3 is not configured.
- Adds per-tenant active report job cap (`AGENT_BOM_API_MAX_ACTIVE_REPORT_JOBS_PER_TENANT`) and Helm/ENV_VARS wiring.

Closes #3512

## Verification
- `uv run pytest tests/test_report_jobs.py tests/test_report_artifact_store.py -q` (10 passed)
- `uv run ruff check` on touched files
- `uv run mypy` on report artifact/worker/route modules

## Notes
- S3 only in this PR; GCS/Azure backends can follow the same `report_artifact_store` interface.
- Requires `boto3` (`pip install 'agent-bom[aws]'`); credentials follow the standard AWS SDK chain (IRSA recommended on EKS).

Made with [Cursor](https://cursor.com)