### PR TITLE
fix(fleet): local discovery push for fleet sync

### DIFF
--- a/src/agent_bom/cli/claw.py
+++ b/src/agent_bom/cli/claw.py
@@ -84,16 +84,57 @@ def fleet_group(ctx: click.Context) -> None:
 
 
 @click.command("sync")
+@click.option(
+    "--project",
+    "project_dir",
+    type=click.Path(exists=True, file_okay=False),
+    default=None,
+    help="Restrict discovery to a project directory",
+)
+@click.option(
+    "--push-url",
+    default=None,
+    envvar="AGENT_BOM_PUSH_URL",
+    metavar="URL",
+    help="Control-plane fleet sync URL (full /v1/fleet/sync or API base URL)",
+)
+@click.option(
+    "--push-api-key",
+    default=None,
+    envvar="AGENT_BOM_PUSH_API_KEY",
+    metavar="TOKEN",
+    help="Bearer token for fleet sync",
+)
+@click.option("--source-id", default=None, envvar="AGENT_BOM_PUSH_SOURCE_ID", help="Stable endpoint source identifier")
 @click.option("--quiet", "-q", is_flag=True)
-def fleet_sync_cmd(quiet: bool) -> None:
-    """Run agent discovery and sync results into fleet registry."""
+def fleet_sync_cmd(project_dir: str | None, push_url: str | None, push_api_key: str | None, source_id: str | None, quiet: bool) -> None:
+    """Run agent discovery and sync results into the fleet registry."""
     from rich.console import Console
 
+    from agent_bom.fleet.sync_client import run_fleet_sync
+
     con = Console(stderr=True, quiet=quiet)
