### PR TITLE
refactor(severity): unify API scan and compact CIS sort ranks

### DIFF
--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1247,8 +1247,9 @@ def _finding_sort_key(row: dict[str, Any], sort: str) -> tuple[float, float, flo
     deterministic for a given input.
     """
     from agent_bom.api.compliance_hub_store import compute_effective_reach_score
+    from agent_bom.graph.severity import severity_policy_rank
 
-    sev_rank = {"critical": 4, "high": 3, "medium": 2, "low": 1}.get(str(row.get("severity", "")).lower(), 0)
+    sev_rank = severity_policy_rank(str(row.get("severity", "")))
     cvss = float(row.get("cvss_score") or 0.0)
     reach_val = compute_effective_reach_score(row)
 

--- a/src/agent_bom/output/compact.py
+++ b/src/agent_bom/output/compact.py
@@ -696,11 +696,12 @@ def print_compact_cis_posture(report: AIBOMReport, limit: int = 5) -> None:
 
         # Sort by remediation priority (1 = fix first), then severity.
         def _sort_key(c: dict) -> tuple[int, int]:
+            from agent_bom.graph.severity import severity_worst_first_rank
+
             rem = c.get("remediation") or {}
             priority = rem.get("priority", 3)
-            sev = (c.get("severity") or "").lower()
-            sev_rank = {"critical": 0, "high": 1, "medium": 2, "low": 3}.get(sev, 4)
-            return (priority, sev_rank)
+            sev = c.get("severity") or ""
+            return (priority, severity_worst_first_rank(sev))
 
         failed_sorted = sorted(failed, key=_sort_key)
         shown = failed_sorted[:limit]

--- a/tests/test_severity_sort_unification.py
+++ b/tests/test_severity_sort_unification.py
@@ -1,0 +1,22 @@
+"""Regression tests for canonical severity ordering in API/output sort paths."""
+
+from __future__ import annotations
+
+from agent_bom.api.routes.scan import _finding_sort_key
+from agent_bom.graph.severity import severity_policy_rank, severity_worst_first_rank
+
+
+def test_finding_sort_key_uses_policy_rank_for_severity_sort() -> None:
+    critical = {"severity": "critical", "cvss_score": 1.0}
+    high = {"severity": "high", "cvss_score": 9.0}
+    assert _finding_sort_key(critical, "severity") < _finding_sort_key(high, "severity")
+
+
+def test_finding_sort_key_matches_compliance_hub_policy_rank() -> None:
+    row = {"severity": "medium", "cvss_score": 0.0}
+    _, _, neg_rank = _finding_sort_key(row, "severity")
+    assert -neg_rank == severity_policy_rank("medium")
+
+
+def test_worst_first_rank_orders_critical_before_low() -> None:
+    assert severity_worst_first_rank("critical") < severity_worst_first_rank("low")


### PR DESCRIPTION
## Summary
- Route `/v1/findings` severity sort through `severity_policy_rank()` instead of a hardcoded dict in `scan.py`.
- Route compact CIS failed-check ordering through `severity_worst_first_rank()` instead of inline ranks in `compact.py`.
- Add regression tests locking both paths to the canonical graph severity helpers.

Part of #3242

## Verification
- `uv run ruff check src/agent_bom/api/routes/scan.py src/agent_bom/output/compact.py tests/test_severity_sort_unification.py`
- `uv run pytest -q tests/test_severity_sort_unification.py` (3 passed)

## Notes
Continues #2918 severity canonicalization after #3559 (remediation plan) and #3562 (trust_score CVE weights). Remaining local dicts: `output/html.py` `_CIS_SEV_RANK`, `output/mermaid.py`, `output/console_render.py` — follow-up slices.

Made with [Cursor](https://cursor.com)