### PR TITLE
feat(scan,docs): GLM/Zhipu inventory + BYOM quickstart (closes #3609 tail)

### DIFF
--- a/docs/DEPLOY_QUICKSTART.md
+++ b/docs/DEPLOY_QUICKSTART.md
@@ -343,7 +343,7 @@ See [`docs/operations/ENV_VARS.md`](operations/ENV_VARS.md) for the full enrichm
 **Runtime / MCP IdP without OIDC discovery:** legacy issuers that cannot publish
 `/.well-known/openid-configuration` can use the gateway OIDC discovery shim —
 [`docs/design/OIDC_DISCOVERY_SHIM.md`](design/OIDC_DISCOVERY_SHIM.md) and
-[`deploy/helm/agent-bom/values/oidc-discovery-shim-values.yaml`](../deploy/helm/agent-bom/values/oidc-discovery-shim-values.yaml).
+[`deploy/helm/agent-bom/examples/oidc-discovery-shim-values.yaml`](../deploy/helm/agent-bom/examples/oidc-discovery-shim-values.yaml).
 
 ---
 

--- a/docs/DEPLOY_QUICKSTART.md
+++ b/docs/DEPLOY_QUICKSTART.md
@@ -309,6 +309,44 @@ AGENT_BOM_RELEASE_SMOKE_FINDINGS_BENCH=1 scripts/release_smoke.sh   # optional r
 
 ---
 
+## Optional BYOM enrichment (your models, your keys)
+
+Core inventory, scans, graph, and compliance **do not** require an LLM. When you want
+`--ai-enrich` on scan jobs or worker-side summarization, point workers at **your**
+model endpoint — nothing routes through a vendor SaaS.
+
+| Path | When to use | Worker env |
+|------|-------------|------------|
+| **Ollama** (local) | Laptop, airgap, pilot VM | `AGENT_BOM_AI_PROVIDER=ollama`, `OLLAMA_HOST=http://127.0.0.1:11434` |
+| **litellm** | 100+ cloud APIs via one proxy | `AGENT_BOM_AI_PROVIDER=litellm`, `LITELLM_PROXY_URL=…` |
+| **OpenAI-compatible** | vLLM, TGI, custom gateway | `AGENT_BOM_AI_PROVIDER=openai`, `OPENAI_API_BASE=…` |
+| **HuggingFace** | Hosted inference endpoints | `AGENT_BOM_AI_PROVIDER=huggingface`, `HF_TOKEN=…` |
+
+**GLM / Zhipu examples** (same BYOM contract — you supply keys and base URL):
+
+```bash
+# Local Ollama
+ollama pull glm4:9b
+export AGENT_BOM_AI_PROVIDER=ollama OLLAMA_HOST=http://127.0.0.1:11434
+
+# Zhipu cloud via litellm proxy
+export AGENT_BOM_AI_PROVIDER=litellm LITELLM_PROXY_URL=http://litellm:4000
+# litellm model id: zhipu/glm-4-plus (see litellm provider docs)
+
+# vLLM OpenAI-compatible
+export AGENT_BOM_AI_PROVIDER=openai OPENAI_API_BASE=http://vllm:8000/v1 OPENAI_API_KEY=local
+```
+
+Inventory scans detect `zhipuai` imports and `glm-*` / `chatglm*` model strings in source.
+See [`docs/operations/ENV_VARS.md`](operations/ENV_VARS.md) for the full enrichment env surface.
+
+**Runtime / MCP IdP without OIDC discovery:** legacy issuers that cannot publish
+`/.well-known/openid-configuration` can use the gateway OIDC discovery shim —
+[`docs/design/OIDC_DISCOVERY_SHIM.md`](design/OIDC_DISCOVERY_SHIM.md) and
+[`deploy/helm/agent-bom/values/oidc-discovery-shim-values.yaml`](../deploy/helm/agent-bom/values/oidc-discovery-shim-values.yaml).
+
+---
+
 ## What is not automatic yet (honest boundaries)
 
 - **No single UI wizard** for “click Connect AWS” — today: Terraform connect modules + API `POST /v1/cloud/connections`. UI connections tab is the registration surface.
@@ -324,4 +362,5 @@ AGENT_BOM_RELEASE_SMOKE_FINDINGS_BENCH=1 scripts/release_smoke.sh   # optional r
 - [`DEPLOYMENT.md`](DEPLOYMENT.md) — scalability and architecture reference
 - [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md) — long enterprise rollout
 - [`deploy/RUNBOOK.md`](../deploy/RUNBOOK.md) — cross-cloud collector federation
+- [`docs/design/OIDC_DISCOVERY_SHIM.md`](design/OIDC_DISCOVERY_SHIM.md) — legacy IdP MCP OIDC discovery
 - [`site-docs/deployment/overview.md`](../site-docs/deployment/overview.md) — published chooser

--- a/src/agent_bom/ai_components/patterns.py
+++ b/src/agent_bom/ai_components/patterns.py
@@ -122,6 +122,7 @@ PYTHON_SDK_PATTERNS: list[SDKPattern] = [
     SDKPattern(re.compile(_py_import("ollama")), "ollama", AIComponentType.LLM_PROVIDER, "ollama", "pypi", "python"),
     SDKPattern(re.compile(_py_import("replicate")), "replicate", AIComponentType.LLM_PROVIDER, "replicate", "pypi", "python"),
     SDKPattern(re.compile(_py_import("deepseek")), "deepseek", AIComponentType.LLM_PROVIDER, "deepseek", "pypi", "python"),
+    SDKPattern(re.compile(_py_import("zhipuai")), "zhipu", AIComponentType.LLM_PROVIDER, "zhipuai", "pypi", "python"),
     SDKPattern(re.compile(_py_import("fireworks")), "fireworks", AIComponentType.LLM_PROVIDER, "fireworks-ai", "pypi", "python"),
     SDKPattern(re.compile(_py_import("ai21")), "ai21", AIComponentType.LLM_PROVIDER, "ai21", "pypi", "python"),
     SDKPattern(re.compile(_py_import("cerebras")), "cerebras", AIComponentType.LLM_PROVIDER, "cerebras-cloud-sdk", "pypi", "python"),
@@ -597,6 +598,13 @@ MODEL_PATTERNS: list[ModelPattern] = [
     ModelPattern(re.compile(rf"{_WB}deepseek-(?:chat|coder|reasoner)(?:-v\d+(?:\.\d+)?)?{_WB}"), "deepseek"),
     ModelPattern(re.compile(rf"{_WB}deepseek-r1(?:-\d+b)?(?:-distill)?{_WB}", re.I), "deepseek"),
     ModelPattern(re.compile(rf"{_WB}deepseek-v[23](?:\.\d+)?(?:-\d+b)?{_WB}", re.I), "deepseek"),
+    # Zhipu GLM models
+    ModelPattern(
+        re.compile(rf"{_WB}glm-4(?:-(?:plus|air|flash|long|x|v(?:-plus)?))?(?:-\d+b)?{_WB}", re.I),
+        "zhipu",
+    ),
+    ModelPattern(re.compile(rf"{_WB}glm-4\.6(?:-(?:plus|flash|air))?{_WB}", re.I), "zhipu"),
+    ModelPattern(re.compile(rf"{_WB}chatglm[23](?:-6b|-turbo)?{_WB}", re.I), "zhipu"),
     # Qwen models
     ModelPattern(re.compile(rf"{_WB}qwen-?[23](?:\.\d+)?(?:-\d+b)?(?:-instruct)?{_WB}", re.I), "alibaba"),
     # Embedding models

--- a/src/agent_bom/ai_enrich.py
+++ b/src/agent_bom/ai_enrich.py
@@ -85,6 +85,8 @@ OLLAMA_MODEL_PREFERENCE = [
     "llama3.2",
     "llama3.2:3b",
     "qwen2.5:7b",
+    "glm4:9b",
+    "glm4",
     "mistral:7b",
     "mistral",
     "gemma2:9b",

--- a/tests/test_ai_components.py
+++ b/tests/test_ai_components.py
@@ -619,6 +619,38 @@ class TestDeepSeekDetection:
         assert "deepseek-v3" in models
 
 
+class TestGlmDetection:
+    """Tests for Zhipu GLM SDK and model detection."""
+
+    def test_zhipu_python_import(self, tmp_path: Path):
+        f = tmp_path / "app.py"
+        f.write_text("from zhipuai import ZhipuAI\n")
+        report = scan_source(str(tmp_path))
+        names = [c.name for c in report.components if c.component_type == AIComponentType.LLM_PROVIDER]
+        assert "zhipu" in names
+
+    def test_glm4_model_ref(self, tmp_path: Path):
+        f = tmp_path / "app.py"
+        f.write_text('model = "glm-4-plus"\n')
+        report = scan_source(str(tmp_path))
+        models = [c.name for c in report.components if c.component_type == AIComponentType.MODEL_REFERENCE]
+        assert "glm-4-plus" in models
+
+    def test_glm46_model_ref(self, tmp_path: Path):
+        f = tmp_path / "app.py"
+        f.write_text('model = "glm-4.6-flash"\n')
+        report = scan_source(str(tmp_path))
+        models = [c.name for c in report.components if c.component_type == AIComponentType.MODEL_REFERENCE]
+        assert "glm-4.6-flash" in models
+
+    def test_chatglm_model_ref(self, tmp_path: Path):
+        f = tmp_path / "app.py"
+        f.write_text('model = "chatglm3-6b"\n')
+        report = scan_source(str(tmp_path))
+        models = [c.name for c in report.components if c.component_type == AIComponentType.MODEL_REFERENCE]
+        assert "chatglm3-6b" in models
+
+
 class TestInvisibleUnicodeDetection:
     """Tests for GlassWorm-style invisible Unicode supply-chain attack detection."""
 


### PR DESCRIPTION
## Summary
- Add `zhipuai` SDK and `glm-*` / `chatglm*` model reference patterns for inventory scans.
- Document optional BYOM enrichment paths (Ollama, litellm, OpenAI-compatible, HuggingFace) with GLM/Zhipu examples in `DEPLOY_QUICKSTART.md`.
- Cross-link OIDC discovery shim design + Helm example to close #3609 documentation tail (runtime shipped in #3612).

## Verification
- `uv run pytest tests/test_ai_components.py::TestGlmDetection -q` — 4 passed

## Notes
- Closes #3609 when merged.

Made with [Cursor](https://cursor.com)