### PR TITLE
fix(cli): eliminate silent profile-redirect, add empty-DB nudge, unify first command

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,22 @@ listing; install and liveness checks live in the integration docs.
 
 ```bash
 pip install agent-bom
-agent-bom db update                      # populate ~/.agent-bom vuln DB before --offline scans
-agent-bom quickstart --run --offline    # sample scan, gateway policy seed, dashboard data
-agent-bom agents -p . -f html -o agent-bom-report.html
+agent-bom scan -p .                       # scan this repo: rich console panel with posture grade
+```
+
+The console panel is the fastest first impression — posture grade, blast radius,
+and fix-first findings inline, no file to open. For a reproducible run (safe to
+screenshot or attach to a bug report), use the release-pinned demo:
+
+```bash
+agent-bom scan --demo --offline           # curated sample, no network, deterministic
+```
+
+Then export or hand off when you need a file:
+
+```bash
+agent-bom db update                       # populate ~/.agent-bom vuln DB before --offline scans
+agent-bom scan -p . -f html -o agent-bom-report.html
 ```
 
 Run `agent-bom db update` before `--offline` image or package scans. Guided path:

--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -1,21 +1,35 @@
 # First Run Guide
 
-This guide gives new users a deterministic path from install to a real
-inventory and graph without asking them to scan a private repository first.
+This guide is the canonical quickstart for `agent-bom`. It gives new users a
+deterministic path from install to a real inventory and graph.
 
 **Hosting the control plane?** See [`DEPLOY_QUICKSTART.md`](DEPLOY_QUICKSTART.md) —
 `scripts/deploy/install.sh pilot` for local Docker, or EKS/AKS/GKE/Snowflake
 paths with read-only cloud connect.
 
+## 0. One command to see value
+
+```bash
+pip install agent-bom
+agent-bom scan -p .
+```
+
+`agent-bom scan -p .` prints a rich console panel — posture grade, blast radius,
+and fix-first findings inline — with nothing to open. This is the recommended
+first command. When you need a file, add `-f html -o agent-bom-report.html` (or
+`-f json`, `-f sarif`); run `agent-bom db update` first for offline package/image
+scans.
+
 ## 1. Run the Release-Pinned Demo
 
 ```bash
-agent-bom agents --demo --offline
+agent-bom scan --demo --offline
 ```
 
-Use this when you need reproducible output. The package versions and
-advisory-backed ranges are curated in code and guarded by tests, so screenshots
-and docs do not depend on fabricated CVEs or a machine-specific local DB.
+Use this when you need reproducible output — for example a screenshot or a bug
+report. The package versions and advisory-backed ranges are curated in code and
+guarded by tests, so it does not depend on fabricated CVEs or a machine-specific
+local DB. Everyday scans should use `agent-bom scan -p .` (section 0) instead.
 
 ### Annotated demo output
 
@@ -76,7 +90,7 @@ Those names are environment variable identifiers, not secret values.
 The most useful next command is usually a structured export:
 
 ```bash
-agent-bom agents --demo --offline -f json -o /tmp/agent-bom-demo.json
+agent-bom scan --demo --offline -f json -o /tmp/agent-bom-demo.json
 ```
 
 Use that JSON to push the same evidence into a control plane, inspect the graph,
@@ -89,13 +103,13 @@ From any directory after installing `agent-bom`:
 ```bash
 agent-bom samples first-run
 cd agent-bom-first-run
-agent-bom agents --inventory inventory.json -p . --enrich
+agent-bom scan --inventory inventory.json -p . --enrich
 ```
 
 From a repository checkout, you can also scan the checked-in fixture directly:
 
 ```bash
-agent-bom agents \
+agent-bom scan \
   --inventory examples/first-run-ai-stack/inventory.json \
   --project examples/first-run-ai-stack \
   --enrich
@@ -142,7 +156,7 @@ For the sample project, export JSON and push it through your normal API import
 flow:
 
 ```bash
-agent-bom agents \
+agent-bom scan \
   --inventory agent-bom-first-run/inventory.json \
   --project agent-bom-first-run \
   -f json \
