### PR TITLE
feat(reachability): wire JS/TS npm symbol reach into CVE join

### DIFF
--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 from agent_bom.ast_go import _go_function_key
 from agent_bom.ast_go import build_go_flow_findings as _build_go_flow_findings
 from agent_bom.ast_go import scan_go_file as _scan_go_file
-from agent_bom.ast_js_ts import _JS_TS_EXTS, _js_ts_function_key
+from agent_bom.ast_js_ts import _JS_TS_EXTS, _js_ts_function_key, build_js_ts_dependency_symbol_reach
 from agent_bom.ast_js_ts import build_js_ts_flow_findings as _build_js_ts_flow_findings
 from agent_bom.ast_js_ts import scan_js_ts_file as _scan_js_ts_file
 from agent_bom.ast_models import ASTAnalysisResult, CallEdge, _FunctionAnalysis, _GoFunctionAnalysis, _GoToolRegistration
@@ -172,6 +172,13 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
     )
     result.call_edges.extend(go_call_edges)
     result.flow_findings.extend(go_interprocedural_findings)
+    result.dependency_symbol_reach.extend(
+        build_js_ts_dependency_symbol_reach(
+            functions=js_ts_functions,
+            tool_registrations=js_ts_tool_registrations,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
 
     deduped_call_edges: list[CallEdge] = []
     seen_call_edges: set[tuple[str, str, str, int]] = set()

--- a/src/agent_bom/ast_js_ts.py
+++ b/src/agent_bom/ast_js_ts.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
-from agent_bom.ast_models import CallEdge, DetectedGuardrail, ExtractedPrompt, FlowFinding, ToolSignature
+from agent_bom.ast_models import CallEdge, DependencySymbolReach, DetectedGuardrail, ExtractedPrompt, FlowFinding, ToolSignature
 from agent_bom.ast_signal_utils import _GUARDRAIL_CALL_PATTERNS, check_prompt_risks, classify_prompt_type
 
 if TYPE_CHECKING:
@@ -758,3 +758,127 @@ def scan_js_ts_file(
             )
 
     return prompts, guardrails, tools, flow_findings, frameworks, call_edges, analysis_result
+
+
+def _npm_package_from_module(module_name: str) -> str | None:
+    """Map a JS/TS module specifier to an npm package name."""
+    mod = module_name.strip()
+    if not mod or mod.startswith(".") or mod.startswith("node:"):
+        return None
+    if mod.startswith("@"):
+        parts = mod.split("/")
+        return f"{parts[0]}/{parts[1]}" if len(parts) >= 2 else mod
+    return mod.split("/", 1)[0]
+
+
+def _resolve_js_ts_external_dependency_symbol(function: JSTSFunction, call_name: str) -> tuple[str, str, str] | None:
+    """Resolve an external import call to ``(package, module, symbol)``."""
+    if not call_name:
+        return None
+
+    direct = function.imported_function_refs.get(call_name)
+    if direct is not None:
+        package = _npm_package_from_module(direct.module_name)
+        if package is None:
+            return None
+        symbol = direct.exported_name or call_name
+        return package, direct.module_name, symbol
+
+    if "." in call_name:
+        alias, tail = call_name.split(".", 1)
+        fn_ref = function.imported_function_refs.get(alias)
+        if fn_ref is not None:
+            package = _npm_package_from_module(fn_ref.module_name)
+            if package is not None:
+                base = fn_ref.exported_name or alias
+                return package, fn_ref.module_name, f"{base}.{tail}" if tail else base
+        mod_ref = function.imported_module_refs.get(alias)
+        if mod_ref is not None:
+            package = _npm_package_from_module(mod_ref.module_name)
+            if package is not None:
+                symbol = tail.split(".", 1)[0]
+                return package, mod_ref.module_name, symbol
+
+    mod_ref = function.imported_module_refs.get(call_name)
+    if mod_ref is not None:
+        package = _npm_package_from_module(mod_ref.module_name)
+        if package is not None:
+            return package, mod_ref.module_name, call_name
+    return None
+
+
+def build_js_ts_dependency_symbol_reach(
+    *,
+    functions: Mapping[str, JSTSFunction],
+    tool_registrations: Sequence[JSTSToolRegistration],
+    max_depth: int = 4,
+) -> list[DependencySymbolReach]:
+    """Build bounded MCP tool-entrypoint -> npm dependency symbol reach evidence."""
+    if not functions or not tool_registrations:
+        return []
+
+    adjacency: dict[str, set[str]] = {name: set() for name in functions}
+    name_counts: dict[str, int] = {}
+    same_module_names: dict[str, set[str]] = {}
+    for function in functions.values():
+        name_counts[function.name] = name_counts.get(function.name, 0) + 1
+        same_module_names.setdefault(function.module_name, set()).add(function.name)
+
+    for function_key, function in functions.items():
+        module_names = same_module_names.get(function.module_name, set())
+        for call_site in function.call_sites:
+            callee_key = _resolve_js_ts_callee_key(
+                call_site.name,
+                function,
+                module_names,
+                functions,
+            )
+            if callee_key and callee_key != function_key:
+                adjacency[function_key].add(callee_key)
+
+    reached: list[DependencySymbolReach] = []
+    seen: set[tuple[str, str, str, str, int]] = set()
+
+    def display_name(function_key: str) -> str:
+        function = functions[function_key]
+        return _js_ts_function_display_name(function.module_name, function.name, name_counts)
+
+    for registration in tool_registrations:
+        if registration.handler_name not in functions:
+            continue
+        queue: list[tuple[str, list[str]]] = [(registration.handler_name, [registration.handler_name])]
+        visited: set[str] = set()
+        while queue:
+            current_name, path = queue.pop(0)
+            if len(path) > max_depth:
+                continue
+            if current_name in visited:
+                continue
+            visited.add(current_name)
+            current = functions[current_name]
+            for call_site in current.call_sites:
+                external = _resolve_js_ts_external_dependency_symbol(current, call_site.name)
+                if external is None:
+                    continue
+                package, module_name, symbol = external
+                dedup_key = (registration.tool_name, module_name, symbol, current.file_path, call_site.line_number)
+                if dedup_key in seen:
+                    continue
+                seen.add(dedup_key)
+                reached.append(
+                    DependencySymbolReach(
+                        entrypoint=registration.tool_name,
+                        package=package,
+                        module=module_name,
+                        symbol=symbol,
+                        file_path=current.file_path,
+                        line_number=call_site.line_number,
+                        call_path=[registration.tool_name, *[display_name(name) for name in path], f"{module_name}.{symbol}"],
+                        depth=max(0, len(path) - 1),
+                        ecosystem="npm",
+                    )
+                )
+            for next_callee in sorted(adjacency.get(current_name, ())):
+                queue.append((next_callee, [*path, next_callee]))
+
+    return reached

--- a/src/agent_bom/ast_models.py
+++ b/src/agent_bom/ast_models.py
@@ -94,6 +94,7 @@ class DependencySymbolReach:
     call_path: list[str] = field(default_factory=list)
     depth: int = 0
     confidence: str = "import-symbol"
+    ecosystem: str = "pypi"
 
 
 @dataclass
@@ -193,6 +194,7 @@ class ASTAnalysisResult:
                     "call_path": reach.call_path,
                     "depth": reach.depth,
                     "confidence": reach.confidence,
+                    "ecosystem": reach.ecosystem,
                 }
                 for reach in self.dependency_symbol_reach
             ],

