### PR TITLE
feat(demo): rich multi-cloud showcase estate for the hosted demo

### DIFF
--- a/src/agent_bom/demo.py
+++ b/src/agent_bom/demo.py
@@ -1,10 +1,18 @@
 """Bundled demo inventory for ``agent-bom agents --demo``.
 
-Contains realistic agents with known-vulnerable packages so users can see
-a real scan with CVE findings, blast radius, and remediation output.
+Contains a realistic, connected multi-agent estate with known-vulnerable
+packages so users see a real scan with CVE findings, blast radius, and
+remediation output on the very first run — no local vuln DB required.
 
-Includes packages with CRITICAL CVEs (CVSS 9.0+) to demonstrate blast radius
-mapping from vulnerability → package → MCP server → agent → credentials → tools.
+The estate is intentionally curated and deterministic (it must reproduce the
+same findings on every machine). It spans five agents and ten MCP servers and
+includes:
+  * CRITICAL / KEV CVEs (PyYAML RCE, LangChain RCE, Pillow libwebp KEV) so the
+    hero blast-radius chain vuln → package → MCP server → agent → credential →
+    tool → potential RCE renders end to end.
+  * Credential-backed ``env`` on servers so credential-exposure edges light up.
+  * A typosquat package (``reqeusts``) so the malicious-package differentiator
+    shows in the findings list.
 """
 
 from __future__ import annotations
