### PR TITLE
docs(security): publication policy and positioning hygiene

### DIFF
--- a/docs/DEPLOY_PLATFORM.md
+++ b/docs/DEPLOY_PLATFORM.md
@@ -1,7 +1,7 @@
 # Deploy agent-bom anywhere
 
 > **Quickstart:** [`DEPLOY_QUICKSTART.md`](DEPLOY_QUICKSTART.md) — one script,
-> Wiz-style onboarding (deploy → connect accounts → inventory → scans).
+> connect-and-scan onboarding (deploy → connect accounts → inventory → scans).
 > Run `scripts/deploy/install.sh list` from the repo root.
 
 agent-bom is one product with one control plane (API + UI) and a stateless

--- a/docs/DEPLOY_QUICKSTART.md
+++ b/docs/DEPLOY_QUICKSTART.md
@@ -1,6 +1,6 @@
 # Deploy quickstart — one product, any cloud
 
-This is the **Wiz-style onboarding story** for agent-bom: deploy the control
+This is the **connect-and-scan onboarding story** for agent-bom: deploy the control
 plane once, connect read-only cloud accounts and endpoints, and get inventory,
 assets, scans, MCP/agents, and AI BOM evidence in one graph — without handing
 credentials to a hosted SaaS.

--- a/docs/ENTERPRISE_SECURITY_POSTURE.md
+++ b/docs/ENTERPRISE_SECURITY_POSTURE.md
@@ -141,6 +141,10 @@ secret material.
 access management system. The product exposes posture and supports rotation
 paths; the operator owns secret authority, approval workflow, and key custody.
 
+Rotation procedures and `*_LAST_ROTATED` env var names are public in this
+repository; live secret values and production rotation timestamps are
+operator-private. See [PUBLICATION_POLICY.md](PUBLICATION_POLICY.md).
+
 ## SCIM And Revocation Boundary
 
 SCIM is the provisioned identity lifecycle store. User and group resources

--- a/docs/PRODUCT_BOUNDARIES.md
+++ b/docs/PRODUCT_BOUNDARIES.md
@@ -79,3 +79,4 @@ Avoid unless a future release proves it:
 See the site-docs page for the full lane matrix and release checklist.
 
 Trust boundary and verification hooks: [`TRUST.md`](TRUST.md).
+Publication and operator-private custody: [`PUBLICATION_POLICY.md`](PUBLICATION_POLICY.md).

