### PR TITLE
docs: canonical how-it-works + deployment matrix + editions page

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,17 +5,11 @@ CLI entry points, API/UI, MCP server mode, runtime proxy/gateway, cloud posture,
 IaC scanning, fleet, graph, reporting, and compliance workflows over the same
 core evidence model.
 
----
-
-## 0. Hermetic single-language stack
-
-agent-bom is pure Python (3.11+) end to end — CLI, FastAPI surface, MCP server, parsers, OSV/NVD/EPSS/KEV/GHSA enrichment, blast-radius scoring, IaC engine, and CIS benchmarks all live in the same interpreter. There is no Rust/Go/CGo extension on the scan path. Disk-image scans use native `dpkg` / RPM parsers (`src/agent_bom/filesystem.py`); the `syft` Go binary is opt-in only as a tar-archive fallback for VM-style images.
-
-Operational consequences:
-
-- One language, one dep tree, one pip-audit/SBOM surface to audit and reproduce.
-- Wheels build cleanly on `linux/amd64` and `linux/arm64` — no per-arch native toolchain.
-- Slower than Rust/Go scanners on huge fanouts; per-package memory is higher. For VM disk-image scanning at scale, install `syft` alongside agent-bom and let the fallback path take over.
+> **Product overview lives in [`HOW_IT_WORKS.md`](HOW_IT_WORKS.md)** — the
+> canonical five-stage flow (intake → scan → evidence → control → artifacts) and
+> the symbol-level CVE reachability differentiator. This document is the deeper
+> surface and module architecture: it leads with the product mental model, then
+> the implementation stack.
 
 ---
 
