### PR TITLE
fix(output): SARIF/json finding-count parity + --reproducible timestamps + /dev/null exit

### DIFF
--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -237,6 +237,24 @@ def _scan_output_target_was_explicit() -> bool:
     return ctx.get_parameter_source("output") in explicit_sources or ctx.get_parameter_source("output_format") in explicit_sources
 
 
+def _is_null_device(output: Any) -> bool:
+    """Return True when ``-o`` points at the platform null device (discard sink).
+
+    Writing to the null device must succeed silently and never override the
+    policy exit code, so callers treat it as "produce no file" rather than a
+    real path (which would otherwise gain a format suffix and fail to write).
+    """
+    import os
+
+    if not output or output == "-":
+        return False
+    candidates = {os.devnull, "/dev/null"}
+    try:
+        return os.path.realpath(str(output)) in {os.path.realpath(c) for c in candidates}
+    except OSError:
+        return str(output) in candidates
+
+
 def _reproducible_generated_at(enabled: bool):
     """Return a pinned report timestamp when reproducible output is requested."""
     import os
@@ -581,9 +599,15 @@ def scan(
         verify_instructions = True
 
     if output_format == "sarif" and not enrich and not no_scan and not offline:
+        # SARIF benefits from EPSS/KEV enrichment (annotation only — never adds or
+        # removes findings). Do NOT auto-enable dynamic discovery or the context
+        # graph here: those *change the finding set* (e.g. the graph evaluator
+        # emits toxic-combination COMBINATION findings). Gating them on the output
+        # format made `-f sarif` surface findings that `-f json`/`-f csv` of the
+        # same input never emitted — a SIEM/API parity bug (#3643). Discovery and
+        # graph analysis stay driven by explicit flags/presets so the finding set
+        # is identical across every output format.
         enrich = True
-        dynamic_discovery = True
-        context_graph_flag = True
     elif preset == "quick":
         transitive = False
         enrich = False
@@ -629,11 +653,16 @@ def scan(
 
     # Route console output based on flags
     is_stdout = output == "-"
+    is_null_sink = _is_null_device(output)
     con = _make_console(quiet=quiet or is_stdout, output_format=output_format, no_color=no_color)
     runtime_console = Console(stderr=True, quiet=quiet or is_stdout, no_color=no_color)
     _sync_runtime_consoles(runtime_console)
 
-    if output and output != "-" and output_format == "console" and _output_format_was_explicit():
+    # `-o /dev/null` is a discard sink: run the scan, write nothing, and let the
+    # policy exit code stand. Without this the console-to-file guard below tripped
+    # `SystemExit(2)` (because passing `-o` alone makes the format "explicit"),
+    # masking `--fail-on-severity` (#3643).
+    if output and output != "-" and not is_null_sink and output_format == "console" and _output_format_was_explicit():
         click.echo(
             "Error: --format console renders to the terminal only; use --format plain, markdown, or json with --output.",
             err=True,
@@ -1719,6 +1748,16 @@ def scan(
 
     _generated_at = _reproducible_generated_at(reproducible)
     _report_kwargs = {"generated_at": _generated_at} if _generated_at is not None else {}
+    if _generated_at is not None:
+        # Reproducible/attestable output: entity discovery timestamps are
+        # wall-clock by default, so two scans of the same input diverged on every
+        # agent's discovered_at/last_seen (#3643). Pin them to the same pinned
+        # report timestamp so `--reproducible` (or SOURCE_DATE_EPOCH) yields a
+        # byte-identical artifact.
+        _pinned_ts = _generated_at.isoformat().replace("+00:00", "Z")
+        for _agent in agents:
+            _agent.discovered_at = _pinned_ts
+            _agent.last_seen = _pinned_ts
     report = AIBOMReport(
         agents=agents,
         blast_radii=blast_radii,

--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -82,6 +82,19 @@ _FORMAT_OUTPUT_RULES: dict[str, tuple[str, tuple[str, ...]]] = {
 }
 
 
+def _is_null_device(output: Any) -> bool:
+    """Return True when ``output`` points at the platform null device."""
+    import os
+
+    if not output or output == "-":
+        return False
+    candidates = {os.devnull, "/dev/null"}
+    try:
+        return os.path.realpath(str(output)) in {os.path.realpath(c) for c in candidates}
+    except OSError:
+        return str(output) in candidates
+
+
 def _resolve_output_path(output: Any, output_format: str) -> str:
     """Return an output path whose suffix matches the selected format."""
     default_name, allowed_suffixes = _FORMAT_OUTPUT_RULES[output_format]
@@ -89,6 +102,11 @@ def _resolve_output_path(output: Any, output_format: str) -> str:
         return default_name
 
     raw_path = str(output)
+    # Null device is a discard sink: keep the path verbatim so the write lands on
+    # /dev/null (which succeeds silently) rather than a suffixed sibling like
+    # `/dev/null.json` that lives in an unwritable dir and would fail (#3643).
+    if _is_null_device(raw_path):
+        return raw_path
     lower_path = raw_path.lower()
     if any(lower_path.endswith(suffix) for suffix in allowed_suffixes):
         return raw_path
@@ -326,6 +344,12 @@ def render_output(
             else:
                 sys.stdout.write(json.dumps(to_json(report), indent=2))
             sys.stdout.write("\n")
+        elif _is_null_device(output) and output_format in ("console", "text", "plain"):
+            # `-o /dev/null` with a terminal-only format: discard silently rather
+            # than falling through to extension inference (which exited 2 and
+            # masked --fail-on-severity). The scan already ran; the policy exit
+            # code stands (#3643).
+            pass
         elif output_format == "console" and not output:
             _skill_audit_obj = ctx._skill_audit_obj
             if verbose:

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1060,6 +1060,136 @@ def test_scan_sarif_auto_enables_enrich(monkeypatch):
     assert captured["enable_enrichment"] is True
 
 
+def _critical_scan_mocks():
+    """Return (agent, blast_radii) with one CRITICAL CVE for output-parity tests."""
+    vuln = Vulnerability(id="CVE-2099-0001", summary="crit", severity=Severity.CRITICAL, fixed_version="9.9.9")
+    pkg = Package(name="badpkg", version="1.0.0", ecosystem="pypi", vulnerabilities=[vuln])
+    server = MCPServer(name="srv", command="python", packages=[pkg])
+    agent = Agent(name="ag", agent_type=AgentType.CUSTOM, config_path="a.json", mcp_servers=[server])
+    br = [
+        BlastRadius(
+            vulnerability=vuln,
+            package=pkg,
+            affected_servers=[server],
+            affected_agents=[agent],
+            exposed_credentials=[],
+            exposed_tools=[],
+        )
+    ]
+    return agent, br
+
+
+def test_scan_sarif_does_not_auto_enable_context_graph(tmp_path):
+    """`-f sarif` must not silently run the context graph / toxic-combo evaluator.
+
+    Gating it on the output format made SARIF emit COMBINATION findings that the
+    same input as `-f json`/`-f csv` never produced — a SIEM/API parity bug
+    (#3643). Enrichment (annotation only) stays on; the finding set must not.
+    """
+    agent, br = _critical_scan_mocks()
+    with (
+        patch("agent_bom.cli.agents.discover_all", return_value=[agent]),
+        patch("agent_bom.cli.agents.extract_packages", return_value=[]),
+        patch("agent_bom.cli.agents.scan_agents_sync", return_value=br),
+        patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=[]),
+        patch("agent_bom.context_graph.build_context_graph") as build_cg,
+    ):
+        result = _run(["scan", "--project", str(tmp_path), "-f", "sarif", "-o", str(tmp_path / "r.sarif"), "--no-auto-update-db"])
+    assert result.exit_code in (0, 1), result.output
+    build_cg.assert_not_called()
+
+
+def test_scan_finding_count_parity_across_formats(tmp_path):
+    """json/csv/sarif of the same scan must report identical finding counts (#3643)."""
+    out = tmp_path / "out"
+    out.mkdir()
+
+    def _scan(fmt: str, path):
+        agent, br = _critical_scan_mocks()
+        with (
+            patch("agent_bom.cli.agents.discover_all", return_value=[agent]),
+            patch("agent_bom.cli.agents.extract_packages", return_value=[]),
+            patch("agent_bom.cli.agents.scan_agents_sync", return_value=br),
+            patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=[]),
+        ):
+            return _run(["scan", "--project", str(tmp_path), "-f", fmt, "-o", str(path), "--no-auto-update-db"])
+
+    jf, sf, cf = out / "r.json", out / "r.sarif", out / "r.csv"
+    _scan("json", jf)
+    _scan("sarif", sf)
+    _scan("csv", cf)
+
+    json_count = len(json.loads(jf.read_text())["findings"])
+    sarif_count = len(json.loads(sf.read_text())["runs"][0]["results"])
+    csv_count = cf.read_text().strip().count("\n")  # minus header
+    assert json_count == sarif_count == csv_count == 1
+
+
+def test_scan_reproducible_pins_agent_timestamps(tmp_path):
+    """--reproducible must pin per-agent discovered_at/last_seen, not just generated_at (#3643)."""
+    inventory = tmp_path / "inventory.json"
+    inventory.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "generated_at": "2026-05-09T00:00:00Z",
+                "agents": [{"name": "fixture-agent", "agent_type": "custom", "mcp_servers": []}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def _emit(path):
+        return _run(
+            [
+                "scan",
+                "--inventory",
+                str(inventory),
+                "--inventory-only",
+                "--no-scan",
+                "--reproducible",
+                "--format",
+                "json",
+                "--output",
+                str(path),
+            ]
+        )
+
+    a, b = tmp_path / "a.json", tmp_path / "b.json"
+    assert _emit(a).exit_code == 0
+    assert _emit(b).exit_code == 0
+
+    report = json.loads(a.read_text(encoding="utf-8"))
+    agent = report["agents"][0]
+    assert agent["discovered_at"] == "1970-01-01T00:00:00Z"
+    assert agent["last_seen"] == "1970-01-01T00:00:00Z"
+    # Byte-identical across repeated runs of the same input.
+    assert a.read_text(encoding="utf-8") == b.read_text(encoding="utf-8")
+
+
+def test_scan_dev_null_output_honors_policy_exit_code(tmp_path):
+    """`-o /dev/null` discards output but must not mask --fail-on-severity (#3643).
+
+    Previously the null sink tripped SystemExit(2) (console-to-file guard /
+    extension inference) regardless of findings.
+    """
+    agent, br = _critical_scan_mocks()
+
+    def _scan(extra):
+        with (
+            patch("agent_bom.cli.agents.discover_all", return_value=[agent]),
+            patch("agent_bom.cli.agents.extract_packages", return_value=[]),
+            patch("agent_bom.cli.agents.scan_agents_sync", return_value=br),
+            patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=[]),
+        ):
+            return _run(["scan", "--project", str(tmp_path), "-o", "/dev/null", *extra, "--no-auto-update-db"])
+
+    # Critical present + fail-on-severity critical -> policy exit 1 (not 2).
+    assert _scan(["-f", "json", "--fail-on-severity", "critical"]).exit_code == 1
+    # Default console format + null sink no longer false-exits 2.
+    assert _scan(["--fail-on-severity", "critical"]).exit_code == 1
+
+
 def test_scan_format_html(tmp_path):
     """--format html should produce an HTML file."""
     out = tmp_path / "report.html"


### PR DESCRIPTION
Closes #3643

Fixes three QA-found output-consistency defects. Output format must never change the finding set, `--reproducible` must be byte-identical, and `-o /dev/null` must not mask the policy exit code.

## 1. SARIF finding-count parity (SARIF 76 ≠ json/csv/console 75)
`-f sarif` silently auto-enabled dynamic discovery **and the context-graph / toxic-combination evaluator**, so the same input scanned as SARIF emitted a `finding/COMBINATION` result ("AI agent can reach a credential or privileged tool") that `-f json` / `-f csv` of that input never produced — a SIEM/API parity bug. The COMBINATION is a real, gate-tripping finding, but gating it on the *output format* is the defect.

Fix: the SARIF branch keeps only the annotation-only EPSS/KEV enrichment (`enrich`, which never adds/removes findings). Dynamic discovery and the context graph now come solely from explicit flags/presets, so the finding set is identical across every format.

- Before: `-f sarif` results = CVEs + auto-graph COMBINATION; `-f json` = CVEs only.
- After: json `findings[]` == sarif `results` == csv rows for the same scan.

## 2. `--reproducible` didn't pin `discovered_at` / `last_seen`
Per-agent discovery timestamps were wall-clock, so two `--reproducible` scans of the same input diverged (~12 lines) and weren't byte-identical. Now pinned to the same pinned report timestamp (from `--reproducible` / `SOURCE_DATE_EPOCH`), matching how `generated_at` is already handled.

- Verified: two `--reproducible` runs → `diff` empty.

## 3. `scan -o /dev/null` exited 2, masking `--fail-on-severity`
Passing `-o` alone marks the output "explicit", so with the default console format the console-to-file guard raised `SystemExit(2)` before the policy exit code; file formats also mangled `/dev/null` → `/dev/null.json` (unwritable). `/dev/null` (and `os.devnull`) is now a first-class discard sink: writes land on the null device cleanly and the policy exit code stands.

- Verified: `scan <fixture> -f json -o /dev/null --fail-on-severity critical` with a critical present → **exit 1** (was 2); default-console `-o /dev/null` → no false exit 2.

## Tests
Adds 4 regression tests to `tests/test_cli_scan.py` (context-graph not auto-enabled for SARIF, cross-format finding-count parity, reproducible agent-timestamp pinning + byte-identity, `/dev/null` honors policy exit code). Existing `test_cli_scan`, `test_sarif_schema_2_1_0`, `test_output_*`, `test_toxic_findings` suites stay green.