### PR TITLE
feat(demo): seed runtime gateway feed so the AI-firewall shows on the demo

### DIFF
--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -94,6 +94,20 @@ def _reset_audit_dedupe_for_tests() -> None:
         _audit_dedupe.clear()
 
 
+def _reset_proxy_runtime_for_tests() -> None:
+    """Test helper to clear the process-global proxy alert/metric ring buffers.
+
+    The alert deque and metrics maps are module-global (the ring buffer is
+    process-wide), so seeded demo data or per-test alerts otherwise leak across
+    tests. Callers pair this with the firewall decision store reset.
+    """
+    global _proxy_alerts_total, _proxy_metrics
+    _proxy_alerts.clear()
+    _proxy_alerts_total = 0
+    _proxy_metrics = None
+    _proxy_metrics_by_tenant.clear()
+
+
 def push_proxy_alert(alert: dict) -> None:
     """Called by the proxy to record a runtime alert (in-process path)."""
     global _proxy_alerts_total

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -114,6 +114,18 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
     graph_seeded = seed_showcase_graph_if_empty(graph_store, tenant_id=tenant_id)
     summary["graph_seeded"] = graph_seeded
 
+    # Seed the runtime gateway feed (proxy alerts + metrics + firewall
+    # decisions) so the gateway/proxy/runtime dashboards show the AI-firewall in
+    # action on the demo. Idempotent and independent of the scan-job seeding
+    # below, so it must run even when demo jobs already exist.
+    try:
+        from agent_bom.demo_estate.showcase_gateway import seed_showcase_gateway_events
+
+        summary["gateway_feed"] = seed_showcase_gateway_events(tenant_id=tenant_id)
+    except Exception:
+        _logger.warning("demo estate gateway feed seeding failed", exc_info=True)
+        summary["gateway_feed_error"] = True
+
     if _tenant_has_demo_jobs(store, tenant_id):
         summary["reason"] = "demo_jobs_present"
         return summary

