### PR TITLE
docs(audit): headless ingest docs and audit ledger sync

### DIFF
--- a/docs/CLI_MAP.md
+++ b/docs/CLI_MAP.md
@@ -75,7 +75,7 @@ Graph, mesh, dashboard, and narrative reporting workflows.
 | `graph` | Build / export the context graph. |
 | `mesh` | Agent-mesh view. |
 | `report` | Reporting group (history, narrative, exports). |
-| `findings` | Findings workbench for CLI users: list normalized findings, triage queue items, decisions, and signed OpenVEX export. |
+| `findings` | Findings workbench for CLI users: `list` normalized findings (lifecycle columns when bulk-ingest metadata exists), `push` external scanner or normalized JSON to `POST /v1/findings/bulk`, triage queue items, decisions, and signed OpenVEX export. |
 
 ## Governance
 
@@ -85,7 +85,7 @@ Policy, trust, fleet, FinOps, identity, API, scheduling, and control-plane ops.
 |---|---|
 | `policy` | Policy-as-code group. |
 | `trust` | Trust-boundary commands. |
-| `fleet` | Fleet inventory group. |
+| `fleet` | Fleet inventory group — `sync` discovers local MCP agents and pushes to `POST /v1/fleet/sync` (requires `--push-url` or `AGENT_BOM_PUSH_URL`; HTTPS-only unless `AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS=1`). |
 | `cost` | LLM cost / FinOps group (forecast, budget, chargeback). |
 | `identity` | Non-human identity group (credential-expiry, access review). |
 | `serve` | Run the local API + bundled dashboard. |
@@ -158,3 +158,25 @@ the source is:
 
 Both paths normalize into the same `Finding` and `ContextGraph` model; the
 split is only the operator command and provider API boundary.
+
+---
+
+## Headless control-plane ingest
+
+Push scanner or CI evidence into a running control plane without the dashboard:
+
+| Command | API | Notes |
+|---|---|---|
+| `findings push <file>` | `POST /v1/findings/bulk` | Accepts normalized findings JSON or Trivy / Grype / Syft output. Defaults `--api-url` to `http://127.0.0.1:8422` for local pilots. |
+| `fleet sync` | `POST /v1/fleet/sync` | Local discovery only — no dry-run preview without a push URL. |
+| `mcp` tool `ingest_external_scan` | same bulk route when `AGENT_BOM_API_URL` + credentials are set | Parse-only when credentials are absent. |
+
+Ingested external findings land in the unified `GET /v1/findings` queue (and
+`GET /v1/compliance/hub/findings` for hub-native clients). The dashboard
+`/findings` page reads the unified list — lifecycle **Status** / **Last seen**
+columns appear only when rows carry bulk-ingest lifecycle metadata; scan-only
+rows omit those fields by design.
+
+Air-gap installs: set `AGENT_BOM_SKIP_UPDATE_CHECK=1` or `AGENT_BOM_OFFLINE=1`
+before any CLI invocation to suppress the background PyPI version check (the
+check starts before subcommand flags are parsed).

--- a/docs/audits/AUDIT-2026-07-03.md
+++ b/docs/audits/AUDIT-2026-07-03.md
@@ -1,7 +1,7 @@
 # agent-bom v0.92.0 — Audit ledger (2026-07-03)
 
