### PR TITLE
docs(audit): consolidate epic queue merge state (#3601–#3607)

### DIFF
--- a/docs/audits/AUDIT-2026-07-03.md
+++ b/docs/audits/AUDIT-2026-07-03.md
@@ -1,7 +1,7 @@
 # agent-bom v0.92.0 — Audit ledger (2026-07-03)
 
 **Scope:** Multi-wave audit 2026-07-02 → 2026-07-05. Live verification against post-fix commits.
-**Baseline:** `main @ 009a35573` (post OIDC jti replay #3561). **Product version:** 0.92.0.
+**Baseline:** `main @ 693bac578` (epic queue slices #3601–#3607). **Product version:** 0.93.0.
 **Policy:** Canonical model is product truth; OCSF is export/interop only (`docs/OCSF_BOUNDARY.md`). No vendor parity claims in this doc.
 
 ---
@@ -141,10 +141,23 @@
 ### Remaining priority list
 
 1. **#3463** — declarative partitioning + retention rollover
-2. **#3499** — reachability + data-lake interop epic
-3. **#2918** — Finding model convergence (formatter read path)
-4. **#3468** — guided activation + labeled demo estate (UI)
-5. **#3192** — graph excellence epic
+2. **#3499** — reachability + data-lake interop epic (**partial** — #3607; tails #3608)
+3. **#2918** — Finding model convergence (**partial** — #3601; `json_fmt` blast_radius tail)
+4. **#3468** — guided activation + labeled demo estate (**partial** — #3602; `capture:product-proof` tail)
+5. **#3192** — graph excellence epic (**partial** — #3606; tails #3610)
+6. **#3175** — connections plane (**partial** — #3603; tails #3609)
+
+### Epic queue slices shipped (2026-07-06)
+
+| PR | Epic | Slice | Closes epic? |
+|---|---|---|---|
+| [#3601](https://github.com/msaad00/agent-bom/pull/3601) | #2918 | svg/html Finding convergence | No — `json_fmt` tail |
+| [#3602](https://github.com/msaad00/agent-bom/pull/3602) | #3468 | Guided demo lock cards on runtime surfaces | No — proof capture refresh |
+| [#3603](https://github.com/msaad00/agent-bom/pull/3603) | #3175 | `/login` + collector mTLS defaults | No — OIDC discovery shim (#3609) |
+| [#3606](https://github.com/msaad00/agent-bom/pull/3606) | #3192 | Rollup-by-default + asset drift lens | No — snapshot diff, evidence overlay (#3610) |
+| [#3607](https://github.com/msaad00/agent-bom/pull/3607) | #3499 | PHP/Swift symbol reach + Parquet export | No — Iceberg catalog, trace explorer (#3608) |
+
+Tail issues filed same day: **#3608** (trace explorer), **#3609** (OIDC discovery shim), **#3610** (graph evidence overlay).
 
 ---
 
@@ -189,9 +202,9 @@ Hands-on re-validation (clean install, API scan, MCP/proxy/gateway, UI build, re
 
 | Claim | Action |
 |---|---|
-| CWE-aware reachability (README) | Precise wording or ship call-graph path (**#3499**) |
+| CWE-aware reachability (README) | **Partial** — multi-lang symbol reach + Parquet (#3607); graph-walk + OTEL ingest shipped |
 | Dedicated hub-findings UI | Document unified `/findings` queue; hub API for integrators only |
 
 ---
 
-_Sanitized from consolidated audit dossier 2026-07-03. Vendor parity sections omitted per repo policy. Last ledger sync: 2026-07-05 (post #3561 merge)._
+_Sanitized from consolidated audit dossier 2026-07-03. Vendor parity sections omitted per repo policy. Last ledger sync: 2026-07-06 (post epic queue #3601–#3607 merge)._


### PR DESCRIPTION
## Summary
- Update `docs/audits/AUDIT-2026-07-03.md` with `main @ 693bac578` / v0.93.0 baseline after epic queue PRs #3601–#3607 merged.
- Add shipped-slices table and tail-issue refs (#3608–#3610); refresh §D priority list and CWE reachability row.

## Verification
- `git diff --check`
- Doc-only change; no runtime commands required.

## Notes
Post-merge housekeeping: delete merged `feat/epic-*` remote branches.

Made with [Cursor](https://cursor.com)