### PR TITLE
docs(readme): product-first flow, compact persona band, plain-language taglines

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
 <p align="center"><b>Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.</b></p>
-<p align="center">Headless agent primitives and human cockpit surfaces over one shared evidence model.</p>
+<p align="center">Scan locally, centralize findings, govern runtime — one evidence model for your team and your agents.</p>
 
 <p align="center">
   <a href="https://msaad00.github.io/agent-bom/">Docs</a> ·
@@ -28,6 +28,80 @@
   <a href="https://github.com/msaad00/agent-bom/releases">Changelog</a>
 </p>
 
+## What Is agent-bom
+
+`agent-bom` is a read-only scanner and self-hosted control plane for local
+projects, agent fleets, MCP runtimes, containers, and cloud estates. Every
+surface writes into one evidence model — `Finding` + `ContextGraph` — and the
+same model comes back through CLI, CI, API, dashboard, MCP tools, exports, and
+optional runtime policy.
+
+Blast radius is the core idea: a vulnerable package is linked to the MCP server
+that loads it, the tools it exposes, reachable credential references, and the
+agents that can call it — not just a CVE row.
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-light.svg" alt="agent-bom workflow from read-only intake through scan engine, evidence graph, control plane, and outputs" width="980" />
+  </picture>
+</p>
+
+Coverage depth and honest boundaries:
+[AI infrastructure scanning](docs/AI_INFRASTRUCTURE_SCANNING.md) ·
+[product boundaries](docs/PRODUCT_BOUNDARIES.md)
+
+<details>
+<summary><b>Control-plane architecture</b></summary>
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-light.svg" alt="agent-bom layered control-plane architecture" width="980" />
+  </picture>
+</p>
+
+</details>
+
+<details>
+<summary><b>Blast radius drilldown</b></summary>
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-light.svg" alt="agent-bom blast-radius drilldown — package to finding to MCP server to agent" width="900" />
+  </picture>
+</p>
+
+```text
+package -> vulnerability finding -> MCP server -> tools + credential refs -> agent
+```
+
+</details>
+
+<details>
+<summary><b>Accuracy model</b> — match-confidence tiers and NVD key model</summary>
+
+agent-bom normalizes advisory and distro evidence into canonical CVE findings
+with match-confidence tiers:
+
+`distro_confirmed` > `osv_range` > `osv_ecosystem` > `unfixed_distro` > `nvd_cpe_candidate`
+
+Distro-confirmed findings are treated as confirmed. Optional NVD CPE candidate
+matching widens long-tail OS/vendor software coverage, but remains review-grade
+and off by default.
+
+**NVD key model.** End users do not need an NVD API key. CVE/CPE enrichment
+ships through the distributed vulnerability database. `NVD_API_KEY` is only an
+optional self-hosted freshness knob for operators rebuilding or refreshing the
+database.
+
+Matching mechanics and release evidence:
+[vulnerability matching](docs/VULNERABILITY_MATCHING.md) ·
+[scanner accuracy baseline](docs/SCANNER_ACCURACY_BASELINE.md)
+
+</details>
+
 ## Who It's For
 
 <p align="center">
@@ -36,8 +110,6 @@
     <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/persona-value-light.svg" alt="agent-bom personas mapped to value proof: AppSec/GRC to SARIF and compliance, Platform/SRE to fleet sync and CI gates, agent builders to MCP inventory and runtime shield, security engineers to findings queue and attack paths" width="980" />
   </picture>
 </p>
-
-<p align="center"><em>Four buyer lanes · one evidence model (<code>Finding</code> + <code>UnifiedGraph</code>)</em></p>
 
 <details>
 <summary><b>Persona lane detail</b></summary>
@@ -58,34 +130,6 @@ Registry metadata is tracked through the committed Smithery manifest and Glama
 listing; install and liveness checks live in the integration docs.
 
 </details>
-
-## Start Here
-
-Every lane writes into the same `Finding` and `ContextGraph` model. Pick the
-entry point that matches your role; see [docs/PRODUCT_MAP.md](docs/PRODUCT_MAP.md)
-for ingest lanes, auth boundaries, and surface detail.
-
-| Need | Surface | First action | Main artifact |
-|---|---|---|---|
-| Scan a repo, image, or local agent config | CLI / CI | `agent-bom agents -p .` | JSON, SARIF, SBOM, HTML |
-| Connect cloud and data-estate evidence | Cloud connectors | `agent-bom connect aws` then `agent-bom cloud scan` | assets, CIS findings, graph edges |
-| Review posture as a team | API + dashboard | `pip install 'agent-bom[ui]' && agent-bom serve` | findings, graph, audit, compliance |
-| Give agents security tools | MCP server | `agent-bom mcp server` | strict MCP tool responses |
-| Govern runtime tool calls | Proxy / gateway | configure proxy or gateway policy | allow/warn/block audit trail |
-| Package evidence for audit | Reports / exports | `agent-bom agents -p . -f html -o report.html` | SARIF, CycloneDX, SPDX, OCSF, compliance bundle |
-
-| Goal | Command |
-|---|---|
-| Multi-hop exposure paths | `agent-bom graph` |
-| LLM cost forecast | `agent-bom cost forecast` |
-| Non-human identity posture | `agent-bom identity credential-expiry` |
-| Advisory remediation plan | `agent-bom remediate -p .` |
-| Gated-capability readiness | `agent-bom capabilities` |
-| CI gate | `uses: msaad00/agent-bom@v0.92.0` |
-
-Full command map: [docs/CLI_MAP.md](docs/CLI_MAP.md) · role routing:
-[docs/START_HERE.md](docs/START_HERE.md) · repo layout:
-[PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md)
 
 ## First Run
 
