### PR TITLE
fix(cli): unified terminal UX — sections, deduped CIS, quiet cloud

### DIFF
--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -114,6 +114,7 @@ def _run_cloud_scan(
     output_format: str = "console",
     output_path: Optional[str] = None,
     quiet: bool = False,
+    verbose: bool = False,
 ) -> None:
     """Run the shared cloud-scan body across one or more providers.
 
@@ -163,9 +164,9 @@ def _run_cloud_scan(
             f"\n[bold]Cloud scan[/bold] [dim]· {', '.join(p.upper() for p in providers)} · {'CIS + ' if cis else ''}discovery[/dim]"
         )
 
-    # Pass --show-passed through to the grouped CIS renderer in run_benchmarks
-    # (the scan command itself has no such flag). click.Context.meta is shared
-    # across the whole context stack, so it survives the invoke into `scan`.
+    # Pass --show-passed through to the grouped CIS renderer at report time.
+    # click.Context.meta is shared across the whole context stack, so it survives
+    # the invoke into `scan`.
     from agent_bom.cli.agents._cloud import CIS_SHOW_PASSED_META
 
     ctx = click.get_current_context()
@@ -190,6 +191,7 @@ def _run_cloud_scan(
         output_format=output_format,
         output=output_path,
         quiet=quiet,
+        verbose=verbose,
     )
 
 
@@ -266,6 +268,7 @@ def cloud_group(ctx: click.Context) -> None:
 @click.option("-f", "--format", "output_format", default="console", help="Output format")
 @click.option("-o", "--output", "output_path", help="Output file path")
 @click.option("--quiet", "-q", is_flag=True)
+@click.option("--verbose", "-v", is_flag=True, help="Expanded terminal output (full CIS plan, detail tables).")
 def scan_cmd(
     provider: str,
     region: Optional[str],
@@ -282,6 +285,7 @@ def scan_cmd(
     output_format: str,
     output_path: Optional[str],
     quiet: bool,
+    verbose: bool,
 ) -> None:
     """Scan one or every configured cloud — AI agents, infra, and CIS compliance.
 
@@ -315,6 +319,7 @@ def scan_cmd(
         output_format=output_format,
         output_path=output_path,
         quiet=quiet,
+        verbose=verbose,
     )
 
 
