### PR TITLE
feat(headless): wire findings push CLI and hub current-state list (#3482)

### DIFF
--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -832,9 +832,26 @@ def _sqlite_order_clause(sort: str) -> str:
 
 
 def _sqlite_current_order_clause(sort: str) -> str:
-    """ORDER BY for ``hub_findings_current`` (no ingest ``ordinal`` column)."""
+    """ORDER BY for ``hub_findings_current``.
+
+    Current-state rows keep a ``ledger_finding_id`` pointer to the durable
+    ingest row. For the legacy hub-list ``ordinal`` contract, preserve ingest
+    order by looking up that ledger ordinal; timestamp/canonical ordering is
+    only a fallback for rows without a ledger reference.
+    """
     if sort == "ordinal":
-        return "ORDER BY last_seen ASC, canonical_id ASC"
+        return """
+        ORDER BY COALESCE(
+            (
+                SELECT f.ordinal
+                FROM compliance_hub_findings f
+                WHERE f.tenant_id = hub_findings_current.tenant_id
+                  AND f.finding_id = hub_findings_current.ledger_finding_id
+                LIMIT 1
+            ),
+            9223372036854775807
+        ) ASC, first_seen ASC, canonical_id ASC
+        """
     if sort == "cvss":
         return "ORDER BY COALESCE(cvss_score, 0) DESC, last_seen DESC, canonical_id ASC"
     if sort == "severity":

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -1959,12 +1959,12 @@ async def list_hub_findings(request: Request, limit: int = 200, offset: int = 0)
     if callable(list_page):
         if native:
             window = safe_offset + safe_limit
-            hub_rows, hub_total = _unpack_hub_list_page(list_page(tenant_id, limit=window, offset=0))
+            hub_rows, hub_total = _unpack_hub_list_page(list_page(tenant_id, limit=window, offset=0, sort="ordinal"))
             combined = native + hub_rows
             page = combined[safe_offset : safe_offset + safe_limit]
             total = len(native) + hub_total
         else:
-            page, total = _unpack_hub_list_page(list_page(tenant_id, limit=safe_limit, offset=safe_offset))
+            page, total = _unpack_hub_list_page(list_page(tenant_id, limit=safe_limit, offset=safe_offset, sort="ordinal"))
     else:
         findings = store.list(tenant_id) + native
         page = findings[safe_offset : safe_offset + safe_limit]

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -1935,6 +1935,12 @@ async def ingest_compliance_findings(request: Request) -> dict:
     return response
 
 
+def _unpack_hub_list_page(result: tuple[Any, ...]) -> tuple[list[dict[str, Any]], int]:
+    page = result[0]
+    total = result[1] if len(result) > 1 else None
+    return page, total or 0
+
+
 @router.get("/v1/compliance/hub/findings", tags=["compliance"])
 async def list_hub_findings(request: Request, limit: int = 200, offset: int = 0) -> dict:
     """List compliance-hub findings for the current tenant.
@@ -1949,17 +1955,16 @@ async def list_hub_findings(request: Request, limit: int = 200, offset: int = 0)
     safe_offset = max(0, offset)
     native = _native_hub_findings(request)
     store = get_compliance_hub_store()
-    list_page = getattr(store, "list_page", None)
+    list_page = getattr(store, "list_current_page", None) or getattr(store, "list_page", None)
     if callable(list_page):
         if native:
             window = safe_offset + safe_limit
-            hub_rows, hub_total = list_page(tenant_id, limit=window, offset=0)
+            hub_rows, hub_total = _unpack_hub_list_page(list_page(tenant_id, limit=window, offset=0))
             combined = native + hub_rows
             page = combined[safe_offset : safe_offset + safe_limit]
-            total = len(native) + (hub_total or 0)
+            total = len(native) + hub_total
         else:
-            page, total = list_page(tenant_id, limit=safe_limit, offset=safe_offset)
-            total = total or 0
+            page, total = _unpack_hub_list_page(list_page(tenant_id, limit=safe_limit, offset=safe_offset))
     else:
         findings = store.list(tenant_id) + native
         page = findings[safe_offset : safe_offset + safe_limit]

--- a/src/agent_bom/cli/_findings_group.py
+++ b/src/agent_bom/cli/_findings_group.py
@@ -68,7 +68,7 @@ def _print_findings_table(payload: JsonObject) -> None:
     rows = payload.get("findings")
     if not isinstance(rows, list):
         rows = []
-    click.echo("id\tseverity\tpackage\ttitle")
+    click.echo("id\tseverity\tstatus\tpackage\tfirst_seen\tlast_seen\ttitle")
     for item in rows:
         if not isinstance(item, dict):
             continue
@@ -77,7 +77,10 @@ def _print_findings_table(payload: JsonObject) -> None:
                 [
                     _finding_id(item),
                     _string(item.get("severity")),
+                    _string(item.get("status")),
                     _package_name(item),
+                    _string(item.get("first_seen")),
+                    _string(item.get("last_seen")),
                     _string(item.get("title") or item.get("summary") or item.get("message")),
                 ]
             )
@@ -120,6 +123,46 @@ def _run_request(client: AgentBomClient, callback: Any) -> JsonObject:
 @click.group(name="findings")
 def findings_cmd() -> None:
     """Inspect and triage normalized findings from the control plane."""
+
+
+@findings_cmd.command("push")
+@click.argument("input_path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.option("--source", default="external_scan", show_default=True, help="Source label stored on ingested findings.")
+@click.option("--reconcile", "reconcile_absent", is_flag=True, help="Mark findings absent from this batch as resolved.")
+@click.option("--observed-at", help="ISO-8601 observation timestamp for the batch.")
+@click.option("--idempotency-key", help="Optional Idempotency-Key header for safe retries.")
+@click.option("--format", "output_format", type=click.Choice(["json"]), default="json", show_default=True)
+@_common_api_options
+def push_findings_cmd(
+    api_url: str | None,
+    api_key: str | None,
+    bearer_token: str | None,
+    tenant_id: str | None,
+    input_path: Path,
+    source: str,
+    reconcile_absent: bool,
+    observed_at: str | None,
+    idempotency_key: str | None,
+    output_format: str,
+) -> None:
+    """Push normalized findings or external scanner JSON to the control plane."""
+
+    from agent_bom.findings_push import load_push_findings_file
+
+    findings = load_push_findings_file(input_path, source=source)
+    client = _make_client(api_url, api_key, bearer_token, tenant_id)
+    payload = _run_request(
+        client,
+        lambda api: api.ingest_findings(
+            findings,
+            source=source,
+            observed_at=observed_at,
+            reconcile_absent=reconcile_absent,
+            idempotency_key=idempotency_key,
+        ),
+    )
+    if output_format == "json":
+        _emit_json(payload)
 
 
 @findings_cmd.command("list")

--- a/src/agent_bom/findings_push.py
+++ b/src/agent_bom/findings_push.py
@@ -1,0 +1,83 @@
+"""Load external scanner output or finding JSON for bulk control-plane ingest."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from agent_bom.models import Package, Severity
+
+
+def _severity_value(severity: Severity | str) -> str:
+    if isinstance(severity, Severity):
+        return severity.value
+    return str(severity)
+
+
+def packages_to_bulk_findings(
+    packages: list[Package],
+    *,
+    source: str = "external_scan",
+) -> list[dict[str, Any]]:
+    """Project scanner packages into bulk-ingest finding rows."""
+
+    findings: list[dict[str, Any]] = []
+    for pkg in packages:
+        for vuln in pkg.vulnerabilities:
+            vulnerability_id = vuln.id or "unknown"
+            findings.append(
+                {
+                    "id": f"{vulnerability_id}:{pkg.name}:{pkg.version}",
+                    "vulnerability_id": vulnerability_id,
+                    "cve_id": vulnerability_id if vulnerability_id.upper().startswith("CVE-") else None,
+                    "package": pkg.name,
+                    "package_name": pkg.name,
+                    "package_version": pkg.version,
+                    "ecosystem": pkg.ecosystem,
+                    "severity": _severity_value(vuln.severity),
+                    "title": vuln.summary or vulnerability_id,
+                    "summary": vuln.summary,
+                    "fixed_version": vuln.fixed_version,
+                    "cvss_score": vuln.cvss_score,
+                    "is_kev": bool(vuln.is_kev),
+                    "source": source,
+                    "origin": "bulk_ingest",
+                }
+            )
+    return findings
+
+
+def load_push_findings(payload: object, *, source: str = "external_scan") -> list[dict[str, Any]]:
+    """Normalize a JSON payload into bulk-ingest finding rows."""
+
+    if isinstance(payload, list):
+        rows = [row for row in payload if isinstance(row, dict)]
+        if rows:
+            return rows
+        raise ValueError("findings JSON list is empty")
+
+    if not isinstance(payload, dict):
+        raise ValueError("findings JSON must be an object or list")
+
+    embedded = payload.get("findings")
+    if isinstance(embedded, list):
+        rows = [row for row in embedded if isinstance(row, dict)]
+        if rows:
+            return rows
+
+    from agent_bom.parsers.external_scanners import detect_and_parse
+
+    packages = detect_and_parse(payload)
+    findings = packages_to_bulk_findings(packages, source=source)
+    if not findings:
+        raise ValueError("scanner JSON parsed successfully but produced zero vulnerability findings")
+    return findings
+
+
+def load_push_findings_file(path: str | Path, *, source: str = "external_scan") -> list[dict[str, Any]]:
+    """Read a JSON file and normalize it for bulk ingest."""
+
+    text = Path(path).read_text(encoding="utf-8")
+    payload = json.loads(text)
+    return load_push_findings(payload, source=source)

--- a/src/agent_bom/mcp_server_specialized.py
+++ b/src/agent_bom/mcp_server_specialized.py
@@ -308,31 +308,73 @@ def register_specialized_ai_tools(
                 description="JSON string from Trivy, Grype, or Syft scan output",
             ),
         ],