@@ -150,99 +194,39 @@ with <code>npm run capture:product-proof</code> (see
 
 </details>
 
-## How It Works
+## Start Here
 
-Read-only intake, scan and enrichment, one evidence graph, then the same model
-through CLI, CI, API, UI, MCP, exports, and optional runtime policy.
+Every lane writes into the same `Finding` and `ContextGraph` model. Pick the
+entry point that matches your role; see [docs/PRODUCT_MAP.md](docs/PRODUCT_MAP.md)
+for ingest lanes, auth boundaries, and surface detail.
 
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-light.svg" alt="agent-bom workflow from read-only intake through scan engine, evidence graph, control plane, and outputs" width="980" />
-  </picture>
-</p>
+| Need | Surface | First action | Main artifact |
+|---|---|---|---|
+| Scan a repo, image, or local agent config | CLI / CI | `agent-bom agents -p .` | JSON, SARIF, SBOM, HTML |
+| Connect cloud and data-estate evidence | Cloud connectors | `agent-bom connect aws` then `agent-bom cloud scan` | assets, CIS findings, graph edges |
+| Review posture as a team | API + dashboard | `pip install 'agent-bom[ui]' && agent-bom serve` | findings, graph, audit, compliance |
+| Give agents security tools | MCP server | `agent-bom mcp server` | strict MCP tool responses |
+| Govern runtime tool calls | Proxy / gateway | configure proxy or gateway policy | allow/warn/block audit trail |
+| Package evidence for audit | Reports / exports | `agent-bom agents -p . -f html -o report.html` | SARIF, CycloneDX, SPDX, OCSF, compliance bundle |
 
-<details>
-<summary><b>Control-plane architecture</b></summary>
+| Goal | Command |
+|---|---|
+| Multi-hop exposure paths | `agent-bom graph` |
+| LLM cost forecast | `agent-bom cost forecast` |
+| Non-human identity posture | `agent-bom identity credential-expiry` |
+| Advisory remediation plan | `agent-bom remediate -p .` |
+| Gated-capability readiness | `agent-bom capabilities` |
+| CI gate | `uses: msaad00/agent-bom@v0.92.0` |
 
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/architecture-light.svg" alt="agent-bom layered control-plane architecture" width="980" />
-  </picture>
-</p>
+Full command map: [docs/CLI_MAP.md](docs/CLI_MAP.md) · role routing:
+[docs/START_HERE.md](docs/START_HERE.md) · repo layout:
+[PROJECT_STRUCTURE.md](PROJECT_STRUCTURE.md)
 
-</details>
+## Cloud Connectors
 
-<details>
-<summary><b>Blast radius drilldown</b></summary>
-
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-light.svg" alt="agent-bom blast-radius drilldown — package to finding to MCP server to agent" width="900" />
-  </picture>
-</p>
-
-```text
-package -> vulnerability finding -> MCP server -> tools + credential refs -> agent
-```
-
-</details>
-
-<details>
-<summary><b>What it is</b> — scanner, ContextGraph, and blast radius</summary>
-
-`agent-bom` is a read-only scanner and self-hosted control plane for local
-projects, agent fleets, MCP runtimes, and cloud estates (AWS, Azure, GCP,
-Snowflake).
-
-**ContextGraph** is agent-bom's unified evidence graph across CLI, API, UI, MCP
-tools, reports, and gateway decisions. Findings, assets, packages, cloud
-resources, identities, agents, MCP servers, credentials, and runtime decisions
-all normalize into that graph so posture, blast radius, and enforcement read
-from the same evidence.
-
-Blast radius is the core idea: a vulnerable package is linked to the MCP server
-that loads it, the tools it exposes, reachable credential references, and the
-agents that can call it — not just a CVE row.
-
-Coverage depth and honest boundaries:
-[AI infrastructure scanning](docs/AI_INFRASTRUCTURE_SCANNING.md) ·
-[product boundaries](docs/PRODUCT_BOUNDARIES.md)
-
-</details>
-
-<details>
-<summary><b>Accuracy model</b> — match-confidence tiers and NVD key model</summary>
-
-agent-bom normalizes advisory and distro evidence into canonical CVE findings
-with match-confidence tiers:
-
-`distro_confirmed` > `osv_range` > `osv_ecosystem` > `unfixed_distro` > `nvd_cpe_candidate`
-
-Distro-confirmed findings are treated as confirmed. Optional NVD CPE candidate
-matching widens long-tail OS/vendor software coverage, but remains review-grade
-and off by default.
-
-**NVD key model.** End users do not need an NVD API key. CVE/CPE enrichment
-ships through the distributed vulnerability database. `NVD_API_KEY` is only an
-optional self-hosted freshness knob for operators rebuilding or refreshing the
-database.
-
-Matching mechanics and release evidence:
-[vulnerability matching](docs/VULNERABILITY_MATCHING.md) ·
-[scanner accuracy baseline](docs/SCANNER_ACCURACY_BASELINE.md)
-
-</details>
-
-## Cloud, Deploy, Trust
-
-**Cloud (read-only).** Four connectors — AWS, Azure, GCP, Snowflake — are
-opt-in, agentless, and default-off. No secret values are read or stored.
-`agent-bom connect <provider>` prints the grant template and enable flag without
-network I/O until you opt in. Full intake map:
-[docs/DATA_SOURCES.md](docs/DATA_SOURCES.md)
+Read-only, opt-in, and default-off. No secret values are read or stored.
+`agent-bom connect <provider>` prints the grant template and enable flag —
+no network I/O until you opt in.
 
 | Cloud | Enable | Scan |
 |---|---|---|
@@ -251,13 +235,24 @@ network I/O until you opt in. Full intake map:
 | GCP | `AGENT_BOM_GCP_INVENTORY=1` | `agent-bom cloud gcp` |
 | Snowflake | SSO or key-pair auth | `pip install 'agent-bom[snowflake]'` then `agent-bom agents --snowflake` |
 
+Setup and grants: [docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md) · full intake
+map: [docs/DATA_SOURCES.md](docs/DATA_SOURCES.md)
+
+<details>
+<summary><b>Snowflake auth detail</b></summary>
+
 Snowflake auth defaults to browser SSO (`externalbrowser`); use
 `SNOWFLAKE_AUTHENTICATOR=snowflake_jwt` with `SNOWFLAKE_PRIVATE_KEY_PATH` for
 CI. agent-bom authenticates through the Python connector — no `snowsql` session
-needed. Setup and grants: [docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md)
+needed.
 
-**Deploy in your boundary.** OSS CLI, self-hosted API/UI, gated hosted POC, or
-optional Snowflake-native lane — no managed public SaaS in this repo yet.
+</details>
+
+## Deploy in Your Boundary
+
+OSS CLI, self-hosted API/UI, gated hosted POC, or optional Snowflake-native
+lane — no managed public SaaS in this repo yet. One compose file starts a local
+control plane:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
@@ -269,12 +264,15 @@ Pilot compose binds to `127.0.0.1` with loopback CORS only. Use
 `docker-compose.platform.yml` or [docs/HOSTED_POC.md](docs/HOSTED_POC.md) before
 sharing a link.
 
-- [Deploy anywhere](docs/DEPLOY_PLATFORM.md) · [Helm](deploy/helm/agent-bom) ·
-  [EKS module](deploy/terraform/platform-eks) ·
-  [Docker Hub](https://hub.docker.com/r/agentbom/agent-bom) ·
-  [CloudFormation one-click](deploy/cloudformation)
+| Target | Path |
+|---|---|
+| Any container platform | [Deploy anywhere](docs/DEPLOY_PLATFORM.md) |
+| Kubernetes | [Helm chart](deploy/helm/agent-bom) |
+| AWS EKS | [Terraform module](deploy/terraform/platform-eks) |
+| AWS one-click | [CloudFormation](deploy/cloudformation) |
+| Images | [Docker Hub](https://hub.docker.com/r/agentbom/agent-bom) |
 
-**Trust.**
+## Trust
 
 - Read-only discovery by default; no mandatory telemetry.
 - Credential values redacted; env names preserved for explainable exposure paths.
@@ -282,9 +280,9 @@ sharing a link.
 - Tenant scope, auth boundaries, and audit evidence on API/runtime paths.
 
 [Threat model](docs/THREAT_MODEL.md) · [Pentest readiness](docs/PENTEST_READINESS.md) ·
-[Python client](docs/PYTHON_API.md) · [Go client](sdks/go/README.md) ·
 [Release verification](docs/RELEASE_VERIFICATION.md) ·
-[MCP security model](docs/MCP_SECURITY_MODEL.md)
+[MCP security model](docs/MCP_SECURITY_MODEL.md) ·
+[Python client](docs/PYTHON_API.md) · [Go client](sdks/go/README.md)
 
 ## Contributing
 

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -1,8 +1,8 @@
 # Product Brief
 
 `agent-bom` is an open security scanner and self-hosted control plane for
-AI/MCP infrastructure. It adds headless agent primitives and human cockpit
-surfaces over the same evidence model. It generates a reachability-backed AI
+AI/MCP infrastructure. It serves security teams and AI agents from the same
+evidence model. It generates a reachability-backed AI
 BOM across agents, MCP servers, packages, credential environment names, cloud,
 runtime, and skill surfaces, then exposes the same evidence through CLI/CI,
 API/UI, MCP tools, and selected runtime controls.

--- a/docs/VISUAL_LANGUAGE.md
+++ b/docs/VISUAL_LANGUAGE.md
@@ -40,10 +40,10 @@ Current SVG inventory:
 | File | What it shows | Where it lives in the README |
 |---|---|---|
 | `logo-{light,dark}.svg` | Brand mark | hero |
-| `architecture-{light,dark}.svg` | End-to-end LR data flow: sources → scan/ingest → unified Finding + ContextGraph → control plane (API / Gateway / MCP) → consumers (humans + headless agents) + artifacts | `docs/ARCHITECTURE.md` System Overview; available for README architecture section |
-| `how-it-works-{light,dark}.svg` | Six-step scan pipeline from read-only intake through evidence core to outputs | README "How It Works" |
-| `persona-value-{light,dark}.svg` | Four buyer personas in a 2×2 lane-colored card grid (persona → value proof per card) | README hero — Who It's For |
-| `blast-radius-{light,dark}.svg` | CVE, package, MCP server, agent, credentials, and tools in one blast-radius path | hero, under tagline |
+| `architecture-{light,dark}.svg` | End-to-end LR data flow: sources → scan/ingest → unified Finding + ContextGraph → control plane (API / Gateway / MCP) → consumers (humans + headless agents) + artifacts | `docs/ARCHITECTURE.md` System Overview; README "What Is agent-bom", collapsed detail |
+| `how-it-works-{light,dark}.svg` | Six-step scan pipeline from read-only intake through evidence core to outputs | README "What Is agent-bom" |
+| `persona-value-{light,dark}.svg` | Four buyer personas in a compact single-row band — neutral cards, one restrained accent hue and person-with-role-badge icon per persona, value proof pill per card | README "Who It's For", after the product intro |
+| `blast-radius-{light,dark}.svg` | CVE, package, MCP server, agent, credentials, and tools in one blast-radius path | README "What Is agent-bom", collapsed drilldown |
 | `scan-pipeline-{light,dark}.svg` | 5-stage pipeline (discover → scan → analyze → report → enforce) | "How a scan moves" |
 | `engine-internals-{light,dark}.svg` | Inside the scanner | available for deeper architecture docs; not currently embedded in the README |
 | `compliance-{light,dark}.svg` | Finding → control → evidence packet | Compliance section |

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -1,49 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="980" height="720" viewBox="0 0 980 720" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="218" viewBox="0 0 1080 218" fill="none">
 <title>agent-bom personas and value</title>
-<rect width="980" height="720" rx="12" fill="#16161d"/>
-<text x="28" y="42" font-family="Inter,system-ui,sans-serif" font-size="28" font-weight="800" fill="#f4f4f5">Who it serves · what they get</text>
-<text x="28" y="68" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="500" fill="#71717a">One evidence model — inventory -&gt; findings -&gt; graph -&gt; gates</text>
-<rect x="24" y="96" width="456" height="274" rx="14" fill="#065f46" stroke="#34d399" stroke-width="1.8"/>
-<rect x="44" y="114" width="44" height="44" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,118) scale(1.5)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="100" y="136" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#a7f3d0">AppSec / GRC</text>
-<text x="100" y="158" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#34d399">SARIF · compliance · audit chain</text>
-<line x1="44" y1="188" x2="460" y2="188" stroke="#34d399" stroke-width="1.2" opacity="0.55"/>
-<polygon points="252,202 245,192 259,192" fill="#34d399"/>
-<rect x="40" y="210" width="424" height="144" rx="10" fill="#12121a" stroke="#34d399"/>
-<rect x="52" y="224" width="36" height="36" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(56,228) scale(1.1666666666666667)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="100" y="242" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#a7f3d0">Accurate SCA</text>
-<text x="100" y="264" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#34d399">15 ecosystems · EPSS/KEV · distro-aware</text>
-<rect x="500" y="96" width="456" height="274" rx="14" fill="#78350f" stroke="#fbbf24" stroke-width="1.8"/>
-<rect x="520" y="114" width="44" height="44" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(524,118) scale(1.5)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="576" y="136" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#fde68a">Platform / SRE</text>
-<text x="576" y="158" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#fbbf24">fleet sync · Helm · CI · SBOM</text>
-<line x1="520" y1="188" x2="936" y2="188" stroke="#fbbf24" stroke-width="1.2" opacity="0.55"/>
-<polygon points="728,202 721,192 735,192" fill="#fbbf24"/>
-<rect x="516" y="210" width="424" height="144" rx="10" fill="#12121a" stroke="#fbbf24"/>
-<rect x="528" y="224" width="36" height="36" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(532,228) scale(1.1666666666666667)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
-<text x="576" y="242" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#fde68a">Container coverage</text>
-<text x="576" y="264" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#fbbf24">OCI native · Grype · CIS posture</text>
-<rect x="24" y="390" width="456" height="274" rx="14" fill="#1e3a5f" stroke="#60a5fa" stroke-width="1.8"/>
-<rect x="44" y="408" width="44" height="44" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(48,412) scale(1.5)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="100" y="430" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#93c5fd">Agent builders</text>
-<text x="100" y="452" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#60a5fa">MCP inventory · Shield · runtime</text>
-<line x1="44" y1="482" x2="460" y2="482" stroke="#60a5fa" stroke-width="1.2" opacity="0.55"/>
-<polygon points="252,496 245,486 259,486" fill="#60a5fa"/>
-<rect x="40" y="504" width="424" height="144" rx="10" fill="#12121a" stroke="#60a5fa"/>
-<rect x="52" y="518" width="36" height="36" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(56,522) scale(1.1666666666666667)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="100" y="536" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#93c5fd">Self-hosted control plane</text>
-<text x="100" y="558" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#60a5fa">your VPC · signed audit · Helm</text>
-<rect x="500" y="390" width="456" height="274" rx="14" fill="#5b21b6" stroke="#a78bfa" stroke-width="1.8"/>
-<rect x="520" y="408" width="44" height="44" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(524,412) scale(1.5)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="576" y="430" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#ddd6fe">Security engineers</text>
-<text x="576" y="452" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#a78bfa">findings queue · paths · graph</text>
-<line x1="520" y1="482" x2="936" y2="482" stroke="#a78bfa" stroke-width="1.2" opacity="0.55"/>
-<polygon points="728,496 721,486 735,486" fill="#a78bfa"/>
-<rect x="516" y="504" width="424" height="144" rx="10" fill="#12121a" stroke="#a78bfa"/>
-<rect x="528" y="518" width="36" height="36" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(532,522) scale(1.1666666666666667)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="576" y="536" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#ddd6fe">Agent-native surface</text>
-<text x="576" y="558" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#a78bfa">283 API ops · 70 MCP tools · SARIF</text>
-<rect x="24" y="676" width="932" height="32" rx="10" fill="#0c1a14" stroke="#1f4438"/>
-<text x="490" y="697" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<rect width="1080" height="218" rx="12" fill="#16161d"/>
+<rect x="23" y="18" width="248" height="148" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
+<rect x="37" y="30" width="40" height="40" rx="11" fill="#2dd4bf" opacity="0.16"/><g transform="translate(41,34) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#2dd4bf"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#2dd4bf"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#2dd4bf"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.2" y="14.7" width="4.6" height="6.2" rx="1" fill="#0f0f13" stroke="none"/><path d="M17.3 17.9l.95.95 1.75-1.75" stroke="#2dd4bf" stroke-width="1.05"/></g></g>
+<text x="85" y="55" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="800" fill="#e9e9ec">AppSec / GRC</text>
+<text x="39" y="86" font-family="ui-monospace,monospace" font-size="9.5" font-weight="600" fill="#82828c">SARIF · compliance · audit chain</text>
+<line x1="39" y1="98" x2="255" y2="98" stroke="#2a2a31" stroke-width="1"/>
+<polygon points="147,108 142,101 152,101" fill="#2dd4bf" opacity="0.9"/>
+<rect x="35" y="112" width="224" height="42" rx="8" fill="#2dd4bf" opacity="0.10"/>
+<rect x="35" y="112" width="224" height="42" rx="8" fill="none" stroke="#2dd4bf" opacity="0.4"/>
+<text x="47" y="132" font-family="Inter,system-ui,sans-serif" font-size="12.5" font-weight="800" fill="#e9e9ec">Accurate SCA</text>
+<text x="47" y="149" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#82828c">15 ecosystems · EPSS/KEV · distro-aware</text>
+<rect x="285" y="18" width="248" height="148" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
+<rect x="299" y="30" width="40" height="40" rx="11" fill="#38bdf8" opacity="0.16"/><g transform="translate(303,34) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#38bdf8"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#38bdf8"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#38bdf8"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/></g></g>
+<text x="347" y="55" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="800" fill="#e9e9ec">Platform / SRE</text>
+<text x="301" y="86" font-family="ui-monospace,monospace" font-size="9.5" font-weight="600" fill="#82828c">fleet sync · Helm · CI · SBOM</text>
+<line x1="301" y1="98" x2="517" y2="98" stroke="#2a2a31" stroke-width="1"/>
+<polygon points="409,108 404,101 414,101" fill="#38bdf8" opacity="0.9"/>
+<rect x="297" y="112" width="224" height="42" rx="8" fill="#38bdf8" opacity="0.10"/>
+<rect x="297" y="112" width="224" height="42" rx="8" fill="none" stroke="#38bdf8" opacity="0.4"/>
+<text x="309" y="132" font-family="Inter,system-ui,sans-serif" font-size="12.5" font-weight="800" fill="#e9e9ec">Container coverage</text>
+<text x="309" y="149" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#82828c">OCI native · Grype · CIS posture</text>
+<rect x="547" y="18" width="248" height="148" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
+<rect x="561" y="30" width="40" height="40" rx="11" fill="#a78bfa" opacity="0.16"/><g transform="translate(565,34) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#a78bfa"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#a78bfa"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#a78bfa"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/></g></g>
+<text x="609" y="55" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="800" fill="#e9e9ec">Agent builders</text>
+<text x="563" y="86" font-family="ui-monospace,monospace" font-size="9.5" font-weight="600" fill="#82828c">MCP inventory · Shield · runtime</text>
+<line x1="563" y1="98" x2="779" y2="98" stroke="#2a2a31" stroke-width="1"/>
+<polygon points="671,108 666,101 676,101" fill="#a78bfa" opacity="0.9"/>
+<rect x="559" y="112" width="224" height="42" rx="8" fill="#a78bfa" opacity="0.10"/>
+<rect x="559" y="112" width="224" height="42" rx="8" fill="none" stroke="#a78bfa" opacity="0.4"/>
+<text x="571" y="132" font-family="Inter,system-ui,sans-serif" font-size="12.5" font-weight="800" fill="#e9e9ec">Self-hosted control plane</text>
+<text x="571" y="149" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#82828c">your VPC · signed audit · Helm</text>
+<rect x="809" y="18" width="248" height="148" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
+<rect x="823" y="30" width="40" height="40" rx="11" fill="#fb7185" opacity="0.16"/><g transform="translate(827,34) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#fb7185"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#fb7185"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#fb7185"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#fb7185" stroke-width="1.05"/></g></g>
+<text x="871" y="55" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="800" fill="#e9e9ec">Security engineers</text>
+<text x="825" y="86" font-family="ui-monospace,monospace" font-size="9.5" font-weight="600" fill="#82828c">findings queue · paths · graph</text>
+<line x1="825" y1="98" x2="1041" y2="98" stroke="#2a2a31" stroke-width="1"/>
+<polygon points="933,108 928,101 938,101" fill="#fb7185" opacity="0.9"/>
+<rect x="821" y="112" width="224" height="42" rx="8" fill="#fb7185" opacity="0.10"/>
+<rect x="821" y="112" width="224" height="42" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
+<text x="833" y="132" font-family="Inter,system-ui,sans-serif" font-size="12.5" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
+<text x="833" y="149" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#82828c">283 API ops · 70 MCP tools · SARIF</text>
+<rect x="24" y="178" width="1032" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="540" y="198" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -1,49 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="980" height="720" viewBox="0 0 980 720" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="218" viewBox="0 0 1080 218" fill="none">
 <title>agent-bom personas and value</title>
-<rect width="980" height="720" rx="12" fill="#ffffff"/>
-<text x="28" y="42" font-family="Inter,system-ui,sans-serif" font-size="28" font-weight="800" fill="#18181b">Who it serves · what they get</text>
-<text x="28" y="68" font-family="Inter,system-ui,sans-serif" font-size="13" font-weight="500" fill="#71717a">One evidence model — inventory -&gt; findings -&gt; graph -&gt; gates</text>
-<rect x="24" y="96" width="456" height="274" rx="14" fill="#ffffff" stroke="#34d399" stroke-width="1.8"/>
-<rect x="44" y="114" width="44" height="44" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,118) scale(1.5)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="100" y="136" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#18181b">AppSec / GRC</text>
-<text x="100" y="158" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#34d399">SARIF · compliance · audit chain</text>
-<line x1="44" y1="188" x2="460" y2="188" stroke="#34d399" stroke-width="1.2" opacity="0.55"/>
-<polygon points="252,202 245,192 259,192" fill="#34d399"/>
-<rect x="40" y="210" width="424" height="144" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
-<rect x="52" y="224" width="36" height="36" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(56,228) scale(1.1666666666666667)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="100" y="242" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#18181b">Accurate SCA</text>
-<text x="100" y="264" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#71717a">15 ecosystems · EPSS/KEV · distro-aware</text>
-<rect x="500" y="96" width="456" height="274" rx="14" fill="#ffffff" stroke="#fbbf24" stroke-width="1.8"/>
-<rect x="520" y="114" width="44" height="44" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(524,118) scale(1.5)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="576" y="136" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#18181b">Platform / SRE</text>
-<text x="576" y="158" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#fbbf24">fleet sync · Helm · CI · SBOM</text>
-<line x1="520" y1="188" x2="936" y2="188" stroke="#fbbf24" stroke-width="1.2" opacity="0.55"/>
-<polygon points="728,202 721,192 735,192" fill="#fbbf24"/>
-<rect x="516" y="210" width="424" height="144" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
-<rect x="528" y="224" width="36" height="36" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(532,228) scale(1.1666666666666667)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="6" width="14" height="12" rx="2"/><path d="M7 15l3-3 2 2 3-3 2 4"/></g>
-<text x="576" y="242" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#18181b">Container coverage</text>
-<text x="576" y="264" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#71717a">OCI native · Grype · CIS posture</text>
-<rect x="24" y="390" width="456" height="274" rx="14" fill="#ffffff" stroke="#60a5fa" stroke-width="1.8"/>
-<rect x="44" y="408" width="44" height="44" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(48,412) scale(1.5)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="100" y="430" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#18181b">Agent builders</text>
-<text x="100" y="452" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#60a5fa">MCP inventory · Shield · runtime</text>
-<line x1="44" y1="482" x2="460" y2="482" stroke="#60a5fa" stroke-width="1.2" opacity="0.55"/>
-<polygon points="252,496 245,486 259,486" fill="#60a5fa"/>
-<rect x="40" y="504" width="424" height="144" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
-<rect x="52" y="518" width="36" height="36" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(56,522) scale(1.1666666666666667)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="100" y="536" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#18181b">Self-hosted control plane</text>
-<text x="100" y="558" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#71717a">your VPC · signed audit · Helm</text>
-<rect x="500" y="390" width="456" height="274" rx="14" fill="#ffffff" stroke="#a78bfa" stroke-width="1.8"/>
-<rect x="520" y="408" width="44" height="44" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(524,412) scale(1.5)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="576" y="430" font-family="Inter,system-ui,sans-serif" font-size="18" font-weight="800" fill="#18181b">Security engineers</text>
-<text x="576" y="452" font-family="ui-monospace,monospace" font-size="11.5" font-weight="600" fill="#a78bfa">findings queue · paths · graph</text>
-<line x1="520" y1="482" x2="936" y2="482" stroke="#a78bfa" stroke-width="1.2" opacity="0.55"/>
-<polygon points="728,496 721,486 735,486" fill="#a78bfa"/>
-<rect x="516" y="504" width="424" height="144" rx="10" fill="#f5f3ff" stroke="#c4b5fd"/>
-<rect x="528" y="518" width="36" height="36" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(532,522) scale(1.1666666666666667)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="576" y="536" font-family="Inter,system-ui,sans-serif" font-size="16" font-weight="800" fill="#18181b">Agent-native surface</text>
-<text x="576" y="558" font-family="ui-monospace,monospace" font-size="11" font-weight="600" fill="#71717a">283 API ops · 70 MCP tools · SARIF</text>
-<rect x="24" y="676" width="932" height="32" rx="10" fill="#ecfdf5" stroke="#bbf7d0"/>
-<text x="490" y="697" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11" font-weight="700" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<rect width="1080" height="218" rx="12" fill="#ffffff"/>
+<rect x="23" y="18" width="248" height="148" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
+<rect x="37" y="30" width="40" height="40" rx="11" fill="#0d9488" opacity="0.10"/><g transform="translate(41,34) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0d9488"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0d9488"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0d9488"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.2" y="14.7" width="4.6" height="6.2" rx="1" fill="#ffffff" stroke="none"/><path d="M17.3 17.9l.95.95 1.75-1.75" stroke="#0d9488" stroke-width="1.05"/></g></g>
+<text x="85" y="55" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="800" fill="#18181b">AppSec / GRC</text>
+<text x="39" y="86" font-family="ui-monospace,monospace" font-size="9.5" font-weight="600" fill="#71717a">SARIF · compliance · audit chain</text>
+<line x1="39" y1="98" x2="255" y2="98" stroke="#e6e6ea" stroke-width="1"/>
+<polygon points="147,108 142,101 152,101" fill="#0d9488" opacity="0.9"/>
+<rect x="35" y="112" width="224" height="42" rx="8" fill="#0d9488" opacity="0.07"/>
+<rect x="35" y="112" width="224" height="42" rx="8" fill="none" stroke="#0d9488" opacity="0.4"/>
+<text x="47" y="132" font-family="Inter,system-ui,sans-serif" font-size="12.5" font-weight="800" fill="#18181b">Accurate SCA</text>
+<text x="47" y="149" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#71717a">15 ecosystems · EPSS/KEV · distro-aware</text>
+<rect x="285" y="18" width="248" height="148" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
+<rect x="299" y="30" width="40" height="40" rx="11" fill="#0284c7" opacity="0.10"/><g transform="translate(303,34) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0284c7"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0284c7"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0284c7"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/></g></g>
+<text x="347" y="55" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="800" fill="#18181b">Platform / SRE</text>
+<text x="301" y="86" font-family="ui-monospace,monospace" font-size="9.5" font-weight="600" fill="#71717a">fleet sync · Helm · CI · SBOM</text>
+<line x1="301" y1="98" x2="517" y2="98" stroke="#e6e6ea" stroke-width="1"/>
+<polygon points="409,108 404,101 414,101" fill="#0284c7" opacity="0.9"/>
+<rect x="297" y="112" width="224" height="42" rx="8" fill="#0284c7" opacity="0.07"/>
+<rect x="297" y="112" width="224" height="42" rx="8" fill="none" stroke="#0284c7" opacity="0.4"/>
+<text x="309" y="132" font-family="Inter,system-ui,sans-serif" font-size="12.5" font-weight="800" fill="#18181b">Container coverage</text>
+<text x="309" y="149" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#71717a">OCI native · Grype · CIS posture</text>
+<rect x="547" y="18" width="248" height="148" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
+<rect x="561" y="30" width="40" height="40" rx="11" fill="#7c3aed" opacity="0.10"/><g transform="translate(565,34) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#7c3aed"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#7c3aed"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#7c3aed"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/></g></g>
+<text x="609" y="55" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="800" fill="#18181b">Agent builders</text>
+<text x="563" y="86" font-family="ui-monospace,monospace" font-size="9.5" font-weight="600" fill="#71717a">MCP inventory · Shield · runtime</text>
+<line x1="563" y1="98" x2="779" y2="98" stroke="#e6e6ea" stroke-width="1"/>
+<polygon points="671,108 666,101 676,101" fill="#7c3aed" opacity="0.9"/>
+<rect x="559" y="112" width="224" height="42" rx="8" fill="#7c3aed" opacity="0.07"/>
+<rect x="559" y="112" width="224" height="42" rx="8" fill="none" stroke="#7c3aed" opacity="0.4"/>
+<text x="571" y="132" font-family="Inter,system-ui,sans-serif" font-size="12.5" font-weight="800" fill="#18181b">Self-hosted control plane</text>
+<text x="571" y="149" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#71717a">your VPC · signed audit · Helm</text>
+<rect x="809" y="18" width="248" height="148" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
+<rect x="823" y="30" width="40" height="40" rx="11" fill="#e11d48" opacity="0.10"/><g transform="translate(827,34) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#e11d48"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#e11d48"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#e11d48"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#ffffff" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#e11d48" stroke-width="1.05"/></g></g>
+<text x="871" y="55" font-family="Inter,system-ui,sans-serif" font-size="15" font-weight="800" fill="#18181b">Security engineers</text>
+<text x="825" y="86" font-family="ui-monospace,monospace" font-size="9.5" font-weight="600" fill="#71717a">findings queue · paths · graph</text>
+<line x1="825" y1="98" x2="1041" y2="98" stroke="#e6e6ea" stroke-width="1"/>
+<polygon points="933,108 928,101 938,101" fill="#e11d48" opacity="0.9"/>
+<rect x="821" y="112" width="224" height="42" rx="8" fill="#e11d48" opacity="0.07"/>
+<rect x="821" y="112" width="224" height="42" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
+<text x="833" y="132" font-family="Inter,system-ui,sans-serif" font-size="12.5" font-weight="800" fill="#18181b">Agent-native surface</text>
+<text x="833" y="149" font-family="ui-monospace,monospace" font-size="8.5" font-weight="600" fill="#71717a">283 API ops · 70 MCP tools · SARIF</text>
+<rect x="24" y="178" width="1032" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="540" y="198" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/scripts/generate_doc_architecture_svgs.py
+++ b/scripts/generate_doc_architecture_svgs.py
@@ -980,157 +980,156 @@ def architecture(theme_name: str) -> str:
     return "\n".join(parts)
 
 
+# Persona band accents — one restrained hue per buyer lane, on neutral cards.
+PERSONA_ACCENTS = {
+    "appsec": ("#2dd4bf", "#0d9488"),
+    "platform": ("#38bdf8", "#0284c7"),
+    "builders": ("#a78bfa", "#7c3aed"),
+    "seceng": ("#fb7185", "#e11d48"),
+}
+
+# Role badge glyphs on the solid accent badge circle at (18.5, 18): compliance
+# doc-with-check, platform layers, agent bot, security shield-with-check.
+# GLYPH / ACCENT tokens are substituted per theme when the card is drawn.
+PERSONA_BADGES = {
+    "appsec": (
+        '<rect x="16.2" y="14.7" width="4.6" height="6.2" rx="1" fill="GLYPH" stroke="none"/>'
+        '<path d="M17.3 17.9l.95.95 1.75-1.75" stroke="ACCENT" stroke-width="1.05"/>'
+    ),
+    "platform": '<path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/>',
+    "builders": '<rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/>',
+    "seceng": (
+        '<path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="GLYPH" stroke="none"/>'
+        '<path d="M17.1 17.95l1 1 1.8-1.8" stroke="ACCENT" stroke-width="1.05"/>'
+    ),
+}
+
+
 def _persona_lane_card(
     x: int,
     y: int,
     w: int,
     h: int,
-    persona_icon: str,
     persona_title: str,
     persona_sub: str,
-    value_icon: str,
     value_title: str,
     value_sub: str,
-    lane_key: str,
+    accent_key: str,
     theme: str,
     t: dict,
 ) -> list[str]:
-    lane_bg, lane_accent, lane_text = LANE_COLORS[lane_key]
+    accent = PERSONA_ACCENTS[accent_key][0 if theme == "dark" else 1]
+    tint_opacity = "0.10" if theme == "dark" else "0.07"
     parts: list[str] = []
-    if theme == "dark":
-        card_fill = lane_bg
-        card_stroke = lane_accent
-        persona_title_fill = lane_text
-        persona_sub_fill = lane_accent
-        value_fill = "#12121a"
-        value_stroke = lane_accent
-        value_title_fill = lane_text
-        value_sub_fill = lane_accent
-    else:
-        card_fill = t["card"]
-        card_stroke = lane_accent
-        persona_title_fill = t["text"]
-        persona_sub_fill = lane_accent
-        value_fill = t["accent_fill"]
-        value_stroke = t["accent_stroke"]
-        value_title_fill = t["text"]
-        value_sub_fill = t["text_muted"]
 
     parts.append(
-        f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="14" fill="{card_fill}" stroke="{card_stroke}" stroke-width="1.8"/>'
+        f'<rect x="{x}" y="{y}" width="{w}" height="{h}" rx="12" fill="{t["card"]}" stroke="{t["card_stroke"]}" stroke-width="1.4"/>'
     )
-    parts.append(_icon_box(x + 20, y + 18, ICONS[persona_icon], t, accent=True, size=44))
+
+    # SaaS-style avatar chip: tinted app-icon square, filled person silhouette,
+    # solid accent badge with a reverse-contrast role glyph.
+    chip_x, chip_y, chip_size = x + 14, y + 12, 40
+    chip_tint = "0.16" if theme == "dark" else "0.10"
+    glyph_stroke = "#0f0f13" if theme == "dark" else "#ffffff"
+    scale = 32 / 24
+    parts.append(
+        f'<rect x="{chip_x}" y="{chip_y}" width="{chip_size}" height="{chip_size}" rx="11" fill="{accent}" opacity="{chip_tint}"/>'
+        f'<g transform="translate({chip_x + 4},{chip_y + 4}) scale({scale})">'
+        f'<circle cx="10.5" cy="7.5" r="3.4" fill="{accent}"/>'
+        f'<path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="{accent}"/>'
+        f'<circle cx="18.5" cy="18" r="6" fill="{t["card"]}"/>'
+        f'<circle cx="18.5" cy="18" r="4.6" fill="{accent}"/>'
+        f'<g fill="none" stroke="{glyph_stroke}" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">'
+        f'{PERSONA_BADGES[accent_key].replace("GLYPH", glyph_stroke).replace("ACCENT", accent)}</g></g>'
+    )
     parts.append(
         _text(
-            x + 76,
-            y + 40,
+            x + 62,
+            y + 37,
             persona_title,
-            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "18", "font-weight": "800", "fill": persona_title_fill},
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "15", "font-weight": "800", "fill": t["text"]},
         )
     )
     parts.append(
         _text(
-            x + 76,
-            y + 62,
+            x + 16,
+            y + 68,
             persona_sub,
-            **{"font-family": "ui-monospace,monospace", "font-size": "11.5", "font-weight": "600", "fill": persona_sub_fill},
+            **{"font-family": "ui-monospace,monospace", "font-size": "9.5", "font-weight": "600", "fill": t["text_muted"]},
         )
     )
 
