### PR TITLE
fix(cloud): scan Lambda deployment packages + deep-scan pre-tagged container images

### DIFF
--- a/src/agent_bom/cli/agents/_cloud.py
+++ b/src/agent_bom/cli/agents/_cloud.py
@@ -180,7 +180,12 @@ def run_cloud_discovery(
     _cloud_image_targets: list[tuple[str, Any]] = []  # (image_ref, MCPServer to populate)
     for agent in ctx.agents[_pre_cloud_idx:]:
         for server in agent.mcp_servers:
-            if server.command == "docker" and len(server.args) >= 2 and server.args[0] == "run" and not server.packages:
+            # A ``container-image`` package is just the image name:tag placeholder
+            # that ECS/EKS/SageMaker/Cloud Run pre-fill — not real dependency
+            # extraction. Treat it as empty so those images still get deep-scanned
+            # (Azure already works because it leaves packages empty).
+            _real_pkgs = [p for p in server.packages if p.ecosystem != "container-image"]
+            if server.command == "docker" and len(server.args) >= 2 and server.args[0] == "run" and not _real_pkgs:
                 _cloud_image_targets.append((server.args[1], server))
 
     if _cloud_image_targets:

--- a/src/agent_bom/cloud/aws.py
+++ b/src/agent_bom/cloud/aws.py
@@ -884,10 +884,27 @@ def _extract_lambda_packages(
             except Exception as exc:
                 warnings.append(f"Could not extract packages from Lambda layer {layer_arn}: {exc}")
 
+        # Extract from the function's own deployment package. Most functions
+        # bundle their dependencies inline (vendored into the zip) rather than
+        # in a layer, so scanning layers alone misses the common case.
+        code_location = func_config.get("Code", {}).get("Location", "")
+        if code_location and ecosystem in ("pypi", "npm"):
+            try:
+                from agent_bom.http_client import fetch_bytes
+
+                code_bytes = fetch_bytes(code_location, timeout=60)
+                with zipfile.ZipFile(io.BytesIO(code_bytes)) as zf:
+                    if ecosystem == "pypi":
+                        packages.extend(_parse_python_packages_from_zip(zf))
+                    else:
+                        packages.extend(_parse_node_packages_from_zip(zf))
+            except Exception as exc:
+                warnings.append(f"Could not extract packages from Lambda deployment package {lambda_arn}: {exc}")
+
     except Exception as exc:
         warnings.append(f"Could not get Lambda function {lambda_arn}: {exc}")
 
-    return packages
+    return _dedupe_packages(packages)
 
 
 def _packages_from_layer(
@@ -917,6 +934,20 @@ def _packages_from_layer(
             packages = _parse_node_packages_from_zip(zf)
 
     return packages
+
+
+def _dedupe_packages(packages: list[Package]) -> list[Package]:
+    """Drop duplicate packages when the same dep appears in a layer and the
+    function's own zip (or across multiple layers)."""
+    seen: set[tuple[str, str, str]] = set()
+    unique: list[Package] = []
+    for pkg in packages:
+        key = (pkg.ecosystem, pkg.name.lower(), pkg.version)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(pkg)
+    return unique
 
 
 def _parse_python_packages_from_zip(zf: zipfile.ZipFile) -> list[Package]:

--- a/tests/test_cloud_container_image_bridge.py
+++ b/tests/test_cloud_container_image_bridge.py
@@ -1,0 +1,31 @@
+"""Regression: cloud container images (ECS/EKS/SageMaker/Cloud Run) that are
+pre-filled with a ``container-image`` name:tag placeholder must still be routed
+to the deep image scanner. Previously the ``not server.packages`` guard saw the
+placeholder as non-empty and silently skipped deep scanning — while Azure (which
+leaves packages empty) worked, an inconsistency proving the bug.
+"""
+
+from __future__ import annotations
+
+from agent_bom.models import Package
+
+
+def _target_selected(packages: list[Package]) -> bool:
+    """Mirror the bridge guard in cli/agents/_cloud.py."""
+    real = [p for p in packages if p.ecosystem != "container-image"]
+    command, args = "docker", ["run", "myapp:latest"]
+    return command == "docker" and len(args) >= 2 and args[0] == "run" and not real
+
+
+def test_container_image_placeholder_still_scanned():
+    placeholder = [Package(name="myapp", version="latest", ecosystem="container-image")]
+    assert _target_selected(placeholder) is True
+
+
+def test_already_extracted_packages_not_rescanned():
+    real = [Package(name="requests", version="2.25.0", ecosystem="pypi")]
+    assert _target_selected(real) is False
+
+
+def test_empty_packages_scanned():
+    assert _target_selected([]) is True

--- a/tests/test_lambda_deployment_package_sca.py
+++ b/tests/test_lambda_deployment_package_sca.py
@@ -1,0 +1,71 @@
+"""Regression: Lambda SCA must scan the function's own deployment package,
+not just its layers. Most functions vendor dependencies inline into the zip,
+so the layer-only path silently missed the common case.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+import agent_bom.http_client as http_client
+from agent_bom.cloud import aws
+from agent_bom.models import Package
+
+
+def _zip_with_requests() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("requests/__init__.py", "# code")
+        zf.writestr("requests-2.25.0.dist-info/METADATA", "Name: requests\nVersion: 2.25.0\n")
+    return buf.getvalue()
+
+
+class _FakeLambdaClient:
+    def __init__(self, *, with_code: bool):
+        self._with_code = with_code
+
+    def get_function(self, FunctionName):  # noqa: N803 (boto3 kwarg)
+        payload = {"Configuration": {"Runtime": "python3.12", "Layers": []}}
+        if self._with_code:
+            payload["Code"] = {"Location": "https://example.test/code.zip"}
+        return payload
+
+
+class _FakeSession:
+    def __init__(self, client):
+        self._client = client
+
+    def client(self, name, region_name=None):
+        return self._client
+
+
+def test_lambda_scans_inline_deployment_package(monkeypatch):
+    monkeypatch.setattr(http_client, "fetch_bytes", lambda url, timeout=60: _zip_with_requests())
+    session = _FakeSession(_FakeLambdaClient(with_code=True))
+    warnings: list[str] = []
+
+    pkgs = aws._extract_lambda_packages(session, "arn:aws:lambda:us-east-2:1:function:fn", "us-east-2", warnings)
+
+    assert any(p.name == "requests" and p.version == "2.25.0" for p in pkgs), pkgs
+    assert warnings == []
+
+
+def test_lambda_no_code_location_is_graceful(monkeypatch):
+    monkeypatch.setattr(http_client, "fetch_bytes", lambda url, timeout=60: b"")
+    session = _FakeSession(_FakeLambdaClient(with_code=False))
+    warnings: list[str] = []
+    pkgs = aws._extract_lambda_packages(session, "arn:aws:lambda:us-east-2:1:function:fn", "us-east-2", warnings)
+    assert pkgs == []
+    assert warnings == []
+
+
+def test_dedupe_packages_collapses_layer_and_code_duplicates():
+    dupes = [
+        Package(name="requests", version="2.25.0", ecosystem="pypi"),
+        Package(name="Requests", version="2.25.0", ecosystem="pypi"),  # case-insensitive
+        Package(name="urllib3", version="1.26.0", ecosystem="pypi"),
+    ]
+    out = aws._dedupe_packages(dupes)
+    assert len(out) == 2
+    assert {p.name.lower() for p in out} == {"requests", "urllib3"}


### PR DESCRIPTION
Two same-class **cloud SCA coverage** gaps found while dogfooding `agent-bom cloud aws` against a real account — both silently return 0 packages, so the AI workload looks clean when it isn't.

## 1. Lambda inline dependencies were never scanned (P1)
`cloud/aws.py:_extract_lambda_packages` docstring said *"layers and deployment package"* but only iterated `config["Layers"]`. The function's own deployment zip (`get_function()["Code"]["Location"]`) — where **most** Lambdas vendor their dependencies — was never downloaded. Result: 0 packages, 0 CVEs, no warning. Now downloads and parses the deployment zip (Python `.dist-info` + Node `node_modules`) and dedupes against layer packages.

## 2. ECS/EKS/SageMaker/Cloud Run images silently not deep-scanned (P1)
The CLI has a bridge (`cli/agents/_cloud.py`) that routes discovered container servers to `scan_image()`, guarded by `not server.packages`. But ECS/EKS/SageMaker/Cloud Run pre-fill a `container-image` **name:tag placeholder** package, so the guard saw them as "already extracted" and skipped deep scanning — an ECS task running an image with 200 vulnerable packages reported as **one** `container-image` package with ~0 CVEs. Azure Container Apps (which leaves packages empty) was scanned correctly, proving the inconsistency. Guard now ignores the `container-image` placeholder.

## Tests
`test_lambda_deployment_package_sca.py` (inline-dep extraction, graceful no-code, dedup) + `test_cloud_container_image_bridge.py` (placeholder still scanned, real packages not rescanned). 12 pass across these + existing cloud package tests.

## Follow-ups (same class, tracked separately)
GCP Cloud Functions (never downloads source), Azure Functions (runtime pseudo-package only), GKE/AKS workload images not enumerated, and the cloud read-only **permission gaps** (e.g. `lambda:GetFunction` missing from SecurityAudit+ViewOnly) — separate PRs.