### PR TITLE
refactor(severity): canonical sort ranks in skills, license, extensions

### DIFF
--- a/src/agent_bom/cli/_skills_group.py
+++ b/src/agent_bom/cli/_skills_group.py
@@ -13,6 +13,7 @@ from rich.console import Console
 from rich.table import Table
 
 from agent_bom.cli._grouped_help import SuggestingGroup
+from agent_bom.graph.severity import severity_worst_first_rank
 from agent_bom.skills_policy import SkillsPolicyError, evaluate_skills_policy, load_skills_policy
 from agent_bom.skills_service import rescan_skill_catalog, scan_skill_targets, verify_skill_targets
 
@@ -238,7 +239,7 @@ def skills_scan_cmd(
             sev_style = {"critical": "red bold", "high": "red", "medium": "yellow", "low": "dim"}
             ordered = sorted(
                 all_findings,
-                key=lambda finding: ({"critical": 0, "high": 1, "medium": 2, "low": 3}.get(finding.severity, 4), finding.title.lower()),
+                key=lambda finding: (severity_worst_first_rank(finding.severity), finding.title.lower()),
             )
             for finding in ordered[: len(ordered) if verbose else 8]:
                 style = sev_style.get(finding.severity, "white")

--- a/src/agent_bom/license_policy.py
+++ b/src/agent_bom/license_policy.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from fnmatch import fnmatch
 from typing import TYPE_CHECKING
 
+from agent_bom.graph.severity import severity_worst_first_rank
 from agent_bom.models import Agent
 
 if TYPE_CHECKING:
@@ -522,7 +523,7 @@ def print_license_report(report: LicenseReport, console: Console) -> None:
         "unknown": "dim",
     }
 
-    for f in sorted(report.findings, key=lambda x: {"critical": 0, "high": 1, "medium": 2, "low": 3}.get(x.risk_level, 4)):
+    for f in sorted(report.findings, key=lambda x: severity_worst_first_rank(x.risk_level)):
         risk_color = risk_colors.get(f.risk_level, "white")
         cat_color = cat_colors.get(f.category, "white")
         table.add_row(

--- a/src/agent_bom/parsers/browser_extensions.py
+++ b/src/agent_bom/parsers/browser_extensions.py
@@ -21,6 +21,8 @@ import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from agent_bom.graph.severity import severity_worst_first_rank
+
 logger = logging.getLogger(__name__)
 
 # ─── Permission risk taxonomy ─────────────────────────────────────────────────
@@ -71,12 +73,6 @@ _AI_ASSISTANT_HOSTS: list[str] = [
     "perplexity.ai",
     "anthropic.com",
 ]
-
-_RISK_ORDER: dict[str, int] = {"critical": 0, "high": 1, "medium": 2, "low": 3}
-
-
-# ─── Data model ───────────────────────────────────────────────────────────────
-
 
 @dataclass
 class BrowserExtension:
@@ -375,7 +371,7 @@ def discover_browser_extensions(
     if not include_low_risk:
         all_extensions = [e for e in all_extensions if e.risk_level != "low"]
 
-    all_extensions.sort(key=lambda e: _RISK_ORDER.get(e.risk_level, 4))
+    all_extensions.sort(key=lambda e: severity_worst_first_rank(e.risk_level))
 
     logger.debug(
         "Browser extension scan: %d extensions (%d medium+)",

--- a/tests/test_severity_sort_unification.py
+++ b/tests/test_severity_sort_unification.py
@@ -49,3 +49,8 @@ def test_console_cis_sort_key_orders_critical_before_medium() -> None:
     medium = {"check_id": "med-1", "severity": "medium", "remediation": {"priority": 1}}
     critical = {"check_id": "crit-1", "severity": "critical", "remediation": {"priority": 3}}
     assert _cis_check_sort_key(critical) < _cis_check_sort_key(medium)
+
+
+def test_remaining_sort_paths_use_worst_first_rank() -> None:
+    assert severity_worst_first_rank("critical") < severity_worst_first_rank("high")
+    assert severity_worst_first_rank("high") < severity_worst_first_rank("unknown")


### PR DESCRIPTION
## Summary
- `cli/_skills_group.py` — skill audit findings sort via `severity_worst_first_rank()`
- `license_policy.py` — license findings table sort via canonical rank
- `parsers/browser_extensions.py` — drop `_RISK_ORDER`, sort extensions canonically

Closes the mechanical severity **sort-order** slice from #3242 / #2918. Count-only severity bucket dicts (graph, compliance hub) unchanged — display counters, not ordering.

Part of #3242

## Verification
- `uv run ruff check src/agent_bom/cli/_skills_group.py src/agent_bom/license_policy.py src/agent_bom/parsers/browser_extensions.py tests/test_severity_sort_unification.py`
- `uv run pytest -q tests/test_severity_sort_unification.py` (7 passed)

Made with [Cursor](https://cursor.com)