@@ -96,6 +90,24 @@ flowchart TB
 
     L1 --> L2 --> L3 --> L4 --> L5 --> L6 --> L7
 ```
+
+---
+
+## 1c. Implementation stack — hermetic and single-language
+
+With the product mental model in place, the implementation detail: agent-bom is
+pure Python (3.11+) end to end — CLI, FastAPI surface, MCP server, parsers,
+OSV/NVD/EPSS/KEV/GHSA enrichment, blast-radius scoring, IaC engine, and CIS
+benchmarks all live in the same interpreter. There is no Rust/Go/CGo extension
+on the scan path. Disk-image scans use native `dpkg` / RPM parsers
+(`src/agent_bom/filesystem.py`); the `syft` Go binary is opt-in only as a
+tar-archive fallback for VM-style images.
+
+Operational consequences:
+
+- One language, one dep tree, one pip-audit/SBOM surface to audit and reproduce.
+- Wheels build cleanly on `linux/amd64` and `linux/arm64` — no per-arch native toolchain.
+- Slower than Rust/Go scanners on huge fanouts; per-package memory is higher. For VM disk-image scanning at scale, install `syft` alongside agent-bom and let the fallback path take over.
 
 ---
 

--- a/docs/EDITIONS.md
+++ b/docs/EDITIONS.md
@@ -1,0 +1,78 @@
+# Editions and cost posture
+
+This is the single canonical statement of which lanes exist and what they cost.
+It folds together what used to be scattered across
+[`PRODUCT_BOUNDARIES.md`](PRODUCT_BOUNDARIES.md),
+[`DEPLOY_QUICKSTART.md`](DEPLOY_QUICKSTART.md), and
+[`HOSTED_POC.md`](HOSTED_POC.md). For what to deploy in each lane, use the
+[deployment decision matrix](../site-docs/deployment/overview.md).
+
+## Cost posture, stated plainly
+
+**Every lane that ships in this repository is free to run.** There is no
+managed public SaaS and no paid tier in this repo yet. You run agent-bom in your
+own boundary — laptop, cluster, or Snowflake account — and you pay only for the
+infrastructure you already own.
+
+This page describes cost *posture*, not prices. Where a lane's licensing is not
+yet finalized, that is called out below rather than guessed.
+
+## The lanes
+
+| Lane | Cost today | What ships | Boundary |
+|---|---|---|---|
+| **OSS** | Free (open source) | CLI, Docker, GitHub Action, reports, SBOM/SARIF/HTML/JSON, graph exports, MCP tools, local API/UI pilot | no hosted service or vendor telemetry required |
+| **Self-hosted** | Free to run today; a licensed enterprise tier is roadmap, not shipped | API/UI, Helm, Postgres/Supabase, auth/RBAC, tenant isolation, audit, graph, fleet, selected runtime proxy/gateway controls | operated in the customer's own infrastructure |
+| **Gated hosted POC** | Free but access-gated (operator-run, invite only) | a small operator-run demo environment for customer-0 proof | limited-access evaluation only; not generally available managed SaaS |
+| **Snowflake** | Free to run in the customer's account (customer pays Snowflake for compute) | Snowflake discovery, CIS/posture evidence, Native App packaging, selected backend paths | governance and warehouse-native lane, not full transactional parity for every feature |
+
+Managed `agent-bom Cloud` is **not shipped in this repository today**. It can be
+discussed as a roadmap lane only when labeled that way. Echoing the repo's own
+language: OSS CLI, self-hosted API/UI, gated hosted POC, or optional
+Snowflake-native lane — no managed public SaaS in this repo yet.
+
+## First proof per lane
+
+**OSS local scanner** — free, no account:
+
+```bash
+agent-bom agents --demo --offline
+```
+
+**Self-hosted control plane** — one workstation pilot, free:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
+docker compose -f docker-compose.pilot.yml up -d
+# Dashboard -> http://localhost:3000
+```
+
+For production self-hosting (Helm / EKS Terraform), see the
+[deployment decision matrix](../site-docs/deployment/overview.md).
+
+**Gated hosted POC** — operator-run, invite only. See
+[`HOSTED_POC.md`](HOSTED_POC.md) for the runbook.
+
+**Snowflake** — read-only evidence in the customer's account:
+
+```bash
+agent-bom agents --snowflake --format json --output snowflake-inventory.json
+```
+
+## How this maps to deployment
+
+| If you are... | Lane | Deploy |
+|---|---|---|
+| scanning a laptop or repo | OSS | `pip install agent-bom` |
+| running a team demo | Self-hosted | docker compose pilot |
+| going to production | Self-hosted | Helm / EKS Terraform |
+| a Snowflake shop | Snowflake | SPCS / Native App |
+| evaluating a live URL without operating it | Gated hosted POC | request access |
+
+## Related
+
+- Boundary table and copy rules: [`PRODUCT_BOUNDARIES.md`](PRODUCT_BOUNDARIES.md)
+- Connect-and-scan onboarding: [`DEPLOY_QUICKSTART.md`](DEPLOY_QUICKSTART.md)
+- Product flow and differentiator: [`HOW_IT_WORKS.md`](HOW_IT_WORKS.md)
+- Deployment decision matrix: [deployment overview](../site-docs/deployment/overview.md)
+</content>

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -1,0 +1,63 @@
+# How agent-bom works, and why it's different
+
+This is the single canonical overview of the product flow. Other docs link here
+instead of re-deriving the stages with their own counts. If you are choosing
+what to run, start with [`START_HERE.md`](START_HERE.md); if you are choosing
+what to deploy, use the
+[deployment decision matrix](../site-docs/deployment/overview.md).
+
+## Why it's different: symbol-level CVE reachability
+
+Most scanners stop at "this package has a CVE." `agent-bom` joins the
+CVE-affected symbols from OSV/GHSA advisories to your call graph, so you see the
+subset that is actually reachable from your code — typically a fraction of the
+raw match count — and then fuses that verdict into the agent graph. A reachable
+CVE in a package an MCP server exposes to an agent that holds a credential is a
+different risk than the same CVE sitting in dead code, and the product treats it
+that way.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="images/blast-radius-dark.svg">
+  <img alt="agent-bom blast radius: one vulnerable package fanning out through finding, MCP server, agent, credentials, and reachable tools" src="images/blast-radius-light.svg">
+</picture>
+
+That drilldown — package to finding to MCP server to agent to credentials and
+reachable tools — is the product's center of gravity. Everything else exists to
+produce and act on it. Function-level de-noising joins OSV/GHSA affected symbols
+to Python, npm, Go, Java, Rust, and Ruby call graphs when `--project` AST
+analysis is available; the CVE/CWE/CPE identifiers ride along on the
+reachability verdict. See [`VULNERABILITY_MATCHING.md`](VULNERABILITY_MATCHING.md)
+for the mechanics.
+
+## The five-stage flow
+
+Read it in one direction: read-only **intake**, then **scan**, then normalize
+into one **evidence** model, then serve and enforce over it from a self-hosted
+**control** plane, then emit **artifacts** in the formats each consumer already
+trusts.
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="images/how-it-works-dark.svg">
+  <img alt="agent-bom five-stage flow: intake, scan, evidence, control, artifacts" src="images/how-it-works-light.svg">
+</picture>
+
+| Stage | What happens | Key output |
+|---|---|---|
+| **1. Intake** | Read-only collection from repos, CI, lockfiles, SBOMs, container images, IaC, MCP configs, cloud accounts, and runtime events. No writes, no secret values read. | raw evidence sources |
+| **2. Scan** | The six-step engine — discover, extract, scan, enrich, analyze, report — runs parsers and advisory scanners, enriches with NVD CVSS / EPSS / KEV / GHSA, and **analyzes symbol-level CVE reachability** against the call graph. | matched, enriched, reachability-scored findings |
+| **3. Evidence** | Everything normalizes into one `Finding` model and one `ContextGraph`, so triage never forks per source. Reachable CVEs are fused into the agent/MCP graph to produce the blast radius above. | unified `Finding` + `ContextGraph` |
+| **4. Control** | The same evidence is served and enforced through a self-hosted control plane: REST API, dashboard, MCP server, gateway/proxy, fleet — all behind auth, RBAC, tenant scope, and signed audit. | tenant-scoped, audited access + runtime decisions |
+| **5. Artifacts** | Decisions leave in the format each consumer trusts: SARIF, CycloneDX, SPDX, OCSF, HTML, PDF, JSON, CSV, webhooks — for humans (CLI, UI) and agents (MCP tools, API) alike. | gates, reports, compliance evidence, runtime blocks |
+
+Stage 2's "analyze" step is where symbol-level reachability is computed; stage 3
+is where it becomes a blast radius. That pairing is the differentiator — the
+rest of the flow is table stakes done cleanly.
+
+## Where to go next
+
+- Deeper module and surface architecture: [`ARCHITECTURE.md`](ARCHITECTURE.md)
+- Service lanes and backend choices: [`PRODUCT_MAP.md`](PRODUCT_MAP.md)
+- Positioning and shipped-vs-not: [`PRODUCT_BRIEF.md`](PRODUCT_BRIEF.md)
+- Lanes and cost posture: [`EDITIONS.md`](EDITIONS.md)
+- What to deploy first: [deployment overview](../site-docs/deployment/overview.md)
+</content>

