### PR TITLE
fix(scanners): correct OSV fixed_version resolution

### DIFF
--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -57,6 +57,7 @@ from agent_bom.package_utils import (
 )
 from agent_bom.scanners.blast_radius import _HOP_RISK_FACTORS, expand_blast_radius_hops
 from agent_bom.scanners.osv import candidate_package_names as _candidate_package_names
+from agent_bom.scanners.osv import ecosystem_matches as _ecosystem_matches
 from agent_bom.scanners.osv import enrich_results_if_needed as _enrich_results_if_needed_impl
 from agent_bom.scanners.osv import is_valid_fix_version as _is_valid_fix_version
 from agent_bom.scanners.osv import package_lookup_names as _package_lookup_names
@@ -385,6 +386,28 @@ async def query_osv_batch(packages: list[Package]) -> dict[str, list[dict]]:
     )
 
 
+def _version_matches_list(version: str, versions_list: list[str], ecosystem: str = "") -> bool:
+    """Whether ``version`` equals any entry in an OSV ``affected[].versions`` list.
+
+    Uses version-normalized equality so PEP 440 / SemVer trailing-zero forms
+    match (``2.2.0`` == ``2.2``, ``2.3`` == ``2.3.0``). Falls back to the raw
+    membership test first for speed and for versions that don't parse.
+    """
+    if version in versions_list:
+        return True
+    from agent_bom.version_utils import compare_version_order
+
+    for candidate in versions_list:
+        if candidate == version:
+            return True
+        try:
+            if compare_version_order(version, candidate, ecosystem) == 0:
+                return True
+        except Exception:  # noqa: BLE001
+            continue
+    return False
+
+
 def _is_version_affected(
     vuln_data: dict,
     package_name: str,
@@ -414,16 +437,23 @@ def _is_version_affected(
     for affected in vuln_data.get("affected", []):
         pkg = affected.get("package", {})
         osv_eco = pkg.get("ecosystem", ecosystem)
+        # Shared advisories list affected entries across ecosystems; only match
+        # against same-ecosystem entries so a different ecosystem's range/version
+        # set can't (falsely) include or exclude our package.
+        if not _ecosystem_matches(osv_eco, ecosystem):
+            continue
         osv_name = normalize_package_name(pkg.get("name", ""), osv_eco)
         if osv_name not in norm_names:
             continue
 
         found_package = True
 
-        # Check explicit version list first
+        # Check explicit version list first (OSV enumerates affected versions
+        # here). Compare version-normalized so "2.2.0" matches an enumerated
+        # "2.2" — a raw string ``in`` check drops trailing-zero equivalents.
         versions_list = affected.get("versions", [])
         if versions_list:
-            if package_version in versions_list:
+            if _version_matches_list(package_version, versions_list, ecosystem):
                 return True
             # If explicit list exists and our version isn't in it, not affected
             continue

--- a/src/agent_bom/scanners/osv.py
+++ b/src/agent_bom/scanners/osv.py
@@ -36,6 +36,36 @@ def candidate_package_names(package_name: str, ecosystem: str = "", source_packa
     return names
 
 
+def ecosystem_matches(osv_ecosystem: str, query_ecosystem: str) -> bool:
+    """Whether an OSV ``affected[].package.ecosystem`` matches the queried ecosystem.
+
+    OSV advisories are frequently shared across ecosystems (a single GHSA can
+    list npm, PyPI, NuGet, Maven … affected entries). When resolving a fix or
+    matching an installed version we must only consider entries from the same
+    ecosystem, otherwise a fix version from a different ecosystem's entry can
+    bleed in (e.g. jQuery's npm ``3.4.0`` being reported as Django's PyPI fix).
+
+    Returns True when either side is unknown (nothing to disqualify on), and
+    compares on the base ecosystem so OSV release-suffixed ecosystems such as
+    ``Debian:11`` or ``Alpine:v3.16`` still match their bare form.
+    """
+    if not osv_ecosystem or not query_ecosystem:
+        return True
+    osv_base = osv_ecosystem.split(":", 1)[0].strip().lower()
+    query_base = query_ecosystem.split(":", 1)[0].strip().lower()
+    if osv_base == query_base:
+        return True
+    # The queried ecosystem is often the internal code ("deb", "rpm", "conda")
+    # while OSV uses its own name ("Debian:11", "Linux", "PyPI"). Map the query
+    # code to its OSV ecosystem and compare on that base too.
+    from agent_bom.scanners import ECOSYSTEM_MAP  # lazy: avoids import cycle
+
+    mapped = ECOSYSTEM_MAP.get(query_base)
+    if mapped and mapped.split(":", 1)[0].strip().lower() == osv_base:
+        return True
+    return False
+
+
 def is_valid_fix_version(version: str) -> bool:
     """Check if a string looks like a usable package version."""
     if not version or not any(c.isdigit() for c in version):
@@ -81,6 +111,15 @@ def parse_fixed_version(
             _logger.debug("Skipping affected entry with empty package name in %s", vuln_data.get("id", "?"))
             continue
         osv_eco = pkg.get("ecosystem", ecosystem)
+        if not ecosystem_matches(osv_eco, ecosystem):
+            _logger.debug(
+                "Skipping cross-ecosystem affected entry %s/%s (want %s) in %s",
+                osv_eco,
+                pkg_name,
+                ecosystem,
+                vuln_data.get("id", "?"),
+            )
+            continue
         osv_norm = normalize_package_name(pkg_name, osv_eco)
         if osv_norm in norm_inputs:
             for rng in affected.get("ranges", []):
@@ -146,6 +185,28 @@ async def enrich_vuln_details(
     return dict(pairs)
 
 
+def vuln_needs_enrichment(vuln: dict) -> bool:
+    """Whether an OSV record must be enriched before fix/version resolution.
+
+    The OSV ``/v1/querybatch`` endpoint returns minimal ``{id, modified}``
+    stubs, and a partially-enriched record (e.g. one carrying only a
+    ``summary`` from a prior run) can still be missing the ``affected`` block.
+    Both ``parse_fixed_version`` and version-range matching need ``affected``
+    with at least one ranges/versions entry, so gate enrichment on the presence
+    of that resolution data rather than on the ``summary`` field. Keying off
+    ``summary`` alone dropped fixes for records that had a summary but no
+    ``affected`` and, because ``summary``-less advisories (e.g. PYSEC) were
+    re-fetched every run, made the null-fix count nondeterministic across
+    cache-cold and cache-warm runs.
+    """
+    if not vuln.get("id"):
+        return False
+    affected = vuln.get("affected")
+    if not affected:
+        return True
+    return not any(isinstance(entry, dict) and (entry.get("ranges") or entry.get("versions")) for entry in affected)
+
+
 async def enrich_results_if_needed(
     results: dict[str, list[dict]],
     *,
@@ -160,9 +221,11 @@ async def enrich_results_if_needed(
     all_vuln_ids: list[str] = []
     for vuln_list in results.values():
         for vuln in vuln_list:
-            if "summary" not in vuln and vuln.get("id"):
+            if vuln_needs_enrichment(vuln):
                 all_vuln_ids.append(vuln["id"])
-    unique_ids = list(dict.fromkeys(all_vuln_ids))
+    # Deterministic order/dedup: the same set of ids is enriched regardless of
+    # cache-cold vs cache-warm runs, so fix-version resolution is reproducible.
+    unique_ids = sorted(dict.fromkeys(all_vuln_ids))
     if not unique_ids:
         return results
     try:
@@ -394,9 +457,7 @@ async def query_osv_batch_impl(
                     # concurrent 429s just wait the pause out.
                     if rate_gate.is_set():
                         rate_gate.clear()
-                        console.print(
-                            f"  [yellow]⚠[/yellow] OSV rate limit (429) — pausing the OSV pipeline {pipeline_wait:.0f}s"
-                        )
+                        console.print(f"  [yellow]⚠[/yellow] OSV rate limit (429) — pausing the OSV pipeline {pipeline_wait:.0f}s")
                         _logger.warning("OSV rate limit hit after all retries; pausing pipeline %.0fs", pipeline_wait)
                         try:
                             await asyncio.sleep(pipeline_wait)
@@ -412,9 +473,7 @@ async def query_osv_batch_impl(
                     for idx in range(batch_start, min(batch_start + len(batch), len(queries))):
                         pkg_err = pkg_index.get(idx)
                         if pkg_err:
-                            batch_errors.append(
-                                (pkg_err[0].name, pkg_err[0].ecosystem, "rate limited (HTTP 429) after retries")
-                            )
+                            batch_errors.append((pkg_err[0].name, pkg_err[0].ecosystem, "rate limited (HTTP 429) after retries"))
                 elif response:
                     record_enrichment_source("osv", "failure", error=f"HTTP {response.status_code}")
                     console.print(f"  [red]✗[/red] OSV API error: HTTP {response.status_code}")

--- a/tests/test_osv_fixed_version_accuracy.py
+++ b/tests/test_osv_fixed_version_accuracy.py
@@ -1,0 +1,279 @@
+"""Regression tests for OSV fixed_version accuracy (issue #3642).
+
+Covers three defects, all exercised with mocked OSV payloads (no live calls):
+
+1. fixed_version dropped / nondeterministic — the enrich gate only re-fetched
+   records missing a ``summary``; a record that had a summary but no
+   ``affected`` block was left un-enriched so ``parse_fixed_version`` never saw
+   the fix.
+2. Cross-ecosystem bleed — a shared advisory listing affected entries for
+   several ecosystems (jQuery/npm 3.4.0 alongside Django/PyPI 2.2.2) returned
+   the wrong ecosystem's fix.
+3. False negative — a version enumerated in ``affected[].versions`` in a
+   trailing-zero form (``django==2.2.0`` vs enumerated ``2.2``) was filtered
+   out as "not affected".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from rich.console import Console
+
+from agent_bom.models import Package
+from agent_bom.scanners import _is_version_affected, build_vulnerabilities, parse_fixed_version
+from agent_bom.scanners.osv import (
+    ecosystem_matches,
+    enrich_results_if_needed,
+    vuln_needs_enrichment,
+)
+
+# --- Defect 2: cross-ecosystem bleed --------------------------------------
+
+
+def _shared_advisory() -> dict:
+    """CVE-2019-11358 shape: jQuery (npm/NuGet/Maven) + Django (PyPI) in one record."""
+    return {
+        "id": "GHSA-6c3j-c64m-qhgq",
+        "aliases": ["CVE-2019-11358"],
+        "summary": "Prototype pollution",
+        "affected": [
+            {
+                "package": {"name": "jquery", "ecosystem": "npm"},
+                "ranges": [{"type": "SEMVER", "events": [{"introduced": "0"}, {"fixed": "3.4.0"}]}],
+            },
+            {
+                "package": {"name": "jQuery", "ecosystem": "NuGet"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "3.4.0"}]}],
+            },
+            {
+                "package": {"name": "django", "ecosystem": "PyPI"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "2.0a1"}, {"fixed": "2.1.9"}]}],
+            },
+            {
+                "package": {"name": "django", "ecosystem": "PyPI"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "2.2a1"}, {"fixed": "2.2.2"}]}],
+            },
+        ],
+    }
+
+
+def test_no_cross_ecosystem_fix_bleed():
+    """Django must get its PyPI fix (2.2.2), never jQuery's npm 3.4.0."""
+    fixed = parse_fixed_version(_shared_advisory(), "django", "PyPI", current_version="2.2.0")
+    assert fixed == "2.2.2"
+
+
+def test_same_name_cross_ecosystem_does_not_bleed():
+    """A same-name package in another ecosystem must not donate its fix."""
+    vuln = {
+        "id": "SHARED-1",
+        "affected": [
+            {
+                "package": {"name": "foo", "ecosystem": "npm"},
+                "ranges": [{"type": "SEMVER", "events": [{"introduced": "0"}, {"fixed": "9.9.9"}]}],
+            },
+            {
+                "package": {"name": "foo", "ecosystem": "PyPI"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "1.2.3"}]}],
+            },
+        ],
+    }
+    assert parse_fixed_version(vuln, "foo", "PyPI", current_version="1.0.0") == "1.2.3"
+
+
+def test_ecosystem_matches_maps_internal_codes():
+    """Internal ecosystem codes must map to their OSV names."""
+    assert ecosystem_matches("Debian:11", "deb")
+    assert ecosystem_matches("PyPI", "pypi")
+    assert ecosystem_matches("Linux", "rpm")
+    assert not ecosystem_matches("npm", "PyPI")
+    # Unknown on either side -> nothing to disqualify on.
+    assert ecosystem_matches("", "PyPI")
+    assert ecosystem_matches("npm", "")
+
+
+def test_build_vulnerabilities_reports_django_fix_not_jquery(monkeypatch):
+    """End-to-end (build): CVE-2019-11358 on Django resolves to 2.2.2."""
+    pkg = Package(name="django", version="2.2", ecosystem="PyPI")
+    vulns = build_vulnerabilities([_shared_advisory()], pkg)
+    assert len(vulns) == 1
+    assert vulns[0].id == "CVE-2019-11358"
+    assert vulns[0].fixed_version == "2.2.2"
+
+
+# --- Defect 3: versions-list trailing-zero false negative ------------------
+
+
+def _pysec_2024_225() -> dict:
+    """cryptography advisory: 2.3 enumerated in `versions` but outside the range."""
+    return {
+        "id": "PYSEC-2024-225",
+        "aliases": ["CVE-2024-26130", "GHSA-6vqw-3v5j-54x4"],
+        "summary": "NULL pointer dereference",
+        "affected": [
+            {
+                "package": {"name": "cryptography", "ecosystem": "PyPI"},
+                "ranges": [
+                    {"type": "ECOSYSTEM", "events": [{"introduced": "38.0.0"}, {"fixed": "42.0.4"}]},
+                ],
+                "versions": ["2.3", "38.0.0", "41.0.0"],
+            }
+        ],
+    }
+
+
+def test_version_in_explicit_list_is_affected():
+    """cryptography 2.3 is enumerated in `versions` -> affected (CVE-2024-26130)."""
+    assert _is_version_affected(_pysec_2024_225(), "cryptography", "2.3", "PyPI") is True
+
+
+def test_trailing_zero_version_matches_enumerated_version():
+    """django==2.2.0 must match an enumerated '2.2' (PEP 440 trailing-zero)."""
+    vuln = {
+        "id": "GHSA-x",
+        "affected": [
+            {
+                "package": {"name": "django", "ecosystem": "PyPI"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "2.2a1"}, {"fixed": "2.2.2"}]}],
+                "versions": ["2.2", "2.2.1"],
+            },
+        ],
+    }
+    assert _is_version_affected(vuln, "django", "2.2.0", "PyPI") is True
+
+
+def test_version_not_enumerated_is_not_affected():
+    """A version outside both the enumerated list and range is not affected."""
+    vuln = {
+        "id": "GHSA-y",
+        "affected": [
+            {
+                "package": {"name": "django", "ecosystem": "PyPI"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "2.2a1"}, {"fixed": "2.2.2"}]}],
+                "versions": ["2.2", "2.2.1"],
+            },
+        ],
+    }
+    assert _is_version_affected(vuln, "django", "2.2.5", "PyPI") is False
+
+
+def test_cross_ecosystem_versions_do_not_flag_our_package():
+    """Another ecosystem's enumerated versions must not mark our package affected."""
+    vuln = {
+        "id": "GHSA-z",
+        "affected": [
+            {"package": {"name": "foo", "ecosystem": "npm"}, "versions": ["1.0.0"]},
+        ],
+    }
+    # foo/PyPI is not listed at all -> no same-ecosystem affected entry found ->
+    # conservative True (trust OSV's original match); the npm versions list must
+    # not be what decides it.
+    assert _is_version_affected(vuln, "foo", "1.0.0", "PyPI") is True
+    # And a different version still must not be filtered on the npm list.
+    assert _is_version_affected(vuln, "foo", "2.0.0", "PyPI") is True
+
+
+# --- Defect 1: enrich gate + determinism -----------------------------------
+
+
+def test_vuln_needs_enrichment_gate():
+    # Minimal batch stub -> needs enrichment.
+    assert vuln_needs_enrichment({"id": "X", "modified": "t"}) is True
+    # Has summary but NO affected -> STILL needs enrichment (the bug).
+    assert vuln_needs_enrichment({"id": "X", "summary": "s"}) is True
+    # Affected present but no ranges/versions -> needs enrichment.
+    assert vuln_needs_enrichment({"id": "X", "affected": [{"package": {"name": "p"}}]}) is True
+    # Fully resolvable (affected + ranges) -> no enrichment (deterministic, no refetch).
+    assert vuln_needs_enrichment({"id": "X", "affected": [{"package": {"name": "p"}, "ranges": [{"events": []}]}]}) is False
+    # summary-less record that already has affected/versions -> no refetch either.
+    assert vuln_needs_enrichment({"id": "PYSEC-1", "affected": [{"package": {"name": "p"}, "versions": ["1.0"]}]}) is False
+    # No id -> can't enrich.
+    assert vuln_needs_enrichment({"summary": "s"}) is False
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict):
+        self.status_code = 200
+        self._payload = payload
+
+    def json(self) -> dict:
+        return self._payload
+
+
+class _FakeClient:
+    async def __aenter__(self) -> "_FakeClient":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_enrich_fetches_records_missing_affected_even_with_summary():
+    """A record with a summary but no `affected` must be enriched (defect 1)."""
+    detail = {
+        "id": "PYSEC-2024-225",
+        "summary": "NULL pointer dereference",
+        "affected": [
+            {
+                "package": {"name": "cryptography", "ecosystem": "PyPI"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "38.0.0"}, {"fixed": "42.0.4"}]}],
+                "versions": ["2.3"],
+            },
+        ],
+    }
+    fetched: list[str] = []
+
+    async def _fake_request(client, method, url, **kwargs):
+        vid = url.rsplit("/", 1)[-1]
+        fetched.append(vid)
+        return _FakeResponse(detail)
+
+    results = {
+        "pypi:cryptography@2.3": [
+            # HAS a summary, but NO affected -> old gate skipped it, dropping the fix.
+            {"id": "PYSEC-2024-225", "summary": "NULL pointer dereference"},
+        ]
+    }
+    out = await enrich_results_if_needed(
+        results,
+        console=Console(quiet=True),
+        record_scan_warning=lambda _m: None,
+        create_client_fn=lambda **kw: _FakeClient(),
+        request_with_retry_fn=_fake_request,
+    )
+    assert fetched == ["PYSEC-2024-225"]
+    enriched = out["pypi:cryptography@2.3"][0]
+    assert enriched.get("affected"), "record must gain affected data after enrichment"
+    assert parse_fixed_version(enriched, "cryptography", "PyPI", current_version="2.3") == "42.0.4"
+
+
+@pytest.mark.asyncio
+async def test_enrich_skips_records_already_resolvable():
+    """Records that already carry affected ranges are not re-fetched (determinism)."""
+    called: list[str] = []
+
+    async def _fake_request(client, method, url, **kwargs):
+        called.append(url)
+        return _FakeResponse({})
+
+    results = {
+        "pypi:django@2.2": [
+            {
+                "id": "GHSA-ok",
+                "affected": [
+                    {"package": {"name": "django", "ecosystem": "PyPI"}, "ranges": [{"events": [{"introduced": "0"}, {"fixed": "2.2.2"}]}]}
+                ],
+            },
+        ]
+    }
+    await enrich_results_if_needed(
+        results,
+        console=Console(quiet=True),
+        record_scan_warning=lambda _m: None,
+        create_client_fn=lambda **kw: _FakeClient(),
+        request_with_retry_fn=_fake_request,
+    )
+    assert called == [], "records with resolvable affected data must not be re-fetched"


