### PR TITLE
feat(reachability): multilang symbol join + CWE/CVE/CPE advisory context

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -113,12 +113,12 @@ helm upgrade --install agent-bom deploy/helm/agent-bom \
 ## Key features
 
 - **Blast radius + attack-path fusion** — multi-hop exposure paths over one unified `ContextGraph`, from package → finding → MCP server → credentials → connected agents
-- **CWE-aware impact** — RCE shows credential exposure, DoS does not
+- **CWE-aware impact** — RCE shows credential exposure, DoS does not; symbol-level CVE reachability joins CWE/CVE/CPE advisory context when OSV/GHSA carry affected symbols (Python, npm, Go)
 - **Portable outputs** — SARIF, CycloneDX, SPDX, OCSF, HTML, graph, JSON, ZIP evidence bundles, and more
 - **MCP server mode** — 69 MCP tools, 6 resources, and 6 workflow prompts exposed to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
 - **Skill bundle identity** — stable bundle hashes for skill and instruction file review
 - **Dependency confusion detection** — flags internal naming patterns
-- **VEX generation** — auto-triage with CWE-aware reachability
+- **VEX generation** — auto-triage with CWE/CVE/CPE-aware reachability (package + function-level when advisory symbols exist)
 
 Read-only. Agentless. No secrets leave your machine unless you explicitly enable an outbound integration.
 

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -143,7 +143,7 @@ The scanner covers package risk, malicious or suspicious package indicators, con
 
 ### Blast radius
 
-Blast radius is the product center of gravity. `agent-bom` connects vulnerabilities to packages, MCP servers, agents, credential exposure, and reachable tools. Impact is CWE-aware so the reported consequences match the weakness class instead of inflating every issue into full compromise.
+Blast radius is the product center of gravity. `agent-bom` connects vulnerabilities to packages, MCP servers, agents, credential exposure, and reachable tools. Impact is CWE-aware so the reported consequences match the weakness class instead of inflating every issue into full compromise. Function-level CVE de-noising joins OSV/GHSA affected symbols to Python, npm, and Go call graphs when `--project` AST analysis is available; CVE/CWE/CPE identifiers ride along on the reachability verdict.
 
 The highest-risk trust chain is surfaced directly in the human and machine surfaces, not only the JSON report. The `--posture` card renders the top exposure path as a one-line spine (`agent → MCP server → package@version → CVE → tool`) with its blast-radius summary (`N cred(s), N tool(s) reachable`), and SARIF results carry the same chain in the result message, an `exposure_chain` property, and `relatedLocations` so it renders in code-scanning viewers.
 

--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 from agent_bom.ast_go import _go_function_key
 from agent_bom.ast_go import build_go_flow_findings as _build_go_flow_findings
 from agent_bom.ast_go import scan_go_file as _scan_go_file
-from agent_bom.ast_js_ts import _JS_TS_EXTS, _js_ts_function_key
+from agent_bom.ast_js_ts import _JS_TS_EXTS, _js_ts_function_key, build_js_ts_dependency_symbol_reach
 from agent_bom.ast_js_ts import build_js_ts_flow_findings as _build_js_ts_flow_findings
 from agent_bom.ast_js_ts import scan_js_ts_file as _scan_js_ts_file
 from agent_bom.ast_models import ASTAnalysisResult, CallEdge, _FunctionAnalysis, _GoFunctionAnalysis, _GoToolRegistration
@@ -172,6 +172,13 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
     )
     result.call_edges.extend(go_call_edges)
     result.flow_findings.extend(go_interprocedural_findings)
