### PR TITLE
chore(glama): pin release ref and verify Dockerfile on publish

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -177,10 +177,6 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          # Pin to the release commit so manifest/Dockerfile checks and webhook
-          # payload match the tag the Release workflow just published.
-          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Extract release metadata
         id: meta
@@ -214,8 +210,13 @@ jobs:
           echo "release_ref=$RELEASE_REF" >> "$GITHUB_OUTPUT"
           echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
 
+      - name: Fetch release commit for manifest verification
+        env:
+          RELEASE_SHA: ${{ steps.meta.outputs.release_sha }}
+        run: git fetch --no-tags --depth=1 origin "$RELEASE_SHA"
+
       - name: Verify Glama build manifest
-        run: python scripts/check_glama_listing.py --verify-manifest
+        run: python scripts/check_glama_listing.py --verify-manifest --git-ref "${{ steps.meta.outputs.release_sha }}"
 
       - name: Trigger Glama rebuild
         env:

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -172,6 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
+      actions: read
       contents: read
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
@@ -202,8 +203,12 @@ jobs:
             if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
               VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
             fi
-            RELEASE_REF="refs/tags/${HEAD_BRANCH}"
-            RELEASE_SHA="${HEAD_SHA}"
+            if [ -n "${HEAD_BRANCH:-}" ]; then
+              RELEASE_REF="refs/tags/${HEAD_BRANCH}"
+            else
+              RELEASE_REF="refs/tags/v${VERSION}"
+            fi
+            RELEASE_SHA="${HEAD_SHA:-$(git rev-parse HEAD)}"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "release_ref=$RELEASE_REF" >> "$GITHUB_OUTPUT"
@@ -221,16 +226,17 @@ jobs:
           GLAMA_DOCKERFILE: integrations/glama/Dockerfile
         run: |
           if [ -z "$GLAMA_WEBHOOK_URL" ]; then
-            echo "::warning::GLAMA_WEBHOOK_URL not configured — verifying Glama auto-sync freshness instead"
+            echo "::warning::GLAMA_WEBHOOK_URL not configured — skipping webhook trigger"
+            echo "Release pin for Glama: ${RELEASE_REF} (${RELEASE_SHA:0:7}) dockerfile=${GLAMA_DOCKERFILE}"
             echo "To enable instant rebuild, set GLAMA_WEBHOOK_URL in repo variables"
             exit 0
           fi
