### PR TITLE
feat(reachability): NuGet/C# AST symbol join for .NET MCP backends

### DIFF
--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -30,6 +30,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from agent_bom.js_ts_ast import JSTSFunction, JSTSToolRegistration
+from agent_bom.ast_csharp import _csharp_method_key, build_csharp_dependency_symbol_reach, load_nuget_namespace_map
+from agent_bom.ast_csharp import scan_csharp_file as _scan_csharp_file
 from agent_bom.ast_go import _go_function_key, build_go_dependency_symbol_reach
 from agent_bom.ast_go import build_go_flow_findings as _build_go_flow_findings
 from agent_bom.ast_go import scan_go_file as _scan_go_file
@@ -41,6 +43,8 @@ from agent_bom.ast_js_ts import scan_js_ts_file as _scan_js_ts_file
 from agent_bom.ast_models import (
     ASTAnalysisResult,
     CallEdge,
+    _CSharpMethodAnalysis,
+    _CSharpToolRegistration,
     _FunctionAnalysis,
     _GoFunctionAnalysis,
     _GoToolRegistration,
@@ -133,13 +137,24 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
             continue
         java_files.append(f)
 
+    csharp_files = []
+    for f in sorted(project.rglob("*.cs")):
+        if any(part in _SKIP_DIRS for part in f.parts):
+            continue
+        if any(skip in f.name.lower() for skip in _SKIP_FILE_PATTERNS):
+            continue
+        csharp_files.append(f)
+
     py_files = py_files[:_MAX_FILES]
     js_ts_files = js_ts_files[: max(0, _MAX_FILES - len(py_files))]
     go_files = go_files[: max(0, _MAX_FILES - len(py_files) - len(js_ts_files))]
     remaining = max(0, _MAX_FILES - len(py_files) - len(js_ts_files) - len(go_files))
     rust_files = rust_files[: remaining]
     java_files = java_files[: max(0, remaining - len(rust_files))]
-    result.files_analyzed = len(py_files) + len(js_ts_files) + len(go_files) + len(rust_files) + len(java_files)
+    csharp_files = csharp_files[: max(0, remaining - len(rust_files) - len(java_files))]
+    result.files_analyzed = (
+        len(py_files) + len(js_ts_files) + len(go_files) + len(rust_files) + len(java_files) + len(csharp_files)
+    )
     function_analyses: list[_FunctionAnalysis] = []
     js_ts_functions: dict[str, JSTSFunction] = {}
     js_ts_tool_registrations: list[JSTSToolRegistration] = []
@@ -149,7 +164,10 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
     rust_tool_registrations: list[_RustToolRegistration] = []
     java_methods: dict[str, _JavaMethodAnalysis] = {}
     java_tool_registrations: list[_JavaToolRegistration] = []
+    csharp_methods: dict[str, _CSharpMethodAnalysis] = {}
+    csharp_tool_registrations: list[_CSharpToolRegistration] = []
     maven_dependency_map = _load_maven_dependency_map(project)
+    nuget_namespace_map = load_nuget_namespace_map(project)
 
     for py_file in py_files:
         rel = str(py_file.relative_to(project))
@@ -227,6 +245,24 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
                 java_methods[_java_method_key(java_method.class_name, java_method.name)] = java_method
             java_tool_registrations.extend(java_analysis.tool_registrations)
 
+    for csharp_file in csharp_files:
+        rel = str(csharp_file.relative_to(project))
+        prompts, guardrails, tools, flow_findings, frameworks, csharp_call_edges, csharp_analysis = _scan_csharp_file(
+            csharp_file,
+            rel,
+            nuget_map=nuget_namespace_map,
+        )
+        result.prompts.extend(prompts)
+        result.guardrails.extend(guardrails)
+        result.tools.extend(tools)
+        result.flow_findings.extend(flow_findings)
+        result.frameworks_detected.extend(frameworks)
+        result.call_edges.extend(csharp_call_edges)
+        if csharp_analysis is not None:
+            for csharp_method in csharp_analysis.functions.values():
+                csharp_methods[_csharp_method_key(csharp_method.class_name, csharp_method.name)] = csharp_method
+            csharp_tool_registrations.extend(csharp_analysis.tool_registrations)
+
     python_call_edges, interprocedural_findings = _build_call_graph(function_analyses)
     result.call_edges.extend(python_call_edges)
     result.flow_findings.extend(interprocedural_findings)
@@ -269,6 +305,13 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
         build_java_dependency_symbol_reach(
             methods=java_methods,
             tool_registrations=java_tool_registrations,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
+    result.dependency_symbol_reach.extend(
+        build_csharp_dependency_symbol_reach(
+            methods=csharp_methods,
+            tool_registrations=csharp_tool_registrations,
             max_depth=_python_max_taint_depth(),
         )
     )

--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -149,12 +149,10 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
     js_ts_files = js_ts_files[: max(0, _MAX_FILES - len(py_files))]
     go_files = go_files[: max(0, _MAX_FILES - len(py_files) - len(js_ts_files))]
     remaining = max(0, _MAX_FILES - len(py_files) - len(js_ts_files) - len(go_files))
-    rust_files = rust_files[: remaining]
+    rust_files = rust_files[:remaining]
     java_files = java_files[: max(0, remaining - len(rust_files))]
     csharp_files = csharp_files[: max(0, remaining - len(rust_files) - len(java_files))]
-    result.files_analyzed = (
-        len(py_files) + len(js_ts_files) + len(go_files) + len(rust_files) + len(java_files) + len(csharp_files)
-    )
+    result.files_analyzed = len(py_files) + len(js_ts_files) + len(go_files) + len(rust_files) + len(java_files) + len(csharp_files)
     function_analyses: list[_FunctionAnalysis] = []
     js_ts_functions: dict[str, JSTSFunction] = {}
     js_ts_tool_registrations: list[JSTSToolRegistration] = []

--- a/src/agent_bom/ast_csharp.py
+++ b/src/agent_bom/ast_csharp.py
@@ -1,0 +1,482 @@
+"""C# / NuGet analyzer helpers for MCP symbol-level reachability.
+
+Regex-backed and conservative: NuGet package IDs must be declared in
+``packages.lock.json`` or ``*.csproj`` before ``using`` / local-type bindings
+are trusted. Unresolved MCP tool handlers are dropped so headless agents do
+not inherit false ``function_reachable`` upgrades at CVE join time.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agent_bom.ast_models import (
+    CallEdge,
+    DependencySymbolReach,
+    DetectedGuardrail,
+    ExtractedPrompt,
+    FlowFinding,
+    ToolSignature,
+    _CSharpCallSite,
+    _CSharpFileAnalysis,
+    _CSharpMethodAnalysis,
+    _CSharpToolRegistration,
+)
+from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol, is_verified_nuget_package
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+_MAX_FILE_SIZE = 512 * 1024
+_CS_USING_RE = re.compile(r"^\s*using\s+(?:static\s+)?(?P<path>[\w.]+)\s*;", re.MULTILINE)
+_CS_USING_ALIAS_RE = re.compile(r"^\s*using\s+(?P<alias>[\w]+)\s*=\s*(?P<path>[\w.]+)\s*;", re.MULTILINE)
+_CS_CLASS_RE = re.compile(r"\bclass\s+(?P<name>\w+)")
+_CS_METHOD_RE = re.compile(
+    r"(?:public|private|protected|internal)?\s*(?:static\s+)?(?:async\s+)?[\w<>\[\],\s.?]+\s+(?P<name>[A-Za-z]\w*)\s*\(",
+    re.MULTILINE,
+)
+_CS_CALL_RE = re.compile(r"\b(?P<name>\w+(?:\.\w+)+)\s*\(")
+_CS_CALL_SKIP = frozenset(
+    {
+        "if",
+        "for",
+        "while",
+        "switch",
+        "return",
+        "new",
+        "catch",
+        "throw",
+        "class",
+        "public",
+        "private",
+        "protected",
+        "internal",
+        "static",
+        "async",
+        "void",
+        "using",
+        "await",
+    }
+)
+_CS_ADD_TOOL_RE = re.compile(r'\.AddTool\s*\(\s*"(?P<name>[^"]+)"', re.IGNORECASE)
+_CS_MCP_TOOL_ATTR_RE = re.compile(r"\[\s*McpServerTool(?:\s*\([^)]*\))?\s*\]", re.IGNORECASE)
+_CS_LOCAL_BINDING_RE = re.compile(r"\b(?P<type>[\w.]+)\s+(?P<var>[a-z]\w*)\s*=\s*new\s+(?P<ctor>[\w.]+)")
+_CS_FRAMEWORK_HINTS: dict[str, str] = {
+    "modelcontextprotocol": "MCP",
+    "microsoft.semantickernel": "SemanticKernel",
+}
+
+
+def _line_number_from_index(source: str, index: int) -> int:
+    return source[:index].count("\n") + 1
+
+
+def _balanced_segment(source: str, open_index: int, *, open_char: str, close_char: str) -> tuple[str, int] | None:
+    if open_index < 0 or open_index >= len(source) or source[open_index] != open_char:
+        return None
+    depth = 0
+    in_quote = ""
+    escaped = False
+    for index in range(open_index, len(source)):
+        char = source[index]
+        if in_quote:
+            if char == "\\" and not escaped:
+                escaped = True
+                continue
+            if char == in_quote and not escaped:
+                in_quote = ""
+            escaped = False
+            continue
+        if char in {'"', "'"}:
+            in_quote = char
+            escaped = False
+            continue
+        if char == open_char:
+            depth += 1
+        elif char == close_char:
+            depth -= 1
+            if depth == 0:
+                return source[open_index : index + 1], index + 1
+    return None
+
+
+def load_nuget_namespace_map(project: Path) -> dict[str, str]:
+    """Map C# namespace prefixes and aliases to declared NuGet package IDs."""
+    from agent_bom.parsers.dotnet_parsers import parse_nuget_packages
+
+    mapping: dict[str, str] = {}
+    for pkg in parse_nuget_packages(project):
+        package_id = pkg.name.strip()
+        if not package_id:
+            continue
+        mapping[package_id] = package_id
+        parts = package_id.split(".")
+        for index in range(1, len(parts) + 1):
+            prefix = ".".join(parts[:index])
+            mapping.setdefault(prefix, package_id)
+    return mapping
+
+
+def _nuget_package_for_namespace(namespace: str, nuget_map: Mapping[str, str]) -> str | None:
+    if not namespace or not nuget_map:
+        return None
+    if namespace in nuget_map:
+        package_id = nuget_map[namespace]
+        return package_id if is_verified_nuget_package(package_id, dict(nuget_map)) else None
+    parts = namespace.split(".")
+    for index in range(len(parts), 0, -1):
+        prefix = ".".join(parts[:index])
+        package_id = nuget_map.get(prefix)
+        if package_id and is_verified_nuget_package(package_id, dict(nuget_map)):
+            return package_id
+    return None
+
+
+def _csharp_using_bindings(source: str, nuget_map: Mapping[str, str]) -> dict[str, str]:
+    bindings: dict[str, str] = {}
+    for match in _CS_USING_ALIAS_RE.finditer(source):
+        package_id = _nuget_package_for_namespace(match.group("path").strip(), nuget_map)
+        if package_id:
+            bindings[match.group("alias")] = package_id
+    for match in _CS_USING_RE.finditer(source):
+        namespace = match.group("path").strip()
+        package_id = _nuget_package_for_namespace(namespace, nuget_map)
+        if not package_id:
+            continue
+        bindings[namespace] = package_id
+        simple = namespace.rsplit(".", 1)[-1]
+        bindings[simple] = package_id
+    return bindings
+
+
+def _csharp_local_bindings(body: str, import_bindings: Mapping[str, str]) -> dict[str, str]:
+    locals_map: dict[str, str] = {}
+    for match in _CS_LOCAL_BINDING_RE.finditer(body):
+        type_name = match.group("type").rsplit(".", 1)[-1]
+        var_name = match.group("var")
+        qualified_type = match.group("type")
+        package_id = (
+            import_bindings.get(type_name)
+            or import_bindings.get(qualified_type)
+            or (
+                import_bindings.get(qualified_type.split(".", 1)[0])
+                if "." in qualified_type
+                else None
+            )
+        )
+        if package_id:
+            locals_map[var_name] = package_id
+    return locals_map
+
+
+def _csharp_call_sites(body: str, *, line_offset: int) -> list[_CSharpCallSite]:
+    sites: list[_CSharpCallSite] = []
+    for match in _CS_CALL_RE.finditer(body):
+        name = match.group("name")
+        name_start = match.start("name")
+        if re.search(r"\bnew\s*$", body[max(0, name_start - 8) : name_start]):
+            continue
+        head = name.split(".", 1)[0]
+        if head in _CS_CALL_SKIP:
+            continue
+        sites.append(
+            _CSharpCallSite(
+                name=name,
+                line_number=line_offset + body[: match.start()].count("\n") + 1,
+            )
+        )
+    return sites
+
+
+def _csharp_method_key(class_name: str, name: str) -> str:
+    return f"{class_name}::{name}"
+
+
+def _csharp_method_display_name(class_name: str, name: str, name_counts: dict[str, int]) -> str:
+    if name_counts.get(name, 0) > 1:
+        return _csharp_method_key(class_name, name)
+    return name
+
+
+def _collect_csharp_methods(
+    source: str,
+    *,
+    rel_path: str,
+    class_name: str,
+    bindings: dict[str, str],
+) -> dict[str, _CSharpMethodAnalysis]:
+    methods: dict[str, _CSharpMethodAnalysis] = {}
+    for match in _CS_METHOD_RE.finditer(source):
+        name = match.group("name")
+        name_start = match.start("name")
+        if re.search(r"\bnew\s+(?:[\w.]+\s*)?$", source[max(0, name_start - 64) : name_start]):
+            continue
+        brace_index = source.find("{", match.end())
+        body_segment = _balanced_segment(source, brace_index, open_char="{", close_char="}") if brace_index >= 0 else None
+        call_sites: list[_CSharpCallSite] = []
+        method_bindings = dict(bindings)
+        if body_segment is not None:
+            body_text, _ = body_segment
+            body_line_offset = _line_number_from_index(source, brace_index) - 1
+            call_sites = _csharp_call_sites(body_text, line_offset=body_line_offset)
+            method_bindings.update(_csharp_local_bindings(body_text, bindings))
+        methods[_csharp_method_key(class_name, name)] = _CSharpMethodAnalysis(
+            name=name,
+            line_number=_line_number_from_index(source, match.start()),
+            file_path=rel_path,
+            class_name=class_name,
+            import_bindings=method_bindings,
+            call_sites=call_sites,
+        )
+    return methods
+
+
+def _collect_csharp_tool_registrations(
+    source: str,
+    *,
+    rel_path: str,
+    class_name: str,
+    bindings: dict[str, str],
+    methods: Mapping[str, _CSharpMethodAnalysis],
+) -> list[_CSharpToolRegistration]:
+    registrations: list[_CSharpToolRegistration] = []
+    seen: set[tuple[str, int]] = set()
+
+    for match in _CS_ADD_TOOL_RE.finditer(source):
+        tool_name = match.group("name").strip()
+        if not tool_name:
+            continue
+        handler_name: str | None = None
+        args_start = source.find("(", match.start())
+        args_segment = _balanced_segment(source, args_start, open_char="(", close_char=")") if args_start >= 0 else None
+        if args_segment is not None:
+            args_text, _ = args_segment
+            ref_match = re.search(r"(?P<method>[A-Za-z]\w*)\s*[,)]", args_text.split(",", 1)[-1] if "," in args_text else args_text)
+            if ref_match:
+                candidate = ref_match.group("method")
+                key = _csharp_method_key(class_name, candidate)
+                if key in methods:
+                    handler_name = key
+        if handler_name is None:
+            continue
+        key = (tool_name, match.start())
+        if key in seen:
+            continue
+        seen.add(key)
+        registrations.append(
+            _CSharpToolRegistration(
+                tool_name=tool_name,
+                handler_name=handler_name,
+                line_number=_line_number_from_index(source, match.start()),
+                file_path=rel_path,
+                class_name=class_name,
+                import_bindings=dict(bindings),
+            )
+        )
+
+    for attr_match in _CS_MCP_TOOL_ATTR_RE.finditer(source):
+        method_match = _CS_METHOD_RE.search(source, attr_match.end())
+        if not method_match:
+            continue
+        method_name = method_match.group("name")
+        tool_name = method_name
+        key = (tool_name, attr_match.start())
+        if key in seen:
+            continue
+        seen.add(key)
+        handler_key = _csharp_method_key(class_name, method_name)
+        if handler_key not in methods:
+            continue
+        registrations.append(
+            _CSharpToolRegistration(
+                tool_name=tool_name,
+                handler_name=handler_key,
+                line_number=_line_number_from_index(source, attr_match.start()),
+                file_path=rel_path,
+                class_name=class_name,
+                import_bindings=dict(bindings),
+            )
+        )
+    return registrations
+
+
+def _resolve_csharp_callee_key(
+    call_name: str,
+    *,
+    class_name: str,
+    methods: Mapping[str, _CSharpMethodAnalysis],
+) -> str | None:
+    bare = call_name.split("(", 1)[0].strip()
+    if "." in bare:
+        _, tail = bare.split(".", 1)
+        candidate = _csharp_method_key(class_name, tail)
+        if candidate in methods:
+            return candidate
+    candidate = _csharp_method_key(class_name, bare)
+    if candidate in methods:
+        return candidate
+    return None
+
+
+def _resolve_csharp_external_dependency_symbol(
+    method: _CSharpMethodAnalysis,
+    call_name: str,
+) -> tuple[str, str, str] | None:
+    """Resolve an external import call to ``(package, module, symbol)``."""
+    if not call_name or "." not in call_name:
+        return None
+    head, tail = call_name.split(".", 1)
+    package_id = method.import_bindings.get(head)
+    if not package_id or not is_verified_nuget_package(package_id, method.import_bindings):
+        return None
+    symbol = tail.split(".", 1)[0]
+    if not is_actionable_dependency_symbol(symbol):
+        return None
+    return package_id, package_id, symbol
+
+
+def build_csharp_dependency_symbol_reach(
+    *,
+    methods: Mapping[str, _CSharpMethodAnalysis],
+    tool_registrations: Sequence[_CSharpToolRegistration],
+    max_depth: int = 4,
+) -> list[DependencySymbolReach]:
+    """Build bounded MCP tool-entrypoint -> NuGet dependency symbol reach."""
+    if not methods or not tool_registrations:
+        return []
+
+    adjacency: dict[str, set[str]] = {name: set() for name in methods}
+    name_counts: dict[str, int] = {}
+    for method in methods.values():
+        name_counts[method.name] = name_counts.get(method.name, 0) + 1
+
+    for method_key, method in methods.items():
+        for call_site in method.call_sites:
+            callee_key = _resolve_csharp_callee_key(
+                call_site.name,
+                class_name=method.class_name,
+                methods=methods,
+            )
+            if callee_key and callee_key != method_key:
+                adjacency[method_key].add(callee_key)
+
+    reached: list[DependencySymbolReach] = []
+    seen: set[tuple[str, str, str, str, int]] = set()
+
+    def display_name(method_key: str) -> str:
+        method = methods[method_key]
+        return _csharp_method_display_name(method.class_name, method.name, name_counts)
+
+    for registration in tool_registrations:
+        handler_key = registration.handler_name
+        if handler_key not in methods:
+            continue
+        queue: list[tuple[str, list[str]]] = [(handler_key, [handler_key])]
+        visited: set[str] = set()
+        while queue:
+            current_key, path = queue.pop(0)
+            if len(path) > max_depth:
+                continue
+            if current_key in visited:
+                continue
+            visited.add(current_key)
+            current = methods[current_key]
+            for call_site in current.call_sites:
+                external = _resolve_csharp_external_dependency_symbol(current, call_site.name)
+                if external is None:
+                    continue
+                package_id, module_name, symbol = external
+                dedup_key = (registration.tool_name, module_name, symbol, current.file_path, call_site.line_number)
+                if dedup_key in seen:
+                    continue
+                seen.add(dedup_key)
+                reached.append(
+                    DependencySymbolReach(
+                        entrypoint=registration.tool_name,
+                        package=package_id,
+                        module=module_name,
+                        symbol=symbol,
+                        file_path=current.file_path,
+                        line_number=call_site.line_number,
+                        call_path=[registration.tool_name, *[display_name(name) for name in path], f"{module_name}.{symbol}"],
+                        depth=max(0, len(path) - 1),
+                        ecosystem="nuget",
+                    )
+                )
+            for next_callee in sorted(adjacency.get(current_key, ())):
+                queue.append((next_callee, [*path, next_callee]))
+
+    return reached
+
+
+def scan_csharp_file(
+    file_path: Path,
+    rel_path: str,
+    *,
+    nuget_map: Mapping[str, str],
+) -> tuple[
+    list[ExtractedPrompt],
+    list[DetectedGuardrail],
+    list[ToolSignature],
+    list[FlowFinding],
+    list[str],
+    list[CallEdge],
+    _CSharpFileAnalysis | None,
+]:
+    """Extract MCP/tool signals and call sites from C# source files."""
+    try:
+        source = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return [], [], [], [], [], [], None
+
+    if len(source) > _MAX_FILE_SIZE:
+        return [], [], [], [], [], [], None
+
+    class_match = _CS_CLASS_RE.search(source)
+    class_name = class_match.group("name") if class_match else Path(rel_path).stem
+    bindings = _csharp_using_bindings(source, nuget_map)
+    frameworks = sorted(
+        {
+            framework
+            for prefix, framework in _CS_FRAMEWORK_HINTS.items()
+            if any(prefix in binding.lower() for binding in bindings.values())
+        }
+    )
+    methods = _collect_csharp_methods(source, rel_path=rel_path, class_name=class_name, bindings=bindings)
+    tool_registrations = _collect_csharp_tool_registrations(
+        source,
+        rel_path=rel_path,
+        class_name=class_name,
+        bindings=bindings,
+        methods=methods,
+    )
+    tools: list[ToolSignature] = []
+    for registration in tool_registrations:
+        tools.append(
+            ToolSignature(
+                name=registration.tool_name,
+                parameters=[],
+                return_type="unknown",
+                description="C# MCP/tool registration",
+                file_path=rel_path,
+                line_number=registration.line_number,
+                decorators=["csharp-tool"],
+                is_async=False,
+            )
+        )
+
+    return (
+        [],
+        [],
+        tools,
+        [],
+        frameworks,
+        [],
+        _CSharpFileAnalysis(
+            class_name=class_name,
+            functions=methods,
+            tool_registrations=tool_registrations,
+        ),
+    )

--- a/src/agent_bom/ast_csharp.py
+++ b/src/agent_bom/ast_csharp.py
@@ -128,9 +128,9 @@ def _nuget_package_for_namespace(namespace: str, nuget_map: Mapping[str, str]) -
     parts = namespace.split(".")
     for index in range(len(parts), 0, -1):
         prefix = ".".join(parts[:index])
-        package_id = nuget_map.get(prefix)
-        if package_id and is_verified_nuget_package(package_id, dict(nuget_map)):
-            return package_id
+        candidate_package_id = nuget_map.get(prefix)
+        if candidate_package_id and is_verified_nuget_package(candidate_package_id, dict(nuget_map)):
+            return candidate_package_id
     return None
 
 
@@ -160,11 +160,7 @@ def _csharp_local_bindings(body: str, import_bindings: Mapping[str, str]) -> dic
         package_id = (
             import_bindings.get(type_name)
             or import_bindings.get(qualified_type)
-            or (
-                import_bindings.get(qualified_type.split(".", 1)[0])
-                if "." in qualified_type
-                else None
-            )
+            or (import_bindings.get(qualified_type.split(".", 1)[0]) if "." in qualified_type else None)
         )
         if package_id:
             locals_map[var_name] = package_id
@@ -261,10 +257,10 @@ def _collect_csharp_tool_registrations(
                     handler_name = key
         if handler_name is None:
             continue
-        key = (tool_name, match.start())
-        if key in seen:
+        registration_key = (tool_name, match.start())
+        if registration_key in seen:
             continue
-        seen.add(key)
+        seen.add(registration_key)
         registrations.append(
             _CSharpToolRegistration(
                 tool_name=tool_name,
@@ -282,10 +278,10 @@ def _collect_csharp_tool_registrations(
             continue
         method_name = method_match.group("name")
         tool_name = method_name
-        key = (tool_name, attr_match.start())
-        if key in seen:
+        registration_key = (tool_name, attr_match.start())
+        if registration_key in seen:
             continue
-        seen.add(key)
+        seen.add(registration_key)
         handler_key = _csharp_method_key(class_name, method_name)
         if handler_key not in methods:
             continue
@@ -438,11 +434,7 @@ def scan_csharp_file(
     class_name = class_match.group("name") if class_match else Path(rel_path).stem
     bindings = _csharp_using_bindings(source, nuget_map)
     frameworks = sorted(
-        {
-            framework
-            for prefix, framework in _CS_FRAMEWORK_HINTS.items()
-            if any(prefix in binding.lower() for binding in bindings.values())
-        }
+        {framework for prefix, framework in _CS_FRAMEWORK_HINTS.items() if any(prefix in binding.lower() for binding in bindings.values())}
     )
     methods = _collect_csharp_methods(source, rel_path=rel_path, class_name=class_name, bindings=bindings)
     tool_registrations = _collect_csharp_tool_registrations(

--- a/src/agent_bom/ast_models.py
+++ b/src/agent_bom/ast_models.py
@@ -319,6 +319,39 @@ class _JavaFileAnalysis:
 
 
 @dataclass
+class _CSharpCallSite:
+    name: str
+    line_number: int
+
+
+@dataclass
+class _CSharpMethodAnalysis:
+    name: str
+    line_number: int
+    file_path: str = ""
+    class_name: str = ""
+    import_bindings: dict[str, str] = field(default_factory=dict)
+    call_sites: list[_CSharpCallSite] = field(default_factory=list)
+
+
+@dataclass
+class _CSharpToolRegistration:
+    tool_name: str
+    handler_name: str
+    line_number: int
+    file_path: str = ""
+    class_name: str = ""
+    import_bindings: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class _CSharpFileAnalysis:
+    class_name: str
+    functions: dict[str, _CSharpMethodAnalysis] = field(default_factory=dict)
+    tool_registrations: list[_CSharpToolRegistration] = field(default_factory=list)
+
+
+@dataclass
 class _FunctionAnalysis:
     """Internal representation of a function for call-graph construction."""
 

--- a/src/agent_bom/ast_symbol_reach_guards.py
+++ b/src/agent_bom/ast_symbol_reach_guards.py
@@ -30,9 +30,7 @@ _GENERIC_SYMBOL_DENYLIST: frozenset[str] = frozenset(
 )
 
 # Rust std/internal crates are not Cargo.lock CVE targets for third-party join.
-_RUST_INTRINSIC_CRATES: frozenset[str] = frozenset(
-    {"std", "core", "alloc", "proc_macro", "test", "self", "super", "crate"}
-)
+_RUST_INTRINSIC_CRATES: frozenset[str] = frozenset({"std", "core", "alloc", "proc_macro", "test", "self", "super", "crate"})
 
 
 def is_actionable_dependency_symbol(symbol: str) -> bool:

--- a/src/agent_bom/ast_symbol_reach_guards.py
+++ b/src/agent_bom/ast_symbol_reach_guards.py
@@ -56,8 +56,16 @@ def is_verified_maven_coord(coord: str, maven_map: dict[str, str]) -> bool:
     return coord in set(maven_map.values())
 
 
+def is_verified_nuget_package(package_id: str, nuget_map: dict[str, str]) -> bool:
+    """Return True when a NuGet package ID is declared in the project manifest map."""
+    if not package_id or not nuget_map:
+        return False
+    return package_id in set(nuget_map.values())
+
+
 __all__ = [
     "is_actionable_dependency_symbol",
     "is_external_rust_crate",
     "is_verified_maven_coord",
+    "is_verified_nuget_package",
 ]

--- a/src/agent_bom/graph/blast_reach.py
+++ b/src/agent_bom/graph/blast_reach.py
@@ -31,9 +31,7 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 # Ecosystems where a symbol-level call graph join is supported.
-_SYMBOL_REACH_ECOSYSTEMS: frozenset[str] = frozenset(
-    {"pypi", "python", "npm", "go", "maven", "java", "cargo", "rust", "nuget"}
-)
+_SYMBOL_REACH_ECOSYSTEMS: frozenset[str] = frozenset({"pypi", "python", "npm", "go", "maven", "java", "cargo", "rust", "nuget"})
 
 
 def apply_dependency_reachability_to_blast_radii(

--- a/src/agent_bom/graph/blast_reach.py
+++ b/src/agent_bom/graph/blast_reach.py
@@ -32,7 +32,7 @@ _logger = logging.getLogger(__name__)
 
 # Ecosystems where a symbol-level call graph join is supported.
 _SYMBOL_REACH_ECOSYSTEMS: frozenset[str] = frozenset(
-    {"pypi", "python", "npm", "go", "maven", "java", "cargo", "rust"}
+    {"pypi", "python", "npm", "go", "maven", "java", "cargo", "rust", "nuget"}
 )
 
 

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -522,6 +522,43 @@ def test_analyze_project_surfaces_java_dependency_symbol_reach(tmp_path: Path) -
     assert reach.package == "com.squareup.okhttp3:okhttp"
 
 
+def test_analyze_project_surfaces_csharp_dependency_symbol_reach(tmp_path: Path) -> None:
+    import json
+
+    lock = {
+        "version": 1,
+        "dependencies": {
+            "net8.0": {
+                "RestSharp": {
+                    "type": "Direct",
+                    "requested": "[112.0.0, )",
+                    "resolved": "112.1.0",
+                }
+            }
+        },
+    }
+    (tmp_path / "packages.lock.json").write_text(json.dumps(lock))
+    (tmp_path / "Server.cs").write_text(
+        "using RestSharp;\n\n"
+        "class Server {\n"
+        "    void Register(dynamic server) {\n"
+        '        server.AddTool("fetch_url", FetchUrl);\n'
+        "    }\n\n"
+        "    void FetchUrl(string url) {\n"
+        "        RestSharp.RestClient client = new RestSharp.RestClient();\n"
+        "        client.ExecuteAsync(new RestRequest(url));\n"
+        "    }\n"
+        "}\n"
+    )
+
+    result = analyze_project(tmp_path)
+    nuget_reaches = [reach for reach in result.dependency_symbol_reach if reach.ecosystem == "nuget"]
+    assert nuget_reaches
+    reach = next(item for item in nuget_reaches if item.symbol == "ExecuteAsync")
+    assert reach.entrypoint == "fetch_url"
+    assert reach.package == "RestSharp"
+
+
 def test_analyze_project_treats_validation_branch_as_guard(tmp_path: Path):
     (tmp_path / "agent.py").write_text(
         "import subprocess\n\n"

--- a/tests/test_ast_symbol_reach_guards.py
+++ b/tests/test_ast_symbol_reach_guards.py
@@ -9,6 +9,7 @@ from agent_bom.ast_symbol_reach_guards import (
     is_actionable_dependency_symbol,
     is_external_rust_crate,
     is_verified_maven_coord,
+    is_verified_nuget_package,
 )
 
 
@@ -29,6 +30,12 @@ def test_maven_coord_requires_manifest_entry() -> None:
     assert not is_verified_maven_coord("com.invented:guess", maven_map)
 
 
+def test_nuget_package_requires_manifest_entry() -> None:
+    nuget_map = {"RestSharp": "RestSharp", "Rest": "RestSharp"}
+    assert is_verified_nuget_package("RestSharp", nuget_map)
+    assert not is_verified_nuget_package("Invented.Package", nuget_map)
+
+
 def test_analyze_project_java_without_pom_emits_no_maven_symbol_reach(tmp_path: Path) -> None:
     (tmp_path / "Server.java").write_text(
         "import com.squareup.okhttp3.OkHttpClient;\n"
@@ -40,6 +47,20 @@ def test_analyze_project_java_without_pom_emits_no_maven_symbol_reach(tmp_path: 
     )
     result = analyze_project(tmp_path)
     assert not [reach for reach in result.dependency_symbol_reach if reach.ecosystem == "maven"]
+
+
+def test_analyze_project_csharp_without_lock_emits_no_nuget_symbol_reach(tmp_path: Path) -> None:
+    (tmp_path / "Server.cs").write_text(
+        "using RestSharp;\n"
+        "class Server {\n"
+        "  void FetchUrl(string url) {\n"
+        "    RestSharp.RestClient client = new RestSharp.RestClient();\n"
+        "    client.ExecuteAsync(null);\n"
+        "  }\n"
+        "}\n"
+    )
+    result = analyze_project(tmp_path)
+    assert not [reach for reach in result.dependency_symbol_reach if reach.ecosystem == "nuget"]
 
 
 def test_analyze_project_rust_skips_std_and_unresolved_tool(tmp_path: Path) -> None:

--- a/tests/test_reachability_cve.py
+++ b/tests/test_reachability_cve.py
@@ -404,6 +404,25 @@ def test_wiring_stamps_maven_row() -> None:
     assert br.reachable_affected_symbols == ["newCall"]
 
 
+def test_wiring_stamps_nuget_row() -> None:
+    br = _python_br(["ExecuteAsync"], pkg_name="RestSharp")
+    br.package.ecosystem = "nuget"
+    nuget_reach = DependencySymbolReach(
+        entrypoint="fetch_url",
+        package="RestSharp",
+        module="RestSharp",
+        symbol="ExecuteAsync",
+        file_path="Server.cs",
+        line_number=10,
+        call_path=["fetch_url", "FetchUrl", "RestSharp.ExecuteAsync"],
+        ecosystem="nuget",
+    )
+    stamped = apply_symbol_reachability_to_blast_radii([br], ASTAnalysisResult(dependency_symbol_reach=[nuget_reach]))
+    assert stamped == 1
+    assert br.symbol_reachability == FUNCTION_REACHABLE
+    assert br.reachable_affected_symbols == ["ExecuteAsync"]
+
+
 def test_wiring_stamps_cargo_row() -> None:
     br = _python_br(["get"], pkg_name="reqwest")
     br.package.ecosystem = "cargo"


### PR DESCRIPTION
## Summary
- Add conservative C# / NuGet `dependency_symbol_reach` via `ast_csharp.py`: manifest proof from `packages.lock.json` / `*.csproj`, `using` bindings, resolved `AddTool` / `[McpServerTool]` handlers, and bounded call-graph walk.
- Wire `.cs` scanning in `ast_analyzer.py` and extend blast-radius symbol join with `nuget` ecosystem.
- Guardrails: no lock/csproj → no NuGet symbol rows; skip `new` constructor calls; generic symbol denylist (`execute` blocked — use specific symbols like `ExecuteAsync`).

## Verification
- `uv run pytest -q tests/test_reachability_cve.py tests/test_ast_analyzer.py::test_analyze_project_surfaces_csharp_dependency_symbol_reach tests/test_ast_symbol_reach_guards.py`
- `uv run ruff check src/agent_bom/ast_csharp.py src/agent_bom/ast_analyzer.py src/agent_bom/ast_models.py src/agent_bom/ast_symbol_reach_guards.py src/agent_bom/graph/blast_reach.py`

## Notes
- Stacks on #3579 (Java/Rust symbol join). Rebase onto `main` after #3577 + #3579 land.
- C++/R remain SBOM/container lane only; cloud/GPU inventory is separate from AST symbol join.


Made with [Cursor](https://cursor.com)