--- a/src/agent_bom/demo_estate/showcase_gateway.py
+++ b/src/agent_bom/demo_estate/showcase_gateway.py
@@ -1,0 +1,257 @@
+"""Curated runtime gateway feed for the demo estate.
+
+The showcase graph, findings, and CIS posture render on the demo, but the
+runtime gateway / proxy / firewall dashboards read from live in-process runtime
+stores that a demo deployment never populates (no real proxy traffic flows).
+This module seeds a small, deterministic, tenant-scoped set of AI-firewall
+events into those exact stores so a visitor to the hosted demo SEES the gateway
+in action: authorized tool calls, policy blocks, shadow / undeclared-agent
+blocks, and credential / PII data-filter redactions.
+
+Stores seeded (all the ones the gateway/proxy/runtime dashboards read):
+
+    * proxy alert ring buffer (``agent_bom.api.routes.proxy.push_proxy_alert``)
+      — backs ``/v1/gateway/feed``, ``/v1/gateway/feed/kpis``,
+      ``/v1/proxy/alerts`` and ``/v1/runtime/production-index``.
+    * proxy metrics summary (``push_proxy_metrics``) — backs
+      ``/v1/proxy/status`` and the traffic/uptime rollup in
+      ``/v1/runtime/production-index``.
+    * firewall decision store (``FirewallDecisionStore.record``) — backs
+      ``/v1/firewall/stats`` and the ``firewall_runtime`` block of
+      ``/v1/gateway/stats``.
+
+Events reuse the demo estate's real agent / server / tool names so the feed is
+consistent with the showcase graph. Everything is deterministic (a fixed time
+anchor, no wall-clock or randomness) and idempotent (re-running detects the
+demo marker and skips) so repeated bootstraps do not inflate the counters.
+
+The event records are shaped exactly like alerts ingested through
+``/v1/proxy/audit`` (they are pushed through ``push_proxy_alert``, which applies
+the same secret-sanitization + evidence-tier redaction), so the classification
+fields the feed relies on (``event_type``, ``detector``, ``decision``,
+``reason_code``, ``agent_name``, ``tool_name``) survive redaction — free-text
+fields intentionally do not.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from agent_bom.demo_estate.showcase_graph import SHOWCASE_TENANT
+
+_logger = logging.getLogger(__name__)
+
+# Marker written onto every seeded alert so the seeding is idempotent and so the
+# events are unmistakably demo data (never mixed with real ingested traffic).
+_DEMO_SOURCE_ID = "demo-estate-gateway"
+
+# Fixed time anchor — deterministic across runs (no Date.now / randomness). The
+# gateway KPI counters and feed are windowed by ring-buffer contents, not a
+# wall-clock midnight cut, so a fixed anchor still reads as recent activity.
+_ANCHOR = datetime(2026, 7, 6, 15, 30, 0, tzinfo=timezone.utc)
+
+
+def _ts(minutes_ago: int) -> str:
+    """ISO-8601 timestamp ``minutes_ago`` before the fixed anchor."""
+    return (_ANCHOR - timedelta(minutes=minutes_ago)).isoformat()
+
+
+def _epoch(minutes_ago: int) -> float:
+    return (_ANCHOR - timedelta(minutes=minutes_ago)).timestamp()
+
+
+# ── Curated feed ────────────────────────────────────────────────────────────
+#
+# Each tuple: (minutes_ago, agent_name, tool_name, event_type, detector,
+#              decision, reason_code, severity). ``event_type`` + ``detector`` +
+# ``decision`` + ``reason_code`` are the redaction-safe fields the gateway feed
+# classifier reads; agent_name / tool_name provide per-event attribution.
+_AUTHORIZED = "tool_call_authorized"
+_BLOCKED = "tool_call_blocked"
+_DATA_FILTER = "data_filter_applied"
+
+_FEED_EVENTS: tuple[tuple[int, str, str, str, str, str, str, str], ...] = (
+    # ── authorized tool calls (agent -> server.tool) ──
+    (1, "Cursor IDE Agent", "filesystem-server.read_file", _AUTHORIZED, "policy", "allow", "policy_allow", "info"),
+    (3, "Claude Desktop Agent", "github-server.create_issue", _AUTHORIZED, "policy", "allow", "policy_allow", "info"),
+    (5, "Support Copilot", "helpdesk-server.create_ticket", _AUTHORIZED, "policy", "allow", "policy_allow", "info"),
+    (7, "LangChain Service Agent", "vector-db-server.query_vectors", _AUTHORIZED, "policy", "allow", "policy_allow", "info"),
+    (9, "Data Pipeline Agent", "warehouse-server.run_query", _AUTHORIZED, "policy", "allow", "policy_allow", "info"),
+    (12, "Claude Desktop Agent", "team-chat-server.send_message", _AUTHORIZED, "policy", "allow", "policy_allow", "info"),
+    (15, "Support Copilot", "email-server.list_inbox", _AUTHORIZED, "policy", "allow", "policy_allow", "info"),
+    (19, "Cursor IDE Agent", "filesystem-server.list_directory", _AUTHORIZED, "policy", "allow", "policy_allow", "info"),
+    # ── credential / PII data-filter redactions ──
+    (4, "Support Copilot", "helpdesk-server.search_tickets", _DATA_FILTER, "credential_leak", "allow", "aws_key_masked", "medium"),
+    (10, "Claude Desktop Agent", "team-chat-server.send_message", _DATA_FILTER, "pii", "allow", "email_pii_redacted", "medium"),
+    (16, "Data Pipeline Agent", "warehouse-server.export_csv", _DATA_FILTER, "credential_leak", "allow", "db_password_masked", "medium"),
+    # ── policy blocks (destructive / disallowed tool calls) ──
+    (6, "Data Pipeline Agent", "warehouse-server.execute_sql", _BLOCKED, "policy", "deny", "destructive_sql_denied", "high"),
+    (11, "Cursor IDE Agent", "shell-runner-server.run_shell", _BLOCKED, "policy", "deny", "destructive_command_blocked", "high"),
+    (14, "Support Copilot", "email-server.send_email", _BLOCKED, "policy", "deny", "external_recipient_blocked", "medium"),
+    # ── shadow / undeclared-agent blocks (the AI-firewall differentiator) ──
+    (8, "shadow-agent (unregistered)", "warehouse-server.export_csv", _BLOCKED, "undeclared_agent", "deny", "undeclared_agent_blocked", "critical"),  # noqa: E501
+    (13, "shadow-agent (unregistered)", "shell-runner-server.exec_command", _BLOCKED, "shadow_mcp", "deny", "shadow_server_blocked", "critical"),  # noqa: E501
+    # ── rate-limit / replay protection blocks ──
+    (17, "LangChain Service Agent", "llm-orchestrator-server.http_get", _BLOCKED, "rate_limit", "deny", "rate_limited", "medium"),
+    (20, "shadow-agent (unregistered)", "github-server.push_files", _BLOCKED, "replay", "deny", "replay_blocked", "high"),
+)
+
+# ── Inter-agent firewall decisions (source_agent -> target_agent) ───────────
+# Backs /v1/firewall/stats and gateway/stats.firewall_runtime. effective ==
+# decision here (no dry-run downgrade in the demo). matched_rule mirrors the
+# AgentFirewallPolicy rule payload shape (source/target/decision/description).
+_FIREWALL_DECISIONS: tuple[tuple[int, str, str, str, dict[str, Any] | None], ...] = (
+    (2, "Cursor IDE Agent", "github-server", "allow", None),
+    (5, "LangChain Service Agent", "vector-db-server", "allow", None),
+    (9, "Claude Desktop Agent", "team-chat-server", "allow", None),
+    (
+        13,
+        "Support Copilot",
+        "email-server",
+        "warn",
+        {"source": "Support Copilot", "target": "email-server", "decision": "warn", "description": "external email requires review"},
+    ),
+    (
+        6,
+        "Data Pipeline Agent",
+        "warehouse-server",
+        "deny",
+        {"source": "Data Pipeline Agent", "target": "warehouse-server", "decision": "deny", "description": "bulk export blocked"},
+    ),
+    (
+        8,
+        "shadow-agent (unregistered)",
+        "warehouse-server",
+        "deny",
+        {"source": "*", "target": "warehouse-server", "decision": "deny", "description": "undeclared source agent"},
+    ),
+)
+
+
+def _proxy_metrics_summary(tenant_id: str) -> dict[str, Any]:
+    """Believable traffic / uptime rollup for the proxy + runtime dashboards.
+
+    Numbers are a curated day of activity — larger than the visible feed sample
+    (the feed shows the most recent events; the rollup reflects the day) but
+    internally consistent (block reasons match feed reason codes).
+    """
+    calls_by_tool = {
+        "read_file": 312,
+        "query_vectors": 208,
+        "create_ticket": 141,
+        "run_query": 189,
+        "create_issue": 74,
+        "send_message": 96,
+        "list_inbox": 52,
+        "search_tickets": 67,
+        "http_get": 88,
+        "run_shell": 18,
+        "execute_sql": 23,
+        "export_csv": 31,
+    }
+    blocked_by_reason = {
+        "destructive_command_blocked": 9,
+        "destructive_sql_denied": 6,
+        "external_recipient_blocked": 5,
+        "undeclared_agent_blocked": 4,
+        "shadow_server_blocked": 3,
+        "rate_limited": 7,
+        "replay_blocked": 2,
+    }
+    total_tool_calls = sum(calls_by_tool.values())
+    total_blocked = sum(blocked_by_reason.values())
+    return {
+        "tenant_id": tenant_id,
+        "source_id": _DEMO_SOURCE_ID,
+        "session_id": "demo-estate",
+        "received_at": _ts(0),
+        "ts": _ts(0),
+        "uptime_seconds": 356_400.0,  # ~4.1 days
+        "total_tool_calls": total_tool_calls,
+        "total_blocked": total_blocked,
+        "calls_by_tool": calls_by_tool,
+        "blocked_by_reason": blocked_by_reason,
+        "latency": {"p50_ms": 11.0, "p95_ms": 42.0},
+    }
+
+
+def _tenant_has_demo_gateway_events(tenant_id: str) -> bool:
+    """True when this tenant's proxy alert buffer already holds the demo feed."""
+    from agent_bom.api.routes.proxy import _load_proxy_alerts
+
+    for alert in _load_proxy_alerts(tenant_id):
+        if str(alert.get("source_id") or "") == _DEMO_SOURCE_ID:
+            return True
+    return False
+
+
+def seed_showcase_gateway_events(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str, Any]:
+    """Seed the curated runtime gateway feed for the demo tenant (idempotent)."""
+    from agent_bom.api.routes.proxy import push_proxy_alert, push_proxy_metrics
+    from agent_bom.api.stores import _get_firewall_decision_store
+
+    if _tenant_has_demo_gateway_events(tenant_id):
+        return {"seeded": False, "reason": "already_present", "tenant_id": tenant_id}
+
+    authorized = blocked = data_filters = shadow_blocked = 0
+    for (minutes_ago, agent_name, tool_name, event_type, detector, decision, reason_code, severity) in _FEED_EVENTS:
+        alert = {
+            "event_id": f"{_DEMO_SOURCE_ID}:{minutes_ago}:{tool_name}",
+            "ts": _ts(minutes_ago),
+            "timestamp": _ts(minutes_ago),
+            "tenant_id": tenant_id,
+            "source_id": _DEMO_SOURCE_ID,
+            "session_id": "demo-estate",
+            "agent_name": agent_name,
+            "tool_name": tool_name,
+            "event_type": event_type,
+            "action": event_type,
+            "detector": detector,
+            "decision": decision,
+            "effective_decision": decision,
+            "reason_code": reason_code,
+            "severity": severity,
+        }
+        push_proxy_alert(alert)
+        if event_type == _AUTHORIZED:
+            authorized += 1
+        elif event_type == _DATA_FILTER:
+            data_filters += 1
+        else:
+            blocked += 1
+            if detector in {"undeclared_agent", "shadow_mcp"}:
+                shadow_blocked += 1
+
+    push_proxy_metrics(_proxy_metrics_summary(tenant_id))
+
+    firewall_store = _get_firewall_decision_store()
+    for (minutes_ago, source_agent, target_agent, decision, matched_rule) in _FIREWALL_DECISIONS:
+        firewall_store.record(
+            tenant_id=tenant_id,
+            event={
+                "action": "gateway.firewall_decision",
+                "source_agent": source_agent,
+                "target_agent": target_agent,
+                "decision": decision,
+                "effective_decision": decision,
+                "matched_rule": matched_rule,
+                "enforcement_mode": "enforce",
+                "timestamp": _epoch(minutes_ago),
+                "tenant_id": tenant_id,
+            },
+        )
+
+    summary = {
+        "seeded": True,
+        "tenant_id": tenant_id,
+        "feed_events": len(_FEED_EVENTS),
+        "authorized": authorized,
+        "blocked": blocked,
+        "data_filters": data_filters,
+        "shadow_blocked": shadow_blocked,
+        "firewall_decisions": len(_FIREWALL_DECISIONS),
+    }
+    _logger.info("demo estate gateway feed seeded %s", summary)
+    return summary

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -30,6 +30,13 @@ def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
     finally:
         api_stores._store = original_job_store
         api_stores._graph_store = original_graph_store
