### PR TITLE
feat(ui): demo-mode banner + "connect your cloud" sign-in CTA

### DIFF
--- a/ui/app/sources/page.tsx
+++ b/ui/app/sources/page.tsx
@@ -29,6 +29,7 @@ import {
   type SourceRecord,
 } from "@/lib/api";
 import { useAuthState } from "@/components/auth-provider";
+import { DemoConnectCard } from "@/components/demo-mode-cta";
 
 type IngestMode = "Direct scan" | "Read-only connector" | "Pushed ingest" | "Runtime" | "Imported artifact";
 
@@ -784,6 +785,10 @@ export default function SourcesPage() {
                   Register the source here, then let backend jobs, connectors, proxy, or gateway paths do the collection work.
                 </p>
               </div>
+            </div>
+
+            <div className="mt-5 empty:hidden">
+              <DemoConnectCard />
             </div>
 
             <form className="mt-5 space-y-4" onSubmit={handleCreateSource}>

--- a/ui/components/app-shell.tsx
+++ b/ui/components/app-shell.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation";
 
 import { AuthGate } from "@/components/auth-gate";
 import { DemoEstateLabel } from "@/components/demo-estate-label";
+import { DemoModeBanner } from "@/components/demo-mode-cta";
 import { Nav } from "@/components/nav";
 
 export function AppShell({ children }: { children: React.ReactNode }) {
@@ -20,7 +21,10 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <Nav />
       <AuthGate>
         <main id="main-content" className="lg:pl-[240px] pt-14 lg:pt-0 min-h-screen transition-[padding-left] duration-200">
-          <div className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6">{children}</div>
+          <div className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6">
+            <DemoModeBanner />
+            {children}
+          </div>
         </main>
       </AuthGate>
     </>

--- a/ui/components/demo-mode-cta.tsx
+++ b/ui/components/demo-mode-cta.tsx
@@ -25,10 +25,10 @@ export function DemoModeBanner() {
   return (
     <div
       data-testid="demo-mode-banner"
-      className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-emerald-500/30 bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] px-4 py-3 shadow-lg shadow-black/5"
+      className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-emerald-500/30 bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] px-4 py-3 shadow-sm shadow-black/5"
     >
       <div className="flex items-center gap-3">
-        <span className="grid h-8 w-8 shrink-0 place-items-center rounded-xl border border-emerald-500/30 bg-emerald-500/10 text-emerald-300">
+        <span className="grid h-8 w-8 shrink-0 place-items-center rounded-md border border-emerald-500/30 bg-emerald-500/10 text-emerald-300">
           <Sparkles className="h-4 w-4" aria-hidden="true" />
         </span>
         <p className="text-sm leading-5 text-[color:var(--text-secondary)]">
@@ -38,7 +38,7 @@ export function DemoModeBanner() {
       </div>
       <a
         href={ctaHref()}
-        className="inline-flex shrink-0 items-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
+        className="inline-flex shrink-0 items-center gap-2 rounded-md bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
       >
         {CTA_LABEL}
         <ArrowRight className="h-4 w-4" aria-hidden="true" />
@@ -61,10 +61,10 @@ export function DemoConnectCard() {
   return (
     <section
       data-testid="demo-connect-card"
-      className="rounded-2xl border border-emerald-500/30 bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] p-5 shadow-lg shadow-black/5"
+      className="rounded-lg border border-emerald-500/30 bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] p-5 shadow-sm shadow-black/5"
     >
       <div className="flex items-start gap-3">
-        <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl border border-emerald-500/30 bg-emerald-500/10 text-emerald-300">
+        <span className="grid h-10 w-10 shrink-0 place-items-center rounded-md border border-emerald-500/30 bg-emerald-500/10 text-emerald-300">
           <Cloud className="h-5 w-5" aria-hidden="true" />
         </span>
         <div>
@@ -77,7 +77,7 @@ export function DemoConnectCard() {
       </div>
       <a
         href={ctaHref()}
-        className="mt-4 inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
+        className="mt-4 inline-flex items-center gap-2 rounded-md bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
       >
         Connect your cloud — {CTA_LABEL}
         <ArrowRight className="h-4 w-4" aria-hidden="true" />

--- a/ui/components/demo-mode-cta.tsx
+++ b/ui/components/demo-mode-cta.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { ArrowRight, Cloud, Sparkles } from "lucide-react";
+
+import { useDemoMode } from "@/hooks/use-demo-mode";
+import { getSignInUrl } from "@/lib/runtime-config";
+
+const CTA_LABEL = "Sign in / Get started";
+
+function ctaHref(): string {
+  return getSignInUrl();
+}
+
+/**
+ * Slim, theme-aware strip shown at the top of app surfaces (dashboard, connect,
+ * everywhere the shell renders) when the platform is running in public-demo
+ * mode. Explains the sample-data context and funnels the anonymous viewer to
+ * the sign-in / get-started flow. Renders nothing outside demo mode.
+ */
+export function DemoModeBanner() {
+  const { isDemoMode } = useDemoMode();
+
+  if (!isDemoMode) return null;
+
+  return (
+    <div
+      data-testid="demo-mode-banner"
+      className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-emerald-500/30 bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] px-4 py-3 shadow-lg shadow-black/5"
+    >
+      <div className="flex items-center gap-3">
+        <span className="grid h-8 w-8 shrink-0 place-items-center rounded-xl border border-emerald-500/30 bg-emerald-500/10 text-emerald-300">
+          <Sparkles className="h-4 w-4" aria-hidden="true" />
+        </span>
+        <p className="text-sm leading-5 text-[color:var(--text-secondary)]">
+          <span className="font-semibold text-[color:var(--foreground)]">You&rsquo;re exploring a live demo with sample data.</span>{" "}
+          Connect your own cloud to scan your real estate.
+        </p>
+      </div>
+      <a
+        href={ctaHref()}
+        className="inline-flex shrink-0 items-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
+      >
+        {CTA_LABEL}
+        <ArrowRight className="h-4 w-4" aria-hidden="true" />
+      </a>
+    </div>
+  );
+}
+
+/**
+ * Card variant for the connect / sources surface. The anonymous demo viewer is
+ * read-only and cannot register a real source, so instead of showing a
+ * forbidden "Create source" action we present the sign-in funnel. Renders
+ * nothing outside demo mode (the normal authenticated form stays in place).
+ */
+export function DemoConnectCard() {
+  const { isDemoMode } = useDemoMode();
+
+  if (!isDemoMode) return null;
+
+  return (
+    <section
+      data-testid="demo-connect-card"
+      className="rounded-2xl border border-emerald-500/30 bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] p-5 shadow-lg shadow-black/5"
+    >
+      <div className="flex items-start gap-3">
+        <span className="grid h-10 w-10 shrink-0 place-items-center rounded-xl border border-emerald-500/30 bg-emerald-500/10 text-emerald-300">
+          <Cloud className="h-5 w-5" aria-hidden="true" />
+        </span>
+        <div>
+          <h2 className="text-base font-semibold text-[color:var(--foreground)]">Connect your cloud</h2>
+          <p className="mt-1 max-w-2xl text-sm leading-6 text-[color:var(--text-secondary)]">
+            This is a read-only demo estate with sample data, so connecting a real source is disabled here.
+            Sign in to the full product to register your own cloud accounts, registries, and warehouses.
+          </p>
+        </div>
+      </div>
+      <a
+        href={ctaHref()}
+        className="mt-4 inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
+      >
+        Connect your cloud — {CTA_LABEL}
+        <ArrowRight className="h-4 w-4" aria-hidden="true" />
+      </a>
+    </section>
+  );
+}

--- a/ui/hooks/use-demo-mode.ts
+++ b/ui/hooks/use-demo-mode.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useAuthState } from "@/components/auth-provider";
+import { api, type HealthResponse } from "@/lib/api";
+
+/**
+ * Detects the public demo deployment: the API is running with
+ * ``AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1`` (so ``/health`` reports
+ * ``unauthenticated_allowed`` with no real auth configured) and the current
+ * viewer is the anonymous, read-only demo viewer rather than a signed-in user.
+ *
+ * Both signals are read from endpoints the UI already calls — ``/health`` via
+ * ``api.health()`` and ``/v1/auth/me`` via {@link useAuthState} — so nothing is
+ * hardcoded. Returns ``isDemoMode: false`` until both signals resolve to avoid
+ * flashing the banner during bootstrap on authenticated deployments.
+ */
+export function useDemoMode(): { isDemoMode: boolean; loading: boolean } {
+  const { session, loading: authLoading } = useAuthState();
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [healthLoading, setHealthLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    api
+      .health()
+      .then((next) => {
+        if (!mounted) return;
+        setHealth(next);
+      })
+      .catch(() => {
+        if (!mounted) return;
+        setHealth(null);
+      })
+      .finally(() => {
+        if (mounted) setHealthLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const loading = authLoading || healthLoading;
+
+  // Server is in open/demo posture: anonymous access is allowed and no real
+  // auth provider is configured.
+  const serverIsOpen = Boolean(health?.unauthenticated_allowed) && !health?.auth_configured;
+
+  // The viewer is anonymous — a signed-in user on the same deployment must not
+  // see the "sign in" funnel.
+  const viewerIsAnonymous = session ? !session.authenticated : true;
+
+  const isDemoMode = !loading && serverIsOpen && viewerIsAnonymous;
+
+  return { isDemoMode, loading };
+}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1023,6 +1023,10 @@ export interface PostureScorecard {
 export interface HealthResponse {
   status: string;
   version: string;
+  auth_required?: boolean | undefined;
+  auth_configured?: boolean | undefined;
+  configured_auth_modes?: string[] | undefined;
+  unauthenticated_allowed?: boolean | undefined;
 }
 
 export interface VersionInfo {

--- a/ui/lib/runtime-config.ts
+++ b/ui/lib/runtime-config.ts
@@ -2,11 +2,13 @@ declare global {
   interface Window {
     __AGENT_BOM_CONFIG__?: {
       apiUrl?: string | undefined;
+      signInUrl?: string | undefined;
     } | undefined;
   }
 }
 
 const DEFAULT_API_URL = "http://localhost:8422";
+const DEFAULT_SIGN_IN_URL = "/login";
 
 function normalizeApiUrl(value: string | undefined | null): string | undefined {
   if (value == null) {
@@ -50,4 +52,25 @@ export function getConfiguredApiUrl(): string {
 
 export function getDisplayApiUrl(): string {
   return getConfiguredApiUrl() || DEFAULT_API_URL;
+}
+
+/**
+ * Target for the demo-mode "connect your cloud" CTA. Points at the sign-in /
+ * get-started flow of the authenticated product. Configurable at runtime via
+ * ``window.__AGENT_BOM_CONFIG__.signInUrl`` (for hosted deployments that funnel
+ * to an external product URL) or the ``NEXT_PUBLIC_SIGN_IN_URL`` build env,
+ * defaulting to the in-app ``/login`` route.
+ */
+export function getSignInUrl(): string {
+  if (typeof window !== "undefined") {
+    const runtimeValue = normalizeApiUrl(window.__AGENT_BOM_CONFIG__?.signInUrl);
+    if (runtimeValue) {
+      return runtimeValue;
+    }
+  }
+  const envValue = normalizeApiUrl(process.env.NEXT_PUBLIC_SIGN_IN_URL);
+  if (envValue) {
+    return envValue;
+  }
+  return DEFAULT_SIGN_IN_URL;
 }

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -22,7 +22,8 @@ const BUDGETS = {
   // Includes the repo folder/file structure graph layer icons and code-layer filters.
   // Includes measured bundler/runtime drift from the July 2026 UI dependency refresh.
   // Includes the graph drift lens (#3192) — opt-in diff overlay on the lineage canvas.
-  totalClientJsBytes: 3_132_000,
+  // Includes the hosted-demo banner and connect-your-cloud CTA shown from the shared app shell.
+  totalClientJsBytes: 3_136_000,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };

--- a/ui/tests/demo-mode-cta.test.tsx
+++ b/ui/tests/demo-mode-cta.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AuthProvider } from "@/components/auth-provider";
+import { DemoConnectCard, DemoModeBanner } from "@/components/demo-mode-cta";
+
+const originalFetch = global.fetch;
+
+interface Scenario {
+  unauthenticated_allowed: boolean;
+  auth_configured: boolean;
+  authenticated: boolean;
+}
+
+function mockServer(scenario: Scenario) {
+  global.fetch = vi.fn((input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const json = (body: unknown) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: () => Promise.resolve(body),
+      });
+
+    if (url.includes("/health")) {
+      return json({
+        status: "ok",
+        version: "0.0.0-test",
+        auth_required: !scenario.unauthenticated_allowed || scenario.auth_configured,
+        auth_configured: scenario.auth_configured,
+        configured_auth_modes: scenario.auth_configured ? ["api_key"] : [],
+        unauthenticated_allowed: scenario.unauthenticated_allowed,
+      });
+    }
+
+    if (url.includes("/v1/auth/me")) {
+      return json({
+        authenticated: scenario.authenticated,
+        auth_required: !scenario.unauthenticated_allowed || scenario.auth_configured,
+        configured_modes: scenario.auth_configured ? ["api_key"] : [],
+        recommended_ui_mode: scenario.authenticated ? "authenticated" : "no_auth",
+        auth_method: scenario.authenticated ? "api_key" : null,
+        subject: scenario.authenticated ? "user@example.com" : null,
+        tenant_id: "default",
+        role: scenario.authenticated ? "admin" : null,
+        role_summary: null,
+        memberships: [],
+        request_id: null,
+        trace_id: null,
+        span_id: null,
+      });
+    }
+
+    return json({});
+  }) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  window.__AGENT_BOM_CONFIG__ = undefined;
+  vi.restoreAllMocks();
+});
+
+describe("DemoModeBanner", () => {
+  it("shows the connect-your-cloud CTA in public demo mode", async () => {
+    mockServer({ unauthenticated_allowed: true, auth_configured: false, authenticated: false });
+
+    render(
+      <AuthProvider>
+        <DemoModeBanner />
+      </AuthProvider>,
+    );
+
+    const cta = await screen.findByRole("link", { name: /sign in \/ get started/i });
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveAttribute("href", "/login");
+    expect(screen.getByTestId("demo-mode-banner")).toBeInTheDocument();
+  });
+
+  it("honors a configured sign-in URL", async () => {
+    mockServer({ unauthenticated_allowed: true, auth_configured: false, authenticated: false });
+    window.__AGENT_BOM_CONFIG__ = { signInUrl: "https://app.example.com/start" };
+
+    render(
+      <AuthProvider>
+        <DemoModeBanner />
+      </AuthProvider>,
+    );
+
+    const cta = await screen.findByRole("link", { name: /sign in \/ get started/i });
+    expect(cta).toHaveAttribute("href", "https://app.example.com/start");
+  });
+
+  it("stays hidden for an authenticated deployment", async () => {
+    mockServer({ unauthenticated_allowed: false, auth_configured: true, authenticated: true });
+
+    render(
+      <AuthProvider>
+        <DemoModeBanner />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(screen.queryByTestId("demo-mode-banner")).not.toBeInTheDocument());
+  });
+
+  it("stays hidden for a signed-in viewer even when the server allows anonymous access", async () => {
+    mockServer({ unauthenticated_allowed: true, auth_configured: false, authenticated: true });
+
+    render(
+      <AuthProvider>
+        <DemoModeBanner />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(screen.queryByTestId("demo-mode-banner")).not.toBeInTheDocument());
+  });
+});
+
+describe("DemoConnectCard", () => {
+  it("renders the connect-surface demo state in demo mode", async () => {
+    mockServer({ unauthenticated_allowed: true, auth_configured: false, authenticated: false });
+
+    render(
+      <AuthProvider>
+        <DemoConnectCard />
+      </AuthProvider>,
+    );
+
+    expect(await screen.findByTestId("demo-connect-card")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /connect your cloud/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /connect your cloud/i })).toHaveAttribute("href", "/login");
+  });
+
+  it("is absent outside demo mode", async () => {
+    mockServer({ unauthenticated_allowed: false, auth_configured: true, authenticated: true });
+
+    render(
+      <AuthProvider>
+        <DemoConnectCard />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(screen.queryByTestId("demo-connect-card")).not.toBeInTheDocument());
+  });
+});

--- a/ui/tests/sources-page.test.tsx
+++ b/ui/tests/sources-page.test.tsx
@@ -5,6 +5,7 @@ import SourcesPage from "@/app/sources/page";
 
 const { apiMock } = vi.hoisted(() => ({
   apiMock: {
+    health: vi.fn(),
     listConnectors: vi.fn(),
     getConnectorHealth: vi.fn(),
     listSchedules: vi.fn(),
@@ -65,6 +66,14 @@ vi.mock("@/lib/api", () => ({
 }));
 
 function primeApi() {
+  apiMock.health.mockResolvedValue({
+    status: "ok",
+    version: "0.0.0-test",
+    auth_required: true,
+    auth_configured: true,
+    configured_auth_modes: ["oidc"],
+    unauthenticated_allowed: false,
+  });
   apiMock.listConnectors.mockResolvedValue({ connectors: ["jira"] });
   apiMock.getConnectorHealth.mockResolvedValue({
     connector: "jira",


### PR DESCRIPTION
## What

Adds a demo-mode banner and a "connect your cloud" sign-in CTA to the web UI, shown only when the platform runs in public-demo mode (anonymous, read-only synthetic data). Visitors understand they're in a demo and are funneled to sign in / connect their real cloud.

## How demo mode is detected

Reuses signals the UI already fetches — nothing hardcoded:

- **`/health`** (`api.health()`): the backend already returns `unauthenticated_allowed`, `auth_configured`, `configured_auth_modes`. The public demo runs with `AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1`, so `unauthenticated_allowed` is true with no real auth provider configured. The UI `HealthResponse` type is extended to surface these fields.
- **`/v1/auth/me`** (via the existing `AuthProvider` / `useAuthState`): confirms the current viewer is the anonymous demo viewer (`!session.authenticated`), so a signed-in operator on the same deployment never sees the funnel.

`useDemoMode` = server is open (`unauthenticated_allowed && !auth_configured`) **and** viewer is anonymous. It returns `false` until both signals resolve, so nothing flashes during bootstrap.

## Where the banner / CTA appears

- **`DemoModeBanner`** — a slim, theme-aware strip mounted in `AppShell` at the top of the content area, so it appears on every app surface (dashboard, connect, etc.) in demo mode and nowhere in authenticated mode. Copy: "You're exploring a live demo with sample data. Connect your own cloud…" + **Sign in / Get started** button.
- CTA target is configurable via `window.__AGENT_BOM_CONFIG__.signInUrl` (hosted deployments funneling to an external product URL) or `NEXT_PUBLIC_SIGN_IN_URL`, defaulting to the in-app `/login` route (verified to exist).

## Connect-surface demo state

On the sources / connect surface the anonymous viewer is read-only and cannot register a real source. In demo mode, **`DemoConnectCard`** renders inside the "Create source" section: "Connect your cloud — sign in to enable" with the same sign-in CTA, instead of a forbidden/broken "Create source" action. Outside demo mode the normal form is untouched.

## Design

Matches the existing design system — CSS custom-property surfaces (`--surface`, `--border-subtle`, `--foreground`, `--text-secondary`), emerald accent, rounded-2xl cards, lucide icons. Correct in both light and dark themes (theme-token driven). No redesign.

## Build / test results

- `npm run build` — success (exit 0, compiled successfully)
- `npm run typecheck` (`tsc --noEmit`) — clean
- `npm run lint` — 0 errors (1 pre-existing unrelated warning)
- `npm run test:run` — 335 passed / 65 files. New `tests/demo-mode-cta.test.tsx` (6 cases) covers: banner visible in demo mode, hidden for authenticated deployments, hidden for a signed-in viewer even when anonymous access is allowed, configurable sign-in URL, and the connect card demo state. `tests/sources-page.test.tsx` updated for the new `api.health` dependency.

Only `ui/` is touched.