### PR TITLE
chore(cli): hide advanced scan flags from default --help (#3675)

### DIFF
--- a/src/agent_bom/cli/_scan_help.py
+++ b/src/agent_bom/cli/_scan_help.py
@@ -7,7 +7,9 @@ three tiers without changing any option's behavior:
 
 * **Core options** — the narrow front-door set (path, ``-f/--format``,
   ``-o/--output``, ``--fail-on-*``, ``--demo``, provider connect flags, …).
+  This is the only option block rendered by default ``--help``.
 * **More options** — everything else that is not a vendor-token integration.
+  Shown only under ``--help-all``.
 * **Integrations & vendor tokens** — third-party credential/endpoint flags
   (Jira, Slack, ServiceNow, Snyk tokens, Drata, Vanta, W&B, Nebius, OpenAI, HF
   tokens, Iceberg, SIEM, …). These are shown only under ``--help-all`` and their
@@ -190,8 +192,16 @@ class TieredCommand(click.Command):
             with formatter.section("Core options"):
                 formatter.write_dl(core)
         if more:
-            with formatter.section("More options"):
-                formatter.write_dl(more)
+            if show_all:
+                with formatter.section("More options"):
+                    formatter.write_dl(more)
+            else:
+                with formatter.section("More options"):
+                    formatter.write_text(
+                        f"{len(more)} additional scan flags (SBOM, compliance, cloud deep-scan, "
+                        "output formats, analytics, …) are hidden. Run "
+                        "`agent-bom scan --help-all` to see the full catalog."
+                    )
         if show_all:
             if vendor:
                 with formatter.section("Integrations & vendor tokens"):

--- a/tests/test_ai_enrich.py
+++ b/tests/test_ai_enrich.py
@@ -356,7 +356,7 @@ def test_cli_has_ai_enrich_flag():
     from agent_bom.cli import main
 
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--ai-enrich" in result.output
 
 
@@ -367,7 +367,7 @@ def test_cli_has_ai_model_option():
     from agent_bom.cli import main
 
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--ai-model" in result.output
 
 
@@ -378,7 +378,7 @@ def test_cli_ai_model_shows_ollama_examples():
     from agent_bom.cli import main
 
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "ollama" in result.output.lower()
 
 

--- a/tests/test_cli_clarity.py
+++ b/tests/test_cli_clarity.py
@@ -4,8 +4,8 @@ Covers the back-compat guarantees and the new help tiering introduced by the
 "CLI front door" cleanup:
 
 * ``scan`` is the visible canonical verb; ``agents`` stays as a hidden alias.
-* ``scan --help`` tiers options into Core / More; vendor-token flags only show
-  under ``scan --help-all`` (with their env var).
+* ``scan --help`` shows Core options only (~25–40 flags); advanced More and
+  vendor-token flags only show under ``scan --help-all`` (with their env var).
 * ``-f text`` remains accepted as a deprecated alias of ``plain``.
 * ``--inventory-only`` remains accepted as a hidden alias of ``--no-discover``.
 * ``api`` is hidden but reachable; ``serve --no-ui`` provides REST-only mode.
@@ -57,11 +57,21 @@ class TestFlagTiering:
         for flag in ("--jira-url", "--siem-token", "--vanta-token", "--drata-token", "--wandb-api-key"):
             assert flag not in out, f"{flag} should be hidden in default help"
 
-    def test_default_help_shows_core_and_more(self):
+    def test_default_help_shows_core_only(self):
         out = _run(["scan", "--help"]).output
         assert "Core options:" in out
-        # A representative core flag and a non-vendor "more" flag.
         assert "--fail-on-severity" in out
+        assert "additional scan flags" in out
+        assert not any(line.strip().startswith("--sbom") for line in out.splitlines())
+        assert "scan --help-all" in out
+
+    def test_default_help_core_option_count_bounded(self):
+        out = _run(["scan", "--help"]).output
+        option_lines = [line for line in out.splitlines() if line.strip().startswith("--")]
+        assert 20 <= len(option_lines) <= 40, f"expected 20–40 core flags, got {len(option_lines)}"
+
+    def test_help_all_shows_advanced_more_flags(self):
+        out = _run(["scan", "--help-all"]).output
         assert "--sbom" in out
 
     def test_help_all_reveals_vendor_tokens_with_env(self):

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -38,6 +38,7 @@ def _run(args: list, catch_exceptions: bool = False, **kwargs):
     if (
         args[:1] == ["scan"]
         and "--help" not in args
+        and "--help-all" not in args
         and "--no-scan" not in args
         and "--dry-run" not in args
         and "--no-auto-update-db" not in args
@@ -70,16 +71,20 @@ def test_main_version():
 
 def test_scan_help():
     result = _run(["scan", "--help"])
-    normalized = " ".join(result.output.split())
     assert result.exit_code == 0
     assert "--output" in result.output
     assert "--format" in result.output
     assert "--no-discover" in result.output
     # --inventory-only is a deprecated hidden alias — no longer advertised.
     assert "--inventory-only" not in result.output
-    assert "--no-follow-symlinks" in result.output
-    assert "graph (Cytoscape.js graph JSON)" in normalized
-    assert "graph (raw graph JSON)" not in normalized
+    assert "additional scan flags" in result.output
+
+    full = _run(["scan", "--help-all"])
+    full_normalized = " ".join(full.output.split())
+    assert full.exit_code == 0
+    assert "--no-follow-symlinks" in full.output
+    assert "graph (Cytoscape.js graph JSON)" in full_normalized
+    assert "graph (raw graph JSON)" not in full_normalized
 
 
 def test_scan_agent_mode_emits_machine_envelope(monkeypatch):
@@ -1725,7 +1730,7 @@ def test_format_choices_include_plain():
 
 def test_compliance_export_help_lists_supported_values():
     """--compliance-export help should document the accepted slugs clearly."""
-    result = _run(["scan", "--help"])
+    result = _run(["scan", "--help-all"])
     assert result.exit_code == 0
     assert "--compliance-export" in result.output
     assert "cmmc" in result.output

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1344,7 +1344,7 @@ def test_cli_image_output_json_extension_writes_report(monkeypatch, tmp_path):
 
 def test_cli_scan_has_k8s_flags():
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--k8s" in result.output
     assert "--namespace" in result.output
 
@@ -1671,7 +1671,7 @@ def test_html_trust_assessment_absent():
 
 def test_cli_open_flag_accepted():
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--open" in result.output
 
 
@@ -1771,7 +1771,7 @@ def test_prometheus_clean_report_zero_vulns():
 
 def test_cli_scan_has_prometheus_format():
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "prometheus" in result.output
     assert "--push-gateway" in result.output
 
@@ -1927,7 +1927,7 @@ variable "anthropic_api_key" {
 
 def test_cli_scan_has_tf_dir_flag():
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--tf-dir" in result.output
 
 
@@ -2019,7 +2019,7 @@ def test_gha_no_workflows_dir(tmp_path):
 
 def test_cli_scan_has_gha_flag():
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--gha" in result.output
 
 
@@ -2230,7 +2230,7 @@ def test_python_agents_detects_langgraph_positional_tools_arg(tmp_path):
 def test_cli_scan_has_agent_project_flag():
     """CLI scan command exposes --agent-project flag."""
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert result.exit_code == 0
     assert "--agent-project" in result.output
 
@@ -2677,7 +2677,7 @@ def test_integrity_module_imports():
 def test_cli_scan_has_verify_integrity_flag():
     """The scan command accepts --verify-integrity."""
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert result.exit_code == 0
     assert "--verify-integrity" in result.output
 
@@ -4021,7 +4021,7 @@ def test_cli_scan_has_verbose_flag():
 def test_cli_scan_has_no_color_flag():
     """--no-color flag appears in scan --help."""
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--no-color" in result.output
 
 

--- a/tests/test_image_auth.py
+++ b/tests/test_image_auth.py
@@ -291,7 +291,7 @@ def test_detect_multi_arch_not_manifest_list(monkeypatch):
 def test_scan_cli_has_registry_options():
     """scan --help includes registry auth and platform options."""
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--registry-user" in result.output
     assert "--registry-pass" in result.output
     assert "--platform" in result.output

--- a/tests/test_model_provenance.py
+++ b/tests/test_model_provenance.py
@@ -395,7 +395,7 @@ class TestCLIFlags:
         from agent_bom.cli import scan
 
         runner = CliRunner()
-        result = runner.invoke(scan, ["--help"])
+        result = runner.invoke(scan, ["--help-all"])
         assert "--model-provenance" in result.output
 
     def test_hf_model_in_help(self):
@@ -404,5 +404,5 @@ class TestCLIFlags:
         from agent_bom.cli import scan
 
         runner = CliRunner()
-        result = runner.invoke(scan, ["--help"])
+        result = runner.invoke(scan, ["--help-all"])
         assert "--hf-model" in result.output

--- a/tests/test_project_mode.py
+++ b/tests/test_project_mode.py
@@ -326,7 +326,8 @@ def test_cli_has_sbom_name_flag():
     runner = CliRunner()
     result = runner.invoke(main, ["scan", "--help"])
     assert "--project" in result.output
-    assert "--sbom-name" in result.output
+    full = runner.invoke(main, ["scan", "--help-all"])
+    assert "--sbom-name" in full.output
 
 
 def test_project_scan_via_cli_no_agents(tmp_path):


### PR DESCRIPTION
## Summary
- **#3675 PR-A:** default `scan --help` shows Core options only (~29 flags); More + vendor catalogs require `--help-all`.
- Adds `test_default_help_core_option_count_bounded` (20–40 core flags).
- Updates help contract tests to use `--help-all` for advanced flags.

## Test plan
- [x] `uv run pytest -q tests/test_cli_clarity.py tests/test_cli_scan.py::test_scan_help tests/test_core.py -k help` (targeted)
- [ ] Full CI

## Notes
- Does not change flag behavior — help rendering only.
- **#3666** breaking API work intentionally deferred.


Made with [Cursor](https://cursor.com)