### PR TITLE
fix(cis): ERROR on partial permission denial (strict GRC coverage)

### DIFF
--- a/src/agent_bom/cloud/aws_cis_benchmark.py
+++ b/src/agent_bom/cloud/aws_cis_benchmark.py
@@ -189,33 +189,38 @@ def finalize_read_coverage(
 ) -> CISCheckResult:
     """Decide PASS vs ERROR for a per-resource read check with no failures.
 
-    Guards the "list-but-not-get" false-PASS class: a check that lists N
-    resources but is denied the per-resource read on every one of them has
-    inspected *nothing*, so it must not report PASS. Call this only in the
-    branch where the ``failing`` accumulator is empty — FAIL is decided by the
-    caller and left untouched.
+    Strict GRC contract: any permission denial on a listed resource means the
+    full scope cannot be certified compliant. PASS only when every listed
+    resource was read successfully (or there were genuinely zero resources).
+    Call this only in the branch where the ``failing`` accumulator is empty —
+    FAIL is decided by the caller and left untouched.
 
     Decision table (``denied`` is the list of resources whose read was denied):
-      * ``inspected == 0 and denied``  -> ERROR (names the missing permission);
-        zero resources were actually evaluated, so compliance is unknown.
-      * otherwise                      -> PASS with ``pass_evidence`` (plus a
-        note when some — but not all — reads were denied). This preserves the
-        genuine "0 resources exist" PASS/NOT_APPLICABLE semantics because that
-        path reaches here with ``inspected == 0`` and an empty ``denied``.
+      * ``denied`` non-empty  -> ERROR (names missing permission + coverage);
+      * ``denied`` empty      -> PASS with ``pass_evidence`` (includes the
+        genuine "0 resources exist" NOT_APPLICABLE path).
     """
     denied_count = len(denied)
-    if inspected == 0 and denied_count:
+    if denied_count:
         result.status = CheckStatus.ERROR
-        result.evidence = (
-            f"Could not read {denied_count} {resource_kind}(s) — permission denied on every one "
-            f"(0 inspected). Grant '{permission}' so this check can be evaluated; "
-            "reporting PASS here would be a false compliant."
-        )
+        if inspected == 0:
+            result.evidence = (
+                f"Could not read {denied_count} {resource_kind}(s) — permission denied on every one "
+                f"(0 inspected). Grant '{permission}' so this check can be evaluated; "
+                "reporting PASS here would be a false compliant."
+            )
+        else:
+            total = inspected + denied_count
+            result.evidence = (
+                f"Incomplete evaluation: read {inspected}/{total} {resource_kind}(s); "
+                f"{denied_count} could not be read (permission denied). "
+                f"Grant '{permission}' for full coverage — PASS not reported; "
+                "compliance is unknown for skipped resources."
+            )
         result.resource_ids = list(denied)[:20]
     else:
-        note = f" ({denied_count} {resource_kind}(s) skipped — permission denied)" if denied_count else ""
         result.status = CheckStatus.PASS
-        result.evidence = pass_evidence + note
+        result.evidence = pass_evidence
     return result
 
 

--- a/tests/test_cis_denied_read_coverage.py
+++ b/tests/test_cis_denied_read_coverage.py
@@ -6,8 +6,9 @@ denied the per-resource read) previously left the check at its default
 failure accumulator stayed empty. That minted a false "compliant" for a scope
 that was never actually inspected.
 
-These tests assert the fixed contract across AWS, GCP, and Azure:
+These tests assert the strict GRC contract across AWS, GCP, and Azure:
   * every per-resource read denied  -> ERROR (never PASS), evidence names perm;
+  * any per-resource read denied    -> ERROR (partial coverage cannot PASS);
   * resources exist and all clean   -> PASS;
   * a real violation                -> FAIL;
   * genuinely zero resources        -> PASS (not ERROR — nothing was denied).
@@ -71,7 +72,7 @@ class TestAwsCheck212DeniedReads:
         result = _check_2_1_2(client)
         assert result.status == CheckStatus.PASS, result.evidence
 
-    def test_mixed_some_denied_some_clean_is_pass(self):
+    def test_mixed_some_denied_some_clean_is_error_not_pass(self):
         client = MagicMock()
         client.list_buckets.return_value = {"Buckets": [{"Name": "ok"}, {"Name": "denied"}]}
 
@@ -82,9 +83,9 @@ class TestAwsCheck212DeniedReads:
 
         client.get_bucket_encryption.side_effect = _side_effect
         result = _check_2_1_2(client)
-        # One bucket inspected clean -> PASS, but the skipped one is disclosed.
-        assert result.status == CheckStatus.PASS, result.evidence
-        assert "skipped" in result.evidence.lower()
+        assert result.status == CheckStatus.ERROR, result.evidence
+        assert "Incomplete evaluation" in result.evidence
+        assert "s3:GetEncryptionConfiguration" in result.evidence
 
 
 class TestAwsCheck116DeniedReads:


### PR DESCRIPTION
## Summary
- Tightens `finalize_read_coverage()` after #3691: any permission denial on a listed resource → **ERROR**, not PASS with a footnote.
- PASS only when every resource was read successfully (or zero resources exist).
- Evidence names missing permission and coverage ratio (`read 3/10 buckets…`).

## Verification
- `uv run pytest tests/test_cis_denied_read_coverage.py -q`

## Notes
- Follow-up to #3691 (all-denied fix). This closes the partial-coverage softness discussed in triage.

Made with [Cursor](https://cursor.com)