### PR TITLE
fix(audit): P3 login redirect, Swift bare calls, rollup URL persistence

### DIFF
--- a/src/agent_bom/ast_swift.py
+++ b/src/agent_bom/ast_swift.py
@@ -34,6 +34,31 @@ _SWIFT_IMPORT_RE = re.compile(r"^\s*import\s+(?P<module>\w+)", re.MULTILINE)
 _SWIFT_FUNC_RE = re.compile(r"^\s*func\s+(?P<name>\w+)\s*\(", re.MULTILINE)
 _SWIFT_MODULE_CALL_RE = re.compile(r"\b(?P<module>\w+)\.(?P<method>\w+)\s*\(")
 _SWIFT_DOT_CALL_RE = re.compile(r"(?P<receiver>\w+)\.(?P<method>\w+)\s*\(")
+_SWIFT_BARE_CALL_RE = re.compile(r"(?<![.\w\"])\b(?P<name>\w+)\s*\(")
+_SWIFT_CALL_KEYWORDS = frozenset(
+    {
+        "if",
+        "for",
+        "while",
+        "switch",
+        "return",
+        "guard",
+        "catch",
+        "func",
+        "init",
+        "let",
+        "var",
+        "try",
+        "throw",
+        "await",
+        "async",
+        "in",
+        "where",
+        "case",
+        "server",
+        "tool",
+    },
+)
 _SWIFT_TOOL_RE = re.compile(
     r'\.(?:tool|registerTool|addTool)\s*\(\s*"(?P<name>[^"]+)"',
     re.IGNORECASE,
@@ -118,6 +143,16 @@ def _swift_call_sites(body: str, *, line_offset: int) -> list[_SwiftCallSite]:
         sites.append(
             _SwiftCallSite(
                 name=f"{match.group('receiver')}.{match.group('method')}",
+                line_number=line_offset + body[: match.start()].count("\n") + 1,
+            ),
+        )
+    for match in _SWIFT_BARE_CALL_RE.finditer(body):
+        name = match.group("name")
+        if name in _SWIFT_CALL_KEYWORDS:
+            continue
+        sites.append(
+            _SwiftCallSite(
+                name=name,
                 line_number=line_offset + body[: match.start()].count("\n") + 1,
             ),
         )

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -657,6 +657,30 @@ def test_analyze_project_surfaces_swift_dependency_symbol_reach(tmp_path: Path) 
     assert reach.package == "alamofire"
 
 
+def test_analyze_project_swift_bare_helper_call_chain(tmp_path: Path) -> None:
+    (tmp_path / "Package.resolved").write_text(
+        '{"pins": [{"identity": "alamofire", "state": {"version": "5.9.0"}}], "version": 2}',
+        encoding="utf-8",
+    )
+    (tmp_path / "Server.swift").write_text(
+        'import Alamofire\n\n'
+        "func register(server: MCPServer) {\n"
+        '    server.tool("fetch_url", handler)\n'
+        "}\n\n"
+        "func handler(_ url: String) {\n"
+        "    helper(url)\n"
+        "}\n\n"
+        "func helper(_ url: String) {\n"
+        "    Alamofire.request(url)\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    result = analyze_project(tmp_path)
+    swift_reaches = [reach for reach in result.dependency_symbol_reach if reach.ecosystem == "swift"]
+    assert any(reach.symbol == "request" and reach.entrypoint == "fetch_url" for reach in swift_reaches)
+
+
 def test_analyze_project_treats_validation_branch_as_guard(tmp_path: Path):
     (tmp_path / "agent.py").write_text(
         "import subprocess\n\n"

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -108,6 +108,7 @@ import { decideGraphRenderer } from "@/lib/graph-renderer-switch";
 import {
   graphRollupEligible,
   parseGraphRollupUrlPreference,
+  parseRollupNodeParam,
   rollupViewHasContainers,
 } from "@/lib/graph-rollup-default";
 import {
@@ -666,7 +667,11 @@ function GraphPageInner() {
   const [loadingBlast, setLoadingBlast] = useState(false);
   const [blastError, setBlastError] = useState<string | null>(null);
   const [rollupView, setRollupView] = useState<GraphRollupResponse | null>(null);
-  const [rollupStack, setRollupStack] = useState<RollupBreadcrumb[]>([]);
+  const [rollupStack, setRollupStack] = useState<RollupBreadcrumb[]>(() => {
+    if (typeof window === "undefined") return [];
+    const nodeId = parseRollupNodeParam(new URLSearchParams(window.location.search));
+    return nodeId ? [{ id: nodeId, label: nodeId }] : [];
+  });
   const [rollupDismissed, setRollupDismissed] = useState(
     () =>
       typeof window !== "undefined" &&
@@ -1119,8 +1124,18 @@ function GraphPageInner() {
     }
     if (rollupDismissed) {
       nextParams.set("rollup", "0");
-    } else if (rollupPreferenceRef.current === "force") {
+      nextParams.delete("rollup_node");
+    } else if (rollupNavigationActive || rollupPreferenceRef.current === "force") {
       nextParams.set("rollup", "1");
+      const drillNode = rollupStack.at(-1)?.id;
+      if (drillNode) {
+        nextParams.set("rollup_node", drillNode);
+      } else {
+        nextParams.delete("rollup_node");
+      }
+    } else {
+      nextParams.delete("rollup");
+      nextParams.delete("rollup_node");
     }
     const next = nextParams.toString();
     const url = next ? `${pathname}?${next}` : pathname;
@@ -1143,6 +1158,8 @@ function GraphPageInner() {
     investigationMode,
     pathname,
     rollupDismissed,
+    rollupNavigationActive,
+    rollupStack,
     router,
     selectedScanId,
   ]);

--- a/ui/app/login/page.tsx
+++ b/ui/app/login/page.tsx
@@ -6,16 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 
 import { LoginPanel } from "@/components/login-panel";
 import { useAuthState } from "@/components/auth-provider";
-
-function safeReturnPath(value: string | null): string {
-  if (!value || !value.startsWith("/") || value.startsWith("//")) {
-    return "/";
-  }
-  if (value.startsWith("/login")) {
-    return "/";
-  }
-  return value;
-}
+import { safeReturnPath } from "@/lib/safe-return-path";
 
 function LoginPageContent() {
   const router = useRouter();

--- a/ui/lib/graph-rollup-default.ts
+++ b/ui/lib/graph-rollup-default.ts
@@ -14,6 +14,14 @@ export function parseGraphRollupUrlPreference(
   return "default";
 }
 
+/** Drill-down container id persisted in shareable graph URLs. */
+export function parseRollupNodeParam(
+  params: URLSearchParams | { get(name: string): string | null },
+): string | null {
+  const node = params.get("rollup_node")?.trim();
+  return node || null;
+}
+
 export interface GraphRollupEligibilityInput {
   hasSelectedScan: boolean;
   rollupPreference: GraphRollupUrlPreference;

--- a/ui/lib/safe-return-path.ts
+++ b/ui/lib/safe-return-path.ts
@@ -5,7 +5,7 @@ const BLOCKED_PREFIXES = ["/login"];
 export function safeReturnPath(value: string | null): string {
   if (!value) return "/";
 
-  let candidate = value.trim();
+  const candidate = value.trim();
   if (!candidate) return "/";
 
   // Reject backslashes and control chars (encoded open-redirect tricks).

--- a/ui/lib/safe-return-path.ts
+++ b/ui/lib/safe-return-path.ts
@@ -1,0 +1,28 @@
+/** Sanitize post-login redirects — block open redirects and protocol-relative paths. */
+
+const BLOCKED_PREFIXES = ["/login"];
+
+export function safeReturnPath(value: string | null): string {
+  if (!value) return "/";
+
+  let candidate = value.trim();
+  if (!candidate) return "/";
+
+  // Reject backslashes and control chars (encoded open-redirect tricks).
+  if (/[\\<>]/.test(candidate) || /[\u0000-\u001f\u007f]/.test(candidate)) {
+    return "/";
+  }
+
+  // Must be a same-origin relative path.
+  if (!candidate.startsWith("/") || candidate.startsWith("//")) {
+    return "/";
+  }
+
+  for (const blocked of BLOCKED_PREFIXES) {
+    if (candidate === blocked || candidate.startsWith(`${blocked}/`) || candidate.startsWith(`${blocked}?`)) {
+      return "/";
+    }
+  }
+
+  return candidate;
+}

--- a/ui/tests/graph-rollup-default.test.ts
+++ b/ui/tests/graph-rollup-default.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   graphRollupEligible,
   parseGraphRollupUrlPreference,
+  parseRollupNodeParam,
   rollupViewHasContainers,
 } from "@/lib/graph-rollup-default";
 
@@ -15,6 +16,12 @@ describe("parseGraphRollupUrlPreference", () => {
     expect(parseGraphRollupUrlPreference(new URLSearchParams("rollup=0"))).toBe(
       "off",
     );
+  });
+
+  it("parses rollup_node drill param", () => {
+    expect(
+      parseRollupNodeParam(new URLSearchParams("rollup_node=account%3Aprod")),
+    ).toBe("account:prod");
   });
 });
 

--- a/ui/tests/safe-return-path.test.ts
+++ b/ui/tests/safe-return-path.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { safeReturnPath } from "@/lib/safe-return-path";
+
+describe("safeReturnPath", () => {
+  it("allows normal in-app paths", () => {
+    expect(safeReturnPath("/connections")).toBe("/connections");
+    expect(safeReturnPath("/findings?severity=critical")).toBe("/findings?severity=critical");
+  });
+
+  it("rejects protocol-relative and off-site open redirects", () => {
+    expect(safeReturnPath("//evil.example/phish")).toBe("/");
+    expect(safeReturnPath("https://evil.example/phish")).toBe("/");
+    expect(safeReturnPath(null)).toBe("/");
+    expect(safeReturnPath("")).toBe("/");
+  });
+
+  it("rejects login loops and backslash tricks", () => {
+    expect(safeReturnPath("/login")).toBe("/");
+    expect(safeReturnPath("/login?returnTo=%2F")).toBe("/");
+    expect(safeReturnPath("/\\evil.example")).toBe("/");
+  });
+});


### PR DESCRIPTION
## Summary
- **Login** — shared `safeReturnPath` blocks `//`, off-site, backslash, and `/login` loop redirects.
- **Swift AST** — bare `helper()` calls participate in intra-file reach chains to external modules.
- **Graph rollup** — active rollup navigation persists `rollup=1` and drill `rollup_node` in the URL.

## Test plan
- [x] `uv run pytest -q tests/test_ast_analyzer.py::test_analyze_project_swift_bare_helper_call_chain`
- [x] `cd ui && npm test -- --run tests/safe-return-path.test.ts tests/graph-rollup-default.test.ts`


Made with [Cursor](https://cursor.com)