### PR TITLE
feat(reachability): RubyGems AST symbol join for Rails MCP backends

### DIFF
--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -143,7 +143,7 @@ The scanner covers package risk, malicious or suspicious package indicators, con
 
 ### Blast radius
 
-Blast radius is the product center of gravity. `agent-bom` connects vulnerabilities to packages, MCP servers, agents, credential exposure, and reachable tools. Impact is CWE-aware so the reported consequences match the weakness class instead of inflating every issue into full compromise. Function-level CVE de-noising joins OSV/GHSA affected symbols to Python, npm, and Go call graphs when `--project` AST analysis is available; CVE/CWE/CPE identifiers ride along on the reachability verdict.
+Blast radius is the product center of gravity. `agent-bom` connects vulnerabilities to packages, MCP servers, agents, credential exposure, and reachable tools. Impact is CWE-aware so the reported consequences match the weakness class instead of inflating every issue into full compromise. Function-level CVE de-noising joins OSV/GHSA affected symbols to Python, npm, Go, Java, Rust, and Ruby call graphs when ``--project`` AST analysis is available; CVE/CWE/CPE identifiers ride along on the reachability verdict.
 
 The highest-risk trust chain is surfaced directly in the human and machine surfaces, not only the JSON report. The `--posture` card renders the top exposure path as a one-line spine (`agent → MCP server → package@version → CVE → tool`) with its blast-radius summary (`N cred(s), N tool(s) reachable`), and SARIF results carry the same chain in the result message, an `exposure_chain` property, and `relatedLocations` so it renders in code-scanning viewers.
 

--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -13,8 +13,8 @@ Extends the regex-based scanner with semantic analysis:
 Python files use full AST parsing. JS/TS files contribute prompt/tool/guardrail
 signals plus parser-backed import, handler, and call-chain extraction so
 non-Python agent projects participate in the same inventory and flow model.
-Go, Rust, and Java sources also contribute MCP tool entrypoints and
-dependency-symbol reach for Cargo/Maven CVE join.
+Go, Rust, Java, C#, and Ruby sources also contribute MCP tool entrypoints and
+dependency-symbol reach for Cargo/Maven/NuGet/RubyGems CVE join.
 
 Compliance mapping:
 - OWASP LLM01 (Prompt Injection) — prompt inventory and risk review signals
@@ -50,6 +50,8 @@ from agent_bom.ast_models import (
     _GoToolRegistration,
     _JavaMethodAnalysis,
     _JavaToolRegistration,
+    _RubyMethodAnalysis,
+    _RubyToolRegistration,
     _RustFunctionAnalysis,
     _RustToolRegistration,
 )
