### PR TITLE
Part of #3192 (drift-as-UI lens)

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1685,6 +1685,68 @@ async def get_fix_first_graph_view(
     return await _graph_compute_call(_fix_first_graph_view_payload, graph, cve=cve, package=package, agent=agent, limit=limit)
 
 
+def _diff_entry_node_id(entry: Any) -> str | None:
+    """Node id for a diff entry, tolerating both dict and bare-id shapes."""
+    if isinstance(entry, dict):
+        nid = entry.get("id")
+        return str(nid) if nid is not None else None
+    if entry is None:
+        return None
+    return str(entry)
+
+
+def _diff_entry_edge_key(entry: Any) -> str:
+    """Stable ``source|target|relationship`` key for a diff edge entry.
+
+    Handles the three shapes the stores emit: ``(source, target, relationship)``
+    tuples for added/removed edges, and ``{"before"|"after": edge}`` wrappers
+    (or a bare edge dict) for changed edges.
+    """
+    if isinstance(entry, dict):
+        edge = entry.get("after") or entry.get("before") or entry
+        src = edge.get("source_id") or edge.get("source") or ""
+        tgt = edge.get("target_id") or edge.get("target") or ""
+        rel = edge.get("relationship") or ""
+        return f"{src}|{tgt}|{rel}"
+    if isinstance(entry, (list, tuple)) and len(entry) >= 3:
+        return f"{entry[0]}|{entry[1]}|{entry[2]}"
+    return str(entry)
+
+
+def _tag_diff_change_kinds(diff: dict[str, Any]) -> dict[str, Any]:
+    """Tag each diff node/edge with a ``change_kind`` for the drift UI lens.
+
+    Adds an in-place ``change_kind`` (``new`` | ``removed`` | ``changed``) to
+    every dict-shaped node/edge entry (leaving any pre-existing value intact)
+    and attaches a ``change_kind_index`` mapping node ids and edge keys to
+    their kind so the client can classify the rendered graph without having to
+    reconcile the three heterogeneous entry shapes. Entries not present in the
+    index are treated as ``unchanged`` by consumers.
+    """
+    if not isinstance(diff, dict):
+        return diff
+
+    node_kinds: dict[str, str] = {}
+    for kind, key in (("new", "nodes_added"), ("removed", "nodes_removed"), ("changed", "nodes_changed")):
+        for entry in diff.get(key) or []:
+            nid = _diff_entry_node_id(entry)
+            if nid is None:
+                continue
+            node_kinds[nid] = kind
+            if isinstance(entry, dict):
+                entry.setdefault("change_kind", kind)
+
+    edge_kinds: dict[str, str] = {}
+    for kind, key in (("new", "edges_added"), ("removed", "edges_removed"), ("changed", "edges_changed")):
+        for entry in diff.get(key) or []:
+            edge_kinds[_diff_entry_edge_key(entry)] = kind
+            if isinstance(entry, dict):
+                entry.setdefault("change_kind", kind)
+
+    diff["change_kind_index"] = {"nodes": node_kinds, "edges": edge_kinds}
+    return diff
+
+
 @router.get("/v1/graph/diff", tags=["graph"])
 async def get_graph_diff(
     request: Request,
@@ -1692,7 +1754,8 @@ async def get_graph_diff(
     new: str = Query(..., description="New scan ID"),
 ) -> dict:
     """Diff two scan snapshots — nodes/edges added, removed, changed."""
-    return await _graph_store_call(_get_graph_store_or_503().diff_snapshots, old, new, tenant_id=_tenant(request))
+    diff = await _graph_store_call(_get_graph_store_or_503().diff_snapshots, old, new, tenant_id=_tenant(request))
+    return _tag_diff_change_kinds(diff)
 
 
 @router.get("/v1/graph/edges/active", tags=["graph"])

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -364,6 +364,61 @@ class TestGraphEndpointLogic:
         assert diff["nodes_added"][0]["label"] == "new-agent"
         assert {node["id"] for node in diff["nodes_removed"]} >= {"agent:b"}
 
+
+def test_graph_diff_route_tags_change_kind(tmp_path) -> None:
+    """/v1/graph/diff must tag nodes/edges with change_kind for the drift lens."""
+    store = SQLiteGraphStore(tmp_path / "diff-graph.db")
+
+    g1 = UnifiedGraph(scan_id="drift-s1")
+    g1.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+    g1.add_node(UnifiedNode(id="agent:gone", entity_type=EntityType.AGENT, label="agent-gone"))
+    g1.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+    g1.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES))
+    g1.add_edge(UnifiedEdge(source="agent:gone", target="server:s", relationship=RelationshipType.USES))
+    store.save_graph(g1)
+
+    g2 = UnifiedGraph(scan_id="drift-s2")
+    g2.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+    g2.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+    # Same id as s1 but a mutated risk_score -> classified as "changed".
+    g2.add_node(
+        UnifiedNode(
+            id="vuln:v",
+            entity_type=EntityType.VULNERABILITY,
+            label="vuln-v",
+            severity="critical",
+            risk_score=9.0,
+        )
+    )
+    g2.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES))
+    g2.add_edge(UnifiedEdge(source="server:s", target="vuln:v", relationship=RelationshipType.VULNERABLE_TO))
+    store.save_graph(g2)
+
+    original = api_stores._graph_store
+    try:
+        set_graph_store(store)
+        client = TestClient(app)
+        resp = client.get("/v1/graph/diff?old=drift-s1&new=drift-s2")
+        assert resp.status_code == 200
+        body = resp.json()
+
+        # Per-entry tags on the dict-shaped node lists.
+        assert all(node["change_kind"] == "new" for node in body["nodes_added"])
+        assert {node["id"] for node in body["nodes_added"]} == {"vuln:v"}
+        assert all(node["change_kind"] == "removed" for node in body["nodes_removed"])
+        assert {node["id"] for node in body["nodes_removed"]} == {"agent:gone"}
+
+        # Unified index the client consumes to classify the rendered graph.
+        index = body["change_kind_index"]
+        assert index["nodes"]["vuln:v"] == "new"
+        assert index["nodes"]["agent:gone"] == "removed"
+        # server:s + agent:a persisted unchanged, so they are absent from the index.
+        assert "server:s" not in index["nodes"]
+        assert index["edges"]["server:s|vuln:v|vulnerable_to"] == "new"
+        assert index["edges"]["agent:gone|server:s|uses"] == "removed"
+    finally:
+        set_graph_store(original)
+
     def test_edge_history_tracks_new_changed_removed_and_unchanged_edges(self, graph_db):
         g1 = UnifiedGraph(scan_id="history-s1", tenant_id="default", created_at="2026-06-01T00:00:00Z")
         for node_id in ("agent:a", "server:b", "tool:c", "vuln:d"):

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -132,3 +132,23 @@ main > div {
   from { opacity: 0; transform: translateY(4px); }
   to { opacity: 1; transform: translateY(0); }
 }
