### PR TITLE
feat(graph): edge drift panel + showcase hierarchy (#3192 tail)

### DIFF
--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -228,6 +228,34 @@ def build_showcase_graph(
 
     node("cloud:logs-bucket", EntityType.CLOUD_RESOURCE, "app-logs (S3)", resource_type="s3")
 
+    # Cloud estate hierarchy — org → account → resources for rollup/containment demos.
+    node("org:corp", EntityType.ORG, "Corp (root org)")
+    node(
+        "account:aws:123456789012",
+        EntityType.ACCOUNT,
+        "AWS prod (123456789012)",
+        cloud_provider="aws",
+        account_id="123456789012",
+    )
+    node("env:production", EntityType.ENVIRONMENT, "production")
+    edge("org:corp", "account:aws:123456789012", RelationshipType.CONTAINS)
+    edge("account:aws:123456789012", "env:production", RelationshipType.CONTAINS)
+    for cloud_id in (
+        "cloud:pii-bucket",
+        "cloud:payments-db",
+        "cloud:bastion",
+        "cloud:logs-bucket",
+    ):
+        edge("account:aws:123456789012", cloud_id, RelationshipType.CONTAINS)
+
+    # Hero exposure path: internet-facing bastion reaches the PII bucket.
+    edge(
+        "cloud:bastion",
+        "cloud:pii-bucket",
+        RelationshipType.EXPOSED_TO,
+        evidence={"reason": "bastion_ssh_to_pii_bucket_network_path"},
+    )
+
     node("user:alice", EntityType.USER, "alice@corp (developer)")
     node("user:bob", EntityType.USER, "bob@contractor (external)")
     node("role:prod-admin", EntityType.ROLE, "prod-admin-role")
@@ -318,8 +346,41 @@ def apply_showcase_overlays(
     return {"cnapp": cnapp, "effective_permissions": eff, "governance": gov}
 
 
+def _ensure_showcase_edge(
+    graph: UnifiedGraph,
+    source: str,
+    target: str,
+    relationship: RelationshipType,
+    **kwargs: object,
+) -> None:
+    for edge in graph.edges:
+        if edge.source == source and edge.target == target and edge.relationship == relationship:
+            return
+    graph.add_edge(UnifiedEdge(source=source, target=target, relationship=relationship, **kwargs))
+
+
 def finalize_showcase_snapshot(graph: UnifiedGraph, *, profile: ShowcaseProfile) -> None:
     """Pin deliberate drift markers after overlays that may rewrite attributes."""
+    _ensure_showcase_edge(
+        graph,
+        "cloud:bastion",
+        "cloud:pii-bucket",
+        RelationshipType.EXPOSED_TO,
+        evidence={"reason": "bastion_ssh_to_pii_bucket_network_path"},
+    )
+    for cloud_id in (
+        "cloud:pii-bucket",
+        "cloud:payments-db",
+        "cloud:bastion",
+        "cloud:logs-bucket",
+    ):
+        _ensure_showcase_edge(
+            graph,
+            "account:aws:123456789012",
+            cloud_id,
+            RelationshipType.CONTAINS,
+        )
+
     bucket = graph.nodes.get("cloud:pii-bucket")
     if bucket is None:
         return

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from agent_bom.api.agent_identity_store import (
     InMemoryAgentIdentityStore,
@@ -351,7 +351,7 @@ def _ensure_showcase_edge(
     source: str,
     target: str,
     relationship: RelationshipType,
-    **kwargs: object,
+    **kwargs: Any,
 ) -> None:
     for edge in graph.edges:
         if edge.source == source and edge.target == target and edge.relationship == relationship:

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -270,6 +270,33 @@ def test_demo_estate_graph_snapshots_support_drift_lens(demo_estate_client: Test
     assert body.get("nodes_changed"), "expected at least one changed node in the showcase drift story"
 
 
+def test_demo_estate_showcase_cloud_hierarchy_and_exposure(demo_estate_client: TestClient) -> None:
+    """Showcase graph carries org→account containment and a bastion→PII exposure edge."""
+    payload = demo_estate_client.get("/v1/graph", headers=ADMIN).json()
+    node_ids = {node.get("id") for node in payload.get("nodes") or []}
+    assert "org:corp" in node_ids
+    assert "account:aws:123456789012" in node_ids
+
+    edges = payload.get("edges") or []
+    contains = {
+        (row.get("source"), row.get("target"))
+        for row in edges
+        if row.get("relationship") == "contains"
+    }
+    assert ("org:corp", "account:aws:123456789012") in contains
+    assert ("account:aws:123456789012", "cloud:pii-bucket") in contains
+    assert ("account:aws:123456789012", "cloud:bastion") in contains
+
+    exposed = [
+        row
+        for row in edges
+        if row.get("relationship") == "exposed_to"
+        and row.get("source") == "cloud:bastion"
+        and row.get("target") == "cloud:pii-bucket"
+    ]
+    assert exposed, "expected bastion→PII EXPOSED_TO edge in showcase snapshot"
+
+
 def test_demo_estate_graph_tags_runtime_evidence_tiers(demo_estate_client: TestClient) -> None:
     payload = demo_estate_client.get("/v1/graph", headers=ADMIN).json()
     attrs_by_id = {

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -139,16 +139,20 @@ main > div {
 .drift-ring-new {
   border-radius: 0.85rem;
   box-shadow: 0 0 0 2px #10b981, 0 0 14px -2px rgba(16, 185, 129, 0.55);
+  transition: box-shadow 0.2s ease, opacity 0.2s ease;
 }
 .drift-ring-changed {
   border-radius: 0.85rem;
   box-shadow: 0 0 0 2px #f59e0b, 0 0 14px -2px rgba(245, 158, 11, 0.55);
+  transition: box-shadow 0.2s ease, opacity 0.2s ease;
 }
 .drift-ring-removed {
   border-radius: 0.85rem;
   box-shadow: 0 0 0 2px #f43f5e, 0 0 14px -2px rgba(244, 63, 94, 0.55);
+  transition: box-shadow 0.2s ease, opacity 0.2s ease;
 }
 .drift-ring-critical {
   border-radius: 0.85rem;
   box-shadow: 0 0 0 2px #f43f5e, 0 0 0 5px rgba(244, 63, 94, 0.25);
+  transition: box-shadow 0.2s ease, opacity 0.2s ease;
 }

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -10,6 +10,7 @@ import {
   Panel,
   ReactFlow,
   ReactFlowProvider,
+  useReactFlow,
   type Edge,
   type Node,
 } from "@xyflow/react";
@@ -98,6 +99,7 @@ import { evaluateGraphUx } from "@/lib/graph-ux-evaluation";
 import {
   api,
   type GraphDiffResponse,
+  type GraphEdgeChangesResponse,
   type GraphNodeDetailResponse,
   type GraphQueryResponse,
   type GraphSnapshot,
@@ -141,6 +143,14 @@ const GraphEvidenceLegend = dynamic(
   () =>
     import("@/components/graph-evidence-legend").then(
       (mod) => mod.GraphEvidenceLegend,
+    ),
+  { ssr: false },
+);
+
+const GraphEdgeChangesPanel = dynamic(
+  () =>
+    import("@/components/graph-edge-changes-panel").then(
+      (mod) => mod.GraphEdgeChangesPanel,
     ),
   { ssr: false },
 );
@@ -204,7 +214,7 @@ function PulseStyles() {
          deliberate dim, not a flicker. */
       .lineage-node-dim {
         opacity: 0.15;
-        transition: opacity 0.15s ease;
+        transition: opacity 0.2s ease;
       }
       .lineage-node-focus {
         box-shadow: 0 0 16px rgba(56, 189, 248, 0.6);
@@ -661,6 +671,7 @@ export default function GraphPageClient() {
 }
 
 function GraphPageInner() {
+  const reactFlow = useReactFlow();
   const [snapshots, setSnapshots] = useState<GraphSnapshot[]>([]);
   const [selectedScanId, setSelectedScanId] = useState("");
   const [graphData, setGraphData] = useState<UnifiedGraphResponse | null>(null);
@@ -671,6 +682,11 @@ function GraphPageInner() {
   const [error, setError] = useState<string | null>(null);
   const [diffError, setDiffError] = useState<string | null>(null);
   const [graphDiff, setGraphDiff] = useState<GraphDiffResponse | null>(null);
+  const [edgeChanges, setEdgeChanges] = useState<GraphEdgeChangesResponse | null>(
+    null,
+  );
+  const [loadingEdgeChanges, setLoadingEdgeChanges] = useState(false);
+  const [edgeChangesError, setEdgeChangesError] = useState<string | null>(null);
   const [driftLensActive, setDriftLensActive] = useState(false);
   const [driftFilter, setDriftFilter] = useState<DriftLensFilter>("all");
   const [evidenceLensActive, setEvidenceLensActive] = useState(false);
@@ -920,21 +936,34 @@ function GraphPageInner() {
     let cancelled = false;
     setGraphDiff(null);
     setDiffError(null);
+    setEdgeChanges(null);
+    setEdgeChangesError(null);
     if (!selectedScanId || !previousSnapshot) {
       setLoadingDiff(false);
+      setLoadingEdgeChanges(false);
       return;
     }
     setLoadingDiff(true);
-    api
-      .getGraphDiff(previousSnapshot.scan_id, selectedScanId)
-      .then((result) => {
-        if (!cancelled) setGraphDiff(result);
+    setLoadingEdgeChanges(true);
+    Promise.all([
+      api.getGraphDiff(previousSnapshot.scan_id, selectedScanId),
+      api.getGraphEdgeChanges(previousSnapshot.scan_id, selectedScanId),
+    ])
+      .then(([diffResult, edgeResult]) => {
+        if (cancelled) return;
+        setGraphDiff(diffResult);
+        setEdgeChanges(edgeResult);
       })
-      .catch((e) => {
-        if (!cancelled) setDiffError(e.message);
+      .catch((e: Error) => {
+        if (cancelled) return;
+        setDiffError(e.message);
+        setEdgeChangesError(e.message);
       })
       .finally(() => {
-        if (!cancelled) setLoadingDiff(false);
+        if (!cancelled) {
+          setLoadingDiff(false);
+          setLoadingEdgeChanges(false);
+        }
       });
     return () => {
       cancelled = true;
@@ -1726,6 +1755,8 @@ function GraphPageInner() {
           stroke: meta.color,
           opacity: Math.max(currentOpacity, 0.85),
           strokeWidth: Math.max(currentWidth, 2.2),
+          transition:
+            "stroke 0.2s ease, opacity 0.2s ease, stroke-width 0.2s ease",
         },
       };
     });
@@ -1794,6 +1825,25 @@ function GraphPageInner() {
     graphOnlyFindings,
     webglEnabled: webglGraphEnabled,
   });
+
+  // Soft re-frame when drift/evidence lenses engage so ring emphasis stays in view.
+  useEffect(() => {
+    if (graphRenderer.kind !== "react-flow") return;
+    if (!driftLensActive && !evidenceLensActive) return;
+    const timer = window.setTimeout(() => {
+      void reactFlow.fitView({ ...viewportOptions, duration: 280 });
+    }, 80);
+    return () => window.clearTimeout(timer);
+  }, [
+    driftLensActive,
+    evidenceLensActive,
+    driftFilter,
+    evidenceFilter,
+    graphRenderer.kind,
+    reactFlow,
+    viewportOptions,
+  ]);
+
   const graphPanelError =
     error && snapshots.length > 0 ? graphErrorState(error) : null;
   const findingNodes = useMemo(
@@ -2592,6 +2642,15 @@ function GraphPageInner() {
             attributeSummaries={driftAttributeSummaryList}
           />
         )}
+
+        {driftLensActive && graphDiff ? (
+          <GraphEdgeChangesPanel
+            changes={edgeChanges}
+            loading={loadingEdgeChanges}
+            error={edgeChangesError}
+            comparedLabel={previousSnapshot?.scan_id.slice(0, 12)}
+          />
+        ) : null}
 
         <GraphEvidenceLegend
           active={evidenceLensActive}

--- a/ui/components/graph-edge-changes-panel.tsx
+++ b/ui/components/graph-edge-changes-panel.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+/**
+ * Edge lifecycle drill-down for the drift lens (#3192 tail).
+ *
+ * Surfaces `/v1/graph/edges/changes` alongside the node diff so operators can
+ * see which relationships were added, removed, or materially changed between
+ * snapshots — including before/after fingerprints on shared edges.
+ */
+
+import { ArrowRightLeft, Loader2 } from "lucide-react";
+
+import type {
+  GraphEdgeChangePair,
+  GraphEdgeChangesResponse,
+  GraphEdgeHistoryRecord,
+} from "@/lib/api-types";
+
+function edgeKey(edge: GraphEdgeHistoryRecord): string {
+  return `${edge.source_id} → ${edge.target_id} (${edge.relationship})`;
+}
+
+function EdgeRow({
+  edge,
+  tone,
+}: {
+  edge: GraphEdgeHistoryRecord;
+  tone: "added" | "removed" | "changed";
+}) {
+  const toneClass =
+    tone === "added"
+      ? "border-emerald-500/25 bg-emerald-500/10 text-emerald-100"
+      : tone === "removed"
+        ? "border-rose-500/25 bg-rose-500/10 text-rose-100"
+        : "border-amber-500/25 bg-amber-500/10 text-amber-100";
+  return (
+    <li
+      className={`rounded-lg border px-2.5 py-1.5 font-mono text-[11px] ${toneClass}`}
+      data-testid={`graph-edge-change-${tone}`}
+    >
+      {edgeKey(edge)}
+    </li>
+  );
+}
+
+function ChangedEdgeRow({ pair }: { pair: GraphEdgeChangePair }) {
+  return (
+    <li
+      className="rounded-lg border border-amber-500/25 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-100"
+      data-testid="graph-edge-change-changed"
+    >
+      <div className="font-mono">{edgeKey(pair.after)}</div>
+      <div className="mt-1 text-[10px] text-amber-200/80">
+        weight {pair.before.weight} → {pair.after.weight}
+        {pair.before.traversable !== pair.after.traversable
+          ? ` · traversable ${String(pair.before.traversable)} → ${String(pair.after.traversable)}`
+          : null}
+      </div>
+    </li>
+  );
+}
+
+export interface GraphEdgeChangesPanelProps {
+  changes: GraphEdgeChangesResponse | null;
+  loading: boolean;
+  error: string | null;
+  comparedLabel?: string | undefined;
+}
+
+export function GraphEdgeChangesPanel({
+  changes,
+  loading,
+  error,
+  comparedLabel,
+}: GraphEdgeChangesPanelProps) {
+  const summary = changes?.summary;
+  const hasDrillDown =
+    Boolean(summary) &&
+    (summary!.added > 0 || summary!.removed > 0 || summary!.changed > 0);
+
+  return (
+    <div
+      data-testid="graph-edge-changes-panel"
+      className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <ArrowRightLeft className="h-4 w-4 text-violet-400" />
+          <span className="text-[10px] uppercase tracking-[0.24em] text-violet-400">
+            Edge changes
+          </span>
+          {comparedLabel ? (
+            <span className="text-xs text-zinc-500">
+              vs <span className="font-mono">{comparedLabel}</span>
+            </span>
+          ) : null}
+        </div>
+        {loading ? (
+          <span className="flex items-center gap-1 text-xs text-violet-300">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            loading
+          </span>
+        ) : summary ? (
+          <span className="font-mono text-[11px] text-zinc-500">
+            +{summary.added} −{summary.removed} ~{summary.changed}
+          </span>
+        ) : null}
+      </div>
+
+      {error ? (
+        <p className="mt-2 text-xs text-amber-200">{error}</p>
+      ) : loading && !changes ? (
+        <p className="mt-2 text-xs text-zinc-500">Loading edge lifecycle diff…</p>
+      ) : !hasDrillDown ? (
+        <p className="mt-2 text-xs text-zinc-500">
+          No relationship additions, removals, or material changes between
+          snapshots.
+        </p>
+      ) : (
+        <div className="mt-3 grid gap-3 lg:grid-cols-3">
+          {changes!.edges_added.length > 0 ? (
+            <div>
+              <p className="mb-1.5 text-[10px] uppercase tracking-[0.18em] text-emerald-400">
+                Added ({changes!.edges_added.length})
+              </p>
+              <ul className="space-y-1.5">
+                {changes!.edges_added.slice(0, 8).map((edge) => (
+                  <EdgeRow key={edgeKey(edge)} edge={edge} tone="added" />
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          {changes!.edges_removed.length > 0 ? (
+            <div>
+              <p className="mb-1.5 text-[10px] uppercase tracking-[0.18em] text-rose-400">
+                Removed ({changes!.edges_removed.length})
+              </p>
+              <ul className="space-y-1.5">
+                {changes!.edges_removed.slice(0, 8).map((edge) => (
+                  <EdgeRow key={edgeKey(edge)} edge={edge} tone="removed" />
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          {changes!.edges_changed.length > 0 ? (
+            <div>
+              <p className="mb-1.5 text-[10px] uppercase tracking-[0.18em] text-amber-400">
+                Changed ({changes!.edges_changed.length})
+              </p>
+              <ul className="space-y-1.5">
+                {changes!.edges_changed.slice(0, 8).map((pair) => (
+                  <ChangedEdgeRow key={edgeKey(pair.after)} pair={pair} />
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -470,6 +470,46 @@ export interface GraphAttributeDelta {
   summary: string;
 }
 
+/** Rich edge record returned by `/v1/graph/edges/changes` and `/v1/graph/edges/active`. */
+export interface GraphEdgeHistoryRecord {
+  source_id: string;
+  target_id: string;
+  relationship: string;
+  direction: string;
+  weight: number;
+  traversable: boolean;
+  confidence: number;
+  provenance: Record<string, unknown>;
+  evidence: Record<string, unknown>;
+  valid_from?: string | undefined;
+  valid_to?: string | null | undefined;
+  first_seen?: string | undefined;
+  last_seen?: string | undefined;
+  scan_id?: string | undefined;
+}
+
+export interface GraphEdgeChangePair {
+  before: GraphEdgeHistoryRecord;
+  after: GraphEdgeHistoryRecord;
+}
+
+export interface GraphEdgeChangesSummary {
+  added: number;
+  removed: number;
+  changed: number;
+  unchanged: number;
+}
+
+export interface GraphEdgeChangesResponse {
+  scan_id_old: string;
+  scan_id_new: string;
+  edges_added: GraphEdgeHistoryRecord[];
+  edges_removed: GraphEdgeHistoryRecord[];
+  edges_changed: GraphEdgeChangePair[];
+  edges_unchanged: GraphEdgeHistoryRecord[];
+  summary: GraphEdgeChangesSummary;
+}
+
 export type GraphExportFormat =
   "json" | "dot" | "mermaid" | "graphml" | "cypher";
 

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -22,6 +22,7 @@ import type {
   GraphSemanticClustersResponse,
   GraphAgentsResponse,
   GraphDiffResponse,
+  GraphEdgeChangesResponse,
   GraphExportFormat,
   AgentBomManifestResponse,
   PostureCountsResponse,
@@ -142,6 +143,7 @@ export type {
   GraphAgentSelectorItem,
   GraphAgentsResponse,
   GraphDiffResponse,
+  GraphEdgeChangesResponse,
   GraphExportFormat,
   AgentBomManifestResponse,
   AgentBomManifestNode,
@@ -577,6 +579,14 @@ export const api = {
     params.set("old", oldScanId);
     params.set("new", newScanId);
     return get<GraphDiffResponse>(`/v1/graph/diff?${params.toString()}`);
+  },
+
+  /** Rich edge lifecycle changes between two snapshots (added/removed/changed). */
+  getGraphEdgeChanges: (oldScanId: string, newScanId: string) => {
+    const params = new URLSearchParams();
+    params.set("old", oldScanId);
+    params.set("new", newScanId);
+    return get<GraphEdgeChangesResponse>(`/v1/graph/edges/changes?${params.toString()}`);
   },
 
   /** Load the unified graph for a specific snapshot or the latest persisted state */

--- a/ui/tests/graph-edge-changes-panel.test.tsx
+++ b/ui/tests/graph-edge-changes-panel.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { GraphEdgeChangesPanel } from "@/components/graph-edge-changes-panel";
+import type { GraphEdgeChangesResponse } from "@/lib/api-types";
+
+const sampleChanges: GraphEdgeChangesResponse = {
+  scan_id_old: "showcase-baseline",
+  scan_id_new: "showcase",
+  edges_added: [
+    {
+      source_id: "user:bob",
+      target_id: "role:prod-admin",
+      relationship: "trusts",
+      direction: "forward",
+      weight: 1,
+      traversable: true,
+      confidence: 1,
+      provenance: {},
+      evidence: {},
+    },
+  ],
+  edges_removed: [
+    {
+      source_id: "agent:support-copilot",
+      target_id: "server:legacy-chat-server",
+      relationship: "uses",
+      direction: "forward",
+      weight: 1,
+      traversable: true,
+      confidence: 1,
+      provenance: {},
+      evidence: {},
+    },
+  ],
+  edges_changed: [],
+  edges_unchanged: [],
+  summary: { added: 1, removed: 1, changed: 0, unchanged: 0 },
+};
+
+describe("GraphEdgeChangesPanel", () => {
+  it("renders added and removed edge rows", () => {
+    render(
+      <GraphEdgeChangesPanel
+        changes={sampleChanges}
+        loading={false}
+        error={null}
+        comparedLabel="showcase-base"
+      />,
+    );
+    expect(screen.getByTestId("graph-edge-changes-panel")).toBeInTheDocument();
+    expect(screen.getByText(/user:bob → role:prod-admin/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/agent:support-copilot → server:legacy-chat-server/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when no edge lifecycle changes", () => {
+    render(
+      <GraphEdgeChangesPanel
+        changes={{
+          ...sampleChanges,
+          edges_added: [],
+          edges_removed: [],
+          summary: { added: 0, removed: 0, changed: 0, unchanged: 10 },
+        }}
+        loading={false}
+        error={null}
+      />,
+    );
+    expect(screen.getByText(/No relationship additions/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Wire `/v1/graph/edges/changes` into the graph page when the drift lens is on — added/removed/changed edges with before→after on material changes.
- Demo showcase accuracy: org→account→resource `CONTAINS` hierarchy and bastion→PII `EXPOSED_TO`, pinned after CNAPP overlay.
- Lens layout polish: drift ring/edge transitions and soft `fitView` when drift/evidence lenses engage.

Follows merged #3738 → #3739 → #3740. Does not re-open #3192 (closed on #3740); prod connector accuracy tracked separately.

## Test plan
- [x] `uv run pytest -q tests/test_demo_estate_bootstrap.py::test_demo_estate_showcase_cloud_hierarchy_and_exposure`
- [x] `cd ui && npm test -- --run tests/graph-edge-changes-panel.test.tsx`
- [x] `cd ui && npm run typecheck`


Made with [Cursor](https://cursor.com)