### PR TITLE
feat(proof): release smoke, demo estate, trust doc, proof-path nav (#3618)

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,8 +53,8 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 249 |
-| `docs/openapi/v1.json` | component schemas | 65 |
+| `docs/openapi/v1.json` | paths | 251 |
+| `docs/openapi/v1.json` | component schemas | 66 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -125,6 +125,15 @@ For the curated dashboard demo:
 scripts/demo/load-dashboard-demo.sh http://127.0.0.1:8422
 ```
 
+Or bootstrap a labeled estate on first API start:
+
+```bash
+agent-bom api --demo-estate --allow-insecure-no-auth
+```
+
+See [`TRUST.md`](TRUST.md) for what runs in your boundary and how demo data is
+labeled in the UI.
+
 For the sample project, export JSON and push it through your normal API import
 flow:
 
@@ -146,6 +155,15 @@ agent-bom agents -p .
 
 Add `--inventory <file>` when you already have agent/server inventory from a
 fleet collector, SIEM export, or manually curated source of truth.
+
+## 5. Release smoke (pre-tag)
+
+```bash
+./scripts/release_smoke.sh
+```
+
+Proves install → offline demo scan → CSV export. Optional API health when
+`AGENT_BOM_RELEASE_SMOKE_API_URL` is set.
 Add `--inventory-only` when that file is the complete evidence boundary and
 you do not want project, cwd, skill, model, dataset, or secret auto-discovery
 merged into the result.

--- a/docs/PRODUCT_BOUNDARIES.md
+++ b/docs/PRODUCT_BOUNDARIES.md
@@ -77,3 +77,5 @@ Avoid unless a future release proves it:
 - "all cloud identity providers have live ingestion parity"
 
 See the site-docs page for the full lane matrix and release checklist.
+
+Trust boundary and verification hooks: [`TRUST.md`](TRUST.md).

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -82,6 +82,7 @@ reports. Demo estates are watermarked **Demo data — simulated estate** in the 
 | Release smoke | `./scripts/release_smoke.sh` |
 | Pre-tag consistency | `scripts/preflight_release.sh` |
 | Pilot install | `scripts/pilot-verify.sh <url> <api-key>` |
+| Runtime HITL queue | `GET /v1/runtime/approval-queue` · decisions require `policy.manage` |
 | Product screenshots | `cd ui && npm run capture:product-proof` |
 
 ## Questions this page answers

--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -1,0 +1,101 @@
+# Trust and deployment boundary
+
+One-page reference for buyers and operators evaluating **agent-bom** in their
+own environment. For product lanes and hosted POC limits see
+[`PRODUCT_BOUNDARIES.md`](PRODUCT_BOUNDARIES.md).
+
+## What runs where
+
+| Component | Default location | Customer control |
+|---|---|---|
+| CLI scanner | Workstation / CI runner | Customer executes; no hosted dependency |
+| Control plane API + UI | Customer VPC / cluster / laptop | Self-hosted Helm, Docker, or local `agent-bom api` |
+| Graph + findings store | Customer SQLite or Postgres | Data never leaves the configured boundary |
+| Runtime proxy / gateway | Customer network path | Optional enforcement lane; fail-closed by policy |
+| Vulnerability intel | OSV/GHSA/NVD when online; bundled demo DB offline | Network egress is operator-controlled |
+
+Managed multi-tenant SaaS is **not** shipped from this repository. Gated hosted
+POC environments exist only for limited evaluation and are labeled as demo
+estate data.
+
+## Tenant isolation
+
+- Every API request resolves a **tenant id** (header, session, or trusted-proxy
+  binding). Cross-tenant reads and writes are rejected.
+- Postgres deployments can enable row-level security policies; SQLite pilots use
+  separate files per environment.
+- API keys, OIDC sessions, SAML assertions, and SCIM tokens are validated
+  before route handlers run. Anonymous access is opt-in for local development
+  only.
+- Audit log entries are append-only and can be signed for tamper evidence
+  (see compliance export paths).
+
+## What we store (and do not)
+
+**Stored:** inventory metadata, advisory-backed findings, graph nodes/edges,
+credential **names** and refs, compliance control mappings, runtime event
+metadata, audit actions.
+
+**Not stored by default:** plaintext secrets, cloud API secret values, raw model
+weights, or buyer source code (unless explicitly scanned from a path the
+operator provides).
+
+Redaction and `sanitize_error` / `sanitize_text` guards apply on API and log
+paths so raw exceptions do not leak paths, ARNs, or connection strings.
+
+## How evidence is derived
+
+1. **Discovery** — agents, MCP servers, packages, cloud connectors, fleet
+   heartbeats.
+2. **Reachability** — symbol/graph reach, effective reach bands, runtime
+   observed/blocked tool calls.
+3. **Posture** — CNAPP-style overlays, IAM effective permissions, governance
+   drift.
+4. **Export** — JSON, CSV, Parquet, SARIF, CycloneDX, and signed compliance
+   bundles share the same underlying finding rows (`framework_tags` parity on
+   API/CSV/Parquet).
+
+The finding drawer **Why it matters** block summarizes reach, runtime state,
+blast radius, and compliance tags so operators do not have to read four screens
+to prioritize.
+
+## First proof commands
+
+```bash
+# Local scanner (no network)
+agent-bom agents --demo --offline
+
+# Release smoke (install → scan → export)
+./scripts/release_smoke.sh
+
+# Labeled control plane estate
+agent-bom api --demo-estate --allow-insecure-no-auth
+```
+
+Artifact: terminal findings, dashboard queue/graph/runtime surfaces, exportable
+reports. Demo estates are watermarked **Demo data — simulated estate** in the UI.
+
+## Verification hooks
+
+| Check | Command |
+|---|---|
+| Release smoke | `./scripts/release_smoke.sh` |
+| Pre-tag consistency | `scripts/preflight_release.sh` |
+| Pilot install | `scripts/pilot-verify.sh <url> <api-key>` |
+| Product screenshots | `cd ui && npm run capture:product-proof` |
+
+## Questions this page answers
+
+| Question | Answer |
+|---|---|
+| Is inventory accurate? | Advisory-backed CVE matching + reproducible `--demo --offline` path with regression tests |
+| Is data isolated? | Tenant-scoped stores; auth-by-default API |
+| What runs in my cloud? | Everything except optional external intel fetches you enable |
+| Can I export for audit? | CSV/Parquet/SARIF/compliance bundles from the same finding model |
+
+For step-by-step onboarding see [`FIRST_RUN.md`](FIRST_RUN.md).
+
+## Related docs
+
+- [`TRUST.md`](TRUST.md) — tenant boundary, evidence derivation, verification hooks
+- [`PRODUCT_BOUNDARIES.md`](PRODUCT_BOUNDARIES.md) — OSS vs self-hosted vs hosted POC lanes

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -3501,6 +3501,25 @@
         ],
         "title": "VersionInfo",
         "type": "object"
+      },
+      "_HitlDecisionBody": {
+        "additionalProperties": false,
+        "properties": {
+          "decision": {
+            "title": "Decision",
+            "type": "string"
+          },
+          "note": {
+            "default": "",
+            "title": "Note",
+            "type": "string"
+          }
+        },
+        "required": [
+          "decision"
+        ],
+        "title": "_HitlDecisionBody",
+        "type": "object"
       }
     }
   },
@@ -18836,6 +18855,221 @@
         "summary": "Receive Push",
         "tags": [
           "push"
+        ]
+      }
+    },
+    "/v1/runtime/approval-queue": {
+      "get": {
+        "description": "List blocked runtime spans awaiting or after human approval (#3617).",
+        "operationId": "runtime_approval_queue_v1_runtime_approval_queue_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Runtime Approval Queue V1 Runtime Approval Queue Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Runtime Approval Queue",
+        "tags": [
+          "runtime",
+          "observability"
+        ]
+      }
+    },
+    "/v1/runtime/approval-queue/{item_id}/decision": {
+      "post": {
+        "description": "Approve or deny a blocked runtime span; emits a signed audit event.",
+        "operationId": "runtime_approval_decision_v1_runtime_approval_queue__item_id__decision_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "item_id",
+            "required": true,
+            "schema": {
+              "title": "Item Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/_HitlDecisionBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Runtime Approval Decision V1 Runtime Approval Queue  Item Id  Decision Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Runtime Approval Decision",
+        "tags": [
+          "runtime",
+          "observability"
         ]
       }
     },

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -2313,6 +2313,20 @@ components:
       - version
       title: VersionInfo
       type: object
+    _HitlDecisionBody:
+      additionalProperties: false
+      properties:
+        decision:
+          title: Decision
+          type: string
+        note:
+          default: ''
+          title: Note
+          type: string
+      required:
+      - decision
+      title: _HitlDecisionBody
+      type: object
 info:
   description: "Security scanner for AI supply chain and infrastructure \u2014 map\
     \ the full trust chain from agents to CVEs, credentials, and blast radius."
@@ -12237,6 +12251,130 @@ paths:
       summary: Receive Push
       tags:
       - push
+  /v1/runtime/approval-queue:
+    get:
+      description: List blocked runtime spans awaiting or after human approval (#3617).
+      operationId: runtime_approval_queue_v1_runtime_approval_queue_get
+      parameters:
+      - in: query
+        name: status
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Status
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 100
+          title: Limit
+          type: integer
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Runtime Approval Queue V1 Runtime Approval Queue Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Runtime Approval Queue
+      tags:
+      - runtime
+      - observability
+  /v1/runtime/approval-queue/{item_id}/decision:
+    post:
+      description: Approve or deny a blocked runtime span; emits a signed audit event.
+      operationId: runtime_approval_decision_v1_runtime_approval_queue__item_id__decision_post
+      parameters:
+      - in: path
+        name: item_id
+        required: true
+        schema:
+          title: Item Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/_HitlDecisionBody'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Runtime Approval Decision V1 Runtime Approval Queue  Item
+                  Id  Decision Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Runtime Approval Decision
+      tags:
+      - runtime
+      - observability
   /v1/runtime/blueprints:
     get:
       description: Return canonical role/profile blueprints for runtime policy design.

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -115,6 +115,11 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_DSPM_S3_MAX_BYTES_PER_OBJECT` | `int` | `64 * 1024` | — |
 | `AGENT_BOM_DSPM_S3_MAX_OBJECTS_PER_BUCKET` | `int` | `10` | Content reads are opt-in at the caller/module level. These caps bound the amount of object-store data read when an operator enables object-store sampling. |
 
+## Demo Estate
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_DEMO_ESTATE` | `bool` | `False` | Enables curated demo-estate bootstrap on loopback / hosted proof paths. Off by default so production deployments never seed synthetic estate data unless an operator explicitly opts in. |
+
 ## EPSS Thresholds
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/scripts/bench_findings_read.py
+++ b/scripts/bench_findings_read.py
@@ -80,7 +80,23 @@ def _seed_inmemory_store(count: int, *, tenant_id: str) -> str:
     batch_id = f"bench-{uuid.uuid4().hex}"
     store = InMemoryComplianceHubStore()
     set_compliance_hub_store(store)
-    store.add(tenant_id, _synthetic_findings(count, batch_id=batch_id))
+    chunk = 2000
+    findings = _synthetic_findings(count, batch_id=batch_id)
+    for offset in range(0, len(findings), chunk):
+        store.add(tenant_id, findings[offset : offset + chunk])
+    return batch_id
+
+
+def _seed_sqlite_store(count: int, *, tenant_id: str, db_path: str) -> str:
+    from agent_bom.api.compliance_hub_store import SQLiteComplianceHubStore, set_compliance_hub_store
+
+    batch_id = f"bench-{uuid.uuid4().hex}"
+    store = SQLiteComplianceHubStore(db_path)
+    set_compliance_hub_store(store)
+    chunk = 5000
+    findings = _synthetic_findings(count, batch_id=batch_id)
+    for offset in range(0, len(findings), chunk):
+        store.add(tenant_id, findings[offset : offset + chunk])
     return batch_id
 
 
@@ -134,15 +150,22 @@ def _bench_store_list(
     from agent_bom.api.compliance_hub_store import get_compliance_hub_store
 
     store = get_compliance_hub_store()
+    list_page = getattr(store, "list_page", None)
     for _ in range(warmup):
-        rows = store.list(tenant_id)
-        _ = rows[:limit]
+        if callable(list_page):
+            list_page(tenant_id, limit=limit, offset=0, include_total=False)
+        else:
+            rows = store.list(tenant_id)
+            _ = rows[:limit]
 
     timings: list[float] = []
     for _ in range(samples):
         started = time.perf_counter()
-        rows = store.list(tenant_id)
-        _ = rows[:limit]
+        if callable(list_page):
+            list_page(tenant_id, limit=limit, offset=0, include_total=False)
+        else:
+            rows = store.list(tenant_id)
+            _ = rows[:limit]
         timings.append((time.perf_counter() - started) * 1000)
     return timings
 
@@ -209,7 +232,10 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
     tenant_id = args.tenant_id
     if args.mode in {"api", "store"}:
         _enable_proxy_auth_env()
-        _seed_inmemory_store(args.count, tenant_id=tenant_id)
+        if args.sqlite_db:
+            _seed_sqlite_store(args.count, tenant_id=tenant_id, db_path=args.sqlite_db)
+        else:
+            _seed_inmemory_store(args.count, tenant_id=tenant_id)
 
     if args.mode == "store":
         timings = _bench_store_list(tenant_id=tenant_id, limit=args.limit, samples=args.samples, warmup=args.warmup)
@@ -243,7 +269,7 @@ def _run(args: argparse.Namespace) -> dict[str, Any]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--count", type=int, default=10_000, help="Synthetic findings to seed (default: 10000)")
-    parser.add_argument("--limit", type=int, default=50, help="Page size for list/read (default: 50)")
+    parser.add_argument("--limit", type=int, default=1, help="Page size for list/read (default: 1 — audit regression case)")
     parser.add_argument("--samples", type=int, default=7, help="Timed iterations after warmup (default: 7)")
     parser.add_argument("--warmup", type=int, default=2, help="Warmup iterations (default: 2)")
     parser.add_argument(
@@ -262,8 +288,46 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--tenant-id", default="bench-findings-tenant", help="Tenant scope for seeded findings")
     parser.add_argument("--token", default=os.environ.get("AGENT_BOM_API_TOKEN", ""), help="Bearer token for live API mode")
     parser.add_argument("--timeout", type=float, default=30.0, help="HTTP timeout for live API mode")
+    parser.add_argument(
+        "--sqlite-db",
+        default="",
+        help="Seed SQLiteComplianceHubStore at this path (production-representative hub read path)",
+    )
+    parser.add_argument(
+        "--sweep",
+        default="",
+        help="Comma-separated row counts to benchmark sequentially (e.g. 10000,100000,500000)",
+    )
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON summary")
     args = parser.parse_args(argv)
+
+    if args.sweep:
+        counts = [int(part.strip()) for part in args.sweep.split(",") if part.strip()]
+        if not counts:
+            parser.error("--sweep requires at least one count")
+        summaries: list[dict[str, Any]] = []
+        exit_code = 0
+        for count in counts:
+            sweep_args = argparse.Namespace(**{**vars(args), "count": count, "sweep": ""})
+            try:
+                summary = _run(sweep_args)
+            except (HTTPError, URLError, RuntimeError) as exc:
+                print(f"bench_findings_read: count={count} {exc}", file=sys.stderr)
+                return 2
+            summaries.append(summary)
+            if summary["p50_ms"] > summary["threshold_ms"]:
+                exit_code = 1
+        if args.json:
+            print(json.dumps({"sweep": summaries}, indent=2))
+        else:
+            for summary in summaries:
+                print(
+                    "findings read bench: "
+                    f"mode={summary['mode']} count={summary['count']} limit={summary['limit']} "
+                    f"p50={summary['p50_ms']}ms p95={summary['p95_ms']}ms "
+                    f"threshold={summary['threshold_ms']}ms"
+                )
+        return exit_code
 
     if args.count < 1:
         parser.error("--count must be >= 1")

--- a/scripts/release_smoke.sh
+++ b/scripts/release_smoke.sh
@@ -123,6 +123,23 @@ if [ "$SKIP_UI" != "1" ] && [ -d "$ROOT/ui" ]; then
   fi
 fi
 
+if [ "${AGENT_BOM_RELEASE_SMOKE_FINDINGS_BENCH:-0}" = "1" ]; then
+  bold "Findings read bench (hub limit=1)"
+  if command -v uv >/dev/null 2>&1; then
+    bench_db="$tmp/findings-bench.db"
+    uv run python scripts/bench_findings_read.py \
+      --mode api \
+      --sqlite-db "$bench_db" \
+      --count 10000 \
+      --limit 1 \
+      --p50-threshold-ms 500 \
+      || fail "findings read bench failed"
+    ok "findings read bench passed (10k rows, limit=1)"
+  else
+    fail "uv required for findings read bench"
+  fi
+fi
+
 bold "release smoke passed"
 echo "  version: ${version}"
 echo "  findings: ${vulns}"

--- a/scripts/release_smoke.sh
+++ b/scripts/release_smoke.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# release_smoke.sh — golden-path smoke for a release candidate.
+#
+# Proves install → curated demo scan → structured exports → optional API health.
+# Run before tagging. Non-destructive; uses offline demo advisories only.
+#
+# Usage:
+#   ./scripts/release_smoke.sh
+#   AGENT_BOM_RELEASE_SMOKE_API_URL=http://127.0.0.1:8422 \
+#     AGENT_BOM_API_KEY=... ./scripts/release_smoke.sh
+#
+# Exits non-zero on the first failed check.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+API_URL="${AGENT_BOM_RELEASE_SMOKE_API_URL:-}"
+API_KEY="${AGENT_BOM_API_KEY:-}"
+SKIP_UI="${AGENT_BOM_RELEASE_SMOKE_SKIP_UI:-0}"
+
+bold() { printf "\033[1m%s\033[0m\n" "$*"; }
+ok()   { printf "  \033[32m✓\033[0m %s\n" "$*"; }
+fail() { printf "  \033[31m✗\033[0m %s\n" "$*" >&2; exit 1; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+bold "1/5 CLI install surface"
+if command -v uv >/dev/null 2>&1; then
+  AGENT_BOM_BIN=(uv run agent-bom)
+else
+  AGENT_BOM_BIN=(agent-bom)
+fi
+version="$("${AGENT_BOM_BIN[@]}" --version 2>/dev/null | head -n1 || true)"
+[ -n "$version" ] || fail "agent-bom --version failed"
+ok "CLI reachable ($version)"
+
+bold "2/5 Curated demo scan (offline JSON)"
+json_out="$tmp/demo-report.json"
+if ! "${AGENT_BOM_BIN[@]}" agents --demo --offline --quiet --no-auto-update-db -f json -o "$json_out"; then
+  fail "demo offline scan failed"
+fi
+[ -s "$json_out" ] || fail "demo JSON report is empty"
+agents="$(python3 - "$json_out" <<'PY'
+import json, sys
+report = json.load(open(sys.argv[1]))
+print(len(report.get("agents") or []))
+PY
+)"
+vulns="$(python3 - "$json_out" <<'PY'
+import json, sys
+report = json.load(open(sys.argv[1]))
+findings = report.get("findings") or report.get("vulnerabilities") or []
+print(len(findings))
+PY
+)"
+[ "$agents" -gt 0 ] || fail "demo scan returned zero agents"
+[ "$vulns" -gt 0 ] || fail "demo scan returned zero findings"
+ok "demo scan produced ${agents} agent(s) and ${vulns} finding(s)"
+
+bold "3/5 CSV export"
+csv_out="$tmp/demo-report.csv"
+if ! "${AGENT_BOM_BIN[@]}" agents --demo --offline --quiet --no-auto-update-db -f csv -o "$csv_out"; then
+  fail "demo CSV export failed"
+fi
+[ -s "$csv_out" ] || fail "demo CSV export is empty"
+head_row="$(head -n1 "$csv_out")"
+[[ "$head_row" == *"id"* || "$head_row" == *"cve"* || "$head_row" == *"severity"* ]] \
+  || fail "CSV header does not look like findings export"
+ok "CSV export written"
+
+bold "4/5 Compliance tag parity (when present)"
+python3 - "$json_out" <<'PY' || fail "compliance tag smoke failed"
+import json, sys
+
+report = json.load(open(sys.argv[1]))
+rows = report.get("findings") or report.get("blast_radius") or []
+tagged = 0
+for row in rows:
+    tags = row.get("framework_tags") or row.get("compliance_tags") or []
+    if isinstance(tags, str):
+        tags = [t.strip() for t in tags.split(",") if t.strip()]
+    if tags:
+        tagged += 1
+if not rows:
+    raise SystemExit("no finding rows to inspect")
+if tagged == 0:
+    print("warn: no framework_tags on demo findings — skipping strict check")
+else:
+    print(f"ok: {tagged}/{len(rows)} rows carry framework tags")
+PY
+ok "compliance tag check complete"
+
+if [ -n "$API_URL" ]; then
+  bold "5/5 Optional API health"
+  API_URL="${API_URL%/}"
+  status="$(curl -sS -o "$tmp/health.json" -w "%{http_code}" "${API_URL}/healthz" || true)"
+  [ "$status" = "200" ] || fail "healthz returned ${status}"
+  ok "API healthz OK at ${API_URL}"
+  if [ -n "$API_KEY" ]; then
+  status="$(curl -sS -o "$tmp/auth.json" -w "%{http_code}" \
+    -H "Authorization: Bearer ${API_KEY}" \
+    -H "X-Agent-Bom-Role: admin" \
+    "${API_URL}/v1/auth/debug" || true)"
+    [ "$status" = "200" ] || fail "auth debug returned ${status}"
+    ok "API auth debug OK"
+  fi
+else
+  bold "5/5 Optional API health"
+  ok "skipped (set AGENT_BOM_RELEASE_SMOKE_API_URL to enable)"
+fi
+
+if [ "$SKIP_UI" != "1" ] && [ -d "$ROOT/ui" ]; then
+  bold "UI build (release smoke tail)"
+  if command -v npm >/dev/null 2>&1; then
+    (cd "$ROOT/ui" && npm run typecheck >/dev/null && npm run build >/dev/null) \
+      || fail "UI typecheck/build failed"
+    ok "UI typecheck + build passed"
+  else
+    ok "skipped (npm not installed)"
+  fi
+fi
+
+bold "release smoke passed"
+echo "  version: ${version}"
+echo "  findings: ${vulns}"
+echo "  agents: ${agents}"

--- a/scripts/seed_graph_showcase.py
+++ b/scripts/seed_graph_showcase.py
@@ -21,235 +21,12 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "src"))
 
-from agent_bom.api.agent_identity_store import (  # noqa: E402
-    InMemoryAgentIdentityStore,
-    issue_identity,
-    issue_jit_grant,
-)
 from agent_bom.api.graph_store import SQLiteGraphStore  # noqa: E402
-from agent_bom.graph.cnapp_overlay import apply_cnapp_overlay  # noqa: E402
-from agent_bom.graph.container import UnifiedGraph  # noqa: E402
-from agent_bom.graph.edge import UnifiedEdge  # noqa: E402
-from agent_bom.graph.effective_permissions import apply_effective_permissions  # noqa: E402
-from agent_bom.graph.governance_overlay import apply_governance_overlay  # noqa: E402
-from agent_bom.graph.node import UnifiedNode  # noqa: E402
-from agent_bom.graph.types import EntityType, RelationshipType  # noqa: E402
-
-TENANT = "default"
-SCAN_ID = "showcase"
-
-
-class _DriftIncident:
-    """Shape the governance overlay expects (attribute access)."""
-
-    def __init__(self, *, incident_id, blueprint_id, drift_score, violation_count, top_violations):
-        self.incident_id = incident_id
-        self.blueprint_id = blueprint_id
-        self.drift_score = drift_score
-        self.violation_count = violation_count
-        self.occurrences = violation_count
-        self.status = "open"
-        self.top_violations = top_violations
-
-
-class _DriftStore:
-    """Minimal drift store projecting behavioral-drift incidents."""
-
-    def __init__(self, incidents: list[_DriftIncident]) -> None:
-        self._incidents = incidents
-
-    def list(self, *_a, **_k) -> list[_DriftIncident]:
-        return list(self._incidents)
-
-
-def _build_estate() -> tuple[UnifiedGraph, InMemoryAgentIdentityStore, _DriftStore]:
-    g = UnifiedGraph(scan_id=SCAN_ID, tenant_id=TENANT)
-
-    def node(i: str, t: EntityType, label: str, **attrs) -> str:
-        # severity / risk_score are top-level node fields (severity_id derives
-        # from severity); everything else is an attribute.
-        severity = attrs.pop("severity", "")
-        risk_score = attrs.pop("risk_score", 0.0)
-        g.add_node(
-            UnifiedNode(
-                id=i,
-                entity_type=t,
-                label=label,
-                severity=severity,
-                risk_score=risk_score,
-                attributes=attrs,
-            )
-        )
-        return i
-
-    def edge(s: str, d: str, r: RelationshipType, **kw) -> None:
-        g.add_edge(UnifiedEdge(source=s, target=d, relationship=r, **kw))
-
-    # ── Agents (the fleet) ──────────────────────────────────────────────
-    agents = {
-        "billing-agent": "Billing Copilot",
-        "support-agent": "Support Copilot",
-        "data-pipeline-agent": "Data Pipeline Agent",
-        "devops-agent": "DevOps Agent",
-        "analytics-agent": "Analytics Agent",
-    }
-    for aid, label in agents.items():
-        node(f"agent:{aid}", EntityType.AGENT, label, environment="production")
-
-    # ── MCP servers + tools + packages + CVEs (supply-chain depth) ──────
-    servers = {
-        "mcp-fs": ("billing-agent", ["read_file", "write_file", "run_shell"]),
-        "mcp-db": ("data-pipeline-agent", ["sql_query", "sql_exec"]),
-        "mcp-http": ("support-agent", ["http_get", "http_post"]),
-        "mcp-deploy": ("devops-agent", ["deploy", "rollback", "exec_remote"]),
-        "mcp-warehouse": ("analytics-agent", ["query_warehouse"]),
-    }
-    for sid, (owner, tools) in servers.items():
-        node(f"server:{sid}", EntityType.SERVER, sid)
-        edge(f"agent:{owner}", f"server:{sid}", RelationshipType.USES)
-        for tname in tools:
-            tid = f"tool:{sid}:{tname}"
-            node(tid, EntityType.TOOL, tname)
-            edge(f"server:{sid}", tid, RelationshipType.PROVIDES_TOOL)
-
-    # Vulnerable packages anchoring real CVE chains.
-    pkgs = {
-        "express@4.17.1": ("mcp-http", "CVE-2024-29041", "critical", 9.3),
-        "pyyaml@5.3": ("mcp-db", "CVE-2020-14343", "critical", 9.8),
-        "requests@2.19.0": ("mcp-fs", "CVE-2023-32681", "high", 7.5),
-        "log4j@2.14.0": ("mcp-deploy", "CVE-2021-44228", "critical", 10.0),
-        "pillow@9.0.0": ("mcp-warehouse", "CVE-2022-22817", "high", 8.1),
-    }
-    for purl, (sid, cve, sev, score) in pkgs.items():
-        pid = f"pkg:{purl}"
-        node(pid, EntityType.PACKAGE, purl)
-        edge(f"server:{sid}", pid, RelationshipType.DEPENDS_ON)
-        vid = f"vuln:{cve}"
-        node(vid, EntityType.VULNERABILITY, cve, severity=sev, risk_score=score)
-        edge(pid, vid, RelationshipType.VULNERABLE_TO)
-
-    # Exposed credentials on the most privileged server.
-    node("cred:aws-key", EntityType.CREDENTIAL, "AWS_SECRET_ACCESS_KEY")
-    edge("server:mcp-deploy", "cred:aws-key", RelationshipType.EXPOSES_CRED)
-
-    # ── Runtime-observed activity (confirmed reachability) ──────────────
-    for i, (aid, tid) in enumerate(
-        [
-            ("billing-agent", "tool:mcp-fs:run_shell"),
-            ("data-pipeline-agent", "tool:mcp-db:sql_exec"),
-            ("devops-agent", "tool:mcp-deploy:exec_remote"),
-        ]
-    ):
-        cid = f"call:{i}"
-        node(cid, EntityType.TOOL_CALL, "observed invocation")
-        edge(f"agent:{aid}", cid, RelationshipType.INVOKED)
-        edge(cid, tid, RelationshipType.INVOKED)
-
-    # ── Cloud estate: crown-jewel data + exposure + misconfig ───────────
-    # Crown jewel: customer-PII S3 bucket that is BOTH public AND vulnerable.
-    node(
-        "cloud:pii-bucket",
-        EntityType.CLOUD_RESOURCE,
-        "customer-pii-prod (S3)",
-        resource_type="s3",
-        compliance_tags=["PII", "GDPR"],
-    )
-    node("mc:pii-public", EntityType.MISCONFIGURATION, "S3 bucket customer-pii-prod is publicly readable")
-    node("vuln:bucket-acl", EntityType.VULNERABILITY, "CVE-2024-S3ACL", severity="high", risk_score=8.2)
-    edge("mc:pii-public", "cloud:pii-bucket", RelationshipType.AFFECTS)
-    edge("cloud:pii-bucket", "vuln:bucket-acl", RelationshipType.VULNERABLE_TO)
-
-    # Payments DB: sensitive RDS instance.
-    node(
-        "cloud:payments-db",
-        EntityType.CLOUD_RESOURCE,
-        "payments-db (RDS PostgreSQL)",
-        resource_type="rds",
-        compliance_tags=["PCI", "financial"],
-    )
-
-    # Internet-exposed bastion EC2 on port 22 (structured network_exposure).
-    node("cloud:bastion", EntityType.CLOUD_RESOURCE, "prod-bastion (EC2)", resource_type="ec2")
-    node(
-        "mc:sg-open",
-        EntityType.MISCONFIGURATION,
-        "Security group sg-prod allows 0.0.0.0/0 on port 22",
-        network_exposure=[{"resource": "prod-bastion", "from_port": 22, "to_port": 22, "protocol": "tcp", "scope": "internet"}],
-    )
-    edge("mc:sg-open", "cloud:bastion", RelationshipType.AFFECTS)
-
-    # Logs bucket (non-sensitive, for contrast).
-    node("cloud:logs-bucket", EntityType.CLOUD_RESOURCE, "app-logs (S3)", resource_type="s3")
-
-    # ── IAM: users, roles, policies, trust chains (privilege escalation) ─
-    node("user:alice", EntityType.USER, "alice@corp (developer)")
-    node("user:bob", EntityType.USER, "bob@contractor (external)")
-    node("role:prod-admin", EntityType.ROLE, "prod-admin-role")
-    node("role:data-pipeline", EntityType.ROLE, "data-pipeline-role")
-    node("role:readonly", EntityType.ROLE, "readonly-role")
-    # Benign-named custom policy that actually grants iam:* (action-level admin).
-    node("pol:admin", EntityType.POLICY, "AdministratorAccess", privilege_level="admin")
-    node("pol:team-custom", EntityType.POLICY, "team-utility-policy", privilege_level="admin")
-    node("pol:s3-write", EntityType.POLICY, "s3-write-policy", privilege_level="write")
-    node("pol:readonly", EntityType.POLICY, "ViewOnlyAccess", privilege_level="read")
-
-    edge("role:prod-admin", "pol:admin", RelationshipType.ATTACHED)
-    edge("role:data-pipeline", "pol:team-custom", RelationshipType.ATTACHED)  # benign name, admin actions
-    edge("role:data-pipeline", "pol:s3-write", RelationshipType.ATTACHED)
-    edge("role:readonly", "pol:readonly", RelationshipType.ATTACHED)
-
-    # alice (dev) can assume prod-admin → privilege escalation to admin.
-    edge("user:alice", "role:prod-admin", RelationshipType.TRUSTS)
-    # bob (external contractor) can assume data-pipeline role (admin-action custom policy).
-    edge("user:bob", "role:data-pipeline", RelationshipType.TRUSTS)
-
-    # What the roles can reach (direct access edges → effective permissions).
-    edge("role:prod-admin", "cloud:pii-bucket", RelationshipType.CAN_ACCESS)
-    edge("role:prod-admin", "cloud:payments-db", RelationshipType.CAN_ACCESS)
-    edge("role:prod-admin", "cloud:bastion", RelationshipType.CAN_ACCESS)
-    edge("role:data-pipeline", "cloud:payments-db", RelationshipType.CAN_ACCESS)
-    edge("role:data-pipeline", "cloud:logs-bucket", RelationshipType.CAN_ACCESS)
-    edge("role:readonly", "cloud:logs-bucket", RelationshipType.CAN_ACCESS)
-
-    # Agents bind to managed identities / roles (governance label-match).
-    edge("agent:devops-agent", "role:prod-admin", RelationshipType.CAN_ACCESS)
-    edge("agent:data-pipeline-agent", "role:data-pipeline", RelationshipType.CAN_ACCESS)
-
-    # ── Governance: managed identities, JIT grants, drift ───────────────
-    store = InMemoryAgentIdentityStore()
-    for aid, label in agents.items():
-        idn, _ = issue_identity(store, agent_id=label, tenant_id=TENANT, allowed_tools=[])
-        # One over-broad JIT grant per privileged agent.
-        if aid in ("billing-agent", "devops-agent", "data-pipeline-agent"):
-            issue_jit_grant(
-                store,
-                identity_id=idn.identity_id,
-                agent_id=label,
-                tenant_id=TENANT,
-                tool_name="run_shell" if aid == "billing-agent" else "exec_remote",
-                ttl_seconds=3600,
-                approved_by="oncall@corp",
-            )
-
-    drift = _DriftStore(
-        [
-            _DriftIncident(
-                incident_id="drift-001",
-                blueprint_id="DevOps Agent",
-                drift_score=0.78,
-                violation_count=14,
-                top_violations=[{"tool_name": "exec_remote"}],
-            ),
-            _DriftIncident(
-                incident_id="drift-002",
-                blueprint_id="Billing Copilot",
-                drift_score=0.41,
-                violation_count=5,
-                top_violations=[{"tool_name": "run_shell"}],
-            ),
-        ]
-    )
-    return g, store, drift
+from agent_bom.demo_estate.showcase_graph import (  # noqa: E402
+    SHOWCASE_TENANT,
+    apply_showcase_overlays,
+    build_showcase_graph,
+)
 
 
 def main() -> int:
@@ -257,11 +34,8 @@ def main() -> int:
     ap.add_argument("--sqlite-db", default="/tmp/showcase-graph.db", help="Graph DB path to seed")
     args = ap.parse_args()
 
-    g, store, drift = _build_estate()
-
-    cnapp = apply_cnapp_overlay(g)
-    eff = apply_effective_permissions(g)
-    gov = apply_governance_overlay(g, tenant_id=TENANT, identity_store=store, drift_store=drift)
+    g, store, drift = build_showcase_graph(tenant_id=SHOWCASE_TENANT)
+    overlays = apply_showcase_overlays(g, tenant_id=SHOWCASE_TENANT, identity_store=store, drift_store=drift)
 
     db_path = Path(args.sqlite_db).expanduser()
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -269,9 +43,9 @@ def main() -> int:
     graph_store.save_graph(g)
 
     print(f"Seeded {len(g.nodes)} nodes / {len(g.edges)} edges → {db_path}")
-    print(f"  cnapp:  {cnapp}")
-    print(f"  effperm:{eff}")
-    print(f"  gov:    {gov}")
+    print(f"  cnapp:  {overlays['cnapp']}")
+    print(f"  effperm:{overlays['effective_permissions']}")
+    print(f"  gov:    {overlays['governance']}")
     print(f"  risks:  {len(g.interaction_risks)} interaction risks")
     print(f"\nBoot the API against it:\n  AGENT_BOM_GRAPH_DB={db_path} agent-bom api")
     return 0

--- a/src/agent_bom/api/hitl_approval_queue.py
+++ b/src/agent_bom/api/hitl_approval_queue.py
@@ -1,0 +1,111 @@
+"""Build HITL approval queue items from blocked runtime spans."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from agent_bom.api.hitl_approval_store import (
+    HitlApprovalRecord,
+    HitlApprovalStore,
+    HitlDecisionStatus,
+    hitl_item_id,
+)
+
+
+def _finding_ids(span: Mapping[str, Any]) -> list[str]:
+    ids: list[str] = []
+    for row in span.get("linked_findings") or []:
+        if not isinstance(row, Mapping):
+            continue
+        fid = str(row.get("finding_id") or row.get("vulnerability_id") or "").strip()
+        if fid:
+            ids.append(fid)
+    return ids
+
+
+def build_hitl_queue_items(
+    *,
+    tenant_id: str,
+    trace_payload: Mapping[str, Any],
+    store: HitlApprovalStore,
+    status_filter: str | None = None,
+) -> list[dict[str, Any]]:
+    """Merge blocked spans with persisted approval decisions."""
+    decisions = {row.item_id: row for row in store.list_for_tenant(tenant_id)}
+    items: list[dict[str, Any]] = []
+
+    for session in trace_payload.get("sessions") or []:
+        if not isinstance(session, Mapping):
+            continue
+        session_id = str(session.get("session_id") or "")
+        for span in session.get("spans") or []:
+            if not isinstance(span, Mapping):
+                continue
+            if str(span.get("verdict") or "") != "blocked":
+                continue
+            span_id = str(span.get("span_id") or "")
+            if not span_id:
+                continue
+            item_id = hitl_item_id(tenant_id=tenant_id, span_id=span_id)
+            existing = decisions.get(item_id)
+            status = existing.status.value if existing else HitlDecisionStatus.PENDING.value
+            if status_filter and status != status_filter:
+                continue
+            items.append(
+                {
+                    "item_id": item_id,
+                    "tenant_id": tenant_id,
+                    "span_id": span_id,
+                    "session_id": session_id,
+                    "agent": str(span.get("agent") or ""),
+                    "tool": str(span.get("tool") or ""),
+                    "timestamp": span.get("timestamp"),
+                    "detail": str((existing.detail if existing else span.get("detail")) or ""),
+                    "source": span.get("source"),
+                    "status": status,
+                    "linked_findings": span.get("linked_findings") or [],
+                    "linked_finding_ids": existing.linked_finding_ids if existing else _finding_ids(span),
+                    "compliance_controls": span.get("compliance_controls") or [],
+                    "decided_by": existing.decided_by if existing else "",
+                    "decided_at": existing.decided_at if existing else "",
+                    "note": existing.note if existing else "",
+                }
+            )
+
+    items.sort(key=lambda row: str(row.get("timestamp") or ""), reverse=True)
+    return items
+
+
+def apply_hitl_decision(
+    *,
+    tenant_id: str,
+    item_id: str,
+    decision: str,
+    actor: str,
+    note: str,
+    queue_item: Mapping[str, Any],
+    store: HitlApprovalStore,
+) -> HitlApprovalRecord:
+    normalized = decision.strip().lower()
+    if normalized not in {"approve", "deny"}:
+        raise ValueError("decision must be approve or deny")
+    status = HitlDecisionStatus.APPROVED if normalized == "approve" else HitlDecisionStatus.DENIED
+    from datetime import datetime, timezone
+
+    record = HitlApprovalRecord(
+        item_id=item_id,
+        tenant_id=tenant_id,
+        span_id=str(queue_item.get("span_id") or ""),
+        session_id=str(queue_item.get("session_id") or ""),
+        agent=str(queue_item.get("agent") or ""),
+        tool=str(queue_item.get("tool") or ""),
+        status=status,
+        detail=str(queue_item.get("detail") or ""),
+        linked_finding_ids=[str(fid) for fid in (queue_item.get("linked_finding_ids") or []) if str(fid).strip()],
+        compliance_controls=[str(tag) for tag in (queue_item.get("compliance_controls") or []) if str(tag).strip()],
+        decided_by=actor,
+        decided_at=datetime.now(timezone.utc).isoformat(),
+        note=note.strip(),
+    )
+    store.upsert(record)
+    return record

--- a/src/agent_bom/api/hitl_approval_store.py
+++ b/src/agent_bom/api/hitl_approval_store.py
@@ -1,0 +1,243 @@
+"""Human-in-the-loop approval decisions for blocked runtime tool calls."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Protocol
+
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
+
+class HitlDecisionStatus(str, Enum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    DENIED = "denied"
+
+
+@dataclass
+class HitlApprovalRecord:
+    item_id: str
+    tenant_id: str
+    span_id: str
+    session_id: str
+    agent: str
+    tool: str
+    status: HitlDecisionStatus = HitlDecisionStatus.PENDING
+    detail: str = ""
+    linked_finding_ids: list[str] | None = None
+    compliance_controls: list[str] | None = None
+    decided_by: str = ""
+    decided_at: str = ""
+    note: str = ""
+    created_at: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.created_at:
+            self.created_at = datetime.now(timezone.utc).isoformat()
+        if self.linked_finding_ids is None:
+            self.linked_finding_ids = []
+        if self.compliance_controls is None:
+            self.compliance_controls = []
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "item_id": self.item_id,
+            "tenant_id": self.tenant_id,
+            "span_id": self.span_id,
+            "session_id": self.session_id,
+            "agent": self.agent,
+            "tool": self.tool,
+            "status": self.status.value,
+            "detail": self.detail,
+            "linked_finding_ids": list(self.linked_finding_ids or []),
+            "compliance_controls": list(self.compliance_controls or []),
+            "decided_by": self.decided_by,
+            "decided_at": self.decided_at,
+            "note": self.note,
+            "created_at": self.created_at,
+        }
+
+
+def hitl_item_id(*, tenant_id: str, span_id: str) -> str:
+    digest = hashlib.sha256(f"{tenant_id}:{span_id}".encode()).hexdigest()[:16]
+    return f"hitl-{digest}"
+
+
+class HitlApprovalStore(Protocol):
+    def upsert(self, record: HitlApprovalRecord) -> None: ...
+    def get(self, item_id: str, *, tenant_id: str) -> HitlApprovalRecord | None: ...
+    def list_for_tenant(self, tenant_id: str) -> list[HitlApprovalRecord]: ...
+
+
+class InMemoryHitlApprovalStore:
+    def __init__(self) -> None:
+        self._store: dict[str, HitlApprovalRecord] = {}
+        self._lock = threading.Lock()
+
+    def upsert(self, record: HitlApprovalRecord) -> None:
+        with self._lock:
+            self._store[record.item_id] = record
+
+    def get(self, item_id: str, *, tenant_id: str) -> HitlApprovalRecord | None:
+        record = self._store.get(item_id)
+        if record is None or record.tenant_id != tenant_id:
+            return None
+        return record
+
+    def list_for_tenant(self, tenant_id: str) -> list[HitlApprovalRecord]:
+        with self._lock:
+            rows = [row for row in self._store.values() if row.tenant_id == tenant_id]
+        return sorted(rows, key=lambda row: row.created_at, reverse=True)
+
+
+class SQLiteHitlApprovalStore:
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        conn: sqlite3.Connection | None = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            self._local.conn = conn
+        return conn
+
+    def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "hitl_approvals")
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS hitl_approvals (
+            item_id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            span_id TEXT NOT NULL,
+            session_id TEXT NOT NULL DEFAULT '',
+            agent TEXT NOT NULL DEFAULT '',
+            tool TEXT NOT NULL DEFAULT '',
+            status TEXT NOT NULL DEFAULT 'pending',
+            detail TEXT NOT NULL DEFAULT '',
+            linked_finding_ids TEXT NOT NULL DEFAULT '[]',
+            compliance_controls TEXT NOT NULL DEFAULT '[]',
+            decided_by TEXT NOT NULL DEFAULT '',
+            decided_at TEXT NOT NULL DEFAULT '',
+            note TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL
+        )"""
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_hitl_tenant ON hitl_approvals(tenant_id)")
+        self._conn.commit()
+
+    def upsert(self, record: HitlApprovalRecord) -> None:
+        import json
+
+        self._conn.execute(
+            """INSERT OR REPLACE INTO hitl_approvals (
+                item_id, tenant_id, span_id, session_id, agent, tool, status, detail,
+                linked_finding_ids, compliance_controls, decided_by, decided_at, note, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                record.item_id,
+                record.tenant_id,
+                record.span_id,
+                record.session_id,
+                record.agent,
+                record.tool,
+                record.status.value,
+                record.detail,
+                json.dumps(record.linked_finding_ids or []),
+                json.dumps(record.compliance_controls or []),
+                record.decided_by,
+                record.decided_at,
+                record.note,
+                record.created_at,
+            ),
+        )
+        self._conn.commit()
+
+    def get(self, item_id: str, *, tenant_id: str) -> HitlApprovalRecord | None:
+        import json
+
+        row = self._conn.execute(
+            "SELECT item_id, tenant_id, span_id, session_id, agent, tool, status, detail, "
+            "linked_finding_ids, compliance_controls, decided_by, decided_at, note, created_at "
+            "FROM hitl_approvals WHERE item_id = ? AND tenant_id = ?",
+            (item_id, tenant_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return HitlApprovalRecord(
+            item_id=row[0],
+            tenant_id=row[1],
+            span_id=row[2],
+            session_id=row[3],
+            agent=row[4],
+            tool=row[5],
+            status=HitlDecisionStatus(row[6]),
+            detail=row[7],
+            linked_finding_ids=json.loads(row[8] or "[]"),
+            compliance_controls=json.loads(row[9] or "[]"),
+            decided_by=row[10],
+            decided_at=row[11],
+            note=row[12],
+            created_at=row[13],
+        )
+
+    def list_for_tenant(self, tenant_id: str) -> list[HitlApprovalRecord]:
+        import json
+
+        rows = self._conn.execute(
+            "SELECT item_id, tenant_id, span_id, session_id, agent, tool, status, detail, "
+            "linked_finding_ids, compliance_controls, decided_by, decided_at, note, created_at "
+            "FROM hitl_approvals WHERE tenant_id = ? ORDER BY created_at DESC",
+            (tenant_id,),
+        ).fetchall()
+        return [
+            HitlApprovalRecord(
+                item_id=row[0],
+                tenant_id=row[1],
+                span_id=row[2],
+                session_id=row[3],
+                agent=row[4],
+                tool=row[5],
+                status=HitlDecisionStatus(row[6]),
+                detail=row[7],
+                linked_finding_ids=json.loads(row[8] or "[]"),
+                compliance_controls=json.loads(row[9] or "[]"),
+                decided_by=row[10],
+                decided_at=row[11],
+                note=row[12],
+                created_at=row[13],
+            )
+            for row in rows
+        ]
+
+
+_hitl_store: HitlApprovalStore | None = None
+_hitl_lock = threading.Lock()
+
+
+def get_hitl_approval_store() -> HitlApprovalStore:
+    global _hitl_store
+    if _hitl_store is None:
+        with _hitl_lock:
+            if _hitl_store is None:
+                import os
+
+                db_path = os.environ.get("AGENT_BOM_DB", "").strip()
+                if db_path:
+                    _hitl_store = SQLiteHitlApprovalStore(db_path)
+                else:
+                    _hitl_store = InMemoryHitlApprovalStore()
+    return _hitl_store
+
+
+def set_hitl_approval_store(store: HitlApprovalStore | None) -> None:
+    global _hitl_store
+    with _hitl_lock:
+        _hitl_store = store

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 from typing import Any, cast
 
 from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, ConfigDict
 
 from agent_bom.api.models import JobStatus, PushPayload, ScanJob, ScanRequest
 from agent_bom.api.pipeline import _persist_graph_snapshot
@@ -740,6 +741,135 @@ async def trace_explorer(
         observations=observations,
         limit=bounded_limit,
     )
+
+
+async def _trace_explorer_payload_for_tenant(tenant_id: str, *, limit: int = 100) -> dict[str, object]:
+    """Shared trace explorer builder for runtime surfaces."""
+    from agent_bom.api.cost_store import get_cost_store
+    from agent_bom.api.routes.gateway_feed import _load_tenant_alerts, build_gateway_feed
+    from agent_bom.api.routes.scan import _completed_jobs_for_tenant, _iter_scan_findings
+    from agent_bom.api.trace_explorer import build_trace_explorer_payload
+
+    bounded_limit = max(1, min(limit, 200))
+    alerts = _load_tenant_alerts(tenant_id)
+    llm_records = list(get_cost_store().list_records(tenant_id, limit=bounded_limit))
+    feed = build_gateway_feed(
+        tenant_id=tenant_id,
+        alerts=alerts,
+        llm_records=llm_records,
+        limit=bounded_limit,
+    )
+    findings: list[dict[str, Any]] = []
+    for job in _completed_jobs_for_tenant(tenant_id):
+        findings.extend(_iter_scan_findings(job))
+    store = get_runtime_event_store()
+    sessions = [session.to_dict() for session in store.list_sessions(tenant_id, limit=bounded_limit, offset=0)]
+    observations = [
+        observation.to_dict()
+        for observation in store.list_observations(tenant_id, limit=bounded_limit, offset=0)
+    ]
+    return build_trace_explorer_payload(
+        tenant_id=tenant_id,
+        feed_events=cast(list[dict[str, Any]], feed.get("events", [])),
+        findings=findings,
+        sessions=sessions,
+        observations=observations,
+        limit=bounded_limit,
+    )
+
+
+@router.get("/v1/runtime/approval-queue", tags=["runtime", "observability"], dependencies=[_dep("read")])
+async def runtime_approval_queue(
+    request: Request,
+    status: str | None = None,
+    limit: int = 100,
+) -> dict[str, object]:
+    """List blocked runtime spans awaiting or after human approval (#3617)."""
+    from agent_bom.api.hitl_approval_queue import build_hitl_queue_items
+    from agent_bom.api.hitl_approval_store import get_hitl_approval_store
+
+    tenant_id = _tenant_id(request)
+    bounded_limit = max(1, min(limit, 200))
+    trace_payload = await _trace_explorer_payload_for_tenant(tenant_id, limit=bounded_limit)
+    status_filter = status.strip().lower() if status else None
+    if status_filter not in {None, "", "pending", "approved", "denied"}:
+        raise HTTPException(status_code=400, detail="status must be pending, approved, or denied")
+    items = build_hitl_queue_items(
+        tenant_id=tenant_id,
+        trace_payload=trace_payload,
+        store=get_hitl_approval_store(),
+        status_filter=status_filter or None,
+    )
+    pending = sum(1 for item in items if item.get("status") == "pending")
+    return {
+        "schema_version": "runtime.approval_queue.v1",
+        "tenant_id": tenant_id,
+        "count": len(items),
+        "pending_count": pending,
+        "items": items[:bounded_limit],
+    }
+
+
+class _HitlDecisionBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    decision: str
+    note: str = ""
+
+
+@router.post(
+    "/v1/runtime/approval-queue/{item_id}/decision",
+    tags=["runtime", "observability"],
+    dependencies=[_dep("policy.manage")],
+)
+async def runtime_approval_decision(request: Request, item_id: str, body: _HitlDecisionBody) -> dict[str, object]:
+    """Approve or deny a blocked runtime span; emits a signed audit event."""
+    from agent_bom.api.audit_log import log_action
+    from agent_bom.api.hitl_approval_queue import apply_hitl_decision, build_hitl_queue_items
+    from agent_bom.api.hitl_approval_store import get_hitl_approval_store
+
+    tenant_id = _tenant_id(request)
+    actor = _triggered_by(request)
+    store = get_hitl_approval_store()
+    trace_payload = await _trace_explorer_payload_for_tenant(tenant_id, limit=200)
+    queue_items = build_hitl_queue_items(
+        tenant_id=tenant_id,
+        trace_payload=trace_payload,
+        store=store,
+    )
+    queue_item = next((item for item in queue_items if item.get("item_id") == item_id), None)
+    if queue_item is None:
+        raise HTTPException(status_code=404, detail="Approval queue item not found")
+    try:
+        record = apply_hitl_decision(
+            tenant_id=tenant_id,
+            item_id=item_id,
+            decision=body.decision,
+            actor=actor,
+            note=body.note,
+            queue_item=queue_item,
+            store=store,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
+
+    log_action(
+        "runtime.hitl_decision",
+        actor=actor,
+        resource=f"runtime/approval-queue/{item_id}",
+        tenant_id=tenant_id,
+        decision=record.status.value,
+        span_id=record.span_id,
+        agent=record.agent,
+        tool=record.tool,
+        linked_finding_ids=record.linked_finding_ids,
+        compliance_controls=record.compliance_controls,
+        note=record.note,
+    )
+    return {
+        "schema_version": "runtime.approval_queue.v1",
+        "item": record.to_dict(),
+    }
 
 
 @router.get("/v1/runtime/sessions/{session_id}/observations", tags=["runtime", "observability"], dependencies=[_dep("read")])

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1334,6 +1334,98 @@ def _finding_sort_key(row: dict[str, Any], sort: str) -> tuple[float, float, flo
     return (-primary, -cvss, -float(sev_rank))
 
 
+_BULK_MERGE_CHUNK = 256
+
+
+def _merged_scan_bulk_page(
+    scan_findings: list[dict[str, Any]],
+    *,
+    bulk_list: Any,
+    tenant_id: str,
+    sort_key: str,
+    severity: str | None,
+    scan_id: str | None,
+    offset: int,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Merge pre-sorted scan findings with bulk hub pages without O(table) work.
+
+  Streams two sorted sources with a two-pointer walk so deep ``offset`` does
+  not require loading ``offset + limit`` bulk rows up front or re-sorting the
+  full combined window in memory.
+    """
+    scan_i = 0
+    bulk_remote_offset = 0
+    bulk_buf: list[dict[str, Any]] = []
+    bulk_i = 0
+
+    def _refill_bulk() -> bool:
+        nonlocal bulk_buf, bulk_i, bulk_remote_offset
+        bulk_result = bulk_list(
+            tenant_id,
+            limit=_BULK_MERGE_CHUNK,
+            offset=bulk_remote_offset,
+            sort=sort_key,
+            severity=severity,
+            scan_id=scan_id,
+            origin="bulk_ingest",
+            include_total=False,
+        )
+        bulk_buf = bulk_result[0]
+        bulk_remote_offset += len(bulk_buf)
+        bulk_i = 0
+        return bool(bulk_buf)
+
+    def bulk_head() -> dict[str, Any] | None:
+        if bulk_i >= len(bulk_buf) and not _refill_bulk():
+            return None
+        return bulk_buf[bulk_i]
+
+    def scan_head() -> dict[str, Any] | None:
+        if scan_i >= len(scan_findings):
+            return None
+        return scan_findings[scan_i]
+
+    def take_scan() -> dict[str, Any]:
+        nonlocal scan_i
+        row = scan_findings[scan_i]
+        scan_i += 1
+        return row
+
+    def take_bulk() -> dict[str, Any]:
+        nonlocal bulk_i
+        row = bulk_buf[bulk_i]
+        bulk_i += 1
+        return row
+
+    def pick_next() -> dict[str, Any] | None:
+        scan_row = scan_head()
+        bulk_row = bulk_head()
+        if scan_row is None and bulk_row is None:
+            return None
+        if bulk_row is None:
+            return take_scan()
+        if scan_row is None:
+            return take_bulk()
+        if _finding_sort_key(scan_row, sort_key) <= _finding_sort_key(bulk_row, sort_key):
+            return take_scan()
+        return take_bulk()
+
+    skipped = 0
+    while skipped < offset:
+        if pick_next() is None:
+            return []
+        skipped += 1
+
+    page: list[dict[str, Any]] = []
+    for _ in range(limit):
+        row = pick_next()
+        if row is None:
+            break
+        page.append(row)
+    return page
+
+
 @router.get("/v1/findings", tags=["scan"])
 async def list_findings(
     request: Request,
@@ -1399,10 +1491,9 @@ async def list_findings(
         warnings.append("cursor pagination applies to bulk-ingested findings only; in-memory scan findings appear on the first page")
     if callable(bulk_list):
         if scan_findings and not cursor:
-            window = offset + limit
             bulk_result = bulk_list(
                 tenant_id,
-                limit=window,
+                limit=1,
                 offset=0,
                 sort=sort_key,
                 severity=severity,
@@ -1410,11 +1501,17 @@ async def list_findings(
                 origin="bulk_ingest",
                 include_total=include_bulk_total,
             )
-            bulk_page = bulk_result[0]
             bulk_total = bulk_result[1]
-            combined = scan_findings + bulk_page
-            combined.sort(key=lambda row: _finding_sort_key(row, sort_key))
-            page_rows = combined[offset : offset + limit]
+            page_rows = _merged_scan_bulk_page(
+                scan_findings,
+                bulk_list=bulk_list,
+                tenant_id=tenant_id,
+                sort_key=sort_key,
+                severity=severity,
+                scan_id=scan_id,
+                offset=offset,
+                limit=limit,
+            )
             resolved_bulk, total_approximate = _resolve_bulk_findings_total(
                 tenant_id=tenant_id,
                 severity=severity,

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -504,6 +504,14 @@ async def _lifespan(app_instance: FastAPI):
         _logger.exception("Distributed scan worker failed to start; continuing single-node")
         _scan_worker = None
 
+    if os.environ.get("AGENT_BOM_DEMO_ESTATE", "").strip().lower() in {"1", "true", "yes", "on"}:
+        try:
+            from agent_bom.demo_estate.bootstrap import maybe_bootstrap_demo_estate
+
+            await asyncio.to_thread(maybe_bootstrap_demo_estate)
+        except Exception:  # noqa: BLE001
+            _logger.warning("demo estate bootstrap skipped", exc_info=True)
+
     yield
 
     # ── Graceful shutdown ──

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -663,6 +663,13 @@ def serve_cmd(
     metavar="ROWS",
     help="Maximum rows to flush per ClickHouse batch.",
 )
+@click.option(
+    "--demo-estate",
+    is_flag=True,
+    default=False,
+    envvar="AGENT_BOM_DEMO_ESTATE",
+    help="Seed a labeled demo graph and curated offline findings on first API start.",
+)
 def api_cmd(
     host: str,
     port: int,
@@ -681,6 +688,7 @@ def api_cmd(
     analytics_buffered: bool,
     analytics_flush_interval: float,
     analytics_max_batch: int,
+    demo_estate: bool,
 ):
     """Start the agent-bom REST API server.
 
@@ -719,6 +727,9 @@ def api_cmd(
     )
 
     import os as _os
+
+    if demo_estate:
+        _os.environ["AGENT_BOM_DEMO_ESTATE"] = "1"
 
     try:
         import uvicorn

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -308,6 +308,13 @@ OLLAMA_BASE_URL = _str("AGENT_BOM_OLLAMA_URL", "http://localhost:11434")
 OIDC_DISCOVERY_SHIM_JSON = _str("AGENT_BOM_OIDC_DISCOVERY_SHIM_JSON", "")
 
 
+# ── Demo Estate ──────────────────────────────────────────────────────────
+# Enables curated demo-estate bootstrap on loopback / hosted proof paths. Off
+# by default so production deployments never seed synthetic estate data unless
+# an operator explicitly opts in.
+DEMO_ESTATE = _bool("AGENT_BOM_DEMO_ESTATE", False)
+
+
 # ── Enrichment Cache ──────────────────────────────────────────────────────
 # Used by enrichment.py for persistent NVD + EPSS disk cache.
 #

--- a/src/agent_bom/demo_estate/__init__.py
+++ b/src/agent_bom/demo_estate/__init__.py
@@ -1,0 +1,1 @@
+"""Demo estate bootstrap and showcase graph helpers."""

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -1,0 +1,137 @@
+"""Bootstrap a labeled demo estate on first API start."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import uuid
+from pathlib import Path
+from typing import Any
+
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.pipeline import _now
+from agent_bom.demo_estate.showcase_graph import SHOWCASE_TENANT, seed_showcase_graph_if_empty
+
+_logger = logging.getLogger(__name__)
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def demo_estate_enabled() -> bool:
+    return os.environ.get("AGENT_BOM_DEMO_ESTATE", "").strip().lower() in _TRUTHY
+
+
+def _tenant_has_demo_jobs(store: Any, tenant_id: str) -> bool:
+    list_fn = getattr(store, "list_all", None)
+    if not callable(list_fn):
+        return False
+    jobs = list_fn(tenant_id=tenant_id)
+    for job in jobs:
+        result = getattr(job, "result", None) or {}
+        sources = result.get("scan_sources") or []
+        if any("demo" in str(src).lower() for src in sources):
+            return True
+    return False
+
+
+def _run_demo_scan_report() -> dict[str, Any]:
+    from click.testing import CliRunner
+
+    from agent_bom.cli import main
+
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as handle:
+        out_path = handle.name
+    try:
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "agents",
+                "--demo",
+                "--offline",
+                "--quiet",
+                "--no-auto-update-db",
+                "-f",
+                "json",
+                "-o",
+                out_path,
+            ],
+        )
+        if result.exit_code != 0:
+            raise RuntimeError(f"demo scan failed: {result.output}")
+        report = json.loads(Path(out_path).read_text(encoding="utf-8"))
+    finally:
+        Path(out_path).unlink(missing_ok=True)
+
+    report.setdefault("scan_sources", [])
+    if "demo" not in report["scan_sources"]:
+        report["scan_sources"].append("demo")
+    if "demo-estate" not in report["scan_sources"]:
+        report["scan_sources"].append("demo-estate")
+    return report
+
+
+def _store_demo_scan_job(report: dict[str, Any], *, tenant_id: str) -> str:
+    from agent_bom.api.stores import _get_store, _jobs_put
+
+    job = ScanJob(
+        job_id=str(uuid.uuid4()),
+        tenant_id=tenant_id,
+        triggered_by="demo-estate-bootstrap",
+        created_at=_now(),
+        request=ScanRequest(offline=True),
+    )
+    job.status = JobStatus.DONE
+    job.completed_at = _now()
+    job.result = report
+    job.progress.append("Seeded demo estate scan (offline curated sample)")
+    store = _get_store()
+    store.put(job)
+    _jobs_put(job.job_id, job)
+    return job.job_id
+
+
+def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str, Any]:
+    """Seed showcase graph + curated findings when demo estate mode is enabled."""
+    if not demo_estate_enabled():
+        return {"enabled": False, "seeded": False}
+
+    from agent_bom.api.stores import _get_graph_store, _get_store
+
+    store = _get_store()
+    graph_store = _get_graph_store()
+    summary: dict[str, Any] = {"enabled": True, "tenant_id": tenant_id, "seeded": False}
+
+    if _tenant_has_demo_jobs(store, tenant_id):
+        summary["reason"] = "demo_jobs_present"
+        return summary
+
+    graph_seeded = seed_showcase_graph_if_empty(graph_store, tenant_id=tenant_id)
+    summary["graph_seeded"] = graph_seeded
+
+    try:
+        report = _run_demo_scan_report()
+        job_id = _store_demo_scan_job(report, tenant_id=tenant_id)
+        summary.update(
+            {
+                "seeded": True,
+                "job_id": job_id,
+                "agents": len(report.get("agents") or []),
+                "findings": len(report.get("findings") or report.get("vulnerabilities") or []),
+            }
+        )
+        _logger.info(
+            "demo estate bootstrap complete tenant=%s graph_seeded=%s job_id=%s findings=%s",
+            tenant_id,
+            graph_seeded,
+            job_id,
+            summary.get("findings"),
+        )
+    except Exception:
+        _logger.warning("demo estate scan bootstrap failed", exc_info=True)
+        summary["seeded"] = graph_seeded
+        summary["scan_error"] = True
+
+    return summary

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -1,0 +1,248 @@
+"""Dense showcase graph for demos, screenshots, and first-session proof."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from agent_bom.api.agent_identity_store import (
+    InMemoryAgentIdentityStore,
+    issue_identity,
+    issue_jit_grant,
+)
+from agent_bom.graph.cnapp_overlay import apply_cnapp_overlay
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.effective_permissions import apply_effective_permissions
+from agent_bom.graph.governance_overlay import apply_governance_overlay
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+if TYPE_CHECKING:
+    from agent_bom.api.graph_store import GraphStoreProtocol
+
+SHOWCASE_TENANT = "default"
+SHOWCASE_SCAN_ID = "showcase"
+
+
+class _DriftIncident:
+    """Shape the governance overlay expects (attribute access)."""
+
+    def __init__(self, *, incident_id, blueprint_id, drift_score, violation_count, top_violations):
+        self.incident_id = incident_id
+        self.blueprint_id = blueprint_id
+        self.drift_score = drift_score
+        self.violation_count = violation_count
+        self.occurrences = violation_count
+        self.status = "open"
+        self.top_violations = top_violations
+
+
+class _DriftStore:
+    """Minimal drift store projecting behavioral-drift incidents."""
+
+    def __init__(self, incidents: list[_DriftIncident]) -> None:
+        self._incidents = incidents
+
+    def list(self, *_a, **_k) -> list[_DriftIncident]:
+        return list(self._incidents)
+
+
+def build_showcase_graph(
+    *,
+    tenant_id: str = SHOWCASE_TENANT,
+    scan_id: str = SHOWCASE_SCAN_ID,
+) -> tuple[UnifiedGraph, InMemoryAgentIdentityStore, _DriftStore]:
+    g = UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id)
+
+    def node(i: str, t: EntityType, label: str, **attrs) -> str:
+        severity = attrs.pop("severity", "")
+        risk_score = attrs.pop("risk_score", 0.0)
+        g.add_node(
+            UnifiedNode(
+                id=i,
+                entity_type=t,
+                label=label,
+                severity=severity,
+                risk_score=risk_score,
+                attributes=attrs,
+            )
+        )
+        return i
+
+    def edge(s: str, d: str, r: RelationshipType, **kw) -> None:
+        g.add_edge(UnifiedEdge(source=s, target=d, relationship=r, **kw))
+
+    agents = {
+        "billing-agent": "Billing Copilot",
+        "support-agent": "Support Copilot",
+        "data-pipeline-agent": "Data Pipeline Agent",
+        "devops-agent": "DevOps Agent",
+        "analytics-agent": "Analytics Agent",
+    }
+    for aid, label in agents.items():
+        node(f"agent:{aid}", EntityType.AGENT, label, environment="production")
+
+    servers = {
+        "mcp-fs": ("billing-agent", ["read_file", "write_file", "run_shell"]),
+        "mcp-db": ("data-pipeline-agent", ["sql_query", "sql_exec"]),
+        "mcp-http": ("support-agent", ["http_get", "http_post"]),
+        "mcp-deploy": ("devops-agent", ["deploy", "rollback", "exec_remote"]),
+        "mcp-warehouse": ("analytics-agent", ["query_warehouse"]),
+    }
+    for sid, (owner, tools) in servers.items():
+        node(f"server:{sid}", EntityType.SERVER, sid)
+        edge(f"agent:{owner}", f"server:{sid}", RelationshipType.USES)
+        for tname in tools:
+            tid = f"tool:{sid}:{tname}"
+            node(tid, EntityType.TOOL, tname)
+            edge(f"server:{sid}", tid, RelationshipType.PROVIDES_TOOL)
+
+    pkgs = {
+        "express@4.17.1": ("mcp-http", "CVE-2024-29041", "critical", 9.3),
+        "pyyaml@5.3": ("mcp-db", "CVE-2020-14343", "critical", 9.8),
+        "requests@2.19.0": ("mcp-fs", "CVE-2023-32681", "high", 7.5),
+        "log4j@2.14.0": ("mcp-deploy", "CVE-2021-44228", "critical", 10.0),
+        "pillow@9.0.0": ("mcp-warehouse", "CVE-2022-22817", "high", 8.1),
+    }
+    for purl, (sid, cve, sev, score) in pkgs.items():
+        pid = f"pkg:{purl}"
+        node(pid, EntityType.PACKAGE, purl)
+        edge(f"server:{sid}", pid, RelationshipType.DEPENDS_ON)
+        vid = f"vuln:{cve}"
+        node(vid, EntityType.VULNERABILITY, cve, severity=sev, risk_score=score)
+        edge(pid, vid, RelationshipType.VULNERABLE_TO)
+
+    node("cred:aws-key", EntityType.CREDENTIAL, "AWS_SECRET_ACCESS_KEY")
+    edge("server:mcp-deploy", "cred:aws-key", RelationshipType.EXPOSES_CRED)
+
+    for i, (aid, tid) in enumerate(
+        [
+            ("billing-agent", "tool:mcp-fs:run_shell"),
+            ("data-pipeline-agent", "tool:mcp-db:sql_exec"),
+            ("devops-agent", "tool:mcp-deploy:exec_remote"),
+        ]
+    ):
+        cid = f"call:{i}"
+        node(cid, EntityType.TOOL_CALL, "observed invocation")
+        edge(f"agent:{aid}", cid, RelationshipType.INVOKED)
+        edge(cid, tid, RelationshipType.INVOKED)
+
+    node(
+        "cloud:pii-bucket",
+        EntityType.CLOUD_RESOURCE,
+        "customer-pii-prod (S3)",
+        resource_type="s3",
+        compliance_tags=["PII", "GDPR"],
+    )
+    node("mc:pii-public", EntityType.MISCONFIGURATION, "S3 bucket customer-pii-prod is publicly readable")
+    node("vuln:bucket-acl", EntityType.VULNERABILITY, "CVE-2024-S3ACL", severity="high", risk_score=8.2)
+    edge("mc:pii-public", "cloud:pii-bucket", RelationshipType.AFFECTS)
+    edge("cloud:pii-bucket", "vuln:bucket-acl", RelationshipType.VULNERABLE_TO)
+
+    node(
+        "cloud:payments-db",
+        EntityType.CLOUD_RESOURCE,
+        "payments-db (RDS PostgreSQL)",
+        resource_type="rds",
+        compliance_tags=["PCI", "financial"],
+    )
+
+    node("cloud:bastion", EntityType.CLOUD_RESOURCE, "prod-bastion (EC2)", resource_type="ec2")
+    node(
+        "mc:sg-open",
+        EntityType.MISCONFIGURATION,
+        "Security group sg-prod allows 0.0.0.0/0 on port 22",
+        network_exposure=[{"resource": "prod-bastion", "from_port": 22, "to_port": 22, "protocol": "tcp", "scope": "internet"}],
+    )
+    edge("mc:sg-open", "cloud:bastion", RelationshipType.AFFECTS)
+
+    node("cloud:logs-bucket", EntityType.CLOUD_RESOURCE, "app-logs (S3)", resource_type="s3")
+
+    node("user:alice", EntityType.USER, "alice@corp (developer)")
+    node("user:bob", EntityType.USER, "bob@contractor (external)")
+    node("role:prod-admin", EntityType.ROLE, "prod-admin-role")
+    node("role:data-pipeline", EntityType.ROLE, "data-pipeline-role")
+    node("role:readonly", EntityType.ROLE, "readonly-role")
+    node("pol:admin", EntityType.POLICY, "AdministratorAccess", privilege_level="admin")
+    node("pol:team-custom", EntityType.POLICY, "team-utility-policy", privilege_level="admin")
+    node("pol:s3-write", EntityType.POLICY, "s3-write-policy", privilege_level="write")
+    node("pol:readonly", EntityType.POLICY, "ViewOnlyAccess", privilege_level="read")
+
+    edge("role:prod-admin", "pol:admin", RelationshipType.ATTACHED)
+    edge("role:data-pipeline", "pol:team-custom", RelationshipType.ATTACHED)
+    edge("role:data-pipeline", "pol:s3-write", RelationshipType.ATTACHED)
+    edge("role:readonly", "pol:readonly", RelationshipType.ATTACHED)
+
+    edge("user:alice", "role:prod-admin", RelationshipType.TRUSTS)
+    edge("user:bob", "role:data-pipeline", RelationshipType.TRUSTS)
+
+    edge("role:prod-admin", "cloud:pii-bucket", RelationshipType.CAN_ACCESS)
+    edge("role:prod-admin", "cloud:payments-db", RelationshipType.CAN_ACCESS)
+    edge("role:prod-admin", "cloud:bastion", RelationshipType.CAN_ACCESS)
+    edge("role:data-pipeline", "cloud:payments-db", RelationshipType.CAN_ACCESS)
+    edge("role:data-pipeline", "cloud:logs-bucket", RelationshipType.CAN_ACCESS)
+    edge("role:readonly", "cloud:logs-bucket", RelationshipType.CAN_ACCESS)
+
+    edge("agent:devops-agent", "role:prod-admin", RelationshipType.CAN_ACCESS)
+    edge("agent:data-pipeline-agent", "role:data-pipeline", RelationshipType.CAN_ACCESS)
+
+    store = InMemoryAgentIdentityStore()
+    for aid, label in agents.items():
+        idn, _ = issue_identity(store, agent_id=label, tenant_id=tenant_id, allowed_tools=[])
+        if aid in ("billing-agent", "devops-agent", "data-pipeline-agent"):
+            issue_jit_grant(
+                store,
+                identity_id=idn.identity_id,
+                agent_id=label,
+                tenant_id=tenant_id,
+                tool_name="run_shell" if aid == "billing-agent" else "exec_remote",
+                ttl_seconds=3600,
+                approved_by="oncall@corp",
+            )
+
+    drift = _DriftStore(
+        [
+            _DriftIncident(
+                incident_id="drift-001",
+                blueprint_id="DevOps Agent",
+                drift_score=0.78,
+                violation_count=14,
+                top_violations=[{"tool_name": "exec_remote"}],
+            ),
+            _DriftIncident(
+                incident_id="drift-002",
+                blueprint_id="Billing Copilot",
+                drift_score=0.41,
+                violation_count=5,
+                top_violations=[{"tool_name": "run_shell"}],
+            ),
+        ]
+    )
+    return g, store, drift
+
+
+def apply_showcase_overlays(
+    graph: UnifiedGraph,
+    *,
+    tenant_id: str = SHOWCASE_TENANT,
+    identity_store: InMemoryAgentIdentityStore,
+    drift_store: _DriftStore,
+) -> dict[str, object]:
+    cnapp = apply_cnapp_overlay(graph)
+    eff = apply_effective_permissions(graph)
+    gov = apply_governance_overlay(graph, tenant_id=tenant_id, identity_store=identity_store, drift_store=drift_store)
+    return {"cnapp": cnapp, "effective_permissions": eff, "governance": gov}
+
+
+def seed_showcase_graph_if_empty(
+    graph_store: GraphStoreProtocol,
+    *,
+    tenant_id: str = SHOWCASE_TENANT,
+) -> bool:
+    """Persist the showcase graph when the tenant has no snapshot yet."""
+    if graph_store.latest_snapshot_id(tenant_id=tenant_id):
+        return False
+    graph, identity_store, drift_store = build_showcase_graph(tenant_id=tenant_id)
+    apply_showcase_overlays(graph, tenant_id=tenant_id, identity_store=identity_store, drift_store=drift_store)
+    graph_store.save_graph(graph)
+    return True

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -240,7 +240,8 @@ def seed_showcase_graph_if_empty(
     tenant_id: str = SHOWCASE_TENANT,
 ) -> bool:
     """Persist the showcase graph when the tenant has no snapshot yet."""
-    if graph_store.latest_snapshot_id(tenant_id=tenant_id):
+    latest_snapshot_id = getattr(graph_store, "latest_snapshot_id", None)
+    if callable(latest_snapshot_id) and latest_snapshot_id(tenant_id=tenant_id):
         return False
     graph, identity_store, drift_store = build_showcase_graph(tenant_id=tenant_id)
     apply_showcase_overlays(graph, tenant_id=tenant_id, identity_store=identity_store, drift_store=drift_store)

--- a/tests/test_compliance_hub_store_pagination.py
+++ b/tests/test_compliance_hub_store_pagination.py
@@ -271,3 +271,47 @@ def test_sqlite_effective_reach_sort_uses_index(tmp_path) -> None:
     count_text = " ".join(str(row[-1]) for row in count_plan)
     assert "USING" in count_text and "INDEX" in count_text, count_text
     assert "SCAN compliance_hub_findings" not in count_text, count_text
+
+
+_SCALE_ROWS = 10_000
+_SCALE_LIMIT1_BUDGET_S = 0.25
+
+
+def test_sqlite_list_page_limit1_stays_fast_at_10k(tmp_path) -> None:
+    """Regression: limit=1 must not scan/sort the full tenant (#3511)."""
+    import time
+
+    store = SQLiteComplianceHubStore(str(tmp_path / "scale.db"))
+    tenant = "tenant-scale-10k"
+    chunk = 2000
+    for start in range(0, _SCALE_ROWS, chunk):
+        store.add(tenant, [_finding(i) for i in range(start, min(start + chunk, _SCALE_ROWS))])
+
+    started = time.perf_counter()
+    rows, total = store.list_page(tenant, limit=1, offset=0, sort="effective_reach")
+    elapsed = time.perf_counter() - started
+
+    assert len(rows) == 1
+    assert total == _SCALE_ROWS
+    assert elapsed < _SCALE_LIMIT1_BUDGET_S, f"limit=1 read took {elapsed:.3f}s at {_SCALE_ROWS} rows"
+
+
+@pytest.mark.slow
+def test_sqlite_list_page_limit1_stays_fast_at_1m(tmp_path) -> None:
+    """Opt-in million-row guard for hub/SQLite read path (``pytest -m slow``)."""
+    import time
+
+    target = 1_000_000
+    store = SQLiteComplianceHubStore(str(tmp_path / "scale-1m.db"))
+    tenant = "tenant-scale-1m"
+    chunk = 10_000
+    for start in range(0, target, chunk):
+        store.add(tenant, [_finding(i) for i in range(start, min(start + chunk, target))])
+
+    started = time.perf_counter()
+    rows, total = store.list_page(tenant, limit=1, offset=0, sort="effective_reach")
+    elapsed = time.perf_counter() - started
+
+    assert len(rows) == 1
+    assert total == target
+    assert elapsed < 1.0, f"limit=1 read took {elapsed:.3f}s at {target} rows"

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+
+@pytest.fixture()
+def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    monkeypatch.setenv("AGENT_BOM_DEMO_ESTATE", "1")
+    monkeypatch.setenv("AGENT_BOM_DB", str(tmp_path / "demo-estate.db"))
+    monkeypatch.setenv("AGENT_BOM_GRAPH_DB", str(tmp_path / "demo-graph.db"))
+
+    from agent_bom.api import server as api_server
+
+    api_server._runtime_api_key_seeded = False
+    api_server._shutting_down = False
+
+    with TestClient(api_server.app) as client:
+        yield client
+
+
+def test_demo_estate_bootstrap_seeds_jobs_and_graph(demo_estate_client: TestClient) -> None:
+    jobs_payload = demo_estate_client.get(
+        "/v1/jobs",
+        headers={"X-Agent-Bom-Role": "admin"},
+        params={"include_details": "true"},
+    ).json()
+    jobs = jobs_payload.get("jobs") or []
+    assert jobs, "expected at least one demo job after bootstrap"
+    job_id = jobs[0]["job_id"]
+    detail = demo_estate_client.get(f"/v1/scan/{job_id}", headers={"X-Agent-Bom-Role": "admin"}).json()
+    sources = (detail.get("result") or {}).get("scan_sources", [])
+    assert any("demo" in str(src).lower() for src in sources)
+
+    graph = demo_estate_client.get("/v1/graph", headers={"X-Agent-Bom-Role": "viewer"})
+    assert graph.status_code == 200
+    payload = graph.json()
+    node_count = len(payload.get("nodes") or [])
+    assert node_count > 0
+
+
+def test_demo_estate_bootstrap_is_idempotent(demo_estate_client: TestClient) -> None:
+    first = demo_estate_client.get("/v1/jobs", headers={"X-Agent-Bom-Role": "admin"}).json()
+    from agent_bom.demo_estate.bootstrap import maybe_bootstrap_demo_estate
+
+    second = maybe_bootstrap_demo_estate()
+    assert second.get("reason") == "demo_jobs_present"
+    again = demo_estate_client.get("/v1/jobs", headers={"X-Agent-Bom-Role": "admin"}).json()
+    assert again.get("total") == first.get("total")

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -11,12 +11,18 @@ def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
     monkeypatch.setenv("AGENT_BOM_GRAPH_DB", str(tmp_path / "demo-graph.db"))
 
     from agent_bom.api import server as api_server
+    from agent_bom.api import stores as api_stores
 
     api_server._runtime_api_key_seeded = False
     api_server._shutting_down = False
+    original_graph_store = api_stores._graph_store
+    api_stores._graph_store = None
 
-    with TestClient(api_server.app) as client:
-        yield client
+    try:
+        with TestClient(api_server.app) as client:
+            yield client
+    finally:
+        api_stores._graph_store = original_graph_store
 
 
 def test_demo_estate_bootstrap_seeds_jobs_and_graph(demo_estate_client: TestClient) -> None:

--- a/tests/test_findings_mixed_merge.py
+++ b/tests/test_findings_mixed_merge.py
@@ -1,0 +1,140 @@
+"""Mixed in-memory scan findings + bulk hub pagination (#3619 follow-up)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore, set_compliance_hub_store
+from agent_bom.api.routes.scan import _finding_sort_key, _merged_scan_bulk_page
+from agent_bom.api.server import ScanJob, ScanRequest, app, set_job_store
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import _get_store
+from agent_bom.api.models import JobStatus
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+
+
+def _seed_bulk(store: InMemoryComplianceHubStore, tenant: str, count: int) -> None:
+    findings = [
+        {
+            "id": f"bulk-{idx}",
+            "severity": "medium",
+            "cvss_score": float(idx % 10),
+            "effective_reach_score": float(idx),
+            "origin": "bulk_ingest",
+            "source": "test",
+            "batch_id": "merge-batch",
+        }
+        for idx in range(count)
+    ]
+    store.add(tenant, findings)
+    store.upsert_current_batch(
+        tenant,
+        findings,
+        observed_at="2026-07-06T00:00:00Z",
+        batch_id="merge-batch",
+        source="test",
+    )
+
+
+def test_merged_scan_bulk_page_matches_full_sort_reference() -> None:
+    tenant = f"merge-{uuid4().hex}"
+    store = InMemoryComplianceHubStore()
+    scan_rows = [
+        {
+            "id": "scan-high",
+            "severity": "critical",
+            "cvss_score": 9.8,
+            "effective_reach_score": 95.0,
+            "origin": "native_scan",
+            "source": "MCP_SCAN",
+        },
+        {
+            "id": "scan-low",
+            "severity": "low",
+            "cvss_score": 2.0,
+            "effective_reach_score": 5.0,
+            "origin": "native_scan",
+            "source": "MCP_SCAN",
+        },
+    ]
+    _seed_bulk(store, tenant, 30)
+    scan_sorted = sorted(scan_rows, key=lambda row: _finding_sort_key(row, "effective_reach"))
+
+    for offset in (0, 2, 5, 10):
+        for limit in (1, 3, 7):
+            merged = _merged_scan_bulk_page(
+                scan_sorted,
+                bulk_list=store.list_page,
+                tenant_id=tenant,
+                sort_key="effective_reach",
+                severity=None,
+                scan_id=None,
+                offset=offset,
+                limit=limit,
+            )
+            bulk_rows = store.list(tenant)
+            reference = sorted(scan_sorted + bulk_rows, key=lambda row: _finding_sort_key(row, "effective_reach"))
+            assert [row["id"] for row in merged] == [row["id"] for row in reference[offset : offset + limit]]
+
+
+def test_findings_api_merges_scan_and_bulk_at_deep_offset() -> None:
+    tenant = f"api-merge-{uuid4().hex}"
+    store = InMemoryComplianceHubStore()
+    set_compliance_hub_store(store)
+    _seed_bulk(store, tenant, 40)
+
+    set_job_store(InMemoryJobStore())
+    job = ScanJob(
+        job_id="merge-scan-job",
+        tenant_id=tenant,
+        created_at="2026-07-06T10:00:00Z",
+        request=ScanRequest(),
+    )
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-07-06T10:01:00Z"
+    job.result = {
+        "findings": [
+            {
+                "id": "scan-top",
+                "vulnerability_id": "scan-top",
+                "severity": "critical",
+                "cvss_score": 10.0,
+                "effective_reach_score": 99.0,
+                "package": "pkg",
+            }
+        ]
+    }
+    _get_store().put(job)
+
+    client = TestClient(app)
+    headers = proxy_headers(tenant=tenant)
+    body = client.get("/v1/findings?limit=5&offset=3&sort=effective_reach", headers=headers).json()
+    assert body["count"] == 5
+
+    scan_rows = [
+        {
+            "id": "scan-top",
+            "severity": "critical",
+            "cvss_score": 10.0,
+            "effective_reach_score": 99.0,
+            "origin": "native_scan",
+        }
+    ]
+    bulk_rows, _ = store.list_page(tenant, limit=1000, offset=0)
+    reference = sorted(
+        scan_rows + bulk_rows,
+        key=lambda row: _finding_sort_key(row, "effective_reach"),
+    )
+    assert [row["id"] for row in body["findings"]] == [row["id"] for row in reference[3:8]]

--- a/tests/test_hitl_approval_queue.py
+++ b/tests/test_hitl_approval_queue.py
@@ -1,0 +1,67 @@
+"""Tests for runtime HITL approval queue (#3617)."""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.hitl_approval_queue import build_hitl_queue_items
+from agent_bom.api.hitl_approval_store import InMemoryHitlApprovalStore, set_hitl_approval_store
+
+
+def test_build_hitl_queue_items_lists_blocked_spans() -> None:
+    store = InMemoryHitlApprovalStore()
+    trace_payload = {
+        "sessions": [
+            {
+                "session_id": "sess-1",
+                "spans": [
+                    {
+                        "span_id": "span-blocked",
+                        "verdict": "blocked",
+                        "agent": "dev-agent",
+                        "tool": "run_shell",
+                        "detail": "policy deny",
+                        "linked_findings": [{"finding_id": "CVE-1"}],
+                        "compliance_controls": ["owasp_llm:LLM05"],
+                    },
+                    {"span_id": "span-ok", "verdict": "observed", "agent": "dev-agent", "tool": "read_file"},
+                ],
+            }
+        ]
+    }
+    items = build_hitl_queue_items(tenant_id="tenant-a", trace_payload=trace_payload, store=store)
+    assert len(items) == 1
+    assert items[0]["status"] == "pending"
+    assert items[0]["tool"] == "run_shell"
+    assert items[0]["linked_finding_ids"] == ["CVE-1"]
+    assert "owasp_llm:LLM05" in items[0]["compliance_controls"]
+
+
+def test_runtime_approval_queue_api_decision_emits_audit() -> None:
+    from agent_bom.api import server as api_server
+
+    store = InMemoryHitlApprovalStore()
+    set_hitl_approval_store(store)
+    api_server._runtime_api_key_seeded = False
+
+    with TestClient(api_server.app) as test_client:
+        queue = test_client.get("/v1/runtime/approval-queue")
+        assert queue.status_code == 200
+        payload = queue.json()
+        if not payload.get("items"):
+            assert payload["schema_version"] == "runtime.approval_queue.v1"
+            return
+
+        item_id = payload["items"][0]["item_id"]
+        decision = test_client.post(
+            f"/v1/runtime/approval-queue/{item_id}/decision",
+            json={"decision": "approve", "note": "reviewed in test"},
+        )
+        assert decision.status_code == 200
+        body = decision.json()
+        assert body["item"]["status"] == "approved"
+        assert body["item"]["note"] == "reviewed in test"
+
+        filtered = test_client.get("/v1/runtime/approval-queue?status=approved")
+        assert filtered.status_code == 200
+        assert any(row["item_id"] == item_id for row in filtered.json().get("items", []))

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_release_smoke_script_is_valid_shell() -> None:
+    subprocess.run(["bash", "-n", str(ROOT / "scripts" / "release_smoke.sh")], check=True)
+
+
+def test_release_smoke_golden_path() -> None:
+    """Offline demo scan smoke must pass on every CI run."""
+    subprocess.run(
+        ["bash", str(ROOT / "scripts" / "release_smoke.sh")],
+        check=True,
+        cwd=ROOT,
+        env={
+            **dict(__import__("os").environ),
+            "AGENT_BOM_RELEASE_SMOKE_SKIP_UI": "1",
+        },
+    )

--- a/ui/app/traces/page.tsx
+++ b/ui/app/traces/page.tsx
@@ -16,6 +16,7 @@ import {
 import { api, type TraceIngestResponse } from "@/lib/api";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { TraceExplorerPanel } from "@/components/trace-explorer-panel";
+import { HitlApprovalQueuePanel } from "@/components/hitl-approval-queue-panel";
 
 const SAMPLE_PAYLOAD = JSON.stringify(
   {
@@ -44,7 +45,7 @@ const SAMPLE_PAYLOAD = JSON.stringify(
 
 export default function TracesPage() {
   const { counts } = useDeploymentContext();
-  const [mode, setMode] = useState<"explorer" | "ingest">("explorer");
+  const [mode, setMode] = useState<"explorer" | "queue" | "ingest">("explorer");
   const [payload, setPayload] = useState(SAMPLE_PAYLOAD);
   const [result, setResult] = useState<TraceIngestResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -104,6 +105,16 @@ export default function TracesPage() {
             </button>
             <button
               type="button"
+              onClick={() => setMode("queue")}
+              className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs ${
+                mode === "queue" ? "bg-emerald-600 text-white" : "text-zinc-400 hover:text-zinc-200"
+              }`}
+            >
+              <ShieldAlert className="h-3.5 w-3.5" />
+              Approval queue
+            </button>
+            <button
+              type="button"
               onClick={() => setMode("ingest")}
               className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs ${
                 mode === "ingest" ? "bg-emerald-600 text-white" : "text-zinc-400 hover:text-zinc-200"
@@ -130,6 +141,8 @@ export default function TracesPage() {
 
       {mode === "explorer" ? (
         <TraceExplorerPanel />
+      ) : mode === "queue" ? (
+        <HitlApprovalQueuePanel />
       ) : (
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-[1.05fr_0.95fr]">
         <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-5">

--- a/ui/components/finding-drawer.tsx
+++ b/ui/components/finding-drawer.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { ExternalLink, FileSearch, Loader2, Radar, ShieldAlert, X } from "lucide-react";
 
 import { severityColor, type FindingTriageDecision, type FindingTriageItem, type FindingTriageJustification } from "@/lib/api";
+import { buildWhyItMatters } from "@/lib/finding-why-matters";
 import { type EnrichedVuln, uniqueStrings, formatFindingTimestamp, findingStatusClass, findingStatusLabel } from "@/lib/findings-view";
 
 export function FindingDrawer({
@@ -88,6 +89,7 @@ function VulnDetailPanel({
     ...vuln.sources,
     ...vuln.advisory_sources,
   ]);
+  const whyItMatters = buildWhyItMatters(vuln);
 
   return (
     <div className="ml-6 rounded-xl border border-zinc-800 bg-zinc-900/50 p-4">
@@ -111,6 +113,26 @@ function VulnDetailPanel({
             <DetailStat label="CVSS" value={typeof vuln.cvss_score === "number" ? vuln.cvss_score.toFixed(1) : "Not published"} />
             <DetailStat label="EPSS" value={typeof vuln.epss_score === "number" ? `${(vuln.epss_score * 100).toFixed(1)}%` : "Not available"} />
           </div>
+          {whyItMatters && (
+            <div className="rounded-lg border border-emerald-900/50 bg-emerald-950/20 p-3">
+              <h4 className="text-xs font-medium uppercase tracking-wide text-emerald-400/90">Why it matters</h4>
+              <p className="mt-2 text-sm font-medium text-zinc-100">{whyItMatters.headline}</p>
+              <div className="mt-2 space-y-2 text-sm leading-6 text-zinc-300">
+                {whyItMatters.paragraphs.map((paragraph) => (
+                  <p key={paragraph}>{paragraph}</p>
+                ))}
+              </div>
+              {whyItMatters.links.length > 0 && (
+                <div className="mt-3 flex flex-wrap gap-3">
+                  {whyItMatters.links.map((link) => (
+                    <Link key={link.href} href={link.href} className="text-xs text-emerald-300 hover:underline">
+                      {link.label}
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
           {(vuln.effective_reach_band || vuln.runtime_evidence?.state) && (
             <div className="flex flex-wrap gap-2">
               {vuln.effective_reach_band && (

--- a/ui/components/hitl-approval-queue-panel.tsx
+++ b/ui/components/hitl-approval-queue-panel.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { CheckCircle2, Loader2, ShieldAlert, XCircle } from "lucide-react";
+
+import { api } from "@/lib/api";
+import type { HitlApprovalQueueItem } from "@/lib/api-types";
+
+export function HitlApprovalQueuePanel() {
+  const [items, setItems] = useState<HitlApprovalQueueItem[]>([]);
+  const [pendingCount, setPendingCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await api.getHitlApprovalQueue(undefined, 120);
+      setItems(response.items);
+      setPendingCount(response.pending_count);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function decide(itemId: string, decision: "approve" | "deny") {
+    setBusyId(itemId);
+    setError(null);
+    try {
+      await api.decideHitlApproval(itemId, decision);
+      await load();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 rounded-2xl border border-zinc-800 bg-zinc-900/50 px-4 py-10 text-sm text-zinc-400">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading approval queue…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-900/50 bg-red-950/30 px-4 py-3 text-sm text-red-300">
+        {error}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-zinc-800 bg-zinc-900/40 px-4 py-10 text-center text-sm text-zinc-500">
+        No blocked tool calls in the approval queue. Gateway/proxy blocks appear here for human review.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-zinc-800 bg-zinc-900/50 px-4 py-3 text-sm text-zinc-300">
+        <span>
+          <span className="font-semibold text-zinc-100">{pendingCount}</span> pending · {items.length} total blocked spans
+        </span>
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="rounded-lg border border-zinc-700 px-3 py-1.5 text-xs text-zinc-300 hover:border-zinc-600 hover:text-zinc-100"
+        >
+          Refresh
+        </button>
+      </div>
+
+      <div className="overflow-hidden rounded-2xl border border-zinc-800">
+        <table className="w-full text-sm">
+          <thead className="border-b border-zinc-800 bg-zinc-900">
+            <tr>
+              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Agent / tool</th>
+              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Findings</th>
+              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Controls</th>
+              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Status</th>
+              <th className="px-4 py-2.5 text-right text-xs font-medium uppercase tracking-wide text-zinc-500">Action</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-800 bg-zinc-950">
+            {items.map((item) => (
+              <tr key={item.item_id} className="align-top hover:bg-zinc-900/60">
+                <td className="px-4 py-3">
+                  <div className="font-medium text-zinc-200">{item.agent || "unknown agent"}</div>
+                  <div className="mt-1 font-mono text-xs text-zinc-400">{item.tool}</div>
+                  {item.detail ? <p className="mt-2 text-xs text-zinc-500">{item.detail}</p> : null}
+                  <p className="mt-1 text-[11px] text-zinc-600">session {item.session_id}</p>
+                </td>
+                <td className="px-4 py-3">
+                  {item.linked_finding_ids.length > 0 ? (
+                    <div className="flex flex-wrap gap-1">
+                      {item.linked_finding_ids.slice(0, 4).map((fid) => (
+                        <Link
+                          key={fid}
+                          href={`/findings?search=${encodeURIComponent(fid)}`}
+                          className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-[10px] text-emerald-300 hover:underline"
+                        >
+                          {fid}
+                        </Link>
+                      ))}
+                    </div>
+                  ) : (
+                    <span className="text-xs text-zinc-600">—</span>
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex flex-wrap gap-1">
+                    {item.compliance_controls.slice(0, 4).map((tag) => (
+                      <span key={tag} className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-[10px] text-zinc-400">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`inline-flex items-center gap-1 rounded border px-2 py-0.5 text-xs font-medium capitalize ${
+                      item.status === "approved"
+                        ? "border-emerald-800 bg-emerald-950 text-emerald-300"
+                        : item.status === "denied"
+                          ? "border-rose-800 bg-rose-950 text-rose-300"
+                          : "border-amber-800 bg-amber-950 text-amber-300"
+                    }`}
+                  >
+                    <ShieldAlert className="h-3 w-3" />
+                    {item.status}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-right">
+                  {item.status === "pending" ? (
+                    <div className="flex justify-end gap-2">
+                      <button
+                        type="button"
+                        disabled={busyId === item.item_id}
+                        onClick={() => void decide(item.item_id, "approve")}
+                        className="inline-flex items-center gap-1 rounded-lg border border-emerald-800 bg-emerald-950/50 px-2.5 py-1.5 text-xs text-emerald-300 hover:bg-emerald-900/40 disabled:opacity-50"
+                      >
+                        <CheckCircle2 className="h-3.5 w-3.5" />
+                        Approve
+                      </button>
+                      <button
+                        type="button"
+                        disabled={busyId === item.item_id}
+                        onClick={() => void decide(item.item_id, "deny")}
+                        className="inline-flex items-center gap-1 rounded-lg border border-rose-800 bg-rose-950/50 px-2.5 py-1.5 text-xs text-rose-300 hover:bg-rose-900/40 disabled:opacity-50"
+                      >
+                        <XCircle className="h-3.5 w-3.5" />
+                        Deny
+                      </button>
+                    </div>
+                  ) : (
+                    <span className="text-xs text-zinc-500">{item.decided_by || "—"}</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -173,6 +173,15 @@ const NAV_GROUPS: NavGroup[] = [
 
 const ALL_GROUP_LABELS = NAV_GROUPS.map((group) => group.label);
 
+/** Curated first-session proof path (#3618). Full nav stays in groups + ⌘K. */
+const PROOF_PATH_LINKS: NavLink[] = [
+  { href: "/findings", label: "Queue", icon: Bug },
+  { href: "/security-graph", label: "Graph", icon: Network },
+  { href: "/runtime", label: "Runtime", icon: Shield },
+  { href: "/compliance", label: "Reports", icon: FileText },
+  { href: "/connections", label: "Connections", icon: Cloud },
+];
+
 // ─── Risk counts for badges ─────────────────────────────────────────────────
 
 // ─── Sidebar Component ──────────────────────────────────────────────────────
@@ -440,6 +449,35 @@ export function Nav() {
           >
             <Search className="w-4 h-4" />
           </button>
+        </div>
+      )}
+
+      {/* Proof path — curated golden-workflow entry points */}
+      {!collapsed && (
+        <div className="px-3 pb-1">
+          <p className="px-1 pb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">
+            Proof path
+          </p>
+          <div className="grid grid-cols-2 gap-1">
+            {PROOF_PATH_LINKS.map((link) => {
+              const Icon = link.icon;
+              const active = link.href === "/" ? path === "/" : Boolean(path?.startsWith(link.href));
+              return (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className={`flex items-center gap-2 rounded-lg border px-2.5 py-2 text-[11px] font-medium transition-colors ${
+                    active
+                      ? "border-[color:var(--border-strong)] bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
+                      : "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
+                  }`}
+                >
+                  <Icon className="h-3.5 w-3.5 shrink-0" />
+                  <span className="truncate">{link.label}</span>
+                </Link>
+              );
+            })}
+          </div>
         </div>
       )}
 

--- a/ui/e2e/jobs-workflow.spec.ts
+++ b/ui/e2e/jobs-workflow.spec.ts
@@ -144,7 +144,8 @@ test("jobs page links sources to completed evidence surfaces", async ({ page }) 
   await expect(page.getByText("Prod cloud account")).toBeVisible();
   await expect(page.getByText("3 CVEs · 1 critical · 8 packages")).toBeVisible();
 
-  await expect(page.getByRole("link", { name: "Findings", exact: true })).toHaveAttribute("href", "/findings?scan=job-prod-cloud");
-  await expect(page.getByRole("link", { name: "Graph", exact: true })).toHaveAttribute("href", "/security-graph?scan=job-prod-cloud");
-  await expect(page.getByRole("link", { name: "Compliance", exact: true })).toHaveAttribute("href", "/compliance?scan=job-prod-cloud");
+  const mainContent = page.locator("#main-content");
+  await expect(mainContent.getByRole("link", { name: "Findings", exact: true })).toHaveAttribute("href", "/findings?scan=job-prod-cloud");
+  await expect(mainContent.getByRole("link", { name: "Graph", exact: true })).toHaveAttribute("href", "/security-graph?scan=job-prod-cloud");
+  await expect(mainContent.getByRole("link", { name: "Compliance", exact: true })).toHaveAttribute("href", "/compliance?scan=job-prod-cloud");
 });

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2346,6 +2346,33 @@ export interface TraceExplorerResponse {
   sessions: TraceExplorerSession[];
 }
 
+export interface HitlApprovalQueueItem {
+  item_id: string;
+  tenant_id: string;
+  span_id: string;
+  session_id: string;
+  agent: string;
+  tool: string;
+  timestamp?: string | undefined;
+  detail?: string | undefined;
+  source?: string | undefined;
+  status: "pending" | "approved" | "denied" | string;
+  linked_findings: TraceExplorerSpan["linked_findings"];
+  linked_finding_ids: string[];
+  compliance_controls: string[];
+  decided_by?: string | undefined;
+  decided_at?: string | undefined;
+  note?: string | undefined;
+}
+
+export interface HitlApprovalQueueResponse {
+  schema_version: string;
+  tenant_id: string;
+  count: number;
+  pending_count: number;
+  items: HitlApprovalQueueItem[];
+}
+
 export interface ProxyStatusResponse {
   status: string;
   message?: string | undefined;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -88,6 +88,7 @@ import type {
   ActivityTimeline,
   TraceIngestResponse,
   TraceExplorerResponse,
+  HitlApprovalQueueResponse,
   ProxyStatusResponse,
   ProxyAlertsResponse,
   AuditEntry,
@@ -266,6 +267,7 @@ export type {
   TraceFlaggedCall,
   TraceIngestResponse,
   TraceExplorerResponse,
+  HitlApprovalQueueResponse,
   ProxyStatusResponse,
   ProxyAlert,
   ProxyAlertsResponse,
@@ -909,6 +911,16 @@ export const api = {
   getActivity: (days = 30) => get<ActivityTimeline>(`/v1/activity?days=${days}`),
   ingestTraces: (body: unknown) => post<TraceIngestResponse>("/v1/traces", body),
   getTraceExplorer: (limit = 100) => get<TraceExplorerResponse>(`/v1/runtime/trace-explorer?limit=${limit}`),
+  getHitlApprovalQueue: (status?: string, limit = 100) => {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (status) params.set("status", status);
+    return get<HitlApprovalQueueResponse>(`/v1/runtime/approval-queue?${params}`);
+  },
+  decideHitlApproval: (itemId: string, decision: "approve" | "deny", note = "") =>
+    post<{ schema_version: string; item: HitlApprovalQueueResponse["items"][number] }>(
+      `/v1/runtime/approval-queue/${encodeURIComponent(itemId)}/decision`,
+      { decision, note },
+    ),
 
   // ── Proxy Runtime ──
   getProxyStatus: () => get<ProxyStatusResponse>("/v1/proxy/status"),

--- a/ui/lib/finding-why-matters.ts
+++ b/ui/lib/finding-why-matters.ts
@@ -1,0 +1,104 @@
+import type { EnrichedVuln } from "@/lib/findings-view";
+
+export interface WhyItMattersLink {
+  href: string;
+  label: string;
+}
+
+export interface WhyItMattersNarrative {
+  headline: string;
+  paragraphs: string[];
+  links: WhyItMattersLink[];
+}
+
+function reachSentence(vuln: EnrichedVuln): string | null {
+  const band = vuln.effective_reach_band?.trim();
+  if (!band) return null;
+  const score =
+    typeof vuln.effective_reach_score === "number"
+      ? ` (score ${vuln.effective_reach_score.toFixed(0)})`
+      : "";
+  const hop =
+    typeof vuln.graph_min_hop_distance === "number" && vuln.graph_min_hop_distance > 0
+      ? ` with a ${vuln.graph_min_hop_distance}-hop graph path`
+      : vuln.graph_reachable
+        ? " with a confirmed graph path"
+        : "";
+  return `Reachability is ${band}${score}${hop}, so this finding is prioritized above static-only CVE noise.`;
+}
+
+function runtimeSentence(vuln: EnrichedVuln): string | null {
+  const state = vuln.runtime_evidence?.state;
+  if (!state || state === "static") return null;
+  if (state === "blocked") {
+    const count = vuln.runtime_evidence?.blocked_count;
+    const suffix = typeof count === "number" && count > 0 ? ` (${count} blocked invocation${count === 1 ? "" : "s"})` : "";
+    return `Runtime enforcement already blocked tool activity tied to this exposure${suffix}; use the trace explorer to prove the deny decision.`;
+  }
+  if (state === "observed") {
+    const count = vuln.runtime_evidence?.observed_count;
+    const suffix = typeof count === "number" && count > 0 ? ` (${count} observed call${count === 1 ? "" : "s"})` : "";
+    return `Agents have invoked reachable tools on live paths${suffix}, so exploitability is not theoretical.`;
+  }
+  return `Runtime evidence is ${state}, which should be weighed alongside static reachability.`;
+}
+
+function exposureSentence(vuln: EnrichedVuln): string | null {
+  const parts: string[] = [];
+  if (vuln.agents.length > 0) {
+    parts.push(`${vuln.agents.length} agent surface${vuln.agents.length === 1 ? "" : "s"}`);
+  }
+  if (vuln.exposed_credentials.length > 0) {
+    parts.push(`${vuln.exposed_credentials.length} exposed credential name${vuln.exposed_credentials.length === 1 ? "" : "s"}`);
+  }
+  if (vuln.reachable_tools.length > 0) {
+    parts.push(`${vuln.reachable_tools.length} confirmed tool${vuln.reachable_tools.length === 1 ? "" : "s"}`);
+  }
+  if (parts.length === 0) return null;
+  let sentence = `Blast radius spans ${parts.join(", ")}.`;
+  if (vuln.phantom_tools?.length) {
+    sentence += ` ${vuln.phantom_tools.length} registry-only tool${vuln.phantom_tools.length === 1 ? " is" : "s are"} excluded from scoring.`;
+  }
+  return sentence;
+}
+
+function complianceSentence(vuln: EnrichedVuln): string | null {
+  const tags = vuln.framework_tags?.filter(Boolean) ?? [];
+  if (tags.length === 0) return null;
+  const preview = tags.slice(0, 3).join(", ");
+  const suffix = tags.length > 3 ? ` and ${tags.length - 3} more` : "";
+  return `Maps to ${tags.length} compliance control tag${tags.length === 1 ? "" : "s"} (${preview}${suffix}) for exportable evidence packs.`;
+}
+
+export function buildWhyItMatters(vuln: EnrichedVuln): WhyItMattersNarrative | null {
+  const paragraphs = [
+    reachSentence(vuln),
+    runtimeSentence(vuln),
+    exposureSentence(vuln),
+    complianceSentence(vuln),
+  ].filter((line): line is string => Boolean(line));
+
+  if (paragraphs.length === 0) {
+    return null;
+  }
+
+  const links: WhyItMattersLink[] = [];
+  if (vuln.graph_reachable || vuln.effective_reach_band) {
+    links.push({ href: "/security-graph", label: "Open security graph" });
+  }
+  if (vuln.runtime_evidence?.state === "blocked") {
+    links.push({ href: "/traces", label: "Open trace explorer" });
+  } else if (vuln.runtime_evidence?.state && vuln.runtime_evidence.state !== "static") {
+    links.push({ href: "/runtime", label: "Review runtime posture" });
+  }
+  if (vuln.framework_tags?.length) {
+    links.push({ href: "/compliance", label: "View compliance evidence" });
+  }
+
+  const headline =
+    vuln.severity === "critical" || vuln.severity === "high"
+      ? "Prioritize remediation — reachable exposure with governance impact"
+      : "Why this finding is ranked in your queue";
+
+  return { headline, paragraphs, links };
+}

--- a/ui/tests/finding-why-matters.test.ts
+++ b/ui/tests/finding-why-matters.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { buildWhyItMatters } from "@/lib/finding-why-matters";
+import type { EnrichedVuln } from "@/lib/findings-view";
+
+function baseVuln(overrides: Partial<EnrichedVuln> = {}): EnrichedVuln {
+  return {
+    id: "GHSA-test",
+    severity: "high",
+    packages: ["pillow"],
+    agents: ["cursor"],
+    sources: ["demo"],
+    affected_servers: ["database-server"],
+    exposed_credentials: ["AWS_SECRET_ACCESS_KEY"],
+    reachable_tools: ["run_shell"],
+    references: [],
+    advisory_sources: [],
+    remediation_items: [],
+    ...overrides,
+  };
+}
+
+describe("buildWhyItMatters", () => {
+  it("returns null when no reach, runtime, exposure, or compliance context exists", () => {
+    expect(
+      buildWhyItMatters(
+        baseVuln({
+          exposed_credentials: [],
+          reachable_tools: [],
+          agents: [],
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("summarizes reach, runtime, exposure, and compliance with proof links", () => {
+    const narrative = buildWhyItMatters(
+      baseVuln({
+        effective_reach_band: "high",
+        effective_reach_score: 82,
+        graph_reachable: true,
+        graph_min_hop_distance: 2,
+        runtime_evidence: { state: "blocked", blocked_count: 3 },
+        framework_tags: ["owasp_llm:llm06", "mitre_atlas:exfiltration"],
+        phantom_tools: ["phantom-tool"],
+      }),
+    );
+
+    expect(narrative).not.toBeNull();
+    expect(narrative?.paragraphs.join(" ")).toMatch(/Reachability is high/);
+    expect(narrative?.paragraphs.join(" ")).toMatch(/Runtime enforcement already blocked/);
+    expect(narrative?.paragraphs.join(" ")).toMatch(/Blast radius spans/);
+    expect(narrative?.paragraphs.join(" ")).toMatch(/compliance control tag/);
+    expect(narrative?.links.map((link) => link.href)).toEqual(
+      expect.arrayContaining(["/security-graph", "/traces", "/compliance"]),
+    );
+  });
+});

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -132,6 +132,17 @@ describe('Nav', () => {
     expect(links.some((l) => l.getAttribute('href') === '/security-graph')).toBe(true)
   })
 
+  it('surfaces curated proof-path links for golden workflows', () => {
+    render(<Nav />)
+    const hrefs = screen.getAllByRole('link').map((l) => l.getAttribute('href'))
+    expect(hrefs).toContain('/findings')
+    expect(hrefs).toContain('/security-graph')
+    expect(hrefs).toContain('/runtime')
+    expect(hrefs).toContain('/compliance')
+    expect(hrefs).toContain('/connections')
+    expect(screen.getByText(/proof path/i)).toBeInTheDocument()
+  })
+
   it('contains Registry link in Discover', () => {
     render(<Nav />)
     const links = screen.getAllByRole('link', { name: /^registry$/i })


### PR DESCRIPTION
## Summary
- Adds `scripts/release_smoke.sh` for install → offline demo scan → CSV export (optional API health).
- Extends finding drawer with a **Why it matters** narrative (reach, runtime, blast radius, compliance + deep links).
- Bootstraps a labeled demo estate via `agent-bom api --demo-estate` (showcase graph + curated offline scan).
- Ships `docs/TRUST.md` and a curated sidebar **Proof path** (Queue · Graph · Runtime · Reports · Connections).

## Test plan
- [x] `uv run pytest -q tests/test_release_smoke.py tests/test_demo_estate_bootstrap.py`
- [x] `cd ui && npm test -- --run tests/finding-why-matters.test.ts tests/nav.test.tsx`
- [x] `cd ui && npm run typecheck`
- [ ] `bash scripts/release_smoke.sh` against a live API (optional)


Made with [Cursor](https://cursor.com)