@@ -331,6 +336,7 @@ def scan_cmd(
 @click.option("-f", "--format", "output_format", default="console", help="Output format")
 @click.option("-o", "--output", "output_path", help="Output file path")
 @click.option("--quiet", "-q", is_flag=True)
+@click.option("--verbose", "-v", is_flag=True, help="Expanded terminal output (full CIS plan, detail tables).")
 def aws_cmd(
     region: Optional[str],
     profile: Optional[str],
@@ -344,6 +350,7 @@ def aws_cmd(
     output_format: str,
     output_path: Optional[str],
     quiet: bool,
+    verbose: bool,
 ) -> None:
     """Scan AWS for AI agents, infrastructure, and CIS compliance.
 
@@ -362,6 +369,7 @@ def aws_cmd(
         output_format=output_format,
         output_path=output_path,
         quiet=quiet,
+        verbose=verbose,
     )
 
 
@@ -373,6 +381,7 @@ def aws_cmd(
 @click.option("-f", "--format", "output_format", default="console", help="Output format")
 @click.option("-o", "--output", "output_path", help="Output file path")
 @click.option("--quiet", "-q", is_flag=True)
+@click.option("--verbose", "-v", is_flag=True, help="Expanded terminal output (full CIS plan, detail tables).")
 def azure_cmd(
     subscription: Optional[str],
     cis: bool,
@@ -381,6 +390,7 @@ def azure_cmd(
     output_format: str,
     output_path: Optional[str],
     quiet: bool,
+    verbose: bool,
 ) -> None:
     """Scan Azure for AI agents, infrastructure, and CIS compliance.
 
@@ -405,6 +415,7 @@ def azure_cmd(
 @click.option("-f", "--format", "output_format", default="console", help="Output format")
 @click.option("-o", "--output", "output_path", help="Output file path")
 @click.option("--quiet", "-q", is_flag=True)
+@click.option("--verbose", "-v", is_flag=True, help="Expanded terminal output (full CIS plan, detail tables).")
 def gcp_cmd(
     project: Optional[str],
     cis: bool,
@@ -413,6 +424,7 @@ def gcp_cmd(
     output_format: str,
     output_path: Optional[str],
     quiet: bool,
+    verbose: bool,
 ) -> None:
     """Scan GCP for AI agents, infrastructure, and CIS compliance.
 
@@ -426,6 +438,7 @@ def gcp_cmd(
         output_format=output_format,
         output_path=output_path,
         quiet=quiet,
+        verbose=verbose,
     )
 
 

--- a/src/agent_bom/cli/_entry_points.py
+++ b/src/agent_bom/cli/_entry_points.py
@@ -123,35 +123,43 @@ def _render_connect_guidance(con: object, source: _ConnectSource) -> None:
     Output is fixed for a given environment (only the credential-detection line
     reflects the current env), so it is safe to snapshot in tests.
     """
-    printer = con.print  # type: ignore[attr-defined]
-    printer()
-    printer(f"  [bold]Connect {source.title}[/bold] [dim](read-only)[/dim]")
-    printer(f"  [dim]{source.role_summary}[/dim]")
-    printer()
-    printer("  [bold]1. Provision the read-only grant[/bold]")
-    printer(f"     [cyan]terraform -chdir={source.terraform_module} init && terraform -chdir={source.terraform_module} apply[/cyan]")
-    printer("     [dim]Module mints exactly the read-only role agent-bom needs — nothing is created or modified in your account.[/dim]")
-    printer()
-    printer("  [bold]2. Opt in to inventory[/bold] [dim](default-off; agent-bom does zero network I/O until set)[/dim]")
-    printer(f"     [cyan]export {source.inventory_env}={source.inventory_value}[/cyan]")
-    printer()
-    printer("  [bold]3. Scan[/bold]")
-    printer(f"     [cyan]{source.scan_command}[/cyan]")
-    printer()
+    from agent_bom.cli._terminal_sections import render_connect_card
 
+    body_lines = [
+        "[bold]1. Provision the read-only grant[/bold]",
+        f"   [cyan]terraform -chdir={source.terraform_module} init && terraform -chdir={source.terraform_module} apply[/cyan]",
+        "   [dim]Read-only role only — nothing is created or modified in your account.[/dim]",
+        "",
+        "[bold]2. Opt in to inventory[/bold] [dim](default-off)[/dim]",
+        f"   [cyan]export {source.inventory_env}={source.inventory_value}[/cyan]",
+        "",
+        "[bold]3. Scan[/bold]",
+        f"   [cyan]{source.scan_command}[/cyan]",
+    ]
     if source.audit_trail_note:
-        printer("  [bold]Optional: audit-trail behavioral edges[/bold] [dim](opt-in, read-only)[/dim]")
-        printer("     [cyan]export AGENT_BOM_AUDIT_TRAIL=1[/cyan]")
-        printer(f"     [dim]{source.audit_trail_note}[/dim]")
-        printer()
+        body_lines.extend(
+            [
+                "",
+                "[bold]Optional: audit-trail edges[/bold] [dim](opt-in)[/dim]",
+                "   [cyan]export AGENT_BOM_AUDIT_TRAIL=1[/cyan]",
+                f"   [dim]{source.audit_trail_note}[/dim]",
+            ]
+        )
 
     detected = _detected_cred_vars(source)
     if detected:
-        printer(f"  [green]Credentials detected:[/green] {', '.join(detected)}")
+        body_lines.extend(["", f"[green]Credentials detected:[/green] {', '.join(detected)}"])
     else:
         expected = ", ".join(source.cred_env_vars)
-        printer(f"  [yellow]No credentials detected.[/yellow] Set one of: [dim]{expected}[/dim]")
-    printer()
+        body_lines.extend(["", f"[yellow]No credentials detected.[/yellow] Set one of: [dim]{expected}[/dim]"])
+
+    render_connect_card(
+        con,  # type: ignore[arg-type]
+        title=source.title,
+        role_summary=f"{source.role_summary} (read-only)",
+        body="\n".join(body_lines),
+        next_command=source.scan_command,
+    )
 
 
 def _list_connect_sources() -> None:

--- a/src/agent_bom/cli/_interactive.py
+++ b/src/agent_bom/cli/_interactive.py
@@ -51,8 +51,9 @@ def _print_interactive_help(output: Callable[[str], None]) -> None:
     output("")
     output("Run normal commands without the program name, for example:")
     output("  agents --demo --offline")
+    output("  cloud aws --no-cis          # discovery without CIS wall")
+    output("  report -f html -o out.html  # generate shareable report")
     output("  doctor")
-    output("  report history")
 
 
 def _invoke_root_command(root_command: click.Command, args: Sequence[str], output: Callable[[str], None]) -> int:

--- a/src/agent_bom/cli/_terminal_sections.py
+++ b/src/agent_bom/cli/_terminal_sections.py
@@ -1,0 +1,171 @@
+"""Shared terminal layout for scan, cloud, connect, and interactive CLI paths.
+
+Keeps provider-agnostic output consistent: lane-labelled sections, collapsed
+warnings, verdict-first summaries, and a single footer with next-step commands.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Iterator
+
+from rich.panel import Panel
+from rich.rule import Rule
+
+from agent_bom.output.brand_tokens import lane_title
+from agent_bom.output.compact import _compact_detail
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+    from agent_bom.cli.agents._context import ScanContext
+    from agent_bom.models import AIBOMReport
+
+
+def ctx_quiet(ctx: ScanContext) -> bool:
+    """True when console output should be suppressed (``-q`` / pipe mode)."""
+    con = getattr(ctx, "con", None)
+    return bool(getattr(ctx, "quiet", False) or getattr(con, "quiet", False))
+
+
+def ctx_verbose(ctx: ScanContext) -> bool:
+    """True when the operator asked for expanded terminal detail."""
+    return bool(getattr(ctx, "verbose", False))
+
+
+@contextmanager
+def stage_status(con: Console, message: str, *, enabled: bool) -> Iterator[None]:
+    """Rich status spinner when enabled; no-op otherwise."""
+    if not enabled:
+        yield
+        return
+    with con.status(message, spinner="dots"):
+        yield
+
+
+def print_lane_header(con: Console, lane: str, title: str) -> None:
+    """Open a lane-labelled section (DISCOVER | SCAN | GOVERN …)."""
+    con.print()
+    con.print(f"  {lane_title(lane, title)}")
+
+
+def print_section_divider(con: Console, label: str = "") -> None:
+    """Visual separator between major report blocks."""
+    con.print()
+    con.print(Rule(label, style="dim") if label else Rule(style="dim"))
+
+
+def print_collapsed_warnings(
+    con: Console,
+    warnings: list[str] | tuple[str, ...],
+    *,
+    verbose: bool,
+    max_visible: int = 2,
+    prefix: str = "!",
+) -> None:
+    """Print warnings; collapse long lists unless *verbose*."""
+    clean = [str(w).strip() for w in warnings if str(w or "").strip()]
+    if not clean:
+        return
+    if verbose:
+        for warning in clean:
+            con.print(f"  [yellow]{prefix}[/yellow] {_compact_detail(warning, 120)}")
+        return
+    for warning in clean[:max_visible]:
+        con.print(f"  [yellow]{prefix}[/yellow] {_compact_detail(warning, 100)}")
+    remaining = len(clean) - min(len(clean), max_visible)
+    if remaining > 0:
+        con.print(f"  [dim]… {remaining} more warning(s) — use --verbose to expand[/dim]")
+
+
+def print_provider_discovery_result(
+    con: Console,
+    provider: str,
+    *,
+    agent_count: int,
+    package_count: int,
+    warnings: list[str] | tuple[str, ...],
+    verbose: bool,
+) -> None:
+    """One-line provider discovery summary plus collapsed warnings."""
+    label = provider.upper()
+    if agent_count:
+        con.print(f"  [green]✓[/green] {label} · {agent_count} agent(s) · {package_count} package(s)")
+    else:
+        con.print(f"  [dim]—[/dim] {label} · no AI agents found")
+    print_collapsed_warnings(con, warnings, verbose=verbose)
+
+
+def print_benchmark_line(
+    con: Console,
+    label: str,
+    *,
+    total: int,
+    passed: int,
+    failed: int,
+    pass_rate: float,
+    scope: str = "",
+) -> None:
+    """Compact one-line benchmark result."""
+    scope_bit = f" · {scope}" if scope else ""
+    con.print(
+        f"  [green]✓[/green] {label} · {total} checks{scope_bit} · "
+        f"{passed} passed · {failed} failed ({pass_rate:.0f}% pass)"
+    )
+
+
+def print_scan_next_steps(con: Console, report: AIBOMReport, *, quiet: bool = False) -> None:
+    """Footer with graph / report / drill-down commands."""
+    if quiet:
+        return
+
+    steps: list[str] = []
+    if getattr(report, "total_agents", 0):
+        steps.append("agent-bom graph")
+    if getattr(report, "total_vulnerabilities", 0) or getattr(report, "critical_vulns", None):
+        steps.append("agent-bom report -f html -o agent-bom-report.html")
+    else:
+        steps.append("agent-bom report -f html -o agent-bom-report.html")
+
+    cis_attrs = (
+        "cis_benchmark_data",
+        "azure_cis_benchmark_data",
+        "gcp_cis_benchmark_data",
+        "snowflake_cis_benchmark_data",
+    )
+    if any(getattr(report, attr, None) for attr in cis_attrs):
+        steps.append("agent-bom cloud scan --verbose --show-passed   # full CIS plan")
+
+    print_section_divider(con, "Next")
+    for step in steps:
+        con.print(f"  [cyan]→[/cyan] {step}")
+
+
+def render_connect_card(con: Console, *, title: str, role_summary: str, body: str, next_command: str) -> None:
+    """Readable connect/onboarding card for every cloud source."""
+    con.print()
+    con.print(
+        Panel(
+            body,
+            title=f"[bold]Connect {title}[/bold]",
+            subtitle=f"[dim]{role_summary}[/dim]",
+            border_style="cyan",
+            padding=(1, 2),
+        )
+    )
+    con.print(f"  [bold]Next[/bold]  [cyan]{next_command}[/cyan]")
+    con.print()
+
+
+__all__ = [
+    "ctx_quiet",
+    "ctx_verbose",
+    "print_benchmark_line",
+    "print_collapsed_warnings",
+    "print_lane_header",
+    "print_provider_discovery_result",
+    "print_scan_next_steps",
+    "print_section_divider",
+    "render_connect_card",
+    "stage_status",
+]

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -846,7 +846,7 @@ def scan(
         return
 
     # Create shared context object
-    ctx = ScanContext(con=con)
+    ctx = ScanContext(con=con, quiet=quiet, verbose=verbose)
     try:
         from agent_bom.resolver import reset_performance_stats as _reset_resolver_performance
         from agent_bom.scanners import reset_scan_performance as _reset_scan_performance

--- a/src/agent_bom/cli/agents/_cloud.py
+++ b/src/agent_bom/cli/agents/_cloud.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 from typing import Any
 
+from agent_bom.cli._terminal_sections import (
+    ctx_quiet,
+    ctx_verbose,
+    print_benchmark_line,
+    print_lane_header,
+    print_provider_discovery_result,
+    stage_status,
+)
 from agent_bom.cli.agents._context import ScanContext
 
 # Shared CIS status badges across every provider table. ``not_applicable`` is
@@ -136,22 +144,31 @@ def run_cloud_discovery(
         cloud_providers.append(("ollama", {"host": ollama_host}))
 
     _pre_cloud_idx = len(ctx.agents)
+    quiet = ctx_quiet(ctx)
+    verbose = ctx_verbose(ctx)
     for provider_name, provider_kwargs in cloud_providers:
         from agent_bom.cloud import CloudDiscoveryError, discover_from_provider
 
-        con.print(f"\n[bold blue]Discovering agents from {provider_name.upper()}...[/bold blue]\n")
+        if verbose and not quiet:
+            print_lane_header(con, "discover", f"{provider_name.upper()} agents")
         try:
-            cloud_agents, cloud_warnings = discover_from_provider(provider_name, **provider_kwargs)
-            for w in cloud_warnings:
-                con.print(f"  [yellow]⚠[/yellow] {w}")
+            with stage_status(con, f"[bold]Discovering {provider_name.upper()}…[/bold]", enabled=not quiet and not verbose):
+                cloud_agents, cloud_warnings = discover_from_provider(provider_name, **provider_kwargs)
+            if not quiet:
+                pkg_count = sum(a.total_packages for a in cloud_agents) if cloud_agents else 0
+                print_provider_discovery_result(
+                    con,
+                    provider_name,
+                    agent_count=len(cloud_agents),
+                    package_count=pkg_count,
+                    warnings=cloud_warnings,
+                    verbose=verbose,
+                )
             if cloud_agents:
-                pkg_count = sum(a.total_packages for a in cloud_agents)
-                con.print(f"  [green]✓[/green] {len(cloud_agents)} agent(s) discovered, {pkg_count} package(s) to scan")
                 ctx.agents.extend(cloud_agents)
-            else:
-                con.print(f"  [dim]  No AI agents found in {provider_name.upper()}[/dim]")
         except CloudDiscoveryError as exc:
-            con.print(f"\n  [red]{provider_name.upper()} discovery error: {_safe_error(exc)}[/red]")
+            if not quiet:
+                con.print(f"\n  [red]{provider_name.upper()} discovery error: {_safe_error(exc)}[/red]")
             # A requested provider whose SDK or credentials are missing/invalid is a
             # hard failure, not a clean empty result. Record it so the final exit code
             # is non-zero (silent CI passes are the bug). The loop continues, so the
@@ -176,17 +193,24 @@ def run_cloud_discovery(
             srv.surface = ServerSurface.CONTAINER_IMAGE
             _seen.setdefault(img_ref, []).append(srv)
 
-        con.print(f"\n[bold blue]Scanning {len(_seen)} cloud container image(s)...[/bold blue]\n")
-        for img_ref, servers in _seen.items():
-            try:
-                img_packages, strategy = scan_image(img_ref)
-                for srv in servers:
-                    srv.packages = img_packages
-                con.print(f"  [green]✓[/green] {img_ref}: {len(img_packages)} package(s) [dim](via {strategy})[/dim]")
-            except ImageScanError as exc:
-                con.print(f"  [yellow]⚠[/yellow] cloud image {img_ref}: {exc}")
-            except Exception as exc:
-                con.print(f"  [yellow]⚠[/yellow] cloud image {img_ref}: could not scan — {exc}")
+        if verbose and not quiet:
+            print_lane_header(con, "scan", f"{len(_seen)} cloud container image(s)")
+        with stage_status(con, f"[bold]Scanning {len(_seen)} cloud image(s)…[/bold]", enabled=not quiet and not verbose):
+            for img_ref, servers in _seen.items():
+                try:
+                    img_packages, strategy = scan_image(img_ref)
+                    for srv in servers:
+                        srv.packages = img_packages
+                    if not quiet:
+                        con.print(
+                            f"  [green]✓[/green] {img_ref}: {len(img_packages)} package(s) [dim](via {strategy})[/dim]"
+                        )
+                except ImageScanError as exc:
+                    if not quiet:
+                        con.print(f"  [yellow]![/yellow] cloud image {img_ref}: {exc}")
+                except Exception as exc:
+                    if not quiet:
+                        con.print(f"  [yellow]![/yellow] cloud image {img_ref}: could not scan — {exc}")
 
     # Step 1y: SaaS connector discovery
     saas_connectors: list[tuple[str, dict]] = []
@@ -200,18 +224,25 @@ def run_cloud_discovery(
     for connector_name, connector_kwargs in saas_connectors:
         from agent_bom.connectors import ConnectorError, discover_from_connector
 
-        con.print(f"\n[bold blue]Discovering agents from {connector_name.upper()} connector...[/bold blue]\n")
+        if verbose and not quiet:
+            print_lane_header(con, "discover", f"{connector_name.upper()} connector")
         try:
-            con_agents, con_warnings = discover_from_connector(connector_name, **connector_kwargs)
-            for w in con_warnings:
-                con.print(f"  [yellow]![/yellow] {w}")
+            with stage_status(con, f"[bold]Discovering {connector_name.upper()}…[/bold]", enabled=not quiet and not verbose):
+                con_agents, con_warnings = discover_from_connector(connector_name, **connector_kwargs)
+            if not quiet:
+                print_provider_discovery_result(
+                    con,
+                    connector_name,
+                    agent_count=len(con_agents),
+                    package_count=0,
+                    warnings=con_warnings,
+                    verbose=verbose,
+                )
             if con_agents:
-                con.print(f"  [green]v[/green] {len(con_agents)} agent(s) discovered from {connector_name.upper()}")
                 ctx.agents.extend(con_agents)
-            else:
-                con.print(f"  [dim]  No AI agents found in {connector_name.upper()}[/dim]")
         except ConnectorError as exc:
-            con.print(f"\n  [red]{connector_name.upper()} connector error: {exc}[/red]")
+            if not quiet:
+                con.print(f"\n  [red]{connector_name.upper()} connector error: {exc}[/red]")
 
     # Step 1z: Multi-source correlation (dedup + merge across sources)
     if not skill_only and ctx.agents:
@@ -220,7 +251,7 @@ def run_cloud_discovery(
             from agent_bom.correlate import correlate_agents
 
             ctx.agents, corr_result = correlate_agents(ctx.agents)
-            if corr_result.cross_source_matches:
+            if corr_result.cross_source_matches and not quiet:
                 con.print(
                     f"\n  [bold]Correlated:[/bold] {corr_result.cross_source_matches} package(s) "
                     f"merged across {len(corr_result.source_summary)} source(s)"
@@ -261,6 +292,8 @@ def run_benchmarks(
 ) -> None:
     """Steps 1x–1z: model hash, CIS benchmarks, AISVS, vector DB, GPU, SaaS connectors."""
     con = ctx.con
+    quiet = ctx_quiet(ctx)
+    verbose = ctx_verbose(ctx)
 
     # Step 1x: Model hash verification (supply chain integrity)
     if verify_model_hashes:
@@ -316,137 +349,181 @@ def run_benchmarks(
     if aws_cis_benchmark:
         from agent_bom.cloud import CloudDiscoveryError
 
-        con.print("\n[bold blue]Running CIS AWS Foundations Benchmark v3.0...[/bold blue]\n")
+        if verbose and not quiet:
+            print_lane_header(con, "govern", "CIS AWS Foundations Benchmark v3.0")
         try:
             from agent_bom.cloud import aws_organizations
 
-            # When the org fan-out flag is on, fan the benchmark across every
-            # member account of the organization (same boundary set the inventory
-            # fan-out uses) and aggregate with per-account attribution. Each
-            # account is reached via a read-only AssumeRole; an account that denies
-            # the role is skipped. Off = unchanged single-account/region run.
-            if aws_organizations.org_fanout_enabled():
-                from agent_bom.cloud.aws_cis_benchmark import run_all_account_benchmarks
+            with stage_status(con, "[bold]CIS AWS Foundations Benchmark v3.0[/bold]", enabled=not quiet and not verbose):
+                # When the org fan-out flag is on, fan the benchmark across every
+                # member account of the organization (same boundary set the inventory
+                # fan-out uses) and aggregate with per-account attribution. Each
+                # account is reached via a read-only AssumeRole; an account that denies
+                # the role is skipped. Off = unchanged single-account/region run.
+                if aws_organizations.org_fanout_enabled():
+                    from agent_bom.cloud.aws_cis_benchmark import run_all_account_benchmarks
 
-                ctx.cis_benchmark_report = run_all_account_benchmarks(profile=aws_profile)
-            else:
-                from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_cis
+                    ctx.cis_benchmark_report = run_all_account_benchmarks(profile=aws_profile)
+                else:
+                    from agent_bom.cloud.aws_cis_benchmark import run_benchmark as run_cis
 
-                ctx.cis_benchmark_report = run_cis(region=aws_region, profile=aws_profile)
+                    ctx.cis_benchmark_report = run_cis(region=aws_region, profile=aws_profile)
             passed = ctx.cis_benchmark_report.passed
             failed = ctx.cis_benchmark_report.failed
             total = ctx.cis_benchmark_report.total
             rate = ctx.cis_benchmark_report.pass_rate
             scanned = getattr(ctx.cis_benchmark_report, "accounts_scanned", []) or []
-            scope = f" across {len(scanned)} account(s)" if len(scanned) > 1 else ""
-            con.print(f"  [green]✓[/green] {total} checks evaluated{scope} — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
+            scope = f"{len(scanned)} account(s)" if len(scanned) > 1 else ""
+            if not quiet:
+                print_benchmark_line(
+                    con,
+                    "CIS AWS",
+                    total=total,
+                    passed=passed,
+                    failed=failed,
+                    pass_rate=rate,
+                    scope=scope,
+                )
         except CloudDiscoveryError as exc:
-            con.print(f"  [red]CIS Benchmark error: {_safe_error(exc)}[/red]")
+            if not quiet:
+                con.print(f"  [red]CIS Benchmark error: {_safe_error(exc)}[/red]")
             ctx.cloud_provider_failures.append({"provider": "aws", "stage": "cis_benchmark", "error": str(exc)})
 
     # Step 1x-sf: CIS Snowflake Benchmark
     if snowflake_cis_benchmark:
         from agent_bom.cloud import CloudDiscoveryError as _SFCISError
 
-        con.print("\n[bold blue]Running CIS Snowflake Benchmark v1.0...[/bold blue]\n")
+        if verbose and not quiet:
+            print_lane_header(con, "govern", "CIS Snowflake Benchmark v1.0")
         try:
             from agent_bom.cloud.snowflake_cis_benchmark import run_benchmark as run_sf_cis
 
-            # Forward the chosen authenticator; account/user resolve from env.
-            ctx.sf_cis_benchmark_report = run_sf_cis(authenticator=snowflake_authenticator or None)
+            with stage_status(con, "[bold]CIS Snowflake Benchmark v1.0[/bold]", enabled=not quiet and not verbose):
+                # Forward the chosen authenticator; account/user resolve from env.
+                ctx.sf_cis_benchmark_report = run_sf_cis(authenticator=snowflake_authenticator or None)
             passed = ctx.sf_cis_benchmark_report.passed
             failed = ctx.sf_cis_benchmark_report.failed
             total = ctx.sf_cis_benchmark_report.total
             rate = ctx.sf_cis_benchmark_report.pass_rate
-            con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
+            if not quiet:
+                print_benchmark_line(con, "CIS Snowflake", total=total, passed=passed, failed=failed, pass_rate=rate)
         except _SFCISError as exc:
-            con.print(f"  [red]CIS Snowflake Benchmark error: {_safe_error(exc)}[/red]")
+            if not quiet:
+                con.print(f"  [red]CIS Snowflake Benchmark error: {_safe_error(exc)}[/red]")
             ctx.cloud_provider_failures.append({"provider": "snowflake", "stage": "cis_benchmark", "error": str(exc)})
 
     # Step 1x-az: CIS Azure Benchmark
     if azure_cis_benchmark:
         from agent_bom.cloud import CloudDiscoveryError as _AZCISError
 
-        con.print("\n[bold blue]Running CIS Azure Security Benchmark v3.0...[/bold blue]\n")
+        if verbose and not quiet:
+            print_lane_header(con, "govern", "CIS Azure Security Benchmark v3.0")
         try:
             from agent_bom.cloud import azure_inventory
 
-            # When the multi-subscription flag is on, fan the benchmark across
-            # every subscription in the tenant (same boundary set the inventory
-            # fan-out uses) and aggregate with per-subscription attribution.
-            # Off = unchanged single-subscription run.
-            if azure_inventory.all_subscriptions_enabled():
-                from agent_bom.cloud.azure_cis_benchmark import run_all_subscription_benchmarks
+            with stage_status(con, "[bold]CIS Azure Security Benchmark v3.0[/bold]", enabled=not quiet and not verbose):
+                # When the multi-subscription flag is on, fan the benchmark across
+                # every subscription in the tenant (same boundary set the inventory
+                # fan-out uses) and aggregate with per-subscription attribution.
+                # Off = unchanged single-subscription run.
+                if azure_inventory.all_subscriptions_enabled():
+                    from agent_bom.cloud.azure_cis_benchmark import run_all_subscription_benchmarks
 
-                ctx.azure_cis_benchmark_report = run_all_subscription_benchmarks()
-            else:
-                from agent_bom.cloud.azure_cis_benchmark import run_benchmark as run_az_cis
+                    ctx.azure_cis_benchmark_report = run_all_subscription_benchmarks()
+                else:
+                    from agent_bom.cloud.azure_cis_benchmark import run_benchmark as run_az_cis
 
-                # Forward the --subscription value; run_benchmark falls back to
-                # AZURE_SUBSCRIPTION_ID only when this is None.
-                ctx.azure_cis_benchmark_report = run_az_cis(subscription_id=azure_subscription or None)
+                    # Forward the --subscription value; run_benchmark falls back to
+                    # AZURE_SUBSCRIPTION_ID only when this is None.
+                    ctx.azure_cis_benchmark_report = run_az_cis(subscription_id=azure_subscription or None)
             passed = ctx.azure_cis_benchmark_report.passed
             failed = ctx.azure_cis_benchmark_report.failed
             total = ctx.azure_cis_benchmark_report.total
             rate = ctx.azure_cis_benchmark_report.pass_rate
             scanned = getattr(ctx.azure_cis_benchmark_report, "subscriptions_scanned", []) or []
-            scope = f" across {len(scanned)} subscription(s)" if len(scanned) > 1 else ""
-            con.print(f"  [green]✓[/green] {total} checks evaluated{scope} — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
+            scope = f"{len(scanned)} subscription(s)" if len(scanned) > 1 else ""
+            if not quiet:
+                print_benchmark_line(
+                    con,
+                    "CIS Azure",
+                    total=total,
+                    passed=passed,
+                    failed=failed,
+                    pass_rate=rate,
+                    scope=scope,
+                )
         except _AZCISError as exc:
-            con.print(f"  [red]CIS Azure Benchmark error: {_safe_error(exc)}[/red]")
+            if not quiet:
+                con.print(f"  [red]CIS Azure Benchmark error: {_safe_error(exc)}[/red]")
             ctx.cloud_provider_failures.append({"provider": "azure", "stage": "cis_benchmark", "error": str(exc)})
 
     # Step 1x-gcp: CIS GCP Benchmark
     if gcp_cis_benchmark:
         from agent_bom.cloud import CloudDiscoveryError as _GCPCISError
 
-        con.print("\n[bold blue]Running CIS GCP Foundation Benchmark v3.0...[/bold blue]\n")
+        if verbose and not quiet:
+            print_lane_header(con, "govern", "CIS GCP Foundation Benchmark v3.0")
         try:
             from agent_bom.cloud import gcp_inventory
 
-            # When the multi-project flag is on, fan the benchmark across every
-            # project in the org/folder tree (same boundary set the inventory
-            # fan-out uses) and aggregate with per-project attribution.
-            # Off = unchanged single-project run.
-            if gcp_inventory.all_projects_enabled():
-                from agent_bom.cloud.gcp_cis_benchmark import run_all_project_benchmarks
+            with stage_status(con, "[bold]CIS GCP Foundation Benchmark v3.0[/bold]", enabled=not quiet and not verbose):
+                # When the multi-project flag is on, fan the benchmark across every
+                # project in the org/folder tree (same boundary set the inventory
+                # fan-out uses) and aggregate with per-project attribution.
+                # Off = unchanged single-project run.
+                if gcp_inventory.all_projects_enabled():
+                    from agent_bom.cloud.gcp_cis_benchmark import run_all_project_benchmarks
 
-                ctx.gcp_cis_benchmark_report = run_all_project_benchmarks()
-            else:
-                from agent_bom.cloud.gcp_cis_benchmark import run_benchmark as run_gcp_cis
+                    ctx.gcp_cis_benchmark_report = run_all_project_benchmarks()
+                else:
+                    from agent_bom.cloud.gcp_cis_benchmark import run_benchmark as run_gcp_cis
 
-                ctx.gcp_cis_benchmark_report = run_gcp_cis()
+                    ctx.gcp_cis_benchmark_report = run_gcp_cis()
             passed = ctx.gcp_cis_benchmark_report.passed
             failed = ctx.gcp_cis_benchmark_report.failed
             total = ctx.gcp_cis_benchmark_report.total
             rate = ctx.gcp_cis_benchmark_report.pass_rate
             scanned = getattr(ctx.gcp_cis_benchmark_report, "projects_scanned", []) or []
-            scope = f" across {len(scanned)} project(s)" if len(scanned) > 1 else ""
-            con.print(f"  [green]✓[/green] {total} checks evaluated{scope} — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
+            scope = f"{len(scanned)} project(s)" if len(scanned) > 1 else ""
+            if not quiet:
+                print_benchmark_line(
+                    con,
+                    "CIS GCP",
+                    total=total,
+                    passed=passed,
+                    failed=failed,
+                    pass_rate=rate,
+                    scope=scope,
+                )
         except _GCPCISError as exc:
-            con.print(f"  [red]CIS GCP Benchmark error: {_safe_error(exc)}[/red]")
+            if not quiet:
+                con.print(f"  [red]CIS GCP Benchmark error: {_safe_error(exc)}[/red]")
             ctx.cloud_provider_failures.append({"provider": "gcp", "stage": "cis_benchmark", "error": str(exc)})
 
     # Step 1x-db: Databricks Security Best Practices
     if databricks_security:
         from agent_bom.cloud import CloudDiscoveryError as _DBSecError
 
-        con.print("\n[bold blue]Running Databricks Security Best Practices checks...[/bold blue]\n")
+        if verbose and not quiet:
+            print_lane_header(con, "govern", "Databricks Security Best Practices")
         try:
             import os
 
             from agent_bom.cloud.databricks_security import run_security_checks as run_db_sec
 
-            _db_host = os.environ.get("DATABRICKS_HOST")
-            _db_token = os.environ.get("DATABRICKS_TOKEN")
-            ctx.databricks_security_report = run_db_sec(host=_db_host, token=_db_token)
+            with stage_status(con, "[bold]Databricks security checks[/bold]", enabled=not quiet and not verbose):
+                _db_host = os.environ.get("DATABRICKS_HOST")
+                _db_token = os.environ.get("DATABRICKS_TOKEN")
+                ctx.databricks_security_report = run_db_sec(host=_db_host, token=_db_token)
             passed = ctx.databricks_security_report.passed
             failed = ctx.databricks_security_report.failed
             total = ctx.databricks_security_report.total
             rate = ctx.databricks_security_report.pass_rate
-            con.print(f"  [green]✓[/green] {total} checks evaluated — {passed} passed, {failed} failed ({rate:.0f}% pass rate)")
+            if not quiet:
+                print_benchmark_line(con, "Databricks", total=total, passed=passed, failed=failed, pass_rate=rate)
         except _DBSecError as exc:
-            con.print(f"  [red]Databricks security check error: {_safe_error(exc)}[/red]")
+            if not quiet:
+                con.print(f"  [red]Databricks security check error: {_safe_error(exc)}[/red]")
             ctx.cloud_provider_failures.append({"provider": "databricks", "stage": "security_checks", "error": str(exc)})
 
     # Step 1x-b: Vector DB scan
@@ -549,53 +626,50 @@ def run_benchmarks(
     if aisvs_flag:
         from rich.table import Table as _RTable
 
-        con.print("\n[bold blue]Running AISVS v1.0 compliance checks...[/bold blue]\n")
+        if verbose and not quiet:
+            print_lane_header(con, "govern", "AISVS v1.0 compliance")
         try:
             from agent_bom.cloud.aisvs_benchmark import run_benchmark as _run_aisvs
 
-            ctx.aisvs_report = _run_aisvs()
+            with stage_status(con, "[bold]AISVS v1.0 compliance[/bold]", enabled=not quiet and not verbose):
+                ctx.aisvs_report = _run_aisvs()
             passed = ctx.aisvs_report.passed
             failed = ctx.aisvs_report.failed
             total = ctx.aisvs_report.total
             rate = ctx.aisvs_report.pass_rate
-            con.print(
-                f"  [bold]AISVS v1.0[/bold]: {passed}/{total} checks passed "
-                f"([{'green' if rate >= 80 else 'yellow' if rate >= 50 else 'red'}]{rate:.1f}%[/])"
-            )
-            tbl = _RTable(title="AISVS Compliance", show_lines=True)
-            tbl.add_column("Check", width=8)
-            tbl.add_column("Title", max_width=45)
-            tbl.add_column("Status", width=8)
-            tbl.add_column("Sev", width=8)
-            tbl.add_column("MAESTRO", width=22)
-            tbl.add_column("Evidence", max_width=40)
-            _aiv_status = {
-                "pass": "[green]PASS[/]",
-                "fail": "[red]FAIL[/]",
-                "error": "[yellow]ERR[/]",
-                "not_applicable": "[dim]N/A[/]",
-            }
-            from agent_bom.maestro import tag_aisvs_check as _maestro_tag
+            if not quiet:
+                print_benchmark_line(con, "AISVS", total=total, passed=passed, failed=failed, pass_rate=rate)
+            if verbose and not quiet:
+                tbl = _RTable(title="AISVS Compliance", show_lines=True)
+                tbl.add_column("Check", width=8)
+                tbl.add_column("Title", max_width=45)
+                tbl.add_column("Status", width=8)
+                tbl.add_column("Sev", width=8)
+                tbl.add_column("MAESTRO", width=22)
+                tbl.add_column("Evidence", max_width=40)
+                _aiv_status = {
+                    "pass": "[green]PASS[/]",
+                    "fail": "[red]FAIL[/]",
+                    "error": "[yellow]ERR[/]",
+                    "not_applicable": "[dim]N/A[/]",
+                }
+                from agent_bom.maestro import tag_aisvs_check as _maestro_tag
 
-            for c in ctx.aisvs_report.checks:
-                maestro = _maestro_tag(c.check_id).value
-                tbl.add_row(
-                    c.check_id,
-                    c.title,
-                    _aiv_status.get(c.status.value, c.status.value),
-                    c.severity,
-                    maestro,
-                    c.evidence,
-                )
-            con.print()
-            con.print(tbl)
+                for c in ctx.aisvs_report.checks:
+                    maestro = _maestro_tag(c.check_id).value
+                    tbl.add_row(
+                        c.check_id,
+                        c.title,
+                        _aiv_status.get(c.status.value, c.status.value),
+                        c.severity,
+                        maestro,
+                        c.evidence,
+                    )
+                con.print()
+                con.print(tbl)
         except Exception as exc:
-            con.print(f"  [red]AISVS benchmark error: {exc}[/red]")
-
-    # Grouped CIS posture: prioritized failed-first plan with evidence + fix
-    # per check and PASS collapsed (the flat per-provider tables above are
-    # unreadable past ~60 checks). Renders once across every benchmarked cloud.
-    _render_cis_findings(ctx)
+            if not quiet:
+                con.print(f"  [red]AISVS benchmark error: {exc}[/red]")
 
 
 # click.Context.meta key the cloud command writes when --show-passed is set;
@@ -604,8 +678,8 @@ def run_benchmarks(
 CIS_SHOW_PASSED_META = "cis_show_passed"
 
 
-def _render_cis_findings(ctx: ScanContext) -> None:
-    """Route benchmarked CIS results through the grouped console renderer.
+def render_cis_findings_from_context(ctx: ScanContext) -> None:
+    """Render grouped CIS posture once at report time (not during discovery).
 
     Builds a lightweight report-shaped view exposing each provider's
     serialized bundle under the attribute name the renderer reads

--- a/src/agent_bom/cli/agents/_context.py
+++ b/src/agent_bom/cli/agents/_context.py
@@ -11,6 +11,8 @@ class ScanContext:
     """Mutable state accumulated across scan phases."""
 
     con: Any  # rich Console
+    quiet: bool = False
+    verbose: bool = False
     agents: list = field(default_factory=list)
     blast_radii: list = field(default_factory=list)
     report: Any = None

--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -12,6 +12,8 @@ from typing import Any, Iterator
 import click
 
 from agent_bom.cli._agent_mode import dumps_envelope, success_envelope
+from agent_bom.cli._terminal_sections import print_scan_next_steps, print_section_divider
+from agent_bom.cli.agents._cloud import render_cis_findings_from_context
 from agent_bom.cli.agents._context import ScanContext
 from agent_bom.models import AIBOMReport
 from agent_bom.output import (
@@ -328,6 +330,7 @@ def render_output(
             _skill_audit_obj = ctx._skill_audit_obj
             if verbose:
                 # Full output (--verbose)
+                print_section_divider(con, "Report")
                 print_summary(report)
                 print_scan_performance_summary(report)
                 print_posture_summary(report)
@@ -340,9 +343,10 @@ def render_output(
                 print_threat_frameworks(report)
             else:
                 # Compact output (default) — verdict-led posture summary.
+                print_section_divider(con, "Summary")
                 print_compact_summary(report, verbose=verbose)
-                print_scan_performance_summary(report)
                 print_compact_agents(report)
+                print_section_divider(con, "Findings")
                 print_compact_blast_radius(report, fixable_only=fixable_only, page=compact_page)
 
             # AI enrichment output (both modes)
@@ -391,13 +395,18 @@ def render_output(
                             con.print(f"      [green]→ {sk_f.recommendation}[/green]")
 
             if verbose:
+                print_section_divider(con, "Remediation")
                 print_remediation_plan(report)
-                print_compact_cis_posture(report, limit=20)
+                print_section_divider(con, "CIS Posture")
+                render_cis_findings_from_context(ctx)
                 print_export_hint(report)
             else:
+                print_section_divider(con, "Remediation")
                 print_compact_remediation(report, page=compact_page)
+                print_section_divider(con, "CIS Posture")
                 print_compact_cis_posture(report)
                 print_compact_export_hint(report)
+            print_scan_next_steps(con, report, quiet=quiet)
         elif output_format in ("text", "plain") and not output:
             _print_text(report, blast_radii)
         elif output_format == "json":

--- a/tests/test_cli_cloud_scan.py
+++ b/tests/test_cli_cloud_scan.py
@@ -300,7 +300,7 @@ class TestShowPassedWiring:
         assert seen == [True]
 
 
-# ── grouped CIS renderer routing (run_benchmarks → print_cis_findings) ────────
+# ── grouped CIS renderer routing (render_output → print_cis_findings) ────────
 
 
 class _FakeBenchmarkReport:
@@ -351,14 +351,14 @@ def _cis_bundle() -> dict:
 
 
 def _render_ctx_cis(monkeypatch, *, show_passed: bool) -> str:
-    """Run ``_render_cis_findings`` with one AWS bundle and capture console output."""
+    """Run ``render_cis_findings_from_context`` with one AWS bundle and capture console output."""
     from io import StringIO
 
     import click
     from rich.console import Console
 
     import agent_bom.output as output_mod
-    from agent_bom.cli.agents._cloud import CIS_SHOW_PASSED_META, _render_cis_findings
+    from agent_bom.cli.agents._cloud import CIS_SHOW_PASSED_META, render_cis_findings_from_context
     from agent_bom.cli.agents._context import ScanContext
 
     buf = StringIO()
@@ -372,7 +372,7 @@ def _render_ctx_cis(monkeypatch, *, show_passed: bool) -> str:
     # context that mirrors how the cloud command sets it.
     with click.Context(click.Command("scan")) as click_ctx:
         click_ctx.meta[CIS_SHOW_PASSED_META] = show_passed
-        _render_cis_findings(ctx)
+        render_cis_findings_from_context(ctx)
     return buf.getvalue()
 
 
@@ -402,13 +402,13 @@ class TestGroupedCisRendererRouting:
         from rich.console import Console
 
         import agent_bom.output as output_mod
-        from agent_bom.cli.agents._cloud import _render_cis_findings
+        from agent_bom.cli.agents._cloud import render_cis_findings_from_context
         from agent_bom.cli.agents._context import ScanContext
 
         buf = StringIO()
         con = Console(file=buf, force_terminal=False, width=200)
         monkeypatch.setattr(output_mod, "console", con)
-        _render_cis_findings(ScanContext(con=con))
+        render_cis_findings_from_context(ScanContext(con=con))
         assert buf.getvalue() == ""
 
 

--- a/tests/test_cli_terminal_ux.py
+++ b/tests/test_cli_terminal_ux.py
@@ -1,0 +1,163 @@
+"""Terminal UX consistency — quiet mode, collapsed warnings, single CIS render."""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+from rich.console import Console
+
+from agent_bom.cli._terminal_sections import print_collapsed_warnings, print_scan_next_steps
+from agent_bom.cli.agents._cloud import run_cloud_discovery
+from agent_bom.cli.agents._context import ScanContext
+from agent_bom.models import AIBOMReport
+
+
+def test_collapsed_warnings_default_shows_count_hint():
+    buf = StringIO()
+    con = Console(file=buf, force_terminal=False, width=120)
+    warnings = [f"warning-{i}" for i in range(5)]
+    print_collapsed_warnings(con, warnings, verbose=False, max_visible=2)
+    out = buf.getvalue()
+    assert "warning-0" in out
+    assert "warning-1" in out
+    assert "3 more warning(s)" in out
+    assert "warning-4" not in out
+
+
+def test_collapsed_warnings_verbose_lists_all():
+    buf = StringIO()
+    con = Console(file=buf, force_terminal=False, width=120)
+    warnings = ["alpha", "beta"]
+    print_collapsed_warnings(con, warnings, verbose=True)
+    out = buf.getvalue()
+    assert "alpha" in out and "beta" in out
+
+
+def test_quiet_discovery_suppresses_success_lines(monkeypatch):
+    buf = StringIO()
+    con = Console(file=buf, force_terminal=False, width=120)
+    ctx = ScanContext(con=con, quiet=True)
+
+    def _discover(provider, **kwargs):
+        return ([], [f"{provider}-warn-1", f"{provider}-warn-2", f"{provider}-warn-3"])
+
+    monkeypatch.setattr("agent_bom.cloud.discover_from_provider", _discover)
+
+    run_cloud_discovery(
+        ctx,
+        skill_only=False,
+        aws=True,
+        aws_region=None,
+        aws_profile=None,
+        aws_include_lambda=False,
+        aws_include_eks=False,
+        aws_include_step_functions=False,
+        aws_include_ec2=False,
+        aws_include_iam=False,
+        aws_ec2_tag=None,
+        azure_flag=False,
+        azure_subscription=None,
+        gcp_flag=False,
+        gcp_project=None,
+        coreweave_flag=False,
+        coreweave_context=None,
+        coreweave_namespace=None,
+        databricks_flag=False,
+        snowflake_flag=False,
+        snowflake_authenticator=None,
+        nebius_flag=False,
+        nebius_api_key=None,
+        nebius_project_id=None,
+        hf_flag=False,
+        hf_token=None,
+        hf_username=None,
+        hf_organization=None,
+        wandb_flag=False,
+        wandb_api_key=None,
+        wandb_entity=None,
+        wandb_project=None,
+        mlflow_flag=False,
+        mlflow_tracking_uri=None,
+        openai_flag=False,
+        openai_api_key=None,
+        openai_org_id=None,
+        ollama_flag=False,
+        ollama_host=None,
+    )
+    assert buf.getvalue() == ""
+
+
+def test_scan_next_steps_footer():
+    buf = StringIO()
+    con = Console(file=buf, force_terminal=False, width=120)
+    report = AIBOMReport(agents=[object(), object()])  # type: ignore[list-item]
+    report.cis_benchmark_data = {"checks": [{"check_id": "1.1", "status": "fail"}]}
+    print_scan_next_steps(con, report, quiet=False)
+    out = buf.getvalue()
+    assert "Next" in out
+    assert "agent-bom graph" in out
+    assert "agent-bom report -f html" in out
+
+
+def test_run_benchmarks_does_not_render_cis_inline(monkeypatch):
+    """CIS grouped plan renders at report time only, not during benchmarks."""
+    from agent_bom.cli.agents._cloud import run_benchmarks
+
+    buf = StringIO()
+    con = Console(file=buf, force_terminal=False, width=120)
+    ctx = ScanContext(con=con, quiet=True)
+
+    fake_report = MagicMock()
+    fake_report.passed = 1
+    fake_report.failed = 1
+    fake_report.total = 2
+    fake_report.pass_rate = 50.0
+    fake_report.to_dict.return_value = {"checks": []}
+
+    monkeypatch.setattr("agent_bom.cloud.aws_cis_benchmark.run_benchmark", lambda **kwargs: fake_report)
+    monkeypatch.setattr(
+        "agent_bom.cli.agents._cloud.render_cis_findings_from_context",
+        lambda _ctx: (_ for _ in ()).throw(AssertionError("CIS must not render mid-scan")),
+    )
+
+    run_benchmarks(
+        ctx,
+        skill_only=False,
+        verify_model_hashes=False,
+        project=None,
+        hf_token=None,
+        aws_cis_benchmark=True,
+        aws_region=None,
+        aws_profile=None,
+        snowflake_cis_benchmark=False,
+        snowflake_authenticator=None,
+        azure_cis_benchmark=False,
+        azure_subscription=None,
+        gcp_cis_benchmark=False,
+        gcp_project=None,
+        databricks_security=False,
+        aisvs_flag=False,
+        vector_db_scan=False,
+        gpu_scan_flag=False,
+        gpu_k8s_context=None,
+        no_dcgm_probe=False,
+        smithery_flag=False,
+        smithery_token=None,
+        mcp_registry_flag=False,
+        snyk_flag=False,
+        snyk_token=None,
+        snyk_org=None,
+        cortex_observability=False,
+    )
+    assert ctx.cis_benchmark_report is fake_report
+
+
+def test_connect_aws_renders_next_command():
+    from agent_bom.cli import main
+
+    r = CliRunner().invoke(main, ["connect", "aws"])
+    assert r.exit_code == 0
+    assert "Next" in r.output
+    assert "agent-bom scan --aws" in r.output


### PR DESCRIPTION
## Summary
- Add shared `_terminal_sections` helpers: lane-labelled sections (DISCOVER | SCAN | GOVERN), collapsed warnings, connect cards, and a **Next** footer with graph/report commands.
- **Dedupe CIS output**: benchmarks emit one-line progress during scan; full grouped CIS plan renders **once** at report time (`--verbose` / `--show-passed`), compact top-fails in default mode.
- **Quiet mode works end-to-end** for cloud discovery/benchmarks (AWS/Azure/GCP/Snowflake + connectors); `-v` on `cloud scan|aws|azure|gcp` forwards to scan verbose.
- Report console output uses separated **Summary / Findings / Remediation / CIS Posture / Next** blocks; connect onboarding uses a scannable panel.

## Test plan
- [x] `uv run pytest tests/test_cli_terminal_ux.py tests/test_cli_cloud_scan.py tests/test_cli_interactive.py tests/test_cli_canonical_verbs.py -q`
- [x] `uv run ruff check src/agent_bom/cli/_terminal_sections.py src/agent_bom/cli/agents/_cloud.py …`

## Notes
Single PR by design — all changes share the same terminal layout module and ScanContext quiet/verbose flags.

Made with [Cursor](https://cursor.com)