-          PAYLOAD=$(python3 -c 'import json, os; print(json.dumps({
-              "ref": os.environ["RELEASE_REF"],
-              "commit": os.environ["RELEASE_SHA"],
-              "version": os.environ["VERSION"],
-              "dockerfile": os.environ["GLAMA_DOCKERFILE"],
-          }, separators=(",", ":")))')
+          PAYLOAD=$(jq -n \
+            --arg ref "$RELEASE_REF" \
+            --arg commit "$RELEASE_SHA" \
+            --arg version "$VERSION" \
+            --arg dockerfile "$GLAMA_DOCKERFILE" \
+            '{ref: $ref, commit: $commit, version: $version, dockerfile: $dockerfile}')
           echo "Triggering Glama rebuild for ${RELEASE_REF} (${RELEASE_SHA:0:7}) using ${GLAMA_DOCKERFILE}"
           HTTP_STATUS=$(curl -s --connect-timeout 10 --max-time 30 \
             -o /dev/null -w "%{http_code}" \

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -6,6 +6,7 @@ name: Publish to Registries
 #   CLAWHUB_TOKEN       — ClawHub auth token (clawhub.ai → Settings)
 # Optional vars:
 #   SMITHERY_MCP_URL    — Explicit public, unauthenticated MCP endpoint for Smithery
+#   GLAMA_WEBHOOK_URL   — Glama rebuild webhook (POST JSON: ref, commit, version, dockerfile)
 
 on:
   workflow_run:
@@ -175,18 +176,66 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Pin to the release commit so manifest/Dockerfile checks and webhook
+          # payload match the tag the Release workflow just published.
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+      - name: Extract release metadata
+        id: meta
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            REF="${GITHUB_REF_NAME#v}"
+            if echo "$REF" | grep -qE '^[0-9]+\.[0-9]+'; then
+              VERSION="$REF"
+            else
+              VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+            fi
+            RELEASE_REF="refs/tags/v${VERSION}"
+            RELEASE_SHA=$(git rev-parse HEAD)
+          else
+            VERSION="${HEAD_BRANCH#v}"
+            if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+              VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+            fi
+            RELEASE_REF="refs/tags/${HEAD_BRANCH}"
+            RELEASE_SHA="${HEAD_SHA}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_ref=$RELEASE_REF" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Verify Glama build manifest
+        run: python scripts/check_glama_listing.py --verify-manifest
 
       - name: Trigger Glama rebuild
         env:
           GLAMA_WEBHOOK_URL: ${{ vars.GLAMA_WEBHOOK_URL }}
+          RELEASE_REF: ${{ steps.meta.outputs.release_ref }}
+          RELEASE_SHA: ${{ steps.meta.outputs.release_sha }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          GLAMA_DOCKERFILE: integrations/glama/Dockerfile
         run: |
           if [ -z "$GLAMA_WEBHOOK_URL" ]; then
             echo "::warning::GLAMA_WEBHOOK_URL not configured — verifying Glama auto-sync freshness instead"
             echo "To enable instant rebuild, set GLAMA_WEBHOOK_URL in repo variables"
             exit 0
           fi
+          PAYLOAD=$(python3 -c 'import json, os; print(json.dumps({
+              "ref": os.environ["RELEASE_REF"],
+              "commit": os.environ["RELEASE_SHA"],
+              "version": os.environ["VERSION"],
+              "dockerfile": os.environ["GLAMA_DOCKERFILE"],
+          }, separators=(",", ":")))')
+          echo "Triggering Glama rebuild for ${RELEASE_REF} (${RELEASE_SHA:0:7}) using ${GLAMA_DOCKERFILE}"
           HTTP_STATUS=$(curl -s --connect-timeout 10 --max-time 30 \
             -o /dev/null -w "%{http_code}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
             -X POST "$GLAMA_WEBHOOK_URL")
           if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 400 ]; then
             echo "Glama rebuild triggered successfully"
@@ -200,8 +249,10 @@ jobs:
       # publish; the listing self-resolves once Glama re-crawls.
       - name: Verify Glama listing freshness
         continue-on-error: true
+        env:
+          EXPECTED_VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          if ! python scripts/check_glama_listing.py --retries 6 --delay-seconds 30; then
+          if ! python scripts/check_glama_listing.py --expected "$EXPECTED_VERSION" --retries 6 --delay-seconds 30; then
             echo "::warning::Glama listing not yet refreshed to the new version. Glama re-crawls asynchronously (can take hours); the rebuild was already triggered, so this self-resolves. Listing: https://glama.ai/mcp/servers/msaad00/agent-bom"
           fi
 

--- a/docs/audits/AUDIT-2026-07-03.md
+++ b/docs/audits/AUDIT-2026-07-03.md
@@ -24,7 +24,7 @@
 
 ## §B. Master issue ledger
 
-### Fixed & live-verified (19 items)
+### Fixed & live-verified (21 items)
 
 | # | Finding | PR / issue |
 |---|---|---|
@@ -47,6 +47,8 @@
 | 17 | P3 SBOM/air-gap/KEV+EPSS offline | #3451, #3466 |
 | 18 | Finding lifecycle L1+L2 | #3470, #3480 |
 | 19 | P3 SAML RelayState cluster | #3478 |
+| 20 | P3 Stale Alembic docs | **#3496** — Helm auto-migration on main |
+| 21 | P3 Finding encryption prerequisite (document) | **#3497** — `ENTERPRISE_DEPLOYMENT.md` + site mirrors |
 
 ### Open (A–T) → GitHub issues
 
