### PR TITLE
fix(ingest): chunked reconcile_absent + pip-visible ai-enrich security floors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,14 @@ wandb = ["wandb>=0.16"]
 # Temporarily unbundled from agent-bom extras until upstream MLflow CVEs are fixed.
 # MLflow discovery still works if users install `mlflow` separately.
 openai = ["openai>=1.12"]
-ai-enrich = ["litellm>=1.83.14"]
+ai-enrich = [
+    "litellm>=1.83.14",
+    # Security floors mirrored from [tool.uv].override-dependencies so pip installs
+    # cannot land vulnerable litellm transitives (Closes #3684).
+    "python-dotenv>=1.2.2",
+    "aiohttp>=3.13.4",
+    "openai>=2.30.0",
+]
 graph = [
     "networkx>=3.0",
     "numpy>=1.26",

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -530,9 +530,7 @@ def _migrate_current_origin_col_sqlite(conn: sqlite3.Connection) -> None:
     cols = {row[1] for row in conn.execute("PRAGMA table_info(hub_findings_current)").fetchall()}
     if "origin" not in cols:
         conn.execute("ALTER TABLE hub_findings_current ADD COLUMN origin TEXT NOT NULL DEFAULT ''")
-        conn.execute(
-            "UPDATE hub_findings_current SET origin = COALESCE(json_extract(payload, '$.origin'), '') WHERE origin = ''"
-        )
+        conn.execute("UPDATE hub_findings_current SET origin = COALESCE(json_extract(payload, '$.origin'), '') WHERE origin = ''")
 
 
 def _ensure_current_lifecycle_sqlite(conn: sqlite3.Connection) -> None:

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -48,10 +48,10 @@ from agent_bom.api.hub_reference_store import (
     persist_finding_references_sqlite,
 )
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
+from agent_bom.graph.severity import severity_policy_rank
 
 # Chunk size for reconcile UPDATE … IN (…) to stay under SQLite/Postgres bind limits.
 RECONCILE_ABSENT_CHUNK = 500
-from agent_bom.graph.severity import severity_policy_rank
 
 # Defined here (module scope) so ``list`` resolves to the builtin: the store
 # classes below define a ``list`` method that would otherwise shadow it in

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -48,6 +48,9 @@ from agent_bom.api.hub_reference_store import (
     persist_finding_references_sqlite,
 )
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
+
+# Chunk size for reconcile UPDATE … IN (…) to stay under SQLite/Postgres bind limits.
+RECONCILE_ABSENT_CHUNK = 500
 from agent_bom.graph.severity import severity_policy_rank
 
 # Defined here (module scope) so ``list`` resolves to the builtin: the store
@@ -1498,24 +1501,34 @@ class SQLiteComplianceHubStore:
     ) -> int:
         now = _now_utc_iso()
         where = ["tenant_id = ?", "status IN ('open', 'reopened')"]
-        params: list[Any] = [observed_at, now, tenant_id]
+        params: list[Any] = [tenant_id]
         if scope_source is not None:
             where.append("json_extract(payload, '$.source') = ?")
             params.append(scope_source)
-        if present_canonical_ids:
-            placeholders = ",".join("?" * len(present_canonical_ids))
-            where.append(f"canonical_id NOT IN ({placeholders})")
-            params.extend(sorted(present_canonical_ids))
-        cur = self._conn.execute(
-            f"""
-            UPDATE hub_findings_current
-            SET status = 'resolved', resolved_at = ?, updated_at = ?
-            WHERE {" AND ".join(where)}
-            """,  # nosec B608
+        where_sql = " AND ".join(where)
+        rows = self._conn.execute(
+            f"SELECT canonical_id FROM hub_findings_current WHERE {where_sql}",  # nosec B608
             params,
-        )
+        ).fetchall()
+        open_ids = {str(row[0]) for row in rows}
+        absent = sorted(open_ids - present_canonical_ids)
+        if not absent:
+            return 0
+        total = 0
+        for offset in range(0, len(absent), RECONCILE_ABSENT_CHUNK):
+            chunk = absent[offset : offset + RECONCILE_ABSENT_CHUNK]
+            placeholders = ",".join("?" * len(chunk))
+            cur = self._conn.execute(
+                f"""
+                UPDATE hub_findings_current
+                SET status = 'resolved', resolved_at = ?, updated_at = ?
+                WHERE {where_sql} AND canonical_id IN ({placeholders})
+                """,  # nosec B608
+                [observed_at, now, *params, *chunk],
+            )
+            total += int(cur.rowcount or 0)
         self._conn.commit()
-        return int(cur.rowcount or 0)
+        return total
 
 
 # ─── Module-level access (set/reset wired in stores.py) ──────────────────────

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -15,6 +15,7 @@ from typing import Any
 from agent_bom.api.compliance_hub_store import (
     FindingCursorPage,
     FindingPage,
+    RECONCILE_ABSENT_CHUNK,
     _cvss_value,
     _frameworks_csv,
     _now_utc_iso,
@@ -808,22 +809,32 @@ class PostgresComplianceHubStore:
     ) -> int:
         now = _now_utc_iso()
         where = ["tenant_id = %s", "status IN ('open', 'reopened')"]
-        params: list[Any] = [observed_at, now, tenant_id]
+        params: list[Any] = [tenant_id]
         if scope_source is not None:
             where.append("payload->>'source' = %s")
             params.append(scope_source)
