### PR TITLE
docs: consolidate duplicate doc clusters (stage 1 of #3703)

### DIFF
--- a/docs/DEPLOY_PLATFORM.md
+++ b/docs/DEPLOY_PLATFORM.md
@@ -10,6 +10,17 @@ your own Kubernetes cluster, or as a hosted service where you operate the
 control plane and customers connect read-only. This guide covers all three
 tiers, each with the exact command.
 
+## Deployment doc set
+
+This page is the docs-tree hub for deployment. Each sibling owns one job:
+
+| Doc | Purpose |
+|---|---|
+| [`site-docs/deployment/overview.md`](../site-docs/deployment/overview.md) | Canonical deployment chooser (published site) |
+| [`DEPLOY_QUICKSTART.md`](DEPLOY_QUICKSTART.md) | Connect-and-scan onboarding — deploy → connect → inventory → scan |
+| [`DEPLOYMENT.md`](DEPLOYMENT.md) | Deployment and scalability architecture reference |
+| [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md) | Org-wide rollout — endpoints to cloud, container/image choices |
+
 ## Posture, in one breath
 
 Across every tier the posture is the same:

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -1,5 +1,11 @@
 # Enterprise Controls Map
 
+> **Start here for enterprise.** This page maps enterprise claims to code and is
+> the entry point to the enterprise doc set. Jump to the
+> [Enterprise doc set](#enterprise-doc-set) index at the bottom for the
+> deployment, security-posture, procurement, operations-evidence, and support
+> siblings.
+
 This page maps enterprise-facing `agent-bom` claims to the code that implements them.
 
 It exists for a simple reason: the controls are real, but they should not require a repo archeology session to verify.
@@ -154,9 +160,22 @@ flowchart LR
     API --> UI["Dashboard / JSON / MCP / reports"]
 ```
 
-## Related Docs
+## Enterprise doc set
 
-- `docs/ENTERPRISE_DEPLOYMENT.md`
+This page is the hub. Each sibling below owns one concern; start here, then go
+deep where you need to.
+
+| Doc | Purpose |
+|---|---|
+| [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md) | Org-wide deployment guide — endpoints to cloud, container/image choices, rollout |
+| [`ENTERPRISE_SECURITY_POSTURE.md`](ENTERPRISE_SECURITY_POSTURE.md) | Procurement-facing security posture and trust boundaries |
+| [`ENTERPRISE_SECURITY_PLAYBOOK.md`](ENTERPRISE_SECURITY_PLAYBOOK.md) | Enterprise concern → capability → concrete code + test walkthrough |
+| [`ENTERPRISE_PROCUREMENT_PACKET.md`](ENTERPRISE_PROCUREMENT_PACKET.md) | Procurement evidence index for security, platform, and legal review |
+| [`ENTERPRISE_OPERATIONS_EVIDENCE.md`](ENTERPRISE_OPERATIONS_EVIDENCE.md) | Release-facing operations evidence (deploy, backup, restore, air-gap, upgrade, key custody) |
+| [`ENTERPRISE_SUPPORT_MODEL.md`](ENTERPRISE_SUPPORT_MODEL.md) | Support, patch, and disclosure model |
+
+## Related reference
+
 - `docs/CONTROL_PLANE_TESTING.md`
 - `docs/RUNTIME_MONITORING.md`
 - `docs/PERMISSIONS.md`

--- a/docs/ENTERPRISE_OPERATIONS_EVIDENCE.md
+++ b/docs/ENTERPRISE_OPERATIONS_EVIDENCE.md
@@ -1,5 +1,9 @@
 # Enterprise Operations and Procurement Evidence
 
+> Part of the **[enterprise doc set](ENTERPRISE.md#enterprise-doc-set)**. Start
+> at [`ENTERPRISE.md`](ENTERPRISE.md) for the controls-to-code map and the full
+> index of enterprise docs.
+
 This page is the release-facing evidence index for self-hosted enterprise
 operations reviews. It connects the procurement packet to the concrete
 deployment, backup, restore, air-gap, upgrade, support, and key-custody

--- a/docs/ENTERPRISE_PROCUREMENT_PACKET.md
+++ b/docs/ENTERPRISE_PROCUREMENT_PACKET.md
@@ -1,5 +1,9 @@
 # Enterprise Procurement Evidence Packet
 
+> Part of the **[enterprise doc set](ENTERPRISE.md#enterprise-doc-set)**. Start
+> at [`ENTERPRISE.md`](ENTERPRISE.md) for the controls-to-code map and the full
+> index of enterprise docs.
+
 This packet is an evidence index for enterprise security, platform, legal, and
 procurement review of self-hosted `agent-bom`. It is not a certification claim.
 Validate every linked control against the exact release tag and deployment mode

--- a/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
+++ b/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
@@ -1,5 +1,9 @@
 # Enterprise Security Playbook
 
+> Part of the **[enterprise doc set](ENTERPRISE.md#enterprise-doc-set)**. Start
+> at [`ENTERPRISE.md`](ENTERPRISE.md) for the controls-to-code map and the full
+> index of enterprise docs.
+
 > **Who this is for:** a security or platform team preparing to pilot
 > `agent-bom` inside their own AWS / EKS (or equivalent) environment,
 > with employees running Cursor / VS Code / Claude / Codex / Copilot on

--- a/docs/ENTERPRISE_SECURITY_POSTURE.md
+++ b/docs/ENTERPRISE_SECURITY_POSTURE.md
@@ -1,5 +1,9 @@
 # Enterprise Security Posture
 
+> Part of the **[enterprise doc set](ENTERPRISE.md#enterprise-doc-set)**. Start
+> at [`ENTERPRISE.md`](ENTERPRISE.md) for the controls-to-code map and the full
+> index of enterprise docs.
+
 This is the procurement-facing security posture for self-hosted `agent-bom`.
 It summarizes what the product does, where trust boundaries sit, and what an
 enterprise buyer must configure in its own environment.

--- a/docs/ENTERPRISE_SUPPORT_MODEL.md
+++ b/docs/ENTERPRISE_SUPPORT_MODEL.md
@@ -1,5 +1,9 @@
 # Enterprise Support, Patch, And Disclosure Model
 
+> Part of the **[enterprise doc set](ENTERPRISE.md#enterprise-doc-set)**. Start
+> at [`ENTERPRISE.md`](ENTERPRISE.md) for the controls-to-code map and the full
+> index of enterprise docs.
+
 This document defines the support and response model for self-hosted
 `agent-bom` deployments. It is written for procurement and security review. It
 does not create a paid support contract, hosted-service SLA, or legal DPA.

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,10 +36,11 @@ material. The index below groups the canonical docs by audience.
 
 ## Platform / SRE (self-host · deploy · operate)
 
-- [`DEPLOYMENT.md`](DEPLOYMENT.md) — deployment reference
-- [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md) — enterprise deployment
-- [`ENTERPRISE.md`](ENTERPRISE.md) — enterprise capabilities
-- [`ENTERPRISE_SECURITY_POSTURE.md`](ENTERPRISE_SECURITY_POSTURE.md) — security posture
+Two hubs cover the clustered material — start at the hub, then follow it to the detail sibling:
+
+- [`DEPLOY_PLATFORM.md`](DEPLOY_PLATFORM.md) — **deployment doc-set hub**: deploy anywhere (Compose · EKS · hosted); indexes `DEPLOYMENT.md`, `DEPLOY_QUICKSTART.md`, `ENTERPRISE_DEPLOYMENT.md`
+- [`ENTERPRISE.md`](ENTERPRISE.md) — **enterprise doc-set hub**: controls-to-code map; indexes deployment, security posture, playbook, procurement, operations-evidence, and support siblings
+- [`RUNTIME_REFERENCE.md`](RUNTIME_REFERENCE.md) — runtime surface map; indexes `RUNTIME_MONITORING.md` and `RUNTIME_PROXY_AUDIT_JSONL.md`
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -1,5 +1,10 @@
 # Runtime Monitoring — Deployment Guide
 
+> Part of the **runtime doc set**. For the canonical map of all five runtime
+> surfaces and which one owns which decision, see
+> [`RUNTIME_REFERENCE.md`](RUNTIME_REFERENCE.md). The audit record format is in
+> [`RUNTIME_PROXY_AUDIT_JSONL.md`](RUNTIME_PROXY_AUDIT_JSONL.md).
+
 agent-bom includes a runtime security proxy (`agent-bom proxy`) that sits between MCP clients and servers, intercepting JSON-RPC messages in real time. This guide covers sidecar deployment, detector configuration, enforcement modes, and alert routing.
 
 ## What the Runtime Proxy Does

--- a/docs/RUNTIME_PROXY_AUDIT_JSONL.md
+++ b/docs/RUNTIME_PROXY_AUDIT_JSONL.md
@@ -1,5 +1,9 @@
 # Runtime Proxy Audit JSONL
 
+> Part of the **runtime doc set**. For the canonical runtime surface map see
+> [`RUNTIME_REFERENCE.md`](RUNTIME_REFERENCE.md); for proxy deployment see
+> [`RUNTIME_MONITORING.md`](RUNTIME_MONITORING.md).
+
 `agent-bom proxy --log audit.jsonl` writes one JSON object per line. The file
 is intended for local review, SIEM forwarding, runtime correlation, and release
 evidence. Durable records are sanitized before they are appended to the log.

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -9,6 +9,16 @@ single canonical version.
 For policy-layer ordering inside a single tool-call see
 `docs/POLICY_PRECEDENCE.md`. This page is the higher-level surface map.
 
+### Runtime doc set
+
+This page is the canonical runtime surface map. The detail docs:
+
+- [`RUNTIME_MONITORING.md`](RUNTIME_MONITORING.md) — proxy sidecar deployment,
+  detector configuration, enforcement modes, and alert routing
+- [`RUNTIME_PROXY_AUDIT_JSONL.md`](RUNTIME_PROXY_AUDIT_JSONL.md) — the proxy
+  audit JSONL record format for SIEM forwarding and release evidence
+- `docs/POLICY_PRECEDENCE.md` — policy-layer ordering inside a single tool-call
+
 ## Which surface owns which decision
 
 | Surface | Module | Owns |


### PR DESCRIPTION
Stage 1 of #3703 — a **safe, docs-only** consolidation. Scope is strictly the docs trees: only files under `docs/` change. `site-docs/` and `mkdocs.yml` are untouched (mkdocs publishes `site-docs/`; `docs/` is the separate engineering/operator reference tree). Zero runtime surface: no `src/`, `tests/`, `scripts/`, root files, `.github/`, or `pyproject.toml`.

The approach is conservative: **cross-link + hub index, no moves, no deletes, no unique content removed.** It builds on #3668 (which created canonical `HOW_IT_WORKS.md` / `EDITIONS.md`) rather than undoing it. Cluster files hardlinked from root files (README, CHANGELOG, PYPI_README, DOCKER_HUB_README, SECURITY) were kept in place — none were moved or renamed.

## Clusters consolidated (before → after)

**Enterprise doc set (7 files → 1 hub + 6 siblings)**
- Before: `ENTERPRISE*.md` cross-linked each other in a partial web with no single entry point.
- After: `ENTERPRISE.md` is the hub, with a "Enterprise doc set" index table (one line of purpose per sibling). Each of the six siblings (`ENTERPRISE_DEPLOYMENT`, `ENTERPRISE_SECURITY_POSTURE`, `ENTERPRISE_SECURITY_PLAYBOOK`, `ENTERPRISE_PROCUREMENT_PACKET`, `ENTERPRISE_OPERATIONS_EVIDENCE`, `ENTERPRISE_SUPPORT_MODEL`) carries a short back-link banner to the hub. `ENTERPRISE_DEPLOYMENT` already linked the hub, so it kept its existing pointer.

**Runtime doc set (3 files → 1 hub + 2 details)**
- Before: `RUNTIME_REFERENCE.md` already declares itself the canonical surface map, but the two detail docs didn't reliably link back to it.
- After: `RUNTIME_REFERENCE.md` gains a "Runtime doc set" index of `RUNTIME_MONITORING.md` and `RUNTIME_PROXY_AUDIT_JSONL.md`; both detail docs now carry a banner linking back to the surface map.

**Deployment doc set (hub index added)**
- Before: `DEPLOYMENT.md`, `DEPLOY_QUICKSTART.md`, `ENTERPRISE_DEPLOYMENT.md` cross-linked `DEPLOY_PLATFORM.md` ad hoc.
- After: `DEPLOY_PLATFORM.md` (the canonical "deploy anywhere" guide, hardlinked from root) gains a "Deployment doc set" index pointing at the three siblings plus the published `site-docs/deployment/overview.md` chooser.

**`docs/README.md`** now points the "Platform / SRE" section at the three hubs instead of listing individual cluster files flatly.

## Deliberately left for follow-up (with reason)

- **`PRODUCT_*` (`PRODUCT_BRIEF`/`PRODUCT_MAP`/`PRODUCT_BOUNDARIES`/`PRODUCT_METRICS`)** — already consolidated by #3668: each already cross-links the canonical `EDITIONS.md` / `HOW_IT_WORKS.md`, and `PRODUCT_METRICS` is script-generated. No duplication left to remove.
- **`DATA_*` (`DATA_MODEL`/`DATA_GOVERNANCE_RETENTION`/`DATABASE_EVIDENCE`/`DATA_SOURCES`)** — a naming-prefix coincidence, not a duplicate cluster: schema atlas vs retention/deletion evidence vs DB connectors vs intake-permission map are genuinely distinct docs. `DATA_MODEL` is unique 52 KB wired into the docs site. Forcing a hub here would be misleading.
- **`SECURITY_*` (`SECURITY_ARCHITECTURE`/`SECURITY_AUTH_TENANCY_AUDIT`/`SECURITY_TESTING_EVIDENCE`)** — distinct purposes (architecture vs a dated audit snapshot vs a testing-evidence index); `SECURITY_ARCHITECTURE` is already reachable from the enterprise hub's related-reference list. Low duplication, left as-is.
- **Prose-level intro dedup** (the shared "read-only / one product / posture" paragraph that recurs across `DEPLOYMENT` / `DEPLOY_PLATFORM` / `ENTERPRISE_DEPLOYMENT`) — deliberately not trimmed to keep this PR zero-risk and reviewable; the wording differs per doc and trimming risks losing nuance. Candidate for a later stage.

## Verification

- `mkdocs build --strict` → **EXIT 0, green**. (The only console line is an unrelated MkDocs-2.0-vs-Material version notice printed by the theme banner; no doc/link warnings.) `docs/` isn't in the mkdocs nav, so these changes carry no build risk; every new internal link was checked to resolve to an existing file.
- `git diff --stat` confirms **docs-only** (11 files under `docs/`, +76/-6). No `src/`, `tests/`, `scripts/`, root, `.github/`, `pyproject.toml`, `site-docs/`, or `mkdocs.yml` changes.