@@ -68,8 +70,6 @@
 | **N** | P3 | NetworkPolicy API egress 0.0.0.0/0:443 | **#3494** |
 | **O** | P3 | No table partitioning | **#3463** |
 | **P** | P3 | Batch parent empty graph exports | **#3495** |
-| **Q** | P3 | Stale Alembic docs | **#3496** |
-| **R** | P3 | Finding encryption prerequisite (document) | **#3497** |
 | **S** | P3 | OCSF product attribution on ingest | **#3498** → PR **#3509** |
 | **T** | scope | Multi-language reachability; data-lake interop | **#3499** |
 

--- a/docs/audits/AUDIT-2026-07-03.md
+++ b/docs/audits/AUDIT-2026-07-03.md
@@ -24,7 +24,7 @@
 
 ## §B. Master issue ledger
 
-### Fixed & live-verified (21 items)
+### Fixed & live-verified (19 items)
 
 | # | Finding | PR / issue |
 |---|---|---|
@@ -47,8 +47,6 @@
 | 17 | P3 SBOM/air-gap/KEV+EPSS offline | #3451, #3466 |
 | 18 | Finding lifecycle L1+L2 | #3470, #3480 |
 | 19 | P3 SAML RelayState cluster | #3478 |
-| 20 | P3 Stale Alembic docs | **#3496** — Helm auto-migration on main |
-| 21 | P3 Finding encryption prerequisite (document) | **#3497** — `ENTERPRISE_DEPLOYMENT.md` + site mirrors |
 
 ### Open (A–T) → GitHub issues
 
@@ -70,6 +68,8 @@
 | **N** | P3 | NetworkPolicy API egress 0.0.0.0/0:443 | **#3494** |
 | **O** | P3 | No table partitioning | **#3463** |
 | **P** | P3 | Batch parent empty graph exports | **#3495** |
+| **Q** | P3 | Stale Alembic docs | **#3496** |
+| **R** | P3 | Finding encryption prerequisite (document) | **#3497** |
 | **S** | P3 | OCSF product attribution on ingest | **#3498** → PR **#3509** |
 | **T** | scope | Multi-language reachability; data-lake interop | **#3499** |
 

--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -17,6 +17,8 @@ ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = ROOT / "pyproject.toml"
 README = ROOT / "README.md"
 DEFAULT_URL = "https://glama.ai/mcp/servers/msaad00/agent-bom"
+GLAMA_DOCKERFILE = "integrations/glama/Dockerfile"
+GLAMA_MANIFESTS = (ROOT / "glama.json", ROOT / "integrations" / "glama" / "server.json")
 
 
 def _load_version() -> str:
@@ -33,6 +35,40 @@ def _load_readme_tool_count() -> str:
     if not match:
         raise SystemExit("README.md MCP tool count sentence not found")
     return match.group(1)
+
+
+def verify_build_manifest() -> list[str]:
+    """Ensure Glama manifests point at the curated Dockerfile before rebuild."""
+
+    failures: list[str] = []
+    dockerfile_path = ROOT / GLAMA_DOCKERFILE
+    if not dockerfile_path.is_file():
+        failures.append(f"missing Glama Dockerfile at {GLAMA_DOCKERFILE}")
+    else:
+        dockerfile_text = dockerfile_path.read_text(encoding="utf-8")
+        run_lines = [
+            line
+            for line in dockerfile_text.splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+        if any("uv sync" in line for line in run_lines):
+            failures.append(f"{GLAMA_DOCKERFILE} must not use uv sync (mcp-proxy PATH issue)")
+        if 'ENTRYPOINT ["agent-bom", "mcp", "server"]' not in dockerfile_text:
+            failures.append(f"{GLAMA_DOCKERFILE} must ENTRYPOINT agent-bom mcp server")
+        if 'pip install --no-cache-dir --prefix=/install ".[mcp-server]"' not in dockerfile_text:
+            failures.append(f"{GLAMA_DOCKERFILE} must pip install agent-bom onto system PATH")
+
+    for manifest in GLAMA_MANIFESTS:
+        if not manifest.is_file():
+            failures.append(f"missing Glama manifest: {manifest.relative_to(ROOT)}")
+            continue
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+        if data.get("dockerfile") != GLAMA_DOCKERFILE:
+            failures.append(
+                f"{manifest.relative_to(ROOT)} dockerfile must be {GLAMA_DOCKERFILE!r}, "
+                f"found {data.get('dockerfile')!r}"
+            )
+    return failures
 
 
 def _fetch(url: str, timeout: int) -> str:
@@ -52,6 +88,8 @@ def _check(page: str, version: str, tool_count: str) -> list[str]:
         r"uses:\s*msaad00/agent-bom@v0\.88\.4",
         r"MCP server mode advertises\s+55\s+MCP tools",
         r"18 tools for CVE scanning",
+        r"98c3e543",  # pre-0.92.0 pinned Glama build ref from audit #3472
+        r"git checkout 98c3e543",
     ]
     failures.extend(f"stale Glama listing pattern still present: {pattern}" for pattern in stale_patterns if re.search(pattern, page))
     return failures