### PR DESCRIPTION
Closes #3642

Three defects in OSV fix-version resolution, all found by background QA vs OSV.dev ground truth. Fixes are in `scanners/osv.py` and `scanners/__init__.py`, with regression tests using mocked OSV payloads (no live calls).

## Defect 1 — fixed_version dropped / nondeterministic
`enrich_results_if_needed` re-fetched only records **missing a `summary`**. A record that had a summary but no `affected` block was left un-enriched, so `parse_fixed_version` never saw the fix. Summary-less advisories (e.g. PYSEC) were also re-fetched every run, so the null-fix count drifted between cache-cold and cache-warm runs (the reported 13 vs 11).

**Fix:** gate enrichment on the presence of the data needed for resolution (`affected` with `ranges`/`versions`) via a new `vuln_needs_enrichment` helper, and `sorted()`-dedup the id list so the same set is enriched every run.

## Defect 2 — cross-ecosystem fix bleed
A shared advisory (e.g. CVE-2019-11358: jQuery/npm `3.4.0` + Django/PyPI `2.2.2`) could return the wrong ecosystem's fix. `parse_fixed_version` and `_is_version_affected` now only consider `affected[]` entries whose ecosystem matches the queried package, via `ecosystem_matches` (internal codes like `deb`/`rpm`/`conda` are mapped through `ECOSYSTEM_MAP` to their OSV names).

## Defect 3 — false negative on trailing-zero enumerated versions
`_is_version_affected` compared the installed version against `affected[].versions` with a raw string `in`, so `django==2.2.0` failed to match an enumerated `2.2` and the finding was dropped. Membership is now version-normalized (`2.2.0` == `2.2`, `2.3` == `2.3.0`).

## Verification (live OSV, fixture django==2.2.0 / cryptography==2.3 / urllib3==1.26.0)
| package | before | after |
|---|---|---|
| django 2.2.0 | 0 findings (all filtered) | 35 findings, 0 null-fix |
| CVE-2019-11358 fix | 3.4.0 (jQuery) / dropped | **2.2.2** |
| cryptography CVE-2024-26130 | missed | **reported, fix 42.0.4** |
| urllib3 1.26.0 | null fixes | 10 findings, 0 null-fix |

Results are deterministic across repeated runs. Existing scanner tests stay green; 11 new regression tests added.