### PR TITLE
docs(audit): sync ledger post #3561 OIDC jti replay

### DIFF
--- a/docs/audits/AUDIT-2026-07-03.md
+++ b/docs/audits/AUDIT-2026-07-03.md
@@ -1,7 +1,7 @@
 # agent-bom v0.92.0 — Audit ledger (2026-07-03)
 
 **Scope:** Multi-wave audit 2026-07-02 → 2026-07-05. Live verification against post-fix commits.
-**Baseline:** `main @ fe3577c37` (post commit-msg hygiene #3558). **Product version:** 0.92.0.
+**Baseline:** `main @ 009a35573` (post OIDC jti replay #3561). **Product version:** 0.92.0.
 **Policy:** Canonical model is product truth; OCSF is export/interop only (`docs/OCSF_BOUNDARY.md`). No vendor parity claims in this doc.
 
 ---
@@ -78,6 +78,8 @@
 | **#3556** | PyPI `--offline` argv + loopback headless push | **#3556** |
 | **#3557** | MCP `check` version field + token-derived destructive auth | **#3557** |
 | **#3558** | Commit-msg hygiene (no LLM co-author trailers) | **#3558** |
+| **#3559** | Severity slice: `console_render` uses `severity_rank()` | **#3559** |
+| **#3561** | OIDC JWT `jti` one-time consumption (replay) | **#3561** |
 
 ### Open (remaining from audit)
 
@@ -86,7 +88,7 @@
 | **O** | P3 | No table partitioning | **#3463** | Ledger `compliance_hub_findings`; distinct from current-state sort |
 | **T** | scope | Multi-language reachability; data-lake interop | **#3499** | Parquet/Iceberg + call-graph reachability |
 
-**Epics (cross-cutting):** **#3242** post-audit hardening (severity unification, OIDC jti replay); **#3468** guided demo estate; **#3192** graph excellence.
+**Epics (cross-cutting):** **#3242** post-audit hardening (severity unification — #3559/#3562 in flight); **#3468** guided demo estate; **#3192** graph excellence.
 
 ### Documented product boundaries (not wiring bugs)
 
@@ -97,7 +99,7 @@
 | Fleet sync local pilot | Loopback HTTP allowed for localhost push/sync without extra env (#3556); remote destinations require HTTPS. |
 | PyPI update check | Env skip (#3552) and `--offline` argv (#3556) both suppress the pre-parse background check. |
 | Async report export | Local NDJSON fallback by default; set `AGENT_BOM_REPORT_S3_BUCKET` for presigned S3 artifacts (#3542). |
-| Headless auth replay | SAML relay + assertion digest one-time (#3478); MCP bearer expiry (#3557); webhook signatures include `x-agent-bom-timestamp` (`delivery.py`). OIDC `jti` one-time consumption tracked on **#3242**. |
+| Headless auth replay | SAML relay + assertion digest (#3478); MCP bearer expiry (#3557); webhook timestamps; OIDC `jti` one-time (#3561). |
 
 ### New gaps filed (Fable consolidated audit — all shipped or tracked above)
 
@@ -109,7 +111,7 @@
 | **P2** | Reference-table normalization | **#3513** | **Closed** — #3528 |
 | **P2** | Delta-stream connector | **#3514** | **Closed** — #3531 |
 
-**Cross-cutting (tracked on #3242):** severity unification (#3559 in flight); OIDC JWT `jti` one-time consumption; epics **#3463**, **#3499**.
+**Cross-cutting (tracked on #3242):** severity unification (#3559 shipped, #3562 in flight); epics **#3463**, **#3499**.
 
 ---
 
@@ -180,6 +182,8 @@ Hands-on re-validation (clean install, API scan, MCP/proxy/gateway, UI build, re
 | MCP `check` version discoverability | optional `version` + embedded spec | **#3557** |
 | MCP destructive auth | token-derived scopes; `operator_role` audit-only | **#3557** |
 | LLM co-author in git history | commit-msg + prepare-commit-msg hooks | **#3558** |
+| OIDC JWT replay | `jti` one-time via `shared_auth_state` | **#3561** |
+| Severity slice (console_render) | `severity_rank()` in remediation plan | **#3559** |
 
 ### Make-it-true overclaims (wire or narrow)
 
@@ -190,4 +194,4 @@ Hands-on re-validation (clean install, API scan, MCP/proxy/gateway, UI build, re
 
 ---
 
-_Sanitized from consolidated audit dossier 2026-07-03. Vendor parity sections omitted per repo policy. Last ledger sync: 2026-07-05 (post #3558 merge; headless #3556/#3557 validated)._
+_Sanitized from consolidated audit dossier 2026-07-03. Vendor parity sections omitted per repo policy. Last ledger sync: 2026-07-05 (post #3561 merge)._


### PR DESCRIPTION
## Summary
- Refresh audit ledger baseline to `main @ 009a35573`.
- Mark #3559 and #3561 shipped; replay protection row complete.

## Test plan
- [x] `git diff --check`

## Notes
- Part of #3242 tracker hygiene.

Made with [Cursor](https://cursor.com)