### PR TITLE
refactor(api): centralize /v1 mount on shared API router (#3666)

### DIFF
--- a/scripts/check_product_surface_contract.py
+++ b/scripts/check_product_surface_contract.py
@@ -24,19 +24,47 @@ def _require_text(path: str, needles: list[str], failures: list[str]) -> None:
             failures.append(f"{path}: missing {needle!r}")
 
 
+def _require_v1_routes(path: str, routes: list[tuple[str, str]], failures: list[str]) -> None:
+    """Require route decorators for full /v1 paths after shared-prefix mounting."""
+    text = _text(path)
+    prefix = "/v1"
+    for method, full_path in routes:
+        if not full_path.startswith(prefix):
+            failures.append(f"{path}: expected v1 route path, got {full_path!r}")
+            continue
+        route_path = full_path.removeprefix(prefix) or "/"
+        needle = f'@router.{method.lower()}("{route_path}"'
+        if needle not in text:
+            failures.append(f"{path}: missing {needle!r} for {method.upper()} {full_path}")
+
+
 def main() -> int:
     failures: list[str] = []
 
     _require_text(
+        "src/agent_bom/api/versioning.py",
+        [
+            'API_V1_PREFIX = "/v1"',
+            "create_v1_api_router",
+        ],
+        failures,
+    )
+    _require_v1_routes(
         "src/agent_bom/api/routes/enterprise.py",
         [
-            '@router.get("/v1/auth/policy"',
-            '@router.get("/v1/auth/scim/config"',
-            '@router.get("/v1/auth/secrets/lifecycle"',
-            '@router.get("/v1/auth/secrets/rotation-plan"',
-            '@router.get("/v1/auth/secrets/credential-expiry"',
-            '@router.get("/v1/auth/quota"',
-            '@router.put("/v1/auth/quota"',
+            ("GET", "/v1/auth/policy"),
+            ("GET", "/v1/auth/scim/config"),
+            ("GET", "/v1/auth/secrets/lifecycle"),
+            ("GET", "/v1/auth/secrets/rotation-plan"),
+            ("GET", "/v1/auth/secrets/credential-expiry"),
+            ("GET", "/v1/auth/quota"),
+            ("PUT", "/v1/auth/quota"),
+        ],
+        failures,
+    )
+    _require_text(
+        "src/agent_bom/api/routes/enterprise.py",
+        [
             "tenant_quota_runtime",
             "configured_modes",
             "audit_hmac",
@@ -78,25 +106,37 @@ def main() -> int:
         ],
         failures,
     )
+    _require_v1_routes(
+        "src/agent_bom/api/routes/fleet.py",
+        [
+            ("GET", "/v1/fleet"),
+            ("GET", "/v1/fleet/stats"),
+            ("GET", "/v1/fleet/{agent_id}"),
+            ("POST", "/v1/fleet/sync"),
+        ],
+        failures,
+    )
     _require_text(
         "src/agent_bom/api/routes/fleet.py",
         [
-            '@router.get("/v1/fleet"',
-            '@router.get("/v1/fleet/stats"',
-            '@router.get("/v1/fleet/{agent_id}"',
-            '@router.post("/v1/fleet/sync"',
             "limit: int",
             "offset: int",
+        ],
+        failures,
+    )
+    _require_v1_routes(
+        "src/agent_bom/api/routes/graph.py",
+        [
+            ("GET", "/v1/graph"),
+            ("GET", "/v1/graph/agents"),
+            ("GET", "/v1/graph/search"),
+            ("GET", "/v1/graph/node/{node_id}"),
         ],
         failures,
     )
     _require_text(
         "src/agent_bom/api/routes/graph.py",
         [
-            '@router.get("/v1/graph"',
-            '@router.get("/v1/graph/agents"',
-            '@router.get("/v1/graph/search"',
-            '@router.get("/v1/graph/node/{node_id}"',
             "limit: int",
             "offset: int",
         ],

--- a/src/agent_bom/api/routes/agent_manifest.py
+++ b/src/agent_bom/api/routes/agent_manifest.py
@@ -8,7 +8,7 @@ from agent_bom.agent_manifest import build_control_plane_agent_manifest
 from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store
 from agent_bom.api.tenancy import require_request_tenant_id
 
-router = APIRouter(prefix="/v1/agent-bom", tags=["Agent BOM"])
+router = APIRouter(prefix="/agent-bom", tags=["Agent BOM"])
 
 
 @router.get("/manifest")

--- a/src/agent_bom/api/routes/assets.py
+++ b/src/agent_bom/api/routes/assets.py
@@ -17,7 +17,7 @@ router = APIRouter()
 _logger = logging.getLogger(__name__)
 
 
-@router.get("/v1/assets", tags=["assets"])
+@router.get("/assets", tags=["assets"])
 async def list_assets(
     request: Request,
     status: str | None = None,
@@ -55,7 +55,7 @@ async def list_assets(
         }
 
 
-@router.get("/v1/assets/stats", tags=["assets"])
+@router.get("/assets/stats", tags=["assets"])
 async def get_asset_stats(request: Request) -> dict:
     """Return aggregate asset tracking statistics including MTTR."""
     try:

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -127,7 +127,7 @@ def _audit_metadata(payloads: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-@router.get("/v1/cloud/{provider}/inventory")
+@router.get("/cloud/{provider}/inventory")
 async def cloud_inventory(
     request: Request,
     provider: str,
@@ -201,7 +201,7 @@ async def cloud_inventory(
         raise HTTPException(status_code=500, detail="Cloud inventory failed; see server logs.") from exc
 
 
-@router.get("/v1/cloud/{provider}/cis-benchmark")
+@router.get("/cloud/{provider}/cis-benchmark")
 async def cloud_cis_benchmark(
     request: Request,
     provider: str,

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -183,7 +183,7 @@ def _validate_regions(regions: list[str]) -> list[str]:
     return cleaned
 
 
-@router.post("/v1/cloud/connections", status_code=201)
+@router.post("/cloud/connections", status_code=201)
 async def create_connection(request: Request, body: CloudConnectionCreate, _role: Any = _SCAN_DEP) -> dict[str, Any]:
     """Create a read-only cloud connection for the authenticated tenant.
 
@@ -244,7 +244,7 @@ async def create_connection(request: Request, body: CloudConnectionCreate, _role
     return record.to_public_dict()
 
 
-@router.get("/v1/cloud/connections")
+@router.get("/cloud/connections")
 async def list_connections(request: Request, _role: Any = _SCAN_DEP) -> dict[str, Any]:
     """List the authenticated tenant's connections (non-secret metadata only)."""
     tenant_id = _tenant(request)
@@ -265,13 +265,13 @@ def _require_connection(request: Request, connection_id: str) -> CloudConnection
     return record
 
 
-@router.get("/v1/cloud/connections/{connection_id}")
+@router.get("/cloud/connections/{connection_id}")
 async def get_connection(request: Request, connection_id: str, _role: Any = _SCAN_DEP) -> dict[str, Any]:
     """Return one connection's non-secret metadata (tenant-scoped)."""
     return _require_connection(request, connection_id).to_public_dict()
 
 
-@router.patch("/v1/cloud/connections/{connection_id}")
+@router.patch("/cloud/connections/{connection_id}")
 async def update_connection(
     request: Request,
     connection_id: str,
@@ -298,7 +298,7 @@ async def update_connection(
     return record.to_public_dict()
 
 
-@router.delete("/v1/cloud/connections/{connection_id}", status_code=204)
+@router.delete("/cloud/connections/{connection_id}", status_code=204)
 async def delete_connection(request: Request, connection_id: str, _role: Any = _SCAN_DEP) -> None:
     """Delete a connection owned by the authenticated tenant."""
     record = _require_connection(request, connection_id)
@@ -615,7 +615,7 @@ def _run_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> dict[
     return runner(record, tenant_id)
 
 
-@router.post("/v1/cloud/connections/{connection_id}/test")
+@router.post("/cloud/connections/{connection_id}/test")
 async def test_connection(request: Request, connection_id: str, _role: Any = _SCAN_DEP) -> dict[str, Any]:
     """Validate a stored connection's brokered read-only credential.
 
@@ -670,7 +670,7 @@ async def test_connection(request: Request, connection_id: str, _role: Any = _SC
     }
 
 
-@router.post("/v1/cloud/connections/{connection_id}/scan")
+@router.post("/cloud/connections/{connection_id}/scan")
 async def scan_connection(request: Request, connection_id: str, _role: Any = _SCAN_DEP) -> dict[str, Any]:
     """Launch a read-only cloud scan for a stored connection via the broker.
 

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -302,7 +302,7 @@ def _derive_deployment_context(request: Request, jobs: list[Any]) -> dict[str, A
     }
 
 
-@router.get("/v1/compliance", tags=["compliance"])
+@router.get("/compliance", tags=["compliance"])
 async def get_compliance(request: Request) -> dict:
     """Aggregate OWASP LLM Top 10, OWASP MCP Top 10, MITRE ATLAS, NIST AI RMF,
     OWASP Agentic Top 10, and EU AI Act compliance posture across all completed scans.
@@ -452,7 +452,7 @@ async def get_compliance(request: Request) -> dict:
     return response
 
 
-@router.get("/v1/cis/checks", tags=["compliance"])
+@router.get("/cis/checks", tags=["compliance"])
 async def list_cis_benchmark_checks(
     request: Request,
     cloud: str | None = None,
@@ -539,7 +539,7 @@ def _coerce_cis_row(row: dict[str, Any]) -> dict[str, Any]:
 # ─── CIS Benchmark Trend / Drilldown (#1832) ──────────────────────────────
 
 
-@router.get("/v1/cis/trends", tags=["compliance"])
+@router.get("/cis/trends", tags=["compliance"])
 async def cis_benchmark_trends(
     request: Request,
     days: int = 30,
@@ -831,7 +831,7 @@ def _narrative_to_dict(narrative: "ComplianceNarrative") -> dict:
     }
 
 
-@router.get("/v1/compliance/narrative", tags=["compliance"])
+@router.get("/compliance/narrative", tags=["compliance"])
 async def get_compliance_narrative(request: Request) -> dict:
     """Generate a review-ready compliance narrative from all completed scans.
 
@@ -860,7 +860,7 @@ async def get_compliance_narrative(request: Request) -> dict:
     return _narrative_to_dict(narrative)
 
 
-@router.get("/v1/compliance/narrative/{framework}", tags=["compliance"])
+@router.get("/compliance/narrative/{framework}", tags=["compliance"])
 async def get_compliance_narrative_by_framework(request: Request, framework: str) -> dict:
     """Generate a single-framework compliance narrative.
 
@@ -897,7 +897,7 @@ async def get_compliance_narrative_by_framework(request: Request, framework: str
     return _narrative_to_dict(narrative)
 
 
-@router.get("/v1/compliance/verification-key", tags=["compliance"])
+@router.get("/compliance/verification-key", tags=["compliance"])
 async def get_compliance_verification_key(request: Request) -> dict:
     """Return the Ed25519 public key used to sign compliance evidence bundles.
 
@@ -937,13 +937,13 @@ async def get_compliance_verification_key(request: Request) -> dict:
     }
 
 
-@router.get("/v1/compliance/aisvs", tags=["compliance"])
+@router.get("/compliance/aisvs", tags=["compliance"])
 async def get_aisvs_compliance(request: Request) -> dict:
     """Return the latest tenant-scoped OWASP AISVS benchmark result from completed scans."""
     return _latest_aisvs_benchmark_from_jobs(_tenant_jobs(request))
 
 
-@router.get("/v1/compliance/summary", tags=["compliance"])
+@router.get("/compliance/summary", tags=["compliance"])
 async def get_compliance_summary(request: Request) -> dict:
     """Return aggregate compliance score and per-framework status counts.
 
@@ -989,7 +989,7 @@ async def get_compliance_summary(request: Request) -> dict:
     return response
 
 
-@router.get("/v1/compliance/{framework}", tags=["compliance"])
+@router.get("/compliance/{framework}", tags=["compliance"])
 async def get_compliance_by_framework(request: Request, framework: str) -> dict:
     """Get compliance posture for a single framework.
 
@@ -1204,7 +1204,7 @@ def _enrich_controls_with_evidence(
     return enriched_controls, total_findings, counts
 
 
-@router.get("/v1/compliance/{framework}/report", tags=["compliance"], response_model=ComplianceReportBundle)
+@router.get("/compliance/{framework}/report", tags=["compliance"], response_model=ComplianceReportBundle)
 async def export_compliance_report(
     request: Request,
     framework: str,
@@ -1447,7 +1447,7 @@ async def export_compliance_report(
 # ─── Multi-framework evidence pack ─────────────────────────────────────────
 
 
-@router.get("/v1/compliance/report/pack", tags=["compliance"])
+@router.get("/compliance/report/pack", tags=["compliance"])
 async def export_compliance_pack(
     request: Request,
     since: str | None = None,
@@ -1602,7 +1602,7 @@ async def export_compliance_pack(
 # ─── Posture Scorecard ─────────────────────────────────────────────────────
 
 
-@router.get("/v1/posture", tags=["compliance"])
+@router.get("/posture", tags=["compliance"])
 async def get_posture_scorecard(request: Request) -> dict:
     """Compute enterprise posture scorecard from the latest completed scan.
 
@@ -1637,7 +1637,7 @@ async def get_posture_scorecard(request: Request) -> dict:
     }
 
 
-@router.get("/v1/posture/enrichment", tags=["compliance"])
+@router.get("/posture/enrichment", tags=["compliance"])
 async def get_enrichment_posture() -> dict:
     """Report runtime health for external vulnerability enrichment sources."""
 
@@ -1646,7 +1646,7 @@ async def get_enrichment_posture() -> dict:
     return describe_enrichment_posture()
 
 
-@router.get("/v1/posture/backpressure", tags=["compliance"])
+@router.get("/posture/backpressure", tags=["compliance"])
 async def get_backpressure_posture() -> dict:
     """Report adaptive runtime backpressure state for expensive paths."""
 
@@ -1655,7 +1655,7 @@ async def get_backpressure_posture() -> dict:
     return describe_backpressure_posture()
 
 
-@router.get("/v1/posture/counts", tags=["compliance"])
+@router.get("/posture/counts", tags=["compliance"])
 async def get_posture_counts(request: Request) -> dict:
     """Aggregate vulnerability counts across all completed scans.
 
@@ -1703,7 +1703,7 @@ async def get_posture_counts(request: Request) -> dict:
     return counts
 
 
-@router.get("/v1/posture/credentials", tags=["compliance"])
+@router.get("/posture/credentials", tags=["compliance"])
 async def get_credential_risk_ranking(request: Request) -> dict:
     """Rank credentials by blast radius exposure from the latest scan.
 
@@ -1726,7 +1726,7 @@ async def get_credential_risk_ranking(request: Request) -> dict:
     return {"credentials": ranking, "count": len(ranking), "rotation_governance": rotation_governance}
 
 
-@router.get("/v1/posture/incidents", tags=["compliance"])
+@router.get("/posture/incidents", tags=["compliance"])
 async def get_incident_correlation(request: Request) -> dict:
     """Group vulnerabilities by agent for SOC incident correlation.
 
@@ -1805,7 +1805,7 @@ def _native_hub_findings(request: Request) -> list[dict[str, Any]]:
 
 
 @router.post(
-    "/v1/compliance/ingest",
+    "/compliance/ingest",
     tags=["compliance"],
     status_code=201,
     dependencies=[_dep("scan")],
@@ -1941,7 +1941,7 @@ def _unpack_hub_list_page(result: tuple[Any, ...]) -> tuple[list[dict[str, Any]]
     return page, total or 0
 
 
-@router.get("/v1/compliance/hub/findings", tags=["compliance"])
+@router.get("/compliance/hub/findings", tags=["compliance"])
 async def list_hub_findings(request: Request, limit: int = 200, offset: int = 0) -> dict:
     """List compliance-hub findings for the current tenant.
 
@@ -1978,7 +1978,7 @@ async def list_hub_findings(request: Request, limit: int = 200, offset: int = 0)
     }
 
 
-@router.get("/v1/compliance/hub/posture", tags=["compliance"])
+@router.get("/compliance/hub/posture", tags=["compliance"])
 async def get_hub_posture(request: Request) -> dict:
     """Aggregate compliance posture across native scans + hub-ingested findings.
 
@@ -2051,7 +2051,7 @@ async def get_hub_posture(request: Request) -> dict:
     }
 
 
-@router.delete("/v1/compliance/hub/findings", tags=["compliance"], dependencies=[_dep("policy_write")])
+@router.delete("/compliance/hub/findings", tags=["compliance"], dependencies=[_dep("policy_write")])
 async def clear_hub_findings(request: Request) -> dict:
     """Clear all hub-ingested findings for the current tenant.
 

--- a/src/agent_bom/api/routes/connectors.py
+++ b/src/agent_bom/api/routes/connectors.py
@@ -91,7 +91,7 @@ def _load_registry() -> list[dict]:
 # ─── Connector endpoints ─────────────────────────────────────────────────────
 
 
-@router.get("/v1/connectors", tags=["connectors"])
+@router.get("/connectors", tags=["connectors"])
 async def list_available_connectors() -> dict:
     """List available SaaS connectors for AI agent discovery."""
     from agent_bom.connectors import list_connectors
@@ -99,7 +99,7 @@ async def list_available_connectors() -> dict:
     return {"connectors": list_connectors()}
 
 
-@router.get("/v1/connectors/{name}/health", tags=["connectors"])
+@router.get("/connectors/{name}/health", tags=["connectors"])
 async def connector_health(name: str) -> dict:
     """Check connectivity for a SaaS connector."""
     try:
@@ -114,14 +114,14 @@ async def connector_health(name: str) -> dict:
 # ─── Registry endpoints ──────────────────────────────────────────────────────
 
 
-@router.get("/v1/registry", tags=["registry"])
+@router.get("/registry", tags=["registry"])
 async def list_registry() -> dict:
     """List all known MCP servers from the agent-bom registry."""
     servers = _load_registry()
     return {"servers": servers, "count": len(servers)}
 
 
-@router.get("/v1/registry/{server_id:path}", tags=["registry"])
+@router.get("/registry/{server_id:path}", tags=["registry"])
 async def get_registry_server(server_id: str) -> dict:
     """Get a single MCP server entry by ID (e.g. 'modelcontextprotocol/filesystem')."""
     servers = _load_registry()
@@ -134,7 +134,7 @@ async def get_registry_server(server_id: str) -> dict:
 # ─── Security lookup endpoints ───────────────────────────────────────────────
 
 
-@router.get("/v1/malicious/check", tags=["security"])
+@router.get("/malicious/check", tags=["security"])
 async def check_malicious(name: str, ecosystem: str = "npm") -> dict:
     """Check if a package name is a known malicious package or typosquat.
 
@@ -153,7 +153,7 @@ async def check_malicious(name: str, ecosystem: str = "npm") -> dict:
     }
 
 
-@router.get("/v1/scorecard/{ecosystem}/{package:path}", tags=["security"])
+@router.get("/scorecard/{ecosystem}/{package:path}", tags=["security"])
 async def scorecard_lookup(ecosystem: str, package: str) -> dict:
     """Look up OpenSSF Scorecard for a package.
 

--- a/src/agent_bom/api/routes/credentials.py
+++ b/src/agent_bom/api/routes/credentials.py
@@ -71,7 +71,7 @@ def _apply_update(credential: CredentialRefRecord, body: CredentialRefUpdate) ->
     return credential
 
 
-@router.post("/v1/credentials", tags=["credentials"], status_code=201)
+@router.post("/credentials", tags=["credentials"], status_code=201)
 async def create_credential_ref(request: Request, body: CredentialRefCreate) -> dict:
     tenant_id = _tenant_id(request)
     if body.tenant_id not in ("default", tenant_id):
@@ -111,7 +111,7 @@ async def create_credential_ref(request: Request, body: CredentialRefCreate) -> 
     return credential.model_dump()
 
 
-@router.get("/v1/credentials", tags=["credentials"])
+@router.get("/credentials", tags=["credentials"])
 async def list_credential_refs(
     request: Request,
     limit: int = Query(1000, ge=1, le=1000),
@@ -131,19 +131,19 @@ async def list_credential_refs(
     }
 
 
-@router.get("/v1/credentials/posture", tags=["credentials"])
+@router.get("/credentials/posture", tags=["credentials"])
 async def get_credential_rotation_posture(request: Request) -> dict:
     tenant_id = _tenant_id(request)
     credentials = _get_credential_ref_store().list_all(tenant_id=tenant_id)
     return build_credential_rotation_governance(credentials, tenant_id=tenant_id)
 
 
-@router.get("/v1/credentials/{credential_ref_id}", tags=["credentials"])
+@router.get("/credentials/{credential_ref_id}", tags=["credentials"])
 async def get_credential_ref(request: Request, credential_ref_id: str) -> dict:
     return _credential_for_request(request, credential_ref_id).model_dump()
 
 
-@router.put("/v1/credentials/{credential_ref_id}", tags=["credentials"])
+@router.put("/credentials/{credential_ref_id}", tags=["credentials"])
 async def update_credential_ref(request: Request, credential_ref_id: str, body: CredentialRefUpdate) -> dict:
     credential = _apply_update(_credential_for_request(request, credential_ref_id), body)
     _get_credential_ref_store().put(credential)
@@ -158,7 +158,7 @@ async def update_credential_ref(request: Request, credential_ref_id: str, body: 
     return credential.model_dump()
 
 
-@router.post("/v1/credentials/{credential_ref_id}/test", tags=["credentials"])
+@router.post("/credentials/{credential_ref_id}/test", tags=["credentials"])
 async def test_credential_ref(request: Request, credential_ref_id: str) -> dict:
     credential = _credential_for_request(request, credential_ref_id)
     status, message = validate_credential_ref(credential)
@@ -183,7 +183,7 @@ async def test_credential_ref(request: Request, credential_ref_id: str) -> dict:
     }
 
 
-@router.delete("/v1/credentials/{credential_ref_id}", tags=["credentials"], status_code=204)
+@router.delete("/credentials/{credential_ref_id}", tags=["credentials"], status_code=204)
 async def delete_credential_ref(request: Request, credential_ref_id: str) -> None:
     credential = _credential_for_request(request, credential_ref_id)
     _get_credential_ref_store().delete(credential_ref_id)

--- a/src/agent_bom/api/routes/datasets.py
+++ b/src/agent_bom/api/routes/datasets.py
@@ -68,7 +68,7 @@ def _validate_dataset_id(dataset_id: str) -> str:
     return normalized
 
 
-@router.post("/v1/datasets/{dataset_id}/versions", tags=["datasets"], status_code=201)
+@router.post("/datasets/{dataset_id}/versions", tags=["datasets"], status_code=201)
 async def register_dataset_version(
     request: Request,
     dataset_id: Annotated[str, Path(min_length=1, max_length=128)],
@@ -101,7 +101,7 @@ async def register_dataset_version(
     return {"schema_version": "v1", "dataset": record.to_dict(), "warnings": warnings}
 
 
-@router.get("/v1/datasets/{dataset_id}/versions", tags=["datasets"])
+@router.get("/datasets/{dataset_id}/versions", tags=["datasets"])
 async def list_dataset_versions(
     request: Request,
     dataset_id: Annotated[str, Path(min_length=1, max_length=128)],
@@ -118,7 +118,7 @@ async def list_dataset_versions(
     }
 
 
-@router.get("/v1/datasets/{dataset_id}/versions/{version_id}", tags=["datasets"])
+@router.get("/datasets/{dataset_id}/versions/{version_id}", tags=["datasets"])
 async def get_dataset_version(
     request: Request,
     dataset_id: Annotated[str, Path(min_length=1, max_length=128)],

--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -414,7 +414,7 @@ def _build_agents_response(tenant_id: str) -> dict[str, Any]:
     }
 
 
-@router.get("/v1/agents", tags=["discovery"])
+@router.get("/agents", tags=["discovery"])
 async def list_agents(
     request: Request,
     refresh: bool = Query(False, description="Bypass the sidebar cache and perform live local discovery"),
@@ -437,7 +437,7 @@ async def list_agents(
         raise HTTPException(status_code=500, detail=sanitize_error(exc)) from exc
 
 
-@router.get("/v1/discovery/providers", tags=["discovery"])
+@router.get("/discovery/providers", tags=["discovery"])
 async def list_discovery_providers() -> dict:
     """Return registered discovery provider capability and trust contracts."""
 
@@ -446,7 +446,7 @@ async def list_discovery_providers() -> dict:
     return provider_contracts()
 
 
-@router.get("/v1/agents/mesh", tags=["discovery"])
+@router.get("/agents/mesh", tags=["discovery"])
 async def get_agent_mesh(request: Request) -> dict:
     """Get a ReactFlow-compatible mesh topology of all discovered agents.
 
@@ -500,7 +500,7 @@ async def get_agent_mesh(request: Request) -> dict:
         raise HTTPException(status_code=500, detail=sanitize_error(exc)) from exc
 
 
-@router.get("/v1/agents/{agent_name}", tags=["discovery"])
+@router.get("/agents/{agent_name}", tags=["discovery"])
 async def get_agent_detail(request: Request, agent_name: str) -> dict:
     """Get detailed view of a single agent with cross-referenced scan data."""
     try:
@@ -586,7 +586,7 @@ async def get_agent_detail(request: Request, agent_name: str) -> dict:
         raise HTTPException(status_code=500, detail=sanitize_error(exc)) from exc
 
 
-@router.get("/v1/agents/{agent_name}/lifecycle", tags=["discovery"])
+@router.get("/agents/{agent_name}/lifecycle", tags=["discovery"])
 async def get_agent_lifecycle(request: Request, agent_name: str) -> dict:
     """Get React Flow nodes/edges for an agent's full lifecycle graph.
 

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -449,7 +449,7 @@ def _clear_browser_session_cookie(response: Response, request: Request) -> None:
 # ── API Key Management (RBAC) ───────────────────────────────────────────────
 
 
-@router.post("/v1/auth/session", tags=["enterprise"], status_code=204)
+@router.post("/auth/session", tags=["enterprise"], status_code=204)
 async def create_browser_session(request: Request, response: Response, body: BrowserSessionRequest) -> None:
     """Exchange an API key for a same-origin httpOnly browser session cookie.
 
@@ -516,7 +516,7 @@ async def create_browser_session(request: Request, response: Response, body: Bro
     raise HTTPException(status_code=401, detail="Invalid API key")
 
 
-@router.delete("/v1/auth/session", tags=["enterprise"], status_code=204)
+@router.delete("/auth/session", tags=["enterprise"], status_code=204)
 async def delete_browser_session(request: Request, response: Response) -> None:
     """Clear the same-origin browser session cookie."""
     from agent_bom.api.audit_log import log_action
@@ -528,7 +528,7 @@ async def delete_browser_session(request: Request, response: Response) -> None:
     return None
 
 
-@router.post("/v1/auth/keys", tags=["enterprise"], status_code=201)
+@router.post("/auth/keys", tags=["enterprise"], status_code=201)
 async def create_key(request: Request, req: CreateKeyRequest) -> dict:
     """Create a new API key. Returns the raw key once — store it securely."""
     from agent_bom.api.audit_log import log_action
@@ -578,7 +578,7 @@ async def create_key(request: Request, req: CreateKeyRequest) -> dict:
     }
 
 
-@router.post("/v1/auth/keys/{key_id}/rotate", tags=["enterprise"], status_code=201)
+@router.post("/auth/keys/{key_id}/rotate", tags=["enterprise"], status_code=201)
 async def rotate_key(
     request: Request,
     key_id: str,
@@ -652,7 +652,7 @@ async def rotate_key(
     }
 
 
-@router.get("/v1/auth/keys", tags=["enterprise"])
+@router.get("/auth/keys", tags=["enterprise"])
 async def list_keys(request: Request) -> dict:
     """List all API keys (without hashes or raw values)."""
     from agent_bom.api.auth import get_key_store
@@ -663,7 +663,7 @@ async def list_keys(request: Request) -> dict:
     return {"schema_version": "v1", "keys": [k.to_dict() for k in keys]}
 
 
-@router.get("/v1/auth/policy", tags=["enterprise"])
+@router.get("/auth/policy", tags=["enterprise"])
 async def auth_policy(request: Request) -> dict:
     """Report control-plane operator posture for auth, rate-limit and runtime safety controls.
 
@@ -761,7 +761,7 @@ async def auth_policy(request: Request) -> dict:
     }
 
 
-@router.get("/v1/auth/scopes", tags=["enterprise"])
+@router.get("/auth/scopes", tags=["enterprise"])
 async def auth_scopes() -> dict:
     """Return the enforced RBAC scope catalog for operator tooling."""
     from agent_bom.api.middleware import APIKeyMiddleware
@@ -775,7 +775,7 @@ async def auth_scopes() -> dict:
     }
 
 
-@router.get("/v1/auth/secrets/lifecycle", tags=["enterprise"])
+@router.get("/auth/secrets/lifecycle", tags=["enterprise"])
 async def auth_secret_lifecycle() -> dict:
     """Return non-secret lifecycle posture for configured control-plane secrets."""
     from agent_bom.api.secret_lifecycle import describe_secret_lifecycle_posture
@@ -783,7 +783,7 @@ async def auth_secret_lifecycle() -> dict:
     return describe_secret_lifecycle_posture()
 
 
-@router.get("/v1/auth/secrets/rotation-plan", tags=["enterprise"])
+@router.get("/auth/secrets/rotation-plan", tags=["enterprise"])
 async def auth_secret_rotation_plan() -> dict:
     """Return a non-secret operator plan for rotating control-plane secrets."""
     from agent_bom.api.secret_lifecycle import build_secret_rotation_plan
@@ -791,7 +791,7 @@ async def auth_secret_rotation_plan() -> dict:
     return build_secret_rotation_plan()
 
 
-@router.get("/v1/auth/secrets/credential-expiry", tags=["enterprise"])
+@router.get("/auth/secrets/credential-expiry", tags=["enterprise"])
 async def auth_secret_credential_expiry() -> dict:
     """Return non-secret credential expiry/rotation governance.
 
@@ -842,7 +842,7 @@ def _discover_nhi_credentials() -> list[dict]:
         return []
 
 
-@router.get("/v1/auth/scim/config", tags=["enterprise"])
+@router.get("/auth/scim/config", tags=["enterprise"])
 async def auth_scim_config() -> dict:
     """Return the operator-facing SCIM configuration posture."""
     from agent_bom.api.scim import describe_scim_posture
@@ -850,7 +850,7 @@ async def auth_scim_config() -> dict:
     return describe_scim_posture()
 
 
-@router.get("/v1/auth/quota", tags=["enterprise"])
+@router.get("/auth/quota", tags=["enterprise"])
 async def auth_quota(request: Request) -> dict:
     """Return the effective tenant quota runtime surface for the current tenant."""
     from agent_bom.api.tenant_quota import get_tenant_quota_runtime
@@ -859,7 +859,7 @@ async def auth_quota(request: Request) -> dict:
     return get_tenant_quota_runtime(tenant_id)
 
 
-@router.put("/v1/auth/quota", tags=["enterprise"])
+@router.put("/auth/quota", tags=["enterprise"])
 async def update_auth_quota(request: Request, req: TenantQuotaUpdateRequest) -> dict:
     """Update tenant-specific quota overrides for the current tenant."""
     from agent_bom.api.audit_log import log_action
@@ -890,7 +890,7 @@ async def update_auth_quota(request: Request, req: TenantQuotaUpdateRequest) -> 
     return get_tenant_quota_runtime(tenant_id)
 
 
-@router.delete("/v1/auth/quota", tags=["enterprise"], status_code=204)
+@router.delete("/auth/quota", tags=["enterprise"], status_code=204)
 async def reset_auth_quota(request: Request) -> None:
     """Clear all tenant-specific quota overrides for the current tenant."""
     from agent_bom.api.audit_log import log_action
@@ -909,7 +909,7 @@ async def reset_auth_quota(request: Request) -> None:
     )
 
 
-@router.get("/v1/auth/debug", tags=["enterprise"])
+@router.get("/auth/debug", tags=["enterprise"])
 async def auth_debug(request: Request) -> dict:
     """Introspect how the current request was authenticated.
 
@@ -941,7 +941,7 @@ async def auth_debug(request: Request) -> dict:
     }
 
 
-@router.get("/v1/auth/me", tags=["enterprise"])
+@router.get("/auth/me", tags=["enterprise"])
 async def auth_me(request: Request) -> dict:
     """Return the current UI-facing actor/session contract for the active tenant."""
     state = _auth_session_state(request)
@@ -975,7 +975,7 @@ async def auth_me(request: Request) -> dict:
     }
 
 
-@router.delete("/v1/auth/keys/{key_id}", tags=["enterprise"], status_code=204)
+@router.delete("/auth/keys/{key_id}", tags=["enterprise"], status_code=204)
 async def delete_key(request: Request, key_id: str) -> None:
     """Revoke an API key."""
     from agent_bom.api.audit_log import log_action
@@ -992,7 +992,7 @@ async def delete_key(request: Request, key_id: str) -> None:
     log_action("auth.key_revoked", actor=actor, resource=f"key/{key_id}", tenant_id=tenant_id)
 
 
-@router.get("/v1/auth/saml/metadata", tags=["enterprise"])
+@router.get("/auth/saml/metadata", tags=["enterprise"])
 async def saml_metadata() -> PlainTextResponse:
     """Return SP metadata XML for enterprise IdP configuration."""
     from agent_bom.api.saml import SAML_INSTALL_HINT, SAMLConfig, SAMLError, saml_runtime_available
@@ -1009,7 +1009,7 @@ async def saml_metadata() -> PlainTextResponse:
     return PlainTextResponse(content=metadata, media_type="application/samlmetadata+xml")
 
 
-@router.post("/v1/auth/saml/relay-state", tags=["enterprise"])
+@router.post("/auth/saml/relay-state", tags=["enterprise"])
 async def saml_relay_state() -> dict:
     """Issue a one-time RelayState nonce for SP-initiated SAML login."""
     relay_state, expires_at = _new_saml_relay_state()
@@ -1020,7 +1020,7 @@ async def saml_relay_state() -> dict:
     }
 
 
-@router.post("/v1/auth/saml/login", tags=["enterprise"], status_code=201)
+@router.post("/auth/saml/login", tags=["enterprise"], status_code=201)
 async def saml_login(req: SAMLLoginRequest) -> dict:
     """Verify a SAML assertion and return a short-lived API key."""
     from agent_bom.api.audit_log import log_action
@@ -1075,7 +1075,7 @@ async def saml_login(req: SAMLLoginRequest) -> dict:
 # ── Audit Log ────────────────────────────────────────────────────────────────
 
 
-@router.get("/v1/audit", tags=["enterprise"])
+@router.get("/audit", tags=["enterprise"])
 async def list_audit_entries(
     request: Request,
     action: str | None = None,
@@ -1111,7 +1111,7 @@ def _configured_runtime_audit_log_path() -> Path | None:
     return None
 
 
-@router.get("/v1/audit/integrity", tags=["enterprise"])
+@router.get("/audit/integrity", tags=["enterprise"])
 async def audit_integrity(
     request: Request,
     limit: Annotated[int, Query(ge=1, le=10_000)] = 1000,
@@ -1165,7 +1165,7 @@ async def audit_integrity(
     }
 
 
-@router.get("/v1/audit/export", tags=["enterprise"])
+@router.get("/audit/export", tags=["enterprise"])
 async def export_audit_entries(
     request: Request,
     action: str | None = None,
@@ -1238,7 +1238,7 @@ async def export_audit_entries(
     )
 
 
-@router.post("/v1/audit/export/verify", tags=["enterprise"])
+@router.post("/audit/export/verify", tags=["enterprise"])
 async def verify_audit_export(request: Request, body: AuditExportVerifyRequest) -> dict:
     """Verify a signed audit export packet without returning HMAC key material."""
     from agent_bom.api.audit_log import log_action, verify_export_payload
@@ -1265,7 +1265,7 @@ async def verify_audit_export(request: Request, body: AuditExportVerifyRequest) 
 # ── Exception / Waiver Management ────────────────────────────────────────────
 
 
-@router.post("/v1/exceptions", tags=["enterprise"], status_code=201)
+@router.post("/exceptions", tags=["enterprise"], status_code=201)
 async def create_exception(request: Request, req: ExceptionRequest) -> dict:
     """Request a vulnerability exception / waiver."""
     from agent_bom.api.audit_log import log_action
@@ -1294,7 +1294,7 @@ async def create_exception(request: Request, req: ExceptionRequest) -> dict:
     return exc.to_dict()
 
 
-@router.get("/v1/exceptions", tags=["enterprise"])
+@router.get("/exceptions", tags=["enterprise"])
 async def list_exceptions(
     request: Request,
     status: str | None = None,
@@ -1317,7 +1317,7 @@ async def list_exceptions(
     }
 
 
-@router.get("/v1/exceptions/{exception_id}", tags=["enterprise"])
+@router.get("/exceptions/{exception_id}", tags=["enterprise"])
 async def get_exception(request: Request, exception_id: str) -> dict:
     """Get a specific exception."""
     tenant_id = require_request_tenant_id(request)
@@ -1327,7 +1327,7 @@ async def get_exception(request: Request, exception_id: str) -> dict:
     return exc.to_dict()
 
 
-@router.put("/v1/exceptions/{exception_id}/approve", tags=["enterprise"])
+@router.put("/exceptions/{exception_id}/approve", tags=["enterprise"])
 async def approve_exception(request: Request, exception_id: str) -> dict:
     """Approve a pending exception (admin only)."""
     from agent_bom.api.audit_log import log_action
@@ -1349,7 +1349,7 @@ async def approve_exception(request: Request, exception_id: str) -> dict:
     return exc.to_dict()
 
 
-@router.put("/v1/exceptions/{exception_id}/revoke", tags=["enterprise"])
+@router.put("/exceptions/{exception_id}/revoke", tags=["enterprise"])
 async def revoke_exception(request: Request, exception_id: str) -> dict:
     """Revoke an active exception."""
     from agent_bom.api.audit_log import log_action
@@ -1368,7 +1368,7 @@ async def revoke_exception(request: Request, exception_id: str) -> dict:
     return exc.to_dict()
 
 
-@router.delete("/v1/exceptions/{exception_id}", tags=["enterprise"], status_code=204)
+@router.delete("/exceptions/{exception_id}", tags=["enterprise"], status_code=204)
 async def delete_exception(request: Request, exception_id: str) -> None:
     """Delete an exception."""
     from agent_bom.api.audit_log import log_action
@@ -1388,7 +1388,7 @@ async def delete_exception(request: Request, exception_id: str) -> None:
 # ── Baseline Comparison & Trends ─────────────────────────────────────────────
 
 
-@router.post("/v1/baseline/compare", tags=["enterprise"])
+@router.post("/baseline/compare", tags=["enterprise"])
 async def compare_baseline(
     request: Request,
     previous_job_id: Annotated[str, Query(min_length=1)],
@@ -1423,7 +1423,7 @@ async def compare_baseline(
     return diff.to_dict()
 
 
-@router.get("/v1/trends", tags=["enterprise"])
+@router.get("/trends", tags=["enterprise"])
 async def get_trends(request: Request, limit: int = 30) -> dict:
     """Get historical trend data — posture score and vuln counts over time."""
     from agent_bom.api.audit_log import log_action
@@ -1441,7 +1441,7 @@ async def get_trends(request: Request, limit: int = 30) -> dict:
 # ── SIEM Connectors ─────────────────────────────────────────────────────────
 
 
-@router.get("/v1/siem/connectors", tags=["enterprise"])
+@router.get("/siem/connectors", tags=["enterprise"])
 async def list_siem_connectors() -> dict:
     """List available SIEM connector types."""
     from agent_bom.siem import list_connectors
@@ -1449,7 +1449,7 @@ async def list_siem_connectors() -> dict:
     return {"connectors": list_connectors()}
 
 
-@router.post("/v1/siem/test", tags=["enterprise"])
+@router.post("/siem/test", tags=["enterprise"])
 async def test_siem_connection(
     request: Request,
     siem_type: str = "",
@@ -1510,7 +1510,7 @@ async def test_siem_connection(
 # ── Jira Integration ────────────────────────────────────────────────────────
 
 
-@router.post("/v1/findings/jira", tags=["enterprise"], status_code=201)
+@router.post("/findings/jira", tags=["enterprise"], status_code=201)
 async def create_jira_ticket_route(
     request: Request,
     req: JiraTicketRequest,
@@ -1580,7 +1580,7 @@ async def create_jira_ticket_route(
     return {"ticket_key": ticket_key, "status": "created", "mapping": mapping.to_dict()}
 
 
-@router.put("/v1/integrations/issues/{mapping_id}/status", tags=["enterprise"])
+@router.put("/integrations/issues/{mapping_id}/status", tags=["enterprise"])
 async def update_issue_mapping_status(request: Request, mapping_id: str, req: IssueStatusUpdateRequest) -> dict:
     """Update tenant-scoped external issue mapping status after provider sync."""
     from agent_bom.api.audit_log import log_action
@@ -1604,7 +1604,7 @@ async def update_issue_mapping_status(request: Request, mapping_id: str, req: Is
 # ── False Positive Management ────────────────────────────────────────────────
 
 
-@router.post("/v1/findings/false-positive", tags=["enterprise"], status_code=201)
+@router.post("/findings/false-positive", tags=["enterprise"], status_code=201)
 async def mark_false_positive(request: Request, req: FalsePositiveRequest) -> dict:
     """Mark a finding as false positive."""
     feedback = await create_finding_feedback(
@@ -1629,7 +1629,7 @@ async def mark_false_positive(request: Request, req: FalsePositiveRequest) -> di
     }
 
 
-@router.post("/v1/findings/feedback", tags=["enterprise"], status_code=201)
+@router.post("/findings/feedback", tags=["enterprise"], status_code=201)
 async def create_finding_feedback(request: Request, req: FindingFeedbackRequest) -> dict:
     """Record tenant-scoped finding feedback or suppression state."""
     from agent_bom.api.audit_log import log_action
@@ -1661,7 +1661,7 @@ async def create_finding_feedback(request: Request, req: FindingFeedbackRequest)
     return _feedback_response(exc)
 
 
-@router.get("/v1/findings/feedback", tags=["enterprise"])
+@router.get("/findings/feedback", tags=["enterprise"])
 async def list_finding_feedback(request: Request, state: str | None = None) -> dict:
     """List tenant-scoped finding feedback entries."""
     tenant_id = require_request_tenant_id(request)
@@ -1677,7 +1677,7 @@ async def list_finding_feedback(request: Request, state: str | None = None) -> d
     return {"feedback": entries, "total": len(entries)}
 
 
-@router.post("/v1/findings/triage", tags=["enterprise"], status_code=201)
+@router.post("/findings/triage", tags=["enterprise"], status_code=201)
 async def create_finding_triage(request: Request, req: FindingTriageRequest) -> dict:
     """Create a tenant-scoped finding triage queue item."""
     from agent_bom.api.audit_log import log_action
@@ -1724,7 +1724,7 @@ async def create_finding_triage(request: Request, req: FindingTriageRequest) -> 
     return _triage_response(exc)
 
 
-@router.get("/v1/findings/triage", tags=["enterprise"])
+@router.get("/findings/triage", tags=["enterprise"])
 async def list_finding_triage(
     request: Request,
     queue_state: str | None = None,
@@ -1755,7 +1755,7 @@ async def list_finding_triage(
     }
 
 
-@router.put("/v1/findings/triage/{triage_id}/decision", tags=["enterprise"])
+@router.put("/findings/triage/{triage_id}/decision", tags=["enterprise"])
 async def update_finding_triage_decision(request: Request, triage_id: str, req: FindingTriageDecisionRequest) -> dict:
     """Record a finding triage decision and review timestamp."""
     from agent_bom.api.audit_log import log_action
@@ -1797,7 +1797,7 @@ async def update_finding_triage_decision(request: Request, triage_id: str, req: 
     return _triage_response(exc)
 
 
-@router.get("/v1/findings/triage/vex", tags=["enterprise"])
+@router.get("/findings/triage/vex", tags=["enterprise"])
 async def export_finding_triage_vex(request: Request) -> dict:
     """Export signed OpenVEX for eligible tenant-scoped not_affected triage decisions."""
     from agent_bom.api.compliance_signing import sign_compliance_bundle
@@ -1848,7 +1848,7 @@ async def export_finding_triage_vex(request: Request) -> dict:
     }
 
 
-@router.get("/v1/findings/false-positives", tags=["enterprise"])
+@router.get("/findings/false-positives", tags=["enterprise"])
 async def list_false_positives(request: Request) -> dict:
     """List all false positive entries."""
     tenant_id = require_request_tenant_id(request)
@@ -1871,7 +1871,7 @@ async def list_false_positives(request: Request) -> dict:
     }
 
 
-@router.delete("/v1/findings/false-positive/{fp_id}", tags=["enterprise"], status_code=204)
+@router.delete("/findings/false-positive/{fp_id}", tags=["enterprise"], status_code=204)
 async def remove_false_positive(request: Request, fp_id: str) -> None:
     """Un-mark a false positive."""
     from agent_bom.api.audit_log import log_action
@@ -1888,7 +1888,7 @@ async def remove_false_positive(request: Request, fp_id: str) -> None:
     log_action("findings.false_positive_removed", actor=actor, resource=f"fp/{fp_id}", tenant_id=tenant_id)
 
 
-@router.delete("/v1/findings/feedback/{feedback_id}", tags=["enterprise"], status_code=204)
+@router.delete("/findings/feedback/{feedback_id}", tags=["enterprise"], status_code=204)
 async def remove_finding_feedback(request: Request, feedback_id: str) -> None:
     """Remove tenant-scoped finding feedback without deleting audit history."""
     from agent_bom.api.audit_log import log_action

--- a/src/agent_bom/api/routes/entitlements.py
+++ b/src/agent_bom/api/routes/entitlements.py
@@ -30,7 +30,7 @@ def _audit_entitlement_read(request: Request, *, resource: str, details: dict[st
         _logger.exception("Failed to append entitlement audit entry")
 
 
-@router.get("/v1/entitlements", tags=["enterprise"])
+@router.get("/entitlements", tags=["enterprise"])
 async def get_entitlements(request: Request) -> dict:
     """Return local entitlement metadata for self-hosted packaging.
 
@@ -52,7 +52,7 @@ async def get_entitlements(request: Request) -> dict:
     return state.to_dict()
 
 
-@router.get("/v1/entitlements/check/{feature}", tags=["enterprise"])
+@router.get("/entitlements/check/{feature}", tags=["enterprise"])
 async def check_entitlement(feature: str, request: Request) -> dict:
     """Evaluate one feature against local entitlement metadata."""
     state = load_entitlement_state()

--- a/src/agent_bom/api/routes/estate.py
+++ b/src/agent_bom/api/routes/estate.py
@@ -49,7 +49,7 @@ def _match_payload(match: Any) -> dict[str, Any]:
     return payload
 
 
-@router.get("/v1/estate/correlations", tags=["estate"])
+@router.get("/estate/correlations", tags=["estate"])
 async def get_estate_correlations(
     request: Request,
     scan_id: str | None = Query(None, description="Scan job ID; latest completed scan if omitted"),

--- a/src/agent_bom/api/routes/evaluations.py
+++ b/src/agent_bom/api/routes/evaluations.py
@@ -122,7 +122,7 @@ def _validate_dataset_link(tenant_id: str, body: EvaluationRunCreate) -> None:
         raise HTTPException(status_code=404, detail="Dataset version not found for evaluation run")
 
 
-@router.post("/v1/evaluations", tags=["evaluations"], status_code=201)
+@router.post("/evaluations", tags=["evaluations"], status_code=201)
 async def register_evaluation_run(request: Request, body: EvaluationRunCreate) -> dict[str, Any]:
     """Register an evaluation run linked to dataset versions, traces, models, and prompt hashes."""
     tenant_id = _tenant_id(request)
@@ -159,7 +159,7 @@ async def register_evaluation_run(request: Request, body: EvaluationRunCreate) -
     return {"schema_version": "evals.runs.v1", "evaluation": record.to_dict(), "warnings": warnings}
 
 
-@router.get("/v1/evaluations", tags=["evaluations"])
+@router.get("/evaluations", tags=["evaluations"])
 async def list_evaluation_runs(
     request: Request,
     dataset_id: Annotated[str | None, Query(max_length=128)] = None,
@@ -187,7 +187,7 @@ async def list_evaluation_runs(
     }
 
 
-@router.get("/v1/evaluations/{evaluation_id}", tags=["evaluations"])
+@router.get("/evaluations/{evaluation_id}", tags=["evaluations"])
 async def get_evaluation_run(
     request: Request,
     evaluation_id: Annotated[str, Path(min_length=1, max_length=128)],

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -91,8 +91,8 @@ def _request_header(request: Request, key: str) -> str:
     return str(headers.get(key, "") or "")
 
 
-@router.get("/v1/fleet", tags=["fleet"])
-@router.get("/v1/fleet/agents", tags=["fleet"], include_in_schema=False)
+@router.get("/fleet", tags=["fleet"])
+@router.get("/fleet/agents", tags=["fleet"], include_in_schema=False)
 async def list_fleet(
     request: Request,
     state: str | None = None,
@@ -151,7 +151,7 @@ async def list_fleet(
     }
 
 
-@router.get("/v1/fleet/stats", tags=["fleet"])
+@router.get("/fleet/stats", tags=["fleet"])
 async def fleet_stats(request: Request):
     """Fleet-wide statistics."""
     tenant_id = require_request_tenant_id(request)
@@ -174,7 +174,7 @@ async def fleet_stats(request: Request):
     }
 
 
-@router.get("/v1/fleet/{agent_id}", tags=["fleet"])
+@router.get("/fleet/{agent_id}", tags=["fleet"])
 async def get_fleet_agent(request: Request, agent_id: str):
     """Get a single fleet agent with trust score breakdown."""
     tenant_id = require_request_tenant_id(request)
@@ -265,7 +265,7 @@ def _persist_payload_observations(tenant_id: str, agent: dict, *, last_discovery
         store.put(merge_observations(store.get(tenant_id, observation_id), candidate))
 
 
-@router.post("/v1/fleet/sync", tags=["fleet"])
+@router.post("/fleet/sync", tags=["fleet"])
 async def sync_fleet(request: Request, body: PushPayload | None = None):
     """Run discovery and sync results into the fleet registry.
 
@@ -470,7 +470,7 @@ async def sync_fleet(request: Request, body: PushPayload | None = None):
     return response
 
 
-@router.put("/v1/fleet/{agent_id}/state", tags=["fleet"])
+@router.put("/fleet/{agent_id}/state", tags=["fleet"])
 async def update_fleet_state(request: Request, agent_id: str, body: StateUpdate):
     """Update agent lifecycle state."""
     from agent_bom.api.audit_log import log_action
@@ -500,7 +500,7 @@ async def update_fleet_state(request: Request, agent_id: str, body: StateUpdate)
     return {"agent_id": agent_id, "lifecycle_state": new_state.value}
 
 
-@router.post("/v1/fleet/{agent_id}/quarantine", tags=["fleet"], dependencies=[_dep("policy_write")])
+@router.post("/fleet/{agent_id}/quarantine", tags=["fleet"], dependencies=[_dep("policy_write")])
 async def quarantine_fleet_agent(request: Request, agent_id: str):
     """Quarantine an agent and fail closed with a gateway DENY policy for its identity.
 
@@ -607,7 +607,7 @@ async def quarantine_fleet_agent(request: Request, agent_id: str):
     }
 
 
-@router.put("/v1/fleet/{agent_id}", tags=["fleet"])
+@router.put("/fleet/{agent_id}", tags=["fleet"])
 async def update_fleet_agent(request: Request, agent_id: str, body: FleetAgentUpdate):
     """Update agent metadata (owner, environment, tags, notes)."""
     from agent_bom.api.audit_log import log_action

--- a/src/agent_bom/api/routes/frameworks.py
+++ b/src/agent_bom/api/routes/frameworks.py
@@ -11,7 +11,7 @@ from agent_bom.mitre_fetch import get_catalog_metadata
 router = APIRouter()
 
 
-@router.get("/v1/frameworks/catalogs", tags=["frameworks"])
+@router.get("/frameworks/catalogs", tags=["frameworks"])
 def framework_catalogs() -> dict:
     """Return active framework catalog metadata used by scans and outputs."""
     atlas_meta = get_atlas_metadata()

--- a/src/agent_bom/api/routes/gateway.py
+++ b/src/agent_bom/api/routes/gateway.py
@@ -165,7 +165,7 @@ def _firewall_string_list(value: Any, field_name: str) -> set[str]:
     return {role for role in value if role}
 
 
-@router.get("/v1/gateway/policies", tags=["gateway"], dependencies=[_dep("policy_read")])
+@router.get("/gateway/policies", tags=["gateway"], dependencies=[_dep("policy_read")])
 async def list_gateway_policies(request: Request, enabled: bool | None = None, mode: str | None = None):
     """List all gateway policies."""
     tenant_id = require_request_tenant_id(request)
@@ -183,7 +183,7 @@ async def list_gateway_policies(request: Request, enabled: bool | None = None, m
     )
 
 
-@router.post("/v1/gateway/policies", tags=["gateway"], status_code=201, dependencies=[_dep("policy_write")])
+@router.post("/gateway/policies", tags=["gateway"], status_code=201, dependencies=[_dep("policy_write")])
 async def create_gateway_policy(body: PolicyCreate, request: Request):
     """Create a new gateway policy."""
     from agent_bom.api.audit_log import log_action
@@ -228,7 +228,7 @@ async def create_gateway_policy(body: PolicyCreate, request: Request):
     return policy.model_dump()
 
 
-@router.get("/v1/gateway/policies/{policy_id}", tags=["gateway"], dependencies=[_dep("policy_read")])
+@router.get("/gateway/policies/{policy_id}", tags=["gateway"], dependencies=[_dep("policy_read")])
 async def get_gateway_policy(policy_id: str, request: Request):
     """Get a gateway policy by ID."""
     tenant_id = require_request_tenant_id(request)
@@ -238,7 +238,7 @@ async def get_gateway_policy(policy_id: str, request: Request):
     return policy.model_dump()
 
 
-@router.put("/v1/gateway/policies/{policy_id}", tags=["gateway"], dependencies=[_dep("policy_write")])
+@router.put("/gateway/policies/{policy_id}", tags=["gateway"], dependencies=[_dep("policy_write")])
 async def update_gateway_policy(policy_id: str, body: PolicyUpdate, request: Request):
     """Update an existing gateway policy."""
     from agent_bom.api.audit_log import log_action
@@ -287,7 +287,7 @@ async def update_gateway_policy(policy_id: str, body: PolicyUpdate, request: Req
     return policy.model_dump()
 
 
-@router.delete("/v1/gateway/policies/{policy_id}", tags=["gateway"], dependencies=[_dep("policy_write")])
+@router.delete("/gateway/policies/{policy_id}", tags=["gateway"], dependencies=[_dep("policy_write")])
 async def delete_gateway_policy(policy_id: str, request: Request):
     """Delete a gateway policy."""
     tenant_id = require_request_tenant_id(request)
@@ -312,7 +312,7 @@ async def delete_gateway_policy(policy_id: str, request: Request):
     return {"deleted": True, "policy_id": policy_id}
 
 
-@router.post("/v1/gateway/evaluate", tags=["gateway"], dependencies=[_dep("policy_read")])
+@router.post("/gateway/evaluate", tags=["gateway"], dependencies=[_dep("policy_read")])
 async def evaluate_gateway(body: EvaluateRequest, request: Request):
     """Evaluate gateway policies against a tool call and audit-log every decision.
 
@@ -408,7 +408,7 @@ async def evaluate_gateway(body: EvaluateRequest, request: Request):
     }
 
 
-@router.get("/v1/gateway/audit", tags=["gateway"], dependencies=[_dep("audit_read")])
+@router.get("/gateway/audit", tags=["gateway"], dependencies=[_dep("audit_read")])
 async def list_gateway_audit(
     request: Request,
     policy_id: str | None = None,
@@ -427,7 +427,7 @@ async def list_gateway_audit(
 
 
 @router.get(
-    "/v1/gateway/upstreams/discovered",
+    "/gateway/upstreams/discovered",
     tags=["gateway"],
     dependencies=[cast(Any, require_authenticated_permission("read"))],
 )
@@ -542,7 +542,7 @@ async def discovered_upstreams(request: Request) -> dict:
     }
 
 
-@router.get("/v1/gateway/stats", tags=["gateway"], dependencies=[_dep("audit_read")])
+@router.get("/gateway/stats", tags=["gateway"], dependencies=[_dep("audit_read")])
 async def gateway_stats(request: Request):
     """Gateway-wide statistics."""
     from agent_bom.gateway import summarize_gateway_policies
@@ -576,7 +576,7 @@ async def gateway_stats(request: Request):
     }
 
 
-@router.post("/v1/firewall/check", tags=["gateway"], dependencies=[_dep("scan")])
+@router.post("/firewall/check", tags=["gateway"], dependencies=[_dep("scan")])
 async def firewall_check(request: Request):
     """Evaluate a source -> target agent decision through the control plane.
 
@@ -644,7 +644,7 @@ async def firewall_check(request: Request):
     }
 
 
-@router.get("/v1/firewall/stats", tags=["gateway"], dependencies=[_dep("audit_read")])
+@router.get("/firewall/stats", tags=["gateway"], dependencies=[_dep("audit_read")])
 async def firewall_stats(request: Request):
     """Aggregated inter-agent firewall decisions for the runtime-tab overlay.
 

--- a/src/agent_bom/api/routes/gateway_feed.py
+++ b/src/agent_bom/api/routes/gateway_feed.py
@@ -413,7 +413,7 @@ def _load_tenant_llm_records(tenant_id: str, *, limit: int) -> list[Any]:
         return []
 
 
-@router.get("/v1/gateway/feed", tags=["gateway"], dependencies=[_dep("read")])
+@router.get("/gateway/feed", tags=["gateway"], dependencies=[_dep("read")])
 async def gateway_feed(
     request: Request,
     limit: int = Query(default=100, ge=1, le=500, description="Max fused events to return (1-500)"),
@@ -437,7 +437,7 @@ async def gateway_feed(
     )
 
 
-@router.get("/v1/gateway/feed/kpis", tags=["gateway"], dependencies=[_dep("read")])
+@router.get("/gateway/feed/kpis", tags=["gateway"], dependencies=[_dep("read")])
 async def gateway_feed_kpis(request: Request) -> dict[str, Any]:
     """KPI header rollup for the gateway live feed.
 

--- a/src/agent_bom/api/routes/governance.py
+++ b/src/agent_bom/api/routes/governance.py
@@ -22,7 +22,7 @@ router = APIRouter()
 _logger = logging.getLogger(__name__)
 
 
-@router.get("/v1/governance", tags=["governance"])
+@router.get("/governance", tags=["governance"])
 async def governance_report(days: int = 30):
     """Run Snowflake governance discovery and return findings.
 
@@ -49,7 +49,7 @@ async def governance_report(days: int = 30):
         raise HTTPException(status_code=500, detail=sanitize_error(exc))
 
 
-@router.get("/v1/governance/findings", tags=["governance"])
+@router.get("/governance/findings", tags=["governance"])
 async def governance_findings(
     days: int = 30,
     severity: str | None = None,
@@ -87,7 +87,7 @@ async def governance_findings(
         raise HTTPException(status_code=500, detail=sanitize_error(exc))
 
 
-@router.get("/v1/activity", tags=["governance"])
+@router.get("/activity", tags=["governance"])
 async def activity_timeline(days: int = 30):
     """Agent activity timeline from Snowflake QUERY_HISTORY + AI_OBSERVABILITY_EVENTS.
 
@@ -114,7 +114,7 @@ async def activity_timeline(days: int = 30):
         raise HTTPException(status_code=500, detail=sanitize_error(exc))
 
 
-@router.get("/v1/cortex/telemetry", tags=["governance"])
+@router.get("/cortex/telemetry", tags=["governance"])
 async def cortex_telemetry(hours: int = 24):
     """Aggregated Cortex agent telemetry with health assessments.
 
@@ -145,7 +145,7 @@ async def cortex_telemetry(hours: int = 24):
         raise HTTPException(status_code=500, detail=sanitize_error(exc))
 
 
-@router.get("/v1/cortex/agents/{name}/telemetry", tags=["governance"])
+@router.get("/cortex/agents/{name}/telemetry", tags=["governance"])
 async def cortex_agent_telemetry(name: str, hours: int = 24):
     """Telemetry for a specific Cortex agent."""
     import os
@@ -169,7 +169,7 @@ async def cortex_agent_telemetry(name: str, hours: int = 24):
         raise HTTPException(status_code=500, detail=sanitize_error(exc))
 
 
-@router.get("/v1/cortex/health", tags=["governance"])
+@router.get("/cortex/health", tags=["governance"])
 async def cortex_health():
     """Health status for all Cortex agents."""
     import os
@@ -210,7 +210,7 @@ async def cortex_health():
         raise HTTPException(status_code=500, detail=sanitize_error(exc))
 
 
-@router.get("/v1/siem/formats", tags=["siem"])
+@router.get("/siem/formats", tags=["siem"])
 async def siem_formats():
     """List supported SIEM event formats."""
     from agent_bom.siem import list_formats

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1547,7 +1547,7 @@ def _filtered_query_graph(
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@router.get("/v1/graph", tags=["graph"])
+@router.get("/graph", tags=["graph"])
 async def get_graph(
     request: Request,
     scan_id: Optional[str] = Query(None, description="Filter by scan ID"),
@@ -1672,7 +1672,7 @@ async def get_graph(
     }
 
 
-@router.get("/v1/graph/views/fix-first", tags=["graph"], responses={200: _FIX_FIRST_VIEW_OPENAPI_RESPONSE})
+@router.get("/graph/views/fix-first", tags=["graph"], responses={200: _FIX_FIRST_VIEW_OPENAPI_RESPONSE})
 async def get_fix_first_graph_view(
     request: Request,
     scan_id: Optional[str] = Query(None, description="Scan snapshot ID; latest if omitted"),
@@ -1766,7 +1766,7 @@ def _tag_diff_change_kinds(diff: dict[str, Any]) -> dict[str, Any]:
     return diff
 
 
-@router.get("/v1/graph/diff", tags=["graph"])
+@router.get("/graph/diff", tags=["graph"])
 async def get_graph_diff(
     request: Request,
     old: str = Query(..., description="Old scan ID"),
@@ -1777,7 +1777,7 @@ async def get_graph_diff(
     return _tag_diff_change_kinds(diff)
 
 
-@router.get("/v1/graph/edges/active", tags=["graph"])
+@router.get("/graph/edges/active", tags=["graph"])
 async def get_active_graph_edges(
     request: Request,
     at: str = Query(..., description="ISO timestamp for replay lookup"),
@@ -1786,7 +1786,7 @@ async def get_active_graph_edges(
     return await _graph_store_call(_get_graph_store_or_503().active_edges_at, at, tenant_id=_tenant(request))
 
 
-@router.get("/v1/graph/edges/changes", tags=["graph"])
+@router.get("/graph/edges/changes", tags=["graph"])
 async def get_graph_edge_changes(
     request: Request,
     old: str = Query(..., description="Old scan ID"),
@@ -1796,7 +1796,7 @@ async def get_graph_edge_changes(
     return await _graph_store_call(_get_graph_store_or_503().changed_edges_between_scans, old, new, tenant_id=_tenant(request))
 
 
-@router.get("/v1/graph/attack-paths", tags=["graph"], responses={200: _ATTACK_PATHS_OPENAPI_RESPONSE})
+@router.get("/graph/attack-paths", tags=["graph"], responses={200: _ATTACK_PATHS_OPENAPI_RESPONSE})
 async def get_graph_attack_paths(
     request: Request,
     scan_id: Optional[str] = Query(None, description="Scan ID"),
@@ -1864,7 +1864,7 @@ async def get_graph_attack_paths(
     )
 
 
-@router.get("/v1/graph/governance", tags=["graph"])
+@router.get("/graph/governance", tags=["graph"])
 async def get_graph_governance(
     request: Request,
     scan_id: Optional[str] = Query(None, description="Scan ID"),
@@ -1903,7 +1903,7 @@ async def get_graph_governance(
     )
 
 
-@router.get("/v1/graph/nhi/governance", tags=["graph"])
+@router.get("/graph/nhi/governance", tags=["graph"])
 async def get_nhi_governance(
     request: Request,
     scan_id: Optional[str] = Query(None, description="Scan ID"),
@@ -1932,7 +1932,7 @@ async def get_nhi_governance(
     return posture
 
 
-@router.get("/v1/graph/exposure-paths", tags=["graph"])
+@router.get("/graph/exposure-paths", tags=["graph"])
 async def get_graph_exposure_paths(
     request: Request,
     tenant_id: Optional[str] = Query(None, include_in_schema=False),
@@ -1958,7 +1958,7 @@ async def get_graph_exposure_paths(
     return payload
 
 
-@router.post("/v1/graph/should-i-deploy", tags=["graph"])
+@router.post("/graph/should-i-deploy", tags=["graph"])
 async def post_graph_should_i_deploy(request: Request, body: GraphDeployDecisionRequest) -> dict:
     """Return the MCP-compatible allow/warn/block deploy decision over REST."""
     _ = (body.tenant_id, body.context)  # SDK compatibility/future policy context; request tenant scope is authoritative today.
@@ -2002,7 +2002,7 @@ async def post_graph_should_i_deploy(request: Request, body: GraphDeployDecision
     return payload
 
 
-@router.get("/v1/graph/paths", tags=["graph"])
+@router.get("/graph/paths", tags=["graph"])
 async def get_graph_paths(
     request: Request,
     source_id: Optional[str] = Query(None, description="Source node ID (e.g. agent:claude-desktop)"),
@@ -2070,7 +2070,7 @@ async def get_graph_paths(
     }
 
 
-@router.get("/v1/graph/impact", tags=["graph"])
+@router.get("/graph/impact", tags=["graph"])
 async def get_graph_impact(
     request: Request,
     node: str = Query(..., description="Node ID to compute impact for"),
@@ -2090,7 +2090,7 @@ async def get_graph_impact(
     return impact
 
 
-@router.get("/v1/graph/search", tags=["graph"])
+@router.get("/graph/search", tags=["graph"])
 async def search_graph(
     request: Request,
     q: str = Query(..., min_length=1, description="Search query"),
@@ -2145,7 +2145,7 @@ async def search_graph(
     }
 
 
-@router.get("/v1/graph/clusters", tags=["graph"])
+@router.get("/graph/clusters", tags=["graph"])
 async def get_graph_clusters(
     request: Request,
     scan_id: Optional[str] = Query(None, description="Scan snapshot ID; latest if omitted"),
@@ -2179,7 +2179,7 @@ async def get_graph_clusters(
     return await _graph_compute_call(_semantic_cluster_payload, graph, selected_kinds=selected_kinds, min_members=min_members, limit=limit)
 
 
-@router.get("/v1/graph/agents", tags=["graph"])
+@router.get("/graph/agents", tags=["graph"])
 async def list_graph_agents(
     request: Request,
     q: str = Query("", description="Optional agent label/id search"),
@@ -2237,7 +2237,7 @@ async def list_graph_agents(
     }
 
 
-@router.post("/v1/graph/query", tags=["graph"])
+@router.post("/graph/query", tags=["graph"])
 async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
     """Run a bounded programmable traversal over the canonical graph."""
     graph_store = _get_graph_store_or_503()
@@ -2336,7 +2336,7 @@ async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
     }
 
 
-@router.get("/v1/graph/node/{node_id}", tags=["graph"])
+@router.get("/graph/node/{node_id}", tags=["graph"])
 async def get_graph_node(
     request: Request,
     node_id: str,
@@ -2362,7 +2362,7 @@ async def get_graph_node(
     }
 
 
-@router.get("/v1/graph/snapshots", tags=["graph"])
+@router.get("/graph/snapshots", tags=["graph"])
 async def get_graph_snapshots(
     request: Request,
     limit: int = Query(50, ge=1, le=500, description="Max snapshots"),
@@ -2371,7 +2371,7 @@ async def get_graph_snapshots(
     return await _graph_store_call(_get_graph_store_or_503().list_snapshots, tenant_id=_tenant(request), limit=limit)
 
 
-@router.get("/v1/graph/history", tags=["graph"])
+@router.get("/graph/history", tags=["graph"])
 async def get_graph_history(
     request: Request,
     limit: int = Query(50, ge=1, le=500, description="Max snapshots"),
@@ -2380,7 +2380,7 @@ async def get_graph_history(
     return await _graph_store_call(_get_graph_store_or_503().graph_history, tenant_id=_tenant(request), limit=limit)
 
 
-@router.get("/v1/graph/evidence-manifest", tags=["graph"])
+@router.get("/graph/evidence-manifest", tags=["graph"])
 async def get_graph_evidence_manifest(
     request: Request,
     scan_id: Optional[str] = Query(None, description="Scan snapshot ID; latest if omitted"),
@@ -2398,7 +2398,7 @@ async def get_graph_evidence_manifest(
     return manifest
 
 
-@router.get("/v1/graph/compliance", tags=["graph"])
+@router.get("/graph/compliance", tags=["graph"])
 async def get_graph_compliance(
     request: Request,
     scan_id: Optional[str] = Query(None, description="Scan ID"),
@@ -2417,7 +2417,7 @@ async def get_graph_compliance(
     )
 
 
-@router.get("/v1/graph/legend", tags=["graph"])
+@router.get("/graph/legend", tags=["graph"])
 async def get_graph_legend() -> dict:
     """Return entity and relationship legends for UI rendering."""
     from agent_bom.graph import ENTITY_LEGEND, RELATIONSHIP_LEGEND
@@ -2996,7 +2996,7 @@ _RELATIONSHIP_SCHEMA_META: dict[str, dict[str, object]] = {
 }
 
 
-@router.get("/v1/graph/schema", tags=["graph"])
+@router.get("/graph/schema", tags=["graph"])
 async def get_graph_schema() -> dict:
     """Canonical graph entity/edge taxonomy — single source of truth.
 
@@ -3082,7 +3082,7 @@ async def get_graph_schema() -> dict:
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@router.post("/v1/graph/presets", tags=["graph"])
+@router.post("/graph/presets", tags=["graph"])
 async def create_preset(request: Request, body: PresetCreate) -> dict:
     """Save a named graph filter preset for the current tenant."""
     from agent_bom.graph.util import _now_iso
@@ -3099,13 +3099,13 @@ async def create_preset(request: Request, body: PresetCreate) -> dict:
     return {"name": body.name, "status": "saved"}
 
 
-@router.get("/v1/graph/presets", tags=["graph"])
+@router.get("/graph/presets", tags=["graph"])
 async def list_presets(request: Request) -> list[dict]:
     """List saved filter presets for the current tenant."""
     return await _graph_store_call(_get_graph_store_or_503().list_presets, tenant_id=_tenant(request))
 
 
-@router.delete("/v1/graph/presets/{name}", tags=["graph"])
+@router.delete("/graph/presets/{name}", tags=["graph"])
 async def delete_preset(request: Request, name: str) -> dict:
     """Delete a saved filter preset."""
     deleted = await _graph_store_call(_get_graph_store_or_503().delete_preset, tenant_id=_tenant(request), name=name)
@@ -3119,7 +3119,7 @@ async def delete_preset(request: Request, name: str) -> dict:
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-@router.get("/v1/graph/rollup", tags=["graph"])
+@router.get("/graph/rollup", tags=["graph"])
 async def get_graph_rollup(
     request: Request,
     scan_id: Optional[str] = Query(None, description="Scan snapshot ID; latest if omitted"),

--- a/src/agent_bom/api/routes/identities.py
+++ b/src/agent_bom/api/routes/identities.py
@@ -77,7 +77,7 @@ def _identity_for_tenant(request: Request, identity_id: str):
     return identity
 
 
-@router.post("/v1/identities", status_code=201, dependencies=[_dep("config")])
+@router.post("/identities", status_code=201, dependencies=[_dep("config")])
 async def issue_agent_identity(request: Request, body: dict) -> dict[str, object]:
     """Issue a new agent identity. Returns the raw token exactly once."""
     agent_id = str(body.get("agent_id", "") or "").strip()
@@ -142,7 +142,7 @@ async def issue_agent_identity(request: Request, body: dict) -> dict[str, object
     }
 
 
-@router.post("/v1/identities/{identity_id}/rotate", dependencies=[_dep("config")])
+@router.post("/identities/{identity_id}/rotate", dependencies=[_dep("config")])
 async def rotate_agent_identity(request: Request, identity_id: str, body: dict | None = None) -> dict[str, object]:
     """Rotate an identity: issue a replacement and keep the old one live briefly."""
     payload = body or {}
@@ -187,7 +187,7 @@ async def rotate_agent_identity(request: Request, identity_id: str, body: dict |
     }
 
 
-@router.post("/v1/identities/{identity_id}/revoke", dependencies=[_dep("config")])
+@router.post("/identities/{identity_id}/revoke", dependencies=[_dep("config")])
 async def revoke_agent_identity(request: Request, identity_id: str, body: dict | None = None) -> dict[str, object]:
     """Revoke an identity immediately; its token can no longer authenticate."""
     store = get_agent_identity_store()
@@ -212,7 +212,7 @@ async def revoke_agent_identity(request: Request, identity_id: str, body: dict |
     return {"schema_version": "agent.identity.v1", "revoked": True, "identity": revoked.to_public_dict()}
 
 
-@router.post("/v1/identities/{identity_id}/jit-requests", status_code=201, dependencies=[_dep("config")])
+@router.post("/identities/{identity_id}/jit-requests", status_code=201, dependencies=[_dep("config")])
 async def request_agent_identity_jit(request: Request, identity_id: str, body: dict) -> dict[str, object]:
     """Request time-bound access to one tool. Requests do not authorize calls."""
     identity = _identity_for_tenant(request, identity_id)
@@ -240,7 +240,7 @@ async def request_agent_identity_jit(request: Request, identity_id: str, body: d
     return {"schema_version": "agent.identity.jit.v1", "grant": grant.to_public_dict()}
 
 
-@router.post("/v1/identities/{identity_id}/jit-grants", status_code=201, dependencies=[_dep("config")])
+@router.post("/identities/{identity_id}/jit-grants", status_code=201, dependencies=[_dep("config")])
 async def grant_agent_identity_jit(request: Request, identity_id: str, body: dict) -> dict[str, object]:
     """Grant one identity time-bound access to one tool."""
     identity = _identity_for_tenant(request, identity_id)
@@ -278,7 +278,7 @@ async def grant_agent_identity_jit(request: Request, identity_id: str, body: dic
     return {"schema_version": "agent.identity.jit.v1", "grant": grant.to_public_dict()}
 
 
-@router.post("/v1/identity-jit-grants/{grant_id}/approve", dependencies=[_dep("config")])
+@router.post("/identity-jit-grants/{grant_id}/approve", dependencies=[_dep("config")])
 async def approve_agent_identity_jit(request: Request, grant_id: str, body: dict | None = None) -> dict[str, object]:
     """Approve a pending JIT request for a bounded TTL."""
     payload = body or {}
@@ -302,7 +302,7 @@ async def approve_agent_identity_jit(request: Request, grant_id: str, body: dict
     return {"schema_version": "agent.identity.jit.v1", "grant": grant.to_public_dict()}
 
 
-@router.post("/v1/identity-jit-grants/{grant_id}/deny", dependencies=[_dep("config")])
+@router.post("/identity-jit-grants/{grant_id}/deny", dependencies=[_dep("config")])
 async def deny_agent_identity_jit(request: Request, grant_id: str, body: dict | None = None) -> dict[str, object]:
     """Deny a pending JIT request."""
     store = get_agent_identity_store()
@@ -324,7 +324,7 @@ async def deny_agent_identity_jit(request: Request, grant_id: str, body: dict | 
     return {"schema_version": "agent.identity.jit.v1", "grant": grant.to_public_dict()}
 
 
-@router.post("/v1/identity-jit-grants/{grant_id}/revoke", dependencies=[_dep("config")])
+@router.post("/identity-jit-grants/{grant_id}/revoke", dependencies=[_dep("config")])
 async def revoke_agent_identity_jit(request: Request, grant_id: str, body: dict | None = None) -> dict[str, object]:
     """Revoke an active JIT grant immediately."""
     store = get_agent_identity_store()
@@ -353,7 +353,7 @@ async def revoke_agent_identity_jit(request: Request, grant_id: str, body: dict 
     return {"schema_version": "agent.identity.jit.v1", "grant": grant.to_public_dict()}
 
 
-@router.get("/v1/identity-jit-grants", dependencies=[_dep("read")])
+@router.get("/identity-jit-grants", dependencies=[_dep("read")])
 async def list_agent_identity_jit_grants(
     request: Request,
     identity_id: str | None = None,
@@ -376,7 +376,7 @@ async def list_agent_identity_jit_grants(
     }
 
 
-@router.get("/v1/identities/{identity_id}/jit-grants", dependencies=[_dep("read")])
+@router.get("/identities/{identity_id}/jit-grants", dependencies=[_dep("read")])
 async def list_agent_identity_jit_for_identity(
     request: Request,
     identity_id: str,
@@ -428,7 +428,7 @@ def _int_list(body: dict, key: str, *, lo: int, hi: int) -> list[int]:
     return out
 
 
-@router.post("/v1/conditional-access-policies", status_code=201, dependencies=[_dep("config")])
+@router.post("/conditional-access-policies", status_code=201, dependencies=[_dep("config")])
 async def create_conditional_access_policy(request: Request, body: dict) -> dict[str, object]:
     """Create a context-aware access policy (time / CIDR / environment guardrail)."""
     name = str(body.get("name", "") or "").strip()
@@ -482,7 +482,7 @@ def _conditional_policy_for_tenant(request: Request, policy_id: str):
     return policy
 
 
-@router.post("/v1/conditional-access-policies/{policy_id}/disable", dependencies=[_dep("config")])
+@router.post("/conditional-access-policies/{policy_id}/disable", dependencies=[_dep("config")])
 async def disable_conditional_access_policy(request: Request, policy_id: str) -> dict[str, object]:
     """Disable a conditional-access policy without deleting it."""
     _conditional_policy_for_tenant(request, policy_id)
@@ -499,7 +499,7 @@ async def disable_conditional_access_policy(request: Request, policy_id: str) ->
     return {"schema_version": "agent.identity.conditional.v1", "policy": policy.to_public_dict()}
 
 
-@router.post("/v1/conditional-access-policies/{policy_id}/enable", dependencies=[_dep("config")])
+@router.post("/conditional-access-policies/{policy_id}/enable", dependencies=[_dep("config")])
 async def enable_conditional_access_policy(request: Request, policy_id: str) -> dict[str, object]:
     """Re-enable a previously disabled conditional-access policy."""
     _conditional_policy_for_tenant(request, policy_id)
@@ -516,7 +516,7 @@ async def enable_conditional_access_policy(request: Request, policy_id: str) -> 
     return {"schema_version": "agent.identity.conditional.v1", "policy": policy.to_public_dict()}
 
 
-@router.get("/v1/conditional-access-policies", dependencies=[_dep("read")])
+@router.get("/conditional-access-policies", dependencies=[_dep("read")])
 async def list_conditional_access_policies(request: Request, include_disabled: bool = False, limit: int = 200) -> dict[str, object]:
     """List conditional-access policies for the active tenant."""
     tenant_id = _tenant(request)
@@ -530,14 +530,14 @@ async def list_conditional_access_policies(request: Request, include_disabled: b
     }
 
 
-@router.get("/v1/conditional-access-policies/{policy_id}", dependencies=[_dep("read")])
+@router.get("/conditional-access-policies/{policy_id}", dependencies=[_dep("read")])
 async def get_conditional_access_policy(request: Request, policy_id: str) -> dict[str, object]:
     """Return one conditional-access policy."""
     policy = _conditional_policy_for_tenant(request, policy_id)
     return {"schema_version": "agent.identity.conditional.v1", "policy": policy.to_public_dict()}
 
 
-@router.post("/v1/identities/discover", dependencies=[_dep("read")])
+@router.post("/identities/discover", dependencies=[_dep("read")])
 async def discover_non_human_identities(request: Request, body: dict | None = None) -> dict[str, object]:
     """Discover non-human identities (service accounts / principals) from IdPs.
 
@@ -588,7 +588,7 @@ async def discover_non_human_identities(request: Request, body: dict | None = No
     }
 
 
-@router.get("/v1/identities", dependencies=[_dep("read")])
+@router.get("/identities", dependencies=[_dep("read")])
 async def list_agent_identities(request: Request, include_inactive: bool = False, limit: int = 200) -> dict[str, object]:
     """List managed agent identities for the active tenant (metadata only)."""
     tenant_id = _tenant(request)
@@ -625,7 +625,7 @@ def _discover_nhi_subjects() -> list[dict[str, object]]:
     return list(merged.get("identities", []))
 
 
-@router.post("/v1/identities/access-reviews", status_code=201, dependencies=[_dep("config")])
+@router.post("/identities/access-reviews", status_code=201, dependencies=[_dep("config")])
 async def create_access_review(request: Request, body: dict | None = None) -> dict[str, object]:
     """Create a scheduled access-review / recertification campaign over NHIs.
 
@@ -702,7 +702,7 @@ async def create_access_review(request: Request, body: dict | None = None) -> di
     }
 
 
-@router.get("/v1/identities/access-reviews", dependencies=[_dep("read")])
+@router.get("/identities/access-reviews", dependencies=[_dep("read")])
 async def list_access_reviews(request: Request, limit: int = 200) -> dict[str, object]:
     """List access-review campaigns for the active tenant (overdue refreshed)."""
     from agent_bom.api.access_review import get_access_review_store, refresh_campaign_status
@@ -720,7 +720,7 @@ async def list_access_reviews(request: Request, limit: int = 200) -> dict[str, o
     }
 
 
-@router.get("/v1/identities/access-reviews/{campaign_id}", dependencies=[_dep("read")])
+@router.get("/identities/access-reviews/{campaign_id}", dependencies=[_dep("read")])
 async def get_access_review(request: Request, campaign_id: str) -> dict[str, object]:
     """Return one access-review campaign and its review items."""
     from agent_bom.api.access_review import get_access_review_store, refresh_campaign_status
@@ -739,7 +739,7 @@ async def get_access_review(request: Request, campaign_id: str) -> dict[str, obj
     }
 
 
-@router.post("/v1/identities/access-reviews/{campaign_id}/items/{item_id}/decision", dependencies=[_dep("config")])
+@router.post("/identities/access-reviews/{campaign_id}/items/{item_id}/decision", dependencies=[_dep("config")])
 async def submit_access_review_decision(request: Request, campaign_id: str, item_id: str, body: dict) -> dict[str, object]:
     """Record a reviewer decision (attest / revoke_recommended / flag) on one item.
 
@@ -793,7 +793,7 @@ async def submit_access_review_decision(request: Request, campaign_id: str, item
     }
 
 
-@router.get("/v1/identities/access-reviews/{campaign_id}/evidence", dependencies=[_dep("read")])
+@router.get("/identities/access-reviews/{campaign_id}/evidence", dependencies=[_dep("read")])
 async def export_access_review_evidence(request: Request, campaign_id: str) -> dict[str, object]:
     """Export a non-secret, signable evidence bundle for one campaign."""
     from agent_bom.api.access_review import export_evidence, get_access_review_store
@@ -807,7 +807,7 @@ async def export_access_review_evidence(request: Request, campaign_id: str) -> d
 
 # Declared last so the ``access-reviews`` static routes above take precedence
 # over this single-identity catch-all.
-@router.get("/v1/identities/{identity_id}", dependencies=[_dep("read")])
+@router.get("/identities/{identity_id}", dependencies=[_dep("read")])
 async def get_agent_identity(request: Request, identity_id: str) -> dict[str, object]:
     """Return one agent identity's lifecycle status (metadata only)."""
     identity = get_agent_identity_store().get(identity_id)

--- a/src/agent_bom/api/routes/intel.py
+++ b/src/agent_bom/api/routes/intel.py
@@ -33,14 +33,14 @@ class IntelDailyBriefRequest(BaseModel):
     limit: int = Field(default=100, ge=1, le=500)
 
 
-@router.get("/v1/intel/sources", tags=["intel"])
+@router.get("/intel/sources", tags=["intel"])
 async def get_intel_sources() -> dict[str, Any]:
     """Return canonical threat-intel source and feed-run metadata."""
 
     return list_intel_sources()
 
 
-@router.get("/v1/intel/advisories/{advisory_id}", tags=["intel"])
+@router.get("/intel/advisories/{advisory_id}", tags=["intel"])
 async def get_intel_advisory(advisory_id: str) -> dict[str, Any]:
     """Look up one CVE/GHSA/OSV advisory from local intel."""
 
@@ -50,7 +50,7 @@ async def get_intel_advisory(advisory_id: str) -> dict[str, Any]:
         raise HTTPException(status_code=422, detail=sanitize_error(exc)) from exc
 
 
-@router.post("/v1/intel/match", tags=["intel"])
+@router.post("/intel/match", tags=["intel"])
 async def post_intel_match(
     body: IntelPackageMatchRequest,
     include_unmatched: Annotated[bool, Query(description="Return packages with zero matched advisories.")] = True,
@@ -66,7 +66,7 @@ async def post_intel_match(
     return result
 
 
-@router.post("/v1/intel/daily-brief", tags=["intel"])
+@router.post("/intel/daily-brief", tags=["intel"])
 async def post_intel_daily_brief(body: IntelDailyBriefRequest) -> dict[str, Any]:
     """Return a local analyst threat brief from governed intel sources."""
 

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -45,6 +45,7 @@ from agent_bom.security import (
 )
 
 router = APIRouter()
+infra_router = APIRouter()
 _logger = logging.getLogger(__name__)
 
 
@@ -455,7 +456,7 @@ def _persist_llm_costs(body: dict, *, tenant_id: str) -> dict[str, Any]:
     return {"calls": len(calls), "cost_usd": round(total, 6)}
 
 
-@router.post("/v1/traces", tags=["observability"])
+@router.post("/traces", tags=["observability"])
 async def ingest_traces(request: Request, body: dict) -> dict:
     """Ingest OpenTelemetry trace data and flag vulnerable tool calls.
 
@@ -554,7 +555,7 @@ async def ingest_traces(request: Request, body: dict) -> dict:
         raise HTTPException(status_code=500, detail=sanitize_error(exc)) from exc
 
 
-@router.post("/v1/results/push", tags=["push"], status_code=201)
+@router.post("/results/push", tags=["push"], status_code=201)
 async def receive_push(request: Request, body: PushPayload) -> dict:
     """Receive pushed scan results from a CLI instance.
 
@@ -586,7 +587,7 @@ async def receive_push(request: Request, body: PushPayload) -> dict:
     return {"job_id": job.job_id, "source_id": body.source_id, "status": "stored"}
 
 
-@router.post("/v1/ocsf/ingest", tags=["observability"], status_code=202)
+@router.post("/ocsf/ingest", tags=["observability"], status_code=202)
 async def ingest_ocsf(request: Request, body: dict | list[dict]) -> dict:
     """Ingest OCSF events and normalize them onto the canonical runtime-event path."""
     from agent_bom.api.audit_log import log_action
@@ -628,7 +629,7 @@ async def ingest_ocsf(request: Request, body: dict | list[dict]) -> dict:
     }
 
 
-@router.post("/v1/runtime/events", tags=["runtime", "observability"], status_code=202, dependencies=[_dep("runtime_ingest")])
+@router.post("/runtime/events", tags=["runtime", "observability"], status_code=202, dependencies=[_dep("runtime_ingest")])
 async def ingest_runtime_events(request: Request, body: dict | list[dict]) -> dict[str, object]:
     """Persist metadata-only runtime observations for tenant-scoped querying."""
     tenant_id = _tenant_id(request)
@@ -650,7 +651,7 @@ async def ingest_runtime_events(request: Request, body: dict | list[dict]) -> di
     }
 
 
-@router.get("/v1/runtime/sessions", tags=["runtime", "observability"], dependencies=[_dep("read")])
+@router.get("/runtime/sessions", tags=["runtime", "observability"], dependencies=[_dep("read")])
 async def list_runtime_sessions(
     request: Request,
     limit: int = 100,
@@ -671,7 +672,7 @@ async def list_runtime_sessions(
     }
 
 
-@router.get("/v1/runtime/observations", tags=["runtime", "observability"], dependencies=[_dep("read")])
+@router.get("/runtime/observations", tags=["runtime", "observability"], dependencies=[_dep("read")])
 async def list_runtime_observations(
     request: Request,
     session_id: str | None = None,
@@ -698,7 +699,7 @@ async def list_runtime_observations(
     }
 
 
-@router.get("/v1/runtime/trace-explorer", tags=["runtime", "observability"], dependencies=[_dep("read")])
+@router.get("/runtime/trace-explorer", tags=["runtime", "observability"], dependencies=[_dep("read")])
 async def trace_explorer(
     request: Request,
     limit: int = 100,
@@ -778,7 +779,7 @@ async def _trace_explorer_payload_for_tenant(tenant_id: str, *, limit: int = 100
     )
 
 
-@router.get("/v1/runtime/approval-queue", tags=["runtime", "observability"], dependencies=[_dep("read")])
+@router.get("/runtime/approval-queue", tags=["runtime", "observability"], dependencies=[_dep("read")])
 async def runtime_approval_queue(
     request: Request,
     status: str | None = None,
@@ -818,7 +819,7 @@ class _HitlDecisionBody(BaseModel):
 
 
 @router.post(
-    "/v1/runtime/approval-queue/{item_id}/decision",
+    "/runtime/approval-queue/{item_id}/decision",
     tags=["runtime", "observability"],
     dependencies=[_dep("policy.manage")],
 )
@@ -872,7 +873,7 @@ async def runtime_approval_decision(request: Request, item_id: str, body: _HitlD
     }
 
 
-@router.get("/v1/runtime/sessions/{session_id}/observations", tags=["runtime", "observability"], dependencies=[_dep("read")])
+@router.get("/runtime/sessions/{session_id}/observations", tags=["runtime", "observability"], dependencies=[_dep("read")])
 async def list_runtime_session_observations(
     request: Request,
     session_id: str,
@@ -899,7 +900,7 @@ async def list_runtime_session_observations(
     }
 
 
-@router.post("/v1/ui/errors", tags=["observability"], dependencies=[_dep("read")])
+@router.post("/ui/errors", tags=["observability"], dependencies=[_dep("read")])
 async def ingest_ui_error(request: Request, body: dict) -> dict:
     """Ingest a sanitized client-side dashboard error report."""
     from agent_bom.api.audit_log import log_action
@@ -971,12 +972,12 @@ async def _render_prometheus_metrics(request: Request | None = None):
         return Response("# No metrics available\n", media_type="text/plain; version=0.0.4; charset=utf-8")
 
 
-@router.get("/metrics", tags=["observability"], dependencies=[_dep("read")])
+@infra_router.get("/metrics", tags=["observability"], dependencies=[_dep("read")])
 async def prometheus_metrics(request: Request):
     return await _render_prometheus_metrics(request)
 
 
-@router.get("/v1/observability/costs", tags=["observability", "finops"], dependencies=[_dep("read")])
+@router.get("/observability/costs", tags=["observability", "finops"], dependencies=[_dep("read")])
 async def get_llm_costs(
     request: Request,
     agent: str | None = None,
@@ -1025,7 +1026,7 @@ async def get_llm_costs(
     return report
 
 
-@router.get("/v1/observability/costs/budget", tags=["observability", "finops"], dependencies=[_dep("read")])
+@router.get("/observability/costs/budget", tags=["observability", "finops"], dependencies=[_dep("read")])
 async def get_llm_cost_budget(request: Request, agent: str = "", cost_center: str = "") -> dict[str, object]:
     """Return the configured spend budget and current utilization.
 
@@ -1045,7 +1046,7 @@ async def get_llm_cost_budget(request: Request, agent: str = "", cost_center: st
     return {"schema_version": "observability.costs.v1", "tenant_id": tenant_id, **budget_status(spend, budget)}
 
 
-@router.put("/v1/observability/costs/budget", tags=["observability", "finops"], dependencies=[_dep("config")])
+@router.put("/observability/costs/budget", tags=["observability", "finops"], dependencies=[_dep("config")])
 async def set_llm_cost_budget(request: Request, body: dict) -> dict[str, object]:
     """Set a USD spend cap. Body: {limit_usd, agent?, cost_center?, mode?}.
 
@@ -1090,7 +1091,7 @@ async def set_llm_cost_budget(request: Request, body: dict) -> dict[str, object]
     }
 
 
-@router.get("/v1/observability/costs/forecast", tags=["observability", "finops"], dependencies=[_dep("read")])
+@router.get("/observability/costs/forecast", tags=["observability", "finops"], dependencies=[_dep("read")])
 async def get_llm_cost_forecast(request: Request, agent: str | None = None, limit: int = 10000) -> dict[str, object]:
     """Project LLM spend burn rate and budget runway for the active tenant.
 
@@ -1107,7 +1108,7 @@ async def get_llm_cost_forecast(request: Request, agent: str | None = None, limi
     return forecast_for_tenant(_tenant_id(request), agent=scoped_agent, limit=bounded_limit)
 
 
-@router.get("/v1/observability/anomalies", tags=["observability", "finops"], dependencies=[_dep("read")])
+@router.get("/observability/anomalies", tags=["observability", "finops"], dependencies=[_dep("read")])
 async def get_anomalies(request: Request, z_threshold: float = 3.0) -> dict[str, object]:
     """Detect cost and behavior anomalies (per-agent spend + per-session call-rate
     z-scores) for the active tenant. Proactive surfacing of runaway agents."""

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -342,7 +342,7 @@ def _identity_snapshot(request: Request) -> dict[str, Any]:
     }
 
 
-@router.get("/v1/overview", tags=["overview"])
+@router.get("/overview", tags=["overview"])
 async def get_overview(request: Request) -> dict[str, Any]:
     """Cross-domain posture snapshot for the unified landing page.
 

--- a/src/agent_bom/api/routes/plugins.py
+++ b/src/agent_bom/api/routes/plugins.py
@@ -9,7 +9,7 @@ from agent_bom.plugin_entrypoints import plugin_registry_status
 router = APIRouter()
 
 
-@router.get("/v1/plugins/status", tags=["plugins"])
+@router.get("/plugins/status", tags=["plugins"])
 def get_plugin_registry_status() -> dict[str, object]:
     """Return metadata-only plugin registry status for operator dashboards."""
 

--- a/src/agent_bom/api/routes/posture_streaming.py
+++ b/src/agent_bom/api/routes/posture_streaming.py
@@ -40,7 +40,7 @@ def set_posture_webhook_outbox(outbox: WebhookOutbox | None) -> None:
     _OUTBOX_OVERRIDE = outbox is not None
 
 
-@router.get("/v1/posture/webhooks/outbox", tags=["posture"])
+@router.get("/posture/webhooks/outbox", tags=["posture"])
 async def list_posture_webhook_outbox(
     request: Request,
     status: str | None = Query(default=None, pattern="^(pending|delivered|dead_letter)$"),
@@ -64,13 +64,13 @@ async def list_posture_webhook_outbox(
     }
 
 
-@router.get("/v1/posture/webhooks/outbox/stats", tags=["posture"])
+@router.get("/posture/webhooks/outbox/stats", tags=["posture"])
 async def get_posture_webhook_outbox_stats(request: Request) -> dict:
     """Return webhook outbox status counts for the current tenant."""
     return {"schema_version": "v1", "stats": get_posture_webhook_outbox().stats(tenant_id=_tenant_id(request))}
 
 
-@router.post("/v1/posture/webhooks/outbox/{row_id}/retry", tags=["posture"], status_code=202)
+@router.post("/posture/webhooks/outbox/{row_id}/retry", tags=["posture"], status_code=202)
 async def retry_posture_webhook_outbox_record(request: Request, row_id: int) -> dict:
     """Requeue one dead-lettered webhook row for the current tenant."""
     tenant_id = _tenant_id(request)

--- a/src/agent_bom/api/routes/privacy.py
+++ b/src/agent_bom/api/routes/privacy.py
@@ -181,7 +181,7 @@ def _delete_records(tenant_id: str) -> dict[str, int]:
     return deleted
 
 
-@router.get("/v1/tenant/{tenant_id}/data", dependencies=[_dep("config")])
+@router.get("/tenant/{tenant_id}/data", dependencies=[_dep("config")])
 def export_tenant_data(
     tenant_id: str,
     request: Request,
@@ -202,7 +202,7 @@ def export_tenant_data(
     return payload
 
 
-@router.delete("/v1/tenant/{tenant_id}/data", dependencies=[_dep("config")])
+@router.delete("/tenant/{tenant_id}/data", dependencies=[_dep("config")])
 def delete_tenant_data(
     tenant_id: str,
     request: Request,

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -34,6 +34,7 @@ from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.security import sanitize_error, sanitize_sensitive_payload
 
 router = APIRouter()
+ws_router = APIRouter()
 
 # ── In-process ring buffer for proxy alerts/metrics ──────────────────────────
 #
@@ -903,7 +904,7 @@ async def _ws_accept_and_check_auth(websocket: WebSocket) -> _WebSocketAuthConte
     return None
 
 
-@router.websocket("/ws/proxy/metrics")
+@ws_router.websocket("/ws/proxy/metrics")
 async def ws_proxy_metrics(websocket: WebSocket) -> None:
     """WebSocket endpoint — push proxy metrics every second.
 
@@ -972,7 +973,7 @@ async def ws_proxy_metrics(websocket: WebSocket) -> None:
         pass
 
 
-@router.websocket("/ws/proxy/alerts")
+@ws_router.websocket("/ws/proxy/alerts")
 async def ws_proxy_alerts(websocket: WebSocket) -> None:
     """WebSocket endpoint — push new proxy alerts as they arrive.
 

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -128,7 +128,7 @@ def _alert_visible_to_tenant(alert: dict, tenant_id: str) -> bool:
     return alert_tenant == tenant_id
 
 
-@router.post("/v1/proxy/audit", tags=["proxy"])
+@router.post("/proxy/audit", tags=["proxy"])
 async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) -> dict:
     """Ingest alerts and summary from an external proxy process."""
     from agent_bom.api.audit_log import log_action
@@ -622,7 +622,7 @@ def _read_metrics_from_log(path: _Path, tenant_id: str = "default") -> dict | No
 # ── HTTP endpoints ───────────────────────────────────────────────────────────
 
 
-@router.get("/v1/proxy/status", tags=["proxy"])
+@router.get("/proxy/status", tags=["proxy"])
 async def proxy_status(request: Request) -> dict:
     """Get runtime proxy metrics.
 
@@ -657,7 +657,7 @@ async def proxy_status(request: Request) -> dict:
     }
 
 
-@router.get("/v1/runtime/production-index", tags=["runtime", "proxy"])
+@router.get("/runtime/production-index", tags=["runtime", "proxy"])
 async def runtime_production_index(request: Request) -> dict:
     """Return tenant-scoped runtime security observability for proxy/gateway traffic.
 
@@ -672,7 +672,7 @@ async def runtime_production_index(request: Request) -> dict:
     return _build_runtime_production_index(tenant_id, metrics, alerts)
 
 
-@router.get("/v1/proxy/alerts", tags=["proxy"])
+@router.get("/proxy/alerts", tags=["proxy"])
 async def proxy_alerts(
     request: Request,
     severity: str | None = None,
@@ -1034,7 +1034,7 @@ def _get_engine(tenant_id: str, session_id: str) -> ProtectionEngine | None:
     return _shield_engines.get(_shield_key(tenant_id, session_id))
 
 
-@router.post("/v1/shield/start", tags=["shield"])
+@router.post("/shield/start", tags=["shield"])
 async def shield_start(request: Request, session_id: str = "default", correlation_window: float = 30.0) -> dict:
     """Start the deep defense protection engine for a session.
 
@@ -1089,7 +1089,7 @@ async def shield_start(request: Request, session_id: str = "default", correlatio
     return {"status": "started", "tenant_id": tenant_id, "session_id": session_id, **engine.status()}
 
 
-@router.get("/v1/shield/status", tags=["shield"])
+@router.get("/shield/status", tags=["shield"])
 async def shield_status(request: Request, session_id: str = "default") -> dict:
     """Get current shield threat assessment for a session."""
     tenant_id = _request_tenant_id(request)
@@ -1117,7 +1117,7 @@ async def shield_status(request: Request, session_id: str = "default") -> dict:
     }
 
 
-@router.post("/v1/shield/unblock", tags=["shield"])
+@router.post("/shield/unblock", tags=["shield"])
 async def shield_unblock(request: Request, session_id: str = "default") -> dict:
     """Deactivate kill-switch for a session and reset to ELEVATED."""
     tenant_id = _request_tenant_id(request)
@@ -1132,7 +1132,7 @@ async def shield_unblock(request: Request, session_id: str = "default") -> dict:
     return {"status": "unblocked", "tenant_id": tenant_id, "session_id": session_id, **engine.status()}
 
 
-@router.post("/v1/shield/break-glass", tags=["shield"])
+@router.post("/shield/break-glass", tags=["shield"])
 async def break_glass(request: Request, session_id: str = "default", reason: str = "") -> dict:
     """Emergency kill-switch override — admin only, audit logged.
 

--- a/src/agent_bom/api/routes/reports.py
+++ b/src/agent_bom/api/routes/reports.py
@@ -59,7 +59,7 @@ def _enforce_active_report_quota(tenant_id: str) -> None:
         )
 
 
-@router.post("/v1/reports", tags=["reports"], status_code=202)
+@router.post("/reports", tags=["reports"], status_code=202)
 async def create_report_job(request: Request, body: ReportJobRequest) -> dict:
     """Enqueue an async findings export (gzipped NDJSON) instead of a synchronous body."""
     tenant_id = _tenant_id(request)
@@ -78,7 +78,7 @@ async def create_report_job(request: Request, body: ReportJobRequest) -> dict:
     return _job_payload(job, request=request)
 
 
-@router.get("/v1/reports/{job_id}", tags=["reports"])
+@router.get("/reports/{job_id}", tags=["reports"])
 async def get_report_job(request: Request, job_id: str) -> dict:
     """Return async report job status and download URL when complete."""
     tenant_id = _tenant_id(request)
@@ -88,7 +88,7 @@ async def get_report_job(request: Request, job_id: str) -> dict:
     return _job_payload(job, request=request)
 
 
-@router.get("/v1/reports/{job_id}/download", tags=["reports"], name="download_report_artifact")
+@router.get("/reports/{job_id}/download", tags=["reports"], name="download_report_artifact")
 async def download_report_artifact(
     request: Request,
     job_id: str,

--- a/src/agent_bom/api/routes/runtime_blueprints.py
+++ b/src/agent_bom/api/routes/runtime_blueprints.py
@@ -29,7 +29,7 @@ def _actor(request: Request) -> str:
     return getattr(getattr(request, "state", None), "actor", None) or "api"
 
 
-@router.get("/v1/runtime/blueprints", dependencies=[_dep("read")])
+@router.get("/runtime/blueprints", dependencies=[_dep("read")])
 async def list_runtime_blueprints(request: Request) -> dict[str, object]:
     """Return canonical role/profile blueprints for runtime policy design."""
     return {
@@ -39,7 +39,7 @@ async def list_runtime_blueprints(request: Request) -> dict[str, object]:
     }
 
 
-@router.get("/v1/runtime/blueprints/{blueprint_id}", dependencies=[_dep("read")])
+@router.get("/runtime/blueprints/{blueprint_id}", dependencies=[_dep("read")])
 async def get_runtime_blueprint(request: Request, blueprint_id: str) -> dict[str, object]:
     """Return one canonical role/profile blueprint by ID."""
     blueprint = runtime_role_blueprint(blueprint_id)
@@ -52,7 +52,7 @@ async def get_runtime_blueprint(request: Request, blueprint_id: str) -> dict[str
     }
 
 
-@router.get("/v1/runtime/blueprints/{blueprint_id}/drift", dependencies=[_dep("read")])
+@router.get("/runtime/blueprints/{blueprint_id}/drift", dependencies=[_dep("read")])
 async def get_runtime_blueprint_drift(request: Request, blueprint_id: str) -> dict[str, object]:
     """Evaluate current runtime posture against one role/profile blueprint."""
     from agent_bom.api.routes.proxy import _build_runtime_production_index, _load_proxy_alerts, _runtime_metrics_for_tenant
@@ -90,7 +90,7 @@ async def get_runtime_blueprint_drift(request: Request, blueprint_id: str) -> di
     return result
 
 
-@router.get("/v1/runtime/drift/incidents", dependencies=[_dep("read")])
+@router.get("/runtime/drift/incidents", dependencies=[_dep("read")])
 async def list_drift_incidents(request: Request, include_resolved: bool = False, limit: int = 200) -> dict[str, object]:
     """List open (or all) blueprint-drift incidents for the active tenant."""
     tenant_id = _request_tenant_id(request)
@@ -105,7 +105,7 @@ async def list_drift_incidents(request: Request, include_resolved: bool = False,
     }
 
 
-@router.post("/v1/runtime/drift/incidents/{incident_id}/resolve", dependencies=[_dep("config")])
+@router.post("/runtime/drift/incidents/{incident_id}/resolve", dependencies=[_dep("config")])
 async def resolve_drift_incident(request: Request, incident_id: str, body: dict | None = None) -> dict[str, object]:
     """Resolve a drift incident once the blueprint/agent has been reconciled."""
     tenant_id = _request_tenant_id(request)

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -897,7 +897,7 @@ def enqueue_scan_job(
 # ─── Core Scan Endpoints ─────────────────────────────────────────────────────
 
 
-@router.post("/v1/scan", response_model=ScanJob, status_code=202, tags=["scan"])
+@router.post("/scan", response_model=ScanJob, status_code=202, tags=["scan"])
 async def create_scan(request: Request, body: ScanRequest) -> ScanJob:
     """Start a scan. Returns immediately with a job_id.
     Poll GET /v1/scan/{job_id} for results, or stream via /v1/scan/{job_id}/stream.
@@ -946,7 +946,7 @@ async def create_scan(request: Request, body: ScanRequest) -> ScanJob:
     return job
 
 
-@router.get("/v1/scan/drivers", tags=["scan"])
+@router.get("/scan/drivers", tags=["scan"])
 async def list_scan_drivers(include_planned: bool = True) -> dict:
     """List scanner driver contracts and orchestration semantics."""
 
@@ -963,19 +963,19 @@ async def list_scan_drivers(include_planned: bool = True) -> dict:
     }
 
 
-@router.get("/v1/scan/{job_id}", response_model=ScanJob, tags=["scan"])
+@router.get("/scan/{job_id}", response_model=ScanJob, tags=["scan"])
 async def get_scan(request: Request, job_id: str) -> ScanJob:
     """Fetch scan status and full results."""
     return _job_response_payload(_job_for_request(request, job_id))
 
 
-@router.get("/v1/scan/{job_id}/status", tags=["scan"])
+@router.get("/scan/{job_id}/status", tags=["scan"])
 async def get_scan_status(request: Request, job_id: str) -> dict[str, Any]:
     """Poll lightweight scan status without serializing large result payloads."""
     return _job_summary_payload(_job_for_request(request, job_id))
 
 
-@router.get("/v1/scan/{job_id}/attack-flow", tags=["scan"])
+@router.get("/scan/{job_id}/attack-flow", tags=["scan"])
 async def get_attack_flow(
     request: Request,
     job_id: str,
@@ -1014,7 +1014,7 @@ async def get_attack_flow(
     )
 
 
-@router.get("/v1/scan/{job_id}/context-graph", tags=["scan"])
+@router.get("/scan/{job_id}/context-graph", tags=["scan"])
 async def get_context_graph(request: Request, job_id: str, agent: str | None = None) -> dict:
     """Get the agent context graph with lateral movement analysis.
 
@@ -1032,7 +1032,7 @@ async def get_context_graph(request: Request, job_id: str, agent: str | None = N
     return await _scan_graph_compute_call(_context_graph_payload, job.result, agent=agent, scan_id=job.job_id, tenant_id=tenant_id)
 
 
-@router.get("/v1/scan/{job_id}/graph-export", tags=["scan"], response_model=None)
+@router.get("/scan/{job_id}/graph-export", tags=["scan"], response_model=None)
 async def get_graph_export(
     request: Request,
     job_id: str,
@@ -1064,7 +1064,7 @@ async def get_graph_export(
     return await _scan_graph_compute_call(_graph_export_response, result, format=format, mermaid_limit=mermaid_limit)
 
 
-@router.get("/v1/scan/{job_id}/licenses", tags=["scan"])
+@router.get("/scan/{job_id}/licenses", tags=["scan"])
 async def get_licenses(request: Request, job_id: str) -> dict:
     """Get the license compliance report for a completed scan.
 
@@ -1111,7 +1111,7 @@ async def get_licenses(request: Request, job_id: str) -> dict:
     return _lic_ser(lic_report)
 
 
-@router.get("/v1/scan/{job_id}/vex", tags=["scan"])
+@router.get("/scan/{job_id}/vex", tags=["scan"])
 async def get_vex(request: Request, job_id: str) -> dict:
     """Get the VEX (Vulnerability Exploitability eXchange) document for a completed scan.
 
@@ -1130,7 +1130,7 @@ async def get_vex(request: Request, job_id: str) -> dict:
     return {"statements": [], "stats": {"total_statements": 0, "affected": 0, "not_affected": 0, "fixed": 0, "under_investigation": 0}}
 
 
-@router.get("/v1/scan/{job_id}/skill-audit", tags=["scan"])
+@router.get("/scan/{job_id}/skill-audit", tags=["scan"])
 async def get_skill_audit(request: Request, job_id: str) -> dict:
     """Get the skill security audit results for a completed scan.
 
@@ -1155,7 +1155,7 @@ async def get_skill_audit(request: Request, job_id: str) -> dict:
     )
 
 
-@router.delete("/v1/scan/{job_id}", status_code=204, tags=["scan"])
+@router.delete("/scan/{job_id}", status_code=204, tags=["scan"])
 async def delete_scan(request: Request, job_id: str) -> None:
     """Discard a job record."""
     job = _job_for_request(request, job_id)
@@ -1165,7 +1165,7 @@ async def delete_scan(request: Request, job_id: str) -> None:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
 
 
-@router.get("/v1/scan/{job_id}/stream", tags=["scan"])
+@router.get("/scan/{job_id}/stream", tags=["scan"])
 async def stream_scan(request: Request, job_id: str):
     """Server-Sent Events stream for real-time scan progress.
 
@@ -1221,7 +1221,7 @@ async def stream_scan(request: Request, job_id: str):
     return EventSourceResponse(event_generator())
 
 
-@router.get("/v1/jobs", tags=["scan"])
+@router.get("/jobs", tags=["scan"])
 async def list_jobs(
     request: Request,
     # enforce limit/offset caps via Pydantic so callers
@@ -1432,7 +1432,7 @@ def _merged_scan_bulk_page(
     return page
 
 
-@router.get("/v1/findings", tags=["scan"])
+@router.get("/findings", tags=["scan"])
 async def list_findings(
     request: Request,
     severity: str | None = None,
@@ -1614,7 +1614,7 @@ async def list_findings(
     return response
 
 
-@router.post("/v1/findings/bulk", tags=["scan"], status_code=201)
+@router.post("/findings/bulk", tags=["scan"], status_code=201)
 async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> dict:
     """Append normalized findings for the request tenant.
 
@@ -1730,7 +1730,7 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
     return response
 
 
-@router.get("/v1/inventory", tags=["scan"])
+@router.get("/inventory", tags=["scan"])
 async def list_inventory(
     request: Request,
     # enforce limit cap server-side via Pydantic.
@@ -1772,7 +1772,7 @@ async def list_inventory(
 # Each returns results directly (no job queue — these are fast local scans).
 
 
-@router.post("/v1/scan/dataset-cards", tags=["scan"], status_code=200)
+@router.post("/scan/dataset-cards", tags=["scan"], status_code=200)
 async def scan_dataset_cards(request: DatasetCardsRequest) -> dict:
     """Scan directories for HuggingFace dataset cards, DVC files, and data lineage.
 
@@ -1792,7 +1792,7 @@ async def scan_dataset_cards(request: DatasetCardsRequest) -> dict:
     return {"scan_type": "dataset-cards", "directories": safe_dirs, "results": results}
 
 
-@router.post("/v1/scan/training-pipelines", tags=["scan"], status_code=200)
+@router.post("/scan/training-pipelines", tags=["scan"], status_code=200)
 async def scan_training_pipelines(request: TrainingPipelinesRequest) -> dict:
     """Scan directories for ML training pipeline artifacts.
 
@@ -1812,7 +1812,7 @@ async def scan_training_pipelines(request: TrainingPipelinesRequest) -> dict:
     return {"scan_type": "training-pipelines", "directories": safe_dirs, "results": results}
 
 
-@router.post("/v1/scan/browser-extensions", tags=["scan"], status_code=200)
+@router.post("/scan/browser-extensions", tags=["scan"], status_code=200)
 async def scan_browser_extensions_endpoint(request: BrowserExtensionsRequest) -> dict:
     """Scan installed browser extensions (Chrome, Chromium, Brave, Edge, Firefox).
 
@@ -1833,7 +1833,7 @@ async def scan_browser_extensions_endpoint(request: BrowserExtensionsRequest) ->
     }
 
 
-@router.post("/v1/scan/model-provenance", tags=["scan"], status_code=200)
+@router.post("/scan/model-provenance", tags=["scan"], status_code=200)
 async def scan_model_provenance(request: ModelProvenanceRequest) -> dict:
     """Check model provenance for HuggingFace and Ollama models.
 
@@ -1858,7 +1858,7 @@ async def scan_model_provenance(request: ModelProvenanceRequest) -> dict:
     }
 
 
-@router.post("/v1/scan/prompt-scan", tags=["scan"], status_code=200)
+@router.post("/scan/prompt-scan", tags=["scan"], status_code=200)
 async def scan_prompts(request: PromptScanRequest) -> dict:
     """Scan prompt files for injection patterns, hardcoded secrets, and unsafe instructions.
 
@@ -1887,7 +1887,7 @@ async def scan_prompts(request: PromptScanRequest) -> dict:
     return {"scan_type": "prompt-scan", "results": results}
 
 
-@router.post("/v1/scan/model-files", tags=["scan"], status_code=200)
+@router.post("/scan/model-files", tags=["scan"], status_code=200)
 async def scan_model_files_endpoint(request: ModelFilesRequest) -> dict:
     """Scan directories for ML model files and assess serialization safety.
 

--- a/src/agent_bom/api/routes/schedules.py
+++ b/src/agent_bom/api/routes/schedules.py
@@ -23,7 +23,7 @@ from agent_bom.api.tenant_quota import enforce_schedule_quota, tenant_quota_guar
 router = APIRouter()
 
 
-@router.post("/v1/schedules", tags=["schedules"], status_code=201)
+@router.post("/schedules", tags=["schedules"], status_code=201)
 async def create_schedule(request: Request, body: ScheduleCreate) -> dict:
     """Create a recurring scan schedule."""
     from agent_bom.api.audit_log import log_action
@@ -65,14 +65,14 @@ async def create_schedule(request: Request, body: ScheduleCreate) -> dict:
     return schedule.model_dump()
 
 
-@router.get("/v1/schedules", tags=["schedules"])
+@router.get("/schedules", tags=["schedules"])
 async def list_schedules(request: Request) -> list[dict]:
     """List all scan schedules."""
     tenant_id = require_request_tenant_id(request)
     return [s.model_dump() for s in _get_schedule_store().list_all(tenant_id=tenant_id)]
 
 
-@router.get("/v1/schedules/{schedule_id}", tags=["schedules"])
+@router.get("/schedules/{schedule_id}", tags=["schedules"])
 async def get_schedule(request: Request, schedule_id: str) -> dict:
     """Get a specific schedule."""
     tenant_id = require_request_tenant_id(request)
@@ -82,7 +82,7 @@ async def get_schedule(request: Request, schedule_id: str) -> dict:
     return s.model_dump()
 
 
-@router.delete("/v1/schedules/{schedule_id}", tags=["schedules"], status_code=204)
+@router.delete("/schedules/{schedule_id}", tags=["schedules"], status_code=204)
 async def delete_schedule(request: Request, schedule_id: str):
     """Delete a schedule."""
     from agent_bom.api.audit_log import log_action
@@ -96,7 +96,7 @@ async def delete_schedule(request: Request, schedule_id: str):
     log_action("schedule.delete", actor=actor, resource=f"schedule/{schedule_id}", tenant_id=tenant_id)
 
 
-@router.put("/v1/schedules/{schedule_id}/toggle", tags=["schedules"])
+@router.put("/schedules/{schedule_id}/toggle", tags=["schedules"])
 async def toggle_schedule(request: Request, schedule_id: str) -> dict:
     """Enable or disable a schedule."""
     from agent_bom.api.audit_log import log_action

--- a/src/agent_bom/api/routes/sources.py
+++ b/src/agent_bom/api/routes/sources.py
@@ -108,7 +108,7 @@ def _request_for_source(source: SourceRecord) -> ScanRequest:
         raise HTTPException(status_code=422, detail=exc.errors()) from exc
 
 
-@router.post("/v1/sources", tags=["sources"], status_code=201)
+@router.post("/sources", tags=["sources"], status_code=201)
 async def create_source(request: Request, body: SourceCreate) -> dict:
     tenant_id = _tenant_id(request)
     if body.tenant_id not in ("default", tenant_id):
@@ -144,7 +144,7 @@ async def create_source(request: Request, body: SourceCreate) -> dict:
     return source.model_dump()
 
 
-@router.get("/v1/sources", tags=["sources"])
+@router.get("/sources", tags=["sources"])
 async def list_sources(
     request: Request,
     # cap pagination so hostile callers cannot probe an
@@ -167,12 +167,12 @@ async def list_sources(
     }
 
 
-@router.get("/v1/sources/{source_id}", tags=["sources"])
+@router.get("/sources/{source_id}", tags=["sources"])
 async def get_source(request: Request, source_id: str) -> dict:
     return _source_for_request(request, source_id).model_dump()
 
 
-@router.put("/v1/sources/{source_id}", tags=["sources"])
+@router.put("/sources/{source_id}", tags=["sources"])
 async def update_source(request: Request, source_id: str, body: SourceUpdate) -> dict:
     source = _apply_update(_source_for_request(request, source_id), body)
     _validate_credential_ref(request, source)
@@ -188,7 +188,7 @@ async def update_source(request: Request, source_id: str, body: SourceUpdate) ->
     return source.model_dump()
 
 
-@router.delete("/v1/sources/{source_id}", tags=["sources"], status_code=204)
+@router.delete("/sources/{source_id}", tags=["sources"], status_code=204)
 async def delete_source(request: Request, source_id: str) -> None:
     source = _source_for_request(request, source_id)
     _get_source_store().delete(source_id)
@@ -201,7 +201,7 @@ async def delete_source(request: Request, source_id: str) -> None:
     )
 
 
-@router.post("/v1/sources/{source_id}/test", tags=["sources"])
+@router.post("/sources/{source_id}/test", tags=["sources"])
 async def test_source(request: Request, source_id: str) -> dict:
     source = _source_for_request(request, source_id)
     _validate_credential_ref(request, source)
@@ -255,7 +255,7 @@ async def test_source(request: Request, source_id: str) -> dict:
     }
 
 
-@router.post("/v1/sources/{source_id}/run", tags=["sources"], status_code=202)
+@router.post("/sources/{source_id}/run", tags=["sources"], status_code=202)
 async def run_source(request: Request, source_id: str) -> dict:
     source = _source_for_request(request, source_id)
     if not source.enabled:
@@ -282,7 +282,7 @@ async def run_source(request: Request, source_id: str) -> dict:
     return {"source_id": source.source_id, "job_id": job.job_id, "status": job.status.value}
 
 
-@router.get("/v1/sources/{source_id}/jobs", tags=["sources"])
+@router.get("/sources/{source_id}/jobs", tags=["sources"])
 async def list_source_jobs(request: Request, source_id: str) -> dict:
     source = _source_for_request(request, source_id)
     jobs = [job.model_dump() for job in _get_store().list_all(tenant_id=source.tenant_id) if job.source_id == source.source_id]

--- a/src/agent_bom/api/routes/webhooks.py
+++ b/src/agent_bom/api/routes/webhooks.py
@@ -45,7 +45,7 @@ def _subscription_for_tenant(request: Request, subscription_id: str):
     return subscription
 
 
-@router.post("/v1/webhooks", status_code=201, dependencies=[_dep("config")])
+@router.post("/webhooks", status_code=201, dependencies=[_dep("config")])
 async def create_webhook_subscription(request: Request, body: dict) -> dict[str, object]:
     """Register a governance webhook destination. Returns the signing secret once."""
     url = str(body.get("url", "") or "").strip()
@@ -86,7 +86,7 @@ async def create_webhook_subscription(request: Request, body: dict) -> dict[str,
     }
 
 
-@router.get("/v1/webhooks", dependencies=[_dep("read")])
+@router.get("/webhooks", dependencies=[_dep("read")])
 async def list_webhook_subscriptions(request: Request, include_disabled: bool = False, limit: int = 200) -> dict[str, object]:
     """List governance webhook subscriptions for the active tenant."""
     tenant_id = _tenant(request)
@@ -101,14 +101,14 @@ async def list_webhook_subscriptions(request: Request, include_disabled: bool = 
     }
 
 
-@router.get("/v1/webhooks/{subscription_id}", dependencies=[_dep("read")])
+@router.get("/webhooks/{subscription_id}", dependencies=[_dep("read")])
 async def get_webhook_subscription(request: Request, subscription_id: str) -> dict[str, object]:
     """Return one webhook subscription (without the signing secret)."""
     subscription = _subscription_for_tenant(request, subscription_id)
     return {"schema_version": "webhook.subscription.v1", "subscription": subscription.to_public_dict()}
 
 
-@router.post("/v1/webhooks/{subscription_id}/disable", dependencies=[_dep("config")])
+@router.post("/webhooks/{subscription_id}/disable", dependencies=[_dep("config")])
 async def disable_webhook_subscription(request: Request, subscription_id: str) -> dict[str, object]:
     """Disable a subscription without deleting it."""
     _subscription_for_tenant(request, subscription_id)
@@ -124,7 +124,7 @@ async def disable_webhook_subscription(request: Request, subscription_id: str) -
     return {"schema_version": "webhook.subscription.v1", "subscription": subscription.to_public_dict()}
 
 
-@router.post("/v1/webhooks/{subscription_id}/enable", dependencies=[_dep("config")])
+@router.post("/webhooks/{subscription_id}/enable", dependencies=[_dep("config")])
 async def enable_webhook_subscription(request: Request, subscription_id: str) -> dict[str, object]:
     """Re-enable a disabled subscription."""
     _subscription_for_tenant(request, subscription_id)
@@ -140,7 +140,7 @@ async def enable_webhook_subscription(request: Request, subscription_id: str) ->
     return {"schema_version": "webhook.subscription.v1", "subscription": subscription.to_public_dict()}
 
 
-@router.delete("/v1/webhooks/{subscription_id}", dependencies=[_dep("config")])
+@router.delete("/webhooks/{subscription_id}", dependencies=[_dep("config")])
 async def delete_webhook_subscription(request: Request, subscription_id: str) -> dict[str, object]:
     """Delete a webhook subscription."""
     _subscription_for_tenant(request, subscription_id)
@@ -156,7 +156,7 @@ async def delete_webhook_subscription(request: Request, subscription_id: str) ->
     return {"schema_version": "webhook.subscription.v1", "deleted": True, "subscription_id": subscription_id}
 
 
-@router.post("/v1/webhooks/{subscription_id}/test", dependencies=[_dep("config")])
+@router.post("/webhooks/{subscription_id}/test", dependencies=[_dep("config")])
 async def test_webhook_subscription(request: Request, subscription_id: str) -> dict[str, object]:
     """Enqueue a synthetic ``webhook.test`` event directly to this destination.
 

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -849,6 +849,7 @@ from agent_bom.api.routes.governance import router as _governance_router  # noqa
 from agent_bom.api.routes.graph import router as _graph_router  # noqa: E402
 from agent_bom.api.routes.identities import router as _identities_router  # noqa: E402
 from agent_bom.api.routes.intel import router as _intel_router  # noqa: E402
+from agent_bom.api.routes.observability import infra_router as _observability_infra_router  # noqa: E402
 from agent_bom.api.routes.observability import router as _observability_router  # noqa: E402
 from agent_bom.api.routes.overview import router as _overview_router  # noqa: E402
 from agent_bom.api.routes.plugins import router as _plugins_router  # noqa: E402
@@ -862,41 +863,52 @@ from agent_bom.api.routes.schedules import router as _schedules_router  # noqa: 
 from agent_bom.api.routes.scim import router as _scim_router  # noqa: E402
 from agent_bom.api.routes.sources import router as _sources_router  # noqa: E402
 from agent_bom.api.routes.webhooks import router as _webhooks_router  # noqa: E402
+from agent_bom.api.versioning import create_v1_api_router  # noqa: E402
 
-app.include_router(_assets_router)
-app.include_router(_agent_manifest_router)
-app.include_router(_cloud_router)
-app.include_router(_cloud_connections_router)
-app.include_router(_compliance_router)
-app.include_router(_connectors_router)
-app.include_router(_credentials_router)
-app.include_router(_datasets_router)
-app.include_router(_discovery_router)
-app.include_router(_entitlements_router)
-app.include_router(_estate_router)
-app.include_router(_enterprise_router)
-app.include_router(_fleet_router)
-app.include_router(_evaluations_router)
-app.include_router(_frameworks_router)
-app.include_router(_gateway_router)
-app.include_router(_gateway_feed_router)
-app.include_router(_governance_router)
-app.include_router(_graph_router)
-app.include_router(_identities_router)
-app.include_router(_intel_router)
-app.include_router(_observability_router)
-app.include_router(_overview_router)
-app.include_router(_plugins_router)
-app.include_router(_posture_streaming_router)
-app.include_router(_privacy_router)
-app.include_router(_proxy_router)
-app.include_router(_reports_router)
-app.include_router(_runtime_blueprints_router)
-app.include_router(_scan_router)
-app.include_router(_schedules_router)
+_v1_api_router = create_v1_api_router()
+
+for _router in (
+    _assets_router,
+    _agent_manifest_router,
+    _cloud_router,
+    _cloud_connections_router,
+    _compliance_router,
+    _connectors_router,
+    _credentials_router,
+    _datasets_router,
+    _discovery_router,
+    _entitlements_router,
+    _estate_router,
+    _enterprise_router,
+    _fleet_router,
+    _evaluations_router,
+    _frameworks_router,
+    _gateway_router,
+    _gateway_feed_router,
+    _governance_router,
+    _graph_router,
+    _identities_router,
+    _intel_router,
+    _observability_router,
+    _overview_router,
+    _plugins_router,
+    _posture_streaming_router,
+    _privacy_router,
+    _proxy_router,
+    _reports_router,
+    _runtime_blueprints_router,
+    _scan_router,
+    _schedules_router,
+    _sources_router,
+    _webhooks_router,
+):
+    _v1_api_router.include_router(_router)
+
+app.include_router(_v1_api_router)
+# SCIM base path is RFC-driven (/scim/v2 by default), not under API_V1_PREFIX.
 app.include_router(_scim_router)
-app.include_router(_sources_router)
-app.include_router(_webhooks_router)
+# Prometheus scrape surface stays unversioned (infra contract).
+app.include_router(_observability_infra_router)
 
 # Resolve agent-bom-issued (abi_) identity tokens through the lifecycle store so
 # the proxy/gateway honor issuance, rotation overlap, and revocation.

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -856,6 +856,7 @@ from agent_bom.api.routes.plugins import router as _plugins_router  # noqa: E402
 from agent_bom.api.routes.posture_streaming import router as _posture_streaming_router  # noqa: E402
 from agent_bom.api.routes.privacy import router as _privacy_router  # noqa: E402
 from agent_bom.api.routes.proxy import router as _proxy_router  # noqa: E402
+from agent_bom.api.routes.proxy import ws_router as _proxy_ws_router  # noqa: E402
 from agent_bom.api.routes.reports import router as _reports_router  # noqa: E402
 from agent_bom.api.routes.runtime_blueprints import router as _runtime_blueprints_router  # noqa: E402
 from agent_bom.api.routes.scan import router as _scan_router  # noqa: E402
@@ -909,6 +910,8 @@ app.include_router(_v1_api_router)
 app.include_router(_scim_router)
 # Prometheus scrape surface stays unversioned (infra contract).
 app.include_router(_observability_infra_router)
+# Proxy live streams are root-level WebSocket paths (/ws/proxy/*), not /v1.
+app.include_router(_proxy_ws_router)
 
 # Resolve agent-bom-issued (abi_) identity tokens through the lifecycle store so
 # the proxy/gateway honor issuance, rotation overlap, and revocation.

--- a/src/agent_bom/api/versioning.py
+++ b/src/agent_bom/api/versioning.py
@@ -1,0 +1,18 @@
+"""API version surface helpers.
+
+``API_V1_PREFIX`` is the single source of truth for the public REST version
+segment. Domain route modules declare paths relative to this prefix; ``server``
+mounts the aggregated v1 router once instead of scattering ``/v1`` literals
+across ~30 route files (#3666).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+API_V1_PREFIX = "/v1"
+
+
+def create_v1_api_router() -> APIRouter:
+    """Return the parent router for all versioned public REST endpoints."""
+    return APIRouter(prefix=API_V1_PREFIX)

--- a/tests/test_api_v1_router_prefix.py
+++ b/tests/test_api_v1_router_prefix.py
@@ -25,3 +25,9 @@ def test_versioned_and_infra_paths_unchanged_at_runtime() -> None:
     assert "/v1/findings" in schema_paths
     assert "/metrics" in schema_paths
     assert "/metrics" not in {p for p in schema_paths if p.startswith("/v1/")}
+
+
+def test_proxy_websocket_stays_at_root_unversioned() -> None:
+    client = TestClient(app)
+    with client.websocket_connect("/ws/proxy/metrics"):
+        pass

--- a/tests/test_api_v1_router_prefix.py
+++ b/tests/test_api_v1_router_prefix.py
@@ -1,0 +1,27 @@
+"""Regression: v1 API paths are mounted via a single router prefix (#3666)."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from agent_bom.api.server import app
+from agent_bom.api.versioning import API_V1_PREFIX, create_v1_api_router
+
+
+def test_v1_prefix_constant() -> None:
+    assert API_V1_PREFIX == "/v1"
+
+
+def test_create_v1_api_router_has_prefix() -> None:
+    router = create_v1_api_router()
+    assert router.prefix == API_V1_PREFIX
+
+
+def test_versioned_and_infra_paths_unchanged_at_runtime() -> None:
+    client = TestClient(app)
+    schema_paths = set(client.get("/openapi.json").json()["paths"])
+
+    assert "/v1/health" not in schema_paths
+    assert "/v1/findings" in schema_paths
+    assert "/metrics" in schema_paths
+    assert "/metrics" not in {p for p in schema_paths if p.startswith("/v1/")}


### PR DESCRIPTION
## Summary
- Add `api/versioning.py` with `API_V1_PREFIX` and `create_v1_api_router()` as the single version surface.
- Mount domain route modules under one `/v1` parent router in `server.py`; route decorators now declare paths relative to that prefix.
- Keep SCIM (`/scim/v2` by default) and Prometheus `/metrics` on the app root; update the product surface contract guard for the shared-prefix layout.

Foundation slice of #3666. No wire-contract change: OpenAPI paths and client parity tests are unchanged.

## Verification
- `make preflight`
- `uv run ruff check scripts/check_product_surface_contract.py src/agent_bom/api/server.py src/agent_bom/api/versioning.py tests/test_api_v1_router_prefix.py`
- `uv run pytest -q tests/test_api_v1_router_prefix.py tests/test_openapi_artifact.py tests/test_api_endpoints.py::test_openapi_schema_available tests/test_api_endpoints.py::test_openapi_runtime_routes_do_not_404 tests/test_python_client_route_parity.py tests/test_go_client_route_parity.py tests/test_typescript_client_route_parity.py tests/test_estate_correlations.py tests/test_cis_benchmark_analytics.py` — 32 passed

## Notes
- Root cause: Version Alignment failed because `scripts/check_product_surface_contract.py` still looked for literal `/v1` route decorators after the PR moved `/v1` to the shared parent router.
- Branch was rebased onto current `origin/main` and collapsed to one clean commit.