### PR TITLE
docs(readme): lead with personas, Start Here, and demo proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,46 +28,6 @@
   <a href="https://github.com/msaad00/agent-bom/releases">Changelog</a>
 </p>
 
-## What It Is
-
-`agent-bom` is a read-only scanner and self-hosted control plane for local
-projects, agent fleets, MCP runtimes, and cloud estates (AWS, Azure, GCP,
-Snowflake).
-
-**ContextGraph** is agent-bom's unified evidence graph across CLI, API, UI, MCP
-tools, reports, and gateway decisions. Findings, assets, packages, cloud
-resources, identities, agents, MCP servers, credentials, and runtime decisions
-all normalize into that graph so posture, blast radius, and enforcement read
-from the same evidence.
-
-Blast radius is the core idea: a vulnerable package is linked to the MCP server
-that loads it, the tools it exposes, reachable credential references, and the
-agents that can call it — not just a CVE row.
-
-Coverage depth and honest boundaries:
-[AI infrastructure scanning](docs/AI_INFRASTRUCTURE_SCANNING.md) ·
-[product boundaries](docs/PRODUCT_BOUNDARIES.md)
-
-## Accuracy Model
-
-agent-bom normalizes advisory and distro evidence into canonical CVE findings
-with match-confidence tiers:
-
-`distro_confirmed` > `osv_range` > `osv_ecosystem` > `unfixed_distro` > `nvd_cpe_candidate`
-
-Distro-confirmed findings are treated as confirmed. Optional NVD CPE candidate
-matching widens long-tail OS/vendor software coverage, but remains review-grade
-and off by default.
-
-**NVD key model.** End users do not need an NVD API key. CVE/CPE enrichment
-ships through the distributed vulnerability database. `NVD_API_KEY` is only an
-optional self-hosted freshness knob for operators rebuilding or refreshing the
-database.
-
-Matching mechanics and release evidence:
-[vulnerability matching](docs/VULNERABILITY_MATCHING.md) ·
-[scanner accuracy baseline](docs/SCANNER_ACCURACY_BASELINE.md)
-
 ## Who It's For
 
 <p align="center">
@@ -93,46 +53,6 @@ Snowflake is a supported connector lane, not the product center.
 MCP server mode advertises 70 MCP tools, 6 resources, and 8 workflow prompts.
 Registry metadata is tracked through the committed Smithery manifest and Glama
 listing; install and liveness checks live in the integration docs.
-
-## How It Works
-
-Read-only intake, scan and enrichment, one evidence graph, then the same model
-through CLI, CI, API, UI, MCP, exports, and optional runtime policy.
-
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-light.svg" alt="agent-bom workflow from read-only intake through scan engine, evidence graph, control plane, and outputs" width="980" />
-  </picture>
-</p>
-
-<details>
-<summary><b>Control-plane architecture</b></summary>
-
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-light.svg" alt="agent-bom layered control-plane architecture" width="980" />
-  </picture>
-</p>
-
-</details>
-
-<details>
-<summary><b>Blast radius drilldown</b></summary>
-
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-light.svg" alt="agent-bom blast-radius drilldown — package to finding to MCP server to agent" width="900" />
-  </picture>
-</p>
-
-```text
-package -> vulnerability finding -> MCP server -> tools + credential refs -> agent
-```
-
-</details>
 
 ## Start Here
 
@@ -222,6 +142,92 @@ routes with a visible <strong>Demo data — simulated estate</strong> label — 
 claim these entities came from a buyer environment. Regenerate from the UI package
 with <code>npm run capture:product-proof</code> (see
 <a href="docs/CAPTURE.md">docs/CAPTURE.md</a>).</sub>
