### PR TITLE
feat(plugins): runtime activation for opt-in plugin entry points

### DIFF
--- a/docs/PLUGIN_ENTRYPOINTS.md
+++ b/docs/PLUGIN_ENTRYPOINTS.md
@@ -24,11 +24,58 @@ installed entry-point declarations, and whether opt-in loading is enabled.
 
 ## Supported Groups
 
-| Group | Purpose | Default runtime behavior |
-|---|---|---|
-| `agent_bom.mcp_tools` | Advertise an MCP tool registration module and function. | Not registered on the live MCP server. |
-| `agent_bom.advisory_sources` | Advertise a private advisory lookup or sync source. | Not queried during scans. |
-| `agent_bom.runtime_emitters` | Advertise a runtime event emitter. | Not added to proxy, gateway, or alert dispatch. |
+| Group | Purpose | Default runtime behavior | Activation flag |
+|---|---|---|---|
+| `agent_bom.mcp_tools` | Advertise an MCP tool registration module and function. | Not registered on the live MCP server. | `AGENT_BOM_ACTIVATE_MCP_TOOL_PLUGINS` |
+| `agent_bom.advisory_sources` | Advertise a private advisory lookup or sync source. | Not queried during scans. | `AGENT_BOM_ACTIVATE_ADVISORY_SOURCE_PLUGINS` |
+| `agent_bom.runtime_emitters` | Advertise a runtime event emitter. | Not added to proxy, gateway, or alert dispatch. | `AGENT_BOM_ACTIVATE_RUNTIME_EMITTER_PLUGINS` |
+
+## Runtime Activation
+
+Discovery is metadata-only: it never imports or runs third-party plugin code.
+Runtime activation is a **second, explicit opt-in** on top of discovery. A group
+activates only when both `AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS` (discovery) and
+that group's activation flag are set. With no activation flag set, every surface
+below is a no-op and default behavior is unchanged.
+
+```bash
+# Register discovered third-party MCP tools on the live MCP server.
+AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS=true \
+AGENT_BOM_ACTIVATE_MCP_TOOL_PLUGINS=true \
+  agent-bom mcp
+
+# Augment `intel lookup` with operator-owned advisory sources.
+AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS=true \
+AGENT_BOM_ACTIVATE_ADVISORY_SOURCE_PLUGINS=true agent-bom ...
+
+# Fan runtime observations out to operator-owned event emitters.
+AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS=true \
+AGENT_BOM_ACTIVATE_RUNTIME_EMITTER_PLUGINS=true agent-bom serve
+```
+
+Activation surfaces, per group:
+
+- **MCP tools** — each activated plugin's `register_attr` (default `register_tools`)
+  is called with the live server during `create_mcp_server`; plugin-added tools
+  are then hardened with the same strict-argument contract as built-ins.
+- **Advisory sources** — the `intel lookup` MCP tool calls each activated source's
+  `lookup_attr` (default `lookup`) and appends provenance-tagged records under
+  `operator_advisory_sources`. The deterministic local result is never replaced.
+- **Runtime emitters** — every persisted runtime observation is forwarded to each
+  activated emitter's `emit_attr` (default `emit`) as a **redacted routing
+  envelope** (`runtime.emitter_envelope.v1`) that carries only metadata — never
+  raw prompts, tool arguments, or credential values.
+
+Every activation is isolated: an import, binding, or invocation failure in one
+plugin is sanitized into a warning and never crashes the server or scan, and one
+failing plugin does not stop the others. Inspect the live wiring with:
+
+```bash
+agent-bom plugins activation --format json
+```
+
+The `agent-bom plugins status` view also reports each group's `activation_enabled`
+state so operators can see what would run before enabling it.
 
 The registry status view also includes existing built-in extension groups:
 `agent_bom.cloud_providers`, `agent_bom.connectors`, and

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -124,6 +124,9 @@ so they cannot regress silently, but they are not part of this reference.
 ## Extension Loading
 | Env var | Type | Default | Description |
 |---|---|---|---|
