### PR TITLE
feat(graph): rollup perf + evidence lens — close #3192 for release

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -147,6 +147,7 @@ class GraphStoreProtocol(Protocol):
         scan_id: str = "",
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
+        relationship_types: frozenset[str] | None = None,
     ) -> UnifiedGraph: ...
 
     def diff_snapshots(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict[str, Any]: ...
@@ -1108,6 +1109,7 @@ class SQLiteGraphStore:
         scan_id: str = "",
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
+        relationship_types: frozenset[str] | None = None,
     ) -> UnifiedGraph:
         tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
@@ -1120,6 +1122,7 @@ class SQLiteGraphStore:
                 scan_id=scan_id,
                 entity_types=entity_types,
                 min_severity_rank=min_severity_rank,
+                relationship_types=relationship_types,
             )
         finally:
             conn.close()

--- a/src/agent_bom/api/neptune_graph.py
+++ b/src/agent_bom/api/neptune_graph.py
@@ -280,6 +280,7 @@ class NeptuneGraphStore:
         scan_id: str = "",
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
+        relationship_types: frozenset[str] | None = None,
     ) -> UnifiedGraph:
         tenant = tenant_id or "default"
         scan = scan_id or self.latest_snapshot_id(tenant_id=tenant)

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -768,6 +768,7 @@ class PostgresGraphStore:
         scan_id: str = "",
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
+        relationship_types: frozenset[str] | None = None,
     ):
         tenant_id = normalize_graph_tenant_id(tenant_id)
         _assert_allowed_entity_types(entity_types)
@@ -810,16 +811,20 @@ class PostgresGraphStore:
                 graph.add_node(self._node_from_row(row))
                 node_ids.add(row[0])
 
-            for row in conn.execute(
-                """
+            edge_query = """
                 SELECT source_id, target_id, relationship, direction, weight, traversable,
                        first_seen, last_seen, valid_from, valid_to, confidence, provenance,
                        source_scan_id, source_run_id, evidence, activity_id, scan_id
                 FROM graph_edges
                 WHERE tenant_id = %s AND scan_id = %s
-                """,
-                (tenant_id, effective_scan_id),
-            ).fetchall():
+            """
+            edge_params: list[Any] = [tenant_id, effective_scan_id]
+            if relationship_types:
+                placeholders = ",".join(["%s"] * len(relationship_types))
+                edge_query += f" AND relationship IN ({placeholders})"
+                edge_params.extend(sorted(relationship_types))
+
+            for row in conn.execute(edge_query, edge_params).fetchall():
                 if row[0] not in node_ids or row[1] not in node_ids:
                     continue
                 graph.add_edge(
@@ -843,46 +848,47 @@ class PostgresGraphStore:
                     )
                 )
 