@@ -154,7 +168,7 @@ agent-bom agents \
 After the sample makes sense, scan your own project:
 
 ```bash
-agent-bom agents -p .
+agent-bom scan -p .
 ```
 
 Add `--inventory <file>` when you already have agent/server inventory from a

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -14,10 +14,13 @@ You want findings, an SBOM, and a CI gate.
 
 ```bash
 pip install agent-bom
-agent-bom agents -p .                     # scan this repo: packages, agents, MCP servers, blast radius
-agent-bom agents -p . -f sarif -o out.sarif   # SARIF for code-scanning
+agent-bom scan -p .                       # scan this repo: rich console panel with posture grade
+agent-bom scan -p . -f sarif -o out.sarif     # SARIF for code-scanning
 agent-bom check flask@2.0.0 --ecosystem pypi  # pre-install allow/warn/block
 ```
+
+New here? [`FIRST_RUN.md`](FIRST_RUN.md) is the canonical quickstart —
+`agent-bom scan -p .` is the one first command it leads with.
 
 CI gate (GitHub Action):
 

--- a/src/agent_bom/cli/_profiles.py
+++ b/src/agent_bom/cli/_profiles.py
@@ -167,6 +167,35 @@ def _string_value(profile: dict[str, Any], *keys: str) -> str | None:
     return None
 
 
