### PR TITLE
docs(config): canonical env aliases and regenerated ENV_VARS (#3677)

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -128,6 +128,14 @@ so they cannot regress silently, but they are not part of this reference.
 |---|---|---|---|
 | `AGENT_BOM_DEMO_ESTATE` | `bool` | `False` | Enables curated demo-estate bootstrap on loopback / hosted proof paths. Off by default so production deployments never seed synthetic estate data unless an operator explicitly opts in. |
 
+## Deployment / integration env aliases
+| Env var | Type | Default | Description |
+|---|---|---|---|
+| `AGENT_BOM_CORS_ORIGINS` | `str` | `''` | — |
+| `AGENT_BOM_DEPLOYMENT_ENV` | `str` | `''` | Canonical AGENT_BOM_* keys below. Legacy unprefixed or alternate names are still honored via the resolved_* helpers for back-compat: AGENT_BOM_ENV / ENVIRONMENT → DEPLOYMENT_ENV CORS_ORIGINS → CORS_ORIGINS (prefixed) SERVICENOW_INSTANCE → S |
+| `AGENT_BOM_SERVICENOW_INSTANCE` | `str` | `''` | — |
+| `AGENT_BOM_VAULT_ADDR` | `str` | `''` | — |
+
 ## EPSS Thresholds
 | Env var | Type | Default | Description |
 |---|---|---|---|
@@ -276,6 +284,7 @@ so they cannot regress silently, but they are not part of this reference.
 ## Rate-limit fingerprint key rotation policy
 | Env var | Type | Default | Description |
 |---|---|---|---|
+| `AGENT_BOM_RATE_LIMIT_KEY_LAST_ROTATED` | `str` | `''` | — |
 | `AGENT_BOM_RATE_LIMIT_KEY_MAX_AGE_DAYS` | `int` | `90` | — |
 | `AGENT_BOM_RATE_LIMIT_KEY_ROTATION_DAYS` | `int` | `30` | Operators rotate AGENT_BOM_RATE_LIMIT_KEY periodically and record the rotation timestamp in AGENT_BOM_RATE_LIMIT_KEY_LAST_ROTATED (ISO-8601 with timezone). The control plane warns when the configured key age approaches the rotation interval |
 

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -101,8 +101,6 @@ AGENT_BOM_CONNECTIONS_KEY
 AGENT_BOM_CONNECTIONS_KEY_PROVIDER
 # Reference (not a secret value) to the managed connection key: the Secrets Manager secret id/ARN for provider=aws-secrets, or the Vault KV v2 'mount/path#field' for provider=vault; resolved read-only at key-load time. The resolved value may be a comma-separated list of Fernet keys for rotation.
 AGENT_BOM_CONNECTIONS_KEY_REF
-# Base URL of the HashiCorp Vault server for provider=vault (e.g. https://vault.internal:8200); read-only KV v2 GET at key-load time in api/connection_crypto.py. Not a secret.
-AGENT_BOM_VAULT_ADDR
 # HashiCorp Vault token for provider=vault, sent as the X-Vault-Token header on the read-only KV v2 GET; secret, env/reference-only, never logged.
 AGENT_BOM_VAULT_TOKEN
 # opt-in flag (default OFF) enabling the background loop that re-scans due cloud connections (Phase B.2); read live in api/connection_scheduler.py
@@ -147,7 +145,6 @@ AGENT_BOM_DELIVERY_DB  # optional SQLite path for the outbound delivery foundati
 AGENT_BOM_DB_PATH
 AGENT_BOM_DB_SOURCES
 AGENT_BOM_DEFAULT_ROLE
-AGENT_BOM_DEPLOYMENT_ENV
 AGENT_BOM_DISABLE_DOCS
 AGENT_BOM_DISTRIBUTED_SCANS
 AGENT_BOM_ENABLE_LOCAL_PATH_SCANS

--- a/src/agent_bom/api/connection_crypto.py
+++ b/src/agent_bom/api/connection_crypto.py
@@ -82,6 +82,8 @@ import os
 from collections.abc import Callable
 from typing import Any
 
+from agent_bom.config import resolved_vault_addr
+
 CONNECTIONS_KEY_ENV = "AGENT_BOM_CONNECTIONS_KEY"
 CONNECTIONS_KEY_PROVIDER_ENV = "AGENT_BOM_CONNECTIONS_KEY_PROVIDER"
 CONNECTIONS_KEY_REF_ENV = "AGENT_BOM_CONNECTIONS_KEY_REF"
@@ -146,7 +148,7 @@ def connections_key_configured() -> bool:
         return bool(os.environ.get(CONNECTIONS_KEY_ENV, "").strip())
     if provider == PROVIDER_VAULT:
         return bool(
-            os.environ.get(VAULT_ADDR_ENV, "").strip()
+            resolved_vault_addr()
             and os.environ.get(VAULT_TOKEN_ENV, "").strip()
             and os.environ.get(CONNECTIONS_KEY_REF_ENV, "").strip()
         )
@@ -250,7 +252,7 @@ def _parse_vault_ref(ref: str) -> tuple[str, str, str]:
 
 def _resolve_vault() -> bytes:
     """Fetch the base64 Fernet key from a HashiCorp Vault KV v2 secret (read-only)."""
-    addr = os.environ.get(VAULT_ADDR_ENV, "").strip().rstrip("/")
+    addr = resolved_vault_addr().rstrip("/")
     token = os.environ.get(VAULT_TOKEN_ENV, "").strip()
     ref = os.environ.get(CONNECTIONS_KEY_REF_ENV, "").strip()
     if not addr or not token or not ref:

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -191,11 +191,9 @@ def _configured_listener_host(host: str | None = None) -> str:
 
 
 def _production_or_clustered_control_plane() -> bool:
-    deployment = (
-        (os.environ.get("AGENT_BOM_ENV") or os.environ.get("AGENT_BOM_DEPLOYMENT_ENV") or os.environ.get("ENVIRONMENT") or "")
-        .strip()
-        .lower()
-    )
+    from agent_bom.config import resolved_deployment_env
+
+    deployment = resolved_deployment_env()
     return deployment in {"prod", "production"} or clustered_control_plane_required()
 
 

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -72,6 +72,7 @@ from agent_bom.api.stores import (
 )
 from agent_bom.api.tracing import configure_otel_tracing, get_tracing_health
 from agent_bom.config import API_JOB_TTL_SECONDS as _JOB_TTL_SECONDS
+from agent_bom.config import resolved_cors_origins_raw
 
 _logger = logging.getLogger(__name__)
 _DASHBOARD_CSP_META_RE = re.compile(
@@ -581,7 +582,7 @@ _default_origins = [
     "http://localhost:3001",
     "http://127.0.0.1:3001",
 ]
-_cors_env = os.environ.get("CORS_ORIGINS")
+_cors_env = resolved_cors_origins_raw()
 _cors_origins: list[str] = [o.strip() for o in _cors_env.split(",") if o.strip()] if _cors_env else _default_origins
 _api_key: str | None = None
 DEFAULT_RATE_LIMIT_RPM = DEFAULT_SCAN_RATE_LIMIT_RPM
@@ -618,7 +619,7 @@ def _env_truthy(name: str) -> bool:
 
 
 def _parse_cors_origins_from_env(default: list[str]) -> tuple[list[str], bool]:
-    raw = os.environ.get("CORS_ORIGINS", "").strip()
+    raw = resolved_cors_origins_raw()
     if not raw:
         return default, False
     origins = [origin.strip() for origin in raw.split(",") if origin.strip()]

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -540,7 +540,47 @@ DELTA_STREAM_SIGNING_SECRET = _str("AGENT_BOM_DELTA_STREAM_SIGNING_SECRET", "")
 
 RATE_LIMIT_KEY_ROTATION_DAYS = _int("AGENT_BOM_RATE_LIMIT_KEY_ROTATION_DAYS", 30)
 RATE_LIMIT_KEY_MAX_AGE_DAYS = _int("AGENT_BOM_RATE_LIMIT_KEY_MAX_AGE_DAYS", 90)
-RATE_LIMIT_KEY_LAST_ROTATED = (os.environ.get("AGENT_BOM_RATE_LIMIT_KEY_LAST_ROTATED") or "").strip()
+RATE_LIMIT_KEY_LAST_ROTATED = _str("AGENT_BOM_RATE_LIMIT_KEY_LAST_ROTATED", "")
+
+
+# ── Deployment / integration env aliases ───────────────────────────────────
+# Canonical AGENT_BOM_* keys below. Legacy unprefixed or alternate names are
+# still honored via the resolved_* helpers for back-compat:
+#   AGENT_BOM_ENV / ENVIRONMENT → DEPLOYMENT_ENV
+#   CORS_ORIGINS → CORS_ORIGINS (prefixed)
+#   SERVICENOW_INSTANCE → SERVICENOW_INSTANCE (prefixed)
+#   VAULT_ADDR → VAULT_ADDR (prefixed)
+
+DEPLOYMENT_ENV = _str("AGENT_BOM_DEPLOYMENT_ENV", "")
+CORS_ORIGINS = _str("AGENT_BOM_CORS_ORIGINS", "")
+SERVICENOW_INSTANCE = _str("AGENT_BOM_SERVICENOW_INSTANCE", "")
+VAULT_ADDR = _str("AGENT_BOM_VAULT_ADDR", "")
+
+
+def _env_first_non_empty(*keys: str) -> str:
+    for key in keys:
+        raw = os.environ.get(key)
+        if raw is not None and str(raw).strip():
+            return str(raw).strip()
+    return ""
+
+
+def resolved_deployment_env() -> str:
+    """Return the normalized deployment label from canonical + legacy env keys."""
+    return _env_first_non_empty("AGENT_BOM_DEPLOYMENT_ENV", "AGENT_BOM_ENV", "ENVIRONMENT").lower()
+
+
+def resolved_cors_origins_raw() -> str:
+    """Return comma-separated CORS origins from canonical or legacy env key."""
+    return _env_first_non_empty("AGENT_BOM_CORS_ORIGINS", "CORS_ORIGINS")
+
+
+def resolved_servicenow_instance_url() -> str:
+    return _env_first_non_empty("AGENT_BOM_SERVICENOW_INSTANCE", "SERVICENOW_INSTANCE")
+
+
+def resolved_vault_addr() -> str:
+    return _env_first_non_empty("AGENT_BOM_VAULT_ADDR", "VAULT_ADDR")
 
 
 # ── Runtime → graph incident feedback ────────────────────────────────────

--- a/src/agent_bom/connectors/servicenow_connector.py
+++ b/src/agent_bom/connectors/servicenow_connector.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 import os
 
+from agent_bom.config import resolved_servicenow_instance_url
 from agent_bom.http_client import create_client, request_with_retry
 from agent_bom.models import Agent, AgentType, MCPServer, TransportType
 
@@ -30,7 +31,7 @@ def _get_config(
     token: str | None = None,
 ) -> tuple[str, str]:
     """Resolve ServiceNow config from args or env vars."""
-    url = instance_url or os.environ.get("SERVICENOW_INSTANCE", "")
+    url = instance_url or resolved_servicenow_instance_url()
     tok = token or os.environ.get("AGENT_BOM_SERVICENOW_TOKEN", "")
     if not url:
         raise ConnectorError("ServiceNow instance URL required. Set --servicenow-instance or SERVICENOW_INSTANCE env var.")

--- a/tests/test_config_env_aliases.py
+++ b/tests/test_config_env_aliases.py
@@ -1,0 +1,68 @@
+"""Regression: legacy env aliases resolve through canonical AGENT_BOM_* keys (#3677)."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _reload_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    import agent_bom.config as config_mod
+
+    importlib.reload(config_mod)
+
+
+def test_resolved_deployment_env_prefers_canonical_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_DEPLOYMENT_ENV", "Production")
+    monkeypatch.setenv("AGENT_BOM_ENV", "staging")
+    monkeypatch.setenv("ENVIRONMENT", "dev")
+    _reload_config(monkeypatch)
+    from agent_bom.config import resolved_deployment_env
+
+    assert resolved_deployment_env() == "production"
+
+
+def test_resolved_deployment_env_falls_back_to_legacy_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_DEPLOYMENT_ENV", raising=False)
+    monkeypatch.setenv("AGENT_BOM_ENV", "Staging")
+    _reload_config(monkeypatch)
+    from agent_bom.config import resolved_deployment_env
+
+    assert resolved_deployment_env() == "staging"
+
+
+def test_resolved_cors_origins_prefers_canonical_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_CORS_ORIGINS", "https://app.example.com")
+    monkeypatch.setenv("CORS_ORIGINS", "https://legacy.example.com")
+    _reload_config(monkeypatch)
+    from agent_bom.config import resolved_cors_origins_raw
+
+    assert resolved_cors_origins_raw() == "https://app.example.com"
+
+
+def test_resolved_cors_origins_falls_back_to_legacy_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_CORS_ORIGINS", raising=False)
+    monkeypatch.setenv("CORS_ORIGINS", "https://legacy.example.com")
+    _reload_config(monkeypatch)
+    from agent_bom.config import resolved_cors_origins_raw
+
+    assert resolved_cors_origins_raw() == "https://legacy.example.com"
+
+
+def test_resolved_servicenow_instance_prefers_canonical_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_SERVICENOW_INSTANCE", "https://canonical.example.com")
+    monkeypatch.setenv("SERVICENOW_INSTANCE", "https://legacy.example.com")
+    _reload_config(monkeypatch)
+    from agent_bom.config import resolved_servicenow_instance_url
+
+    assert resolved_servicenow_instance_url() == "https://canonical.example.com"
+
+
+def test_resolved_vault_addr_prefers_canonical_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_VAULT_ADDR", "https://vault-canonical.example.com")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault-legacy.example.com")
+    _reload_config(monkeypatch)
+    from agent_bom.config import resolved_vault_addr
+
+    assert resolved_vault_addr() == "https://vault-canonical.example.com"


### PR DESCRIPTION
## Summary
- Promote `AGENT_BOM_DEPLOYMENT_ENV`, `AGENT_BOM_CORS_ORIGINS`, `AGENT_BOM_VAULT_ADDR`, and `AGENT_BOM_SERVICENOW_INSTANCE` to `config.py` with `resolved_*` helpers that honor legacy unprefixed aliases (`ENVIRONMENT`, `CORS_ORIGINS`, `VAULT_ADDR`, `SERVICENOW_INSTANCE`).
- Wire CORS, deployment-env policy checks, Vault connection crypto, and ServiceNow connector through the helpers.
- Regenerate `docs/operations/ENV_VARS.md` and trim promoted keys from `scripts/env_var_allowlist.txt`.

Follow-up to #3711 (PR-A env parse warnings). Closes the docs/alias slice of #3677.

## Verification
- `uv run pytest -q tests/test_config_env_aliases.py tests/test_config_env_parse.py tests/test_hosted_poc_preflight.py`
- `uv run python scripts/generate_env_var_reference.py --check`
- `uv run ruff check` on touched Python files


Made with [Cursor](https://cursor.com)