+        # The proxy alert/metric ring buffers and the firewall decision store are
+        # process-global; the demo bootstrap seeds them, so clear them here to
+        # keep the seeded gateway feed from leaking into later tests.
+        from agent_bom.api.routes.proxy import _reset_proxy_runtime_for_tests
+
+        _reset_proxy_runtime_for_tests()
+        api_stores._get_firewall_decision_store().reset()
 
 
 def _demo_report(client: TestClient) -> dict:
@@ -159,6 +166,75 @@ def test_demo_estate_cis_posture_spans_aws_gcp_azure(demo_estate_client: TestCli
     assert {"aws", "gcp", "azure"} <= set(clouds), clouds
     statuses = Counter(r["status"] for r in rows)
     assert statuses["pass"] > 0 and statuses["fail"] > 0, statuses
+
+
+def test_demo_estate_gateway_feed_shows_the_ai_firewall(demo_estate_client: TestClient) -> None:
+    """The gateway live feed renders authorized / blocked / shadow / redacted
+    tool-call events on the demo — the AI-firewall differentiator."""
+    feed = demo_estate_client.get("/v1/gateway/feed")
+    assert feed.status_code == 200, feed.text
+    payload = feed.json()
+    events = payload.get("events") or []
+    assert len(events) >= 12, f"expected a dense gateway feed, got {len(events)}"
+
+    by_action = Counter(e.get("action_type") for e in events)
+    # A believable mix mirroring a real AI-firewall feed.
+    assert by_action["tool_call_authorized"] >= 5, by_action
+    assert by_action["tool_call_blocked"] >= 5, by_action
+    assert by_action["data_filter_applied"] >= 2, by_action
+
+    # Shadow / undeclared-agent blocks are labeled as such.
+    shadow = [e for e in events if e.get("shadow")]
+    assert len(shadow) >= 2, "expected shadow/undeclared-agent blocks in the feed"
+    assert any("shadow" in (e.get("agent") or "").lower() for e in shadow)
+
+    # Attribution uses the showcase graph's real agent names.
+    agents = {e.get("agent") for e in events}
+    assert {"Cursor IDE Agent", "Claude Desktop Agent", "Data Pipeline Agent"} & agents
+
+    # Feed is time-ordered newest-first and redaction-safe (metadata only).
+    ts_values = [e.get("ts") for e in events]
+    assert ts_values == sorted(ts_values, reverse=True)
+    for e in events:
+        assert "arguments" not in e and "response" not in e
+
+
+def test_demo_estate_gateway_feed_kpis_populated(demo_estate_client: TestClient) -> None:
+    kpis = demo_estate_client.get("/v1/gateway/feed/kpis").json()
+    assert kpis.get("calls_today", 0) >= 12, kpis
+    assert kpis.get("blocked_today", 0) >= 5, kpis
+    assert kpis.get("shadow_ai_blocked", 0) >= 2, kpis
+    assert kpis.get("data_filters_applied", 0) >= 2, kpis
+    assert kpis.get("uptime_seconds", 0) > 0, kpis
+
+
+def test_demo_estate_runtime_production_index_has_traffic(demo_estate_client: TestClient) -> None:
+    idx = demo_estate_client.get("/v1/runtime/production-index", headers=ADMIN).json()
+    assert idx.get("status") == "ok", idx
+    traffic = idx.get("traffic") or {}
+    assert traffic.get("total_tool_calls", 0) > 100, traffic
+    assert traffic.get("blocked_tool_calls", 0) > 0, traffic
+    assert traffic.get("uptime_seconds", 0) > 0, traffic
+    trace = (idx.get("authorization_trace") or {}).get("recent") or []
+    assert trace, "expected recent authorization-trace events"
+
+
+def test_demo_estate_firewall_stats_populated(demo_estate_client: TestClient) -> None:
+    stats = demo_estate_client.get("/v1/firewall/stats").json()
+    assert stats.get("total_decisions", 0) >= 6, stats
+    assert stats.get("deny", 0) >= 2, stats
+    assert stats.get("allow", 0) >= 2, stats
+    assert stats.get("recent"), "expected recent firewall decisions"
+
+
+def test_demo_estate_gateway_feed_is_idempotent(demo_estate_client: TestClient) -> None:
+    first = len(demo_estate_client.get("/v1/gateway/feed").json().get("events") or [])
+    from agent_bom.demo_estate.showcase_gateway import seed_showcase_gateway_events
+
+    again = seed_showcase_gateway_events()
+    assert again.get("seeded") is False and again.get("reason") == "already_present"
+    second = len(demo_estate_client.get("/v1/gateway/feed").json().get("events") or [])
+    assert second == first
 
 
 def test_demo_estate_bootstrap_is_idempotent(demo_estate_client: TestClient) -> None:


### PR DESCRIPTION
## What

The demo estate (`AGENT_BOM_DEMO_ESTATE=1`) seeds the showcase graph, findings, and CIS posture, but the runtime **gateway / proxy / firewall dashboards read from live in-process runtime stores** that a demo deployment never populates (no real proxy traffic flows). So the product's strongest differentiator — the AI-firewall live feed — rendered **empty** on the hosted demo.

This adds `demo_estate/showcase_gateway.py::seed_showcase_gateway_events()`, called from `maybe_bootstrap_demo_estate()`, which inserts a curated, deterministic, tenant-scoped set of runtime events into the exact stores those dashboards read.

## Stores / endpoints seeded

| Store | Function | Backs |
|---|---|---|
| Proxy alert ring buffer | `push_proxy_alert` | `/v1/gateway/feed`, `/v1/gateway/feed/kpis`, `/v1/proxy/alerts`, `/v1/runtime/production-index` |
| Proxy metrics summary | `push_proxy_metrics` | `/v1/proxy/status` + traffic/uptime rollup in `/v1/runtime/production-index` |
| Firewall decision store | `FirewallDecisionStore.record` | `/v1/firewall/stats`, `firewall_runtime` block of `/v1/gateway/stats` |

Alerts are pushed through the **same secret-sanitization + evidence-tier redaction** the real `/v1/proxy/audit` ingest path applies, so only the redaction-safe classification fields (`event_type`, `detector`, `decision`, `reason_code`, `agent_name`, `tool_name`) survive — exactly like real ingested traffic.

## Event mix (18 feed events + 6 firewall decisions)

- **8 authorized** tool calls (agent → server.tool)
- **3 policy blocks** (destructive SQL / shell / external-recipient)
- **2 shadow / undeclared-agent blocks** (unregistered agent → `warehouse.export_csv`, `shell.exec_command`) — labeled `shadow_ai_blocked`
- **3 credential / PII data-filter redactions** (AWS key masked, email PII redacted, DB password masked)
- **2 rate-limit / replay** blocks
- **6 inter-agent firewall decisions** — 3 allow / 1 warn / 2 deny

All events reuse the showcase graph's real agent / server / tool names (Cursor IDE Agent, Claude Desktop Agent, Data Pipeline Agent, …) so the feed is consistent with the graph. Timestamps derive from a **fixed anchor** (no `Date.now`/randomness); seeding is **idempotent** via a demo source marker so repeat bootstraps never inflate counters.

### How it renders
- **Gateway feed** (`GatewayDashboard` / `GatewayFeedPanel`): time-ordered newest-first stream of authorized / blocked / shadow / redacted events with per-agent attribution; KPI header shows `calls_today=15`, `blocked_today=7`, `shadow_ai_blocked=2`, `data_filters_applied=3`, ~4-day uptime.
- **Proxy dashboard** (`ProxyDashboard`) / **runtime page**: `/v1/runtime/production-index` reports `status=ok`, ~1300 total tool calls, block counts, uptime, and a recent authorization trace.
- **Firewall stats overlay**: 6 decisions with allow/warn/deny spread + recent list.

## Tests

Extended `tests/test_demo_estate_bootstrap.py`:
- feed renders ≥12 events with the authorized/blocked/data-filter mix + shadow labels + real-agent attribution + newest-first ordering + redaction-safety
- KPIs populated; production-index has traffic + uptime; firewall stats populated
- gateway-feed idempotency

Also added `proxy._reset_proxy_runtime_for_tests()` and wired it (plus firewall-store reset) into the demo-estate fixture teardown so the seeded process-global feed does not leak across tests.

`pytest -k "demo or estate or gateway or proxy or runtime or firewall or showcase"` → **1117 passed, 2 skipped**. `make preflight` green; `ruff` clean.