### PR TITLE
feat(reachability): export Python symbol reachability in findings

### DIFF
--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -541,6 +541,50 @@ def _optional_str(value: object) -> str:
 # ─── Scan Pipeline Runner ───────────────────────────────────────────────────
 
 
+def _project_paths_for_symbol_reach(req: Any) -> list[str]:
+    """Collect scan-target paths that may contain Python source for symbol reach."""
+    paths: list[str] = []
+    seen: set[str] = set()
+    for raw in (
+        list(getattr(req, "agent_projects", []) or [])
+        + list(getattr(req, "filesystem_paths", []) or [])
+        + list(getattr(req, "jupyter_dirs", []) or [])
+        + ([req.gha_path] if getattr(req, "gha_path", None) else [])
+    ):
+        if raw and raw not in seen:
+            seen.add(raw)
+            paths.append(raw)
+    return paths
+
+
+def _ast_result_for_symbol_reach(paths: Iterable[str]) -> Any | None:
+    """Best-effort AST symbol-reach for API pipeline parity with CLI --project."""
+    from pathlib import Path
+
+    from agent_bom.ast_analyzer import analyze_project
+    from agent_bom.ast_models import ASTAnalysisResult
+
+    merged: ASTAnalysisResult | None = None
+    for raw in paths:
+        project = Path(raw)
+        try:
+            if not list(project.rglob("*.py"))[:1]:
+                continue
+        except OSError as path_exc:
+            _logger.debug("AST symbol-reach path skipped for %s: %s", raw, sanitize_error(path_exc))
+            continue
+        try:
+            result = analyze_project(project)
+        except Exception as ast_exc:  # noqa: BLE001
+            _logger.debug("AST symbol-reach analysis skipped for %s: %s", raw, sanitize_error(ast_exc))
+            continue
+        if merged is None:
+            merged = result
+        elif result.dependency_symbol_reach:
+            merged.dependency_symbol_reach.extend(result.dependency_symbol_reach)
+    return merged
+
+
 def _run_scan_sync(job: ScanJob) -> None:
     """Run the full scan pipeline in a thread (blocking). Updates job in-place."""
     lock = _job_lock(job.job_id)
@@ -938,12 +982,21 @@ def _run_scan_sync(job: ScanJob) -> None:
         try:
             from agent_bom.graph.blast_reach import (
                 apply_dependency_reachability_to_blast_radii,
+                apply_symbol_reachability_to_blast_radii,
             )
 
             stamped = apply_dependency_reachability_to_blast_radii(blast_radii, agents, rescore=True)
             if stamped:
                 with lock:
                     job.progress.append(f"Reachability: stamped {stamped} blast-radius row(s) with graph-walk evidence")
+            _ast_for_reach = _ast_result_for_symbol_reach(_project_paths_for_symbol_reach(req))
+            if _ast_for_reach is not None:
+                sym_stamped = apply_symbol_reachability_to_blast_radii(blast_radii, _ast_for_reach)
+                if sym_stamped:
+                    with lock:
+                        job.progress.append(
+                            f"Symbol reachability: stamped {sym_stamped} blast-radius row(s) with function-level evidence"
+                        )
         except Exception as reach_exc:  # noqa: BLE001
             _logger.warning("Reachability surfacing skipped: %s", sanitize_error(reach_exc))
         pipeline.complete_step("analysis", f"Computed {len(blast_radii)} blast radius entries", {"blast_radius": len(blast_radii)})

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -832,6 +832,8 @@ def blast_radius_to_finding(br: object) -> "Finding":
         "graph_reachable": getattr(br, "graph_reachable", None),
         "graph_min_hop_distance": getattr(br, "graph_min_hop_distance", None),
         "graph_reachable_from_agents": _sanitized_evidence_field(getattr(br, "graph_reachable_from_agents", [])),
+        "symbol_reachability": getattr(br, "symbol_reachability", None),
+        "reachable_affected_symbols": _sanitized_evidence_field(getattr(br, "reachable_affected_symbols", [])),
         "layer_attribution": _sanitized_evidence_field([_package_occurrence_evidence(occ) for occ in br.layer_attribution]),
         "published_at": getattr(vuln, "published_at", None),
         "modified_at": getattr(vuln, "modified_at", None),

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -1165,6 +1165,11 @@ def to_json(report: AIBOMReport) -> dict:
                 "graph_reachable": getattr(br, "graph_reachable", None),
                 "graph_min_hop_distance": getattr(br, "graph_min_hop_distance", None),
                 "graph_reachable_from_agents": getattr(br, "graph_reachable_from_agents", []),
+                # Function-level symbol reachability stamped by
+                # `agent_bom.graph.blast_reach.apply_symbol_reachability_to_blast_radii`
+                # when AST symbol-reach evidence exists. ``None`` = join did not run.
+                "symbol_reachability": getattr(br, "symbol_reachability", None),
+                "reachable_affected_symbols": getattr(br, "reachable_affected_symbols", []),
             }
             for rank, br in enumerate(report.blast_radii, start=1)
         ],

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -459,6 +459,8 @@ def to_sarif(report: AIBOMReport, *, exclude_unfixable: bool = False) -> dict:
             "impact_category": getattr(br, "impact_category", "code-execution"),
             "attack_vector_summary": getattr(br, "attack_vector_summary", None),
             "reachability": br.reachability,
+            "symbol_reachability": getattr(br, "symbol_reachability", None),
+            "reachable_affected_symbols": getattr(br, "reachable_affected_symbols", []),
             # Structured reach lists + AI-native context (unified Finding parity).
             "affected_servers": [s.name for s in br.affected_servers],
             "affected_agents": [a.name for a in br.affected_agents],

