### PR TITLE
security(db): fail startup when app DB role bypasses RLS (Part of #3665)

### DIFF
--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -1135,11 +1135,15 @@ BEGIN
     app_pass := current_setting('init.app_password', true);
 
     IF app_pass IS NOT NULL AND app_pass != '' THEN
-        -- Create app user if not exists
+        -- Create app user if not exists.
+        -- NOSUPERUSER NOBYPASSRLS is explicit (and the CREATE ROLE default) so
+        -- FORCE ROW LEVEL SECURITY tenant policies are always enforced for the
+        -- app role. A superuser/BYPASSRLS role silently voids tenant isolation
+        -- (#3665).
         IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_app') THEN
-            EXECUTE format('CREATE ROLE agent_bom_app LOGIN PASSWORD %L', app_pass);
+            EXECUTE format('CREATE ROLE agent_bom_app LOGIN NOSUPERUSER NOBYPASSRLS PASSWORD %L', app_pass);
         ELSE
-            EXECUTE format('ALTER ROLE agent_bom_app PASSWORD %L', app_pass);
+            EXECUTE format('ALTER ROLE agent_bom_app NOSUPERUSER NOBYPASSRLS PASSWORD %L', app_pass);
         END IF;
 
         -- Connection limit: prevent app from exhausting all connections
@@ -1189,13 +1193,42 @@ GRANT SELECT ON ALL TABLES IN SCHEMA public TO agent_bom_readonly;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO agent_bom_readonly;
 
 -- ══════════════════════════════════════════════════════════════════════════════
+-- TENANT ISOLATION: strip RLS-bypassing attributes from the app/admin role (#3665)
+-- ══════════════════════════════════════════════════════════════════════════════
+--
+-- The bundled quickstart connects as POSTGRES_USER (default: agent_bom), which
+-- the postgres image creates as a SUPERUSER. Superusers and BYPASSRLS roles
+-- IGNORE the FORCE ROW LEVEL SECURITY clause on every table, so the tenant
+-- isolation policies become silent no-ops and cross-tenant queries return other
+-- tenants' rows.
+--
+-- This runs as the very last init step, after all extensions and tables are
+-- created and owned by agent_bom. Dropping SUPERUSER/BYPASSRLS does NOT remove
+-- table ownership: agent_bom still performs the app's runtime idempotent DDL
+-- (table creation, ENABLE/FORCE RLS, policy and function definition) as the
+-- schema owner, but is now itself subject to the tenant RLS policies.
+-- The change only takes effect on the next connection (the current bootstrap
+-- session keeps its cached superuser status), so the rest of init is unaffected.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_roles
+        WHERE rolname = current_user AND (rolsuper OR rolbypassrls)
+    ) THEN
+        EXECUTE format('ALTER ROLE %I NOSUPERUSER NOBYPASSRLS', current_user);
+        RAISE NOTICE 'Stripped SUPERUSER/BYPASSRLS from % so tenant RLS is enforced (#3665)', current_user;
+    END IF;
+END
+$$;
+
+-- ══════════════════════════════════════════════════════════════════════════════
 -- SUMMARY
 -- ══════════════════════════════════════════════════════════════════════════════
 --
 --  Role               | Can do                          | Cannot do
 --  -------------------|--------------------------------|---------------------------
---  agent_bom (admin)  | DDL + DML (schema owner)       | — (superuser on this DB)
---  agent_bom_app      | SELECT, INSERT, UPDATE, DELETE  | CREATE, DROP, ALTER, TRUNCATE
+--  agent_bom (owner)  | DDL + DML (schema owner)       | bypass tenant RLS (NOSUPERUSER NOBYPASSRLS)
+--  agent_bom_app      | SELECT, INSERT, UPDATE, DELETE  | CREATE, DROP, ALTER, TRUNCATE, bypass RLS
 --  agent_bom_readonly | SELECT only                     | Any writes
 --
 --  Connection: AGENT_BOM_POSTGRES_URL=postgresql://agent_bom_app:<pw>@<host>:5432/agent_bom

--- a/src/agent_bom/api/postgres_common.py
+++ b/src/agent_bom/api/postgres_common.py
@@ -17,6 +17,7 @@ from contextvars import ContextVar, Token
 from typing import TYPE_CHECKING
 
 from agent_bom.config import (
+    ALLOW_SUPERUSER_DB,
     POSTGRES_CONNECT_TIMEOUT_SECONDS,
     POSTGRES_POOL_MAX_SIZE,
     POSTGRES_POOL_MIN_SIZE,
@@ -36,8 +37,20 @@ else:
 logger = logging.getLogger(__name__)
 
 _pool = None
+_rls_role_checked = False
 _current_tenant: ContextVar[str] = ContextVar("agent_bom_postgres_tenant", default="default")
 _bypass_tenant_rls: ContextVar[bool] = ContextVar("agent_bom_postgres_bypass_rls", default=False)
+
+
+class RlsRolePrivilegeError(RuntimeError):
+    """Raised when the connected Postgres role can bypass tenant RLS.
+
+    Postgres superusers and roles with ``BYPASSRLS`` ignore
+    ``FORCE ROW LEVEL SECURITY``, so every ``*_tenant_isolation`` policy in
+    this module becomes a no-op and tenants can read each other's rows. We
+    refuse to start rather than serve traffic with tenant isolation silently
+    disabled.
+    """
 
 
 def set_current_tenant(tenant_id: str) -> Token[str]:
@@ -113,13 +126,70 @@ def _get_pool() -> ConnectionPool:
             max_size=max_size,
             kwargs=kwargs,
         )
+    _guard_rls_capable_role(_pool)
     return _pool
+
+
+def _guard_rls_capable_role(pool: ConnectionPool) -> None:
+    """Fail closed when the connected role can bypass tenant RLS.
+
+    Tenant isolation on Postgres is enforced entirely through the
+    ``FORCE ROW LEVEL SECURITY`` policies created by :func:`_ensure_tenant_rls`.
+    Superusers and ``BYPASSRLS`` roles ignore that clause, so if the app
+    connects as such a role every tenant policy is void and cross-tenant reads
+    succeed. We inspect the role once per pool and refuse to continue unless the
+    operator has explicitly opted into a single-tenant / dev setup via
+    ``AGENT_BOM_ALLOW_SUPERUSER_DB`` (#3665).
+    """
+    global _rls_role_checked
+    if _rls_role_checked:
+        return
+    try:
+        with pool.connection() as conn:
+            cursor = conn.execute(
+                "SELECT rolsuper, rolbypassrls, rolname FROM pg_roles WHERE rolname = current_user"
+            )
+            row = cursor.fetchone() if cursor is not None else None
+    except Exception:
+        # Best-effort probe: a transient connect error or a store mock without a
+        # real role table must not mask the primary failure. A genuinely
+        # RLS-bypassing role is still caught on the next successful pool use.
+        logger.debug("Postgres RLS role guard could not inspect role attributes", exc_info=True)
+        return
+
+    _rls_role_checked = True
+    if not row:
+        return
+    rolsuper, rolbypassrls = bool(row[0]), bool(row[1])
+    role_name = row[2] if len(row) > 2 and row[2] else "current_user"
+    if not (rolsuper or rolbypassrls):
+        return
+
+    attrs = " and ".join(
+        label for label, present in (("SUPERUSER", rolsuper), ("BYPASSRLS", rolbypassrls)) if present
+    )
+    message = (
+        f"Postgres role {role_name!r} has {attrs}, which bypasses FORCE ROW LEVEL SECURITY "
+        "and silently disables agent-bom tenant isolation — cross-tenant reads/writes would "
+        "succeed. Connect as a NOSUPERUSER NOBYPASSRLS role (e.g. run "
+        f"'ALTER ROLE {role_name} NOSUPERUSER NOBYPASSRLS;' or point AGENT_BOM_POSTGRES_URL at the "
+        "dedicated agent_bom_app role). For a single-tenant or local dev deployment, set "
+        "AGENT_BOM_ALLOW_SUPERUSER_DB=1 to acknowledge this and downgrade to a warning."
+    )
+    if ALLOW_SUPERUSER_DB:
+        logger.warning(
+            "AGENT_BOM_ALLOW_SUPERUSER_DB is set: %s Tenant isolation is NOT enforced by the database.",
+            message,
+        )
+        return
+    raise RlsRolePrivilegeError(message)
 
 
 def reset_pool() -> None:
     """Reset the connection pool (for testing)."""
-    global _pool
+    global _pool, _rls_role_checked
     _pool = None
+    _rls_role_checked = False
 
 
 def _apply_tenant_session(conn: Connection) -> None:

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -475,6 +475,14 @@ POSTGRES_CONNECT_TIMEOUT_SECONDS = _int("AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECO
 POSTGRES_STATEMENT_TIMEOUT_MS = _int("AGENT_BOM_POSTGRES_STATEMENT_TIMEOUT_MS", 15_000)
 POSTGRES_GRAPH_SEARCH_TIMEOUT_MS = _int("AGENT_BOM_POSTGRES_GRAPH_SEARCH_TIMEOUT_MS", 3_000)
 
+# Tenant isolation on Postgres relies on Row-Level Security. Postgres superusers
+# and roles with BYPASSRLS ignore ``FORCE ROW LEVEL SECURITY``, which silently
+# voids every tenant policy. By default the store refuses to start when the
+# connected role can bypass RLS. Set this to ``1`` only for single-tenant or
+# local dev deployments, where it downgrades the hard error to a one-time
+# warning. See ``agent_bom.api.postgres_common`` (#3665).
+ALLOW_SUPERUSER_DB = _bool("AGENT_BOM_ALLOW_SUPERUSER_DB", False)
+
 # Compliance hub reference-table normalization (#3513). When enabled, repeated
 # CVE/framework blobs are stored once per tenant and ledger rows keep join keys.
 # Set to 0 to disable new extractions (reads still hydrate existing refs).

--- a/tests/test_rls_superuser_guard.py
+++ b/tests/test_rls_superuser_guard.py
@@ -1,0 +1,123 @@
+"""Startup guard: refuse to serve when the DB role can bypass tenant RLS (#3665).
+
+Postgres superusers and BYPASSRLS roles ignore ``FORCE ROW LEVEL SECURITY``,
+which silently voids every ``*_tenant_isolation`` policy created by
+``_ensure_tenant_rls``. These tests exercise the fail-closed guard wired into
+``_get_pool`` and the ``AGENT_BOM_ALLOW_SUPERUSER_DB`` escape hatch.
+"""
+
+import logging
+
+import pytest
+
+from agent_bom.api import postgres_common
+from agent_bom.api.postgres_common import RlsRolePrivilegeError
+
+
+class _RoleCursor:
+    def __init__(self, row):
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class _RoleConnection:
+    def __init__(self, row):
+        self._row = row
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql, params=None):
+        assert "pg_roles" in sql and "rolsuper" in sql and "rolbypassrls" in sql
+        return _RoleCursor(self._row)
+
+
+class _RolePool:
+    """Minimal pool whose connection reports fixed pg_roles attributes."""
+
+    def __init__(self, row):
+        self._row = row
+
+    def connection(self):
+        return _RoleConnection(self._row)
+
+
+@pytest.fixture(autouse=True)
+def _reset_guard():
+    postgres_common.reset_pool()
+    yield
+    postgres_common.reset_pool()
+
+
+def test_guard_raises_when_role_is_superuser(monkeypatch):
+    """A SUPERUSER role must abort startup because FORCE RLS is a no-op for it."""
+    monkeypatch.setattr(postgres_common, "ALLOW_SUPERUSER_DB", False, raising=False)
+    pool = _RolePool((True, False, "agent_bom"))
+
+    with pytest.raises(RlsRolePrivilegeError) as excinfo:
+        postgres_common._guard_rls_capable_role(pool)
+
+    message = str(excinfo.value)
+    assert "agent_bom" in message
+    assert "SUPERUSER" in message
+    assert "AGENT_BOM_ALLOW_SUPERUSER_DB" in message
+
+
+def test_guard_raises_when_role_has_bypassrls(monkeypatch):
+    """A BYPASSRLS (non-superuser) role must also abort startup."""
+    monkeypatch.setattr(postgres_common, "ALLOW_SUPERUSER_DB", False, raising=False)
+    pool = _RolePool((False, True, "sneaky_role"))
+
+    with pytest.raises(RlsRolePrivilegeError) as excinfo:
+        postgres_common._guard_rls_capable_role(pool)
+
+    assert "BYPASSRLS" in str(excinfo.value)
+
+
+def test_escape_hatch_downgrades_to_warning(monkeypatch, caplog):
+    """AGENT_BOM_ALLOW_SUPERUSER_DB downgrades the hard error to a warning."""
+    monkeypatch.setattr(postgres_common, "ALLOW_SUPERUSER_DB", True, raising=False)
+    pool = _RolePool((True, False, "agent_bom"))
+
+    with caplog.at_level(logging.WARNING, logger=postgres_common.logger.name):
+        postgres_common._guard_rls_capable_role(pool)  # must not raise
+
+    assert any("AGENT_BOM_ALLOW_SUPERUSER_DB" in rec.message for rec in caplog.records)
+    assert any("not enforced" in rec.message.lower() for rec in caplog.records)
+
+
+def test_guard_passes_for_nonprivileged_role(monkeypatch):
+    """A NOSUPERUSER NOBYPASSRLS role is the supported config and must pass."""
+    monkeypatch.setattr(postgres_common, "ALLOW_SUPERUSER_DB", False, raising=False)
+    pool = _RolePool((False, False, "agent_bom_app"))
+
+    postgres_common._guard_rls_capable_role(pool)  # must not raise
+
+
+def test_guard_runs_once_per_pool(monkeypatch):
+    """The role is inspected once; a later escape-hatch flip is not re-evaluated."""
+    monkeypatch.setattr(postgres_common, "ALLOW_SUPERUSER_DB", True, raising=False)
+    pool = _RolePool((True, False, "agent_bom"))
+    postgres_common._guard_rls_capable_role(pool)  # warns, marks checked
+
+    # Even if the operator "tightens" the flag afterwards, the cached check
+    # short-circuits — the guard is a startup gate, not a per-query one.
+    monkeypatch.setattr(postgres_common, "ALLOW_SUPERUSER_DB", False, raising=False)
+    postgres_common._guard_rls_capable_role(pool)  # must not raise
+
+
+def test_guard_is_best_effort_when_probe_fails(monkeypatch):
+    """A connection/probe error must not mask the primary failure path."""
+    monkeypatch.setattr(postgres_common, "ALLOW_SUPERUSER_DB", False, raising=False)
+
+    class _BrokenPool:
+        def connection(self):
+            raise RuntimeError("connection refused")
+
+    # Swallows the probe error and returns without raising.
+    postgres_common._guard_rls_capable_role(_BrokenPool())


### PR DESCRIPTION
## The defect

Tenant isolation on Postgres is enforced entirely through the
`FORCE ROW LEVEL SECURITY` policies created in
`src/agent_bom/api/postgres_common.py:_ensure_tenant_rls` (the RLS policy keys
on `current_setting('app.tenant_id')`). **Postgres superusers and roles with
`BYPASSRLS` ignore `FORCE ROW LEVEL SECURITY`** — so when the app connects as
such a role, every `*_tenant_isolation` policy becomes a silent no-op and
cross-tenant reads/writes succeed.

The default bundled quickstart connects as `POSTGRES_USER` (`agent_bom`), which
the `postgres:16-alpine` image creates as a **SUPERUSER**. Result: tenant
isolation was silently, completely disabled on the default deployment.

## Fix 1 — fail closed at startup

`src/agent_bom/api/postgres_common.py` — new `_guard_rls_capable_role()` called
from `_get_pool()` right after the pool is established. It runs
`SELECT rolsuper, rolbypassrls, rolname FROM pg_roles WHERE rolname = current_user`
once per pool and raises `RlsRolePrivilegeError` (new, ~line 45) when the role is
`SUPERUSER` or `BYPASSRLS`. The message names the role and the fix
(`ALTER ROLE <role> NOSUPERUSER NOBYPASSRLS` or point at `agent_bom_app`).

**Escape hatch:** `AGENT_BOM_ALLOW_SUPERUSER_DB=1`
(`src/agent_bom/config.py`, `ALLOW_SUPERUSER_DB`) downgrades the hard error to a
one-time warning for single-tenant / local dev. The probe is best-effort — a
transient connect error never masks the primary failure path.

Fail-closed by default; opt-in fail-open via the env var (documented in the
config docstring).

## Fix 2 — provision the bundled role correctly

`deploy/supabase/postgres/init.sql`:
- `agent_bom_app` is now created `NOSUPERUSER NOBYPASSRLS` explicitly.
- A final init step strips `SUPERUSER`/`BYPASSRLS` from the schema-owning
  `agent_bom` role (`ALTER ROLE ... NOSUPERUSER NOBYPASSRLS`). It runs last,
  after all extensions/tables are created; ownership is preserved so the app's
  runtime idempotent DDL still works, but the role is now subject to its own
  tenant RLS policies. The attribute change only applies on the next connection,
  so the rest of init is unaffected.

DDL is not broken: a non-superuser **owner** can still `ALTER TABLE`,
`ENABLE`/`FORCE` RLS, and `CREATE POLICY`/`FUNCTION`, and `FORCE ROW LEVEL
SECURITY` correctly applies to a non-superuser owner. No migration/runtime role
split was required.

## Tests

`tests/test_rls_superuser_guard.py`: guard raises for SUPERUSER and for
BYPASSRLS; escape hatch downgrades to a warning; non-privileged role passes;
one-time semantics; best-effort on probe failure.

```
python -m pytest tests/ -k "tenant or rls or postgres or isolation" -p no:randomly -q
# 533 passed, 6 skipped
```

Part of #3665