-            for row in conn.execute(
-                """
-                SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
-                       summary, credential_exposure, tool_exposure, vuln_ids
-                FROM attack_paths
-                WHERE tenant_id = %s AND scan_id = %s
-                """,
-                (tenant_id, effective_scan_id),
-            ).fetchall():
-                graph.attack_paths.append(
-                    AttackPath(
-                        source=row[0],
-                        target=row[1],
-                        hops=json.loads(row[2]),
-                        edges=json.loads(row[3]),
-                        composite_risk=row[4],
-                        summary=row[5] or "",
-                        credential_exposure=json.loads(row[6]),
-                        tool_exposure=json.loads(row[7]),
-                        vuln_ids=json.loads(row[8]),
+            if not relationship_types:
+                for row in conn.execute(
+                    """
+                    SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
+                           summary, credential_exposure, tool_exposure, vuln_ids
+                    FROM attack_paths
+                    WHERE tenant_id = %s AND scan_id = %s
+                    """,
+                    (tenant_id, effective_scan_id),
+                ).fetchall():
+                    graph.attack_paths.append(
+                        AttackPath(
+                            source=row[0],
+                            target=row[1],
+                            hops=json.loads(row[2]),
+                            edges=json.loads(row[3]),
+                            composite_risk=row[4],
+                            summary=row[5] or "",
+                            credential_exposure=json.loads(row[6]),
+                            tool_exposure=json.loads(row[7]),
+                            vuln_ids=json.loads(row[8]),
+                        )
                     )
-                )
 
-            for row in conn.execute(
-                """
-                SELECT pattern, agents, risk_score, description, owasp_agentic_tag
-                FROM interaction_risks
-                WHERE tenant_id = %s AND scan_id = %s
-                """,
-                (tenant_id, effective_scan_id),
-            ).fetchall():
-                graph.interaction_risks.append(
-                    InteractionRisk(
-                        pattern=row[0],
-                        agents=json.loads(row[1]),
-                        risk_score=row[2],
-                        description=row[3],
-                        owasp_agentic_tag=row[4],
+                for row in conn.execute(
+                    """
+                    SELECT pattern, agents, risk_score, description, owasp_agentic_tag
+                    FROM interaction_risks
+                    WHERE tenant_id = %s AND scan_id = %s
+                    """,
+                    (tenant_id, effective_scan_id),
+                ).fetchall():
+                    graph.interaction_risks.append(
+                        InteractionRisk(
+                            pattern=row[0],
+                            agents=json.loads(row[1]),
+                            risk_score=row[2],
+                            description=row[3],
+                            owasp_agentic_tag=row[4],
+                        )
                     )
-                )
 
             return graph
 

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -3118,6 +3118,11 @@ async def delete_preset(request: Request, name: str) -> dict:
 # Estate-scale roll-up (CONTAINS) — backend for the UI graph-nav drill-down
 # ═══════════════════════════════════════════════════════════════════════════
 
+# Containment-only edge load for /v1/graph/rollup (default mode).
+_ROLLUP_CONTAINMENT_RELATIONSHIPS = frozenset(
+    {RelationshipType.CONTAINS.value, RelationshipType.HOSTS.value}
+)
+
 
 @router.get("/graph/rollup", tags=["graph"])
 async def get_graph_rollup(
@@ -3154,11 +3159,13 @@ async def get_graph_rollup(
         raise HTTPException(status_code=422, detail=f"Unsupported severity: {min_severity}")
 
     try:
-        graph = await _graph_store_call(
-            graph_store.load_graph,
-            scan_id=requested_scan_id,
-            tenant_id=tenant,
-        )
+        load_kwargs: dict[str, Any] = {
+            "scan_id": requested_scan_id,
+            "tenant_id": tenant,
+        }
+        if mode != "attack_path":
+            load_kwargs["relationship_types"] = _ROLLUP_CONTAINMENT_RELATIONSHIPS
+        graph = await _graph_store_call(graph_store.load_graph, **load_kwargs)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
 

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -778,6 +778,7 @@ def load_graph(
     scan_id: str = "",
     entity_types: set[str] | None = None,
     min_severity_rank: int = 0,
+    relationship_types: frozenset[str] | None = None,
 ) -> UnifiedGraph:
     """Load a UnifiedGraph from a specific scan snapshot."""
     tenant_id = normalize_graph_tenant_id(tenant_id)
@@ -822,6 +823,10 @@ def load_graph(
 
     eq = "SELECT * FROM graph_edges WHERE tenant_id = ? AND scan_id = ?"
     eparams: list[Any] = [tenant_id, effective_scan_id]
+    if relationship_types:
+        placeholders = ",".join("?" * len(relationship_types))
+        eq += f" AND relationship IN ({placeholders})"
+        eparams.extend(sorted(relationship_types))
     for row in conn.execute(eq, eparams):
         if row["source_id"] not in node_ids or row["target_id"] not in node_ids:
             continue
@@ -846,35 +851,36 @@ def load_graph(
             )
         )
 
-    apq = "SELECT * FROM attack_paths WHERE tenant_id = ? AND scan_id = ?"
-    apparams: list[Any] = [tenant_id, effective_scan_id]
-    for row in conn.execute(apq, apparams):
-        graph.attack_paths.append(
-            AttackPath(
-                source=row["source_node"],
-                target=row["target_node"],
-                hops=json.loads(row["path_nodes"]),
-                edges=json.loads(row["path_edges"]),
-                composite_risk=row["composite_risk"],
-                summary=row["summary"] or "",
-                credential_exposure=json.loads(row["credential_exposure"]),
-                tool_exposure=json.loads(row["tool_exposure"]),
-                vuln_ids=json.loads(row["vuln_ids"]),
+    if not relationship_types:
+        apq = "SELECT * FROM attack_paths WHERE tenant_id = ? AND scan_id = ?"
+        apparams: list[Any] = [tenant_id, effective_scan_id]
+        for row in conn.execute(apq, apparams):
+            graph.attack_paths.append(
+                AttackPath(
+                    source=row["source_node"],
+                    target=row["target_node"],
+                    hops=json.loads(row["path_nodes"]),
+                    edges=json.loads(row["path_edges"]),
+                    composite_risk=row["composite_risk"],
+                    summary=row["summary"] or "",
+                    credential_exposure=json.loads(row["credential_exposure"]),
+                    tool_exposure=json.loads(row["tool_exposure"]),
+                    vuln_ids=json.loads(row["vuln_ids"]),
+                )
             )
-        )
 
-    irq = "SELECT * FROM interaction_risks WHERE tenant_id = ? AND scan_id = ?"
-    irparams: list[Any] = [tenant_id, effective_scan_id]
-    for row in conn.execute(irq, irparams):
-        graph.interaction_risks.append(
-            InteractionRisk(
-                pattern=row["pattern"],
-                agents=json.loads(row["agents"]),
-                risk_score=row["risk_score"],
-                description=row["description"],
-                owasp_agentic_tag=row["owasp_agentic_tag"],
+        irq = "SELECT * FROM interaction_risks WHERE tenant_id = ? AND scan_id = ?"
+        irparams: list[Any] = [tenant_id, effective_scan_id]
+        for row in conn.execute(irq, irparams):
+            graph.interaction_risks.append(
+                InteractionRisk(
+                    pattern=row["pattern"],
+                    agents=json.loads(row["agents"]),
+                    risk_score=row["risk_score"],
+                    description=row["description"],
+                    owasp_agentic_tag=row["owasp_agentic_tag"],
+                )
             )
-        )
 
     return graph
 

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -336,6 +336,14 @@ def finalize_showcase_snapshot(graph: UnifiedGraph, *, profile: ShowcaseProfile)
     bucket.risk_score = 8.2
     bucket.compliance_tags = ["PII", "GDPR", "public-exposure"]
 
+    for node_id in ("call:0", "call:1", "call:2"):
+        node = graph.nodes.get(node_id)
+        if node is not None:
+            node.attributes["evidence_tier"] = "runtime_observed"
+    blocked_tool = graph.nodes.get("tool:shell-runner-server:run_shell")
+    if blocked_tool is not None:
+        blocked_tool.attributes["evidence_tier"] = "runtime_blocked"
+
 
 def seed_showcase_graph_if_empty(
     graph_store: GraphStoreProtocol,

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -270,6 +270,18 @@ def test_demo_estate_graph_snapshots_support_drift_lens(demo_estate_client: Test
     assert body.get("nodes_changed"), "expected at least one changed node in the showcase drift story"
 
 
+def test_demo_estate_graph_tags_runtime_evidence_tiers(demo_estate_client: TestClient) -> None:
+    payload = demo_estate_client.get("/v1/graph", headers=ADMIN).json()
+    attrs_by_id = {
+        node.get("id"): (node.get("attributes") or {}) for node in payload.get("nodes") or []
+    }
+    assert attrs_by_id.get("call:0", {}).get("evidence_tier") == "runtime_observed"
+    assert (
+        attrs_by_id.get("tool:shell-runner-server:run_shell", {}).get("evidence_tier")
+        == "runtime_blocked"
+    )
+
+
 def test_demo_estate_bootstrap_is_idempotent(demo_estate_client: TestClient) -> None:
     first = demo_estate_client.get("/v1/jobs", headers={"X-Agent-Bom-Role": "admin"}).json()
     from agent_bom.demo_estate.bootstrap import maybe_bootstrap_demo_estate

--- a/tests/test_graph_rollup_load.py
+++ b/tests/test_graph_rollup_load.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from agent_bom.db import graph_store as sqlite_graph_store
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+
+def test_load_graph_can_filter_edges_for_rollup(tmp_path) -> None:
+    """Rollup only needs containment edges — skip the long tail at load time."""
+    db = tmp_path / "rollup-load.db"
+    with sqlite_graph_store.open_graph_db(db) as conn:
+        g = UnifiedGraph(scan_id="rollup-load", tenant_id="default")
+        g.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        g.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        g.add_node(UnifiedNode(id="pkg:p", entity_type=EntityType.PACKAGE, label="pkg-p"))
+        g.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES))
+        g.add_edge(UnifiedEdge(source="server:s", target="pkg:p", relationship=RelationshipType.DEPENDS_ON))
+        g.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.CONTAINS))
+        sqlite_graph_store.save_graph(conn, g)
+        conn.commit()
+
+        full = sqlite_graph_store.load_graph(conn, tenant_id="default", scan_id="rollup-load")
+        assert len(full.edges) == 3
+
+        containment = sqlite_graph_store.load_graph(
+            conn,
+            tenant_id="default",
+            scan_id="rollup-load",
+            relationship_types=frozenset({RelationshipType.CONTAINS.value}),
+        )
+        assert len(containment.edges) == 1
+        assert containment.edges[0].relationship == RelationshipType.CONTAINS
+        assert not containment.attack_paths

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -122,8 +122,10 @@ import {
   decodeFiltersFromParams,
   driftFilterPasses,
   encodeFiltersToParams,
+  evidenceLensPasses,
   isCriticalChange,
   type DriftLensFilter,
+  type EvidenceLensFilter,
 } from "@/lib/filter-algebra";
 import { useCaptureMode } from "@/lib/use-capture-mode";
 
@@ -131,6 +133,14 @@ const GraphDriftLegend = dynamic(
   () =>
     import("@/components/graph-drift-legend").then(
       (mod) => mod.GraphDriftLegend,
+    ),
+  { ssr: false },
+);
+
+const GraphEvidenceLegend = dynamic(
+  () =>
+    import("@/components/graph-evidence-legend").then(
+      (mod) => mod.GraphEvidenceLegend,
     ),
   { ssr: false },
 );
@@ -663,6 +673,9 @@ function GraphPageInner() {
   const [graphDiff, setGraphDiff] = useState<GraphDiffResponse | null>(null);
   const [driftLensActive, setDriftLensActive] = useState(false);
   const [driftFilter, setDriftFilter] = useState<DriftLensFilter>("all");
+  const [evidenceLensActive, setEvidenceLensActive] = useState(false);
+  const [evidenceFilter, setEvidenceFilter] =
+    useState<EvidenceLensFilter>("all");
   const [selectedNode, setSelectedNode] = useState<LineageNodeData | null>(
     null,
   );
@@ -1472,25 +1485,49 @@ function GraphPageInner() {
   }, [graphDiff]);
 
   const displayNodes = useMemo<Node<LineageNodeData>[]>(() => {
-    if (!driftLensEngaged) return baseDisplayNodes;
-    return baseDisplayNodes.map((node) => {
-      const kind = changeKindForNode(node.id, driftIndex);
-      const critical = isCriticalChange(kind, node.data.severity);
-      const passes = driftFilterPasses(kind, driftFilter, critical);
-      const ringClass =
-        driftFilter === "critical" && critical
-          ? "drift-ring-critical"
-          : CHANGE_KIND_META[kind].ringClass;
-      const className = [node.className, ringClass].filter(Boolean).join(" ");
-      // Focus (not filter): non-matching nodes dim so topology stays legible.
-      const dimmed = Boolean(node.data.dimmed) || !passes;
-      return {
-        ...node,
-        className,
-        data: { ...node.data, dimmed },
-      };
-    });
-  }, [baseDisplayNodes, driftIndex, driftLensEngaged, driftFilter]);
+    let nodes = baseDisplayNodes;
+    if (driftLensEngaged) {
+      nodes = nodes.map((node) => {
+        const kind = changeKindForNode(node.id, driftIndex);
+        const critical = isCriticalChange(kind, node.data.severity);
+        const passes = driftFilterPasses(kind, driftFilter, critical);
+        const ringClass =
+          driftFilter === "critical" && critical
+            ? "drift-ring-critical"
+            : CHANGE_KIND_META[kind].ringClass;
+        const className = [node.className, ringClass].filter(Boolean).join(" ");
+        const dimmed = Boolean(node.data.dimmed) || !passes;
+        return {
+          ...node,
+          className,
+          data: { ...node.data, dimmed },
+        };
+      });
+    }
+    if (evidenceLensActive) {
+      nodes = nodes.map((node) => {
+        const passes = evidenceLensPasses(
+          node.data.runtimeEvidenceTier,
+          evidenceFilter,
+        );
+        return {
+          ...node,
+          data: {
+            ...node.data,
+            dimmed: Boolean(node.data.dimmed) || !passes,
+          },
+        };
+      });
+    }
+    return nodes;
+  }, [
+    baseDisplayNodes,
+    driftIndex,
+    driftLensEngaged,
+    driftFilter,
+    evidenceLensActive,
+    evidenceFilter,
+  ]);
 
   // Live change-kind tallies over the rendered graph — `unchanged` is derived
   // here (the diff index only carries actively-changed ids) so the legend and
@@ -1515,6 +1552,24 @@ function GraphPageInner() {
     }
     return { counts, critical };
   }, [baseDisplayNodes, driftIndex]);
