### PR TITLE
Part of #1469 (Phase 0: hardware-backed device identity)

### DIFF
--- a/src/agent_bom/api/fleet_store.py
+++ b/src/agent_bom/api/fleet_store.py
@@ -38,6 +38,7 @@ class FleetAgent(BaseModel):
     agent_type: str
     config_path: str = ""
     source_id: str = ""
+    device_fingerprint: str = ""
     enrollment_name: str = ""
     mdm_provider: str = ""
     lifecycle_state: FleetLifecycleState = FleetLifecycleState.DISCOVERED
@@ -76,7 +77,12 @@ class FleetAgent(BaseModel):
         if not self.updated_at:
             self.updated_at = self.created_at
         if not self.canonical_id:
-            self.canonical_id = canonical_agent_id(self.agent_type, self.name, source_id=self.source_id)
+            self.canonical_id = canonical_agent_id(
+                self.agent_type,
+                self.name,
+                source_id=self.source_id,
+                device_fingerprint=self.device_fingerprint,
+            )
         return self
 
 
@@ -279,14 +285,19 @@ class SQLiteFleetStore:
                 lifecycle_state TEXT NOT NULL,
                 trust_score REAL DEFAULT 0.0,
                 updated_at TEXT NOT NULL,
+                device_fingerprint TEXT NOT NULL DEFAULT '',
                 data TEXT NOT NULL
             )
         """)
         if "canonical_id" not in _table_columns(self._conn, "fleet_agents"):
             self._conn.execute("ALTER TABLE fleet_agents ADD COLUMN canonical_id TEXT NOT NULL DEFAULT ''")
+        if "device_fingerprint" not in _table_columns(self._conn, "fleet_agents"):
+            self._conn.execute("ALTER TABLE fleet_agents ADD COLUMN device_fingerprint TEXT NOT NULL DEFAULT ''")
         self._backfill_canonical_ids()
+        self._backfill_device_fingerprints()
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_name ON fleet_agents(name)")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_canonical_id ON fleet_agents(canonical_id)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_device_fingerprint ON fleet_agents(device_fingerprint)")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_state ON fleet_agents(lifecycle_state)")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_fleet_state_trust_name ON fleet_agents(lifecycle_state, trust_score DESC, name)")
         self._conn.commit()
@@ -300,12 +311,31 @@ class SQLiteFleetStore:
                 (agent.canonical_id, agent.model_dump_json(), agent_id),
             )
 
+    def _backfill_device_fingerprints(self) -> None:
+        """Mirror the persisted ``device_fingerprint`` into its dedicated column.
+
+        Idempotent and cheap: only rows whose column is empty *and* whose stored
+        JSON actually carries a fingerprint are touched, so evidence-less agents
+        (the common case) keep a null/empty column and are never re-processed.
+        """
+        rows = self._conn.execute(
+            "SELECT agent_id, data FROM fleet_agents "
+            "WHERE COALESCE(device_fingerprint, '') = '' "
+            "AND COALESCE(json_extract(data, '$.device_fingerprint'), '') != ''"
+        ).fetchall()
+        for agent_id, raw in rows:
+            agent = FleetAgent.model_validate_json(raw)
+            self._conn.execute(
+                "UPDATE fleet_agents SET device_fingerprint = ? WHERE agent_id = ?",
+                (agent.device_fingerprint, agent_id),
+            )
+
     def put(self, agent: FleetAgent) -> None:
         normalized = FleetAgent.model_validate(agent.model_dump())
         self._conn.execute(
             """INSERT OR REPLACE INTO fleet_agents
-               (agent_id, canonical_id, name, lifecycle_state, trust_score, updated_at, data)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+               (agent_id, canonical_id, name, lifecycle_state, trust_score, updated_at, device_fingerprint, data)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 normalized.agent_id,
                 normalized.canonical_id,
@@ -313,6 +343,7 @@ class SQLiteFleetStore:
                 normalized.lifecycle_state.value,
                 normalized.trust_score,
                 normalized.updated_at,
+                normalized.device_fingerprint,
                 normalized.model_dump_json(),
             ),
         )
