### PR TITLE
docs(deploy): unified install script, quickstart, and intake diagrams

### DIFF
--- a/deploy/RUNBOOK.md
+++ b/deploy/RUNBOOK.md
@@ -1,0 +1,136 @@
+# agent-bom deployment runbook
+
+Operator runbook for multicloud collectors, cross-cloud federation, and
+post-install onboarding. Complements [`docs/DEPLOY_QUICKSTART.md`](../docs/DEPLOY_QUICKSTART.md).
+
+---
+
+## Quick entry
+
+```bash
+scripts/deploy/install.sh list
+scripts/deploy/install.sh pilot                    # local proof
+scripts/deploy/install.sh eks --create-cluster     # AWS production path
+scripts/deploy/install.sh connect aws              # read-only account onboarding
+scripts/deploy/install.sh onboard --url URL --api-key KEY
+```
+
+---
+
+## Control-plane + collector seam
+
+```
+  control plane (you run)          collector / connect (read-only in customer cloud)
+  ───────────────────────          ─────────────────────────────────────────────
+  API + UI + Postgres + graph  ←── IAM / RBAC / SA roles (connect-* Terraform)
+  fleet ingest /v1/fleet/sync
+  POST /v1/cloud/connections
+```
+
+The control plane is the same Helm chart / Docker images everywhere. Collectors
+are read-only principals minted by `deploy/terraform/connect-*`.
+
+---
+
+## Per-cloud collector starting points
+
+| Cloud | Connect module | Helm collector overlay |
+|-------|----------------|------------------------|
+| AWS | `deploy/terraform/connect-aws` | `eks-collector-irsa-values.yaml` |
+| Azure | `deploy/terraform/connect-azure` | `aks-collector-workload-identity-values.yaml` |
+| GCP | `deploy/terraform/connect-gcp` | `gke-collector-workload-identity-values.yaml` |
+| Snowflake | `deploy/terraform/connect-snowflake` | key-pair Secret in `multicloud-collector-values.yaml` |
+| All four | apply each connect module | `multicloud-collector-values.yaml` |
+
+Enable inventory in Helm:
+
+```yaml
+scanner:
+  enabled: true
+  cloud:
+    enabled: true
+    aws:   { inventory: true }
+    azure: { inventory: true }
+    gcp:   { inventory: true }
+    snowflake: { inventory: true, account: "...", user: "...", keySecretName: "..." }
+```
+
+Or per-provider env flags — see [`docs/CLOUD_CONNECT.md`](../docs/CLOUD_CONNECT.md).
+
+---
+
+## Cross-cloud federation
+
+`multicloud-collector-values.yaml` runs **one CronJob on EKS** and reaches AWS +
+GCP + Azure + Snowflake. Two supported patterns:
+
+### Pattern A — Single-cloud collectors (simplest)
+
+Run a collector **native to each cloud** with that cloud's workload identity:
+
+1. EKS + `eks-collector-irsa-values.yaml` → AWS inventory
+2. AKS + `aks-collector-workload-identity-values.yaml` → Azure inventory
+3. GKE + `gke-collector-workload-identity-values.yaml` → GCP inventory
+4. Snowflake key-pair Secret on whichever cluster runs the Snowflake scan job
+
+Each collector pushes to the same control plane (`AGENT_BOM_PUSH_URL` or API
+cloud connection scans). **Recommended for production.**
+
+### Pattern B — Multicloud CronJob on EKS (advanced)
+
+One pod on EKS with:
+
+- **AWS:** IRSA role (`eks.amazonaws.com/role-arn`)
+- **GCP:** Workload Identity Federation — `connect-gcp` README § workload identity pool trusting the EKS OIDC issuer; annotate SA with `iam.gke.io/gcp-service-account`
+- **Azure:** Federated credential on the EKS OIDC issuer → `azure.workload.identity/client-id` annotation
+- **Snowflake:** PEM key in Kubernetes Secret (no cloud WI); passphrase via optional Secret
+
+Prereqs:
+
+1. EKS OIDC provider enabled on the cluster
+2. `connect-gcp` / `connect-azure` federation configured to trust that issuer
+3. `multicloud-collector-values.yaml` values filled with real ARNs/client IDs
+4. NetworkPolicy egress allowed to cloud APIs + Snowflake
+
+If federation is not configured, use Pattern A.
+
+---
+
+## Post-install onboarding checklist
+
+1. **Health** — `GET /healthz` returns 200
+2. **Auth** — API key or OIDC; non-loopback fails closed without auth
+3. **Connect** — at least one `connect-*` module applied; register via API or Helm
+4. **Scan** — `POST /v1/scan` or wait for CronJob; findings appear in Queue
+5. **Fleet** — `proxy-bootstrap` bundle on a pilot workstation; `POST /v1/fleet/sync` succeeds
+6. **Graph** — non-empty nodes after connect + fleet
+7. **Smoke** — `scripts/pilot-verify.sh <url> <key>` or `scripts/release_smoke.sh`
+
+---
+
+## Snowflake lanes
+
+| Lane | When | Doc |
+|------|------|-----|
+| Self-hosted POV | API/UI in customer K8s/VM; Snowflake read-only | `site-docs/deployment/snowflake-pov.md` |
+| Native App + SPCS | In-account install; scanner/MCP runtime opt-in | `docs/snowflake-native-app/INSTALL.md` |
+| Warehouse backend | Export findings to Snowflake tables | `snowflake-backend` Helm profile |
+
+---
+
+## Teardown
+
+```bash
+scripts/deploy/teardown-eks-reference.sh    # EKS reference install
+helm uninstall agent-bom -n agent-bom        # Helm-only
+cd deploy/terraform/connect-aws && terraform destroy   # per connect module
+```
+
+---
+
+## Related
+
+- [`docs/DEPLOY_QUICKSTART.md`](../docs/DEPLOY_QUICKSTART.md)
+- [`docs/DEPLOY_PLATFORM.md`](../docs/DEPLOY_PLATFORM.md)
+- [`deploy/terraform/README.md`](terraform/README.md)
+- [`deploy/helm/agent-bom/examples/README.md`](helm/agent-bom/examples/README.md)

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -33,6 +33,7 @@ services:
     environment:
       AGENT_BOM_DB_PATH: /var/lib/agent-bom/vulns.db
       AGENT_BOM_DEPLOYMENT_ENV: pilot-loopback
