### PR TITLE
feat(identity): SCIM patch fixes, audit RBAC, session logout hardening

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -21543,12 +21543,12 @@
             }
           },
           {
-            "in": "query",
-            "name": "token",
+            "in": "header",
+            "name": "X-Siem-Token",
             "required": false,
             "schema": {
               "default": "",
-              "title": "Token",
+              "title": "X-Siem-Token",
               "type": "string"
             }
           }

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -14003,12 +14003,12 @@ paths:
           default: ''
           title: Url
           type: string
-      - in: query
-        name: token
+      - in: header
+        name: X-Siem-Token
         required: false
         schema:
           default: ''
-          title: Token
+          title: X-Siem-Token
           type: string
       responses:
         '200':

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -806,6 +806,8 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("POST", "/v1/graph/query", "viewer"),
         ("POST", "/v1/graph/should-i-deploy", "viewer"),
         ("POST", "/v1/audit/export/verify", "viewer"),
+        ("GET", "/v1/audit", "analyst"),
+        ("GET", "/v1/audit/", "analyst"),
         ("GET", "/scim/v2", "admin"),
         ("POST", "/scim/v2", "admin"),
         ("PATCH", "/scim/v2", "admin"),
@@ -1135,12 +1137,15 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 required = self._required_role(request.method, request.url.path)
                 required_role = Role(required)
                 effective_role = api_key.role
-                if api_key.name.startswith("saml:"):
+                if api_key.name.startswith("saml:") or api_key.scim_subject_id:
+                    subjects = [api_key.name.removeprefix("saml:"), api_key.name]
+                    if api_key.scim_subject_id:
+                        subjects.append(api_key.scim_subject_id)
                     effective_role, scim_error = self._resolve_runtime_role(
                         request,
                         tenant_id=api_key.tenant_id,
                         upstream_role=api_key.role,
-                        subjects=(api_key.name.removeprefix("saml:"), api_key.name),
+                        subjects=tuple(subjects),
                     )
                     if scim_error is not None:
                         return scim_error

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -521,9 +521,9 @@ async def delete_browser_session(request: Request, response: Response) -> None:
     """Clear the same-origin browser session cookie."""
     from agent_bom.api.audit_log import log_action
 
-    tenant_id = require_request_tenant_id(request)
-    actor = getattr(request.state, "api_key_name", "") or "browser-session"
     _clear_browser_session_cookie(response, request)
+    tenant_id = getattr(request.state, "tenant_id", None) or "default"
+    actor = getattr(request.state, "api_key_name", "") or "browser-session"
     log_action("auth.browser_session_cleared", actor=actor, resource="auth/session", tenant_id=tenant_id)
     return None
 