-    con.print("[dim]Fleet sync requires the API server. Start with:[/dim]")
-    con.print("  [cyan]agent-bom api[/cyan]")
-    con.print("  [cyan]curl -X POST http://localhost:8422/v1/fleet/sync[/cyan]")
-    raise click.ClickException("fleet sync is not available as a local-only command; call the API endpoint instead")
+    try:
+        result = run_fleet_sync(
+            push_url=push_url,
+            api_key=push_api_key,
+            project_dir=project_dir,
+            source_id=source_id,
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if not quiet:
+        con.print(
+            "[green]Fleet sync complete[/green] "
+            f"discovered={result.get('discovered', 0)} "
+            f"synced={result.get('synced', 0)} "
+            f"new={result.get('new', 0)} "
+            f"updated={result.get('updated', 0)} "
+            f"source_id={result.get('source_id', '')}"
+        )
 
 
 @click.command("list")

--- a/src/agent_bom/fleet/sync_client.py
+++ b/src/agent_bom/fleet/sync_client.py
@@ -1,0 +1,75 @@
+"""Local discovery → control-plane fleet sync (#3471)."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict
+from typing import Any
+
+from agent_bom.fleet.trust_scoring import compute_trust_score
+from agent_bom.push import generate_source_id, push_json, sanitize_results
+
+
+def _default_fleet_sync_url(raw: str | None) -> str:
+    url = (raw or os.environ.get("AGENT_BOM_PUSH_URL") or "").strip()
+    if not url:
+        raise ValueError("Set --push-url or AGENT_BOM_PUSH_URL to the control-plane /v1/fleet/sync endpoint")
+    if url.rstrip("/").endswith("/v1/fleet/sync"):
+        return url
+    return f"{url.rstrip('/')}/v1/fleet/sync"
+
+
+def _agent_to_fleet_dict(agent: Any, *, source_id: str) -> dict[str, Any]:
+    score, factors = compute_trust_score(agent)
+    agent_type = agent.agent_type
+    agent_type_value = agent_type.value if hasattr(agent_type, "value") else str(agent_type)
+    mcp_servers: list[dict[str, Any]] = []
+    for server in getattr(agent, "mcp_servers", []) or []:
+        server_payload = asdict(server)
+        server_payload.pop("config_path", None)
+        server_payload["credential_names"] = list(getattr(server, "credential_names", []) or [])
+        mcp_servers.append(server_payload)
+    payload: dict[str, Any] = {
+        "name": agent.name,
+        "agent_type": agent_type_value,
+        "source_id": source_id,
+        "trust_score": score,
+        "trust_factors": factors,
+        "mcp_servers": mcp_servers,
+    }
+    canonical_id = str(getattr(agent, "canonical_id", "") or "").strip()
+    if canonical_id:
+        payload["canonical_id"] = canonical_id
+    return payload
+
+
+def build_fleet_sync_payload(agents: list[Any], *, source_id: str | None = None) -> dict[str, Any]:
+    sid = (source_id or generate_source_id()).strip()
+    return {
+        "source_id": sid,
+        "agents": [_agent_to_fleet_dict(agent, source_id=sid) for agent in agents],
+    }
+
+
+def run_fleet_sync(
+    *,
+    push_url: str | None = None,
+    api_key: str | None = None,
+    project_dir: str | None = None,
+    source_id: str | None = None,
+) -> dict[str, Any]:
+    """Discover local MCP agents and push them to ``POST /v1/fleet/sync``."""
+    from agent_bom.discovery import discover_all
+
+    url = _default_fleet_sync_url(push_url)
+    token = api_key if api_key is not None else os.environ.get("AGENT_BOM_PUSH_API_KEY")
+    agents = discover_all(project_dir=project_dir)
+    payload = sanitize_results(build_fleet_sync_payload(agents, source_id=source_id))
+    response = push_json(url, payload, api_key=token)
+    if response is None:
+        raise RuntimeError(f"Fleet sync push failed for {url}")
+    return {
+        "discovered": len(agents),
+        "push_url": url,
+        **response,
+    }

--- a/src/agent_bom/push.py
+++ b/src/agent_bom/push.py
@@ -229,5 +229,8 @@ def push_results(push_url: str, results: dict, api_key: str | None = None) -> bo
 
 def push_json(push_url: str, results: dict, api_key: str | None = None) -> dict | None:
     """POST sanitized JSON and return the parsed response body on success."""
-    ok, body = asyncio.run(_push_async(push_url, results, api_key, return_body=True))
+    pushed = asyncio.run(_push_async(push_url, results, api_key, return_body=True))
+    if not isinstance(pushed, tuple):
+        return None
+    ok, body = pushed
     return body if ok else None

--- a/src/agent_bom/push.py
+++ b/src/agent_bom/push.py
@@ -15,7 +15,7 @@ import logging
 import os
 import platform
 import uuid
-from typing import Any
+from typing import Any, Literal, overload
 
 import httpx
 
@@ -125,6 +125,32 @@ def _push_retry_delay(attempt: int, base: float, cap: float) -> float:
     exp = base * (2 ** (attempt - 1))
     jitter = random.uniform(0, exp * 0.1)
     return min(cap, exp + jitter)
+
+
+@overload
+async def _push_async(
+    push_url: str,
+    results: dict,
+    api_key: str | None = None,
+    *,
+    max_attempts: int = _DEFAULT_PUSH_MAX_ATTEMPTS,
+    base_delay_seconds: float = _DEFAULT_PUSH_BASE_DELAY,
+    max_delay_seconds: float = _DEFAULT_PUSH_MAX_DELAY,
+    return_body: Literal[False] = False,
+) -> bool: ...
+
+
+@overload
+async def _push_async(
+    push_url: str,
+    results: dict,
+    api_key: str | None = None,
+    *,
+    max_attempts: int = _DEFAULT_PUSH_MAX_ATTEMPTS,
+    base_delay_seconds: float = _DEFAULT_PUSH_BASE_DELAY,
+    max_delay_seconds: float = _DEFAULT_PUSH_MAX_DELAY,
+    return_body: Literal[True],
+) -> tuple[bool, dict[str, Any] | None]: ...
 
 
 async def _push_async(

--- a/src/agent_bom/push.py
+++ b/src/agent_bom/push.py
@@ -15,6 +15,7 @@ import logging
 import os
 import platform
 import uuid
+from typing import Any
 
 import httpx
 
@@ -134,7 +135,8 @@ async def _push_async(
     max_attempts: int = _DEFAULT_PUSH_MAX_ATTEMPTS,
     base_delay_seconds: float = _DEFAULT_PUSH_BASE_DELAY,
     max_delay_seconds: float = _DEFAULT_PUSH_MAX_DELAY,
-) -> bool:
+    return_body: bool = False,
+) -> bool | tuple[bool, dict[str, Any] | None]:
     """POST sanitized results to the central dashboard with bounded retries.
 
     Retries on network errors (``httpx.HTTPError``, ``OSError``) and on
@@ -151,7 +153,7 @@ async def _push_async(
         validate_url(push_url)
     except SecurityError as exc:
         logger.error("Push URL rejected by outbound URL policy: %s", exc)
-        return False
+        return (False, None) if return_body else False
 
     headers: dict[str, str] = {"Content-Type": "application/json"}
     if api_key:
@@ -183,6 +185,12 @@ async def _push_async(
                         resp.status_code,
                         attempt,
                     )
+                    if return_body:
+                        try:
+                            parsed = resp.json()
+                        except ValueError:
+                            parsed = {}
+                        return True, parsed if isinstance(parsed, dict) else {}
                     return True
                 if resp.status_code not in retryable_status:
                     logger.warning(
@@ -190,7 +198,7 @@ async def _push_async(
                         resp.status_code,
                         sanitize_text(resp.text[:200]),
                     )
-                    return False
+                    return (False, None) if return_body else False
                 last_error = sanitize_text(resp.text[:200])
                 logger.warning(
                     "Push attempt %d/%d returned retryable status %d",
@@ -208,9 +216,18 @@ async def _push_async(
         last_status,
         last_error,
     )
+    if return_body:
+        return False, None
     return False
 
 
 def push_results(push_url: str, results: dict, api_key: str | None = None) -> bool:
     """Synchronous wrapper for pushing results to a dashboard."""
-    return asyncio.run(_push_async(push_url, results, api_key))
+    result = asyncio.run(_push_async(push_url, results, api_key))
+    return bool(result)
+
+
+def push_json(push_url: str, results: dict, api_key: str | None = None) -> dict | None:
+    """POST sanitized JSON and return the parsed response body on success."""
+    ok, body = asyncio.run(_push_async(push_url, results, api_key, return_body=True))
+    return body if ok else None

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -343,10 +343,17 @@ class TestAgentClaw:
         fleet = claw.get_command(None, "fleet")
         assert fleet.get_command(None, "state") is None
 
-    def test_fleet_placeholder_commands_fail_closed(self):
+    def test_fleet_sync_requires_push_url(self):
         from agent_bom.cli.claw import claw
 
-        for command in ("sync", "list", "stats"):
+        r = CliRunner().invoke(claw, ["fleet", "sync"])
+        assert r.exit_code != 0
+        assert "AGENT_BOM_PUSH_URL" in r.output
+
+    def test_fleet_list_and_stats_fail_closed(self):
+        from agent_bom.cli.claw import claw
+
+        for command in ("list", "stats"):
             r = CliRunner().invoke(claw, ["fleet", command])
             assert r.exit_code != 0
             assert "agent-bom api" in r.output

--- a/tests/test_fleet_sync_client.py
+++ b/tests/test_fleet_sync_client.py
@@ -1,0 +1,49 @@
+"""Tests for local fleet sync discovery push (#3471)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_bom.fleet.sync_client import build_fleet_sync_payload, run_fleet_sync
+
+
+def test_build_fleet_sync_payload_includes_trust_score() -> None:
+    agent = MagicMock()
+    agent.name = "cursor"
+    agent.agent_type.value = "cursor"
+    agent.canonical_id = "cursor:local"
+    agent.mcp_servers = []
+    payload = build_fleet_sync_payload([agent], source_id="device-a")
+    assert payload["source_id"] == "device-a"
+    assert len(payload["agents"]) == 1
+    assert payload["agents"][0]["name"] == "cursor"
+    assert "trust_score" in payload["agents"][0]
+    assert payload["agents"][0]["mcp_servers"] == []
+
+
+def test_run_fleet_sync_discovers_and_pushes(monkeypatch: pytest.MonkeyPatch) -> None:
+    agent = MagicMock()
+    agent.name = "cursor"
+    agent.agent_type.value = "cursor"
+    agent.canonical_id = "cursor:local"
+    agent.mcp_servers = []
+
+    monkeypatch.setenv("AGENT_BOM_PUSH_URL", "https://control-plane.example/v1/fleet/sync")
+    api_response = {"synced": 1, "new": 1, "updated": 0, "source_id": "device-a"}
+    with patch("agent_bom.discovery.discover_all", return_value=[agent]) as discover:
+        with patch("agent_bom.fleet.sync_client.push_json", return_value=api_response) as push:
+            result = run_fleet_sync(source_id="device-a")
+
+    discover.assert_called_once_with(project_dir=None)
+    push.assert_called_once()
+    assert push.call_args.args[0] == "https://control-plane.example/v1/fleet/sync"
+    assert result["discovered"] == 1
+    assert result["synced"] == 1
+
+
+def test_run_fleet_sync_requires_push_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_PUSH_URL", raising=False)
+    with pytest.raises(ValueError, match="AGENT_BOM_PUSH_URL"):
+        run_fleet_sync()


### PR DESCRIPTION
## Summary
- `agent-bom fleet sync` (and `agent-claw fleet sync`) runs local MCP discovery and pushes a fleet `PushPayload` to the control plane instead of raising a stub error.
- Reuses `AGENT_BOM_PUSH_URL`, `AGENT_BOM_PUSH_API_KEY`, and `AGENT_BOM_PUSH_SOURCE_ID` — same contract as endpoint onboarding scripts.
- Adds `push_json()` for callers that need the API response body (synced/new/updated counts).

Closes #3471

## Verification
- `uv run pytest tests/test_fleet_sync_client.py tests/test_api_fleet.py tests/test_push.py -q` (59 passed)
- `uv run ruff check` on touched files

## First command
```bash
export AGENT_BOM_PUSH_URL=https://control-plane.example/v1/fleet/sync
export AGENT_BOM_PUSH_API_KEY=your-token
agent-bom fleet sync
```

Made with [Cursor](https://cursor.com)