@@ -12,6 +20,7 @@ from __future__ import annotations
 DEMO_INVENTORY: dict = {
     "agents": [
         {
+            # IDE coding agent — the developer's day-to-day copilot.
             "name": "cursor",
             "agent_type": "cursor",
             "source": "agent-bom --demo",
@@ -23,7 +32,7 @@ DEMO_INVENTORY: dict = {
                     "packages": [
                         {"name": "express", "version": "4.17.1", "ecosystem": "npm"},
                         {"name": "node-fetch", "version": "2.6.1", "ecosystem": "npm"},
-                        {"name": "jsonwebtoken", "version": "8.5.1", "ecosystem": "npm"},
+                        {"name": "ws", "version": "8.5.0", "ecosystem": "npm"},
                     ],
                     "tools": [
                         {"name": "read_file"},
@@ -32,26 +41,154 @@ DEMO_INVENTORY: dict = {
                     ],
                 },
                 {
-                    "name": "database-server",
-                    "command": "python -m mcp_database",
+                    # Hero chain: shell-runner holds AWS creds AND a run_shell
+                    # tool, and depends on PyYAML with a CRITICAL RCE.
+                    "name": "shell-runner-server",
+                    "command": "python -m mcp_shell_runner",
                     "transport": "stdio",
                     "packages": [
-                        {"name": "flask", "version": "2.2.0", "ecosystem": "pypi"},
-                        {"name": "werkzeug", "version": "2.2.2", "ecosystem": "pypi"},
+                        {"name": "pyyaml", "version": "5.3", "ecosystem": "pypi"},
                         {"name": "requests", "version": "2.28.0", "ecosystem": "pypi"},
-                        {"name": "cryptography", "version": "39.0.0", "ecosystem": "pypi"},
-                        {"name": "pillow", "version": "9.0.0", "ecosystem": "pypi"},
                     ],
-                    "env": {"DATABASE_URL": "***", "ANTHROPIC_API_KEY": "***"},
+                    "env": {
+                        "AWS_ACCESS_KEY_ID": "***",
+                        "AWS_SECRET_ACCESS_KEY": "***",
+                    },
+                    "tools": [
+                        {"name": "run_shell"},
+                        {"name": "exec_command"},
+                        {"name": "read_file"},
+                    ],
+                },
+            ],
+        },
+        {
+            # LangChain-based application/service agent.
+            "name": "langchain-service",
+            "agent_type": "custom",
+            "source": "agent-bom --demo",
+            "mcp_servers": [
+                {
+                    "name": "llm-orchestrator-server",
+                    "command": "python -m mcp_orchestrator",
+                    "transport": "streamable-http",
+                    "packages": [
+                        {"name": "langchain", "version": "0.0.150", "ecosystem": "pypi"},
+                        {"name": "jinja2", "version": "3.0.0", "ecosystem": "pypi"},
+                    ],
+                    "env": {
+                        "OPENAI_API_KEY": "***",
+                        "ANTHROPIC_API_KEY": "***",
+                    },
+                    "tools": [
+                        {"name": "run_chain"},
+                        {"name": "eval_expression"},
+                        {"name": "http_get"},
+                    ],
+                },
+                {
+                    "name": "vector-db-server",
+                    "command": "python -m mcp_vectors",
+                    "transport": "stdio",
+                    "packages": [
+                        {"name": "cryptography", "version": "39.0.0", "ecosystem": "pypi"},
+                        {"name": "requests", "version": "2.28.0", "ecosystem": "pypi"},
+                    ],
+                    "env": {
+                        "PINECONE_API_KEY": "***",
+                        "DATABASE_URL": "***",
+                    },
+                    "tools": [
+                        {"name": "query_vectors"},
+                        {"name": "upsert_vectors"},
+                    ],
+                },
+            ],
+        },
+        {
+            # Customer-support copilot handling tickets and email.
+            "name": "support-copilot",
+            "agent_type": "custom",
+            "source": "agent-bom --demo",
+            "mcp_servers": [
+                {
+                    "name": "helpdesk-server",
+                    "command": "python -m mcp_helpdesk",
+                    "transport": "sse",
+                    "packages": [
+                        {"name": "axios", "version": "1.4.0", "ecosystem": "npm"},
+                        {"name": "jsonwebtoken", "version": "8.5.1", "ecosystem": "npm"},
+                    ],
+                    "env": {
+                        "HELPDESK_API_TOKEN": "***",
+                        "JWT_SECRET": "***",
+                    },
+                    "tools": [
+                        {"name": "create_ticket"},
+                        {"name": "search_tickets"},
+                        {"name": "send_reply"},
+                    ],
+                },
+                {
+                    "name": "email-server",
+                    "command": "python -m mcp_email",
+                    "transport": "stdio",
+                    "packages": [
+                        {"name": "node-fetch", "version": "2.6.1", "ecosystem": "npm"},
+                        {"name": "certifi", "version": "2022.12.7", "ecosystem": "pypi"},
+                    ],
+                    "env": {"SMTP_PASSWORD": "***"},
+                    "tools": [
+                        {"name": "send_email"},
+                        {"name": "list_inbox"},
+                    ],
+                },
+            ],
+        },
+        {
+            # Data-pipeline / ETL orchestration agent.
+            "name": "data-pipeline",
+            "agent_type": "custom",
+            "source": "agent-bom --demo",
+            "mcp_servers": [
+                {
+                    "name": "warehouse-server",
+                    "command": "python -m mcp_warehouse",
+                    "transport": "stdio",
+                    "packages": [
+                        {"name": "pyyaml", "version": "5.3", "ecosystem": "pypi"},
+                        {"name": "cryptography", "version": "39.0.0", "ecosystem": "pypi"},
+                    ],
+                    "env": {
+                        "SNOWFLAKE_PASSWORD": "***",
+                        "DATABASE_URL": "***",
+                    },
                     "tools": [
                         {"name": "run_query"},
                         {"name": "execute_sql"},
                         {"name": "export_csv"},
                     ],
                 },
+                {
+                    # Ships a KEV package (Pillow/libwebp) alongside a typosquat
+                    # of "requests" — the malicious-package differentiator.
+                    "name": "etl-server",
+                    "command": "python -m mcp_etl",
+                    "transport": "stdio",
+                    "packages": [
+                        {"name": "pillow", "version": "9.0.0", "ecosystem": "pypi"},
+                        {"name": "reqeusts", "version": "2.99.0", "ecosystem": "pypi"},
+                    ],
+                    "env": {"GCS_SERVICE_ACCOUNT_KEY": "***"},
+                    "tools": [
+                        {"name": "transform_image"},
+                        {"name": "load_data"},
+                    ],
+                },
             ],
         },
         {
+            # Desktop assistant wired to source control and team chat.
             "name": "claude-desktop",
             "agent_type": "claude-desktop",
             "source": "agent-bom --demo",
@@ -62,6 +199,7 @@ DEMO_INVENTORY: dict = {
                     "transport": "stdio",
                     "packages": [
                         {"name": "axios", "version": "1.4.0", "ecosystem": "npm"},
+                        {"name": "lodash", "version": "4.17.20", "ecosystem": "npm"},
                         {"name": "semver", "version": "7.5.2", "ecosystem": "npm"},
                     ],
                     "env": {"GITHUB_TOKEN": "***"},
@@ -76,10 +214,14 @@ DEMO_INVENTORY: dict = {
                     "command": "python -m slack_mcp",
                     "transport": "stdio",
                     "packages": [
+                        {"name": "flask", "version": "2.2.0", "ecosystem": "pypi"},
+                        {"name": "werkzeug", "version": "2.2.2", "ecosystem": "pypi"},
                         {"name": "jinja2", "version": "3.0.0", "ecosystem": "pypi"},
-                        {"name": "certifi", "version": "2022.12.7", "ecosystem": "pypi"},
                     ],
-                    "env": {"SLACK_BOT_TOKEN": "***", "SLACK_SIGNING_SECRET": "***"},
+                    "env": {
+                        "SLACK_BOT_TOKEN": "***",
+                        "SLACK_SIGNING_SECRET": "***",
+                    },
                     "tools": [
                         {"name": "send_message"},
                         {"name": "list_channels"},

--- a/src/agent_bom/demo_advisories.py
+++ b/src/agent_bom/demo_advisories.py
@@ -1,9 +1,16 @@
 """Curated advisory evidence for the bundled demo inventory.
 
 These rows are intentionally narrow and are used only for
-``agent-bom agents --demo``. They keep the first-run demo deterministic when a
-developer or CI machine has no local vulnerability DB, while still exercising
-the same SQLite lookup and version-range parser used by real scans.
+``agent-bom agents --demo`` and the hosted demo estate. They keep the
+first-run demo deterministic when a developer or CI machine has no local
+vulnerability DB, while still exercising the same SQLite lookup and
+version-range parser used by real scans.
+
+Every row uses a genuine, published advisory ID (CVE / GHSA / PYSEC) with a
+real CWE and CVSS so the findings list, blast radius, and reachability
+screenshots map to something an operator can look up. A subset is on the
+CISA Known Exploited Vulnerabilities (KEV) catalog so the KEV differentiator
+lights up in the demo.
 """
 
 from __future__ import annotations
@@ -22,21 +29,90 @@ class DemoAdvisory:
     severity: str
     cvss_score: float
     summary: str
+    cwe: str = ""
+    is_kev: bool = False
     source: str = "demo-advisory"
 
 
 DEMO_ADVISORIES: tuple[DemoAdvisory, ...] = (
-    DemoAdvisory("npm", "express", "0", "4.19.2", "GHSA-rv95-896h-c2vc", "medium", 5.3, "express open redirect advisory"),
-    DemoAdvisory("npm", "node-fetch", "0", "3.1.1", "GHSA-r683-j2x4-v87g", "high", 8.8, "node-fetch exposure advisory"),
-    DemoAdvisory("npm", "jsonwebtoken", "0", "9.0.0", "GHSA-8cf7-32gw-wr33", "high", 7.6, "jsonwebtoken signature validation advisory"),
-    DemoAdvisory("npm", "axios", "0", "1.6.0", "GHSA-jr5f-v2jv-69x6", "high", 7.5, "axios CSRF credential disclosure advisory"),
-    DemoAdvisory("pypi", "flask", "0", "2.3.2", "GHSA-m2qf-hxjv-5gpq", "high", 7.5, "Flask cookie parsing advisory"),
-    DemoAdvisory("pypi", "werkzeug", "0", "2.2.3", "GHSA-q34m-jh98-gwm2", "high", 7.5, "Werkzeug multipart parsing advisory"),
-    DemoAdvisory("pypi", "requests", "0", "2.32.0", "GHSA-j8r2-6x86-q33q", "medium", 5.3, "Requests credential leakage advisory"),
-    DemoAdvisory("pypi", "cryptography", "0", "41.0.3", "PYSEC-2023-254", "high", 7.5, "cryptography OpenSSL advisory"),
-    DemoAdvisory("pypi", "pillow", "0", "9.0.1", "GHSA-8vj2-vxx3-667w", "critical", 9.8, "Pillow buffer overflow advisory"),
-    DemoAdvisory("pypi", "jinja2", "0", "3.1.5", "GHSA-gmj6-6f8f-6699", "medium", 8.8, "Jinja2 sandbox escape advisory"),
-    DemoAdvisory("pypi", "certifi", "0", "2023.7.22", "GHSA-xqr8-7jwr-rhp7", "high", 7.5, "certifi trust store advisory"),
+    # ── npm ───────────────────────────────────────────────────────────────
+    DemoAdvisory(
+        "npm", "express", "0", "4.19.2", "CVE-2024-29041", "medium", 6.1,
+        "Express open redirect via malformed URLs passed to res.location/redirect",
+        cwe="CWE-601",
+    ),
+    DemoAdvisory(
+        "npm", "jsonwebtoken", "0", "9.0.0", "CVE-2022-23529", "high", 7.6,
+        "jsonwebtoken insecure key handling allows signature verification bypass",
+        cwe="CWE-347",
+    ),
+    DemoAdvisory(
+        "npm", "node-fetch", "0", "3.1.1", "CVE-2022-0235", "high", 6.1,
+        "node-fetch leaks Cookie/Authorization headers on cross-origin redirect",
+        cwe="CWE-200",
+    ),
+    DemoAdvisory(
+        "npm", "axios", "0", "1.6.0", "CVE-2023-45857", "high", 6.5,
+        "axios SSRF and credential leak via follow-redirects proxy handling",
+        cwe="CWE-918",
+    ),
+    DemoAdvisory(
+        "npm", "ws", "0", "8.17.1", "CVE-2024-37890", "high", 7.5,
+        "ws denial of service when handling a request with many HTTP headers",
+        cwe="CWE-400",
+    ),
+    DemoAdvisory(
+        "npm", "lodash", "0", "4.17.21", "CVE-2021-23337", "high", 7.2,
+        "lodash command injection via template() with tainted options",
+        cwe="CWE-77",
+    ),
+    # ── pypi ──────────────────────────────────────────────────────────────
+    DemoAdvisory(
+        "pypi", "pyyaml", "0", "5.4", "CVE-2020-14343", "critical", 9.8,
+        "PyYAML arbitrary code execution via yaml.full_load on untrusted input",
+        cwe="CWE-20",
+    ),
+    DemoAdvisory(
+        "pypi", "langchain", "0", "0.0.247", "CVE-2023-36258", "critical", 9.8,
+        "LangChain arbitrary code execution via PALChain prompt-to-Python evaluation",
+        cwe="CWE-94",
+    ),
+    DemoAdvisory(
+        "pypi", "pillow", "0", "10.0.1", "CVE-2023-4863", "high", 8.8,
+        "Pillow bundled libwebp heap buffer overflow — exploited in the wild (CISA KEV)",
+        cwe="CWE-787",
+        is_kev=True,
+    ),
+    DemoAdvisory(
+        "pypi", "requests", "0", "2.31.0", "CVE-2023-32681", "medium", 6.1,
+        "Requests leaks Proxy-Authorization header to destination on redirect",
+        cwe="CWE-200",
+    ),
+    DemoAdvisory(
+        "pypi", "cryptography", "0", "42.0.0", "CVE-2023-50782", "high", 7.5,
+        "pyca/cryptography Bleichenbacher timing oracle in RSA PKCS#1 v1.5 decryption",
+        cwe="CWE-208",
+    ),
+    DemoAdvisory(
+        "pypi", "flask", "0", "2.3.2", "CVE-2023-30861", "high", 7.5,
+        "Flask session cookie disclosed to other clients via a caching proxy",
+        cwe="CWE-539",
+    ),
+    DemoAdvisory(
+        "pypi", "werkzeug", "0", "2.2.3", "CVE-2023-25577", "high", 7.5,
+        "Werkzeug multipart form-data parsing denial of service",
+        cwe="CWE-400",
+    ),
+    DemoAdvisory(
+        "pypi", "jinja2", "0", "3.1.3", "CVE-2024-22195", "medium", 5.4,
+        "Jinja2 cross-site scripting via the xmlattr filter with attacker-controlled keys",
+        cwe="CWE-79",
+    ),
+    DemoAdvisory(
+        "pypi", "certifi", "0", "2023.7.22", "CVE-2023-37920", "high", 7.5,
+        "certifi trusted a compromised e-Tugra root certificate authority",
+        cwe="CWE-345",
+    ),
 )
 
 # The demo deliberately includes semver@7.5.2 as a clean package. This sentinel
@@ -64,8 +140,8 @@ def seed_demo_advisories(conn: sqlite3.Connection) -> None:
         conn.execute(
             """
             INSERT OR REPLACE INTO vulns(
-                id, summary, severity, cvss_score, fixed_version, source
-            ) VALUES (?, ?, ?, ?, ?, ?)
+                id, summary, severity, cvss_score, fixed_version, cwe_ids, source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 advisory.vuln_id,
@@ -73,6 +149,7 @@ def seed_demo_advisories(conn: sqlite3.Connection) -> None:
                 advisory.severity,
                 advisory.cvss_score,
                 advisory.fixed,
+                advisory.cwe,
                 advisory.source,
             ),
         )
@@ -90,4 +167,19 @@ def seed_demo_advisories(conn: sqlite3.Connection) -> None:
                 advisory.fixed,
             ),
         )
+        if advisory.is_kev:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO kev_entries(
+                    cve_id, date_added, due_date, product, vendor_project
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    advisory.vuln_id,
+                    "2023-09-27",
+                    "2023-10-04",
+                    advisory.package,
+                    advisory.ecosystem,
+                ),
+            )
     conn.commit()

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import os
-import tempfile
 import uuid
-from pathlib import Path
 from typing import Any
 
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
@@ -37,33 +34,35 @@ def _tenant_has_demo_jobs(store: Any, tenant_id: str) -> bool:
 
 
 def _run_demo_scan_report() -> dict[str, Any]:
-    from click.testing import CliRunner
+    from agent_bom.cli._common import _build_agents_from_inventory
+    from agent_bom.demo import DEMO_INVENTORY
+    from agent_bom.finding import blast_radius_to_finding
+    from agent_bom.mcp_auth_posture import evaluate_mcp_auth_posture
+    from agent_bom.mcp_blocklist import blocklist_findings_for_agents
+    from agent_bom.models import AIBOMReport
+    from agent_bom.output import to_json
+    from agent_bom.scanners import scan_agents_sync
 
-    from agent_bom.cli import main
-
-    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as handle:
-        out_path = handle.name
-    try:
-        runner = CliRunner()
-        result = runner.invoke(
-            main,
-            [
-                "agents",
-                "--demo",
-                "--offline",
-                "--quiet",
-                "--no-auto-update-db",
-                "-f",
-                "json",
-                "-o",
-                out_path,
-            ],
+    agents = _build_agents_from_inventory(DEMO_INVENTORY, "agent-bom --demo")
+    blast_radii = scan_agents_sync(
+        agents,
+        compliance_enabled=True,
+        show_scan_banner=False,
+        offline=True,
+        demo_advisories=True,
+    )
+    findings = [blast_radius_to_finding(br) for br in blast_radii]
+    findings.extend(blocklist_findings_for_agents(agents))
+    findings.extend(evaluate_mcp_auth_posture(agents))
+    report = to_json(
+        AIBOMReport(
+            agents=agents,
+            blast_radii=blast_radii,
+            findings=findings,
+            scan_sources=["demo", "demo-estate"],
+            scan_id="showcase",
         )
-        if result.exit_code != 0:
-            raise RuntimeError(f"demo scan failed: {result.output}")
-        report = json.loads(Path(out_path).read_text(encoding="utf-8"))
-    finally:
-        Path(out_path).unlink(missing_ok=True)
+    )
 
     report.setdefault("scan_sources", [])
     if "demo" not in report["scan_sources"]:

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -70,6 +70,14 @@ def _run_demo_scan_report() -> dict[str, Any]:
         report["scan_sources"].append("demo")
     if "demo-estate" not in report["scan_sources"]:
         report["scan_sources"].append("demo-estate")
+
+    # Overlay a curated multi-cloud CIS benchmark posture so the CIS/compliance
+    # surfaces render a believable AWS/GCP/Azure pass-fail spread. The keys are
+    # exactly what build_cis_benchmark_check_rows() reads from a scan result.
+    from agent_bom.demo_estate.showcase_cis import demo_cis_benchmarks
+
+    for key, benchmark in demo_cis_benchmarks().items():
+        report.setdefault(key, benchmark)
     return report
 
 

--- a/src/agent_bom/demo_estate/showcase_cis.py
+++ b/src/agent_bom/demo_estate/showcase_cis.py
@@ -1,0 +1,251 @@
+"""Curated CIS benchmark posture for the hosted demo estate.
+
+Injected into the demo scan-job result so the CIS / compliance surfaces
+(``/v1/cis/checks``, ``/v1/cis/trends``, the compliance scorecard) render a
+believable multi-cloud posture — a spread of pass/fail across AWS, GCP, and
+Azure that yields a realistic grade (not empty, not a perfect 100%).
+
+Every check uses a real CIS Foundations Benchmark control id and section so
+the screenshots map to controls an auditor can look up. Deterministic — the
+same estate reproduces the same posture on every run.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _check(
+    check_id: str,
+    title: str,
+    status: str,
+    severity: str,
+    cis_section: str,
+    evidence: str,
+    resource_ids: list[str],
+    remediation: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "check_id": check_id,
+        "title": title,
+        "status": status,
+        "severity": severity,
+        "cis_section": cis_section,
+        "evidence": evidence,
+        "resource_ids": resource_ids,
+        "remediation": remediation,
+    }
+
+
+def _rem(
+    fix_cli: str,
+    fix_console: str,
+    effort: str,
+    priority: int,
+    *,
+    guardrails: list[str] | None = None,
+    requires_human_review: bool = False,
+) -> dict[str, Any]:
+    return {
+        "fix_cli": fix_cli,
+        "fix_console": fix_console,
+        "effort": effort,
+        "priority": priority,
+        "guardrails": guardrails or [],
+        "requires_human_review": requires_human_review,
+    }
+
+
+_AWS_CHECKS: list[dict[str, Any]] = [
+    _check(
+        "1.4", "Ensure no root user account access key exists", "pass", "high",
+        "1 Identity and Access Management",
+        "No access keys attached to the root account.", ["root"],
+        _rem("aws iam delete-access-key --user-name root", "IAM > Security credentials", "low", 3),
+    ),
+    _check(
+        "1.12", "Ensure credentials unused for 45 days are disabled", "fail", "medium",
+        "1 Identity and Access Management",
+        "IAM user 'bob@contractor' has an access key unused for 118 days.", ["bob@contractor"],
+        _rem(
+            "aws iam update-access-key --user-name bob --status Inactive --access-key-id AKIA...",
+            "IAM > Users > bob > Security credentials > Make inactive",
+            "low", 6,
+        ),
+    ),
+    _check(
+        "2.1.1", "Ensure S3 bucket server-side encryption is enabled", "pass", "medium",
+        "2 Storage",
+        "Default SSE-KMS enabled on all in-scope buckets.", ["customer-pii-prod"],
+        _rem("aws s3api put-bucket-encryption ...", "S3 > Bucket > Properties > Encryption", "low", 4),
+    ),
+    _check(
+        "2.1.5", "Ensure S3 buckets block public access", "fail", "critical",
+        "2 Storage",
+        "Bucket 'customer-pii-prod' is publicly readable (Block Public Access off).",
+        ["customer-pii-prod"],
+        _rem(
+            "aws s3api put-public-access-block --bucket customer-pii-prod "
+            "--public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,"
+            "BlockPublicPolicy=true,RestrictPublicBuckets=true",
+            "S3 > customer-pii-prod > Permissions > Block public access > Edit",
+            "low", 9, guardrails=["Confirm no legitimate anonymous readers before enabling."],
+            requires_human_review=True,
+        ),
+    ),
+    _check(
+        "3.1", "Ensure CloudTrail is enabled in all regions", "pass", "high",
+        "3 Logging",
+        "Multi-region trail 'org-trail' active with log file validation.", ["org-trail"],
+        _rem("aws cloudtrail update-trail --name org-trail --is-multi-region-trail",
+             "CloudTrail > Trails", "medium", 5),
+    ),
+    _check(
+        "4.1", "Ensure no security group allows ingress from 0.0.0.0/0 to port 22", "fail", "high",
+        "4 Networking",
+        "Security group 'sg-prod' allows 0.0.0.0/0 on tcp/22 (prod-bastion).", ["sg-prod"],
+        _rem(
+            "aws ec2 revoke-security-group-ingress --group-id sg-prod --protocol tcp "
+            "--port 22 --cidr 0.0.0.0/0",
+            "VPC > Security Groups > sg-prod > Inbound rules > Edit",
+            "low", 8,
+        ),
+    ),
+    _check(
+        "2.2.1", "Ensure EBS volume encryption is enabled by default", "pass", "medium",
+        "2 Storage",
+        "Account-level default EBS encryption is on in all active regions.", ["ec2-default"],
+        _rem("aws ec2 enable-ebs-encryption-by-default", "EC2 > Settings > Data protection", "low", 4),
+    ),
+    _check(
+        "1.20", "Ensure IAM Access Analyzer is enabled for all regions", "pass", "low",
+        "1 Identity and Access Management",
+        "Access Analyzer 'org-analyzer' enabled in all regions.", ["org-analyzer"],
+        _rem("aws accessanalyzer create-analyzer --analyzer-name org-analyzer --type ORGANIZATION",
+             "IAM > Access Analyzer", "low", 2),
+    ),
+]
+
+_GCP_CHECKS: list[dict[str, Any]] = [
+    _check(
+        "1.4", "Ensure user-managed service account keys are rotated <= 90 days", "fail", "medium",
+        "1 Identity and Access Management",
+        "Key for 'data-pipeline@proj.iam' is 214 days old.", ["data-pipeline@proj.iam"],
+        _rem(
+            "gcloud iam service-accounts keys create key.json --iam-account data-pipeline@proj.iam "
+            "&& gcloud iam service-accounts keys delete OLD_KEY",
+            "IAM & Admin > Service Accounts > Keys",
+            "medium", 6, requires_human_review=True,
+        ),
+    ),
+    _check(
+        "3.6", "Ensure SSH access is restricted from the internet", "fail", "high",
+        "3 Networking",
+        "Firewall 'allow-ssh' permits 0.0.0.0/0 on tcp/22.", ["allow-ssh"],
+        _rem("gcloud compute firewall-rules update allow-ssh --source-ranges=10.0.0.0/8",
+             "VPC network > Firewall > allow-ssh", "low", 8),
+    ),
+    _check(
+        "5.1", "Ensure Cloud Storage bucket is not anonymously/publicly accessible", "pass", "high",
+        "5 Storage",
+        "No buckets grant allUsers/allAuthenticatedUsers.", ["analytics-exports"],
+        _rem("gsutil iam ch -d allUsers gs://BUCKET", "Cloud Storage > Bucket > Permissions", "low", 5),
+    ),
+    _check(
+        "2.2", "Ensure a log sink captures all log entries", "pass", "medium",
+        "2 Logging and Monitoring",
+        "Aggregated sink 'org-sink' exports to a locked bucket.", ["org-sink"],
+        _rem("gcloud logging sinks create org-sink ...", "Logging > Log Router", "medium", 4),
+    ),
+    _check(
+        "6.2.4", "Ensure PostgreSQL 'log_min_messages' flag is set appropriately", "pass", "low",
+        "6 Cloud SQL Database Services",
+        "Flag set to 'warning' on all Cloud SQL PostgreSQL instances.", ["payments-db"],
+        _rem("gcloud sql instances patch payments-db --database-flags=log_min_messages=warning",
+             "SQL > Instance > Flags", "low", 3),
+    ),
+    _check(
+        "1.5", "Ensure Service Account has no admin privileges", "fail", "high",
+        "1 Identity and Access Management",
+        "'data-pipeline@proj.iam' holds roles/owner.", ["data-pipeline@proj.iam"],
+        _rem("gcloud projects remove-iam-policy-binding proj --member=... --role=roles/owner",
+             "IAM & Admin > IAM", "medium", 7, requires_human_review=True),
+    ),
+]
+
+_AZURE_CHECKS: list[dict[str, Any]] = [
+    _check(
+        "3.1", "Ensure 'Secure transfer required' is enabled on storage accounts", "pass", "medium",
+        "3 Storage Accounts",
+        "HTTPS-only enforced on all storage accounts.", ["stpiiprod"],
+        _rem("az storage account update -n stpiiprod --https-only true",
+             "Storage account > Configuration", "low", 4),
+    ),
+    _check(
+        "3.7", "Ensure public network access to blob storage is disabled", "fail", "high",
+        "3 Storage Accounts",
+        "'stpiiprod' allows public blob access.", ["stpiiprod"],
+        _rem("az storage account update -n stpiiprod --allow-blob-public-access false",
+             "Storage account > Networking", "low", 8, requires_human_review=True),
+    ),
+    _check(
+        "4.1.1", "Ensure auditing is enabled on SQL servers", "pass", "high",
+        "4 Database Services",
+        "Auditing enabled and shipping to Log Analytics for all SQL servers.", ["sql-payments"],
+        _rem("az sql server audit-policy update ...", "SQL server > Auditing", "medium", 5),
+    ),
+    _check(
+        "6.1", "Ensure RDP access is restricted from the internet", "fail", "high",
+        "6 Networking",
+        "NSG 'nsg-prod' allows Internet on tcp/3389.", ["nsg-prod"],
+        _rem("az network nsg rule update -g rg --nsg-name nsg-prod -n rdp --source-address-prefixes 10.0.0.0/8",
+             "Network security group > Inbound security rules", "low", 8),
+    ),
+    _check(
+        "1.23", "Ensure no custom subscription owner roles are created", "pass", "medium",
+        "1 Identity and Access Management",
+        "No custom roles grant subscription-scoped Owner.", ["subscription"],
+        _rem("az role definition delete --name CUSTOM_OWNER", "Subscriptions > Access control (IAM)", "medium", 4),
+    ),
+    _check(
+        "8.1", "Ensure Key Vault is recoverable (soft-delete + purge protection)", "pass", "medium",
+        "8 Key Vault",
+        "Soft-delete and purge protection enabled on all vaults.", ["kv-prod"],
+        _rem("az keyvault update --name kv-prod --enable-purge-protection true",
+             "Key Vault > Properties", "low", 3),
+    ),
+]
+
+
+def _benchmark(name: str, version: str, checks: list[dict[str, Any]]) -> dict[str, Any]:
+    passed = sum(1 for c in checks if c["status"] == "pass")
+    failed = sum(1 for c in checks if c["status"] == "fail")
+    total = len(checks)
+    return {
+        "benchmark": name,
+        "version": version,
+        "passed": passed,
+        "failed": failed,
+        "total": total,
+        "pass_rate": round((passed / total) * 100, 1) if total else 0.0,
+        "checks": checks,
+    }
+
+
+def demo_cis_benchmarks() -> dict[str, Any]:
+    """Return the curated AWS/GCP/Azure CIS benchmark blobs for the demo report.
+
+    Keys match what ``build_cis_benchmark_check_rows`` reads from a scan result:
+    ``cis_benchmark`` (AWS), ``gcp_cis_benchmark``, ``azure_cis_benchmark``.
+    """
+    return {
+        "cis_benchmark": _benchmark(
+            "CIS Amazon Web Services Foundations Benchmark", "3.0.0", _AWS_CHECKS
+        ),
+        "gcp_cis_benchmark": _benchmark(
+            "CIS Google Cloud Platform Foundation Benchmark", "2.0.0", _GCP_CHECKS
+        ),
+        "azure_cis_benchmark": _benchmark(
+            "CIS Microsoft Azure Foundations Benchmark", "2.1.0", _AZURE_CHECKS
+        ),
+    }

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -73,21 +73,26 @@ def build_showcase_graph(
         g.add_edge(UnifiedEdge(source=s, target=d, relationship=r, **kw))
 
     agents = {
-        "billing-agent": "Billing Copilot",
-        "support-agent": "Support Copilot",
-        "data-pipeline-agent": "Data Pipeline Agent",
-        "devops-agent": "DevOps Agent",
-        "analytics-agent": "Analytics Agent",
+        "cursor": "Cursor IDE Agent",
+        "langchain-service": "LangChain Service Agent",
+        "support-copilot": "Support Copilot",
+        "data-pipeline": "Data Pipeline Agent",
+        "claude-desktop": "Claude Desktop Agent",
     }
     for aid, label in agents.items():
         node(f"agent:{aid}", EntityType.AGENT, label, environment="production")
 
     servers = {
-        "mcp-fs": ("billing-agent", ["read_file", "write_file", "run_shell"]),
-        "mcp-db": ("data-pipeline-agent", ["sql_query", "sql_exec"]),
-        "mcp-http": ("support-agent", ["http_get", "http_post"]),
-        "mcp-deploy": ("devops-agent", ["deploy", "rollback", "exec_remote"]),
-        "mcp-warehouse": ("analytics-agent", ["query_warehouse"]),
+        "filesystem-server": ("cursor", ["read_file", "write_file", "list_directory"]),
+        "shell-runner-server": ("cursor", ["run_shell", "exec_command", "read_file"]),
+        "llm-orchestrator-server": ("langchain-service", ["run_chain", "eval_expression", "http_get"]),
+        "vector-db-server": ("langchain-service", ["query_vectors", "upsert_vectors"]),
+        "helpdesk-server": ("support-copilot", ["create_ticket", "search_tickets", "send_reply"]),
+        "email-server": ("support-copilot", ["send_email", "list_inbox"]),
+        "warehouse-server": ("data-pipeline", ["run_query", "execute_sql", "export_csv"]),
+        "etl-server": ("data-pipeline", ["transform_image", "load_data"]),
+        "github-server": ("claude-desktop", ["create_issue", "search_repos", "push_files"]),
+        "team-chat-server": ("claude-desktop", ["send_message", "list_channels"]),
     }
     for sid, (owner, tools) in servers.items():
         node(f"server:{sid}", EntityType.SERVER, sid)
@@ -97,29 +102,75 @@ def build_showcase_graph(
             node(tid, EntityType.TOOL, tname)
             edge(f"server:{sid}", tid, RelationshipType.PROVIDES_TOOL)
 
+    # Real CVEs on real package@versions — mirrors the demo advisory catalog.
     pkgs = {
-        "express@4.17.1": ("mcp-http", "CVE-2024-29041", "critical", 9.3),
-        "pyyaml@5.3": ("mcp-db", "CVE-2020-14343", "critical", 9.8),
-        "requests@2.19.0": ("mcp-fs", "CVE-2023-32681", "high", 7.5),
-        "log4j@2.14.0": ("mcp-deploy", "CVE-2021-44228", "critical", 10.0),
-        "pillow@9.0.0": ("mcp-warehouse", "CVE-2022-22817", "high", 8.1),
+        "pyyaml@5.3": ("shell-runner-server", "CVE-2020-14343", "critical", 9.8),
+        "langchain@0.0.150": ("llm-orchestrator-server", "CVE-2023-36258", "critical", 9.8),
+        "pillow@9.0.0": ("etl-server", "CVE-2023-4863", "high", 8.8),
+        "jsonwebtoken@8.5.1": ("helpdesk-server", "CVE-2022-23529", "high", 7.6),
+        "axios@1.4.0": ("helpdesk-server", "CVE-2023-45857", "high", 6.5),
+        "cryptography@39.0.0": ("warehouse-server", "CVE-2023-50782", "high", 7.5),
+        "ws@8.5.0": ("filesystem-server", "CVE-2024-37890", "high", 7.5),
+        "flask@2.2.0": ("team-chat-server", "CVE-2023-30861", "high", 7.5),
+        "certifi@2022.12.7": ("email-server", "CVE-2023-37920", "high", 7.5),
+        "lodash@4.17.20": ("github-server", "CVE-2021-23337", "high", 7.2),
+        "express@4.17.1": ("filesystem-server", "CVE-2024-29041", "medium", 6.1),
+        "requests@2.28.0": ("vector-db-server", "CVE-2023-32681", "medium", 6.1),
+        "jinja2@3.0.0": ("team-chat-server", "CVE-2024-22195", "medium", 5.4),
     }
+    kev_cves = {"CVE-2023-4863"}
     for purl, (sid, cve, sev, score) in pkgs.items():
         pid = f"pkg:{purl}"
         node(pid, EntityType.PACKAGE, purl)
         edge(f"server:{sid}", pid, RelationshipType.DEPENDS_ON)
         vid = f"vuln:{cve}"
-        node(vid, EntityType.VULNERABILITY, cve, severity=sev, risk_score=score)
+        node(vid, EntityType.VULNERABILITY, cve, severity=sev, risk_score=score, is_kev=cve in kev_cves)
         edge(pid, vid, RelationshipType.VULNERABLE_TO)
 
-    node("cred:aws-key", EntityType.CREDENTIAL, "AWS_SECRET_ACCESS_KEY")
-    edge("server:mcp-deploy", "cred:aws-key", RelationshipType.EXPOSES_CRED)
+    # Malicious/typosquat package — the malicious-package differentiator.
+    node(
+        "pkg:reqeusts@2.99.0",
+        EntityType.PACKAGE,
+        "reqeusts@2.99.0",
+        severity="critical",
+        risk_score=9.1,
+        is_malicious=True,
+        malicious_reason="Possible typosquat of 'requests'",
+    )
+    edge("server:etl-server", "pkg:reqeusts@2.99.0", RelationshipType.DEPENDS_ON)
+    node("vuln:MAL-2024-reqeusts", EntityType.VULNERABILITY, "MAL-2024-reqeusts", severity="critical", risk_score=9.1)
+    edge("pkg:reqeusts@2.99.0", "vuln:MAL-2024-reqeusts", RelationshipType.VULNERABLE_TO)
+
+    # Credential-backed env on servers — lights up credential-exposure edges.
+    creds = {
+        "cred:aws-secret": ("AWS_SECRET_ACCESS_KEY", "shell-runner-server"),
+        "cred:openai-key": ("OPENAI_API_KEY", "llm-orchestrator-server"),
+        "cred:db-url": ("DATABASE_URL", "vector-db-server"),
+        "cred:jwt-secret": ("JWT_SECRET", "helpdesk-server"),
+        "cred:snowflake-pw": ("SNOWFLAKE_PASSWORD", "warehouse-server"),
+        "cred:gcs-key": ("GCS_SERVICE_ACCOUNT_KEY", "etl-server"),
+        "cred:github-token": ("GITHUB_TOKEN", "github-server"),
+        "cred:slack-token": ("SLACK_BOT_TOKEN", "team-chat-server"),
+    }
+    for cid, (label, sid) in creds.items():
+        node(cid, EntityType.CREDENTIAL, label)
+        edge(f"server:{sid}", cid, RelationshipType.EXPOSES_CRED)
+
+    # Hero blast-radius chain: the PyYAML RCE on shell-runner-server reaches an
+    # AWS credential AND the run_shell tool → potential RCE. This is the top
+    # exposure path the graph/posture surfaces should headline.
+    edge("vuln:CVE-2020-14343", "cred:aws-secret", RelationshipType.EXPLOITABLE_VIA, weight=9.8)
+    edge("vuln:CVE-2020-14343", "tool:shell-runner-server:run_shell", RelationshipType.EXPLOITABLE_VIA, weight=9.8)
+    edge("cred:aws-secret", "tool:shell-runner-server:run_shell", RelationshipType.REACHES_TOOL)
+    # Second high-signal chain: LangChain RCE reaches the eval_expression tool.
+    edge("vuln:CVE-2023-36258", "tool:llm-orchestrator-server:eval_expression", RelationshipType.EXPLOITABLE_VIA, weight=9.8)
+    edge("vuln:CVE-2023-36258", "cred:openai-key", RelationshipType.EXPLOITABLE_VIA, weight=9.8)
 
     for i, (aid, tid) in enumerate(
         [
-            ("billing-agent", "tool:mcp-fs:run_shell"),
-            ("data-pipeline-agent", "tool:mcp-db:sql_exec"),
-            ("devops-agent", "tool:mcp-deploy:exec_remote"),
+            ("cursor", "tool:shell-runner-server:run_shell"),
+            ("data-pipeline", "tool:warehouse-server:execute_sql"),
+            ("langchain-service", "tool:llm-orchestrator-server:eval_expression"),
         ]
     ):
         cid = f"call:{i}"
@@ -183,19 +234,22 @@ def build_showcase_graph(
     edge("role:data-pipeline", "cloud:logs-bucket", RelationshipType.CAN_ACCESS)
     edge("role:readonly", "cloud:logs-bucket", RelationshipType.CAN_ACCESS)
 
-    edge("agent:devops-agent", "role:prod-admin", RelationshipType.CAN_ACCESS)
-    edge("agent:data-pipeline-agent", "role:data-pipeline", RelationshipType.CAN_ACCESS)
+    # cursor drives the shell-runner (AWS creds + run_shell) → toxic combo with
+    # prod-admin; data-pipeline maps to the least-privilege pipeline role.
+    edge("agent:cursor", "role:prod-admin", RelationshipType.CAN_ACCESS)
+    edge("agent:data-pipeline", "role:data-pipeline", RelationshipType.CAN_ACCESS)
 
     store = InMemoryAgentIdentityStore()
+    _jit_tools = {"cursor": "run_shell", "data-pipeline": "execute_sql", "langchain-service": "eval_expression"}
     for aid, label in agents.items():
         idn, _ = issue_identity(store, agent_id=label, tenant_id=tenant_id, allowed_tools=[])
-        if aid in ("billing-agent", "devops-agent", "data-pipeline-agent"):
+        if aid in _jit_tools:
             issue_jit_grant(
                 store,
                 identity_id=idn.identity_id,
                 agent_id=label,
                 tenant_id=tenant_id,
-                tool_name="run_shell" if aid == "billing-agent" else "exec_remote",
+                tool_name=_jit_tools[aid],
                 ttl_seconds=3600,
                 approved_by="oncall@corp",
             )
@@ -204,17 +258,17 @@ def build_showcase_graph(
         [
             _DriftIncident(
                 incident_id="drift-001",
-                blueprint_id="DevOps Agent",
+                blueprint_id="Cursor IDE Agent",
                 drift_score=0.78,
                 violation_count=14,
-                top_violations=[{"tool_name": "exec_remote"}],
+                top_violations=[{"tool_name": "run_shell"}],
             ),
             _DriftIncident(
                 incident_id="drift-002",
-                blueprint_id="Billing Copilot",
+                blueprint_id="Data Pipeline Agent",
                 drift_score=0.41,
                 violation_count=5,
-                top_violations=[{"tool_name": "run_shell"}],
+                top_violations=[{"tool_name": "execute_sql"}],
             ),
         ]
     )

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -1176,7 +1176,7 @@ async def scan_packages(
     if scan_offline or (scan_prefer_local_db and not osv_targets):
         if scan_offline:
             covered_ecos = _db_covered_ecosystems()
-            if not covered_ecos and osv_targets:
+            if not covered_ecos and osv_targets and not scan_options.demo_advisories:
                 # Genuinely empty/missing DB — nothing can be scanned offline.
                 raise IncompleteScanError(
                     "Offline mode requires a populated local vulnerability DB. Run `agent-bom db update` before using `--offline`."

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1033,8 +1033,8 @@ def test_demo_scan_preserves_curated_inventory_without_registry_fallback(monkeyp
     result = _run(["scan", "--demo", "--offline", "--no-auto-update-db"])
 
     assert result.exit_code == 0
-    assert captured["packages"] == 12
-    assert "12 packages" in result.output
+    assert captured["packages"] == 23
+    assert "23 packages" in result.output
     assert "PARTIAL COVERAGE" not in result.output
 
 

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -19,13 +19,16 @@ def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
 
     api_server._runtime_api_key_seeded = False
     api_server._shutting_down = False
+    original_job_store = api_stores._store
     original_graph_store = api_stores._graph_store
+    api_stores._store = None
     api_stores._graph_store = None
 
     try:
         with TestClient(api_server.app) as client:
             yield client
     finally:
+        api_stores._store = original_job_store
         api_stores._graph_store = original_graph_store
 
 

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from collections import Counter
+
 import pytest
 from starlette.testclient import TestClient
+
+ADMIN = {"X-Agent-Bom-Role": "admin"}
 
 
 @pytest.fixture()
@@ -25,6 +29,16 @@ def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
         api_stores._graph_store = original_graph_store
 
 
+def _demo_report(client: TestClient) -> dict:
+    jobs = (
+        client.get("/v1/jobs", headers=ADMIN, params={"include_details": "true"}).json().get("jobs")
+        or []
+    )
+    assert jobs, "expected at least one demo job after bootstrap"
+    detail = client.get(f"/v1/scan/{jobs[0]['job_id']}", headers=ADMIN).json()
+    return detail.get("result") or {}
+
+
 def test_demo_estate_bootstrap_seeds_jobs_and_graph(demo_estate_client: TestClient) -> None:
     jobs_payload = demo_estate_client.get(
         "/v1/jobs",
@@ -43,6 +57,105 @@ def test_demo_estate_bootstrap_seeds_jobs_and_graph(demo_estate_client: TestClie
     payload = graph.json()
     node_count = len(payload.get("nodes") or [])
     assert node_count > 0
+
+
+def test_demo_estate_graph_is_a_rich_multi_agent_estate(demo_estate_client: TestClient) -> None:
+    payload = demo_estate_client.get("/v1/graph", headers=ADMIN).json()
+    nodes = payload.get("nodes") or []
+    by_type = Counter(n.get("entity_type") for n in nodes)
+
+    # Several AI agents, many MCP servers, real packages + CVEs, credentials.
+    assert by_type["agent"] >= 5, by_type
+    assert by_type["server"] >= 10, by_type
+    assert by_type["package"] >= 10, by_type
+    assert by_type["vulnerability"] >= 10, by_type
+    assert by_type["credential"] >= 5, by_type
+    assert by_type["tool"] >= 15, by_type
+
+    labels = {n.get("label") for n in nodes}
+    # Realistic, distinct agents render.
+    assert {"Cursor IDE Agent", "LangChain Service Agent", "Support Copilot", "Data Pipeline Agent"} <= labels
+
+    # Malicious/typosquat package differentiator.
+    malicious = [n for n in nodes if n.get("attributes", {}).get("is_malicious")]
+    assert malicious, "expected a malicious/typosquat package node"
+    assert any("reqeusts" in (n.get("label") or "") for n in malicious)
+
+    # KEV vulnerability lights up.
+    kev = [n for n in nodes if n.get("attributes", {}).get("is_kev")]
+    assert any("CVE-2023-4863" in (n.get("label") or "") for n in kev), "expected a KEV CVE node"
+
+
+def test_demo_estate_headline_blast_radius_chain(demo_estate_client: TestClient) -> None:
+    """agent -> MCP server -> vulnerable package -> critical CVE -> reachable
+    credential + reachable run_shell tool -> potential RCE renders in the graph."""
+    payload = demo_estate_client.get("/v1/graph", headers=ADMIN).json()
+    node_ids = {n.get("id") for n in payload.get("nodes") or []}
+    edges = payload.get("edges") or []
+    edge_pairs = {(e.get("source"), e.get("target")) for e in edges}
+
+    # Chain nodes exist.
+    for nid in (
+        "agent:cursor",
+        "server:shell-runner-server",
+        "pkg:pyyaml@5.3",
+        "vuln:CVE-2020-14343",
+        "cred:aws-secret",
+        "tool:shell-runner-server:run_shell",
+    ):
+        assert nid in node_ids, f"missing chain node {nid}"
+
+    assert ("agent:cursor", "server:shell-runner-server") in edge_pairs
+    assert ("server:shell-runner-server", "pkg:pyyaml@5.3") in edge_pairs
+    assert ("pkg:pyyaml@5.3", "vuln:CVE-2020-14343") in edge_pairs
+    assert ("server:shell-runner-server", "cred:aws-secret") in edge_pairs
+    # The critical CVE reaches both the credential and the run_shell tool (RCE).
+    assert ("vuln:CVE-2020-14343", "cred:aws-secret") in edge_pairs
+    assert ("vuln:CVE-2020-14343", "tool:shell-runner-server:run_shell") in edge_pairs
+
+
+def test_demo_estate_findings_include_critical_and_kev(demo_estate_client: TestClient) -> None:
+    result = _demo_report(demo_estate_client)
+    summary = result.get("summary") or {}
+    assert summary.get("total_agents") == 5
+    assert summary.get("total_mcp_servers") == 10
+    assert (summary.get("critical_findings") or 0) >= 2, summary
+
+    findings = result.get("findings") or []
+    assert len(findings) >= 12, f"expected a dense findings list, got {len(findings)}"
+
+    # KEV differentiator surfaces in the blast radius (Pillow/libwebp).
+    blast = result.get("blast_radius") or []
+    kev = [b for b in blast if b.get("is_kev") or b.get("cisa_kev")]
+    assert any(b.get("vulnerability_id") == "CVE-2023-4863" for b in kev), "expected KEV CVE in blast radius"
+
+
+def test_demo_estate_cis_posture_spans_aws_gcp_azure(demo_estate_client: TestClient) -> None:
+    result = _demo_report(demo_estate_client)
+    # Curated multi-cloud CIS posture is attached to the demo scan result, which
+    # is exactly what the CIS/compliance surfaces read (build_cis_benchmark_check_rows).
+    seen_clouds: set[str] = set()
+    for key, cloud in (
+        ("cis_benchmark", "aws"),
+        ("gcp_cis_benchmark", "gcp"),
+        ("azure_cis_benchmark", "azure"),
+    ):
+        checks = (result.get(key) or {}).get("checks") or []
+        assert checks, f"expected CIS checks for {key}"
+        statuses = {c.get("status") for c in checks}
+        # A believable spread — neither empty nor all-passing.
+        assert "pass" in statuses and "fail" in statuses, f"{key} needs a pass/fail spread: {statuses}"
+        seen_clouds.add(cloud)
+    assert seen_clouds == {"aws", "gcp", "azure"}
+
+    # The rows normalize through the same contract the /v1/cis/checks route uses.
+    from agent_bom.analytics_contract import build_cis_benchmark_check_rows
+
+    rows = build_cis_benchmark_check_rows(result, "showcase")
+    clouds = Counter(r["cloud"] for r in rows)
+    assert {"aws", "gcp", "azure"} <= set(clouds), clouds
+    statuses = Counter(r["status"] for r in rows)
+    assert statuses["pass"] > 0 and statuses["fail"] > 0, statuses
 
 
 def test_demo_estate_bootstrap_is_idempotent(demo_estate_client: TestClient) -> None:

--- a/tests/test_demo_inventory_accuracy.py
+++ b/tests/test_demo_inventory_accuracy.py
@@ -28,8 +28,14 @@ from agent_bom.demo_advisories import seed_demo_advisories
 # Confirmed clean via `agent-bom check <name>@<version> --ecosystem <eco>`:
 # - semver@7.5.2: paired with vulnerable axios@1.4.0 in the demo to show
 #   that not every dependency is on fire.
+#
+# Intentional malicious/typosquat sample (flagged by the typosquat heuristic,
+# not by a CVE advisory — so it correctly resolves to no advisory row):
+# - reqeusts@2.99.0: typosquat of "requests"; demonstrates the
+#   malicious-package differentiator. See test_typosquat_package_is_flagged.
 NO_KNOWN_VULNS_ALLOWLIST: set[tuple[str, str, str]] = {
     ("npm", "semver", "7.5.2"),
+    ("pypi", "reqeusts", "2.99.0"),
 }
 
 
@@ -92,3 +98,24 @@ def test_demo_inventory_has_critical_or_high_for_screenshot_paths(vuln_db) -> No
     assert high_or_above, (
         "Demo inventory yields no HIGH or CRITICAL findings — the README blast-radius story needs at least one to remain credible."
     )
+
+
+def test_demo_inventory_has_at_least_two_criticals() -> None:
+    """The estate ships a couple of genuine CRITICALs (PyYAML + LangChain RCE)."""
+    from agent_bom.demo_advisories import DEMO_ADVISORIES
+
+    demo_pkgs = {(eco, name) for eco, name, _ in _all_demo_packages()}
+    criticals = {
+        adv.vuln_id
+        for adv in DEMO_ADVISORIES
+        if adv.severity == "critical" and (adv.ecosystem, adv.package) in demo_pkgs
+    }
+    assert len(criticals) >= 2, f"expected >=2 critical advisories on demo packages, got {criticals}"
+
+
+def test_typosquat_package_is_flagged() -> None:
+    """The intentional typosquat sample must trip the malicious-package heuristic."""
+    from agent_bom.malicious import check_typosquat
+
+    assert ("pypi", "reqeusts", "2.99.0") in _all_demo_packages(), "typosquat sample missing from demo inventory"
+    assert check_typosquat("reqeusts", "pypi") == "requests"

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -10,14 +11,27 @@ def test_release_smoke_script_is_valid_shell() -> None:
     subprocess.run(["bash", "-n", str(ROOT / "scripts" / "release_smoke.sh")], check=True)
 
 
-def test_release_smoke_golden_path() -> None:
+def test_release_smoke_golden_path(tmp_path: Path) -> None:
     """Offline demo scan smoke must pass on every CI run."""
+    env = dict(os.environ)
+    for key in (
+        "AGENT_BOM_API_KEY",
+        "AGENT_BOM_API_KEYS",
+        "AGENT_BOM_DB",
+        "AGENT_BOM_GRAPH_DB",
+        "AGENT_BOM_POSTGRES_URL",
+        "AGENT_BOM_RELEASE_SMOKE_API_URL",
+    ):
+        env.pop(key, None)
+    env.update(
+        {
+            "AGENT_BOM_RELEASE_SMOKE_SKIP_UI": "1",
+            "AGENT_BOM_STATE_DIR": str(tmp_path / "release-smoke-state"),
+        }
+    )
     subprocess.run(
         ["bash", str(ROOT / "scripts" / "release_smoke.sh")],
         check=True,
         cwd=ROOT,
-        env={
-            **dict(__import__("os").environ),
-            "AGENT_BOM_RELEASE_SMOKE_SKIP_UI": "1",
-        },
+        env=env,
     )

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -13,16 +13,7 @@ def test_release_smoke_script_is_valid_shell() -> None:
 
 def test_release_smoke_golden_path(tmp_path: Path) -> None:
     """Offline demo scan smoke must pass on every CI run."""
-    env = dict(os.environ)
-    for key in (
-        "AGENT_BOM_API_KEY",
-        "AGENT_BOM_API_KEYS",
-        "AGENT_BOM_DB",
-        "AGENT_BOM_GRAPH_DB",
-        "AGENT_BOM_POSTGRES_URL",
-        "AGENT_BOM_RELEASE_SMOKE_API_URL",
-    ):
-        env.pop(key, None)
+    env = {key: value for key, value in os.environ.items() if not key.startswith("AGENT_BOM_")}
     env.update(
         {
             "AGENT_BOM_RELEASE_SMOKE_SKIP_UI": "1",


### PR DESCRIPTION
## What

Makes the public **demo estate** (`AGENT_BOM_DEMO_ESTATE=1`) look like a real, connected multi-cloud account so an anonymous visitor to the hosted demo sees a rich, believable cloud on every dashboard surface — graph, overview/posture, findings, and CIS/compliance.

Everything is curated and **deterministic** (reproduces identically on every run) and driven off the existing data model — no schema changes.

## What the enriched estate now contains

**Graph** (`/v1/graph`, `/v1/overview`, blast-radius/posture) — `showcase_graph.py`:

| entity | before | after |
|---|---|---|
| agents | 5 | 5 (realistic: Cursor IDE, LangChain Service, Support Copilot, Data Pipeline, Claude Desktop) |
| MCP servers | 5 | 10 |
| packages | 5 | 14 (13 CVE-backed + 1 malicious) |
| vulnerabilities | 6 | 15 |
| credentials | 1 | 8 |
| tools | 11 | 26 |

**Findings** (`agents --demo` scan report → `/v1/findings`, compliance) — `demo.py` + `demo_advisories.py`:

| metric | before | after |
|---|---|---|
| agents | 2 | 5 |
| MCP servers | 4 | 10 |
| packages | 12 | 23 |
| findings | 11 | 20 |
| CRITICAL | 1 | 2 |
| KEV | 0 | 1 |
| malicious | 0 | 1 |

- 15 advisories now use **genuine CVE IDs + CWE + CVSS** (e.g. `CVE-2020-14343` PyYAML RCE, `CVE-2023-36258` LangChain RCE, `CVE-2023-45857` axios SSRF, `CVE-2022-23529` jsonwebtoken).
- **KEV**: Pillow/libwebp `CVE-2023-4863` seeded into `kev_entries` so the KEV differentiator lights up.
- **Malicious**: `reqeusts@2.99.0`, a typosquat of `requests`, flagged by the offline typosquat heuristic.

## Headline blast-radius chain

`Cursor IDE Agent → shell-runner-server → pyyaml@5.3 → CVE-2020-14343 (CRITICAL RCE, CWE-20) → reachable AWS_SECRET_ACCESS_KEY + reachable run_shell tool → potential RCE`

(A second chain runs LangChain `CVE-2023-36258` → `eval_expression` tool + OpenAI key.)

## CIS / compliance spread

Curated AWS/GCP/Azure CIS Foundations posture attached to the demo scan result (`showcase_cis.py`) — real control ids/sections, believable pass/fail so the grade isn't empty or a perfect 100%:

- AWS — 8 checks (5 pass / 3 fail), incl. S3 public-access + SSH 0.0.0.0/0 fails
- GCP — 6 checks (3 pass / 3 fail)
- Azure — 6 checks (4 pass / 2 fail)

## Tests

- Extended `tests/test_demo_estate_bootstrap.py`: enriched graph counts, the headline blast-radius chain, KEV + critical findings, multi-cloud CIS spread.
- Extended `tests/test_demo_inventory_accuracy.py`: ≥2 criticals, typosquat flagged; every package resolves to a real advisory or is allowlisted.
- Updated the one hardcoded demo package count in `tests/test_cli_scan.py` (12 → 23).

Ran: `pytest -k "demo or estate or showcase or graph or overview"` (green), the full set of `--demo`-touching files (305 passed), CIS/compliance/malicious/advisory tests (green — one unrelated 1M-row perf-timing flake), `make preflight` (green), ruff + mypy on changed files (clean).