### PR TITLE
fix(cloud): Key Vault CIS false-PASS + least-privilege deep-scan grants

### DIFF
--- a/deploy/terraform/connect-aws/deep-scan.tf
+++ b/deploy/terraform/connect-aws/deep-scan.tf
@@ -1,0 +1,91 @@
+# Deep-scan content reads.
+#
+# The AWS-managed SecurityAudit / ViewOnlyAccess policies grant List/Describe/
+# Get-*metadata* only — they structurally exclude *content* reads. Without the
+# actions below, agent-bom silently returns empty for: Lambda deployment-package
+# SCA (lambda:GetFunction), Lambda layer SCA (lambda:GetLayerVersion), ECR image
+# SBOM (ecr pull), Inspector findings, CIS account-contact checks, and
+# Bedrock-agent inventory. All are read-only Get/List calls; no mutation.
+#
+# S3 object-content read (DSPM/PII sampling) is the one sensitive grant, so it is
+# OPT-IN and scoped to named buckets (empty list = disabled).
+
+data "aws_iam_policy_document" "deep_scan" {
+  count = var.enable_deep_scan_reads ? 1 : 0
+
+  statement {
+    sid       = "LambdaCodeRead"
+    effect    = "Allow"
+    actions   = ["lambda:GetFunction", "lambda:GetLayerVersion"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "EcrImagePull"
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:DescribeImageScanFindings",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "InspectorSbom"
+    effect    = "Allow"
+    actions   = ["inspector2:ListFindings"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "CisAccountContacts"
+    effect    = "Allow"
+    actions   = ["account:GetContactInformation", "account:GetAlternateContact"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "BedrockAgentInventory"
+    effect    = "Allow"
+    actions   = ["bedrock:ListAgents", "bedrock:GetAgent", "bedrock:GetAgentActionGroup"]
+    resources = ["*"]
+  }
+
+  # Opt-in, bucket-scoped object read for DSPM/PII classification.
+  dynamic "statement" {
+    for_each = length(var.dspm_s3_bucket_arns) > 0 ? [1] : []
+    content {
+      sid       = "DspmS3ObjectSample"
+      effect    = "Allow"
+      actions   = ["s3:GetObject", "s3:ListBucket"]
+      resources = concat(var.dspm_s3_bucket_arns, [for arn in var.dspm_s3_bucket_arns : "${arn}/*"])
+    }
+  }
+}
+
+resource "aws_iam_policy" "deep_scan" {
+  count = var.enable_deep_scan_reads ? 1 : 0
+
+  name        = "${local.principal_name}-deep-scan"
+  path        = var.path
+  description = "agent-bom deep-scan content reads (Lambda code, ECR pull, Inspector, CIS contacts, Bedrock; opt-in S3 DSPM). Read-only."
+  policy      = data.aws_iam_policy_document.deep_scan[0].json
+  tags        = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "deep_scan" {
+  count = var.enable_deep_scan_reads && local.use_role ? 1 : 0
+
+  role       = aws_iam_role.this[0].name
+  policy_arn = aws_iam_policy.deep_scan[0].arn
+}
+
+resource "aws_iam_user_policy_attachment" "deep_scan" {
+  count = var.enable_deep_scan_reads && !local.use_role ? 1 : 0
+
+  user       = aws_iam_user.this[0].name
+  policy_arn = aws_iam_policy.deep_scan[0].arn
+}

--- a/deploy/terraform/connect-aws/variables.tf
+++ b/deploy/terraform/connect-aws/variables.tf
@@ -74,3 +74,15 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "enable_deep_scan_reads" {
+  type        = bool
+  default     = true
+  description = "Attach the deep-scan content-read policy (Lambda code, ECR image pull, Inspector, CIS account contacts, Bedrock agents). Without it those scans silently return empty, since SecurityAudit/ViewOnlyAccess grant metadata reads only."
+}
+
+variable "dspm_s3_bucket_arns" {
+  type        = list(string)
+  default     = []
+  description = "Bucket ARNs to grant s3:GetObject/s3:ListBucket for DSPM/PII object sampling. Empty (default) disables object-content reads. Scope to specific buckets — do not leave as a wildcard in production."
+}

--- a/deploy/terraform/connect-azure/deep-scan.tf
+++ b/deploy/terraform/connect-azure/deep-scan.tf
@@ -1,0 +1,26 @@
+# Data-plane reads the built-in Reader role does NOT cover.
+#
+# Reader grants control-plane (*/read) only. Two agent-bom scans need data-plane
+# reads: Key Vault CIS 8.1/8.2 (keys/secrets expiry metadata) and ACR image SBOM.
+# Both are read-only. Key Vault Reader covers RBAC-model vaults; access-policy
+# vaults instead need a List access policy on keys/secrets (not managed here).
+
+resource "azurerm_role_assignment" "key_vault_reader" {
+  count = var.assign_key_vault_reader ? 1 : 0
+
+  scope                = local.scope
+  role_definition_name = "Key Vault Reader"
+  principal_id         = var.principal_id
+  principal_type       = var.principal_type
+  description          = "Read-only Key Vault data-plane metadata (keys/secrets properties, not secret values) for CIS 8.1/8.2. RBAC-model vaults only."
+}
+
+resource "azurerm_role_assignment" "acr_pull" {
+  count = var.assign_acr_pull ? 1 : 0
+
+  scope                = local.scope
+  role_definition_name = "AcrPull"
+  principal_id         = var.principal_id
+  principal_type       = var.principal_type
+  description          = "Read-only ACR data-plane pull for container-image SBOM extraction."
+}

--- a/deploy/terraform/connect-azure/variables.tf
+++ b/deploy/terraform/connect-azure/variables.tf
@@ -71,3 +71,15 @@ variable "federated_credential_audience" {
   type        = string
   default     = "api://AzureADTokenExchange"
 }
+
+variable "assign_key_vault_reader" {
+  type        = bool
+  default     = true
+  description = "Assign the built-in 'Key Vault Reader' role so CIS 8.1/8.2 (key/secret expiry) can read vault data-plane metadata. Reader alone cannot, and the check would otherwise be unevaluable. RBAC-model vaults only."
+}
+
+variable "assign_acr_pull" {
+  type        = bool
+  default     = true
+  description = "Assign the built-in 'AcrPull' role so agent-bom can pull ACR images for SBOM/CVE extraction. Reader cannot pull image content."
+}

--- a/deploy/terraform/connect-gcp/deep-scan.tf
+++ b/deploy/terraform/connect-gcp/deep-scan.tf
@@ -1,0 +1,13 @@
+# Artifact Registry data-plane read.
+#
+# roles/viewer covers metadata + GCS object reads, but Artifact Registry image
+# *pull* (downloadArtifacts) is a data-plane permission not guaranteed by the
+# primitive viewer role. Without it, GAR image SBOM extraction can fail.
+
+resource "google_project_iam_member" "artifactregistry_reader" {
+  count = var.assign_artifact_registry_reader ? 1 : 0
+
+  project = var.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.this.email}"
+}

--- a/deploy/terraform/connect-gcp/variables.tf
+++ b/deploy/terraform/connect-gcp/variables.tf
@@ -75,3 +75,9 @@ variable "wif_principal_set" {
   type        = string
   default     = ""
 }
+
+variable "assign_artifact_registry_reader" {
+  type        = bool
+  default     = true
+  description = "Grant roles/artifactregistry.reader so agent-bom can pull GAR images (downloadArtifacts) for SBOM/CVE extraction. Primitive viewer does not guarantee image pull."
+}

--- a/scripts/check_provisioning_readonly.py
+++ b/scripts/check_provisioning_readonly.py
@@ -88,8 +88,16 @@ AWS_READONLY_MANAGED_POLICIES = {
 }
 AWS_MANAGED_POLICY_RE = re.compile(r'"(arn:aws[a-z-]*:iam::aws:policy/[^"]+)"')
 
-# Azure built-in roles that are read-only.
-AZURE_READONLY_ROLES = {"reader", "security reader", "monitoring reader"}
+# Azure built-in roles that are read-only. "Key Vault Reader" reads key/secret
+# METADATA only (never secret values); "AcrPull" is a data-plane image *pull*
+# (read). Both are read-only deep-scan content grants — no mutation.
+AZURE_READONLY_ROLES = {
+    "reader",
+    "security reader",
+    "monitoring reader",
+    "key vault reader",
+    "acrpull",
+}
 AZURE_ROLE_RE = re.compile(r'role_definition_name\s*=\s*"([^"]+)"')
 
 # GCP predefined roles that are read-only (viewer-family + securityReviewer).
@@ -100,6 +108,7 @@ GCP_READONLY_ROLES = {
     "roles/browser",
     "roles/iam.workloaduser",  # impersonation binding, not a data-plane write
     "roles/iam.workloadidentityuser",
+    "roles/artifactregistry.reader",  # read-only image pull (downloadArtifacts)
 }
 
 # Snowflake privileges that mutate. Read-only role may grant only the read set.

--- a/src/agent_bom/cloud/azure_cis_benchmark.py
+++ b/src/agent_bom/cloud/azure_cis_benchmark.py
@@ -2760,6 +2760,8 @@ def _check_8_4(kv_client: Any, subscription_id: str) -> CISCheckResult:
         vaults = list(kv_client.vaults.list())
         failing_keys: list[str] = []
         rbac_vault_count = 0
+        readable = 0
+        denied: list[str] = []
         for vault in vaults:
             vault_name = vault.name or "unknown"
             vault_id = getattr(vault, "id", "") or ""
@@ -2787,15 +2789,26 @@ def _check_8_4(kv_client: Any, subscription_id: str) -> CISCheckResult:
                 for key_prop in key_client.list_properties_of_keys():
                     if getattr(key_prop, "expires_on", None) is None:
                         failing_keys.append(f"{vault_name}/{key_prop.name}")
+                readable += 1
             except Exception as exc:
+                # Denied RBAC vault is UNREADABLE, not compliant — never PASS.
+                denied.append(vault_name)
                 logger.debug("Could not enumerate keys in RBAC vault %s: %s", vault_name, exc)
         if failing_keys:
             result.status = CheckStatus.FAIL
             result.evidence = f"Keys without expiration in RBAC vaults: {', '.join(failing_keys[:10])}"
             result.resource_ids = failing_keys
+        elif rbac_vault_count and readable == 0:
+            result.status = CheckStatus.ERROR
+            result.evidence = (
+                f"Could not read keys in any of {rbac_vault_count} RBAC vault(s) — data-plane access denied. "
+                "Grant the scanner 'Key Vault Reader' to evaluate CIS 8.4."
+            )
+            result.resource_ids = denied
         else:
+            note = f" ({len(denied)} vault(s) skipped — data-plane access denied)" if denied else ""
             result.status = CheckStatus.PASS
-            result.evidence = f"All keys in {rbac_vault_count} RBAC vault(s) have expiration dates set."
+            result.evidence = f"All keys in {readable} readable RBAC vault(s) have expiration dates set.{note}"
     except Exception as exc:
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not check Key Vault key expiration: {exc}"
@@ -2816,6 +2829,8 @@ def _check_8_5(kv_client: Any, subscription_id: str) -> CISCheckResult:
         vaults = list(kv_client.vaults.list())
         failing_secrets: list[str] = []
         rbac_vault_count = 0
+        readable = 0
+        denied: list[str] = []
         for vault in vaults:
             vault_name = vault.name or "unknown"
             vault_id = getattr(vault, "id", "") or ""
@@ -2843,15 +2858,26 @@ def _check_8_5(kv_client: Any, subscription_id: str) -> CISCheckResult:
                 for secret_prop in secret_client.list_properties_of_secrets():
                     if getattr(secret_prop, "expires_on", None) is None:
                         failing_secrets.append(f"{vault_name}/{secret_prop.name}")
+                readable += 1
             except Exception as exc:
+                # Denied RBAC vault is UNREADABLE, not compliant — never PASS.
+                denied.append(vault_name)
                 logger.debug("Could not enumerate secrets in RBAC vault %s: %s", vault_name, exc)
         if failing_secrets:
             result.status = CheckStatus.FAIL
             result.evidence = f"Secrets without expiration in RBAC vaults: {', '.join(failing_secrets[:10])}"
             result.resource_ids = failing_secrets
+        elif rbac_vault_count and readable == 0:
+            result.status = CheckStatus.ERROR
+            result.evidence = (
+                f"Could not read secrets in any of {rbac_vault_count} RBAC vault(s) — data-plane access denied. "
+                "Grant the scanner 'Key Vault Reader' to evaluate CIS 8.5."
+            )
+            result.resource_ids = denied
         else:
+            note = f" ({len(denied)} vault(s) skipped — data-plane access denied)" if denied else ""
             result.status = CheckStatus.PASS
-            result.evidence = f"All secrets in {rbac_vault_count} RBAC vault(s) have expiration dates set."
+            result.evidence = f"All secrets in {readable} readable RBAC vault(s) have expiration dates set.{note}"
     except Exception as exc:
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not check Key Vault secret expiration: {exc}"
@@ -2871,6 +2897,8 @@ def _check_8_6(kv_client: Any, subscription_id: str) -> CISCheckResult:
     try:
         vaults = list(kv_client.vaults.list())
         failing_secrets: list[str] = []
+        readable = 0
+        denied: list[str] = []
         for vault in vaults:
             vault_name = vault.name or "unknown"
             vault_url = f"https://{vault_name}.vault.azure.net/"
@@ -2883,15 +2911,27 @@ def _check_8_6(kv_client: Any, subscription_id: str) -> CISCheckResult:
                     content_type = getattr(secret_prop, "content_type", None)
                     if not content_type:
                         failing_secrets.append(f"{vault_name}/{secret_prop.name}")
+                readable += 1
             except Exception as exc:
+                # Denied vault is UNREADABLE, not compliant — never PASS.
+                denied.append(vault_name)
                 logger.debug("Could not enumerate secrets in vault %s: %s", vault_name, exc)
         if failing_secrets:
             result.status = CheckStatus.FAIL
             result.evidence = f"Secrets without content type: {', '.join(failing_secrets[:10])}"
             result.resource_ids = failing_secrets
+        elif vaults and readable == 0:
+            result.status = CheckStatus.ERROR
+            result.evidence = (
+                f"Could not read secrets in any of {len(vaults)} vault(s) — data-plane access denied. "
+                "Grant the scanner 'Key Vault Reader' (RBAC vaults) or a List access policy "
+                "(access-policy vaults) to evaluate CIS 8.6."
+            )
+            result.resource_ids = denied
         else:
+            note = f" ({len(denied)} vault(s) skipped — data-plane access denied)" if denied else ""
             result.status = CheckStatus.PASS
-            result.evidence = f"All secrets across {len(vaults)} vault(s) have content type set."
+            result.evidence = f"All secrets across {readable} readable vault(s) have content type set.{note}"
     except Exception as exc:
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not check Key Vault secret content types: {exc}"

--- a/src/agent_bom/cloud/azure_cis_benchmark.py
+++ b/src/agent_bom/cloud/azure_cis_benchmark.py
@@ -2599,6 +2599,8 @@ def _check_8_1(kv_client: Any, subscription_id: str) -> CISCheckResult:
     try:
         vaults = list(kv_client.vaults.list())
         failing_keys: list[str] = []
+        readable = 0
+        denied: list[str] = []
 
         for vault in vaults:
             vault_name = vault.name or "unknown"
@@ -2612,17 +2614,29 @@ def _check_8_1(kv_client: Any, subscription_id: str) -> CISCheckResult:
                     exp = getattr(key_prop, "expires_on", None)
                     if exp is None:
                         failing_keys.append(f"{vault_name}/{key_prop.name}")
+                readable += 1
             except Exception as exc:
-                # Key enumeration is best-effort per vault
+                # Data-plane read denied (Reader has no vault data-plane) — this
+                # vault is UNREADABLE, not compliant. Never let it fall through
+                # to PASS: a denied vault must not read as "keys have expiration".
+                denied.append(vault_name)
                 logger.debug("Could not enumerate keys in vault %s: %s", vault_name, exc)
 
         if failing_keys:
             result.status = CheckStatus.FAIL
             result.evidence = f"Keys without expiration: {', '.join(failing_keys[:10])}"
             result.resource_ids = failing_keys
+        elif vaults and readable == 0:
+            result.status = CheckStatus.ERROR
+            result.evidence = (
+                f"Could not read keys in any of {len(vaults)} vault(s) — data-plane access denied. "
+                "Grant the scanner 'Key Vault Reader' (RBAC vaults) or a List access policy "
+                "(access-policy vaults) to evaluate CIS 8.1."
+            )
         else:
+            note = f" ({len(denied)} vault(s) skipped — data-plane access denied)" if denied else ""
             result.status = CheckStatus.PASS
-            result.evidence = f"All keys across {len(vaults)} vault(s) have expiration dates set."
+            result.evidence = f"All keys across {readable} readable vault(s) have expiration dates set.{note}"
     except Exception as exc:
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not enumerate Key Vault keys: {exc}"
@@ -2642,6 +2656,8 @@ def _check_8_2(kv_client: Any, subscription_id: str) -> CISCheckResult:
     try:
         vaults = list(kv_client.vaults.list())
         failing_secrets: list[str] = []
+        readable = 0
+        denied: list[str] = []
 
         for vault in vaults:
             vault_name = vault.name or "unknown"
@@ -2654,17 +2670,27 @@ def _check_8_2(kv_client: Any, subscription_id: str) -> CISCheckResult:
                 for secret_prop in secret_client.list_properties_of_secrets():
                     if getattr(secret_prop, "expires_on", None) is None:
                         failing_secrets.append(f"{vault_name}/{secret_prop.name}")
+                readable += 1
             except Exception as exc:
-                # Secret enumeration is best-effort per vault
+                # Denied vault is UNREADABLE, not compliant — never fall through to PASS.
+                denied.append(vault_name)
                 logger.debug("Could not enumerate secrets in vault %s: %s", vault_name, exc)
 
         if failing_secrets:
             result.status = CheckStatus.FAIL
             result.evidence = f"Secrets without expiration: {', '.join(failing_secrets[:10])}"
             result.resource_ids = failing_secrets
+        elif vaults and readable == 0:
+            result.status = CheckStatus.ERROR
+            result.evidence = (
+                f"Could not read secrets in any of {len(vaults)} vault(s) — data-plane access denied. "
+                "Grant the scanner 'Key Vault Reader' (RBAC vaults) or a List access policy "
+                "(access-policy vaults) to evaluate CIS 8.2."
+            )
         else:
+            note = f" ({len(denied)} vault(s) skipped — data-plane access denied)" if denied else ""
             result.status = CheckStatus.PASS
-            result.evidence = f"All secrets across {len(vaults)} vault(s) have expiration dates set."
+            result.evidence = f"All secrets across {readable} readable vault(s) have expiration dates set.{note}"
     except Exception as exc:
         result.status = CheckStatus.ERROR
         result.evidence = f"Could not enumerate Key Vault secrets: {exc}"

--- a/tests/test_azure_keyvault_cis_denied.py
+++ b/tests/test_azure_keyvault_cis_denied.py
@@ -5,11 +5,15 @@ unevaluated, not compliant — returning PASS was a false compliance pass.
 
 from __future__ import annotations
 
-import azure.identity
-import azure.keyvault.keys
-import azure.keyvault.secrets
+import pytest
 
-from agent_bom.cloud import azure_cis_benchmark as m
+# The checks import azure.* lazily inside the function; these tests patch those
+# symbols, so the SDK must be importable. Skip cleanly where it is not installed.
+azure_identity = pytest.importorskip("azure.identity")
+azure_keys = pytest.importorskip("azure.keyvault.keys")
+azure_secrets = pytest.importorskip("azure.keyvault.secrets")
+
+from agent_bom.cloud import azure_cis_benchmark as m  # noqa: E402
 
 
 class _Vault:
@@ -44,12 +48,12 @@ class _CompliantKeyClient:
 
 
 def _patch_identity(monkeypatch):
-    monkeypatch.setattr(azure.identity, "DefaultAzureCredential", lambda **kw: object())
+    monkeypatch.setattr(azure_identity, "DefaultAzureCredential", lambda **kw: object())
 
 
 def test_cis_8_1_all_vaults_denied_is_error_not_pass(monkeypatch):
     _patch_identity(monkeypatch)
-    monkeypatch.setattr(azure.keyvault.keys, "KeyClient", _DeniedKeyClient)
+    monkeypatch.setattr(azure_keys, "KeyClient", _DeniedKeyClient)
     res = m._check_8_1(_KVMgmt(), "sub-1")
     assert res.status == m.CheckStatus.ERROR, f"expected ERROR, got {res.status}: {res.evidence}"
     assert "data-plane access denied" in res.evidence
@@ -57,7 +61,7 @@ def test_cis_8_1_all_vaults_denied_is_error_not_pass(monkeypatch):
 
 def test_cis_8_1_readable_and_compliant_is_pass(monkeypatch):
     _patch_identity(monkeypatch)
-    monkeypatch.setattr(azure.keyvault.keys, "KeyClient", _CompliantKeyClient)
+    monkeypatch.setattr(azure_keys, "KeyClient", _CompliantKeyClient)
     res = m._check_8_1(_KVMgmt(), "sub-1")
     assert res.status == m.CheckStatus.PASS, res.evidence
 
@@ -72,7 +76,58 @@ class _DeniedSecretClient:
 
 def test_cis_8_2_all_vaults_denied_is_error_not_pass(monkeypatch):
     _patch_identity(monkeypatch)
-    monkeypatch.setattr(azure.keyvault.secrets, "SecretClient", _DeniedSecretClient)
+    monkeypatch.setattr(azure_secrets, "SecretClient", _DeniedSecretClient)
     res = m._check_8_2(_KVMgmt(), "sub-1")
+    assert res.status == m.CheckStatus.ERROR, f"expected ERROR, got {res.status}: {res.evidence}"
+    assert "data-plane access denied" in res.evidence
+
+
+# --- RBAC-vault checks 8.4 / 8.5 and content-type check 8.6 -----------------
+# These had the same swallow-to-PASS bug and must also surface ERROR on denial.
+
+
+class _RbacVault:
+    def __init__(self, name):
+        self.name = name
+        self.id = (
+            f"/subscriptions/sub-1/resourceGroups/rg1/providers/"
+            f"Microsoft.KeyVault/vaults/{name}"
+        )
+
+
+class _RbacKVMgmt:
+    """Management client whose vaults are all RBAC-model."""
+
+    class vaults:
+        @staticmethod
+        def list():
+            return [_RbacVault("v1"), _RbacVault("v2")]
+
+        @staticmethod
+        def get(resource_group, vault_name):
+            props = type("P", (), {"enable_rbac_authorization": True})()
+            return type("V", (), {"properties": props})()
+
+
+def test_cis_8_4_all_rbac_vaults_denied_is_error_not_pass(monkeypatch):
+    _patch_identity(monkeypatch)
+    monkeypatch.setattr(azure_keys, "KeyClient", _DeniedKeyClient)
+    res = m._check_8_4(_RbacKVMgmt(), "sub-1")
+    assert res.status == m.CheckStatus.ERROR, f"expected ERROR, got {res.status}: {res.evidence}"
+    assert "data-plane access denied" in res.evidence
+
+
+def test_cis_8_5_all_rbac_vaults_denied_is_error_not_pass(monkeypatch):
+    _patch_identity(monkeypatch)
+    monkeypatch.setattr(azure_secrets, "SecretClient", _DeniedSecretClient)
+    res = m._check_8_5(_RbacKVMgmt(), "sub-1")
+    assert res.status == m.CheckStatus.ERROR, f"expected ERROR, got {res.status}: {res.evidence}"
+    assert "data-plane access denied" in res.evidence
+
+
+def test_cis_8_6_all_vaults_denied_is_error_not_pass(monkeypatch):
+    _patch_identity(monkeypatch)
+    monkeypatch.setattr(azure_secrets, "SecretClient", _DeniedSecretClient)
+    res = m._check_8_6(_KVMgmt(), "sub-1")
     assert res.status == m.CheckStatus.ERROR, f"expected ERROR, got {res.status}: {res.evidence}"
     assert "data-plane access denied" in res.evidence

--- a/tests/test_azure_keyvault_cis_denied.py
+++ b/tests/test_azure_keyvault_cis_denied.py
@@ -1,0 +1,78 @@
+"""Regression: Azure Key Vault CIS 8.1/8.2 must NOT report PASS when the
+scanner is denied data-plane access to the vaults. A vault it cannot read is
+unevaluated, not compliant — returning PASS was a false compliance pass.
+"""
+
+from __future__ import annotations
+
+import azure.identity
+import azure.keyvault.keys
+import azure.keyvault.secrets
+
+from agent_bom.cloud import azure_cis_benchmark as m
+
+
+class _Vault:
+    def __init__(self, name):
+        self.name = name
+
+
+class _KVMgmt:
+    class vaults:
+        @staticmethod
+        def list():
+            return [_Vault("v1"), _Vault("v2")]
+
+
+class _DeniedKeyClient:
+    def __init__(self, **kw):
+        pass
+
+    def list_properties_of_keys(self):
+        raise Exception("(Forbidden) Caller is not authorized to perform action on resource")
+
+
+class _CompliantKeyClient:
+    def __init__(self, **kw):
+        pass
+
+    def list_properties_of_keys(self):
+        class _K:
+            name = "k1"
+            expires_on = "2027-01-01"
+        return [_K()]
+
+
+def _patch_identity(monkeypatch):
+    monkeypatch.setattr(azure.identity, "DefaultAzureCredential", lambda **kw: object())
+
+
+def test_cis_8_1_all_vaults_denied_is_error_not_pass(monkeypatch):
+    _patch_identity(monkeypatch)
+    monkeypatch.setattr(azure.keyvault.keys, "KeyClient", _DeniedKeyClient)
+    res = m._check_8_1(_KVMgmt(), "sub-1")
+    assert res.status == m.CheckStatus.ERROR, f"expected ERROR, got {res.status}: {res.evidence}"
+    assert "data-plane access denied" in res.evidence
+
+
+def test_cis_8_1_readable_and_compliant_is_pass(monkeypatch):
+    _patch_identity(monkeypatch)
+    monkeypatch.setattr(azure.keyvault.keys, "KeyClient", _CompliantKeyClient)
+    res = m._check_8_1(_KVMgmt(), "sub-1")
+    assert res.status == m.CheckStatus.PASS, res.evidence
+
+
+class _DeniedSecretClient:
+    def __init__(self, **kw):
+        pass
+
+    def list_properties_of_secrets(self):
+        raise Exception("(Forbidden) Caller is not authorized")
+
+
+def test_cis_8_2_all_vaults_denied_is_error_not_pass(monkeypatch):
+    _patch_identity(monkeypatch)
+    monkeypatch.setattr(azure.keyvault.secrets, "SecretClient", _DeniedSecretClient)
+    res = m._check_8_2(_KVMgmt(), "sub-1")
+    assert res.status == m.CheckStatus.ERROR, f"expected ERROR, got {res.status}: {res.evidence}"
+    assert "data-plane access denied" in res.evidence


### PR DESCRIPTION
From the cloud read-only **permission-completeness audit** (found via the same dogfooding that surfaced the `lambda:GetFunction` gap).

## 1. Correctness — Azure Key Vault CIS 8.1/8.2 false compliance PASS
The built-in `Reader` role has **no Key Vault data-plane** access. When key/secret enumeration was denied for every vault, the per-vault `except` logged at debug and continued, leaving `failing_keys` empty → the check returned **PASS "all keys have expiration"**. A vault the scanner can't read is *unevaluated*, not compliant — this reported customers as compliant when nothing was checked.

Now: PASS only when ≥1 vault was actually readable; **all-denied → ERROR** naming the role to add; partial → PASS with a "N vault(s) skipped" note. Regression tests cover all-denied→ERROR (8.1 + 8.2) and readable+compliant→PASS.

## 2. Coverage — recommended read-only roles under-grant for content reads
`SecurityAudit`+`ViewOnlyAccess` / `roles/viewer` / `Reader` grant metadata reads only, so agent-bom silently returns empty for code/image/object content. Added **gated, opt-in** least-privilege grants to the `connect-*` Terraform modules:

- **AWS** (`enable_deep_scan_reads`, default on): `lambda:GetFunction`/`GetLayerVersion`, ECR pull, `inspector2:ListFindings`, CIS account contacts, Bedrock agents. **S3 object read is separate + opt-in** (`dspm_s3_bucket_arns`, default empty, bucket-scoped) since object content is sensitive.
- **Azure** (`assign_key_vault_reader` / `assign_acr_pull`, default on): Key Vault Reader (data-plane metadata, not secret values) + AcrPull.
- **GCP** (`assign_artifact_registry_reader`, default on): `roles/artifactregistry.reader`.

`terraform validate` passes for all three modules.

## Follow-up (tracked)
Port GCP's structured `record_discovery_failure(permission=…)` pattern to the AWS/Azure scanners so an AccessDenied surfaces as "add permission X to scan Y" in the scan report instead of a silent empty result. Managed-policy 'Verify' rows (Bedrock/Inspector/account) should be confirmed against a live `aws iam get-policy-version` — they're additive so a redundant grant is harmless.