### PR TITLE
Part of #3499 (Iceberg catalog export)

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -171,6 +171,14 @@ so they cannot regress silently, but they are not part of this reference.
 |---|---|---|---|
 | `AGENT_BOM_HUB_OBSERVATIONS_RETENTION_DAYS` | `int` | `365` | Age-based retention for the Postgres occurrence log (``hub_findings_current_observations``). Monthly RANGE partitions are detached and dropped once wholly past this window. ``<= 0`` disables rollover. SQLite and legacy unpartitioned Postgre |
 
+## Iceberg Catalog Export
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_ICEBERG_CATALOG_URL` | `str` | `''` | Optional findings-lake side-write. Disabled unless a REST catalog URL is set. Credentials are deliberately not mirrored here; they stay env/KMS-only and are allowlisted as secret material in scripts/env_var_allowlist.txt. |
+| `AGENT_BOM_ICEBERG_NAMESPACE` | `str` | `'agent_bom'` | — |
+| `AGENT_BOM_ICEBERG_TABLE` | `str` | `'findings'` | — |
+| `AGENT_BOM_ICEBERG_WAREHOUSE` | `str` | `''` | — |
+
 ## Image Scanning
 | Env var | Type | Default | Description |
 |---|---|---|---|

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -92,6 +92,10 @@ AGENT_BOM_DSPM_S3_SAMPLING
 AGENT_BOM_DSPM_GCS_SAMPLING
 # Opt-in (default OFF) bounded database/warehouse row sampling for DSPM content classification. Stores redacted classification counts, never raw row values.
 AGENT_BOM_DSPM_DB_SAMPLING
+# Iceberg REST catalog OAuth2 credential; secret material stays env/KMS-only and out of generated config docs.
+AGENT_BOM_ICEBERG_CREDENTIAL
+# Iceberg REST catalog bearer token; secret material stays env/KMS-only and out of generated config docs.
+AGENT_BOM_ICEBERG_TOKEN
 # base64 Fernet key for at-rest encryption of cloud-connection secrets (ExternalId); secret, env/KMS-only, never in config.py or ENV_VARS.md. With provider=aws-kms it holds the base64 KMS-wrapped data key instead. Accepts a comma-separated list of keys for MultiFernet rotation (first key = primary/encrypt, any key decrypts).
 AGENT_BOM_CONNECTIONS_KEY
 # Selects how the connection encryption key is resolved: env (default) | aws-secrets | aws-kms | vault; read at key-load time in api/connection_crypto.py.

--- a/src/agent_bom/cli/agents/_output.py
+++ b/src/agent_bom/cli/agents/_output.py
@@ -241,6 +241,24 @@ def _enospc_report_fallback(
             )
 
 
+def _register_iceberg_if_configured(report, blast_radii, con, quiet: bool) -> None:
+    """Best-effort Iceberg REST-catalog registration alongside the .parquet file.
+
+    No-op unless an Iceberg catalog URL is configured (env / --iceberg-catalog-url).
+    A catalog/deps error is surfaced as a warning without failing the scan, since
+    the flat Parquet file has already been written.
+    """
+    from agent_bom.output.iceberg_catalog import maybe_register_iceberg
+
+    try:
+        result = maybe_register_iceberg(report, blast_radii)
+    except Exception as exc:  # noqa: BLE001 - degrade cleanly, file already written
+        con.print(f"  [yellow]⚠[/yellow] Iceberg catalog registration skipped: {exc}")
+        return
+    if result and not quiet:
+        con.print(f"  [green]✓[/green] Iceberg snapshot: {result['identifier']} ({result['rows']} rows) → {result['catalog_url']}")
+
+
 def render_output(
     ctx: ScanContext,
     *,
@@ -471,6 +489,7 @@ def render_output(
             out_path = _resolve_output_path(output, output_format)
             export_parquet(report, out_path, blast_radii)
             con.print(f"\n  [green]✓[/green] Parquet findings: {out_path}")
+            _register_iceberg_if_configured(report, blast_radii, con, quiet)
         elif output_format == "markdown":
             out_path = _resolve_output_path(output, output_format)
             export_markdown(report, out_path, blast_radii)
@@ -567,6 +586,7 @@ def render_output(
                 export_csv(report, output, blast_radii)
             elif output.endswith(".parquet"):
                 export_parquet(report, output, blast_radii)
+                _register_iceberg_if_configured(report, blast_radii, con, quiet)
             elif output.endswith(".md"):
                 export_markdown(report, output, blast_radii)
             else:

--- a/src/agent_bom/cli/options_sources.py
+++ b/src/agent_bom/cli/options_sources.py
@@ -2,9 +2,27 @@
 
 from __future__ import annotations
 
+import os
+
 import click
 
 from agent_bom.cli.options_helpers import _apply
+
+
+def _set_env(var: str):
+    """Click callback: mirror a CLI value into ``os.environ`` when provided.
+
+    Keeps Iceberg-catalog config env-driven (the canonical contract) while
+    letting ``--iceberg-*`` flags act as sugar, without threading extra params
+    through the large scan command signature (``expose_value=False``).
+    """
+
+    def _cb(_ctx, _param, value):
+        if value:
+            os.environ[var] = value
+        return value
+
+    return _cb
 
 
 def input_options(fn):
@@ -178,6 +196,39 @@ def output_options(fn):
                     "Visualization: mermaid, graph-html (interactive), svg.\n"
                     "Other: graph (Cytoscape.js graph JSON), badge (single-line status)."
                 ),
+            ),
+            click.option(
+                "--iceberg-catalog-url",
+                "iceberg_catalog_url",
+                default=None,
+                metavar="URL",
+                expose_value=False,
+                callback=_set_env("AGENT_BOM_ICEBERG_CATALOG_URL"),
+                help=(
+                    "Register Parquet findings into an Iceberg REST catalog as a table snapshot "
+                    "(in addition to the flat .parquet file). Requires agent-bom[lake]. "
+                    "Env: AGENT_BOM_ICEBERG_CATALOG_URL. Namespace/table default to agent_bom.findings; "
+                    "override with --iceberg-namespace / --iceberg-table. "
+                    "Auth via AGENT_BOM_ICEBERG_CREDENTIAL or AGENT_BOM_ICEBERG_TOKEN. Disabled by default."
+                ),
+            ),
+            click.option(
+                "--iceberg-namespace",
+                "iceberg_namespace",
+                default=None,
+                metavar="NS",
+                expose_value=False,
+                callback=_set_env("AGENT_BOM_ICEBERG_NAMESPACE"),
+                help="Iceberg namespace for the findings table (default: agent_bom). Env: AGENT_BOM_ICEBERG_NAMESPACE.",
+            ),
+            click.option(
+                "--iceberg-table",
+                "iceberg_table",
+                default=None,
+                metavar="NAME",
+                expose_value=False,
+                callback=_set_env("AGENT_BOM_ICEBERG_TABLE"),
+                help="Iceberg table name for findings (default: findings). Env: AGENT_BOM_ICEBERG_TABLE.",
             ),
             click.option(
                 "--mermaid-mode",

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -254,6 +254,17 @@ DSPM_DB_MAX_CELL_CHARS = _int("AGENT_BOM_DSPM_DB_MAX_CELL_CHARS", 4096)
 LOCAL_ANALYTICS_DB = _str("AGENT_BOM_LOCAL_ANALYTICS_DB", "")
 
 
+# ── Iceberg Catalog Export ───────────────────────────────────────────────────
+# Optional findings-lake side-write. Disabled unless a REST catalog URL is set.
+# Credentials are deliberately not mirrored here; they stay env/KMS-only and are
+# allowlisted as secret material in scripts/env_var_allowlist.txt.
+
+ICEBERG_CATALOG_URL = _str("AGENT_BOM_ICEBERG_CATALOG_URL", "")
+ICEBERG_NAMESPACE = _str("AGENT_BOM_ICEBERG_NAMESPACE", "agent_bom")
+ICEBERG_TABLE = _str("AGENT_BOM_ICEBERG_TABLE", "findings")
+ICEBERG_WAREHOUSE = _str("AGENT_BOM_ICEBERG_WAREHOUSE", "")
+
+
 # ── Graph Retention ───────────────────────────────────────────────────────
 # Age-based graph snapshot retention for self-hosted graph stores. Per-tenant
 # overrides resolve from ``AGENT_BOM_GRAPH_RETENTION_OVERRIDES`` (JSON map) and

--- a/src/agent_bom/output/__init__.py
+++ b/src/agent_bom/output/__init__.py
@@ -41,6 +41,13 @@ from agent_bom.output.cyclonedx_fmt import (  # noqa: E402
     export_cyclonedx,  # noqa: F401
     to_cyclonedx,  # noqa: F401
 )
+from agent_bom.output.iceberg_catalog import (  # noqa: E402
+    IcebergCatalogConfig,  # noqa: F401
+    maybe_register_iceberg,  # noqa: F401
+)
+from agent_bom.output.iceberg_catalog import (
+    register_findings as register_iceberg_findings,  # noqa: F401
+)
 from agent_bom.output.json_fmt import (  # noqa: E402
     _build_framework_summary,  # noqa: F401
     _build_remediation_json,  # noqa: F401
@@ -58,6 +65,7 @@ from agent_bom.output.markdown import (  # noqa: E402
 )
 from agent_bom.output.parquet_fmt import (  # noqa: E402
     export_parquet,  # noqa: F401
+    to_arrow_table,  # noqa: F401
     to_parquet_bytes,  # noqa: F401
 )
 from agent_bom.output.sarif import (  # noqa: E402

--- a/src/agent_bom/output/iceberg_catalog.py
+++ b/src/agent_bom/output/iceberg_catalog.py
@@ -1,0 +1,170 @@
+"""Iceberg REST-catalog registration for the findings lake table (#3499).
+
+Complements ``parquet_fmt`` (flat ``.parquet`` files) by registering the same
+findings as an Apache Iceberg table snapshot through the Iceberg REST Catalog
+API: create the namespace and table if needed, append the finding rows as a
+data file, and commit a new snapshot. Lake consumers then query one consistent,
+versioned table instead of loose files.
+
+Design: this reuses ``pyiceberg``'s ``RestCatalog`` rather than hand-rolling an
+Avro manifest writer. Iceberg's on-disk format needs manifest + manifest-list
+Avro files and column statistics for every commit; ``pyiceberg`` already writes
+those and speaks the REST protocol. The dependency is optional and imported
+lazily, mirroring ``parquet_fmt._require_pyarrow`` — nothing here runs unless a
+catalog URL is configured and the operator installed ``pyiceberg``.
+
+Configuration is env-driven and disabled by default:
+
+- ``AGENT_BOM_ICEBERG_CATALOG_URL`` / ``--iceberg-catalog-url`` (required to enable)
+- ``AGENT_BOM_ICEBERG_NAMESPACE`` / ``--iceberg-namespace`` (default ``agent_bom``)
+- ``AGENT_BOM_ICEBERG_TABLE`` / ``--iceberg-table`` (default ``findings``)
+- ``AGENT_BOM_ICEBERG_CREDENTIAL`` — OAuth2 ``client_id:client_secret``
+- ``AGENT_BOM_ICEBERG_TOKEN`` — bearer token
+- ``AGENT_BOM_ICEBERG_WAREHOUSE`` — warehouse location / identifier
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from agent_bom import config as app_config
+from agent_bom.models import AIBOMReport, BlastRadius
+from agent_bom.output.parquet_fmt import to_arrow_table
+
+DEFAULT_NAMESPACE = "agent_bom"
+DEFAULT_TABLE = "findings"
+
+
+def _require_pyiceberg():
+    try:
+        from pyiceberg.catalog.rest import RestCatalog  # noqa: PLC0415
+    except ImportError as exc:  # pragma: no cover - exercised via test monkeypatch
+        raise RuntimeError("Iceberg catalog export requires pyiceberg. Install with: pip install pyiceberg") from exc
+    return RestCatalog
+
+
+@dataclass(frozen=True)
+class IcebergCatalogConfig:
+    """Connection + target-table settings for the Iceberg REST catalog."""
+
+    catalog_url: str | None = None
+    namespace: str = DEFAULT_NAMESPACE
+    table: str = DEFAULT_TABLE
+    credential: str | None = None
+    token: str | None = None
+    warehouse: str | None = None
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.catalog_url)
+
+    @property
+    def identifier(self) -> str:
+        return f"{self.namespace}.{self.table}"
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        catalog_url: str | None = None,
+        namespace: str | None = None,
+        table: str | None = None,
+    ) -> IcebergCatalogConfig:
+        """Build config from explicit args, falling back to ``AGENT_BOM_ICEBERG_*`` env."""
+        return cls(
+            catalog_url=catalog_url or os.environ.get("AGENT_BOM_ICEBERG_CATALOG_URL") or app_config.ICEBERG_CATALOG_URL or None,
+            namespace=namespace or os.environ.get("AGENT_BOM_ICEBERG_NAMESPACE") or app_config.ICEBERG_NAMESPACE or DEFAULT_NAMESPACE,
+            table=table or os.environ.get("AGENT_BOM_ICEBERG_TABLE") or app_config.ICEBERG_TABLE or DEFAULT_TABLE,
+            credential=os.environ.get("AGENT_BOM_ICEBERG_CREDENTIAL") or None,
+            token=os.environ.get("AGENT_BOM_ICEBERG_TOKEN") or None,
+            warehouse=os.environ.get("AGENT_BOM_ICEBERG_WAREHOUSE") or app_config.ICEBERG_WAREHOUSE or None,
+        )
+
+    def catalog_properties(self) -> dict[str, str]:
+        """REST-catalog property map passed to ``RestCatalog(name, **props)``."""
+        if not self.catalog_url:
+            raise RuntimeError("Iceberg catalog export requires a catalog URL. Set --iceberg-catalog-url or AGENT_BOM_ICEBERG_CATALOG_URL.")
+        props: dict[str, str] = {"uri": self.catalog_url}
+        if self.credential:
+            props["credential"] = self.credential
+        if self.token:
+            props["token"] = self.token
+        if self.warehouse:
+            props["warehouse"] = self.warehouse
+        return props
+
+
+def _build_catalog(config: IcebergCatalogConfig):
+    rest_catalog_cls = _require_pyiceberg()
+    return rest_catalog_cls("agent-bom", **config.catalog_properties())
+
+
+def register_findings(
+    report: AIBOMReport,
+    config: IcebergCatalogConfig,
+    blast_radii: list[BlastRadius] | None = None,
+    *,
+    catalog: Any | None = None,
+) -> dict[str, Any]:
+    """Append the report's CVE findings to the Iceberg table as a new snapshot.
+
+    Creates the namespace and table (matching the shared 27-col Parquet schema)
+    if they do not yet exist, then appends a data file and commits a snapshot.
+    Returns a small summary dict for logging.
+
+    ``catalog`` is injectable for tests; production callers leave it ``None`` so
+    a :class:`RestCatalog` is built from ``config``.
+    """
+    if not config.enabled:
+        raise RuntimeError(
+            "Iceberg catalog export is not configured. Set --iceberg-catalog-url or AGENT_BOM_ICEBERG_CATALOG_URL to enable it."
+        )
+
+    arrow_table = to_arrow_table(report, blast_radii)
+    catalog = catalog if catalog is not None else _build_catalog(config)
+
+    catalog.create_namespace_if_not_exists((config.namespace,))
+    iceberg_table = catalog.create_table_if_not_exists(config.identifier, schema=arrow_table.schema)
+    iceberg_table.append(arrow_table)
+
+    snapshot = None
+    current = getattr(iceberg_table, "current_snapshot", None)
+    if callable(current):
+        snap = current()
+        snapshot = getattr(snap, "snapshot_id", None) if snap is not None else None
+
+    return {
+        "identifier": config.identifier,
+        "rows": arrow_table.num_rows,
+        "snapshot_id": snapshot,
+        "catalog_url": config.catalog_url,
+    }
+
+
+def maybe_register_iceberg(
+    report: AIBOMReport,
+    blast_radii: list[BlastRadius] | None = None,
+    *,
+    catalog_url: str | None = None,
+    namespace: str | None = None,
+    table: str | None = None,
+) -> dict[str, Any] | None:
+    """Register findings to Iceberg iff a catalog is configured; else no-op.
+
+    Returns the summary dict on success, or ``None`` when disabled (the common
+    default path). Used by the CLI output layer as a best-effort side-write
+    alongside the flat ``.parquet`` file.
+    """
+    config = IcebergCatalogConfig.from_env(catalog_url=catalog_url, namespace=namespace, table=table)
+    if not config.enabled:
+        return None
+    return register_findings(report, config, blast_radii)
+
+
+__all__ = [
+    "IcebergCatalogConfig",
+    "maybe_register_iceberg",
+    "register_findings",
+]

--- a/src/agent_bom/output/parquet_fmt.py
+++ b/src/agent_bom/output/parquet_fmt.py
@@ -57,9 +57,7 @@ def _require_pyarrow():
         import pyarrow as pa  # noqa: PLC0415
         import pyarrow.parquet as pq  # noqa: PLC0415
     except ImportError as exc:  # pragma: no cover - exercised via test monkeypatch
-        raise RuntimeError(
-            "Parquet export requires pyarrow. Install with: pip install 'agent-bom[lake]'"
-        ) from exc
+        raise RuntimeError("Parquet export requires pyarrow. Install with: pip install 'agent-bom[lake]'") from exc
     return pa, pq
 
 
@@ -89,18 +87,27 @@ def _row_dict(finding) -> dict[str, Any]:
         "kev_due_date": evidence(finding, "kev_due_date", "") or None,
         "compliance_tags": ";".join(framework_qualified_finding_tags(finding)) or None,
         "symbol_reachability": evidence(finding, "symbol_reachability", "") or None,
-        "reachable_affected_symbols": ";".join(evidence(finding, "reachable_affected_symbols", []) or [])
-        or None,
+        "reachable_affected_symbols": ";".join(evidence(finding, "reachable_affected_symbols", []) or []) or None,
         "graph_reachable": evidence(finding, "graph_reachable", None),
         "graph_min_hop_distance": evidence(finding, "graph_min_hop_distance", None),
     }
 
 
+def to_arrow_table(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None):
+    """Build a PyArrow table of CVE findings using the shared 27-col schema.
+
+    Shared by the Parquet file writer and the Iceberg catalog exporter so lake
+    consumers always see one consistent table shape.
+    """
+    pa, _ = _require_pyarrow()
+    rows = [_row_dict(finding) for finding in cve_findings(report, blast_radii)]
+    return pa.Table.from_pylist(rows, schema=_schema(pa))
+
+
 def to_parquet_bytes(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> bytes:
     """Serialize CVE findings to an in-memory Parquet file."""
     pa, pq = _require_pyarrow()
-    rows = [_row_dict(finding) for finding in cve_findings(report, blast_radii)]
-    table = pa.Table.from_pylist(rows, schema=_schema(pa))
+    table = to_arrow_table(report, blast_radii)
     sink = pa.BufferOutputStream()
     pq.write_table(table, sink, compression="snappy")
     return sink.getvalue().to_pybytes()
@@ -149,4 +156,4 @@ def _schema(pa):
     )
 
 
-__all__ = ["export_parquet", "to_parquet_bytes"]
+__all__ = ["export_parquet", "to_arrow_table", "to_parquet_bytes"]

--- a/tests/test_discovery_envelope.py
+++ b/tests/test_discovery_envelope.py
@@ -165,7 +165,8 @@ def test_aws_envelope_attached_to_discovered_agents(monkeypatch: pytest.MonkeyPa
 
     import agent_bom.cloud.aws as aws_module
 
-    # Feed a single fake Bedrock agent. ECS/SageMaker/etc. are off by default.
+    # Feed a single fake Bedrock agent. Disable the other discovery lanes so this
+    # stays an envelope-wiring test and does not require a fake client per AWS API.
     fake_agent = Agent(
         name="bedrock-agent-1",
         agent_type=AgentType.CUSTOM,
@@ -187,7 +188,15 @@ def test_aws_envelope_attached_to_discovered_agents(monkeypatch: pytest.MonkeyPa
 
     monkeypatch.setattr(aws_module.boto3 if hasattr(aws_module, "boto3") else __import__("boto3"), "Session", lambda **kw: _FakeSession())
 
-    agents, warnings = aws_module.discover(include_ecs=False)
+    agents, warnings = aws_module.discover(
+        include_ecs=False,
+        include_lambda=False,
+        include_sagemaker=False,
+        include_eks=False,
+        include_step_functions=False,
+        include_ec2=False,
+        include_iam=False,
+    )
     assert len(agents) == 1
     envelope = agents[0].discovery_envelope
     assert envelope is not None

--- a/tests/test_iceberg_catalog.py
+++ b/tests/test_iceberg_catalog.py
@@ -1,0 +1,203 @@
+"""Iceberg REST-catalog registration contract for data-lake interop (#3499)."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.models import AIBOMReport, BlastRadius, Package, Severity, Vulnerability
+from agent_bom.output import iceberg_catalog
+from agent_bom.output.iceberg_catalog import (
+    DEFAULT_NAMESPACE,
+    DEFAULT_TABLE,
+    IcebergCatalogConfig,
+    maybe_register_iceberg,
+    register_findings,
+)
+
+pytest.importorskip("pyarrow")
+
+_ICEBERG_ENV = (
+    "AGENT_BOM_ICEBERG_CATALOG_URL",
+    "AGENT_BOM_ICEBERG_NAMESPACE",
+    "AGENT_BOM_ICEBERG_TABLE",
+    "AGENT_BOM_ICEBERG_CREDENTIAL",
+    "AGENT_BOM_ICEBERG_TOKEN",
+    "AGENT_BOM_ICEBERG_WAREHOUSE",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for var in _ICEBERG_ENV:
+        monkeypatch.delenv(var, raising=False)
+
+
+def _report() -> tuple[AIBOMReport, BlastRadius]:
+    vuln = Vulnerability(id="CVE-2099-8", summary="x", severity=Severity.HIGH)
+    pkg = Package(name="requests", version="2.0.0", ecosystem="pypi")
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=[],
+        affected_agents=["agent-a"],
+        exposed_credentials=[],
+        exposed_tools=[],
+        graph_reachable=True,
+        graph_min_hop_distance=1,
+    )
+    return AIBOMReport(agents=[], blast_radii=[br], scan_id="iceberg-test"), br
+
+
+class _FakeSnapshot:
+    snapshot_id = 4242
+
+
+class _FakeTable:
+    def __init__(self, identifier, schema):
+        self.identifier = identifier
+        self.schema = schema
+        self.appended = []
+
+    def append(self, arrow_table):
+        self.appended.append(arrow_table)
+
+    def current_snapshot(self):
+        return _FakeSnapshot()
+
+
+class _FakeCatalog:
+    """In-memory stand-in for pyiceberg RestCatalog (no network)."""
+
+    def __init__(self):
+        self.namespaces: list[tuple] = []
+        self.tables: dict[str, _FakeTable] = {}
+
+    def create_namespace_if_not_exists(self, namespace):
+        self.namespaces.append(namespace)
+
+    def create_table_if_not_exists(self, identifier, schema):
+        table = self.tables.get(identifier)
+        if table is None:
+            table = _FakeTable(identifier, schema)
+            self.tables[identifier] = table
+        return table
+
+
+# ── config / request construction ────────────────────────────────────────────
+
+
+def test_config_disabled_by_default() -> None:
+    assert IcebergCatalogConfig().enabled is False
+    assert IcebergCatalogConfig(catalog_url="http://cat/").enabled is True
+
+
+def test_config_from_env(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_ICEBERG_CATALOG_URL", "http://catalog:8181")
+    monkeypatch.setenv("AGENT_BOM_ICEBERG_NAMESPACE", "lake")
+    monkeypatch.setenv("AGENT_BOM_ICEBERG_TABLE", "cves")
+    monkeypatch.setenv("AGENT_BOM_ICEBERG_TOKEN", "tok123")
+
+    config = IcebergCatalogConfig.from_env()
+    assert config.enabled is True
+    assert config.identifier == "lake.cves"
+    props = config.catalog_properties()
+    assert props == {"uri": "http://catalog:8181", "token": "tok123"}
+
+
+def test_config_defaults_and_explicit_args_win() -> None:
+    config = IcebergCatalogConfig.from_env(catalog_url="http://c/", namespace="ns")
+    assert config.namespace == "ns"
+    assert config.table == DEFAULT_TABLE
+    assert config.namespace != DEFAULT_NAMESPACE
+
+
+def test_catalog_properties_requires_url() -> None:
+    with pytest.raises(RuntimeError, match="catalog URL"):
+        IcebergCatalogConfig().catalog_properties()
+
+
+def test_catalog_properties_includes_credential_and_warehouse() -> None:
+    config = IcebergCatalogConfig(catalog_url="http://c/", credential="id:secret", warehouse="s3://wh")
+    props = config.catalog_properties()
+    assert props["credential"] == "id:secret"
+    assert props["warehouse"] == "s3://wh"
+
+
+# ── disabled-by-default no-op ─────────────────────────────────────────────────
+
+
+def test_maybe_register_noop_when_disabled() -> None:
+    report, br = _report()
+    assert maybe_register_iceberg(report, [br]) is None
+
+
+def test_register_findings_rejects_disabled_config() -> None:
+    report, br = _report()
+    with pytest.raises(RuntimeError, match="not configured"):
+        register_findings(report, IcebergCatalogConfig(), [br])
+
+
+# ── deps-absent graceful error ────────────────────────────────────────────────
+
+
+def test_deps_absent_graceful_error(monkeypatch) -> None:
+    def _boom():
+        raise RuntimeError("Iceberg catalog export requires pyiceberg. Install with: pip install pyiceberg")
+
+    monkeypatch.setattr(iceberg_catalog, "_require_pyiceberg", _boom)
+    report, br = _report()
+    config = IcebergCatalogConfig(catalog_url="http://c/")
+    # catalog built internally -> _require_pyiceberg raises install hint
+    with pytest.raises(RuntimeError, match=r"pip install pyiceberg"):
+        register_findings(report, config, [br])
+
+
+# ── round-trip against a fake REST catalog ────────────────────────────────────
+
+
+def test_round_trip_against_fake_catalog() -> None:
+    report, br = _report()
+    config = IcebergCatalogConfig(catalog_url="http://c/", namespace="lake", table="cves")
+    fake = _FakeCatalog()
+
+    result = register_findings(report, config, [br], catalog=fake)
+
+    assert fake.namespaces == [("lake",)]
+    assert "lake.cves" in fake.tables
+    table = fake.tables["lake.cves"]
+    # schema handed to Iceberg must match the shared 27-col Parquet schema
+    assert len(table.schema) == 27
+    assert table.schema.names[0] == "cve_id"
+    assert len(table.appended) == 1
+    assert table.appended[0].num_rows == 1
+    assert result == {
+        "identifier": "lake.cves",
+        "rows": 1,
+        "snapshot_id": 4242,
+        "catalog_url": "http://c/",
+    }
+
+
+def test_round_trip_appends_to_existing_table() -> None:
+    report, br = _report()
+    config = IcebergCatalogConfig(catalog_url="http://c/")
+    fake = _FakeCatalog()
+
+    register_findings(report, config, [br], catalog=fake)
+    register_findings(report, config, [br], catalog=fake)
+
+    # namespace + table create-if-not-exists are idempotent; two snapshots appended
+    table = fake.tables[f"{DEFAULT_NAMESPACE}.{DEFAULT_TABLE}"]
+    assert len(table.appended) == 2
+
+
+def test_maybe_register_uses_env(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_ICEBERG_CATALOG_URL", "http://c/")
+    fake = _FakeCatalog()
+    monkeypatch.setattr(iceberg_catalog, "_build_catalog", lambda config: fake)
+
+    report, br = _report()
+    result = maybe_register_iceberg(report, [br])
+    assert result is not None
+    assert result["identifier"] == f"{DEFAULT_NAMESPACE}.{DEFAULT_TABLE}"
+    assert fake.tables[result["identifier"]].appended[0].num_rows == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1364,11 +1364,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "7.1.4"
+version = "6.2.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/8b/0d3945a13955303b81272f759a0331e54c5c793da455e6f5706b89d2639c/cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6", size = 40085, upload-time = "2026-05-21T22:40:43.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/91/d9ae9a66b01102a18cd16db0cf4cd54187ffe10f0865cc80071a4104fbb3/cachetools-6.2.6.tar.gz", hash = "sha256:16c33e1f276b9a9c0b49ab5782d901e3ad3de0dd6da9bf9bcd29ac5672f2f9e6", size = 32363, upload-time = "2026-01-27T20:32:59.956Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8c/7b/1fc1c09cc0756cf25861a3be10565915953876da48bb228fb9a672b20a42/cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54", size = 16761, upload-time = "2026-05-21T22:40:41.845Z" },
+    { url = "https://files.pythonhosted.org/packages/90/45/f458fa2c388e79dd9d8b9b0c99f1d31b568f27388f2fdba7bb66bbc0c6ed/cachetools-6.2.6-py3-none-any.whl", hash = "sha256:8c9717235b3c651603fff0076db52d6acbfd1b338b8ed50256092f7ce9c85bda", size = 11668, upload-time = "2026-01-27T20:32:58.527Z" },
 ]
 
 [[package]]
@@ -5032,15 +5032,15 @@ wheels = [
 
 [[package]]
 name = "rich"
-version = "15.0.0"
+version = "14.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Registers Parquet finding exports into an **Iceberg REST catalog** as versioned table snapshots — the data-lake tail of #3499 (audit item T). Today only flat `.parquet` files are written (`parquet_fmt.py`); this adds an opt-in path that creates the namespace + table, appends a data file, and commits a snapshot so lake consumers query one consistent, versioned table.

## Design: pyiceberg vs thin client

Uses **pyiceberg's `RestCatalog`** rather than a hand-rolled REST client. A real Iceberg append must write Avro manifest + manifest-list files and per-column statistics for every commit; pyiceberg already does this and speaks the REST protocol, and it depends on `pyarrow` which the `[lake]` extra already ships. A thin client that only POSTs to the catalog cannot produce valid snapshots without reimplementing the Avro manifest writer — too heavy and error-prone. The dependency is optional and imported lazily (mirrors `parquet_fmt._require_pyarrow`); nothing runs unless a catalog URL is configured.

## What's wired

- **`output/iceberg_catalog.py`** (new) — `IcebergCatalogConfig` (env + args), `register_findings()` (namespace/table create-if-not-exists → append → snapshot), `maybe_register_iceberg()` (no-op unless configured). Schema comes from the shared Parquet schema, so no drift.
- **`parquet_fmt.py`** — extracted `to_arrow_table()` so both the flat-file writer and the Iceberg path reuse the identical 27-col schema + rows.
- **CLI** — `--iceberg-catalog-url` / `--iceberg-namespace` / `--iceberg-table` (env: `AGENT_BOM_ICEBERG_*`), disabled by default. Registration runs best-effort right after the `.parquet` write and degrades to a warning if the catalog/deps are unavailable — the file is already on disk.
- **`pyiceberg>=0.7`** added to the optional `[lake]` extra.

Config (env-driven, disabled by default): `AGENT_BOM_ICEBERG_CATALOG_URL`, `_NAMESPACE` (default `agent_bom`), `_TABLE` (default `findings`), `_CREDENTIAL` (OAuth2 `id:secret`), `_TOKEN` (bearer), `_WAREHOUSE`.

## Tests

`tests/test_iceberg_catalog.py` — 12 tests: config/request construction, disabled-by-default no-op, deps-absent graceful error (monkeypatched `_require_pyiceberg`), and round-trip against an in-memory fake REST catalog (no network) asserting namespace/table creation, the 27-col schema handed to Iceberg, snapshot append, and idempotent re-append. Existing `test_parquet_export.py` stays green (14 passed total).

## Tradeoff to note

pyiceberg caps `rich<15`, so the lock moves **rich 15.0.0 → 14.3.4** and **cachetools 7 → 6.2.6** project-wide. Core only requires `rich>=13`; the app imports and the full parquet/iceberg suite pass on 14.3.4. Flagging for awareness since `rich` is central to the CLI — no pyiceberg release allows `rich>=15`, so this is unavoidable if pyiceberg lands in the lock.

## Deferred (issue tail)

ClickHouse findings-ingest wiring and Swift bare-call precision remain separate items on #3499.