### PR TITLE
feat(bench): synthetic-estate generator for GB/TB scale testing

### DIFF
--- a/scripts/bench/SCALE_RUNBOOK.md
+++ b/scripts/bench/SCALE_RUNBOOK.md
@@ -1,0 +1,187 @@
+# Agent-BOM Scale Runbook — GB→TB synthetic estates
+
+This runbook takes you from an empty Postgres/RDS + EKS control plane to a
+**TB-scale ingest+read latency number**, using two tools that live in this dir:
+
+| Tool | Role |
+| --- | --- |
+| `generate_estate.py` | Produces arbitrarily large, **realistic** synthetic findings (weighted severity, real-looking CVE/GHSA ids, 8 ecosystems, cvss/epss/kev, reachability, compliance tags). Streams — never buffers the whole set. |
+| `agent_bom_scale_bench.py` | Drives bulk ingest + keyset-read latency against a running control plane and reports flatness / regression. |
+
+The generator **feeds** the bench (and any lake target). Keep them separate: the
+generator makes data at scale; the bench measures the plane under that data.
+
+---
+
+## 0. Sizing cheat-sheet
+
+The generator emits ~**990 bytes/finding** as compact NDJSON. So:
+
+| Target (uncompressed NDJSON) | `--findings` (approx) | `--target-gb` |
+| --- | --- | --- |
+| 1 GB | ~1.08 M | `--target-gb 1` |
+| 100 GB | ~108 M | `--target-gb 100` |
+| 1 TB | ~1.08 B | `--target-gb 1024` |
+
+Either pass `--findings N` directly or `--target-gb G` and let it compute `N`.
+Postgres on-disk footprint will differ (indexes, TOAST, row overhead) — budget
+**~1.5–2.5x** the NDJSON size for the `hub_findings` tables + sort indexes.
+
+Everything is deterministic in `--seed`: the same seed reproduces the same
+estate byte-for-byte, and generation is resumable (row `idx` never depends on
+wall-clock), so a killed TB run can be re-pointed at the same seed.
+
+---
+
+## 1. Provision Postgres (RDS)
+
+```bash
+# RDS: a db.r6g.2xlarge (8 vCPU / 64 GB) comfortably holds a ~1 TB estate.
+aws rds create-db-instance \
+  --db-instance-identifier agentbom-scale \
+  --engine postgres --engine-version 16 \
+  --db-instance-class db.r6g.2xlarge \
+  --allocated-storage 2000 --storage-type gp3 --iops 12000 \
+  --master-username agentbom --manage-master-user-password \
+  --backup-retention-period 0 --no-multi-az
+
+# Grab the endpoint once it's "available":
+aws rds describe-db-instances --db-instance-identifier agentbom-scale \
+  --query 'DBInstances[0].Endpoint.Address' --output text
+```
+
+Local alternative (laptop smoke test before spending on RDS):
+
+```bash
+docker run -d --name agentbom-pg -e POSTGRES_PASSWORD=agentbom \
+  -e POSTGRES_DB=agentbom -p 5432:5432 postgres:16
+export DATABASE_URL=postgresql://postgres:agentbom@127.0.0.1:5432/agentbom
+```
+
+---
+
+## 2. Deploy the control plane on EKS (or run it locally)
+
+Point agent-bom at the RDS endpoint via `DATABASE_URL` and start the API. On EKS
+you want the ingest pods and the generator pod in the **same AZ/VPC** as RDS so
+the bench measures the plane, not the WAN.
+
+```bash
+# minimal local boot (same image you ship to EKS)
+export DATABASE_URL=postgresql://agentbom:...@agentbom-scale.xxxx.rds.amazonaws.com:5432/agentbom
+export AGENT_BOM_API_KEY=$(python3 -c "import secrets;print(secrets.token_urlsafe(32))")
+docker run -d --name agentbom-api -p 8422:8422 \
+  -e DATABASE_URL -e AGENT_BOM_API_KEY \
+  ghcr.io/<org>/agent-bom:latest agent-bom serve --host 0.0.0.0 --port 8422
+
+export AGENT_BOM_URL=http://127.0.0.1:8422   # or the EKS service DNS
+curl -sf "$AGENT_BOM_URL/health"
+```
+
+On EKS, run the generator from a Job in-cluster:
+
+```bash
+kubectl run estate-gen --image=ghcr.io/<org>/agent-bom:latest --restart=Never -- \
+  python3 /app/scripts/bench/generate_estate.py \
+    --target-gb 1024 --out bulk --url http://agent-bom.default.svc:8422 \
+    --api-key "$AGENT_BOM_API_KEY" --concurrency 16 --batch-size 1000
+```
+
+---
+
+## 3. Generate + load the estate
+
+### 3a. Stream straight into the plane (recommended for TB)
+
+No intermediate file — the generator POSTs `/v1/findings/bulk` batches with a
+deterministic `Idempotency-Key` per batch, so a retried/resumed run collapses
+server-side instead of double-counting.
+
+```bash
+# 100 GB, 16-way concurrent ingest
+python3 scripts/bench/generate_estate.py \
+  --target-gb 100 \
+  --out bulk --url "$AGENT_BOM_URL" --api-key "$AGENT_BOM_API_KEY" \
+  --concurrency 16 --batch-size 1000 --seed 1337
+```
+
+Memory stays flat regardless of `--target-gb`: at most `--concurrency` batches
+are ever in flight.
+
+### 3b. Materialize a file first (reusable corpus / lake tests)
+
+```bash
+# NDJSON (streamed; '-' writes to stdout for piping)
+python3 scripts/bench/generate_estate.py --target-gb 10 --out ndjson estate-10gb.jsonl
+
+# Parquet matching agent-bom's 27-col finding schema (needs the `lake` extra)
+pip install 'agent-bom[lake]'
+python3 scripts/bench/generate_estate.py --findings 50000000 --out parquet estate.parquet
+```
+
+The parquet columns are byte-identical to
+`src/agent_bom/output/parquet_fmt.py` (a test asserts this), so the file drops
+straight into Athena/Trino/Snowflake/Iceberg lake pipelines.
+
+### Estate-axis knobs (graph realism)
+
+Defaults scale off the findings count; override to widen/narrow fan-in:
+
+```
+--agents N --servers N --packages N --cloud-resources N --identities N
+```
+
+Fewer agents/servers ⇒ higher findings-per-node fan-in ⇒ heavier blast-radius
+rollups. Defaults: agents≈N/200, servers≈N/500, packages≈N/20,
+cloud-resources≈N/100, identities≈N/50.
+
+---
+
+## 4. Run the latency bench
+
+Once the estate is loaded, measure ingest flatness + keyset read latency at
+depth (the bench's own trivial rows are fine for the *ingest* phase; the *read*
+phase reads whatever is already in the plane — i.e. your synthetic estate):
+
+```bash
+# Read-only walk over the loaded estate (no new ingest)
+PHASES=read TARGET=0 READ_PAGES=30 PAGE_LIMIT=500 \
+  python3 scripts/bench/agent_bom_scale_bench.py
+
+# Ingest-flatness under concurrency (first-10 vs last-10 batch latency ratio)
+PHASES=ingest,idempotency INGEST_CONC=8 TARGET=1000000 BATCH=1000 \
+  python3 scripts/bench/agent_bom_scale_bench.py
+```
+
+---
+
+## 5. Read the results
+
+The bench prints `[PASS]/[FAIL]` per check:
+
+* **`ingest_flatness`** — `ratio = last10_mean / first10_mean`. Ratio near 1.0
+  means ingest cost is independent of table size (good). A climbing ratio is the
+  O(table-size) ingest regression to watch for at scale.
+* **`keyset_walk`** — mean ms per keyset page and unique-id count. This is the
+  sorted-read latency at depth; it should stay flat across pages if the sort
+  indexes are healthy. A synthetic estate with a **real severity/cvss/epss
+  distribution** (what this generator produces) is what actually exercises those
+  indexes — uniform rows do not.
+* **`first_page_count`** — exact vs approximate total latency; at TB scale the
+  exact `COUNT(*)` is the expensive one, so confirm `approximate_total=true` is
+  the fast path your UI uses.
+
+**TB-scale number to report:** load `--target-gb 1024`, then record
+`keyset_walk mean_ms` and the `ingest_flatness ratio` at that depth. That pair —
+"sorted-read latency and ingest flatness at 1 TB / ~1 B findings on
+db.r6g.2xlarge" — is the headline scale result.
+
+---
+
+## 6. Teardown
+
+```bash
+docker rm -f agentbom-api agentbom-pg 2>/dev/null || true
+aws rds delete-db-instance --db-instance-identifier agentbom-scale \
+  --skip-final-snapshot --delete-automated-backups
+```

