### PR TITLE
fix(config): warn on unparseable env bool/int/float values

### DIFF
--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -10,7 +10,13 @@ Environment variable convention: ``AGENT_BOM_<SECTION>_<NAME>``
 
 from __future__ import annotations
 
+import logging
 import os
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY_BOOLS = frozenset({"1", "true", "yes", "on"})
+_FALSY_BOOLS = frozenset({"0", "false", "no", "off"})
 
 
 def _float(env_key: str, default: float) -> float:
@@ -21,6 +27,12 @@ def _float(env_key: str, default: float) -> float:
     try:
         return float(raw)
     except ValueError:
+        logger.warning(
+            "Ignoring unparseable float env %s=%r; using default %s",
+            env_key,
+            raw,
+            default,
+        )
         return default
 
 
@@ -32,6 +44,12 @@ def _int(env_key: str, default: int) -> int:
     try:
         return int(raw)
     except ValueError:
+        logger.warning(
+            "Ignoring unparseable int env %s=%r; using default %s",
+            env_key,
+            raw,
+            default,
+        )
         return default
 
 
@@ -40,7 +58,18 @@ def _bool(env_key: str, default: bool) -> bool:
     raw = os.environ.get(env_key)
     if raw is None:
         return default
-    return raw.strip().lower() in {"1", "true", "yes", "on"}
+    normalized = raw.strip().lower()
+    if normalized in _TRUTHY_BOOLS:
+        return True
+    if normalized in _FALSY_BOOLS:
+        return False
+    logger.warning(
+        "Ignoring unparseable boolean env %s=%r; using default %s",
+        env_key,
+        raw,
+        default,
+    )
+    return default
 
 
 def _str(env_key: str, default: str) -> str:

--- a/tests/test_config_env_parse.py
+++ b/tests/test_config_env_parse.py
@@ -1,0 +1,48 @@
+"""Regression: env parse helpers must not silently flip security defaults (#3677)."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _reload_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    import agent_bom.config as config_mod
+
+    importlib.reload(config_mod)
+
+
+def test_bool_typo_on_true_default_keeps_default(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setenv("AGENT_BOM_MCP_AUTH_REQUIRE_TLS", "Ture")
+    _reload_config(monkeypatch)
+    from agent_bom.config import MCP_AUTH_REQUIRE_TLS
+
+    assert MCP_AUTH_REQUIRE_TLS is True
+    assert "unparseable boolean env AGENT_BOM_MCP_AUTH_REQUIRE_TLS" in caplog.text
+
+
+def test_bool_explicit_false_overrides_true_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_MCP_AUTH_REQUIRE_TLS", "false")
+    _reload_config(monkeypatch)
+    from agent_bom.config import MCP_AUTH_REQUIRE_TLS
+
+    assert MCP_AUTH_REQUIRE_TLS is False
+
+
+def test_int_typo_falls_back_to_default(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setenv("AGENT_BOM_HTTP_MAX_RETRIES", "not-a-number")
+    _reload_config(monkeypatch)
+    from agent_bom.config import HTTP_MAX_RETRIES
+
+    assert HTTP_MAX_RETRIES == 3
+    assert "unparseable int env AGENT_BOM_HTTP_MAX_RETRIES" in caplog.text
+
+
+def test_float_typo_falls_back_to_default(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setenv("AGENT_BOM_HTTP_INITIAL_BACKOFF", "NaN-ish")
+    _reload_config(monkeypatch)
+    from agent_bom.config import HTTP_INITIAL_BACKOFF
+
+    assert HTTP_INITIAL_BACKOFF == 1.0
+    assert "unparseable float env AGENT_BOM_HTTP_INITIAL_BACKOFF" in caplog.text


### PR DESCRIPTION
## Summary
- Harden `_bool`, `_int`, and `_float` in `config.py` to log a warning and fall back to the declared default when env values are unparseable.
- Fixes the security footgun where `AGENT_BOM_MCP_AUTH_REQUIRE_TLS=Ture` silently disabled a True-default flag.

## Verification
- `uv run pytest tests/test_config_env_parse.py -q`
- `uv run ruff check src/agent_bom/config.py tests/test_config_env_parse.py`

## Notes
- Closes #3677 (PR-A). Env-var doc regen / alias cleanup remains for a follow-up.

Made with [Cursor](https://cursor.com)