### PR TITLE
chore(deploy): rename runtime compose example (#3675)

### DIFF
--- a/deploy/docker-compose.runtime-example.yml
+++ b/deploy/docker-compose.runtime-example.yml
@@ -9,7 +9,7 @@
 # Postgres+secrets layout).
 #
 # Quick start:
-#   docker compose -f deploy/docker-compose.runtime.yml up
+#   docker compose -f deploy/docker-compose.runtime-example.yml up
 #
 # The proxy wraps the filesystem MCP server and logs all tool calls to
 # ./audit-logs/audit.jsonl on the host.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,10 @@
 version: '3.8'
 
+# ── DEPRECATED (DEV profile) ─────────────────────────────────────────────────
+# Prefer `deploy/docker-compose.fullstack.yml` for local API+UI dev, or
+# `deploy/docker-compose.platform.yml` for a production-shaped stack.
+# This file remains for backward-compatible one-shot scanner+Postgres dev only.
+#
 # ── Profile: DEV ─────────────────────────────────────────────────────────────
 # Development compose — scanner + Redis + PostgreSQL
 # Useful for one-shot scans against a local Postgres + Redis. For an

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -58,10 +58,10 @@ docker run --rm \
 
 ### Docker Compose
 
-Use the provided `deploy/docker-compose.runtime.yml` for a complete sidecar example:
+Use the provided `deploy/docker-compose.runtime-example.yml` for a complete sidecar example:
 
 ```bash
-docker compose -f deploy/docker-compose.runtime.yml up
+docker compose -f deploy/docker-compose.runtime-example.yml up
 ```
 
 This starts:

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -34,7 +34,7 @@ VERSION_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
     ("Dockerfile", re.compile(r"^(ARG VERSION=)\S+", re.M), r"\g<1>{v}"),
     # Compose + packaged manifests
     ("deploy/docker-compose.pilot.yml", re.compile(r"(agentbom/agent-bom(?:-ui)?:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
-    ("deploy/docker-compose.runtime.yml", re.compile(r"(agentbom/agent-bom(?:-ui)?:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
+    ("deploy/docker-compose.runtime-example.yml", re.compile(r"(agentbom/agent-bom(?:-ui)?:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
     ("deploy/docker-compose.fullstack.yml", re.compile(r"(agentbom/agent-bom(?:-ui)?:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
     ("deploy/docker-compose.platform.yml", re.compile(r"(agentbom/agent-bom(?:-ui)?:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
     ("deploy/k8s/daemonset.yaml", re.compile(r"(agentbom/agent-bom:)\d+\.\d+\.\d+"), r"\g<1>{v}"),

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -34,7 +34,7 @@ CANONICAL_TAGLINE_SURFACES: list[Path] = [
 ]
 MANAGED_IMAGE_REFS: list[tuple[Path, re.Pattern[str]]] = [
     (ROOT / "deploy" / "docker-compose.pilot.yml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)")),
-    (ROOT / "deploy" / "docker-compose.runtime.yml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)")),
+    (ROOT / "deploy" / "docker-compose.runtime-example.yml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)")),
     (ROOT / "deploy" / "docker-compose.fullstack.yml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)")),
     (ROOT / "deploy" / "docker-compose.platform.yml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)")),
     (ROOT / "deploy" / "k8s" / "daemonset.yaml", re.compile(r"agentbom/agent-bom:([0-9]+\.[0-9]+\.[0-9]+)")),

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -30,7 +30,7 @@ Use these in this order:
 | `deploy/docker-compose.pilot.yml` | recommended | fastest one-machine pilot with the shipped images |
 | `deploy/docker-compose.fullstack.yml` | advanced local example | you want a fuller single-machine compose setup and are comfortable editing local compose files |
 | `deploy/docker-compose.platform.yml` | component example | you are focusing on the control-plane/platform layer only |
-| `deploy/docker-compose.runtime.yml` | component example | you are focusing on proxy/runtime behavior only |
+| `deploy/docker-compose.runtime-example.yml` | component example | you are focusing on proxy/runtime behavior only |
 
 If you want the full self-hosted deployment path for your own infrastructure,
 use `scripts/deploy/install-eks-reference.sh` instead of trying to stretch a

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -200,7 +200,7 @@ These are the maintained building blocks for this model:
 - advanced local Compose references, not the primary production path:
   [deploy/docker-compose.platform.yml](https://github.com/msaad00/agent-bom/blob/main/deploy/docker-compose.platform.yml)
   and
-  [deploy/docker-compose.runtime.yml](https://github.com/msaad00/agent-bom/blob/main/deploy/docker-compose.runtime.yml)
+  [deploy/docker-compose.runtime-example.yml](https://github.com/msaad00/agent-bom/blob/main/deploy/docker-compose.runtime-example.yml)
 - sidecar examples:
   [deploy/k8s/sidecar-example.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/k8s/sidecar-example.yaml)
   and

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -33,7 +33,7 @@ HEALTHCHECK_EXEMPT: dict[str, set[str]] = {
         # depends_on uses postgres healthcheck for ordering.
         "agent-bom",
     },
-    "docker-compose.runtime.yml": {
+    "docker-compose.runtime-example.yml": {
         # The mcp-server container talks stdio to the proxy and never opens a
         # TCP listener — there is no port to probe.
         "mcp-server",

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -597,7 +597,7 @@ def test_compose_examples_pass_through_proxy_and_ca_env():
     """Compose examples should expose the same enterprise network env contract."""
     compose_files = [
         ROOT / "deploy" / "docker-compose.yml",
-        ROOT / "deploy" / "docker-compose.runtime.yml",
+        ROOT / "deploy" / "docker-compose.runtime-example.yml",
     ]
     required_tokens = [
         "HTTP_PROXY",


### PR DESCRIPTION
## Summary
- **#3675 PR-B:** `docker-compose.runtime.yml` → `docker-compose.runtime-example.yml` (sidecar example; avoids PILOT collision).
- Deprecation banner on `deploy/docker-compose.yml` pointing to `fullstack` / `platform` profiles.
- Updates docs, bump-version, release consistency, and compose tests.

## Test plan
- [x] `uv run pytest -q tests/test_deployment.py -k compose tests/test_compose_secrets_healthcheck.py`

## Notes
For AWS VM hosting: see `deploy/docker-compose.platform.yml` or Helm chart (`controlPlane.enabled=true`).


Made with [Cursor](https://cursor.com)