--- a/docs/PRODUCT_BOUNDARIES.md
+++ b/docs/PRODUCT_BOUNDARIES.md
@@ -1,7 +1,9 @@
 # Product Boundaries
 
 This is the GitHub-facing companion to
-`site-docs/deployment/product-boundaries.md`.
+`site-docs/deployment/product-boundaries.md`. For the lanes stated together with
+their cost posture, see [EDITIONS.md](EDITIONS.md) — the canonical editions page.
+This page is the boundary and copy-rules reference.
 
 `agent-bom` has three current product lanes:
 

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -25,6 +25,11 @@ enterprise-hardening track.
 
 Current repo-derived counts live in [PRODUCT_METRICS.md](PRODUCT_METRICS.md). This brief intentionally keeps volatile metrics out of the main narrative.
 
+For the canonical product flow and the headline differentiator — symbol-level
+CVE reachability — see [HOW_IT_WORKS.md](HOW_IT_WORKS.md). This brief covers
+positioning and shipped-vs-not; it does not re-derive the stage-by-stage flow.
+For the lanes and cost posture, see [EDITIONS.md](EDITIONS.md).
+
 ## Positioning contract
 
 The product should converge curious users into real adoption by answering four
@@ -143,7 +148,7 @@ The scanner covers package risk, malicious or suspicious package indicators, con
 
 ### Blast radius
 
