### PR TITLE
deploy(docs): authenticated hosted instance + connect-your-cloud runbook

### DIFF
--- a/deploy/docker-compose.product.yml
+++ b/deploy/docker-compose.product.yml
@@ -1,0 +1,51 @@
+version: "3.8"
+
+# ── Profile: AUTHENTICATED PRODUCT OVERLAY ───────────────────────────────────
+# The private customer / CISO experience: a single-host, login-gated agent-bom
+# instance where a REAL cloud account is connected read-only. This is the exact
+# opposite of the public anonymous demo.
+#
+# Layer it on top of the production-shaped platform compose:
+#
+#   docker compose \
+#     -f deploy/docker-compose.platform.yml \
+#     -f deploy/docker-compose.product.yml \
+#     up -d --build
+#
+# Full step-by-step (first admin, connect-your-cloud, log in) lives in
+# site-docs/deployment/authenticated-hosted-instance.md.
+#
+# What this overlay guarantees vs. the demo overlays
+# (docker-compose.hosted-poc.yml sets DEMO_ESTATE=1 + NO_AUTH_ROLE=viewer):
+#   - AGENT_BOM_DEMO_ESTATE=0         no synthetic estate is ever seeded
+#   - AGENT_BOM_ALLOW_UNAUTHENTICATED_API=0   anonymous API access is off
+#   - NO_AUTH_ROLE is NOT set         there is no implicit unauthenticated role
+#   - Postgres URL REQUIRES the non-superuser app role (agent_bom_app), so the
+#     RLS superuser guard (#3665) is satisfied by least privilege, not by the
+#     AGENT_BOM_ALLOW_SUPERUSER_DB escape hatch. The `:?` guards fail closed
+#     when the operator has not provisioned the DML-only role.
+#   - Session cookies stay Secure because Caddy terminates public TLS on 443 and
+#     proxies to the loopback-bound API/UI (see deploy/caddy/Caddyfile.hosted-poc).
+#
+# Auth itself (API key and/or OIDC/SAML) is configured through the same env the
+# platform compose already wires: AGENT_BOM_API_KEY / AGENT_BOM_API_KEYS,
+# AGENT_BOM_OIDC_ISSUER / AGENT_BOM_OIDC_AUDIENCE. Set at least one before boot;
+# the CLI refuses a non-loopback bind with no auth configured.
+#
+# TLS: keep the platform default loopback bind (127.0.0.1) and run Caddy on the
+# host with deploy/caddy/Caddyfile.hosted-poc as the only public listener. No
+# Caddy service is duplicated here on purpose.
+
+services:
+  api:
+    environment:
+      # Fail closed unless the DML-only, NOSUPERUSER/NOBYPASSRLS app role created
+      # by deploy/supabase/postgres/init.sql is provisioned. No admin fallback.
+      - AGENT_BOM_POSTGRES_URL=postgresql://${POSTGRES_APP_USER:?set POSTGRES_APP_USER=agent_bom_app}:${POSTGRES_APP_PASSWORD:?set POSTGRES_APP_PASSWORD to the app-role password}@postgres:5432/${POSTGRES_DB:-agent_bom}
+      # Anti-demo guards: opposite of docker-compose.hosted-poc.yml.
+      - AGENT_BOM_DEMO_ESTATE=0
+      - AGENT_BOM_ALLOW_UNAUTHENTICATED_API=0
+      # Public TLS terminates at Caddy; keep browser-session cookies Secure.
+      - AGENT_BOM_SESSION_COOKIE_SECURE=1
+      # Audit trail must be HMAC-signed and verifiable across restarts.
+      - AGENT_BOM_REQUIRE_AUDIT_HMAC=1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
           - Runtime Operations: deployment/runtime-operations.md
           - Gateway Auto-Discovery: deployment/gateway-auto-discovery.md
       - Enterprise Controls:
+          - Hosted Authenticated Instance + Connect Your Cloud: deployment/authenticated-hosted-instance.md
           - Enterprise Auth and Tenancy: deployment/enterprise-auth-and-tenancy.md
           - Data Access Boundaries: deployment/data-access-boundaries.md
           - Customer Data and Support Boundary: deployment/customer-data-and-support-boundary.md

--- a/site-docs/deployment/authenticated-hosted-instance.md
+++ b/site-docs/deployment/authenticated-hosted-instance.md
@@ -1,0 +1,270 @@
+# Hosted Authenticated Instance + Connect Your Cloud
+
+This runbook stands up the **private customer / CISO experience**: a single-host,
+**login-gated** `agent-bom` instance with **no synthetic data**, real
+authentication, a least-privilege Postgres role, and a **real cloud account
+connected read-only**. It is the deliberate opposite of the public anonymous
+demo.
+
+!!! danger "Safety rule — never mix the two"
+    **Never connect a real cloud account to the anonymous demo.** The public
+    demo (`AGENT_BOM_DEMO_ESTATE=1` + `AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1`)
+    serves synthetic data to unauthenticated viewers. Real cloud posture,
+    findings, and graph data must only ever live behind the authenticated
+    profile described here.
+
+## Demo vs. authenticated product
+
+Both run from the same `deploy/docker-compose.platform.yml` base; only the
+**overlay** differs.
+
+| Setting | Public anonymous demo | Authenticated product |
+|---|---|---|
+| Overlay | `deploy/docker-compose.hosted-poc.yml` | `deploy/docker-compose.product.yml` |
+| `AGENT_BOM_DEMO_ESTATE` | `1` (synthetic estate seeded) | `0` (never seeded) |
+| `AGENT_BOM_ALLOW_UNAUTHENTICATED_API` | `1` (anonymous read) | `0` (auth required) |
+| `AGENT_BOM_NO_AUTH_ROLE` | `viewer` (implicit role) | unset (no implicit role) |
+| Auth | none — anyone with the URL | API key and/or OIDC/SAML SSO |
+| Postgres role | falls back to admin owner | **requires** `agent_bom_app` (DML-only, NOSUPERUSER/NOBYPASSRLS) |
+| Data | curated fake graph | real connected cloud posture / CIS / graph |
+
+The product overlay is minimal on purpose: it flips the demo guards off,
+forces the non-superuser app role via `:?` (fail-closed) env expansion, and
+keeps browser-session cookies Secure. Auth env is wired by the platform base.
+
+## 0. Prerequisites
+
+- A small CPU-only host (4 vCPU / 8–16 GB RAM) with Docker + Compose.
+- DNS pointing at the host, for example `app.agent-bom.com`. Open inbound `443`
+  only; restrict SSH to your IP.
+- A checkout of this repository on the host.
+
+## 1. Stand up the gated instance
+
+### 1a. Generate secrets and the non-superuser DB role
+
+The app connects as `agent_bom_app`, the DML-only role created by
+`deploy/supabase/postgres/init.sql` on first boot. Provide its password via
+`POSTGRES_APP_PASSWORD`; the init wrapper (`init-wrapper.sh`) injects it and the
+init SQL creates the role `NOSUPERUSER NOBYPASSRLS`, satisfying the RLS
+superuser guard (#3665) by least privilege.
+
+```bash
+cp .env.example .env
+
+# Postgres: superuser owner (schema init only) + DML-only app role (runtime)
+export POSTGRES_PASSWORD="$(openssl rand -hex 32)"
+export POSTGRES_APP_USER=agent_bom_app
+export POSTGRES_APP_PASSWORD="$(openssl rand -hex 32)"
+
+# Control-plane secrets
+export AGENT_BOM_API_KEY="$(openssl rand -hex 32)"          # bootstrap admin key
+export AGENT_BOM_AUDIT_HMAC_KEY="$(openssl rand -hex 32)"
+export AGENT_BOM_BROWSER_SESSION_SIGNING_KEY="$(openssl rand -hex 32)"
+export AGENT_BOM_CONNECTIONS_KEY="$(
+  python - <<'PY'
+from cryptography.fernet import Fernet
+print(Fernet.generate_key().decode())
+PY
+)"
+
+# Public URL wiring (Caddy terminates TLS on 443)
+export AGENT_BOM_HOSTED_DOMAIN="app.agent-bom.com"
+export ACME_EMAIL="ops@example.com"
+export NEXT_PUBLIC_API_URL="https://app.agent-bom.com"
+export CORS_ORIGINS="https://app.agent-bom.com,http://ui:3000"
+
+# Mount the Postgres superuser password as a Docker secret (fails closed if absent)
+mkdir -p deploy/secrets
+printf '%s' "$POSTGRES_PASSWORD" > deploy/secrets/postgres_password
+chmod 0400 deploy/secrets/postgres_password
+```
+
+`AGENT_BOM_API_KEY` seeds a single **admin** key. To seed viewer/analyst keys
+by env instead of (or in addition to) OIDC, set
+`AGENT_BOM_API_KEYS="<raw-key>:viewer,<raw-key>:analyst"` — each entry is
+`<raw-key>:<admin|analyst|viewer>`.
+
+### 1b. Optional — wire OIDC / SAML SSO instead of (or alongside) API keys
+
+```bash
+export AGENT_BOM_OIDC_ISSUER="https://login.example.com/"
+export AGENT_BOM_OIDC_AUDIENCE="agent-bom"
+# For multi-tenant IdP setups also set AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON.
+```
+
+The CLI refuses to expose the API on a non-loopback host unless **at least one**
+of API key, `AGENT_BOM_API_KEYS`, OIDC, or a SCIM bearer token is configured, so
+the gated posture is enforced at boot, not just documented.
+
+### 1c. Boot the authenticated stack
+
+```bash
+docker compose \
+  -f deploy/docker-compose.platform.yml \
+  -f deploy/docker-compose.product.yml \
+  up -d --build
+
+docker compose \
+  -f deploy/docker-compose.platform.yml \
+  -f deploy/docker-compose.product.yml \
+  ps
+```
+
+The platform base binds API (`8422`) and UI (`3000`) to loopback. Do **not**
+seed a demo graph — the product overlay sets `AGENT_BOM_DEMO_ESTATE=0`.
+
+### 1d. Front door: TLS via Caddy
+
+Run Caddy on the host as the only public listener, reusing the shipped
+`deploy/caddy/Caddyfile.hosted-poc` (it already splits `/v1/*`, `/health`, and
+`/ws/*` to `127.0.0.1:8422` and everything else to `127.0.0.1:3000`, and sets
+HSTS/security headers). `AGENT_BOM_HOSTED_DOMAIN` and `ACME_EMAIL` from step 1a
+drive its TLS.
+
+```bash
+caddy run --config deploy/caddy/Caddyfile.hosted-poc
+```
+
+### 1e. Preflight (fail-closed)
+
+```bash
+python scripts/deploy/hosted_poc_preflight.py --write-postgres-secret
+```
+
+This fails closed when required secrets are missing, `AGENT_BOM_ALLOW_UNAUTHENTICATED_API`
+is enabled, CORS is wildcarded, or API/UI ports bind publicly. Re-run it after
+any `.env`, DNS, or compose change.
+
+## 2. Create the first admin and issue a viewer/analyst key
+
+Mint the first admin key **inside the API container** so the record lands in the
+same persistent store the API reads:
+
+```bash
+docker compose \
+  -f deploy/docker-compose.platform.yml \
+  -f deploy/docker-compose.product.yml \
+  exec api \
+  python scripts/deploy/mint_hosted_admin_key.py \
+    --tenant-id customer-0 \
+    --name customer-0-admin \
+    --raw-key-file /tmp/customer0-admin.key
+```
+
+The raw key is written once to the `0600` file passed with `--raw-key-file`.
+Store it in your password manager; never commit, screenshot, or paste it.
+
+Issue scoped viewer/analyst keys for the account with the admin key against the
+RBAC endpoint (`POST /v1/auth/keys` requires the `admin` role):
+
+```bash
+curl -sS -X POST "https://app.agent-bom.com/v1/auth/keys" \
+  -H "Authorization: Bearer <raw admin key>" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "ciso-viewer", "role": "viewer"}'
+```
+
+If you wired OIDC in step 1b instead, skip key issuance and map IdP group claims
+to roles via `AGENT_BOM_OIDC_ROLE_CLAIM`; each invited user signs in at
+`/login`.
+
+## 3. Connect a real cloud account read-only
+
+`agent-bom` never mutates the target and does no cloud I/O until you opt in. Use
+the built-in onboarding helper to print the exact read-only setup and confirm
+your credentials are detectable:
+
+```bash
+agent-bom connect aws     # or: connect azure | connect gcp
+```
+
+### 3a. Apply the read-only Terraform (AWS)
+
+`deploy/terraform/connect-aws` mints a least-privilege role: AWS-managed
+`SecurityAudit` (+ optional `ViewOnlyAccess`), a unique non-guessable name, and
+an **always-enforced high-entropy `sts:ExternalId`**. No access keys, no
+write permissions.
+
+```bash
+cd deploy/terraform/connect-aws
+terraform init
+terraform apply \
+  -var 'trusted_principal_arns=["arn:aws:iam::<scanner-acct>:role/agent-bom-scanner"]'
+
+terraform output -raw role_arn        # the read-only role to assume
+terraform output -raw external_id     # sensitive; confused-deputy defense
+```
+
+GCP and Azure follow the same pattern with their own modules:
+`deploy/terraform/connect-gcp` (viewer + `iam.securityReviewer`, keyless
+Workload Identity Federation) and `deploy/terraform/connect-azure` (Reader +
+Security Reader, pinned federated identity credential).
+
+### 3b. Run the first authenticated scan against the tenant
+
+Authenticate via the standard provider chain (named profile, assumed role, or
+SSO — no secrets stored in `agent-bom`), opt in with the per-provider inventory
+flag, and scan from inside the API container so findings land in the customer-0
+tenant store:
+
+```bash
+docker compose \
+  -f deploy/docker-compose.platform.yml \
+  -f deploy/docker-compose.product.yml \
+  exec \
+    -e AGENT_BOM_AWS_INVENTORY=1 \
+    -e AWS_PROFILE=abom-readonly \
+    api \
+  agent-bom agents --preset enterprise --aws --aws-cis-benchmark
+```
+
+Azure and GCP equivalents:
+
+```bash
+# Azure — Reader / Security Reader via DefaultAzureCredential
+AGENT_BOM_AZURE_INVENTORY=1 agent-bom agents --preset enterprise --azure
+
+# GCP — roles/viewer + roles/iam.securityReviewer via ADC
+AGENT_BOM_GCP_INVENTORY=1 agent-bom cloud gcp --project <PROJECT_ID> --cis
+```
+
+For org/tenant fan-out use `AGENT_BOM_AWS_ORG_INVENTORY=1`,
+`AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS=1`, or `AGENT_BOM_GCP_ALL_PROJECTS=1`. See
+[`docs/CLOUD_CONNECT.md`](https://github.com/msaad00/agent-bom/blob/main/docs/CLOUD_CONNECT.md)
+for the full per-provider matrix and scale caps.
+
+## 4. Log in and see real posture
+
+1. Open `https://app.agent-bom.com` and sign in at `/login` (API key or SSO).
+2. Confirm the dashboard shows the connected account's **real** findings, CIS
+   benchmark posture, and blast-radius graph — not the demo estate.
+3. Run the smoke check before inviting others:
+
+   ```bash
+   AGENT_BOM_SMOKE_URL="https://app.agent-bom.com" \
+   AGENT_BOM_SMOKE_API_KEY="<raw admin key>" \
+   scripts/deploy/hosted_poc_smoke.sh
+   ```
+
+## Verify the gated posture
+
+Re-confirm the anti-demo guards any time you change config:
+
+```bash
+docker compose \
+  -f deploy/docker-compose.platform.yml \
+  -f deploy/docker-compose.product.yml \
+  config | grep -E 'AGENT_BOM_DEMO_ESTATE|AGENT_BOM_ALLOW_UNAUTHENTICATED_API|AGENT_BOM_POSTGRES_URL'
+# expect: DEMO_ESTATE "0", ALLOW_UNAUTHENTICATED_API "0",
+#         POSTGRES_URL using agent_bom_app (never the admin owner)
+```
+
+If `AGENT_BOM_ALLOW_UNAUTHENTICATED_API` is anything but `0`, or the Postgres
+URL is not using `agent_bom_app`, stop and fix before connecting any cloud.
+
+## Related
+
+- Public anonymous demo runbook: [`docs/HOSTED_POC.md`](https://github.com/msaad00/agent-bom/blob/main/docs/HOSTED_POC.md)
+- Cloud connect reference: [`docs/CLOUD_CONNECT.md`](https://github.com/msaad00/agent-bom/blob/main/docs/CLOUD_CONNECT.md)
+- Auth model and tenancy: [Enterprise Auth and Tenancy](enterprise-auth-and-tenancy.md)

--- a/site-docs/deployment/overview.md
+++ b/site-docs/deployment/overview.md
@@ -20,6 +20,7 @@ from them.
 | **Laptop scan** | `pip install agent-bom` | local findings, SBOM, SARIF, HTML, graph export |
 | **Team demo** | `docker compose` pilot | shared API + UI control plane on one workstation |
 | **Production** | Helm / EKS Terraform | tenant-aware self-hosted control plane in your cluster |
+| **Private customer / CISO instance** | `docker compose` platform + product overlay | login-gated single host, no demo data, real cloud connected read-only |
 | **Snowflake shop** | SPCS / Native App | warehouse-native governance lane in your account |
 
 Same one-liner in prose: laptop scan → pip; team demo → docker compose pilot;
@@ -27,6 +28,11 @@ production → Helm / EKS Terraform; Snowflake shop → SPCS / Native App. Every
 here runs in your own boundary. Cost posture: all in-repo lanes are free and no
 managed public SaaS ships in this repo yet; see
 [Product boundaries](product-boundaries.md) for the full lane matrix.
+
+For the private, login-gated single-host instance where a real cloud account is
+connected read-only (the customer / CISO experience, distinct from the public
+anonymous demo), follow
+[Hosted Authenticated Instance + Connect Your Cloud](authenticated-hosted-instance.md).
 
 `agent-bom` is one product with two deployable images:
 

--- a/tests/api/test_api_operator_policy.py
+++ b/tests/api/test_api_operator_policy.py
@@ -647,6 +647,7 @@ def test_auth_secret_rotation_plan_is_non_secret_and_actionable(monkeypatch: pyt
 
 def test_auth_secret_rotation_plan_supports_vault_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
     _clear_rate_limit_env(monkeypatch)
+    monkeypatch.setattr("agent_bom.api.middleware.clustered_control_plane_required", lambda: False)
     monkeypatch.setenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY", "browser-secret")
     monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "2")
     monkeypatch.setenv("AGENT_BOM_SECRET_PROVIDER", "hashicorp_vault")
@@ -664,6 +665,7 @@ def test_auth_secret_rotation_plan_supports_vault_adapter(monkeypatch: pytest.Mo
 
 def test_auth_secret_rotation_plan_supports_kubernetes_secret_adapter(monkeypatch: pytest.MonkeyPatch) -> None:
     _clear_rate_limit_env(monkeypatch)
+    monkeypatch.setattr("agent_bom.api.middleware.clustered_control_plane_required", lambda: False)
     monkeypatch.setenv("AGENT_BOM_CONTROL_PLANE_REPLICAS", "2")
     monkeypatch.setenv("AGENT_BOM_SECRET_PROVIDER", "kubernetes_secret")
 

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -44,6 +44,12 @@ HEALTHCHECK_EXEMPT: dict[str, set[str]] = {
         # base platform compose and inherited at merge time.
         "api",
     },
+    "docker-compose.product.yml": {
+        # Overlay applied on top of docker-compose.platform.yml; it only sets
+        # authenticated-product environment. Healthchecks are defined once in
+        # the base platform compose and inherited at merge time.
+        "api",
+    },
 }
 
 


### PR DESCRIPTION
## Summary

Adds a **login-gated authenticated product profile** — the private customer /
CISO experience where a real cloud account is connected read-only — as a
first-class, distinct alternative to the public anonymous demo. Touches only
`deploy/` and `site-docs/`; no `src/` or `ui/`.

## The overlay — `deploy/docker-compose.product.yml`

A minimal overlay on `docker-compose.platform.yml` (reuses the platform base's
auth env plumbing, Postgres networks, secrets, and `init.sql` app-role
creation). It only sets what makes the profile authenticated:

- `AGENT_BOM_POSTGRES_URL` rebuilt to **require** `agent_bom_app` (DML-only,
  NOSUPERUSER/NOBYPASSRLS) via `:?` fail-closed env expansion — no admin
  fallback, so the RLS superuser guard (#3665) is satisfied by least privilege.
- `AGENT_BOM_DEMO_ESTATE=0`, `AGENT_BOM_ALLOW_UNAUTHENTICATED_API=0` — the
  anti-demo guards.
- `AGENT_BOM_SESSION_COOKIE_SECURE=1`, `AGENT_BOM_REQUIRE_AUDIT_HMAC=1`.
- No `NO_AUTH_ROLE` (unlike the demo overlay). TLS via the existing
  `deploy/caddy/Caddyfile.hosted-poc` on the host; no duplicated Caddy service.

## The runbook — `site-docs/deployment/authenticated-hosted-instance.md`

Copy-pasteable, verified against the code/terraform:

1. Stand up the gated instance (secrets + `agent_bom_app` role + boot + Caddy + fail-closed preflight).
2. Mint the first admin (`scripts/deploy/mint_hosted_admin_key.py`) and issue viewer/analyst keys (`POST /v1/auth/keys`) or wire OIDC (`AGENT_BOM_OIDC_ISSUER`/`AUDIENCE`).
3. Apply read-only `deploy/terraform/connect-aws` (and gcp/azure), assisted by `agent-bom connect aws`.
4. Log in at `/login` and see real posture/CIS/graph.

Explicitly contrasts with the public demo and states the safety rule: **never
connect a real cloud to the anonymous demo.** Linked from the deployment
decision matrix (`overview.md`) and the mkdocs Enterprise Controls nav.

## Demo vs. authenticated product config

| Setting | Public anonymous demo | Authenticated product |
|---|---|---|
| Overlay | `docker-compose.hosted-poc.yml` | `docker-compose.product.yml` |
| `AGENT_BOM_DEMO_ESTATE` | `1` | `0` |
| `AGENT_BOM_ALLOW_UNAUTHENTICATED_API` | `1` | `0` |
| `AGENT_BOM_NO_AUTH_ROLE` | `viewer` | unset |
| Auth | none | API key and/or OIDC/SAML |
| Postgres role | admin owner fallback | requires `agent_bom_app` (DML-only) |
| Data | synthetic estate | real connected cloud posture |

## Validation

- `docker compose -f platform -f product config` → exit 0; renders
  `DEMO_ESTATE=0`, `ALLOW_UNAUTHENTICATED_API=0`, app-role URL, cookies Secure.
- Fail-closed confirmed: without `POSTGRES_APP_USER`/`POSTGRES_APP_PASSWORD`,
  `config` exits 1 with the guard message.
- `mkdocs build --strict` → exit 0, no link/nav warnings.
- Every cited `AGENT_BOM_*` flag, script, and terraform path verified present.