+
+/* Drift lens (#3192) — snapshot change-kind rings painted on React Flow node
+   wrappers when the drift lens is active. Kept as static classes so Tailwind's
+   purge never strips them and both graph renderers share one visual language. */
+.drift-ring-new {
+  border-radius: 0.85rem;
+  box-shadow: 0 0 0 2px #10b981, 0 0 14px -2px rgba(16, 185, 129, 0.55);
+}
+.drift-ring-changed {
+  border-radius: 0.85rem;
+  box-shadow: 0 0 0 2px #f59e0b, 0 0 14px -2px rgba(245, 158, 11, 0.55);
+}
+.drift-ring-removed {
+  border-radius: 0.85rem;
+  box-shadow: 0 0 0 2px #f43f5e, 0 0 14px -2px rgba(244, 63, 94, 0.55);
+}
+.drift-ring-critical {
+  border-radius: 0.85rem;
+  box-shadow: 0 0 0 2px #f43f5e, 0 0 0 5px rgba(244, 63, 94, 0.25);
+}

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -124,8 +124,15 @@ import {
   isCriticalChange,
   type DriftLensFilter,
 } from "@/lib/filter-algebra";
-import { GraphDriftLegend } from "@/components/graph-drift-legend";
 import { useCaptureMode } from "@/lib/use-capture-mode";