+def active_profile_banner(
+    name: str | None,
+    output_format: str | None,
+    output: str | None,
+    *,
+    auto_active: bool,
+    user_chose: bool,
+    agent_mode: bool = False,
+) -> str | None:
+    """Build the one-line "profile active" banner, or ``None`` when unwarranted.
+
+    Only fires when a profile was *auto-activated* from ``current_profile`` (no
+    ``--profile``/env), the user did not explicitly pick the format/output, and
+    the profile actually redirects output away from the console default. This is
+    the silent-redirect trap — a profile that pins ``format=json`` +
+    ``output=agent-bom-report.json`` otherwise writes a file with no indication a
+    profile was in play.
+    """
+    if not name or not auto_active or user_chose or agent_mode:
+        return None
+    redirects = (bool(output_format) and output_format != "console") or bool(output)
+    if not redirects:
+        return None
+    detail = f"format={output_format}" if output_format else "format=console"
+    if output:
+        detail += f" → {output}"
+    return f"Profile {name!r} active ({detail}). Override with --format console."
+
+
 def apply_scan_profile_defaults(
     *,
     output: str | None,
@@ -176,9 +205,10 @@ def apply_scan_profile_defaults(
     push_url: str | None,
     push_api_key: str | None,
     clickhouse_url: str | None,
+    agent_mode: bool = False,
 ) -> tuple[str | None, str, str | None, str | None, str | None, str | None, str | None]:
     """Apply active profile defaults for the main scan command."""
-    _name, profile = load_active_profile()
+    name, profile = load_active_profile()
     if not profile:
         return output, output_format, preset, nvd_api_key, push_url, push_api_key, clickhouse_url
     apply_profile_environment(profile)
@@ -208,6 +238,29 @@ def apply_scan_profile_defaults(
         else profile_default(ctx, profile, "output_format", output_format, "format", "output_format")
     )
 
+    # Surface a one-line banner when a profile was auto-activated from
+    # ``current_profile`` and silently redirected output. Without this, a bare
+    # `agent-bom scan` writes a JSON file to CWD with no indication a profile was
+    # active. Suppressed for explicit --profile/env, explicit format/output, and
+    # agent-mode (which owns stdout for machine JSON — the banner goes to stderr,
+    # but stays quiet in agent-mode to keep automation logs clean).
+    from agent_bom.cli._agent_mode import AGENT_MODE_ENV_VAR
+
+    auto_active = not (os.environ.get(PROFILE_ENV_VAR) or "").strip()
+    user_chose = explicit_output or explicit_format or caller_supplied_output or caller_supplied_format
+    quiet = bool(ctx.params.get("quiet")) if ctx is not None else False
+    agent_mode_active = agent_mode or bool((os.environ.get(AGENT_MODE_ENV_VAR) or "").strip())
+    banner = active_profile_banner(
+        name,
+        profile_format,
+        profile_output,
+        auto_active=auto_active,
+        user_chose=user_chose,
+        agent_mode=agent_mode_active,
+    )
+    if banner and not quiet:
+        click.echo(banner, err=True)
+
     return (
         profile_output,
         profile_format,
@@ -233,8 +286,12 @@ def write_profile_template(path: Path, name: str, *, force: bool = False) -> Non
                 "",
                 f"[profiles.{name}]",
                 'tenant_id = "default"',
-                'format = "json"',
-                'output = "agent-bom-report.json"',
+                # Console keeps the rich value panel on stdout by default. A
+                # profile that pins format=json + an output file would silently
+                # redirect `agent-bom scan` to a file — `profiles init` must not
+                # manufacture that footgun. Uncomment to opt into file output:
+                'format = "console"',
+                '# output = "agent-bom-report.json"',
                 'preset = "quick"',
                 'push_url = ""',
                 'push_api_key_env = "AGENT_BOM_PUSH_API_KEY"',

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -530,6 +530,7 @@ def scan(
             push_url=push_url,
             push_api_key=push_api_key,
             clickhouse_url=clickhouse_url,
+            agent_mode=agent_mode,
         )
 
     if agent_token_budget < 0:
@@ -2543,6 +2544,28 @@ def scan(
             agent_token_budget=agent_token_budget,
             agent_mode_full=agent_mode_full,
             page=page,
+        )
+
+    # ── First-run nudge: offline scan with no local advisory data ─────────────
+    # A clean install running `scan … --offline` with no synced advisory DB
+    # reports "0 vulns / PARTIAL COVERAGE" — alarming and unexplained. Surface an
+    # actionable line right under the summary so the empty result reads as a
+    # setup gap, not a clean bill of health. Console output only (machine formats
+    # stay clean) and never in demo mode, which ships a bundled advisory DB.
+    if (
+        offline
+        and not demo
+        and not quiet
+        and not agent_mode
+        and output_format == "console"
+        and not output
+        and _vuln_freshness is not None
+        and _vuln_freshness.mode == "offline"
+        and _vuln_freshness.record_count == 0
+    ):
+        con.print(
+            "[yellow]No local advisory DB — run 'agent-bom db update' "
+            "(or drop --offline). Coverage may be incomplete.[/yellow]"
         )
 
     # ── Posture summary mode (--posture) ──────────────────────────────────────

--- a/tests/test_cli_profiles.py
+++ b/tests/test_cli_profiles.py
@@ -5,7 +5,14 @@ import pytest
 from click.testing import CliRunner
 
 from agent_bom.cli import main
-from agent_bom.cli._profiles import apply_scan_profile_defaults, load_active_profile, set_current_profile
+from agent_bom.cli._profiles import (
+    active_profile_banner,
+    apply_scan_profile_defaults,
+    default_config_path,
+    load_active_profile,
+    set_current_profile,
+    write_profile_template,
+)
 
 
 def test_profile_loader_uses_current_profile(monkeypatch, tmp_path):
@@ -236,6 +243,140 @@ format = "json"
     assert show_result.exit_code == 0
     assert "[prod]" in show_result.output
     assert "tenant_id = team-a" in show_result.output
+
+
+def test_active_profile_banner_fires_on_auto_active_json_redirect():
+    banner = active_profile_banner(
+        "default",
+        "json",
+        "agent-bom-report.json",
+        auto_active=True,
+        user_chose=False,
+    )
+    assert banner == (
+        "Profile 'default' active (format=json → agent-bom-report.json). "
+        "Override with --format console."
+    )
+
+
+def test_active_profile_banner_silent_when_console_default():
+    # A console-format profile does not redirect output — no banner.
+    assert active_profile_banner("default", "console", None, auto_active=True, user_chose=False) is None
+
+
+def test_active_profile_banner_silent_when_explicit_or_agent_mode():
+    # Explicit --profile/env (not auto-active), explicit flag, or agent-mode all suppress.
+    assert active_profile_banner("prod", "json", "r.json", auto_active=False, user_chose=False) is None
+    assert active_profile_banner("prod", "json", "r.json", auto_active=True, user_chose=True) is None
+    assert (
+        active_profile_banner("prod", "json", "r.json", auto_active=True, user_chose=False, agent_mode=True) is None
+    )
+
+
+def test_scan_profile_defaults_emit_banner_on_silent_redirect(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+current_profile = "default"
+
+[profiles.default]
+format = "json"
+output = "agent-bom-report.json"
+"""
+    )
+    monkeypatch.setenv("AGENT_BOM_CONFIG", str(config_path))
+    monkeypatch.delenv("AGENT_BOM_PROFILE", raising=False)
+    monkeypatch.delenv("AGENT_BOM_AGENT_MODE", raising=False)
+
+    @click.command()
+    @click.option("--output")
+    @click.option("--format", "output_format", default="console")
+    @click.option("--quiet", is_flag=True)
+    def _bare_scan(output, output_format, quiet):
+        apply_scan_profile_defaults(
+            output=output,
+            output_format=output_format,
+            preset=None,
+            nvd_api_key=None,
+            push_url=None,
+            push_api_key=None,
+            clickhouse_url=None,
+        )
+
+    runner = CliRunner()
+    result = runner.invoke(_bare_scan, [])
+    assert result.exit_code == 0, result.output
+    assert "Profile 'default' active (format=json → agent-bom-report.json)" in result.stderr
+
+
+def test_scan_profile_defaults_no_banner_with_explicit_profile_env(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        """
+current_profile = "default"
+
+[profiles.default]
+format = "json"
+output = "agent-bom-report.json"
+"""
+    )
+    monkeypatch.setenv("AGENT_BOM_CONFIG", str(config_path))
+    monkeypatch.setenv("AGENT_BOM_PROFILE", "default")  # explicit selection → no surprise
+
+    @click.command()
+    @click.option("--output")
+    @click.option("--format", "output_format", default="console")
+    def _bare_scan(output, output_format):
+        apply_scan_profile_defaults(
+            output=output,
+            output_format=output_format,
+            preset=None,
+            nvd_api_key=None,
+            push_url=None,
+            push_api_key=None,
+            clickhouse_url=None,
+        )
+
+    runner = CliRunner()
+    result = runner.invoke(_bare_scan, [])
+    assert result.exit_code == 0, result.output
+    assert "active" not in result.stderr
+
+
+def test_profiles_init_writes_console_default_template(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.toml"
+    monkeypatch.setenv("AGENT_BOM_CONFIG", str(config_path))
+
+    write_profile_template(default_config_path(), "default")
+    text = config_path.read_text()
+
+    # Console stays the default — the generated template must not manufacture the
+    # silent-redirect footgun (format=json + output=file).
+    assert 'format = "console"' in text
+    assert '\noutput = ' not in text  # no active output redirect (commented only)
+    assert '# output = "agent-bom-report.json"' in text
+
+    # And a bare scan under this fresh template stays on the console with no banner.
+    @click.command()
+    @click.option("--output")
+    @click.option("--format", "output_format", default="console")
+    def _bare_scan(output, output_format):
+        values = apply_scan_profile_defaults(
+            output=output,
+            output_format=output_format,
+            preset=None,
+            nvd_api_key=None,
+            push_url=None,
+            push_api_key=None,
+            clickhouse_url=None,
+        )
+        assert values[:2] == (None, "console")
+
+    monkeypatch.delenv("AGENT_BOM_PROFILE", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(_bare_scan, [])
+    assert result.exit_code == 0, result.output
+    assert result.stderr == ""
 
 
 def test_profiles_use_missing_profile_lists_available(monkeypatch, tmp_path):

--- a/tests/test_vuln_freshness.py
+++ b/tests/test_vuln_freshness.py
@@ -210,5 +210,24 @@ def test_enrichment_cache_age_missing_returns_none(tmp_path, monkeypatch):
     assert enrichment.enrichment_cache_age_hours(now=_NOW) is None
 
 
+def test_offline_empty_db_signals_first_run_nudge_contract(tmp_path, monkeypatch):
+    """The first-run empty-DB nudge keys off ``mode == 'offline'`` with a
+    zero ``record_count``. Lock that contract so an absent local advisory DB
+    scanned ``--offline`` stays detectable as "no coverage", not a clean run.
+    """
+    from agent_bom.db import schema
+
+    monkeypatch.setattr(schema, "DB_PATH", tmp_path / "does-not-exist.db")
+
+    freshness = compute_freshness(offline=True)
+
+    assert freshness.mode == "offline"
+    assert freshness.record_count == 0
+    assert freshness.sources == []
+    # Same probe without --offline degrades to live mode (network fallback),
+    # so the nudge must not fire there.
+    assert compute_freshness(offline=False).mode == "live"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-q"])


### PR DESCRIPTION
## First-run UX cleanup

Three first-run traps reproduced live and fixed as one coherent PR. No behavior change to scan results.

### FIX 1 — Kill the silent config-profile redirect
A `~/.agent-bom/config.toml` with `current_profile = "default"` + `format="json"` + `output="agent-bom-report.json"` made a bare `agent-bom scan` silently write a JSON file to CWD with terse progress and **no indication a profile was active**.

- `cli/_profiles.py` `apply_scan_profile_defaults` (new `active_profile_banner` helper): when a profile is auto-activated from `current_profile` (no `--profile`/env) **and** redirects output, print one line to **stderr**. Suppressed for explicit `--profile`/env, explicit `--format`/`--output`, `--quiet`, and agent-mode (keeps machine JSON on stdout clean).
- `cli/_profiles.py:229` `write_profile_template` (`profiles init`): template now defaults to `format = "console"` and comments out `output`, so it no longer manufactures the footgun.

**Live before/after** (`agent-bom scan -p . --offline`, profile pins json):
```
before: (silently writes agent-bom-report.json, no notice)
after (stderr): Profile 'default' active (format=json → agent-bom-report.json). Override with --format console.
```
`profiles init` template:
```
before: format = "json" / output = "agent-bom-report.json"
after:  format = "console" / # output = "agent-bom-report.json"
```

### FIX 2 — First-run empty-DB nudge
A clean-install `scan … --offline` with no local advisory DB reported "0 vulns / PARTIAL COVERAGE" — alarming and unexplained.

- `cli/agents/__init__.py` (scan-summary output path): when an offline scan **completes** against an empty/absent local advisory DB (`freshness.mode == "offline"` and `record_count == 0`), print an inline hint under the console summary. Console output only; never in demo mode (bundled DB). Scan results unchanged.

**Live after** (`agent-bom scan -p <empty> --offline`, fresh HOME):
```
No local advisory DB — run 'agent-bom db update' (or drop --offline). Coverage may be incomplete.
```

### FIX 3 — One documented first command everywhere
`README.md`, `docs/START_HERE.md`, and `docs/FIRST_RUN.md` each showed a different first command.

- All three now lead with `agent-bom scan -p .` (console panel with posture grade) as the primary, with `scan --demo --offline` as the reproducible-screenshot variant.
- `README.md:176` First-Run section now leads with the console command **before** any `-o file` example.
- `docs/FIRST_RUN.md` is the canonical quickstart (new "One command to see value" section); `README`/`START_HERE` link to it identically. `agents` → `scan` throughout the docs (the hidden `scan` alias already works today).

### Tests
`python -m pytest tests/ -k "profile or first_run or offline or scan_summary" -p no:randomly -q` → **140 passed, 2 skipped**. New regression tests: banner helper + `apply_scan_profile_defaults` banner/suppression (incl. agent-mode + explicit `--profile`), console-default template, and the offline empty-DB freshness contract the nudge keys off.

Scope: touches only `cli/_profiles.py`, the scan-summary path in `cli/agents/__init__.py`, the three owned docs, and tests. Did not touch `options_sources.py`, `options_surfaces.py`, `cli/agents/_output.py`, `_server.py`, `ui/`, or `api/`.