+      AGENT_BOM_DEMO_ESTATE: ${AGENT_BOM_DEMO_ESTATE:-0}
     ports:
       - "127.0.0.1:8422:8422"
     volumes:

--- a/docs/DEPLOY_PLATFORM.md
+++ b/docs/DEPLOY_PLATFORM.md
@@ -1,5 +1,9 @@
 # Deploy agent-bom anywhere
 
+> **Quickstart:** [`DEPLOY_QUICKSTART.md`](DEPLOY_QUICKSTART.md) — one script,
+> Wiz-style onboarding (deploy → connect accounts → inventory → scans).
+> Run `scripts/deploy/install.sh list` from the repo root.
+
 agent-bom is one product with one control plane (API + UI) and a stateless
 scanner. You can run that control plane wherever you want it — on a laptop, on
 your own Kubernetes cluster, or as a hosted service where you operate the
@@ -174,6 +178,8 @@ enterprise customer-owned install path.
 
 ## Related
 
+- [`DEPLOY_QUICKSTART.md`](DEPLOY_QUICKSTART.md) — unified install script + onboarding
+- [`deploy/RUNBOOK.md`](../deploy/RUNBOOK.md) — multicloud collector federation
 - [`platform-eks` module](../deploy/terraform/platform-eks/README.md) — one-apply EKS
 - [`aws/baseline` module](../deploy/terraform/aws/baseline/README.md) — RDS/IRSA/S3/Secrets
 - [`connect-*` modules](../deploy/terraform/) — read-only cloud connect roles