+
+const GraphDriftLegend = dynamic(
+  () =>
+    import("@/components/graph-drift-legend").then(
+      (mod) => mod.GraphDriftLegend,
+    ),
+  { ssr: false },
+);
 
 const SigmaGraphOverview = dynamic(
   () =>

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -71,6 +71,10 @@ import {
 import {
   BACKGROUND_COLOR,
   BACKGROUND_GAP,
+  buildDriftIndex,
+  changeKindForEdge,
+  changeKindForNode,
+  CHANGE_KIND_META,
   CONTROLS_CLASS,
   legendItemsForVisibleGraph,
   MINIMAP_BG,
@@ -78,6 +82,7 @@ import {
   MINIMAP_MASK,
   minimapNodeColor,
   readableGraphEdges,
+  type ChangeKind,
 } from "@/lib/graph-utils";
 import {
   graphFitViewOptions,
@@ -114,8 +119,12 @@ import {
 import {
   applyFilters,
   decodeFiltersFromParams,
+  driftFilterPasses,
   encodeFiltersToParams,
+  isCriticalChange,
+  type DriftLensFilter,
 } from "@/lib/filter-algebra";
+import { GraphDriftLegend } from "@/components/graph-drift-legend";
 import { useCaptureMode } from "@/lib/use-capture-mode";
 
 const SigmaGraphOverview = dynamic(
@@ -644,6 +653,8 @@ function GraphPageInner() {
   const [error, setError] = useState<string | null>(null);
   const [diffError, setDiffError] = useState<string | null>(null);
   const [graphDiff, setGraphDiff] = useState<GraphDiffResponse | null>(null);
+  const [driftLensActive, setDriftLensActive] = useState(false);
+  const [driftFilter, setDriftFilter] = useState<DriftLensFilter>("all");
   const [selectedNode, setSelectedNode] = useState<LineageNodeData | null>(
     null,
   );
@@ -1341,7 +1352,7 @@ function GraphPageInner() {
   const canvasLayoutNodes = rollupNavigationActive
     ? (aggregated.nodes as Node<LineageNodeData>[])
     : lineageLayoutNodes;
-  const displayNodes = useMemo<Node<LineageNodeData>[]>(() => {
+  const baseDisplayNodes = useMemo<Node<LineageNodeData>[]>(() => {
     if (blastRadius) {
       return canvasLayoutNodes.map((node) => {
         const inBlast = blastRadius.nodeIds.has(node.id);
@@ -1431,13 +1442,75 @@ function GraphPageInner() {
     effectiveLodBand,
   ]);
 
+  // Drift lens (#3192) — classify the currently-rendered snapshot against the
+  // previous one using the diff index the server tags. The lens is inert unless
+  // a diff exists AND the operator armed it, so the default view never changes.
+  const driftIndex = useMemo(() => buildDriftIndex(graphDiff), [graphDiff]);
+  const driftLensEngaged =
+    driftLensActive && Boolean(graphDiff) && driftIndex.hasChanges;
+
+  // Keep the lens honest: a snapshot with no older baseline (or no changes)
+  // disarms the lens and resets the focus chip so it can never linger as a
+  // stale overlay on the default view.
+  useEffect(() => {
+    if (!graphDiff) {
+      setDriftLensActive(false);
+      setDriftFilter("all");
+    }
+  }, [graphDiff]);
+
+  const displayNodes = useMemo<Node<LineageNodeData>[]>(() => {
+    if (!driftLensEngaged) return baseDisplayNodes;
+    return baseDisplayNodes.map((node) => {
+      const kind = changeKindForNode(node.id, driftIndex);
+      const critical = isCriticalChange(kind, node.data.severity);
+      const passes = driftFilterPasses(kind, driftFilter, critical);
+      const ringClass =
+        driftFilter === "critical" && critical
+          ? "drift-ring-critical"
+          : CHANGE_KIND_META[kind].ringClass;
+      const className = [node.className, ringClass].filter(Boolean).join(" ");
+      // Focus (not filter): non-matching nodes dim so topology stays legible.
+      const dimmed = Boolean(node.data.dimmed) || !passes;
+      return {
+        ...node,
+        className,
+        data: { ...node.data, dimmed },
+      };
+    });
+  }, [baseDisplayNodes, driftIndex, driftLensEngaged, driftFilter]);
+
+  // Live change-kind tallies over the rendered graph — `unchanged` is derived
+  // here (the diff index only carries actively-changed ids) so the legend and
+  // chips reflect exactly what the operator sees on the canvas.
+  const drift = useMemo<{
+    counts: Record<ChangeKind, number>;
+    critical: number;
+  }>(() => {
+    const counts: Record<ChangeKind, number> = {
+      new: 0,
+      changed: 0,
+      removed: driftIndex.counts.removed,
+      unchanged: 0,
+    };
+    let critical = 0;
+    for (const node of baseDisplayNodes) {
+      const kind = changeKindForNode(node.id, driftIndex);
+      if (kind === "new" || kind === "changed" || kind === "unchanged") {
+        counts[kind] += 1;
+      }
+      if (isCriticalChange(kind, node.data.severity)) critical += 1;
+    }
+    return { counts, critical };
+  }, [baseDisplayNodes, driftIndex]);
+
   const compressedGroupCount = aggregatedClusterNodes.length;
   const sourceNodeCount = rollupNavigationActive
     ? (rollupView?.summary.total_nodes ?? estateNodeCount)
     : (graphData?.nodes.length ?? flow.nodes.length);
   const renderedNodeCount = displayNodes.length;
 
-  const displayEdges = useMemo(() => {
+  const baseDisplayEdges = useMemo(() => {
     if (attackPathEdgeKeys) {
       return layoutEdges
         .filter((edge) =>
@@ -1554,6 +1627,42 @@ function GraphPageInner() {
     graphLayoutKind,
     captureMode,
   ]);
+
+  // Drift lens edge emphasis — new/changed edges adopt their change-kind colour
+  // so the lens reads as one system with the node rings. Inert (identity) when
+  // the lens is disengaged.
+  const displayEdges = useMemo(() => {
+    if (!driftLensEngaged) return baseDisplayEdges;
+    return baseDisplayEdges.map((edge): Edge => {
+      const relationship =
+        typeof edge.data?.relationship === "string"
+          ? edge.data.relationship
+          : "";
+      const kind = changeKindForEdge(
+        edge.source,
+        edge.target,
+        relationship,
+        driftIndex,
+      );
+      if (kind === "unchanged") return edge;
+      const meta = CHANGE_KIND_META[kind];
+      const currentOpacity =
+        typeof edge.style?.opacity === "number" ? edge.style.opacity : 0.4;
+      const currentWidth =
+        typeof edge.style?.strokeWidth === "number"
+          ? edge.style.strokeWidth
+          : 1.4;
+      return {
+        ...edge,
+        style: {
+          ...edge.style,
+          stroke: meta.color,
+          opacity: Math.max(currentOpacity, 0.85),
+          strokeWidth: Math.max(currentWidth, 2.2),
+        },
+      };
+    });
+  }, [baseDisplayEdges, driftLensEngaged, driftIndex]);
 
   const graphEvaluation = useMemo(
     () => evaluateGraphUx(graphData, displayNodes, displayEdges),
@@ -2399,6 +2508,21 @@ function GraphPageInner() {
                 </div>
               )}
           </details>
+        )}
+
+        {graphDiff && (
+          <GraphDriftLegend
+            active={driftLensActive}
+            onToggleActive={(next) => {
+              setDriftLensActive(next);
+              if (!next) setDriftFilter("all");
+            }}
+            filter={driftFilter}
+            onFilterChange={setDriftFilter}
+            counts={drift.counts}
+            criticalCount={drift.critical}
+            comparedLabel={previousSnapshot?.scan_id.slice(0, 12)}
+          />
         )}
 
         <details className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3 text-xs text-zinc-400 group">

--- a/ui/components/graph-drift-legend.tsx
+++ b/ui/components/graph-drift-legend.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+/**
+ * Drift lens legend + filter chips (#3192).
+ *
+ * A first-class UI surface for asset-lifecycle drift. Given the change-kind
+ * counts the client derives from the `/v1/graph/diff` index, it renders:
+ *   - a toggle that arms/disarms the lens (inert when no diff is available),
+ *   - focus chips (all / new / changed / critical / removed),
+ *   - a colour legend so the node rings on the canvas are self-explanatory.
+ *
+ * Purely presentational — all classification lives in graph-utils/filter-algebra
+ * so this component stays reusable across the ReactFlow and WebGL renderers.
+ */
+
+import { GitCompareArrows } from "lucide-react";
+
+import {
+  CHANGE_KIND_META,
+  CHANGE_KIND_ORDER,
+  type ChangeKind,
+} from "@/lib/graph-utils";
+import {
+  DRIFT_LENS_FILTERS,
+  type DriftLensFilter,
+} from "@/lib/filter-algebra";
+
+const CHIP_LABELS: Record<DriftLensFilter, string> = {
+  all: "All",
+  new: "New",
+  changed: "Changed",
+  critical: "Critical change",
+  removed: "Removed",
+};
+
+function chipCount(
+  filter: DriftLensFilter,
+  counts: Record<ChangeKind, number>,
+  criticalCount: number,
+): number {
+  if (filter === "all") {
+    return counts.new + counts.changed + counts.removed + counts.unchanged;
+  }
+  if (filter === "critical") return criticalCount;
+  return counts[filter];
+}
+
+export interface GraphDriftLegendProps {
+  active: boolean;
+  onToggleActive: (next: boolean) => void;
+  filter: DriftLensFilter;
+  onFilterChange: (filter: DriftLensFilter) => void;
+  counts: Record<ChangeKind, number>;
+  criticalCount: number;
+  /** Short id of the older snapshot this diff compares against, if any. */
+  comparedLabel?: string | undefined;
+}
+
+export function GraphDriftLegend({
+  active,
+  onToggleActive,
+  filter,
+  onFilterChange,
+  counts,
+  criticalCount,
+  comparedLabel,
+}: GraphDriftLegendProps) {
+  return (
+    <div
+      data-testid="graph-drift-legend"
+      className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <GitCompareArrows className="h-4 w-4 text-sky-400" />
+          <span className="text-[10px] uppercase tracking-[0.24em] text-sky-400">
+            Drift lens
+          </span>
+          {comparedLabel ? (
+            <span className="text-xs text-zinc-500">
+              vs <span className="font-mono">{comparedLabel}</span>
+            </span>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={active}
+          data-testid="graph-drift-toggle"
+          onClick={() => onToggleActive(!active)}
+          className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+            active
+              ? "border-sky-500/60 bg-sky-500/15 text-sky-200"
+              : "border-zinc-700 bg-zinc-900/60 text-zinc-400 hover:text-zinc-200"
+          }`}
+        >
+          {active ? "Lens on" : "Lens off"}
+        </button>
+      </div>
+
+      {active ? (
+        <>
+          <div
+            className="mt-3 flex flex-wrap gap-2"
+            data-testid="graph-drift-chips"
+            role="group"
+            aria-label="Drift focus"
+          >
+            {DRIFT_LENS_FILTERS.map((chip) => {
+              const selected = chip === filter;
+              const count = chipCount(chip, counts, criticalCount);
+              return (
+                <button
+                  key={chip}
+                  type="button"
+                  aria-pressed={selected}
+                  data-testid={`graph-drift-chip-${chip}`}
+                  onClick={() => onFilterChange(chip)}
+                  className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+                    selected
+                      ? "border-sky-500/60 bg-sky-500/15 text-sky-100"
+                      : "border-zinc-700 bg-zinc-900/60 text-zinc-400 hover:text-zinc-200"
+                  }`}
+                >
+                  {CHIP_LABELS[chip]}
+                  <span className="ml-1.5 font-mono text-[11px] text-zinc-500">
+                    {count}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          <div
+            className="mt-3 flex flex-wrap gap-x-4 gap-y-1.5"
+            data-testid="graph-drift-legend-items"
+          >
+            {CHANGE_KIND_ORDER.map((kind) => {
+              const meta = CHANGE_KIND_META[kind];
+              return (
+                <div
+                  key={kind}
+                  className="flex items-center gap-1.5"
+                  title={meta.description}
+                  data-testid={`graph-drift-legend-item-${kind}`}
+                >
+                  <span
+                    className="inline-block h-2.5 w-2.5 rounded-full"
+                    style={{ backgroundColor: meta.color }}
+                  />
+                  <span className="text-[11px] text-zinc-300">{meta.label}</span>
+                  <span className="font-mono text-[11px] text-zinc-500">
+                    {counts[kind]}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      ) : (
+        <p className="mt-2 text-xs text-zinc-500">
+          Turn the lens on to classify this snapshot against{" "}
+          {comparedLabel ? (
+            <span className="font-mono">{comparedLabel}</span>
+          ) : (
+            "the previous snapshot"
+          )}{" "}
+          — new, changed, and removed assets get distinct rings and chips.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -415,12 +415,26 @@ export interface GraphAgentsResponse {
   pagination: GraphPagination;
 }
 
+/** Lifecycle classification the drift lens paints onto graph nodes/edges. */
+export type GraphChangeKind = "new" | "removed" | "changed" | "unchanged";
+
+/**
+ * Server-computed map from node id / `source|target|relationship` edge key to
+ * its change kind between two snapshots. Entries absent from the map are
+ * treated as `unchanged`. Populated by `/v1/graph/diff`.
+ */
+export interface GraphChangeKindIndex {
+  nodes: Record<string, GraphChangeKind>;
+  edges: Record<string, GraphChangeKind>;
+}
+
 export interface GraphDiffResponse {
   nodes_added: string[];
   nodes_removed: string[];
   nodes_changed: string[];
   edges_added: [string, string, string][];
   edges_removed: [string, string, string][];
+  change_kind_index?: GraphChangeKindIndex | undefined;
 }
 
 export type GraphExportFormat =

--- a/ui/lib/filter-algebra.ts
+++ b/ui/lib/filter-algebra.ts
@@ -28,6 +28,7 @@ import {
   type UnifiedNode,
 } from "@/lib/graph-schema";
 import type { UnifiedGraphResponse } from "@/lib/api-types";
+import type { ChangeKind } from "@/lib/graph-utils";
 
 // ───────────────────────────────────────────────────────────────────────
 // Public types
@@ -545,6 +546,57 @@ export function computeValidValues(
   }
 
   return { severities, agents, layers, relationships };
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Drift lens predicates (#3192)
+// ───────────────────────────────────────────────────────────────────────
+//
+// The drift lens is a focus overlay, not a hard filter: when a chip other than
+// "all" is active, non-matching nodes are dimmed rather than removed so the
+// surrounding topology stays legible (mirroring the blast-radius / reachability
+// overlays). These predicates are the pure decision core the client dims by.
+
+export type DriftLensFilter = "all" | "new" | "removed" | "changed" | "critical";
+
+export const DRIFT_LENS_FILTERS: DriftLensFilter[] = [
+  "all",
+  "new",
+  "changed",
+  "critical",
+  "removed",
+];
+
+/**
+ * Whether a node with the given change kind passes the active drift chip.
+ *
+ * `critical` is a cross-cutting chip: it keeps any node the client has flagged
+ * as a critical change (a new/changed asset carrying a high-or-worse severity),
+ * independent of its raw new/changed kind.
+ */
+export function driftFilterPasses(
+  kind: ChangeKind,
+  filter: DriftLensFilter,
+  isCritical: boolean,
+): boolean {
+  if (filter === "all") return true;
+  if (filter === "critical") return isCritical;
+  return kind === filter;
+}
+
+/**
+ * A node counts as a critical change when it appeared or drifted (new/changed)
+ * *and* it carries a high-or-worse severity. Removed criticality is intentionally
+ * excluded here — removed assets are surfaced by the dedicated `removed` chip.
+ */
+export function isCriticalChange(
+  kind: ChangeKind,
+  severity: string | null | undefined,
+): boolean {
+  if (kind !== "new" && kind !== "changed") return false;
+  const rank = SEVERITY_RANK[String(severity ?? "").toLowerCase()] ?? 0;
+  const highRank = SEVERITY_RANK["high"] ?? 0;
+  return rank >= highRank && highRank > 0;
 }
 
 // ───────────────────────────────────────────────────────────────────────

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -14,6 +14,7 @@ import {
   type GraphEdgeKindKey,
   type GraphNodeKindKey,
 } from "@/lib/graph-schema";
+import type { GraphChangeKind, GraphDiffResponse } from "@/lib/api-types";
 
 // ─── Shared Styling Constants ────────────────────────────────────────────────
 
@@ -542,6 +543,139 @@ export const MESH_LEGEND: LegendItem[] = [
   { label: "Cred", color: "#f59e0b", kind: "node", shape: "dot" },
   { label: "Tool", color: "#a855f7", kind: "node", shape: "pill" },
 ];
+
+// ─── Drift lens — snapshot change-kind helpers (#3192) ───────────────────────
+//
+// The graph diff API (/v1/graph/diff) classifies every node/edge between two
+// snapshots as new / removed / changed. These helpers turn that response into
+// a lookup the graph client can paint onto the rollup-default rendered graph
+// without re-implementing the diff. Anything the diff does not mention is
+// treated as `unchanged` (the stable estate).
+
+export type ChangeKind = GraphChangeKind;
+
+export interface ChangeKindMeta {
+  label: string;
+  color: string;
+  description: string;
+  ringClass: string;
+}
+
+export const CHANGE_KIND_ORDER: ChangeKind[] = [
+  "new",
+  "changed",
+  "removed",
+  "unchanged",
+];
+
+export const CHANGE_KIND_META: Record<ChangeKind, ChangeKindMeta> = {
+  new: {
+    label: "New",
+    color: "#10b981",
+    description: "Asset appeared since the compared snapshot.",
+    ringClass: "drift-ring-new",
+  },
+  changed: {
+    label: "Changed",
+    color: "#f59e0b",
+    description: "Asset persisted but its posture or metadata drifted.",
+    ringClass: "drift-ring-changed",
+  },
+  removed: {
+    label: "Removed",
+    color: "#f43f5e",
+    description: "Asset disappeared since the compared snapshot.",
+    ringClass: "drift-ring-removed",
+  },
+  unchanged: {
+    label: "Unchanged",
+    color: "#52525b",
+    description: "Asset is stable across both snapshots.",
+    ringClass: "",
+  },
+};
+
+export function edgeChangeKey(
+  source: string,
+  target: string,
+  relationship: string,
+): string {
+  return `${source}|${target}|${relationship}`;
+}
+
+export interface DriftIndex {
+  nodeKind: Map<string, ChangeKind>;
+  edgeKind: Map<string, ChangeKind>;
+  counts: Record<ChangeKind, number>;
+  /** True when the diff surfaced at least one changed node or edge. */
+  hasChanges: boolean;
+}
+
+const EMPTY_DRIFT_COUNTS = (): Record<ChangeKind, number> => ({
+  new: 0,
+  changed: 0,
+  removed: 0,
+  unchanged: 0,
+});
+
+export function buildDriftIndex(
+  diff: GraphDiffResponse | null | undefined,
+): DriftIndex {
+  const nodeKind = new Map<string, ChangeKind>();
+  const edgeKind = new Map<string, ChangeKind>();
+  const counts = EMPTY_DRIFT_COUNTS();
+
+  const index = diff?.change_kind_index;
+  if (index) {
+    for (const [id, kind] of Object.entries(index.nodes)) {
+      nodeKind.set(id, kind);
+      counts[kind] += 1;
+    }
+    for (const [key, kind] of Object.entries(index.edges)) {
+      edgeKind.set(key, kind);
+    }
+  }
+
+  return {
+    nodeKind,
+    edgeKind,
+    counts,
+    hasChanges: nodeKind.size > 0 || edgeKind.size > 0,
+  };
+}
+
+export function changeKindForNode(id: string, index: DriftIndex): ChangeKind {
+  return index.nodeKind.get(id) ?? "unchanged";
+}
+
+export function changeKindForEdge(
+  source: string,
+  target: string,
+  relationship: string,
+  index: DriftIndex,
+): ChangeKind {
+  return (
+    index.edgeKind.get(edgeChangeKey(source, target, relationship)) ??
+    "unchanged"
+  );
+}
+
+/** Legend rows for the drift lens, optionally annotated with live counts. */
+export function driftLegendItems(
+  counts?: Partial<Record<ChangeKind, number>>,
+): LegendItem[] {
+  return CHANGE_KIND_ORDER.map((kind) => {
+    const meta = CHANGE_KIND_META[kind];
+    const count = counts?.[kind];
+    return {
+      label: count !== undefined ? `${meta.label} · ${count}` : meta.label,
+      color: meta.color,
+      description: meta.description,
+      kind: "node",
+      shape: "dot",
+    };
+  });
+}
 
 export const CONTEXT_LEGEND: LegendItem[] = [
   { label: "Agent", color: "#10b981", kind: "node", shape: "dot" },

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -20,7 +20,8 @@ const BUDGETS = {
   // Includes the self-service cloud-connections page + Add Cloud Account wizard.
   // Includes recurring cloud-connection scan schedules; keep small CI variance headroom.
   // Includes the repo folder/file structure graph layer icons and code-layer filters.
-  totalClientJsBytes: 3_125_000,
+  // Includes the graph drift lens (#3192) — opt-in diff overlay on the lineage canvas.
+  totalClientJsBytes: 3_132_000,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };

--- a/ui/tests/graph-drift-lens.test.tsx
+++ b/ui/tests/graph-drift-lens.test.tsx
@@ -1,0 +1,173 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { GraphDriftLegend } from "@/components/graph-drift-legend";
+import {
+  buildDriftIndex,
+  changeKindForEdge,
+  changeKindForNode,
+  driftLegendItems,
+  type ChangeKind,
+} from "@/lib/graph-utils";
+import {
+  driftFilterPasses,
+  isCriticalChange,
+  DRIFT_LENS_FILTERS,
+  type DriftLensFilter,
+} from "@/lib/filter-algebra";
+import type { GraphDiffResponse } from "@/lib/api-types";
+
+const DIFF: GraphDiffResponse = {
+  nodes_added: [],
+  nodes_removed: [],
+  nodes_changed: [],
+  edges_added: [],
+  edges_removed: [],
+  change_kind_index: {
+    nodes: {
+      "agent:new": "new",
+      "vuln:changed": "changed",
+      "agent:gone": "removed",
+    },
+    edges: {
+      "agent:new|server:s|uses": "new",
+    },
+  },
+};
+
+const COUNTS: Record<ChangeKind, number> = {
+  new: 1,
+  changed: 1,
+  removed: 1,
+  unchanged: 4,
+};
+
+describe("drift index helpers", () => {
+  it("classifies nodes and edges from the change_kind_index", () => {
+    const index = buildDriftIndex(DIFF);
+    expect(index.hasChanges).toBe(true);
+    expect(changeKindForNode("agent:new", index)).toBe("new");
+    expect(changeKindForNode("vuln:changed", index)).toBe("changed");
+    expect(changeKindForNode("agent:gone", index)).toBe("removed");
+    // Anything not in the index is stable estate.
+    expect(changeKindForNode("server:s", index)).toBe("unchanged");
+    expect(changeKindForEdge("agent:new", "server:s", "uses", index)).toBe(
+      "new",
+    );
+    expect(changeKindForEdge("x", "y", "uses", index)).toBe("unchanged");
+    expect(index.counts.new).toBe(1);
+    expect(index.counts.removed).toBe(1);
+  });
+
+  it("is inert for an empty or missing diff", () => {
+    expect(buildDriftIndex(null).hasChanges).toBe(false);
+    expect(
+      buildDriftIndex({
+        nodes_added: [],
+        nodes_removed: [],
+        nodes_changed: [],
+        edges_added: [],
+        edges_removed: [],
+      }).hasChanges,
+    ).toBe(false);
+  });
+
+  it("emits a legend row per change kind with counts", () => {
+    const items = driftLegendItems(COUNTS);
+    expect(items.map((i) => i.label)).toEqual([
+      "New · 1",
+      "Changed · 1",
+      "Removed · 1",
+      "Unchanged · 4",
+    ]);
+  });
+});
+
+describe("drift filter predicates", () => {
+  it("passes only the matching kind for single-kind chips", () => {
+    expect(driftFilterPasses("new", "new", false)).toBe(true);
+    expect(driftFilterPasses("changed", "new", false)).toBe(false);
+    expect(driftFilterPasses("unchanged", "all", false)).toBe(true);
+  });
+
+  it("routes the critical chip through the isCritical flag", () => {
+    expect(driftFilterPasses("changed", "critical", true)).toBe(true);
+    expect(driftFilterPasses("changed", "critical", false)).toBe(false);
+  });
+
+  it("marks new/changed high-severity assets as critical changes", () => {
+    expect(isCriticalChange("new", "critical")).toBe(true);
+    expect(isCriticalChange("changed", "high")).toBe(true);
+    expect(isCriticalChange("changed", "medium")).toBe(false);
+    // Removed assets are surfaced by their own chip, not "critical".
+    expect(isCriticalChange("removed", "critical")).toBe(false);
+    expect(isCriticalChange("new", undefined)).toBe(false);
+  });
+});
+
+describe("GraphDriftLegend component", () => {
+  function renderLegend(overrides: Partial<{
+    active: boolean;
+    filter: DriftLensFilter;
+    onToggleActive: (next: boolean) => void;
+    onFilterChange: (f: DriftLensFilter) => void;
+  }> = {}) {
+    const onToggleActive = overrides.onToggleActive ?? vi.fn();
+    const onFilterChange = overrides.onFilterChange ?? vi.fn();
+    render(
+      <GraphDriftLegend
+        active={overrides.active ?? true}
+        onToggleActive={onToggleActive}
+        filter={overrides.filter ?? "all"}
+        onFilterChange={onFilterChange}
+        counts={COUNTS}
+        criticalCount={2}
+        comparedLabel="abc123def456"
+      />,
+    );
+    return { onToggleActive, onFilterChange };
+  }
+
+  it("renders the legend swatches and every chip when armed", () => {
+    renderLegend({ active: true });
+    expect(screen.getByTestId("graph-drift-legend")).toBeInTheDocument();
+    // One legend item per change kind.
+    for (const kind of ["new", "changed", "removed", "unchanged"] as ChangeKind[]) {
+      expect(
+        screen.getByTestId(`graph-drift-legend-item-${kind}`),
+      ).toBeInTheDocument();
+    }
+    // One chip per drift filter.
+    for (const chip of DRIFT_LENS_FILTERS) {
+      expect(
+        screen.getByTestId(`graph-drift-chip-${chip}`),
+      ).toBeInTheDocument();
+    }
+    // Critical chip surfaces the critical count passed in.
+    expect(screen.getByTestId("graph-drift-chip-critical").textContent).toContain(
+      "2",
+    );
+  });
+
+  it("hides chips until the lens is armed", () => {
+    renderLegend({ active: false });
+    expect(screen.queryByTestId("graph-drift-chips")).not.toBeInTheDocument();
+    expect(screen.getByTestId("graph-drift-toggle").textContent).toContain(
+      "Lens off",
+    );
+  });
+
+  it("fires the filter callback when a chip is clicked", () => {
+    const { onFilterChange } = renderLegend({ active: true, filter: "all" });
+    fireEvent.click(screen.getByTestId("graph-drift-chip-new"));
+    expect(onFilterChange).toHaveBeenCalledWith("new");
+    fireEvent.click(screen.getByTestId("graph-drift-chip-critical"));
+    expect(onFilterChange).toHaveBeenCalledWith("critical");
+  });
+
+  it("toggles the lens on/off through the switch", () => {
+    const { onToggleActive } = renderLegend({ active: false });
+    fireEvent.click(screen.getByTestId("graph-drift-toggle"));
+    expect(onToggleActive).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
## Slice 1 of #3192 — drift as a first-class UI lens

The graph already had snapshot diff data (`/v1/graph/diff`, `/edges/changes`, `/snapshots`) but the 3.2k-line WebGL client only surfaced it as a read-only count card. This slice turns that data into an interactive drift lens on the lineage graph.

### Server
- `/v1/graph/diff` now tags each dict-shaped node/edge entry with a `change_kind` (`new` | `removed` | `changed`) and attaches a normalized `change_kind_index` (node id → kind, `source|target|relationship` → kind). One route-level tagger works across the sqlite/postgres/neptune backends without the client having to reconcile the three heterogeneous diff entry shapes. Absent entries are treated as `unchanged`.

### UI
- **`ui/lib/graph-utils.ts`** — `ChangeKind` + `CHANGE_KIND_META`, `buildDriftIndex`, `changeKindForNode/Edge`, `driftLegendItems`.
- **`ui/lib/filter-algebra.ts`** — drift focus predicates `driftFilterPasses` / `isCriticalChange` and the `DriftLensFilter` chip set.
- **`ui/components/graph-drift-legend.tsx`** (new) — legend + focus chips + arm/disarm toggle.
- **`ui/app/graph/graph-page-client.tsx`** — wires the lens over the existing rollup-default renderer: node change-kind rings, edge emphasis, and dim-to-focus chips (all / new / changed / critical / removed). Reuses the filter/rollup machinery; the renderer is untouched.

The lens is **inert unless a diff exists and the operator arms it** — when two snapshots aren't available the default view is byte-for-byte unchanged, and disarming/losing the diff resets the chip.

### Verify
- Python: new `test_graph_diff_route_tags_change_kind` (route asserts `change_kind` + `change_kind_index`); `tests/test_graph_api.py` 55 passed.
- UI (node@22): `typecheck` clean, `lint` clean (0 errors), `build` compiles, new `tests/graph-drift-lens.test.tsx` (10) + related suites 31 passed.

### Deferred (stay open under #3192)
- Slice 2: config-drift attribute deltas (public-exposure / encryption / IAM / tag) on drift nodes.
- Slice 3: runtime evidence overlay (#3610).
- Slice 4: rollup drill-in polish / bounded path expansion.
- Slice 5: accuracy backfill (data-gated on #3176 / #3187).