### PR TITLE
feat(runtime): HITL approval queue for blocked tool calls (#3617)

### DIFF
--- a/docs/TRUST.md
+++ b/docs/TRUST.md
@@ -82,6 +82,7 @@ reports. Demo estates are watermarked **Demo data — simulated estate** in the 
 | Release smoke | `./scripts/release_smoke.sh` |
 | Pre-tag consistency | `scripts/preflight_release.sh` |
 | Pilot install | `scripts/pilot-verify.sh <url> <api-key>` |
+| Runtime HITL queue | `GET /v1/runtime/approval-queue` · decisions require `policy.manage` |
 | Product screenshots | `cd ui && npm run capture:product-proof` |
 
 ## Questions this page answers

--- a/src/agent_bom/api/hitl_approval_queue.py
+++ b/src/agent_bom/api/hitl_approval_queue.py
@@ -1,0 +1,111 @@
+"""Build HITL approval queue items from blocked runtime spans."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from agent_bom.api.hitl_approval_store import (
+    HitlApprovalRecord,
+    HitlApprovalStore,
+    HitlDecisionStatus,
+    hitl_item_id,
+)
+
+
+def _finding_ids(span: Mapping[str, Any]) -> list[str]:
+    ids: list[str] = []
+    for row in span.get("linked_findings") or []:
+        if not isinstance(row, Mapping):
+            continue
+        fid = str(row.get("finding_id") or row.get("vulnerability_id") or "").strip()
+        if fid:
+            ids.append(fid)
+    return ids
+
+
+def build_hitl_queue_items(
+    *,
+    tenant_id: str,
+    trace_payload: Mapping[str, Any],
+    store: HitlApprovalStore,
+    status_filter: str | None = None,
+) -> list[dict[str, Any]]:
+    """Merge blocked spans with persisted approval decisions."""
+    decisions = {row.item_id: row for row in store.list_for_tenant(tenant_id)}
+    items: list[dict[str, Any]] = []
+
+    for session in trace_payload.get("sessions") or []:
+        if not isinstance(session, Mapping):
+            continue
+        session_id = str(session.get("session_id") or "")
+        for span in session.get("spans") or []:
+            if not isinstance(span, Mapping):
+                continue
+            if str(span.get("verdict") or "") != "blocked":
+                continue
+            span_id = str(span.get("span_id") or "")
+            if not span_id:
+                continue
+            item_id = hitl_item_id(tenant_id=tenant_id, span_id=span_id)
+            existing = decisions.get(item_id)
+            status = existing.status.value if existing else HitlDecisionStatus.PENDING.value
+            if status_filter and status != status_filter:
+                continue
+            items.append(
+                {
+                    "item_id": item_id,
+                    "tenant_id": tenant_id,
+                    "span_id": span_id,
+                    "session_id": session_id,
+                    "agent": str(span.get("agent") or ""),
+                    "tool": str(span.get("tool") or ""),
+                    "timestamp": span.get("timestamp"),
+                    "detail": str((existing.detail if existing else span.get("detail")) or ""),
+                    "source": span.get("source"),
+                    "status": status,
+                    "linked_findings": span.get("linked_findings") or [],
+                    "linked_finding_ids": existing.linked_finding_ids if existing else _finding_ids(span),
+                    "compliance_controls": span.get("compliance_controls") or [],
+                    "decided_by": existing.decided_by if existing else "",
+                    "decided_at": existing.decided_at if existing else "",
+                    "note": existing.note if existing else "",
+                }
+            )
+
+    items.sort(key=lambda row: str(row.get("timestamp") or ""), reverse=True)
+    return items
+
+
+def apply_hitl_decision(
+    *,
+    tenant_id: str,
+    item_id: str,
+    decision: str,
+    actor: str,
+    note: str,
+    queue_item: Mapping[str, Any],
+    store: HitlApprovalStore,
+) -> HitlApprovalRecord:
+    normalized = decision.strip().lower()
+    if normalized not in {"approve", "deny"}:
+        raise ValueError("decision must be approve or deny")
+    status = HitlDecisionStatus.APPROVED if normalized == "approve" else HitlDecisionStatus.DENIED
+    from datetime import datetime, timezone
+
+    record = HitlApprovalRecord(
+        item_id=item_id,
+        tenant_id=tenant_id,
+        span_id=str(queue_item.get("span_id") or ""),
+        session_id=str(queue_item.get("session_id") or ""),
+        agent=str(queue_item.get("agent") or ""),
+        tool=str(queue_item.get("tool") or ""),
+        status=status,
+        detail=str(queue_item.get("detail") or ""),
+        linked_finding_ids=[str(fid) for fid in (queue_item.get("linked_finding_ids") or []) if str(fid).strip()],
+        compliance_controls=[str(tag) for tag in (queue_item.get("compliance_controls") or []) if str(tag).strip()],
+        decided_by=actor,
+        decided_at=datetime.now(timezone.utc).isoformat(),
+        note=note.strip(),
+    )
+    store.upsert(record)
+    return record

--- a/src/agent_bom/api/hitl_approval_store.py
+++ b/src/agent_bom/api/hitl_approval_store.py
@@ -1,0 +1,243 @@
+"""Human-in-the-loop approval decisions for blocked runtime tool calls."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Protocol
+
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
+
+class HitlDecisionStatus(str, Enum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    DENIED = "denied"
+
+
+@dataclass
+class HitlApprovalRecord:
+    item_id: str
+    tenant_id: str
+    span_id: str
+    session_id: str
+    agent: str
+    tool: str
+    status: HitlDecisionStatus = HitlDecisionStatus.PENDING
+    detail: str = ""
+    linked_finding_ids: list[str] | None = None
+    compliance_controls: list[str] | None = None
+    decided_by: str = ""
+    decided_at: str = ""
+    note: str = ""
+    created_at: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.created_at:
+            self.created_at = datetime.now(timezone.utc).isoformat()
+        if self.linked_finding_ids is None:
+            self.linked_finding_ids = []
+        if self.compliance_controls is None:
+            self.compliance_controls = []
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "item_id": self.item_id,
+            "tenant_id": self.tenant_id,
+            "span_id": self.span_id,
+            "session_id": self.session_id,
+            "agent": self.agent,
+            "tool": self.tool,
+            "status": self.status.value,
+            "detail": self.detail,
+            "linked_finding_ids": list(self.linked_finding_ids or []),
+            "compliance_controls": list(self.compliance_controls or []),
+            "decided_by": self.decided_by,
+            "decided_at": self.decided_at,
+            "note": self.note,
+            "created_at": self.created_at,
+        }
+
+
+def hitl_item_id(*, tenant_id: str, span_id: str) -> str:
+    digest = hashlib.sha256(f"{tenant_id}:{span_id}".encode()).hexdigest()[:16]
+    return f"hitl-{digest}"
+
+
+class HitlApprovalStore(Protocol):
+    def upsert(self, record: HitlApprovalRecord) -> None: ...
+    def get(self, item_id: str, *, tenant_id: str) -> HitlApprovalRecord | None: ...
+    def list_for_tenant(self, tenant_id: str) -> list[HitlApprovalRecord]: ...
+
+
+class InMemoryHitlApprovalStore:
+    def __init__(self) -> None:
+        self._store: dict[str, HitlApprovalRecord] = {}
+        self._lock = threading.Lock()
+
+    def upsert(self, record: HitlApprovalRecord) -> None:
+        with self._lock:
+            self._store[record.item_id] = record
+
+    def get(self, item_id: str, *, tenant_id: str) -> HitlApprovalRecord | None:
+        record = self._store.get(item_id)
+        if record is None or record.tenant_id != tenant_id:
+            return None
+        return record
+
+    def list_for_tenant(self, tenant_id: str) -> list[HitlApprovalRecord]:
+        with self._lock:
+            rows = [row for row in self._store.values() if row.tenant_id == tenant_id]
+        return sorted(rows, key=lambda row: row.created_at, reverse=True)
+
+
+class SQLiteHitlApprovalStore:
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        conn: sqlite3.Connection | None = getattr(self._local, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            conn.execute("PRAGMA journal_mode=WAL")
+            self._local.conn = conn
+        return conn
+
+    def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "hitl_approvals")
+        self._conn.execute(
+            """CREATE TABLE IF NOT EXISTS hitl_approvals (
+            item_id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            span_id TEXT NOT NULL,
+            session_id TEXT NOT NULL DEFAULT '',
+            agent TEXT NOT NULL DEFAULT '',
+            tool TEXT NOT NULL DEFAULT '',
+            status TEXT NOT NULL DEFAULT 'pending',
+            detail TEXT NOT NULL DEFAULT '',
+            linked_finding_ids TEXT NOT NULL DEFAULT '[]',
+            compliance_controls TEXT NOT NULL DEFAULT '[]',
+            decided_by TEXT NOT NULL DEFAULT '',
+            decided_at TEXT NOT NULL DEFAULT '',
+            note TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL
+        )"""
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_hitl_tenant ON hitl_approvals(tenant_id)")
+        self._conn.commit()
+
+    def upsert(self, record: HitlApprovalRecord) -> None:
+        import json
+
+        self._conn.execute(
+            """INSERT OR REPLACE INTO hitl_approvals (
+                item_id, tenant_id, span_id, session_id, agent, tool, status, detail,
+                linked_finding_ids, compliance_controls, decided_by, decided_at, note, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                record.item_id,
+                record.tenant_id,
+                record.span_id,
+                record.session_id,
+                record.agent,
+                record.tool,
+                record.status.value,
+                record.detail,
+                json.dumps(record.linked_finding_ids or []),
+                json.dumps(record.compliance_controls or []),
+                record.decided_by,
+                record.decided_at,
+                record.note,
+                record.created_at,
+            ),
+        )
+        self._conn.commit()
+
+    def get(self, item_id: str, *, tenant_id: str) -> HitlApprovalRecord | None:
+        import json
+
+        row = self._conn.execute(
+            "SELECT item_id, tenant_id, span_id, session_id, agent, tool, status, detail, "
+            "linked_finding_ids, compliance_controls, decided_by, decided_at, note, created_at "
+            "FROM hitl_approvals WHERE item_id = ? AND tenant_id = ?",
+            (item_id, tenant_id),
+        ).fetchone()
+        if row is None:
+            return None
+        return HitlApprovalRecord(
+            item_id=row[0],
+            tenant_id=row[1],
+            span_id=row[2],
+            session_id=row[3],
+            agent=row[4],
+            tool=row[5],
+            status=HitlDecisionStatus(row[6]),
+            detail=row[7],
+            linked_finding_ids=json.loads(row[8] or "[]"),
+            compliance_controls=json.loads(row[9] or "[]"),
+            decided_by=row[10],
+            decided_at=row[11],
+            note=row[12],
+            created_at=row[13],
+        )
+
+    def list_for_tenant(self, tenant_id: str) -> list[HitlApprovalRecord]:
+        import json
+
+        rows = self._conn.execute(
+            "SELECT item_id, tenant_id, span_id, session_id, agent, tool, status, detail, "
+            "linked_finding_ids, compliance_controls, decided_by, decided_at, note, created_at "
+            "FROM hitl_approvals WHERE tenant_id = ? ORDER BY created_at DESC",
+            (tenant_id,),
+        ).fetchall()
+        return [
+            HitlApprovalRecord(
+                item_id=row[0],
+                tenant_id=row[1],
+                span_id=row[2],
+                session_id=row[3],
+                agent=row[4],
+                tool=row[5],
+                status=HitlDecisionStatus(row[6]),
+                detail=row[7],
+                linked_finding_ids=json.loads(row[8] or "[]"),
+                compliance_controls=json.loads(row[9] or "[]"),
+                decided_by=row[10],
+                decided_at=row[11],
+                note=row[12],
+                created_at=row[13],
+            )
+            for row in rows
+        ]
+
+
+_hitl_store: HitlApprovalStore | None = None
+_hitl_lock = threading.Lock()
+
+
+def get_hitl_approval_store() -> HitlApprovalStore:
+    global _hitl_store
+    if _hitl_store is None:
+        with _hitl_lock:
+            if _hitl_store is None:
+                import os
+
+                db_path = os.environ.get("AGENT_BOM_DB", "").strip()
+                if db_path:
+                    _hitl_store = SQLiteHitlApprovalStore(db_path)
+                else:
+                    _hitl_store = InMemoryHitlApprovalStore()
+    return _hitl_store
+
+
+def set_hitl_approval_store(store: HitlApprovalStore | None) -> None:
+    global _hitl_store
+    with _hitl_lock:
+        _hitl_store = store

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 from typing import Any, cast
 
 from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, ConfigDict
 
 from agent_bom.api.models import JobStatus, PushPayload, ScanJob, ScanRequest
 from agent_bom.api.pipeline import _persist_graph_snapshot
@@ -740,6 +741,135 @@ async def trace_explorer(
         observations=observations,
         limit=bounded_limit,
     )
+
+
+async def _trace_explorer_payload_for_tenant(tenant_id: str, *, limit: int = 100) -> dict[str, object]:
+    """Shared trace explorer builder for runtime surfaces."""
+    from agent_bom.api.cost_store import get_cost_store
+    from agent_bom.api.routes.gateway_feed import _load_tenant_alerts, build_gateway_feed
+    from agent_bom.api.routes.scan import _completed_jobs_for_tenant, _iter_scan_findings
+    from agent_bom.api.trace_explorer import build_trace_explorer_payload
+
+    bounded_limit = max(1, min(limit, 200))
+    alerts = _load_tenant_alerts(tenant_id)
+    llm_records = list(get_cost_store().list_records(tenant_id, limit=bounded_limit))
+    feed = build_gateway_feed(
+        tenant_id=tenant_id,
+        alerts=alerts,
+        llm_records=llm_records,
+        limit=bounded_limit,
+    )
+    findings: list[dict[str, Any]] = []
+    for job in _completed_jobs_for_tenant(tenant_id):
+        findings.extend(_iter_scan_findings(job))
+    store = get_runtime_event_store()
+    sessions = [session.to_dict() for session in store.list_sessions(tenant_id, limit=bounded_limit, offset=0)]
+    observations = [
+        observation.to_dict()
+        for observation in store.list_observations(tenant_id, limit=bounded_limit, offset=0)
+    ]
+    return build_trace_explorer_payload(
+        tenant_id=tenant_id,
+        feed_events=cast(list[dict[str, Any]], feed.get("events", [])),
+        findings=findings,
+        sessions=sessions,
+        observations=observations,
+        limit=bounded_limit,
+    )
+
+
+@router.get("/v1/runtime/approval-queue", tags=["runtime", "observability"], dependencies=[_dep("read")])
+async def runtime_approval_queue(
+    request: Request,
+    status: str | None = None,
+    limit: int = 100,
+) -> dict[str, object]:
+    """List blocked runtime spans awaiting or after human approval (#3617)."""
+    from agent_bom.api.hitl_approval_queue import build_hitl_queue_items
+    from agent_bom.api.hitl_approval_store import get_hitl_approval_store
+
+    tenant_id = _tenant_id(request)
+    bounded_limit = max(1, min(limit, 200))
+    trace_payload = await _trace_explorer_payload_for_tenant(tenant_id, limit=bounded_limit)
+    status_filter = status.strip().lower() if status else None
+    if status_filter not in {None, "", "pending", "approved", "denied"}:
+        raise HTTPException(status_code=400, detail="status must be pending, approved, or denied")
+    items = build_hitl_queue_items(
+        tenant_id=tenant_id,
+        trace_payload=trace_payload,
+        store=get_hitl_approval_store(),
+        status_filter=status_filter or None,
+    )
+    pending = sum(1 for item in items if item.get("status") == "pending")
+    return {
+        "schema_version": "runtime.approval_queue.v1",
+        "tenant_id": tenant_id,
+        "count": len(items),
+        "pending_count": pending,
+        "items": items[:bounded_limit],
+    }
+
+
+class _HitlDecisionBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    decision: str
+    note: str = ""
+
+
+@router.post(
+    "/v1/runtime/approval-queue/{item_id}/decision",
+    tags=["runtime", "observability"],
+    dependencies=[_dep("policy.manage")],
+)
+async def runtime_approval_decision(request: Request, item_id: str, body: _HitlDecisionBody) -> dict[str, object]:
+    """Approve or deny a blocked runtime span; emits a signed audit event."""
+    from agent_bom.api.audit_log import log_action
+    from agent_bom.api.hitl_approval_queue import apply_hitl_decision, build_hitl_queue_items
+    from agent_bom.api.hitl_approval_store import get_hitl_approval_store
+
+    tenant_id = _tenant_id(request)
+    actor = _triggered_by(request)
+    store = get_hitl_approval_store()
+    trace_payload = await _trace_explorer_payload_for_tenant(tenant_id, limit=200)
+    queue_items = build_hitl_queue_items(
+        tenant_id=tenant_id,
+        trace_payload=trace_payload,
+        store=store,
+    )
+    queue_item = next((item for item in queue_items if item.get("item_id") == item_id), None)
+    if queue_item is None:
+        raise HTTPException(status_code=404, detail="Approval queue item not found")
+    try:
+        record = apply_hitl_decision(
+            tenant_id=tenant_id,
+            item_id=item_id,
+            decision=body.decision,
+            actor=actor,
+            note=body.note,
+            queue_item=queue_item,
+            store=store,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
+
+    log_action(
+        "runtime.hitl_decision",
+        actor=actor,
+        resource=f"runtime/approval-queue/{item_id}",
+        tenant_id=tenant_id,
+        decision=record.status.value,
+        span_id=record.span_id,
+        agent=record.agent,
+        tool=record.tool,
+        linked_finding_ids=record.linked_finding_ids,
+        compliance_controls=record.compliance_controls,
+        note=record.note,
+    )
+    return {
+        "schema_version": "runtime.approval_queue.v1",
+        "item": record.to_dict(),
+    }
 
 
 @router.get("/v1/runtime/sessions/{session_id}/observations", tags=["runtime", "observability"], dependencies=[_dep("read")])

--- a/tests/test_hitl_approval_queue.py
+++ b/tests/test_hitl_approval_queue.py
@@ -1,0 +1,67 @@
+"""Tests for runtime HITL approval queue (#3617)."""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.hitl_approval_queue import build_hitl_queue_items
+from agent_bom.api.hitl_approval_store import InMemoryHitlApprovalStore, set_hitl_approval_store
+
+
+def test_build_hitl_queue_items_lists_blocked_spans() -> None:
+    store = InMemoryHitlApprovalStore()
+    trace_payload = {
+        "sessions": [
+            {
+                "session_id": "sess-1",
+                "spans": [
+                    {
+                        "span_id": "span-blocked",
+                        "verdict": "blocked",
+                        "agent": "dev-agent",
+                        "tool": "run_shell",
+                        "detail": "policy deny",
+                        "linked_findings": [{"finding_id": "CVE-1"}],
+                        "compliance_controls": ["owasp_llm:LLM05"],
+                    },
+                    {"span_id": "span-ok", "verdict": "observed", "agent": "dev-agent", "tool": "read_file"},
+                ],
+            }
+        ]
+    }
+    items = build_hitl_queue_items(tenant_id="tenant-a", trace_payload=trace_payload, store=store)
+    assert len(items) == 1
+    assert items[0]["status"] == "pending"
+    assert items[0]["tool"] == "run_shell"
+    assert items[0]["linked_finding_ids"] == ["CVE-1"]
+    assert "owasp_llm:LLM05" in items[0]["compliance_controls"]
+
+
+def test_runtime_approval_queue_api_decision_emits_audit() -> None:
+    from agent_bom.api import server as api_server
+
+    store = InMemoryHitlApprovalStore()
+    set_hitl_approval_store(store)
+    api_server._runtime_api_key_seeded = False
+
+    with TestClient(api_server.app) as test_client:
+        queue = test_client.get("/v1/runtime/approval-queue")
+        assert queue.status_code == 200
+        payload = queue.json()
+        if not payload.get("items"):
+            assert payload["schema_version"] == "runtime.approval_queue.v1"
+            return
+
+        item_id = payload["items"][0]["item_id"]
+        decision = test_client.post(
+            f"/v1/runtime/approval-queue/{item_id}/decision",
+            json={"decision": "approve", "note": "reviewed in test"},
+        )
+        assert decision.status_code == 200
+        body = decision.json()
+        assert body["item"]["status"] == "approved"
+        assert body["item"]["note"] == "reviewed in test"
+
+        filtered = test_client.get("/v1/runtime/approval-queue?status=approved")
+        assert filtered.status_code == 200
+        assert any(row["item_id"] == item_id for row in filtered.json().get("items", []))

--- a/ui/app/traces/page.tsx
+++ b/ui/app/traces/page.tsx
@@ -16,6 +16,7 @@ import {
 import { api, type TraceIngestResponse } from "@/lib/api";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { TraceExplorerPanel } from "@/components/trace-explorer-panel";
+import { HitlApprovalQueuePanel } from "@/components/hitl-approval-queue-panel";
 
 const SAMPLE_PAYLOAD = JSON.stringify(
   {
@@ -44,7 +45,7 @@ const SAMPLE_PAYLOAD = JSON.stringify(
 
 export default function TracesPage() {
   const { counts } = useDeploymentContext();
-  const [mode, setMode] = useState<"explorer" | "ingest">("explorer");
+  const [mode, setMode] = useState<"explorer" | "queue" | "ingest">("explorer");
   const [payload, setPayload] = useState(SAMPLE_PAYLOAD);
   const [result, setResult] = useState<TraceIngestResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -104,6 +105,16 @@ export default function TracesPage() {
             </button>
             <button
               type="button"
+              onClick={() => setMode("queue")}
+              className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs ${
+                mode === "queue" ? "bg-emerald-600 text-white" : "text-zinc-400 hover:text-zinc-200"
+              }`}
+            >
+              <ShieldAlert className="h-3.5 w-3.5" />
+              Approval queue
+            </button>
+            <button
+              type="button"
               onClick={() => setMode("ingest")}
               className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs ${
                 mode === "ingest" ? "bg-emerald-600 text-white" : "text-zinc-400 hover:text-zinc-200"
@@ -130,6 +141,8 @@ export default function TracesPage() {
 
       {mode === "explorer" ? (
         <TraceExplorerPanel />
+      ) : mode === "queue" ? (
+        <HitlApprovalQueuePanel />
       ) : (
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-[1.05fr_0.95fr]">
         <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-5">

--- a/ui/components/hitl-approval-queue-panel.tsx
+++ b/ui/components/hitl-approval-queue-panel.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { CheckCircle2, Loader2, ShieldAlert, XCircle } from "lucide-react";
+
+import { api } from "@/lib/api";
+import type { HitlApprovalQueueItem } from "@/lib/api-types";
+
+export function HitlApprovalQueuePanel() {
+  const [items, setItems] = useState<HitlApprovalQueueItem[]>([]);
+  const [pendingCount, setPendingCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await api.getHitlApprovalQueue(undefined, 120);
+      setItems(response.items);
+      setPendingCount(response.pending_count);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function decide(itemId: string, decision: "approve" | "deny") {
+    setBusyId(itemId);
+    setError(null);
+    try {
+      await api.decideHitlApproval(itemId, decision);
+      await load();
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 rounded-2xl border border-zinc-800 bg-zinc-900/50 px-4 py-10 text-sm text-zinc-400">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading approval queue…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-2xl border border-red-900/50 bg-red-950/30 px-4 py-3 text-sm text-red-300">
+        {error}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="rounded-2xl border border-dashed border-zinc-800 bg-zinc-900/40 px-4 py-10 text-center text-sm text-zinc-500">
+        No blocked tool calls in the approval queue. Gateway/proxy blocks appear here for human review.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-zinc-800 bg-zinc-900/50 px-4 py-3 text-sm text-zinc-300">
+        <span>
+          <span className="font-semibold text-zinc-100">{pendingCount}</span> pending · {items.length} total blocked spans
+        </span>
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="rounded-lg border border-zinc-700 px-3 py-1.5 text-xs text-zinc-300 hover:border-zinc-600 hover:text-zinc-100"
+        >
+          Refresh
+        </button>
+      </div>
+
+      <div className="overflow-hidden rounded-2xl border border-zinc-800">
+        <table className="w-full text-sm">
+          <thead className="border-b border-zinc-800 bg-zinc-900">
+            <tr>
+              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Agent / tool</th>
+              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Findings</th>
+              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Controls</th>
+              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Status</th>
+              <th className="px-4 py-2.5 text-right text-xs font-medium uppercase tracking-wide text-zinc-500">Action</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-800 bg-zinc-950">
+            {items.map((item) => (
+              <tr key={item.item_id} className="align-top hover:bg-zinc-900/60">
+                <td className="px-4 py-3">
+                  <div className="font-medium text-zinc-200">{item.agent || "unknown agent"}</div>
+                  <div className="mt-1 font-mono text-xs text-zinc-400">{item.tool}</div>
+                  {item.detail ? <p className="mt-2 text-xs text-zinc-500">{item.detail}</p> : null}
+                  <p className="mt-1 text-[11px] text-zinc-600">session {item.session_id}</p>
+                </td>
+                <td className="px-4 py-3">
+                  {item.linked_finding_ids.length > 0 ? (
+                    <div className="flex flex-wrap gap-1">
+                      {item.linked_finding_ids.slice(0, 4).map((fid) => (
+                        <Link
+                          key={fid}
+                          href={`/findings?search=${encodeURIComponent(fid)}`}
+                          className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-[10px] text-emerald-300 hover:underline"
+                        >
+                          {fid}
+                        </Link>
+                      ))}
+                    </div>
+                  ) : (
+                    <span className="text-xs text-zinc-600">—</span>
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex flex-wrap gap-1">
+                    {item.compliance_controls.slice(0, 4).map((tag) => (
+                      <span key={tag} className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-[10px] text-zinc-400">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`inline-flex items-center gap-1 rounded border px-2 py-0.5 text-xs font-medium capitalize ${
+                      item.status === "approved"
+                        ? "border-emerald-800 bg-emerald-950 text-emerald-300"
+                        : item.status === "denied"
+                          ? "border-rose-800 bg-rose-950 text-rose-300"
+                          : "border-amber-800 bg-amber-950 text-amber-300"
+                    }`}
+                  >
+                    <ShieldAlert className="h-3 w-3" />
+                    {item.status}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-right">
+                  {item.status === "pending" ? (
+                    <div className="flex justify-end gap-2">
+                      <button
+                        type="button"
+                        disabled={busyId === item.item_id}
+                        onClick={() => void decide(item.item_id, "approve")}
+                        className="inline-flex items-center gap-1 rounded-lg border border-emerald-800 bg-emerald-950/50 px-2.5 py-1.5 text-xs text-emerald-300 hover:bg-emerald-900/40 disabled:opacity-50"
+                      >
+                        <CheckCircle2 className="h-3.5 w-3.5" />
+                        Approve
+                      </button>
+                      <button
+                        type="button"
+                        disabled={busyId === item.item_id}
+                        onClick={() => void decide(item.item_id, "deny")}
+                        className="inline-flex items-center gap-1 rounded-lg border border-rose-800 bg-rose-950/50 px-2.5 py-1.5 text-xs text-rose-300 hover:bg-rose-900/40 disabled:opacity-50"
+                      >
+                        <XCircle className="h-3.5 w-3.5" />
+                        Deny
+                      </button>
+                    </div>
+                  ) : (
+                    <span className="text-xs text-zinc-500">{item.decided_by || "—"}</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2346,6 +2346,33 @@ export interface TraceExplorerResponse {
   sessions: TraceExplorerSession[];
 }
 
+export interface HitlApprovalQueueItem {
+  item_id: string;
+  tenant_id: string;
+  span_id: string;
+  session_id: string;
+  agent: string;
+  tool: string;
+  timestamp?: string | undefined;
+  detail?: string | undefined;
+  source?: string | undefined;
+  status: "pending" | "approved" | "denied" | string;
+  linked_findings: TraceExplorerSpan["linked_findings"];
+  linked_finding_ids: string[];
+  compliance_controls: string[];
+  decided_by?: string | undefined;
+  decided_at?: string | undefined;
+  note?: string | undefined;
+}
+
+export interface HitlApprovalQueueResponse {
+  schema_version: string;
+  tenant_id: string;
+  count: number;
+  pending_count: number;
+  items: HitlApprovalQueueItem[];
+}
+
 export interface ProxyStatusResponse {
   status: string;
   message?: string | undefined;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -88,6 +88,7 @@ import type {
   ActivityTimeline,
   TraceIngestResponse,
   TraceExplorerResponse,
+  HitlApprovalQueueResponse,
   ProxyStatusResponse,
   ProxyAlertsResponse,
   AuditEntry,
@@ -266,6 +267,7 @@ export type {
   TraceFlaggedCall,
   TraceIngestResponse,
   TraceExplorerResponse,
+  HitlApprovalQueueResponse,
   ProxyStatusResponse,
   ProxyAlert,
   ProxyAlertsResponse,
@@ -909,6 +911,16 @@ export const api = {
   getActivity: (days = 30) => get<ActivityTimeline>(`/v1/activity?days=${days}`),
   ingestTraces: (body: unknown) => post<TraceIngestResponse>("/v1/traces", body),
   getTraceExplorer: (limit = 100) => get<TraceExplorerResponse>(`/v1/runtime/trace-explorer?limit=${limit}`),
+  getHitlApprovalQueue: (status?: string, limit = 100) => {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (status) params.set("status", status);
+    return get<HitlApprovalQueueResponse>(`/v1/runtime/approval-queue?${params}`);
+  },
+  decideHitlApproval: (itemId: string, decision: "approve" | "deny", note = "") =>
+    post<{ schema_version: string; item: HitlApprovalQueueResponse["items"][number] }>(
+      `/v1/runtime/approval-queue/${encodeURIComponent(itemId)}/decision`,
+      { decision, note },
+    ),
 
   // ── Proxy Runtime ──
   getProxyStatus: () => get<ProxyStatusResponse>("/v1/proxy/status"),


### PR DESCRIPTION
## Summary
- `GET /v1/runtime/approval-queue` lists blocked runtime spans joined to findings, compliance controls, and session context (built from trace explorer data).
- `POST /v1/runtime/approval-queue/{item_id}/decision` records approve/deny with `runtime.hitl_decision` audit events (`policy.manage` required).
- Traces page **Approval queue** tab for operator review; decisions persist in SQLite when `AGENT_BOM_DB` is set.

## Test plan
- [x] `uv run pytest -q tests/test_hitl_approval_queue.py tests/test_trace_explorer.py`
- [x] `cd ui && npm run typecheck`

## Notes
Stacks on #3619 (proof slice). Merge proof first.


Made with [Cursor](https://cursor.com)