### PR TITLE
fix(accuracy): git-SHA advisory false positives + malicious packages missing from CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **git-SHA advisory false positives (offline scan)** — the local `db/lookup`
+  matcher no longer conservatively reports advisories whose only bounds are git
+  commit SHAs (OSS-Fuzz / OSV-2022-* rows) against concrete semver versions;
+  such rows are now classified `uncomparable` rather than `unknown`, so e.g.
+  `pillow==11.0.0` stops drawing `OSV-2022-1074` / `OSV-2022-715`. Genuine semver
+  in-range/past-fix matching and mixed SHA-plus-semver sibling rows are
+  unaffected.
+- **Malicious packages missing from CSV/Parquet export** — vuln-less
+  malicious/typosquat packages (synthesized findings) now appear in the CSV and
+  Parquet exports even when CVE findings are present, matching JSON/SARIF, with
+  `is_malicious` and `malicious_reason` populated.
+
 ## [0.94.0] - 2026-07-08
 
 Minor release shipping the post-0.93.5 audit/security batch, cloud and runtime

--- a/src/agent_bom/db/lookup.py
+++ b/src/agent_bom/db/lookup.py
@@ -331,33 +331,51 @@ def _cached_version_match_state(
     intro = introduced or None
     fix = fixed or None
     last = last_affected or None
-    unknown = False
+    # ``ambiguous``: a genuine version-vs-version comparison yielded no ordering
+    # (unusual/unparseable version string) — worth a conservative include.
+    # ``uncomparable``: a bound is a git-commit SHA or other non-version token
+    # that can never establish semver range membership — NOT grounds for
+    # inclusion. Mirrors ``version_utils.version_in_range`` returning False for
+    # SHA bounds so this offline path stops emitting OSS-Fuzz/OSV-2022 false
+    # positives against concrete semver versions.
+    ambiguous = False
+    uncomparable = False
 
     if intro:
-        intro_cmp = compare_version_order(version, intro, ecosystem)
-        if intro_cmp is not None and intro_cmp < 0:
-            return "unaffected"
-        if intro_cmp is None:
-            unknown = True
+        if _looks_like_commit_sha(intro):
+            uncomparable = True
+        else:
+            intro_cmp = compare_version_order(version, intro, ecosystem)
+            if intro_cmp is not None and intro_cmp < 0:
+                return "unaffected"
+            if intro_cmp is None:
+                ambiguous = True
 
     if fix:
         if _looks_like_commit_sha(fix):
-            unknown = True
+            uncomparable = True
         else:
             fix_cmp = compare_version_order(version, fix, ecosystem)
             if fix_cmp is not None and fix_cmp >= 0:
                 return "unaffected"
             if fix_cmp is None:
-                unknown = True
+                ambiguous = True
 
     if last:
-        last_cmp = compare_version_order(version, last, ecosystem)
-        if last_cmp is not None and last_cmp > 0:
-            return "unaffected"
-        if last_cmp is None:
-            unknown = True
+        if _looks_like_commit_sha(last):
+            uncomparable = True
+        else:
+            last_cmp = compare_version_order(version, last, ecosystem)
+            if last_cmp is not None and last_cmp > 0:
+                return "unaffected"
+            if last_cmp is None:
+                ambiguous = True
 
-    return "unknown" if unknown else "affected"
+    if ambiguous:
+        return "unknown"
+    if uncomparable:
+        return "uncomparable"
+    return "affected"
 
 
 def _version_match_state(
@@ -367,7 +385,13 @@ def _version_match_state(
     last_affected: Optional[str],
     ecosystem: str = "",
 ) -> str:
-    """Return ``affected``, ``unaffected``, or ``unknown`` for one affected-range row."""
+    """Classify one affected-range row for a version.
+
+    Returns ``affected`` / ``unaffected`` for a definitive semver comparison,
+    ``unknown`` for a genuine version-vs-version ambiguity (conservatively
+    included), or ``uncomparable`` when a bound is a git SHA / non-version token
+    that can never match a concrete semver (never a reason to include).
+    """
     return _cached_version_match_state(version, introduced, fixed, last_affected, _comparator_ecosystem(ecosystem))
 
 
@@ -378,8 +402,10 @@ def _select_vulnerability_rows(rows: list[sqlite3.Row], version: Optional[str]) 
     include the vulnerability. If no rows match but at least one row
     definitively excludes the version, suppress the vulnerability even if
     sibling rows are ambiguous (for example, duplicate PYSEC rows with git-SHA
-    fix bounds). If all rows are ambiguous, include the first one
-    conservatively.
+    fix bounds). If all rows are genuinely ambiguous, include the first one
+    conservatively. Rows whose only signal is ``uncomparable`` (git-SHA /
+    non-version bounds — e.g. OSV-2022 OSS-Fuzz advisories) are never grounds
+    for inclusion, so a concrete semver version does not draw a false positive.
     """
     if not version:
         grouped_rows: dict[str, list[sqlite3.Row]] = defaultdict(list)

--- a/src/agent_bom/output/csv_fmt.py
+++ b/src/agent_bom/output/csv_fmt.py
@@ -12,9 +12,9 @@ import io
 from agent_bom.compliance_utils import framework_qualified_finding_tags
 from agent_bom.models import AIBOMReport, BlastRadius
 from agent_bom.output.finding_views import (
-    cve_findings,
     evidence,
     is_package_malicious,
+    machine_export_findings,
     package_ecosystem,
     package_name,
     package_version,
@@ -54,7 +54,7 @@ _COLUMNS = [
 
 def to_csv(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> str:
     """Convert an AIBOMReport to CSV string with UTF-8 BOM."""
-    findings = cve_findings(report, blast_radii)
+    findings = machine_export_findings(report, blast_radii)
 
     buf = io.StringIO()
     # UTF-8 BOM for Excel auto-detection

--- a/src/agent_bom/output/finding_views.py
+++ b/src/agent_bom/output/finding_views.py
@@ -19,6 +19,28 @@ def cve_findings(report: AIBOMReport, blast_radii: list[BlastRadius] | None = No
     return [finding for finding in report.to_findings() if finding.finding_type in _MACHINE_EXPORT_TYPES]
 
 
+def machine_export_findings(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> list[Finding]:
+    """Rows for flat machine exports (CSV/Parquet): CVE findings plus synthesized
+    malicious-package findings.
+
+    ``cve_findings`` only includes synthesized malicious (vuln-less typosquat /
+    dep-confusion) findings when there are no BlastRadius rows to override with;
+    once any CVE BlastRadius exists it returns the BlastRadius list alone, so a
+    malicious-only package would silently vanish from CSV/Parquet even though
+    JSON/SARIF (which read ``report.to_findings()``) still surface it. Append the
+    malicious findings that the BlastRadius list doesn't already carry, deduped by
+    finding id, so every export sees the same rows.
+    """
+    findings = cve_findings(report, blast_radii)
+    seen = {getattr(finding, "id", None) for finding in findings}
+    findings.extend(
+        finding
+        for finding in report.to_findings()
+        if finding.finding_type == FindingType.MALICIOUS_PACKAGE and getattr(finding, "id", None) not in seen
+    )
+    return findings
+
+
 def active_cve_findings(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> list[Finding]:
     """Return CVE findings that remain active after VEX suppression."""
     from agent_bom.vex import active_blast_radii

--- a/src/agent_bom/output/parquet_fmt.py
+++ b/src/agent_bom/output/parquet_fmt.py
@@ -12,9 +12,9 @@ from typing import Any
 from agent_bom.compliance_utils import framework_qualified_finding_tags
 from agent_bom.models import AIBOMReport, BlastRadius
 from agent_bom.output.finding_views import (
-    cve_findings,
     evidence,
     is_package_malicious,
+    machine_export_findings,
     package_ecosystem,
     package_name,
     package_version,
@@ -100,7 +100,7 @@ def to_arrow_table(report: AIBOMReport, blast_radii: list[BlastRadius] | None = 
     consumers always see one consistent table shape.
     """
     pa, _ = _require_pyarrow()
-    rows = [_row_dict(finding) for finding in cve_findings(report, blast_radii)]
+    rows = [_row_dict(finding) for finding in machine_export_findings(report, blast_radii)]
     return pa.Table.from_pylist(rows, schema=_schema(pa))
 
 

--- a/tests/test_malicious_export.py
+++ b/tests/test_malicious_export.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import pytest
+
 from agent_bom.finding import FindingType
-from agent_bom.models import Agent, AIBOMReport, MCPServer, Package
+from agent_bom.models import Agent, AIBOMReport, BlastRadius, MCPServer, Package, Severity, Vulnerability
 from agent_bom.output.csv_fmt import to_csv
+from agent_bom.output.finding_views import machine_export_findings
 from agent_bom.output.parquet_fmt import _row_dict
 from agent_bom.policy import evaluate_policy
 
@@ -56,3 +59,57 @@ def test_malicious_parquet_row_has_compliance_tags() -> None:
     row = _row_dict(finding)
     assert row["is_malicious"] is True
     assert row["malicious_reason"]
+
+
+def _report_with_cve_and_malicious() -> AIBOMReport:
+    """A report carrying a CVE BlastRadius *and* a vuln-less malicious package.
+
+    This is the regression case: once a CVE BlastRadius exists the flat exporters
+    used to return only BlastRadius rows, silently dropping the typosquat package.
+    """
+    vulnerable = Package(name="flask", version="0.12.2", ecosystem="pypi")
+    vuln = Vulnerability(id="CVE-2018-1000656", summary="x", severity=Severity.HIGH, fixed_version="0.12.3")
+    vulnerable.vulnerabilities = [vuln]
+    evil = Package(name="reqeusts", version="1.0.0", ecosystem="pypi", is_malicious=True, malicious_reason="Typosquat of requests")
+    server = MCPServer(name="tools", command="npx", packages=[vulnerable, evil])
+    agent = Agent(name="dev-agent", agent_type="cli", config_path="/tmp/agent", mcp_servers=[server])
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=vulnerable,
+        affected_servers=[server],
+        affected_agents=[agent],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+    return AIBOMReport(agents=[agent], blast_radii=[br])
+
+
+def test_machine_export_includes_malicious_alongside_cve() -> None:
+    report = _report_with_cve_and_malicious()
+    findings = machine_export_findings(report, report.blast_radii)
+    kinds = {f.finding_type for f in findings}
+    assert FindingType.CVE in kinds
+    assert FindingType.MALICIOUS_PACKAGE in kinds
+
+
+def test_malicious_package_in_csv_when_cve_present() -> None:
+    report = _report_with_cve_and_malicious()
+    csv_text = to_csv(report)
+    lines = csv_text.splitlines()
+    header = lines[0].lstrip("﻿").split(",")
+    mal_idx = header.index("is_malicious")
+    evil_rows = [line.split(",") for line in lines[1:] if line.split(",")[1] == "reqeusts"]
+    assert len(evil_rows) == 1, "typosquat package missing from CSV export"
+    assert evil_rows[0][mal_idx] == "yes"
+
+
+def test_malicious_package_in_parquet_when_cve_present() -> None:
+    pytest.importorskip("pyarrow")
+    from agent_bom.output.parquet_fmt import to_arrow_table
+
+    report = _report_with_cve_and_malicious()
+    rows = to_arrow_table(report).to_pylist()
+    evil = [r for r in rows if r["package"] == "reqeusts"]
+    assert len(evil) == 1, "typosquat package missing from Parquet export"
+    assert evil[0]["is_malicious"] is True
+    assert evil[0]["malicious_reason"]

--- a/tests/test_sha_bound_advisories.py
+++ b/tests/test_sha_bound_advisories.py
@@ -1,0 +1,99 @@
+"""Regression: git-SHA-bound advisories must not false-positive on offline scans.
+
+OSS-Fuzz / OSV-2022 advisories store git commit SHAs as their ``introduced`` /
+``fixed`` bounds. A SHA can never be ordered against a concrete semver, so such a
+row must not be reported for a real package version. The offline ``db/lookup``
+matcher previously classified these rows as ``unknown`` and then *conservatively
+included* them, emitting a false positive on every version (e.g. OSV-2022-1074 /
+OSV-2022-715 against ``pillow==11.0.0``).
+
+Mirrors the fixtures in ``test_debian_release_matching.py``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from agent_bom.db.lookup import _version_match_state, lookup_package
+from agent_bom.db.schema import init_db
+
+_SHA_A = "bb2016794f1f9bf9e4726727080e1beb789823fb"
+_SHA_B = "f7363c1091c70356d92e56abfca6b65bef9e7b26"
+
+
+@pytest.fixture
+def tmp_db(tmp_path) -> sqlite3.Connection:
+    db_file = tmp_path / "test_vulns.db"
+    conn = init_db(db_file)
+    yield conn
+    conn.close()
+
+
+def _insert(conn, vuln_id, ecosystem, pkg, introduced="0", fixed="", last_affected=""):
+    conn.execute(
+        "INSERT OR REPLACE INTO vulns(id,summary,severity,cvss_score,source) VALUES (?,?,?,?,'osv')",
+        (vuln_id, f"Test {vuln_id}", "high", 7.5),
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO affected(vuln_id,ecosystem,package_name,introduced,fixed,last_affected) VALUES (?,?,?,?,?,?)",
+        (vuln_id, ecosystem, pkg, introduced, fixed, last_affected),
+    )
+    conn.commit()
+
+
+# ── _version_match_state classification ──────────────────────────────────────
+
+
+def test_sha_bounds_are_uncomparable_not_unknown():
+    # Both bounds are git SHAs → cannot order against a semver → uncomparable.
+    assert _version_match_state("11.0.0", _SHA_A, _SHA_B, "", "pypi") == "uncomparable"
+    assert _version_match_state("99.99.99", _SHA_A, _SHA_B, "", "pypi") == "uncomparable"
+    # A single SHA fix bound is equally uncomparable.
+    assert _version_match_state("2.0.0", "0", _SHA_B, "", "pypi") == "uncomparable"
+
+
+def test_semver_bounds_still_classified():
+    # In-range semver still affected; past-fix still unaffected.
+    assert _version_match_state("0.12.2", "0", "0.12.3", "", "pypi") == "affected"
+    assert _version_match_state("0.12.3", "0", "0.12.3", "", "pypi") == "unaffected"
+
+
+# ── lookup_package end-to-end ────────────────────────────────────────────────
+
+
+def test_sha_bound_advisory_not_reported_for_semver(tmp_db):
+    _insert(tmp_db, "OSV-2022-1074", "pypi", "pillow", introduced=_SHA_A, fixed=_SHA_B)
+    _insert(
+        tmp_db,
+        "OSV-2022-715",
+        "pypi",
+        "pillow",
+        introduced="c58d2817bc891c26e6b8098b8909c0eb2e7ce61b",
+        fixed="9887544fafcd13cc8afcfa0c6d0f2e6facc1a8b8",
+    )
+    assert lookup_package(tmp_db, "pypi", "pillow", "11.0.0") == []
+    assert lookup_package(tmp_db, "pypi", "pillow", "99.99.99") == []
+
+
+def test_semver_advisory_still_reported_and_excluded(tmp_db):
+    _insert(tmp_db, "CVE-2018-1000656", "pypi", "flask", introduced="0", fixed="0.12.3")
+    # In-range version is affected.
+    assert [m.id for m in lookup_package(tmp_db, "pypi", "flask", "0.12.2")] == ["CVE-2018-1000656"]
+    # Fixed / past-fix version is excluded.
+    assert lookup_package(tmp_db, "pypi", "flask", "0.12.3") == []
+
+
+def test_mixed_sha_and_semver_rows_resolve_via_comparable_sibling(tmp_db):
+    # Same vuln, two affected rows: one SHA-bound (uncomparable), one semver.
+    # A comparable "affected" sibling wins → reported for an in-range version.
+    _insert(tmp_db, "OSV-2021-1", "pypi", "widget", introduced=_SHA_A, fixed=_SHA_B)
+    tmp_db.execute(
+        "INSERT INTO affected(vuln_id,ecosystem,package_name,introduced,fixed,last_affected) VALUES (?,?,?,?,?,?)",
+        ("OSV-2021-1", "pypi", "widget", "0", "2.0.0", ""),
+    )
+    tmp_db.commit()
+    assert [m.id for m in lookup_package(tmp_db, "pypi", "widget", "1.0.0")] == ["OSV-2021-1"]
+    # And a version past the semver sibling's fix is excluded despite the SHA row.
+    assert lookup_package(tmp_db, "pypi", "widget", "3.0.0") == []


### PR DESCRIPTION
Two pre-release accuracy defects found by hands-on smoke testing, both reproduced live before/after.

## Fix 1 (P1) — git-SHA-range advisories false-positive on the offline scan path

OSS-Fuzz / OSV-2022-* advisories store git commit SHAs as their `introduced`/`fixed` bounds (~33k rows in the local vuln DB). `src/agent_bom/db/lookup.py:_version_match_state` returned `"unknown"` for such rows because a SHA can't be ordered against a semver, and `_select_vulnerability_rows` then *conservatively included* the `unknown` row — so every concrete version drew a false positive. The already-blessed online path (`version_utils.version_in_range`, #3696) returns `False` for SHA bounds, but this offline matcher has its own logic and didn't.

**Change:** `_cached_version_match_state` now returns a distinct `"uncomparable"` state when a bound is a git SHA / non-version token (detected via the existing `_looks_like_commit_sha`), separate from genuine version-vs-version `"unknown"` ambiguity. The `_select_vulnerability_rows` loop only ever includes on `affected` or genuine `unknown`, so an `uncomparable`-only vuln is no longer reported. Genuine semver in-range/past-fix matching is unchanged, and when a vuln has both a SHA-bound row and a comparable semver row the comparable sibling still wins.

- `src/agent_bom/db/lookup.py:329-372` (`_cached_version_match_state` / `_version_match_state`)
- `src/agent_bom/db/lookup.py:374-431` (`_select_vulnerability_rows` docstring; logic already ignores the new state)

**Live before/after** (real local vuln DB):

| package | before | after |
| --- | --- | --- |
| `pillow==11.0.0` | 8 findings incl. `OSV-2022-1074`, `OSV-2022-715` | 6 findings, **0** OSV-2022 |
| `pillow==99.99.99` | 2 (both OSV-2022) | **0** |

Genuine semver still resolves: `flask 0.12.2 < 0.12.3` → affected; `0.12.3` → excluded.

## Fix 2 (P2) — malicious (vuln-less) packages missing from CSV export

CSV/Parquet built rows from `cve_findings()`, which returns only BlastRadius rows once any CVE finding exists — so a synthesized malicious/typosquat finding (#3694) vanished from CSV/Parquet even though JSON/SARIF (which read `report.to_findings()`) still surfaced it.

**Change:** added `machine_export_findings()` in `finding_views.py` (CVE findings + synthesized `MALICIOUS_PACKAGE` findings, deduped by id) and routed the CSV and Parquet writers through it. Parquet had the same gap (shares `cve_findings`) and is fixed the same way.

- `src/agent_bom/output/finding_views.py:22-42` (`machine_export_findings`)
- `src/agent_bom/output/csv_fmt.py:57` (writer uses the new helper)
- `src/agent_bom/output/parquet_fmt.py:103` (writer uses the new helper)

**Live before/after** — report with a CVE BlastRadius *and* a `reqeusts==1.0.0` typosquat:

| export | before | after |
| --- | --- | --- |
| CSV rows | 1 (flask CVE only) | 2 — typosquat present with `is_malicious=yes` |

## Tests

- New `tests/test_sha_bound_advisories.py`: SHA bounds classify `uncomparable`; SHA-bound advisories not reported for `11.0.0`/`99.99.99`; semver advisories still match in-range and exclude past-fix; mixed SHA+semver sibling rows resolve via the comparable sibling.
- `tests/test_malicious_export.py`: added cases asserting a vuln-less malicious package appears in CSV **and** Parquet when a CVE is also present.
- `python -m pytest tests/ -k "lookup or version_match or csv or malicious or offline or scan or sha_bound" -p no:randomly` → **1655 passed, 8 skipped, 0 failed**.
- `make preflight` → green (no API/schema/env drift; these changes don't touch API routes/models).

CHANGELOG updated under `## [Unreleased]`.