@@ -79,7 +117,22 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--timeout", type=int, default=20)
     parser.add_argument("--retries", type=int, default=1)
     parser.add_argument("--delay-seconds", type=int, default=30)
+    parser.add_argument(
+        "--verify-manifest",
+        action="store_true",
+        help="Validate glama.json/server.json and integrations/glama/Dockerfile, then exit.",
+    )
     args = parser.parse_args(argv)
+
+    if args.verify_manifest:
+        failures = verify_build_manifest()
+        if failures:
+            print("ERROR: Glama build manifest check failed:", file=sys.stderr)
+            for failure in failures:
+                print(f"- {failure}", file=sys.stderr)
+            return 1
+        print(f"Glama build manifest is valid ({GLAMA_DOCKERFILE})")
+        return 0
 
     version = (args.expected or _load_version()).lstrip("v").strip()
     tool_count = _load_readme_tool_count()

--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import re
+import subprocess
 import sys
 import time
 import urllib.error
@@ -19,6 +20,21 @@ README = ROOT / "README.md"
 DEFAULT_URL = "https://glama.ai/mcp/servers/msaad00/agent-bom"
 GLAMA_DOCKERFILE = "integrations/glama/Dockerfile"
 GLAMA_MANIFESTS = (ROOT / "glama.json", ROOT / "integrations" / "glama" / "server.json")
+
+
+def _read_repo_file(relative_path: str, *, git_ref: str | None = None) -> str:
+    if not git_ref:
+        return (ROOT / relative_path).read_text(encoding="utf-8")
+    try:
+        return subprocess.check_output(
+            ["git", "show", f"{git_ref}:{relative_path}"],
+            cwd=ROOT,
+            text=True,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or "").strip()
+        raise FileNotFoundError(f"{relative_path} at {git_ref}: {detail}") from exc
 
 
 def _load_version() -> str:
@@ -37,15 +53,16 @@ def _load_readme_tool_count() -> str:
     return match.group(1)
 
 
-def verify_build_manifest() -> list[str]:
+def verify_build_manifest(git_ref: str | None = None) -> list[str]:
     """Ensure Glama manifests point at the curated Dockerfile before rebuild."""
 
     failures: list[str] = []
-    dockerfile_path = ROOT / GLAMA_DOCKERFILE
-    if not dockerfile_path.is_file():
-        failures.append(f"missing Glama Dockerfile at {GLAMA_DOCKERFILE}")
+    try:
+        dockerfile_text = _read_repo_file(GLAMA_DOCKERFILE, git_ref=git_ref)
+    except FileNotFoundError:
+        location = f" at {git_ref}" if git_ref else ""
+        failures.append(f"missing Glama Dockerfile at {GLAMA_DOCKERFILE}{location}")
     else:
-        dockerfile_text = dockerfile_path.read_text(encoding="utf-8")
         run_lines = [
             line
             for line in dockerfile_text.splitlines()
@@ -59,13 +76,17 @@ def verify_build_manifest() -> list[str]:
             failures.append(f"{GLAMA_DOCKERFILE} must pip install agent-bom onto system PATH")
 
     for manifest in GLAMA_MANIFESTS:
-        if not manifest.is_file():
-            failures.append(f"missing Glama manifest: {manifest.relative_to(ROOT)}")
+        manifest_path = str(manifest.relative_to(ROOT))
+        try:
+            manifest_text = _read_repo_file(manifest_path, git_ref=git_ref)
+        except FileNotFoundError:
+            location = f" at {git_ref}" if git_ref else ""
+            failures.append(f"missing Glama manifest: {manifest_path}{location}")
             continue
-        data = json.loads(manifest.read_text(encoding="utf-8"))
+        data = json.loads(manifest_text)
         if data.get("dockerfile") != GLAMA_DOCKERFILE:
             failures.append(
-                f"{manifest.relative_to(ROOT)} dockerfile must be {GLAMA_DOCKERFILE!r}, "
+                f"{manifest_path} dockerfile must be {GLAMA_DOCKERFILE!r}, "
                 f"found {data.get('dockerfile')!r}"
             )
     return failures
@@ -122,16 +143,22 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Validate glama.json/server.json and integrations/glama/Dockerfile, then exit.",
     )
+    parser.add_argument(
+        "--git-ref",
+        default=None,
+        help="Read manifest files from this git ref/SHA while running trusted checker code.",
+    )
     args = parser.parse_args(argv)
 
     if args.verify_manifest:
-        failures = verify_build_manifest()
+        failures = verify_build_manifest(args.git_ref)
         if failures:
             print("ERROR: Glama build manifest check failed:", file=sys.stderr)
             for failure in failures:
                 print(f"- {failure}", file=sys.stderr)
             return 1
-        print(f"Glama build manifest is valid ({GLAMA_DOCKERFILE})")
+        suffix = f" at {args.git_ref}" if args.git_ref else ""
+        print(f"Glama build manifest is valid ({GLAMA_DOCKERFILE}{suffix})")
         return 0
 
     version = (args.expected or _load_version()).lstrip("v").strip()

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -410,6 +410,11 @@ def main() -> int:
     glama_text = GLAMA_SERVER.read_text()
     if f'"version": "{version}"' not in glama_text:
         _fail(f"integrations/glama/server.json must be aligned to {version}")
+    if '"dockerfile": "integrations/glama/Dockerfile"' not in glama_text:
+        _fail("integrations/glama/server.json must point at integrations/glama/Dockerfile")
+    glama_root = (ROOT / "glama.json").read_text()
+    if '"dockerfile": "integrations/glama/Dockerfile"' not in glama_root:
+        _fail("glama.json must point at integrations/glama/Dockerfile")
     if f"`{version}` | Current stable version (pinned)" not in DOCKER_README.read_text():
         _fail(f"DOCKER_HUB_README.md must mark {version} as the current stable version")
     if f"ARG VERSION={version}" not in TOP_DOCKERFILE.read_text():

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -496,7 +496,9 @@ def test_publish_registries_workflow_validates_smithery_best_effort_and_curated_
     assert '_publish_skill "integrations/openclaw" "agent-bom"' not in workflow
     assert "check_glama_listing.py --verify-manifest" in workflow
     assert "workflow_run.head_sha || github.ref" in workflow
-    assert '"dockerfile": os.environ["GLAMA_DOCKERFILE"]' in workflow
+    assert "actions: read" in workflow
+    assert "jq -n" in workflow
+    assert "dockerfile: $dockerfile" in workflow
 
 
 def test_refresh_latest_container_keeps_release_code_but_applies_runtime_security_overlay():

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -494,6 +494,9 @@ def test_publish_registries_workflow_validates_smithery_best_effort_and_curated_
     assert "integrations/openclaw/ingest" in workflow
     assert "integrations/openclaw/vulnerability-intel" in workflow
     assert '_publish_skill "integrations/openclaw" "agent-bom"' not in workflow
