### PR TITLE
feat(audit): signed chain checkpoint detects tail truncation

### DIFF
--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -356,6 +356,27 @@ def _verify_audit_chain(entries: list[AuditEntry]) -> tuple[int, int]:
     return verified, tampered
 
 
+@dataclass(frozen=True)
+class _AuditChainCheckpoint:
+    entry_count: int
+    head_signature: str
+
+
+def _verify_audit_chain_with_checkpoint(
+    entries: list[AuditEntry],
+    checkpoint: _AuditChainCheckpoint | None,
+) -> tuple[int, int]:
+    """Verify chain integrity and detect tail truncation via signed checkpoint."""
+    verified, tampered = _verify_audit_chain(entries)
+    if checkpoint is None or not entries:
+        return verified, tampered
+    if len(entries) != checkpoint.entry_count:
+        return verified, tampered + 1
+    if entries[-1].hmac_signature != checkpoint.head_signature:
+        return verified, tampered + 1
+    return verified, tampered
+
+
 class InMemoryAuditLog:
     """In-memory audit log for development."""
 
@@ -365,6 +386,14 @@ class InMemoryAuditLog:
         self._entries: list[AuditEntry] = []
         self._lock = threading.Lock()
         self._last_sig_by_tenant: dict[str, str] = defaultdict(str)
+        self._checkpoint_by_tenant: dict[str, _AuditChainCheckpoint] = {}
+
+    def _update_checkpoint(self, tenant_id: str, head_signature: str) -> None:
+        current = self._checkpoint_by_tenant.get(tenant_id)
+        self._checkpoint_by_tenant[tenant_id] = _AuditChainCheckpoint(
+            entry_count=(current.entry_count + 1) if current else 1,
+            head_signature=head_signature,
+        )
 
     def append(self, entry: AuditEntry) -> None:
         tenant_id = _entry_tenant(entry)
@@ -373,6 +402,7 @@ class InMemoryAuditLog:
         self._last_sig_by_tenant[tenant_id] = entry.hmac_signature
         with self._lock:
             self._entries.append(entry)
+            self._update_checkpoint(tenant_id, entry.hmac_signature)
             if len(self._entries) > self._MAX_ENTRIES:
                 self._entries = self._entries[self._MAX_ENTRIES // 2 :]
 
@@ -414,8 +444,9 @@ class InMemoryAuditLog:
             filtered = self._entries
             if tenant_id is not None:
                 filtered = [e for e in filtered if str((e.details or {}).get("tenant_id", "")) == tenant_id]
-            entries = filtered[:limit]
-        return _verify_audit_chain(entries)
+            entries = filtered
+            checkpoint = self._checkpoint_by_tenant.get(tenant_id or "default")
+        return _verify_audit_chain_with_checkpoint(entries, checkpoint)
 
 
 class SQLiteAuditLog:
@@ -454,7 +485,61 @@ class SQLiteAuditLog:
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_log(action)")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_audit_ts ON audit_log(timestamp)")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_audit_resource ON audit_log(resource)")
+        self._conn.execute("""CREATE TABLE IF NOT EXISTS audit_chain_checkpoint (
+            tenant_id TEXT PRIMARY KEY,
+            entry_count INTEGER NOT NULL,
+            head_signature TEXT NOT NULL
+        )""")
         self._conn.commit()