--- a/src/agent_bom/graph/blast_reach.py
+++ b/src/agent_bom/graph/blast_reach.py
@@ -30,10 +30,8 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
-# Package ecosystems where a Python symbol-level call graph exists. The
-# function-reachability join only applies here — for everything else we leave
-# the signal untouched rather than over-claim.
-_PYTHON_ECOSYSTEMS: frozenset[str] = frozenset({"pypi", "python"})
+# Ecosystems where a symbol-level call graph join is supported.
+_SYMBOL_REACH_ECOSYSTEMS: frozenset[str] = frozenset({"pypi", "python", "npm"})
 
 
 def apply_dependency_reachability_to_blast_radii(
@@ -95,11 +93,11 @@ def apply_symbol_reachability_to_blast_radii(
 ) -> int:
     """Join CVE affected-symbols to AST symbol reach on each BlastRadius row.
 
-    Thin additive surfacing of :mod:`agent_bom.reachability_cve`. For every
-    Python finding it stamps ``symbol_reachability`` (function_reachable /
+    Thin additive surfacing of :mod:`agent_bom.reachability_cve`. For Python and
+    npm findings it stamps ``symbol_reachability`` (function_reachable /
     package_reachable / unreachable) and, when a match is found,
-    ``reachable_affected_symbols``. Non-Python findings are left untouched —
-    the call graph only exists for Python.
+    ``reachable_affected_symbols``. Other ecosystems are left untouched until
+    their call-graph symbol reach is implemented.
 
     The graph-walk reach already on the row (``graph_reachable``) is fed in as
     the import / dependency-closure fallback so a package that is reached but
@@ -129,7 +127,7 @@ def apply_symbol_reachability_to_blast_radii(
     stamped = 0
     for br in blast_radii:
         ecosystem = (getattr(br.package, "ecosystem", "") or "").lower()
-        if ecosystem not in _PYTHON_ECOSYSTEMS:
+        if ecosystem not in _SYMBOL_REACH_ECOSYSTEMS:
             continue
         try:
             signal = classify_reachability(
@@ -137,6 +135,7 @@ def apply_symbol_reachability_to_blast_radii(
                 advisory=br.vulnerability,
                 index=index,
                 package_reachable=br.graph_reachable,
+                ecosystem=ecosystem,
             )
         except Exception as exc:  # noqa: BLE001
             _logger.warning("Symbol reachability classify skipped for %s: %s", br.package.name, exc)

--- a/src/agent_bom/reachability_cve.py
+++ b/src/agent_bom/reachability_cve.py
@@ -29,12 +29,12 @@ is a three-state reachability signal on the finding:
 * ``unreachable`` — the package is present in the dependency set but no
   entrypoint reaches it at all.
 
-Honest scope: Python only — that is where the call graph exists — and the
-``function_reachable`` upgrade only fires when the advisory genuinely
-carries affected symbols. Everything else degrades to ``package_reachable``
-or ``unreachable``; we do not fabricate symbol reachability we cannot back
-with evidence. JS/TS/Go call graphs and additional advisory symbol sources
-(e.g. GHSA REST ``vulnerable_functions``) are follow-up work.
+Honest scope: Python and npm symbol-level call graphs are supported; Go and
+other ecosystems are follow-up work. The ``function_reachable`` upgrade only
+fires when the advisory genuinely carries affected symbols. Everything else
+degrades to ``package_reachable`` or ``unreachable``; we do not fabricate
+symbol reachability we cannot back with evidence. Additional advisory symbol
+sources (e.g. GHSA REST ``vulnerable_functions``) are follow-up work.
 
 The module is read-only: no graph mutation, no network. It is safe to call
 from the report layer, the graph/blast-radius surfacing, the API, or a
@@ -47,7 +47,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from agent_bom.package_utils import normalize_package_name
+from agent_bom.package_utils import normalize_package_ecosystem, normalize_package_name
 
 if TYPE_CHECKING:
     from agent_bom.ast_models import ASTAnalysisResult, DependencySymbolReach
@@ -63,9 +63,15 @@ UNREACHABLE = "unreachable"
 _MAX_SYMBOLS = 512
 
 
-def _normalize_pkg(name: str) -> str:
-    """Normalize a package name for cross-source matching (PyPI rules)."""
-    return normalize_package_name(name or "", "pypi")
+def _normalize_pkg(name: str, ecosystem: str = "pypi") -> str:
+    """Normalize a package name for cross-source matching."""
+    eco = normalize_package_ecosystem(ecosystem or "pypi")
+    return normalize_package_name(name or "", eco)
+
+
+def _pkg_index_key(package: str, ecosystem: str) -> str:
+    eco = normalize_package_ecosystem(ecosystem or "pypi")
+    return f"{eco}:{_normalize_pkg(package, eco)}"
 
 
 def _symbol_tokens(symbol: str) -> set[str]:
@@ -92,42 +98,42 @@ def _symbol_tokens(symbol: str) -> set[str]:
 class SymbolReachIndex:
     """Per-package reached-symbol index built from AST symbol reach."""
 
-    _symbols_by_package: dict[str, set[str]] = field(default_factory=dict)
-    _paths_by_package: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    _symbols_by_key: dict[str, set[str]] = field(default_factory=dict)
+    _paths_by_key: dict[str, tuple[str, ...]] = field(default_factory=dict)
 
     @classmethod
     def from_reaches(cls, reaches: Iterable["DependencySymbolReach"]) -> "SymbolReachIndex":
-        symbols_by_package: dict[str, set[str]] = {}
-        paths_by_package: dict[str, tuple[str, ...]] = {}
+        symbols_by_key: dict[str, set[str]] = {}
+        paths_by_key: dict[str, tuple[str, ...]] = {}
         for reach in reaches:
-            pkg = _normalize_pkg(reach.package)
-            if not pkg:
+            if not reach.package:
                 continue
-            bucket = symbols_by_package.setdefault(pkg, set())
+            key = _pkg_index_key(reach.package, reach.ecosystem)
+            bucket = symbols_by_key.setdefault(key, set())
             bucket |= _symbol_tokens(reach.symbol)
             # Keep the shortest (closest) call path as evidence per package.
-            existing = paths_by_package.get(pkg)
+            existing = paths_by_key.get(key)
             candidate = tuple(reach.call_path)
             if candidate and (existing is None or len(candidate) < len(existing)):
-                paths_by_package[pkg] = candidate
-        return cls(symbols_by_package, paths_by_package)
+                paths_by_key[key] = candidate
+        return cls(symbols_by_key, paths_by_key)
 
     @classmethod
     def from_ast_result(cls, result: "ASTAnalysisResult") -> "SymbolReachIndex":
         return cls.from_reaches(result.dependency_symbol_reach)
 
-    def is_package_reached(self, package: str) -> bool:
+    def is_package_reached(self, package: str, *, ecosystem: str = "pypi") -> bool:
         """True when any symbol of ``package`` is reached from an entrypoint."""
-        return _normalize_pkg(package) in self._symbols_by_package
+        return _pkg_index_key(package, ecosystem) in self._symbols_by_key
 
-    def symbols_for_package(self, package: str) -> set[str]:
-        return set(self._symbols_by_package.get(_normalize_pkg(package), set()))
+    def symbols_for_package(self, package: str, *, ecosystem: str = "pypi") -> set[str]:
+        return set(self._symbols_by_key.get(_pkg_index_key(package, ecosystem), set()))
 
-    def call_path_for_package(self, package: str) -> tuple[str, ...]:
-        return self._paths_by_package.get(_normalize_pkg(package), ())
+    def call_path_for_package(self, package: str, *, ecosystem: str = "pypi") -> tuple[str, ...]:
+        return self._paths_by_key.get(_pkg_index_key(package, ecosystem), ())
 
     def __bool__(self) -> bool:
-        return bool(self._symbols_by_package)
+        return bool(self._symbols_by_key)
 
 
 @dataclass(frozen=True)
@@ -215,6 +221,7 @@ def classify_reachability(
     advisory: "Vulnerability | Mapping[str, Any] | None",
     index: SymbolReachIndex,
     package_reachable: bool | None = None,
+    ecosystem: str = "pypi",
 ) -> ReachabilitySignal:
     """Classify one vulnerable package into a three-state reachability signal.
 
@@ -234,11 +241,14 @@ def classify_reachability(
         whose symbols were not individually captured. ``None`` means the
         caller has no graph-reach evidence and we rely on the symbol index
         alone.
+    ecosystem:
+        Package ecosystem for index lookup (``pypi``, ``npm``, …).
     """
+    eco = normalize_package_ecosystem(ecosystem or "pypi")
     advisory_symbols = extract_affected_symbols(advisory)
-    reached_symbols = index.symbols_for_package(package)
-    pkg_reached = index.is_package_reached(package) or package_reachable is True
-    call_path = index.call_path_for_package(package)
+    reached_symbols = index.symbols_for_package(package, ecosystem=eco)
+    pkg_reached = index.is_package_reached(package, ecosystem=eco) or package_reachable is True
+    call_path = index.call_path_for_package(package, ecosystem=eco)
 
     if advisory_symbols and reached_symbols:
         matched = sorted(advisory_symbols & reached_symbols)

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -398,6 +398,7 @@ def test_analyze_project_surfaces_dependency_symbol_reach_from_tool(tmp_path: Pa
             "call_path": ["fetch", "requests.get"],
             "depth": 0,
             "confidence": "import-symbol",
+            "ecosystem": "pypi",
         }
     ]
 
@@ -427,8 +428,26 @@ def test_analyze_project_surfaces_dependency_symbol_reach_through_helper(tmp_pat
             "call_path": ["answer", "ask_model", "openai.OpenAI"],
             "depth": 1,
             "confidence": "import-symbol",
+            "ecosystem": "pypi",
         }
     ]
+
+
+def test_analyze_project_surfaces_js_dependency_symbol_reach(tmp_path: Path):
+    (tmp_path / "server.ts").write_text(
+        'import axios from "axios";\n'
+        'server.tool("fetch_url", "Fetch a URL", async (url: string) => axios.get(url));\n'
+    )
+
+    result = analyze_project(tmp_path)
+    if _js_ts_parser_available():
+        npm_reaches = [reach for reach in result.dependency_symbol_reach if reach.ecosystem == "npm"]
+        assert len(npm_reaches) == 1
+        reach = npm_reaches[0]
+        assert reach.entrypoint == "fetch_url"
+        assert reach.package == "axios"
+        assert reach.symbol == "get"
+        assert reach.call_path[0] == "fetch_url"
 
 
 def test_analyze_project_treats_validation_branch_as_guard(tmp_path: Path):

--- a/tests/test_reachability_cve.py
+++ b/tests/test_reachability_cve.py
@@ -11,7 +11,8 @@ Pins the contract that:
    over-claimed function reach.
 4. A package present but not reached classifies as ``unreachable``.
 5. The thin ``apply_symbol_reachability_to_blast_radii`` hook stamps the
-   signal onto Python BlastRadius rows and leaves non-Python rows alone.
+   signal onto Python and npm BlastRadius rows and leaves unsupported
+   ecosystems untouched.
 """
 
 from __future__ import annotations
@@ -19,6 +20,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from agent_bom.ast_analyzer import analyze_project
+from agent_bom.ast_js_ts import _npm_package_from_module
 from agent_bom.ast_models import ASTAnalysisResult, DependencySymbolReach
 from agent_bom.graph.blast_reach import apply_symbol_reachability_to_blast_radii
 from agent_bom.models import BlastRadius, Package, Severity, Vulnerability
@@ -155,6 +157,53 @@ def test_package_name_normalization_matches() -> None:
     assert signal.state == FUNCTION_REACHABLE
 
 
+def test_ecosystem_keys_do_not_cross_match() -> None:
+    npm_reach = DependencySymbolReach(
+        entrypoint="fetch_url",
+        package="lodash",
+        module="lodash",
+        symbol="get",
+        file_path="server.ts",
+        line_number=3,
+        call_path=["fetch_url", "lodash.get"],
+        ecosystem="npm",
+    )
+    index = SymbolReachIndex.from_reaches([npm_reach])
+    signal = classify_reachability(
+        package="lodash",
+        advisory={"id": "CVE-2099-8", "affected": [{"package": {"ecosystem": "npm", "name": "lodash"}}]},
+        index=index,
+        ecosystem="pypi",
+    )
+    assert signal.state == UNREACHABLE
+
+
+def test_npm_function_reachable_when_affected_symbol_is_reached() -> None:
+    npm_reach = DependencySymbolReach(
+        entrypoint="fetch_url",
+        package="axios",
+        module="axios",
+        symbol="get",
+        file_path="server.ts",
+        line_number=3,
+        call_path=["fetch_url", "axios.get"],
+        ecosystem="npm",
+    )
+    index = SymbolReachIndex.from_reaches([npm_reach])
+    advisory = {
+        "id": "CVE-2099-9",
+        "affected": [
+            {
+                "package": {"ecosystem": "npm", "name": "axios"},
+                "ecosystem_specific": {"imports": [{"path": "axios", "symbols": ["get"]}]},
+            }
+        ],
+    }
+    signal = classify_reachability(package="axios", advisory=advisory, index=index, ecosystem="npm")
+    assert signal.state == FUNCTION_REACHABLE
+    assert signal.matched_symbols == ("get",)
+
+
 # ── end-to-end through the real AST call graph ────────────────────────────
 
 
@@ -229,12 +278,31 @@ def test_wiring_stamps_unreachable_when_symbol_absent() -> None:
     assert br.symbol_reachability == UNREACHABLE
 
 
-def test_wiring_skips_non_python_rows() -> None:
+def test_wiring_skips_unsupported_ecosystem_rows() -> None:
     br = _python_br(["get"])
-    br.package.ecosystem = "npm"
+    br.package.ecosystem = "maven"
     stamped = apply_symbol_reachability_to_blast_radii([br], _ast_result_with_get())
     assert stamped == 0
     assert br.symbol_reachability is None
+
+
+def test_wiring_stamps_npm_row() -> None:
+    br = _python_br(["get"], pkg_name="axios")
+    br.package.ecosystem = "npm"
+    npm_reach = DependencySymbolReach(
+        entrypoint="fetch_url",
+        package="axios",
+        module="axios",
+        symbol="get",
+        file_path="server.ts",
+        line_number=3,
+        call_path=["fetch_url", "axios.get"],
+        ecosystem="npm",
+    )
+    stamped = apply_symbol_reachability_to_blast_radii([br], ASTAnalysisResult(dependency_symbol_reach=[npm_reach]))
+    assert stamped == 1
+    assert br.symbol_reachability == FUNCTION_REACHABLE
+    assert br.reachable_affected_symbols == ["get"]
 
 
 def test_wiring_no_op_without_symbol_reach_evidence() -> None:
@@ -255,3 +323,10 @@ def test_wiring_is_best_effort_no_op(monkeypatch) -> None:
     monkeypatch.setattr("agent_bom.reachability_cve.SymbolReachIndex.from_ast_result", explode)
     assert apply_symbol_reachability_to_blast_radii([br], _ast_result_with_get()) == 0
     assert br.symbol_reachability is None
+
+
+def test_npm_package_from_module() -> None:
+    assert _npm_package_from_module("axios") == "axios"
+    assert _npm_package_from_module("@scope/pkg/subpath") == "@scope/pkg"
+    assert _npm_package_from_module("./relative") is None
+    assert _npm_package_from_module("node:fs") is None


### PR DESCRIPTION
## Summary

- Wire the existing JS/TS MCP call graph into `dependency_symbol_reach` (npm packages from import symbols reachable from tool entrypoints).
- Extend `SymbolReachIndex` and `apply_symbol_reachability_to_blast_radii` to stamp `symbol_reachability` on **npm** BlastRadius rows alongside Python.
- Add ecosystem field on `DependencySymbolReach` so PyPI and npm symbol evidence do not cross-match.

### Reachability matrix after this PR

| Signal | Python | JS/TS (npm) | Go |
|---|---|---|---|
| `graph_reachable` | ✅ | ✅ | ✅ |
| `reachability_evidence` | ✅ | ✅ | ✅ |
| `effective_reach_score` | ✅ | ✅ | ✅ |
| `dependency_symbol_reach` (AST) | ✅ | ✅ **new** | ❌ B2 |
| `symbol_reachability` on CVE | ✅ | ✅ **new** | ❌ B2 |

Part of #3242. Part of #3499.

## Verification

```bash
uv run ruff check src/agent_bom/ast_analyzer.py src/agent_bom/ast_js_ts.py src/agent_bom/ast_models.py src/agent_bom/graph/blast_reach.py src/agent_bom/reachability_cve.py tests/test_reachability_cve.py tests/test_ast_analyzer.py
uv run pytest -q tests/test_reachability_cve.py tests/test_ast_analyzer.py::test_analyze_project_surfaces_js_dependency_symbol_reach tests/test_symbol_reachability_export.py
```

30 tests passed.


Made with [Cursor](https://cursor.com)