--- a/docs/DEPLOY_QUICKSTART.md
+++ b/docs/DEPLOY_QUICKSTART.md
@@ -1,0 +1,327 @@
+# Deploy quickstart — one product, any cloud
+
+This is the **Wiz-style onboarding story** for agent-bom: deploy the control
+plane once, connect read-only cloud accounts and endpoints, and get inventory,
+assets, scans, MCP/agents, and AI BOM evidence in one graph — without handing
+credentials to a hosted SaaS.
+
+For architecture depth see [`DEPLOY_PLATFORM.md`](DEPLOY_PLATFORM.md). For the
+read-only connect model see [`CLOUD_CONNECT.md`](CLOUD_CONNECT.md). For trust
+boundaries see [`TRUST.md`](TRUST.md).
+
+---
+
+## What you get out of the box
+
+Once the control plane is live **and** you connect at least one source:
+
+| Capability | Source | How it appears |
+|------------|--------|----------------|
+| **Cloud inventory** | AWS, Azure, GCP, Snowflake | Resources, identities, IAM/CNAPP posture in the security graph |
+| **AI / MCP agents** | Workstations, K8s, fleet sync | Agents, MCP servers, tools, skills in fleet + graph |
+| **Findings queue** | Scans + cloud posture | Ranked by reach, blast radius, compliance tags |
+| **Auto / scheduled scans** | Helm CronJob, API, CLI | Recurring inventory + vulnerability evidence |
+| **MCP runtime** | MCP server mode, gateway, proxy | Policy on tool calls; optional HITL approval queue |
+| **Exports** | CLI + API | SARIF, SBOM, CSV, compliance bundles |
+
+Nothing is mutated in your cloud. Connect modules mint **read-only** roles only.
+
+---
+
+## BYOC / self-hosted (the default product model)
+
+**BYOC = Bring Your Own Cloud.** You run the control plane; agent-bom does not
+require a vendor-hosted SaaS.
+
+| Layer | You run | agent-bom provides |
+|-------|---------|-------------------|
+| **Control plane** | Your VM, EKS, AKS, GKE, or Snowflake Native App lane | API + UI + Postgres + graph (Helm / Compose / Terraform) |
+| **Scanned estates** | Your AWS/Azure/GCP/Snowflake accounts | Read-only `connect-*` Terraform modules |
+| **Endpoints** | Your laptops / golden images | `proxy-bootstrap` → fleet sync bundle |
+| **Runtime** (optional) | Your MCP workloads | Proxy sidecar / gateway in your cluster |
+| **Model** (optional) | Your Ollama / litellm keys on workers | `--ai-enrich` on scan jobs — not required for core product |
+
+Managed agent-bom Cloud is **not** shipped in this repo. Hosted POC is
+invite-only operator-run evaluation — see [`HOSTED_POC.md`](HOSTED_POC.md).
+
+---
+
+## What feeds the control plane (automatic-ish inventory)
+
+Once hosted, data flows **into** the API from many paths — not only CLI.
+
+```text
+┌─────────────────────────────────────────────────────────┐
+│              YOUR HOSTED CONTROL PLANE                   │
+│         API + UI + Postgres + graph                      │
+└────────▲────────▲────────▲────────▲────────▲──────────────┘
+         │        │        │        │        │
+    fleet sync  scans   cloud     proxy/    CI / bulk
+    (endpoints) (jobs)  connect   gateway   ingest
+```
+
+```mermaid
+flowchart TB
+    subgraph Intake["Intake paths (customer-owned)"]
+        Fleet["Endpoint fleet<br/>proxy-bootstrap · MDM"]
+        ScanJobs["Scan jobs<br/>UI · API · CronJob · CI"]
+        Cloud["Cloud connect<br/>read-only roles"]
+        Runtime["Runtime<br/>proxy · gateway"]
+        Bulk["External evidence<br/>bulk · SARIF · SBOM"]
+    end
+
+    subgraph CP["Your hosted control plane"]
+        API["API<br/>auth · RBAC · tenant · jobs"]
+        UI["Dashboard"]
+        Graph["Graph + findings + audit"]
+        PG[("Postgres")]
+    end
+
+    Fleet -->|POST /v1/fleet/sync| API
+    ScanJobs -->|POST /v1/scan| API
+    Cloud -->|connections + inventory scans| API
+    Runtime -->|POST /v1/proxy/audit · policy pull| API
+    Bulk -->|POST /v1/findings/bulk · /v1/compliance/ingest| API
+    API --> Graph
+    API --> PG
+    UI --> API
+```
+
+### Intake reference
+
+| Intake | How | Endpoint / mechanism |
+|--------|-----|----------------------|
+| **Cloud inventory** | Read-only connect + scheduled scan | `POST /v1/cloud/connections`, Helm CronJob, `GET /v1/cloud/{provider}/inventory` |
+| **Endpoint / MCP agents** | Fleet push from laptops | `POST /v1/fleet/sync` via `proxy-bootstrap` bundle |
+| **On-demand scans** | Dashboard or API | `POST /v1/scan` · UI `/scan` |
+| **Scheduled scans** | K8s CronJob / enterprise-demo profile | Helm `scanner.enabled=true` |
+| **Runtime events** | Proxy / gateway | `POST /v1/proxy/audit`, gateway policy pull |
+| **External findings** | Other scanners | `POST /v1/findings/bulk` |
+| **SBOM / SARIF / CSV** | Compliance hub import | `POST /v1/compliance/ingest` |
+| **CLI / local dev** | Same evidence model | `agent-bom agents`, `fleet sync`, GitHub Action → API |
+
+The browser **never** reads your cloud directly — UI triggers work; workers and
+collectors execute. See
+[`site-docs/architecture/self-hosted-product-architecture.md`](../site-docs/architecture/self-hosted-product-architecture.md).
+
+### Hosted dashboard (not CLI-only)
+
+| Area | Route | Operator action |
+|------|-------|-----------------|
+| Overview | `/overview` | Estate posture |
+| Findings | `/findings` | Triage queue |
+| Graph | `/security-graph`, `/graph` | Inventory + reach |
+| Fleet | `/fleet`, `/agents` | Endpoints + MCP configs |
+| Connections | `/connections` | Register cloud accounts |
+| Scan | `/scan` | Run-now scans |
+| Jobs | `/jobs` | Job history |
+| Runtime | `/runtime`, `/proxy`, `/gateway`, `/traces` | Policy + audit + HITL queue |
+| Compliance | `/compliance` | Framework evidence + exports |
+
+Proof-path nav in the UI: **Queue · Graph · Runtime · Reports · Connections**.
+
+---
+
+## One script, pick your host
+
+```bash
+scripts/deploy/install.sh list          # all targets
+scripts/deploy/install.sh pilot         # fastest — laptop Docker, ~2 min
+```
+
+### Local pilot (fastest proof)
+
+```bash
+scripts/deploy/install.sh pilot
+# Dashboard → http://localhost:3000
+# API       → http://localhost:8422/docs
+```
+
+Optional curated demo estate (showcase graph + offline scan on API start):
+
+```bash
+AGENT_BOM_DEMO_ESTATE=1 scripts/deploy/install.sh pilot
+# or: agent-bom api --demo-estate
+```
+
+### Docker on a VM (team pilot)
+
+```bash
+cp .env.example .env    # set POSTGRES_PASSWORD
+scripts/deploy/install.sh docker
+```
+
+Production-shaped single host (Docker secrets, split networks):
+
+```bash
+scripts/deploy/install.sh platform-docker
+```
+
+### AWS / EKS (recommended production installer)
+
+```bash
+export AWS_REGION="<your-aws-region>"
+scripts/deploy/install.sh eks --create-cluster --region "$AWS_REGION" --enable-gateway
+```
+
+Or one `terraform apply` (cluster + RDS + IRSA + Helm):
+
+```bash
+cd deploy/terraform/platform-eks
+cp terraform.tfvars.example terraform.tfvars
+terraform init && terraform apply
+```
+
+### Azure / AKS
+
+agent-bom does not ship a `platform-aks` Terraform root yet. On a cluster you
+already manage:
+
+```bash
+scripts/deploy/install.sh aks --profile enterprise-demo
+scripts/deploy/install.sh connect azure    # per subscription
+```
+
+Helm overlay: `deploy/helm/agent-bom/examples/aks-collector-workload-identity-values.yaml`
+
+### GCP / GKE
+
+```bash
+scripts/deploy/install.sh gke --profile enterprise-demo
+scripts/deploy/install.sh connect gcp       # per project
+```
+
+Helm overlay: `deploy/helm/agent-bom/examples/gke-collector-workload-identity-values.yaml`
+
+### Any Kubernetes (Helm profile)
+
+```bash
+python3 scripts/install_helm_profile.py --list
+scripts/deploy/install.sh helm production
+```
+
+### Snowflake
+
+**Self-hosted POV** (API + UI in your infra, Snowflake as read-only source):
+
+```bash
+scripts/deploy/install.sh snowflake
+scripts/deploy/install.sh connect snowflake
+```
+
+Guide: [`site-docs/deployment/snowflake-pov.md`](../site-docs/deployment/snowflake-pov.md)
+
+**Native App + SPCS** (customer Snowflake account, in-account scanner/MCP):
+
+```bash
+scripts/deploy/install.sh snowflake-native
+# → docs/snowflake-native-app/INSTALL.md
+```
+
+---
+
+## Onboarding flow (after control plane is live)
+
+Same pattern as CSPM onboarding: **deploy → connect accounts → inventory → scan**.
+
+```
+  ┌─────────────┐     read-only      ┌──────────────────┐
+  │ Control     │◀──── connect ──────│ AWS / Azure /    │
+  │ plane       │                    │ GCP / Snowflake  │
+  │ API+UI+graph│                    └──────────────────┘
+  └──────┬──────┘
+         │ fleet sync (workstations, MCP configs)
+         ▼
+  ┌─────────────┐
+  │ Endpoints   │
+  │ + K8s pods  │
+  └─────────────┘
+```
+
+### Step 1 — Connect cloud accounts (read-only)
+
+```bash
+scripts/deploy/install.sh connect aws
+scripts/deploy/install.sh connect azure
+scripts/deploy/install.sh connect gcp
+scripts/deploy/install.sh connect snowflake
+```
+
+Each module prints outputs (role ARN, external ID, etc.). Register them:
+
+- **API:** `POST /v1/cloud/connections` → test → scan
+- **Helm:** `scanner.cloud.<provider>.inventory=true` in values
+- **CLI:** `AGENT_BOM_AWS_INVENTORY=1` (and per-provider flags) — see [`CLOUD_CONNECT.md`](CLOUD_CONNECT.md)
+
+### Step 2 — Auto inventory + scheduled scans
+
+| Path | Command / config |
+|------|------------------|
+| Helm scheduled AWS inventory | `enterprise-demo` profile or `eks-enterprise-demo-overlay.yaml` |
+| Multicloud collector | `multicloud-collector-values.yaml` — see [`deploy/RUNBOOK.md`](../deploy/RUNBOOK.md) |
+| On-demand API scan | `POST /v1/scan` |
+| CLI | `agent-bom agents --preset enterprise --aws` |
+
+### Step 3 — Endpoint + MCP/agent fleet
+
+Workstations and IDE agents push inventory without inline traffic control:
+
+```bash
+agent-bom proxy-bootstrap \
+  --control-plane-url https://agent-bom.example.com \
+  --push-url https://agent-bom.example.com/v1/fleet/sync \
+  --push-api-key "$AGENT_BOM_API_KEY"
+```
+
+MDM bundles: `deploy/endpoints/` (Jamf, Kandji, Intune).
+
+### Step 4 — Verify + proof path
+
+```bash
+scripts/deploy/install.sh onboard \
+  --url https://agent-bom.example.com \
+  --api-key "$AGENT_BOM_API_KEY"
+```
+
+Dashboard proof path: **Queue · Graph · Runtime · Reports · Connections**
+
+Pre-tag release smoke:
+
+```bash
+scripts/release_smoke.sh
+AGENT_BOM_RELEASE_SMOKE_FINDINGS_BENCH=1 scripts/release_smoke.sh   # optional read bench
+```
+
+---
+
+## Platform chooser
+
+| You want to host on… | Start here |
+|----------------------|------------|
+| Laptop / demo | `install.sh pilot` |
+| Single VM | `install.sh docker` or `platform-docker` |
+| **AWS EKS** | `install.sh eks` or `platform-eks` Terraform |
+| **Azure AKS** | `install.sh aks` + `connect azure` |
+| **GCP GKE** | `install.sh gke` + `connect gcp` |
+| **Snowflake SPCS / Native App** | `install.sh snowflake-native` |
+| Snowflake as inventory source | `install.sh snowflake` + `connect snowflake` |
+| Invite-only hosted POC | [`HOSTED_POC.md`](HOSTED_POC.md) |
+
+---
+
+## What is not automatic yet (honest boundaries)
+
+- **No single UI wizard** for “click Connect AWS” — today: Terraform connect modules + API `POST /v1/cloud/connections`. UI connections tab is the registration surface.
+- **No agentless continuous CSPM agent** — inventory is scheduled CronJob + opt-in CLI/API scans + fleet push.
+- **AKS/GKE platform Terraform** — collector Helm overlays exist; full one-apply platform modules are EKS-only today.
+- **MSSP multi-tenant provider ops** — self-hosted team tenancy (OIDC/SCIM) ships; provider-style tenant automation is a later track.
+
+---
+
+## Related
+
+- [`DEPLOY_PLATFORM.md`](DEPLOY_PLATFORM.md) — three-tier deploy model
+- [`DEPLOYMENT.md`](DEPLOYMENT.md) — scalability and architecture reference
+- [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md) — long enterprise rollout
+- [`deploy/RUNBOOK.md`](../deploy/RUNBOOK.md) — cross-cloud collector federation
+- [`site-docs/deployment/overview.md`](../site-docs/deployment/overview.md) — published chooser