-    divider_y = y + 92
+    divider_y = y + 80
     parts.append(
-        f'<line x1="{x + 20}" y1="{divider_y}" x2="{x + w - 20}" y2="{divider_y}" '
-        f'stroke="{lane_accent}" stroke-width="1.2" opacity="0.55"/>'
+        f'<line x1="{x + 16}" y1="{divider_y}" x2="{x + w - 16}" y2="{divider_y}" '
+        f'stroke="{t["card_stroke"]}" stroke-width="1"/>'
     )
     arrow_x = x + w // 2
     parts.append(
-        f'<polygon points="{arrow_x},{divider_y + 14} {arrow_x - 7},{divider_y + 4} {arrow_x + 7},{divider_y + 4}" '
-        f'fill="{lane_accent}"/>'
+        f'<polygon points="{arrow_x},{divider_y + 10} {arrow_x - 5},{divider_y + 3} {arrow_x + 5},{divider_y + 3}" '
+        f'fill="{accent}" opacity="0.9"/>'
     )
 
-    value_y = divider_y + 22
-    value_h = h - (value_y - y) - 16
+    value_y = divider_y + 14
+    value_h = h - (value_y - y) - 12
     parts.append(
-        f'<rect x="{x + 16}" y="{value_y}" width="{w - 32}" height="{value_h}" rx="10" '
-        f'fill="{value_fill}" stroke="{value_stroke}"/>'
+        f'<rect x="{x + 12}" y="{value_y}" width="{w - 24}" height="{value_h}" rx="8" '
+        f'fill="{accent}" opacity="{tint_opacity}"/>'
     )
