### PR TITLE
fix(api): consistent empty-scan response shape across MCP and HTTP surfaces (CI flake)

### DIFF
--- a/tests/test_mcp_http_scan_contract.py
+++ b/tests/test_mcp_http_scan_contract.py
@@ -4,7 +4,37 @@ import pytest
 
 from agent_bom.api.models import ScanJob, ScanRequest
 from agent_bom.api.pipeline import _now, _run_scan_sync
+from agent_bom.api.stores import _COMPACTED_RESULT_MARKER
 from agent_bom.mcp_tools.scanning import scan_impl
+
+_CONTRACT_KEYS = ("agents", "blast_radii", "blast_radius", "status", "vulnerabilities", "warnings")
+
+
+class _RetainingStore:
+    """Job store that shares the caller's job object, like ``InMemoryJobStore``.
+
+    The pipeline's ``finally`` block compacts terminal results *in place* when
+    the active store declares ``retains_job_objects_in_memory = False`` (the
+    durable SQLite/Postgres/Snowflake stores). That compaction strips
+    ``agents``/``status``/``blast_radius``/... off the very object a synchronous
+    caller is holding, replacing them with a hot-cache stub.
+
+    The global job store is a process-wide singleton, so if an earlier test in
+    the suite left a durable store installed via ``set_job_store`` without
+    restoring it, this contract test would inherit it and see a compacted
+    ``job.result`` (``agents == None``) instead of the canonical empty shape
+    (``agents == []``) — the CI flake this guards against. Pinning a retaining
+    store makes the HTTP surface's response shape deterministic regardless of
+    test ordering.
+    """
+
+    retains_job_objects_in_memory = True
+
+    def __init__(self) -> None:
+        self.jobs: list[ScanJob] = []
+
+    def put(self, job: ScanJob) -> None:
+        self.jobs.append(job)
 
 
 def _truncate(value: str) -> str:
@@ -16,14 +46,17 @@ async def _empty_scan_pipeline(*_args, **_kwargs):
 
 
 def _contract_subset(payload: dict[str, object]) -> dict[str, object]:
-    keys = {"status", "agents", "vulnerabilities", "blast_radius", "blast_radii", "warnings"}
-    return {key: payload.get(key) for key in sorted(keys)}
+    return {key: payload.get(key) for key in _CONTRACT_KEYS}
 
 
 @pytest.mark.asyncio
 async def test_mcp_scan_no_agent_shape_matches_http_scan(monkeypatch):
     """Guard the shared scan response contract across MCP and HTTP surfaces."""
     monkeypatch.setattr("agent_bom.discovery.discover_all", lambda **_kwargs: [])
+    # Isolate from the process-global job store singleton so a durable store
+    # leaked by an earlier test cannot compaction-strip ``job.result`` (see
+    # _RetainingStore) and flip the HTTP surface's empty-scan shape.
+    monkeypatch.setattr("agent_bom.api.pipeline._get_store", lambda: _RetainingStore())
 
     job = ScanJob(
         job_id="contract-no-agents",
@@ -39,6 +72,17 @@ async def test_mcp_scan_no_agent_shape_matches_http_scan(monkeypatch):
     )
     mcp_result = json.loads(raw_mcp)
 
+    # Neither surface may hand back a compacted hot-cache stub for a live scan.
+    assert _COMPACTED_RESULT_MARKER not in mcp_result
+    assert _COMPACTED_RESULT_MARKER not in job.result
+
+    # Field-by-field parity of the empty-scan contract shape across surfaces.
     assert _contract_subset(mcp_result) == _contract_subset(job.result)
-    assert mcp_result["blast_radius"] == mcp_result["blast_radii"] == []
-    assert job.result["blast_radius"] == job.result["blast_radii"] == []
+
+    # Canonical empty shape: non-null collections, not ``None``, on BOTH sides.
+    for result in (mcp_result, job.result):
+        assert result["status"] == "no_agents_found"
+        assert result["agents"] == []
+        assert result["vulnerabilities"] == []
+        assert result["blast_radius"] == result["blast_radii"] == []
+        assert result["warnings"] == []


### PR DESCRIPTION
## Problem

`tests/test_mcp_http_scan_contract.py::test_mcp_scan_no_agent_shape_matches_http_scan` intermittently reddened main with:

```
assert {'agents': []...} == {'agents': None...}
```

The MCP scan surface returned `agents: []` for a no-agent scan while the HTTP surface returned `agents: None` (and `None` for `status`, `vulnerabilities`, `blast_radius`, `blast_radii`, `warnings`).

## Root cause

Both surfaces *construct* the same canonical empty payload:

```
{"status": "no_agents_found", "agents": [], "vulnerabilities": [],
 "blast_radius": [], "blast_radii": [], "warnings": []}
```

The divergence is **not** in the construction. It comes from `_run_scan_sync`'s terminal `finally` block, which compacts the job result **in place** when the active job store declares `retains_job_objects_in_memory = False` (the durable SQLite / Postgres / Snowflake stores):

```python
if not bool(getattr(store, "retains_job_objects_in_memory", True)):
    _compact_terminal_job_in_place(job)   # strips job.result -> {"_agent_bom_hot_cache_compacted": True}
```

The job store is a **process-global singleton**. When an earlier test installs a durable store via `set_job_store(...)` without restoring it, that store leaks into this contract test. The HTTP pipeline then compaction-strips the very `job.result` the test asserts on, so `job.result.get("agents")` is `None` — an order-dependent flake. The MCP surface never compacts, so it always returns `[]`.

Reproduced deterministically by leaking a durable store into the global singleton before the test body (`agents: []` vs `agents: None`).

## Fix

Pin a retaining job store for the contract test — the identical isolation the sibling `test_api_pipeline_image_contract.py` already uses and documents. The HTTP surface's response shape is now deterministic regardless of test ordering. No production behavior changes; the in-place compaction remains the intended durable-store memory optimization.

Regression strengthened (not loosened):
- field-by-field parity of the contract subset across both surfaces
- canonical non-null collections asserted explicitly on **both** surfaces (`agents == []`, `vulnerabilities == []`, `blast_radius == blast_radii == []`, `status == "no_agents_found"`, `warnings == []`)
- neither surface may return a compacted hot-cache stub

## Verification

- Fixed test: 30/30 green in a repeat loop
- Green even with a durable store leaked into the global singleton (the flake condition)
- Broader suites green: `test_api_store`, `test_api_pipeline_image_contract`, `test_mcp_server`, `test_mcp_tool_impls`, `test_api_endpoints`, `test_api_scan_batches`, `test_api_tenant_isolation` (283 passed); hostile-ordering run with store-mutating suites before the contract test (54 passed)