--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -3,6 +3,10 @@
 This guide gives new users a deterministic path from install to a real
 inventory and graph without asking them to scan a private repository first.
 
+**Hosting the control plane?** See [`DEPLOY_QUICKSTART.md`](DEPLOY_QUICKSTART.md) —
+`scripts/deploy/install.sh pilot` for local Docker, or EKS/AKS/GKE/Snowflake
+paths with read-only cloud connect.
+
 ## 1. Run the Release-Pinned Demo
 
 ```bash

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
       - Policy Engine: features/policy.md
   - Deployment:
       - Overview: deployment/overview.md
+      - Deploy Quickstart: deployment/quickstart.md
       - Product Boundaries: deployment/product-boundaries.md
       - Paved Paths:
           - One-machine Docker Pilot: deployment/docker.md

--- a/scripts/deploy/install.sh
+++ b/scripts/deploy/install.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+# install.sh — unified deploy entrypoint for agent-bom control planes.
+#
+# One script, many targets. Delegates to existing compose, Helm, Terraform, and
+# reference installers — does not duplicate infrastructure logic.
+#
+# Usage:
+#   scripts/deploy/install.sh list
+#   scripts/deploy/install.sh pilot
+#   scripts/deploy/install.sh eks --create-cluster --region us-east-1
+#   scripts/deploy/install.sh connect aws
+#   scripts/deploy/install.sh onboard --url https://agent-bom.example.com --api-key "$KEY"
+#
+# See docs/DEPLOY_QUICKSTART.md for the Wiz-style onboarding story.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+TARGET="${1:-}"
+shift || true
+
+CONNECT_CLOUD=""
+HELM_PROFILE_ARG=""
+case "$TARGET" in
+  connect)
+    CONNECT_CLOUD="${1:-}"
+    shift || true
+    ;;
+  helm)
+    HELM_PROFILE_ARG="${1:-}"
+    shift || true
+    ;;
+esac
+
+DRY_RUN=0
+DEMO_ESTATE=0
+CREATE_CLUSTER=0
+ENABLE_GATEWAY=0
+HELM_PROFILE="enterprise-demo"
+HELM_RELEASE="agent-bom"
+HELM_NAMESPACE="agent-bom"
+AWS_REGION="${AWS_REGION:-us-east-1}"
+ONBOARD_URL=""
+ONBOARD_API_KEY=""
+ONBOARD_TENANT="default"
+
+usage() {
+  cat <<'EOF'
+agent-bom unified deploy installer
+
+Deploy the control plane (API + UI + graph), then connect read-only cloud
+accounts and endpoint fleet for inventory, scans, MCP/agents, and AI BOM.
+
+Usage:
+  scripts/deploy/install.sh <target> [options]
+
+Targets (control plane):
+  list              Show all targets and what you get out of the box
+  pilot             Fastest local pilot (loopback Docker, SQLite, demo UI)
+  docker            Full local stack (API + UI + Postgres via compose)
+  platform-docker   Production-shaped single-host Docker (secrets + split nets)
+  eks               AWS EKS reference installer (scripts/deploy/install-eks-reference.sh)
+  eks-terraform     One terraform apply (deploy/terraform/platform-eks)
+  aks               Helm on AKS + Azure collector overlay (BYO cluster)
+  gke               Helm on GKE + GCP collector overlay (BYO cluster)
+  helm <profile>    Shipped Helm profile (scripts/install_helm_profile.py --list)
+  snowflake         Snowflake POV path (Helm snowflake-backend + connect module)
+  snowflake-native  Snowflake Native App / SPCS lane (docs pointer)
+
+Targets (connect read-only clouds — Wiz-style account onboarding):
+  connect aws       Mint read-only IAM role (deploy/terraform/connect-aws)
+  connect azure     Mint Reader RBAC (deploy/terraform/connect-azure)
+  connect gcp       Mint viewer + securityReviewer (deploy/terraform/connect-gcp)
+  connect snowflake Mint ABOM_READONLY role (deploy/terraform/connect-snowflake)
+
+Post-deploy onboarding helper:
+  onboard           Print/run fleet bootstrap + smoke checks after control plane is live
+
+Common options:
+  --dry-run         Print delegated commands without running them
+  --demo-estate     Start API with curated demo graph + offline scan (pilots)
+  --region REGION   AWS region for EKS/connect paths (default: AWS_REGION or us-east-1)
+  --create-cluster  Pass through to EKS reference installer (create cluster with eksctl)
+  --enable-gateway  Pass through to EKS reference installer (enable gateway Deployment)
+  --profile NAME    Helm profile for aks/gke/helm targets (default: enterprise-demo)
+  --release NAME    Helm release name (default: agent-bom)
+  --namespace NAME  Kubernetes namespace (default: agent-bom)
+  --url URL         Control-plane base URL (onboard target)
+  --api-key KEY     Admin/API key (onboard target)
+  --tenant ID       Tenant scope (onboard target, default: default)
+  -h, --help        Show this help
+
+Examples:
+  # Fastest look — dashboard + demo inventory in under 2 minutes
+  scripts/deploy/install.sh pilot
+
+  # Production AWS / EKS (creates cluster + baseline + Helm + next-step hints)
+  export AWS_REGION="<your-aws-region>"
+  scripts/deploy/install.sh eks --create-cluster --region "$AWS_REGION" --enable-gateway
+
+  # Connect a second AWS account read-only (after control plane is live)
+  scripts/deploy/install.sh connect aws
+
+  # Post-deploy: fleet bundle command + smoke
+  scripts/deploy/install.sh onboard --url https://agent-bom.internal.example.com --api-key "$AGENT_BOM_API_KEY"
+
+Docs:
+  docs/DEPLOY_QUICKSTART.md   — onboarding story (deploy → connect → inventory → scans)
+  docs/DEPLOY_PLATFORM.md     — three-tier architecture reference
+  docs/CLOUD_CONNECT.md       — read-only multicloud connect model
+EOF
+}
+
+log() { printf "\n[%s] %s\n" "$(date +%H:%M:%S)" "$*"; }
+warn() { printf "\n[warn] %s\n" "$*" >&2; }
+die() { printf "\n[error] %s\n" "$*" >&2; exit 1; }
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf "+ %q" "$1"
+    shift
+    for arg in "$@"; do
+      printf " %q" "$arg"
+    done
+    printf "\n"
+    return 0
+  fi
+  "$@"
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+print_list() {
+  cat <<'EOF'
+agent-bom deploy targets
+
+After any control-plane target you get (out of the box once connected):
+  • Unified security graph (cloud resources, identities, MCP servers, agents)
+  • Findings queue with reach / blast-radius ranking
+  • Fleet inventory from workstations and K8s collectors
+  • Scheduled or on-demand scans (CLI, API, CronJob)
+  • MCP server mode, optional gateway/proxy runtime enforcement
+  • Compliance evidence, SBOM/SARIF exports, audit trail
+
+Local / pilot
+  pilot             Loopback Docker pilot (SQLite). Fastest product proof.
+  docker            API + UI + Postgres on one machine.
+  platform-docker   Production-shaped Docker on one host.
+
+Kubernetes control plane
+  eks               Opinionated AWS EKS installer (cluster optional).
+  eks-terraform     Single terraform apply (EKS + RDS + Helm).
+  aks               Helm enterprise-demo + AKS workload-identity collector overlay.
+  gke               Helm enterprise-demo + GKE workload-identity collector overlay.
+  helm <profile>    Any shipped profile (production, focused-pilot, snowflake-backend, …).
+
+Snowflake
+  snowflake         Self-hosted POV with Snowflake/Cortex inventory.
+  snowflake-native  Customer-account Native App + SPCS scanner/MCP runtime.
+
+Read-only cloud connect (per account / subscription / project / Snowflake account)
+  connect aws | azure | gcp | snowflake
+
+Post-deploy
+  onboard           Fleet bootstrap hints + pilot-verify smoke wrapper.
+
+Run: scripts/deploy/install.sh <target> --help  (via -h on this script)
+Read: docs/DEPLOY_QUICKSTART.md
+EOF
+}
+
+print_onboarding_card() {
+  local url="${1:-http://localhost:3000}"
+  local api_url="${2:-http://localhost:8422}"
+  cat <<EOF
+
+══════════════════════════════════════════════════════════════════════
+ Next: Wiz-style onboarding (read-only — nothing is mutated in your cloud)
+══════════════════════════════════════════════════════════════════════
+
+1) Connect cloud accounts (inventory + posture, opt-in per provider)
+   scripts/deploy/install.sh connect aws
+   scripts/deploy/install.sh connect azure
+   scripts/deploy/install.sh connect gcp
+   scripts/deploy/install.sh connect snowflake
+
+   Or via API after minting keys:
+   POST ${api_url}/v1/cloud/connections  (test → scan)
+
+2) Enable auto-discovery / scheduled scans
+   • Helm: enterprise-demo profile schedules AWS inventory CronJob
+   • API:  POST ${api_url}/v1/scan
+   • CLI:  agent-bom agents --preset enterprise --aws
+
+3) Endpoint + MCP/agent fleet (workstations, IDE agents, local MCP configs)
+   agent-bom proxy-bootstrap \\
+     --control-plane-url ${api_url} \\
+     --push-url ${api_url}/v1/fleet/sync \\
+     --push-api-key "<admin-or-tenant-key>"
+
+4) Open the proof path in the dashboard
+   ${url}  →  Queue · Graph · Runtime · Reports · Connections
+
+5) Verify the five pilot capabilities
+   scripts/pilot-verify.sh ${api_url} "<api-key>"
+
+Trust boundary: docs/TRUST.md
+Full connect model: docs/CLOUD_CONNECT.md
+EOF
+}
+
+compose_up() {
+  local file="$1"
+  need_cmd docker
+  if [ ! -f .env ] && [ -f .env.example ]; then
+    warn ".env missing — copy .env.example and set POSTGRES_PASSWORD for non-pilot stacks"
+  fi
+  log "Starting compose stack: ${file}"
+  if [ "$DEMO_ESTATE" -eq 1 ]; then
+    export AGENT_BOM_DEMO_ESTATE=1
+    log "Demo estate enabled (showcase graph + curated offline scan on API start)"
+  fi
+  run docker compose -f "$file" up -d
+  log "Dashboard → http://localhost:3000"
+  log "API docs  → http://localhost:8422/docs"
+  print_onboarding_card "http://localhost:3000" "http://localhost:8422"
+}
+
+install_eks() {
+  need_cmd bash
+  local args=(--region "$AWS_REGION")
+  [ "$CREATE_CLUSTER" -eq 1 ] && args+=(--create-cluster)
+  [ "$ENABLE_GATEWAY" -eq 1 ] && args+=(--enable-gateway)
+  [ "$DRY_RUN" -eq 1 ] && args+=(--dry-run)
+  log "Delegating to install-eks-reference.sh"
+  run bash scripts/deploy/install-eks-reference.sh "${args[@]}"
+}
+
+install_eks_terraform() {
+  need_cmd terraform
+  log "EKS platform module — one terraform apply"
+  warn "Prereqs: ingress controller, cert-manager, External Secrets Operator — see deploy/terraform/platform-eks/README.md"
+  run bash -c "cd deploy/terraform/platform-eks && terraform init && terraform apply"
+  print_onboarding_card "https://<your-ingress-host>" "https://<your-ingress-host>"
+}
+
+install_helm_platform() {
+  local profile="$1"
+  local extra_values=()
+  case "$TARGET" in
+    aks)
+      extra_values+=(deploy/helm/agent-bom/examples/aks-collector-workload-identity-values.yaml)
+      ;;
+    gke)
+      extra_values+=(deploy/helm/agent-bom/examples/gke-collector-workload-identity-values.yaml)
+      ;;
+  esac
+  need_cmd helm
+  log "Installing Helm profile: ${profile}"
+  local cmd=(python3 scripts/install_helm_profile.py "$profile" --release "$HELM_RELEASE" --namespace "$HELM_NAMESPACE")
+  for vf in "${extra_values[@]}"; do
+    cmd+=(--values "$vf")
+  done
+  [ "$DRY_RUN" -eq 1 ] && cmd+=(--print-command)
+  run "${cmd[@]}"
+  case "$TARGET" in
+    aks)
+      warn "Apply connect-azure in each subscription, then set workload identity on the scanner SA."
+      run bash -c 'echo "  cd deploy/terraform/connect-azure && terraform apply"'
+      ;;
+    gke)
+      warn "Apply connect-gcp, bind WI, then set iam.gke.io/gcp-service-account on the scanner SA."
+      run bash -c 'echo "  cd deploy/terraform/connect-gcp && terraform apply"'
+      ;;
+  esac
+  print_onboarding_card "https://<ingress-host>" "https://<ingress-host>"
+}
+
+install_snowflake_pov() {
+  install_helm_platform "snowflake-backend"
+  log "Mint Snowflake read-only role in the customer account"
+  run bash -c 'echo "  cd deploy/terraform/connect-snowflake && terraform apply"'
+  warn "See site-docs/deployment/snowflake-pov.md for Postgres + Cortex inventory smoke."
+}
+
+install_connect() {
+  local cloud="$1"
+  local module_dir=""
+  case "$cloud" in
+    aws) module_dir="deploy/terraform/connect-aws" ;;
+    azure) module_dir="deploy/terraform/connect-azure" ;;
+    gcp) module_dir="deploy/terraform/connect-gcp" ;;
+    snowflake) module_dir="deploy/terraform/connect-snowflake" ;;
+    *) die "unknown connect cloud: ${cloud}" ;;
+  esac
+  need_cmd terraform
+  log "Read-only connect: ${cloud} (${module_dir})"
+  cat <<EOF
+
+This mints a least-privilege read-only principal in YOUR account.
+agent-bom never mutates resources — only List/Describe/Get (or Snowflake SELECT/SHOW).
+
+After apply, register the output with your control plane:
+  • API: POST /v1/cloud/connections
+  • Helm scanner: set scanner.cloud.${cloud}.inventory=true
+  • CLI: export AGENT_BOM_$(echo "$cloud" | tr '[:lower:]' '[:upper:]')_INVENTORY=1
+
+EOF
+  if [ "$DRY_RUN" -eq 1 ]; then
+    run bash -c "cd ${module_dir} && terraform init && terraform plan"
+  else
+    run bash -c "cd ${module_dir} && terraform init && terraform apply"
+    log "Hand terraform outputs to the control plane (role ARN, external ID, etc.)"
+  fi
+}
+
+install_onboard() {
+  [ -n "$ONBOARD_URL" ] || die "onboard requires --url (control-plane base URL)"
+  [ -n "$ONBOARD_API_KEY" ] || die "onboard requires --api-key"
+  local api_url="${ONBOARD_URL%/}"
+  log "Post-deploy onboarding for ${api_url}"
+
+  cat <<EOF
+
+Fleet bootstrap (run on a workstation or golden image):
+  agent-bom proxy-bootstrap \\
+    --control-plane-url ${api_url} \\
+    --push-url ${api_url}/v1/fleet/sync \\
+    --push-api-key "${ONBOARD_API_KEY}" \\
+    --tenant-id ${ONBOARD_TENANT}
+
+Cloud connect (repeat per account):
+  scripts/deploy/install.sh connect aws
+  scripts/deploy/install.sh connect azure
+  scripts/deploy/install.sh connect gcp
+  scripts/deploy/install.sh connect snowflake
+
+EOF
+  if [ "$DRY_RUN" -eq 1 ]; then
+    run bash -c "echo scripts/pilot-verify.sh ${api_url} '<api-key>'"
+  else
+    need_cmd curl
+    need_cmd jq
+    run bash scripts/pilot-verify.sh "$api_url" "$ONBOARD_API_KEY"
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1 ;;
+    --demo-estate) DEMO_ESTATE=1 ;;
+    --create-cluster) CREATE_CLUSTER=1 ;;
+    --enable-gateway) ENABLE_GATEWAY=1 ;;
+    --region) shift; AWS_REGION="${1:?--region requires value}" ;;
+    --profile) shift; HELM_PROFILE="${1:?--profile requires value}" ;;
+    --release) shift; HELM_RELEASE="${1:?--release requires value}" ;;
+    --namespace) shift; HELM_NAMESPACE="${1:?--namespace requires value}" ;;
+    --url) shift; ONBOARD_URL="${1:?--url requires value}" ;;
+    --api-key) shift; ONBOARD_API_KEY="${1:?--api-key requires value}" ;;
+    --tenant) shift; ONBOARD_TENANT="${1:?--tenant requires value}" ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown option: $1 (try -h)" ;;
+  esac
+  shift
+done
+
+if [ -z "$TARGET" ] || [ "$TARGET" = "-h" ] || [ "$TARGET" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+case "$TARGET" in
+  list)
+    print_list
+    ;;
+  pilot)
+    compose_up deploy/docker-compose.pilot.yml
+    ;;
+  docker)
+    compose_up deploy/docker-compose.fullstack.yml
+    ;;
+  platform-docker)
+    compose_up deploy/docker-compose.platform.yml
+    ;;
+  eks)
+    install_eks
+    ;;
+  eks-terraform|terraform-eks|platform-eks)
+    install_eks_terraform
+    ;;
+  aks)
+    install_helm_platform "$HELM_PROFILE"
+    ;;
+  gke)
+    install_helm_platform "$HELM_PROFILE"
+    ;;
+  helm)
+    install_helm_platform "${HELM_PROFILE_ARG:-$HELM_PROFILE}"
+    ;;
+  snowflake|snowflake-pov)
+    install_snowflake_pov
+    ;;
+  snowflake-native|snowflake-spcs)
+    log "Snowflake Native App + SPCS lane (customer-owned install)"
+    cat <<'EOF'
+
+Install in the Snowflake customer account (not a hosted SaaS):
+  docs/snowflake-native-app/INSTALL.md
+  deploy/snowflake/native-app/
+
+Out of the box after install + enable:
+  • SPCS scanner service (opt-in egress to advisory feeds)
+  • MCP runtime service (opt-in, bearer-gated)
+  • Native App security graph + findings in-account
+
+Self-hosted API/UI POV (often faster first): scripts/deploy/install.sh snowflake
+EOF
+    ;;
+  connect)
+    [ -n "$CONNECT_CLOUD" ] || die "connect requires a cloud: aws | azure | gcp | snowflake"
+    install_connect "$CONNECT_CLOUD"
+    ;;
+  onboard)
+    install_onboard
+    ;;
+  *)
+    die "unknown target: ${TARGET} (run: scripts/deploy/install.sh list)"
+    ;;
+esac

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -1,5 +1,9 @@
 # Deployment Overview
 
+> **Unified quickstart:** [`docs/DEPLOY_QUICKSTART.md`](../../docs/DEPLOY_QUICKSTART.md)
+> — `scripts/deploy/install.sh` for pilot, EKS, AKS, GKE, Snowflake, and
+> read-only cloud connect.
+
 Use this page when the question is not "how do I install `agent-bom`?" but
 "what should I deploy first, what does that give me, and when do I add runtime
 enforcement?"
@@ -16,6 +20,8 @@ teams intentionally diverging from them.
 Pilot on one workstation:
 
 ```bash