+        self._hydrate_checkpoints()
+
+    def _hydrate_checkpoints(self) -> None:
+        existing = self._conn.execute("SELECT COUNT(*) FROM audit_chain_checkpoint").fetchone()
+        if existing and int(existing[0]) > 0:
+            return
+        tenants = self._conn.execute(
+            """
+            SELECT DISTINCT COALESCE(NULLIF(json_extract(details, '$.tenant_id'), ''), 'default')
+            FROM audit_log
+            """
+        ).fetchall()
+        for (tenant_id,) in tenants:
+            count_row = self._conn.execute(
+                """
+                SELECT COUNT(*) FROM audit_log
+                WHERE COALESCE(NULLIF(json_extract(details, '$.tenant_id'), ''), 'default') = ?
+                """,
+                (str(tenant_id),),
+            ).fetchone()
+            head = self._latest_signature_for_tenant(str(tenant_id))
+            if not count_row or not head:
+                continue
+            self._conn.execute(
+                "INSERT OR REPLACE INTO audit_chain_checkpoint (tenant_id, entry_count, head_signature) VALUES (?, ?, ?)",
+                (str(tenant_id), int(count_row[0]), head),
+            )
+        self._conn.commit()
+
+    def _get_checkpoint(self, tenant_id: str) -> _AuditChainCheckpoint | None:
+        row = self._conn.execute(
+            "SELECT entry_count, head_signature FROM audit_chain_checkpoint WHERE tenant_id = ?",
+            (tenant_id,),
+        ).fetchone()
+        if not row:
+            return None
+        return _AuditChainCheckpoint(entry_count=int(row[0]), head_signature=str(row[1]))
+
+    def _upsert_checkpoint(self, tenant_id: str, head_signature: str) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO audit_chain_checkpoint (tenant_id, entry_count, head_signature)
+            VALUES (?, 1, ?)
+            ON CONFLICT(tenant_id) DO UPDATE SET
+                entry_count = entry_count + 1,
+                head_signature = excluded.head_signature
+            """,
+            (tenant_id, head_signature),
+        )
 
     def _latest_signature_for_tenant(self, tenant_id: str) -> str:
         row = self._conn.execute(
@@ -513,6 +598,7 @@ class SQLiteAuditLog:
                 entry.hmac_signature,
             ),
         )
+        self._upsert_checkpoint(tenant_id, entry.hmac_signature)
         self._conn.commit()
 
     def list_entries(
@@ -607,8 +693,12 @@ class SQLiteAuditLog:
 
     def verify_integrity(self, limit: int = 1000, tenant_id: str | None = None) -> tuple[int, int]:
         """Verify chain-hashed HMAC signatures. Returns (verified_count, tampered_count)."""
-        entries = self._list_entries_chronological(limit=limit, tenant_id=tenant_id)
-        return _verify_audit_chain(entries)
+        tenant_key = tenant_id or "default"
+        total = self.count(tenant_id=tenant_id)
+        fetch_limit = total if total else limit
+        entries = self._list_entries_chronological(limit=fetch_limit, tenant_id=tenant_id)
+        checkpoint = self._get_checkpoint(tenant_key)
+        return _verify_audit_chain_with_checkpoint(entries, checkpoint)
 
 
 # ── Module-level singleton ──

--- a/src/agent_bom/api/postgres_audit.py
+++ b/src/agent_bom/api/postgres_audit.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
-from agent_bom.api.audit_log import AuditEntry, _verify_audit_chain
+from agent_bom.api.audit_log import AuditEntry, _AuditChainCheckpoint, _verify_audit_chain_with_checkpoint
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 from agent_bom.baseline import TrendPoint
 
@@ -44,8 +45,71 @@ class PostgresAuditLog:
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_audit_log_team_resource_ts ON audit_log(team_id, resource text_pattern_ops, timestamp DESC)"
             )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS audit_chain_checkpoint (
+                    tenant_id TEXT PRIMARY KEY,
+                    entry_count INTEGER NOT NULL,
+                    head_signature TEXT NOT NULL
+                )
+                """
+            )
             _ensure_tenant_rls(conn, "audit_log", "team_id")
             conn.commit()
+        self._hydrate_checkpoints()
+
+    def _hydrate_checkpoints(self) -> None:
+        with self._pool.connection() as conn:
+            row = conn.execute("SELECT COUNT(*) FROM audit_chain_checkpoint").fetchone()
+            if row and int(row[0]) > 0:
+                return
+            tenants = conn.execute("SELECT DISTINCT team_id FROM audit_log").fetchall()
+            for (tenant_id,) in tenants:
+                count_row = conn.execute(
+                    "SELECT COUNT(*) FROM audit_log WHERE team_id = %s",
+                    (tenant_id,),
+                ).fetchone()
+                head_row = conn.execute(
+                    "SELECT hmac_signature FROM audit_log WHERE team_id = %s ORDER BY timestamp DESC, entry_id DESC LIMIT 1",
+                    (tenant_id,),
+                ).fetchone()
+                if not count_row or not head_row:
+                    continue
+                conn.execute(
+                    """
+                    INSERT INTO audit_chain_checkpoint (tenant_id, entry_count, head_signature)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT (tenant_id) DO UPDATE SET
+                        entry_count = EXCLUDED.entry_count,
+                        head_signature = EXCLUDED.head_signature
+                    """,
+                    (tenant_id, int(count_row[0]), str(head_row[0])),
+                )
+            conn.commit()
+
+    def _get_checkpoint(self, tenant_id: str) -> _AuditChainCheckpoint | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT entry_count, head_signature FROM audit_chain_checkpoint WHERE tenant_id = %s",
+                (tenant_id,),
+            ).fetchone()
+        if not row:
+            return None
+        if len(row) >= 3:
+            return _AuditChainCheckpoint(entry_count=int(row[1]), head_signature=str(row[2]))
+        return _AuditChainCheckpoint(entry_count=int(row[0]), head_signature=str(row[1]))
+
+    def _upsert_checkpoint(self, conn: Any, tenant_id: str, head_signature: str) -> None:
+        conn.execute(
+            """
+            INSERT INTO audit_chain_checkpoint (tenant_id, entry_count, head_signature)
+            VALUES (%s, 1, %s)
+            ON CONFLICT (tenant_id) DO UPDATE SET
+                entry_count = audit_chain_checkpoint.entry_count + 1,
+                head_signature = EXCLUDED.head_signature
+            """,
+            (tenant_id, head_signature),
+        )
 
     def _latest_signature_for_tenant(self, tenant_id: str) -> str:
         with self._pool.connection() as conn:
@@ -88,6 +152,7 @@ class PostgresAuditLog:
                     entry.hmac_signature,
                 ),
             )
+            self._upsert_checkpoint(conn, tenant_id, entry.hmac_signature)
             conn.commit()
         self._last_sig_by_tenant[tenant_id] = entry.hmac_signature
 
@@ -185,8 +250,12 @@ class PostgresAuditLog:
         ]
 
     def verify_integrity(self, limit: int = 1000, tenant_id: str | None = None) -> tuple[int, int]:
-        entries = self._list_entries_chronological(limit=limit, tenant_id=tenant_id)
-        return _verify_audit_chain(entries)
+        tenant_key = tenant_id or "default"
+        total = self.count(tenant_id=tenant_id)
+        fetch_limit = total if total else limit
+        entries = self._list_entries_chronological(limit=fetch_limit, tenant_id=tenant_id)
+        checkpoint = self._get_checkpoint(tenant_key)
+        return _verify_audit_chain_with_checkpoint(entries, checkpoint)
 
 
 class PostgresTrendStore:

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -43,18 +43,18 @@ def test_chain_hash_detects_leading_truncation():
     log._entries.pop(0)
     verified, tampered = log.verify_integrity()
     assert verified == 1
-    assert tampered == 1
+    assert tampered == 2
 
 
-def test_chain_hash_head_deletion_still_verifies_internal_chain():
-    """Deleting newest entries leaves a valid sub-chain (known limitation)."""
+def test_chain_hash_head_deletion_detected_with_checkpoint():
+    """Deleting newest entries without updating the checkpoint must fail verification."""
     log = InMemoryAuditLog()
     for i in range(3):
         log.append(AuditEntry(action="scan", actor="test", resource=f"pkg-{i}"))
     log._entries.pop()
     verified, tampered = log.verify_integrity()
     assert verified == 2
-    assert tampered == 0
+    assert tampered == 1
 
 
 def test_sqlite_audit_hydrates_last_signature_after_restart(tmp_path):

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -78,6 +78,14 @@ class MockConnection:
                     table = "policy_audit_log"
                 elif "audit_log" in sql:
                     table = "audit_log"
+                elif "audit_chain_checkpoint" in sql:
+                    table = "audit_chain_checkpoint"
+                    tenant_id, head_signature = params
+                    existing = self._store.setdefault(table, {}).get(tenant_id)
+                    entry_count = int(existing[1]) + 1 if existing and "on conflict" in sql_lower else 1
+                    self._store[table][tenant_id] = (tenant_id, entry_count, head_signature)
+                    self._cursors.append(cursor)
+                    return cursor
                 elif "trend_history" in sql:
                     table = "trend_history"
                 elif "scan_schedules" in sql:
@@ -115,6 +123,20 @@ class MockConnection:
                     rows = [row for row in rows if row[5] == params[0]]
                 rows = sorted(rows, key=lambda row: (row[1], row[0]), reverse=True)
                 cursor.rows = [(rows[0][8],)] if rows else []
+            elif "count(*) from audit_chain_checkpoint" in sql_lower.replace(" ", ""):
+                total = len(self._store.get("audit_chain_checkpoint", {}))
+                cursor.rows = [(total,)]
+            elif "select distinct team_id from audit_log" in sql_lower:
+                rows = list(self._store.get("audit_log", {}).values())
+                cursor.rows = [(row[5],) for row in rows]
+            elif "count(*) from audit_log" in sql_lower and "team_id = %s" in sql_lower:
+                rows = [row for row in self._store.get("audit_log", {}).values() if row[5] == params[0]]
+                cursor.rows = [(len(rows),)]
+            elif "from audit_chain_checkpoint" in sql_lower:
+                rows = list(self._store.get("audit_chain_checkpoint", {}).values())
+                if params and "tenant_id = %s" in sql_lower:
+                    rows = [row for row in rows if row[0] == params[0]]
+                cursor.rows = [(int(row[1]), row[2]) for row in rows]
             elif "group by" in sql_lower:
                 # Aggregate query — return empty list
                 cursor.rows = []


### PR DESCRIPTION
## Summary
- Per-tenant `audit_chain_checkpoint` stores `entry_count` + `head_signature` on every append (SQLite, Postgres, in-memory).
- `verify_integrity()` compares the full genesis-verified chain against the checkpoint — lazy **tail deletion** now increments `tampered`.
- Existing audit logs hydrate checkpoints on first boot.

Closes #3697.

## Verification
- `uv run pytest tests/test_audit_chain.py tests/test_postgres_store.py -k audit -q` — 12 passed

## Notes
- Re-signing attacker with DB write can still rebuild chain + checkpoint; external WORM anchor remains future hardening.

Made with [Cursor](https://cursor.com)