### PR TITLE
perf(db): partition hub observations with retention rollover

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260705_01_hub_observations_partition.py
+++ b/deploy/supabase/postgres/alembic/versions/20260705_01_hub_observations_partition.py
@@ -1,0 +1,46 @@
+"""Partition hub_findings_current_observations by observed_at (#3463).
+
+Foundation migration for monthly RANGE partitions. Safe to run on databases
+that already use the partitioned parent (no-op). Existing unpartitioned tables
+are converted via the shared ``migrate_observations_to_partitioned`` helper.
+
+Follow-up: wire automatic partition creation on every ingest path and add
+operator runbook for large-table maintenance windows.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260705_01"
+down_revision = "20260530_01"
+branch_labels = None
+depends_on = None
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from agent_bom.api.hub_observations_partition import (  # noqa: E402
+    ensure_observation_partitions,
+    migrate_observations_to_partitioned,
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    migrated = migrate_observations_to_partitioned(bind)
+    if migrated:
+        ensure_observation_partitions(bind)
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "Downgrading hub_findings_current_observations partitioning is not "
+        "supported automatically. Restore from backup if rollback is required."
+    )

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -152,6 +152,11 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_HTTP_MAX_RETRIES` | `int` | `3` | Used by http_client.create_client() and request_with_retry().  Defaults: 3 retries with 1s initial backoff (doubles each retry, capped at 30s).  30s per-request timeout covers most external APIs; NVD can be slow so operators may raise this. |
 | `AGENT_BOM_HTTP_RATE_LIMIT_BREAKER_THRESHOLD` | `int` | `3` | Registry rate-limit circuit breaker: number of HTTP 429 responses from a single host within one scan before live lookups to that host are short- circuited to the cached/bundled fallback path for the rest of the run. Keeps a registry throttl |
 
+## Hub Observations Retention
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_HUB_OBSERVATIONS_RETENTION_DAYS` | `int` | `365` | Age-based retention for the Postgres occurrence log (``hub_findings_current_observations``). Monthly RANGE partitions are detached and dropped once wholly past this window. ``<= 0`` disables rollover. SQLite and legacy unpartitioned Postgre |
+
 ## Image Scanning
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/src/agent_bom/api/finding_lifecycle.py
+++ b/src/agent_bom/api/finding_lifecycle.py
@@ -224,14 +224,6 @@ CREATE TABLE IF NOT EXISTS hub_findings_current (
     PRIMARY KEY (tenant_id, canonical_id)
 );
 
-CREATE TABLE IF NOT EXISTS hub_findings_current_observations (
-    tenant_id TEXT NOT NULL,
-    canonical_id TEXT NOT NULL,
-    scan_id TEXT NOT NULL,
-    observed_at TEXT NOT NULL,
-    PRIMARY KEY (tenant_id, canonical_id, scan_id)
-);
-
 CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_last_seen
     ON hub_findings_current(tenant_id, last_seen DESC);
 CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_reach
@@ -240,4 +232,17 @@ CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_cvss
     ON hub_findings_current(tenant_id, cvss_score DESC, last_seen DESC, canonical_id ASC);
 CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_severity
     ON hub_findings_current(tenant_id, severity_rank DESC, last_seen DESC, canonical_id ASC);
+"""
+
+# Legacy unpartitioned observations DDL for existing Postgres deployments that
+# have not yet run the partition migration (#3463). New installs use
+# hub_observations_partition.partitioned_observations_parent_ddl() instead.
+_CURRENT_LIFECYCLE_POSTGRES_OBSERVATIONS_LEGACY_DDL = """
+CREATE TABLE IF NOT EXISTS hub_findings_current_observations (
+    tenant_id TEXT NOT NULL,
+    canonical_id TEXT NOT NULL,
+    scan_id TEXT NOT NULL,
+    observed_at TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, canonical_id, scan_id)
+);
 """

