### PR TITLE
refactor(severity): canonical package severity rank in Mermaid output

### DIFF
--- a/src/agent_bom/output/mermaid.py
+++ b/src/agent_bom/output/mermaid.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+from agent_bom.graph.severity import severity_rank
+
 if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport, BlastRadius
 
@@ -200,7 +202,7 @@ def to_mermaid_supply_chain(report: AIBOMReport) -> str:
                 if pkg.vulnerabilities:
                     sev = max(
                         (v.severity.value.lower() for v in pkg.vulnerabilities),
-                        key=lambda s: {"critical": 4, "high": 3, "medium": 2, "low": 1}.get(s, 0),
+                        key=severity_rank,
                         default="low",
                     )
                     vuln_count = len(pkg.vulnerabilities)

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -97,6 +97,33 @@ def test_mermaid_supply_chain_uses_short_ids_with_descriptive_labels():
     assert "express@4.17.1" in result
 
 
+def test_mermaid_supply_chain_uses_canonical_severity_rank() -> None:
+    """Supply-chain package styling picks the worst vuln via severity_rank()."""
+    crit = Vulnerability(id="CVE-CRIT", severity=Severity.CRITICAL, summary="critical pkg vuln")
+    low = Vulnerability(id="CVE-LOW", severity=Severity.LOW, summary="low pkg vuln")
+    pkg = Package(
+        name="lodash",
+        version="4.17.20",
+        ecosystem="npm",
+        vulnerabilities=[low, crit],
+    )
+    server = MCPServer(
+        name="pkg-server",
+        command="npx",
+        args=["-y", "@test/server"],
+        transport=TransportType.STDIO,
+        packages=[pkg],
+    )
+    agent = Agent(
+        name="desktop",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/config.json",
+        mcp_servers=[server],
+    )
+    result = to_mermaid_supply_chain(AIBOMReport(agents=[agent]))
+    assert "fill:#d32f2f" in result
+
+
 def test_mermaid_credential_exposure():
     """Mermaid output shows exposed credentials."""
     report, brs = _make_report_and_blast_radii()


### PR DESCRIPTION
## Summary
- Replace inline `{"critical": 4, ...}` dict in `to_mermaid_supply_chain` package vuln max with `severity_rank()`.
- Add regression test confirming a package with mixed severities gets critical styling.

Part of #3242

## Verification
- `uv run ruff check src/agent_bom/output/mermaid.py tests/test_mermaid.py`
- `uv run pytest -q tests/test_mermaid.py::test_mermaid_supply_chain_uses_canonical_severity_rank tests/test_mermaid.py::test_mermaid_critical_styling tests/test_core.py::test_mermaid_supply_chain` (3 passed)

Made with [Cursor](https://cursor.com)