### PR TITLE
feat(identity): auto-bind SCIM subject on API key issuance

### DIFF
--- a/src/agent_bom/api/auth.py
+++ b/src/agent_bom/api/auth.py
@@ -231,6 +231,41 @@ def resolve_scim_user_role(tenant_id: str, *subjects: object) -> SCIMRoleResolut
     return SCIMRoleResolution(matched=True, active=True, role=best_role, user_id=best_user.user_id, user_name=best_user.user_name)
 
 
+def resolve_scim_subject_binding(request: object, explicit: str | None = None) -> str | None:
+    """Resolve the SCIM subject id to persist on a newly issued API key.
+
+    Precedence: explicit request field → runtime SCIM resolution on the session →
+    parent key binding → canonical SCIM user id for OIDC/SAML callers.
+    """
+    if explicit and str(explicit).strip():
+        return str(explicit).strip()
+
+    state = getattr(request, "state", request)
+    state_user_id = getattr(state, "scim_user_id", None)
+    if state_user_id:
+        return str(state_user_id)
+
+    bound = getattr(state, "scim_subject_id", None)
+    if bound:
+        return str(bound)
+
+    key_id = getattr(state, "api_key_id", None)
+    if key_id:
+        parent = get_key_store().get(str(key_id))
+        if parent and parent.scim_subject_id:
+            return parent.scim_subject_id
+
+    tenant_id = getattr(state, "tenant_id", None) or "default"
+    auth_method = str(getattr(state, "auth_method", "") or "")
+    api_key_name = str(getattr(state, "api_key_name", "") or "")
+    if auth_method in {"saml", "oidc", "browser_session"} and api_key_name:
+        subjects: tuple[object, ...] = (api_key_name.removeprefix("saml:"), api_key_name)
+        resolution = resolve_scim_user_role(tenant_id, *subjects)
+        if resolution.user_id:
+            return resolution.user_id
+    return None
+
+
 def get_api_key_policy() -> ApiKeyPolicy:
     """Load API key lifetime policy from env with safe defaults."""
     default_ttl = int(os.environ.get("AGENT_BOM_API_KEY_DEFAULT_TTL_SECONDS", str(30 * 24 * 60 * 60)))

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1020,6 +1020,8 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         if resolution.role is None:
             return None, JSONResponse(status_code=403, content={"detail": "Forbidden — SCIM user has no runtime role"})
         self._record_scim_role_state(request, user_id=resolution.user_id, user_name=resolution.user_name)
+        if resolution.user_id:
+            request.state.scim_subject_id = resolution.user_id
         return resolution.role, None
 
     async def dispatch(self, request: StarletteRequest, call_next):
@@ -1166,6 +1168,8 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 request.state.tenant_id = api_key.tenant_id
                 request.state.api_key_id = api_key.key_id
                 request.state.api_key_scopes = list(api_key.scopes)
+                if api_key.scim_subject_id:
+                    request.state.scim_subject_id = api_key.scim_subject_id
                 # SAML-minted keys are named "saml:<subject>" — surface that
                 # as a distinct auth method so operators can trace who came
                 # in via which IdP path even after the key has been issued.

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -532,7 +532,7 @@ async def delete_browser_session(request: Request, response: Response) -> None:
 async def create_key(request: Request, req: CreateKeyRequest) -> dict:
     """Create a new API key. Returns the raw key once — store it securely."""
     from agent_bom.api.audit_log import log_action
-    from agent_bom.api.auth import Role, create_api_key, get_key_store
+    from agent_bom.api.auth import Role, create_api_key, get_key_store, resolve_scim_subject_binding
 
     tenant_id = require_request_tenant_id(request)
     actor = getattr(request.state, "api_key_name", "") or req.name
@@ -549,7 +549,7 @@ async def create_key(request: Request, req: CreateKeyRequest) -> dict:
             expires_at=req.expires_at,
             scopes=req.scopes,
             tenant_id=tenant_id,
-            scim_subject_id=req.scim_subject_id,
+            scim_subject_id=resolve_scim_subject_binding(request, req.scim_subject_id),
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
@@ -1024,7 +1024,7 @@ async def saml_relay_state() -> dict:
 async def saml_login(req: SAMLLoginRequest) -> dict:
     """Verify a SAML assertion and return a short-lived API key."""
     from agent_bom.api.audit_log import log_action
-    from agent_bom.api.auth import Role, create_api_key, get_key_store
+    from agent_bom.api.auth import Role, create_api_key, get_key_store, resolve_scim_user_role
     from agent_bom.api.saml import SAML_INSTALL_HINT, SAMLConfig, SAMLError, saml_runtime_available
 
     if not saml_runtime_available():