-Blast radius is the product center of gravity. `agent-bom` connects vulnerabilities to packages, MCP servers, agents, credential exposure, and reachable tools. Impact is CWE-aware so the reported consequences match the weakness class instead of inflating every issue into full compromise. Function-level CVE de-noising joins OSV/GHSA affected symbols to Python, npm, Go, Java, Rust, and Ruby call graphs when ``--project`` AST analysis is available; CVE/CWE/CPE identifiers ride along on the reachability verdict.
+Blast radius is the product center of gravity; [HOW_IT_WORKS.md](HOW_IT_WORKS.md) is the canonical narrative for it. `agent-bom` connects vulnerabilities to packages, MCP servers, agents, credential exposure, and reachable tools. Impact is CWE-aware so the reported consequences match the weakness class instead of inflating every issue into full compromise. Function-level CVE de-noising joins OSV/GHSA affected symbols to Python, npm, Go, Java, Rust, and Ruby call graphs when ``--project`` AST analysis is available; CVE/CWE/CPE identifiers ride along on the reachability verdict.
 
 The highest-risk trust chain is surfaced directly in the human and machine surfaces, not only the JSON report. The `--posture` card renders the top exposure path as a one-line spine (`agent → MCP server → package@version → CVE → tool`) with its blast-radius summary (`N cred(s), N tool(s) reachable`), and SARIF results carry the same chain in the result message, an `exposure_chain` property, and `relatedLocations` so it renders in code-scanning viewers.
 

--- a/docs/PRODUCT_MAP.md
+++ b/docs/PRODUCT_MAP.md
@@ -4,6 +4,11 @@
 changes how data arrives and who operates it; it should not change the finding,
 graph, audit, or export semantics.
 
+For the canonical product flow (intake → scan → evidence → control → artifacts)
+and the symbol-level CVE reachability differentiator, see
+[HOW_IT_WORKS.md](HOW_IT_WORKS.md). This map focuses on lanes, surfaces, and
+backend choices rather than re-deriving the flow.
+
 ## Service lanes
 
 | Lane | Use it for | Entry point | Backing services | Output |
@@ -39,6 +44,9 @@ graph, audit, or export semantics.
 | Evidence exports | caller-selected destination; compliance exports have audit/signing paths where configured | [COMPLIANCE_SIGNING.md](COMPLIANCE_SIGNING.md), [DATA_GOVERNANCE_RETENTION.md](DATA_GOVERNANCE_RETENTION.md) |
 
 ## Data flow
+
+The canonical stage-by-stage narrative is [HOW_IT_WORKS.md](HOW_IT_WORKS.md);
+the map-level view of the same flow is:
 
 1. **Discover** from local files, packages, MCP clients, cloud APIs, imports, or runtime events.
 2. **Match and enrich** with advisory, exploitability, posture, policy, identity, and cloud context.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
           - AWS Company Rollout: deployment/aws-company-rollout.md
           - Enterprise MCP / Endpoint Pilot: deployment/enterprise-pilot.md
           - Terraform AWS Baseline: deployment/terraform-aws-baseline.md
+          - Terraform Azure Ingestion: deployment/terraform-azure-ingestion.md
           - Control-Plane Data Model and Store Parity: deployment/control-plane-data-model.md
           - Backend Parity: deployment/backend-parity.md
           - Backend and Security-Lake Strategy: deployment/backend-and-security-lakes.md

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -8,9 +8,25 @@ Use this page when the question is not "how do I install `agent-bom`?" but
 "what should I deploy first, what does that give me, and when do I add runtime
 enforcement?"
 