--- a/src/agent_bom/api/hub_observations_partition.py
+++ b/src/agent_bom/api/hub_observations_partition.py
@@ -182,9 +182,7 @@ def rollover_observation_partitions(
         partition_end = _partition_end_date(partition_name)
         if partition_end is None or partition_end > cutoff:
             continue
-        conn.execute(
-            f"ALTER TABLE {OBSERVATIONS_TABLE} DETACH PARTITION {partition_name}"
-        )  # nosec B608 — partition_name parsed from pg_catalog
+        conn.execute(f"ALTER TABLE {OBSERVATIONS_TABLE} DETACH PARTITION {partition_name}")  # nosec B608 — partition_name parsed from pg_catalog
         conn.execute(f"DROP TABLE IF EXISTS {partition_name}")  # nosec B608
         dropped += 1
         logger.info(
@@ -217,7 +215,7 @@ def migrate_observations_to_partitioned(conn: Any) -> bool:
             date_trunc('month', MIN(observed_at::timestamptz))::date AS min_month,
             date_trunc('month', MAX(observed_at::timestamptz))::date AS max_month
         FROM {OBSERVATIONS_TABLE}_pre_partition
-        """
+        """  # nosec B608 — table name is a static internal migration table
     ).fetchone()
     min_month = bounds[0] if bounds and bounds[0] else date.today().replace(day=1)
     max_month = bounds[1] if bounds and bounds[1] else min_month
@@ -239,7 +237,7 @@ def migrate_observations_to_partitioned(conn: Any) -> bool:
             (tenant_id, canonical_id, scan_id, observed_at)
         SELECT tenant_id, canonical_id, scan_id, observed_at::timestamptz
         FROM {OBSERVATIONS_TABLE}_pre_partition
-        """
+        """  # nosec B608 — table names are static internal migration tables
     )
     conn.execute(f"DROP TABLE {OBSERVATIONS_TABLE}_pre_partition")
     return True