-        if present_canonical_ids:
-            placeholders = ",".join("%s" for _ in present_canonical_ids)
-            where.append(f"canonical_id NOT IN ({placeholders})")
-            params.extend(sorted(present_canonical_ids))
+        where_sql = " AND ".join(where)
+        total = 0
         with _tenant_connection(self._pool) as conn:
-            cur = conn.execute(
-                f"""
-                UPDATE hub_findings_current
-                SET status = 'resolved', resolved_at = %s, updated_at = %s
-                WHERE {" AND ".join(where)}
-                """,  # nosec B608
+            rows = conn.execute(
+                f"SELECT canonical_id FROM hub_findings_current WHERE {where_sql}",  # nosec B608
                 tuple(params),
-            )
+            ).fetchall()
+            open_ids = {str(row[0]) for row in rows}
+            absent = sorted(open_ids - present_canonical_ids)
+            if not absent:
+                return 0
+            for offset in range(0, len(absent), RECONCILE_ABSENT_CHUNK):
+                chunk = absent[offset : offset + RECONCILE_ABSENT_CHUNK]
+                placeholders = ",".join("%s" for _ in chunk)
+                cur = conn.execute(
+                    f"""
+                    UPDATE hub_findings_current
+                    SET status = 'resolved', resolved_at = %s, updated_at = %s
+                    WHERE {where_sql} AND canonical_id IN ({placeholders})
+                    """,  # nosec B608
+                    (observed_at, now, *params, *chunk),
+                )
+                total += int(cur.rowcount or 0)
             conn.commit()
-        return int(cur.rowcount or 0)
+        return total

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -13,9 +13,9 @@ from collections.abc import Sequence
 from typing import Any
 
 from agent_bom.api.compliance_hub_store import (
+    RECONCILE_ABSENT_CHUNK,
     FindingCursorPage,
     FindingPage,
-    RECONCILE_ABSENT_CHUNK,
     _cvss_value,
     _frameworks_csv,
     _now_utc_iso,

--- a/tests/test_reconcile_absent_chunking.py
+++ b/tests/test_reconcile_absent_chunking.py
@@ -19,7 +19,6 @@ def _finding_with_id(finding_id: str) -> dict:
     return {
         "id": finding_id,
         "finding_type": "CVE",
-        "source": "MCP_SCAN",
         "severity": "high",
         "title": finding_id,
         "asset": {"name": "pkg", "asset_type": "package", "identifier": f"pkg:pypi/{finding_id}@1.0.0"},

--- a/tests/test_reconcile_absent_chunking.py
+++ b/tests/test_reconcile_absent_chunking.py
@@ -1,0 +1,56 @@
+"""Regression: reconcile_absent must not build unbounded NOT IN bind lists (#3689)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from agent_bom.api.compliance_hub_store import RECONCILE_ABSENT_CHUNK, SQLiteComplianceHubStore
+from agent_bom.api.finding_lifecycle import resolve_canonical_id
+
+
+@pytest.fixture
+def hub_store(tmp_path):
+    return SQLiteComplianceHubStore(str(tmp_path / "reconcile-chunk.db"))
+
+
+def _finding_with_id(finding_id: str) -> dict:
+    return {
+        "id": finding_id,
+        "finding_type": "CVE",
+        "source": "MCP_SCAN",
+        "severity": "high",
+        "title": finding_id,
+        "asset": {"name": "pkg", "asset_type": "package", "identifier": f"pkg:pypi/{finding_id}@1.0.0"},
+        "package_name": "pkg",
+        "package_version": "1.0.0",
+        "ecosystem": "pypi",
+        "source": "agent-runtime",
+    }
+
+
+def test_reconcile_absent_large_present_set_does_not_overflow(hub_store) -> None:
+    tenant = f"reconcile-chunk-{uuid4().hex}"
+    batch_size = RECONCILE_ABSENT_CHUNK + 50
+    present = [_finding_with_id(f"present-{i}") for i in range(batch_size)]
+    stale = _finding_with_id("stale-open")
+
+    hub_store.upsert_current_batch(tenant, present + [stale], observed_at="2026-01-01T00:00:00Z", batch_id="b1")
+    present_ids = {resolve_canonical_id(f) for f in present}
+
+    reconciled = hub_store.reconcile_current_absent(
+        tenant,
+        present_canonical_ids=present_ids,
+        observed_at="2026-01-02T00:00:00Z",
+        scope_source="agent-runtime",
+    )
+    assert reconciled == 1
+
+    stale_row = hub_store.get_current(tenant, resolve_canonical_id(stale))
+    assert stale_row is not None
+    assert stale_row["status"] == "resolved"
+
+    kept_row = hub_store.get_current(tenant, resolve_canonical_id(present[0]))
+    assert kept_row is not None
+    assert kept_row["status"] == "open"


### PR DESCRIPTION
## Summary
- Replace unbounded `NOT IN` reconcile_absent with select-then-chunked UPDATE (500/chunk) for SQLite and Postgres — fixes bind-variable overflow on large batches.
- Mirror uv override security floors into `[project.optional-dependencies].ai-enrich` so pip installs get the same transitive pins as uv.

## Verification
- `uv run pytest tests/test_reconcile_absent_chunking.py tests/test_finding_lifecycle.py -q -k reconcile`

## Closes
- #3689
- #3684

Made with [Cursor](https://cursor.com)