+scripts/deploy/install.sh pilot
+# or without a checkout:
 curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
 docker compose -f docker-compose.pilot.yml up -d
 # Dashboard -> http://localhost:3000
@@ -25,11 +31,12 @@ Production in your own cluster from a checked-out repo:
 
 ```bash
 export AWS_REGION="<your-aws-region>"
-scripts/deploy/install-eks-reference.sh \
-  --cluster-name corp-ai \
+scripts/deploy/install.sh eks \
+  --create-cluster \
   --region "$AWS_REGION" \
-  --hostname agent-bom.internal.example.com \
   --enable-gateway
+# or the legacy reference installer directly:
+# scripts/deploy/install-eks-reference.sh ...
 ```
 
 Advanced/manual chart install from a checked-out repo:

--- a/site-docs/deployment/quickstart.md
+++ b/site-docs/deployment/quickstart.md
@@ -1,0 +1,74 @@
+# Deploy Quickstart
+
+Unified entry for **BYOC / self-hosted** rollout: one install script, read-only
+cloud connect, and the intake paths that feed your control plane.
+
+Full doc in the repo: [`docs/DEPLOY_QUICKSTART.md`](../../docs/DEPLOY_QUICKSTART.md).
+
+## Install
+
+```bash
+scripts/deploy/install.sh list
+scripts/deploy/install.sh pilot          # fastest local proof
+scripts/deploy/install.sh eks --create-cluster --region "$AWS_REGION"
+scripts/deploy/install.sh connect aws    # read-only account onboarding
+```
+
+## BYOC in one sentence
+
+You run API + UI + Postgres in **your** cloud/VPC/K8s. Connected accounts get
+**read-only** roles only. Endpoints push fleet inventory. Scans and runtime
+audit flow into one graph — no mandatory vendor SaaS.
+
+## What feeds the control plane
+
+```mermaid
+flowchart TB
+    subgraph Intake["Intake paths (customer-owned)"]
+        Fleet["Endpoint fleet"]
+        ScanJobs["Scan jobs"]
+        Cloud["Cloud connect"]
+        Runtime["Proxy / gateway"]
+        Bulk["Bulk / SARIF / SBOM"]
+    end
+
+    subgraph CP["Your hosted control plane"]
+        API["API"]
+        UI["Dashboard"]
+        Graph["Graph + findings"]
+        PG[("Postgres")]
+    end
+
+    Fleet -->|/v1/fleet/sync| API
+    ScanJobs -->|/v1/scan| API
+    Cloud -->|/v1/cloud/connections| API
+    Runtime -->|/v1/proxy/audit| API
+    Bulk -->|/v1/findings/bulk · /v1/compliance/ingest| API
+    API --> Graph --> PG
+    UI --> API
+```
+
+| Intake | Endpoint |
+|--------|----------|
+| Cloud inventory | `POST /v1/cloud/connections`, Helm CronJob |
+| Endpoints / MCP | `POST /v1/fleet/sync` |
+| On-demand scan | `POST /v1/scan` |
+| Runtime audit | `POST /v1/proxy/audit` |
+| External findings | `POST /v1/findings/bulk` |
+| SARIF / SBOM | `POST /v1/compliance/ingest` |
+
+## Deeper diagrams
+
+The deployment overview includes customer-boundary and evidence-workflow
+mermaid diagrams:
+
+- [Deployment Overview — enterprise diagrams](overview.md#enterprise-self-hosted-diagrams)
+- [Self-Hosted Product Architecture](../architecture/self-hosted-product-architecture.md)
+- [Proxy vs Gateway vs Fleet](proxy-vs-gateway-vs-fleet.md)
+
+## Related
+
+- [Deploy anywhere (three tiers)](../../docs/DEPLOY_PLATFORM.md)
+- [Cloud connect model](../../docs/CLOUD_CONNECT.md)
+- [Cross-cloud runbook](../../deploy/RUNBOOK.md)
+- [Trust boundaries](../../docs/TRUST.md)

--- a/tests/test_deploy_install.py
+++ b/tests/test_deploy_install.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = ROOT / "scripts" / "deploy" / "install.sh"
+
+
+def test_deploy_install_script_is_valid_shell() -> None:
+    subprocess.run(["bash", "-n", str(INSTALL_SH)], check=True)
+
+
+def test_deploy_install_script_list_documents_targets() -> None:
+    proc = subprocess.run(
+        ["bash", str(INSTALL_SH), "list"],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    output = proc.stdout
+    for token in ("pilot", "eks", "connect aws", "snowflake", "onboard"):
+        assert token in output, f"missing target hint: {token}"
+
+
+def test_deploy_quickstart_doc_exists() -> None:
+    doc = ROOT / "docs" / "DEPLOY_QUICKSTART.md"
+    text = doc.read_text(encoding="utf-8")
+    assert "scripts/deploy/install.sh" in text
+    assert "read-only" in text.lower()
+
+
+def test_deploy_runbook_exists() -> None:
+    runbook = ROOT / "deploy" / "RUNBOOK.md"
+    text = runbook.read_text(encoding="utf-8")
+    assert "Cross-cloud federation" in text
+    assert "multicloud-collector-values.yaml" in text


### PR DESCRIPTION
## Summary
- Adds `scripts/deploy/install.sh` — single entry for pilot, Docker, EKS, AKS/GKE Helm, read-only cloud connect, and post-deploy onboard smoke.
- Adds `docs/DEPLOY_QUICKSTART.md` with BYOC positioning, control-plane intake ASCII + mermaid diagram, endpoint table, and dashboard route map.
- Adds `deploy/RUNBOOK.md` (cross-cloud collector federation) and published `site-docs/deployment/quickstart.md`.

## Test plan
- [x] `uv run pytest -q tests/test_deploy_install.py`
- [x] `bash -n scripts/deploy/install.sh && bash scripts/deploy/install.sh list`


Made with [Cursor](https://cursor.com)