### PR TITLE
feat(ui): show findings lifecycle status and timestamps in queue

### DIFF
--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -35,6 +35,7 @@ import {
   uniqueStrings,
   serverFindingsSort,
   formatFindingsTotal,
+  hasLifecycleMetadata,
 } from "@/lib/findings-view";
 import { severityRank } from "@/lib/severity";
 import { Bug, Download, Layers, Loader2, Package, Server, ClipboardCheck } from "lucide-react";
@@ -212,6 +213,12 @@ function collectUnifiedFindings(findings: UnifiedFinding[]): EnrichedVuln[] {
         : [],
       graph_reachable: null,
       graph_min_hop_distance: null,
+      lifecycle_status: finding.status ?? undefined,
+      first_seen: finding.first_seen ?? undefined,
+      last_seen: finding.last_seen ?? undefined,
+      resolved_at: finding.resolved_at ?? undefined,
+      reopened_at: finding.reopened_at ?? undefined,
+      scan_count: finding.scan_count,
     };
   });
 }
@@ -278,6 +285,7 @@ function VulnsPage() {
   const [findingsTotalApproximate, setFindingsTotalApproximate] = useState(false);
   const PAGE_SIZE = 25;
   const useServerPaging = groupBy === "none" && !search.trim();
+  const showLifecycleColumns = useMemo(() => hasLifecycleMetadata(vulns), [vulns]);
 
   // URL-as-source-of-truth: when the query string changes (link, back/forward),
   // re-sync the derived filter state so the view matches the address bar instead
@@ -950,6 +958,7 @@ function VulnsPage() {
                       onMarkFP={handleMarkFP}
                       selectedId={selectedId}
                       onSelect={setSelectedId}
+                      showLifecycle={showLifecycleColumns}
                     />
                     {groupOverflow > 0 && (
                       <p className="mt-2 text-xs text-zinc-600">
@@ -972,6 +981,7 @@ function VulnsPage() {
               onMarkFP={handleMarkFP}
               selectedId={selectedId}
               onSelect={setSelectedId}
+              showLifecycle={showLifecycleColumns}
             />
           )}
 

--- a/ui/components/finding-drawer.tsx
+++ b/ui/components/finding-drawer.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 import { ExternalLink, FileSearch, Loader2, Radar, ShieldAlert, X } from "lucide-react";
 
 import { severityColor, type FindingTriageDecision, type FindingTriageItem, type FindingTriageJustification } from "@/lib/api";
-import { type EnrichedVuln, uniqueStrings } from "@/lib/findings-view";
+import { type EnrichedVuln, uniqueStrings, formatFindingTimestamp, findingStatusClass, findingStatusLabel } from "@/lib/findings-view";
 
 export function FindingDrawer({
   vuln,
@@ -75,6 +75,13 @@ function VulnDetailPanel({
   const cweMatches = summary.match(/CWE-\d+/gi) ?? [];
   const published = vuln.published_at ?? vuln.published ?? vuln.nvd_published;
   const modified = vuln.modified_at;
+  const hasLifecycle =
+    Boolean(vuln.lifecycle_status?.trim()) ||
+    Boolean(vuln.first_seen?.trim()) ||
+    Boolean(vuln.last_seen?.trim()) ||
+    Boolean(vuln.resolved_at?.trim()) ||
+    Boolean(vuln.reopened_at?.trim()) ||
+    typeof vuln.scan_count === "number";
   const references = uniqueStrings(vuln.references).slice(0, 6);
   const fixCandidates = vuln.remediation_items.filter((item) => item.fixed_version || item.command || item.verify_command);
   const investigationSources = uniqueStrings([
@@ -141,6 +148,28 @@ function VulnDetailPanel({
         </div>
 
         <div className="space-y-4">
+          {hasLifecycle && (
+            <div className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
+              <h4 className="text-xs font-medium uppercase tracking-wide text-zinc-500">Lifecycle</h4>
+              <div className="mt-3 space-y-2 text-sm text-zinc-300">
+                {vuln.lifecycle_status && (
+                  <div className="flex items-center gap-2">
+                    <span className="text-zinc-500">Status:</span>
+                    <span className={`text-xs font-medium px-2 py-0.5 rounded border ${findingStatusClass(vuln.lifecycle_status)}`}>
+                      {findingStatusLabel(vuln.lifecycle_status)}
+                    </span>
+                  </div>
+                )}
+                {vuln.first_seen && <div><span className="text-zinc-500">First seen:</span> {formatFindingTimestamp(vuln.first_seen)}</div>}
+                {vuln.last_seen && <div><span className="text-zinc-500">Last seen:</span> {formatFindingTimestamp(vuln.last_seen)}</div>}
+                {vuln.resolved_at && <div><span className="text-zinc-500">Resolved:</span> {formatFindingTimestamp(vuln.resolved_at)}</div>}
+                {vuln.reopened_at && <div><span className="text-zinc-500">Reopened:</span> {formatFindingTimestamp(vuln.reopened_at)}</div>}
+                {typeof vuln.scan_count === "number" && (
+                  <div><span className="text-zinc-500">Scan count:</span> {vuln.scan_count}</div>
+                )}
+              </div>
+            </div>
+          )}
           <div className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
             <h4 className="text-xs font-medium uppercase tracking-wide text-zinc-500">Fix context</h4>
             <div className="mt-3 space-y-2 text-sm text-zinc-300">

--- a/ui/components/findings-queue.tsx
+++ b/ui/components/findings-queue.tsx
@@ -4,6 +4,11 @@ import { ChevronDown, ChevronRight, ChevronUp, ExternalLink, ShieldOff } from "l
 
 import { severityColor, severityDot } from "@/lib/api";
 import type { EnrichedVuln, SortKey } from "@/lib/findings-view";
+import {
+  findingStatusClass,
+  findingStatusLabel,
+  formatFindingTimestamp,
+} from "@/lib/findings-view";
 
 function ReachabilityBadge({
   reachable,
@@ -104,6 +109,7 @@ export function FindingsQueueTable({
   onMarkFP,
   selectedId,
   onSelect,
+  showLifecycle = false,
 }: {
   vulns: EnrichedVuln[];
   sortKey: SortKey;
@@ -113,6 +119,7 @@ export function FindingsQueueTable({
   onMarkFP: (vulnId: string, packageName: string) => void;
   selectedId: string | null;
   onSelect: (vulnId: string | null) => void;
+  showLifecycle?: boolean;
 }) {
   return (
     <div className="border border-zinc-800 rounded-xl overflow-hidden overflow-x-auto">
@@ -125,6 +132,12 @@ export function FindingsQueueTable({
             <th className="text-left px-4 py-3">
               <SortButton label="Severity" field="severity" current={sortKey} dir={sortDir} onClick={handleSort} />
             </th>
+            {showLifecycle ? (
+              <>
+                <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Status</th>
+                <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Last seen</th>
+              </>
+            ) : null}
             <th className="text-left px-4 py-3">
               <SortButton label="CVSS" field="cvss" current={sortKey} dir={sortDir} onClick={handleSort} />
             </th>
@@ -201,6 +214,20 @@ export function FindingsQueueTable({
                       {v.severity}
                     </span>
                   </td>
+                  {showLifecycle ? (
+                    <>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`text-xs font-medium px-2 py-0.5 rounded border ${findingStatusClass(v.lifecycle_status)}`}
+                        >
+                          {findingStatusLabel(v.lifecycle_status)}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-xs font-mono text-zinc-400">
+                        {formatFindingTimestamp(v.last_seen ?? v.first_seen)}
+                      </td>
+                    </>
+                  ) : null}
                   <td className="px-4 py-3 text-xs font-mono text-zinc-400">
                     {renderScoreValue(v.cvss_score, "CVSS not published by the current advisory")}
                   </td>

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -757,6 +757,12 @@ export interface UnifiedFinding {
   exposed_tools?: string[] | undefined;
   scan_id?: string | undefined;
   scan_sources?: string[] | undefined;
+  status?: string | undefined;
+  first_seen?: string | null | undefined;
+  last_seen?: string | null | undefined;
+  resolved_at?: string | null | undefined;
+  reopened_at?: string | null | undefined;
+  scan_count?: number | undefined;
 }
 
 export interface FindingsResponse {

--- a/ui/lib/findings-view.ts
+++ b/ui/lib/findings-view.ts
@@ -15,6 +15,12 @@ export interface EnrichedVuln extends Vulnerability {
   remediation_items: RemediationSummary[];
   graph_reachable?: boolean | null | undefined;
   graph_min_hop_distance?: number | null | undefined;
+  lifecycle_status?: string | undefined;
+  first_seen?: string | undefined;
+  last_seen?: string | undefined;
+  resolved_at?: string | undefined;
+  reopened_at?: string | undefined;
+  scan_count?: number | undefined;
 }
 
 export interface RemediationSummary {
@@ -45,6 +51,51 @@ export function serverFindingsSort(sortKey: SortKey): string {
 export function formatFindingsTotal(total: number, approximate?: boolean): string {
   if (!approximate) return String(total);
   return `~${total}`;
+}
+
+export function formatFindingTimestamp(value: string | undefined | null): string {
+  if (!value || !value.trim()) return "—";
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return value;
+  return new Date(parsed).toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function findingStatusLabel(status: string | undefined): string {
+  const normalized = (status ?? "").trim().toLowerCase();
+  if (normalized === "open" || normalized === "resolved" || normalized === "reopened") {
+    return normalized;
+  }
+  return normalized || "—";
+}
+
+export function findingStatusClass(status: string | undefined): string {
+  const normalized = (status ?? "").trim().toLowerCase();
+  if (normalized === "open") {
+    return "bg-amber-950 border-amber-800 text-amber-300";
+  }
+  if (normalized === "resolved") {
+    return "bg-emerald-950 border-emerald-800 text-emerald-300";
+  }
+  if (normalized === "reopened") {
+    return "bg-orange-950 border-orange-800 text-orange-300";
+  }
+  return "bg-zinc-900 border-zinc-700 text-zinc-500";
+}
+
+export function hasLifecycleMetadata(rows: EnrichedVuln[]): boolean {
+  return rows.some(
+    (row) =>
+      Boolean(row.lifecycle_status?.trim()) ||
+      Boolean(row.first_seen?.trim()) ||
+      Boolean(row.last_seen?.trim()) ||
+      Boolean(row.resolved_at?.trim()),
+  );
 }
 
 export function uniqueStrings(items: Array<string | null | undefined>) {

--- a/ui/tests/findings-view.test.ts
+++ b/ui/tests/findings-view.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  findingStatusClass,
+  findingStatusLabel,
+  formatFindingTimestamp,
+  hasLifecycleMetadata,
+  type EnrichedVuln,
+} from "@/lib/findings-view";
+
+function sampleVuln(overrides: Partial<EnrichedVuln> = {}): EnrichedVuln {
+  return {
+    id: "CVE-2026-0001",
+    severity: "high",
+    packages: ["requests"],
+    agents: [],
+    sources: [],
+    affected_servers: [],
+    exposed_credentials: [],
+    reachable_tools: [],
+    references: [],
+    advisory_sources: [],
+    remediation_items: [],
+    ...overrides,
+  };
+}
+
+describe("findings lifecycle helpers", () => {
+  it("formats ISO timestamps for table display", () => {
+    const formatted = formatFindingTimestamp("2026-07-01T12:00:00Z");
+    expect(formatted).not.toBe("—");
+    expect(formatted).toContain("2026");
+  });
+
+  it("labels lifecycle status values", () => {
+    expect(findingStatusLabel("open")).toBe("open");
+    expect(findingStatusLabel("resolved")).toBe("resolved");
+    expect(findingStatusClass("reopened")).toContain("orange");
+  });
+
+  it("detects lifecycle metadata on enriched rows", () => {
+    expect(hasLifecycleMetadata([sampleVuln()])).toBe(false);
+    expect(hasLifecycleMetadata([sampleVuln({ lifecycle_status: "open", last_seen: "2026-07-01T00:00:00Z" })])).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add lifecycle fields to `UnifiedFinding` / `EnrichedVuln` and map them from `GET /v1/findings`
- Findings queue table shows **Status** and **Last seen** when bulk-ingest lifecycle data is present
- Evidence drawer shows first/last seen, resolved/reopened, and scan count

Related #3468 · completes the UI slice from closed #3482

## Verification
- `cd ui && npm run typecheck`
- `cd ui && npm test -- --run tests/findings-view.test.ts`


Made with [Cursor](https://cursor.com)