+
+</details>
+
+## How It Works
+
+Read-only intake, scan and enrichment, one evidence graph, then the same model
+through CLI, CI, API, UI, MCP, exports, and optional runtime policy.
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-light.svg" alt="agent-bom workflow from read-only intake through scan engine, evidence graph, control plane, and outputs" width="980" />
+  </picture>
+</p>
+
+<details>
+<summary><b>Control-plane architecture</b></summary>
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-light.svg" alt="agent-bom layered control-plane architecture" width="980" />
+  </picture>
+</p>
+
+</details>
+
+<details>
+<summary><b>Blast radius drilldown</b></summary>
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-light.svg" alt="agent-bom blast-radius drilldown — package to finding to MCP server to agent" width="900" />
+  </picture>
+</p>
+
+```text
+package -> vulnerability finding -> MCP server -> tools + credential refs -> agent
+```
+
+</details>
+
+<details>
+<summary><b>What it is</b> — scanner, ContextGraph, and blast radius</summary>
+
+`agent-bom` is a read-only scanner and self-hosted control plane for local
+projects, agent fleets, MCP runtimes, and cloud estates (AWS, Azure, GCP,
+Snowflake).
+
+**ContextGraph** is agent-bom's unified evidence graph across CLI, API, UI, MCP
+tools, reports, and gateway decisions. Findings, assets, packages, cloud
+resources, identities, agents, MCP servers, credentials, and runtime decisions
+all normalize into that graph so posture, blast radius, and enforcement read
+from the same evidence.
+
+Blast radius is the core idea: a vulnerable package is linked to the MCP server
+that loads it, the tools it exposes, reachable credential references, and the
+agents that can call it — not just a CVE row.
+
+Coverage depth and honest boundaries:
+[AI infrastructure scanning](docs/AI_INFRASTRUCTURE_SCANNING.md) ·
+[product boundaries](docs/PRODUCT_BOUNDARIES.md)
+
+</details>
+
+<details>
+<summary><b>Accuracy model</b> — match-confidence tiers and NVD key model</summary>
+
+agent-bom normalizes advisory and distro evidence into canonical CVE findings
+with match-confidence tiers:
+
+`distro_confirmed` > `osv_range` > `osv_ecosystem` > `unfixed_distro` > `nvd_cpe_candidate`
+
+Distro-confirmed findings are treated as confirmed. Optional NVD CPE candidate
+matching widens long-tail OS/vendor software coverage, but remains review-grade
+and off by default.
+
+**NVD key model.** End users do not need an NVD API key. CVE/CPE enrichment
+ships through the distributed vulnerability database. `NVD_API_KEY` is only an
+optional self-hosted freshness knob for operators rebuilding or refreshing the
+database.
+
+Matching mechanics and release evidence:
+[vulnerability matching](docs/VULNERABILITY_MATCHING.md) ·
+[scanner accuracy baseline](docs/SCANNER_ACCURACY_BASELINE.md)
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -33,15 +33,18 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/persona-value-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/persona-value-light.svg" alt="agent-bom personas mapped to value proof: AppSec/GRC to SARIF and compliance, Platform/SRE to fleet and CI gates, agent builders to MCP inventory and runtime shield, security engineers to findings queue and attack paths" width="980" />
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/persona-value-light.svg" alt="agent-bom personas mapped to value proof: AppSec/GRC to SARIF and compliance, Platform/SRE to fleet sync and CI gates, agent builders to MCP inventory and runtime shield, security engineers to findings queue and attack paths" width="980" />
   </picture>
 </p>
 
-Four buyer lanes share one evidence model (`Finding` + `UnifiedGraph`):
+<p align="center"><em>Four buyer lanes · one evidence model (<code>Finding</code> + <code>UnifiedGraph</code>)</em></p>
+
+<details>
+<summary><b>Persona lane detail</b></summary>
 
 - **AppSec / GRC** — SARIF, compliance packs, and audit-ready exports from the
   same scan that powers the dashboard.
-- **Platform / SRE** — fleet inventory, Helm deploy, CI gates, and SBOM output
+- **Platform / SRE** — fleet sync, Helm deploy, CI gates, and SBOM output
   without a separate scanner stack.
 - **Agent builders** — MCP inventory, Shield SDK, and optional runtime proxy or
   gateway enforcement on the same graph.
@@ -53,6 +56,8 @@ Snowflake is a supported connector lane, not the product center.
 MCP server mode advertises 70 MCP tools, 6 resources, and 8 workflow prompts.
 Registry metadata is tracked through the committed Smithery manifest and Glama
 listing; install and liveness checks live in the integration docs.
+
+</details>
 
 ## Start Here
 

--- a/docs/VISUAL_LANGUAGE.md
+++ b/docs/VISUAL_LANGUAGE.md
@@ -42,7 +42,7 @@ Current SVG inventory:
 | `logo-{light,dark}.svg` | Brand mark | hero |
 | `architecture-{light,dark}.svg` | End-to-end LR data flow: sources → scan/ingest → unified Finding + ContextGraph → control plane (API / Gateway / MCP) → consumers (humans + headless agents) + artifacts | `docs/ARCHITECTURE.md` System Overview; available for README architecture section |
 | `how-it-works-{light,dark}.svg` | Six-step scan pipeline from read-only intake through evidence core to outputs | README "How It Works" |
-| `persona-value-{light,dark}.svg` | Buyer personas mapped to product value proof points | README / GTM collateral |
+| `persona-value-{light,dark}.svg` | Four buyer personas in a 2×2 lane-colored card grid (persona → value proof per card) | README hero — Who It's For |
 | `blast-radius-{light,dark}.svg` | CVE, package, MCP server, agent, credentials, and tools in one blast-radius path | hero, under tagline |
 | `scan-pipeline-{light,dark}.svg` | 5-stage pipeline (discover → scan → analyze → report → enforce) | "How a scan moves" |
 | `engine-internals-{light,dark}.svg` | Inside the scanner | available for deeper architecture docs; not currently embedded in the README |

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -1,50 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="980" height="430" viewBox="0 0 980 430" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="720" viewBox="0 0 980 720" fill="none">
 <title>agent-bom personas and value</title>