@@ -614,6 +614,7 @@ async def rotate_key(
             expires_at=req.expires_at,
             scopes=list(current_key.scopes),
             tenant_id=current_key.tenant_id,
+            scim_subject_id=current_key.scim_subject_id,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
@@ -1446,7 +1447,12 @@ async def list_siem_connectors() -> dict:
 
 
 @router.post("/v1/siem/test", tags=["enterprise"])
-async def test_siem_connection(request: Request, siem_type: str = "", url: str = "", token: str = "") -> dict:
+async def test_siem_connection(
+    request: Request,
+    siem_type: str = "",
+    url: str = "",
+    token: str = Header(default="", alias="X-Siem-Token"),
+) -> dict:
     """Test SIEM connectivity."""
     from agent_bom.api.audit_log import log_action
     from agent_bom.security import validate_url

--- a/src/agent_bom/api/routes/scim.py
+++ b/src/agent_bom/api/routes/scim.py
@@ -314,7 +314,11 @@ def _apply_group_patch(group: SCIMGroup, body: dict[str, Any]) -> SCIMGroup:
                 group.members = [entry for entry in group.members if _member_value(entry) != member_id]
                 continue
             if path == "members" or path.startswith("members"):
-                group.members = []
+                if isinstance(value, list) and value:
+                    to_remove = {_member_value(entry) for entry in value if isinstance(entry, dict)}
+                    group.members = [entry for entry in group.members if _member_value(entry) not in to_remove]
+                else:
+                    group.members = []
                 continue
         if op == "add" and path == "members":
             group.members = _dedupe_members([*group.members, *_member_entries_from_value(value)])
@@ -322,12 +326,20 @@ def _apply_group_patch(group: SCIMGroup, body: dict[str, Any]) -> SCIMGroup:
         if path == "displayName":
             group.display_name = str(value or "").strip()
         elif path == "members" and isinstance(value, list):
-            group.members = _dedupe_members([entry for entry in value if isinstance(entry, dict)])
+            member_entries = [entry for entry in value if isinstance(entry, dict)]
+            if op == "add":
+                group.members = _dedupe_members([*group.members, *member_entries])
+            else:
+                group.members = _dedupe_members(member_entries)
         elif isinstance(value, dict) and not path:
             if "displayName" in value:
                 group.display_name = str(value["displayName"]).strip()
             if "members" in value and isinstance(value["members"], list):
-                group.members = _dedupe_members([entry for entry in value["members"] if isinstance(entry, dict)])
+                member_entries = [entry for entry in value["members"] if isinstance(entry, dict)]
+                if op == "add":
+                    group.members = _dedupe_members([*group.members, *member_entries])
+                else:
+                    group.members = _dedupe_members(member_entries)
         else:
             raise HTTPException(status_code=400, detail="Unsupported group patch path")
     if not group.display_name:

--- a/src/agent_bom/rbac.py
+++ b/src/agent_bom/rbac.py
@@ -74,7 +74,7 @@ _PERMISSIONS: dict[str, set[Role]] = {
     "alert_write": {Role.ADMIN},
     "alert_read": {Role.ADMIN, Role.ANALYST, Role.VIEWER},
     "runtime_ingest": {Role.ADMIN, Role.ANALYST},
-    "audit_read": {Role.ADMIN, Role.ANALYST, Role.VIEWER},
+    "audit_read": {Role.ADMIN, Role.ANALYST},
     "sla_write": {Role.ADMIN},
     "sla_read": {Role.ADMIN, Role.ANALYST, Role.VIEWER},
     "config": {Role.ADMIN},

--- a/tests/test_identity_governance_3687.py
+++ b/tests/test_identity_governance_3687.py
@@ -1,0 +1,45 @@
+"""Regression tests for identity/SCIM governance (#3687)."""
+
+from __future__ import annotations
+
+from agent_bom.api.routes.scim import SCIMGroup, _apply_group_patch
+
+
+def test_scim_group_remove_members_value_list_subtracts_only_named() -> None:
+    group = SCIMGroup(
+        group_id="g1",
+        tenant_id="default",
+        display_name="ops",
+        members=[
+            {"value": "u1", "display": "alice"},
+            {"value": "u2", "display": "bob"},
+            {"value": "u3", "display": "carol"},
+        ],
+    )
+    updated = _apply_group_patch(
+        group,
+        {
+            "Operations": [
+                {
+                    "op": "remove",
+                    "path": "members",
+                    "value": [{"value": "u2", "display": "bob"}],
+                }
+            ]
+        },
+    )
+    assert {m["value"] for m in updated.members} == {"u1", "u3"}
+
+
+def test_scim_group_add_members_implicit_path_appends() -> None:
+    group = SCIMGroup(
+        group_id="g1",
+        tenant_id="default",
+        display_name="ops",
+        members=[{"value": "u1", "display": "alice"}],
+    )
+    updated = _apply_group_patch(
+        group,
+        {"Operations": [{"op": "add", "value": {"members": [{"value": "u2", "display": "bob"}]}}]},
+    )
+    assert {m["value"] for m in updated.members} == {"u1", "u2"}


### PR DESCRIPTION
## Summary
- **SCIM groups:** PATCH `remove` with value list subtracts named members (not wipe-all); PATCH `add` appends on implicit path.
- **API keys:** rotation preserves `scim_subject_id`; SCIM liveness overlay runs for all bound keys (not only `saml:` prefix).
- **Audit RBAC:** `GET /v1/audit` requires analyst+; `audit_read` permission drops viewer.
- **Ops hygiene:** SIEM test token via `X-Siem-Token` header; logout clears session cookie without 500 when tenant unset.

Closes #3687 (partial — SCIM key binding at create remains follow-up in issue).

## Verification
- `uv run pytest tests/test_identity_governance_3687.py tests/test_api_scim_lifecycle.py::test_scim_group_member_add_and_remove_are_incremental tests/test_api_enterprise_tenant.py::test_siem_test_logs_attempt -q` — 4 passed
- `uv run ruff check` on changed files

## Notes
- Rebased on `main` after #3699; independent of #3698 (cloud) and audit-tail PR.

Made with [Cursor](https://cursor.com)