-    parts.append(_icon_box(x + 28, value_y + 14, ICONS[value_icon], t, accent=True, size=36))
+    parts.append(
+        f'<rect x="{x + 12}" y="{value_y}" width="{w - 24}" height="{value_h}" rx="8" '
+        f'fill="none" stroke="{accent}" opacity="0.4"/>'
+    )
     parts.append(
         _text(
-            x + 76,
-            value_y + 32,
+            x + 24,
+            value_y + 20,
             value_title,
-            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "16", "font-weight": "800", "fill": value_title_fill},
+            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "12.5", "font-weight": "800", "fill": t["text"]},
         )
     )
     parts.append(
         _text(
-            x + 76,
-            value_y + 54,
+            x + 24,
+            value_y + 37,
             value_sub,
-            **{"font-family": "ui-monospace,monospace", "font-size": "11", "font-weight": "600", "fill": value_sub_fill},
+            **{"font-family": "ui-monospace,monospace", "font-size": "8.5", "font-weight": "600", "fill": t["text_muted"]},
         )
     )
     return parts
 
 
 def persona_value(theme: str) -> str:
+    """Compact single-row buyer-lane band — persona -> value proof per card."""
     t = THEMES[theme]
-    w, h = 980, 720
+    w, h = 1080, 218
     persona_bg = "#16161d" if theme == "dark" else t["bg"]
 
     cards = [
-        ("shield", "AppSec / GRC", "SARIF · compliance · audit chain", "bug", "Accurate SCA", "15 ecosystems · EPSS/KEV · distro-aware", "control"),
-        ("gate", "Platform / SRE", "fleet sync · Helm · CI · SBOM", "image", "Container coverage", "OCI native · Grype · CIS posture", "scan"),
-        ("mcp", "Agent builders", "MCP inventory · Shield · runtime", "audit", "Self-hosted control plane", "your VPC · signed audit · Helm", "intake"),
-        ("graph", "Security engineers", "findings queue · paths · graph", "api", "Agent-native surface", "283 API ops · 70 MCP tools · SARIF", "core"),
+        ("AppSec / GRC", "SARIF · compliance · audit chain", "Accurate SCA", "15 ecosystems · EPSS/KEV · distro-aware", "appsec"),
+        ("Platform / SRE", "fleet sync · Helm · CI · SBOM", "Container coverage", "OCI native · Grype · CIS posture", "platform"),
+        ("Agent builders", "MCP inventory · Shield · runtime", "Self-hosted control plane", "your VPC · signed audit · Helm", "builders"),
+        ("Security engineers", "findings queue · paths · graph", "Agent-native surface", "283 API ops · 70 MCP tools · SARIF", "seceng"),
     ]
 
