### PR TITLE
chore(cli,deploy): combine #3675 cleanup follow-ups

### DIFF
--- a/deploy/docker-compose.runtime-example.yml
+++ b/deploy/docker-compose.runtime-example.yml
@@ -9,7 +9,7 @@
 # Postgres+secrets layout).
 #
 # Quick start:
-#   docker compose -f deploy/docker-compose.runtime.yml up
+#   docker compose -f deploy/docker-compose.runtime-example.yml up
 #
 # The proxy wraps the filesystem MCP server and logs all tool calls to
 # ./audit-logs/audit.jsonl on the host.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,10 @@
 version: '3.8'
 
+# ── DEPRECATED (DEV profile) ─────────────────────────────────────────────────
+# Prefer `deploy/docker-compose.fullstack.yml` for local API+UI dev, or
+# `deploy/docker-compose.platform.yml` for a production-shaped stack.
+# This file remains for backward-compatible one-shot scanner+Postgres dev only.
+#
 # ── Profile: DEV ─────────────────────────────────────────────────────────────
 # Development compose — scanner + Redis + PostgreSQL
 # Useful for one-shot scans against a local Postgres + Redis. For an

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -58,10 +58,10 @@ docker run --rm \
 
 ### Docker Compose
 
-Use the provided `deploy/docker-compose.runtime.yml` for a complete sidecar example:
+Use the provided `deploy/docker-compose.runtime-example.yml` for a complete sidecar example:
 
 ```bash
-docker compose -f deploy/docker-compose.runtime.yml up
+docker compose -f deploy/docker-compose.runtime-example.yml up
 ```
 
 This starts:

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -34,7 +34,7 @@ VERSION_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
     ("Dockerfile", re.compile(r"^(ARG VERSION=)\S+", re.M), r"\g<1>{v}"),
     # Compose + packaged manifests
     ("deploy/docker-compose.pilot.yml", re.compile(r"(agentbom/agent-bom(?:-ui)?:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
-    ("deploy/docker-compose.runtime.yml", re.compile(r"(agentbom/agent-bom(?:-ui)?:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
+    ("deploy/docker-compose.runtime-example.yml", re.compile(r"(agentbom/agent-bom(?:-ui)?:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
     ("deploy/docker-compose.fullstack.yml", re.compile(r"(agentbom/agent-bom(?:-ui)?:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
     ("deploy/docker-compose.platform.yml", re.compile(r"(agentbom/agent-bom(?:-ui)?:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
     ("deploy/k8s/daemonset.yaml", re.compile(r"(agentbom/agent-bom:)\d+\.\d+\.\d+"), r"\g<1>{v}"),

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -34,7 +34,7 @@ CANONICAL_TAGLINE_SURFACES: list[Path] = [
 ]
 MANAGED_IMAGE_REFS: list[tuple[Path, re.Pattern[str]]] = [
     (ROOT / "deploy" / "docker-compose.pilot.yml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)")),
-    (ROOT / "deploy" / "docker-compose.runtime.yml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)")),
+    (ROOT / "deploy" / "docker-compose.runtime-example.yml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)")),
     (ROOT / "deploy" / "docker-compose.fullstack.yml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)")),
     (ROOT / "deploy" / "docker-compose.platform.yml", re.compile(r"agentbom/agent-bom(?:-ui)?:([0-9]+\.[0-9]+\.[0-9]+)")),
     (ROOT / "deploy" / "k8s" / "daemonset.yaml", re.compile(r"agentbom/agent-bom:([0-9]+\.[0-9]+\.[0-9]+)")),

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -30,7 +30,7 @@ Use these in this order:
 | `deploy/docker-compose.pilot.yml` | recommended | fastest one-machine pilot with the shipped images |
 | `deploy/docker-compose.fullstack.yml` | advanced local example | you want a fuller single-machine compose setup and are comfortable editing local compose files |
 | `deploy/docker-compose.platform.yml` | component example | you are focusing on the control-plane/platform layer only |
-| `deploy/docker-compose.runtime.yml` | component example | you are focusing on proxy/runtime behavior only |
+| `deploy/docker-compose.runtime-example.yml` | component example | you are focusing on proxy/runtime behavior only |
 
 If you want the full self-hosted deployment path for your own infrastructure,
 use `scripts/deploy/install-eks-reference.sh` instead of trying to stretch a

--- a/site-docs/deployment/own-infra-eks.md
+++ b/site-docs/deployment/own-infra-eks.md
@@ -200,7 +200,7 @@ These are the maintained building blocks for this model:
 - advanced local Compose references, not the primary production path:
   [deploy/docker-compose.platform.yml](https://github.com/msaad00/agent-bom/blob/main/deploy/docker-compose.platform.yml)
   and
-  [deploy/docker-compose.runtime.yml](https://github.com/msaad00/agent-bom/blob/main/deploy/docker-compose.runtime.yml)
+  [deploy/docker-compose.runtime-example.yml](https://github.com/msaad00/agent-bom/blob/main/deploy/docker-compose.runtime-example.yml)
 - sidecar examples:
   [deploy/k8s/sidecar-example.yaml](https://github.com/msaad00/agent-bom/blob/main/deploy/k8s/sidecar-example.yaml)
   and

--- a/src/agent_bom/cli/_scan_help.py
+++ b/src/agent_bom/cli/_scan_help.py
@@ -7,7 +7,9 @@ three tiers without changing any option's behavior:
 
 * **Core options** — the narrow front-door set (path, ``-f/--format``,
   ``-o/--output``, ``--fail-on-*``, ``--demo``, provider connect flags, …).
+  This is the only option block rendered by default ``--help``.
 * **More options** — everything else that is not a vendor-token integration.
+  Shown only under ``--help-all``.
 * **Integrations & vendor tokens** — third-party credential/endpoint flags
   (Jira, Slack, ServiceNow, Snyk tokens, Drata, Vanta, W&B, Nebius, OpenAI, HF
   tokens, Iceberg, SIEM, …). These are shown only under ``--help-all`` and their
@@ -55,6 +57,8 @@ CORE_FLAGS: frozenset[str] = frozenset(
         "--azure",
         "--gcp",
         "--verbose",
+        "--page",
+        "--snyk",
         "--quiet",
         "--agent-mode",
     }
@@ -190,8 +194,16 @@ class TieredCommand(click.Command):
             with formatter.section("Core options"):
                 formatter.write_dl(core)
         if more:
-            with formatter.section("More options"):
-                formatter.write_dl(more)
+            if show_all:
+                with formatter.section("More options"):
+                    formatter.write_dl(more)
+            else:
+                with formatter.section("More options"):
+                    formatter.write_text(
+                        f"{len(more)} additional scan flags (SBOM, compliance, cloud deep-scan, "
+                        "output formats, analytics, …) are hidden. Run "
+                        "`agent-bom scan --help-all` to see the full catalog."
+                    )
         if show_all:
             if vendor:
                 with formatter.section("Integrations & vendor tokens"):

--- a/tests/test_ai_enrich.py
+++ b/tests/test_ai_enrich.py
@@ -356,7 +356,7 @@ def test_cli_has_ai_enrich_flag():
     from agent_bom.cli import main
 
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--ai-enrich" in result.output
 
 
@@ -367,7 +367,7 @@ def test_cli_has_ai_model_option():
     from agent_bom.cli import main
 
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--ai-model" in result.output
 
 
@@ -378,7 +378,7 @@ def test_cli_ai_model_shows_ollama_examples():
     from agent_bom.cli import main
 
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "ollama" in result.output.lower()
 
 

--- a/tests/test_cli_clarity.py
+++ b/tests/test_cli_clarity.py
@@ -4,8 +4,8 @@ Covers the back-compat guarantees and the new help tiering introduced by the
 "CLI front door" cleanup:
 
 * ``scan`` is the visible canonical verb; ``agents`` stays as a hidden alias.
-* ``scan --help`` tiers options into Core / More; vendor-token flags only show
-  under ``scan --help-all`` (with their env var).
+* ``scan --help`` shows Core options only (~25–40 flags); advanced More and
+  vendor-token flags only show under ``scan --help-all`` (with their env var).
 * ``-f text`` remains accepted as a deprecated alias of ``plain``.
 * ``--inventory-only`` remains accepted as a hidden alias of ``--no-discover``.
 * ``api`` is hidden but reachable; ``serve --no-ui`` provides REST-only mode.
@@ -57,11 +57,21 @@ class TestFlagTiering:
         for flag in ("--jira-url", "--siem-token", "--vanta-token", "--drata-token", "--wandb-api-key"):
             assert flag not in out, f"{flag} should be hidden in default help"
 
-    def test_default_help_shows_core_and_more(self):
+    def test_default_help_shows_core_only(self):
         out = _run(["scan", "--help"]).output
         assert "Core options:" in out
-        # A representative core flag and a non-vendor "more" flag.
         assert "--fail-on-severity" in out
+        assert "additional scan flags" in out
+        assert not any(line.strip().startswith("--sbom") for line in out.splitlines())
+        assert "scan --help-all" in out
+
+    def test_default_help_core_option_count_bounded(self):
+        out = _run(["scan", "--help"]).output
+        option_lines = [line for line in out.splitlines() if line.strip().startswith("--")]
+        assert 20 <= len(option_lines) <= 40, f"expected 20–40 core flags, got {len(option_lines)}"
+
+    def test_help_all_shows_advanced_more_flags(self):
+        out = _run(["scan", "--help-all"]).output
         assert "--sbom" in out
 
     def test_help_all_reveals_vendor_tokens_with_env(self):

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -38,6 +38,7 @@ def _run(args: list, catch_exceptions: bool = False, **kwargs):
     if (
         args[:1] == ["scan"]
         and "--help" not in args
+        and "--help-all" not in args
         and "--no-scan" not in args
         and "--dry-run" not in args
         and "--no-auto-update-db" not in args
@@ -70,16 +71,20 @@ def test_main_version():
 
 def test_scan_help():
     result = _run(["scan", "--help"])
-    normalized = " ".join(result.output.split())
     assert result.exit_code == 0
     assert "--output" in result.output
     assert "--format" in result.output
     assert "--no-discover" in result.output
     # --inventory-only is a deprecated hidden alias — no longer advertised.
     assert "--inventory-only" not in result.output
-    assert "--no-follow-symlinks" in result.output
-    assert "graph (Cytoscape.js graph JSON)" in normalized
-    assert "graph (raw graph JSON)" not in normalized
+    assert "additional scan flags" in result.output
+
+    full = _run(["scan", "--help-all"])
+    full_normalized = " ".join(full.output.split())
+    assert full.exit_code == 0
+    assert "--no-follow-symlinks" in full.output
+    assert "graph (Cytoscape.js graph JSON)" in full_normalized
+    assert "graph (raw graph JSON)" not in full_normalized
 
 
 def test_scan_agent_mode_emits_machine_envelope(monkeypatch):
@@ -1725,7 +1730,7 @@ def test_format_choices_include_plain():
 
 def test_compliance_export_help_lists_supported_values():
     """--compliance-export help should document the accepted slugs clearly."""
-    result = _run(["scan", "--help"])
+    result = _run(["scan", "--help-all"])
     assert result.exit_code == 0
     assert "--compliance-export" in result.output
     assert "cmmc" in result.output

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -33,7 +33,7 @@ HEALTHCHECK_EXEMPT: dict[str, set[str]] = {
         # depends_on uses postgres healthcheck for ordering.
         "agent-bom",
     },
-    "docker-compose.runtime.yml": {
+    "docker-compose.runtime-example.yml": {
         # The mcp-server container talks stdio to the proxy and never opens a
         # TCP listener — there is no port to probe.
         "mcp-server",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1344,7 +1344,7 @@ def test_cli_image_output_json_extension_writes_report(monkeypatch, tmp_path):
 
 def test_cli_scan_has_k8s_flags():
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--k8s" in result.output
     assert "--namespace" in result.output
 
@@ -1671,7 +1671,7 @@ def test_html_trust_assessment_absent():
 
 def test_cli_open_flag_accepted():
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--open" in result.output
 
 
@@ -1771,7 +1771,7 @@ def test_prometheus_clean_report_zero_vulns():
 
 def test_cli_scan_has_prometheus_format():
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "prometheus" in result.output
     assert "--push-gateway" in result.output
 
@@ -1927,7 +1927,7 @@ variable "anthropic_api_key" {
 
 def test_cli_scan_has_tf_dir_flag():
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--tf-dir" in result.output
 
 
@@ -2019,7 +2019,7 @@ def test_gha_no_workflows_dir(tmp_path):
 
 def test_cli_scan_has_gha_flag():
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--gha" in result.output
 
 
@@ -2230,7 +2230,7 @@ def test_python_agents_detects_langgraph_positional_tools_arg(tmp_path):
 def test_cli_scan_has_agent_project_flag():
     """CLI scan command exposes --agent-project flag."""
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert result.exit_code == 0
     assert "--agent-project" in result.output
 
@@ -2677,7 +2677,7 @@ def test_integrity_module_imports():
 def test_cli_scan_has_verify_integrity_flag():
     """The scan command accepts --verify-integrity."""
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert result.exit_code == 0
     assert "--verify-integrity" in result.output
 
@@ -4021,7 +4021,7 @@ def test_cli_scan_has_verbose_flag():
 def test_cli_scan_has_no_color_flag():
     """--no-color flag appears in scan --help."""
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--no-color" in result.output
 
 

--- a/tests/test_coreweave.py
+++ b/tests/test_coreweave.py
@@ -386,7 +386,7 @@ def test_cli_coreweave_flags():
     from agent_bom.cli import scan
 
     runner = CliRunner()
-    result = runner.invoke(scan, ["--help"])
+    result = runner.invoke(scan, ["--help-all"])
     assert "--coreweave" in result.output
     assert "--coreweave-context" in result.output
     assert "--coreweave-namespace" in result.output

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -597,7 +597,7 @@ def test_compose_examples_pass_through_proxy_and_ca_env():
     """Compose examples should expose the same enterprise network env contract."""
     compose_files = [
         ROOT / "deploy" / "docker-compose.yml",
-        ROOT / "deploy" / "docker-compose.runtime.yml",
+        ROOT / "deploy" / "docker-compose.runtime-example.yml",
     ]
     required_tokens = [
         "HTTP_PROXY",

--- a/tests/test_image_auth.py
+++ b/tests/test_image_auth.py
@@ -291,7 +291,7 @@ def test_detect_multi_arch_not_manifest_list(monkeypatch):
 def test_scan_cli_has_registry_options():
     """scan --help includes registry auth and platform options."""
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--registry-user" in result.output
     assert "--registry-pass" in result.output
     assert "--platform" in result.output

--- a/tests/test_mcp_introspect.py
+++ b/tests/test_mcp_introspect.py
@@ -644,4 +644,6 @@ def test_cli_introspect_flag():
     runner = CliRunner()
     result = runner.invoke(main, ["scan", "--help"])
     assert "--introspect" in result.output
+
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert "--introspect-timeout" in result.output

--- a/tests/test_mcp_official_registry.py
+++ b/tests/test_mcp_official_registry.py
@@ -325,7 +325,7 @@ def test_cli_scan_mcp_registry_flag():
     from agent_bom.cli import main
 
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert result.exit_code == 0
     assert "--mcp-registry" in result.output
 

--- a/tests/test_model_provenance.py
+++ b/tests/test_model_provenance.py
@@ -395,7 +395,7 @@ class TestCLIFlags:
         from agent_bom.cli import scan
 
         runner = CliRunner()
-        result = runner.invoke(scan, ["--help"])
+        result = runner.invoke(scan, ["--help-all"])
         assert "--model-provenance" in result.output
 
     def test_hf_model_in_help(self):
@@ -404,5 +404,5 @@ class TestCLIFlags:
         from agent_bom.cli import scan
 
         runner = CliRunner()
-        result = runner.invoke(scan, ["--help"])
+        result = runner.invoke(scan, ["--help-all"])
         assert "--hf-model" in result.output

--- a/tests/test_project_mode.py
+++ b/tests/test_project_mode.py
@@ -326,7 +326,8 @@ def test_cli_has_sbom_name_flag():
     runner = CliRunner()
     result = runner.invoke(main, ["scan", "--help"])
     assert "--project" in result.output
-    assert "--sbom-name" in result.output
+    full = runner.invoke(main, ["scan", "--help-all"])
+    assert "--sbom-name" in full.output
 
 
 def test_project_scan_via_cli_no_agents(tmp_path):

--- a/tests/test_sast.py
+++ b/tests/test_sast.py
@@ -602,7 +602,7 @@ def test_cli_code_flag():
     from agent_bom.cli import scan as scan_cmd
 
     runner = CliRunner()
-    result = runner.invoke(scan_cmd, ["--help"])
+    result = runner.invoke(scan_cmd, ["--help-all"])
     assert "--code" in result.output
     assert "--sast-config" in result.output
     assert "--rules" in result.output

--- a/tests/test_smithery.py
+++ b/tests/test_smithery.py
@@ -315,7 +315,7 @@ def test_cli_scan_smithery_flags():
     from agent_bom.cli import main
 
     runner = CliRunner()
-    result = runner.invoke(main, ["scan", "--help"])
+    result = runner.invoke(main, ["scan", "--help-all"])
     assert result.exit_code == 0
     assert "--smithery" in result.output
     assert "--smithery-token" in result.output


### PR DESCRIPTION
## Summary
- Combine #3725 and #3726 into one #3675 cleanup PR.
- Hide advanced `scan` flags from default help while keeping core navigation toggles (`--page`) and bare `--snyk` visible; advanced catalogs/deep-scan flags remain available through `--help-all`.
- Rename `deploy/docker-compose.runtime.yml` to `deploy/docker-compose.runtime-example.yml`, update docs/tests/release checks, and add the deprecation banner for `deploy/docker-compose.yml`.

## RCA
- #3725 failed Python 3.13 because several full-suite tests still asserted advanced flags in default `scan --help` / `agents --help` after the help tiering change.
- The fix updates those tests to use `--help-all` for advanced flags and keeps genuinely core default-help flags visible.

## Verification
- `uv run pytest -q tests/test_mcp_introspect.py::test_cli_introspect_flag tests/test_sast.py::test_cli_code_flag tests/test_cli_entry_points.py::TestAgentBom::test_agents_help tests/test_smithery.py::test_cli_scan_smithery_flags tests/test_mcp_official_registry.py::test_cli_scan_mcp_registry_flag tests/test_coreweave.py::test_cli_coreweave_flags tests/test_snyk.py::test_cli_snyk_flags`
- `uv run pytest -q tests/test_cli_clarity.py tests/test_cli_scan.py::test_scan_help tests/test_core.py -k help`
- `uv run pytest -q tests/test_deployment.py -k compose tests/test_compose_secrets_healthcheck.py`
- `uv run ruff check src/agent_bom/cli/_scan_help.py tests/test_ai_enrich.py tests/test_cli_clarity.py tests/test_cli_scan.py tests/test_core.py tests/test_image_auth.py tests/test_model_provenance.py tests/test_project_mode.py tests/test_mcp_introspect.py tests/test_sast.py tests/test_cli_entry_points.py tests/test_smithery.py tests/test_mcp_official_registry.py tests/test_coreweave.py tests/test_snyk.py tests/test_compose_secrets_healthcheck.py tests/test_deployment.py scripts/bump-version.py scripts/check_release_consistency.py`
- `git diff --check`
