### PR TITLE
fix(audit): genesis chain verification and git-SHA range false-positive

### DIFF
--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -342,6 +342,20 @@ def _entry_tenant(entry: AuditEntry) -> str:
     return str((entry.details or {}).get("tenant_id") or "default")
 
 
+def _verify_audit_chain(entries: list[AuditEntry]) -> tuple[int, int]:
+    """Verify HMAC chain from genesis (``prev_signature`` must start at ``""``)."""
+    verified = 0
+    tampered = 0
+    prev_sig = ""
+    for entry in entries:
+        if entry.prev_signature != prev_sig or not entry.verify():
+            tampered += 1
+        else:
+            verified += 1
+        prev_sig = entry.hmac_signature
+    return verified, tampered
+
+
 class InMemoryAuditLog:
     """In-memory audit log for development."""
 
@@ -396,17 +410,12 @@ class InMemoryAuditLog:
 
     def verify_integrity(self, limit: int = 1000, tenant_id: str | None = None) -> tuple[int, int]:
         """Verify chain-hashed HMAC signatures. Returns (verified_count, tampered_count)."""
-        entries = list(reversed(self.list_entries(limit=limit, tenant_id=tenant_id)))
-        verified = 0
-        tampered = 0
-        prev_sig = entries[0].prev_signature if entries else ""
-        for entry in entries:
-            if entry.prev_signature != prev_sig or not entry.verify():
-                tampered += 1
-            else:
-                verified += 1
-            prev_sig = entry.hmac_signature
-        return verified, tampered
+        with self._lock:
+            filtered = self._entries
+            if tenant_id is not None:
+                filtered = [e for e in filtered if str((e.details or {}).get("tenant_id", "")) == tenant_id]
+            entries = filtered[:limit]
+        return _verify_audit_chain(entries)
 
 
 class SQLiteAuditLog:
@@ -565,21 +574,41 @@ class SQLiteAuditLog:
         row = self._conn.execute(f"SELECT COUNT(*) FROM audit_log{where}", params).fetchone()  # nosec B608
         return row[0] if row else 0
 
+    def _list_entries_chronological(
+        self,
+        limit: int,
+        tenant_id: str | None = None,
+    ) -> list[AuditEntry]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if tenant_id is not None:
+            clauses.append("json_extract(details, '$.tenant_id') = ?")
+            params.append(tenant_id)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        sql = (
+            f"SELECT entry_id, timestamp, action, actor, resource, details, prev_signature, hmac_signature"  # nosec B608
+            f" FROM audit_log {where} ORDER BY timestamp ASC, rowid ASC LIMIT ?"
+        )
+        params.append(limit)
+        rows = self._conn.execute(sql, params).fetchall()
+        return [
+            AuditEntry(
+                entry_id=r[0],
+                timestamp=r[1],
+                action=r[2],
+                actor=r[3],
+                resource=r[4],
+                details=json.loads(r[5]),
+                prev_signature=r[6],
+                hmac_signature=r[7],
+            )
+            for r in rows
+        ]
+
     def verify_integrity(self, limit: int = 1000, tenant_id: str | None = None) -> tuple[int, int]:
         """Verify chain-hashed HMAC signatures. Returns (verified_count, tampered_count)."""
-        entries = self.list_entries(limit=limit, tenant_id=tenant_id)
-        # list_entries returns most-recent-first; reverse for chronological chain verification
-        entries = list(reversed(entries))
-        verified = 0
-        tampered = 0
-        prev_sig = entries[0].prev_signature if entries else ""
-        for entry in entries:
-            if entry.prev_signature != prev_sig or not entry.verify():
-                tampered += 1
-            else:
-                verified += 1
-            prev_sig = entry.hmac_signature
-        return verified, tampered
+        entries = self._list_entries_chronological(limit=limit, tenant_id=tenant_id)
+        return _verify_audit_chain(entries)
 
 
 # ── Module-level singleton ──