-    margin_x, margin_y = 24, 96
-    gap = 20
-    card_w = (w - margin_x * 2 - gap) // 2
-    card_h = (h - margin_y - 56 - gap) // 2
+    margin_x, margin_y = 23, 18
+    gap = 14
+    card_w = (w - margin_x * 2 - gap * 3) // 4
+    card_h = 148
 
     parts = _svg_open(w, h, "agent-bom personas and value")
     parts.append(f'<rect width="{w}" height="{h}" rx="12" fill="{persona_bg}"/>')
-    parts += [
-        _text(
-            28,
-            42,
-            "Who it serves · what they get",
-            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "28", "font-weight": "800", "fill": t["title"]},
-        ),
-        _text(
-            28,
-            68,
-            "One evidence model — inventory -> findings -> graph -> gates",
-            **{"font-family": "Inter,system-ui,sans-serif", "font-size": "13", "font-weight": "500", "fill": t["subtitle"]},
-        ),
-    ]
 
     for idx, card in enumerate(cards):
-        col = idx % 2
-        row = idx // 2
-        x = margin_x + col * (card_w + gap)
-        y = margin_y + row * (card_h + gap)
-        parts += _persona_lane_card(x, y, card_w, card_h, *card, theme, t)
+        x = margin_x + idx * (card_w + gap)
+        parts += _persona_lane_card(x, margin_y, card_w, card_h, *card, theme, t)
 