+    assert "check_glama_listing.py --verify-manifest" in workflow
+    assert "workflow_run.head_sha || github.ref" in workflow
+    assert '"dockerfile": os.environ["GLAMA_DOCKERFILE"]' in workflow
 
 
 def test_refresh_latest_container_keeps_release_code_but_applies_runtime_security_overlay():

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -494,8 +494,9 @@ def test_publish_registries_workflow_validates_smithery_best_effort_and_curated_
     assert "integrations/openclaw/ingest" in workflow
     assert "integrations/openclaw/vulnerability-intel" in workflow
     assert '_publish_skill "integrations/openclaw" "agent-bom"' not in workflow
-    assert "check_glama_listing.py --verify-manifest" in workflow
-    assert "workflow_run.head_sha || github.ref" in workflow
+    assert 'git fetch --no-tags --depth=1 origin "$RELEASE_SHA"' in workflow
+    assert 'check_glama_listing.py --verify-manifest --git-ref "${{ steps.meta.outputs.release_sha }}"' in workflow
+    assert "workflow_run.head_sha || github.ref" not in workflow
     assert "actions: read" in workflow
     assert "jq -n" in workflow
     assert "dockerfile: $dockerfile" in workflow

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -47,6 +47,11 @@ def test_glama_build_manifest_verify_passes():
     assert script.main(["--verify-manifest"]) == 0
 
 
+def test_glama_build_manifest_verify_reads_git_ref():
+    script = _load_script("check_glama_listing.py")
+    assert script.main(["--verify-manifest", "--git-ref", "HEAD"]) == 0
+
+
 def test_glama_build_manifest_verify_rejects_missing_dockerfile(monkeypatch):
     script = _load_script("check_glama_listing.py")
     monkeypatch.setattr(script, "GLAMA_DOCKERFILE", "integrations/glama/does-not-exist.dockerfile")

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -25,6 +25,7 @@ def test_glama_listing_json_contract_reports_stale_listing(monkeypatch, capsys):
     uses: msaad00/agent-bom@v0.88.4
     MCP server mode advertises 55 MCP tools
     18 tools for CVE scanning
+    git checkout 98c3e543
     """
 
     monkeypatch.setattr(script, "_load_readme_tool_count", lambda: "69")
@@ -39,6 +40,18 @@ def test_glama_listing_json_contract_reports_stale_listing(monkeypatch, capsys):
     assert payload["expected"] == "0.89.2"
     assert payload["listing_version"] == "0.88.4"
     assert "missing current Glama listing token" in payload["error"]
+
+
+def test_glama_build_manifest_verify_passes():
+    script = _load_script("check_glama_listing.py")
+    assert script.main(["--verify-manifest"]) == 0
+
+
+def test_glama_build_manifest_verify_rejects_missing_dockerfile(monkeypatch):
+    script = _load_script("check_glama_listing.py")
+    monkeypatch.setattr(script, "GLAMA_DOCKERFILE", "integrations/glama/does-not-exist.dockerfile")
+    failures = script.verify_build_manifest()
+    assert any("missing Glama Dockerfile" in failure for failure in failures)
 
 
 def test_surface_freshness_reads_smithery_catalog_listing(monkeypatch):


### PR DESCRIPTION
## Summary
- Glama publish checks out the release commit, validates `integrations/glama/Dockerfile` via `--verify-manifest`, and POSTs `ref`/`commit`/`version`/`dockerfile` to the webhook instead of a bare trigger.
- Release consistency and freshness checks reject stale Glama pins (pre-0.92.0 commit SHA, old tool counts).
- `actions: read` granted for `workflow_run` checkout; webhook payload built with `jq`.

Closes #3472.

## Test plan
- [x] `uv run pytest tests/test_surface_freshness.py tests/test_deployment.py::test_publish_registries_workflow_validates_smithery_best_effort_and_curated_clawhub_set -q`
- [x] `uv run ruff check scripts/check_glama_listing.py scripts/check_release_consistency.py tests/test_surface_freshness.py tests/test_deployment.py`
- [x] `uv run mypy scripts/check_glama_listing.py scripts/check_release_consistency.py`
- [x] `python scripts/check_glama_listing.py --verify-manifest`
- [x] `git diff --check`