### PR TITLE
docs(audit): sync ledger for headless hardening #3556-#3558

### DIFF
--- a/docs/audits/AUDIT-2026-07-03.md
+++ b/docs/audits/AUDIT-2026-07-03.md
@@ -1,7 +1,7 @@
 # agent-bom v0.92.0 — Audit ledger (2026-07-03)
 
 **Scope:** Multi-wave audit 2026-07-02 → 2026-07-05. Live verification against post-fix commits.
-**Baseline:** `main @ a511e5efc` (post reserved-tenant CLI/MCP guard #3554). **Product version:** 0.92.0.
+**Baseline:** `main @ fe3577c37` (post commit-msg hygiene #3558). **Product version:** 0.92.0.
 **Policy:** Canonical model is product truth; OCSF is export/interop only (`docs/OCSF_BOUNDARY.md`). No vendor parity claims in this doc.
 
 ---
@@ -75,6 +75,9 @@
 | **#3552** | Air-gap PyPI update-check skip (env) | **#3552** |
 | **#3553** | Compose `~/.agent-bom` mount for `abom` user | **#3553** |
 | **#3554** | Reserved tenant ids on CLI/MCP resolvers | **#3554** |
+| **#3556** | PyPI `--offline` argv + loopback headless push | **#3556** |
+| **#3557** | MCP `check` version field + token-derived destructive auth | **#3557** |
+| **#3558** | Commit-msg hygiene (no LLM co-author trailers) | **#3558** |
 
 ### Open (remaining from audit)
 
@@ -83,7 +86,7 @@
 | **O** | P3 | No table partitioning | **#3463** | Ledger `compliance_hub_findings`; distinct from current-state sort |
 | **T** | scope | Multi-language reachability; data-lake interop | **#3499** | Parquet/Iceberg + call-graph reachability |
 
-**Epics (cross-cutting):** **#3242** post-audit hardening (severity unification, replay protection, PyPI flag gap); **#3468** guided demo estate; **#3192** graph excellence.
+**Epics (cross-cutting):** **#3242** post-audit hardening (severity unification, OIDC jti replay); **#3468** guided demo estate; **#3192** graph excellence.
 
 ### Documented product boundaries (not wiring bugs)
 
@@ -91,8 +94,10 @@
 |---|---|
 | Lifecycle UI columns | Shown only when `GET /v1/findings` returns bulk-ingest lifecycle metadata; scan-only rows omit `status` / `first_seen` / `last_seen` by design. |
 | Hub findings browser | No dedicated UI for `GET /v1/compliance/hub/findings`; ingested external findings appear in unified `/findings` via `GET /v1/findings`. Compliance page shows hub posture totals. |
-| Fleet sync local pilot | HTTPS outbound policy; loopback HTTP requires `AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS=1` (documented in CLI reference). |
-| PyPI update check | Env skip shipped (#3552); subcommand `--offline` does not suppress the pre-parse background check — use env vars in air-gap shells. |
+| Fleet sync local pilot | Loopback HTTP allowed for localhost push/sync without extra env (#3556); remote destinations require HTTPS. |
+| PyPI update check | Env skip (#3552) and `--offline` argv (#3556) both suppress the pre-parse background check. |
+| Async report export | Local NDJSON fallback by default; set `AGENT_BOM_REPORT_S3_BUCKET` for presigned S3 artifacts (#3542). |
+| Headless auth replay | SAML relay + assertion digest one-time (#3478); MCP bearer expiry (#3557); webhook signatures include `x-agent-bom-timestamp` (`delivery.py`). OIDC `jti` one-time consumption tracked on **#3242**. |
 
 ### New gaps filed (Fable consolidated audit — all shipped or tracked above)
 
@@ -104,7 +109,7 @@
 | **P2** | Reference-table normalization | **#3513** | **Closed** — #3528 |
 | **P2** | Delta-stream connector | **#3514** | **Closed** — #3531 |
 
-**Cross-cutting (tracked on #3242):** severity unification; replay protection (SAML/JWT jti, MCP bearer expiry); PyPI update-check `--offline` flag gap; fleet-sync vs findings-push URL policy consistency; MCP `operator_role` audit metadata vs authenticated actor.
+**Cross-cutting (tracked on #3242):** severity unification (#3559 in flight); OIDC JWT `jti` one-time consumption; epics **#3463**, **#3499**.
 
 ---
 
@@ -135,7 +140,7 @@
 
 1. **#3463** — declarative partitioning + retention rollover
 2. **#3499** — reachability + data-lake interop epic
-3. **#3242** — post-audit hardening (severity, replay protection, PyPI flag gap)
+3. **#3242** — post-audit hardening (severity slice #3559; OIDC jti replay)
 4. **#3468** — guided activation + labeled demo estate (UI)
 5. **#3192** — graph excellence epic
 
@@ -150,11 +155,11 @@
 | `/v1/findings?limit=500` egress | ~319 KB uncompressed; ~23 KB gzipped (post-#3516) |
 | Read latency | ~38 ms / 500 rows over 50k; keyset path #3511 |
 
-**Shipped wins:** #3486, #3487, #3485, #3510, #3511, #3545–#3554 (lifecycle headless + UI, fleet sync, air-gap env skip, compose mount, tenant guard).
+**Shipped wins:** #3486, #3487, #3485, #3510, #3511, #3545–#3558 (lifecycle headless + UI, fleet sync, air-gap/offline, compose mount, tenant guard, MCP headless hardening, commit hygiene).
 
 ---
 
-## §F. Fable consolidated audit — re-validation (`main @ a511e5efc`)
+## §F. Fable consolidated audit — re-validation (`main @ fe3577c37`)
 
 Hands-on re-validation (clean install, API scan, MCP/proxy/gateway, UI build, read-path probe). **No functional defects** on MCP surface (70 tools / 6 resources / 8 prompts confirmed).
 
@@ -170,15 +175,19 @@ Hands-on re-validation (clean install, API scan, MCP/proxy/gateway, UI build, re
 | Air-gap PyPI check (env) | `AGENT_BOM_SKIP_UPDATE_CHECK` / `AGENT_BOM_OFFLINE` | **#3242** → #3552 |
 | Compose state loss | `~/.agent-bom:/home/abom/.agent-bom` mount | **#3242** → #3553 |
 | Reserved tenant on CLI/MCP | `platform_invariants` validation | **#3242** → #3554 |
+| PyPI check on `agents --offline` | `_should_skip_update_check()` honors `--offline` in argv | **#3242** → #3556 |
+| Loopback headless push | localhost HTTP without private-egress env | **#3242** → #3556 |
+| MCP `check` version discoverability | optional `version` + embedded spec | **#3557** |
+| MCP destructive auth | token-derived scopes; `operator_role` audit-only | **#3557** |
+| LLM co-author in git history | commit-msg + prepare-commit-msg hooks | **#3558** |
 
 ### Make-it-true overclaims (wire or narrow)
 
 | Claim | Action |
 |---|---|
 | CWE-aware reachability (README) | Precise wording or ship call-graph path (**#3499**) |
-| PyPI check on `agents --offline` | Env skip shipped; extend `_should_skip_update_check()` for `--offline` in `sys.argv` (**#3242**) |
 | Dedicated hub-findings UI | Document unified `/findings` queue; hub API for integrators only |
 
 ---
 
-_Sanitized from consolidated audit dossier 2026-07-03. Vendor parity sections omitted per repo policy. Last ledger sync: 2026-07-05 (post #3554 merge; docs slice for headless ingest boundaries)._
+_Sanitized from consolidated audit dossier 2026-07-03. Vendor parity sections omitted per repo policy. Last ledger sync: 2026-07-05 (post #3558 merge; headless #3556/#3557 validated)._


### PR DESCRIPTION
## Summary
- Sync `docs/audits/AUDIT-2026-07-03.md` to `main @ fe3577c37`.
- Mark #3556–#3558 shipped (offline argv, loopback push, MCP version/auth, commit hygiene).
- Update product boundaries for async S3 export and headless replay posture.

## Test plan
- [x] `git diff --check`

## Notes
- Part of #3242 — ledger hygiene only; does not close the epic.