### PR TITLE
fix(docs): repair out-of-tree links breaking strict mkdocs build

### DIFF
--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -1,6 +1,6 @@
 # Deployment Overview
 
-> **Unified quickstart:** [`docs/DEPLOY_QUICKSTART.md`](../../docs/DEPLOY_QUICKSTART.md)
+> **Unified quickstart:** [`docs/DEPLOY_QUICKSTART.md`](https://github.com/msaad00/agent-bom/blob/main/docs/DEPLOY_QUICKSTART.md)
 > — `scripts/deploy/install.sh` for pilot, EKS, AKS, GKE, Snowflake, and
 > read-only cloud connect.
 

--- a/site-docs/deployment/quickstart.md
+++ b/site-docs/deployment/quickstart.md
@@ -3,7 +3,7 @@
 Unified entry for **BYOC / self-hosted** rollout: one install script, read-only
 cloud connect, and the intake paths that feed your control plane.
 
-Full doc in the repo: [`docs/DEPLOY_QUICKSTART.md`](../../docs/DEPLOY_QUICKSTART.md).
+Full doc in the repo: [`docs/DEPLOY_QUICKSTART.md`](https://github.com/msaad00/agent-bom/blob/main/docs/DEPLOY_QUICKSTART.md).
 
 ## Install
 
@@ -68,7 +68,7 @@ mermaid diagrams:
 
 ## Related
 
-- [Deploy anywhere (three tiers)](../../docs/DEPLOY_PLATFORM.md)
-- [Cloud connect model](../../docs/CLOUD_CONNECT.md)
-- [Cross-cloud runbook](../../deploy/RUNBOOK.md)
-- [Trust boundaries](../../docs/TRUST.md)
+- [Deploy anywhere (three tiers)](https://github.com/msaad00/agent-bom/blob/main/docs/DEPLOY_PLATFORM.md)
+- [Cloud connect model](https://github.com/msaad00/agent-bom/blob/main/docs/CLOUD_CONNECT.md)
+- [Cross-cloud runbook](https://github.com/msaad00/agent-bom/blob/main/deploy/RUNBOOK.md)
+- [Trust boundaries](https://github.com/msaad00/agent-bom/blob/main/docs/TRUST.md)


### PR DESCRIPTION
The v0.93.5 release run's **"Rebuild and deploy docs / build"** job failed with `Aborted with 6 warnings in strict mode!` (release artifacts — PyPI/Docker/Helm/GitHub Release — all published fine; only the docs site didn't refresh).

Cause: `site-docs/deployment/overview.md` and `quickstart.md` (added in #3621) link to files **outside `docs_dir: site-docs`** — `../../docs/DEPLOY_QUICKSTART.md`, `../../docs/DEPLOY_PLATFORM.md`, `../../docs/CLOUD_CONNECT.md`, `../../deploy/RUNBOOK.md`, `../../docs/TRUST.md`. mkdocs runs `--strict`, so unresolved links abort the build.

Fix: point those 6 links at absolute GitHub blob URLs (the targets live in the repo, not the published site), matching how `own-infra-eks.md` already references repo files. No other `../../` cross-tree links remain in site-docs.

Docs-only; unblocks the docs deploy on next build.