### PR TITLE
feat(graph): attribute-aware drift diff + why chips (#3192 PR-B)

### DIFF
--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -1159,42 +1159,37 @@ class PostgresGraphStore:
         }
 
     def diff_snapshots(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict[str, Any]:
+        from agent_bom.graph.drift_attributes import attribute_deltas, node_diff_metadata, node_snapshot_changed
+
         tenant_id = normalize_graph_tenant_id(tenant_id)
 
-        def node_metadata(row) -> dict[str, Any]:
-            return {
-                "id": row[0],
-                "entity_type": row[1],
-                "label": row[2],
-                "status": row[3] or "",
-                "severity": row[4] or "",
-                "severity_id": int(row[5] or 0),
-                "risk_score": float(row[6] or 0.0),
-            }
+        def _load_nodes(conn, scan_id: str) -> dict[str, dict[str, Any]]:
+            loaded: dict[str, dict[str, Any]] = {}
+            for row in conn.execute(
+                """
+                SELECT id, entity_type, label, status, severity, severity_id, risk_score,
+                       attributes, compliance_tags
+                FROM graph_nodes
+                WHERE scan_id = %s AND tenant_id = %s
+                """,
+                (scan_id, tenant_id),
+            ).fetchall():
+                loaded[row[0]] = node_diff_metadata(
+                    node_id=row[0],
+                    entity_type=row[1],
+                    label=row[2],
+                    status=row[3],
+                    severity=row[4],
+                    severity_id=int(row[5] or 0),
+                    risk_score=float(row[6] or 0.0),
+                    attributes=row[7],
+                    compliance_tags=row[8],
+                )
+            return loaded
 
         with _tenant_connection(self._pool) as conn:
-            old_nodes = {
-                row[0]: node_metadata(row)
-                for row in conn.execute(
-                    """
-                    SELECT id, entity_type, label, status, severity, severity_id, risk_score
-                    FROM graph_nodes
-                    WHERE scan_id = %s AND tenant_id = %s
-                    """,
-                    (scan_id_old, tenant_id),
-                ).fetchall()
-            }
-            new_nodes = {
-                row[0]: node_metadata(row)
-                for row in conn.execute(
-                    """
-                    SELECT id, entity_type, label, status, severity, severity_id, risk_score
-                    FROM graph_nodes
-                    WHERE scan_id = %s AND tenant_id = %s
-                    """,
-                    (scan_id_new, tenant_id),
-                ).fetchall()
-            }
+            old_nodes = _load_nodes(conn, scan_id_old)
+            new_nodes = _load_nodes(conn, scan_id_new)
             old_ids, new_ids = set(old_nodes), set(new_nodes)
             old_edges = {
                 (row[0], row[1], row[2])
@@ -1210,10 +1205,20 @@ class PostgresGraphStore:
                     (scan_id_new, tenant_id),
                 ).fetchall()
             }
