### PR TITLE
test: eliminate order-dependent flake class (global-singleton isolation + enable pytest-randomly)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,14 +693,15 @@ jobs:
         run: |
           # -n auto --dist loadscope: spread tests across worker processes,
           # grouping same-module tests on one worker so module-scoped fixtures
-          # behave. -p no:randomly keeps CI in deterministic order (reproducible
-          # failures); it is redundant with the pytest addopts default but kept
-          # explicit. The suite is order-independent — run `pytest -p randomly`
-          # locally to verify.
+          # behave. Test order is randomized by default (pytest-randomly, ON via
+          # pyproject addopts) to keep order-dependence from regressing; the seed
+          # is printed as "Using --randomly-seed=N" and a failure replays exactly
+          # with `pytest --randomly-seed=N`. Isolation is guaranteed by the
+          # global-singleton snapshot/restore fixture in tests/conftest.py.
           if [ "${{ matrix.python-version }}" = "3.11" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
-            uv run pytest tests/ -v --tb=short --cov=agent_bom --cov-report=term-missing --cov-fail-under=75 -m "not network" -n auto --dist loadscope -p no:randomly
+            uv run pytest tests/ -v --tb=short --cov=agent_bom --cov-report=term-missing --cov-fail-under=75 -m "not network" -n auto --dist loadscope
           else
-            uv run pytest tests/ -q --tb=short -m "not network" -n auto --dist loadscope -p no:randomly
+            uv run pytest tests/ -q --tb=short -m "not network" -n auto --dist loadscope
           fi
 
       - name: Graph accuracy guards (#2259 — round-trip + edge-count + visual-diff)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,14 +280,18 @@ server = "agent_bom.mcp_server:create_smithery_server"
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 pythonpath = ["src"]
-# pytest-randomly is installed as a dev dep but kept OFF by default so CI runs
-# in deterministic order — a failing job is then reproducible without hunting
-# for the shuffle seed. The suite is genuinely order-independent (all known
-# coupling was fixed via the global-state resets in tests/conftest.py and the
-# per-module fixtures); contributors can prove it locally by overriding this
-# with `pytest -p randomly`. Disabling here (not per-CI-command) covers every
-# job — main matrix, Alpine/musl, Postgres — and local runs alike.
-addopts = "-p no:randomly"
+# pytest-randomly is ON by default: every run (local + CI — main matrix,
+# Alpine/musl, Postgres) shuffles test order to keep order-dependence from
+# creeping back in. Order-independence is enforced structurally by the autouse
+# reset_global_test_state fixture in tests/conftest.py, which snapshots and
+# restores every process-global store singleton (the ~35 set_*_store accessors),
+# the shared Rich output console, the proxy in-memory alert/metric buffers, and
+# the auth env/config — so a test that swaps a global and skips its own cleanup
+# cannot leak into the next test regardless of order. A failing run stays
+# reproducible: pytest-randomly prints "Using --randomly-seed=N"; re-run with
+# `--randomly-seed=N` to replay the exact order. To force deterministic order
+# for a one-off local run, pass `-p no:randomly`.
+addopts = ""
 markers = [
     "network: tests that require network access (OSV API)",
     "slow: slow tests (e.g. large-scale perf benchmarks) — opt-in only",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,12 +187,18 @@ def _reset_api_runtime_state() -> None:
 
 def _reset_proxy_route_state() -> None:
     # The proxy status/alerts route keeps process-global in-memory buffers:
-    # a bounded _proxy_alerts deque, its _proxy_alerts_total counter, and the
-    # latest _proxy_metrics / _proxy_metrics_by_tenant snapshots. _load_proxy_alerts
-    # only falls back to the AGENT_BOM_LOG file when _proxy_alerts is EMPTY, so an
-    # alert left in the deque by an earlier test makes /v1/proxy/status ignore the
-    # log and report the wrong alert count (order-dependent: test_proxy_status_from_log
-    # asserting total_alerts==1 gets 0). Clear all four so each test starts clean.
+    # a bounded _proxy_alerts deque, its _proxy_alerts_total counter, the latest
+    # _proxy_metrics / _proxy_metrics_by_tenant snapshots, and a 24h audit-event
+    # dedupe table (_audit_dedupe, guarded by _audit_dedupe_lock, up to 50k
+    # entries). _load_proxy_alerts only falls back to the AGENT_BOM_LOG file when
+    # _proxy_alerts is EMPTY, so an alert left in the deque by an earlier test
+    # makes /v1/proxy/status ignore the log and report the wrong count (e.g.
+    # test_proxy_status_from_log asserting total_alerts==1 gets 0). The dedupe
+    # table is just as order-sensitive: a (tenant, event_id) key emitted by one
+    # test suppresses the same event in a later test asserting emission, so a
+    # test that ingests then one that re-ingests the same id can flake. Clear all
+    # of them so each test starts clean. The dedupe table uses the route's own
+    # lock-safe reset helper.
     try:
         from agent_bom.api.routes import proxy as proxy_routes
 
@@ -200,6 +206,7 @@ def _reset_proxy_route_state() -> None:
         proxy_routes._proxy_alerts_total = 0
         proxy_routes._proxy_metrics = None
         proxy_routes._proxy_metrics_by_tenant.clear()
+        proxy_routes._reset_audit_dedupe_for_tests()
     except Exception:
         pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import importlib
+import inspect
 import os
+import sys
 import tempfile
+from typing import Any
 
 import pytest
 
@@ -181,6 +185,25 @@ def _reset_api_runtime_state() -> None:
         pass
 
 
+def _reset_proxy_route_state() -> None:
+    # The proxy status/alerts route keeps process-global in-memory buffers:
+    # a bounded _proxy_alerts deque, its _proxy_alerts_total counter, and the
+    # latest _proxy_metrics / _proxy_metrics_by_tenant snapshots. _load_proxy_alerts
+    # only falls back to the AGENT_BOM_LOG file when _proxy_alerts is EMPTY, so an
+    # alert left in the deque by an earlier test makes /v1/proxy/status ignore the
+    # log and report the wrong alert count (order-dependent: test_proxy_status_from_log
+    # asserting total_alerts==1 gets 0). Clear all four so each test starts clean.
+    try:
+        from agent_bom.api.routes import proxy as proxy_routes
+
+        proxy_routes._proxy_alerts.clear()
+        proxy_routes._proxy_alerts_total = 0
+        proxy_routes._proxy_metrics = None
+        proxy_routes._proxy_metrics_by_tenant.clear()
+    except Exception:
+        pass
+
+
 def _reset_durable_store_singletons() -> None:
     # The agent-identity, JIT-grant, and runtime session/event stores are now
     # durable by default (SQLite under AGENT_BOM_STATE_DIR — the isolated temp
@@ -254,6 +277,147 @@ _SERVER_RUNTIME_ENV_VARS = (
 )
 
 
+# ── Global store-singleton snapshot/restore (order-flake root cause) ─────────
+# The API exposes ~35 ``set_*_store`` accessors across these modules, each of
+# which mutates a process-global singleton holder. A test that swaps a backend
+# via ``set_*`` and skips restoring it (e.g. on an assertion error) leaks that
+# singleton into later tests on the same xdist worker — the order-dependent
+# flake class behind the leaked durable job store (#3663) and NO_AUTH_ROLE
+# poisoning (#3660). Rather than hand-maintain a per-store reset list (which
+# goes stale as stores are added), we snapshot EVERY singleton holder in these
+# modules before each test and restore it verbatim afterward, so a leaked
+# ``set_*`` can never cross a test boundary. New stores added to any of these
+# modules are covered automatically.
+_STORE_SINGLETON_MODULES = (
+    "agent_bom.api.stores",
+    "agent_bom.api.auth",
+    "agent_bom.api.audit_log",
+    "agent_bom.api.proxy_replay_store",
+    "agent_bom.api.agent_identity_store",
+    "agent_bom.api.connection_store",
+    "agent_bom.api.drift_incident_store",
+    "agent_bom.api.cost_store",
+    "agent_bom.api.webhook_store",
+    "agent_bom.api.dataset_version_store",
+    "agent_bom.api.evaluation_store",
+    "agent_bom.api.report_job_store",
+    "agent_bom.api.access_review",
+    "agent_bom.api.hitl_approval_store",
+    "agent_bom.api.runtime_event_store",
+    "agent_bom.api.compliance_hub_store",
+)
+
+# Swappable process-globals in the modules above whose identifier does not end
+# in ``_store`` (case-insensitively) and so is not caught by the suffix rule.
+_STORE_SINGLETON_EXTRA_NAMES = frozenset(
+    {
+        "_last_scan_report",  # stores.py — baseline comparison snapshot
+        "_audit_log",  # audit_log.py — audit sink singleton
+        "_CAPTURE_REPLAY_ENABLED",  # proxy_replay_store.py — capture toggle
+    }
+)
+
+# Auth-posture constants that live-config code (server.py auth wiring) reads
+# directly. ``_sync_test_auth_config_from_env`` re-derives most from env, but a
+# test that assigns the module attribute directly would still leak; snapshot and
+# restore them verbatim as a backstop.
+_CONFIG_AUTH_CONSTANTS = ("NO_AUTH_ROLE", "DEMO_ESTATE", "API_ALLOW_UNAUTHENTICATED")
+
+
+def _is_store_singleton_name(name: str) -> bool:
+    return name.lower().endswith("_store") or name in _STORE_SINGLETON_EXTRA_NAMES
+
+
+def _snapshot_store_singletons() -> list[tuple[Any, str, Any]]:
+    """Capture every process-global store singleton so it can be restored.
+
+    Returns (module, attr_name, value) triples. The ``set_*``/``_get_*``
+    accessors themselves also end in ``_store``; functions and classes are
+    skipped so only state holders (None or a store instance) are captured.
+    Modules are imported eagerly so the very first test to touch a store still
+    has a pristine baseline to restore to (an unimported module has no state to
+    leak, but importing here closes the first-mutation gap).
+    """
+    snapshot: list[tuple[Any, str, Any]] = []
+    for mod_path in _STORE_SINGLETON_MODULES:
+        mod = sys.modules.get(mod_path)
+        if mod is None:
+            try:
+                mod = importlib.import_module(mod_path)
+            except Exception:
+                continue
+        try:
+            members = list(vars(mod).items())
+        except Exception:
+            continue
+        for name, value in members:
+            if not _is_store_singleton_name(name):
+                continue
+            if inspect.isroutine(value) or inspect.isclass(value):
+                continue
+            snapshot.append((mod, name, value))
+    return snapshot
+
+
+def _restore_store_singletons(snapshot: list[tuple[Any, str, Any]]) -> None:
+    for mod, name, value in snapshot:
+        try:
+            setattr(mod, name, value)
+        except Exception:
+            pass
+
+
+def _snapshot_output_console() -> Any:
+    """Capture the shared Rich console the CLI renders through.
+
+    ``console_render._console()`` resolves ``agent_bom.output.console`` at call
+    time. Many tests swap this barrel attribute for a StringIO-backed capture
+    console and restore it in a ``finally`` — but a test that skips its restore
+    (assertion error before cleanup, or no cleanup at all) leaks the capture
+    console into later CLI tests, whose output then lands in the stale console
+    instead of Click's captured stdout — surfacing as empty ``result.output``
+    (e.g. test_diff_quiet_prints_compact_summary asserting on missing text).
+    Snapshot the barrel console and restore it verbatim after each test.
+    """
+    try:
+        import agent_bom.output as output_mod
+
+        return getattr(output_mod, "console", None)
+    except Exception:
+        return None
+
+
+def _restore_output_console(console_obj: Any) -> None:
+    if console_obj is None:
+        return
+    try:
+        import agent_bom.output as output_mod
+
+        output_mod.console = console_obj
+    except Exception:
+        pass
+
+
+def _snapshot_config_auth() -> dict[str, Any]:
+    try:
+        import agent_bom.config as config
+    except Exception:
+        return {}
+    return {name: getattr(config, name) for name in _CONFIG_AUTH_CONSTANTS if hasattr(config, name)}
+
+
+def _restore_config_auth(snapshot: dict[str, Any]) -> None:
+    try:
+        import agent_bom.config as config
+    except Exception:
+        return
+    for name, value in snapshot.items():
+        try:
+            setattr(config, name, value)
+        except Exception:
+            pass
+
+
 @pytest.fixture(autouse=True)
 def reset_global_test_state():
     """Reset process-global caches so test order does not affect outcomes."""
@@ -262,6 +426,7 @@ def reset_global_test_state():
     _reset_identity_cache_state()
     _reset_api_runtime_state()
     _reset_durable_store_singletons()
+    _reset_proxy_route_state()
     _reset_runtime_state()
 
     # Snapshot auth env AFTER module-scoped setup has run (setup_module fires
@@ -274,7 +439,19 @@ def reset_global_test_state():
     storage_env_snapshot = {var: os.environ.get(var) for var in _STORAGE_ENV_VARS}
     server_env_snapshot = {var: os.environ.get(var) for var in _SERVER_RUNTIME_ENV_VARS}
 
+    # Snapshot the pluggable store singletons and auth-config constants AFTER the
+    # resets above have established a clean baseline. Any set_*_store a test body
+    # performs (and skips restoring) is reverted on teardown, killing the
+    # order-dependent flake class at the root.
+    store_singleton_snapshot = _snapshot_store_singletons()
+    config_auth_snapshot = _snapshot_config_auth()
+    output_console_snapshot = _snapshot_output_console()
+
     yield
+
+    _restore_store_singletons(store_singleton_snapshot)
+    _restore_config_auth(config_auth_snapshot)
+    _restore_output_console(output_console_snapshot)
 
     for var, value in {
         **auth_env_snapshot,
@@ -291,4 +468,5 @@ def reset_global_test_state():
     _reset_identity_cache_state()
     _reset_api_runtime_state()
     _reset_durable_store_singletons()
+    _reset_proxy_route_state()
     _reset_runtime_state()

--- a/tests/test_conftest_isolation_registry.py
+++ b/tests/test_conftest_isolation_registry.py
@@ -1,0 +1,106 @@
+"""Guards that keep the conftest test-isolation registries from silently rotting.
+
+The autouse ``reset_global_test_state`` fixture in ``tests/conftest.py`` snapshots
+and restores process-global state by name: a tuple of store-singleton module
+paths, a tuple of auth-config constant names, and the proxy-route buffer globals.
+Those name lists are the whole isolation mechanism — if a module is renamed or a
+constant moves, the fixture's defensive ``try/except`` swallows the failure and
+the suite quietly regains an order-dependent flake surface.
+
+These tests turn that silent rot into a hard, loud failure: every registered
+module must import and actually contribute a snapshot-eligible singleton, every
+registered config constant must exist, and every proxy-route global the reset
+touches must be present. Do NOT relax an assertion to make it pass — update the
+registry (or the code it points at) instead.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+# conftest.py holds the isolation registries under test. It is loaded by pytest
+# as a plugin, not necessarily importable by name, so put its directory on the
+# path and import it explicitly.
+sys.path.insert(0, os.path.dirname(__file__))
+import conftest  # noqa: E402
+
+
+def test_store_singleton_modules_all_import_and_contribute() -> None:
+    """Every module in the store-singleton registry imports and has a holder."""
+    assert conftest._STORE_SINGLETON_MODULES, "registry must not be empty"
+    for mod_path in conftest._STORE_SINGLETON_MODULES:
+        # importlib raises ModuleNotFoundError here if the path is stale — the
+        # fixture would otherwise swallow it, hiding the rot this test exists to
+        # catch.
+        mod = importlib.import_module(mod_path)
+        holders = [
+            name
+            for name, value in vars(mod).items()
+            if conftest._is_store_singleton_name(name) and not callable(value)
+        ]
+        assert holders, (
+            f"{mod_path} is listed in _STORE_SINGLETON_MODULES but exposes no "
+            f"snapshot-eligible singleton (a non-callable global whose name ends "
+            f"in '_store', or one of {sorted(conftest._STORE_SINGLETON_EXTRA_NAMES)}). "
+            f"Remove the module from the registry or fix the introspection rule."
+        )
+
+
+def test_snapshot_captures_every_registered_module() -> None:
+    """The live snapshot covers every registered module (no import swallowed)."""
+    captured = {mod.__name__ for mod, _name, _value in conftest._snapshot_store_singletons()}
+    missing = set(conftest._STORE_SINGLETON_MODULES) - captured
+    assert not missing, f"snapshot silently skipped registered modules: {sorted(missing)}"
+
+
+def test_config_auth_constants_all_exist() -> None:
+    """Every auth-config constant the fixture restores exists on config."""
+    import agent_bom.config as config
+
+    assert conftest._CONFIG_AUTH_CONSTANTS, "registry must not be empty"
+    missing = [name for name in conftest._CONFIG_AUTH_CONSTANTS if not hasattr(config, name)]
+    assert not missing, (
+        f"_CONFIG_AUTH_CONSTANTS names not found on agent_bom.config: {missing}. "
+        f"The fixture's hasattr guard would silently skip these — restoring nothing. "
+        f"Remove the dead names or point them at where the state actually lives."
+    )
+    # And the live snapshot must actually capture each one.
+    snap = conftest._snapshot_config_auth()
+    assert set(conftest._CONFIG_AUTH_CONSTANTS) <= set(snap), (
+        f"snapshot missed config constants: {set(conftest._CONFIG_AUTH_CONSTANTS) - set(snap)}"
+    )
+
+
+def test_proxy_route_reset_targets_exist() -> None:
+    """The proxy-route reset only helps if the globals it clears still exist."""
+    from agent_bom.api.routes import proxy as proxy_routes
+
+    for attr in (
+        "_proxy_alerts",
+        "_proxy_alerts_total",
+        "_proxy_metrics",
+        "_proxy_metrics_by_tenant",
+        "_audit_dedupe",
+        "_audit_dedupe_lock",
+        "_reset_audit_dedupe_for_tests",
+    ):
+        assert hasattr(proxy_routes, attr), (
+            f"agent_bom.api.routes.proxy.{attr} is gone but _reset_proxy_route_state "
+            f"still targets it — the reset is silently a no-op. Update the reset."
+        )
+
+
+def test_reset_clears_leaked_audit_dedupe() -> None:
+    """A leaked dedupe key must not survive into the next test (order flake #1)."""
+    from agent_bom.api.routes import proxy as proxy_routes
+
+    # Simulate a prior test that claimed an audit event id.
+    assert proxy_routes._claim_audit_event("default", "evt-isolation-guard") is True
+    # First claim registered the key; a re-claim now returns False (deduped).
+    assert proxy_routes._claim_audit_event("default", "evt-isolation-guard") is False
+    # The autouse reset runs on teardown; prove the reset primitive clears it so
+    # the next test re-claiming the same id sees it as new again.
+    conftest._reset_proxy_route_state()
+    assert proxy_routes._claim_audit_event("default", "evt-isolation-guard") is True

--- a/tests/test_proxy_audit_dedupe_isolation.py
+++ b/tests/test_proxy_audit_dedupe_isolation.py
@@ -1,0 +1,72 @@
+"""Order-independence guard for the proxy audit-event dedupe table.
+
+``/v1/proxy/audit`` dedupes alerts by ``(tenant_id, event_id)`` in the process-
+global ``_audit_dedupe`` table with a 24h window. That table is NOT reset by the
+in-memory store fixtures, so a ``(tenant, event_id)`` key claimed by one test
+suppresses the SAME event in a later test — a genuine order-dependent flake once
+randomized ordering is on repo-wide.
+
+These two tests deliberately ingest the SAME ``event_id`` and, crucially, the
+second does NOT manually clear the dedupe table. It relies solely on the autouse
+``reset_global_test_state`` fixture having cleared ``_audit_dedupe`` on the prior
+test's teardown. If that reset regresses, ``test_two_...`` fails with
+``accepted_alert_count == 0`` (the event is wrongly treated as a replay).
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+
+_SHARED_EVENT_ID = "evt-dedupe-isolation-shared"
+
+
+def _payload() -> dict:
+    return {
+        "source_id": "proxy-isolation",
+        "session_id": "session-iso",
+        "alerts": [
+            {
+                "event_id": _SHARED_EVENT_ID,
+                "severity": "critical",
+                "detector": "credential_leak",
+                "message": "secret detected",
+            }
+        ],
+        "summary": None,
+    }
+
+
+@pytest.fixture
+def client():
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+
+def test_one_ingests_shared_event_id(client):
+    # First test to claim the shared (default, event_id) key. No manual dedupe
+    # reset here — we intentionally leave the key behind to prove the autouse
+    # teardown clears it before the next test runs.
+    resp = client.post("/v1/proxy/audit", json=_payload())
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["accepted_alert_count"] == 1
+    assert body["duplicate_alert_count"] == 0
+
+
+def test_two_same_event_id_not_deduped_across_test_boundary(client):
+    # This test does NOT call _reset_audit_dedupe_for_tests(). If the conftest
+    # reset covers _audit_dedupe (the fix), the key left by test_one is gone and
+    # this identical event is accepted as new. Without the fix, it would be
+    # deduped: accepted_alert_count == 0, duplicate_alert_count == 1.
+    resp = client.post("/v1/proxy/audit", json=_payload())
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["accepted_alert_count"] == 1, (
+        "shared event_id was deduped across the test boundary — the proxy "
+        "_audit_dedupe table leaked from the previous test (conftest reset regressed)"
+    )
+    assert body["duplicate_alert_count"] == 0
+    assert _SHARED_EVENT_ID not in body["duplicate_event_ids"]


### PR DESCRIPTION
## Problem

Tests that swapped a process-global backend via one of the ~35 `set_*_store` accessors (`api/stores.py` plus 15 sibling store modules) without restoring it leaked that singleton into later tests on the same worker — making outcomes depend on collection order. Two such flakes already reached `main` (NO_AUTH_ROLE poisoning #3660, leaked durable job store behind the MCP/HTTP shape flake #3663). The autouse conftest reset covered only a handful of stores, and `pytest-randomly` was installed but disabled with a stale "suite is order-independent" claim.

## Fix (test isolation only — no `src/` behavior change)

**Snapshot/restore every global singleton per test** in `tests/conftest.py`:
- Discovers store singletons by **introspecting each store module** (any global whose name ends in `_store`, plus a few explicit extras) rather than a hand-maintained list — new stores are covered automatically. Functions/classes are filtered out; only state holders are captured, then restored verbatim on teardown.
- Snapshot/restore the shared Rich output console (`agent_bom.output.console`) — a test that swaps it for a capture console and skips its restore made later CLI tests render into the stale console (empty `result.output`).
- Reset the proxy route in-memory buffers (`_proxy_alerts` / `_proxy_alerts_total` / `_proxy_metrics` / `_proxy_metrics_by_tenant`) — `_load_proxy_alerts` only falls back to the audit log when `_proxy_alerts` is empty, so a leaked alert reported the wrong `/v1/proxy/status` count.
- Snapshot/restore the auth-posture config constants as a backstop.

**Randomization is now ON by default:** dropped `-p no:randomly` from pyproject `addopts` and the CI test step. A failing run stays reproducible — pytest-randomly prints `Using --randomly-seed=N`; re-run with `--randomly-seed=N` to replay the exact order.

## Flakes found & fixed by turning randomization on

| Test | Root cause |
|---|---|
| `test_api_proxy_scorecard.py::test_proxy_status_from_log` | leaked `_proxy_alerts` deque suppressed the audit-log fallback → `total_alerts` 0 vs 1 |
| `test_cli_history.py::test_diff_quiet_prints_compact_summary` | leaked capture `agent_bom.output.console` → empty CLI output |

## Verification (all green)

- **Subset** (`test_api_*`, `test_mcp_*`, `test_cli_*`, `test_hitl_*`, `test_hardening_*` — 1761 tests): randomly seeds **1, 2, 3** and **reverse collection order** → 1760 passed, 1 skipped each.
- **Full suite** (12,947 tests, `-m "not network and not slow"`): serial randomly seeds **4, 5, 6** → 0 failures.