@@ -449,8 +480,8 @@ class SQLiteFleetStore:
             return 0
         self._conn.executemany(
             """INSERT OR REPLACE INTO fleet_agents
-               (agent_id, canonical_id, name, lifecycle_state, trust_score, updated_at, data)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+               (agent_id, canonical_id, name, lifecycle_state, trust_score, updated_at, device_fingerprint, data)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             [
                 (
                     normalized.agent_id,
@@ -459,6 +490,7 @@ class SQLiteFleetStore:
                     normalized.lifecycle_state.value,
                     normalized.trust_score,
                     normalized.updated_at,
+                    normalized.device_fingerprint,
                     normalized.model_dump_json(),
                 )
                 for normalized in (FleetAgent.model_validate(agent.model_dump()) for agent in agents)

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -513,6 +513,7 @@ def _sync_scan_agents_to_fleet(agents: list, tenant_id: str = "default") -> None
             fleet_agent = FleetAgent(
                 agent_id=str(uuid.uuid4()),
                 canonical_id=_optional_str(getattr(agent, "canonical_id", "")),
+                device_fingerprint=_optional_str(getattr(agent, "device_fingerprint", "")),
                 name=agent.name,
                 agent_type=agent.agent_type.value if hasattr(agent.agent_type, "value") else str(agent.agent_type),
                 config_path=agent.config_path or "",
@@ -1026,9 +1027,7 @@ def _run_scan_sync(job: ScanJob) -> None:
                 sym_stamped = apply_symbol_reachability_to_blast_radii(blast_radii, _ast_for_reach)
                 if sym_stamped:
                     with lock:
-                        job.progress.append(
-                            f"Symbol reachability: stamped {sym_stamped} blast-radius row(s) with function-level evidence"
-                        )
+                        job.progress.append(f"Symbol reachability: stamped {sym_stamped} blast-radius row(s) with function-level evidence")
         except Exception as reach_exc:  # noqa: BLE001
             _logger.warning("Reachability surfacing skipped: %s", sanitize_error(reach_exc))
         pipeline.complete_step("analysis", f"Computed {len(blast_radii)} blast radius entries", {"blast_radius": len(blast_radii)})

--- a/src/agent_bom/canonical_ids.py
+++ b/src/agent_bom/canonical_ids.py
@@ -50,7 +50,18 @@ def canonical_package_id(name: str, version: str, ecosystem: str, purl: str | No
     return canonical_id("package", canonical_package_key(name, version, ecosystem, purl))
 
 
-def canonical_agent_id(agent_type: str, name: str, *, source_id: str = "") -> str:
+def canonical_agent_id(agent_type: str, name: str, *, source_id: str = "", device_fingerprint: str = "") -> str:
+    """Return a deterministic agent identity.
+
+    A hardware-backed ``device_fingerprint`` (derived from attestation evidence)
+    is preferred when present, so the identity is rooted in the physical device
+    rather than a mutable hostname/config path. Falls back to ``source_id`` and
+    finally the agent name when no fingerprint is available — preserving the
+    identity of agents that carry no hardware evidence.
+    """
+    fingerprint = (device_fingerprint or "").strip()
+    if fingerprint:
+        return canonical_id("agent", agent_type, f"device:{fingerprint}")
     source = (source_id or "").strip()
     if source:
         return canonical_id("agent", agent_type, source)

--- a/src/agent_bom/hardware_evidence.py
+++ b/src/agent_bom/hardware_evidence.py
@@ -113,6 +113,49 @@ def _str(value: Any) -> str:
     return value.strip() if isinstance(value, str) else ""
 
 
+# Attestation-block keys that anchor a *stable* hardware device identity, in
+# strongest-first order. The TPM endorsement-key public part is immutable per
+# device and is the gold-standard anchor; a signed TPM quote and the device
+# serial are progressively weaker but still hardware-rooted. PCR-derived quote
+# blobs can vary per boot, so they rank below the EK pub.
+_DEVICE_ANCHOR_KEYS: tuple[str, ...] = (
+    "ek_pub",
+    "ek_public_key",
+    "ek_public",
+    "tpm_quote",
+    "quote",
+)
+
+
+def device_fingerprint(host: dict[str, Any]) -> str | None:
+    """Derive a stable, privacy-preserving device fingerprint from evidence.
+
+    The fingerprint is a salt-free SHA-256 of the strongest available
+    hardware-rooted anchor — TPM endorsement-key public part, a signed TPM
+    quote, or the device serial — so the same physical device maps to the same
+    identifier across evidence files without exposing the raw anchor.
+
+    Returns ``None`` when the host carries no usable hardware evidence, letting
+    callers fall back to hostname/config-derived identity with no regression.
+
+    Args:
+        host: A single ``hosts[]`` entry from an
+            ``agent-bom.hardware-evidence/v1`` document.
+    """
+    if not isinstance(host, dict):
+        return None
+    attestation = host.get("attestation")
+    if isinstance(attestation, dict):
+        for key in _DEVICE_ANCHOR_KEYS:
+            anchor = _str(attestation.get(key))
+            if anchor:
+                return _fingerprint(f"{key}:{anchor}")
+    serial = _str(host.get("serial"))
+    if serial:
+        return _fingerprint(f"serial:{serial}")
+    return None
+
+
 def _host_key(host: dict[str, Any]) -> str:
     key = _str(host.get("host_id")) or _str(host.get("hostname"))
     if not key:

--- a/tests/test_device_identity.py
+++ b/tests/test_device_identity.py
@@ -1,0 +1,174 @@
+"""Phase 0 hardware-backed device identity (#1469).
+
+Covers the deterministic device fingerprint derived from attestation evidence,
+its preference over hostname-derived source ids in ``canonical_agent_id``, and
+the fleet-store column + idempotent backfill.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+from pathlib import Path
+
+from agent_bom.api.fleet_store import FleetAgent, SQLiteFleetStore
+from agent_bom.canonical_ids import canonical_agent_id
+from agent_bom.hardware_evidence import device_fingerprint
+
+
+def _host(**overrides) -> dict:
+    host = {
+        "hostname": "gpu-node-01",
+        "vendor": "Acme",
+        "model": "PowerEdge R760",
+        "serial": "ABC123",
+        "attestation": {"source": "tpm-quote", "signed": True, "verified": True},
+    }
+    host.update(overrides)
+    return host
+
+
+# ── device_fingerprint ────────────────────────────────────────────────────────
+
+
+def test_fingerprint_deterministic_same_evidence():
+    assert device_fingerprint(_host()) == device_fingerprint(_host())
+
+
+def test_fingerprint_is_hashed_and_hides_serial():
+    fp = device_fingerprint(_host())
+    assert fp is not None
+    assert fp.startswith("sha256:")
+    assert "ABC123" not in fp
+
+
+def test_different_serial_different_fingerprint():
+    assert device_fingerprint(_host(serial="ABC123")) != device_fingerprint(_host(serial="XYZ789"))
+
+
+def test_ek_pub_preferred_over_serial():
+    with_ek = _host(attestation={"source": "tpm-quote", "ek_pub": "EK-PUBLIC-KEY-BLOB"})
+    # EK pub anchors identity, so changing the serial must not change the fingerprint.
+    assert device_fingerprint(with_ek) == device_fingerprint({**with_ek, "serial": "different"})
+    # ... and it differs from the serial-only fingerprint.
+    assert device_fingerprint(with_ek) != device_fingerprint(_host())
+
+
+def test_different_ek_pub_different_fingerprint():
+    a = _host(attestation={"ek_pub": "EK-A"})
+    b = _host(attestation={"ek_pub": "EK-B"})
+    assert device_fingerprint(a) != device_fingerprint(b)
+
+
+def test_no_evidence_returns_none():
+    assert device_fingerprint({"hostname": "h1"}) is None
+    assert device_fingerprint({"hostname": "h1", "attestation": {"signed": True}}) is None
+    assert device_fingerprint("not-a-dict") is None  # type: ignore[arg-type]
+
+
+def test_serial_used_when_attestation_lacks_anchor():
+    host = {"hostname": "h1", "serial": "S-1", "attestation": {"signed": True, "verified": True}}
+    fp = device_fingerprint(host)
+    assert fp is not None and fp.startswith("sha256:")
+
+
+# ── canonical_agent_id preference ──────────────────────────────────────────────
+
+
+def test_canonical_id_prefers_fingerprint_over_source():
+    fp = device_fingerprint(_host())
+    with_fp = canonical_agent_id("claude-desktop", "agent-a", source_id="host-01", device_fingerprint=fp)
+    without_fp = canonical_agent_id("claude-desktop", "agent-a", source_id="host-01")
+    assert with_fp != without_fp
+
+
+def test_canonical_id_no_fingerprint_no_regression():
+    # Absent a fingerprint, identity is unchanged from prior behavior.
+    assert canonical_agent_id("t", "n", source_id="s", device_fingerprint="") == canonical_agent_id("t", "n", source_id="s")
+    assert canonical_agent_id("t", "n", device_fingerprint="") == canonical_agent_id("t", "n")
+
+
+def test_canonical_id_fingerprint_deterministic():
+    fp = device_fingerprint(_host())
+    assert canonical_agent_id("t", "n", device_fingerprint=fp) == canonical_agent_id("t", "n", device_fingerprint=fp)
+
+
+def test_fleet_agent_uses_fingerprint_for_canonical_id():
+    fp = device_fingerprint(_host())
+    with_fp = FleetAgent(agent_id="a1", name="n", agent_type="t", source_id="host-01", device_fingerprint=fp)
+    plain = FleetAgent(agent_id="a2", name="n", agent_type="t", source_id="host-01")
+    assert with_fp.canonical_id != plain.canonical_id
+    assert with_fp.device_fingerprint == fp
+
+
+# ── fleet store column + backfill ──────────────────────────────────────────────
+
+
+def _column_value(db_path: str, agent_id: str) -> str:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute("SELECT device_fingerprint FROM fleet_agents WHERE agent_id = ?", (agent_id,)).fetchone()
+        return row[0] if row else ""
+    finally:
+        conn.close()
+
+
+def test_store_persists_fingerprint_column():
+    fp = device_fingerprint(_host())
+    with tempfile.TemporaryDirectory() as d:
+        db = str(Path(d) / "fleet.db")
+        store = SQLiteFleetStore(db)
+        store.put(FleetAgent(agent_id="a1", name="n", agent_type="t", device_fingerprint=fp))
+        store.put(FleetAgent(agent_id="a2", name="n2", agent_type="t"))
+        assert _column_value(db, "a1") == fp
+        assert _column_value(db, "a2") == ""
+        got = store.get("a1")
+        assert got is not None and got.device_fingerprint == fp
+
+
+def test_backfill_populates_column_from_data_idempotently():
+    fp = device_fingerprint(_host())
+    with tempfile.TemporaryDirectory() as d:
+        db = str(Path(d) / "fleet.db")
+        store = SQLiteFleetStore(db)
+        agent = FleetAgent(agent_id="a1", name="n", agent_type="t", device_fingerprint=fp)
+        # Simulate a legacy row: JSON carries the fingerprint but the column is stale/empty.
+        store.put(agent)
+        store._conn.execute("UPDATE fleet_agents SET device_fingerprint = '' WHERE agent_id = 'a1'")
+        store._conn.commit()
+        assert _column_value(db, "a1") == ""
+
+        store._backfill_device_fingerprints()
+        store._conn.commit()
+        assert _column_value(db, "a1") == fp
+
+        # Idempotent: a second pass is a no-op and touches no rows.
+        store._backfill_device_fingerprints()
+        store._conn.commit()
+        assert _column_value(db, "a1") == fp
+
+
+def test_backfill_leaves_evidenceless_rows_null():
+    with tempfile.TemporaryDirectory() as d:
+        db = str(Path(d) / "fleet.db")
+        store = SQLiteFleetStore(db)
+        store.put(FleetAgent(agent_id="a1", name="n", agent_type="t"))
+        store._backfill_device_fingerprints()
+        store._conn.commit()
+        assert _column_value(db, "a1") == ""
+
+
+def test_reopen_store_backfills_existing_db():
+    fp = device_fingerprint(_host())
+    with tempfile.TemporaryDirectory() as d:
+        db = str(Path(d) / "fleet.db")
+        store = SQLiteFleetStore(db)
+        store.put(FleetAgent(agent_id="a1", name="n", agent_type="t", device_fingerprint=fp))
+        # Blank the column to emulate a pre-migration database, then reopen.
+        store._conn.execute("UPDATE fleet_agents SET device_fingerprint = '' WHERE agent_id = 'a1'")
+        store._conn.commit()
+
+        reopened = SQLiteFleetStore(db)
+        assert _column_value(db, "a1") == fp
+        got = reopened.get("a1")
+        assert got is not None and got.device_fingerprint == fp


### PR DESCRIPTION
## Summary

Phase 0 of #1469: root fleet agent identity in **hardware attestation evidence** instead of a mutable hostname/config path, closing the weakest identity claim in the endpoint story.

- **`hardware_evidence.device_fingerprint(host)`** — deterministic, privacy-preserving fingerprint derived from the strongest available hardware anchor, strongest-first: TPM endorsement-key public part (`ek_pub`) > signed TPM quote > device serial. Salt-free SHA-256 (`sha256:…`), so the raw anchor is never exposed and the same physical device maps to the same id across evidence files. Returns `None` when a host carries no usable hardware evidence.
- **`canonical_agent_id`** — new `device_fingerprint` keyword, preferred over `source_id`. With no fingerprint the identity is byte-for-byte unchanged from prior behavior (no regression for evidence-less agents).
- **`fleet_store`** — `device_fingerprint` column + index on `fleet_agents`, wired through the `FleetAgent` model, `put`, and `batch_put`. `_backfill_device_fingerprints` mirrors `_backfill_canonical_ids` but is both idempotent and cheap: it only touches rows whose stored JSON actually carries a fingerprint but has a stale/empty column, so evidence-less rows stay null and are never re-processed on subsequent startups. Runs on init for existing DBs (safe `ALTER TABLE` guard).
- **`pipeline`** — fleet sync surfaces the fingerprint forward-compatibly via `getattr`.

Read-only / evidence-driven only — no live device probing or MDM API calls (those are Phases 1-3).

## Tests

New `tests/test_device_identity.py` (18 tests): deterministic fingerprint from the same evidence, different evidence → different fingerprint, EK-pub preferred over serial, graceful `None` fallback with no evidence, `canonical_agent_id`/`FleetAgent` prefer the fingerprint when present, column persistence, backfill idempotency, evidence-less rows left null, and reopen-DB backfill. Existing fleet / hardware-evidence / graph / identity suites stay green.