+            attribute_delta_index: dict[str, list[dict[str, Any]]] = {}
+            nodes_changed: list[str] = []
+            for nid in sorted(old_ids & new_ids):
+                if not node_snapshot_changed(old_nodes[nid], new_nodes[nid]):
+                    continue
+                nodes_changed.append(nid)
+                deltas = attribute_deltas(old_nodes[nid], new_nodes[nid])
+                if deltas:
+                    attribute_delta_index[nid] = deltas
             return {
                 "nodes_added": [new_nodes[nid] for nid in sorted(new_ids - old_ids)],
                 "nodes_removed": [old_nodes[nid] for nid in sorted(old_ids - new_ids)],
-                "nodes_changed": sorted(nid for nid in (old_ids & new_ids) if old_nodes[nid] != new_nodes[nid]),
+                "nodes_changed": nodes_changed,
+                "attribute_deltas": attribute_delta_index,
                 "edges_added": sorted(new_edges - old_edges),
                 "edges_removed": sorted(old_edges - new_edges),
                 "edges_changed": self.changed_edges_between_scans(scan_id_old, scan_id_new, tenant_id=tenant_id)["edges_changed"],

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -892,40 +892,36 @@ def diff_snapshots(
     tenant_id: str = "",
 ) -> dict[str, Any]:
     """Compute the diff between two scan snapshots."""
+    from agent_bom.graph.drift_attributes import attribute_deltas, node_diff_metadata, node_snapshot_changed
+
     tenant_id = normalize_graph_tenant_id(tenant_id)
 
-    def node_metadata(row: sqlite3.Row) -> dict[str, Any]:
-        return {
-            "id": row["id"],
-            "entity_type": row["entity_type"],
-            "label": row["label"],
-            "severity": row["severity"] or "",
-            "severity_id": int(row["severity_id"] or 0),
-            "risk_score": float(row["risk_score"] or 0.0),
-            "status": row["status"] or "",
-        }
+    def _load_nodes(scan_id: str) -> dict[str, dict[str, Any]]:
+        loaded: dict[str, dict[str, Any]] = {}
+        for row in conn.execute(
+            """
+            SELECT id, entity_type, label, status, severity, severity_id, risk_score,
+                   attributes, compliance_tags
+            FROM graph_nodes
+            WHERE scan_id = ? AND tenant_id = ?
+            """,
+            (scan_id, tenant_id),
+        ):
+            loaded[row["id"]] = node_diff_metadata(
+                node_id=row["id"],
+                entity_type=row["entity_type"],
+                label=row["label"],
+                status=row["status"],
+                severity=row["severity"],
+                severity_id=int(row["severity_id"] or 0),
+                risk_score=float(row["risk_score"] or 0.0),
+                attributes=row["attributes"],
+                compliance_tags=row["compliance_tags"],
+            )
+        return loaded
 
-    old_nodes: dict[str, dict] = {}
-    for row in conn.execute(
-        """
-        SELECT id, entity_type, label, status, severity, severity_id, risk_score
-        FROM graph_nodes
-        WHERE scan_id = ? AND tenant_id = ?
-        """,
-        (scan_id_old, tenant_id),
-    ):
-        old_nodes[row["id"]] = node_metadata(row)
-
-    new_nodes: dict[str, dict] = {}
-    for row in conn.execute(
-        """
-        SELECT id, entity_type, label, status, severity, severity_id, risk_score
-        FROM graph_nodes
-        WHERE scan_id = ? AND tenant_id = ?
-        """,
-        (scan_id_new, tenant_id),
-    ):
-        new_nodes[row["id"]] = node_metadata(row)
+    old_nodes = _load_nodes(scan_id_old)
+    new_nodes = _load_nodes(scan_id_new)
 
     old_ids, new_ids = set(old_nodes), set(new_nodes)
 
@@ -943,10 +939,21 @@ def diff_snapshots(
     ):
         new_edges.add((row["source_id"], row["target_id"], row["relationship"]))
 
+    attribute_delta_index: dict[str, list[dict[str, Any]]] = {}
+    nodes_changed: list[str] = []
+    for nid in sorted(old_ids & new_ids):
+        if not node_snapshot_changed(old_nodes[nid], new_nodes[nid]):
+            continue
+        nodes_changed.append(nid)
+        deltas = attribute_deltas(old_nodes[nid], new_nodes[nid])
+        if deltas:
+            attribute_delta_index[nid] = deltas
+
     return {
         "nodes_added": [new_nodes[nid] for nid in sorted(new_ids - old_ids)],
         "nodes_removed": [old_nodes[nid] for nid in sorted(old_ids - new_ids)],
-        "nodes_changed": sorted(nid for nid in (old_ids & new_ids) if old_nodes[nid] != new_nodes[nid]),
+        "nodes_changed": nodes_changed,
+        "attribute_deltas": attribute_delta_index,
         "edges_added": sorted(new_edges - old_edges),
         "edges_removed": sorted(old_edges - new_edges),
         "edges_changed": changed_edges_between_scans(conn, scan_id_old, scan_id_new, tenant_id=tenant_id)["edges_changed"],

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -318,6 +318,25 @@ def apply_showcase_overlays(
     return {"cnapp": cnapp, "effective_permissions": eff, "governance": gov}
 
 
+def finalize_showcase_snapshot(graph: UnifiedGraph, *, profile: ShowcaseProfile) -> None:
+    """Pin deliberate drift markers after overlays that may rewrite attributes."""
+    bucket = graph.nodes.get("cloud:pii-bucket")
+    if bucket is None:
+        return
+    if profile == "baseline":
+        bucket.attributes["internet_exposed"] = False
+        bucket.attributes["encryption_at_rest"] = True
+        bucket.severity = ""
+        bucket.risk_score = 0.0
+        bucket.compliance_tags = ["PII", "GDPR"]
+        return
+    bucket.attributes["internet_exposed"] = True
+    bucket.attributes["encryption_at_rest"] = False
+    bucket.severity = "high"
+    bucket.risk_score = 8.2
+    bucket.compliance_tags = ["PII", "GDPR", "public-exposure"]
+
+
 def seed_showcase_graph_if_empty(
     graph_store: GraphStoreProtocol,
     *,
@@ -340,6 +359,7 @@ def seed_showcase_graph_if_empty(
         identity_store=baseline_identity,
         drift_store=baseline_drift,
     )
+    finalize_showcase_snapshot(baseline_graph, profile="baseline")
     graph_store.save_graph(baseline_graph)
 
     current_graph, identity_store, drift_store = build_showcase_graph(
@@ -354,5 +374,6 @@ def seed_showcase_graph_if_empty(
         identity_store=identity_store,
         drift_store=drift_store,
     )
+    finalize_showcase_snapshot(current_graph, profile="current")
     graph_store.save_graph(current_graph)
     return True

--- a/src/agent_bom/graph/drift_attributes.py
+++ b/src/agent_bom/graph/drift_attributes.py
@@ -1,0 +1,150 @@
+"""Canonical config-drift attribute comparison for graph snapshot diffs (#3192)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+_DRIFT_ATTRIBUTE_KEYS = (
+    "internet_exposed",
+    "encryption_at_rest",
+    "encryption_in_transit",
+    "iam_policy_arn",
+    "iam_role_arn",
+)
+
+_SCALAR_DIFF_FIELDS = (
+    "entity_type",
+    "label",
+    "status",
+    "severity",
+    "severity_id",
+    "risk_score",
+)
+
+
+def _normalize_tags(tags: Any) -> list[str]:
+    if not tags:
+        return []
+    if isinstance(tags, str):
+        try:
+            parsed = json.loads(tags)
+        except json.JSONDecodeError:
+            return [tags]
+        return _normalize_tags(parsed)
+    if isinstance(tags, (list, tuple, set)):
+        return sorted(str(tag) for tag in tags)
+    return [str(tags)]
+
+
+def _normalize_attributes(raw: Any) -> dict[str, Any]:
+    if not raw:
+        return {}
+    if isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return dict(raw) if isinstance(raw, dict) else {}
+
+
+def node_diff_metadata(
+    *,
+    node_id: str,
+    entity_type: str,
+    label: str,
+    status: str,
+    severity: str,
+    severity_id: int,
+    risk_score: float,
+    attributes: Any = None,
+    compliance_tags: Any = None,
+) -> dict[str, Any]:
+    """Normalized node metadata used by snapshot diff."""
+    return {
+        "id": node_id,
+        "entity_type": entity_type,
+        "label": label,
+        "status": status or "",
+        "severity": severity or "",
+        "severity_id": int(severity_id or 0),
+        "risk_score": float(risk_score or 0.0),
+        "attributes": _normalize_attributes(attributes),
+        "compliance_tags": _normalize_tags(compliance_tags),
+    }
+
+
+def _scalar_projection(meta: dict[str, Any]) -> dict[str, Any]:
+    return {field: meta.get(field) for field in _SCALAR_DIFF_FIELDS}
+
+
+def _drift_value(meta: dict[str, Any], field: str) -> Any:
+    if field == "compliance_tags":
+        return meta.get("compliance_tags") or []
+    return meta.get("attributes", {}).get(field)
+
+
+def summarize_attribute_delta(field: str, before: Any, after: Any) -> str:
+    """Human-readable one-liner for drift legend chips."""
+    if field == "internet_exposed":
+        if before is False and after is True:
+            return "Public exposure opened"
+        if before is True and after is False:
+            return "Public exposure closed"
+        return "Public exposure changed"
+    if field == "encryption_at_rest":
+        if before is True and after is False:
+            return "Encryption at rest disabled"
+        if before is False and after is True:
+            return "Encryption at rest enabled"
+        return "Encryption at rest changed"
+    if field == "encryption_in_transit":
+        if before is True and after is False:
+            return "Encryption in transit disabled"
+        if before is False and after is True:
+            return "Encryption in transit enabled"
+        return "Encryption in transit changed"
+    if field.startswith("iam_"):
+        return "IAM attachment changed"
+    if field == "compliance_tags":
+        return "Compliance tags changed"
+    return f"{field} changed"
+
+
+def attribute_deltas(old_meta: dict[str, Any], new_meta: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return canonical attribute deltas between two node snapshots."""
+    deltas: list[dict[str, Any]] = []
+    for field in _DRIFT_ATTRIBUTE_KEYS:
+        before = _drift_value(old_meta, field)
+        after = _drift_value(new_meta, field)
+        if before == after:
+            continue
+        deltas.append(
+            {
+                "field": field,
+                "before": before,
+                "after": after,
+                "summary": summarize_attribute_delta(field, before, after),
+            }
+        )
+
+    old_tags = _drift_value(old_meta, "compliance_tags")
+    new_tags = _drift_value(new_meta, "compliance_tags")
+    if old_tags != new_tags:
+        deltas.append(
+            {
+                "field": "compliance_tags",
+                "before": old_tags,
+                "after": new_tags,
+                "summary": summarize_attribute_delta("compliance_tags", old_tags, new_tags),
+            }
+        )
+    return deltas
+
+
+def node_snapshot_changed(old_meta: dict[str, Any], new_meta: dict[str, Any]) -> bool:
+    """True when scalar fields or canonical attribute deltas differ."""
+    if _scalar_projection(old_meta) != _scalar_projection(new_meta):
+        return True
+    return bool(attribute_deltas(old_meta, new_meta))

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -260,6 +260,11 @@ def test_demo_estate_graph_snapshots_support_drift_lens(demo_estate_client: Test
     kinds = set(node_kinds.values())
     assert kinds & {"new", "removed", "changed"}, kinds
 
+    deltas = body.get("attribute_deltas") or {}
+    pii_deltas = deltas.get("cloud:pii-bucket") or []
+    summaries = {row.get("summary") for row in pii_deltas}
+    assert "Public exposure opened" in summaries or "Encryption at rest disabled" in summaries, pii_deltas
+
     assert body.get("nodes_added"), "expected at least one new node in the showcase drift story"
     assert body.get("nodes_removed"), "expected at least one removed node in the showcase drift story"
     assert body.get("nodes_changed"), "expected at least one changed node in the showcase drift story"

--- a/tests/test_graph_drift_attributes.py
+++ b/tests/test_graph_drift_attributes.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from agent_bom.graph.drift_attributes import (
+    attribute_deltas,
+    node_diff_metadata,
+    node_snapshot_changed,
+    summarize_attribute_delta,
+)
+
+
+def test_attribute_deltas_detect_public_exposure_flip() -> None:
+    old = node_diff_metadata(
+        node_id="cloud:pii-bucket",
+        entity_type="cloud_resource",
+        label="customer-pii-prod (S3)",
+        status="",
+        severity="",
+        severity_id=0,
+        risk_score=0.0,
+        attributes={"internet_exposed": False},
+        compliance_tags=["PII", "GDPR"],
+    )
+    new = node_diff_metadata(
+        node_id="cloud:pii-bucket",
+        entity_type="cloud_resource",
+        label="customer-pii-prod (S3)",
+        status="",
+        severity="high",
+        severity_id=0,
+        risk_score=8.2,
+        attributes={"internet_exposed": True},
+        compliance_tags=["PII", "GDPR"],
+    )
+    deltas = attribute_deltas(old, new)
+    fields = {row["field"] for row in deltas}
+    assert "internet_exposed" in fields
+    assert any(row["summary"] == "Public exposure opened" for row in deltas)
+    assert node_snapshot_changed(old, new)
+
+
+def test_summarize_attribute_delta_encryption_disabled() -> None:
+    assert (
+        summarize_attribute_delta("encryption_at_rest", True, False)
+        == "Encryption at rest disabled"
+    )

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -72,6 +72,7 @@ import {
   BACKGROUND_COLOR,
   BACKGROUND_GAP,
   buildDriftIndex,
+  driftAttributeSummaries,
   changeKindForEdge,
   changeKindForNode,
   CHANGE_KIND_META,
@@ -1453,6 +1454,10 @@ function GraphPageInner() {
   // previous one using the diff index the server tags. The lens is inert unless
   // a diff exists AND the operator armed it, so the default view never changes.
   const driftIndex = useMemo(() => buildDriftIndex(graphDiff), [graphDiff]);
+  const driftAttributeSummaryList = useMemo(
+    () => driftAttributeSummaries(driftIndex),
+    [driftIndex],
+  );
   const driftLensEngaged =
     driftLensActive && Boolean(graphDiff) && driftIndex.hasChanges;
 
@@ -2529,6 +2534,7 @@ function GraphPageInner() {
             counts={drift.counts}
             criticalCount={drift.critical}
             comparedLabel={previousSnapshot?.scan_id.slice(0, 12)}
+            attributeSummaries={driftAttributeSummaryList}
           />
         )}
 

--- a/ui/components/graph-drift-legend.tsx
+++ b/ui/components/graph-drift-legend.tsx
@@ -54,6 +54,8 @@ export interface GraphDriftLegendProps {
   criticalCount: number;
   /** Short id of the older snapshot this diff compares against, if any. */
   comparedLabel?: string | undefined;
+  /** Canonical config-drift summaries from attribute-aware diff (#3192). */
+  attributeSummaries?: string[] | undefined;
 }
 
 export function GraphDriftLegend({
@@ -64,6 +66,7 @@ export function GraphDriftLegend({
   counts,
   criticalCount,
   comparedLabel,
+  attributeSummaries,
 }: GraphDriftLegendProps) {
   return (
     <div
@@ -156,6 +159,22 @@ export function GraphDriftLegend({
               );
             })}
           </div>
+
+          {attributeSummaries && attributeSummaries.length > 0 ? (
+            <div
+              className="mt-3 flex flex-wrap gap-2"
+              data-testid="graph-drift-attribute-summaries"
+            >
+              {attributeSummaries.map((summary) => (
+                <span
+                  key={summary}
+                  className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-0.5 text-[11px] text-amber-100"
+                >
+                  {summary}
+                </span>
+              ))}
+            </div>
+          ) : null}
         </>
       ) : (
         <p className="mt-2 text-xs text-zinc-500">

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -460,6 +460,14 @@ export interface GraphDiffResponse {
   edges_added: [string, string, string][];
   edges_removed: [string, string, string][];
   change_kind_index?: GraphChangeKindIndex | undefined;
+  attribute_deltas?: Record<string, GraphAttributeDelta[]> | undefined;
+}
+
+export interface GraphAttributeDelta {
+  field: string;
+  before: unknown;
+  after: unknown;
+  summary: string;
 }
 
 export type GraphExportFormat =

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -609,6 +609,7 @@ export interface DriftIndex {
   counts: Record<ChangeKind, number>;
   /** True when the diff surfaced at least one changed node or edge. */
   hasChanges: boolean;
+  attributeDeltas: Map<string, import("@/lib/api-types").GraphAttributeDelta[]>;
 }
 
 const EMPTY_DRIFT_COUNTS = (): Record<ChangeKind, number> => ({
@@ -636,12 +637,32 @@ export function buildDriftIndex(
     }
   }
 
+  const attributeDeltas = new Map<string, import("@/lib/api-types").GraphAttributeDelta[]>();
+  if (diff?.attribute_deltas) {
+    for (const [nodeId, deltas] of Object.entries(diff.attribute_deltas)) {
+      if (deltas.length > 0) attributeDeltas.set(nodeId, deltas);
+    }
+  }
+
   return {
     nodeKind,
     edgeKind,
     counts,
     hasChanges: nodeKind.size > 0 || edgeKind.size > 0,
+    attributeDeltas,
   };
+}
+
+export function driftAttributeSummaries(
+  index: DriftIndex,
+): string[] {
+  const seen = new Set<string>();
+  for (const deltas of index.attributeDeltas.values()) {
+    for (const delta of deltas) {
+      if (delta.summary) seen.add(delta.summary);
+    }
+  }
+  return [...seen];
 }
 
 export function changeKindForNode(id: string, index: DriftIndex): ChangeKind {

--- a/ui/tests/graph-drift-lens.test.tsx
+++ b/ui/tests/graph-drift-lens.test.tsx
@@ -6,6 +6,7 @@ import {
   buildDriftIndex,
   changeKindForEdge,
   changeKindForNode,
+  driftAttributeSummaries,
   driftLegendItems,
   type ChangeKind,
 } from "@/lib/graph-utils";
@@ -80,6 +81,23 @@ describe("drift index helpers", () => {
       "Removed · 1",
       "Unchanged · 4",
     ]);
+  });
+
+  it("collects attribute delta summaries from the diff payload", () => {
+    const index = buildDriftIndex({
+      ...DIFF,
+      attribute_deltas: {
+        "cloud:pii-bucket": [
+          {
+            field: "internet_exposed",
+            before: false,
+            after: true,
+            summary: "Public exposure opened",
+          },
+        ],
+      },
+    });
+    expect(driftAttributeSummaries(index)).toEqual(["Public exposure opened"]);
   });
 });
 
@@ -169,5 +187,22 @@ describe("GraphDriftLegend component", () => {
     const { onToggleActive } = renderLegend({ active: false });
     fireEvent.click(screen.getByTestId("graph-drift-toggle"));
     expect(onToggleActive).toHaveBeenCalledWith(true);
+  });
+
+  it("renders attribute drift summaries when provided", () => {
+    render(
+      <GraphDriftLegend
+        active
+        onToggleActive={vi.fn()}
+        filter="all"
+        onFilterChange={vi.fn()}
+        counts={COUNTS}
+        criticalCount={2}
+        attributeSummaries={["Public exposure opened"]}
+      />,
+    );
+    expect(screen.getByTestId("graph-drift-attribute-summaries")).toHaveTextContent(
+      "Public exposure opened",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Add canonical `attribute_deltas` on `/v1/graph/diff` for exposure, encryption, IAM refs, and compliance tags (SQLite + Postgres parity).
- Show drift “why” summary chips in `GraphDriftLegend` when the lens is armed.
- Pin post-overlay showcase snapshot markers so CNAPP normalization does not erase the demo drift story.

## Depends on
- #3738 (dual snapshot demo seed)

## Test plan
- [x] `uv run pytest -q tests/test_graph_drift_attributes.py tests/test_demo_estate_bootstrap.py::test_demo_estate_graph_snapshots_support_drift_lens tests/test_graph_api.py::test_graph_diff_route_tags_change_kind`
- [x] `cd ui && npm test -- --run tests/graph-drift-lens.test.tsx`

## Epic progress
- With #3738 + this PR: drift lens is live in demo with config-level “why” (~85% of #3192).


Made with [Cursor](https://cursor.com)