-<rect width="980" height="430" rx="12" fill="#0a0a0c"/>
-<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#f4f4f5">Who it serves · what they get</text>
-<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">One evidence model — inventory -&gt; findings -&gt; graph -&gt; gates</text>
-<text x="28" y="92" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">PERSONAS</text>
-<text x="510" y="92" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.12em" fill="#a78bfa">VALUE PROOF</text>
-<rect x="28" y="112" width="442" height="58" rx="10" fill="#161619" stroke="#2a2a31"/>
-<rect x="28" y="120" width="4" height="42" rx="2" fill="#34d399"/>
-<rect x="42" y="128" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,132) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="78" y="138" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">AppSec / GRC</text>
-<text x="78" y="154" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#34d399">SARIF · compliance packs · audit chain</text>
-<rect x="510" y="112" width="442" height="58" rx="10" fill="#15121f" stroke="#5b4bbd"/>
-<rect x="524" y="128" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(528,132) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="560" y="138" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Accurate SCA</text>
-<text x="560" y="154" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">15 ecosystems · EPSS/KEV · distro-aware</text>
-<line x1="480" y1="141" x2="493" y2="141" stroke="#8b5cf6" stroke-width="1.6"/><polygon points="499,141 492,137.5 492,144.5" fill="#8b5cf6"/>
-<rect x="28" y="182" width="442" height="58" rx="10" fill="#161619" stroke="#2a2a31"/>
-<rect x="28" y="190" width="4" height="42" rx="2" fill="#fbbf24"/>
-<rect x="42" y="198" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,202) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="78" y="208" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Platform / SRE</text>
-<text x="78" y="224" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#fbbf24">fleet · Helm · CI gates · SBOM</text>
-<rect x="510" y="182" width="442" height="58" rx="10" fill="#15121f" stroke="#5b4bbd"/>
-<rect x="524" y="198" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(528,202) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
-<text x="560" y="208" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Container coverage</text>
-<text x="560" y="224" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">OCI native · Grype opt-in · CIS posture</text>
-<line x1="480" y1="211" x2="493" y2="211" stroke="#8b5cf6" stroke-width="1.6"/><polygon points="499,211 492,207.5 492,214.5" fill="#8b5cf6"/>
-<rect x="28" y="252" width="442" height="58" rx="10" fill="#161619" stroke="#2a2a31"/>
-<rect x="28" y="260" width="4" height="42" rx="2" fill="#60a5fa"/>
-<rect x="42" y="268" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,272) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="78" y="278" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Agent builders</text>
-<text x="78" y="294" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#60a5fa">MCP inventory · shield SDK · runtime</text>
-<rect x="510" y="252" width="442" height="58" rx="10" fill="#15121f" stroke="#5b4bbd"/>
-<rect x="524" y="268" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(528,272) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="560" y="278" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Self-hosted control plane</text>
-<text x="560" y="294" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">your VPC · signed audit · Helm</text>
-<line x1="480" y1="281" x2="493" y2="281" stroke="#8b5cf6" stroke-width="1.6"/><polygon points="499,281 492,277.5 492,284.5" fill="#8b5cf6"/>
-<rect x="28" y="322" width="442" height="58" rx="10" fill="#161619" stroke="#2a2a31"/>
-<rect x="28" y="330" width="4" height="42" rx="2" fill="#a78bfa"/>
-<rect x="42" y="338" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(46,342) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="78" y="348" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Security engineers</text>
-<text x="78" y="364" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#a78bfa">findings queue · attack paths · graph</text>
-<rect x="510" y="322" width="442" height="58" rx="10" fill="#15121f" stroke="#5b4bbd"/>
-<rect x="524" y="338" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(528,342) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="560" y="348" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#e9e9ec">Agent-native surface</text>
-<text x="560" y="364" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#82828c">283 API ops · 70 MCP tools · SARIF</text>
-<line x1="480" y1="351" x2="493" y2="351" stroke="#8b5cf6" stroke-width="1.6"/><polygon points="499,351 492,347.5 492,354.5" fill="#8b5cf6"/>
-<rect x="24" y="392" width="932" height="26" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="490" y="410" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<rect width="980" height="720" rx="12" fill="#16161d"/>
+<text x="28" y="42" font-family="Inter,system-ui,sans-serif" font-size="28" font-weight="800" fill="#f4f4f5">Who it serves · what they get</text>
+<text x="28" y="68" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="500" fill="#71717a">One evidence model — inventory -&gt; findings -&gt; graph -&gt; gates</text>
+<rect x="24" y="96" width="456" height="274" rx="14" fill="#065f46" stroke="#34d399" stroke-width="1.8"/>
+<rect x="44" y="114" width="44" height="44" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,118) scale(1.5)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="100" y="136" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#a7f3d0">AppSec / GRC</text>
+<text x="100" y="158" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#34d399">SARIF · compliance · audit chain</text>
+<line x1="44" y1="188" x2="460" y2="188" stroke="#34d399" stroke-width="1.2" opacity="0.55"/>
+<polygon points="252,202 245,192 259,192" fill="#34d399"/>
+<rect x="40" y="210" width="424" height="144" rx="10" fill="#12121a" stroke="#34d399"/>
+<rect x="52" y="224" width="36" height="36" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(56,228) scale(1.1666666666666667)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="100" y="242" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#a7f3d0">Accurate SCA</text>
+<text x="100" y="264" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#34d399">15 ecosystems · EPSS/KEV · distro-aware</text>
+<rect x="500" y="96" width="456" height="274" rx="14" fill="#78350f" stroke="#fbbf24" stroke-width="1.8"/>
+<rect x="520" y="114" width="44" height="44" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(524,118) scale(1.5)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="576" y="136" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#fde68a">Platform / SRE</text>
+<text x="576" y="158" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#fbbf24">fleet sync · Helm · CI · SBOM</text>
+<line x1="520" y1="188" x2="936" y2="188" stroke="#fbbf24" stroke-width="1.2" opacity="0.55"/>
+<polygon points="728,202 721,192 735,192" fill="#fbbf24"/>
+<rect x="516" y="210" width="424" height="144" rx="10" fill="#12121a" stroke="#fbbf24"/>
+<rect x="528" y="224" width="36" height="36" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(532,228) scale(1.1666666666666667)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
+<text x="576" y="242" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#fde68a">Container coverage</text>
+<text x="576" y="264" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#fbbf24">OCI native · Grype · CIS posture</text>
+<rect x="24" y="390" width="456" height="274" rx="14" fill="#1e3a5f" stroke="#60a5fa" stroke-width="1.8"/>
+<rect x="44" y="408" width="44" height="44" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,412) scale(1.5)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="100" y="430" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#93c5fd">Agent builders</text>
+<text x="100" y="452" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#60a5fa">MCP inventory · Shield · runtime</text>
+<line x1="44" y1="482" x2="460" y2="482" stroke="#60a5fa" stroke-width="1.2" opacity="0.55"/>
+<polygon points="252,496 245,486 259,486" fill="#60a5fa"/>
+<rect x="40" y="504" width="424" height="144" rx="10" fill="#12121a" stroke="#60a5fa"/>
+<rect x="52" y="518" width="36" height="36" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(56,522) scale(1.1666666666666667)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="100" y="536" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#93c5fd">Self-hosted control plane</text>
+<text x="100" y="558" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#60a5fa">your VPC · signed audit · Helm</text>
+<rect x="500" y="390" width="456" height="274" rx="14" fill="#5b21b6" stroke="#a78bfa" stroke-width="1.8"/>
+<rect x="520" y="408" width="44" height="44" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(524,412) scale(1.5)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="576" y="430" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#ddd6fe">Security engineers</text>
+<text x="576" y="452" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#a78bfa">findings queue · paths · graph</text>
+<line x1="520" y1="482" x2="936" y2="482" stroke="#a78bfa" stroke-width="1.2" opacity="0.55"/>
+<polygon points="728,496 721,486 735,486" fill="#a78bfa"/>
+<rect x="516" y="504" width="424" height="144" rx="10" fill="#12121a" stroke="#a78bfa"/>
+<rect x="528" y="518" width="36" height="36" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(532,522) scale(1.1666666666666667)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="576" y="536" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#ddd6fe">Agent-native surface</text>
+<text x="576" y="558" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#a78bfa">283 API ops · 70 MCP tools · SARIF</text>
+<rect x="24" y="676" width="932" height="32" rx="10" fill="#0c1a14" stroke="#1f4438"/>
+<text x="490" y="697" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -1,50 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="980" height="430" viewBox="0 0 980 430" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="720" viewBox="0 0 980 720" fill="none">
 <title>agent-bom personas and value</title>