--- a/docs/PUBLICATION_POLICY.md
+++ b/docs/PUBLICATION_POLICY.md
@@ -1,0 +1,63 @@
+# Publication Policy — Public Repo vs Operator-Private
+
+This repository is **public OSS**. The split below matches how mature security
+products (Grafana, ClickHouse, LangChain OSS) ship code and docs while keeping
+production custody private.
+
+## Public in this repository
+
+- Source code, tests, Helm/Docker/compose, and integration assets
+- User and operator documentation (`README.md`, `site-docs/`, deployment guides)
+- Security artifacts: `SECURITY.md`, threat model, architecture, pentest scope
+- Rotation **framework**: API routes, env var names (`*_LAST_ROTATED`,
+  `*_ROTATION_DAYS`), adapter command templates, default intervals
+- Example configs with placeholders (`.env.example`, `*secret.example.yaml`,
+  `REPLACE_ME_*` Helm values)
+- Illustrative timestamps in docs (for example `2026-04-26T00:00:00+00:00`) —
+  not live production rotation state
+
+Rotation procedures and env var names are public by design. Posture endpoints
+(`GET /v1/auth/secrets/lifecycle`, `GET /v1/auth/secrets/rotation-plan`) are
+admin-authenticated at runtime and return metadata only
+(`secret_values_included=false`). See
+[ENTERPRISE_SECURITY_POSTURE.md](ENTERPRISE_SECURITY_POSTURE.md#secrets-lifecycle).
+
+## Operator-private (never commit)
+
+- Secret **values**: API keys, HMAC/signing keys, SCIM bearer tokens, database
+  passwords, TLS private keys, cloud credentials
+- Live `*_LAST_ROTATED` values for production or hosted POC deployments
+- Bootstrap output (for example `/tmp/agent-bom-customer0-admin.key` from
+  `scripts/deploy/mint_hosted_admin_key.py`)
+- Customer names, contracts, pricing, named buyer references
+- Internal rotation calendars tied to real infrastructure (“rotate SCIM token
+  every N days on cluster X”)
+- Real change-ticket or cloud audit evidence from production rotations
+- Unfixed vulnerability write-ups before the GitHub Security Advisory window
+
+Store operator-private material in a separate private ops repo, vault, or
+GitHub Environments — not in this tree.
+
+## Customer VPC (their boundary)
+
+Customers run self-hosted control planes in their own cloud, database, identity,
+and audit boundary. Their scan data, graphs, API keys, and rotation timestamps
+belong to them — not to this repository.
+
+## Pre-commit checklist
+
+Before pushing deploy or ops changes:
+
+1. No `.env` files except `.env.example`
+2. No files under `deploy/secrets/` except `*.example` and README
+3. No minted keys, kubeconfigs, or connection strings with real hostnames/ARNs
+4. Doc timestamps are clearly examples, not copied from a live environment
+5. Security issues reported via
+   [GitHub Security Advisories](https://github.com/msaad00/agent-bom/security/advisories/new),
+   not public issues
+
+## Related docs
+
+- [PRODUCT_BOUNDARIES.md](PRODUCT_BOUNDARIES.md) — shipped lanes vs roadmap
+- [ENTERPRISE_SECURITY_POSTURE.md](ENTERPRISE_SECURITY_POSTURE.md) — buyer-facing controls
+- [SECURITY.md](../SECURITY.md) — vulnerability reporting

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -1,0 +1,13 @@
+# Engineering audit ledgers
+
+Files in this directory are **historical engineering records** — point-in-time
+audit scores, fixed-issue ledgers, and verification notes from internal review
+waves.
+
+- Issues listed as fixed are addressed on current `main` unless a file header
+  says otherwise.
+- Do **not** treat open-finding language here as current product risk without
+  verifying against `main`, tests, and live smoke.
+- For public vulnerability reporting use [SECURITY.md](../../SECURITY.md).
+- For what belongs in this public repo vs operator-private custody, see
+  [PUBLICATION_POLICY.md](../PUBLICATION_POLICY.md).

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -13757,7 +13757,7 @@
     },
     "/v1/graph/nhi/governance": {
       "get": {
-        "description": "Return the non-human-identity governance posture for the latest graph.\n\nLoads the latest unified graph, projects the live governance control plane\nand resolves effective permissions, then computes the three Natoma-parity\nanalytics \u2014 usage-based right-sizing, dormant/orphaned detection, and the\n0-100 per-identity risk score \u2014 and returns a non-secret posture ranked\nworst risk first. Right-sizing here uses the durable `last_used_at` markers\nin the graph (no caller usage map is accepted over the API).",
+        "description": "Return the non-human-identity governance posture for the latest graph.\n\nLoads the latest unified graph, projects the live governance control plane\nand resolves effective permissions, then computes the three core NHI governance\nanalytics \u2014 usage-based right-sizing, dormant/orphaned detection, and the\n0-100 per-identity risk score \u2014 and returns a non-secret posture ranked\nworst risk first. Right-sizing here uses the durable `last_used_at` markers\nin the graph (no caller usage map is accepted over the API).",
         "operationId": "get_nhi_governance_v1_graph_nhi_governance_get",
         "parameters": [
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -9007,10 +9007,10 @@ paths:
     get:
       description: "Return the non-human-identity governance posture for the latest\
         \ graph.\n\nLoads the latest unified graph, projects the live governance control\
-        \ plane\nand resolves effective permissions, then computes the three Natoma-parity\n\
-        analytics \u2014 usage-based right-sizing, dormant/orphaned detection, and\
-        \ the\n0-100 per-identity risk score \u2014 and returns a non-secret posture\
-        \ ranked\nworst risk first. Right-sizing here uses the durable `last_used_at`\
+        \ plane\nand resolves effective permissions, then computes the three core\
+        \ NHI governance\nanalytics \u2014 usage-based right-sizing, dormant/orphaned\
+        \ detection, and the\n0-100 per-identity risk score \u2014 and returns a non-secret\
+        \ posture ranked\nworst risk first. Right-sizing here uses the durable `last_used_at`\
         \ markers\nin the graph (no caller usage map is accepted over the API)."
       operationId: get_nhi_governance_v1_graph_nhi_governance_get
       parameters:

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1829,7 +1829,7 @@ async def get_nhi_governance(
     """Return the non-human-identity governance posture for the latest graph.
 
     Loads the latest unified graph, projects the live governance control plane
-    and resolves effective permissions, then computes the three Natoma-parity
+    and resolves effective permissions, then computes the three core NHI governance
     analytics — usage-based right-sizing, dormant/orphaned detection, and the
     0-100 per-identity risk score — and returns a non-secret posture ranked
     worst risk first. Right-sizing here uses the durable `last_used_at` markers

--- a/src/agent_bom/graph/nhi_governance.py
+++ b/src/agent_bom/graph/nhi_governance.py
@@ -5,7 +5,7 @@ The discovery (:mod:`agent_bom.graph.nhi_overlay`), governance
 (:mod:`agent_bom.graph.effective_permissions`) overlays place
 ``managed_identity`` nodes, ``HAS_PERMISSION`` / ``SCOPED_TO`` edges, and
 privilege flags into one graph. This module is pure *analytics over that data* —
-the three Natoma-parity capabilities that close the 2026-06-19 audit gap:
+the three core NHI governance analytics that close the 2026-06-19 audit gap:
 
 1. **Usage-based right-sizing.** Diff the permissions an identity is *granted*
    (the ``HAS_PERMISSION`` transitive closure + standing ``SCOPED_TO`` tool


### PR DESCRIPTION
## Summary
- Add `docs/PUBLICATION_POLICY.md` — public OSS vs operator-private custody (secrets, rotation timestamps, hosted POC bootstrap output) with a pre-commit checklist.
- Cross-link from `ENTERPRISE_SECURITY_POSTURE.md` and `PRODUCT_BOUNDARIES.md`; add `docs/audits/README.md` so engineering ledgers are labeled historical, not current open findings.
- Remove competitor names from user-facing deploy copy (`Wiz-style` → connect-and-scan) and NHI governance API docs (`Natoma-parity` → core NHI governance); regenerate OpenAPI.

Closes publication-audit follow-up from customer-0 prep (no dedicated issue — bundles policy + AGENTS.md positioning compliance).

## Test plan
- [x] `uv run python scripts/export_openapi.py --check`
- [x] Grep: no `Wiz-style` / `Natoma-parity` in repo
- [x] Grep: no committed live `*_LAST_ROTATED` values (doc examples only)


Made with [Cursor](https://cursor.com)