@@ -65,6 +67,8 @@ from agent_bom.ast_python_analysis import (
 from agent_bom.ast_python_analysis import (
     _max_taint_depth as _python_max_taint_depth,
 )
+from agent_bom.ast_ruby import _ruby_method_key, build_ruby_dependency_symbol_reach, load_ruby_gem_map
+from agent_bom.ast_ruby import scan_ruby_file as _scan_ruby_file
 from agent_bom.ast_rust import _rust_function_key, build_rust_dependency_symbol_reach
 from agent_bom.ast_rust import scan_rust_file as _scan_rust_file
 
@@ -145,6 +149,14 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
             continue
         csharp_files.append(f)
 
+    ruby_files = []
+    for f in sorted(project.rglob("*.rb")):
+        if any(part in _SKIP_DIRS for part in f.parts):
+            continue
+        if any(skip in f.name.lower() for skip in _SKIP_FILE_PATTERNS):
+            continue
+        ruby_files.append(f)
+
     py_files = py_files[:_MAX_FILES]
     js_ts_files = js_ts_files[: max(0, _MAX_FILES - len(py_files))]
     go_files = go_files[: max(0, _MAX_FILES - len(py_files) - len(js_ts_files))]
@@ -152,7 +164,16 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
     rust_files = rust_files[:remaining]
     java_files = java_files[: max(0, remaining - len(rust_files))]
     csharp_files = csharp_files[: max(0, remaining - len(rust_files) - len(java_files))]
-    result.files_analyzed = len(py_files) + len(js_ts_files) + len(go_files) + len(rust_files) + len(java_files) + len(csharp_files)
+    ruby_files = ruby_files[: max(0, remaining - len(rust_files) - len(java_files) - len(csharp_files))]
+    result.files_analyzed = (
+        len(py_files)
+        + len(js_ts_files)
+        + len(go_files)
+        + len(rust_files)
+        + len(java_files)
+        + len(csharp_files)
+        + len(ruby_files)
+    )
     function_analyses: list[_FunctionAnalysis] = []
     js_ts_functions: dict[str, JSTSFunction] = {}
     js_ts_tool_registrations: list[JSTSToolRegistration] = []
@@ -164,8 +185,11 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
     java_tool_registrations: list[_JavaToolRegistration] = []
     csharp_methods: dict[str, _CSharpMethodAnalysis] = {}
     csharp_tool_registrations: list[_CSharpToolRegistration] = []
+    ruby_methods: dict[str, _RubyMethodAnalysis] = {}
+    ruby_tool_registrations: list[_RubyToolRegistration] = []
     maven_dependency_map = _load_maven_dependency_map(project)
     nuget_namespace_map = load_nuget_namespace_map(project)
+    ruby_gem_map = load_ruby_gem_map(project)
 
     for py_file in py_files:
         rel = str(py_file.relative_to(project))
@@ -261,6 +285,24 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
                 csharp_methods[_csharp_method_key(csharp_method.class_name, csharp_method.name)] = csharp_method
             csharp_tool_registrations.extend(csharp_analysis.tool_registrations)
 
+    for ruby_file in ruby_files:
+        rel = str(ruby_file.relative_to(project))
+        prompts, guardrails, tools, flow_findings, frameworks, ruby_call_edges, ruby_analysis = _scan_ruby_file(
+            ruby_file,
+            rel,
+            gem_map=ruby_gem_map,
+        )
+        result.prompts.extend(prompts)
+        result.guardrails.extend(guardrails)
+        result.tools.extend(tools)
+        result.flow_findings.extend(flow_findings)
+        result.frameworks_detected.extend(frameworks)
+        result.call_edges.extend(ruby_call_edges)
+        if ruby_analysis is not None:
+            for ruby_method in ruby_analysis.functions.values():
+                ruby_methods[_ruby_method_key(ruby_method.class_name, ruby_method.name)] = ruby_method
+            ruby_tool_registrations.extend(ruby_analysis.tool_registrations)
+
     python_call_edges, interprocedural_findings = _build_call_graph(function_analyses)
     result.call_edges.extend(python_call_edges)
     result.flow_findings.extend(interprocedural_findings)
@@ -310,6 +352,13 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
         build_csharp_dependency_symbol_reach(
             methods=csharp_methods,
             tool_registrations=csharp_tool_registrations,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
+    result.dependency_symbol_reach.extend(
+        build_ruby_dependency_symbol_reach(
+            methods=ruby_methods,
+            tool_registrations=ruby_tool_registrations,
             max_depth=_python_max_taint_depth(),
         )
     )

--- a/src/agent_bom/ast_models.py
+++ b/src/agent_bom/ast_models.py
@@ -352,6 +352,39 @@ class _CSharpFileAnalysis:
 
 
 @dataclass
+class _RubyCallSite:
+    name: str
+    line_number: int
+
+
+@dataclass
+class _RubyMethodAnalysis:
+    name: str
+    line_number: int
+    file_path: str = ""
+    class_name: str = ""
+    import_bindings: dict[str, str] = field(default_factory=dict)
+    call_sites: list[_RubyCallSite] = field(default_factory=list)
+
+
+@dataclass
+class _RubyToolRegistration:
+    tool_name: str
+    handler_name: str
+    line_number: int
+    file_path: str = ""
+    class_name: str = ""
+    import_bindings: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class _RubyFileAnalysis:
+    class_name: str
+    functions: dict[str, _RubyMethodAnalysis] = field(default_factory=dict)
+    tool_registrations: list[_RubyToolRegistration] = field(default_factory=list)
+
+
+@dataclass
 class _FunctionAnalysis:
     """Internal representation of a function for call-graph construction."""
 

--- a/src/agent_bom/ast_ruby.py
+++ b/src/agent_bom/ast_ruby.py
@@ -1,0 +1,465 @@
+"""Ruby analyzer helpers for MCP symbol-level reachability.
+
+Regex-backed and conservative: gem names must be declared in ``Gemfile.lock``
+(or ``Gemfile`` when no lock exists) before ``require`` bindings are trusted.
+Unresolved MCP tool handlers are dropped so headless agents do not inherit
+false ``function_reachable`` upgrades at CVE join time.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agent_bom.ast_models import (
+    CallEdge,
+    DependencySymbolReach,
+    DetectedGuardrail,
+    ExtractedPrompt,
+    FlowFinding,
+    ToolSignature,
+    _RubyCallSite,
+    _RubyFileAnalysis,
+    _RubyMethodAnalysis,
+    _RubyToolRegistration,
+)
+from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol, is_verified_ruby_gem
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+_MAX_FILE_SIZE = 512 * 1024
+_RUBY_REQUIRE_RE = re.compile(r"""^\s*require(?:_relative)?\s+['"](?P<path>[^'"]+)['"]""", re.MULTILINE)
+_RUBY_CLASS_RE = re.compile(r"\bclass\s+(?P<name>\w+)")
+_RUBY_METHOD_RE = re.compile(r"^\s*def\s+(?P<name>[a-z]\w*)\s*(?:\(|$)", re.MULTILINE)
+_RUBY_CALL_RE = re.compile(r"\b(?P<name>\w+(?:\.\w+)+)\s*(?:\(|\s|$)")
+_RUBY_CALL_SKIP = frozenset(
+    {
+        "if",
+        "for",
+        "while",
+        "unless",
+        "until",
+        "case",
+        "when",
+        "return",
+        "yield",
+        "raise",
+        "rescue",
+        "ensure",
+        "class",
+        "module",
+        "def",
+        "end",
+        "do",
+        "elsif",
+        "else",
+        "begin",
+    }
+)
+_RUBY_LOCAL_BINDING_RE = re.compile(r"\b(?P<var>[a-z]\w*)\s*=\s*(?P<ctor>\w+)\.")
+_RUBY_ADD_TOOL_RE = re.compile(
+    r"""\.(?:add_tool|register_tool)\s*\(\s*['"](?P<name>[^'"]+)['"]""",
+    re.IGNORECASE,
+)
+_RUBY_FRAMEWORK_HINTS: dict[str, str] = {
+    "modelcontextprotocol": "MCP",
+    "mcp": "MCP",
+}
+
+
+def _line_number_from_index(source: str, index: int) -> int:
+    return source[:index].count("\n") + 1
+
+
+def _balanced_segment(source: str, open_index: int, *, open_char: str, close_char: str) -> tuple[str, int] | None:
+    if open_index < 0 or open_index >= len(source) or source[open_index] != open_char:
+        return None
+    depth = 0
+    in_quote = ""
+    escaped = False
+    for index in range(open_index, len(source)):
+        char = source[index]
+        if in_quote:
+            if char == "\\" and not escaped:
+                escaped = True
+                continue
+            if char == in_quote and not escaped:
+                in_quote = ""
+            escaped = False
+            continue
+        if char in {'"', "'"}:
+            in_quote = char
+            escaped = False
+            continue
+        if char == open_char:
+            depth += 1
+        elif char == close_char:
+            depth -= 1
+            if depth == 0:
+                return source[open_index : index + 1], index + 1
+    return None
+
+
+def _ruby_constant_for_gem(gem_name: str) -> str:
+    parts = re.split(r"[-_.]+", gem_name.strip())
+    return "".join((part[:1].upper() + part[1:]) if part else "" for part in parts)
+
+
+def load_ruby_gem_map(project: Path) -> dict[str, str]:
+    """Map Ruby require paths and constants to declared gem names."""
+    from agent_bom.parsers.ruby_parsers import parse_ruby_packages
+
+    mapping: dict[str, str] = {}
+    for pkg in parse_ruby_packages(project):
+        gem_name = pkg.name.strip()
+        if not gem_name:
+            continue
+        mapping[gem_name.lower()] = gem_name
+        mapping[gem_name] = gem_name
+        mapping[_ruby_constant_for_gem(gem_name)] = gem_name
+    return mapping
+
+
+def _ruby_gem_for_require(path: str, gem_map: Mapping[str, str]) -> str | None:
+    if not path or not gem_map:
+        return None
+    head = path.split("/", 1)[0].strip()
+    if not head:
+        return None
+    for candidate in (head, head.lower(), _ruby_constant_for_gem(head)):
+        gem_name = gem_map.get(candidate)
+        if gem_name and is_verified_ruby_gem(gem_name, dict(gem_map)):
+            return gem_name
+    return None
+
+
+def _ruby_require_bindings(source: str, gem_map: Mapping[str, str]) -> dict[str, str]:
+    bindings: dict[str, str] = {}
+    for match in _RUBY_REQUIRE_RE.finditer(source):
+        gem_name = _ruby_gem_for_require(match.group("path").strip(), gem_map)
+        if not gem_name:
+            continue
+        bindings[gem_name.lower()] = gem_name
+        bindings[gem_name] = gem_name
+        bindings[_ruby_constant_for_gem(gem_name)] = gem_name
+    return bindings
+
+
+def _ruby_local_bindings(body: str, import_bindings: Mapping[str, str]) -> dict[str, str]:
+    locals_map: dict[str, str] = {}
+    for match in _RUBY_LOCAL_BINDING_RE.finditer(body):
+        ctor = match.group("ctor")
+        var_name = match.group("var")
+        gem_name = import_bindings.get(ctor) or import_bindings.get(ctor.lower())
+        if gem_name:
+            locals_map[var_name] = gem_name
+    return locals_map
+
+
+def _ruby_call_sites(body: str, *, line_offset: int) -> list[_RubyCallSite]:
+    sites: list[_RubyCallSite] = []
+    for match in _RUBY_CALL_RE.finditer(body):
+        name = match.group("name")
+        name_start = match.start("name")
+        if re.search(r"\.\s*$", body[max(0, name_start - 2) : name_start]):
+            continue
+        head = name.split(".", 1)[0]
+        if head in _RUBY_CALL_SKIP:
+            continue
+        sites.append(
+            _RubyCallSite(
+                name=name,
+                line_number=line_offset + body[: match.start()].count("\n") + 1,
+            )
+        )
+    return sites
+
+
+def _ruby_method_key(class_name: str, name: str) -> str:
+    return f"{class_name}::{name}"
+
+
+def _ruby_method_display_name(class_name: str, name: str, name_counts: dict[str, int]) -> str:
+    if name_counts.get(name, 0) > 1:
+        return _ruby_method_key(class_name, name)
+    return name
+
+
+def _ruby_method_body(source: str, method_start: int) -> tuple[str, int] | None:
+    next_def = _RUBY_METHOD_RE.search(source, method_start + 1)
+    body_end = next_def.start() if next_def else len(source)
+    body_text = source[method_start:body_end]
+    return body_text, _line_number_from_index(source, method_start)
+
+
+def _collect_ruby_methods(
+    source: str,
+    *,
+    rel_path: str,
+    class_name: str,
+    bindings: dict[str, str],
+) -> dict[str, _RubyMethodAnalysis]:
+    methods: dict[str, _RubyMethodAnalysis] = {}
+    for match in _RUBY_METHOD_RE.finditer(source):
+        name = match.group("name")
+        body_segment = _ruby_method_body(source, match.end())
+        call_sites: list[_RubyCallSite] = []
+        method_bindings = dict(bindings)
+        if body_segment is not None:
+            body_text, body_line_offset = body_segment
+            call_sites = _ruby_call_sites(body_text, line_offset=body_line_offset)
+            method_bindings.update(_ruby_local_bindings(body_text, bindings))
+        methods[_ruby_method_key(class_name, name)] = _RubyMethodAnalysis(
+            name=name,
+            line_number=_line_number_from_index(source, match.start()),
+            file_path=rel_path,
+            class_name=class_name,
+            import_bindings=method_bindings,
+            call_sites=call_sites,
+        )
+    return methods
+
+
+def _resolve_ruby_tool_handler(args_text: str, *, class_name: str, methods: Mapping[str, _RubyMethodAnalysis]) -> str | None:
+    method_match = re.search(r"method\s*\(\s*:(?P<method>\w+)\s*\)", args_text)
+    if method_match:
+        candidate = _ruby_method_key(class_name, method_match.group("method"))
+        if candidate in methods:
+            return candidate
+    symbol_match = re.search(r"[, (]:(?P<method>\w+)\s*[,)]", args_text)
+    if symbol_match:
+        candidate = _ruby_method_key(class_name, symbol_match.group("method"))
+        if candidate in methods:
+            return candidate
+    bare_match = re.search(r"[, (](?P<method>[a-z]\w*)\s*[,)]", args_text)
+    if bare_match:
+        candidate = _ruby_method_key(class_name, bare_match.group("method"))
+        if candidate in methods:
+            return candidate
+    return None
+
+
+def _collect_ruby_tool_registrations(
+    source: str,
+    *,
+    rel_path: str,
+    class_name: str,
+    bindings: dict[str, str],
+    methods: Mapping[str, _RubyMethodAnalysis],
+) -> list[_RubyToolRegistration]:
+    registrations: list[_RubyToolRegistration] = []
+    seen: set[tuple[str, int]] = set()
+
+    for match in _RUBY_ADD_TOOL_RE.finditer(source):
+        tool_name = match.group("name").strip()
+        if not tool_name:
+            continue
+        args_start = source.find("(", match.start())
+        args_segment = _balanced_segment(source, args_start, open_char="(", close_char=")") if args_start >= 0 else None
+        handler_name: str | None = None
+        if args_segment is not None:
+            args_text, _ = args_segment
+            handler_name = _resolve_ruby_tool_handler(args_text, class_name=class_name, methods=methods)
+        if handler_name is None:
+            continue
+        key = (tool_name, match.start())
+        if key in seen:
+            continue
+        seen.add(key)
+        registrations.append(
+            _RubyToolRegistration(
+                tool_name=tool_name,
+                handler_name=handler_name,
+                line_number=_line_number_from_index(source, match.start()),
+                file_path=rel_path,
+                class_name=class_name,
+                import_bindings=dict(bindings),
+            )
+        )
+    return registrations
+
+
+def _resolve_ruby_callee_key(
+    call_name: str,
+    *,
+    class_name: str,
+    methods: Mapping[str, _RubyMethodAnalysis],
+) -> str | None:
+    bare = call_name.split("(", 1)[0].strip()
+    if "." in bare:
+        _, tail = bare.split(".", 1)
+        candidate = _ruby_method_key(class_name, tail)
+        if candidate in methods:
+            return candidate
+    candidate = _ruby_method_key(class_name, bare)
+    if candidate in methods:
+        return candidate
+    return None
+
+
+def _resolve_ruby_external_dependency_symbol(
+    method: _RubyMethodAnalysis,
+    call_name: str,
+) -> tuple[str, str, str] | None:
+    """Resolve an external require call to ``(package, module, symbol)``."""
+    if not call_name or "." not in call_name:
+        return None
+    head, tail = call_name.split(".", 1)
+    gem_name = method.import_bindings.get(head) or method.import_bindings.get(head.lower())
+    if not gem_name or not is_verified_ruby_gem(gem_name, method.import_bindings):
+        return None
+    symbol = tail.split(".", 1)[0]
+    if not is_actionable_dependency_symbol(symbol):
+        return None
+    return gem_name, gem_name, symbol
+
+
+def build_ruby_dependency_symbol_reach(
+    *,
+    methods: Mapping[str, _RubyMethodAnalysis],
+    tool_registrations: Sequence[_RubyToolRegistration],
+    max_depth: int = 4,
+) -> list[DependencySymbolReach]:
+    """Build bounded MCP tool-entrypoint -> RubyGems dependency symbol reach."""
+    if not methods or not tool_registrations:
+        return []
+
+    adjacency: dict[str, set[str]] = {name: set() for name in methods}
+    name_counts: dict[str, int] = {}
+    for method in methods.values():
+        name_counts[method.name] = name_counts.get(method.name, 0) + 1
+
+    for method_key, method in methods.items():
+        for call_site in method.call_sites:
+            callee_key = _resolve_ruby_callee_key(
+                call_site.name,
+                class_name=method.class_name,
+                methods=methods,
+            )
+            if callee_key and callee_key != method_key:
+                adjacency[method_key].add(callee_key)
+
+    reached: list[DependencySymbolReach] = []
+    seen: set[tuple[str, str, str, str, int]] = set()
+
+    def display_name(method_key: str) -> str:
+        method = methods[method_key]
+        return _ruby_method_display_name(method.class_name, method.name, name_counts)
+
+    for registration in tool_registrations:
+        handler_key = registration.handler_name
+        if handler_key not in methods:
+            continue
+        queue: list[tuple[str, list[str]]] = [(handler_key, [handler_key])]
+        visited: set[str] = set()
+        while queue:
+            current_key, path = queue.pop(0)
+            if len(path) > max_depth:
+                continue
+            if current_key in visited:
+                continue
+            visited.add(current_key)
+            current = methods[current_key]
+            for call_site in current.call_sites:
+                external = _resolve_ruby_external_dependency_symbol(current, call_site.name)
+                if external is None:
+                    continue
+                package_name, module_name, symbol = external
+                dedup_key = (registration.tool_name, module_name, symbol, current.file_path, call_site.line_number)
+                if dedup_key in seen:
+                    continue
+                seen.add(dedup_key)
+                reached.append(
+                    DependencySymbolReach(
+                        entrypoint=registration.tool_name,
+                        package=package_name,
+                        module=module_name,
+                        symbol=symbol,
+                        file_path=current.file_path,
+                        line_number=call_site.line_number,
+                        call_path=[
+                            registration.tool_name,
+                            *[display_name(name) for name in path],
+                            f"{module_name}.{symbol}",
+                        ],
+                        depth=max(0, len(path) - 1),
+                        ecosystem="rubygems",
+                    )
+                )
+            for next_callee in sorted(adjacency.get(current_key, ())):
+                queue.append((next_callee, [*path, next_callee]))
+
+    return reached
+
+
+def scan_ruby_file(
+    file_path: Path,
+    rel_path: str,
+    *,
+    gem_map: Mapping[str, str],
+) -> tuple[
+    list[ExtractedPrompt],
+    list[DetectedGuardrail],
+    list[ToolSignature],
+    list[FlowFinding],
+    list[str],
+    list[CallEdge],
+    _RubyFileAnalysis | None,
+]:
+    """Extract MCP/tool signals and call sites from Ruby source files."""
+    try:
+        source = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return [], [], [], [], [], [], None
+
+    if len(source) > _MAX_FILE_SIZE:
+        return [], [], [], [], [], [], None
+
+    class_match = _RUBY_CLASS_RE.search(source)
+    class_name = class_match.group("name") if class_match else Path(rel_path).stem.capitalize()
+    bindings = _ruby_require_bindings(source, gem_map)
+    frameworks = sorted(
+        {
+            framework
+            for prefix, framework in _RUBY_FRAMEWORK_HINTS.items()
+            if any(prefix in binding.lower() for binding in bindings.values())
+        }
+    )
+    methods = _collect_ruby_methods(source, rel_path=rel_path, class_name=class_name, bindings=bindings)
+    tool_registrations = _collect_ruby_tool_registrations(
+        source,
+        rel_path=rel_path,
+        class_name=class_name,
+        bindings=bindings,
+        methods=methods,
+    )
+    tools: list[ToolSignature] = []
+    for registration in tool_registrations:
+        tools.append(
+            ToolSignature(
+                name=registration.tool_name,
+                parameters=[],
+                return_type="unknown",
+                description="Ruby MCP/tool registration",
+                file_path=rel_path,
+                line_number=registration.line_number,
+                decorators=["ruby-tool"],
+                is_async=False,
+            )
+        )
+
+    return (
+        [],
+        [],
+        tools,
+        [],
+        frameworks,
+        [],
+        _RubyFileAnalysis(
+            class_name=class_name,
+            functions=methods,
+            tool_registrations=tool_registrations,
+        ),
+    )

--- a/src/agent_bom/ast_symbol_reach_guards.py
+++ b/src/agent_bom/ast_symbol_reach_guards.py
@@ -1,7 +1,7 @@
 """Conservative guards for regex-backed dependency symbol reach.
 
 Headless agents and MCP posture tools consume ``dependency_symbol_reach``
-evidence. Regex parsers (Rust/Java) are intentionally lossy, so we only emit
+evidence. Regex parsers (Rust/Java/Ruby) are intentionally lossy, so we only emit
 rows that pass the same bar as Go: a proven import/use alias to an external
 package plus a non-generic symbol token. Heuristic Maven coordinates and
 unresolved MCP tool handlers are dropped rather than downgraded to
@@ -61,9 +61,17 @@ def is_verified_nuget_package(package_id: str, nuget_map: dict[str, str]) -> boo
     return package_id in set(nuget_map.values())
 
 
+def is_verified_ruby_gem(gem_name: str, gem_map: dict[str, str]) -> bool:
+    """Return True when a gem name is declared in the project manifest map."""
+    if not gem_name or not gem_map:
+        return False
+    return gem_name in set(gem_map.values())
+
+
 __all__ = [
     "is_actionable_dependency_symbol",
     "is_external_rust_crate",
     "is_verified_maven_coord",
     "is_verified_nuget_package",
+    "is_verified_ruby_gem",
 ]

--- a/src/agent_bom/graph/blast_reach.py
+++ b/src/agent_bom/graph/blast_reach.py
@@ -31,7 +31,9 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 # Ecosystems where a symbol-level call graph join is supported.
-_SYMBOL_REACH_ECOSYSTEMS: frozenset[str] = frozenset({"pypi", "python", "npm", "go", "maven", "java", "cargo", "rust", "nuget"})
+_SYMBOL_REACH_ECOSYSTEMS: frozenset[str] = frozenset(
+    {"pypi", "python", "npm", "go", "maven", "java", "cargo", "rust", "nuget", "rubygems"}
+)
 
 
 def apply_dependency_reachability_to_blast_radii(
@@ -94,10 +96,10 @@ def apply_symbol_reachability_to_blast_radii(
     """Join CVE affected-symbols to AST symbol reach on each BlastRadius row.
 
     Thin additive surfacing of :mod:`agent_bom.reachability_cve`. For Python, npm,
-    Go, Maven, and Cargo findings it stamps ``symbol_reachability``
+    Go, Maven, Cargo, NuGet, and RubyGems findings it stamps ``symbol_reachability``
     (function_reachable / package_reachable / unreachable) when AST evidence
-    passes conservative import-proof guards. Rust/Java parsers are regex-backed:
-    they never invent Maven coordinates or walk unresolved MCP tool handlers.
+    passes conservative import-proof guards. Rust/Java/C#/Ruby parsers are regex-backed:
+    they never invent manifest coordinates or walk unresolved MCP tool handlers.
 
     The graph-walk reach already on the row (``graph_reachable``) is fed in as
     the import / dependency-closure fallback so a package that is reached but

--- a/src/agent_bom/reachability_cve.py
+++ b/src/agent_bom/reachability_cve.py
@@ -29,10 +29,11 @@ is a three-state reachability signal on the finding:
 * ``unreachable`` — the package is present in the dependency set but no
   entrypoint reaches it at all.
 
-Honest scope: Python, npm, Go, Maven/Java, and Cargo/Rust symbol-level call
-graphs are supported when import proof is available (``use`` / ``pom.xml``).
-Rust/Java regex parsers apply conservative guards and omit heuristic rows so
-headless MCP consumers do not receive false ``function_reachable`` upgrades.
+Honest scope: Python, npm, Go, Maven/Java, Cargo/Rust, NuGet/C#, and RubyGems
+symbol-level call graphs are supported when import proof is available (``use`` /
+``pom.xml`` / ``packages.lock.json`` / ``Gemfile.lock``). Regex parsers apply
+conservative guards and omit heuristic rows so headless MCP consumers do not
+receive false ``function_reachable`` upgrades.
 
 The module is read-only: no graph mutation, no network. It is safe to call
 from the report layer, the graph/blast-radius surfacing, the API, or a

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -559,6 +559,35 @@ def test_analyze_project_surfaces_csharp_dependency_symbol_reach(tmp_path: Path)
     assert reach.package == "RestSharp"
 
 
+def test_analyze_project_surfaces_ruby_dependency_symbol_reach(tmp_path: Path) -> None:
+    (tmp_path / "Gemfile").write_text('gem "faraday"\n')
+    (tmp_path / "Gemfile.lock").write_text(
+        "GEM\n"
+        "  remote: https://rubygems.org/\n"
+        "  specs:\n"
+        "    faraday (2.9.0)\n"
+    )
+    (tmp_path / "server.rb").write_text(
+        "require 'faraday'\n\n"
+        "class Server\n"
+        "  def register(server)\n"
+        '    server.add_tool("fetch_url", method(:fetch_url))\n'
+        "  end\n\n"
+        "  def fetch_url(url)\n"
+        "    client = Faraday.new\n"
+        "    client.get(url)\n"
+        "  end\n"
+        "end\n"
+    )
+
+    result = analyze_project(tmp_path)
+    ruby_reaches = [reach for reach in result.dependency_symbol_reach if reach.ecosystem == "rubygems"]
+    assert ruby_reaches
+    reach = next(item for item in ruby_reaches if item.symbol == "get")
+    assert reach.entrypoint == "fetch_url"
+    assert reach.package == "faraday"
+
+
 def test_analyze_project_treats_validation_branch_as_guard(tmp_path: Path):
     (tmp_path / "agent.py").write_text(
         "import subprocess\n\n"

--- a/tests/test_ast_symbol_reach_guards.py
+++ b/tests/test_ast_symbol_reach_guards.py
@@ -10,6 +10,7 @@ from agent_bom.ast_symbol_reach_guards import (
     is_external_rust_crate,
     is_verified_maven_coord,
     is_verified_nuget_package,
+    is_verified_ruby_gem,
 )
 
 
@@ -34,6 +35,12 @@ def test_nuget_package_requires_manifest_entry() -> None:
     nuget_map = {"RestSharp": "RestSharp", "Rest": "RestSharp"}
     assert is_verified_nuget_package("RestSharp", nuget_map)
     assert not is_verified_nuget_package("Invented.Package", nuget_map)
+
+
+def test_ruby_gem_requires_manifest_entry() -> None:
+    gem_map = {"faraday": "faraday", "Faraday": "faraday"}
+    assert is_verified_ruby_gem("faraday", gem_map)
+    assert not is_verified_ruby_gem("invented-gem", gem_map)
 
 
 def test_analyze_project_java_without_pom_emits_no_maven_symbol_reach(tmp_path: Path) -> None:
@@ -61,6 +68,20 @@ def test_analyze_project_csharp_without_lock_emits_no_nuget_symbol_reach(tmp_pat
     )
     result = analyze_project(tmp_path)
     assert not [reach for reach in result.dependency_symbol_reach if reach.ecosystem == "nuget"]
+
+
+def test_analyze_project_ruby_without_lock_emits_no_rubygems_symbol_reach(tmp_path: Path) -> None:
+    (tmp_path / "server.rb").write_text(
+        "require 'faraday'\n"
+        "class Server\n"
+        "  def fetch_url(url)\n"
+        "    client = Faraday.new\n"
+        "    client.get(url)\n"
+        "  end\n"
+        "end\n"
+    )
+    result = analyze_project(tmp_path)
+    assert not [reach for reach in result.dependency_symbol_reach if reach.ecosystem == "rubygems"]
 
 
 def test_analyze_project_rust_skips_std_and_unresolved_tool(tmp_path: Path) -> None:

--- a/tests/test_reachability_cve.py
+++ b/tests/test_reachability_cve.py
@@ -379,7 +379,7 @@ def test_wiring_stamps_unreachable_when_symbol_absent() -> None:
 
 def test_wiring_skips_unsupported_ecosystem_rows() -> None:
     br = _python_br(["get"])
-    br.package.ecosystem = "rubygems"
+    br.package.ecosystem = "composer"
     stamped = apply_symbol_reachability_to_blast_radii([br], _ast_result_with_get())
     assert stamped == 0
     assert br.symbol_reachability is None
@@ -437,6 +437,25 @@ def test_wiring_stamps_cargo_row() -> None:
         ecosystem="cargo",
     )
     stamped = apply_symbol_reachability_to_blast_radii([br], ASTAnalysisResult(dependency_symbol_reach=[cargo_reach]))
+    assert stamped == 1
+    assert br.symbol_reachability == FUNCTION_REACHABLE
+    assert br.reachable_affected_symbols == ["get"]
+
+
+def test_wiring_stamps_rubygems_row() -> None:
+    br = _python_br(["get"], pkg_name="faraday")
+    br.package.ecosystem = "rubygems"
+    ruby_reach = DependencySymbolReach(
+        entrypoint="fetch_url",
+        package="faraday",
+        module="faraday",
+        symbol="get",
+        file_path="server.rb",
+        line_number=9,
+        call_path=["fetch_url", "fetch_url", "faraday.get"],
+        ecosystem="rubygems",
+    )
+    stamped = apply_symbol_reachability_to_blast_radii([br], ASTAnalysisResult(dependency_symbol_reach=[ruby_reach]))
     assert stamped == 1
     assert br.symbol_reachability == FUNCTION_REACHABLE
     assert br.reachable_affected_symbols == ["get"]


### PR DESCRIPTION
## Summary
- Add `ast_ruby.py`: manifest proof from `Gemfile.lock` / `Gemfile`, `require` bindings, resolved `.add_tool` / `.register_tool` + `method(:handler)` handlers, bounded call-graph walk.
- Wire `.rb` scanning in `ast_analyzer.py`; extend `_SYMBOL_REACH_ECOSYSTEMS` with `rubygems`.
- Align reachability docs (`reachability_cve.py`, `blast_reach.py`, `PRODUCT_BRIEF.md`) and fix `test_wiring_skips_unsupported_ecosystem_rows` now that RubyGems is supported.

## Full-stack alignment
| Layer | Change |
|---|---|
| Input / parse | Reuses `parse_ruby_packages` from `ruby_parsers.py` |
| Detection / AST | `dependency_symbol_reach` rows with `ecosystem=rubygems` |
| Join / graph | `apply_symbol_reachability_to_blast_radii` + `classify_reachability` |
| Output | JSON/SARIF already export `symbol_reachability` generically |
| Triage / VEX | `#3577` consumes stamped `symbol_reachability` (no Ruby-specific fork) |
| UI | Blast-radius fields flow via existing JSON API (no new UI surface) |

## Verification
- `uv run pytest -q tests/test_reachability_cve.py tests/test_ast_symbol_reach_guards.py tests/test_ast_analyzer.py::test_analyze_project_surfaces_ruby_dependency_symbol_reach`
- `uv run ruff check src/agent_bom/ast_ruby.py src/agent_bom/ast_analyzer.py src/agent_bom/ast_symbol_reach_guards.py src/agent_bom/graph/blast_reach.py`

## Notes
- NuGet/C# symbol join remains in #3581 (needs rebase onto `main`).
- Next: Gradle-only Java after #3581 lands.


Made with [Cursor](https://cursor.com)