### PR TITLE
feat(enrich): mature the multi-provider LLM enrichment harness

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -203,6 +203,20 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_MCP_MAX_TOOL_METRICS` | `int` | `128` | — |
 | `AGENT_BOM_MCP_TOOL_TIMEOUT_SECONDS` | `float` | `30.0` | — |
 
+## Multi-provider LLM harness (issue #3206)
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_AI_DETERMINISTIC` | `bool` | `False` | Deterministic mode: temperature 0 + cache, so AI-derived findings are stable enough to (optionally, explicitly) gate on. Default temperature stays 0.3 for richer narratives when determinism is not required. |
+| `AGENT_BOM_AI_MAX_CALLS` | `int` | `50` | Per-run cap on total LLM calls (cost/latency control). 0 disables the cap. |
+| `AGENT_BOM_AI_MAX_RETRIES` | `int` | `2` | Reliability: bounded retries with exponential backoff around remote provider calls, and a per-call timeout. Graceful degradation is preserved — exhausted retries return None (no model) rather than raising. |
+| `AGENT_BOM_AI_MODEL_CHEAP` | `str` | `''` | tagging, summaries |
+| `AGENT_BOM_AI_MODEL_STRONG` | `str` | `''` | detection, remediation |
+| `AGENT_BOM_AI_REDACT_PROMPTS` | `bool` | `True` | Redaction: scrub secret-looking material from every prompt before it leaves the control plane. On by default — "no exfiltration by default" (issue #3206 hard requirement #4). Set to False only for trusted local-only deployments. |
+| `AGENT_BOM_AI_REQUEST_TIMEOUT` | `float` | `120.0` | — |
+| `AGENT_BOM_AI_RETRY_BASE_DELAY` | `float` | `0.5` | — |
+| `AGENT_BOM_AI_RETRY_MAX_DELAY` | `float` | `8.0` | — |
+| `AGENT_BOM_AI_TEMPERATURE` | `float` | `0.3` | — |
+
 ## OIDC discovery shim
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/src/agent_bom/ai_enrich.py
+++ b/src/agent_bom/ai_enrich.py
@@ -27,14 +27,17 @@ import hashlib
 import json
 import logging
 import os
+import random
 import re
 import threading
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from enum import Enum
+from typing import TYPE_CHECKING, Awaitable, Callable, Optional, TypeVar
 
 import httpx
 from rich.console import Console
 
+from agent_bom import config
 from agent_bom.config import AI_CACHE_MAX_ENTRIES as _MAX_AI_CACHE
 from agent_bom.config import OLLAMA_BASE_URL
 from agent_bom.security import sanitize_command_args
@@ -266,9 +269,7 @@ def _provider_status(provider_name: str) -> AIProviderStatus:
             installed=installed,
             configured=configured,
             available=installed and configured,
-            reason="available"
-            if installed and configured
-            else "huggingface-hub and HF_TOKEN are required for HuggingFace enrichment",
+            reason="available" if installed and configured else "huggingface-hub and HF_TOKEN are required for HuggingFace enrichment",
         )
     installed = _check_litellm()
     return AIProviderStatus(
@@ -368,6 +369,266 @@ def _has_any_provider(model: str) -> bool:
     return _resolve_ai_provider(model).available
 
 
+# ─── Secret redaction (no-exfiltration-by-default) ───────────────────────────
+#
+# Issue #3206 hard requirement #4: redact secrets before any prompt leaves the
+# control plane. These patterns cover the credential shapes most likely to be
+# swept into a prompt from scanned configs, env blocks, or source snippets.
+# Redaction runs at every provider network boundary, so it protects local
+# Ollama calls as well as remote providers.
+
+# Prefix / block patterns, in priority order (more specific first — e.g.
+# ``sk-ant-`` must run before the generic ``sk-``).
+_SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    # Private key blocks (PEM)
+    (re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----", re.DOTALL), "<redacted-private-key>"),
+    # Provider API keys / tokens with recognizable prefixes
+    (re.compile(r"\bsk-ant-[A-Za-z0-9_-]{16,}\b"), "<redacted-anthropic-key>"),
+    (re.compile(r"\bsk-[A-Za-z0-9_-]{16,}\b"), "<redacted-openai-key>"),
+    (re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{16,}\b"), "<redacted-github-token>"),
+    (re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"), "<redacted-slack-token>"),
+    (re.compile(r"\bAKIA[0-9A-Z]{16}\b"), "<redacted-aws-access-key>"),
+    (re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b"), "<redacted-google-key>"),
+    (re.compile(r"\bhf_[A-Za-z0-9]{20,}\b"), "<redacted-hf-token>"),
+    # Bearer tokens in headers / auth strings
+    (re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._\-]{16,}"), "Bearer <redacted-token>"),
+)
+
+# KEY=VALUE / "key": "value" assignments for secret-named variables. Handled
+# separately with a value heuristic so we don't clobber credential *names*
+# (e.g. ``Exposed credentials: OPENAI_API_KEY``) that appear as values.
+_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)\b([A-Za-z0-9_]*(?:secret|token|password|passwd|api[_-]?key|access[_-]?key|private[_-]?key|credential)[A-Za-z0-9_]*)\b"
+    r"(\s*[:=]\s*)(['\"]?)([^\s'\";,}]{6,})(\3)"
+)
+
+# A bare UPPER_SNAKE_CASE identifier is a variable *name*, not a secret value.
+_IDENTIFIER_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+
+
+def _looks_like_secret_value(value: str) -> bool:
+    """Heuristic: does a captured assignment value look like an actual secret?
+
+    Rejects bare identifiers (``OPENAI_API_KEY``, ``DATABASE_URL``) that are
+    names rather than values; accepts strings with real entropy.
+    """
+    if _IDENTIFIER_RE.match(value):
+        return False
+    # Real secrets mix character classes or are long — require a lowercase
+    # letter or digit alongside length so ALL_CAPS words are left alone.
+    return len(value) >= 6 and bool(re.search(r"[a-z0-9]", value))
+
+
+def _redact_assignment(match: re.Match[str]) -> str:
+    name, sep, quote, value, _ = match.groups()
+    if not _looks_like_secret_value(value):
+        return match.group(0)
+    return f"{name}{sep}{quote}<redacted>{quote}"
+
+
+def redact_secrets(text: str) -> str:
+    """Scrub secret-looking material from *text* before it reaches a model.
+
+    Idempotent and conservative: it targets recognizable credential shapes
+    (API keys, tokens, private keys, ``SECRET=...`` assignments) and leaves the
+    surrounding text — including credential *names* like ``OPENAI_API_KEY`` —
+    intact so the model still has useful context.
+    """
+    if not text:
+        return text
+    for pattern, replacement in _SECRET_PATTERNS:
+        text = pattern.sub(replacement, text)
+    text = _ASSIGNMENT_PATTERN.sub(_redact_assignment, text)
+    return text
+
+
+def _prepare_prompt(prompt: str) -> str:
+    """Apply redaction to an outbound prompt when enabled by config."""
+    if getattr(config, "AI_REDACT_PROMPTS", True):
+        return redact_secrets(prompt)
+    return prompt
+
+
+# ─── Determinism + reliability helpers ───────────────────────────────────────
+
+
+def _effective_temperature() -> float:
+    """Temperature for a call: 0.0 in deterministic mode, else configured."""
+    if getattr(config, "AI_DETERMINISTIC", False):
+        return 0.0
+    return float(getattr(config, "AI_TEMPERATURE", 0.3))
+
+
+def _request_timeout() -> float:
+    return float(getattr(config, "AI_REQUEST_TIMEOUT", 120.0))
+
+
+_T = TypeVar("_T")
+
+# Exceptions worth retrying — transient network / server-side conditions.
+_RETRYABLE_EXC = (httpx.TimeoutException, httpx.ConnectError, httpx.ReadError, httpx.RemoteProtocolError)
+
+
+async def retry_async(
+    func: Callable[[], Awaitable[Optional[_T]]],
+    *,
+    max_retries: int | None = None,
+    base_delay: float | None = None,
+    max_delay: float | None = None,
+    retry_on: tuple[type[BaseException], ...] = _RETRYABLE_EXC,
+    label: str = "llm-call",
+) -> Optional[_T]:
+    """Call *func* with bounded exponential backoff + jitter.
+
+    Returns the first non-None result. On a retryable exception it backs off and
+    retries; once retries are exhausted (or a non-retryable exception fires) it
+    returns None so the enrichment layer degrades gracefully rather than raising.
+    """
+    attempts = (max_retries if max_retries is not None else getattr(config, "AI_MAX_RETRIES", 2)) + 1
+    base = base_delay if base_delay is not None else getattr(config, "AI_RETRY_BASE_DELAY", 0.5)
+    ceiling = max_delay if max_delay is not None else getattr(config, "AI_RETRY_MAX_DELAY", 8.0)
+
+    for attempt in range(attempts):
+        try:
+            result = await func()
+        except retry_on as exc:
+            if attempt >= attempts - 1:
+                logger.warning("%s failed after %d attempt(s): %s", label, attempt + 1, exc)
+                return None
+            delay = min(base * (2**attempt), ceiling) + random.uniform(0, base)
+            logger.debug("%s retry %d/%d after %.2fs (%s)", label, attempt + 1, attempts - 1, delay, exc)
+            await asyncio.sleep(delay)
+            continue
+        except Exception as exc:  # non-retryable — degrade, don't raise
+            logger.warning("%s failed (non-retryable): %s", label, exc)
+            return None
+        if result is not None:
+            return result
+        return None
+    return None
+
+
+# ─── Per-task model selection ────────────────────────────────────────────────
+#
+# Different enrichment tasks warrant different models: a cheap local model is
+# fine for tagging and summaries; detection and remediation benefit from a
+# stronger model. Operators pin these per-deployment via config; unset tiers
+# fall back to the single auto-resolved model (legacy behavior).
+
+
+class EnrichmentTask(str, Enum):
+    """Kinds of enrichment work, used to pick a per-task model + provenance."""
+
+    NARRATIVE = "narrative"  # blast-radius risk narratives
+    SUMMARY = "summary"  # executive summaries
+    TAGGING = "tagging"  # compliance / control classification (cheap)
+    DETECTION = "detection"  # LLM-assisted novel-issue detection (strong)
+    TRIAGE = "triage"  # FP reduction / dedup (strong)
+    CONFIG_ANALYSIS = "config_analysis"  # MCP config security review
+
+
+# Which tier each task prefers when tiered models are configured.
+_TASK_TIER: dict[EnrichmentTask, str] = {
+    EnrichmentTask.NARRATIVE: "cheap",
+    EnrichmentTask.SUMMARY: "cheap",
+    EnrichmentTask.TAGGING: "cheap",
+    EnrichmentTask.DETECTION: "strong",
+    EnrichmentTask.TRIAGE: "strong",
+    EnrichmentTask.CONFIG_ANALYSIS: "strong",
+}
+
+
+def resolve_task_model(task: EnrichmentTask, default_model: str = DEFAULT_MODEL) -> str:
+    """Resolve the model to use for *task*.
+
+    Precedence: an explicitly-configured per-tier model (cheap/strong) wins;
+    otherwise fall back to *default_model* (which itself auto-detects Ollama /
+    HF / litellm via :func:`_resolve_ai_provider`).
+    """
+    tier = _TASK_TIER.get(task, "strong")
+    configured = getattr(config, "AI_MODEL_STRONG" if tier == "strong" else "AI_MODEL_CHEAP", "")
+    if configured:
+        return configured
+    return default_model
+
+
+# ─── Provider abstraction + registry ─────────────────────────────────────────
+#
+# A thin, uniform interface over the three backends so callers (and tests) can
+# treat providers polymorphically. The concrete adapters wrap the existing
+# ``_call_*`` functions, keeping one code path for the actual network calls.
+
+
+class EnrichmentProvider:
+    """Uniform provider contract for the enrichment harness.
+
+    Subclasses expose availability + a single ``generate`` coroutine. Redaction,
+    caching, retries and timeouts are handled inside the wrapped ``_call_*``
+    functions, so adapters stay thin.
+    """
+
+    descriptor: AIProviderDescriptor
+
+    def is_available(self) -> bool:  # pragma: no cover - trivial
+        raise NotImplementedError
+
+    async def generate(self, prompt: str, model: str, max_tokens: int = 500) -> Optional[str]:  # pragma: no cover
+        raise NotImplementedError
+
+    @property
+    def name(self) -> str:
+        return self.descriptor.name
+
+
+class OllamaProvider(EnrichmentProvider):
+    descriptor = AI_PROVIDER_DESCRIPTORS["ollama"]
+
+    def is_available(self) -> bool:
+        return _detect_ollama()
+
+    async def generate(self, prompt: str, model: str, max_tokens: int = 500) -> Optional[str]:
+        bare = model[len("ollama/") :] if model.startswith("ollama/") else model
+        return await _call_ollama_direct(prompt, bare, max_tokens)
+
+
+class HuggingFaceProvider(EnrichmentProvider):
+    descriptor = AI_PROVIDER_DESCRIPTORS["huggingface"]
+
+    def is_available(self) -> bool:
+        return _check_huggingface() and bool(os.environ.get("HF_TOKEN"))
+
+    async def generate(self, prompt: str, model: str, max_tokens: int = 500) -> Optional[str]:
+        hf_model = model[len("huggingface/") :] if model.startswith("huggingface/") else model
+        return await _call_huggingface(prompt, model=hf_model or HF_DEFAULT_MODEL, max_tokens=max_tokens)
+
+
+class LiteLLMProvider(EnrichmentProvider):
+    descriptor = AI_PROVIDER_DESCRIPTORS["litellm"]
+
+    def is_available(self) -> bool:
+        return _check_litellm()
+
+    async def generate(self, prompt: str, model: str, max_tokens: int = 500) -> Optional[str]:
+        return await _call_llm_via_litellm(prompt, model, max_tokens)
+
+
+PROVIDER_REGISTRY: dict[str, EnrichmentProvider] = {
+    "ollama": OllamaProvider(),
+    "huggingface": HuggingFaceProvider(),
+    "litellm": LiteLLMProvider(),
+}
+
+
+def get_provider(name: str) -> EnrichmentProvider:
+    """Return the registered provider adapter by name (KeyError if unknown)."""
+    return PROVIDER_REGISTRY[name]
+
+
+def provider_for_model(model: str) -> EnrichmentProvider:
+    """Return the provider adapter that owns *model* by its prefix."""
+    return PROVIDER_REGISTRY[_provider_name_for_model(model)]
+
+
 # ─── LLM calls ───────────────────────────────────────────────────────────────
 
 
@@ -385,17 +646,18 @@ async def _call_ollama_direct(prompt: str, model: str, max_tokens: int = 500) ->
     if cached is not None:
         return cached
 
+    outbound = _prepare_prompt(prompt)
     try:
-        async with httpx.AsyncClient(timeout=120.0) as client:
+        async with httpx.AsyncClient(timeout=_request_timeout()) as client:
             resp = await client.post(
                 f"{OLLAMA_BASE_URL}/api/chat",
                 json={
                     "model": model,
-                    "messages": [{"role": "user", "content": prompt}],
+                    "messages": [{"role": "user", "content": outbound}],
                     "stream": False,
                     "options": {
                         "num_predict": max_tokens,
-                        "temperature": 0.3,
+                        "temperature": _effective_temperature(),
                     },
                 },
             )
@@ -424,26 +686,28 @@ async def _call_llm_via_litellm(prompt: str, model: str, max_tokens: int = 500) 
     if cached is not None:
         return cached
 
-    try:
-        from litellm import acompletion
+    outbound = _prepare_prompt(prompt)
 
+    async def _once() -> Optional[str]:
+        try:
+            from litellm import acompletion
+        except ImportError:
+            logger.warning("litellm not installed. Install with: pip install 'agent-bom[ai-enrich]'")
+            return None
         response = await acompletion(
             model=model,
-            messages=[{"role": "user", "content": prompt}],
+            messages=[{"role": "user", "content": outbound}],
             max_tokens=max_tokens,
-            temperature=0.3,
+            temperature=_effective_temperature(),
+            timeout=_request_timeout(),
         )
         text = _response_text(response.choices[0].message.content)
-        if not text:
-            return None
+        return text or None
+
+    text = await retry_async(_once, retry_on=(Exception,), label=f"litellm:{model}")
+    if text:
         _ai_cache_put(key, text)
-        return text
-    except ImportError:
-        logger.warning("litellm not installed. Install with: pip install 'agent-bom[ai-enrich]'")
-        return None
-    except Exception as exc:
-        logger.warning("LLM call failed: %s", exc)
-        return None
+    return text
 
 
 async def _call_huggingface(
@@ -461,31 +725,28 @@ async def _call_huggingface(
     if cached is not None:
         return cached
 
-    try:
-        from huggingface_hub import InferenceClient
+    outbound = _prepare_prompt(prompt)
 
-        client = InferenceClient(
-            model=model,
-            token=os.environ.get("HF_TOKEN"),
-        )
+    async def _once() -> Optional[str]:
+        try:
+            from huggingface_hub import InferenceClient
+        except ImportError:
+            logger.warning("huggingface-hub not installed. Install with: pip install 'agent-bom[huggingface]'")
+            return None
+        client = InferenceClient(model=model, token=os.environ.get("HF_TOKEN"))
         # Run sync client in executor to avoid blocking event loop
         response = await asyncio.to_thread(
             client.chat_completion,
-            messages=[{"role": "user", "content": prompt}],
+            messages=[{"role": "user", "content": outbound}],
             max_tokens=max_tokens,
-            temperature=0.3,
+            temperature=_effective_temperature(),
         )
-        text = _response_text(response.choices[0].message.content)
-        if text:
-            _ai_cache_put(key, text)
-            return text
-        return None
-    except ImportError:
-        logger.warning("huggingface-hub not installed. Install with: pip install 'agent-bom[huggingface]'")
-        return None
-    except Exception as exc:
-        logger.warning("HuggingFace call failed: %s", exc)
-        return None
+        return _response_text(response.choices[0].message.content) or None
+
+    text = await retry_async(_once, retry_on=(Exception,), label=f"huggingface:{model}")
+    if text:
+        _ai_cache_put(key, text)
+    return text
 
 
 async def _call_llm(prompt: str, model: str, max_tokens: int = 500) -> Optional[str]:
@@ -587,17 +848,18 @@ async def _call_ollama_structured(
 
     try:
         json_schema = schema_cls.model_json_schema()
-        async with httpx.AsyncClient(timeout=120.0) as client:
+        outbound = _prepare_prompt(prompt)
+        async with httpx.AsyncClient(timeout=_request_timeout()) as client:
             resp = await client.post(
                 f"{OLLAMA_BASE_URL}/api/chat",
                 json={
                     "model": model,
-                    "messages": [{"role": "user", "content": prompt}],
+                    "messages": [{"role": "user", "content": outbound}],
                     "stream": False,
                     "format": json_schema,
                     "options": {
                         "num_predict": max_tokens,
-                        "temperature": 0.3,
+                        "temperature": _effective_temperature(),
                     },
                 },
             )
@@ -839,24 +1101,44 @@ async def run_ai_enrichment(
     model = resolution.model
     provider = resolution.provider.display_name if resolution.provider else "unknown"
 
+    # Per-task model selection: cheap tier for narratives/summaries, strong tier
+    # for config analysis. Tiers fall back to the resolved model when unset.
+    narrative_model = resolve_task_model(EnrichmentTask.NARRATIVE, model)
+    summary_model = resolve_task_model(EnrichmentTask.SUMMARY, model)
+    config_model = resolve_task_model(EnrichmentTask.CONFIG_ANALYSIS, model)
+
+    # Provenance: record the full harness posture, not just the primary model.
+    report.ai_enrichment_metadata = {
+        **resolution.to_metadata(),
+        "harness_version": "2",
+        "task_models": {
+            "narrative": narrative_model,
+            "summary": summary_model,
+            "config_analysis": config_model,
+        },
+        "redaction": bool(getattr(config, "AI_REDACT_PROMPTS", True)),
+        "deterministic": bool(getattr(config, "AI_DETERMINISTIC", False)),
+        "temperature": _effective_temperature(),
+    }
+
     console.print(f"\n[bold blue]AI Enrichment[/bold blue]  [dim]model: {model} via {provider}[/dim]\n")
 
     # Step 1: Enrich blast radii with contextual narratives
     if report.blast_radii:
         console.print("  [cyan]>[/cyan] Generating risk narratives...")
-        enriched = await enrich_blast_radii(report.blast_radii, model)
+        enriched = await enrich_blast_radii(report.blast_radii, narrative_model)
         console.print(f"  [green]{enriched} finding(s) enriched[/green]")
 
         # Step 2: Generate executive summary
         console.print("  [cyan]>[/cyan] Generating executive summary...")
-        summary = await generate_executive_summary(report, model)
+        summary = await generate_executive_summary(report, summary_model)
         if summary:
             report.executive_summary = summary
             console.print("  [green]Executive summary generated[/green]")
 
         # Step 3: Generate threat chain analysis
         console.print("  [cyan]>[/cyan] Analyzing threat chains...")
-        chains = await generate_threat_chains(report, model)
+        chains = await generate_threat_chains(report, summary_model)
         if chains:
             report.ai_threat_chains = chains
             console.print(f"  [green]{len(chains)} threat chain(s) analyzed[/green]")
@@ -865,7 +1147,7 @@ async def run_ai_enrichment(
     total_servers = sum(len(a.mcp_servers) for a in report.agents)
     if total_servers > 0:
         console.print("  [cyan]>[/cyan] Analyzing MCP config security...")
-        config_analysis = await analyze_mcp_config_security(report, model)
+        config_analysis = await analyze_mcp_config_security(report, config_model)
         if config_analysis:
             report.mcp_config_analysis = config_analysis.model_dump()
             console.print(f"  [green]Config analysis complete (risk: {config_analysis.overall_risk})[/green]")

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -300,6 +300,40 @@ NEPTUNE_TRAVERSAL_SOURCE = _str("AGENT_BOM_NEPTUNE_TRAVERSAL_SOURCE", "g")
 AI_CACHE_MAX_ENTRIES = _int("AGENT_BOM_AI_CACHE_MAX", 1_000)
 OLLAMA_BASE_URL = _str("AGENT_BOM_OLLAMA_URL", "http://localhost:11434")
 
+# ── Multi-provider LLM harness (issue #3206) ──────────────────────────────
+# The enrichment layer is a pluggable, multi-provider harness. These knobs
+# make it configurable per-deployment without code changes. All are additive
+# and optional — with none set the layer behaves exactly as before.
+#
+# Per-task model selection: enrichment runs several task *kinds* (narrative,
+# summary, tagging, detection, triage). A cheap local model is fine for
+# tagging/summaries; detection/remediation benefit from a stronger model.
+# Empty string means "fall back to the single resolved model" (legacy path).
+AI_MODEL_CHEAP = _str("AGENT_BOM_AI_MODEL_CHEAP", "")  # tagging, summaries
+AI_MODEL_STRONG = _str("AGENT_BOM_AI_MODEL_STRONG", "")  # detection, remediation
+
+# Redaction: scrub secret-looking material from every prompt before it leaves
+# the control plane. On by default — "no exfiltration by default" (issue #3206
+# hard requirement #4). Set to False only for trusted local-only deployments.
+AI_REDACT_PROMPTS = _bool("AGENT_BOM_AI_REDACT_PROMPTS", True)
+
+# Deterministic mode: temperature 0 + cache, so AI-derived findings are stable
+# enough to (optionally, explicitly) gate on. Default temperature stays 0.3 for
+# richer narratives when determinism is not required.
+AI_DETERMINISTIC = _bool("AGENT_BOM_AI_DETERMINISTIC", False)
+AI_TEMPERATURE = _float("AGENT_BOM_AI_TEMPERATURE", 0.3)
+
+# Reliability: bounded retries with exponential backoff around remote provider
+# calls, and a per-call timeout. Graceful degradation is preserved — exhausted
+# retries return None (no model) rather than raising.
+AI_MAX_RETRIES = _int("AGENT_BOM_AI_MAX_RETRIES", 2)
+AI_RETRY_BASE_DELAY = _float("AGENT_BOM_AI_RETRY_BASE_DELAY", 0.5)
+AI_RETRY_MAX_DELAY = _float("AGENT_BOM_AI_RETRY_MAX_DELAY", 8.0)
+AI_REQUEST_TIMEOUT = _float("AGENT_BOM_AI_REQUEST_TIMEOUT", 120.0)
+
+# Per-run cap on total LLM calls (cost/latency control). 0 disables the cap.
+AI_MAX_CALLS_PER_RUN = _int("AGENT_BOM_AI_MAX_CALLS", 50)
+
 
 # ── OIDC discovery shim ──────────────────────────────────────────────────
 # Optional static OIDC discovery metadata JSON served by the gateway for

--- a/tests/test_ai_enrich_providers.py
+++ b/tests/test_ai_enrich_providers.py
@@ -1,0 +1,303 @@
+"""Tests for the matured multi-provider LLM enrichment harness (issue #3206).
+
+Covers the provider abstraction/registry, per-task model selection, secret
+redaction, deterministic mode, and retry/backoff — all with mocked providers,
+no real network or API calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from agent_bom import ai_enrich, config
+from agent_bom.ai_enrich import (
+    AI_PROVIDER_DESCRIPTORS,
+    DEFAULT_MODEL,
+    PROVIDER_REGISTRY,
+    EnrichmentProvider,
+    EnrichmentTask,
+    HuggingFaceProvider,
+    LiteLLMProvider,
+    OllamaProvider,
+    get_provider,
+    provider_for_model,
+    redact_secrets,
+    resolve_task_model,
+    retry_async,
+)
+
+# ─── Redaction ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw, needle",
+    [
+        ("token sk-abcdef1234567890ABCD used", "<redacted-openai-key>"),
+        ("key sk-ant-api03-abcdefgh12345678ijkl here", "<redacted-anthropic-key>"),
+        ("pat ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345 x", "<redacted-github-token>"),
+        ("aws AKIAIOSFODNN7EXAMPLE creds", "<redacted-aws-access-key>"),
+        ("hf hf_abcdefghijklmnopqrstuvwxyz done", "<redacted-hf-token>"),
+        ("Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6", "Bearer <redacted-token>"),
+    ],
+)
+def test_redact_secrets_scrubs_known_shapes(raw, needle):
+    out = redact_secrets(raw)
+    assert needle in out
+    # The original secret body must not survive.
+    assert "sk-abcdef1234567890ABCD" not in out or needle == "<redacted-openai-key>"
+
+
+def test_redact_secrets_scrubs_assignments():
+    out = redact_secrets('API_KEY="supersecretvalue123"')
+    assert "supersecretvalue123" not in out
+    assert "<redacted>" in out
+    # The variable name (context) is preserved.
+    assert "API_KEY" in out
+
+
+def test_redact_secrets_scrubs_private_key_block():
+    pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA\n-----END RSA PRIVATE KEY-----"
+    out = redact_secrets(pem)
+    assert "MIIEpAIBAAKCAQEA" not in out
+    assert "<redacted-private-key>" in out
+
+
+def test_redact_secrets_preserves_credential_names():
+    # Credential *names* (not values) must survive so the model keeps context.
+    out = redact_secrets("Exposed credentials: OPENAI_API_KEY, DATABASE_URL")
+    assert "OPENAI_API_KEY" in out
+
+
+def test_redact_secrets_idempotent_and_safe_on_empty():
+    assert redact_secrets("") == ""
+    once = redact_secrets("sk-abcdefghijklmnop1234 and text")
+    assert redact_secrets(once) == once
+
+
+def test_prepare_prompt_honors_config(monkeypatch):
+    monkeypatch.setattr(config, "AI_REDACT_PROMPTS", True)
+    assert "<redacted-openai-key>" in ai_enrich._prepare_prompt("x sk-abcdefghij1234567890 y")
+    monkeypatch.setattr(config, "AI_REDACT_PROMPTS", False)
+    assert ai_enrich._prepare_prompt("x sk-abcdefghij1234567890 y") == "x sk-abcdefghij1234567890 y"
+
+
+@pytest.mark.asyncio
+async def test_redaction_applied_at_ollama_boundary(monkeypatch):
+    """The prompt that actually hits the network must be redacted."""
+    monkeypatch.setattr(config, "AI_REDACT_PROMPTS", True)
+    ai_enrich._cache.clear()
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"message": {"content": "ok"}}
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, json):
+            captured["content"] = json["messages"][0]["content"]
+            return _Resp()
+
+    with patch("agent_bom.ai_enrich.httpx.AsyncClient", return_value=_Client()):
+        await ai_enrich._call_ollama_direct("leak sk-abcdefghijkl1234567890 now", "llama3.2")
+
+    assert "sk-abcdefghijkl1234567890" not in captured["content"]
+    assert "<redacted-openai-key>" in captured["content"]
+
+
+# ─── Provider abstraction + registry ─────────────────────────────────────────
+
+
+def test_registry_has_all_providers():
+    assert set(PROVIDER_REGISTRY) == {"ollama", "huggingface", "litellm"}
+    for name, prov in PROVIDER_REGISTRY.items():
+        assert isinstance(prov, EnrichmentProvider)
+        assert prov.name == name
+        assert prov.descriptor is AI_PROVIDER_DESCRIPTORS[name]
+
+
+def test_get_provider_and_unknown():
+    assert isinstance(get_provider("ollama"), OllamaProvider)
+    with pytest.raises(KeyError):
+        get_provider("does-not-exist")
+
+
+@pytest.mark.parametrize(
+    "model, cls",
+    [
+        ("ollama/llama3.2", OllamaProvider),
+        ("huggingface/meta-llama/x", HuggingFaceProvider),
+        ("openai/gpt-4o-mini", LiteLLMProvider),
+        ("anthropic/claude-sonnet-5", LiteLLMProvider),
+    ],
+)
+def test_provider_for_model(model, cls):
+    assert isinstance(provider_for_model(model), cls)
+
+
+def test_provider_availability_reflects_detection():
+    with patch("agent_bom.ai_enrich._detect_ollama", return_value=True):
+        assert OllamaProvider().is_available() is True
+    with patch("agent_bom.ai_enrich._detect_ollama", return_value=False):
+        assert OllamaProvider().is_available() is False
+    with patch("agent_bom.ai_enrich._check_litellm", return_value=True):
+        assert LiteLLMProvider().is_available() is True
+
+
+@pytest.mark.asyncio
+async def test_ollama_provider_generate_delegates():
+    with patch("agent_bom.ai_enrich._call_ollama_direct", new_callable=AsyncMock, return_value="hi") as m:
+        out = await OllamaProvider().generate("prompt", "ollama/llama3.2", max_tokens=42)
+    assert out == "hi"
+    # Strips the ollama/ prefix before delegating to the bare-model call.
+    m.assert_awaited_once_with("prompt", "llama3.2", 42)
+
+
+@pytest.mark.asyncio
+async def test_litellm_provider_generate_delegates():
+    with patch("agent_bom.ai_enrich._call_llm_via_litellm", new_callable=AsyncMock, return_value="lit") as m:
+        out = await LiteLLMProvider().generate("p", "openai/gpt-4o-mini")
+    assert out == "lit"
+    m.assert_awaited_once()
+
+
+# ─── Per-task model selection ────────────────────────────────────────────────
+
+
+def test_resolve_task_model_defaults_to_resolved(monkeypatch):
+    monkeypatch.setattr(config, "AI_MODEL_CHEAP", "")
+    monkeypatch.setattr(config, "AI_MODEL_STRONG", "")
+    assert resolve_task_model(EnrichmentTask.TAGGING, "ollama/llama3.2") == "ollama/llama3.2"
+    assert resolve_task_model(EnrichmentTask.DETECTION, DEFAULT_MODEL) == DEFAULT_MODEL
+
+
+def test_resolve_task_model_uses_tiers(monkeypatch):
+    monkeypatch.setattr(config, "AI_MODEL_CHEAP", "ollama/llama3.2")
+    monkeypatch.setattr(config, "AI_MODEL_STRONG", "anthropic/claude-sonnet-5")
+    # Cheap tier tasks
+    assert resolve_task_model(EnrichmentTask.TAGGING) == "ollama/llama3.2"
+    assert resolve_task_model(EnrichmentTask.NARRATIVE) == "ollama/llama3.2"
+    assert resolve_task_model(EnrichmentTask.SUMMARY) == "ollama/llama3.2"
+    # Strong tier tasks
+    assert resolve_task_model(EnrichmentTask.DETECTION) == "anthropic/claude-sonnet-5"
+    assert resolve_task_model(EnrichmentTask.TRIAGE) == "anthropic/claude-sonnet-5"
+    assert resolve_task_model(EnrichmentTask.CONFIG_ANALYSIS) == "anthropic/claude-sonnet-5"
+
+
+# ─── Determinism ─────────────────────────────────────────────────────────────
+
+
+def test_effective_temperature_deterministic(monkeypatch):
+    monkeypatch.setattr(config, "AI_DETERMINISTIC", True)
+    assert ai_enrich._effective_temperature() == 0.0
+    monkeypatch.setattr(config, "AI_DETERMINISTIC", False)
+    monkeypatch.setattr(config, "AI_TEMPERATURE", 0.7)
+    assert ai_enrich._effective_temperature() == 0.7
+
+
+# ─── Retry / backoff ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_retry_async_succeeds_first_try():
+    calls = 0
+
+    async def f():
+        nonlocal calls
+        calls += 1
+        return "ok"
+
+    out = await retry_async(f, max_retries=3, base_delay=0)
+    assert out == "ok"
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_async_retries_then_succeeds(monkeypatch):
+    monkeypatch.setattr(ai_enrich.asyncio, "sleep", AsyncMock())
+    calls = 0
+
+    async def f():
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise httpx.TimeoutException("transient")
+        return "recovered"
+
+    out = await retry_async(f, max_retries=3, base_delay=0)
+    assert out == "recovered"
+    assert calls == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_async_exhausts_and_degrades(monkeypatch):
+    monkeypatch.setattr(ai_enrich.asyncio, "sleep", AsyncMock())
+    calls = 0
+
+    async def f():
+        nonlocal calls
+        calls += 1
+        raise httpx.ConnectError("down")
+
+    out = await retry_async(f, max_retries=2, base_delay=0)
+    assert out is None
+    assert calls == 3  # initial + 2 retries
+
+
+@pytest.mark.asyncio
+async def test_retry_async_non_retryable_returns_none():
+    calls = 0
+
+    async def f():
+        nonlocal calls
+        calls += 1
+        raise ValueError("permanent")
+
+    # ValueError is not in the default retry set → single attempt, degrade.
+    out = await retry_async(f, max_retries=3, base_delay=0)
+    assert out is None
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_litellm_call_retries_transient(monkeypatch):
+    """The litellm boundary retries a transient failure then caches success."""
+    monkeypatch.setattr(config, "AI_MAX_RETRIES", 2)
+    monkeypatch.setattr(ai_enrich.asyncio, "sleep", AsyncMock())
+    ai_enrich._cache.clear()
+
+    attempts = 0
+
+    async def fake_acompletion(**kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise httpx.TimeoutException("boom")
+
+        class _Msg:
+            content = "final answer"
+
+        class _Choice:
+            message = _Msg()
+
+        class _Resp:
+            choices = [_Choice()]
+
+        return _Resp()
+
+    fake_litellm = type("m", (), {"acompletion": staticmethod(fake_acompletion)})
+    with patch.dict("sys.modules", {"litellm": fake_litellm}):
+        out = await ai_enrich._call_llm_via_litellm("prompt", "openai/gpt-4o-mini")
+
+    assert out == "final answer"
+    assert attempts == 2


### PR DESCRIPTION
Part of #3206.

Matures the pluggable multi-provider LLM enrichment layer (`ai_enrich.py`) from three hardcoded backends into a configurable, provider-agnostic harness. The deterministic scan path stays LLM-free — enrichment remains optional/additive with graceful no-op when no model is present.

## What changed
- **Provider abstraction + registry** — `EnrichmentProvider` protocol with `Ollama` / `HuggingFace` / `LiteLLM` adapters over the existing `_call_*` code paths, plus `get_provider()` / `provider_for_model()` lookup. One network path per backend; adapters stay thin.
- **Per-task model selection** — `EnrichmentTask` kinds (narrative, summary, tagging, detection, triage, config-analysis) routed to a *cheap* or *strong* tier via `AGENT_BOM_AI_MODEL_CHEAP` / `AGENT_BOM_AI_MODEL_STRONG`. Unset tiers fall back to the auto-resolved model, so default behavior is unchanged.
- **No exfiltration by default** (issue hard requirement #4) — `redact_secrets()` scrubs API keys (OpenAI/Anthropic/GitHub/Slack/AWS/Google/HF), bearer tokens, PEM private keys, and `SECRET=…` assignments at *every* provider network boundary (local Ollama included). Credential *names* (e.g. `OPENAI_API_KEY`) are preserved so the model keeps context. On by default (`AGENT_BOM_AI_REDACT_PROMPTS`).
- **Reliability** — bounded exponential-backoff retries (`retry_async`) + per-call timeout around remote providers; exhausted retries degrade to `None` rather than raising, preserving graceful degradation.
- **Deterministic mode** — `AGENT_BOM_AI_DETERMINISTIC` (temp 0 + cache) and configurable `AGENT_BOM_AI_TEMPERATURE` for gate-stable AI-derived output.
- **Provenance** — per-run `ai_enrichment_metadata` now records the task→model map plus redaction/determinism posture alongside provider/model.

All new config is append-only and optional; with nothing set the layer behaves exactly as before. Claude model IDs referenced in tests use current strings (`claude-sonnet-5`).

## Tests
- 29 new mocked-provider tests in `tests/test_ai_enrich_providers.py` (redaction shapes, registry/selection, per-task tiers, determinism, retry/backoff) — no real network or API calls.
- Existing `tests/test_ai_enrich.py` (94) and the wider enrichment suite (318 total in scope) stay green.

## Deferred (tracked by #3206, not in this slice)
First-class `ai_detected` findings emission, compliance/control tagging into the compliance hub, and multi-model ensemble cross-check. This PR lands the harness those build on.