+        parse_only: Annotated[
+            bool,
+            Field(
+                description=(
+                    "When true, parse locally only. When false, bulk-ingest to the control plane "
+                    "when AGENT_BOM_API_URL and credentials are configured."
+                ),
+            ),
+        ] = False,
+        source: Annotated[str, Field(description="Source label stored on ingested findings.")] = "external_scan",
+        reconcile_absent: Annotated[
+            bool,
+            Field(description="When pushing, mark findings absent from this batch as resolved."),
+        ] = False,
     ) -> str:
-        """Ingest Trivy, Grype, or Syft JSON scan output and return packages with blast radius analysis."""
+        """Ingest Trivy, Grype, or Syft JSON scan output and optionally push findings to the control plane."""
 
         async def _impl() -> str:
             import json as _json
+            import os
 
+            from agent_bom.client import AgentBomClient
+            from agent_bom.findings_push import packages_to_bulk_findings
             from agent_bom.parsers.external_scanners import detect_and_parse
 
             try:
                 data = _json.loads(scan_json)
                 packages = detect_and_parse(data)
-                return _json.dumps(
-                    {
-                        "packages": len(packages),
-                        "ingested": [
-                            {
-                                "name": p.name,
-                                "version": p.version,
-                                "ecosystem": p.ecosystem,
-                                "vulnerabilities": len(p.vulnerabilities),
-                            }
-                            for p in packages[:50]
-                        ],
-                    }
-                )
+                findings = packages_to_bulk_findings(packages, source=source)
+                result: dict[str, object] = {
+                    "packages": len(packages),
+                    "findings": len(findings),
+                    "ingested": [
+                        {
+                            "name": p.name,
+                            "version": p.version,
+                            "ecosystem": p.ecosystem,
+                            "vulnerabilities": len(p.vulnerabilities),
+                        }
+                        for p in packages[:50]
+                    ],
+                }
+                if not parse_only:
+                    base_url = os.getenv("AGENT_BOM_API_URL")
+                    api_key = os.getenv("AGENT_BOM_API_KEY")
+                    bearer_token = os.getenv("AGENT_BOM_API_TOKEN")
+                    if base_url and (api_key or bearer_token):
+                        client = AgentBomClient(
+                            base_url=base_url,
+                            api_key=api_key,
+                            bearer_token=bearer_token,
+                            tenant_id=os.getenv("AGENT_BOM_TENANT_ID"),
+                        )
+                        try:
+                            result["control_plane"] = client.ingest_findings(
+                                findings,
+                                source=source,
+                                reconcile_absent=reconcile_absent,
+                            )
+                        finally:
+                            client.close()
+                    elif findings:
+                        result["control_plane"] = {
+                            "skipped": True,
+                            "reason": "Set AGENT_BOM_API_URL and AGENT_BOM_API_KEY or AGENT_BOM_API_TOKEN to bulk-ingest findings",
+                        }
+                return _json.dumps(result)
             except Exception as exc:  # noqa: BLE001
                 return truncate_response(mcp_error_json(CODE_INTERNAL_UNEXPECTED, exc))
 