--- a/src/agent_bom/api/postgres_audit.py
+++ b/src/agent_bom/api/postgres_audit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from agent_bom.api.audit_log import AuditEntry
+from agent_bom.api.audit_log import AuditEntry, _verify_audit_chain
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 from agent_bom.baseline import TrendPoint
 
@@ -152,18 +152,41 @@ class PostgresAuditLog:
             row = conn.execute(sql, tuple(params)).fetchone()
         return row[0] if row else 0
 
+    def _list_entries_chronological(
+        self,
+        limit: int,
+        tenant_id: str | None = None,
+    ) -> list[AuditEntry]:
+        clauses: list[str] = []
+        params: list[object] = []
+        if tenant_id is not None:
+            clauses.append("team_id = %s")
+            params.append(tenant_id)
+        where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
+        sql = (
+            "SELECT entry_id, timestamp, action, actor, resource, details, prev_signature, hmac_signature "
+            f"FROM audit_log{where} ORDER BY timestamp ASC, entry_id ASC LIMIT %s"
+        )
+        params.append(limit)
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(sql, tuple(params)).fetchall()
+        return [
+            AuditEntry(
+                entry_id=row[0],
+                timestamp=row[1],
+                action=row[2],
+                actor=row[3],
+                resource=row[4],
+                details=row[5] if isinstance(row[5], dict) else json.loads(row[5]),
+                prev_signature=row[6],
+                hmac_signature=row[7],
+            )
+            for row in rows
+        ]
+
     def verify_integrity(self, limit: int = 1000, tenant_id: str | None = None) -> tuple[int, int]:
-        entries = list(reversed(self.list_entries(limit=limit, tenant_id=tenant_id)))
-        verified = 0
-        tampered = 0
-        prev_sig = entries[0].prev_signature if entries else ""
-        for entry in entries:
-            if entry.prev_signature != prev_sig or not entry.verify():
-                tampered += 1
-            else:
-                verified += 1
-            prev_sig = entry.hmac_signature
-        return verified, tampered
+        entries = self._list_entries_chronological(limit=limit, tenant_id=tenant_id)
+        return _verify_audit_chain(entries)
 
 
 class PostgresTrendStore:

--- a/src/agent_bom/api/postgres_audit.py
+++ b/src/agent_bom/api/postgres_audit.py
@@ -165,7 +165,7 @@ class PostgresAuditLog:
         where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
         sql = (
             "SELECT entry_id, timestamp, action, actor, resource, details, prev_signature, hmac_signature "
-            f"FROM audit_log{where} ORDER BY timestamp ASC, entry_id ASC LIMIT %s"
+            f"FROM audit_log{where} ORDER BY timestamp ASC, entry_id ASC LIMIT %s"  # nosec B608
         )
         params.append(limit)
         with _tenant_connection(self._pool) as conn:

--- a/src/agent_bom/guard.py
+++ b/src/agent_bom/guard.py
@@ -14,7 +14,9 @@ Shell alias (recommended):
 The guard exits with code 1 (blocking install) if any package has:
   - Critical or High CVEs (configurable via --min-severity)
   - Known-exploited vulnerabilities (CISA KEV)
