### PR TITLE
feat(demo): dual snapshot drift story for graph lens (#3192 PR-A)

### DIFF
--- a/src/agent_bom/api/readiness.py
+++ b/src/agent_bom/api/readiness.py
@@ -42,11 +42,11 @@ def evaluate_control_plane_readiness() -> ReadinessStatus:
     db_path = os.environ.get("AGENT_BOM_DB", "").strip() or default_state_db_path()
     if db_path and db_path != ":memory:":
         try:
-            conn = sqlite3.connect(db_path, timeout=1.0)
+            sqlite_conn = sqlite3.connect(db_path, timeout=1.0)
             try:
-                conn.execute("SELECT 1")
+                sqlite_conn.execute("SELECT 1")
             finally:
-                conn.close()
+                sqlite_conn.close()
         except Exception:  # noqa: BLE001
             return ReadinessStatus(ready=False, reason="database_unavailable")
 

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
+
+ShowcaseProfile = Literal["baseline", "current"]
 
 from agent_bom.api.agent_identity_store import (
     InMemoryAgentIdentityStore,
@@ -22,6 +24,9 @@ if TYPE_CHECKING:
 
 SHOWCASE_TENANT = "default"
 SHOWCASE_SCAN_ID = "showcase"
+SHOWCASE_BASELINE_SCAN_ID = "showcase-baseline"
+SHOWCASE_BASELINE_CREATED_AT = "2026-06-01T12:00:00+00:00"
+SHOWCASE_CURRENT_CREATED_AT = "2026-06-08T12:00:00+00:00"
 
 
 class _DriftIncident:
@@ -51,7 +56,9 @@ def build_showcase_graph(
     *,
     tenant_id: str = SHOWCASE_TENANT,
     scan_id: str = SHOWCASE_SCAN_ID,
+    profile: ShowcaseProfile = "current",
 ) -> tuple[UnifiedGraph, InMemoryAgentIdentityStore, _DriftStore]:
+    is_baseline = profile == "baseline"
     g = UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id)
 
     def node(i: str, t: EntityType, label: str, **attrs) -> str:
@@ -127,19 +134,20 @@ def build_showcase_graph(
         node(vid, EntityType.VULNERABILITY, cve, severity=sev, risk_score=score, is_kev=cve in kev_cves)
         edge(pid, vid, RelationshipType.VULNERABLE_TO)
 
-    # Malicious/typosquat package — the malicious-package differentiator.
-    node(
-        "pkg:reqeusts@2.99.0",
-        EntityType.PACKAGE,
-        "reqeusts@2.99.0",
-        severity="critical",
-        risk_score=9.1,
-        is_malicious=True,
-        malicious_reason="Possible typosquat of 'requests'",
-    )
-    edge("server:etl-server", "pkg:reqeusts@2.99.0", RelationshipType.DEPENDS_ON)
-    node("vuln:MAL-2024-reqeusts", EntityType.VULNERABILITY, "MAL-2024-reqeusts", severity="critical", risk_score=9.1)
-    edge("pkg:reqeusts@2.99.0", "vuln:MAL-2024-reqeusts", RelationshipType.VULNERABLE_TO)
+    # Malicious/typosquat package — appears only in the current snapshot for drift.
+    if not is_baseline:
+        node(
+            "pkg:reqeusts@2.99.0",
+            EntityType.PACKAGE,
+            "reqeusts@2.99.0",
+            severity="critical",
+            risk_score=9.1,
+            is_malicious=True,
+            malicious_reason="Possible typosquat of 'requests'",
+        )
+        edge("server:etl-server", "pkg:reqeusts@2.99.0", RelationshipType.DEPENDS_ON)
+        node("vuln:MAL-2024-reqeusts", EntityType.VULNERABILITY, "MAL-2024-reqeusts", severity="critical", risk_score=9.1)
+        edge("pkg:reqeusts@2.99.0", "vuln:MAL-2024-reqeusts", RelationshipType.VULNERABLE_TO)
 
     # Credential-backed env on servers — lights up credential-exposure edges.
     creds = {
@@ -184,11 +192,22 @@ def build_showcase_graph(
         "customer-pii-prod (S3)",
         resource_type="s3",
         compliance_tags=["PII", "GDPR"],
+        severity="" if is_baseline else "high",
+        risk_score=0.0 if is_baseline else 8.2,
+        internet_exposed=False if is_baseline else True,
     )
-    node("mc:pii-public", EntityType.MISCONFIGURATION, "S3 bucket customer-pii-prod is publicly readable")
-    node("vuln:bucket-acl", EntityType.VULNERABILITY, "CVE-2024-S3ACL", severity="high", risk_score=8.2)
-    edge("mc:pii-public", "cloud:pii-bucket", RelationshipType.AFFECTS)
-    edge("cloud:pii-bucket", "vuln:bucket-acl", RelationshipType.VULNERABLE_TO)
+    if is_baseline:
+        node(
+            "mc:pii-private",
+            EntityType.MISCONFIGURATION,
+            "S3 bucket customer-pii-prod blocks public ACLs",
+        )
+        edge("mc:pii-private", "cloud:pii-bucket", RelationshipType.AFFECTS)
+    else:
+        node("mc:pii-public", EntityType.MISCONFIGURATION, "S3 bucket customer-pii-prod is publicly readable")
+        node("vuln:bucket-acl", EntityType.VULNERABILITY, "CVE-2024-S3ACL", severity="high", risk_score=8.2)
+        edge("mc:pii-public", "cloud:pii-bucket", RelationshipType.AFFECTS)
+        edge("cloud:pii-bucket", "vuln:bucket-acl", RelationshipType.VULNERABLE_TO)
 
     node(
         "cloud:payments-db",
@@ -225,7 +244,11 @@ def build_showcase_graph(
     edge("role:readonly", "pol:readonly", RelationshipType.ATTACHED)
 
     edge("user:alice", "role:prod-admin", RelationshipType.TRUSTS)
-    edge("user:bob", "role:data-pipeline", RelationshipType.TRUSTS)
+    if is_baseline:
+        edge("user:bob", "role:readonly", RelationshipType.TRUSTS)
+    else:
+        edge("user:bob", "role:data-pipeline", RelationshipType.TRUSTS)
+        edge("user:bob", "role:prod-admin", RelationshipType.TRUSTS)
 
     edge("role:prod-admin", "cloud:pii-bucket", RelationshipType.CAN_ACCESS)
     edge("role:prod-admin", "cloud:payments-db", RelationshipType.CAN_ACCESS)
@@ -238,6 +261,13 @@ def build_showcase_graph(
     # prod-admin; data-pipeline maps to the least-privilege pipeline role.
     edge("agent:cursor", "role:prod-admin", RelationshipType.CAN_ACCESS)
     edge("agent:data-pipeline", "role:data-pipeline", RelationshipType.CAN_ACCESS)
+
+    # Retired MCP server — removed in the current snapshot so drift shows a removal.
+    if is_baseline:
+        node("server:legacy-chat-server", EntityType.SERVER, "legacy-chat-server")
+        edge("agent:support-copilot", "server:legacy-chat-server", RelationshipType.USES)
+        node("tool:legacy-chat-server:send_message", EntityType.TOOL, "send_message")
+        edge("server:legacy-chat-server", "tool:legacy-chat-server:send_message", RelationshipType.PROVIDES_TOOL)
 
     store = InMemoryAgentIdentityStore()
     _jit_tools = {"cursor": "run_shell", "data-pipeline": "execute_sql", "langchain-service": "eval_expression"}
@@ -293,11 +323,36 @@ def seed_showcase_graph_if_empty(
     *,
     tenant_id: str = SHOWCASE_TENANT,
 ) -> bool:
-    """Persist the showcase graph when the tenant has no snapshot yet."""
+    """Persist baseline + current showcase snapshots when the tenant has none yet."""
     latest_snapshot_id = getattr(graph_store, "latest_snapshot_id", None)
     if callable(latest_snapshot_id) and latest_snapshot_id(tenant_id=tenant_id):
         return False
-    graph, identity_store, drift_store = build_showcase_graph(tenant_id=tenant_id)
-    apply_showcase_overlays(graph, tenant_id=tenant_id, identity_store=identity_store, drift_store=drift_store)
-    graph_store.save_graph(graph)
+
+    baseline_graph, baseline_identity, baseline_drift = build_showcase_graph(
+        tenant_id=tenant_id,
+        scan_id=SHOWCASE_BASELINE_SCAN_ID,
+        profile="baseline",
+    )
+    baseline_graph.created_at = SHOWCASE_BASELINE_CREATED_AT
+    apply_showcase_overlays(
+        baseline_graph,
+        tenant_id=tenant_id,
+        identity_store=baseline_identity,
+        drift_store=baseline_drift,
+    )
+    graph_store.save_graph(baseline_graph)
+
+    current_graph, identity_store, drift_store = build_showcase_graph(
+        tenant_id=tenant_id,
+        scan_id=SHOWCASE_SCAN_ID,
+        profile="current",
+    )
+    current_graph.created_at = SHOWCASE_CURRENT_CREATED_AT
+    apply_showcase_overlays(
+        current_graph,
+        tenant_id=tenant_id,
+        identity_store=identity_store,
+        drift_store=drift_store,
+    )
+    graph_store.save_graph(current_graph)
     return True

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
-ShowcaseProfile = Literal["baseline", "current"]
-
 from agent_bom.api.agent_identity_store import (
     InMemoryAgentIdentityStore,
     issue_identity,
@@ -21,6 +19,8 @@ from agent_bom.graph.types import EntityType, RelationshipType
 
 if TYPE_CHECKING:
     from agent_bom.api.graph_store import GraphStoreProtocol
+
+ShowcaseProfile = Literal["baseline", "current"]
 
 SHOWCASE_TENANT = "default"
 SHOWCASE_SCAN_ID = "showcase"

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -5,6 +5,8 @@ from collections import Counter
 import pytest
 from starlette.testclient import TestClient
 
+from agent_bom.demo_estate.showcase_graph import SHOWCASE_BASELINE_SCAN_ID
+
 ADMIN = {"X-Agent-Bom-Role": "admin"}
 
 
@@ -235,6 +237,32 @@ def test_demo_estate_gateway_feed_is_idempotent(demo_estate_client: TestClient) 
     assert again.get("seeded") is False and again.get("reason") == "already_present"
     second = len(demo_estate_client.get("/v1/gateway/feed").json().get("events") or [])
     assert second == first
+
+
+def test_demo_estate_graph_snapshots_support_drift_lens(demo_estate_client: TestClient) -> None:
+    """Baseline + current snapshots let the shipped drift lens diff against a prior estate."""
+    snapshots = demo_estate_client.get("/v1/graph/snapshots", headers=ADMIN).json()
+    scan_ids = {row.get("scan_id") for row in snapshots}
+    assert SHOWCASE_BASELINE_SCAN_ID in scan_ids
+    assert "showcase" in scan_ids
+    assert len(snapshots) >= 2
+
+    diff = demo_estate_client.get(
+        "/v1/graph/diff",
+        headers=ADMIN,
+        params={"old": SHOWCASE_BASELINE_SCAN_ID, "new": "showcase"},
+    )
+    assert diff.status_code == 200, diff.text
+    body = diff.json()
+    index = body.get("change_kind_index") or {}
+    node_kinds = index.get("nodes") or {}
+    assert node_kinds, "expected node drift between baseline and current showcase snapshots"
+    kinds = set(node_kinds.values())
+    assert kinds & {"new", "removed", "changed"}, kinds
+
+    assert body.get("nodes_added"), "expected at least one new node in the showcase drift story"
+    assert body.get("nodes_removed"), "expected at least one removed node in the showcase drift story"
+    assert body.get("nodes_changed"), "expected at least one changed node in the showcase drift story"
 
 
 def test_demo_estate_bootstrap_is_idempotent(demo_estate_client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- Seed **two** graph snapshots on demo estate bootstrap: `showcase-baseline` → `showcase`.
- Deliberate drift: new malicious package + public S3 exposure, removed legacy MCP server, changed PII bucket posture, IAM trust expansion for `user:bob`.
- Unlocks the already-shipped drift lens (#3649) on hosted demo / first API start — previously inert with a single snapshot.

## Context
Checked `main` first — #3649 drift UI, #3606 rollup lens, #3731/#3737 demo enrichments are merged; dual snapshot + attribute diff were not.

## Test plan
- [x] `uv run pytest -q tests/test_demo_estate_bootstrap.py`

## Notes
- PR-B (attribute-aware diff + drift “why” chips) stacks on this branch.


Made with [Cursor](https://cursor.com)