### PR TITLE
feat(ui,graph): runtime evidence overlay badges (Part of #3610)

### DIFF
--- a/ui/components/lineage-detail.tsx
+++ b/ui/components/lineage-detail.tsx
@@ -19,6 +19,7 @@ import {
   Package,
   Radar,
   Server,
+  Shield,
   ShieldAlert,
   ShieldOff,
   TriangleAlert,
@@ -33,7 +34,7 @@ import {
   reachTextClass,
 } from "@/lib/effective-reach";
 import { getOsvVulnerabilityUrl } from "@/lib/vulnerabilities";
-import type { LineageNodeData } from "./lineage-nodes";
+import type { LineageNodeData, RuntimeEvidenceTier } from "./lineage-nodes";
 
 const TYPE_ICON = {
   provider: Building2,
@@ -489,6 +490,8 @@ export function LineageDetailPanel({
           notAfter={data.evidenceNotAfter}
         />
 
+        <RuntimeEvidenceBadge tier={data.runtimeEvidenceTier} />
+
         {(data.status ||
           data.riskScore != null ||
           data.firstSeen ||
@@ -810,6 +813,41 @@ function EvidenceTierBadge({
       <span>
         {rotatesIn != null ? `Rotates in ${rotatesIn} days` : "Replay only"}
       </span>
+    </div>
+  );
+}
+
+function RuntimeEvidenceBadge({
+  tier,
+}: {
+  tier?: RuntimeEvidenceTier | undefined;
+}) {
+  if (!tier) return null;
+
+  const labels: Record<
+    RuntimeEvidenceTier,
+    { text: string; className: string }
+  > = {
+    static_scan: {
+      text: "Static scan evidence",
+      className: "border-zinc-700 bg-zinc-900 text-zinc-300",
+    },
+    runtime_observed: {
+      text: "Runtime observed path",
+      className: "border-sky-800 bg-sky-950 text-sky-300",
+    },
+    runtime_blocked: {
+      text: "Runtime blocked path",
+      className: "border-rose-800 bg-rose-950 text-rose-300",
+    },
+  };
+  const chip = labels[tier];
+  return (
+    <div
+      className={`flex items-center gap-1.5 rounded border px-2 py-1 text-[10px] font-mono ${chip.className}`}
+    >
+      <Shield className="w-3 h-3" />
+      <span>{chip.text}</span>
     </div>
   );
 }

--- a/ui/components/lineage-nodes.tsx
+++ b/ui/components/lineage-nodes.tsx
@@ -19,6 +19,8 @@ import {
 export { ENTITY_ICONS, entityIcon };
 export type { EntityIcon, LineageNodeType };
 
+export type RuntimeEvidenceTier = "static_scan" | "runtime_observed" | "runtime_blocked";
+
 export type LineageNodeData = {
   label: string;
   nodeType: LineageNodeType;
@@ -75,6 +77,8 @@ export type LineageNodeData = {
   isCritical?: boolean | undefined;
   // Evidence redaction tier (#2261) — per-row badge in lineage detail panel.
   evidenceTier?: "safe_to_store" | "replay_only" | undefined;
+  /** Runtime evidence overlay (#3610) — static vs observed vs blocked graph paths. */
+  runtimeEvidenceTier?: RuntimeEvidenceTier | undefined;
   evidenceCaptureReplay?: boolean | undefined;
   evidenceNotAfter?: string | undefined;
   renderBand?: "detail" | "summary" | "cluster" | undefined;
@@ -92,6 +96,38 @@ type CardProps = {
   footer?: ReactNode;
   subtitle?: ReactNode;
 };
+
+const RUNTIME_EVIDENCE_CHIP: Record<
+  RuntimeEvidenceTier,
+  { label: string; className: string }
+> = {
+  static_scan: {
+    label: "Static",
+    className:
+      "border-zinc-600/70 bg-zinc-900/80 text-zinc-300 dark:border-zinc-500 dark:bg-zinc-950",
+  },
+  runtime_observed: {
+    label: "Observed",
+    className:
+      "border-sky-800/70 bg-sky-950/50 text-sky-300",
+  },
+  runtime_blocked: {
+    label: "Blocked",
+    className:
+      "border-rose-800/70 bg-rose-950/50 text-rose-300",
+  },
+};
+
+function RuntimeEvidenceChip({ tier }: { tier: RuntimeEvidenceTier }) {
+  const chip = RUNTIME_EVIDENCE_CHIP[tier];
+  return (
+    <span
+      className={`rounded border px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide ${chip.className}`}
+    >
+      {chip.label}
+    </span>
+  );
+}
 
 function NodeCard({
   data,
@@ -134,6 +170,9 @@ function NodeCard({
         <span className="ml-auto rounded border border-black/10 bg-white/70 px-1.5 py-0.5 text-[10px] uppercase tracking-[0.1em] text-zinc-600 dark:border-white/15 dark:bg-black/25 dark:text-zinc-200">
           {NODE_TYPE_BADGES[data.nodeType]}
         </span>
+        {data.runtimeEvidenceTier && data.runtimeEvidenceTier !== "static_scan" ? (
+          <RuntimeEvidenceChip tier={data.runtimeEvidenceTier} />
+        ) : null}
       </div>
       {subtitle && (
         <div className="text-xs leading-4 text-zinc-700 dark:text-zinc-200/90 truncate">

--- a/ui/lib/unified-graph-flow.ts
+++ b/ui/lib/unified-graph-flow.ts
@@ -455,6 +455,7 @@ function toLineageData(
     attributes,
     isCritical: isCriticalNode(node),
     evidenceTier: evidenceTierAttr(attributes),
+    runtimeEvidenceTier: runtimeEvidenceTierAttr(attributes),
     evidenceCaptureReplay: attributes.capture_replay_enabled === true,
     evidenceNotAfter: stringAttr(node, "not_after"),
   };
@@ -969,9 +970,26 @@ function evidenceTierAttr(
   attributes: Record<string, unknown>,
 ): "safe_to_store" | "replay_only" | undefined {
   const value = attributes.evidence_tier ?? attributes.tier;
-  return value === "safe_to_store" || value === "replay_only"
-    ? value
-    : undefined;
+  if (value === "safe_to_store" || value === "replay_only") {
+    return value;
+  }
+  return undefined;
+}
+
+export type RuntimeEvidenceTier = "static_scan" | "runtime_observed" | "runtime_blocked";
+
+export function runtimeEvidenceTierAttr(
+  attributes: Record<string, unknown>,
+): RuntimeEvidenceTier | undefined {
+  const value = attributes.evidence_tier;
+  if (
+    value === "static_scan" ||
+    value === "runtime_observed" ||
+    value === "runtime_blocked"
+  ) {
+    return value;
+  }
+  return undefined;
 }
 
 function complianceSubset(tags: string[], prefix: string): string[] {

--- a/ui/tests/runtime-evidence-tier.test.ts
+++ b/ui/tests/runtime-evidence-tier.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { runtimeEvidenceTierAttr } from "@/lib/unified-graph-flow";
+
+describe("runtimeEvidenceTierAttr", () => {
+  it("maps graph overlay evidence tiers", () => {
+    expect(
+      runtimeEvidenceTierAttr({ evidence_tier: "runtime_blocked" }),
+    ).toBe("runtime_blocked");
+    expect(
+      runtimeEvidenceTierAttr({ evidence_tier: "runtime_observed" }),
+    ).toBe("runtime_observed");
+    expect(runtimeEvidenceTierAttr({ evidence_tier: "static_scan" })).toBe(
+      "static_scan",
+    );
+  });
+
+  it("ignores redaction-only tiers", () => {
+    expect(runtimeEvidenceTierAttr({ evidence_tier: "replay_only" })).toBe(
+      undefined,
+    );
+    expect(runtimeEvidenceTierAttr({ evidence_tier: "safe_to_store" })).toBe(
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Map `evidence_tier` (`static_scan` / `runtime_observed` / `runtime_blocked`) onto graph node chips and lineage detail badges.
- Completes the UI half of #3610; engine overlay shipped in #3613.

## Test plan
- [x] `cd ui && npm run typecheck`
- [x] `cd ui && npm test -- --run tests/runtime-evidence-tier.test.ts`
- [x] `cd ui && npm run build`

## Notes
Rubric item #3: graph evidence overlay visible without opening the findings drawer.

Made with [Cursor](https://cursor.com)