-  - Malicious package indicators
+
+Malicious-package indicators are surfaced by ``agent-bom agents --fail-on-malicious``
+and policy rules; the pre-install guard does not yet block typosquats without CVEs.
 
 Use --allow-risky to install despite findings (logs a warning).
 """

--- a/src/agent_bom/version_utils.py
+++ b/src/agent_bom/version_utils.py
@@ -542,6 +542,12 @@ def version_in_range(
     fix = fixed or None
     last = last_affected or None
 
+    # Git-commit bounds (common in OSS-Fuzz / OSV-2022-* advisories) cannot
+    # establish semver range membership — compare_version_order returns None
+    # and falling through would mark every version as affected.
+    if any(boundary and _looks_like_commit_sha(boundary) for boundary in (intro, fix, last)):
+        return False
+
     if ecosystem.lower() == "go":
         ver_ts = _go_pseudo_timestamp(version)
         if ver_ts:

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -34,6 +34,29 @@ def test_chain_hash_detects_details_tamper():
     assert tampered > 0
 
 
+def test_chain_hash_detects_leading_truncation():
+    """Lazy deletion of oldest entries without re-signing must fail verification."""
+    log = InMemoryAuditLog()
+    log.append(AuditEntry(action="scan", actor="test", resource="pkg-a"))
+    log.append(AuditEntry(action="scan", actor="test", resource="pkg-b"))
+    log.append(AuditEntry(action="scan", actor="test", resource="pkg-c"))
+    log._entries.pop(0)
+    verified, tampered = log.verify_integrity()
+    assert verified == 1
+    assert tampered == 1
+
+
+def test_chain_hash_head_deletion_still_verifies_internal_chain():
+    """Deleting newest entries leaves a valid sub-chain (known limitation)."""
+    log = InMemoryAuditLog()
+    for i in range(3):
+        log.append(AuditEntry(action="scan", actor="test", resource=f"pkg-{i}"))
+    log._entries.pop()
+    verified, tampered = log.verify_integrity()
+    assert verified == 2
+    assert tampered == 0
+
+
 def test_sqlite_audit_hydrates_last_signature_after_restart(tmp_path):
     db = str(tmp_path / "audit.db")
     first = SQLiteAuditLog(db)

--- a/tests/test_version_utils.py
+++ b/tests/test_version_utils.py
@@ -379,3 +379,12 @@ def test_semver_prerelease_orders_below_equal_tagged_release():
     assert version_in_range("13.4.20-canary.13", "0.9.9", "13.4.20", None, "npm") is True
     # while the released fix itself is not affected.
     assert version_in_range("13.4.20", "0.9.9", "13.4.20", None, "npm") is False
+
+
+def test_version_in_range_git_sha_bounds_not_affected():
+    """Git-commit advisory bounds must not mark every semver version as affected."""
+    sha_intro = "a" * 40
+    sha_fix = "b" * 40
+    assert version_in_range("99.99.99", sha_intro, sha_fix, None, "pypi") is False
+    assert version_in_range("10.0.1", sha_intro, None, None, "pypi") is False
+    assert version_in_range("1.0.0", None, sha_fix, None, "pypi") is False


### PR DESCRIPTION
## Summary
- **Audit integrity:** `verify_integrity()` now verifies oldest-first from genesis (`prev_signature == ""`) instead of seeding from the first entry's stored prev link — lazy leading truncation is detected (SQLite, Postgres, in-memory).
- **Version matching:** `version_in_range()` returns `False` when OSV bounds are git commit SHAs, fixing a fail-open that flagged every semver (e.g. OSS-Fuzz / OSV-2022-* advisories on current packages).
- **Guard docstring:** Pre-install guard doc now states CVE/KEV scope; malicious blocking is via `--fail-on-malicious` / policy (#3694).

## Verification
- `uv run pytest tests/test_version_utils.py::test_version_in_range_git_sha_bounds_not_affected tests/test_audit_chain.py -q` — 7 passed
- `uv run pytest tests/test_postgres_store.py -k audit -q` — 6 passed
- `uv run pytest tests/test_enterprise_gaps.py -k audit_verify -q` — 1 passed
- `uv run ruff check src/agent_bom/version_utils.py src/agent_bom/guard.py src/agent_bom/api/audit_log.py src/agent_bom/api/postgres_audit.py`

## Notes
- Head deletion with full re-signing remains undetectable without an external anchor (documented in `test_chain_hash_head_deletion_still_verifies_internal_chain`).
- Malicious-package export parity is handled separately in #3694.

Made with [Cursor](https://cursor.com)