### PR TITLE
feat(ingest): wire SARIF into external scanner detect_and_parse path

### DIFF
--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -243,7 +243,7 @@ def run_local_discovery(
                 _ext_data = _json.load(_ext_f)
             _ext_packages = detect_and_parse(_ext_data)
             _ext_resource_name = Path(external_scan_path).stem
-            con.print(f"\n  [green]✓[/green] Ingested {len(_ext_packages)} packages from Trivy/Grype/Syft report\n")
+            con.print(f"\n  [green]✓[/green] Ingested {len(_ext_packages)} packages from external scan report\n")
             _ext_server = MCPServer(
                 name=_ext_resource_name,
                 command="external-scan",

--- a/src/agent_bom/compliance_hub_ingest.py
+++ b/src/agent_bom/compliance_hub_ingest.py
@@ -150,7 +150,11 @@ def ingest_sarif_findings(path: str | Path) -> list[Finding]:
         return []
     if not isinstance(sarif, dict):
         return []
+    return parse_sarif_document(sarif)
 
+
+def parse_sarif_document(sarif: dict) -> list[Finding]:
+    """Parse an in-memory SARIF 2.1.0 document into hub-classified findings."""
     runs = sarif.get("runs") or []
     findings: list[Finding] = []
     for run in runs:

--- a/src/agent_bom/parsers/external_scanners.py
+++ b/src/agent_bom/parsers/external_scanners.py
@@ -1,11 +1,14 @@
-"""Ingest Trivy, Grype, and Syft JSON reports into agent-bom models."""
+"""Ingest Trivy, Grype, Syft, and SARIF reports into agent-bom models."""
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from agent_bom.models import Package, Severity, Vulnerability, compute_confidence
+
+if TYPE_CHECKING:
+    from agent_bom.finding import Finding
 
 logger = logging.getLogger(__name__)
 
@@ -307,17 +310,101 @@ def parse_syft_json(data: dict[str, Any]) -> list[Package]:
 # ── Auto-detect ───────────────────────────────────────────────────────────────
 
 
+def is_sarif_document(data: dict[str, Any]) -> bool:
+    """Return True when *data* looks like a SARIF 2.x document."""
+    if not isinstance(data, dict):
+        return False
+    runs = data.get("runs")
+    if not isinstance(runs, list):
+        return False
+    version = str(data.get("version") or "")
+    if version.startswith("2."):
+        return True
+    schema = data.get("$schema")
+    return isinstance(schema, str) and "sarif" in schema.lower()
+
+
+def _severity_from_label(label: str) -> Severity:
+    try:
+        return Severity(label.lower())
+    except ValueError:
+        return Severity.UNKNOWN
+
+
+def _sarif_hub_findings_to_packages(findings: list["Finding"]) -> list[Package]:
+    """Group hub-classified SARIF findings into synthetic sast packages."""
+    from agent_bom.finding import Finding
+
+    file_findings: dict[str, list[Finding]] = {}
+    for item in findings:
+        if not isinstance(item, Finding):
+            continue
+        file_path = item.asset.location or item.asset.name.split(":", 1)[0]
+        file_findings.setdefault(file_path or "unknown", []).append(item)
+
+    packages: list[Package] = []
+    for file_path, rows in file_findings.items():
+        vulns: list[Vulnerability] = []
+        seen: set[str] = set()
+        for finding in rows:
+            evidence = finding.evidence or {}
+            rule_id = str(evidence.get("rule_id") or finding.title or "sarif-rule")
+            line_token = ""
+            if finding.asset.name and ":" in finding.asset.name:
+                line_token = finding.asset.name.rsplit(":", 1)[-1]
+            dedup_key = f"{rule_id}:{line_token}"
+            if dedup_key in seen:
+                continue
+            seen.add(dedup_key)
+            vulns.append(
+                Vulnerability(
+                    id=rule_id,
+                    summary=finding.description or finding.title,
+                    severity=_severity_from_label(finding.severity),
+                    cwe_ids=list(finding.cwe_ids),
+                    cvss_score=finding.cvss_score,
+                    references=[],
+                )
+            )
+        if vulns:
+            tool_name = str((rows[0].evidence or {}).get("external_tool") or "sarif")
+            packages.append(
+                Package(
+                    name=file_path,
+                    version="0.0.0",
+                    ecosystem="sast",
+                    vulnerabilities=vulns,
+                    description=f"SARIF findings from {tool_name}",
+                )
+            )
+    return packages
+
+
+def parse_sarif_json(data: dict[str, Any]) -> list[Package]:
+    """Parse a SARIF 2.x document into synthetic per-file sast packages."""
+    from agent_bom.compliance_hub_ingest import parse_sarif_document
+
+    if not is_sarif_document(data):
+        raise ValueError("payload is not a SARIF document")
+    findings = parse_sarif_document(data)
+    return _sarif_hub_findings_to_packages(findings)
+
+
 def detect_and_parse(data: dict[str, Any]) -> list[Package]:
     """Auto-detect the scanner JSON format and parse into Package objects.
 
     Detection rules (checked in order):
-    - ``Results`` key present and at least one result has ``Vulnerabilities`` → Trivy
+    - ``runs`` + SARIF ``version`` / ``$schema`` → SARIF (Semgrep, CodeQL, Bandit, …)
+    - ``Results`` key present → Trivy
     - ``matches`` key present → Grype
     - ``artifacts`` key present and ``schema`` key present → Syft
 
     Raises:
         ValueError: if the format cannot be identified.
     """
+    if is_sarif_document(data):
+        return parse_sarif_json(data)
+
     if "Results" in data:
         results = data["Results"]
         if isinstance(results, list):

--- a/tests/test_external_scanners.py
+++ b/tests/test_external_scanners.py
@@ -1,4 +1,4 @@
-"""Tests for external scanner JSON ingestion (Trivy, Grype, Syft)."""
+"""Tests for external scanner JSON ingestion (Trivy, Grype, Syft, SARIF)."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from agent_bom.models import Severity
 from agent_bom.parsers.external_scanners import (
     detect_and_parse,
     parse_grype_json,
+    parse_sarif_json,
     parse_syft_json,
     parse_trivy_json,
 )
@@ -394,3 +395,55 @@ def test_detect_syft():
 def test_detect_unknown_raises():
     with pytest.raises(ValueError, match="Unrecognized scanner JSON format"):
         detect_and_parse({"foo": "bar"})
+
+
+SARIF_BASIC = {
+    "version": "2.1.0",
+    "runs": [
+        {
+            "tool": {
+                "driver": {
+                    "name": "bandit",
+                    "rules": [
+                        {
+                            "id": "B105",
+                            "properties": {"tags": ["CWE-259"]},
+                        }
+                    ],
+                }
+            },
+            "results": [
+                {
+                    "ruleId": "B105",
+                    "level": "warning",
+                    "message": {"text": "Possible hardcoded password"},
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {"uri": "src/app.py"},
+                                "region": {"startLine": 12},
+                            }
+                        }
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+def test_parse_sarif_json_groups_by_file():
+    packages = parse_sarif_json(SARIF_BASIC)
+    assert len(packages) == 1
+    pkg = packages[0]
+    assert pkg.ecosystem == "sast"
+    assert pkg.name == "src/app.py"
+    assert len(pkg.vulnerabilities) == 1
+    assert pkg.vulnerabilities[0].id == "B105"
+    assert pkg.vulnerabilities[0].cwe_ids == ["CWE-259"]
+
+
+def test_detect_sarif():
+    packages = detect_and_parse(SARIF_BASIC)
+    assert len(packages) == 1
+    assert packages[0].name == "src/app.py"

--- a/tests/test_findings_push.py
+++ b/tests/test_findings_push.py
@@ -33,6 +33,16 @@ def test_load_push_findings_accepts_scanner_json() -> None:
     assert rows[0]["source"] == "trivy"
 
 
+def test_load_push_findings_accepts_sarif_json() -> None:
+    from tests.test_external_scanners import SARIF_BASIC
+
+    rows = load_push_findings(SARIF_BASIC, source="bandit")
+    assert len(rows) == 1
+    assert rows[0]["package"] == "src/app.py"
+    assert rows[0]["vulnerability_id"] == "B105"
+    assert rows[0]["source"] == "bandit"
+
+
 def test_load_push_findings_file(tmp_path: Path) -> None:
     path = tmp_path / "findings.json"
     path.write_text(json.dumps([{"id": "finding-2", "severity": "medium"}]), encoding="utf-8")


### PR DESCRIPTION
## Summary
- Extract `parse_sarif_document()` from compliance hub ingest for in-memory SARIF.
- Add `is_sarif_document`, `parse_sarif_json`, and SARIF branch in `detect_and_parse`.
- Group hub-classified findings into per-file `sast` packages for blast-radius / bulk ingest parity.
- Works for `agent-bom findings push`, `--external-scan`, and MCP `ingest_external_scan`.

## Verification
- `uv run pytest -q tests/test_external_scanners.py tests/test_findings_push.py tests/test_compliance_hub_ingest.py::test_sarif_ingest_produces_external_finding`
- `uv run ruff check src/agent_bom/parsers/external_scanners.py src/agent_bom/compliance_hub_ingest.py`

## Notes
- Closes quick-win #1 (unify). Next: CSAF/CycloneDX VEX (#2).


Made with [Cursor](https://cursor.com)