### PR TITLE
chore(dev): 'make preflight' to catch OpenAPI/schema drift before push

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -224,6 +224,16 @@ Minimum verification matrix:
   `make preflight-fix` to regenerate the artifacts, then review and commit them.
   Skipping this is the most common cause of an approved PR going red on a stale
   generated file — regenerate locally instead of round-tripping through CI.
+- Run the tests for the code you touched **before** pushing (`pytest` on the
+  affected `tests/test_*.py` files; test order is randomized by pytest-randomly,
+  so a green local run on your files is the fastest signal). Push a PR branch
+  **once and let CI finish** — CI uses `cancel-in-progress` on non-`main`
+  branches, so stacking rapid commits (formatter, merge-main, review-dismissals)
+  cancels the in-flight run and the canceled jobs surface as red "failing"
+  checks. When a check's annotation reads "The operation was canceled," that is a
+  supersede/cancel, not a test failure: re-run the job (`gh run rerun --failed`)
+  and leave the branch untouched until it completes — do not debug it as a code
+  bug.
 - For docs, avoid vague capability lists. Prefer "first command -> artifact ->
   next step."
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -216,6 +216,14 @@ Minimum verification matrix:
   (pre-commit + CI) fails on new `detail=str(exc)` / `detail=f"...{exc}"` bodies
   and raw-exception log f-strings; use `# exc-safe: <reason>` only for a vetted
   exception.
+- Before opening or updating a PR that touches `src/agent_bom/api/` routes or
+  models (and after any change that regenerates a checked-in artifact), run
+  `make preflight` — it runs the same drift gates as CI's **Version Alignment**
+  job (OpenAPI `docs/openapi/`, v1 schemas `docs/schemas/v1/`, product-surface
+  contract, release consistency, env-var reference, SDK `patterns.json`). Use
+  `make preflight-fix` to regenerate the artifacts, then review and commit them.
+  Skipping this is the most common cause of an approved PR going red on a stale
+  generated file — regenerate locally instead of round-tripping through CI.
 - For docs, avoid vague capability lists. Prefer "first command -> artifact ->
   next step."
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test lint docker-build docker-run scan clean build-ui analytics dev check-dupes clean-dupes
+.PHONY: help install test lint preflight preflight-fix docker-build docker-run scan clean build-ui analytics dev check-dupes clean-dupes
 
 help:  ## Show this help message
 	@echo 'Usage: make [target]'
@@ -34,6 +34,23 @@ lint:  ## Run linters (ruff + mypy)
 
 format:  ## Format code with ruff
 	ruff format src/ tests/
+
+preflight:  ## Run the drift gates that CI's "Version Alignment" job runs — do this before pushing a PR
+	@echo "→ OpenAPI artifacts (docs/openapi/)";   python scripts/export_openapi.py --check
+	@echo "→ v1 schemas (docs/schemas/v1/)";        python scripts/generate_v1_schemas.py --check
+	@echo "→ product surface contract";             python scripts/check_product_surface_contract.py
+	@echo "→ release/README consistency";           python scripts/check_release_consistency.py
+	@echo "→ env-var reference";                    python scripts/generate_env_var_reference.py --check
+	@echo "→ SDK patterns.json";                    python sdks/shared/generate-patterns.py --check
+	@echo "✓ preflight passed — CI's Version Alignment gate will be green (run 'make lint' separately for ruff/mypy)"
+
+preflight-fix:  ## Regenerate every drift artifact so you never push stale OpenAPI/schemas/patterns; then review + commit
+	python scripts/export_openapi.py
+	python scripts/generate_v1_schemas.py
+	python scripts/generate_env_var_reference.py
+	python sdks/shared/generate-patterns.py
+	ruff format src/ tests/
+	@echo "✓ regenerated — run 'git status', review, and commit the artifacts"
 
 docker-build:  ## Build Docker image
 	docker build -t agent-bom:latest .


### PR DESCRIPTION
## Why
Approved PRs keep going red on the **Version Alignment** CI job because a route/model change didn't regenerate a checked-in artifact (e.g. #3701 — stale `docs/openapi/v1.{json,yaml}`). Those drift gates run **only in CI today** — not in the Makefile or pre-commit — so authors (human or agent) can't catch them before pushing. That's a repeated CI round-trip.

## What
- **`make preflight`** — runs the exact drift gates from CI's Version Alignment job locally: OpenAPI (`docs/openapi/`), v1 schemas (`docs/schemas/v1/`), product-surface contract, release consistency, env-var reference, SDK `patterns.json`. Verified green on clean `main`.
- **`make preflight-fix`** — regenerates all of those artifacts in one shot, so you review + commit instead of guessing which are stale.
- **AGENTS.md** — documents running `make preflight` before opening/updating any PR that touches `src/agent_bom/api/` routes or models.

Ruff/mypy stay in `make lint` (separate CI job, version-sensitive) — preflight is scoped to the deterministic drift gates.

## Test
`make preflight` on clean main → all six gates pass.