-<rect width="980" height="430" rx="12" fill="#ffffff"/>
-<text x="28" y="38" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#18181b">Who it serves · what they get</text>
-<text x="28" y="58" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">One evidence model — inventory -&gt; findings -&gt; graph -&gt; gates</text>
-<text x="28" y="92" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">PERSONAS</text>
-<text x="510" y="92" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.12em" fill="#7c3aed">VALUE PROOF</text>
-<rect x="28" y="112" width="442" height="58" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="28" y="120" width="4" height="42" rx="2" fill="#34d399"/>
-<rect x="42" y="128" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,132) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="78" y="138" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">AppSec / GRC</text>
-<text x="78" y="154" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#34d399">SARIF · compliance packs · audit chain</text>
-<rect x="510" y="112" width="442" height="58" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
-<rect x="524" y="128" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(528,132) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="560" y="138" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Accurate SCA</text>
-<text x="560" y="154" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">15 ecosystems · EPSS/KEV · distro-aware</text>
-<line x1="480" y1="141" x2="493" y2="141" stroke="#7c3aed" stroke-width="1.6"/><polygon points="499,141 492,137.5 492,144.5" fill="#7c3aed"/>
-<rect x="28" y="182" width="442" height="58" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="28" y="190" width="4" height="42" rx="2" fill="#fbbf24"/>
-<rect x="42" y="198" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,202) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="78" y="208" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Platform / SRE</text>
-<text x="78" y="224" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#fbbf24">fleet · Helm · CI gates · SBOM</text>
-<rect x="510" y="182" width="442" height="58" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
-<rect x="524" y="198" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(528,202) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
-<text x="560" y="208" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Container coverage</text>
-<text x="560" y="224" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">OCI native · Grype opt-in · CIS posture</text>
-<line x1="480" y1="211" x2="493" y2="211" stroke="#7c3aed" stroke-width="1.6"/><polygon points="499,211 492,207.5 492,214.5" fill="#7c3aed"/>
-<rect x="28" y="252" width="442" height="58" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="28" y="260" width="4" height="42" rx="2" fill="#60a5fa"/>
-<rect x="42" y="268" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,272) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="78" y="278" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Agent builders</text>
-<text x="78" y="294" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#60a5fa">MCP inventory · shield SDK · runtime</text>
-<rect x="510" y="252" width="442" height="58" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
-<rect x="524" y="268" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(528,272) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="560" y="278" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Self-hosted control plane</text>
-<text x="560" y="294" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">your VPC · signed audit · Helm</text>
-<line x1="480" y1="281" x2="493" y2="281" stroke="#7c3aed" stroke-width="1.6"/><polygon points="499,281 492,277.5 492,284.5" fill="#7c3aed"/>
-<rect x="28" y="322" width="442" height="58" rx="10" fill="#ffffff" stroke="#e6e6ea"/>
-<rect x="28" y="330" width="4" height="42" rx="2" fill="#a78bfa"/>
-<rect x="42" y="338" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(46,342) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="78" y="348" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Security engineers</text>
-<text x="78" y="364" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#a78bfa">findings queue · attack paths · graph</text>
-<rect x="510" y="322" width="442" height="58" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
-<rect x="524" y="338" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(528,342) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="560" y="348" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#18181b">Agent-native surface</text>
-<text x="560" y="364" font-family="ui-monospace,monospace" font-size="7.5" font-weight="600" fill="#71717a">283 API ops · 70 MCP tools · SARIF</text>
-<line x1="480" y1="351" x2="493" y2="351" stroke="#7c3aed" stroke-width="1.6"/><polygon points="499,351 492,347.5 492,354.5" fill="#7c3aed"/>
-<rect x="24" y="392" width="932" height="26" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="490" y="410" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<rect width="980" height="720" rx="12" fill="#ffffff"/>
+<text x="28" y="42" font-family="Inter,system-ui,sans-serif" font-size="28" font-weight="800" fill="#18181b">Who it serves · what they get</text>
+<text x="28" y="68" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="500" fill="#71717a">One evidence model — inventory -&gt; findings -&gt; graph -&gt; gates</text>
+<rect x="24" y="96" width="456" height="274" rx="14" fill="#ffffff" stroke="#34d399" stroke-width="1.8"/>
+<rect x="44" y="114" width="44" height="44" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,118) scale(1.5)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="100" y="136" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#18181b">AppSec / GRC</text>
+<text x="100" y="158" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#34d399">SARIF · compliance · audit chain</text>
+<line x1="44" y1="188" x2="460" y2="188" stroke="#34d399" stroke-width="1.2" opacity="0.55"/>
+<polygon points="252,202 245,192 259,192" fill="#34d399"/>
+<rect x="40" y="210" width="424" height="144" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
+<rect x="52" y="224" width="36" height="36" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(56,228) scale(1.1666666666666667)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
+<text x="100" y="242" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#18181b">Accurate SCA</text>
+<text x="100" y="264" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#71717a">15 ecosystems · EPSS/KEV · distro-aware</text>
+<rect x="500" y="96" width="456" height="274" rx="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.8"/>
+<rect x="520" y="114" width="44" height="44" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(524,118) scale(1.5)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
+<text x="576" y="136" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#18181b">Platform / SRE</text>
+<text x="576" y="158" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#fbbf24">fleet sync · Helm · CI · SBOM</text>
+<line x1="520" y1="188" x2="936" y2="188" stroke="#fbbf24" stroke-width="1.2" opacity="0.55"/>
+<polygon points="728,202 721,192 735,192" fill="#fbbf24"/>
+<rect x="516" y="210" width="424" height="144" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
+<rect x="528" y="224" width="36" height="36" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(532,228) scale(1.1666666666666667)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
+<text x="576" y="242" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#18181b">Container coverage</text>
+<text x="576" y="264" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#71717a">OCI native · Grype · CIS posture</text>
+<rect x="24" y="390" width="456" height="274" rx="14" fill="#ffffff" stroke="#60a5fa" stroke-width="1.8"/>
+<rect x="44" y="408" width="44" height="44" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,412) scale(1.5)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
+<text x="100" y="430" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#18181b">Agent builders</text>
+<text x="100" y="452" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#60a5fa">MCP inventory · Shield · runtime</text>
+<line x1="44" y1="482" x2="460" y2="482" stroke="#60a5fa" stroke-width="1.2" opacity="0.55"/>
+<polygon points="252,496 245,486 259,486" fill="#60a5fa"/>
+<rect x="40" y="504" width="424" height="144" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
+<rect x="52" y="518" width="36" height="36" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(56,522) scale(1.1666666666666667)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
+<text x="100" y="536" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#18181b">Self-hosted control plane</text>
+<text x="100" y="558" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#71717a">your VPC · signed audit · Helm</text>
+<rect x="500" y="390" width="456" height="274" rx="14" fill="#ffffff" stroke="#a78bfa" stroke-width="1.8"/>
+<rect x="520" y="408" width="44" height="44" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(524,412) scale(1.5)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
+<text x="576" y="430" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#18181b">Security engineers</text>
+<text x="576" y="452" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#a78bfa">findings queue · paths · graph</text>
+<line x1="520" y1="482" x2="936" y2="482" stroke="#a78bfa" stroke-width="1.2" opacity="0.55"/>
+<polygon points="728,496 721,486 735,486" fill="#a78bfa"/>
+<rect x="516" y="504" width="424" height="144" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
+<rect x="528" y="518" width="36" height="36" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(532,522) scale(1.1666666666666667)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
+<text x="576" y="536" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#18181b">Agent-native surface</text>
+<text x="576" y="558" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#71717a">283 API ops · 70 MCP tools · SARIF</text>
+<rect x="24" y="676" width="932" height="32" rx="10" fill="#ecfdf5" stroke="#bbf7d0"/>
+<text x="490" y="697" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/scripts/generate_doc_architecture_svgs.py
+++ b/scripts/generate_doc_architecture_svgs.py
@@ -980,132 +980,157 @@ def architecture(theme_name: str) -> str:
     return "\n".join(parts)
 
 
