### PR TITLE
fix(reach): PHP/Swift source masking + PSR-4/module package mapping (Closes #3678)

### DIFF
--- a/src/agent_bom/ast_php.py
+++ b/src/agent_bom/ast_php.py
@@ -8,6 +8,8 @@ agents do not inherit false ``function_reachable`` upgrades at CVE join time.
 
 from __future__ import annotations
 
+import json
+import logging
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -24,6 +26,7 @@ from agent_bom.ast_models import (
     _PhpMethodAnalysis,
     _PhpToolRegistration,
 )
+from agent_bom.ast_source_mask import mask_php_source
 from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol, is_verified_composer_package
 
 if TYPE_CHECKING:
@@ -61,9 +64,52 @@ _PHP_FRAMEWORK_HINTS: dict[str, str] = {
     "mcp": "MCP",
 }
 
+logger = logging.getLogger(__name__)
+
+# Keys that carry a PSR-4/PSR-0 autoload namespace root (rather than a package
+# name / vendor alias) inside the flat package map. The prefix keeps the map a
+# plain ``dict[str, str]`` so ``is_verified_composer_package`` (which inspects
+# ``.values()``) keeps working unchanged.
+_PSR_ROOT_KEY = "\x00psr\x00"
+
 
 def _line_number_from_index(source: str, index: int) -> int:
     return source[:index].count("\n") + 1
+
+
+def _composer_autoload_roots(project: Path) -> dict[str, str]:
+    """Map each package's PSR-4/PSR-0 namespace roots to its Composer name.
+
+    Reads ``packages[].autoload`` from ``composer.lock`` so a ``use`` such as
+    ``PhpParser\\ParserFactory`` resolves to ``nikic/php-parser`` even though
+    the namespace head never matches the vendor segment. Prefixes are returned
+    with the trailing ``\\`` stripped (PSR-0 underscore prefixes are kept).
+    """
+    lockfile = Path(project) / "composer.lock"
+    if not lockfile.is_file():
+        return {}
+    try:
+        data = json.loads(lockfile.read_text(encoding="utf-8", errors="replace"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Cannot read %s for PSR-4 roots: %s", lockfile, exc)
+        return {}
+
+    roots: dict[str, str] = {}
+    for section in ("packages", "packages-dev"):
+        for pkg in data.get(section, []):
+            name = (pkg.get("name") or "").strip()
+            if not name:
+                continue
+            autoload = pkg.get("autoload") or {}
+            for scheme in ("psr-4", "psr-0"):
+                namespaces = autoload.get(scheme) or {}
+                if not isinstance(namespaces, dict):
+                    continue
+                for namespace in namespaces:
+                    prefix = (namespace or "").rstrip("\\").strip()
+                    if prefix:
+                        roots.setdefault(prefix, name)
+    return roots
 
 
 def load_composer_package_map(project: Path) -> dict[str, str]:
@@ -79,18 +125,53 @@ def load_composer_package_map(project: Path) -> dict[str, str]:
         mapping[name] = name
         vendor, _, _short = name.partition("/")
         if vendor:
-            mapping[vendor.lower()] = name
+            # Vendor-segment binding is a last-resort fallback only; PSR-4 roots
+            # below take precedence. ``setdefault`` avoids a multi-package vendor
+            # clobbering itself nondeterministically (finding #5).
+            mapping.setdefault(vendor.lower(), name)
+
+    for prefix, pkg_name in _composer_autoload_roots(project).items():
+        mapping[_PSR_ROOT_KEY + prefix] = pkg_name
+
     return mapping
 
 
+def _ns_matches_prefix(ns: str, prefix: str) -> bool:
+    if ns == prefix:
+        return True
+    if ns.startswith(prefix + "\\"):
+        return True
+    # PSR-0 underscore-style roots (e.g. ``Twig_``) use ``_`` as the boundary.
+    return prefix.endswith("_") and ns.startswith(prefix)
+
+
 def _php_package_for_namespace(ns: str, package_map: Mapping[str, str]) -> str | None:
-    head = ns.split("\\", 1)[0].strip()
+    ns = (ns or "").lstrip("\\").strip()
+    if not ns:
+        return None
+
+    # Prefer a real PSR-4/PSR-0 autoload root, longest-prefix wins so nested
+    # namespaces bind to the most specific declaring package.
+    best_prefix: str | None = None
+    best_pkg: str | None = None
+    for key, pkg in package_map.items():
+        if not key.startswith(_PSR_ROOT_KEY):
+            continue
+        prefix = key[len(_PSR_ROOT_KEY) :]
+        if not _ns_matches_prefix(ns, prefix):
+            continue
+        if best_prefix is None or len(prefix) > len(best_prefix):
+            best_prefix, best_pkg = prefix, pkg
+    if best_pkg and is_verified_composer_package(best_pkg, dict(package_map)):
+        return best_pkg
+
+    # Fallback: legacy vendor-segment match for packages with no autoload roots.
+    head = ns.split("\\", 1)[0].strip().lower()
     if not head:
         return None
-    head_lower = head.lower()
     for pkg_name in set(package_map.values()):
         vendor = pkg_name.split("/", 1)[0].lower()
-        if vendor == head_lower and is_verified_composer_package(pkg_name, dict(package_map)):
+        if vendor == head and is_verified_composer_package(pkg_name, dict(package_map)):
             return pkg_name
     return None
 
@@ -124,6 +205,22 @@ def _php_method_key(class_name: str, name: str) -> str:
     return f"{class_name}::{name}"
 
 
+def _php_class_spans(source: str) -> list[tuple[str, int]]:
+    """Return ``(class_name, start_index)`` for every class declaration in order."""
+    return [(match.group("name"), match.start()) for match in _PHP_CLASS_RE.finditer(source)]
+
+
+def _php_class_at(spans: Sequence[tuple[str, int]], default_class: str, index: int) -> str:
+    """Return the class enclosing ``index`` (the last class declared before it)."""
+    name = default_class
+    for class_name, start in spans:
+        if start <= index:
+            name = class_name
+        else:
+            break
+    return name
+
+
 def _php_method_body(source: str, method_start: int, method_end: int) -> tuple[str, int] | None:
     next_def = _PHP_METHOD_RE.search(source, method_end)
     body_end = next_def.start() if next_def else len(source)
@@ -133,6 +230,11 @@ def _php_method_body(source: str, method_start: int, method_end: int) -> tuple[s
 
 def _php_call_sites(body: str, *, line_offset: int) -> list[_PhpCallSite]:
     sites: list[_PhpCallSite] = []
+    # Blank comments, string literals and heredoc/nowdoc bodies so a
+    # ``Class::method(`` token mentioned in text is never emitted as a call
+    # site (a false ``function_reachable`` upgrade at CVE join time). Offsets
+    # are preserved, so line numbers stay accurate.
+    body = mask_php_source(body)
     for match in _PHP_OBJECT_CALL_RE.finditer(body):
         sites.append(
             _PhpCallSite(
@@ -154,12 +256,16 @@ def _collect_php_methods(
     source: str,
     *,
     rel_path: str,
-    class_name: str,
+    default_class: str,
+    class_spans: Sequence[tuple[str, int]],
     bindings: Mapping[str, str],
 ) -> dict[str, _PhpMethodAnalysis]:
     methods: dict[str, _PhpMethodAnalysis] = {}
     for match in _PHP_METHOD_RE.finditer(source):
         name = match.group("name")
+        # Key each method to the class that actually encloses it so multi-class
+        # files do not collapse every method under the first class declaration.
+        class_name = _php_class_at(class_spans, default_class, match.start())
         body_segment = _php_method_body(source, match.start(), match.end())
         if body_segment is None:
             continue
@@ -195,7 +301,8 @@ def _collect_php_tool_registrations(
     source: str,
     *,
     rel_path: str,
-    class_name: str,
+    default_class: str,
+    class_spans: Sequence[tuple[str, int]],
     bindings: Mapping[str, str],
     methods: Mapping[str, _PhpMethodAnalysis],
 ) -> list[_PhpToolRegistration]:
@@ -205,6 +312,7 @@ def _collect_php_tool_registrations(
         tool_name = match.group("name").strip()
         if not tool_name:
             continue
+        class_name = _php_class_at(class_spans, default_class, match.start())
         window = source[match.start() : match.start() + 240]
         handler_name = _resolve_php_tool_handler(window, class_name=class_name, methods=methods)
         if handler_name is None or handler_name not in methods:
@@ -380,10 +488,17 @@ def scan_php_file(
         return [], [], [], [], [], [], None
 
     if len(source) > _MAX_FILE_SIZE:
+        logger.warning(
+            "Skipping PHP reachability scan for %s: %d bytes exceeds %d-byte limit",
+            rel_path,
+            len(source),
+            _MAX_FILE_SIZE,
+        )
         return [], [], [], [], [], [], None
 
-    class_match = _PHP_CLASS_RE.search(source)
-    class_name = class_match.group("name") if class_match else Path(rel_path).stem
+    class_spans = _php_class_spans(source)
+    default_class = class_spans[0][0] if class_spans else Path(rel_path).stem
+    class_name = default_class
     bindings = _php_use_bindings(source, package_map)
     frameworks = sorted(
         {
@@ -392,11 +507,18 @@ def scan_php_file(
             if any(prefix in binding.lower() for binding in bindings.values())
         },
     )
-    methods = _collect_php_methods(source, rel_path=rel_path, class_name=class_name, bindings=bindings)
+    methods = _collect_php_methods(
+        source,
+        rel_path=rel_path,
+        default_class=default_class,
+        class_spans=class_spans,
+        bindings=bindings,
+    )
     tool_registrations = _collect_php_tool_registrations(
         source,
         rel_path=rel_path,
-        class_name=class_name,
+        default_class=default_class,
+        class_spans=class_spans,
         bindings=bindings,
         methods=methods,
     )

--- a/src/agent_bom/ast_source_mask.py
+++ b/src/agent_bom/ast_source_mask.py
@@ -1,0 +1,218 @@
+"""Blank out comments and string literals before regex call-site extraction.
+
+Conservative reachability analyzers must not treat identifiers mentioned inside
+comments or string literals as executable call sites. A ``Class::method(`` token
+inside a ``//`` comment, a quoted SQL template, or a PHP heredoc body is text,
+not a call, and emitting it as a call site produces a false ``function_reachable``
+verdict — the highest-confidence upgrade — at CVE join time.
+
+Masked spans are replaced character-for-character with spaces (newlines are
+preserved) so that line and column offsets of the surviving code are unchanged.
+The masker is language-parameterised so regex parsers across ecosystems can
+reuse it without pulling in a full lexer.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = [
+    "mask_php_source",
+    "mask_source",
+    "mask_swift_source",
+]
+
+
+def _blank_preserving_newlines(text: str) -> str:
+    """Replace every non-newline character with a space, keeping line count."""
+    return "".join("\n" if ch == "\n" else " " for ch in text)
+
+
+def _consume_heredoc(source: str, start: int) -> tuple[str, int] | None:
+    """Mask a PHP heredoc/nowdoc block starting at ``<<<`` (index ``start``).
+
+    Returns ``(masked_text, next_index)`` covering the opener through the
+    closing label, or ``None`` if ``start`` is not a valid heredoc opener.
+    Newlines are preserved so downstream line numbers stay accurate.
+    """
+    length = len(source)
+    j = start + 3  # past '<<<'
+    while j < length and source[j] in " \t":
+        j += 1
+    quote = ""
+    if j < length and source[j] in "'\"":
+        quote = source[j]
+        j += 1
+    label_start = j
+    while j < length and (source[j].isalnum() or source[j] == "_"):
+        j += 1
+    label = source[label_start:j]
+    if not label or not (source[label_start].isalpha() or source[label_start] == "_"):
+        return None
+    if quote and j < length and source[j] == quote:
+        j += 1
+    # Closing marker: line start, optional indent, the label, then a
+    # non-identifier char (PHP 7.3+ allows the closing label to be indented).
+    close = re.compile(r"^[ \t]*" + re.escape(label) + r"(?![A-Za-z0-9_])", re.MULTILINE)
+    match = close.search(source, j)
+    end = match.end() if match else length
+    return _blank_preserving_newlines(source[start:end]), end
+
+
+def mask_source(
+    source: str,
+    *,
+    hash_comments: bool = False,
+    heredoc: bool = False,
+    nested_block_comments: bool = False,
+    triple_quote: bool = False,
+    quote_chars: str = "'\"",
+) -> str:
+    """Return ``source`` with comments and quoted literals blanked to spaces.
+
+    Parameters
+    ----------
+    hash_comments:
+        Also mask ``#`` line comments (PHP/Ruby/shell-adjacent). A ``#`` inside
+        a string literal is *not* a comment and is left to the string handler.
+    heredoc:
+        Mask PHP heredoc/nowdoc (``<<<EOT`` / ``<<<'EOT'``) bodies. An
+        identifier such as ``$client->request`` inside a SQL/HTML template must
+        not be mistaken for a call site.
+    nested_block_comments:
+        Treat ``/* ... */`` as nesting (Swift). ``/* a /* b */ c */`` is a
+        single comment; a non-nesting parser would stop early at the first
+        ``*/`` and re-expose ``c``.
+    triple_quote:
+        Recognise triple-quoted (multiline) string literals (Swift). Checked
+        before single-character quotes so the opener is consumed whole.
+    quote_chars:
+        Characters that open single-line string literals. PHP uses ``'`` and
+        ``"``; Swift uses only ``"``.
+    """
+    result: list[str] = []
+    i = 0
+    length = len(source)
+    state = "code"
+    quote = ""
+    block_depth = 0
+    quotes = set(quote_chars)
+
+    while i < length:
+        char = source[i]
+        nxt = source[i + 1] if i + 1 < length else ""
+
+        if state == "code":
+            if heredoc and char == "<" and source[i : i + 3] == "<<<":
+                consumed = _consume_heredoc(source, i)
+                if consumed is not None:
+                    masked, end = consumed
+                    result.append(masked)
+                    i = end
+                    continue
+            if char == "/" and nxt == "/":
+                state = "line_comment"
+                result.append("  ")
+                i += 2
+                continue
+            if char == "/" and nxt == "*":
+                state = "block_comment"
+                block_depth = 1
+                result.append("  ")
+                i += 2
+                continue
+            if hash_comments and char == "#":
+                state = "line_comment"
+                result.append(" ")
+                i += 1
+                continue
+            if triple_quote and char == '"' and source[i : i + 3] == '"""':
+                state = "triple_string"
+                result.append("   ")
+                i += 3
+                continue
+            if char in quotes:
+                state = "string"
+                quote = char
+                result.append(" ")
+                i += 1
+                continue
+            result.append(char)
+            i += 1
+            continue
+
+        if state == "line_comment":
+            if char == "\n":
+                state = "code"
+                result.append("\n")
+            else:
+                result.append(" ")
+            i += 1
+            continue
+
+        if state == "block_comment":
+            if nested_block_comments and char == "/" and nxt == "*":
+                block_depth += 1
+                result.append("  ")
+                i += 2
+                continue
+            if char == "*" and nxt == "/":
+                block_depth -= 1
+                result.append("  ")
+                i += 2
+                if block_depth <= 0:
+                    state = "code"
+                continue
+            result.append("\n" if char == "\n" else " ")
+            i += 1
+            continue
+
+        if state == "triple_string":
+            if char == "\\" and i + 1 < length:
+                result.append("\n" if nxt == "\n" else " ")
+                result.append("\n" if nxt == "\n" else " ")
+                i += 2
+                continue
+            if char == '"' and source[i : i + 3] == '"""':
+                state = "code"
+                result.append("   ")
+                i += 3
+                continue
+            result.append("\n" if char == "\n" else " ")
+            i += 1
+            continue
+
+        if state == "string":
+            if char == "\\" and i + 1 < length:
+                result.append("\n" if nxt == "\n" else " ")
+                result.append("\n" if nxt == "\n" else " ")
+                i += 2
+                continue
+            if char == quote:
+                state = "code"
+                result.append(" ")
+                i += 1
+                continue
+            result.append("\n" if char == "\n" else " ")
+            i += 1
+            continue
+
+        result.append(char)
+        i += 1
+
+    return "".join(result)
+
+
+def mask_php_source(source: str) -> str:
+    """Mask PHP comments (``//``, ``#``, ``/* */``), strings and heredoc/nowdoc."""
+    return mask_source(source, hash_comments=True, heredoc=True, quote_chars="'\"")
+
+
+def mask_swift_source(source: str) -> str:
+    """Mask Swift comments (``//``, nested ``/* */``) and single/triple strings."""
+    return mask_source(
+        source,
+        nested_block_comments=True,
+        triple_quote=True,
+        quote_chars='"',
+    )

--- a/src/agent_bom/ast_swift.py
+++ b/src/agent_bom/ast_swift.py
@@ -8,6 +8,7 @@ tool handlers are dropped so headless agents do not inherit false
 
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -24,6 +25,7 @@ from agent_bom.ast_models import (
     _SwiftFunctionAnalysis,
     _SwiftToolRegistration,
 )
+from agent_bom.ast_source_mask import mask_swift_source
 from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol, is_verified_swift_package
 
 if TYPE_CHECKING:
@@ -47,9 +49,78 @@ _SWIFT_FRAMEWORK_HINTS: dict[str, str] = {
     "mcp": "MCP",
 }
 
+logger = logging.getLogger(__name__)
+
+# ``.product(name: "Logging", package: "swift-log")`` in Package.swift — the
+# authoritative module->identity mapping for a dependency's products.
+_SWIFT_PRODUCT_RE = re.compile(
+    r'\.product\(\s*name:\s*"(?P<module>[^"]+)"\s*,\s*package:\s*"(?P<package>[^"]+)"',
+)
+
+# Common SPM packages whose product/module names differ from their identity.
+# Identity (lowercased) -> module names shipped by that package. The SPM
+# identity is a URL slug (``swift-log``) but code imports the module name
+# (``Logging``); no identity transform recovers this, so it must be tabulated.
+_SWIFT_MODULE_TABLE: dict[str, tuple[str, ...]] = {
+    "swift-log": ("Logging",),
+    "swift-nio": ("NIO", "NIOCore", "NIOPosix", "NIOHTTP1", "NIOFoundationCompat", "NIOEmbedded"),
+    "swift-nio-ssl": ("NIOSSL",),
+    "swift-nio-http2": ("NIOHTTP2",),
+    "swift-argument-parser": ("ArgumentParser",),
+    "swift-crypto": ("Crypto", "_CryptoExtras"),
+    "swift-collections": ("Collections", "OrderedCollections", "DequeModule"),
+    "swift-algorithms": ("Algorithms",),
+    "swift-numerics": ("Numerics", "RealModule", "ComplexModule"),
+    "swift-metrics": ("Metrics", "CoreMetrics"),
+    "swift-system": ("SystemPackage",),
+    "swift-syntax": ("SwiftSyntax", "SwiftParser"),
+    "swift-protobuf": ("SwiftProtobuf",),
+    "swift-markdown": ("Markdown",),
+    "async-http-client": ("AsyncHTTPClient",),
+    "grpc-swift": ("GRPC",),
+}
+
 
 def _line_number_from_index(source: str, index: int) -> int:
     return source[:index].count("\n") + 1
+
+
+def _swift_module_aliases(project: Path, identities: set[str]) -> dict[str, str]:
+    """Map real module names to package identities via Package.swift + table.
+
+    ``Package.resolved`` only carries identities (URL slugs), so ``import
+    Logging`` cannot be resolved to ``swift-log`` by any string transform.
+    We recover module names from (1) ``.product(name:package:)`` declarations
+    in ``Package.swift`` and (2) a curated identity->module table for common
+    packages. Only identities actually present in ``Package.resolved`` are
+    emitted so unverified modules never bind.
+    """
+    by_lower = {identity.lower(): identity for identity in identities}
+    aliases: dict[str, str] = {}
+
+    package_swift = Path(project) / "Package.swift"
+    if package_swift.is_file():
+        try:
+            manifest = package_swift.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            logger.warning("Cannot read %s for module names: %s", package_swift, exc)
+            manifest = ""
+        for match in _SWIFT_PRODUCT_RE.finditer(manifest):
+            module = match.group("module").strip()
+            identity = by_lower.get(match.group("package").strip().lower())
+            if module and identity:
+                aliases[module] = identity
+                aliases[module.lower()] = identity
+
+    for identity_lower, modules in _SWIFT_MODULE_TABLE.items():
+        identity = by_lower.get(identity_lower)
+        if not identity:
+            continue
+        for module in modules:
+            aliases.setdefault(module, identity)
+            aliases.setdefault(module.lower(), identity)
+
+    return aliases
 
 
 def load_swift_package_map(project: Path) -> dict[str, str]:
@@ -57,15 +128,23 @@ def load_swift_package_map(project: Path) -> dict[str, str]:
     from agent_bom.parsers.swift_parsers import parse_swift_packages
 
     mapping: dict[str, str] = {}
+    identities: set[str] = set()
     for pkg in parse_swift_packages(project):
         name = pkg.name.strip()
         if not name:
             continue
+        identities.add(name)
         mapping[name.lower()] = name
         mapping[name] = name
         studly = "".join(part[:1].upper() + part[1:] for part in re.split(r"[-_.]+", name) if part)
         if studly:
-            mapping[studly] = name
+            mapping.setdefault(studly, name)
+
+    # Real product/module names (Logging->swift-log, NIO->swift-nio, ...). These
+    # override the studly-cased guesses above, which rarely match real modules.
+    for module, identity in _swift_module_aliases(project, identities).items():
+        mapping[module] = identity
+
     return mapping
 
 
@@ -105,6 +184,10 @@ def _swift_function_body(source: str, func_start: int, func_end: int) -> tuple[s
 
 def _swift_call_sites(body: str, *, line_offset: int) -> list[_SwiftCallSite]:
     sites: list[_SwiftCallSite] = []
+    # Blank comments (incl. nested block comments) and single/triple-quoted
+    # string literals so a ``Module.method(`` token mentioned in text is never
+    # emitted as a call site. Offsets are preserved so line numbers stay right.
+    body = mask_swift_source(body)
     for match in _SWIFT_MODULE_CALL_RE.finditer(body):
         sites.append(
             _SwiftCallSite(
@@ -330,6 +413,12 @@ def scan_swift_file(
         return [], [], [], [], [], [], None
 
     if len(source) > _MAX_FILE_SIZE:
+        logger.warning(
+            "Skipping Swift reachability scan for %s: %d bytes exceeds %d-byte limit",
+            rel_path,
+            len(source),
+            _MAX_FILE_SIZE,
+        )
         return [], [], [], [], [], [], None
 
     scope_name = Path(rel_path).stem

--- a/tests/test_php_swift_reach_masking.py
+++ b/tests/test_php_swift_reach_masking.py
@@ -1,0 +1,392 @@
+"""Regression tests for PHP/Swift symbol-reachability accuracy (issue #3678).
+
+Covers three failure classes that produced either false ``function_reachable``
+verdicts or missed real reachable CVEs:
+
+* source masking — call-site tokens inside comments, strings and PHP
+  heredoc/nowdoc bodies must never be emitted as call sites;
+* PHP package mapping via PSR-4/PSR-0 autoload roots (not the vendor segment);
+* Swift package mapping via real product/module names (not identity transforms).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agent_bom.ast_php import (
+    build_php_dependency_symbol_reach,
+    load_composer_package_map,
+    scan_php_file,
+)
+from agent_bom.ast_source_mask import mask_php_source, mask_source, mask_swift_source
+from agent_bom.ast_swift import (
+    build_swift_dependency_symbol_reach,
+    load_swift_package_map,
+    scan_swift_file,
+)
+
+
+# --------------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------------- #
+def _php_reach(project: Path, rel: str):
+    package_map = load_composer_package_map(project)
+    *_, analysis = scan_php_file(project / rel, rel, package_map=package_map)
+    assert analysis is not None
+    reach = build_php_dependency_symbol_reach(
+        methods=analysis.functions,
+        tool_registrations=analysis.tool_registrations,
+        package_map=package_map,
+    )
+    return reach, analysis, package_map
+
+
+def _swift_reach(project: Path, rel: str):
+    package_map = load_swift_package_map(project)
+    *_, analysis = scan_swift_file(project / rel, rel, package_map=package_map)
+    assert analysis is not None
+    reach = build_swift_dependency_symbol_reach(
+        functions=analysis.functions,
+        tool_registrations=analysis.tool_registrations,
+        package_map=package_map,
+    )
+    return reach, analysis, package_map
+
+
+def _write_composer(project: Path, packages: list[dict]) -> None:
+    (project / "composer.lock").write_text(
+        json.dumps({"packages": packages, "packages-dev": []}),
+        encoding="utf-8",
+    )
+
+
+def _write_resolved(project: Path, identities: list[str]) -> None:
+    pins = [
+        {
+            "identity": identity,
+            "kind": "remoteSourceControl",
+            "location": f"https://github.com/apple/{identity}.git",
+            "state": {"version": "1.0.0"},
+        }
+        for identity in identities
+    ]
+    (project / "Package.resolved").write_text(
+        json.dumps({"pins": pins, "version": 2}),
+        encoding="utf-8",
+    )
+
+
+_NIKIC = {"name": "nikic/php-parser", "version": "4.15.0", "autoload": {"psr-4": {"PhpParser\\": "lib/PhpParser"}}}
+
+
+# --------------------------------------------------------------------------- #
+# masker unit tests
+# --------------------------------------------------------------------------- #
+def test_mask_preserves_offsets_and_blanks_comments():
+    src = "a();\n// b();\n/* c();\nd(); */\ne();\n"
+    masked = mask_source(src)
+    assert len(masked) == len(src)
+    assert masked.count("\n") == src.count("\n")
+    assert "a()" in masked
+    assert "e()" in masked
+    assert "b()" not in masked
+    assert "c()" not in masked
+    assert "d()" not in masked
+
+
+def test_mask_php_string_and_hash_and_heredoc():
+    src = (
+        "$x = 'Foo::bar()';\n"
+        "# Foo::baz()\n"
+        '$y = "Foo::qux()";\n'
+        "$t = <<<SQL\nFoo::heredoc()\nSQL;\n"
+        "$n = <<<'TXT'\nFoo::nowdoc()\nTXT;\n"
+        "Real::call();\n"
+    )
+    masked = mask_php_source(src)
+    for hidden in ("Foo::bar", "Foo::baz", "Foo::qux", "Foo::heredoc", "Foo::nowdoc"):
+        assert hidden not in masked
+    assert "Real::call" in masked
+    assert len(masked) == len(src)
+
+
+def test_mask_swift_nested_block_and_triple_string():
+    src = 'Real.call()\n/* A.one() /* B.two() */ C.three() */\nlet t = """\nD.four()\n"""\n// E.five()\n'
+    masked = mask_swift_source(src)
+    assert "Real.call" in masked
+    for hidden in ("A.one", "B.two", "C.three", "D.four", "E.five"):
+        assert hidden not in masked
+    assert len(masked) == len(src)
+
+
+def test_mask_php_hash_inside_string_is_not_a_comment():
+    # A '#' inside a string must not terminate string masking early.
+    src = "$u = 'http://x#frag'; Real::call();\n"
+    masked = mask_php_source(src)
+    assert "Real::call" in masked
+    assert "http" not in masked
+
+
+# --------------------------------------------------------------------------- #
+# PHP: masking removes false function_reachable
+# --------------------------------------------------------------------------- #
+def test_php_comment_and_string_yield_no_reach(tmp_path: Path):
+    _write_composer(tmp_path, [{"name": "monolog/monolog", "version": "3.0.0", "autoload": {"psr-4": {"Monolog\\": "src/Monolog"}}}])
+    (tmp_path / "Server.php").write_text(
+        """<?php
+namespace App;
+use Monolog\\Logger;
+class Server {
+    public function register() { $this->tool("run", "handle"); }
+    public function handle() {
+        // Logger::alert("not a real call");
+        $sql = "Logger::alert('also not a call')";
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    reach, _analysis, _pmap = _php_reach(tmp_path, "Server.php")
+    assert reach == []
+
+
+def test_php_heredoc_body_yields_no_reach(tmp_path: Path):
+    _write_composer(tmp_path, [_NIKIC])
+    (tmp_path / "Server.php").write_text(
+        """<?php
+namespace App;
+use PhpParser\\ParserFactory;
+class Server {
+    public function register() { $this->tool("run", "handle"); }
+    public function handle() {
+        $tpl = <<<SQL
+        ParserFactory::create() masked in heredoc
+        SQL;
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    reach, _analysis, _pmap = _php_reach(tmp_path, "Server.php")
+    assert reach == []
+
+
+# --------------------------------------------------------------------------- #
+# PHP: PSR-4 autoload-root package mapping
+# --------------------------------------------------------------------------- #
+def test_php_psr4_root_resolves_non_vendor_namespace(tmp_path: Path):
+    _write_composer(tmp_path, [_NIKIC])
+    (tmp_path / "Server.php").write_text(
+        """<?php
+namespace App;
+use PhpParser\\ParserFactory;
+class Server {
+    public function register() { $this->tool("run", "handle"); }
+    public function handle() {
+        $parser = ParserFactory::createForNewestSupportedVersion();
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    reach, _analysis, _pmap = _php_reach(tmp_path, "Server.php")
+    assert len(reach) == 1
+    assert reach[0].package == "nikic/php-parser"
+    assert reach[0].symbol == "createForNewestSupportedVersion"
+
+
+def test_php_longest_prefix_wins_over_shorter_root(tmp_path: Path):
+    _write_composer(
+        tmp_path,
+        [
+            {"name": "psr/log", "version": "3.0.0", "autoload": {"psr-4": {"Psr\\Log\\": "src"}}},
+            {"name": "psr/cache", "version": "3.0.0", "autoload": {"psr-4": {"Psr\\Cache\\": "src"}}},
+        ],
+    )
+    (tmp_path / "Server.php").write_text(
+        """<?php
+namespace App;
+use Psr\\Log\\LoggerInterface;
+class Server {
+    public function register() { $this->tool("run", "handle"); }
+    public function handle() {
+        LoggerInterface::emergency("boom");
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    reach, _analysis, _pmap = _php_reach(tmp_path, "Server.php")
+    assert len(reach) == 1
+    assert reach[0].package == "psr/log"
+
+
+def test_php_multi_package_vendor_binds_by_autoload_not_vendor(tmp_path: Path):
+    # Two packages share the "symfony" vendor; the vendor-segment heuristic
+    # was nondeterministic. PSR-4 roots bind each namespace to its own package.
+    _write_composer(
+        tmp_path,
+        [
+            {"name": "symfony/console", "version": "7.0.0", "autoload": {"psr-4": {"Symfony\\Component\\Console\\": "."}}},
+            {"name": "symfony/finder", "version": "7.0.0", "autoload": {"psr-4": {"Symfony\\Component\\Finder\\": "."}}},
+        ],
+    )
+    (tmp_path / "Server.php").write_text(
+        """<?php
+namespace App;
+use Symfony\\Component\\Finder\\Finder;
+class Server {
+    public function register() { $this->tool("run", "handle"); }
+    public function handle() {
+        Finder::createFromDirectory("/tmp");
+    }
+}
+""",
+        encoding="utf-8",
+    )
+    reach, _analysis, _pmap = _php_reach(tmp_path, "Server.php")
+    assert len(reach) == 1
+    assert reach[0].package == "symfony/finder"
+
+
+# --------------------------------------------------------------------------- #
+# PHP: multi-class file keys methods to the enclosing class
+# --------------------------------------------------------------------------- #
+def test_php_multi_class_methods_key_to_correct_class(tmp_path: Path):
+    _write_composer(tmp_path, [_NIKIC])
+    (tmp_path / "Multi.php").write_text(
+        """<?php
+namespace App;
+class Alpha {
+    public function shared() {}
+}
+class Beta {
+    public function shared() {}
+    public function only_beta() {}
+}
+""",
+        encoding="utf-8",
+    )
+    package_map = load_composer_package_map(tmp_path)
+    *_, analysis = scan_php_file(tmp_path / "Multi.php", "Multi.php", package_map=package_map)
+    keys = set(analysis.functions)
+    assert "Alpha::shared" in keys
+    assert "Beta::shared" in keys
+    assert "Beta::only_beta" in keys
+    assert analysis.functions["Beta::only_beta"].class_name == "Beta"
+
+
+# --------------------------------------------------------------------------- #
+# Swift: product/module package mapping + masking
+# --------------------------------------------------------------------------- #
+def test_swift_logging_module_resolves_swift_log(tmp_path: Path):
+    _write_resolved(tmp_path, ["swift-log"])
+    (tmp_path / "Server.swift").write_text(
+        """import Logging
+
+func register() {
+    server.tool("run", handle)
+}
+func handle() {
+    // Logging.critical("commented out, not a call")
+    let logger = Logging.Logger(label: "x")
+}
+""",
+        encoding="utf-8",
+    )
+    reach, _analysis, package_map = _swift_reach(tmp_path, "Server.swift")
+    assert package_map.get("Logging") == "swift-log"
+    assert len(reach) == 1
+    assert reach[0].package == "swift-log"
+    assert reach[0].symbol == "Logger"
+
+
+def test_swift_nio_module_resolves_swift_nio(tmp_path: Path):
+    _write_resolved(tmp_path, ["swift-nio"])
+    (tmp_path / "Server.swift").write_text(
+        """import NIO
+
+func register() {
+    server.tool("run", handle)
+}
+func handle() {
+    let group = NIO.MultiThreadedEventLoopGroup(numberOfThreads: 1)
+}
+""",
+        encoding="utf-8",
+    )
+    reach, _analysis, _pmap = _swift_reach(tmp_path, "Server.swift")
+    assert len(reach) == 1
+    assert reach[0].package == "swift-nio"
+
+
+def test_swift_product_declaration_maps_module(tmp_path: Path):
+    # A package whose module name is only discoverable from Package.swift.
+    _write_resolved(tmp_path, ["acme-transport"])
+    (tmp_path / "Package.swift").write_text(
+        """// swift-tools-version:5.9
+import PackageDescription
+let package = Package(
+    name: "app",
+    targets: [
+        .target(name: "App", dependencies: [
+            .product(name: "Transport", package: "acme-transport"),
+        ]),
+    ]
+)
+""",
+        encoding="utf-8",
+    )
+    (tmp_path / "Server.swift").write_text(
+        """import Transport
+
+func register() {
+    server.tool("run", handle)
+}
+func handle() {
+    let c = Transport.Client(host: "x")
+}
+""",
+        encoding="utf-8",
+    )
+    reach, _analysis, package_map = _swift_reach(tmp_path, "Server.swift")
+    assert package_map.get("Transport") == "acme-transport"
+    assert len(reach) == 1
+    assert reach[0].package == "acme-transport"
+
+
+def test_swift_comment_only_yields_no_reach(tmp_path: Path):
+    _write_resolved(tmp_path, ["swift-log"])
+    (tmp_path / "Server.swift").write_text(
+        """import Logging
+
+func register() {
+    server.tool("run", handle)
+}
+func handle() {
+    // Logging.Logger(label: "x")
+    let s = "Logging.Logger(label: y)"
+}
+""",
+        encoding="utf-8",
+    )
+    reach, _analysis, _pmap = _swift_reach(tmp_path, "Server.swift")
+    assert reach == []
+
+
+@pytest.mark.parametrize(
+    "identity,module",
+    [
+        ("swift-log", "Logging"),
+        ("swift-nio", "NIO"),
+        ("swift-argument-parser", "ArgumentParser"),
+        ("swift-crypto", "Crypto"),
+    ],
+)
+def test_swift_common_module_table(tmp_path: Path, identity: str, module: str):
+    _write_resolved(tmp_path, [identity])
+    package_map = load_swift_package_map(tmp_path)
+    assert package_map.get(module) == identity


### PR DESCRIPTION
Closes #3678.

The reachability engine is the product's core differentiator. Two failure classes were live-reproduced on the epic branch: a `Class::method(` / `Module.method(` token inside a comment or string emitted a **false `function_reachable`** verdict (the highest-confidence upgrade), and real reachable dependency calls were **missed** because PHP/Swift package mapping used the wrong key.

Base branch: `feat/epic-3499-php-swift-parquet` (these files do not exist on `main` yet).

## Fix 1 — Restore source masking (highest leverage)
There was no masking; parsers ran regexes over raw source. New shared `src/agent_bom/ast_source_mask.py` blanks masked spans to spaces/newlines so line/col offsets are preserved, then wired into `_php_call_sites` (`ast_php.py:215`) and `_swift_call_sites` (`ast_swift.py:107`). Covers PHP `//`/`#` and Swift `//` line comments, `/* */` block comments (Swift nesting handled), PHP single/double strings (with `\` escapes; `#` inside a string is not a comment), Swift `"..."` and `"""..."""`, and PHP heredoc/nowdoc bodies. The masker is a reusable `mask_source(...)` so other regex parsers can adopt it.

**Before** (monolog, comment + string):
```
reach rows: 2
  FALSE function_reachable: monolog/monolog alert line 8 ['run','handle','monolog/monolog.alert']
  FALSE function_reachable: monolog/monolog alert line 9 ['run','handle','monolog/monolog.alert']
```
**After:** `reach rows: 0` (a real `$logger->pushHandler()` in the same file still reaches).

## Fix 2 — PHP package mapping via PSR-4 roots, not vendor segment
`_php_package_for_namespace` (`ast_php.py:86` region) bound a `use` namespace only when its first segment equalled the Composer vendor segment — wrong for `nikic/php-parser`→`PhpParser`, `psr/log`→`Psr\Log`, etc. Now rebuilds the namespace→package map from each package's `autoload.psr-4`/`psr-0` roots in `composer.lock` and resolves by **longest-prefix** match (`_composer_autoload_roots`, `load_composer_package_map`). Deterministically fixes the multi-package-vendor ordering bug (#5). Vendor-segment path kept only as fallback for packages with no autoload roots.

**Before** (`use PhpParser\ParserFactory; ParserFactory::createForNewestSupportedVersion()`): `reach rows: 0` (missed real CVE path).
**After:** `reach rows: 1 → nikic/php-parser createForNewestSupportedVersion`.

## Fix 3 — Swift package mapping via product/module names
`load_swift_package_map` (`ast_swift.py:56` region) keyed only on SPM identity + lowercase + studly-cased identity, so `import Logging` could not resolve `swift-log`. Now maps real module names via `.product(name:package:)` declarations in `Package.swift` plus a curated identity→module table (swift-log→Logging, swift-nio→NIO, argument-parser→ArgumentParser, crypto, collections, nio-ssl, …). Only identities present in `Package.resolved` are emitted.

**Before** (`import Logging; Logging.Logger(...)`): `reach rows: 0`.
**After:** `reach rows: 1 → swift-log Logger` (a commented-out `Logging.critical(...)` on the line above is masked and does not reach).

## Fix 4 — P3s
- `ast_php.py`/`ast_swift.py` `scan_*` now emit a `logger.warning` when a file exceeds the 512 KB limit instead of silently returning empty.
- PHP now detects **all** `class` declarations (`_php_class_spans`/`_php_class_at`) so methods key to the enclosing class (`Alpha::shared` vs `Beta::shared`) rather than collapsing under the first class.

## Tests
New `tests/test_php_swift_reach_masking.py` (18 cases): masker unit tests (offset preservation, PHP string/hash/heredoc/nowdoc, Swift nested block + triple string, `#`-in-string), comment/string/heredoc → no reach, PSR-4 root + longest-prefix + multi-package vendor, multi-class keying, and Swift `Logging`/`NIO`/`.product` module mapping.

```
pytest tests/ -k "php or swift or reach or ast or mask" -p no:randomly -q
503 passed, 3 skipped, 12345 deselected
```
`ruff check` + `ruff format` clean on all touched files. No pre-existing tests regressed (485 → 503, +18 new).