-    footer_y = h - 44
     parts.append(
-        f'<rect x="24" y="{footer_y}" width="{w - 48}" height="32" rx="10" fill="{t["trust_bg"]}" stroke="{t["trust_stroke"]}"/>'
-    )
-    parts.append(
-        _text(
-            w // 2,
-            footer_y + 21,
+        _trust_footer(
+            w,
+            h,
+            t,
             "LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph",
-            **{
-                "text-anchor": "middle",
-                "font-family": "Inter,system-ui,sans-serif",
-                "font-size": "11",
-                "font-weight": "700",
-                "fill": t["trust"],
-            },
         )
     )
     parts.append("</svg>")

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -10,8 +10,8 @@
 
 **Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.**
 
-Headless agent primitives and human cockpit surfaces use the same evidence
-model.
+Scan locally, centralize findings, govern runtime — your team and your agents
+work from the same evidence model.
 
 `agent-bom` is also an open security data plane. It generates a
 reachability-backed AI BOM across agents, MCP servers, tools, packages,
@@ -76,9 +76,8 @@ The dashboard is not the only door into the product. It is the human cockpit
 over the same evidence that agents can request through MCP and platforms can
 consume through API, CLI, reports, and exports.
 
-The product shape is cockpit plus callable primitives: humans get a review
-surface and agents get strict-argument tools over the same security evidence
-and `ExposurePath` graphs.
+Humans get a review surface; agents get strict-argument tools. Both work over
+the same security evidence and `ExposurePath` graphs.
 
 Cloud posture follows the same model: use `agent-bom iac` to block unsafe
 Terraform, CloudFormation, Kubernetes, or Docker changes before deployment,


### PR DESCRIPTION
## Summary

- Restructure the README to introduce the product before the audience: **What Is agent-bom** (intro prose + how-it-works diagram, with architecture / blast-radius / accuracy collapsibles) → **Who It's For** → **First Run** → **Start Here**; split the mixed Cloud/Deploy/Trust block into **Cloud Connectors**, **Deploy in Your Boundary** (deploy-target table), and **Trust**, with Snowflake auth detail collapsed.
- Redesign `persona-value-{dark,light}.svg` from a 980×720 2×2 grid into a compact 1080×218 single-row band: neutral theme cards, one restrained accent hue per buyer lane, and duotone persona avatars — filled silhouette on a tinted app-icon chip with a solid accent role badge (compliance check, platform layers, agent bot, security shield). Generator (`scripts/generate_doc_architecture_svgs.py`) gains `PERSONA_ACCENTS` and `PERSONA_BADGES`.
- Replace "headless agent primitives and human cockpit surfaces" positioning with plain product language in the README hero, `site-docs/index.md`, and `docs/PRODUCT_BRIEF.md` ("Scan locally, centralize findings, govern runtime — one evidence model for your team and your agents").
- Update the `docs/VISUAL_LANGUAGE.md` SVG inventory to match new shapes and README placements.

## Verification

- `python3 scripts/generate_doc_architecture_svgs.py` — regenerated; layout and GitHub-safety audits pass at generation time
- `uv run pytest tests/test_doc_architecture_svgs.py -q` — 7 passed
- `uv run ruff check scripts/generate_doc_architecture_svgs.py` — clean
- `git diff --check` — clean
- Both persona SVG themes rendered via rsvg-convert and visually reviewed (badges legible with reverse-contrast glyphs, light/dark readable, no overflow)
- Repo-wide search confirms no remaining "headless agent primitives" phrasing and no other references to the renamed README sections

## Notes

- No content claims added or removed; sections were reordered, tightened, or collapsed. Counts shown in the persona band (283 API ops, 70 MCP tools, 15 ecosystems) are unchanged from the previous SVG.
- how-it-works and architecture SVGs regenerate byte-identical; only the persona pair changes.