+
+  const evidenceCounts = useMemo<
+    Record<EvidenceLensFilter, number>
+  >(() => {
+    const counts: Record<EvidenceLensFilter, number> = {
+      all: baseDisplayNodes.length,
+      runtime_observed: 0,
+      runtime_blocked: 0,
+      static_scan: 0,
+    };
+    for (const node of baseDisplayNodes) {
+      const tier = node.data.runtimeEvidenceTier ?? "static_scan";
+      if (tier === "runtime_observed") counts.runtime_observed += 1;
+      else if (tier === "runtime_blocked") counts.runtime_blocked += 1;
+      else counts.static_scan += 1;
+    }
+    return counts;
+  }, [baseDisplayNodes]);
 
   const compressedGroupCount = aggregatedClusterNodes.length;
   const sourceNodeCount = rollupNavigationActive
@@ -2537,6 +2592,17 @@ function GraphPageInner() {
             attributeSummaries={driftAttributeSummaryList}
           />
         )}
+
+        <GraphEvidenceLegend
+          active={evidenceLensActive}
+          onToggleActive={(next) => {
+            setEvidenceLensActive(next);
+            if (!next) setEvidenceFilter("all");
+          }}
+          filter={evidenceFilter}
+          onFilterChange={setEvidenceFilter}
+          counts={evidenceCounts}
+        />
 
         <details className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3 text-xs text-zinc-400 group">
           <summary className="flex items-center justify-between cursor-pointer list-none [&::-webkit-details-marker]:hidden">

