### PR TITLE
docs(issues): close post-audit hardening tracker #3242

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Meta
+- Close post-audit hardening tracker **#3242** (corrective arc complete; forward work stays on epic issues).
+
 ## [0.92.0] - 2026-07-02
 
 Release hardens the product path from first run to hosted POC: a user can

--- a/docs/archive/ROADMAP_QUICK_WINS.md
+++ b/docs/archive/ROADMAP_QUICK_WINS.md
@@ -1,8 +1,9 @@
 # Quick wins queue (internal, validated 2026-07-06)
 
 Operator-facing priority queue — **not** published on the docs site. Track customer-facing
-progress via GitHub issues [#3242](https://github.com/msaad00/agent-bom/issues/3242) and
-[#3499](https://github.com/msaad00/agent-bom/issues/3499).
+progress on open epics ([#3499](https://github.com/msaad00/agent-bom/issues/3499) reachability,
+[#2918](https://github.com/msaad00/agent-bom/issues/2918) Finding convergence, [#3192](https://github.com/msaad00/agent-bom/issues/3192) graph).
+Post-audit hardening tracker [#3242](https://github.com/msaad00/agent-bom/issues/3242) is closed.
 
 Ranked by value-per-effort. Claims marked **extend** build on shipped modules; **unify**
 closes a wiring gap; **net-new** is honest greenfield.

--- a/docs/audits/AUDIT-2026-07-03.md
+++ b/docs/audits/AUDIT-2026-07-03.md
@@ -88,7 +88,7 @@
 | **O** | P3 | No table partitioning | **#3463** | Ledger `compliance_hub_findings`; distinct from current-state sort |
 | **T** | scope | Multi-language reachability; data-lake interop | **#3499** | Parquet/Iceberg + call-graph reachability |
 
-**Epics (cross-cutting):** **#3242** post-audit hardening (severity unification — #3559/#3562 in flight); **#3468** guided demo estate; **#3192** graph excellence.
+**Epics (cross-cutting):** **#3468** guided demo estate; **#3192** graph excellence; **#2918** Finding convergence; **#3499** reachability. Post-audit hardening **#3242** closed (severity slice #3559–#3569 shipped).
 
 ### Documented product boundaries (not wiring bugs)
 
@@ -111,7 +111,7 @@
 | **P2** | Reference-table normalization | **#3513** | **Closed** — #3528 |
 | **P2** | Delta-stream connector | **#3514** | **Closed** — #3531 |
 
-**Cross-cutting (tracked on #3242):** severity unification (#3559 shipped, #3562 in flight); epics **#3463**, **#3499**.
+**Cross-cutting:** severity unification shipped (#3559–#3569); open epics **#3463**, **#3499**, **#2918**.
 
 ---
 
@@ -142,7 +142,7 @@
 
 1. **#3463** — declarative partitioning + retention rollover
 2. **#3499** — reachability + data-lake interop epic
-3. **#3242** — post-audit hardening (severity slice #3559; OIDC jti replay)
+3. **#2918** — Finding model convergence (formatter read path)
 4. **#3468** — guided activation + labeled demo estate (UI)
 5. **#3192** — graph excellence epic
 


### PR DESCRIPTION
## Summary
- Close **#3242** — corrective post-audit hardening arc is complete on `main` (#3552–#3569, including last severity sort slice #3569).
- Refresh audit ledger and internal quick-wins queue to point at open **epics** (#2918, #3499, #3463, #3192, …) instead of #3242.
- **Does not** close the 11 remaining epics — each still has open acceptance criteria.

## Epic status (honest, pre-0.93.0)

| Issue | Close? | Why not |
|-------|--------|---------|
| #3242 | **Yes** | Tracker only; corrective work shipped |
| #3499 | No | ~70% — data-lake, GHSA symbols, PHP/Swift open |
| #2918 | No | ~50% — console/compact/graph still on BlastRadius |
| #3463 | No | PR1 #3572 only; online migration/runbook deferred |
| #3192, #3175, #3468, #3206 | No | Multi-phase epics |
| #1971, #1969, #1522, #1469 | No | Backlog |

## Test plan
- [x] `git diff --check`
- [x] Stale #3242-as-open-tracker grep in edited docs

Closes #3242

Made with [Cursor](https://cursor.com)