-def persona_value(theme: str) -> str:
-    t = THEMES[theme]
-    w, h = 980, 430
-
-    personas = [
-        ("shield", "AppSec / GRC", "SARIF · compliance packs · audit chain", "control"),
-        ("gate", "Platform / SRE", "fleet · Helm · CI gates · SBOM", "scan"),
-        ("mcp", "Agent builders", "MCP inventory · shield SDK · runtime", "intake"),
-        ("graph", "Security engineers", "findings queue · attack paths · graph", "core"),
-    ]
-    values = [
-        ("bug", "Accurate SCA", "15 ecosystems · EPSS/KEV · distro-aware"),
-        ("image", "Container coverage", "OCI native · Grype opt-in · CIS posture"),
-        ("audit", "Self-hosted control plane", "your VPC · signed audit · Helm"),
-        ("api", "Agent-native surface", "283 API ops · 70 MCP tools · SARIF"),
-    ]
-
-    left_x, right_x = 28, 510
-    col_w = 442
-    row_h = 58
-    row_gap = 12
-    start_y = 112
-
-    parts = _svg_open(w, h, "agent-bom personas and value")
-    parts += [
-        f'<rect width="{w}" height="{h}" rx="12" fill="{t["bg"]}"/>',
-        _text(
-            28,
-            38,
-            "Who it serves · what they get",
-            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "20", "font-weight": "800", "fill": t["title"]},
-        ),
-        _text(
-            28,
-            58,
-            "One evidence model — inventory -> findings -> graph -> gates",
-            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "10", "font-weight": "500", "fill": t["subtitle"]},
-        ),
-        _text(
-            left_x,
-            92,
-            "PERSONAS",
-            **{
-                "font-family": "Inter,system-ui,sans-serif",
-                "font-size": "7.5",
-                "font-weight": "800",
-                "letter-spacing": "0.12em",
-                "fill": t["accent"],
-            },
-        ),
-        _text(
-            right_x,
-            92,
-            "VALUE PROOF",
-            **{
-                "font-family": "Inter,system-ui,sans-serif",
-                "font-size": "7.5",
-                "font-weight": "800",
-                "letter-spacing": "0.12em",
-                "fill": t["accent"],
-            },
-        ),
-    ]
-
-    arrow_x1 = left_x + col_w + 10
-    arrow_x2 = right_x - 10
-    for i, (icon, title, subtitle, lane) in enumerate(personas):
-        y = start_y + i * (row_h + row_gap)
-        _, accent, _ = LANE_COLORS[lane]
-        parts.append(
-            f'<rect x="{left_x}" y="{y}" width="{col_w}" height="{row_h}" rx="10" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>'
-        )
-        parts.append(f'<rect x="{left_x}" y="{y + 8}" width="4" height="{row_h - 16}" rx="2" fill="{accent}"/>')
-        parts.append(_icon_box(left_x + 14, y + 16, ICONS[icon], t, accent=True))
-        parts.append(
-            _text(
-                left_x + 50,
-                y + 26,
-                title,
-                **{"font-family": "Inter,system-ui,sans-serif", "font-size": "11", "font-weight": "700", "fill": t["text"]},
-            )
-        )
-        parts.append(
-            _text(
-                left_x + 50,
-                y + 42,
-                subtitle,
-                **{"font-family": "ui-monospace,monospace", "font-size": "7.5", "font-weight": "600", "fill": accent},
-            )
-        )
-
-        value_icon, value_title, value_subtitle = values[i]
-        parts.append(
-            f'<rect x="{right_x}" y="{y}" width="{col_w}" height="{row_h}" rx="10" fill="{t["accent_fill"]}" stroke="{t["accent_stroke"]}"/>'
-        )
-        parts.append(_icon_box(right_x + 14, y + 16, ICONS[value_icon], t, accent=True))
-        parts.append(
-            _text(
-                right_x + 50,
-                y + 26,
-                value_title,
-                **{"font-family": "Inter,system-ui,sans-serif", "font-size": "11", "font-weight": "700", "fill": t["text"]},
-            )
-        )
-        parts.append(
-            _text(
-                right_x + 50,
-                y + 42,
-                value_subtitle,
-                **{"font-family": "ui-monospace,monospace", "font-size": "7.5", "font-weight": "600", "fill": t["text_muted"]},
-            )
-        )
-        parts.append(
-            f'<line x1="{arrow_x1}" y1="{y + row_h // 2}" x2="{arrow_x2 - 7}" y2="{y + row_h // 2}" '
-            f'stroke="{t["arrow_accent"]}" stroke-width="1.6"/>'
-            f'<polygon points="{arrow_x2 - 1},{y + row_h // 2} {arrow_x2 - 8},{y + row_h // 2 - 3.5} '
-            f'{arrow_x2 - 8},{y + row_h // 2 + 3.5}" fill="{t["arrow_accent"]}"/>'
-        )
+def _persona_lane_card(
+    x: int,
+    y: int,
+    w: int,
+    h: int,
+    persona_icon: str,
+    persona_title: str,
+    persona_sub: str,
+    value_icon: str,
+    value_title: str,
+    value_sub: str,
+    lane_key: str,
+    theme: str,
+    t: dict,
+) -> list[str]:
+    lane_bg, lane_accent, lane_text = LANE_COLORS[lane_key]
+    parts: list[str] = []
+    if theme == "dark":
+        card_fill = lane_bg
+        card_stroke = lane_accent
+        persona_title_fill = lane_text
+        persona_sub_fill = lane_accent
+        value_fill = "#12121a"
+        value_stroke = lane_accent
+        value_title_fill = lane_text
+        value_sub_fill = lane_accent
+    else:
+        card_fill = t["card"]
+        card_stroke = lane_accent
+        persona_title_fill = t["text"]
+        persona_sub_fill = lane_accent
+        value_fill = t["accent_fill"]
+        value_stroke = t["accent_stroke"]
+        value_title_fill = t["text"]
+        value_sub_fill = t["text_muted"]
 
     parts.append(
-        _trust_footer(
-            w,
-            h,
-            t,
+        f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="14" fill="{card_fill}" stroke="{card_stroke}" stroke-width="1.8"/>'
+    )
+    parts.append(_icon_box(x + 20, y + 18, ICONS[persona_icon], t, accent=True, size=44))
+    parts.append(
+        _text(
+            x + 76,
+            y + 40,
+            persona_title,
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "18", "font-weight": "800", "fill": persona_title_fill},
+        )
+    )
+    parts.append(
+        _text(
+            x + 76,
+            y + 62,
+            persona_sub,
+            **{"font-family": "ui-monospace,monospace", "font-size": "11.5", "font-weight": "600", "fill": persona_sub_fill},
+        )
+    )
+
+    divider_y = y + 92
+    parts.append(
+        f'<line x1="{x + 20}" y1="{divider_y}" x2="{x + w - 20}" y2="{divider_y}" '
+        f'stroke="{lane_accent}" stroke-width="1.2" opacity="0.55"/>'
+    )
+    arrow_x = x + w // 2
+    parts.append(
+        f'<polygon points="{arrow_x},{divider_y + 14} {arrow_x - 7},{divider_y + 4} {arrow_x + 7},{divider_y + 4}" '
+        f'fill="{lane_accent}"/>'
+    )
+
+    value_y = divider_y + 22
+    value_h = h - (value_y - y) - 16
+    parts.append(
+        f'<rect x="{x + 16}" y="{value_y}" width="{w - 32}" height="{value_h}" rx="10" '
+        f'fill="{value_fill}" stroke="{value_stroke}"/>'
+    )
+    parts.append(_icon_box(x + 28, value_y + 14, ICONS[value_icon], t, accent=True, size=36))
+    parts.append(
+        _text(
+            x + 76,
+            value_y + 32,
+            value_title,
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "16", "font-weight": "800", "fill": value_title_fill},
+        )
+    )
+    parts.append(
+        _text(
+            x + 76,
+            value_y + 54,
+            value_sub,
+            **{"font-family": "ui-monospace,monospace", "font-size": "11", "font-weight": "600", "fill": value_sub_fill},
+        )
+    )
+    return parts
+
+
+def persona_value(theme: str) -> str:
+    t = THEMES[theme]
+    w, h = 980, 720
+    persona_bg = "#16161d" if theme == "dark" else t["bg"]
+
+    cards = [
+        ("shield", "AppSec / GRC", "SARIF · compliance · audit chain", "bug", "Accurate SCA", "15 ecosystems · EPSS/KEV · distro-aware", "control"),
+        ("gate", "Platform / SRE", "fleet sync · Helm · CI · SBOM", "image", "Container coverage", "OCI native · Grype · CIS posture", "scan"),
+        ("mcp", "Agent builders", "MCP inventory · Shield · runtime", "audit", "Self-hosted control plane", "your VPC · signed audit · Helm", "intake"),
+        ("graph", "Security engineers", "findings queue · paths · graph", "api", "Agent-native surface", "283 API ops · 70 MCP tools · SARIF", "core"),
+    ]
+
+    margin_x, margin_y = 24, 96
+    gap = 20
+    card_w = (w - margin_x * 2 - gap) // 2
+    card_h = (h - margin_y - 56 - gap) // 2
+
+    parts = _svg_open(w, h, "agent-bom personas and value")
+    parts.append(f'<rect width="{w}" height="{h}" rx="12" fill="{persona_bg}"/>')
+    parts += [
+        _text(
+            28,
+            42,
+            "Who it serves · what they get",
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "28", "font-weight": "800", "fill": t["title"]},
+        ),
+        _text(
+            28,
+            68,
+            "One evidence model — inventory -> findings -> graph -> gates",
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "13", "font-weight": "500", "fill": t["subtitle"]},
+        ),
+    ]
+
+    for idx, card in enumerate(cards):
+        col = idx % 2
+        row = idx // 2
+        x = margin_x + col * (card_w + gap)
+        y = margin_y + row * (card_h + gap)
+        parts += _persona_lane_card(x, y, card_w, card_h, *card, theme, t)
+
+    footer_y = h - 44
+    parts.append(
+        f'<rect x="24" y="{footer_y}" width="{w - 48}" height="32" rx="10" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
+    )
+    parts.append(
+        _text(
+            w // 2,
+            footer_y + 21,
             "LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph",
-            height=26,
+            **{
+                "text-anchor": "middle",
+                "font-family": "Inter,system-ui,sans-serif",
+                "font-size": "11",
+                "font-weight": "700",
+                "fill": t["trust"],
+            },
         )
     )
     parts.append("</svg>")


### PR DESCRIPTION
## Summary
- README hero leads with **Who It's For** (2×2 lane-colored persona cards), then **Start Here**, **First Run**, and the terminal demo GIF before deeper architecture
- **Persona SVG refresh (#3503):** 980×720 card grid, 18px persona titles, 44px icons, lane-tinted dark cards (emerald/amber/blue/violet) — readable at README width
- Persona prose moves into `<details>`; **What it is** and **Accuracy model** stay in expandable blocks

Closes #3503

## Test plan
- [x] `uv run python scripts/generate_doc_architecture_svgs.py`
- [x] `uv run pytest tests/test_doc_architecture_svgs.py tests/test_public_docs_cli_alignment.py::test_public_docs_do_not_overclaim_smithery_catalog_liveness -q`
- [x] `uv run python scripts/check_release_consistency.py`
- [x] `git diff --check`