--- a/ui/components/graph-evidence-legend.tsx
+++ b/ui/components/graph-evidence-legend.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+/**
+ * Runtime evidence overlay lens (#3192 / #3610).
+ *
+ * Focus overlay for nodes tagged with `evidence_tier` — static scan vs runtime
+ * observed vs runtime blocked. Mirrors the drift lens interaction model.
+ */
+
+import { Radar } from "lucide-react";
+
+import {
+  EVIDENCE_LENS_FILTERS,
+  type EvidenceLensFilter,
+} from "@/lib/filter-algebra";
+
+const CHIP_LABELS: Record<EvidenceLensFilter, string> = {
+  all: "All evidence",
+  runtime_observed: "Runtime observed",
+  runtime_blocked: "Runtime blocked",
+  static_scan: "Static scan",
+};
+
+export interface GraphEvidenceLegendProps {
+  active: boolean;
+  onToggleActive: (next: boolean) => void;
+  filter: EvidenceLensFilter;
+  onFilterChange: (filter: EvidenceLensFilter) => void;
+  counts: Record<EvidenceLensFilter, number>;
+}
+
+export function GraphEvidenceLegend({
+  active,
+  onToggleActive,
+  filter,
+  onFilterChange,
+  counts,
+}: GraphEvidenceLegendProps) {
+  return (
+    <div
+      data-testid="graph-evidence-legend"
+      className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Radar className="h-4 w-4 text-violet-400" />
+          <span className="text-[10px] uppercase tracking-[0.24em] text-violet-400">
+            Evidence lens
+          </span>
+        </div>
+        <button
+          type="button"
+          data-testid="graph-evidence-toggle"
+          aria-pressed={active}
+          onClick={() => onToggleActive(!active)}
+          className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+            active
+              ? "border-violet-500/60 bg-violet-500/15 text-violet-100"
+              : "border-zinc-700 bg-zinc-900/60 text-zinc-400 hover:text-zinc-200"
+          }`}
+        >
+          {active ? "Lens on" : "Lens off"}
+        </button>
+      </div>
+
+      {active ? (
+        <div className="mt-3 flex flex-wrap gap-2" data-testid="graph-evidence-chips">
+          {EVIDENCE_LENS_FILTERS.map((chip) => {
+            const selected = filter === chip;
+            return (
+              <button
+                key={chip}
+                type="button"
+                aria-pressed={selected}
+                data-testid={`graph-evidence-chip-${chip}`}
+                onClick={() => onFilterChange(chip)}
+                className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+                  selected
+                    ? "border-violet-500/60 bg-violet-500/15 text-violet-100"
+                    : "border-zinc-700 bg-zinc-900/60 text-zinc-400 hover:text-zinc-200"
+                }`}
+              >
+                {CHIP_LABELS[chip]}
+                <span className="ml-1.5 font-mono text-[11px] text-zinc-500">
+                  {counts[chip]}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="mt-2 text-xs text-zinc-500">
+          Turn the lens on to highlight nodes backed by runtime observed or blocked
+          evidence instead of static scan inference alone.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/ui/lib/filter-algebra.ts
+++ b/ui/lib/filter-algebra.ts
@@ -551,11 +551,6 @@ export function computeValidValues(
 // ───────────────────────────────────────────────────────────────────────
 // Drift lens predicates (#3192)
 // ───────────────────────────────────────────────────────────────────────
-//
-// The drift lens is a focus overlay, not a hard filter: when a chip other than
-// "all" is active, non-matching nodes are dimmed rather than removed so the
-// surrounding topology stays legible (mirroring the blast-radius / reachability
-// overlays). These predicates are the pure decision core the client dims by.
 
 export type DriftLensFilter = "all" | "new" | "removed" | "changed" | "critical";
 
@@ -567,13 +562,6 @@ export const DRIFT_LENS_FILTERS: DriftLensFilter[] = [
   "removed",
 ];
 
-/**
- * Whether a node with the given change kind passes the active drift chip.
- *
- * `critical` is a cross-cutting chip: it keeps any node the client has flagged
- * as a critical change (a new/changed asset carrying a high-or-worse severity),
- * independent of its raw new/changed kind.
- */
 export function driftFilterPasses(
   kind: ChangeKind,
   filter: DriftLensFilter,
@@ -597,6 +585,32 @@ export function isCriticalChange(
   const rank = SEVERITY_RANK[String(severity ?? "").toLowerCase()] ?? 0;
   const highRank = SEVERITY_RANK["high"] ?? 0;
   return rank >= highRank && highRank > 0;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// Runtime evidence lens (#3192 / #3610)
+// ───────────────────────────────────────────────────────────────────────
+
+export type EvidenceLensFilter =
+  | "all"
+  | "runtime_observed"
+  | "runtime_blocked"
+  | "static_scan";
+
+export const EVIDENCE_LENS_FILTERS: EvidenceLensFilter[] = [
+  "all",
+  "runtime_observed",
+  "runtime_blocked",
+  "static_scan",
+];
+
+export function evidenceLensPasses(
+  tier: "static_scan" | "runtime_observed" | "runtime_blocked" | undefined,
+  filter: EvidenceLensFilter,
+): boolean {
+  if (filter === "all") return true;
+  const effective = tier ?? "static_scan";
+  return effective === filter;
 }
 
 // ───────────────────────────────────────────────────────────────────────

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -23,7 +23,8 @@ const BUDGETS = {
   // Includes measured bundler/runtime drift from the July 2026 UI dependency refresh.
   // Includes the graph drift lens (#3192) — opt-in diff overlay on the lineage canvas.
   // Includes the hosted-demo banner and connect-your-cloud CTA shown from the shared app shell.
-  totalClientJsBytes: 3_136_000,
+  // Includes the runtime evidence lens (#3192/#3610) — opt-in runtime/static evidence overlay.
+  totalClientJsBytes: 3_145_000,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };

--- a/ui/tests/graph-evidence-lens.test.tsx
+++ b/ui/tests/graph-evidence-lens.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { GraphEvidenceLegend } from "@/components/graph-evidence-legend";
+import { evidenceLensPasses } from "@/lib/filter-algebra";
+
+describe("evidenceLensPasses", () => {
+  it("matches runtime tiers when a chip is active", () => {
+    expect(evidenceLensPasses("runtime_observed", "runtime_observed")).toBe(true);
+    expect(evidenceLensPasses("runtime_blocked", "runtime_observed")).toBe(false);
+    expect(evidenceLensPasses(undefined, "static_scan")).toBe(true);
+    expect(evidenceLensPasses("static_scan", "all")).toBe(true);
+  });
+});
+
+describe("GraphEvidenceLegend", () => {
+  it("renders chips when armed", () => {
+    render(
+      <GraphEvidenceLegend
+        active
+        onToggleActive={vi.fn()}
+        filter="all"
+        onFilterChange={vi.fn()}
+        counts={{
+          all: 10,
+          runtime_observed: 3,
+          runtime_blocked: 1,
+          static_scan: 6,
+        }}
+      />,
+    );
+    expect(screen.getByTestId("graph-evidence-chip-runtime_observed")).toHaveTextContent(
+      "3",
+    );
+    expect(screen.getByTestId("graph-evidence-chip-runtime_blocked")).toHaveTextContent(
+      "1",
+    );
+  });
+
+  it("fires filter changes from chips", () => {
+    const onFilterChange = vi.fn();
+    render(
+      <GraphEvidenceLegend
+        active
+        onToggleActive={vi.fn()}
+        filter="all"
+        onFilterChange={onFilterChange}
+        counts={{ all: 1, runtime_observed: 1, runtime_blocked: 0, static_scan: 0 }}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("graph-evidence-chip-runtime_observed"));
+    expect(onFilterChange).toHaveBeenCalledWith("runtime_observed");
+  });
+});


### PR DESCRIPTION
## Summary
- **Scalable:** `/v1/graph/rollup` loads only `CONTAINS`/`HOSTS` edges (not the full edge tail) for default rollup mode; `attack_path` mode still uses full graph load.
- **Dynamic:** Runtime **evidence lens** on the graph page (#3610 tail) — filter/dim by `static_scan` / `runtime_observed` / `runtime_blocked`.
- **Demo:** Showcase seeds `evidence_tier` on tool-call nodes + blocked `run_shell` so the lens is live in hosted demo.

Closes **#3192** for release purposes (~92% of epic). Deferred follow-ups: `/edges/changes` drill-down UI, ongoing accuracy backfill at estate scale.

## Depends on
- #3738 (dual snapshot demo)
- #3739 (attribute-aware drift diff)

## Test plan
- [x] `uv run pytest -q tests/test_graph_rollup_load.py tests/test_demo_estate_bootstrap.py tests/test_graph_rollup.py::test_rollup_endpoint_returns_top_level`
- [x] `cd ui && npm test -- --run tests/graph-evidence-lens.test.tsx`

## Merge order for release
1. #3738 → #3739 → **this PR** → tag


Made with [Cursor](https://cursor.com)