### PR TITLE
feat(reachability): include symbol reachability in delta-stream snapshots

### DIFF
--- a/site-docs/deployment/siem-integration.md
+++ b/site-docs/deployment/siem-integration.md
@@ -163,7 +163,7 @@ export AGENT_BOM_DELTA_STREAM_AUTH_TOKEN="$SIEM_TOKEN"
 Each ingest batch emits a delta payload with:
 
 - `new` — canonical id first seen in current state for the ingest source
-- `changed` — severity, CVSS, reach score, or status materially changed
+- `changed` — severity, CVSS, reach score, symbol reachability, or status materially changed
 - `resolved` — open finding absent from a reconcile-absent batch
 
 Watermarks are stored per `(tenant_id, destination_id)` so retries and

--- a/src/agent_bom/delta_stream.py
+++ b/src/agent_bom/delta_stream.py
@@ -27,6 +27,42 @@ DeltaEventKind = Literal["new", "resolved", "changed"]
 DeltaFormat = Literal["ndjson", "ocsf"]
 
 
+def _symbol_reachability_from_finding(finding: dict[str, Any]) -> tuple[str | None, tuple[str, ...]]:
+    """Read symbol reachability from top-level keys or ``evidence`` (export shape)."""
+    evidence = finding.get("evidence")
+    symbol_reachability = finding.get("symbol_reachability")
+    reachable_affected_symbols = finding.get("reachable_affected_symbols")
+    if isinstance(evidence, dict):
+        if symbol_reachability is None:
+            symbol_reachability = evidence.get("symbol_reachability")
+        if reachable_affected_symbols is None:
+            reachable_affected_symbols = evidence.get("reachable_affected_symbols")
+    if symbol_reachability is not None and not isinstance(symbol_reachability, str):
+        symbol_reachability = str(symbol_reachability)
+    if reachable_affected_symbols is None:
+        symbols: tuple[str, ...] = ()
+    elif isinstance(reachable_affected_symbols, list):
+        symbols = tuple(str(item) for item in reachable_affected_symbols)
+    else:
+        symbols = ()
+    return symbol_reachability, symbols
+
+
+def _enrich_finding_symbol_reachability(
+    finding: dict[str, Any],
+    *,
+    symbol_reachability: str | None,
+    reachable_affected_symbols: tuple[str, ...],
+) -> dict[str, Any]:
+    """Promote symbol reachability onto the finding dict for delta payloads."""
+    enriched = dict(finding)
+    if symbol_reachability is not None and "symbol_reachability" not in enriched:
+        enriched["symbol_reachability"] = symbol_reachability
+    if reachable_affected_symbols and "reachable_affected_symbols" not in enriched:
+        enriched["reachable_affected_symbols"] = list(reachable_affected_symbols)
+    return enriched
+
+
 class DeltaStreamError(RuntimeError):
     """Raised for invalid connector configuration."""
 
@@ -38,20 +74,29 @@ class FindingSnapshot:
     severity_rank: int
     cvss_score: float
     effective_reach_score: float
+    symbol_reachability: str | None
+    reachable_affected_symbols: tuple[str, ...]
     status: str
     finding: dict[str, Any]
 
     @classmethod
     def from_finding(cls, finding: dict[str, Any], *, source: str = "") -> FindingSnapshot:
         canonical = str(finding.get("canonical_id") or resolve_canonical_id(finding, source=source))
+        symbol_reachability, reachable_affected_symbols = _symbol_reachability_from_finding(finding)
         return cls(
             canonical_id=canonical,
             severity=str(finding.get("severity") or "unknown").lower(),
             severity_rank=int(finding.get("severity_rank") or 0),
             cvss_score=float(finding.get("cvss_score") or 0.0),
             effective_reach_score=float(finding.get("effective_reach_score") or 0.0),
+            symbol_reachability=symbol_reachability,
+            reachable_affected_symbols=reachable_affected_symbols,
             status=str(finding.get("status") or "open"),
-            finding=dict(finding),
+            finding=_enrich_finding_symbol_reachability(
+                finding,
+                symbol_reachability=symbol_reachability,
+                reachable_affected_symbols=reachable_affected_symbols,
+            ),
         )
 
     def material_fields_changed(self, other: FindingSnapshot) -> bool:
@@ -60,6 +105,8 @@ class FindingSnapshot:
             or self.severity_rank != other.severity_rank
             or self.cvss_score != other.cvss_score
             or self.effective_reach_score != other.effective_reach_score
+            or self.symbol_reachability != other.symbol_reachability
+            or self.reachable_affected_symbols != other.reachable_affected_symbols
             or self.status != other.status
         )
 

--- a/tests/test_delta_stream.py
+++ b/tests/test_delta_stream.py
@@ -19,6 +19,7 @@ from agent_bom.delta_stream import (
     needs_hub_prior_snapshots,
     resolved_canonical_ids,
 )
+from agent_bom.reachability_cve import FUNCTION_REACHABLE, UNREACHABLE
 
 
 def _finding(
@@ -181,3 +182,80 @@ def test_needs_hub_prior_snapshots(monkeypatch) -> None:
     monkeypatch.setenv("AGENT_BOM_DELTA_STREAM_ENABLED", "1")
     monkeypatch.setenv("AGENT_BOM_DELTA_STREAM_URL", "https://siem.example/delta")
     assert needs_hub_prior_snapshots(reconcile_absent=False) is True
+
+
+def test_finding_snapshot_reads_symbol_reachability_from_evidence() -> None:
+    snap = FindingSnapshot.from_finding(
+        {
+            "id": "sym-evidence",
+            "severity": "high",
+            "evidence": {
+                "symbol_reachability": FUNCTION_REACHABLE,
+                "reachable_affected_symbols": ["get"],
+            },
+        },
+        source="src",
+    )
+    assert snap.symbol_reachability == FUNCTION_REACHABLE
+    assert snap.reachable_affected_symbols == ("get",)
+    assert snap.finding["symbol_reachability"] == FUNCTION_REACHABLE
+    assert snap.finding["reachable_affected_symbols"] == ["get"]
+
+
+def test_compute_finding_deltas_emits_changed_on_symbol_reachability() -> None:
+    prior = {
+        "sym-delta": FindingSnapshot.from_finding(
+            {
+                "id": "sym-delta",
+                "severity": "high",
+                "evidence": {
+                    "symbol_reachability": UNREACHABLE,
+                    "reachable_affected_symbols": [],
+                },
+            },
+            source="src",
+        ),
+    }
+    batch = [
+        {
+            "id": "sym-delta",
+            "severity": "high",
+            "evidence": {
+                "symbol_reachability": FUNCTION_REACHABLE,
+                "reachable_affected_symbols": ["get"],
+            },
+        },
+    ]
+    events = compute_finding_deltas(
+        tenant_id="tenant-1",
+        prior=prior,
+        batch_findings=batch,
+        resolved_canonical_ids=set(),
+        observed_at="2026-07-04T12:00:00Z",
+        batch_id="batch-sym",
+        source="src",
+    )
+    assert len(events) == 1
+    assert events[0].kind == "changed"
+    assert events[0].finding["symbol_reachability"] == FUNCTION_REACHABLE
+    assert events[0].finding["reachable_affected_symbols"] == ["get"]
+
+
+def test_compute_finding_deltas_ignores_unchanged_symbol_reachability() -> None:
+    finding = {
+        "id": "sym-stable",
+        "severity": "medium",
+        "symbol_reachability": FUNCTION_REACHABLE,
+        "reachable_affected_symbols": ["get"],
+    }
+    prior = {"sym-stable": FindingSnapshot.from_finding(finding, source="src")}
+    events = compute_finding_deltas(
+        tenant_id="tenant-1",
+        prior=prior,
+        batch_findings=[dict(finding)],
+        resolved_canonical_ids=set(),
+        observed_at="2026-07-04T12:00:00Z",
+        batch_id="batch-sym-stable",
+        source="src",
+    )
+    assert events == []


### PR DESCRIPTION
## Summary
- Extend `FindingSnapshot` to extract `symbol_reachability` and `reachable_affected_symbols` from finding evidence or top-level keys (matching JSON/finding export shape).
- Treat symbol reachability changes as material for hub `changed` delta events and promote fields onto delta payloads when only present in evidence.
- Add regression tests and note symbol reachability in the SIEM delta-stream doc.

Part of #3242, Part of #3499

## Verification
- `uv run ruff check src/agent_bom/delta_stream.py tests/test_delta_stream.py`
- `uv run pytest tests/test_delta_stream.py -q` (8 passed)


Made with [Cursor](https://cursor.com)