### PR TITLE
feat(runtime): OIDC discovery shim for legacy IdP MCP interop (Part of #3609)

### DIFF
--- a/deploy/helm/agent-bom/examples/README.md
+++ b/deploy/helm/agent-bom/examples/README.md
@@ -17,6 +17,7 @@ product split.
 | `eks-vanilla` | `eks-vanilla-values.yaml` | Postgres-backed production EKS rollout with ALB, IRSA, Kubernetes Secrets, and no service mesh / ESO / cert-manager requirement |
 | `mesh-hardening` | `eks-istio-kyverno-values.yaml` | Overlay for Istio mTLS/authz and Kyverno policy-controller packaging |
 | `collector-mtls` | `collector-mtls-values.yaml` | Scanner fleet-sync push with client TLS + delegated control-plane mTLS posture env |
+| `oidc-discovery-shim` | `eks-mcp-pilot-values.yaml` + `gateway-upstreams.example.yaml` + `oidc-discovery-shim-values.yaml` | Gateway-hosted `/.well-known/openid-configuration` for legacy IdPs (MCP OAuth interop) |
 | `snowflake-backend` | `eks-snowflake-values.yaml` | Overlay for Snowflake governance and selected store parity, not a claim of full control-plane replacement |
 | `gateway-runtime` | `eks-mcp-pilot-values.yaml` + `gateway-upstreams.example.yaml` | Focused pilot plus central gateway rendering for shared MCP relay/policy |
 

--- a/deploy/helm/agent-bom/examples/oidc-discovery-shim-values.yaml
+++ b/deploy/helm/agent-bom/examples/oidc-discovery-shim-values.yaml
@@ -1,0 +1,41 @@
+# OIDC discovery shim overlay — MCP clients + legacy IdPs (#3609)
+#
+# Serves /.well-known/openid-configuration on the gateway hostname while
+# authorization/token/JWKS traffic goes to the buyer's existing IdP.
+#
+#   helm upgrade --install agent-bom deploy/helm/agent-bom \
+#     -f deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml \
+#     -f deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml \
+#     -f deploy/helm/agent-bom/examples/oidc-discovery-shim-values.yaml
+#
+# Prerequisites:
+#   1. Gateway enabled and reachable at the shim issuer hostname (ingress TLS).
+#   2. MCP OAuth client registered manually in the IdP (redirect URIs + PKCE).
+#   3. Replace the placeholder IdP URLs below before production use.
+
+gateway:
+  enabled: true
+  env:
+    - name: AGENT_BOM_OIDC_DISCOVERY_SHIM_JSON
+      value: |
+        {
+          "issuer": "https://mcp-auth.example.internal",
+          "authorization_endpoint": "https://idp.example.com/oauth2/v1/authorize",
+          "token_endpoint": "https://idp.example.com/oauth2/v1/token",
+          "jwks_uri": "https://idp.example.com/oauth2/v1/keys",
+          "userinfo_endpoint": "https://idp.example.com/oauth2/v1/userinfo",
+          "scopes_supported": ["openid", "profile", "email"]
+        }
+
+# Optional ingress-only pattern: nginx sidecar serving static discovery JSON
+# when the gateway is not the public hostname. Uncomment and mount a ConfigMap
+# with openid-configuration.json at /usr/share/nginx/html/.well-known/.
+#
+# controlPlane:
+#   ingress:
+#     annotations:
+#       nginx.ingress.kubernetes.io/configuration-snippet: |
+#         location /.well-known/openid-configuration {
+#           default_type application/json;
+#           return 200 '{"issuer":"https://mcp-auth.example.internal",...}';
+#         }

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -369,6 +369,29 @@ open https://<control-plane-host>/login
 After sign-in, open **Connections** (`/connections`) to add a read-only cloud
 account, then launch or schedule a scan from the same dashboard.
 
+### MCP OIDC discovery shim
+
+When MCP OAuth clients require `/.well-known/openid-configuration` at your
+gateway hostname but the buyer IdP only exposes manually configured endpoints,
+enable the read-only discovery shim on the gateway:
+
+```bash
+export AGENT_BOM_OIDC_DISCOVERY_SHIM_JSON='{
+  "issuer": "https://mcp-auth.example.internal",
+  "authorization_endpoint": "https://idp.example.com/oauth2/v1/authorize",
+  "token_endpoint": "https://idp.example.com/oauth2/v1/token",
+  "jwks_uri": "https://idp.example.com/oauth2/v1/keys"
+}'
+```
+
+The shim publishes public metadata only; tokens still come from the upstream
+IdP. For agent-bom-native MCP OAuth (broker AS), use
+`AGENT_BOM_GATEWAY_ENABLE_OAUTH_AS` instead.
+
+See [`docs/design/OIDC_DISCOVERY_SHIM.md`](design/OIDC_DISCOVERY_SHIM.md) and
+`deploy/helm/agent-bom/examples/oidc-discovery-shim-values.yaml` for architecture,
+Helm overlay, and contract tests.
+
 ### Proxy-to-control-plane mTLS posture
 
 The recommended production pattern is delegated mTLS: terminate TLS and verify

--- a/docs/design/OIDC_DISCOVERY_SHIM.md
+++ b/docs/design/OIDC_DISCOVERY_SHIM.md
@@ -1,0 +1,125 @@
+# OIDC discovery shim for MCP clients
+
+Many MCP OAuth clients auto-discover IdP endpoints via
+`/.well-known/openid-configuration` at the configured issuer URL. Enterprise
+buyers often run IdPs that issue valid tokens but **do not publish** discovery
+metadata in the shape MCP tooling expects — or they publish it on a different
+host than the issuer the MCP client is configured to use.
+
+agent-bom already ships:
+
+- **Control-plane OIDC login** — JWT verification for the API and dashboard
+  (`AGENT_BOM_OIDC_ISSUER`, tenant-bound providers).
+- **Gateway OAuth AS** — broker-native OAuth 2.1 for MCP clients that front
+  agent-bom-issued tokens (`AGENT_BOM_GATEWAY_ENABLE_OAUTH_AS`).
+
+The **OIDC discovery shim** is a third, narrowly scoped interop path: a
+read-only metadata surface that tells MCP clients where the **buyer's existing
+IdP** lives. It does not mint tokens, register clients dynamically against
+legacy IdPs, or replace `oauth_as`.
+
+## When to use it
+
+| Scenario | Use shim? | Prefer instead |
+|---|---|---|
+| MCP client needs `/.well-known/openid-configuration` at your gateway hostname | Yes | — |
+| IdP publishes discovery but on a different issuer host | Yes (shim issuer = gateway) | Re-point MCP client if possible |
+| You want agent-bom to issue MCP access tokens | No | Gateway OAuth AS |
+| Browser dashboard login via reverse-proxy OIDC | No | `AGENT_BOM_OIDC_ISSUER` + `/login` |
+
+## Architecture
+
+```text
+ MCP client (Cursor, Claude Desktop, …)
+        │
+        │ 1) GET /.well-known/openid-configuration
+        ▼
+ agent-bom gateway (discovery shim)
+        │  serves static JSON from AGENT_BOM_OIDC_DISCOVERY_SHIM_JSON
+        │
+        │ 2) authorization_code + PKCE (client talks to IdP directly)
+        ▼
+ Buyer IdP (Okta, Entra, Auth0, …)
+        │ 3) access_token (RS256 JWT)
+        ▼
+ MCP client ──► agent-bom gateway relay ──► upstream MCP servers
+```
+
+The shim only answers step 1. Steps 2–3 stay on the buyer IdP. Register the
+MCP client manually in the IdP admin console (redirect URIs, scopes, PKCE).
+
+## Deployment
+
+### Gateway sub-route (recommended)
+
+Set `AGENT_BOM_OIDC_DISCOVERY_SHIM_JSON` on the gateway deployment:
+
+```bash
+export AGENT_BOM_OIDC_DISCOVERY_SHIM_JSON='{
+  "issuer": "https://mcp-auth.acme.internal",
+  "authorization_endpoint": "https://acme.okta.com/oauth2/v1/authorize",
+  "token_endpoint": "https://acme.okta.com/oauth2/v1/token",
+  "jwks_uri": "https://acme.okta.com/oauth2/v1/keys",
+  "userinfo_endpoint": "https://acme.okta.com/oauth2/v1/userinfo",
+  "scopes_supported": ["openid", "profile", "email"]
+}'
+```
+
+Point MCP clients at `issuer` (`https://mcp-auth.acme.internal`). Terminate TLS
+at ingress so the gateway serves discovery on that hostname.
+
+Verify:
+
+```bash
+curl -fsS "https://mcp-auth.acme.internal/.well-known/openid-configuration" | jq .
+```
+
+`GET /healthz` on the gateway reports `oidc_discovery_shim_enabled: true`.
+
+### Helm overlay
+
+Use the packaged example:
+
+```bash
+helm upgrade --install agent-bom deploy/helm/agent-bom \
+  -f deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml \
+  -f deploy/helm/agent-bom/examples/gateway-upstreams.example.yaml \
+  -f deploy/helm/agent-bom/examples/oidc-discovery-shim-values.yaml
+```
+
+Edit the JSON in `oidc-discovery-shim-values.yaml` with your IdP endpoints
+before applying.
+
+### Static nginx sidecar (ingress-only)
+
+When you only need discovery at the edge and the gateway runs elsewhere, serve
+the same JSON from a ConfigMap-backed nginx sidecar. See the commented nginx
+block in `deploy/helm/agent-bom/examples/oidc-discovery-shim-values.yaml`.
+
+## Contract
+
+The shim document must include at minimum:
+
+- `issuer`, `authorization_endpoint`, `token_endpoint`, `jwks_uri`
+- `response_types_supported` (default `["code"]`)
+- `subject_types_supported` (default `["public"]`)
+- `id_token_signing_alg_values_supported` (default `["RS256"]`)
+
+`validate_oidc_discovery_document()` in
+`src/agent_bom/api/oidc_discovery_shim.py` enforces this shape. Tests live in
+`tests/test_oidc_discovery_shim.py`.
+
+## Security posture
+
+- **Read-only metadata** — no secrets, no token minting, no outbound IdP calls.
+- **Fail closed on bad config** — invalid JSON or missing required keys prevent
+  gateway startup when the env var is set.
+- **Not a broker** — for agent-bom-native OAuth, use the gateway AS documented
+  in [`MULTI_MCP_GATEWAY.md`](MULTI_MCP_GATEWAY.md).
+
+## Related
+
+- Parent epic: [#3175](https://github.com/msaad00/agent-bom/issues/3175)
+- Tail issue: [#3609](https://github.com/msaad00/agent-bom/issues/3609)
+- Enterprise deployment: [`ENTERPRISE_DEPLOYMENT.md`](../ENTERPRISE_DEPLOYMENT.md#mcp-oidc-discovery-shim)
+- Gateway OAuth AS: `src/agent_bom/api/oauth_as.py`

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -196,6 +196,11 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_MCP_MAX_TOOL_METRICS` | `int` | `128` | — |
 | `AGENT_BOM_MCP_TOOL_TIMEOUT_SECONDS` | `float` | `30.0` | — |
 
+## OIDC discovery shim
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_OIDC_DISCOVERY_SHIM_JSON` | `str` | `''` | Optional static OIDC discovery metadata JSON served by the gateway for legacy IdPs / MCP clients that need discovery documents but cannot publish them at the normal issuer location. Empty string disables the shim. |
+
 ## OS-package reporting
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/src/agent_bom/api/oidc_discovery_shim.py
+++ b/src/agent_bom/api/oidc_discovery_shim.py
@@ -1,0 +1,197 @@
+"""OIDC discovery shim for MCP clients and legacy enterprise IdPs.
+
+Many MCP OAuth clients require ``/.well-known/openid-configuration`` at the
+issuer URL. Buyer IdPs often issue valid tokens but do not publish discovery
+metadata in the shape those clients expect. This module serves a **static**
+OpenID Provider Metadata document that points at manually configured upstream
+endpoints — a read-only interop shim, not a replacement IdP or OAuth broker.
+
+Configure via ``AGENT_BOM_OIDC_DISCOVERY_SHIM_JSON``::
+
+    {
+      "issuer": "https://mcp-auth.example.com",
+      "authorization_endpoint": "https://idp.example.com/oauth2/v1/authorize",
+      "token_endpoint": "https://idp.example.com/oauth2/v1/token",
+      "jwks_uri": "https://idp.example.com/oauth2/v1/keys"
+    }
+
+Optional fields: ``userinfo_endpoint``, ``scopes_supported``,
+``response_types_supported``, ``grant_types_supported``,
+``code_challenge_methods_supported``.
+
+Mount on the gateway (or any FastAPI app) with
+:func:`build_oidc_discovery_shim_router`. The route is intentionally
+unauthenticated — it only publishes public IdP metadata.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any
+
+# Minimum keys MCP OAuth / OIDC discovery clients expect.
+_REQUIRED_DISCOVERY_KEYS = (
+    "issuer",
+    "authorization_endpoint",
+    "token_endpoint",
+    "jwks_uri",
+    "response_types_supported",
+    "subject_types_supported",
+    "id_token_signing_alg_values_supported",
+)
+
+
+class OIDCDiscoveryShimError(ValueError):
+    """Invalid shim configuration or discovery document."""
+
+
+@dataclass(frozen=True)
+class OIDCDiscoveryShimConfig:
+    """Manual OIDC endpoint wiring for a discovery shim."""
+
+    issuer: str
+    authorization_endpoint: str
+    token_endpoint: str
+    jwks_uri: str
+    userinfo_endpoint: str | None = None
+    scopes_supported: tuple[str, ...] = ()
+    response_types_supported: tuple[str, ...] = ("code",)
+    grant_types_supported: tuple[str, ...] = ("authorization_code", "refresh_token")
+    code_challenge_methods_supported: tuple[str, ...] = ("S256",)
+    subject_types_supported: tuple[str, ...] = ("public",)
+    id_token_signing_alg_values_supported: tuple[str, ...] = ("RS256",)
+
+    def __post_init__(self) -> None:
+        for label, value in (
+            ("issuer", self.issuer),
+            ("authorization_endpoint", self.authorization_endpoint),
+            ("token_endpoint", self.token_endpoint),
+            ("jwks_uri", self.jwks_uri),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise OIDCDiscoveryShimError(f"{label} must be a non-empty string")
+        if self.userinfo_endpoint is not None and not self.userinfo_endpoint.strip():
+            raise OIDCDiscoveryShimError("userinfo_endpoint must be omitted or a non-empty string")
+
+    @classmethod
+    def from_mapping(cls, payload: dict[str, Any]) -> OIDCDiscoveryShimConfig:
+        if not isinstance(payload, dict):
+            raise OIDCDiscoveryShimError("shim config must be a JSON object")
+
+        def _req(key: str) -> str:
+            value = payload.get(key)
+            if not isinstance(value, str) or not value.strip():
+                raise OIDCDiscoveryShimError(f"missing or invalid {key!r}")
+            return value.strip()
+
+        def _opt_str(key: str) -> str | None:
+            value = payload.get(key)
+            if value is None:
+                return None
+            if not isinstance(value, str) or not value.strip():
+                raise OIDCDiscoveryShimError(f"invalid optional field {key!r}")
+            return value.strip()
+
+        def _opt_str_tuple(key: str, default: tuple[str, ...]) -> tuple[str, ...]:
+            value = payload.get(key)
+            if value is None:
+                return default
+            if not isinstance(value, list) or not all(isinstance(item, str) and item.strip() for item in value):
+                raise OIDCDiscoveryShimError(f"{key} must be a list of non-empty strings")
+            return tuple(item.strip() for item in value)
+
+        return cls(
+            issuer=_req("issuer"),
+            authorization_endpoint=_req("authorization_endpoint"),
+            token_endpoint=_req("token_endpoint"),
+            jwks_uri=_req("jwks_uri"),
+            userinfo_endpoint=_opt_str("userinfo_endpoint"),
+            scopes_supported=_opt_str_tuple("scopes_supported", ()),
+            response_types_supported=_opt_str_tuple("response_types_supported", ("code",)),
+            grant_types_supported=_opt_str_tuple("grant_types_supported", ("authorization_code", "refresh_token")),
+            code_challenge_methods_supported=_opt_str_tuple("code_challenge_methods_supported", ("S256",)),
+            subject_types_supported=_opt_str_tuple("subject_types_supported", ("public",)),
+            id_token_signing_alg_values_supported=_opt_str_tuple("id_token_signing_alg_values_supported", ("RS256",)),
+        )
+
+    @classmethod
+    def from_env(cls, *, env_var: str = "AGENT_BOM_OIDC_DISCOVERY_SHIM_JSON") -> OIDCDiscoveryShimConfig | None:
+        raw = os.environ.get(env_var, "").strip()
+        if not raw:
+            return None
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise OIDCDiscoveryShimError(f"{env_var} must be valid JSON") from exc
+        return cls.from_mapping(payload)
+
+
+def build_openid_configuration(config: OIDCDiscoveryShimConfig) -> dict[str, Any]:
+    """Build an OpenID Provider Metadata document from manual endpoint wiring."""
+    doc: dict[str, Any] = {
+        "issuer": config.issuer.rstrip("/"),
+        "authorization_endpoint": config.authorization_endpoint,
+        "token_endpoint": config.token_endpoint,
+        "jwks_uri": config.jwks_uri,
+        "response_types_supported": list(config.response_types_supported),
+        "subject_types_supported": list(config.subject_types_supported),
+        "id_token_signing_alg_values_supported": list(config.id_token_signing_alg_values_supported),
+        "grant_types_supported": list(config.grant_types_supported),
+        "code_challenge_methods_supported": list(config.code_challenge_methods_supported),
+    }
+    if config.userinfo_endpoint:
+        doc["userinfo_endpoint"] = config.userinfo_endpoint
+    if config.scopes_supported:
+        doc["scopes_supported"] = list(config.scopes_supported)
+    validate_oidc_discovery_document(doc)
+    return doc
+
+
+def validate_oidc_discovery_document(doc: dict[str, Any]) -> None:
+    """Validate that ``doc`` satisfies MCP/OIDC discovery client expectations."""
+    if not isinstance(doc, dict):
+        raise OIDCDiscoveryShimError("discovery document must be a JSON object")
+    missing = [key for key in _REQUIRED_DISCOVERY_KEYS if key not in doc]
+    if missing:
+        raise OIDCDiscoveryShimError(f"discovery document missing required keys: {', '.join(missing)}")
+    for key in ("issuer", "authorization_endpoint", "token_endpoint", "jwks_uri"):
+        value = doc.get(key)
+        if not isinstance(value, str) or not value.strip():
+            raise OIDCDiscoveryShimError(f"{key} must be a non-empty string")
+    for list_key in (
+        "response_types_supported",
+        "subject_types_supported",
+        "id_token_signing_alg_values_supported",
+    ):
+        value = doc.get(list_key)
+        if not isinstance(value, list) or not value:
+            raise OIDCDiscoveryShimError(f"{list_key} must be a non-empty list")
+
+
+def build_oidc_discovery_shim_router(config: OIDCDiscoveryShimConfig):
+    """Expose ``/.well-known/openid-configuration`` for the shim issuer."""
+    from fastapi import APIRouter
+    from fastapi.responses import JSONResponse
+
+    router = APIRouter()
+    document = build_openid_configuration(config)
+
+    @router.get("/.well-known/openid-configuration")
+    async def openid_configuration() -> JSONResponse:
+        return JSONResponse(
+            document,
+            headers={"Cache-Control": "public, max-age=300"},
+        )
+
+    return router
+
+
+__all__ = [
+    "OIDCDiscoveryShimConfig",
+    "OIDCDiscoveryShimError",
+    "build_oidc_discovery_shim_router",
+    "build_openid_configuration",
+    "validate_oidc_discovery_document",
+]

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -500,6 +500,16 @@ def serve_cmd(
         oauth_as = OAuthAuthorizationServer(issuer=oauth_as_issuer)
         click.echo(f"OAuth 2.1 AS enabled (issuer={oauth_as_issuer or '<derived from request>'})")
 
+    oidc_discovery_shim = None
+    try:
+        from agent_bom.api.oidc_discovery_shim import OIDCDiscoveryShimConfig, OIDCDiscoveryShimError
+
+        oidc_discovery_shim = OIDCDiscoveryShimConfig.from_env()
+    except OIDCDiscoveryShimError as exc:
+        raise click.ClickException(f"OIDC discovery shim config invalid: {exc}") from exc
+    if oidc_discovery_shim is not None:
+        click.echo(f"OIDC discovery shim enabled (issuer={oidc_discovery_shim.issuer})")
+
     tool_scope_mapping: dict[str, list[str]] = {}
     if tool_scope_map is not None:
         raw_map = read_json_file_for_cli(tool_scope_map, label="tool scope map")
@@ -537,6 +547,7 @@ def serve_cmd(
         graph_reachability_path=graph_reachability_path,
         graph_reachability_enforcement_mode=graph_reachability_enforcement,
         oauth_as=oauth_as,
+        oidc_discovery_shim=oidc_discovery_shim,
         a2a_mutual_auth_enforcement_mode=a2a_mutual_auth_enforcement,
         tool_scope_map=tool_scope_mapping,
         dlp_enabled=enable_dlp,

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -301,6 +301,13 @@ AI_CACHE_MAX_ENTRIES = _int("AGENT_BOM_AI_CACHE_MAX", 1_000)
 OLLAMA_BASE_URL = _str("AGENT_BOM_OLLAMA_URL", "http://localhost:11434")
 
 
+# ── OIDC discovery shim ──────────────────────────────────────────────────
+# Optional static OIDC discovery metadata JSON served by the gateway for
+# legacy IdPs / MCP clients that need discovery documents but cannot publish
+# them at the normal issuer location. Empty string disables the shim.
+OIDC_DISCOVERY_SHIM_JSON = _str("AGENT_BOM_OIDC_DISCOVERY_SHIM_JSON", "")
+
+
 # ── Enrichment Cache ──────────────────────────────────────────────────────
 # Used by enrichment.py for persistent NVD + EPSS disk cache.
 #

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -55,6 +55,7 @@ from agent_bom.api.auth import Role, get_key_store
 from agent_bom.api.metrics import record_gateway_relay, record_rate_limit_hit
 from agent_bom.api.middleware import InMemoryRateLimitStore, PostgresRateLimitStore
 from agent_bom.api.oauth_as import OAuthAuthorizationServer, build_oauth_as_router
+from agent_bom.api.oidc_discovery_shim import OIDCDiscoveryShimConfig, build_oidc_discovery_shim_router
 from agent_bom.api.tracing import get_tracer, inject_trace_headers, make_request_trace
 from agent_bom.firewall import (
     AgentFirewallPolicy,
@@ -235,6 +236,10 @@ class GatewaySettings:
     # the caller's verified agent identity. None = AS disabled (no behaviour
     # change). The OAuth scopes carried in the token feed ``tool_scope_map``.
     oauth_as: OAuthAuthorizationServer | None = None
+    # Static OIDC discovery shim for legacy IdPs that do not publish
+    # /.well-known/openid-configuration. Serves public metadata only; tokens
+    # still come from the upstream IdP endpoints declared in the config.
+    oidc_discovery_shim: OIDCDiscoveryShimConfig | None = None
     # A2A inline mutual-auth enforcement. "off" (default) keeps the existing
     # identity posture; "warn" audits weak (anonymous / unverified / invalid)
     # inter-agent / agent-MCP edges; "enforce" rejects them inline at the relay.
@@ -1141,6 +1146,8 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         app.include_router(build_oauth_as_router(settings.oauth_as))
         if settings.oauth_as.signing_key.ephemeral:
             logger.warning("gateway OAuth AS enabled with an ephemeral signing key; set AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM for production")
+    if settings.oidc_discovery_shim is not None:
+        app.include_router(build_oidc_discovery_shim_router(settings.oidc_discovery_shim))
 
     dlp_config = _gateway_dlp_config(settings)
 
@@ -1188,6 +1195,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             "firewall_runtime": firewall_runtime,
             "broker_runtime": {
                 "oauth_as_enabled": settings.oauth_as is not None,
+                "oidc_discovery_shim_enabled": settings.oidc_discovery_shim is not None,
                 "a2a_mutual_auth_enforcement_mode": settings.a2a_mutual_auth_enforcement_mode,
                 "tool_scope_mapped_tools": len(settings.tool_scope_map),
                 "dlp_enabled": settings.dlp_enabled,

--- a/tests/test_gateway_oauth_broker.py
+++ b/tests/test_gateway_oauth_broker.py
@@ -95,6 +95,7 @@ def test_gateway_healthz_reports_broker_posture() -> None:
     broker = client.get("/healthz").json()["broker_runtime"]
     assert broker == {
         "oauth_as_enabled": True,
+        "oidc_discovery_shim_enabled": False,
         "a2a_mutual_auth_enforcement_mode": "enforce",
         "tool_scope_mapped_tools": 1,
         "dlp_enabled": True,

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -127,6 +127,7 @@ def test_healthz_lists_configured_upstreams() -> None:
         },
         "broker_runtime": {
             "oauth_as_enabled": False,
+            "oidc_discovery_shim_enabled": False,
             "a2a_mutual_auth_enforcement_mode": "off",
             "tool_scope_mapped_tools": 0,
             "dlp_enabled": False,

--- a/tests/test_oidc_discovery_shim.py
+++ b/tests/test_oidc_discovery_shim.py
@@ -1,0 +1,85 @@
+"""Contract tests for the OIDC discovery shim (#3609)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.oidc_discovery_shim import (
+    OIDCDiscoveryShimConfig,
+    OIDCDiscoveryShimError,
+    build_oidc_discovery_shim_router,
+    build_openid_configuration,
+    validate_oidc_discovery_document,
+)
+from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+
+
+def _sample_config() -> OIDCDiscoveryShimConfig:
+    return OIDCDiscoveryShimConfig(
+        issuer="https://mcp-auth.example.com",
+        authorization_endpoint="https://idp.example.com/oauth2/v1/authorize",
+        token_endpoint="https://idp.example.com/oauth2/v1/token",
+        jwks_uri="https://idp.example.com/oauth2/v1/keys",
+        userinfo_endpoint="https://idp.example.com/oauth2/v1/userinfo",
+        scopes_supported=("openid", "profile", "email"),
+    )
+
+
+def test_build_openid_configuration_includes_mcp_client_contract_fields() -> None:
+    doc = build_openid_configuration(_sample_config())
+    validate_oidc_discovery_document(doc)
+    assert doc["issuer"] == "https://mcp-auth.example.com"
+    assert doc["authorization_endpoint"].endswith("/authorize")
+    assert doc["token_endpoint"].endswith("/token")
+    assert doc["jwks_uri"].endswith("/keys")
+    assert doc["response_types_supported"] == ["code"]
+    assert doc["code_challenge_methods_supported"] == ["S256"]
+    assert doc["scopes_supported"] == ["openid", "profile", "email"]
+
+
+def test_validate_oidc_discovery_document_rejects_incomplete_docs() -> None:
+    with pytest.raises(OIDCDiscoveryShimError, match="missing required keys"):
+        validate_oidc_discovery_document({"issuer": "https://example.com"})
+
+
+def test_from_mapping_and_env_round_trip(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload = {
+        "issuer": "https://shim.example.com",
+        "authorization_endpoint": "https://idp.example.com/authorize",
+        "token_endpoint": "https://idp.example.com/token",
+        "jwks_uri": "https://idp.example.com/jwks",
+    }
+    config = OIDCDiscoveryShimConfig.from_mapping(payload)
+    monkeypatch.setenv("AGENT_BOM_OIDC_DISCOVERY_SHIM_JSON", json.dumps(payload))
+    assert OIDCDiscoveryShimConfig.from_env() == config
+
+
+def test_shim_router_serves_well_known_openid_configuration() -> None:
+    from fastapi import FastAPI
+
+    config = _sample_config()
+    app = FastAPI()
+    app.include_router(build_oidc_discovery_shim_router(config))
+    client = TestClient(app)
+    resp = client.get("/.well-known/openid-configuration")
+    assert resp.status_code == 200
+    assert resp.headers["cache-control"] == "public, max-age=300"
+    body = resp.json()
+    validate_oidc_discovery_document(body)
+    assert body["issuer"] == config.issuer
+
+
+def test_gateway_mounts_oidc_discovery_shim_when_configured() -> None:
+    settings = GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://fs.local:8100")]),
+        policy={},
+        oidc_discovery_shim=_sample_config(),
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.get("/.well-known/openid-configuration")
+    assert resp.status_code == 200
+    validate_oidc_discovery_document(resp.json())


### PR DESCRIPTION
## Summary
- Add `oidc_discovery_shim` module: static OpenID Provider Metadata from `AGENT_BOM_OIDC_DISCOVERY_SHIM_JSON`, mounted on the gateway at `/.well-known/openid-configuration`.
- Publish architecture doc, enterprise deployment cross-link, and Helm overlay `oidc-discovery-shim-values.yaml`.
- Contract tests validate required discovery fields and gateway mount behavior.

## Verification
- `uv run pytest tests/test_oidc_discovery_shim.py -q` (5 passed)
- `uv run ruff check` on touched Python files
- `helm template` with `eks-mcp-pilot` + `gateway-upstreams` + `oidc-discovery-shim` overlays

## Notes
Part of #3609 (tail of #3175). Does not replace gateway OAuth AS or control-plane OIDC login.

Made with [Cursor](https://cursor.com)