--- a/scripts/bench/generate_estate.py
+++ b/scripts/bench/generate_estate.py
@@ -1,0 +1,665 @@
+#!/usr/bin/env python3
+"""Synthetic-estate data generator for agent-bom GB→TB scale testing.
+
+Feeds the ingest+read latency harness (``scripts/bench/agent_bom_scale_bench.py``)
+and any other target with *realistic*, non-uniform findings — a weighted severity
+distribution, varied CVE/GHSA ids, packages across eight ecosystems, cvss/epss/kev
+flags, present-or-null fixed versions, reachability states and compliance tags —
+so that indexes, sorts and keyset cursors are exercised the way production data
+exercises them (the existing bench emits trivial all-identical rows).
+
+Design constraints
+------------------
+* **Stdlib only** for core paths; ``pyarrow`` is imported lazily and only for
+  ``--out parquet``. No heavy deps.
+* **Streaming**: rows are produced by a generator and flushed in batches. Nothing
+  buffers the whole set, so ``--target-gb 100`` runs in constant memory.
+* **Deterministic**: every random draw is seeded from ``--seed`` and the row index
+  (never wall-clock), so a run is byte-reproducible and resumable — but rows still
+  *vary* (seed makes a run reproducible, not uniform).
+
+Output modes
+------------
+* ``--out ndjson PATH``   newline-delimited JSON, streamed (``-`` = stdout).
+* ``--out parquet PATH``  columnar file matching agent-bom's 27-col finding
+                          schema (``src/agent_bom/output/parquet_fmt.py``); needs
+                          the ``lake`` extra (pyarrow).
+* ``--out bulk``          POST batches to ``/v1/findings/bulk`` on ``--url`` with a
+                          deterministic ``Idempotency-Key`` per batch and optional
+                          ``--concurrency``.
+
+Examples
+--------
+    # 5k findings to a JSONL file
+    python3 scripts/bench/generate_estate.py --findings 5000 --out ndjson estate.jsonl
+
+    # ~10 GB of findings straight into a running control plane
+    python3 scripts/bench/generate_estate.py --target-gb 10 \\
+        --out bulk --url http://127.0.0.1:8422 --concurrency 8
+
+    # lake-testable parquet
+    python3 scripts/bench/generate_estate.py --findings 1000000 --out parquet estate.parquet
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import random
+import sys
+import time
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+# ─── Realism vocabularies ────────────────────────────────────────────────────
+
+# Ecosystem → representative package names. Kept small but plausible; the row
+# generator combines these with generated versions so cardinality is high without
+# a huge static table.
+_ECOSYSTEM_PACKAGES: dict[str, list[str]] = {
+    "pypi": [
+        "requests",
+        "urllib3",
+        "cryptography",
+        "pyyaml",
+        "jinja2",
+        "flask",
+        "django",
+        "numpy",
+        "torch",
+        "transformers",
+        "langchain",
+        "pydantic",
+        "aiohttp",
+        "sqlalchemy",
+        "pillow",
+    ],
+    "npm": [
+        "lodash",
+        "axios",
+        "express",
+        "react",
+        "webpack",
+        "minimist",
+        "node-fetch",
+        "next",
+        "vue",
+        "moment",
+        "chalk",
+        "debug",
+        "ws",
+        "semver",
+        "tar",
+    ],
+    "go": [
+        "github.com/gin-gonic/gin",
+        "golang.org/x/crypto",
+        "github.com/gorilla/websocket",
+        "google.golang.org/grpc",
+        "github.com/prometheus/client_golang",
+        "github.com/hashicorp/consul",
+        "github.com/spf13/cobra",
+        "github.com/aws/aws-sdk-go",
+    ],
+    "maven": [
+        "org.apache.logging.log4j:log4j-core",
+        "com.fasterxml.jackson.core:jackson-databind",
+        "org.springframework:spring-core",
+        "com.google.guava:guava",
+        "org.apache.commons:commons-lang3",
+        "io.netty:netty-all",
+        "org.hibernate:hibernate-core",
+    ],
+    "cargo": ["tokio", "serde", "hyper", "reqwest", "clap", "openssl", "rand", "regex", "actix-web", "rocket"],
+    "nuget": ["Newtonsoft.Json", "Serilog", "Microsoft.AspNetCore.App", "System.Text.Json", "AutoMapper", "Dapper", "Polly", "xunit"],
+    "composer": [
+        "symfony/http-kernel",
+        "laravel/framework",
+        "guzzlehttp/guzzle",
+        "monolog/monolog",
+        "doctrine/orm",
+        "twig/twig",
+        "phpunit/phpunit",
+    ],
+    "rubygems": ["rails", "rack", "nokogiri", "devise", "puma", "sidekiq", "sinatra", "actionpack", "activerecord"],
+}
+_ECOSYSTEMS = list(_ECOSYSTEM_PACKAGES)
+
+# Severity distribution: mostly low/medium, a long tail of high, few critical —
+# roughly what a real estate looks like. Weights need not sum to 1.
+_SEVERITY_WEIGHTS: list[tuple[str, float]] = [
+    ("low", 0.42),
+    ("medium", 0.34),
+    ("high", 0.17),
+    ("critical", 0.07),
+]
+_SEVERITY_CVSS_RANGE: dict[str, tuple[float, float]] = {
+    "low": (0.1, 3.9),
+    "medium": (4.0, 6.9),
+    "high": (7.0, 8.9),
+    "critical": (9.0, 10.0),
+}
+
+_SYMBOL_REACH_STATES = ["confirmed", "unconfirmed", "not_analyzed"]
+
+_COMPLIANCE_TAGS = [
+    "owasp:A06:2021",
+    "owasp-llm:LLM05",
+    "nist-csf:PR.IP",
+    "iso-27001:A.12.6",
+    "soc2:CC7.1",
+    "pci-dss:6.2",
+    "cis:7.1",
+    "fedramp:RA-5",
+    "nist-800-53:SI-2",
+    "eu-ai-act:Art15",
+    "atlas:AML.T0010",
+    "cwe:CWE-79",
+]
+
+_CWES = ["CWE-79", "CWE-89", "CWE-22", "CWE-352", "CWE-502", "CWE-190", "CWE-400", "CWE-787", "CWE-125", "CWE-94", "CWE-611", "CWE-918"]
+
+# Approximate serialized size of one finding row as compact NDJSON incl. newline.
+# Empirically ~990 B/row for the row shape below (compact json.dumps, sort_keys).
+# Used only for ``--target-gb`` → findings-count sizing; the actual written size
+# is reported at runtime and asserted within ~2x in the sizing self-test.
+_APPROX_BYTES_PER_FINDING = 990
+
+
+# ─── Deterministic row generation ────────────────────────────────────────────
+
+
+def _rng_for(seed: int, idx: int) -> random.Random:
+    """A Random seeded purely from (seed, idx) — never wall-clock.
+
+    Deriving one RNG per row keeps generation resumable: row ``idx`` is identical
+    regardless of where a run starts or stops.
+    """
+    return random.Random((seed * 0x9E3779B1) ^ (idx * 0x85EBCA77))
+
+
+def _weighted_choice(rng: random.Random, weighted: list[tuple[str, float]]) -> str:
+    total = sum(w for _, w in weighted)
+    r = rng.random() * total
+    upto = 0.0
+    for value, weight in weighted:
+        upto += weight
+        if r <= upto:
+            return value
+    return weighted[-1][0]
+
+
+def make_finding(seed: int, idx: int, *, agents: int, servers: int, packages: int, cloud_resources: int, identities: int) -> dict[str, Any]:
+    """Build one realistic finding dict, deterministic in (seed, idx).
+
+    The dict carries both top-level finding fields (consumed by
+    ``/v1/findings/bulk`` and NDJSON) and an ``evidence`` sub-dict, plus the graph
+    axis (affected agents/servers, exposed credentials) sized off the estate knobs
+    so the row exercises reach/blast-radius columns.
+    """
+    rng = _rng_for(seed, idx)
+
+    ecosystem = _ECOSYSTEMS[idx % len(_ECOSYSTEMS)]
+    pkg_pool = _ECOSYSTEM_PACKAGES[ecosystem]
+    package = pkg_pool[rng.randrange(len(pkg_pool))]
+    # High-cardinality but deterministic version.
+    version = f"{rng.randint(0, 9)}.{rng.randint(0, 40)}.{rng.randint(0, 20)}"
+
+    severity = _weighted_choice(rng, _SEVERITY_WEIGHTS)
+    lo, hi = _SEVERITY_CVSS_RANGE[severity]
+    cvss = round(rng.uniform(lo, hi), 1)
+
+    # Vuln id: mostly CVE, some GHSA — both realistic-looking.
+    year = 2016 + (idx % 10)
+    if rng.random() < 0.78:
+        cve_id = f"CVE-{year}-{rng.randint(1000, 99999)}"
+    else:
+        cve_id = "GHSA-" + "-".join("".join(rng.choice("23456789cdefghjkmnpqrstuvwxyz") for _ in range(4)) for _ in range(3))
+
+    # EPSS: skewed low, occasional spike; KEV rare and correlated with high epss.
+    epss = round(min(1.0, rng.betavariate(1.5, 12.0)), 5)
+    is_kev = severity in {"high", "critical"} and epss > 0.4 and rng.random() < 0.35
+    is_malicious = ecosystem in {"npm", "pypi"} and rng.random() < 0.015
+
+    # fixed_version present ~70% of the time, null otherwise (unpatched tail).
+    fixed_version = None
+    if rng.random() < 0.70:
+        parts = [int(p) for p in version.split(".")]
+        parts[-1] += rng.randint(1, 5)
+        fixed_version = ".".join(str(p) for p in parts)
+
+    reachability = _weighted_choice(
+        rng,
+        [("not_reachable", 0.5), ("potentially_reachable", 0.25), ("reachable", 0.15), ("unknown", 0.1)],
+    )
+    graph_reachable = reachability == "reachable"
+    graph_min_hop = rng.randint(1, 6) if graph_reachable else None
+
+    # Graph axis: spread findings across the estate deterministically.
+    agent_id = idx % max(agents, 1)
+    server_id = idx % max(servers, 1)
+    n_agents = rng.randint(0, 3) if graph_reachable else rng.randint(0, 1)
+    n_servers = rng.randint(0, 2)
+    affected_agents = [f"agent-{(agent_id + k) % max(agents, 1):06d}" for k in range(n_agents)]
+    affected_servers = [f"mcp-server-{(server_id + k) % max(servers, 1):05d}" for k in range(n_servers)]
+    n_creds = rng.randint(0, 2) if severity in {"high", "critical"} else 0
+    exposed_credentials = [f"CRED_{(idx + k) % max(identities, 1):05d}" for k in range(n_creds)]
+
+    n_tags = rng.randint(0, 3)
+    compliance_tags = sorted({_COMPLIANCE_TAGS[rng.randrange(len(_COMPLIANCE_TAGS))] for _ in range(n_tags)})
+    cwe_ids = sorted({_CWES[rng.randrange(len(_CWES))] for _ in range(rng.randint(0, 2))})
+
+    pub_year = year
+    pub_month = rng.randint(1, 12)
+    pub_day = rng.randint(1, 28)
+    published_at = f"{pub_year:04d}-{pub_month:02d}-{pub_day:02d}T00:00:00Z"
+    modified_at = f"{pub_year:04d}-{min(12, pub_month + rng.randint(0, 3)):02d}-{pub_day:02d}T00:00:00Z"
+
+    # effective_reach_score drives the read-path sort in the bench harness.
+    reach_score = round(cvss * (2.0 if graph_reachable else 1.0) + epss * 10, 3)
+
+    return {
+        "id": f"estate:{seed}:{idx}",
+        "title": f"{cve_id} in {package} {version}",
+        "description": f"{severity.title()} severity vulnerability in {ecosystem} package {package} ({version}).",
+        "cve_id": cve_id,
+        "severity": severity,
+        "cvss_score": cvss,
+        "epss_score": epss,
+        "is_kev": is_kev,
+        "is_malicious": is_malicious,
+        "malicious_reason": "typosquat heuristic" if is_malicious else None,
+        "fixed_version": fixed_version,
+        "cwe_ids": cwe_ids,
+        "reachability": reachability,
+        "effective_reach_score": reach_score,
+        "risk_score": reach_score,
+        "compliance_tags": compliance_tags,
+        "affected_agents": affected_agents,
+        "affected_servers": affected_servers,
+        "exposed_credentials": exposed_credentials,
+        "evidence": {
+            "package_name": package,
+            "package_version": version,
+            "ecosystem": ecosystem,
+            "published_at": published_at,
+            "modified_at": modified_at,
+            "epss_percentile": round(min(1.0, epss * rng.uniform(1.0, 3.0)), 5),
+            "kev_date_added": published_at if is_kev else "",
+            "kev_due_date": modified_at if is_kev else "",
+            "severity_source": "cvss" if rng.random() < 0.8 else "vendor",
+            "symbol_reachability": _SYMBOL_REACH_STATES[rng.randrange(len(_SYMBOL_REACH_STATES))],
+            "reachable_affected_symbols": [
+                f"{package}.func_{rng.randint(0, 50)}" for _ in range(rng.randint(0, 2) if graph_reachable else 0)
+            ],
+            "graph_reachable": graph_reachable,
+            "graph_min_hop_distance": graph_min_hop,
+            "cloud_resource_id": f"arn:res:{idx % max(cloud_resources, 1):07d}",
+        },
+    }
+
+
+def iter_findings(seed: int, count: int, **estate: int) -> Iterator[dict[str, Any]]:
+    """Yield ``count`` findings lazily — the core streaming primitive."""
+    for idx in range(count):
+        yield make_finding(seed, idx, **estate)
+
+
+# ─── Parquet projection (27-col schema parity) ───────────────────────────────
+
+# Mirrors src/agent_bom/output/parquet_fmt.py::_COLUMNS exactly so a generated
+# file is byte-compatible with agent-bom's own parquet export for lake tests.
+_PARQUET_COLUMNS = [
+    "cve_id",
+    "package",
+    "version",
+    "ecosystem",
+    "severity",
+    "cvss_score",
+    "epss_score",
+    "is_kev",
+    "is_malicious",
+    "malicious_reason",
+    "published_at",
+    "modified_at",
+    "fixed_version",
+    "cwe_ids",
+    "affected_agents",
+    "affected_servers",
+    "exposed_credentials",
+    "summary",
+    "severity_source",
+    "epss_percentile",
+    "kev_date_added",
+    "kev_due_date",
+    "compliance_tags",
+    "symbol_reachability",
+    "reachable_affected_symbols",
+    "graph_reachable",
+    "graph_min_hop_distance",
+]
+
+
+def to_parquet_row(finding: dict[str, Any]) -> dict[str, Any]:
+    """Project a finding dict onto agent-bom's 27-column parquet schema."""
+    ev = finding.get("evidence", {})
+    return {
+        "cve_id": finding.get("cve_id") or finding.get("id"),
+        "package": ev.get("package_name"),
+        "version": ev.get("package_version"),
+        "ecosystem": ev.get("ecosystem"),
+        "severity": finding.get("severity"),
+        "cvss_score": finding.get("cvss_score"),
+        "epss_score": finding.get("epss_score"),
+        "is_kev": bool(finding.get("is_kev")),
+        "is_malicious": bool(finding.get("is_malicious")),
+        "malicious_reason": finding.get("malicious_reason") or None,
+        "published_at": ev.get("published_at") or None,
+        "modified_at": ev.get("modified_at") or None,
+        "fixed_version": finding.get("fixed_version") or None,
+        "cwe_ids": ";".join(finding.get("cwe_ids") or []) or None,
+        "affected_agents": ";".join(finding.get("affected_agents") or []),
+        "affected_servers": ";".join(finding.get("affected_servers") or []),
+        "exposed_credentials": len(finding.get("exposed_credentials") or []),
+        "summary": finding.get("description") or None,
+        "severity_source": ev.get("severity_source") or None,
+        "epss_percentile": ev.get("epss_percentile"),
+        "kev_date_added": ev.get("kev_date_added") or None,
+        "kev_due_date": ev.get("kev_due_date") or None,
+        "compliance_tags": ";".join(finding.get("compliance_tags") or []) or None,
+        "symbol_reachability": ev.get("symbol_reachability") or None,
+        "reachable_affected_symbols": ";".join(ev.get("reachable_affected_symbols") or []) or None,
+        "graph_reachable": bool(ev.get("graph_reachable")),
+        "graph_min_hop_distance": ev.get("graph_min_hop_distance"),
+    }
+
+
+def _parquet_schema(pa):
+    return pa.schema(
+        [
+            ("cve_id", pa.string()),
+            ("package", pa.string()),
+            ("version", pa.string()),
+            ("ecosystem", pa.string()),
+            ("severity", pa.string()),
+            ("cvss_score", pa.float64()),
+            ("epss_score", pa.float64()),
+            ("is_kev", pa.bool_()),
+            ("is_malicious", pa.bool_()),
+            ("malicious_reason", pa.string()),
+            ("published_at", pa.string()),
+            ("modified_at", pa.string()),
+            ("fixed_version", pa.string()),
+            ("cwe_ids", pa.string()),
+            ("affected_agents", pa.string()),
+            ("affected_servers", pa.string()),
+            ("exposed_credentials", pa.int64()),
+            ("summary", pa.string()),
+            ("severity_source", pa.string()),
+            ("epss_percentile", pa.float64()),
+            ("kev_date_added", pa.string()),
+            ("kev_due_date", pa.string()),
+            ("compliance_tags", pa.string()),
+            ("symbol_reachability", pa.string()),
+            ("reachable_affected_symbols", pa.string()),
+            ("graph_reachable", pa.bool_()),
+            ("graph_min_hop_distance", pa.int64()),
+        ]
+    )
+
+
+# ─── Sizing ──────────────────────────────────────────────────────────────────
+
+
+def findings_for_target_gb(target_gb: float) -> int:
+    """Convert a GB target into a findings count via the approx bytes/finding."""
+    total_bytes = target_gb * (1024**3)
+    return max(1, int(total_bytes / _APPROX_BYTES_PER_FINDING))
+
+
+def default_estate(count: int) -> dict[str, int]:
+    """Sensible estate-axis defaults scaled to the findings count.
+
+    A real estate has far fewer agents/servers than findings; ratios below give
+    each agent/server/package a plausible fan-in of findings.
+    """
+    return {
+        "agents": max(1, count // 200),
+        "servers": max(1, count // 500),
+        "packages": max(1, count // 20),
+        "cloud_resources": max(1, count // 100),
+        "identities": max(1, count // 50),
+    }
+
+
+# ─── Output modes ────────────────────────────────────────────────────────────
+
+
+def _iter_batches(it: Iterator[dict[str, Any]], size: int) -> Iterator[list[dict[str, Any]]]:
+    batch: list[dict[str, Any]] = []
+    for row in it:
+        batch.append(row)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def write_ndjson(findings: Iterator[dict[str, Any]], path: str) -> tuple[int, int]:
+    """Stream findings as newline-delimited JSON. Returns (rows, bytes)."""
+    rows = 0
+    nbytes = 0
+    fh = sys.stdout if path == "-" else open(path, "w", encoding="utf-8")
+    try:
+        for row in findings:
+            line = json.dumps(row, separators=(",", ":"), sort_keys=True) + "\n"
+            fh.write(line)
+            rows += 1
+            nbytes += len(line.encode("utf-8"))
+    finally:
+        if fh is not sys.stdout:
+            fh.close()
+    return rows, nbytes
+
+
+def write_parquet(findings: Iterator[dict[str, Any]], path: str, batch_size: int) -> tuple[int, int]:
+    """Stream findings into a Parquet file via row-group batches (constant mem)."""
+    try:
+        import pyarrow as pa  # noqa: PLC0415
+        import pyarrow.parquet as pq  # noqa: PLC0415
+    except ImportError as exc:  # pragma: no cover
+        raise RuntimeError("Parquet output requires pyarrow. Install with: pip install 'agent-bom[lake]'") from exc
+
+    schema = _parquet_schema(pa)
+    rows = 0
+    writer = pq.ParquetWriter(path, schema, compression="snappy")
+    try:
+        for batch in _iter_batches(findings, batch_size):
+            table = pa.Table.from_pylist([to_parquet_row(f) for f in batch], schema=schema)
+            writer.write_table(table)
+            rows += len(batch)
+    finally:
+        writer.close()
+    nbytes = os.path.getsize(path)
+    return rows, nbytes
+
+
+def _batch_idempotency_key(seed: int, source: str, batch_index: int) -> str:
+    """Deterministic per-batch key so retries collapse server-side."""
+    raw = f"{source}:{seed}:{batch_index}"
+    return f"estate-{hashlib.sha256(raw.encode()).hexdigest()[:32]}"
+
+
+def _post_bulk(
+    url: str, api_key: str, source: str, seed: int, batch_index: int, batch: list[dict[str, Any]], timeout: int
+) -> tuple[int, str]:
+    body = json.dumps({"source": source, "findings": batch}).encode()
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Idempotency-Key": _batch_idempotency_key(seed, source, batch_index),
+    }
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = Request(f"{url.rstrip('/')}/v1/findings/bulk", data=body, headers=headers, method="POST")
+    try:
+        with urlopen(req, timeout=timeout) as resp:  # nosec B310 — operator-controlled URL
+            return resp.status, resp.read().decode(errors="replace")[:300]
+    except HTTPError as exc:
+        return exc.code, exc.read().decode(errors="replace")[:300]
+    except URLError as exc:
+        return 0, str(exc.reason)
+
+
+def write_bulk(
+    findings: Iterator[dict[str, Any]], *, url: str, api_key: str, source: str, seed: int, batch_size: int, concurrency: int, timeout: int
+) -> tuple[int, int]:
+    """POST batches to /v1/findings/bulk. Returns (rows_sent, failed_batches)."""
+    rows = 0
+    failed = 0
+    batches = enumerate(_iter_batches(findings, batch_size))
+
+    if concurrency <= 1:
+        for batch_index, batch in batches:
+            status, detail = _post_bulk(url, api_key, source, seed, batch_index, batch, timeout)
+            if status not in (200, 201):
+                failed += 1
+                print(f"[batch {batch_index}] HTTP {status}: {detail}", file=sys.stderr)
+            else:
+                rows += len(batch)
+        return rows, failed
+
+    # Bounded concurrency: keep at most `concurrency` batches in flight so memory
+    # stays constant even for a huge target.
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        in_flight: dict[Any, tuple[int, int]] = {}
+        for batch_index, batch in batches:
+            fut = pool.submit(_post_bulk, url, api_key, source, seed, batch_index, batch, timeout)
+            in_flight[fut] = (batch_index, len(batch))
+            if len(in_flight) >= concurrency:
+                done = next(as_completed(in_flight))
+                bidx, blen = in_flight.pop(done)
+                status, detail = done.result()
+                if status not in (200, 201):
+                    failed += 1
+                    print(f"[batch {bidx}] HTTP {status}: {detail}", file=sys.stderr)
+                else:
+                    rows += blen
+        for done in as_completed(in_flight):
+            bidx, blen = in_flight[done]
+            status, detail = done.result()
+            if status not in (200, 201):
+                failed += 1
+                print(f"[batch {bidx}] HTTP {status}: {detail}", file=sys.stderr)
+            else:
+                rows += blen
+    return rows, failed
+
+
+# ─── CLI ─────────────────────────────────────────────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="generate_estate.py",
+        description="Synthetic-estate generator for agent-bom GB/TB scale testing.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    scale = p.add_mutually_exclusive_group(required=True)
+    scale.add_argument("--findings", type=int, help="Number of findings to generate.")
+    scale.add_argument("--target-gb", type=float, help="Approx uncompressed size target in GB (computes findings count).")
+
+    p.add_argument("--seed", type=int, default=1337, help="RNG seed for reproducibility (default: 1337).")
+    p.add_argument("--batch-size", type=int, default=1000, help="Rows per output batch / parquet row-group / bulk POST (default: 1000).")
+
+    # Estate axis (defaults scale off findings count).
+    p.add_argument("--agents", type=int, default=None, help="Distinct agents in the estate.")
+    p.add_argument("--servers", type=int, default=None, help="Distinct MCP servers.")
+    p.add_argument("--packages", type=int, default=None, help="Distinct packages.")
+    p.add_argument("--cloud-resources", type=int, default=None, help="Distinct cloud resources.")
+    p.add_argument("--identities", type=int, default=None, help="Distinct identities/credentials.")
+
+    p.add_argument("--out", choices=["ndjson", "parquet", "bulk"], required=True, help="Output mode.")
+    p.add_argument("path", nargs="?", help="Output path for ndjson/parquet ('-' = stdout for ndjson).")
+
+    # Bulk mode.
+    p.add_argument("--url", help="Base URL of agent-bom control plane (bulk mode).")
+    p.add_argument("--api-key", default=os.environ.get("AGENT_BOM_API_KEY", ""), help="Bearer token (or AGENT_BOM_API_KEY env).")
+    p.add_argument("--source", default="estate-bench", help="Finding source label (bulk mode).")
+    p.add_argument("--concurrency", type=int, default=1, help="Concurrent bulk POSTs in flight (bulk mode).")
+    p.add_argument("--timeout", type=int, default=120, help="HTTP timeout seconds (bulk mode).")
+    return p
+
+
+def resolve_count(args: argparse.Namespace) -> int:
+    return args.findings if args.findings is not None else findings_for_target_gb(args.target_gb)
+
+
+def resolve_estate(args: argparse.Namespace, count: int) -> dict[str, int]:
+    defaults = default_estate(count)
+    return {
+        "agents": args.agents if args.agents is not None else defaults["agents"],
+        "servers": args.servers if args.servers is not None else defaults["servers"],
+        "packages": args.packages if args.packages is not None else defaults["packages"],
+        "cloud_resources": args.cloud_resources if args.cloud_resources is not None else defaults["cloud_resources"],
+        "identities": args.identities if args.identities is not None else defaults["identities"],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    count = resolve_count(args)
+    estate = resolve_estate(args, count)
+    findings = iter_findings(args.seed, count, **estate)
+
+    started = time.perf_counter()
+    if args.out == "ndjson":
+        if not args.path:
+            print("ndjson mode requires a PATH ('-' for stdout)", file=sys.stderr)
+            return 2
+        rows, nbytes = write_ndjson(findings, args.path)
+    elif args.out == "parquet":
+        if not args.path:
+            print("parquet mode requires a PATH", file=sys.stderr)
+            return 2
+        rows, nbytes = write_parquet(findings, args.path, args.batch_size)
+    else:  # bulk
+        if not args.url:
+            print("bulk mode requires --url", file=sys.stderr)
+            return 2
+        rows, failed = write_bulk(
+            findings,
+            url=args.url,
+            api_key=args.api_key,
+            source=args.source,
+            seed=args.seed,
+            batch_size=args.batch_size,
+            concurrency=args.concurrency,
+            timeout=args.timeout,
+        )
+        elapsed = time.perf_counter() - started
+        rate = rows / elapsed if elapsed else 0
+        print(
+            f"bulk: sent {rows}/{count} findings, {failed} failed batches, {elapsed:.1f}s, {rate:,.0f} findings/s → {args.url}",
+            file=sys.stderr,
+        )
+        return 1 if failed else 0
+
+    elapsed = time.perf_counter() - started
+    gb = nbytes / (1024**3)
+    print(
+        f"{args.out}: wrote {rows} findings ({gb:.4f} GB, {nbytes:,} bytes, "
+        f"{nbytes / max(rows, 1):.0f} B/row) in {elapsed:.1f}s → {args.path}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generate_estate.py
+++ b/tests/test_generate_estate.py
@@ -1,0 +1,225 @@
+"""Tests for the synthetic-estate scale generator (scripts/bench/generate_estate.py)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from collections import Counter
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "bench" / "generate_estate.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("generate_estate", _MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["generate_estate"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ge = _load_module()
+
+
+# ─── Determinism ─────────────────────────────────────────────────────────────
+
+
+def test_same_seed_reproducible():
+    a = ge.make_finding(42, 7, **ge.default_estate(5000))
+    b = ge.make_finding(42, 7, **ge.default_estate(5000))
+    assert a == b
+
+
+def test_different_seed_differs():
+    a = ge.make_finding(1, 7, **ge.default_estate(5000))
+    b = ge.make_finding(2, 7, **ge.default_estate(5000))
+    assert a != b
+
+
+def test_no_wallclock_dependence():
+    """Two runs separated in time must be identical (seeded, not clock-based)."""
+    import time
+
+    first = ge.make_finding(9, 3, **ge.default_estate(5000))
+    time.sleep(0.01)
+    second = ge.make_finding(9, 3, **ge.default_estate(5000))
+    assert first == second
+
+
+# ─── Distribution / realism ──────────────────────────────────────────────────
+
+
+def test_ndjson_valid_jsonl_and_distributed(tmp_path):
+    estate = ge.default_estate(5000)
+    out = tmp_path / "estate.jsonl"
+    rows, nbytes = ge.write_ndjson(ge.iter_findings(123, 5000, **estate), str(out))
+    assert rows == 5000
+    assert nbytes > 0
+
+    lines = out.read_text().splitlines()
+    assert len(lines) == 5000
+    parsed = [json.loads(line) for line in lines]  # every line valid JSON
+    for row in parsed:
+        assert row["id"]
+        assert row["cve_id"]
+        assert row["evidence"]["ecosystem"] in ge._ECOSYSTEMS
+
+    # NOT all-identical: multiple severities, ecosystems, cvss values, ids.
+    severities = Counter(r["severity"] for r in parsed)
+    assert len(severities) >= 3, severities
+    assert len({r["evidence"]["ecosystem"] for r in parsed}) >= 5
+    assert len({r["cvss_score"] for r in parsed}) > 20
+    assert len({r["id"] for r in parsed}) == 5000  # unique ids
+
+    # Weighted realism: low+medium dominate, critical is a minority.
+    assert severities["low"] + severities["medium"] > severities["high"] + severities["critical"]
+    assert severities["critical"] < severities["low"]
+
+    # Both CVE and GHSA ids appear.
+    prefixes = {r["cve_id"].split("-")[0] for r in parsed}
+    assert "CVE" in prefixes and "GHSA" in prefixes
+
+    # fixed_version is a present-or-null mix (exercises null-sort paths).
+    fixed_present = sum(1 for r in parsed if r["fixed_version"])
+    assert 0 < fixed_present < 5000
+
+    # Reachability varies.
+    assert len({r["reachability"] for r in parsed}) >= 3
+
+
+def test_kev_and_epss_are_bounded():
+    for idx in range(500):
+        f = ge.make_finding(7, idx, **ge.default_estate(500))
+        assert 0.0 <= f["epss_score"] <= 1.0
+        assert 0.0 <= f["cvss_score"] <= 10.0
+        assert isinstance(f["is_kev"], bool)
+
+
+# ─── Sizing math ─────────────────────────────────────────────────────────────
+
+
+def test_target_gb_sizing_roughly_right(tmp_path):
+    # 0.01 GB target → a count; the written file should be within ~2x of target.
+    target_gb = 0.01
+    count = ge.findings_for_target_gb(target_gb)
+    assert count > 0
+    estate = ge.default_estate(count)
+    out = tmp_path / "sized.jsonl"
+    rows, nbytes = ge.write_ndjson(ge.iter_findings(5, count, **estate), str(out))
+    assert rows == count
+    target_bytes = target_gb * (1024**3)
+    ratio = nbytes / target_bytes
+    assert 0.5 <= ratio <= 2.0, f"sizing off: {ratio:.2f} ({nbytes} vs {target_bytes})"
+
+
+def test_default_estate_scales_and_sane():
+    est = ge.default_estate(1_000_000)
+    assert est["agents"] < est["packages"]  # fewer agents than packages
+    assert all(v >= 1 for v in est.values())
+    small = ge.default_estate(1)
+    assert all(v >= 1 for v in small.values())  # never zero → no modulo-by-zero
+
+
+# ─── Streaming (no full buffering) ───────────────────────────────────────────
+
+
+def test_iter_findings_is_lazy_generator():
+    it = ge.iter_findings(1, 10_000_000, **ge.default_estate(10_000_000))
+    assert isinstance(it, Iterator)
+    # Pull two rows from a 10M-row stream instantly without materializing it.
+    first = next(it)
+    second = next(it)
+    assert first["id"] != second["id"]
+
+
+def test_write_ndjson_consumes_lazily(tmp_path):
+    """The writer must pull from the generator, not receive a materialized list."""
+    consumed = 0
+
+    def gen() -> Iterator[dict]:
+        nonlocal consumed
+        for idx in range(2000):
+            consumed += 1
+            yield ge.make_finding(1, idx, **ge.default_estate(2000))
+
+    out = tmp_path / "lazy.jsonl"
+    ge.write_ndjson(gen(), str(out))
+    assert consumed == 2000  # generator was driven to completion by the writer
+
+
+def test_batches_stream_in_chunks():
+    def gen() -> Iterator[dict]:
+        for idx in range(2500):
+            yield {"idx": idx}
+
+    sizes = [len(b) for b in ge._iter_batches(gen(), 1000)]
+    assert sizes == [1000, 1000, 500]
+
+
+# ─── Parquet round-trip ──────────────────────────────────────────────────────
+
+
+def test_parquet_roundtrip(tmp_path):
+    pytest.importorskip("pyarrow")
+    import pyarrow.parquet as pq
+
+    estate = ge.default_estate(3000)
+    out = tmp_path / "estate.parquet"
+    rows, nbytes = ge.write_parquet(ge.iter_findings(77, 3000, **estate), str(out), batch_size=500)
+    assert rows == 3000
+    assert nbytes > 0
+
+    table = pq.read_table(str(out))
+    assert table.num_rows == 3000
+    assert table.column_names == ge._PARQUET_COLUMNS
+
+    # Columns carry a distribution, not one repeated value.
+    severities = set(table.column("severity").to_pylist())
+    assert len(severities) >= 3
+    ecosystems = set(table.column("ecosystem").to_pylist())
+    assert len(ecosystems) >= 5
+    # graph_reachable is a real bool column; some true, some false.
+    reach = table.column("graph_reachable").to_pylist()
+    assert any(reach) and not all(reach)
+
+
+def test_parquet_schema_matches_agent_bom():
+    """The generator's column list must equal agent-bom's canonical parquet schema."""
+    pytest.importorskip("pyarrow")
+    try:
+        from agent_bom.output.parquet_fmt import _COLUMNS
+    except Exception:
+        pytest.skip("agent_bom not importable in this environment")
+    assert ge._PARQUET_COLUMNS == list(_COLUMNS)
+
+
+# ─── Idempotency key determinism (bulk mode) ─────────────────────────────────
+
+
+def test_bulk_idempotency_key_deterministic():
+    k1 = ge._batch_idempotency_key(1337, "estate-bench", 4)
+    k2 = ge._batch_idempotency_key(1337, "estate-bench", 4)
+    k3 = ge._batch_idempotency_key(1337, "estate-bench", 5)
+    assert k1 == k2
+    assert k1 != k3
+    assert k1.startswith("estate-")
+
+
+# ─── CLI wiring ──────────────────────────────────────────────────────────────
+
+
+def test_cli_ndjson_end_to_end(tmp_path):
+    out = tmp_path / "cli.jsonl"
+    rc = ge.main(["--findings", "500", "--seed", "3", "--out", "ndjson", str(out)])
+    assert rc == 0
+    assert len(out.read_text().splitlines()) == 500
+
+
+def test_cli_target_gb_and_findings_mutually_exclusive():
+    with pytest.raises(SystemExit):
+        ge.main(["--findings", "10", "--target-gb", "1", "--out", "ndjson", "-"])


### PR DESCRIPTION
## What

Adds a reusable **synthetic-estate data generator** so an operator can produce arbitrarily large, *realistic* datasets to stress agent-bom at GB→TB scale on real infra (RDS/EKS) without OOMing. It feeds the existing bulk-ingest+read latency harness (`scripts/bench/agent_bom_scale_bench.py`) — which emits trivial all-identical rows — with a distribution that actually exercises indexes, sorts and keyset cursors.

New files (isolated under `scripts/bench/` + `tests/`; no `src/` changes):

- `scripts/bench/generate_estate.py`
- `scripts/bench/SCALE_RUNBOOK.md`
- `tests/test_generate_estate.py`

## Generator

- **Parameterized scale** — `--findings N` *or* `--target-gb G` (computed from ~990 B/finding), plus `--agents/--servers/--packages/--cloud-resources/--identities` estate axes with defaults scaled off the findings count.
- **Realism** — weighted severity (mostly low/medium, few critical), real-looking CVE + GHSA ids, 8 ecosystems (pypi/npm/go/maven/cargo/nuget/composer/rubygems), correlated cvss/epss/kev flags, present-or-null `fixed_version` mix, reachability + symbol-reachability states, compliance tags. Not uniform rows.
- **Streaming** — generator-based with batched flush; `--target-gb 100` runs in constant memory across all output modes (bulk keeps at most `--concurrency` batches in flight).
- **Output modes** — `--out ndjson` (streamed JSONL, `-` = stdout), `--out parquet` (matches agent-bom's 27-col finding schema in `output/parquet_fmt.py` for lake tests; needs the `lake` extra), `--out bulk` (POST `/v1/findings/bulk` with a deterministic per-batch `Idempotency-Key` and bounded `--concurrency`).
- **Deterministic** — RNG seeded from `(--seed, row idx)`, never wall-clock, so a run is byte-reproducible and resumable while rows still vary.

## Runbook

`SCALE_RUNBOOK.md` walks the exact commands to spin Postgres/RDS + the EKS control plane, generate at a target GB (stream-to-bulk or materialize NDJSON/parquet), run the latency bench, and read the TB-scale number (`keyset_walk mean_ms` + `ingest_flatness ratio` at `--target-gb 1024`).

## Tests

15 tests in `tests/test_generate_estate.py` — determinism / no-wall-clock, distribution & realism (severity/ecosystem/cvss/id cardinality, CVE+GHSA mix, fixed_version null mix), `--target-gb` sizing math, parquet round-trip + schema parity vs `agent_bom.output.parquet_fmt._COLUMNS`, streaming laziness, idempotency-key determinism, CLI wiring. All green; ruff clean.