--- a/src/agent_bom/api/hub_observations_partition.py
+++ b/src/agent_bom/api/hub_observations_partition.py
@@ -1,0 +1,304 @@
+"""Monthly RANGE partitioning for ``hub_findings_current_observations`` (#3463).
+
+New Postgres installs create a partitioned parent keyed on ``observed_at``.
+Existing unpartitioned tables are left untouched until an operator runs the
+documented migration helper (Alembic revision or
+``migrate_observations_to_partitioned``). SQLite keeps the legacy single-table
+DDL unchanged.
+
+Postgres requires the primary key to include the partition key, so the
+partitioned schema uses ``PRIMARY KEY (tenant_id, canonical_id, scan_id,
+observed_at)`` with ``observed_at`` as ``TIMESTAMPTZ``. Dedup semantics stay
+the same: ``ON CONFLICT DO NOTHING`` on the scan sighting key.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from calendar import monthrange
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+from agent_bom.config import HUB_OBSERVATIONS_RETENTION_DAYS
+
+logger = logging.getLogger(__name__)
+
+OBSERVATIONS_TABLE = "hub_findings_current_observations"
+_PARTITION_NAME_RE = re.compile(r"^hub_findings_current_observations_y(\d{4})m(\d{2})$")
+
+
+def partition_table_name(year: int, month: int) -> str:
+    """Return the child partition relation name for *year*/*month*."""
+    return f"{OBSERVATIONS_TABLE}_y{year}m{month:02d}"
+
+
+def month_range_bounds(year: int, month: int) -> tuple[date, date]:
+    """Return half-open ``[start, end)`` calendar bounds for a monthly partition."""
+    start = date(year, month, 1)
+    if month == 12:
+        end = date(year + 1, 1, 1)
+    else:
+        end = date(year, month + 1, 1)
+    return start, end
+
+
+def partitioned_observations_parent_ddl() -> str:
+    """DDL for a fresh partitioned observations parent (no child partitions)."""
+    return f"""
+CREATE TABLE IF NOT EXISTS {OBSERVATIONS_TABLE} (
+    tenant_id TEXT NOT NULL,
+    canonical_id TEXT NOT NULL,
+    scan_id TEXT NOT NULL,
+    observed_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, canonical_id, scan_id, observed_at)
+) PARTITION BY RANGE (observed_at);
+"""
+
+
+def create_observation_partition_ddl(year: int, month: int) -> str:
+    """Return idempotent DDL for one monthly child partition."""
+    start, end = month_range_bounds(year, month)
+    child = partition_table_name(year, month)
+    return f"""
+CREATE TABLE IF NOT EXISTS {child}
+    PARTITION OF {OBSERVATIONS_TABLE}
+    FOR VALUES FROM ('{start.isoformat()}') TO ('{end.isoformat()}');
+"""
+
+
+def observations_table_exists(conn: Any) -> bool:
+    row = conn.execute(
+        """
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = current_schema()
+          AND table_name = %s
+        """,
+        (OBSERVATIONS_TABLE,),
+    ).fetchone()
+    return row is not None
+
+
+def is_observations_partitioned(conn: Any) -> bool:
+    """Return whether the observations table is a declarative RANGE parent."""
+    row = conn.execute(
+        """
+        SELECT c.relkind
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = current_schema()
+          AND c.relname = %s
+        """,
+        (OBSERVATIONS_TABLE,),
+    ).fetchone()
+    if row is None:
+        return False
+    return str(row[0]) == "p"
+
+
+def _iter_months(center: date, *, behind: int, ahead: int) -> list[tuple[int, int]]:
+    months: list[tuple[int, int]] = []
+    cursor = date(center.year, center.month, 1)
+    start_offset = -behind
+    for offset in range(start_offset, ahead + 1):
+        year = cursor.year + ((cursor.month - 1 + offset) // 12)
+        month = ((cursor.month - 1 + offset) % 12) + 1
+        months.append((year, month))
+    return months
+
+
+def ensure_observation_partitions(
+    conn: Any,
+    *,
+    now: datetime | None = None,
+    months_ahead: int = 2,
+    months_behind: int = 1,
+) -> int:
+    """Create missing monthly child partitions around *now*. Returns partitions created."""
+    if not is_observations_partitioned(conn):
+        return 0
+    anchor = (now or datetime.now(timezone.utc)).date()
+    created = 0
+    for year, month in _iter_months(anchor, behind=months_behind, ahead=months_ahead):
+        child = partition_table_name(year, month)
+        exists = conn.execute(
+            """
+            SELECT 1
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = current_schema()
+              AND c.relname = %s
+            """,
+            (child,),
+        ).fetchone()
+        if exists:
+            continue
+        conn.execute(create_observation_partition_ddl(year, month))
+        created += 1
+    return created
+
+
+def _partition_end_date(partition_name: str) -> date | None:
+    match = _PARTITION_NAME_RE.match(partition_name)
+    if not match:
+        return None
+    year = int(match.group(1))
+    month = int(match.group(2))
+    _, end = month_range_bounds(year, month)
+    return end
+
+
+def list_observation_partition_names(conn: Any) -> list[str]:
+    rows = conn.execute(
+        """
+        SELECT child.relname
+        FROM pg_inherits inh
+        JOIN pg_class parent ON parent.oid = inh.inhparent
+        JOIN pg_class child ON child.oid = inh.inhrelid
+        JOIN pg_namespace n ON n.oid = parent.relnamespace
+        WHERE n.nspname = current_schema()
+          AND parent.relname = %s
+        ORDER BY child.relname
+        """,
+        (OBSERVATIONS_TABLE,),
+    ).fetchall()
+    return [str(row[0]) for row in rows]
+
+
+def rollover_observation_partitions(
+    conn: Any,
+    *,
+    retention_days: int,
+    now: datetime | None = None,
+) -> int:
+    """Detach and drop monthly partitions wholly older than *retention_days*."""
+    if retention_days <= 0 or not is_observations_partitioned(conn):
+        return 0
+    anchor = now or datetime.now(timezone.utc)
+    cutoff = (anchor - timedelta(days=retention_days)).date()
+    dropped = 0
+    for partition_name in list_observation_partition_names(conn):
+        partition_end = _partition_end_date(partition_name)
+        if partition_end is None or partition_end > cutoff:
+            continue
+        conn.execute(
+            f"ALTER TABLE {OBSERVATIONS_TABLE} DETACH PARTITION {partition_name}"
+        )  # nosec B608 — partition_name parsed from pg_catalog
+        conn.execute(f"DROP TABLE IF EXISTS {partition_name}")  # nosec B608
+        dropped += 1
+        logger.info(
+            "hub observations retention dropped partition %s (end=%s cutoff=%s)",
+            partition_name,
+            partition_end.isoformat(),
+            cutoff.isoformat(),
+        )
+    return dropped
+
+
+def migrate_observations_to_partitioned(conn: Any) -> bool:
+    """One-shot migration from legacy unpartitioned observations to partitioned.
+
+    Returns ``True`` when a migration ran, ``False`` when already partitioned or
+    the table is absent. Intended for maintenance windows / Alembic — not run
+    automatically on API bootstrap.
+    """
+    if not observations_table_exists(conn):
+        return False
+    if is_observations_partitioned(conn):
+        return False
+
+    conn.execute(f"ALTER TABLE {OBSERVATIONS_TABLE} RENAME TO {OBSERVATIONS_TABLE}_pre_partition")
+    conn.execute(partitioned_observations_parent_ddl())
+
+    bounds = conn.execute(
+        f"""
+        SELECT
+            date_trunc('month', MIN(observed_at::timestamptz))::date AS min_month,
+            date_trunc('month', MAX(observed_at::timestamptz))::date AS max_month
+        FROM {OBSERVATIONS_TABLE}_pre_partition
+        """
+    ).fetchone()
+    min_month = bounds[0] if bounds and bounds[0] else date.today().replace(day=1)
+    max_month = bounds[1] if bounds and bounds[1] else min_month
+
+    cursor = date(min_month.year, min_month.month, 1)
+    end_cursor = date(max_month.year, max_month.month, 1)
+    while cursor <= end_cursor:
+        conn.execute(create_observation_partition_ddl(cursor.year, cursor.month))
+        if cursor.month == 12:
+            cursor = date(cursor.year + 1, 1, 1)
+        else:
+            cursor = date(cursor.year, cursor.month + 1, 1)
+
+    ensure_observation_partitions(conn, now=datetime.now(timezone.utc), months_ahead=2, months_behind=0)
+
+    conn.execute(
+        f"""
+        INSERT INTO {OBSERVATIONS_TABLE}
+            (tenant_id, canonical_id, scan_id, observed_at)
+        SELECT tenant_id, canonical_id, scan_id, observed_at::timestamptz
+        FROM {OBSERVATIONS_TABLE}_pre_partition
+        """
+    )
+    conn.execute(f"DROP TABLE {OBSERVATIONS_TABLE}_pre_partition")
+    return True
+
+
+def run_hub_observations_retention(*, retention_days: int | None = None) -> int:
+    """Postgres-only retention rollover; no-op for SQLite and legacy tables."""
+    days = HUB_OBSERVATIONS_RETENTION_DAYS if retention_days is None else retention_days
+    if days <= 0:
+        return 0
+    if not _postgres_configured():
+        return 0
+    try:
+        from agent_bom.api.postgres_common import _get_pool, _tenant_connection, bypass_tenant_rls
+
+        with bypass_tenant_rls(audit=False), _tenant_connection(_get_pool()) as conn:
+            ensure_observation_partitions(conn)
+            dropped = rollover_observation_partitions(conn, retention_days=days)
+            conn.commit()
+            return dropped
+    except Exception:  # noqa: BLE001 — cleanup loop must stay fail-open
+        logger.debug("hub observations retention skipped", exc_info=True)
+        return 0
+
+
+def _postgres_configured() -> bool:
+    import os
+
+    return bool(os.environ.get("AGENT_BOM_POSTGRES_URL", "").strip())
+
+
+def partition_months_for_retention(retention_days: int, *, now: date | None = None) -> list[tuple[int, int]]:
+    """Return ``(year, month)`` tuples that should be retained for *retention_days*."""
+    anchor = now or datetime.now(timezone.utc).date()
+    oldest = anchor - timedelta(days=retention_days)
+    months: list[tuple[int, int]] = []
+    cursor = date(oldest.year, oldest.month, 1)
+    end = date(anchor.year, anchor.month, 1)
+    while cursor <= end:
+        months.append((cursor.year, cursor.month))
+        if cursor.month == 12:
+            cursor = date(cursor.year + 1, 1, 1)
+        else:
+            cursor = date(cursor.year, cursor.month + 1, 1)
+    return months
+
+
+def partition_is_expired(partition_name: str, *, retention_days: int, now: date | None = None) -> bool:
+    """Pure helper: whether a partition name falls wholly before the retention window."""
+    if retention_days <= 0:
+        return False
+    partition_end = _partition_end_date(partition_name)
+    if partition_end is None:
+        return False
+    anchor = now or datetime.now(timezone.utc).date()
+    cutoff = anchor - timedelta(days=retention_days)
+    return partition_end <= cutoff
+
+
+def days_in_month(year: int, month: int) -> int:
+    """Return the number of days in a calendar month (test helper)."""
+    return monthrange(year, month)[1]

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -287,9 +287,25 @@ class PostgresComplianceHubStore:
                 "ON compliance_hub_findings(tenant_id, origin, severity_rank, cvss_score DESC, ordinal)"
             )
             _ensure_tenant_rls(conn, "compliance_hub_findings", "tenant_id")
-            from agent_bom.api.finding_lifecycle import _CURRENT_LIFECYCLE_POSTGRES_DDL
+            from agent_bom.api.finding_lifecycle import (
+                _CURRENT_LIFECYCLE_POSTGRES_DDL,
+                _CURRENT_LIFECYCLE_POSTGRES_OBSERVATIONS_LEGACY_DDL,
+            )
+            from agent_bom.api.hub_observations_partition import (
+                ensure_observation_partitions,
+                is_observations_partitioned,
+                observations_table_exists,
+                partitioned_observations_parent_ddl,
+            )
 
             conn.execute(_CURRENT_LIFECYCLE_POSTGRES_DDL)
+            if not observations_table_exists(conn):
+                conn.execute(partitioned_observations_parent_ddl())
+                ensure_observation_partitions(conn)
+            elif not is_observations_partitioned(conn):
+                conn.execute(_CURRENT_LIFECYCLE_POSTGRES_OBSERVATIONS_LEGACY_DDL)
+            else:
+                ensure_observation_partitions(conn)
             _migrate_lifecycle_observations_l2_postgres(conn)
             _migrate_current_ledger_ref_postgres(conn)
             conn.execute("UPDATE hub_findings_current SET cvss_score = 0 WHERE cvss_score IS NULL")

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -936,6 +936,20 @@ async def _cleanup_loop():
                 _logger.info("proxy_replay_log cleanup removed %d expired rows", removed)
         except Exception:  # noqa: BLE001
             _logger.debug("proxy_replay_log cleanup skipped", exc_info=True)
+        # Hub observations partition retention (#3463). Postgres-only; no-op on
+        # SQLite and legacy unpartitioned tables. Fail-open like other cleanup
+        # hooks so a backend hiccup never stops the loop.
+        try:
+            from agent_bom.api.hub_observations_partition import run_hub_observations_retention
+
+            dropped_partitions = run_hub_observations_retention()
+            if dropped_partitions:
+                _logger.info(
+                    "hub_findings_current_observations retention dropped %d partition(s)",
+                    dropped_partitions,
+                )
+        except Exception:  # noqa: BLE001
+            _logger.debug("hub observations retention skipped", exc_info=True)
         # NHI lifecycle enforcement (#nhi): expire lingering JIT grants, opt-in
         # dormant-identity deprovision, advisory token rotation-due flagging.
         # Backend-agnostic and fail-open — a store error logs and is skipped so

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -262,6 +262,15 @@ LOCAL_ANALYTICS_DB = _str("AGENT_BOM_LOCAL_ANALYTICS_DB", "")
 GRAPH_RETENTION_DAYS = _int("AGENT_BOM_GRAPH_RETENTION_DAYS", 180)
 
 
+# ── Hub Observations Retention ────────────────────────────────────────────
+# Age-based retention for the Postgres occurrence log
+# (``hub_findings_current_observations``). Monthly RANGE partitions are
+# detached and dropped once wholly past this window. ``<= 0`` disables
+# rollover. SQLite and legacy unpartitioned Postgres tables are unaffected.
+
+HUB_OBSERVATIONS_RETENTION_DAYS = _int("AGENT_BOM_HUB_OBSERVATIONS_RETENTION_DAYS", 365)
+
+
 # ── Analytics Retention ───────────────────────────────────────────────────
 # Caps local analytics mirrors and runtime observation tables on write. ClickHouse
 # analytics tables carry their own TTL clauses; this knob bounds SQLite/Postgres

--- a/tests/test_hub_observations_partition.py
+++ b/tests/test_hub_observations_partition.py
@@ -1,0 +1,198 @@
+"""Hub observations partition DDL and retention helpers (#3463)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_bom.api.hub_observations_partition import (
+    create_observation_partition_ddl,
+    ensure_observation_partitions,
+    is_observations_partitioned,
+    list_observation_partition_names,
+    migrate_observations_to_partitioned,
+    month_range_bounds,
+    observations_table_exists,
+    partition_is_expired,
+    partition_table_name,
+    partitioned_observations_parent_ddl,
+    rollover_observation_partitions,
+)
+
+
+def test_partitioned_parent_ddl_includes_partition_key_in_pk() -> None:
+    ddl = partitioned_observations_parent_ddl()
+    assert "PARTITION BY RANGE (observed_at)" in ddl
+    assert "observed_at TIMESTAMPTZ NOT NULL" in ddl
+    assert "PRIMARY KEY (tenant_id, canonical_id, scan_id, observed_at)" in ddl
+
+
+def test_create_partition_ddl_monthly_bounds() -> None:
+    ddl = create_observation_partition_ddl(2026, 7)
+    assert "hub_findings_current_observations_y2026m07" in ddl
+    assert "FROM ('2026-07-01') TO ('2026-08-01')" in ddl
+
+    dec_ddl = create_observation_partition_ddl(2026, 12)
+    assert "FROM ('2026-12-01') TO ('2027-01-01')" in dec_ddl
+
+
+def test_month_range_bounds_half_open() -> None:
+    start, end = month_range_bounds(2026, 2)
+    assert start == date(2026, 2, 1)
+    assert end == date(2026, 3, 1)
+
+
+def test_partition_is_expired_uses_partition_end() -> None:
+    now = date(2026, 7, 15)
+    assert partition_is_expired(
+        partition_table_name(2025, 6),
+        retention_days=30,
+        now=now,
+    )
+    assert not partition_is_expired(
+        partition_table_name(2026, 7),
+        retention_days=30,
+        now=now,
+    )
+    assert not partition_is_expired(
+        partition_table_name(2026, 6),
+        retention_days=30,
+        now=now,
+    )
+
+
+def test_ensure_observation_partitions_creates_missing_children() -> None:
+    conn = MagicMock()
+    conn.execute.side_effect = [
+        MagicMock(fetchone=MagicMock(return_value=("p",))),  # is_observations_partitioned
+        MagicMock(fetchone=MagicMock(return_value=None)),  # y2026m06 missing
+        MagicMock(),
+        MagicMock(fetchone=MagicMock(return_value=("child",))),  # y2026m07 exists
+        MagicMock(fetchone=MagicMock(return_value=None)),  # y2026m08 missing
+        MagicMock(),
+        MagicMock(fetchone=MagicMock(return_value=None)),  # y2026m09 missing
+        MagicMock(),
+    ]
+
+    created = ensure_observation_partitions(
+        conn,
+        now=datetime(2026, 7, 5, tzinfo=timezone.utc),
+        months_ahead=2,
+        months_behind=1,
+    )
+
+    assert created == 3
+    executed = [str(call.args[0]).strip() for call in conn.execute.call_args_list]
+    assert any("CREATE TABLE IF NOT EXISTS hub_findings_current_observations_y2026m06" in sql for sql in executed)
+    assert any("CREATE TABLE IF NOT EXISTS hub_findings_current_observations_y2026m08" in sql for sql in executed)
+
+
+def test_ensure_observation_partitions_noop_when_not_partitioned() -> None:
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = ("r",)
+    assert ensure_observation_partitions(conn) == 0
+    conn.execute.assert_called_once()
+
+
+def test_rollover_drops_only_expired_partitions() -> None:
+    conn = MagicMock()
+    conn.execute.side_effect = [
+        MagicMock(fetchone=MagicMock(return_value=("p",))),  # is_observations_partitioned
+        MagicMock(
+            fetchall=MagicMock(
+                return_value=[
+                    ("hub_findings_current_observations_y2025m05",),
+                    ("hub_findings_current_observations_y2026m06",),
+                    ("hub_findings_current_observations_y2026m07",),
+                ]
+            )
+        ),
+        MagicMock(),
+        MagicMock(),
+    ]
+
+    dropped = rollover_observation_partitions(
+        conn,
+        retention_days=30,
+        now=datetime(2026, 7, 5, tzinfo=timezone.utc),
+    )
+
+    assert dropped == 1
+    detach_sql = str(conn.execute.call_args_list[2].args[0])
+    drop_sql = str(conn.execute.call_args_list[3].args[0])
+    assert "DETACH PARTITION hub_findings_current_observations_y2025m05" in detach_sql
+    assert "DROP TABLE IF EXISTS hub_findings_current_observations_y2025m05" in drop_sql
+
+
+def test_rollover_disabled_when_retention_non_positive() -> None:
+    conn = MagicMock()
+    assert rollover_observation_partitions(conn, retention_days=0) == 0
+    conn.execute.assert_not_called()
+
+
+def test_migrate_observations_to_partitioned_renames_and_copies() -> None:
+    conn = MagicMock()
+    fetchone_queue = [
+        (1,),  # observations_table_exists
+        ("r",),  # is_observations_partitioned (legacy)
+        (date(2026, 6, 1), date(2026, 7, 1)),  # min/max month
+        ("p",),  # ensure_observation_partitions: parent is partitioned
+    ]
+
+    def _fetchone() -> object | None:
+        if fetchone_queue:
+            return fetchone_queue.pop(0)
+        return None
+
+    conn.execute.return_value.fetchone.side_effect = _fetchone
+
+    migrated = migrate_observations_to_partitioned(conn)
+
+    assert migrated is True
+    executed = " ".join(str(call.args[0]) for call in conn.execute.call_args_list)
+    assert "RENAME TO hub_findings_current_observations_pre_partition" in executed
+    assert "INSERT INTO hub_findings_current_observations" in executed
+    assert "DROP TABLE hub_findings_current_observations_pre_partition" in executed
+
+
+def test_migrate_observations_noop_when_already_partitioned() -> None:
+    conn = MagicMock()
+    conn.execute.side_effect = [
+        MagicMock(fetchone=MagicMock(return_value=(1,))),
+        MagicMock(fetchone=MagicMock(return_value=("p",))),
+    ]
+    assert migrate_observations_to_partitioned(conn) is False
+
+
+def test_observations_table_exists_and_partition_detection() -> None:
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = None
+    assert observations_table_exists(conn) is False
+
+    conn.execute.return_value.fetchone.return_value = ("p",)
+    assert is_observations_partitioned(conn) is True
+
+
+def test_list_observation_partition_names_returns_child_relations() -> None:
+    conn = MagicMock()
+    conn.execute.return_value.fetchall.return_value = [
+        ("hub_findings_current_observations_y2026m06",),
+        ("hub_findings_current_observations_y2026m07",),
+    ]
+    assert list_observation_partition_names(conn) == [
+        "hub_findings_current_observations_y2026m06",
+        "hub_findings_current_observations_y2026m07",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("year", "month", "expected"),
+    [
+        (2026, 1, "hub_findings_current_observations_y2026m01"),
+        (2026, 12, "hub_findings_current_observations_y2026m12"),
+    ],
+)
+def test_partition_table_name_slug(year: int, month: int, expected: str) -> None:
+    assert partition_table_name(year, month) == expected


### PR DESCRIPTION
## Summary
- Add monthly RANGE partitioning foundation for `hub_findings_current_observations` on Postgres: new installs bootstrap a partitioned parent with `observed_at TIMESTAMPTZ` and composite PK including the partition key.
- Add `AGENT_BOM_HUB_OBSERVATIONS_RETENTION_DAYS` (default 365; `<= 0` disables) and a fail-open cleanup-loop hook that ensures forward partitions and detaches/drops expired monthly children.
- Ship Alembic revision `20260705_01` plus `migrate_observations_to_partitioned()` for existing unpartitioned tables; SQLite and legacy Postgres tables remain unchanged.

Part of #3242
Part of #3463

## Verification
- `uv run pytest tests/test_hub_observations_partition.py -q` (14 passed)
- `uv run ruff check` on touched Python paths
- `python scripts/generate_env_var_reference.py --check`

## Notes
**Deferred follow-up:** automatic online migration during API bootstrap (intentionally opt-in via Alembic/maintenance window), ingest-path partition preflight metrics, and operator runbook for large-table cutovers.


Made with [Cursor](https://cursor.com)