@@ -1041,12 +1041,15 @@ async def saml_login(req: SAMLLoginRequest) -> dict:
         raise HTTPException(status_code=401, detail=sanitize_error(exc)) from exc
 
     expires_at = (datetime.now(timezone.utc) + timedelta(seconds=cfg.session_ttl_seconds)).isoformat()
+    scim_resolution = resolve_scim_user_role(assertion.tenant_id, assertion.subject)
+    scim_subject_id = scim_resolution.user_id if scim_resolution.user_id else assertion.subject
     raw_key, api_key = create_api_key(
         name=f"saml:{assertion.subject}",
         role=Role(assertion.role),
         expires_at=expires_at,
         scopes=["saml-session"],
         tenant_id=assertion.tenant_id,
+        scim_subject_id=scim_subject_id,
     )
     get_key_store().add(api_key)
     log_action(

--- a/tests/test_identity_governance_3687.py
+++ b/tests/test_identity_governance_3687.py
@@ -2,7 +2,24 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pytest
+
+from agent_bom.api.auth import KeyStore, Role, create_api_key_record, get_key_store, resolve_scim_subject_binding, set_key_store
 from agent_bom.api.routes.scim import SCIMGroup, _apply_group_patch
+from agent_bom.api.scim import revoke_credentials_for_scim_user
+
+
+@pytest.fixture
+def isolated_key_store():
+    original = get_key_store()
+    store = KeyStore()
+    set_key_store(store)
+    try:
+        yield store
+    finally:
+        set_key_store(original)
 
 
 def test_scim_group_remove_members_value_list_subtracts_only_named() -> None:
@@ -43,3 +60,53 @@ def test_scim_group_add_members_implicit_path_appends() -> None:
         {"Operations": [{"op": "add", "value": {"members": [{"value": "u2", "display": "bob"}]}}]},
     )
     assert {m["value"] for m in updated.members} == {"u1", "u2"}
+
+
+def test_resolve_scim_subject_binding_prefers_explicit() -> None:
+    request = SimpleNamespace(state=SimpleNamespace(scim_user_id="runtime-id"))
+    assert resolve_scim_subject_binding(request, "explicit-id") == "explicit-id"
+
+
+def test_resolve_scim_subject_binding_uses_runtime_scim_user_id() -> None:
+    request = SimpleNamespace(state=SimpleNamespace(scim_user_id="scim-user-1"))
+    assert resolve_scim_subject_binding(request, None) == "scim-user-1"
+
+
+@pytest.mark.asyncio
+async def test_create_key_auto_binds_scim_subject_from_request_state(isolated_key_store) -> None:
+    from agent_bom.api.models import CreateKeyRequest
+    from agent_bom.api.routes import enterprise
+
+    request = SimpleNamespace(
+        state=SimpleNamespace(
+            tenant_id="tenant-alpha",
+            api_key_name="alice",
+            scim_user_id="scim-user-42",
+        )
+    )
+    created = await enterprise.create_key(request, CreateKeyRequest(name="ci-deploy", role="analyst"))
+    key = isolated_key_store.get(created["key_id"])
+    assert key is not None
+    assert key.name == "ci-deploy"
+    assert key.scim_subject_id == "scim-user-42"
+
+
+def test_scim_revoke_removes_free_form_named_key_with_subject_binding(monkeypatch) -> None:
+    store = KeyStore()
+    set_key_store(store)
+    monkeypatch.setattr("agent_bom.api.auth.get_key_store", lambda: store)
+    try:
+        bound = create_api_key_record(
+            "abom_test_bound_key_123456789012",
+            name="ci-deploy",
+            role=Role.ANALYST,
+            tenant_id="default",
+            scim_subject_id="user-abc",
+        )
+        store.add(bound)
+        user = SimpleNamespace(user_id="user-abc", user_name="alice", external_id=None)
+        revoked = revoke_credentials_for_scim_user("default", user)
+        assert revoked == 1
+        assert bound.is_revoked()
+    finally:
+        set_key_store(KeyStore())


### PR DESCRIPTION
## Summary
- **`resolve_scim_subject_binding()`:** explicit field → runtime `scim_user_id` → parent key binding → OIDC/SAML SCIM user id lookup.
- **`POST /v1/auth/keys`:** auto-binds `scim_subject_id` so free-form names like `ci-deploy` still revoke on SCIM DELETE/deactivate.
- **SAML login:** mints keys with canonical SCIM `user_id` binding when the user is provisioned.
- **Middleware:** propagates `scim_subject_id` on authenticated API-key requests; SCIM role resolution sets binding on session state.

Closes #3687 (full — SCIM deprovision token survival).

## Verification
- `uv run pytest tests/test_identity_governance_3687.py -q` — 6 passed
- `uv run pytest tests/test_api_scim_lifecycle.py tests/test_audit_queue_fixes.py -k scim -q`
- `uv run ruff check` on changed files
- `make preflight` — passed


Made with [Cursor](https://cursor.com)