### PR TITLE
fix(cli): honor --offline for PyPI check and loopback fleet push

### DIFF
--- a/src/agent_bom/cli/_common.py
+++ b/src/agent_bom/cli/_common.py
@@ -274,11 +274,17 @@ def _update_check_cache_file() -> Path:
 
 def _should_skip_update_check() -> bool:
     import os
+    import sys
 
     truthy = {"1", "true", "yes", "on"}
     if os.environ.get("AGENT_BOM_SKIP_UPDATE_CHECK", "").strip().lower() in truthy:
         return True
     if os.environ.get("AGENT_BOM_OFFLINE", "").strip().lower() in truthy:
+        return True
+    # The update-check thread starts before Click parses subcommand flags, so
+    # honor ``--offline`` on argv for air-gap invocations like
+    # ``agent-bom agents --demo --offline``.
+    if "--offline" in sys.argv:
         return True
     return False
 

--- a/src/agent_bom/push.py
+++ b/src/agent_bom/push.py
@@ -23,6 +23,23 @@ from agent_bom.security import sanitize_command_args, sanitize_env_vars, sanitiz
 
 logger = logging.getLogger(__name__)
 
+_LOCAL_CONTROL_PLANE_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def _validate_push_destination_url(push_url: str) -> None:
+    """Validate fleet/scan push URLs with the same local-pilot carve-out as findings push."""
+    from urllib.parse import urlparse
+
+    from agent_bom.security import validate_url
+
+    host = (urlparse(push_url).hostname or "").lower()
+    allow_local = host in _LOCAL_CONTROL_PLANE_HOSTS
+    validate_url(
+        push_url,
+        allowed_schemes=("https", "http") if allow_local else ("https",),
+        allow_private=allow_local,
+    )
+
 
 def _csv_env(name: str) -> list[str]:
     raw = os.environ.get(name, "").strip()
@@ -172,11 +189,11 @@ async def _push_async(
     controller so both egress paths degrade the same way.
     """
     from agent_bom.http_client import create_client
-    from agent_bom.security import SecurityError, validate_url
+    from agent_bom.security import SecurityError
 
     sanitized = sanitize_results(results)
     try:
-        validate_url(push_url)
+        _validate_push_destination_url(push_url)
     except SecurityError as exc:
         logger.error("Push URL rejected by outbound URL policy: %s", exc)
         return (False, None) if return_body else False

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -155,6 +155,17 @@ def test_check_optional_dep_found_exception():
 # ---------------------------------------------------------------------------
 
 
+def test_should_skip_update_check_honors_offline_argv(monkeypatch):
+    import sys
+
+    from agent_bom.cli._common import _should_skip_update_check
+
+    monkeypatch.delenv("AGENT_BOM_SKIP_UPDATE_CHECK", raising=False)
+    monkeypatch.delenv("AGENT_BOM_OFFLINE", raising=False)
+    monkeypatch.setattr(sys, "argv", ["agent-bom", "agents", "--demo", "--offline"])
+    assert _should_skip_update_check() is True
+
+
 def test_check_for_update_bg_skips_when_offline(monkeypatch):
     import agent_bom.cli._common as mod
     from agent_bom.cli._common import _check_for_update_bg
@@ -170,6 +181,38 @@ def test_check_for_update_bg_skips_when_offline(monkeypatch):
     def _fail_fetch(*args, **kwargs):
         fetch_calls.append("called")
         raise AssertionError("PyPI must not be contacted in offline mode")
+
+    monkeypatch.setattr("agent_bom.http_client.fetch_json", _fail_fetch)
+
+    _check_for_update_bg()
+
+    assert fetch_calls == []
+    assert mod._update_check_result is None
+    assert mod._update_check_done.is_set()
+
+    mod._update_check_result = old_result
+    mod._update_check_done = old_done
+
+
+def test_check_for_update_bg_skips_when_offline_argv(monkeypatch):
+    import sys
+
+    import agent_bom.cli._common as mod
+    from agent_bom.cli._common import _check_for_update_bg
+
+    old_result = mod._update_check_result
+    old_done = mod._update_check_done
+
+    mod._update_check_result = "stale"
+    mod._update_check_done = threading.Event()
+    monkeypatch.delenv("AGENT_BOM_SKIP_UPDATE_CHECK", raising=False)
+    monkeypatch.delenv("AGENT_BOM_OFFLINE", raising=False)
+    monkeypatch.setattr(sys, "argv", ["agent-bom", "agents", "--demo", "--offline"])
+    fetch_calls: list[str] = []
+
+    def _fail_fetch(*args, **kwargs):
+        fetch_calls.append("called")
+        raise AssertionError("PyPI must not be contacted when --offline is on argv")
 
     monkeypatch.setattr("agent_bom.http_client.fetch_json", _fail_fetch)
 

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -271,6 +271,21 @@ class TestPushResults:
         assert result is True
         assert mock_client.post.call_args.args[0] == "http://localhost:8422/v1/results/push"
 
+    def test_push_url_loopback_http_allowed_without_private_egress_override(self):
+        mock_resp = AsyncMock()
+        mock_resp.status_code = 200
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("agent_bom.http_client.create_client", return_value=mock_client):
+            result = push_results("http://127.0.0.1:8422/v1/fleet/sync", {"agents": []})
+
+        assert result is True
+        assert mock_client.post.call_args.args[0] == "http://127.0.0.1:8422/v1/fleet/sync"
+
     def test_push_network_error(self):
         """Network errors retry up to max attempts then return False."""
         mock_client = AsyncMock()


### PR DESCRIPTION
## Summary
- Skip the background PyPI update check when `--offline` is present on `sys.argv`, so `agent-bom agents --demo --offline` is truly air-gap without exporting `AGENT_BOM_OFFLINE` first (#3242).
- Align fleet/scan push URL policy with `findings push`: allow `http://127.0.0.1` / `localhost` / `::1` control-plane URLs without `AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS`.

## Test plan
- [x] `uv run pytest -q tests/test_cli_common.py tests/test_push.py -k "offline or loopback or skip_update or push_url"`
- [x] `uv run ruff check` on touched files

## Notes
- Complements #3555 docs slice (update loopback env-var wording there after this merges).
- Related #3242

Made with [Cursor](https://cursor.com)