--- a/tests/test_cli_findings.py
+++ b/tests/test_cli_findings.py
@@ -18,6 +18,10 @@ class FakeFindingsClient:
     def close(self) -> None:
         self.__class__.calls.append(("close", {}))
 
+    def ingest_findings(self, findings: list[dict[str, object]], **kwargs: Any) -> dict[str, object]:
+        self.__class__.calls.append(("ingest_findings", {"findings": findings, **kwargs}))
+        return {"ingested": len(findings), "reconciled": 0}
+
     def list_findings(self, **kwargs: Any) -> dict[str, object]:
         self.__class__.calls.append(("list_findings", kwargs))
         return {
@@ -25,7 +29,10 @@ class FakeFindingsClient:
                 {
                     "id": "finding-1",
                     "severity": "high",
+                    "status": "open",
                     "package": "requests",
+                    "first_seen": "2026-07-01T00:00:00Z",
+                    "last_seen": "2026-07-03T00:00:00Z",
                     "title": "Reachable CVE",
                 }
             ],
@@ -66,6 +73,48 @@ def _install_fake_client(monkeypatch) -> type[FakeFindingsClient]:
     FakeFindingsClient.init_kwargs = {}
     monkeypatch.setattr("agent_bom.cli._findings_group.AgentBomClient", FakeFindingsClient)
     return FakeFindingsClient
