### PR TITLE
feat(runtime): trace explorer joined to findings and compliance (Part of #3608)

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 248 |
+| `docs/openapi/v1.json` | paths | 249 |
 | `docs/openapi/v1.json` | component schemas | 65 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -19797,6 +19797,101 @@
         ]
       }
     },
+    "/v1/runtime/trace-explorer": {
+      "get": {
+        "description": "Langfuse-style trace explorer joined to findings and policy decisions (#3608).\n\nFuses gateway/proxy feed events and persisted runtime observations into\nsession-grouped spans. Each span carries correlated findings (CVE, reach\nband, compliance controls) and blocked/observed verdict metadata.",
+        "operationId": "trace_explorer_v1_runtime_trace_explorer_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Trace Explorer V1 Runtime Trace Explorer Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Trace Explorer",
+        "tags": [
+          "runtime",
+          "observability"
+        ]
+      }
+    },
     "/v1/scan": {
       "post": {
         "description": "Start a scan. Returns immediately with a job_id.\nPoll GET /v1/scan/{job_id} for results, or stream via /v1/scan/{job_id}/stream.\n\nRetry-safe: repeating the request with the same ``Idempotency-Key`` header\nreturns the first job instead of minting a new job_id per attempt; reusing\nthe key with a different body is a 409 conflict.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -12807,6 +12807,69 @@ paths:
       tags:
       - runtime
       - observability
+  /v1/runtime/trace-explorer:
+    get:
+      description: 'Langfuse-style trace explorer joined to findings and policy decisions
+        (#3608).
+
+
+        Fuses gateway/proxy feed events and persisted runtime observations into
+
+        session-grouped spans. Each span carries correlated findings (CVE, reach
+
+        band, compliance controls) and blocked/observed verdict metadata.'
+      operationId: trace_explorer_v1_runtime_trace_explorer_get
+      parameters:
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 100
+          title: Limit
+          type: integer
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Trace Explorer V1 Runtime Trace Explorer Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Trace Explorer
+      tags:
+      - runtime
+      - observability
   /v1/scan:
     post:
       description: 'Start a scan. Returns immediately with a job_id.

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -697,6 +697,51 @@ async def list_runtime_observations(
     }
 
 
+@router.get("/v1/runtime/trace-explorer", tags=["runtime", "observability"], dependencies=[_dep("read")])
+async def trace_explorer(
+    request: Request,
+    limit: int = 100,
+) -> dict[str, object]:
+    """Langfuse-style trace explorer joined to findings and policy decisions (#3608).
+
+    Fuses gateway/proxy feed events and persisted runtime observations into
+    session-grouped spans. Each span carries correlated findings (CVE, reach
+    band, compliance controls) and blocked/observed verdict metadata.
+    """
+    from agent_bom.api.cost_store import get_cost_store
+    from agent_bom.api.routes.gateway_feed import _load_tenant_alerts, build_gateway_feed
+    from agent_bom.api.routes.scan import _completed_jobs_for_tenant, _iter_scan_findings
+    from agent_bom.api.trace_explorer import build_trace_explorer_payload
+
+    tenant_id = _tenant_id(request)
+    bounded_limit = max(1, min(limit, 200))
+    alerts = _load_tenant_alerts(tenant_id)
+    llm_records = list(get_cost_store().list_records(tenant_id, limit=bounded_limit))
+    feed = build_gateway_feed(
+        tenant_id=tenant_id,
+        alerts=alerts,
+        llm_records=llm_records,
+        limit=bounded_limit,
+    )
+    findings: list[dict[str, Any]] = []
+    for job in _completed_jobs_for_tenant(tenant_id):
+        findings.extend(_iter_scan_findings(job))
+    store = get_runtime_event_store()
+    sessions = [session.to_dict() for session in store.list_sessions(tenant_id, limit=bounded_limit, offset=0)]
+    observations = [
+        observation.to_dict()
+        for observation in store.list_observations(tenant_id, limit=bounded_limit, offset=0)
+    ]
+    return build_trace_explorer_payload(
+        tenant_id=tenant_id,
+        feed_events=cast(list[dict[str, Any]], feed.get("events", [])),
+        findings=findings,
+        sessions=sessions,
+        observations=observations,
+        limit=bounded_limit,
+    )
+
+
 @router.get("/v1/runtime/sessions/{session_id}/observations", tags=["runtime", "observability"], dependencies=[_dep("read")])
 async def list_runtime_session_observations(
     request: Request,

--- a/src/agent_bom/api/trace_explorer.py
+++ b/src/agent_bom/api/trace_explorer.py
@@ -1,0 +1,193 @@
+"""Trace explorer payload builder — runtime events joined to findings (#3608).
+
+Fuses gateway/proxy feed events and runtime observations into a Langfuse-style
+session tree where each tool-call span links to correlated findings (CVE,
+compliance controls, policy block reason).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def _norm(value: object) -> str:
+    return str(value or "").strip().lower()
+
+
+def correlate_findings(
+    *,
+    agent: str,
+    tool: str,
+    findings: list[Mapping[str, Any]],
+    limit: int = 5,
+) -> list[dict[str, Any]]:
+    """Return findings whose agent/tool exposure overlaps this runtime event."""
+    agent_key = _norm(agent)
+    tool_key = _norm(tool)
+    if not agent_key and not tool_key:
+        return []
+
+    matched: list[dict[str, Any]] = []
+    for row in findings:
+        if not isinstance(row, Mapping):
+            continue
+        agents = {_norm(a) for a in (row.get("affected_agents") or []) if _norm(a)}
+        tools = set()
+        for key in ("exposed_tools", "reachable_tools", "phantom_tools"):
+            tools.update(_norm(t) for t in (row.get(key) or []) if _norm(t))
+        if agent_key and agents and agent_key not in agents:
+            continue
+        if tool_key and tools and tool_key not in tools:
+            continue
+        if not agents and not tools:
+            continue
+        matched.append(
+            {
+                "finding_id": row.get("id") or row.get("vulnerability_id"),
+                "vulnerability_id": row.get("vulnerability_id") or row.get("cve_id"),
+                "severity": row.get("severity"),
+                "risk_score": row.get("risk_score"),
+                "effective_reach_band": row.get("effective_reach_band"),
+                "framework_tags": row.get("framework_tags") or [],
+                "runtime_evidence": row.get("runtime_evidence"),
+                "policy_state": (row.get("runtime_evidence") or {}).get("state"),
+            }
+        )
+        if len(matched) >= limit:
+            break
+    return matched
+
+
+def _span_from_feed_event(event: Mapping[str, Any], *, findings: list[Mapping[str, Any]]) -> dict[str, Any]:
+    action = str(event.get("action_type") or "")
+    agent = str(event.get("agent") or "")
+    tool = str(event.get("target") or "")
+    blocked = action == "tool_call_blocked"
+    return {
+        "span_id": f"{event.get('ts')}:{agent}:{tool}",
+        "timestamp": event.get("ts"),
+        "agent": agent,
+        "tool": tool,
+        "action_type": action,
+        "verdict": "blocked" if blocked else ("observed" if action == "tool_call_authorized" else action),
+        "detail": event.get("detail"),
+        "shadow": bool(event.get("shadow")),
+        "source": event.get("source"),
+        "linked_findings": correlate_findings(agent=agent, tool=tool, findings=findings),
+        "compliance_controls": sorted(
+            {
+                tag
+                for finding in correlate_findings(agent=agent, tool=tool, findings=findings, limit=8)
+                for tag in (finding.get("framework_tags") or [])
+            }
+        ),
+    }
+
+
+def _span_from_observation(obs: Mapping[str, Any], *, findings: list[Mapping[str, Any]]) -> dict[str, Any]:
+    agent = str(obs.get("agent_name") or "")
+    tool = str(obs.get("tool_name") or "")
+    verdict = str(obs.get("verdict") or "observed")
+    return {
+        "span_id": str(obs.get("observation_id") or obs.get("span_id") or ""),
+        "timestamp": obs.get("observed_at"),
+        "agent": agent,
+        "tool": tool,
+        "action_type": str(obs.get("event_type") or "runtime_observation"),
+        "verdict": verdict,
+        "detail": str((obs.get("summary") or {}).get("message") or obs.get("event_type") or ""),
+        "shadow": False,
+        "source": obs.get("source") or "runtime_store",
+        "trace_id": obs.get("trace_id"),
+        "session_id": obs.get("session_id"),
+        "linked_findings": correlate_findings(agent=agent, tool=tool, findings=findings),
+        "compliance_controls": sorted(
+            {
+                tag
+                for finding in correlate_findings(agent=agent, tool=tool, findings=findings, limit=8)
+                for tag in (finding.get("framework_tags") or [])
+            }
+        ),
+    }
+
+
+def build_trace_explorer_payload(
+    *,
+    tenant_id: str,
+    feed_events: list[Mapping[str, Any]],
+    findings: list[Mapping[str, Any]],
+    sessions: list[Mapping[str, Any]],
+    observations: list[Mapping[str, Any]],
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Build session-grouped trace explorer tree for the UI."""
+    session_map: dict[str, dict[str, Any]] = {}
+
+    def _ensure_session(session_id: str, *, agent: str = "", trace_id: str = "") -> dict[str, Any]:
+        if session_id not in session_map:
+            session_map[session_id] = {
+                "session_id": session_id,
+                "agent": agent,
+                "trace_id": trace_id,
+                "spans": [],
+                "blocked_count": 0,
+                "observed_count": 0,
+            }
+        return session_map[session_id]
+
+    for event in feed_events[:limit]:
+        agent = str(event.get("agent") or "unknown")
+        session_id = f"feed:{agent}"
+        session = _ensure_session(session_id, agent=agent)
+        span = _span_from_feed_event(event, findings=findings)
+        session["spans"].append(span)
+        if span["verdict"] == "blocked":
+            session["blocked_count"] += 1
+        else:
+            session["observed_count"] += 1
+
+    for obs in observations[:limit]:
+        session_id = str(obs.get("session_id") or f"obs:{obs.get('trace_id') or obs.get('agent_name') or 'unknown'}")
+        session = _ensure_session(
+            session_id,
+            agent=str(obs.get("agent_name") or ""),
+            trace_id=str(obs.get("trace_id") or ""),
+        )
+        span = _span_from_observation(obs, findings=findings)
+        session["spans"].append(span)
+        if span["verdict"] == "blocked":
+            session["blocked_count"] += 1
+        else:
+            session["observed_count"] += 1
+
+    for raw_session in sessions:
+        session_id = str(raw_session.get("session_id") or "")
+        if not session_id:
+            continue
+        session = _ensure_session(
+            session_id,
+            agent=str(raw_session.get("agent_name") or ""),
+            trace_id=str(raw_session.get("trace_id") or ""),
+        )
+        session.setdefault("first_seen", raw_session.get("first_seen"))
+        session.setdefault("last_seen", raw_session.get("last_seen"))
+        session.setdefault("observation_count", raw_session.get("observation_count"))
+
+    sessions_out = sorted(session_map.values(), key=lambda row: str(row.get("last_seen") or row.get("session_id")), reverse=True)
+    for session in sessions_out:
+        session["spans"].sort(key=lambda span: str(span.get("timestamp") or ""), reverse=True)
+
+    total_blocked = sum(int(s.get("blocked_count") or 0) for s in sessions_out)
+    total_spans = sum(len(s.get("spans") or []) for s in sessions_out)
+
+    return {
+        "schema_version": "runtime.trace_explorer.v1",
+        "tenant_id": tenant_id,
+        "session_count": len(sessions_out),
+        "span_count": total_spans,
+        "blocked_count": total_blocked,
+        "sessions": sessions_out,
+    }
+
+
+__all__ = ["build_trace_explorer_payload", "correlate_findings"]

--- a/src/agent_bom/api/trace_explorer.py
+++ b/src/agent_bom/api/trace_explorer.py
@@ -7,7 +7,7 @@ compliance controls, policy block reason).
 
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import Any, Mapping, Sequence
 
 
 def _norm(value: object) -> str:
@@ -18,7 +18,7 @@ def correlate_findings(
     *,
     agent: str,
     tool: str,
-    findings: list[Mapping[str, Any]],
+    findings: Sequence[Mapping[str, Any]],
     limit: int = 5,
 ) -> list[dict[str, Any]]:
     """Return findings whose agent/tool exposure overlaps this runtime event."""
@@ -32,7 +32,7 @@ def correlate_findings(
         if not isinstance(row, Mapping):
             continue
         agents = {_norm(a) for a in (row.get("affected_agents") or []) if _norm(a)}
-        tools = set()
+        tools: set[str] = set()
         for key in ("exposed_tools", "reachable_tools", "phantom_tools"):
             tools.update(_norm(t) for t in (row.get(key) or []) if _norm(t))
         if agent_key and agents and agent_key not in agents:
@@ -58,7 +58,7 @@ def correlate_findings(
     return matched
 
 
-def _span_from_feed_event(event: Mapping[str, Any], *, findings: list[Mapping[str, Any]]) -> dict[str, Any]:
+def _span_from_feed_event(event: Mapping[str, Any], *, findings: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     action = str(event.get("action_type") or "")
     agent = str(event.get("agent") or "")
     tool = str(event.get("target") or "")
@@ -84,7 +84,7 @@ def _span_from_feed_event(event: Mapping[str, Any], *, findings: list[Mapping[st
     }
 
 
-def _span_from_observation(obs: Mapping[str, Any], *, findings: list[Mapping[str, Any]]) -> dict[str, Any]:
+def _span_from_observation(obs: Mapping[str, Any], *, findings: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     agent = str(obs.get("agent_name") or "")
     tool = str(obs.get("tool_name") or "")
     verdict = str(obs.get("verdict") or "observed")
@@ -114,10 +114,10 @@ def _span_from_observation(obs: Mapping[str, Any], *, findings: list[Mapping[str
 def build_trace_explorer_payload(
     *,
     tenant_id: str,
-    feed_events: list[Mapping[str, Any]],
-    findings: list[Mapping[str, Any]],
-    sessions: list[Mapping[str, Any]],
-    observations: list[Mapping[str, Any]],
+    feed_events: Sequence[Mapping[str, Any]],
+    findings: Sequence[Mapping[str, Any]],
+    sessions: Sequence[Mapping[str, Any]],
+    observations: Sequence[Mapping[str, Any]],
     limit: int = 100,
 ) -> dict[str, Any]:
     """Build session-grouped trace explorer tree for the UI."""

--- a/tests/test_trace_explorer.py
+++ b/tests/test_trace_explorer.py
@@ -1,0 +1,55 @@
+"""Tests for trace explorer correlation (#3608)."""
+
+from __future__ import annotations
+
+from agent_bom.api.trace_explorer import build_trace_explorer_payload, correlate_findings
+
+
+def test_correlate_findings_matches_agent_and_tool() -> None:
+    findings = [
+        {
+            "id": "CVE-2024-1:pkg",
+            "vulnerability_id": "CVE-2024-1",
+            "affected_agents": ["dev-agent"],
+            "exposed_tools": ["run_shell"],
+            "framework_tags": ["owasp_llm:LLM05"],
+            "runtime_evidence": {"state": "blocked"},
+        }
+    ]
+    matched = correlate_findings(agent="dev-agent", tool="run_shell", findings=findings)
+    assert matched[0]["vulnerability_id"] == "CVE-2024-1"
+    assert "owasp_llm:LLM05" in matched[0]["framework_tags"]
+
+
+def test_build_trace_explorer_payload_groups_blocked_span_with_findings() -> None:
+    payload = build_trace_explorer_payload(
+        tenant_id="tenant-a",
+        feed_events=[
+            {
+                "ts": "2026-07-06T12:00:00Z",
+                "agent": "dev-agent",
+                "action_type": "tool_call_blocked",
+                "target": "run_shell",
+                "detail": "policy",
+                "shadow": False,
+                "source": "proxy",
+            }
+        ],
+        findings=[
+            {
+                "vulnerability_id": "CVE-2024-9",
+                "affected_agents": ["dev-agent"],
+                "exposed_tools": ["run_shell"],
+                "framework_tags": ["nist_csf:ID.RA-01"],
+            }
+        ],
+        sessions=[],
+        observations=[],
+        limit=10,
+    )
+    assert payload["blocked_count"] == 1
+    session = payload["sessions"][0]
+    span = session["spans"][0]
+    assert span["verdict"] == "blocked"
+    assert span["linked_findings"][0]["vulnerability_id"] == "CVE-2024-9"
+    assert "nist_csf:ID.RA-01" in span["compliance_controls"]

--- a/ui/app/traces/page.tsx
+++ b/ui/app/traces/page.tsx
@@ -6,6 +6,7 @@ import {
   AlertTriangle,
   CheckCircle2,
   FileUp,
+  GitBranch,
   Loader2,
   PlayCircle,
   Send,
@@ -14,6 +15,7 @@ import {
 
 import { api, type TraceIngestResponse } from "@/lib/api";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
+import { TraceExplorerPanel } from "@/components/trace-explorer-panel";
 
 const SAMPLE_PAYLOAD = JSON.stringify(
   {
@@ -42,6 +44,7 @@ const SAMPLE_PAYLOAD = JSON.stringify(
 
 export default function TracesPage() {
   const { counts } = useDeploymentContext();
+  const [mode, setMode] = useState<"explorer" | "ingest">("explorer");
   const [payload, setPayload] = useState(SAMPLE_PAYLOAD);
   const [result, setResult] = useState<TraceIngestResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -84,10 +87,32 @@ export default function TracesPage() {
           <h1 className="mt-2 text-3xl font-semibold tracking-tight text-zinc-100">Runtime tool-call correlation</h1>
           <p className="mt-3 text-sm leading-6 text-zinc-400">
             {tracesUnavailable
-              ? "Trace ingest is not enabled for this estate yet. Paste or upload an OTLP JSON export to validate runtime correlation before wiring collectors."
-              : "Review OTLP traces against vulnerable packages and servers already known to agent-bom. This page is for inspection and replay."}{" "}
-            Production collectors should send OTLP JSON to <code className="rounded bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-200">POST /v1/traces</code>.
+              ? "Trace ingest is not enabled for this estate yet. Use the explorer when gateway traffic exists, or paste OTLP JSON to validate correlation."
+              : "Explore blocked and observed tool calls joined to the same findings and compliance controls surfaced in triage."}{" "}
+            Production collectors send OTLP JSON to <code className="rounded bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-200">POST /v1/traces</code>.
           </p>
+          <div className="mt-4 inline-flex rounded-xl border border-zinc-800 bg-zinc-900/70 p-1">
+            <button
+              type="button"
+              onClick={() => setMode("explorer")}
+              className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs ${
+                mode === "explorer" ? "bg-emerald-600 text-white" : "text-zinc-400 hover:text-zinc-200"
+              }`}
+            >
+              <GitBranch className="h-3.5 w-3.5" />
+              Explorer
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode("ingest")}
+              className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs ${
+                mode === "ingest" ? "bg-emerald-600 text-white" : "text-zinc-400 hover:text-zinc-200"
+              }`}
+            >
+              <FileUp className="h-3.5 w-3.5" />
+              OTLP ingest
+            </button>
+          </div>
         </div>
         <div className="grid gap-3 text-xs text-zinc-400 sm:grid-cols-2 lg:w-[360px]">
           <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4">
@@ -103,6 +128,9 @@ export default function TracesPage() {
         </div>
       </div>
 
+      {mode === "explorer" ? (
+        <TraceExplorerPanel />
+      ) : (
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-[1.05fr_0.95fr]">
         <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-5">
           <div className="flex items-center justify-between gap-3">
@@ -261,6 +289,7 @@ export default function TracesPage() {
           )}
         </section>
       </div>
+      )}
     </div>
   );
 }

--- a/ui/components/finding-drawer.tsx
+++ b/ui/components/finding-drawer.tsx
@@ -128,6 +128,11 @@ function VulnDetailPanel({
                   Runtime {vuln.runtime_evidence.state}
                 </span>
               )}
+              {vuln.runtime_evidence?.state === "blocked" && (
+                <Link href="/traces" className="text-xs text-emerald-300 hover:underline">
+                  Open trace explorer
+                </Link>
+              )}
             </div>
           )}
           <div className="grid gap-3 md:grid-cols-2">

--- a/ui/components/trace-explorer-panel.tsx
+++ b/ui/components/trace-explorer-panel.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { AlertTriangle, ChevronRight, Loader2, ShieldAlert } from "lucide-react";
+
+import { api } from "@/lib/api";
+import type { TraceExplorerResponse } from "@/lib/api-types";
+
+export function TraceExplorerPanel() {
+  const [data, setData] = useState<TraceExplorerResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await api.getTraceExplorer(120);
+        if (!cancelled) {
+          setData(response);
+          const firstSession = response.sessions[0];
+          const firstSpan = firstSession?.spans[0];
+          setSelectedSessionId(firstSession?.session_id ?? null);
+          setSelectedSpanId(firstSpan?.span_id ?? null);
+        }
+      } catch (e: unknown) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const selectedSession = useMemo(
+    () => data?.sessions.find((session) => session.session_id === selectedSessionId) ?? null,
+    [data, selectedSessionId],
+  );
+  const selectedSpan = useMemo(
+    () => selectedSession?.spans.find((span) => span.span_id === selectedSpanId) ?? null,
+    [selectedSession, selectedSpanId],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 rounded-2xl border border-zinc-800 bg-zinc-900/50 px-4 py-10 text-sm text-zinc-400">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading runtime trace explorer…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-900/50 bg-red-950/30 px-4 py-3 text-sm text-red-300">
+        {error}
+      </div>
+    );
+  }
+
+  if (!data || data.sessions.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-zinc-800 bg-zinc-900/40 px-4 py-10 text-center text-sm text-zinc-500">
+        No runtime sessions yet. Gateway/proxy blocks and authorized tool calls will appear here once enforcement traffic is flowing.
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-4 xl:grid-cols-[280px_minmax(0,1fr)_320px]">
+      <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-4">
+        <h2 className="text-sm font-semibold text-zinc-200">Sessions</h2>
+        <p className="mt-1 text-xs text-zinc-500">{data.session_count} sessions · {data.blocked_count} blocked spans</p>
+        <div className="mt-4 space-y-2">
+          {data.sessions.map((session) => (
+            <button
+              key={session.session_id}
+              type="button"
+              onClick={() => {
+                setSelectedSessionId(session.session_id);
+                setSelectedSpanId(session.spans[0]?.span_id ?? null);
+              }}
+              className={`w-full rounded-xl border px-3 py-2 text-left transition-colors ${
+                selectedSessionId === session.session_id
+                  ? "border-emerald-700/60 bg-emerald-950/30"
+                  : "border-zinc-800 bg-zinc-950/60 hover:border-zinc-700"
+              }`}
+            >
+              <div className="text-sm font-medium text-zinc-100">{session.agent || session.session_id}</div>
+              <div className="mt-1 text-xs text-zinc-500">
+                {session.spans.length} spans · {session.blocked_count} blocked
+              </div>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-4">
+        <h2 className="text-sm font-semibold text-zinc-200">Flow</h2>
+        <p className="mt-1 text-xs text-zinc-500">Tool-call timeline for the selected session.</p>
+        <div className="mt-4 space-y-2">
+          {(selectedSession?.spans ?? []).map((span) => (
+            <button
+              key={span.span_id}
+              type="button"
+              onClick={() => setSelectedSpanId(span.span_id)}
+              className={`flex w-full items-center gap-3 rounded-xl border px-3 py-3 text-left transition-colors ${
+                selectedSpanId === span.span_id
+                  ? "border-sky-700/60 bg-sky-950/20"
+                  : "border-zinc-800 bg-zinc-950/60 hover:border-zinc-700"
+              }`}
+            >
+              <span
+                className={`inline-flex h-8 w-8 items-center justify-center rounded-full border ${
+                  span.verdict === "blocked"
+                    ? "border-rose-800 bg-rose-950 text-rose-300"
+                    : "border-sky-800 bg-sky-950 text-sky-300"
+                }`}
+              >
+                {span.verdict === "blocked" ? <ShieldAlert className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate font-mono text-xs text-zinc-200">{span.tool || span.action_type}</span>
+                <span className="mt-1 block text-[11px] text-zinc-500">{span.timestamp || "—"} · {span.verdict}</span>
+              </span>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-4">
+        <h2 className="text-sm font-semibold text-zinc-200">Detail</h2>
+        {!selectedSpan ? (
+          <p className="mt-4 text-sm text-zinc-500">Select a span to inspect policy and finding joins.</p>
+        ) : (
+          <div className="mt-4 space-y-4 text-sm">
+            <div>
+              <div className="text-[11px] uppercase tracking-wide text-zinc-500">Tool call</div>
+              <div className="mt-1 font-mono text-zinc-100">{selectedSpan.tool || "unknown"}</div>
+              <div className="mt-2 text-xs text-zinc-400">{selectedSpan.detail}</div>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <span className={`rounded border px-2 py-0.5 text-xs uppercase ${
+                selectedSpan.verdict === "blocked"
+                  ? "border-rose-800 bg-rose-950 text-rose-300"
+                  : "border-sky-800 bg-sky-950 text-sky-300"
+              }`}>
+                {selectedSpan.verdict}
+              </span>
+              <span className="rounded border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-xs text-zinc-300">
+                {selectedSpan.agent}
+              </span>
+            </div>
+            <div>
+              <div className="text-[11px] uppercase tracking-wide text-zinc-500">Linked findings</div>
+              {selectedSpan.linked_findings.length === 0 ? (
+                <p className="mt-2 text-xs text-zinc-500">No correlated CVE findings for this agent/tool path.</p>
+              ) : (
+                <div className="mt-2 space-y-2">
+                  {selectedSpan.linked_findings.map((finding) => (
+                    <div key={String(finding.finding_id)} className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
+                      <div className="flex items-center justify-between gap-2">
+                        <Link href={`/vulns?cve=${encodeURIComponent(String(finding.vulnerability_id || ""))}`} className="font-mono text-xs text-emerald-300 hover:underline">
+                          {finding.vulnerability_id}
+                        </Link>
+                        {finding.effective_reach_band ? (
+                          <span className="text-[10px] uppercase text-amber-300">{finding.effective_reach_band}</span>
+                        ) : null}
+                      </div>
+                      {finding.policy_state ? (
+                        <div className="mt-1 flex items-center gap-1 text-xs text-rose-300">
+                          <AlertTriangle className="h-3 w-3" />
+                          Runtime {finding.policy_state}
+                        </div>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+            {selectedSpan.compliance_controls.length > 0 && (
+              <div>
+                <div className="text-[11px] uppercase tracking-wide text-zinc-500">Compliance controls</div>
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {selectedSpan.compliance_controls.map((tag) => (
+                    <span key={tag} className="rounded border border-zinc-700 bg-zinc-900 px-2 py-0.5 font-mono text-[10px] text-zinc-300">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2309,6 +2309,43 @@ export interface TraceIngestResponse {
   message?: string | undefined;
 }
 
+export interface TraceExplorerSpan {
+  span_id: string;
+  timestamp?: string | undefined;
+  agent: string;
+  tool: string;
+  action_type: string;
+  verdict: string;
+  detail?: string | undefined;
+  linked_findings: Array<{
+    finding_id?: string | undefined;
+    vulnerability_id?: string | undefined;
+    severity?: string | undefined;
+    effective_reach_band?: string | undefined;
+    framework_tags?: string[] | undefined;
+    policy_state?: string | undefined;
+  }>;
+  compliance_controls: string[];
+}
+
+export interface TraceExplorerSession {
+  session_id: string;
+  agent?: string | undefined;
+  trace_id?: string | undefined;
+  blocked_count: number;
+  observed_count: number;
+  spans: TraceExplorerSpan[];
+}
+
+export interface TraceExplorerResponse {
+  schema_version: string;
+  tenant_id: string;
+  session_count: number;
+  span_count: number;
+  blocked_count: number;
+  sessions: TraceExplorerSession[];
+}
+
 export interface ProxyStatusResponse {
   status: string;
   message?: string | undefined;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -87,6 +87,7 @@ import type {
   GovernanceReport,
   ActivityTimeline,
   TraceIngestResponse,
+  TraceExplorerResponse,
   ProxyStatusResponse,
   ProxyAlertsResponse,
   AuditEntry,
@@ -264,6 +265,7 @@ export type {
   ActivityTimeline,
   TraceFlaggedCall,
   TraceIngestResponse,
+  TraceExplorerResponse,
   ProxyStatusResponse,
   ProxyAlert,
   ProxyAlertsResponse,
@@ -906,6 +908,7 @@ export const api = {
   // Activity Timeline
   getActivity: (days = 30) => get<ActivityTimeline>(`/v1/activity?days=${days}`),
   ingestTraces: (body: unknown) => post<TraceIngestResponse>("/v1/traces", body),
+  getTraceExplorer: (limit = 100) => get<TraceExplorerResponse>(`/v1/runtime/trace-explorer?limit=${limit}`),
 
   // ── Proxy Runtime ──
   getProxyStatus: () => get<ProxyStatusResponse>("/v1/proxy/status"),


### PR DESCRIPTION
## Summary
- `GET /v1/runtime/trace-explorer` — sessions → spans → linked findings + compliance controls.
- Langfuse-style 3-pane Explorer tab on `/traces`; finding drawer links blocked runtime evidence here.

## Test plan
- [x] `uv run pytest tests/test_trace_explorer.py tests/test_finding_runtime_evidence.py -q`
- [x] `uv run ruff check src/agent_bom/api/trace_explorer.py src/agent_bom/api/routes/observability.py`
- [x] `cd ui && npm run typecheck && npm run build`

## Notes
Closes the buyer loop: **blocked tool call → same finding → same compliance controls** (#3608).

Made with [Cursor](https://cursor.com)