--- a/tests/test_symbol_reachability_export.py
+++ b/tests/test_symbol_reachability_export.py
@@ -1,0 +1,125 @@
+"""Export contract for function-level symbol reachability on findings.
+
+Pins that ``symbol_reachability`` and ``reachable_affected_symbols`` stamped
+on ``BlastRadius`` rows flow through canonical outputs (unified Finding
+evidence, JSON blast_radius, SARIF properties) and that the API pipeline
+helper mirrors the CLI ``--project`` AST join when a Python project path is
+available.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_bom.api.pipeline import _ast_result_for_symbol_reach, _project_paths_for_symbol_reach
+from agent_bom.ast_models import ASTAnalysisResult, DependencySymbolReach
+from agent_bom.finding import blast_radius_to_finding
+from agent_bom.graph.blast_reach import apply_symbol_reachability_to_blast_radii
+from agent_bom.models import AIBOMReport, BlastRadius, Package, Severity, Vulnerability
+from agent_bom.output import to_json
+from agent_bom.output.sarif import to_sarif
+from agent_bom.reachability_cve import FUNCTION_REACHABLE
+
+
+def _reach(package: str, module: str, symbol: str) -> DependencySymbolReach:
+    return DependencySymbolReach(
+        entrypoint="tool_entry",
+        package=package,
+        module=module,
+        symbol=symbol,
+        file_path="agent.py",
+        line_number=5,
+        call_path=["tool_entry", f"{module}.{symbol}"],
+    )
+
+
+def _python_br(symbols: list[str], *, pkg_name: str = "requests") -> BlastRadius:
+    vuln = Vulnerability(
+        id="CVE-2099-7",
+        summary="x",
+        severity=Severity.HIGH,
+        affected_symbols=symbols,
+    )
+    pkg = Package(name=pkg_name, version="2.0.0", ecosystem="pypi")
+    return BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=[],
+        affected_agents=[],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+
+
+def _stamp_python_br() -> BlastRadius:
+    br = _python_br(["get"])
+    apply_symbol_reachability_to_blast_radii(
+        [br],
+        ASTAnalysisResult(dependency_symbol_reach=[_reach("requests", "requests", "get")]),
+    )
+    return br
+
+
+def test_finding_evidence_exports_symbol_reachability_fields() -> None:
+    br = _stamp_python_br()
+    finding = blast_radius_to_finding(br)
+
+    assert finding.evidence["symbol_reachability"] == FUNCTION_REACHABLE
+    assert finding.evidence["reachable_affected_symbols"] == ["get"]
+
+
+def test_to_json_blast_radius_exports_symbol_reachability_fields() -> None:
+    br = _stamp_python_br()
+    payload = to_json(AIBOMReport(agents=[], blast_radii=[br]))
+
+    row = payload["blast_radius"][0]
+    assert row["symbol_reachability"] == FUNCTION_REACHABLE
+    assert row["reachable_affected_symbols"] == ["get"]
+
+    unified = payload["findings"][0]
+    assert unified["evidence"]["symbol_reachability"] == FUNCTION_REACHABLE
+    assert unified["evidence"]["reachable_affected_symbols"] == ["get"]
+
+
+def test_sarif_exports_symbol_reachability_fields() -> None:
+    br = _stamp_python_br()
+    doc = to_sarif(AIBOMReport(agents=[], blast_radii=[br]))
+
+    props = doc["runs"][0]["results"][0]["properties"]
+    assert props["symbol_reachability"] == FUNCTION_REACHABLE
+    assert props["reachable_affected_symbols"] == ["get"]
+
+
+def test_project_paths_for_symbol_reach_dedupes_scan_targets() -> None:
+    class _Req:
+        agent_projects = ["/tmp/agent-a", "/tmp/agent-b"]
+        filesystem_paths = ["/tmp/agent-a"]
+        jupyter_dirs = ["/tmp/notebooks"]
+        gha_path = "/tmp/repo"
+
+    assert _project_paths_for_symbol_reach(_Req()) == [
+        "/tmp/agent-a",
+        "/tmp/agent-b",
+        "/tmp/notebooks",
+        "/tmp/repo",
+    ]
+
+
+def test_ast_result_for_symbol_reach_reads_python_project(tmp_path: Path) -> None:
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / "agent.py").write_text(
+        "import requests\n\n@tool\ndef fetch(url):\n    return requests.get(url)\n",
+        encoding="utf-8",
+    )
+
+    result = _ast_result_for_symbol_reach([str(project)])
+
+    assert result is not None
+    assert result.dependency_symbol_reach
+
+
+def test_ast_result_for_symbol_reach_skips_non_python_paths(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert _ast_result_for_symbol_reach([str(empty)]) is None


### PR DESCRIPTION
## Summary
- Export `symbol_reachability` and `reachable_affected_symbols` through unified Finding evidence, JSON `blast_radius`, and SARIF properties.
- Add API pipeline parity with the CLI scan path by joining AST symbol-reach evidence when a Python project path is available (`agent_projects`, `filesystem_paths`, `jupyter_dirs`, or `gha_path`).
- Add regression tests in `tests/test_symbol_reachability_export.py` covering export surfaces and pipeline helpers.

Part of #3242
Part of #3499

## Verification
- `uv run ruff check src/agent_bom/api/pipeline.py src/agent_bom/finding.py src/agent_bom/output/json_fmt.py src/agent_bom/output/sarif.py tests/test_symbol_reachability_export.py`
- `uv run pytest -q tests/test_symbol_reachability_export.py tests/test_reachability_cve.py`


Made with [Cursor](https://cursor.com)