### PR TITLE
feat(runtime): shield fail-closed defaults, cred redact, SSRF guard

### DIFF
--- a/src/agent_bom/cli/_runtime.py
+++ b/src/agent_bom/cli/_runtime.py
@@ -166,7 +166,7 @@ from agent_bom.cli._common import OPTIONAL_PORT_RANGE, PORT_RANGE
 @click.option(
     "--firewall-fail-mode",
     type=click.Choice(["open", "closed"], case_sensitive=False),
-    default="open",
+    default="closed",
     show_default=True,
     help="Fail-open (allow) or fail-closed (deny) when the gateway is unreachable AND no local policy is set.",
 )

--- a/src/agent_bom/cloud/vector_db.py
+++ b/src/agent_bom/cloud/vector_db.py
@@ -63,6 +63,8 @@ _HEALTH_ENDPOINTS: dict[str, str] = {
 
 _DEFAULT_TIMEOUT = 3  # seconds
 
+_PROBE_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
 MAESTRO_LAYER = "KC4: Memory & Context"
 
 
@@ -126,6 +128,19 @@ def _is_loopback(host: str) -> bool:
         return addr.startswith("127.") or addr == "::1"
     except OSError:
         return False
+
+
+def _validate_probe_target(host: str, port: int) -> str | None:
+    """Return an error string when the host must not be probed (SSRF guard)."""
+    from agent_bom.security import SecurityError, validate_url
+
+    cleaned = (host or "").strip().lower()
+    allow_private = cleaned in _PROBE_LOOPBACK_HOSTS
+    try:
+        validate_url(f"http://{host}:{port}/", allowed_schemes=("http",), allow_private=allow_private)
+    except SecurityError as exc:
+        return str(exc)
+    return None
 
 
 def _http_get(host: str, port: int, path: str, timeout: int = _DEFAULT_TIMEOUT) -> tuple[int, bytes]:
@@ -231,6 +246,21 @@ def check_vector_db(
             is_loopback=_is_loopback(host),
             risk_flags=[],
             metadata={"error": f"Unknown db_type '{db_type}'"},
+        )
+
+    deny_reason = _validate_probe_target(host, resolved_port)
+    if deny_reason:
+        return VectorDBResult(
+            db_type=db_type,
+            host=host,
+            port=resolved_port,
+            is_reachable=False,
+            requires_auth=True,
+            version="",
+            collection_count=0,
+            is_loopback=_is_loopback(host),
+            risk_flags=[],
+            metadata={"error": deny_reason},
         )
 
     result = VectorDBResult(

--- a/src/agent_bom/firewall_client.py
+++ b/src/agent_bom/firewall_client.py
@@ -6,8 +6,8 @@ on every message would blow the latency budget. This client adds:
 
 - a per-process TTL cache keyed by (source, target, sorted source_roles,
   sorted target_roles) so repeat decisions in a typical session are local,
-- a configurable `fail_mode` (`open` / `closed`) so operators choose between
-  availability and safety when the gateway is unreachable,
+- a configurable `fail_mode` (`open` / `closed`, default `closed`) so operators
+  choose between availability and safety when the gateway is unreachable,
 - a local `AgentFirewallPolicy` fallback so air-gapped / single-host installs
   can run without a control plane.
 
@@ -33,6 +33,7 @@ from agent_bom.firewall import (
 from agent_bom.firewall import (
     evaluate as evaluate_firewall_policy,
 )
+from agent_bom.security import sanitize_text
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +69,7 @@ class FirewallClient:
         bearer_token: str | None = None,
         cache_ttl_seconds: float = 60.0,
         cache_max_entries: int = 1024,
-        fail_mode: FirewallFailMode = FirewallFailMode.OPEN,
+        fail_mode: FirewallFailMode = FirewallFailMode.CLOSED,
         local_policy: AgentFirewallPolicy | None = None,
         request_timeout_seconds: float = 2.0,
         http_client: Any | None = None,
@@ -118,7 +119,7 @@ class FirewallClient:
                     "firewall_client gateway call failed (source=%s, target=%s): %s",
                     source_agent,
                     target_agent,
-                    exc,
+                    sanitize_text(str(exc)),
                 )
 
         evaluation = self._fallback_decision(source_agent, target_agent, source_roles, target_roles)

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -394,7 +394,11 @@ def _evaluate_control_plane_bundle(
                 return False, "control-plane policy malformed"
             return True, ""
         if parse_errors:
-            logger.warning("gateway control-plane bundle: %d policy/policies failed to parse and were skipped", parse_errors)
+            logger.error(
+                "gateway control-plane bundle: %d policy/policies failed to parse; failing closed",
+                parse_errors,
+            )
+            return False, "control-plane policy malformed"
         return _evaluate_gateway_policy_bundle(policies, source_agent, tool_name, arguments)
     except Exception as exc:  # noqa: BLE001
         # Fail closed: a bundle that cannot be evaluated must not silently pass.

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -1899,6 +1899,20 @@ async def run_proxy(
                         tool_for_resp = pending_calls[resp_id][0]
                     cred_alerts = cred_detector.check(tool_for_resp or "unknown", result_text)
                     await _handle_alerts(cred_alerts, log_file)
+                    if cred_alerts and not log_only:
+                        from agent_bom.runtime.detectors import CredentialLeakDetector
+
+                        redacted_text = CredentialLeakDetector.redact(result_text)
+                        if "result" in msg:
+                            try:
+                                msg["result"] = json.loads(redacted_text)
+                            except json.JSONDecodeError:
+                                msg["result"] = redacted_text
+                        else:
+                            try:
+                                msg["error"] = json.loads(redacted_text)
+                            except json.JSONDecodeError:
+                                msg["error"] = redacted_text
 
                 # Runtime detector: response content inspection (cloaking, SVG, invisible chars,
                 # prompt injection). For confirmed vector DB / RAG retrieval tools, also run
@@ -2007,6 +2021,22 @@ async def run_proxy(
                             "code": -32600,
                             "message": "[BLOCKED] Security scanner detected sensitive content in response",
                         }
+                        line = (json.dumps(msg) + "\n").encode()
+                    elif (
+                        scan_config.mode == "enforce"
+                        and scan_config.pii_action == "redact"
+                        and any(sr.scanner == "pii" for sr in resp_results)
+                    ):
+                        from agent_bom.proxy_scanner import redact_pii
+
+                        if isinstance(msg.get("result"), str):
+                            msg["result"] = redact_pii(msg["result"])
+                        elif isinstance(msg.get("result"), dict):
+                            redacted_text = redact_pii(json.dumps(msg["result"]))
+                            try:
+                                msg["result"] = json.loads(redacted_text)
+                            except json.JSONDecodeError:
+                                pass
                         line = (json.dumps(msg) + "\n").encode()
 
                 # Complete latency tracking for tool call responses

--- a/tests/test_local_db_scan.py
+++ b/tests/test_local_db_scan.py
@@ -152,16 +152,19 @@ def test_scan_packages_local_db_db_unavailable():
     assert count == 0
 
 
-def test_scan_packages_local_db_falls_back_to_readonly_open():
+def test_scan_packages_local_db_falls_back_to_readonly_open(tmp_path):
     """Read-only fallback still scans when writable init_db fails."""
     from agent_bom.scanners import _scan_packages_local_db
 
     pkg = _make_pkg()
     lv = _make_local_vuln("CVE-2024-4444", "high", 7.9)
+    db_file = tmp_path / "scan.db"
+    db_file.write_text("placeholder", encoding="utf-8")
     conn = MagicMock()
 
     with (
         patch("agent_bom.db.schema.db_freshness_days", return_value=1),
+        patch("agent_bom.db.schema.DB_PATH", db_file),
         patch("agent_bom.db.schema.init_db", side_effect=RuntimeError("readonly mount")),
         patch("agent_bom.db.schema.open_existing_db_readonly", return_value=conn),
         patch("agent_bom.db.lookup.package_in_db", return_value=True),

--- a/tests/test_runtime_shield_3683.py
+++ b/tests/test_runtime_shield_3683.py
@@ -1,0 +1,63 @@
+"""Regression tests for runtime shield hardening (#3683)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from agent_bom.cloud.vector_db import check_vector_db
+from agent_bom.firewall_client import FirewallClient, FirewallFailMode
+from agent_bom.gateway_server import _evaluate_control_plane_bundle
+from agent_bom.proxy_scanner import ScanConfig, scan_content
+from agent_bom.runtime.detectors import CredentialLeakDetector
+
+
+@pytest.mark.asyncio
+async def test_firewall_client_defaults_to_fail_closed() -> None:
+    client = FirewallClient(gateway_url="http://gateway.test")
+    with patch.object(client, "_call_gateway", side_effect=RuntimeError("down")):
+        evaluation = await client.decision(source_agent="a", target_agent="b")
+    assert evaluation.decision.value == "deny"
+
+
+@pytest.mark.asyncio
+async def test_firewall_client_fail_open_is_explicit() -> None:
+    client = FirewallClient(gateway_url="http://gateway.test", fail_mode=FirewallFailMode.OPEN)
+    with patch.object(client, "_call_gateway", side_effect=RuntimeError("down")):
+        evaluation = await client.decision(source_agent="a", target_agent="b")
+    assert evaluation.decision.value == "allow"
+
+
+def test_gateway_partial_malformed_bundle_fails_closed() -> None:
+    allowed, reason = _evaluate_control_plane_bundle(
+        [{"policy_id": "p1", "name": "ok", "rules": []}, "not-a-policy"],
+        "agent-a",
+        "tool",
+        {},
+    )
+    assert allowed is False
+    assert "malformed" in reason
+
+
+def test_vector_db_rejects_metadata_endpoint() -> None:
+    result = check_vector_db("qdrant", host="169.254.169.254", port=6333)
+    assert result.is_reachable is False
+    assert "metadata" in result.metadata.get("error", "").lower()
+
+
+def test_credential_leak_detector_redacts_before_forward() -> None:
+    key_name = "to" + "ken"
+    secret = "sk-" + "12345678901234567890123456789012"
+    text = json.dumps({key_name: secret})
+    redacted = CredentialLeakDetector.redact(text)
+    assert secret not in redacted
+    assert "[REDACTED:" in redacted
+
+
+def test_inline_scanner_pii_redact_does_not_block_by_default() -> None:
+    config = ScanConfig(enabled=True, mode="enforce", scanners=["pii"], pii_action="redact")
+    findings = scan_content("contact me at alice@example.com", config)
+    assert findings
+    assert all(not f.blocked for f in findings)

--- a/uv.lock
+++ b/uv.lock
@@ -52,9 +52,13 @@ dependencies = [
 
 [package.optional-dependencies]
 ai-enrich = [
+    { name = "aiohttp" },
     { name = "litellm" },
+    { name = "openai" },
+    { name = "python-dotenv" },
 ]
 all = [
+    { name = "aiohttp" },
     { name = "alembic" },
     { name = "azure-ai-projects" },
     { name = "azure-containerregistry" },
@@ -122,6 +126,7 @@ all = [
     { name = "psycopg-pool" },
     { name = "pyjwt" },
     { name = "pytesseract" },
+    { name = "python-dotenv" },
     { name = "python3-saml" },
     { name = "requests" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -403,6 +408,7 @@ requires-dist = [
     { name = "agent-bom", extras = ["visual"], marker = "extra == 'all'" },
     { name = "agent-bom", extras = ["wandb"], marker = "extra == 'cloud'" },
     { name = "agent-bom", extras = ["watch"], marker = "extra == 'all'" },
+    { name = "aiohttp", marker = "extra == 'ai-enrich'", specifier = ">=3.13.4" },
     { name = "alembic", marker = "extra == 'postgres'", specifier = ">=1.13" },
     { name = "azure-ai-projects", marker = "extra == 'azure'", specifier = ">=1.0" },
     { name = "azure-containerregistry", marker = "extra == 'azure'", specifier = ">=1.2" },
@@ -468,6 +474,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "networkx", marker = "extra == 'graph'", specifier = ">=3.0" },
     { name = "numpy", marker = "extra == 'graph'", specifier = ">=1.26" },
+    { name = "openai", marker = "extra == 'ai-enrich'", specifier = ">=2.30.0" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.12" },
     { name = "opentelemetry-api", marker = "extra == 'otel'", specifier = ">=1.20" },
     { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'otel'", specifier = ">=1.20" },
@@ -493,6 +500,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "pytest-randomly", marker = "extra == 'dev'", specifier = ">=3.15" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5" },
+    { name = "python-dotenv", marker = "extra == 'ai-enrich'", specifier = ">=1.2.2" },
     { name = "python3-saml", marker = "extra == 'saml'", specifier = ">=1.16.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.33.0" },


### PR DESCRIPTION
## Summary
- **Fail-closed defaults:** `FirewallClient` and proxy `--firewall-fail-mode` default to `closed` when the gateway is unreachable and no local policy is set.
- **Gateway bundle integrity:** partial malformed control-plane policy bundles fail closed (not skip-and-allow).
- **Proxy enforcement:** credential leaks redacted before forward when `--detect-credentials` fires; inline scanner applies PII redact in enforce + `pii_action=redact` mode.
- **SSRF guard:** `vector_db_scan` validates probe targets via `validate_url` (blocks metadata / non-loopback without operator override).

Closes #3683 (partial — firewall file reload fail-closed, scanner enforce defaults, vector_db P3 hardening remainder in issue).

## Verification
- `uv run pytest tests/test_runtime_shield_3683.py tests/test_firewall_client.py -q` — 19 passed
- `uv run ruff check` on changed runtime files

## Notes
- Rebased on `main` after #3696 merge.

Made with [Cursor](https://cursor.com)