+    result.dependency_symbol_reach.extend(
+        build_js_ts_dependency_symbol_reach(
+            functions=js_ts_functions,
+            tool_registrations=js_ts_tool_registrations,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
 
     deduped_call_edges: list[CallEdge] = []
     seen_call_edges: set[tuple[str, str, str, int]] = set()

--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from agent_bom.js_ts_ast import JSTSFunction, JSTSToolRegistration
-from agent_bom.ast_go import _go_function_key
+from agent_bom.ast_go import _go_function_key, build_go_dependency_symbol_reach
 from agent_bom.ast_go import build_go_flow_findings as _build_go_flow_findings
 from agent_bom.ast_go import scan_go_file as _scan_go_file
 from agent_bom.ast_js_ts import _JS_TS_EXTS, _js_ts_function_key, build_js_ts_dependency_symbol_reach
@@ -176,6 +176,13 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
         build_js_ts_dependency_symbol_reach(
             functions=js_ts_functions,
             tool_registrations=js_ts_tool_registrations,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
+    result.dependency_symbol_reach.extend(
+        build_go_dependency_symbol_reach(
+            functions=go_functions,
+            tool_registrations=go_tool_registrations,
             max_depth=_python_max_taint_depth(),
         )
     )

--- a/src/agent_bom/ast_go.py
+++ b/src/agent_bom/ast_go.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from agent_bom.ast_models import (
     CallEdge,
+    DependencySymbolReach,
     DetectedGuardrail,
     ExtractedPrompt,
     FlowFinding,
@@ -740,6 +741,163 @@ def build_go_flow_findings(
                     taint_queue.append((callee_key, path + [callee_key], frozenset(tainted_callee_params)))
 
     return call_edges, findings
+
+
+def _go_module_package(module_name: str) -> str | None:
+    """Map a Go import path to a module identifier for vulndb matching."""
+    mod = module_name.strip().strip("/")
+    if not mod or mod.startswith("."):
+        return None
+    return mod
+
+
+def _resolve_go_external_dependency_symbol(
+    function: _GoFunctionAnalysis,
+    call_name: str,
+) -> tuple[str, str, str] | None:
+    """Resolve an external import call to ``(package, module, symbol)``."""
+    if not call_name or "." not in call_name:
+        return None
+    alias, remainder = call_name.split(".", 1)
+    module_path = function.imported_aliases.get(alias)
+    if not module_path:
+        return None
+    package = _go_module_package(module_path)
+    if package is None:
+        return None
+    symbol = remainder.split(".", 1)[0]
+    if not symbol:
+        return None
+    return package, module_path, symbol
+
+
+def _resolve_go_registration_handler_key(
+    registration: _GoToolRegistration,
+    *,
+    functions: Mapping[str, _GoFunctionAnalysis],
+    scope_function_names: Mapping[str, set[str]],
+    known_scopes: set[str],
+    package_scopes: Mapping[str, set[str]],
+    basename_scopes: Mapping[str, set[str]],
+) -> str | None:
+    key = _go_function_key(registration.scope_name, registration.handler_name)
+    if key in functions:
+        return key
+    imported_module = registration.imported_aliases.get(registration.handler_name.split(".", 1)[0], "")
+    if imported_module or "." in registration.handler_name:
+        pseudo_function = _GoFunctionAnalysis(
+            name=registration.handler_name,
+            line_number=registration.line_number,
+            file_path=registration.file_path,
+            scope_name=registration.scope_name,
+            imported_aliases=registration.imported_aliases,
+        )
+        return _resolve_go_callee_key(
+            registration.handler_name,
+            pseudo_function,
+            scope_function_names.get(registration.scope_name, set()),
+            functions,
+            known_scopes=known_scopes,
+            package_scopes=package_scopes,
+            basename_scopes=basename_scopes,
+        )
+    return None
+
+
+def build_go_dependency_symbol_reach(
+    *,
+    functions: Mapping[str, _GoFunctionAnalysis],
+    tool_registrations: Sequence[_GoToolRegistration],
+    max_depth: int = 4,
+) -> list[DependencySymbolReach]:
+    """Build bounded MCP tool-entrypoint -> Go module dependency symbol reach."""
+    if not functions or not tool_registrations:
+        return []
+
+    adjacency: dict[str, set[str]] = {name: set() for name in functions}
+    name_counts: dict[str, int] = {}
+    scope_function_names: dict[str, set[str]] = {}
+    package_scopes: dict[str, set[str]] = {}
+    basename_scopes: dict[str, set[str]] = {}
+    known_scopes: set[str] = set()
+
+    for function in functions.values():
+        name_counts[function.name] = name_counts.get(function.name, 0) + 1
+        scope_function_names.setdefault(function.scope_name, set()).add(function.name)
+        known_scopes.add(function.scope_name)
+        if function.package_name:
+            package_scopes.setdefault(function.package_name, set()).add(function.scope_name)
+        scope_basename = PurePosixPath(function.scope_name).name if function.scope_name not in {"", "."} else "."
+        basename_scopes.setdefault(scope_basename, set()).add(function.scope_name)
+
+    for function_key, function in functions.items():
+        for call_site in function.call_sites:
+            callee_key = _resolve_go_callee_key(
+                call_site.name,
+                function,
+                scope_function_names.get(function.scope_name, set()),
+                functions,
+                known_scopes=known_scopes,
+                package_scopes=package_scopes,
+                basename_scopes=basename_scopes,
+            )
+            if callee_key and callee_key != function_key:
+                adjacency[function_key].add(callee_key)
+
+    def display_name(function_key: str) -> str:
+        function = functions[function_key]
+        return _go_function_display_name(function.scope_name, function.name, name_counts)
+
+    reached: list[DependencySymbolReach] = []
+    seen: set[tuple[str, str, str, str, int]] = set()
+
+    for registration in tool_registrations:
+        handler_key = _resolve_go_registration_handler_key(
+            registration,
+            functions=functions,
+            scope_function_names=scope_function_names,
+            known_scopes=known_scopes,
+            package_scopes=package_scopes,
+            basename_scopes=basename_scopes,
+        )
+        if handler_key is None:
+            continue
+        queue: list[tuple[str, list[str]]] = [(handler_key, [handler_key])]
+        visited: set[str] = set()
+        while queue:
+            current_key, path = queue.pop(0)
+            if len(path) > max_depth:
+                continue
+            if current_key in visited:
+                continue
+            visited.add(current_key)
+            current = functions[current_key]
+            for call_site in current.call_sites:
+                external = _resolve_go_external_dependency_symbol(current, call_site.name)
+                if external is None:
+                    continue
+                package, module_name, symbol = external
+                dedup_key = (registration.tool_name, module_name, symbol, current.file_path, call_site.line_number)
+                if dedup_key in seen:
+                    continue
+                seen.add(dedup_key)
+                reached.append(
+                    DependencySymbolReach(
+                        entrypoint=registration.tool_name,
+                        package=package,
+                        module=module_name,
+                        symbol=symbol,
+                        file_path=current.file_path,
+                        line_number=call_site.line_number,
+                        call_path=[registration.tool_name, *[display_name(name) for name in path], f"{module_name}.{symbol}"],
+                        depth=max(0, len(path) - 1),
+                        ecosystem="go",
+                    )
+                )
+            for next_callee in sorted(adjacency.get(current_key, ())):
+                queue.append((next_callee, [*path, next_callee]))
+
+    return reached
 
 
 def scan_go_file(

--- a/src/agent_bom/ast_js_ts.py
+++ b/src/agent_bom/ast_js_ts.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
-from agent_bom.ast_models import CallEdge, DetectedGuardrail, ExtractedPrompt, FlowFinding, ToolSignature
+from agent_bom.ast_models import CallEdge, DependencySymbolReach, DetectedGuardrail, ExtractedPrompt, FlowFinding, ToolSignature
 from agent_bom.ast_signal_utils import _GUARDRAIL_CALL_PATTERNS, check_prompt_risks, classify_prompt_type
 
 if TYPE_CHECKING:
@@ -758,3 +758,127 @@ def scan_js_ts_file(
             )
 
     return prompts, guardrails, tools, flow_findings, frameworks, call_edges, analysis_result
+
+
+def _npm_package_from_module(module_name: str) -> str | None:
+    """Map a JS/TS module specifier to an npm package name."""
+    mod = module_name.strip()
+    if not mod or mod.startswith(".") or mod.startswith("node:"):
+        return None
+    if mod.startswith("@"):
+        parts = mod.split("/")
+        return f"{parts[0]}/{parts[1]}" if len(parts) >= 2 else mod
+    return mod.split("/", 1)[0]
+
+
+def _resolve_js_ts_external_dependency_symbol(function: JSTSFunction, call_name: str) -> tuple[str, str, str] | None:
+    """Resolve an external import call to ``(package, module, symbol)``."""
+    if not call_name:
+        return None
+
+    direct = function.imported_function_refs.get(call_name)
+    if direct is not None:
+        package = _npm_package_from_module(direct.module_name)
+        if package is None:
+            return None
+        symbol = direct.exported_name or call_name
+        return package, direct.module_name, symbol
+
+    if "." in call_name:
+        alias, tail = call_name.split(".", 1)
+        fn_ref = function.imported_function_refs.get(alias)
+        if fn_ref is not None:
+            package = _npm_package_from_module(fn_ref.module_name)
+            if package is not None:
+                base = fn_ref.exported_name or alias
+                return package, fn_ref.module_name, f"{base}.{tail}" if tail else base
+        mod_ref = function.imported_module_refs.get(alias)
+        if mod_ref is not None:
+            package = _npm_package_from_module(mod_ref.module_name)
+            if package is not None:
+                symbol = tail.split(".", 1)[0]
+                return package, mod_ref.module_name, symbol
+
+    mod_ref = function.imported_module_refs.get(call_name)
+    if mod_ref is not None:
+        package = _npm_package_from_module(mod_ref.module_name)
+        if package is not None:
+            return package, mod_ref.module_name, call_name
+    return None
+
+
+def build_js_ts_dependency_symbol_reach(
+    *,
+    functions: Mapping[str, JSTSFunction],
+    tool_registrations: Sequence[JSTSToolRegistration],
+    max_depth: int = 4,
+) -> list[DependencySymbolReach]:
+    """Build bounded MCP tool-entrypoint -> npm dependency symbol reach evidence."""
+    if not functions or not tool_registrations:
+        return []
+
+    adjacency: dict[str, set[str]] = {name: set() for name in functions}
+    name_counts: dict[str, int] = {}
+    same_module_names: dict[str, set[str]] = {}
+    for function in functions.values():
+        name_counts[function.name] = name_counts.get(function.name, 0) + 1
+        same_module_names.setdefault(function.module_name, set()).add(function.name)
+
+    for function_key, function in functions.items():
+        module_names = same_module_names.get(function.module_name, set())
+        for call_site in function.call_sites:
+            callee_key = _resolve_js_ts_callee_key(
+                call_site.name,
+                function,
+                module_names,
+                functions,
+            )
+            if callee_key and callee_key != function_key:
+                adjacency[function_key].add(callee_key)
+
+    reached: list[DependencySymbolReach] = []
+    seen: set[tuple[str, str, str, str, int]] = set()
+
+    def display_name(function_key: str) -> str:
+        function = functions[function_key]
+        return _js_ts_function_display_name(function.module_name, function.name, name_counts)
+
+    for registration in tool_registrations:
+        if registration.handler_name not in functions:
+            continue
+        queue: list[tuple[str, list[str]]] = [(registration.handler_name, [registration.handler_name])]
+        visited: set[str] = set()
+        while queue:
+            current_name, path = queue.pop(0)
+            if len(path) > max_depth:
+                continue
+            if current_name in visited:
+                continue
+            visited.add(current_name)
+            current = functions[current_name]
+            for call_site in current.call_sites:
+                external = _resolve_js_ts_external_dependency_symbol(current, call_site.name)
+                if external is None:
+                    continue
+                package, module_name, symbol = external
+                dedup_key = (registration.tool_name, module_name, symbol, current.file_path, call_site.line_number)
+                if dedup_key in seen:
+                    continue
+                seen.add(dedup_key)
+                reached.append(
+                    DependencySymbolReach(
+                        entrypoint=registration.tool_name,
+                        package=package,
+                        module=module_name,
+                        symbol=symbol,
+                        file_path=current.file_path,
+                        line_number=call_site.line_number,
+                        call_path=[registration.tool_name, *[display_name(name) for name in path], f"{module_name}.{symbol}"],
+                        depth=max(0, len(path) - 1),
+                        ecosystem="npm",
+                    )
+                )
+            for next_callee in sorted(adjacency.get(current_name, ())):
+                queue.append((next_callee, [*path, next_callee]))
+
+    return reached

--- a/src/agent_bom/ast_models.py
+++ b/src/agent_bom/ast_models.py
@@ -94,6 +94,7 @@ class DependencySymbolReach:
     call_path: list[str] = field(default_factory=list)
     depth: int = 0
     confidence: str = "import-symbol"
+    ecosystem: str = "pypi"
 
 
 @dataclass
@@ -193,6 +194,7 @@ class ASTAnalysisResult:
                     "call_path": reach.call_path,
                     "depth": reach.depth,
                     "confidence": reach.confidence,
+                    "ecosystem": reach.ecosystem,
                 }
                 for reach in self.dependency_symbol_reach
             ],

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -866,6 +866,14 @@ def blast_radius_to_finding(br: object) -> "Finding":
     cve_ids = all_cve_identifiers(vuln.id, getattr(vuln, "aliases", []) or [])
     if cve_ids:
         evidence["cve_ids"] = cve_ids
+    if getattr(br, "symbol_reachability", None):
+        from agent_bom.reachability_cve import extract_advisory_identifiers
+
+        reach_ids = extract_advisory_identifiers(vuln)
+        if reach_ids.cwe_ids:
+            evidence["reachability_advisory_cwe_ids"] = list(reach_ids.cwe_ids)
+        if reach_ids.cpe_ids:
+            evidence["reachability_advisory_cpe_ids"] = list(reach_ids.cpe_ids)
 
     sev = vuln.severity.value if hasattr(vuln.severity, "value") else str(vuln.severity)
     from agent_bom.exploitability import fused_triage_priority

--- a/src/agent_bom/graph/blast_reach.py
+++ b/src/agent_bom/graph/blast_reach.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 # Ecosystems where a symbol-level call graph join is supported.
-_SYMBOL_REACH_ECOSYSTEMS: frozenset[str] = frozenset({"pypi", "python", "npm"})
+_SYMBOL_REACH_ECOSYSTEMS: frozenset[str] = frozenset({"pypi", "python", "npm", "go"})
 
 
 def apply_dependency_reachability_to_blast_radii(

--- a/src/agent_bom/graph/blast_reach.py
+++ b/src/agent_bom/graph/blast_reach.py
@@ -30,10 +30,8 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
-# Package ecosystems where a Python symbol-level call graph exists. The
-# function-reachability join only applies here — for everything else we leave
-# the signal untouched rather than over-claim.
-_PYTHON_ECOSYSTEMS: frozenset[str] = frozenset({"pypi", "python"})
+# Ecosystems where a symbol-level call graph join is supported.
+_SYMBOL_REACH_ECOSYSTEMS: frozenset[str] = frozenset({"pypi", "python", "npm"})
 
 
 def apply_dependency_reachability_to_blast_radii(
@@ -95,11 +93,11 @@ def apply_symbol_reachability_to_blast_radii(
 ) -> int:
     """Join CVE affected-symbols to AST symbol reach on each BlastRadius row.
 
-    Thin additive surfacing of :mod:`agent_bom.reachability_cve`. For every
-    Python finding it stamps ``symbol_reachability`` (function_reachable /
+    Thin additive surfacing of :mod:`agent_bom.reachability_cve`. For Python and
+    npm findings it stamps ``symbol_reachability`` (function_reachable /
     package_reachable / unreachable) and, when a match is found,
-    ``reachable_affected_symbols``. Non-Python findings are left untouched —
-    the call graph only exists for Python.
+    ``reachable_affected_symbols``. Other ecosystems are left untouched until
+    their call-graph symbol reach is implemented.
 
     The graph-walk reach already on the row (``graph_reachable``) is fed in as
     the import / dependency-closure fallback so a package that is reached but
@@ -129,7 +127,7 @@ def apply_symbol_reachability_to_blast_radii(
     stamped = 0
     for br in blast_radii:
         ecosystem = (getattr(br.package, "ecosystem", "") or "").lower()
-        if ecosystem not in _PYTHON_ECOSYSTEMS:
+        if ecosystem not in _SYMBOL_REACH_ECOSYSTEMS:
             continue
         try:
             signal = classify_reachability(
@@ -137,6 +135,7 @@ def apply_symbol_reachability_to_blast_radii(
                 advisory=br.vulnerability,
                 index=index,
                 package_reachable=br.graph_reachable,
+                ecosystem=ecosystem,
             )
         except Exception as exc:  # noqa: BLE001
             _logger.warning("Symbol reachability classify skipped for %s: %s", br.package.name, exc)

--- a/src/agent_bom/reachability_cve.py
+++ b/src/agent_bom/reachability_cve.py
@@ -207,21 +207,35 @@ def _collect_cwe_tokens(raw: Any) -> set[str]:
 
 
 def _symbols_from_database_specific(advisory: Mapping[str, Any]) -> set[str]:
-    """GHSA/OSV ``database_specific.vulnerable_functions`` and similar symbol lists."""
+    """GHSA/OSV symbol lists from ``database_specific`` and GHSA REST shapes."""
     tokens: set[str] = set()
+    containers: list[Mapping[str, Any]] = []
     db = advisory.get("database_specific")
-    if not isinstance(db, Mapping):
-        return tokens
-    for key in ("vulnerable_functions", "vulnerableFunctions", "affected_functions"):
-        raw = db.get(key)
-        if not isinstance(raw, list):
-            continue
-        for item in raw:
-            if isinstance(item, str):
-                tokens |= _symbol_tokens(item)
-                if len(tokens) >= _MAX_SYMBOLS:
-                    return tokens
+    if isinstance(db, Mapping):
+        containers.append(db)
+    containers.append(advisory)
+    vulnerabilities = advisory.get("vulnerabilities")
+    if isinstance(vulnerabilities, list):
+        for entry in vulnerabilities:
+            if isinstance(entry, Mapping):
+                containers.append(entry)
+
+    for container in containers:
+        for key in ("vulnerable_functions", "vulnerableFunctions", "affected_functions"):
+            raw = container.get(key)
+            if not isinstance(raw, list):
+                continue
+            for item in raw:
+                if isinstance(item, str):
+                    tokens |= _symbol_tokens(item)
+                    if len(tokens) >= _MAX_SYMBOLS:
+                        return tokens
     return tokens
+
+
+def advisory_affected_symbols_list(advisory: "Vulnerability | Mapping[str, Any] | None") -> list[str]:
+    """Return sorted affected-symbol tokens ready for ``Vulnerability.affected_symbols``."""
+    return sorted(extract_affected_symbols(advisory))
 
 
 def extract_advisory_identifiers(advisory: "Vulnerability | Mapping[str, Any] | None") -> AdvisoryIdentifiers:
@@ -416,6 +430,7 @@ __all__ = [
     "AdvisoryIdentifiers",
     "SymbolReachIndex",
     "ReachabilitySignal",
+    "advisory_affected_symbols_list",
     "extract_advisory_identifiers",
     "extract_affected_symbols",
     "classify_reachability",

--- a/src/agent_bom/reachability_cve.py
+++ b/src/agent_bom/reachability_cve.py
@@ -29,12 +29,12 @@ is a three-state reachability signal on the finding:
 * ``unreachable`` — the package is present in the dependency set but no
   entrypoint reaches it at all.
 
-Honest scope: Python only — that is where the call graph exists — and the
-``function_reachable`` upgrade only fires when the advisory genuinely
-carries affected symbols. Everything else degrades to ``package_reachable``
-or ``unreachable``; we do not fabricate symbol reachability we cannot back
-with evidence. JS/TS/Go call graphs and additional advisory symbol sources
-(e.g. GHSA REST ``vulnerable_functions``) are follow-up work.
+Honest scope: Python and npm symbol-level call graphs are supported; Go and
+other ecosystems are follow-up work. The ``function_reachable`` upgrade only
+fires when the advisory genuinely carries affected symbols. Everything else
+degrades to ``package_reachable`` or ``unreachable``; we do not fabricate
+symbol reachability we cannot back with evidence. Additional advisory symbol
+sources (e.g. GHSA REST ``vulnerable_functions``) are follow-up work.
 
 The module is read-only: no graph mutation, no network. It is safe to call
 from the report layer, the graph/blast-radius surfacing, the API, or a
@@ -47,7 +47,7 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from agent_bom.package_utils import normalize_package_name
+from agent_bom.package_utils import normalize_package_ecosystem, normalize_package_name
 
 if TYPE_CHECKING:
     from agent_bom.ast_models import ASTAnalysisResult, DependencySymbolReach
@@ -63,9 +63,15 @@ UNREACHABLE = "unreachable"
 _MAX_SYMBOLS = 512
 
 
-def _normalize_pkg(name: str) -> str:
-    """Normalize a package name for cross-source matching (PyPI rules)."""
-    return normalize_package_name(name or "", "pypi")
+def _normalize_pkg(name: str, ecosystem: str = "pypi") -> str:
+    """Normalize a package name for cross-source matching."""
+    eco = normalize_package_ecosystem(ecosystem or "pypi")
+    return normalize_package_name(name or "", eco)
+
+
+def _pkg_index_key(package: str, ecosystem: str) -> str:
+    eco = normalize_package_ecosystem(ecosystem or "pypi")
+    return f"{eco}:{_normalize_pkg(package, eco)}"
 
 
 def _symbol_tokens(symbol: str) -> set[str]:
@@ -92,42 +98,42 @@ def _symbol_tokens(symbol: str) -> set[str]:
 class SymbolReachIndex:
     """Per-package reached-symbol index built from AST symbol reach."""
 
-    _symbols_by_package: dict[str, set[str]] = field(default_factory=dict)
-    _paths_by_package: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    _symbols_by_key: dict[str, set[str]] = field(default_factory=dict)
+    _paths_by_key: dict[str, tuple[str, ...]] = field(default_factory=dict)
 
     @classmethod
     def from_reaches(cls, reaches: Iterable["DependencySymbolReach"]) -> "SymbolReachIndex":
-        symbols_by_package: dict[str, set[str]] = {}
-        paths_by_package: dict[str, tuple[str, ...]] = {}
+        symbols_by_key: dict[str, set[str]] = {}
+        paths_by_key: dict[str, tuple[str, ...]] = {}
         for reach in reaches:
-            pkg = _normalize_pkg(reach.package)
-            if not pkg:
+            if not reach.package:
                 continue
-            bucket = symbols_by_package.setdefault(pkg, set())
+            key = _pkg_index_key(reach.package, reach.ecosystem)
+            bucket = symbols_by_key.setdefault(key, set())
             bucket |= _symbol_tokens(reach.symbol)
             # Keep the shortest (closest) call path as evidence per package.
-            existing = paths_by_package.get(pkg)
+            existing = paths_by_key.get(key)
             candidate = tuple(reach.call_path)
             if candidate and (existing is None or len(candidate) < len(existing)):
-                paths_by_package[pkg] = candidate
-        return cls(symbols_by_package, paths_by_package)
+                paths_by_key[key] = candidate
+        return cls(symbols_by_key, paths_by_key)
 
     @classmethod
     def from_ast_result(cls, result: "ASTAnalysisResult") -> "SymbolReachIndex":
         return cls.from_reaches(result.dependency_symbol_reach)
 
-    def is_package_reached(self, package: str) -> bool:
+    def is_package_reached(self, package: str, *, ecosystem: str = "pypi") -> bool:
         """True when any symbol of ``package`` is reached from an entrypoint."""
-        return _normalize_pkg(package) in self._symbols_by_package
+        return _pkg_index_key(package, ecosystem) in self._symbols_by_key
 
-    def symbols_for_package(self, package: str) -> set[str]:
-        return set(self._symbols_by_package.get(_normalize_pkg(package), set()))
+    def symbols_for_package(self, package: str, *, ecosystem: str = "pypi") -> set[str]:
+        return set(self._symbols_by_key.get(_pkg_index_key(package, ecosystem), set()))
 
-    def call_path_for_package(self, package: str) -> tuple[str, ...]:
-        return self._paths_by_package.get(_normalize_pkg(package), ())
+    def call_path_for_package(self, package: str, *, ecosystem: str = "pypi") -> tuple[str, ...]:
+        return self._paths_by_key.get(_pkg_index_key(package, ecosystem), ())
 
     def __bool__(self) -> bool:
-        return bool(self._symbols_by_package)
+        return bool(self._symbols_by_key)
 
 
 @dataclass(frozen=True)
@@ -215,6 +221,7 @@ def classify_reachability(
     advisory: "Vulnerability | Mapping[str, Any] | None",
     index: SymbolReachIndex,
     package_reachable: bool | None = None,
+    ecosystem: str = "pypi",
 ) -> ReachabilitySignal:
     """Classify one vulnerable package into a three-state reachability signal.
 
@@ -234,11 +241,14 @@ def classify_reachability(
         whose symbols were not individually captured. ``None`` means the
         caller has no graph-reach evidence and we rely on the symbol index
         alone.
+    ecosystem:
+        Package ecosystem for index lookup (``pypi``, ``npm``, …).
     """
+    eco = normalize_package_ecosystem(ecosystem or "pypi")
     advisory_symbols = extract_affected_symbols(advisory)
-    reached_symbols = index.symbols_for_package(package)
-    pkg_reached = index.is_package_reached(package) or package_reachable is True
-    call_path = index.call_path_for_package(package)
+    reached_symbols = index.symbols_for_package(package, ecosystem=eco)
+    pkg_reached = index.is_package_reached(package, ecosystem=eco) or package_reachable is True
+    call_path = index.call_path_for_package(package, ecosystem=eco)
 
     if advisory_symbols and reached_symbols:
         matched = sorted(advisory_symbols & reached_symbols)

--- a/src/agent_bom/reachability_cve.py
+++ b/src/agent_bom/reachability_cve.py
@@ -29,12 +29,13 @@ is a three-state reachability signal on the finding:
 * ``unreachable`` — the package is present in the dependency set but no
   entrypoint reaches it at all.
 
-Honest scope: Python and npm symbol-level call graphs are supported; Go and
-other ecosystems are follow-up work. The ``function_reachable`` upgrade only
-fires when the advisory genuinely carries affected symbols. Everything else
-degrades to ``package_reachable`` or ``unreachable``; we do not fabricate
-symbol reachability we cannot back with evidence. Additional advisory symbol
-sources (e.g. GHSA REST ``vulnerable_functions``) are follow-up work.
+Honest scope: Python, npm, and Go symbol-level call graphs are supported.
+The ``function_reachable`` upgrade only fires when the advisory genuinely
+carries affected symbols (OSV ``imports``, GHSA ``vulnerable_functions``, or
+pre-extracted ``affected_symbols``). CVE/CWE/CPE identifiers are carried on
+the advisory and surfaced alongside the reachability verdict for CWE-aware
+impact and VEX triage; they do not substitute for missing symbol data.
+Everything else degrades to ``package_reachable`` or ``unreachable``.
 
 The module is read-only: no graph mutation, no network. It is safe to call
 from the report layer, the graph/blast-radius surfacing, the API, or a
@@ -137,6 +138,15 @@ class SymbolReachIndex:
 
 
 @dataclass(frozen=True)
+class AdvisoryIdentifiers:
+    """CVE/CWE/CPE identifiers extracted from an advisory for reachability context."""
+
+    cve_ids: tuple[str, ...] = ()
+    cwe_ids: tuple[str, ...] = ()
+    cpe_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class ReachabilitySignal:
     """The reachability verdict for one vulnerable package."""
 
@@ -146,6 +156,7 @@ class ReachabilitySignal:
     matched_symbols: tuple[str, ...] = ()
     advisory_symbols: tuple[str, ...] = ()
     call_path: tuple[str, ...] = ()
+    advisory_identifiers: AdvisoryIdentifiers = field(default_factory=AdvisoryIdentifiers)
 
     @property
     def function_reachable(self) -> bool:
@@ -159,6 +170,110 @@ def _iter_affected_blocks(advisory: Mapping[str, Any]) -> Iterable[Mapping[str, 
     for block in affected:
         if isinstance(block, Mapping):
             yield block
+
+
+def _normalize_cve_id(value: str) -> str | None:
+    token = (value or "").strip().upper()
+    return token if token.startswith("CVE-") else None
+
+
+def _normalize_cwe_id(value: str) -> str | None:
+    token = (value or "").strip().upper()
+    if not token:
+        return None
+    return token if token.startswith("CWE-") else f"CWE-{token}" if token.isdigit() else None
+
+
+def _collect_cwe_tokens(raw: Any) -> set[str]:
+    tokens: set[str] = set()
+    if isinstance(raw, str):
+        normalized = _normalize_cwe_id(raw)
+        if normalized:
+            tokens.add(normalized)
+        return tokens
+    if isinstance(raw, (list, tuple, set)):
+        for item in raw:
+            if isinstance(item, str):
+                normalized = _normalize_cwe_id(item)
+                if normalized:
+                    tokens.add(normalized)
+            elif isinstance(item, Mapping):
+                ext_id = item.get("external_id") or item.get("cweId")
+                if isinstance(ext_id, str):
+                    normalized = _normalize_cwe_id(ext_id)
+                    if normalized:
+                        tokens.add(normalized)
+    return tokens
+
+
+def _symbols_from_database_specific(advisory: Mapping[str, Any]) -> set[str]:
+    """GHSA/OSV ``database_specific.vulnerable_functions`` and similar symbol lists."""
+    tokens: set[str] = set()
+    db = advisory.get("database_specific")
+    if not isinstance(db, Mapping):
+        return tokens
+    for key in ("vulnerable_functions", "vulnerableFunctions", "affected_functions"):
+        raw = db.get(key)
+        if not isinstance(raw, list):
+            continue
+        for item in raw:
+            if isinstance(item, str):
+                tokens |= _symbol_tokens(item)
+                if len(tokens) >= _MAX_SYMBOLS:
+                    return tokens
+    return tokens
+
+
+def extract_advisory_identifiers(advisory: "Vulnerability | Mapping[str, Any] | None") -> AdvisoryIdentifiers:
+    """Extract CVE/CWE/CPE identifiers carried on an advisory."""
+    cve_ids: set[str] = set()
+    cwe_ids: set[str] = set()
+    cpe_ids: set[str] = set()
+
+    if advisory is None:
+        return AdvisoryIdentifiers()
+
+    primary_id = getattr(advisory, "id", None)
+    if isinstance(primary_id, str):
+        normalized = _normalize_cve_id(primary_id)
+        if normalized:
+            cve_ids.add(normalized)
+
+    for alias in getattr(advisory, "aliases", None) or ():
+        if isinstance(alias, str):
+            normalized = _normalize_cve_id(alias)
+            if normalized:
+                cve_ids.add(normalized)
+
+    cwe_ids |= _collect_cwe_tokens(getattr(advisory, "cwe_ids", None))
+
+    if isinstance(advisory, Mapping):
+        for alias in advisory.get("aliases", []) or []:
+            if isinstance(alias, str):
+                normalized = _normalize_cve_id(alias)
+                if normalized:
+                    cve_ids.add(normalized)
+        db = advisory.get("database_specific")
+        if isinstance(db, Mapping):
+            cwe_ids |= _collect_cwe_tokens(db.get("cwe_ids") or db.get("cwes") or db.get("cwe"))
+        for block in _iter_affected_blocks(advisory):
+            pkg = block.get("package")
+            if not isinstance(pkg, Mapping):
+                continue
+            for cpe_field in ("cpe", "cpes", "cpe23"):
+                raw = pkg.get(cpe_field)
+                if isinstance(raw, str) and raw.strip():
+                    cpe_ids.add(raw.strip())
+                elif isinstance(raw, list):
+                    for item in raw:
+                        if isinstance(item, str) and item.strip():
+                            cpe_ids.add(item.strip())
+
+    return AdvisoryIdentifiers(
+        cve_ids=tuple(sorted(cve_ids)),
+        cwe_ids=tuple(sorted(cwe_ids)),
+        cpe_ids=tuple(sorted(cpe_ids)),
+    )
 
 
 def extract_affected_symbols(advisory: "Vulnerability | Mapping[str, Any] | None") -> set[str]:
@@ -176,6 +291,8 @@ def extract_affected_symbols(advisory: "Vulnerability | Mapping[str, Any] | None
         {"affected": [{"ecosystem_specific": {"imports": [
             {"path": "jinja2.sandbox", "symbols": ["SandboxedEnvironment"]}
         ]}}]}
+
+    GHSA ``database_specific.vulnerable_functions`` is also parsed when present.
     """
     if advisory is None:
         return set()
@@ -193,6 +310,9 @@ def extract_affected_symbols(advisory: "Vulnerability | Mapping[str, Any] | None
 
     # Raw advisory mapping: parse ecosystem_specific.imports[].symbols.
     if isinstance(advisory, Mapping):
+        tokens |= _symbols_from_database_specific(advisory)
+        if len(tokens) >= _MAX_SYMBOLS:
+            return tokens
         for block in _iter_affected_blocks(advisory):
             eco = block.get("ecosystem_specific")
             if not isinstance(eco, Mapping):
@@ -246,6 +366,7 @@ def classify_reachability(
     """
     eco = normalize_package_ecosystem(ecosystem or "pypi")
     advisory_symbols = extract_affected_symbols(advisory)
+    advisory_ids = extract_advisory_identifiers(advisory)
     reached_symbols = index.symbols_for_package(package, ecosystem=eco)
     pkg_reached = index.is_package_reached(package, ecosystem=eco) or package_reachable is True
     call_path = index.call_path_for_package(package, ecosystem=eco)
@@ -260,6 +381,7 @@ def classify_reachability(
                 matched_symbols=tuple(matched),
                 advisory_symbols=tuple(sorted(advisory_symbols)),
                 call_path=call_path,
+                advisory_identifiers=advisory_ids,
             )
 
     if pkg_reached:
@@ -267,12 +389,15 @@ def classify_reachability(
             reason = "package reached; advisory carries no symbol data"
         else:
             reason = "package reached but no affected symbol is reached"
+        if advisory_ids.cwe_ids:
+            reason = f"{reason}; CWE context: {', '.join(advisory_ids.cwe_ids)}"
         return ReachabilitySignal(
             state=PACKAGE_REACHABLE,
             package=package,
             reason=reason,
             advisory_symbols=tuple(sorted(advisory_symbols)),
             call_path=call_path,
+            advisory_identifiers=advisory_ids,
         )
 
     return ReachabilitySignal(
@@ -280,6 +405,7 @@ def classify_reachability(
         package=package,
         reason="package present in dependencies but not reached from any entrypoint",
         advisory_symbols=tuple(sorted(advisory_symbols)),
+        advisory_identifiers=advisory_ids,
     )
 
 
@@ -287,8 +413,10 @@ __all__ = [
     "FUNCTION_REACHABLE",
     "PACKAGE_REACHABLE",
     "UNREACHABLE",
+    "AdvisoryIdentifiers",
     "SymbolReachIndex",
     "ReachabilitySignal",
+    "extract_advisory_identifiers",
     "extract_affected_symbols",
     "classify_reachability",
 ]

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -538,6 +538,10 @@ def build_vulnerabilities(vuln_data_list: list[dict], package: Package) -> list[
             if isinstance(raw_cwes, list):
                 cwe_ids = [c for c in raw_cwes if isinstance(c, str) and c.startswith("CWE-")]
 
+        from agent_bom.reachability_cve import advisory_affected_symbols_list
+
+        affected_symbols = advisory_affected_symbols_list(vuln_data)
+
         vulns.append(
             Vulnerability(
                 id=canonical_id,
@@ -551,6 +555,7 @@ def build_vulnerabilities(vuln_data_list: list[dict], package: Package) -> list[
                 modified_at=vuln_data.get("modified"),
                 aliases=all_aliases,
                 cwe_ids=cwe_ids,
+                affected_symbols=affected_symbols,
                 advisory_sources=["osv"],
                 match_confidence_tier=match_confidence_tier(
                     advisory_source="osv",

--- a/src/agent_bom/scanners/ghsa_advisory.py
+++ b/src/agent_bom/scanners/ghsa_advisory.py
@@ -19,6 +19,7 @@ from agent_bom.enrichment_posture import record_enrichment_source
 from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.models import Package, Severity, Vulnerability
 from agent_bom.package_utils import normalize_package_name
+from agent_bom.reachability_cve import advisory_affected_symbols_list
 
 logger = logging.getLogger(__name__)
 
@@ -423,6 +424,7 @@ async def check_github_advisories(
                             fixed_version=fixed,
                             references=refs,
                             cwe_ids=cwe_ids,
+                            affected_symbols=advisory_affected_symbols_list(advisory),
                             advisory_sources=["ghsa"],
                         )
                         target_pkg.vulnerabilities.append(vuln)

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -450,6 +450,31 @@ def test_analyze_project_surfaces_js_dependency_symbol_reach(tmp_path: Path):
         assert reach.call_path[0] == "fetch_url"
 
 
+def test_analyze_project_surfaces_go_dependency_symbol_reach(tmp_path: Path):
+    (tmp_path / "server.go").write_text(
+        "package main\n\n"
+        "import (\n"
+        '    "net/http"\n'
+        '    "github.com/modelcontextprotocol/go-sdk/mcp"\n'
+        ")\n\n"
+        "func fetchURL(target string) error {\n"
+        "    _, err := http.Get(target)\n"
+        "    return err\n"
+        "}\n\n"
+        "func register(server *mcp.Server) {\n"
+        '    server.AddTool("fetch_url", fetchURL)\n'
+        "}\n"
+    )
+
+    result = analyze_project(tmp_path)
+    go_reaches = [reach for reach in result.dependency_symbol_reach if reach.ecosystem == "go"]
+    assert len(go_reaches) == 1
+    reach = go_reaches[0]
+    assert reach.entrypoint == "fetch_url"
+    assert reach.package == "net/http"
+    assert reach.symbol == "Get"
+
+
 def test_analyze_project_treats_validation_branch_as_guard(tmp_path: Path):
     (tmp_path / "agent.py").write_text(
         "import subprocess\n\n"

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -398,6 +398,7 @@ def test_analyze_project_surfaces_dependency_symbol_reach_from_tool(tmp_path: Pa
             "call_path": ["fetch", "requests.get"],
             "depth": 0,
             "confidence": "import-symbol",
+            "ecosystem": "pypi",
         }
     ]
 
@@ -427,8 +428,26 @@ def test_analyze_project_surfaces_dependency_symbol_reach_through_helper(tmp_pat
             "call_path": ["answer", "ask_model", "openai.OpenAI"],
             "depth": 1,
             "confidence": "import-symbol",
+            "ecosystem": "pypi",
         }
     ]
+
+
+def test_analyze_project_surfaces_js_dependency_symbol_reach(tmp_path: Path):
+    (tmp_path / "server.ts").write_text(
+        'import axios from "axios";\n'
+        'server.tool("fetch_url", "Fetch a URL", async (url: string) => axios.get(url));\n'
+    )
+
+    result = analyze_project(tmp_path)
+    if _js_ts_parser_available():
+        npm_reaches = [reach for reach in result.dependency_symbol_reach if reach.ecosystem == "npm"]
+        assert len(npm_reaches) == 1
+        reach = npm_reaches[0]
+        assert reach.entrypoint == "fetch_url"
+        assert reach.package == "axios"
+        assert reach.symbol == "get"
+        assert reach.call_path[0] == "fetch_url"
 
 
 def test_analyze_project_treats_validation_branch_as_guard(tmp_path: Path):

--- a/tests/test_reachability_cve.py
+++ b/tests/test_reachability_cve.py
@@ -30,6 +30,7 @@ from agent_bom.reachability_cve import (
     UNREACHABLE,
     SymbolReachIndex,
     classify_reachability,
+    extract_advisory_identifiers,
     extract_affected_symbols,
 )
 
@@ -77,6 +78,43 @@ def test_extract_returns_empty_without_symbol_data() -> None:
     advisory = {"id": "CVE-2099-2", "affected": [{"package": {"ecosystem": "PyPI", "name": "jinja2"}}]}
     assert extract_affected_symbols(advisory) == set()
     assert extract_affected_symbols(None) == set()
+
+
+def test_extract_symbols_from_ghsa_vulnerable_functions() -> None:
+    advisory = {
+        "id": "GHSA-xxxx-yyyy-zzzz",
+        "database_specific": {"vulnerable_functions": ["axios.get", "request"]},
+    }
+    tokens = extract_affected_symbols(advisory)
+    assert "axios.get" in tokens
+    assert "axios" in tokens
+    assert "request" in tokens
+
+
+def test_extract_advisory_identifiers_from_vulnerability_model() -> None:
+    vuln = Vulnerability(
+        id="CVE-2099-42",
+        summary="x",
+        severity=Severity.HIGH,
+        cwe_ids=["CWE-79"],
+        aliases=["GHSA-abcd-efgh-ijkl"],
+    )
+    ids = extract_advisory_identifiers(vuln)
+    assert ids.cve_ids == ("CVE-2099-42",)
+    assert ids.cwe_ids == ("CWE-79",)
+
+
+def test_extract_advisory_identifiers_from_osv_cpe() -> None:
+    advisory = {
+        "id": "CVE-2099-99",
+        "aliases": ["CVE-2099-99"],
+        "database_specific": {"cwe_ids": ["CWE-502"]},
+        "affected": [{"package": {"ecosystem": "PyPI", "name": "pickle", "cpe": "cpe:2.3:a:python:pickle:*:*:*:*:*:*:*:*"}}],
+    }
+    ids = extract_advisory_identifiers(advisory)
+    assert ids.cve_ids == ("CVE-2099-99",)
+    assert ids.cwe_ids == ("CWE-502",)
+    assert ids.cpe_ids == ("cpe:2.3:a:python:pickle:*:*:*:*:*:*:*:*",)
 
 
 def test_extract_ignores_malformed_blocks() -> None:
@@ -303,6 +341,25 @@ def test_wiring_stamps_npm_row() -> None:
     assert stamped == 1
     assert br.symbol_reachability == FUNCTION_REACHABLE
     assert br.reachable_affected_symbols == ["get"]
+
+
+def test_wiring_stamps_go_row() -> None:
+    br = _python_br(["Get"], pkg_name="net/http")
+    br.package.ecosystem = "go"
+    go_reach = DependencySymbolReach(
+        entrypoint="fetch_url",
+        package="net/http",
+        module="net/http",
+        symbol="Get",
+        file_path="server.go",
+        line_number=8,
+        call_path=["fetch_url", "fetchURL", "net/http.Get"],
+        ecosystem="go",
+    )
+    stamped = apply_symbol_reachability_to_blast_radii([br], ASTAnalysisResult(dependency_symbol_reach=[go_reach]))
+    assert stamped == 1
+    assert br.symbol_reachability == FUNCTION_REACHABLE
+    assert br.reachable_affected_symbols == ["Get"]
 
 
 def test_wiring_no_op_without_symbol_reach_evidence() -> None:

--- a/tests/test_reachability_cve.py
+++ b/tests/test_reachability_cve.py
@@ -91,6 +91,28 @@ def test_extract_symbols_from_ghsa_vulnerable_functions() -> None:
     assert "request" in tokens
 
 
+def test_extract_symbols_from_ghsa_rest_top_level_vulnerable_functions() -> None:
+    advisory = {
+        "ghsa_id": "GHSA-xxxx-yyyy-zzzz",
+        "vulnerable_functions": ["express.static", "send"],
+    }
+    tokens = extract_affected_symbols(advisory)
+    assert "express.static" in tokens
+    assert "express" in tokens
+    assert "send" in tokens
+
+
+def test_extract_symbols_from_vulnerability_affected_symbols_field() -> None:
+    vuln = Vulnerability(
+        id="CVE-2099-55",
+        summary="x",
+        severity=Severity.HIGH,
+        affected_symbols=["axios.get", "request"],
+    )
+    assert "axios.get" in extract_affected_symbols(vuln)
+    assert "get" not in extract_affected_symbols(vuln) or "axios" in extract_affected_symbols(vuln)
+
+
 def test_extract_advisory_identifiers_from_vulnerability_model() -> None:
     vuln = Vulnerability(
         id="CVE-2099-42",
@@ -307,6 +329,45 @@ def test_wiring_stamps_function_reachable_on_python_row() -> None:
     assert stamped == 1
     assert br.symbol_reachability == FUNCTION_REACHABLE
     assert br.reachable_affected_symbols == ["get"]
+
+
+def test_wiring_stamps_function_reachable_from_built_vulnerability_model() -> None:
+    from agent_bom.scanners import build_vulnerabilities
+
+    pkg = Package(name="axios", version="1.6.0", ecosystem="npm")
+    vulns = build_vulnerabilities(
+        [
+            {
+                "id": "GHSA-xxxx-yyyy-zzzz",
+                "aliases": ["CVE-2099-1234"],
+                "summary": "axios SSRF",
+                "database_specific": {"vulnerable_functions": ["get"]},
+            }
+        ],
+        pkg,
+    )
+    assert vulns[0].affected_symbols
+    br = BlastRadius(
+        vulnerability=vulns[0],
+        package=pkg,
+        affected_servers=[],
+        affected_agents=[],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+    npm_reach = DependencySymbolReach(
+        entrypoint="fetch_url",
+        package="axios",
+        module="axios",
+        symbol="get",
+        file_path="server.ts",
+        line_number=3,
+        call_path=["fetch_url", "axios.get"],
+        ecosystem="npm",
+    )
+    stamped = apply_symbol_reachability_to_blast_radii([br], ASTAnalysisResult(dependency_symbol_reach=[npm_reach]))
+    assert stamped == 1
+    assert br.symbol_reachability == FUNCTION_REACHABLE
 
 
 def test_wiring_stamps_unreachable_when_symbol_absent() -> None:

--- a/tests/test_reachability_cve.py
+++ b/tests/test_reachability_cve.py
@@ -11,7 +11,8 @@ Pins the contract that:
    over-claimed function reach.
 4. A package present but not reached classifies as ``unreachable``.
 5. The thin ``apply_symbol_reachability_to_blast_radii`` hook stamps the
-   signal onto Python BlastRadius rows and leaves non-Python rows alone.
+   signal onto Python and npm BlastRadius rows and leaves unsupported
+   ecosystems untouched.
 """
 
 from __future__ import annotations
@@ -19,6 +20,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from agent_bom.ast_analyzer import analyze_project
+from agent_bom.ast_js_ts import _npm_package_from_module
 from agent_bom.ast_models import ASTAnalysisResult, DependencySymbolReach
 from agent_bom.graph.blast_reach import apply_symbol_reachability_to_blast_radii
 from agent_bom.models import BlastRadius, Package, Severity, Vulnerability
@@ -155,6 +157,53 @@ def test_package_name_normalization_matches() -> None:
     assert signal.state == FUNCTION_REACHABLE
 
 
+def test_ecosystem_keys_do_not_cross_match() -> None:
+    npm_reach = DependencySymbolReach(
+        entrypoint="fetch_url",
+        package="lodash",
+        module="lodash",
+        symbol="get",
+        file_path="server.ts",
+        line_number=3,
+        call_path=["fetch_url", "lodash.get"],
+        ecosystem="npm",
+    )
+    index = SymbolReachIndex.from_reaches([npm_reach])
+    signal = classify_reachability(
+        package="lodash",
+        advisory={"id": "CVE-2099-8", "affected": [{"package": {"ecosystem": "npm", "name": "lodash"}}]},
+        index=index,
+        ecosystem="pypi",
+    )
+    assert signal.state == UNREACHABLE
+
+
+def test_npm_function_reachable_when_affected_symbol_is_reached() -> None:
+    npm_reach = DependencySymbolReach(
+        entrypoint="fetch_url",
+        package="axios",
+        module="axios",
+        symbol="get",
+        file_path="server.ts",
+        line_number=3,
+        call_path=["fetch_url", "axios.get"],
+        ecosystem="npm",
+    )
+    index = SymbolReachIndex.from_reaches([npm_reach])
+    advisory = {
+        "id": "CVE-2099-9",
+        "affected": [
+            {
+                "package": {"ecosystem": "npm", "name": "axios"},
+                "ecosystem_specific": {"imports": [{"path": "axios", "symbols": ["get"]}]},
+            }
+        ],
+    }
+    signal = classify_reachability(package="axios", advisory=advisory, index=index, ecosystem="npm")
+    assert signal.state == FUNCTION_REACHABLE
+    assert signal.matched_symbols == ("get",)
+
+
 # ── end-to-end through the real AST call graph ────────────────────────────
 
 
@@ -229,12 +278,31 @@ def test_wiring_stamps_unreachable_when_symbol_absent() -> None:
     assert br.symbol_reachability == UNREACHABLE
 
 
-def test_wiring_skips_non_python_rows() -> None:
+def test_wiring_skips_unsupported_ecosystem_rows() -> None:
     br = _python_br(["get"])
-    br.package.ecosystem = "npm"
+    br.package.ecosystem = "maven"
     stamped = apply_symbol_reachability_to_blast_radii([br], _ast_result_with_get())
     assert stamped == 0
     assert br.symbol_reachability is None
+
+
+def test_wiring_stamps_npm_row() -> None:
+    br = _python_br(["get"], pkg_name="axios")
+    br.package.ecosystem = "npm"
+    npm_reach = DependencySymbolReach(
+        entrypoint="fetch_url",
+        package="axios",
+        module="axios",
+        symbol="get",
+        file_path="server.ts",
+        line_number=3,
+        call_path=["fetch_url", "axios.get"],
+        ecosystem="npm",
+    )
+    stamped = apply_symbol_reachability_to_blast_radii([br], ASTAnalysisResult(dependency_symbol_reach=[npm_reach]))
+    assert stamped == 1
+    assert br.symbol_reachability == FUNCTION_REACHABLE
+    assert br.reachable_affected_symbols == ["get"]
 
 
 def test_wiring_no_op_without_symbol_reach_evidence() -> None:
@@ -255,3 +323,10 @@ def test_wiring_is_best_effort_no_op(monkeypatch) -> None:
     monkeypatch.setattr("agent_bom.reachability_cve.SymbolReachIndex.from_ast_result", explode)
     assert apply_symbol_reachability_to_blast_radii([br], _ast_result_with_get()) == 0
     assert br.symbol_reachability is None
+
+
+def test_npm_package_from_module() -> None:
+    assert _npm_package_from_module("axios") == "axios"
+    assert _npm_package_from_module("@scope/pkg/subpath") == "@scope/pkg"
+    assert _npm_package_from_module("./relative") is None
+    assert _npm_package_from_module("node:fs") is None

--- a/tests/test_scanners.py
+++ b/tests/test_scanners.py
@@ -416,6 +416,27 @@ def test_build_vulnerabilities_ghsa_with_cve_alias():
     assert vulns[0].id == "CVE-2025-0001"
 
 
+def test_build_vulnerabilities_extracts_affected_symbols():
+    pkg = Package(name="axios", version="1.6.0", ecosystem="npm")
+    vuln_data = [
+        {
+            "id": "GHSA-xxxx-yyyy-zzzz",
+            "summary": "axios advisory",
+            "database_specific": {"vulnerable_functions": ["get", "request"]},
+            "affected": [
+                {
+                    "package": {"name": "axios", "ecosystem": "npm"},
+                    "ecosystem_specific": {"imports": [{"path": "axios", "symbols": ["defaults"]}]},
+                }
+            ],
+        }
+    ]
+    vulns = build_vulnerabilities(vuln_data, pkg)
+    assert "get" in vulns[0].affected_symbols
+    assert "request" in vulns[0].affected_symbols
+    assert "defaults" in vulns[0].affected_symbols
+
+
 def test_build_vulnerabilities_no_summary():
     pkg = Package(name="pkg", version="1.0", ecosystem="pypi")
     vuln_data = [{"id": "CVE-1", "details": "Detailed description here"}]

--- a/tests/test_symbol_reachability_export.py
+++ b/tests/test_symbol_reachability_export.py
@@ -62,10 +62,12 @@ def _stamp_python_br() -> BlastRadius:
 
 def test_finding_evidence_exports_symbol_reachability_fields() -> None:
     br = _stamp_python_br()
+    br.vulnerability.cwe_ids = ["CWE-502"]
     finding = blast_radius_to_finding(br)
 
     assert finding.evidence["symbol_reachability"] == FUNCTION_REACHABLE
     assert finding.evidence["reachable_affected_symbols"] == ["get"]
+    assert finding.evidence["reachability_advisory_cwe_ids"] == ["CWE-502"]
 
 
 def test_to_json_blast_radius_exports_symbol_reachability_fields() -> None:


### PR DESCRIPTION
## Summary

Consolidated reachability maturity PR (supersedes #3575):

- **B1 — npm/JS/TS**: `dependency_symbol_reach` from MCP tool handlers → npm imports; ecosystem-scoped `SymbolReachIndex`; `symbol_reachability` on npm BlastRadius rows.
- **B2 — Go**: same symbol-reach pipeline for Go MCP servers (`build_go_dependency_symbol_reach`); `go` ecosystem in CVE join.
- **CWE/CVE/CPE advisory context**: parse GHSA `vulnerable_functions`; `extract_advisory_identifiers` for CVE/CWE/CPE; stamp `reachability_advisory_cwe_ids` / `reachability_advisory_cpe_ids` on finding evidence when symbol reachability is set.
- **Docs**: qualify PYPI_README + PRODUCT_BRIEF for honest multi-lang + CWE/CVE/CPE-aware reachability.

Part of #3242. Part of #3499.

## Updated honest matrix (after merge)

```
                    PyPI   npm    Go    Java  Rust  …
SBOM/CVE scan        ✅     ✅     ✅     ✅    ✅
Graph reach          ✅     ✅     ✅     ✅    ✅
AST agent analysis   ✅     ✅*    ✅*    ❌    ❌
Call edges           ✅     ✅     ✅     ❌    ❌
dependency_symbol    ✅     ✅     ✅     ❌    ❌
symbol_reachability  ✅     ✅     ✅     ❌    ❌
Export to findings   ✅     ✅     ✅     ❌    ❌
GHSA vuln_functions  ✅     ✅     ✅     —     —
CVE/CWE/CPE context  ✅     ✅     ✅     ✅*   ✅*

* Java/Rust: advisory IDs from enrichment; no AST symbol join yet
```

### Honest product claims (post-merge)

| Claim | Accurate? |
|---|---|
| Scans npm, PyPI, Go, Maven, … MCP supply chains | ✅ |
| Graph reachability across agents and packages | ✅ |
| Function-level CVE reachability de-noising | ⚠️ Python + npm + Go; only when advisories carry symbols |
| Multi-language call-graph reachability | ⚠️ Python + npm + Go CVE join; Java/Rust graphs not wired |
| CWE/CVE/CPE-aware reachability | ✅ Impact + advisory IDs on reachability evidence |

## Verification

```bash
uv run ruff check src/agent_bom/ast_analyzer.py src/agent_bom/ast_go.py src/agent_bom/ast_js_ts.py src/agent_bom/reachability_cve.py src/agent_bom/graph/blast_reach.py src/agent_bom/finding.py tests/test_reachability_cve.py tests/test_ast_analyzer.py tests/test_symbol_reachability_export.py
uv run pytest -q tests/test_reachability_cve.py tests/test_ast_analyzer.py::test_analyze_project_surfaces_js_dependency_symbol_reach tests/test_ast_analyzer.py::test_analyze_project_surfaces_go_dependency_symbol_reach tests/test_symbol_reachability_export.py
```

33 tests passed.


Made with [Cursor](https://cursor.com)