-**Scope:** Multi-wave audit 2026-07-02 → 2026-07-03. Live verification against post-fix commits.
-**Baseline:** `main @ cad865822` (post–Glama publish pin #3547). **Product version:** 0.92.0.
+**Scope:** Multi-wave audit 2026-07-02 → 2026-07-05. Live verification against post-fix commits.
+**Baseline:** `main @ a511e5efc` (post reserved-tenant CLI/MCP guard #3554). **Product version:** 0.92.0.
 **Policy:** Canonical model is product truth; OCSF is export/interop only (`docs/OCSF_BOUNDARY.md`). No vendor parity claims in this doc.
 
 ---
@@ -70,6 +70,11 @@
 | **#3471** | Fleet sync local discovery push | **#3546** |
 | **#3472** | Glama publish pin + Dockerfile verify | **#3547** |
 | **#3544** | Bulk ingest O(n) snapshot walk | **#3545** |
+| **#3482** | Headless lifecycle (CLI push, hub list, UI columns) | **#3549**, **#3551** |
+| **#3503** | Persona / lane visuals + README hero | **#3548** |
+| **#3552** | Air-gap PyPI update-check skip (env) | **#3552** |
+| **#3553** | Compose `~/.agent-bom` mount for `abom` user | **#3553** |
+| **#3554** | Reserved tenant ids on CLI/MCP resolvers | **#3554** |
 
 ### Open (remaining from audit)
 
@@ -77,10 +82,17 @@
 |---|---|---|---|---|
 | **O** | P3 | No table partitioning | **#3463** | Ledger `compliance_hub_findings`; distinct from current-state sort |
 | **T** | scope | Multi-language reachability; data-lake interop | **#3499** | Parquet/Iceberg + call-graph reachability |
-| — | P2 | Headless lifecycle parity (UI columns) | **#3482** | CLI push + MCP bulk ingest in **#3549**; UI columns follow **#3503** |
-| — | P3 | Persona / lane visuals refresh | **#3503** | Docs-site SVGs; README hero reorder in **#3548** |
 
-**Epics (cross-cutting):** **#3242** post-audit hardening; **#3468** guided demo estate; **#3192** graph excellence.
+**Epics (cross-cutting):** **#3242** post-audit hardening (severity unification, replay protection, PyPI flag gap); **#3468** guided demo estate; **#3192** graph excellence.
+
+### Documented product boundaries (not wiring bugs)
+
+| Topic | Behavior |
+|---|---|
+| Lifecycle UI columns | Shown only when `GET /v1/findings` returns bulk-ingest lifecycle metadata; scan-only rows omit `status` / `first_seen` / `last_seen` by design. |
+| Hub findings browser | No dedicated UI for `GET /v1/compliance/hub/findings`; ingested external findings appear in unified `/findings` via `GET /v1/findings`. Compliance page shows hub posture totals. |
+| Fleet sync local pilot | HTTPS outbound policy; loopback HTTP requires `AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS=1` (documented in CLI reference). |
+| PyPI update check | Env skip shipped (#3552); subcommand `--offline` does not suppress the pre-parse background check — use env vars in air-gap shells. |
 
 ### New gaps filed (Fable consolidated audit — all shipped or tracked above)
 
@@ -92,7 +104,7 @@
 | **P2** | Reference-table normalization | **#3513** | **Closed** — #3528 |
 | **P2** | Delta-stream connector | **#3514** | **Closed** — #3531 |
 
-**Cross-cutting (tracked on #3242):** RBAC middleware/decorator drift; air-gap PyPI check; compose home mount; offline custom-DB warning surfacing; README reachability wording.
+**Cross-cutting (tracked on #3242):** severity unification; replay protection (SAML/JWT jti, MCP bearer expiry); PyPI update-check `--offline` flag gap; fleet-sync vs findings-push URL policy consistency; MCP `operator_role` audit metadata vs authenticated actor.
 
 ---
 
@@ -121,11 +133,11 @@
 
 ### Remaining priority list
 
-1. **#3482** — finish UI lifecycle columns (CLI/MCP/hub list shipped #3549)
-2. **#3503** — persona visuals + README hero polish (#3548 open)
-3. **#3463** — declarative partitioning + retention rollover
-4. **#3499** — reachability + data-lake interop epic
-5. **#3242** — post-audit hardening backlog
+1. **#3463** — declarative partitioning + retention rollover
+2. **#3499** — reachability + data-lake interop epic
+3. **#3242** — post-audit hardening (severity, replay protection, PyPI flag gap)
+4. **#3468** — guided activation + labeled demo estate (UI)
+5. **#3192** — graph excellence epic
 
 ---
 
@@ -138,11 +150,11 @@
 | `/v1/findings?limit=500` egress | ~319 KB uncompressed; ~23 KB gzipped (post-#3516) |
 | Read latency | ~38 ms / 500 rows over 50k; keyset path #3511 |
 
-**Shipped wins:** #3486, #3487, #3485, #3510, #3511, #3545 (bulk ingest snapshot gate).
+**Shipped wins:** #3486, #3487, #3485, #3510, #3511, #3545–#3554 (lifecycle headless + UI, fleet sync, air-gap env skip, compose mount, tenant guard).
 
 ---
 
-## §F. Fable consolidated audit — re-validation (`main @ cad865822`)
+## §F. Fable consolidated audit — re-validation (`main @ a511e5efc`)
 
 Hands-on re-validation (clean install, API scan, MCP/proxy/gateway, UI build, read-path probe). **No functional defects** on MCP surface (70 tools / 6 resources / 8 prompts confirmed).
 
@@ -154,16 +166,19 @@ Hands-on re-validation (clean install, API scan, MCP/proxy/gateway, UI build, re
 | `effective_reach` sort without covering index | Sort indexes + keyset cursors | **#3511** → #3530 |
 | Bulk ingest O(n) snapshot walk | `needs_hub_prior_snapshots` gate | **#3544** → #3545 |
 | Fleet sync stub | Local discovery → `/v1/fleet/sync` | **#3471** → #3546 |
+| Headless lifecycle CLI + UI columns | `findings push`, hub `list_current_page`, queue/drawer | **#3482** → #3549, #3551 |
+| Air-gap PyPI check (env) | `AGENT_BOM_SKIP_UPDATE_CHECK` / `AGENT_BOM_OFFLINE` | **#3242** → #3552 |
+| Compose state loss | `~/.agent-bom:/home/abom/.agent-bom` mount | **#3242** → #3553 |
+| Reserved tenant on CLI/MCP | `platform_invariants` validation | **#3242** → #3554 |
 
-### Make-it-true overclaims (still wire or narrow)
+### Make-it-true overclaims (wire or narrow)
 
 | Claim | Action |
 |---|---|
 | CWE-aware reachability (README) | Precise wording or ship call-graph path (**#3499**) |
-| Air-gap | Skip/opt-out PyPI background check (**#3242**) |
-| Compose persistence | Mount `~/.agent-bom` for `abom` user (**#3242**) |
-| Headless lifecycle UI columns | **#3482** / **#3503** |
+| PyPI check on `agents --offline` | Env skip shipped; extend `_should_skip_update_check()` for `--offline` in `sys.argv` (**#3242**) |
+| Dedicated hub-findings UI | Document unified `/findings` queue; hub API for integrators only |
 
 ---
 
-_Sanitized from consolidated audit dossier 2026-07-03. Vendor parity sections omitted per repo policy. Last ledger sync: 2026-07-04 (post #3547 merge)._
+_Sanitized from consolidated audit dossier 2026-07-03. Vendor parity sections omitted per repo policy. Last ledger sync: 2026-07-05 (post #3554 merge; docs slice for headless ingest boundaries)._

--- a/site-docs/deployment/endpoint-fleet.md
+++ b/site-docs/deployment/endpoint-fleet.md
@@ -40,6 +40,19 @@ agent-bom agents \
   --push-api-key "$AGENT_BOM_PUSH_API_KEY"
 ```
 
+Or use the dedicated fleet sync verb (same push contract, discovery-only):
+
+```bash
+agent-bom fleet sync \
+  --push-url https://agent-bom.internal.example.com/v1/fleet/sync \
+  --push-api-key "$AGENT_BOM_PUSH_API_KEY"
+```
+
+For a local Docker pilot on `http://127.0.0.1:8422`, set
+`AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS=1` because fleet sync enforces HTTPS
+outbound policy. `findings push` accepts the default local HTTP API URL without
+that override.
+
 That gives you:
 
 - endpoint MCP config discovery

--- a/site-docs/features/compliance.md
+++ b/site-docs/features/compliance.md
@@ -52,3 +52,22 @@ agent-bom agents --snowflake --snowflake-cis-benchmark
 ```
 
 Requires cloud credentials (AWS_PROFILE or SNOWFLAKE_ACCOUNT/USER/PASSWORD).
+
+## Compliance hub ingest
+
+External scanner evidence can land in the control plane without a native scan
+job:
+
+```bash
+# CLI — Trivy / Grype / Syft JSON or normalized findings
+agent-bom findings push ./scan.json --api-url https://agent-bom.internal.example.com --api-key "$AGENT_BOM_API_KEY"
+
+# API — SARIF, CycloneDX, CSV, or JSON adapters
+curl -X POST https://agent-bom.internal.example.com/v1/compliance/ingest ...
+```
+
+Ingested rows participate in hub posture (`GET /v1/compliance/hub/posture`) and
+the unified findings queue (`GET /v1/findings`). The dashboard `/findings` page
+reads the unified list; lifecycle status columns appear only on bulk-ingested
+rows. Hub-native listing is available at `GET /v1/compliance/hub/findings` for
+API clients — there is no separate hub-findings browser page in the UI today.

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -70,6 +70,8 @@ verbs are additive entry points that delegate to the underlying implementations.
 | `mesh` | Show lightweight agent/MCP topology without CVE scanning |
 | `report` | History, diff, pipeline-event artifacts, local queries, analytics, dashboard, and compliance narrative workflows |
 | `findings` | List normalized findings, manage the triage queue, record decisions, and export signed OpenVEX evidence |
+| `findings push` | Push normalized findings or Trivy / Grype / Syft JSON to `POST /v1/findings/bulk` on the control plane |
+| `findings list` | List findings from the control plane; prints lifecycle columns when bulk-ingest metadata is present |
 | `attest` | Sign and verify generated SBOM output (SHA-256 digest + in-toto attestation) |
 
 ### Governance And Operations
@@ -80,6 +82,7 @@ verbs are additive entry points that delegate to the underlying implementations.
 | `firewall` | Inter-agent firewall policy validate / list / check |
 | `trust` | Show data access, network, auth, and storage boundaries |
 | `fleet` | Manage AI agent fleet discovery, lifecycle, and posture |
+| `fleet sync` | Discover local MCP agents and push inventory to `POST /v1/fleet/sync` |
 | `cost` | LLM FinOps posture — spend forecast and chargeback rollups (read-only) |
 | `cost forecast` | Project LLM burn rate and budget runway (read-only FinOps) |
 | `cost allocation` | Roll up LLM spend by cost-center / allocation tag (alias: `cost chargeback`) |
@@ -131,6 +134,45 @@ verbs are additive entry points that delegate to the underlying implementations.
 - `agent-bom verify` and `agent-bom verify agent-bom` both self-verify the installed package.
 - `cloud aws` / `cloud azure` / `cloud gcp` (and `cloud scan --provider <name>`) exit non-zero when an explicitly requested provider hard-fails discovery or its CIS benchmark because the provider SDK is not installed or credentials are absent/invalid. The helpful `pip install 'agent-bom[<provider>]'` / credential-setup message is still printed. A genuinely empty-but-successful scan (credentials present, no AI resources) still exits 0, and one provider failing never aborts the others — every requested provider is still attempted, the exit code only reflects that one hard-failed. `cloud scan --provider all` only scans auto-detected configured clouds, so unconfigured clouds are skipped (not failed) and the run stays at exit 0.
 - `secrets` accepts `--offline` as a no-op for parity with `agents`/`scan`; secret scanning is always local and never makes network calls, so shared CI invocations that pass `--offline` work unchanged.
+
+## Headless control-plane ingest
+
+Use these when CI, a laptop, or an MCP client needs to push evidence into a
+running control plane without opening the dashboard.
+
+```bash
+# Push external scanner output (Trivy / Grype / Syft) or normalized findings JSON
+agent-bom findings push ./trivy.json \
+  --api-url https://agent-bom.internal.example.com \
+  --api-key "$AGENT_BOM_API_KEY" \
+  --source trivy
+
+# List findings back from the control plane (lifecycle columns when present)
+agent-bom findings list --api-url https://agent-bom.internal.example.com --api-key "$AGENT_BOM_API_KEY"
+
+# Discover local MCP agents and sync fleet inventory
+agent-bom fleet sync \
+  --push-url https://agent-bom.internal.example.com/v1/fleet/sync \
+  --push-api-key "$AGENT_BOM_PUSH_API_KEY"
+```
+
+**Unified findings queue:** bulk-ingested findings appear in `GET /v1/findings`
+and the dashboard `/findings` page. Hub-native clients can also call
+`GET /v1/compliance/hub/findings`; there is no separate hub-findings browser
+page — compliance shows hub posture totals only.
+
+**Lifecycle columns:** the dashboard and `findings list` show **Status**,
+**First seen**, and **Last seen** only when the API returns lifecycle metadata
+(bulk-ingested / reconciled rows). Scan-only job findings omit those fields.
+
+**Local pilot URLs:** `findings push` defaults `--api-url` to
+`http://127.0.0.1:8422`. `fleet sync` enforces HTTPS outbound policy via
+`validate_url`; for loopback pilots set
+`AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS=1` or use an HTTPS local endpoint.
+
+**Air-gap:** export `AGENT_BOM_SKIP_UPDATE_CHECK=1` or `AGENT_BOM_OFFLINE=1`
+before invoking the CLI to suppress the background PyPI version check (it starts
+before subcommand flags are parsed).
 
 ## Common flags
 
@@ -225,4 +267,8 @@ Contract](remediate-output.md).
 | `AGENT_BOM_OKTA_DISCOVERY` / `AGENT_BOM_ENTRA_DISCOVERY` | Gate `identity discover` and discovered-NHI credential expiry | Only for NHI discovery |
 | `AGENT_BOM_AWS_INVENTORY` / `AGENT_BOM_AZURE_INVENTORY` / `AGENT_BOM_GCP_INVENTORY` | Gate `cloud inventory` and `cloud scan` per provider | Only for cloud connect / estate inventory |
 | `AGENT_BOM_VULN_DB_MAX_AGE_HOURS` / `AGENT_BOM_VULN_DB_OFFLINE` | Staleness threshold and offline override behind the `db freshness` indicator | No |
+| `AGENT_BOM_API_URL` / `AGENT_BOM_API_KEY` / `AGENT_BOM_API_TOKEN` | Control-plane base URL and credentials for `findings push` and MCP bulk ingest | Only for headless push |
+| `AGENT_BOM_PUSH_URL` / `AGENT_BOM_PUSH_API_KEY` | Fleet sync destination (`/v1/fleet/sync`) and bearer token | Only for `fleet sync` |
+| `AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS` | Allow HTTP / loopback outbound URLs for local fleet sync pilots | Only when pushing to local HTTP endpoints |
+| `AGENT_BOM_SKIP_UPDATE_CHECK` / `AGENT_BOM_OFFLINE` | Suppress background PyPI version check on CLI startup | Air-gap / offline installs |
 | `AGENT_BOM_REGISTRY_MAX_IMAGES` / `AGENT_BOM_REGISTRY_MAX_TAGS_PER_REPO` | Cap the `cloud registry-scan` work list | Only for registry sweeps |

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -51,6 +51,8 @@ def test_documented_primary_commands_are_real_cli_surfaces() -> None:
         ["validate", "--help"],
         ["db", "status", "--help"],
         ["skills", "scan", "--help"],
+        ["findings", "push", "--help"],
+        ["fleet", "sync", "--help"],
     ]
 
     for command in commands:


### PR DESCRIPTION
## Summary
- Document `findings push`, `fleet sync`, lifecycle column behavior, and unified `/findings` vs hub API boundaries in `docs/CLI_MAP.md`, `site-docs/reference/cli.md`, endpoint-fleet, and compliance feature docs.
- Refresh `docs/audits/AUDIT-2026-07-03.md` to `main @ a511e5efc` — mark #3482/#3503/#3552–#3554 shipped; record honest product boundaries (conditional lifecycle UI, no hub browser page, fleet HTTPS policy).
- Lock `findings push` and `fleet sync` into public docs CLI alignment tests.

## Test plan
- [x] `uv run pytest -q tests/test_public_docs_cli_alignment.py`
- [x] `git diff --check`

## Notes
- Companion: refresh GitHub #3242 issue body after merge (shipped items checked off; remaining severity/replay/PyPI-flag work only).

Made with [Cursor](https://cursor.com)