### PR TITLE
chore(test): use example AWS account id in public test fixture

### DIFF
--- a/tests/cloud/test_cloud_connections.py
+++ b/tests/cloud/test_cloud_connections.py
@@ -1471,7 +1471,7 @@ def test_summarize_inventory_payload_redacts_raw_warnings() -> None:
 
     payload = {
         "status": "ok",
-        "account_id": "030225640638",
+        "account_id": "123456789012",
         "warnings": [
             "Could not list roles: Traceback (most recent call last): RuntimeError boom",
             "AccessDenied: arn:aws:iam::...:user/x — assume failed: <stack>",


### PR DESCRIPTION
A public test fixture used a real AWS account id as sample `account_id` payload data. Swapped it for the canonical AWS example id `123456789012`. The value is only sample data in a redaction test (not asserted on), so no behavior change. Repo-hygiene: real account ids shouldn't sit in public fixtures even though they aren't secrets.