-Treat this as the primary deployment chooser. The rest of the deployment docs
-either deepen one of these supported paths or act as reference material for
-teams intentionally diverging from them.
+Treat this as the primary deployment chooser and the canonical deployment
+decision matrix. The rest of the deployment docs either deepen one of these
+supported paths or act as reference material for teams intentionally diverging
+from them.
+
+## Decision in one line
+
+| Situation | Deploy | Get |
+|---|---|---|
+| **Laptop scan** | `pip install agent-bom` | local findings, SBOM, SARIF, HTML, graph export |
+| **Team demo** | `docker compose` pilot | shared API + UI control plane on one workstation |
+| **Production** | Helm / EKS Terraform | tenant-aware self-hosted control plane in your cluster |
+| **Snowflake shop** | SPCS / Native App | warehouse-native governance lane in your account |
+
+Same one-liner in prose: laptop scan → pip; team demo → docker compose pilot;
+production → Helm / EKS Terraform; Snowflake shop → SPCS / Native App. Every lane
+here runs in your own boundary. Cost posture: all in-repo lanes are free and no
+managed public SaaS ships in this repo yet; see
+[Product boundaries](product-boundaries.md) for the full lane matrix.
 
 `agent-bom` is one product with two deployable images:
 


### PR DESCRIPTION
## What this consolidates

The product overview and the lane/cost story were re-derived across ~7 docs with conflicting stage counts (3 lanes here, 4 layers there, 5 steps elsewhere, 6 lanes in another). There was also no single cost/pricing statement anywhere. This PR gives each one canonical page and points the rest at it.

## New canonical pages

- **`docs/HOW_IT_WORKS.md`** — the single product-flow narrative. Anchored on the existing 5-stage `how-it-works` SVG (intake → scan → evidence → control → artifacts), with the `blast-radius` SVG as the "why it's different" hero. Surfaces **symbol-level CVE reachability** as a named stage and a hero sentence (previously buried in PRODUCT_BRIEF's blast-radius section).
- **`docs/EDITIONS.md`** — states the lanes together with cost posture explicitly: OSS (free), self-hosted (free to run; licensed tier is roadmap, not shipped), gated hosted POC (free, invite-only), Snowflake (free to run, customer pays Snowflake). Plainly states: all in-repo lanes are free; no managed public SaaS ships in this repo yet. No invented prices — posture only. Folds in what was scattered across PRODUCT_BOUNDARIES, DEPLOY_QUICKSTART, and HOSTED_POC.

## Docs that now link instead of re-deriving

- `docs/PRODUCT_BRIEF.md` — links to HOW_IT_WORKS for the flow + reachability differentiator; links to EDITIONS for lanes/cost.
- `docs/PRODUCT_MAP.md` — top pointer + Data-flow section defer to HOW_IT_WORKS as canonical.
- `docs/ARCHITECTURE.md` — canonical pointer to HOW_IT_WORKS; **reordered** so the product mental model (§1) comes before the hermetic/pure-Python implementation note (now §1c instead of §0).
- `docs/PRODUCT_BOUNDARIES.md` — links to the new EDITIONS page so the boundary table and editions story are connected.

## Deployment decision matrix

- `site-docs/deployment/overview.md` — promoted as THE canonical deployment decision matrix with a one-line chooser: laptop scan → pip; team demo → docker compose pilot; production → Helm / EKS Terraform; Snowflake shop → SPCS / Native App. Cost posture stated inline.

## mkdocs

- Added `deployment/terraform-azure-ingestion.md` to the nav next to its sibling `terraform-aws-baseline.md` (was the only real orphan).

## Verification

- `mkdocs build --strict` → **exit 0**, no warnings/orphans (the cross-tree link that would have failed strict was kept in-tree).
- All internal links in the new docs/ pages verified to resolve.
- No competitor names; no pricing numbers invented.