+| `AGENT_BOM_ACTIVATE_ADVISORY_SOURCE_PLUGINS` | `bool` | `False` | — |
+| `AGENT_BOM_ACTIVATE_MCP_TOOL_PLUGINS` | `bool` | `False` | Per-group runtime activation for discovered plugin entry points. Each is a second, explicit opt-in on top of discovery: even with discovery enabled, an operator must set the group flag before agent-bom binds and executes a third-party MCP t |
+| `AGENT_BOM_ACTIVATE_RUNTIME_EMITTER_PLUGINS` | `bool` | `False` | — |
 | `AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS` | `bool` | `False` | Disabled by default so third-party provider/connector/parser entry points never execute unless an operator explicitly opts in. |
 
 ## Graph Backend Selection

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -323,7 +323,16 @@ def _persist_runtime_observations(events: list[dict[str, Any]], *, tenant_id: st
         return 0
     store = get_runtime_event_store()
     records = [_runtime_observation_from_event(event, tenant_id=tenant_id, source=source) for event in events]
-    return store.put_observations_batch(records)
+    persisted = store.put_observations_batch(records)
+    # Opt-in runtime emitter plugins receive a redacted routing envelope per
+    # persisted observation (off by default; see plugin_activation). Never lets
+    # a third-party emitter failure affect the persisted ingest result.
+    from agent_bom.plugin_activation import fan_out_runtime_event, runtime_emitter_activation_enabled
+
+    if runtime_emitter_activation_enabled():
+        for record in records:
+            fan_out_runtime_event(record)
+    return persisted
 
 
 def _finish_ocsf_ingest(normalized_events: list[dict[str, Any]], *, tenant_id: str) -> None:

--- a/src/agent_bom/cli/_plugins.py
+++ b/src/agent_bom/cli/_plugins.py
@@ -7,6 +7,7 @@ import json
 import click
 
 from agent_bom.cli._grouped_help import SuggestingGroup
+from agent_bom.plugin_activation import plugin_activation_status
 from agent_bom.plugin_entrypoints import plugin_registry_status
 
 
@@ -40,11 +41,41 @@ def plugins_status_cmd(output_format: str) -> None:
     for group in status["groups"]:
         click.echo(f"{group['group']}")
         click.echo(f"  {group['description']}")
-        click.echo(f"  builtin={group['builtin_count']} declared_entrypoints={group['declared_entrypoint_count']}")
+        click.echo(
+            f"  builtin={group['builtin_count']} declared_entrypoints={group['declared_entrypoint_count']} "
+            f"activation_enabled={str(group.get('activation_enabled', False)).lower()}"
+        )
         for entry in group["declared_entrypoints"]:
             value = f" -> {entry['value']}" if entry["value"] else ""
             distribution = f" ({entry['distribution']})" if entry["distribution"] else ""
             click.echo(f"  - {entry['name']}{value}{distribution}")
+    if status["warnings"]:
+        click.echo("")
+        click.echo("Warnings:")
+        for warning in status["warnings"]:
+            click.echo(f"  - {warning}")
+
+
+@plugins_group.command("activation")
+@click.option("-f", "--format", "output_format", type=click.Choice(["console", "json"]), default="console", show_default=True)
+def plugins_activation_cmd(output_format: str) -> None:
+    """Show which discovered plugin groups are activated and bound at runtime."""
+
+    status = plugin_activation_status()
+    if output_format == "json":
+        click.echo(json.dumps(status, indent=2, sort_keys=True))
+        return
+
+    click.echo("Plugin activation status")
+    click.echo(f"  schema_version:      {status['schema_version']}")
+    click.echo(f"  discovery_enabled:   {str(status['discovery_enabled']).lower()}")
+    click.echo(f"  activated_plugins:   {status['totals']['activated_plugins']}")
+    click.echo("")
+    for group in status["groups"]:
+        click.echo(f"{group['group']}")
+        click.echo(f"  activation_env={group['activation_env']} enabled={str(group['enabled']).lower()}")
+        for name in group["activated_plugins"]:
+            click.echo(f"  - {name}")
     if status["warnings"]:
         click.echo("")
         click.echo("Warnings:")

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -54,6 +54,14 @@ def _str(env_key: str, default: str) -> str:
 
 ENABLE_EXTENSION_ENTRYPOINTS = _bool("AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS", False)
 
+# Per-group runtime activation for discovered plugin entry points. Each is a
+# second, explicit opt-in on top of discovery: even with discovery enabled, an
+# operator must set the group flag before agent-bom binds and executes a
+# third-party MCP tool, advisory source, or runtime emitter. Off by default.
+ACTIVATE_MCP_TOOL_PLUGINS = _bool("AGENT_BOM_ACTIVATE_MCP_TOOL_PLUGINS", False)
+ACTIVATE_ADVISORY_SOURCE_PLUGINS = _bool("AGENT_BOM_ACTIVATE_ADVISORY_SOURCE_PLUGINS", False)
+ACTIVATE_RUNTIME_EMITTER_PLUGINS = _bool("AGENT_BOM_ACTIVATE_RUNTIME_EMITTER_PLUGINS", False)
+
 
 # ── OS-package reporting ──────────────────────────────────────────────────────
 # When False (default), OS/distro advisories with no fix for the scanned release

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -1134,6 +1134,15 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
 
     harden_tool_arguments(mcp)
 
+    # Opt-in third-party MCP tool plugins (off by default). Requires both
+    # AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS and AGENT_BOM_ACTIVATE_MCP_TOOL_PLUGINS.
+    from agent_bom.plugin_activation import activate_mcp_tool_plugins
+
+    activated = activate_mcp_tool_plugins(mcp)
+    if activated:
+        logger.info("Activated %d third-party MCP tool plugin(s): %s", len(activated), ", ".join(sorted(activated)))
+        harden_tool_arguments(mcp)
+
     return mcp
 
 

--- a/src/agent_bom/mcp_tools/intel.py
+++ b/src/agent_bom/mcp_tools/intel.py
@@ -19,7 +19,15 @@ async def intel_lookup_impl(*, advisory_id: str, _truncate_response=lambda value
         advisory = (advisory_id or "").strip()
         if not advisory:
             return mcp_error_json(CODE_VALIDATION_INVALID_ARGUMENT, "advisory_id is required", details={"argument": "advisory_id"})
-        return _truncate_response(json.dumps(lookup_advisory(advisory), indent=2, default=str))
+        result = lookup_advisory(advisory)
+        # Opt-in operator advisory source plugins augment the local record with
+        # provenance-tagged metadata (off by default; see plugin_activation).
+        from agent_bom.plugin_activation import advisory_source_lookup
+
+        operator_sources = advisory_source_lookup(advisory)
+        if operator_sources and isinstance(result, dict):
+            result = {**result, "operator_advisory_sources": operator_sources}
+        return _truncate_response(json.dumps(result, indent=2, default=str))
     except ValueError as exc:
         return mcp_error_json(CODE_VALIDATION_INVALID_ARGUMENT, sanitize_error(exc), details={"argument": "advisory_id"})
     except Exception as exc:  # pragma: no cover - defensive redaction

--- a/src/agent_bom/plugin_activation.py
+++ b/src/agent_bom/plugin_activation.py
@@ -1,0 +1,403 @@
+"""Opt-in runtime activation for discovered plugin entry points.
+
+Discovery (``plugin_entrypoints``) is metadata-only: it enumerates installed
+third-party MCP tools, advisory sources, and runtime emitters without executing
+them. This module is the *activation* seam. It imports the operator-owned
+implementation module a registration advertises, binds its declared callables,
+and exposes bounded fan-out helpers that the live MCP server, threat-intel
+lookup, and runtime ingest paths call.
+
+Activation is doubly gated and off by default:
+
+1. ``AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS`` must enable discovery, and
+2. the per-group activation flag must be set:
+   - ``AGENT_BOM_ACTIVATE_MCP_TOOL_PLUGINS``
+   - ``AGENT_BOM_ACTIVATE_ADVISORY_SOURCE_PLUGINS``
+   - ``AGENT_BOM_ACTIVATE_RUNTIME_EMITTER_PLUGINS``
+
+When a group is not activated the helpers are no-ops, so default behavior is
+unchanged. Import, binding, and invocation failures are non-fatal: they are
+sanitized into warnings and the deterministic core keeps running.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from agent_bom.extensions import entrypoint_extensions_enabled, sanitize_registry_warning
+from agent_bom.plugin_entrypoints import (
+    ADVISORY_SOURCES_ENTRY_POINT_GROUP,
+    MAX_PLUGIN_ENTRY_POINTS_PER_GROUP,
+    MCP_TOOLS_ENTRY_POINT_GROUP,
+    RUNTIME_EMITTERS_ENTRY_POINT_GROUP,
+    AdvisorySourcePluginRegistration,
+    McpToolPluginRegistration,
+    RuntimeEmitterPluginRegistration,
+    list_advisory_source_plugins,
+    list_mcp_tool_plugins,
+    list_runtime_emitter_plugins,
+)
+from agent_bom.security import sanitize_text
+
+ACTIVATE_MCP_TOOL_PLUGINS_ENV = "AGENT_BOM_ACTIVATE_MCP_TOOL_PLUGINS"
+ACTIVATE_ADVISORY_SOURCE_PLUGINS_ENV = "AGENT_BOM_ACTIVATE_ADVISORY_SOURCE_PLUGINS"
+ACTIVATE_RUNTIME_EMITTER_PLUGINS_ENV = "AGENT_BOM_ACTIVATE_RUNTIME_EMITTER_PLUGINS"
+
+PLUGIN_ACTIVATION_STATUS_SCHEMA_VERSION = "agent-bom.plugin_activation_status.v1"
+
+# Bound results returned to a plugin call are metadata envelopes; cap how much
+# a third-party plugin can push back into a control-plane response.
+_MAX_PLUGIN_RESULT_ITEMS = 32
+
+
+@dataclass(frozen=True)
+class ActivatedMcpToolPlugin:
+    """A discovered MCP tool plugin bound to its ``register`` callable."""
+
+    name: str
+    register: Callable[[Any], Any]
+
+
+@dataclass(frozen=True)
+class ActivatedAdvisorySource:
+    """A discovered advisory source bound to its ``lookup``/``sync`` callables."""
+
+    name: str
+    lookup: Callable[..., Any]
+    sync: Callable[..., Any] | None
+
+
+@dataclass(frozen=True)
+class ActivatedRuntimeEmitter:
+    """A discovered runtime emitter bound to its ``emit``/``flush`` callables."""
+
+    name: str
+    emit: Callable[..., Any]
+    flush: Callable[..., Any] | None
+
+
+_ACTIVATION_WARNINGS: list[str] = []
+
+
+def _truthy(env_var: str) -> bool:
+    return os.getenv(env_var, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def mcp_tool_activation_enabled() -> bool:
+    """Return True when MCP tool plugins may register on the live server."""
+
+    return entrypoint_extensions_enabled() and _truthy(ACTIVATE_MCP_TOOL_PLUGINS_ENV)
+
+
+def advisory_source_activation_enabled() -> bool:
+    """Return True when advisory source plugins may be queried."""
+
+    return entrypoint_extensions_enabled() and _truthy(ACTIVATE_ADVISORY_SOURCE_PLUGINS_ENV)
+
+
+def runtime_emitter_activation_enabled() -> bool:
+    """Return True when runtime emitter plugins may receive events."""
+
+    return entrypoint_extensions_enabled() and _truthy(ACTIVATE_RUNTIME_EMITTER_PLUGINS_ENV)
+
+
+def _warn(message: str) -> None:
+    _ACTIVATION_WARNINGS.append(sanitize_registry_warning(message))
+
+
+def _resolve_attr(module_name: str, attr: str, *, plugin: str) -> Callable[..., Any] | None:
+    """Import *module_name* and return its *attr* callable, or None on failure."""
+
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as exc:  # noqa: BLE001 - third-party import must not crash us
+        _warn(f"Could not import module for plugin {plugin}: {exc}")
+        return None
+    candidate = getattr(module, attr, None)
+    if not callable(candidate):
+        _warn(f"Plugin {plugin} does not expose a callable '{attr}' attribute")
+        return None
+    return candidate
+
+
+def _capped(registrations: list[Any]) -> list[Any]:
+    return registrations[:MAX_PLUGIN_ENTRY_POINTS_PER_GROUP]
+
+
+def activated_mcp_tool_plugins() -> list[ActivatedMcpToolPlugin]:
+    """Bind discovered MCP tool plugins to their register callables."""
+
+    if not mcp_tool_activation_enabled():
+        return []
+    bound: list[ActivatedMcpToolPlugin] = []
+    plugins: list[McpToolPluginRegistration] = _capped(list_mcp_tool_plugins())
+    for plugin in plugins:
+        register = _resolve_attr(plugin.module, plugin.register_attr, plugin=plugin.name)
+        if register is not None:
+            bound.append(ActivatedMcpToolPlugin(name=plugin.name, register=register))
+    return bound
+
+
+def activated_advisory_sources() -> list[ActivatedAdvisorySource]:
+    """Bind discovered advisory sources to their lookup/sync callables."""
+
+    if not advisory_source_activation_enabled():
+        return []
+    bound: list[ActivatedAdvisorySource] = []
+    plugins: list[AdvisorySourcePluginRegistration] = _capped(list_advisory_source_plugins())
+    for plugin in plugins:
+        lookup = _resolve_attr(plugin.module, plugin.lookup_attr, plugin=plugin.name)
+        if lookup is None:
+            continue
+        sync = getattr(importlib.import_module(plugin.module), plugin.sync_attr, None)
+        bound.append(
+            ActivatedAdvisorySource(
+                name=plugin.name,
+                lookup=lookup,
+                sync=sync if callable(sync) else None,
+            )
+        )
+    return bound
+
+
+def activated_runtime_emitters() -> list[ActivatedRuntimeEmitter]:
+    """Bind discovered runtime emitters to their emit/flush callables."""
+
+    if not runtime_emitter_activation_enabled():
+        return []
+    bound: list[ActivatedRuntimeEmitter] = []
+    plugins: list[RuntimeEmitterPluginRegistration] = _capped(list_runtime_emitter_plugins())
+    for plugin in plugins:
+        emit = _resolve_attr(plugin.module, plugin.emit_attr, plugin=plugin.name)
+        if emit is None:
+            continue
+        flush = getattr(importlib.import_module(plugin.module), plugin.flush_attr, None)
+        bound.append(
+            ActivatedRuntimeEmitter(
+                name=plugin.name,
+                emit=emit,
+                flush=flush if callable(flush) else None,
+            )
+        )
+    return bound
+
+
+def activate_mcp_tool_plugins(mcp: Any) -> list[str]:
+    """Register activated MCP tool plugins on a live FastMCP-compatible server.
+
+    Returns the names of plugins that registered successfully. A plugin whose
+    ``register`` callable raises is skipped with a sanitized warning; the rest
+    of the server stays intact.
+    """
+
+    registered: list[str] = []
+    for plugin in activated_mcp_tool_plugins():
+        try:
+            plugin.register(mcp)
+        except Exception as exc:  # noqa: BLE001 - one bad plugin must not break the server
+            _warn(f"MCP tool plugin {plugin.name} failed to register: {exc}")
+            continue
+        registered.append(plugin.name)
+    return registered
+
+
+def _bounded_result(value: Any) -> Any:
+    """Bound and shallow-sanitize a value returned by a third-party plugin."""
+
+    if isinstance(value, dict):
+        bounded: dict[str, Any] = {}
+        for key in list(value)[:_MAX_PLUGIN_RESULT_ITEMS]:
+            bounded[sanitize_text(str(key), max_len=120)] = _bounded_result(value[key])
+        return bounded
+    if isinstance(value, list):
+        return [_bounded_result(item) for item in value[:_MAX_PLUGIN_RESULT_ITEMS]]
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    return sanitize_text(str(value), max_len=500)
+
+
+def advisory_source_lookup(advisory_id: str) -> list[dict[str, Any]]:
+    """Fan an advisory lookup out to activated operator advisory sources.
+
+    Returns one provenance-tagged record per source. Empty (a no-op) unless
+    advisory source activation is enabled. Never raises: a failing source is
+    reported inline with an ``error`` marker instead of aborting the lookup.
+    """
+
+    advisory = (advisory_id or "").strip()
+    if not advisory:
+        return []
+    results: list[dict[str, Any]] = []
+    for source in activated_advisory_sources():
+        record: dict[str, Any] = {"source": source.name, "provenance": "operator_advisory_plugin"}
+        try:
+            record["result"] = _bounded_result(source.lookup(advisory))
+        except Exception as exc:  # noqa: BLE001 - isolate third-party failures
+            message = sanitize_text(str(exc), max_len=200)
+            _warn(f"Advisory source {source.name} lookup failed: {exc}")
+            record["error"] = message
+        results.append(record)
+    return results
+
+
+def _runtime_event_envelope(observation: Any) -> dict[str, Any]:
+    """Build a redacted routing envelope for a runtime observation.
+
+    Only metadata routing fields are forwarded: never raw prompts, tool
+    arguments, or credential values. Mirrors the ``redacted_payloads`` guarantee
+    declared by runtime emitter plugins.
+    """
+
+    getter = observation.get if isinstance(observation, dict) else lambda key, default=None: getattr(observation, key, default)
+    return {
+        "schema_version": "runtime.emitter_envelope.v1",
+        "tenant_id": sanitize_text(str(getter("tenant_id", "") or "default"), max_len=120),
+        "observation_id": sanitize_text(str(getter("observation_id", "") or ""), max_len=200),
+        "session_id": sanitize_text(str(getter("session_id", "") or ""), max_len=200),
+        "observed_at": sanitize_text(str(getter("observed_at", "") or ""), max_len=80),
+        "source": sanitize_text(str(getter("source", "") or ""), max_len=120),
+        "surface": sanitize_text(str(getter("surface", "") or "runtime"), max_len=80),
+        "event_type": sanitize_text(str(getter("event_type", "") or "runtime_event"), max_len=120),
+        "severity": sanitize_text(str(getter("severity", "") or "unknown"), max_len=40),
+        "verdict": sanitize_text(str(getter("verdict", "") or "observed"), max_len=80),
+        "tool": sanitize_text(str(getter("tool_name", "") or ""), max_len=200),
+        "agent": sanitize_text(str(getter("agent_name", "") or ""), max_len=200),
+        "redaction_status": "metadata_only",
+    }
+
+
+def fan_out_runtime_event(observation: Any) -> int:
+    """Forward a redacted runtime event envelope to activated emitters.
+
+    ``observation`` may be a ``RuntimeObservationRecord`` or a plain dict.
+    Returns the number of emitters that accepted the envelope. Never raises:
+    default deployments (no activation) return 0 with zero overhead.
+    """
+
+    emitters = activated_runtime_emitters()
+    if not emitters:
+        return 0
+    envelope = _runtime_event_envelope(observation)
+    delivered = 0
+    for emitter in emitters:
+        try:
+            emitter.emit(envelope)
+        except Exception as exc:  # noqa: BLE001 - isolate third-party failures
+            _warn(f"Runtime emitter {emitter.name} failed to emit: {exc}")
+            continue
+        delivered += 1
+    return delivered
+
+
+def flush_runtime_emitters() -> dict[str, Any]:
+    """Flush all activated runtime emitters, isolating per-emitter failures."""
+
+    flushed: list[str] = []
+    failed: list[str] = []
+    for emitter in activated_runtime_emitters():
+        if emitter.flush is None:
+            continue
+        try:
+            emitter.flush()
+        except Exception as exc:  # noqa: BLE001 - isolate third-party failures
+            _warn(f"Runtime emitter {emitter.name} failed to flush: {exc}")
+            failed.append(emitter.name)
+            continue
+        flushed.append(emitter.name)
+    return {"flushed": sorted(flushed), "failed": sorted(failed)}
+
+
+def plugin_activation_warnings() -> list[str]:
+    """Return sanitized non-fatal activation warnings collected this process."""
+
+    return list(_ACTIVATION_WARNINGS)
+
+
+def activation_flags() -> dict[str, bool]:
+    """Return the per-group activation flag state (pure env read, no imports)."""
+
+    return {
+        MCP_TOOLS_ENTRY_POINT_GROUP: mcp_tool_activation_enabled(),
+        ADVISORY_SOURCES_ENTRY_POINT_GROUP: advisory_source_activation_enabled(),
+        RUNTIME_EMITTERS_ENTRY_POINT_GROUP: runtime_emitter_activation_enabled(),
+    }
+
+
+def plugin_activation_status() -> dict[str, Any]:
+    """Return activation status, binding activated plugins to report live counts.
+
+    Unlike ``plugin_registry_status`` (strictly metadata-only), this binds the
+    callables for activated groups so operators can confirm what is wired. Groups
+    that are not activated report zero activated plugins without importing any
+    third-party module.
+    """
+
+    group_bindings: list[tuple[str, str, bool, list[str]]] = [
+        (
+            MCP_TOOLS_ENTRY_POINT_GROUP,
+            ACTIVATE_MCP_TOOL_PLUGINS_ENV,
+            mcp_tool_activation_enabled(),
+            [plugin.name for plugin in activated_mcp_tool_plugins()],
+        ),
+        (
+            ADVISORY_SOURCES_ENTRY_POINT_GROUP,
+            ACTIVATE_ADVISORY_SOURCE_PLUGINS_ENV,
+            advisory_source_activation_enabled(),
+            [source.name for source in activated_advisory_sources()],
+        ),
+        (
+            RUNTIME_EMITTERS_ENTRY_POINT_GROUP,
+            ACTIVATE_RUNTIME_EMITTER_PLUGINS_ENV,
+            runtime_emitter_activation_enabled(),
+            [emitter.name for emitter in activated_runtime_emitters()],
+        ),
+    ]
+    groups: list[dict[str, Any]] = [
+        {
+            "group": group,
+            "activation_env": activation_env,
+            "enabled": enabled,
+            "activated_plugins": names,
+            "activated_count": len(names),
+        }
+        for group, activation_env, enabled, names in group_bindings
+    ]
+    return {
+        "schema_version": PLUGIN_ACTIVATION_STATUS_SCHEMA_VERSION,
+        "discovery_enabled": entrypoint_extensions_enabled(),
+        "totals": {"activated_plugins": sum(len(names) for *_, names in group_bindings)},
+        "groups": groups,
+        "warnings": plugin_activation_warnings(),
+    }
+
+
+def _reset_plugin_activation_for_tests() -> None:
+    _ACTIVATION_WARNINGS.clear()
+
+
+__all__ = [
+    "ACTIVATE_ADVISORY_SOURCE_PLUGINS_ENV",
+    "ACTIVATE_MCP_TOOL_PLUGINS_ENV",
+    "ACTIVATE_RUNTIME_EMITTER_PLUGINS_ENV",
+    "PLUGIN_ACTIVATION_STATUS_SCHEMA_VERSION",
+    "ActivatedAdvisorySource",
+    "ActivatedMcpToolPlugin",
+    "ActivatedRuntimeEmitter",
+    "activate_mcp_tool_plugins",
+    "activated_advisory_sources",
+    "activated_mcp_tool_plugins",
+    "activated_runtime_emitters",
+    "activation_flags",
+    "advisory_source_activation_enabled",
+    "advisory_source_lookup",
+    "fan_out_runtime_event",
+    "flush_runtime_emitters",
+    "mcp_tool_activation_enabled",
+    "plugin_activation_status",
+    "plugin_activation_warnings",
+    "runtime_emitter_activation_enabled",
+]

--- a/src/agent_bom/plugin_entrypoints.py
+++ b/src/agent_bom/plugin_entrypoints.py
@@ -301,6 +301,9 @@ def plugin_registry_status() -> dict[str, Any]:
     ``AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS``.
     """
 
+    from agent_bom.plugin_activation import activation_flags
+
+    activation = activation_flags()
     warnings: list[str] = []
     builtin_counts = _builtin_registry_counts()
     groups: list[dict[str, Any]] = []
@@ -318,6 +321,7 @@ def plugin_registry_status() -> dict[str, Any]:
                 "builtin_count": builtin_count,
                 "declared_entrypoint_count": len(entry_points),
                 "declared_entrypoints": entry_points,
+                "activation_enabled": bool(activation.get(group_name, False)),
             }
         )
     return {
@@ -325,6 +329,7 @@ def plugin_registry_status() -> dict[str, Any]:
         "entrypoints_enabled": entrypoint_extensions_enabled(),
         "metadata_only": True,
         "activation_env": "AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS",
+        "activation": {group: bool(enabled) for group, enabled in activation.items()},
         "totals": {
             "groups": len(groups),
             "builtin_registrations": total_builtin,

--- a/tests/test_plugin_activation.py
+++ b/tests/test_plugin_activation.py
@@ -1,0 +1,246 @@
+"""Regression tests for opt-in runtime activation of plugin entry points."""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from agent_bom.extensions import ENTRYPOINTS_ENABLED_ENV
+from agent_bom.plugin_activation import (
+    ACTIVATE_ADVISORY_SOURCE_PLUGINS_ENV,
+    ACTIVATE_MCP_TOOL_PLUGINS_ENV,
+    ACTIVATE_RUNTIME_EMITTER_PLUGINS_ENV,
+)
+
+_FAKE_MODULE = "acme_agent_bom_fake_plugin"
+
+
+class _FakeMcp:
+    def __init__(self) -> None:
+        self.registered: list[str] = []
+
+
+@pytest.fixture()
+def fake_plugin_module():
+    """Install a fake operator plugin module exposing all plugin callables."""
+
+    module = types.ModuleType(_FAKE_MODULE)
+    buffer: list[dict[str, Any]] = []
+
+    def register_tools(mcp: _FakeMcp) -> None:
+        mcp.registered.append("acme-tool")
+
+    def lookup(advisory_id: str) -> dict[str, Any]:
+        return {"id": advisory_id, "summary": "acme advisory", "source_url": "https://feeds.internal/acme"}
+
+    def sync(*, since: str | None = None) -> dict[str, Any]:
+        return {"items": 0, "since": since}
+
+    def emit(event: dict[str, Any]) -> dict[str, Any]:
+        buffer.append(event)
+        return {"queued": True}
+
+    def flush() -> dict[str, Any]:
+        count = len(buffer)
+        buffer.clear()
+        return {"flushed": count}
+
+    module.register_tools = register_tools  # type: ignore[attr-defined]
+    module.lookup = lookup  # type: ignore[attr-defined]
+    module.sync = sync  # type: ignore[attr-defined]
+    module.emit = emit  # type: ignore[attr-defined]
+    module.flush = flush  # type: ignore[attr-defined]
+    module.buffer = buffer  # type: ignore[attr-defined]
+    sys.modules[_FAKE_MODULE] = module
+    try:
+        yield module
+    finally:
+        sys.modules.pop(_FAKE_MODULE, None)
+
+
+@pytest.fixture(autouse=True)
+def seeded_registry(monkeypatch):
+    """Seed discovery with fake registrations and reset activation state."""
+
+    import agent_bom.plugin_activation as plugin_activation
+    import agent_bom.plugin_entrypoints as plugin_entrypoints
+
+    for env in (
+        ENTRYPOINTS_ENABLED_ENV,
+        ACTIVATE_MCP_TOOL_PLUGINS_ENV,
+        ACTIVATE_ADVISORY_SOURCE_PLUGINS_ENV,
+        ACTIVATE_RUNTIME_EMITTER_PLUGINS_ENV,
+    ):
+        monkeypatch.delenv(env, raising=False)
+
+    plugin_entrypoints._reset_plugin_entrypoint_registry_for_tests()
+    plugin_activation._reset_plugin_activation_for_tests()
+
+    plugin_entrypoints._MCP_TOOL_PLUGINS["acme-mcp"] = plugin_entrypoints.McpToolPluginRegistration(name="acme-mcp", module=_FAKE_MODULE)
+    plugin_entrypoints._ADVISORY_SOURCE_PLUGINS["acme-adv"] = plugin_entrypoints.AdvisorySourcePluginRegistration(
+        name="acme-adv", module=_FAKE_MODULE
+    )
+    plugin_entrypoints._RUNTIME_EMITTER_PLUGINS["acme-emit"] = plugin_entrypoints.RuntimeEmitterPluginRegistration(
+        name="acme-emit", module=_FAKE_MODULE
+    )
+    plugin_entrypoints._PLUGIN_ENTRYPOINTS_LOADED = True
+
+    yield
+
+    plugin_entrypoints._reset_plugin_entrypoint_registry_for_tests()
+    plugin_activation._reset_plugin_activation_for_tests()
+
+
+def _enable_all(monkeypatch) -> None:
+    monkeypatch.setenv(ENTRYPOINTS_ENABLED_ENV, "true")
+    monkeypatch.setenv(ACTIVATE_MCP_TOOL_PLUGINS_ENV, "true")
+    monkeypatch.setenv(ACTIVATE_ADVISORY_SOURCE_PLUGINS_ENV, "true")
+    monkeypatch.setenv(ACTIVATE_RUNTIME_EMITTER_PLUGINS_ENV, "true")
+
+
+def test_activation_is_off_by_default(monkeypatch, fake_plugin_module) -> None:
+    import agent_bom.plugin_activation as plugin_activation
+
+    # Even with discovery on, activation stays off without the group flag.
+    monkeypatch.setenv(ENTRYPOINTS_ENABLED_ENV, "true")
+
+    assert plugin_activation.mcp_tool_activation_enabled() is False
+    assert plugin_activation.advisory_source_activation_enabled() is False
+    assert plugin_activation.runtime_emitter_activation_enabled() is False
+
+    mcp = _FakeMcp()
+    assert plugin_activation.activate_mcp_tool_plugins(mcp) == []
+    assert mcp.registered == []
+    assert plugin_activation.advisory_source_lookup("CVE-2026-0001") == []
+    assert plugin_activation.fan_out_runtime_event({"tenant_id": "t1"}) == 0
+
+
+def test_activation_requires_discovery_flag_too(monkeypatch, fake_plugin_module) -> None:
+    import agent_bom.plugin_activation as plugin_activation
+
+    # Group flag on but discovery off => still inert (double gate).
+    monkeypatch.setenv(ACTIVATE_MCP_TOOL_PLUGINS_ENV, "true")
+
+    assert plugin_activation.mcp_tool_activation_enabled() is False
+    assert plugin_activation.activate_mcp_tool_plugins(_FakeMcp()) == []
+
+
+def test_mcp_tool_plugin_registers_on_live_server(monkeypatch, fake_plugin_module) -> None:
+    import agent_bom.plugin_activation as plugin_activation
+
+    _enable_all(monkeypatch)
+    mcp = _FakeMcp()
+    registered = plugin_activation.activate_mcp_tool_plugins(mcp)
+
+    assert registered == ["acme-mcp"]
+    assert mcp.registered == ["acme-tool"]
+
+
+def test_advisory_source_lookup_is_provenance_tagged(monkeypatch, fake_plugin_module) -> None:
+    import agent_bom.plugin_activation as plugin_activation
+
+    _enable_all(monkeypatch)
+    results = plugin_activation.advisory_source_lookup("CVE-2026-0002")
+
+    assert len(results) == 1
+    assert results[0]["source"] == "acme-adv"
+    assert results[0]["provenance"] == "operator_advisory_plugin"
+    assert results[0]["result"]["id"] == "CVE-2026-0002"
+
+
+def test_runtime_emitter_fan_out_forwards_redacted_envelope(monkeypatch, fake_plugin_module) -> None:
+    import agent_bom.plugin_activation as plugin_activation
+
+    _enable_all(monkeypatch)
+    observation = {
+        "tenant_id": "t1",
+        "observation_id": "obs-1",
+        "tool_name": "shell",
+        "verdict": "blocked",
+        # A raw payload field that must NOT be forwarded to the emitter.
+        "raw_prompt": "super secret prompt body",
+    }
+    delivered = plugin_activation.fan_out_runtime_event(observation)
+
+    assert delivered == 1
+    assert len(fake_plugin_module.buffer) == 1
+    envelope = fake_plugin_module.buffer[0]
+    assert envelope["schema_version"] == "runtime.emitter_envelope.v1"
+    assert envelope["redaction_status"] == "metadata_only"
+    assert envelope["tenant_id"] == "t1"
+    assert envelope["tool"] == "shell"
+    assert "raw_prompt" not in envelope
+    assert "super secret prompt body" not in str(envelope)
+
+    flushed = plugin_activation.flush_runtime_emitters()
+    assert flushed == {"flushed": ["acme-emit"], "failed": []}
+    assert fake_plugin_module.buffer == []
+
+
+def test_failing_plugin_is_isolated_and_sanitized(monkeypatch, fake_plugin_module) -> None:
+    import agent_bom.plugin_activation as plugin_activation
+
+    _enable_all(monkeypatch)
+
+    def boom(_advisory_id: str) -> dict[str, Any]:
+        raise RuntimeError("boom https://user:tok999@example.com/feed?key=secret")
+
+    monkeypatch.setattr(fake_plugin_module, "lookup", boom)
+
+    results = plugin_activation.advisory_source_lookup("CVE-2026-0003")
+    assert results[0]["source"] == "acme-adv"
+    assert "error" in results[0]
+    assert "result" not in results[0]
+
+    warnings = " ".join(plugin_activation.plugin_activation_warnings())
+    assert "acme-adv" in warnings
+    assert "tok999" not in warnings
+    assert "key=secret" not in warnings
+
+
+def test_missing_callable_is_reported_not_raised(monkeypatch, fake_plugin_module) -> None:
+    import agent_bom.plugin_activation as plugin_activation
+
+    _enable_all(monkeypatch)
+    # Remove the register callable so binding must fail gracefully.
+    monkeypatch.delattr(fake_plugin_module, "register_tools")
+
+    mcp = _FakeMcp()
+    assert plugin_activation.activate_mcp_tool_plugins(mcp) == []
+    assert mcp.registered == []
+    warnings = " ".join(plugin_activation.plugin_activation_warnings())
+    assert "acme-mcp" in warnings
+
+
+def test_activation_status_reports_bound_plugins(monkeypatch, fake_plugin_module) -> None:
+    import agent_bom.plugin_activation as plugin_activation
+
+    _enable_all(monkeypatch)
+    status = plugin_activation.plugin_activation_status()
+
+    assert status["schema_version"] == plugin_activation.PLUGIN_ACTIVATION_STATUS_SCHEMA_VERSION
+    assert status["discovery_enabled"] is True
+    assert status["totals"]["activated_plugins"] == 3
+    by_group = {group["group"]: group for group in status["groups"]}
+    assert by_group["agent_bom.mcp_tools"]["activated_plugins"] == ["acme-mcp"]
+    assert by_group["agent_bom.advisory_sources"]["enabled"] is True
+    assert by_group["agent_bom.runtime_emitters"]["activated_count"] == 1
+
+
+def test_activation_flags_helper_is_pure_env_read(monkeypatch, fake_plugin_module) -> None:
+    import agent_bom.plugin_activation as plugin_activation
+
+    assert plugin_activation.activation_flags() == {
+        "agent_bom.mcp_tools": False,
+        "agent_bom.advisory_sources": False,
+        "agent_bom.runtime_emitters": False,
+    }
+    _enable_all(monkeypatch)
+    assert plugin_activation.activation_flags() == {
+        "agent_bom.mcp_tools": True,
+        "agent_bom.advisory_sources": True,
+        "agent_bom.runtime_emitters": True,
+    }

--- a/tests/test_plugin_registry_status.py
+++ b/tests/test_plugin_registry_status.py
@@ -101,3 +101,39 @@ def test_plugin_status_api_returns_registry_metadata(monkeypatch):
     assert payload["schema_version"] == "agent-bom.plugin_registry_status.v1"
     assert payload["metadata_only"] is True
     assert payload["totals"]["declared_entrypoints"] == 1
+
+
+def test_registry_status_reports_activation_flags(monkeypatch):
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    monkeypatch.delenv("AGENT_BOM_ACTIVATE_MCP_TOOL_PLUGINS", raising=False)
+    _patch_entry_points(monkeypatch, [])
+
+    status = plugin_registry_status()
+
+    # Activation is off by default; the metadata-only status still advertises the
+    # per-group activation flag state so operators can see what would run.
+    assert status["activation"] == {
+        "agent_bom.mcp_tools": False,
+        "agent_bom.advisory_sources": False,
+        "agent_bom.runtime_emitters": False,
+    }
+    mcp_group = next(group for group in status["groups"] if group["group"] == "agent_bom.mcp_tools")
+    assert mcp_group["activation_enabled"] is False
+
+
+def test_plugins_activation_cli_emits_json(monkeypatch):
+    monkeypatch.delenv(ENTRYPOINTS_ENABLED_ENV, raising=False)
+    _patch_entry_points(monkeypatch, [])
+
+    result = CliRunner().invoke(main, ["plugins", "activation", "--format", "json"])
+
+    assert result.exit_code == 0
+    payload: dict[str, Any] = json.loads(result.output)
+    assert payload["schema_version"] == "agent-bom.plugin_activation_status.v1"
+    assert payload["discovery_enabled"] is False
+    assert payload["totals"]["activated_plugins"] == 0
+    assert {group["group"] for group in payload["groups"]} == {
+        "agent_bom.mcp_tools",
+        "agent_bom.advisory_sources",
+        "agent_bom.runtime_emitters",
+    }


### PR DESCRIPTION
## Summary

- Adds a **second, explicit activation opt-in** on top of metadata-only plugin discovery: discovered MCP tools, advisory sources, and runtime emitters can now be bound and executed behind per-group env flags, with default behavior unchanged.
- New `agent_bom.plugin_activation` module resolves a registration's implementation module, binds its declared callables, and exposes bounded, failure-isolated fan-out helpers plus an activation status view.
- Wires activation into three real surfaces and adds a `plugins activation` CLI command.

## Related Issues

Closes #3473

## What shipped

**Env flags** (declared in `config.py`, off by default). Each requires discovery (`AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS`) to be enabled as well — a double gate:
- `AGENT_BOM_ACTIVATE_MCP_TOOL_PLUGINS`
- `AGENT_BOM_ACTIVATE_ADVISORY_SOURCE_PLUGINS`
- `AGENT_BOM_ACTIVATE_RUNTIME_EMITTER_PLUGINS`

**Activation surfaces:**
- **MCP tools** — `create_mcp_server` registers each activated plugin's `register` callable on the live server, then re-runs the (idempotent) strict-argument hardening so plugin-added tools get the same contract as built-ins.
- **Advisory sources** — the `intel lookup` MCP tool appends provenance-tagged records under `operator_advisory_sources`; the deterministic local result is never replaced.
- **Runtime emitters** — every persisted runtime observation is forwarded to each activated emitter as a **redacted routing envelope** (`runtime.emitter_envelope.v1`) carrying only metadata — never raw prompts, tool arguments, or credential values.

**Visibility** — new `agent-bom plugins activation` command (console/JSON); `plugins status` and the `/v1/plugins/status` response now report each group's `activation_enabled` state.

**Safety** — every import, bind, and invocation is failure-isolated: a bad plugin becomes a sanitized warning, never crashes the server/scan, and never stops the other plugins. Per-group caps are reused from discovery.

## Test plan

- [x] `pytest tests/test_plugin_activation.py tests/test_plugin_entrypoints.py -q` passes (13 tests; new suite covers off-by-default, the double gate, each surface, redaction of raw payload fields, and failure isolation/sanitization)
- [x] `ruff check` + `ruff format --check` clean on all changed files
- [x] `mypy` clean on all changed source files
- [x] `scripts/generate_env_var_reference.py --check` exits 0 (new flags documented)
- [x] No new API route or Pydantic model added — `/v1/plugins/status` remains a free-form `dict[str, object]`, so the OpenAPI spec is unchanged (docstring preserved byte-for-byte)

Note: the full dependency tree is unavailable in this environment (PyPI egress blocked), so the FastAPI-dependent suites (`test_plugin_registry_status.py` CLI/API cases added here) will be exercised by CI. The activation logic was verified end-to-end against a fake plugin.

## Breaking changes
- [x] None

## Checklist
- [x] Docs updated (`docs/PLUGIN_ENTRYPOINTS.md` — new Runtime Activation section; `docs/operations/ENV_VARS.md` regenerated)
- [x] No secrets, credentials, or personally identifiable data in diff
- [x] Backend, CLI, docs, and tests aligned for this change
- [x] Security review: activation is default-off, doubly gated, reference-only (no stored secrets), runtime envelopes are metadata-only/redacted, and third-party failures are sanitized and isolated

## Exceptions

- None



---