+
+
+def test_findings_push_ingests_json_file(monkeypatch, tmp_path) -> None:
+    fake = _install_fake_client(monkeypatch)
+    payload_path = tmp_path / "findings.json"
+    payload_path.write_text(
+        json.dumps([{"id": "finding-push-1", "severity": "high", "package": "requests"}]),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "findings",
+            "push",
+            str(payload_path),
+            "--api-url",
+            "https://agent-bom.example.com",
+            "--api-key",
+            "key",
+            "--source",
+            "ci-trivy",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["ingested"] == 1
+    assert fake.calls[0][0] == "ingest_findings"
+    assert fake.calls[0][1]["source"] == "ci-trivy"
+    assert fake.calls[0][1]["findings"][0]["id"] == "finding-push-1"
+
+
+def test_findings_list_table_includes_lifecycle_columns(monkeypatch) -> None:
+    _install_fake_client(monkeypatch)
+
+    result = CliRunner().invoke(main, ["findings", "list"])
+
+    assert result.exit_code == 0, result.output
+    lines = result.output.strip().splitlines()
+    assert lines[0].startswith("id\tseverity\tstatus\tpackage\tfirst_seen\tlast_seen\ttitle")
+    assert "open" in lines[1]
+    assert "2026-07-01T00:00:00Z" in lines[1]
 
 
 def test_findings_list_outputs_json_and_passes_filters(monkeypatch) -> None:

--- a/tests/test_compliance_hub_api.py
+++ b/tests/test_compliance_hub_api.py
@@ -152,6 +152,34 @@ def test_list_hub_findings_returns_what_we_ingested():
     assert body["findings"][0]["source"] == "EXTERNAL"
 
 
+def test_list_hub_findings_exposes_lifecycle_for_bulk_ingest():
+    client = _client(role="analyst")
+    observed_at = "2026-07-01T12:00:00Z"
+    client.post(
+        "/v1/findings/bulk",
+        json={
+            "source": "external_scan",
+            "observed_at": observed_at,
+            "findings": [
+                {
+                    "id": "finding-hub-list-1",
+                    "vulnerability_id": "CVE-2026-7777",
+                    "severity": "high",
+                    "package": "requests",
+                    "title": "Bulk ingest lifecycle row",
+                }
+            ],
+        },
+    )
+
+    body = client.get("/v1/compliance/hub/findings").json()
+    assert body["total"] == 1
+    row = body["findings"][0]
+    assert row["status"] == "open"
+    assert row["first_seen"] == observed_at
+    assert row["last_seen"] == observed_at
+
+
 def test_list_hub_findings_pagination():
     client = _client()
     csv_rows = "Title,Severity\n" + "\n".join(f"row-{i},low" for i in range(50))

--- a/tests/test_findings_push.py
+++ b/tests/test_findings_push.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_bom.findings_push import load_push_findings, load_push_findings_file, packages_to_bulk_findings
+from agent_bom.parsers.external_scanners import parse_trivy_json
+from tests.test_external_scanners import TRIVY_BASIC
+
+
+def test_packages_to_bulk_findings_projects_scanner_rows() -> None:
+    packages = parse_trivy_json(TRIVY_BASIC)
+    findings = packages_to_bulk_findings(packages, source="trivy-ci")
+
+    assert findings
+    assert findings[0]["source"] == "trivy-ci"
+    assert findings[0]["origin"] == "bulk_ingest"
+    assert findings[0]["package_name"] == packages[0].name
+    assert findings[0]["vulnerability_id"]
+
+
+def test_load_push_findings_accepts_embedded_findings_array() -> None:
+    payload = {"findings": [{"id": "finding-1", "severity": "high", "package": "requests"}]}
+    rows = load_push_findings(payload)
+    assert rows == payload["findings"]
+
+
+def test_load_push_findings_accepts_scanner_json() -> None:
+    rows = load_push_findings(TRIVY_BASIC, source="trivy")
+    assert rows
+    assert rows[0]["source"] == "trivy"
+
+
+def test_load_push_findings_file(tmp_path: Path) -> None:
+    path = tmp_path / "findings.json"
+    path.write_text(json.dumps([{"id": "finding-2", "severity": "medium"}]), encoding="utf-8")
+    rows = load_push_findings_file(path)
+    assert rows[0]["id"] == "finding-2"
+
+
+def test_load_push_findings_rejects_empty_scanner_payload() -> None:
+    with pytest.raises(ValueError, match="zero vulnerability findings"):
+        load_push_findings({"Results": []})


### PR DESCRIPTION
## Summary
- Add `agent-bom findings push` for normalized finding JSON or Trivy/Grype/Syft scanner output via `POST /v1/findings/bulk`
- Prefer `list_current_page` on `GET /v1/compliance/hub/findings` so lifecycle fields (`status`, `first_seen`, `last_seen`) match `/v1/findings`
- Extend CLI `findings list` table with lifecycle columns; MCP `ingest_external_scan` bulk-ingests when `AGENT_BOM_API_URL` and credentials are set

Closes #3482 (partial — UI lifecycle columns remain on #3503 / follow-up)

## Verification
- `uv run pytest tests/test_findings_push.py tests/test_cli_findings.py tests/test_compliance_hub_api.py::test_list_hub_findings_exposes_lifecycle_for_bulk_ingest -q`
- `uv run ruff check src/agent_bom/findings_push.py src/agent_bom/cli/_findings_group.py src/agent_bom/api/routes/compliance.py src/agent_bom/mcp_server_specialized.py`
- `uv run mypy src/agent_bom/findings_push.py`


Made with [Cursor](https://cursor.com)