### PR TITLE
feat(cloud): roll up account→resource OWNS in org hierarchy (#3742 PR 1)

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -3120,7 +3120,11 @@ async def delete_preset(request: Request, name: str) -> dict:
 
 # Containment-only edge load for /v1/graph/rollup (default mode).
 _ROLLUP_CONTAINMENT_RELATIONSHIPS = frozenset(
-    {RelationshipType.CONTAINS.value, RelationshipType.HOSTS.value}
+    {
+        RelationshipType.CONTAINS.value,
+        RelationshipType.HOSTS.value,
+        RelationshipType.OWNS.value,
+    }
 )
 
 

--- a/src/agent_bom/graph/rollup.py
+++ b/src/agent_bom/graph/rollup.py
@@ -40,13 +40,16 @@ _MAX_TOP_LEVEL_ORPHANS: int = 200
 _ORPHAN_SUMMARY_SAMPLE: int = 20
 
 # Estate containment edges: org/account/resource trees use CONTAINS; cloud
-# account→resource lineage may be HOSTS-only on legacy graphs.
+# inventory emits account→resource as OWNS; legacy graphs may use HOSTS-only.
 _CONTAINMENT_RELS: frozenset[str] = frozenset({RelationshipType.CONTAINS.value})
 
-# HOSTS is operational hosting (provider→agent, etc.); only account→cloud_resource
-# HOSTS edges participate in estate roll-up alongside CONTAINS.
-_HOSTS_CONTAINMENT_SOURCES: frozenset[str] = frozenset({EntityType.ACCOUNT.value})
-_HOSTS_CONTAINMENT_TARGETS: frozenset[str] = frozenset({EntityType.CLOUD_RESOURCE.value})
+# Operational edges that roll up like CONTAINS when they link an account to a
+# cloud resource (inventory uses OWNS; some legacy paths use HOSTS).
+_ACCOUNT_RESOURCE_CONTAINMENT_RELS: frozenset[str] = frozenset(
+    {RelationshipType.HOSTS.value, RelationshipType.OWNS.value}
+)
+_ACCOUNT_RESOURCE_CONTAINMENT_SOURCES: frozenset[str] = frozenset({EntityType.ACCOUNT.value})
+_ACCOUNT_RESOURCE_CONTAINMENT_TARGETS: frozenset[str] = frozenset({EntityType.CLOUD_RESOURCE.value})
 
 # Container entity types form the readable top-level scaffold of the estate.
 # A node of one of these types is a candidate roll-up container; everything else
@@ -195,20 +198,24 @@ def _edge_is_containment(graph: UnifiedGraph, edge: Any) -> bool:
     rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
     if rel in _CONTAINMENT_RELS:
         return True
-    if rel != RelationshipType.HOSTS.value:
+    if rel not in _ACCOUNT_RESOURCE_CONTAINMENT_RELS:
         return False
     source = graph.nodes.get(edge.source)
     target = graph.nodes.get(edge.target)
     if source is None or target is None:
         return False
-    return _node_type_value(source) in _HOSTS_CONTAINMENT_SOURCES and _node_type_value(target) in _HOSTS_CONTAINMENT_TARGETS
+    return (
+        _node_type_value(source) in _ACCOUNT_RESOURCE_CONTAINMENT_SOURCES
+        and _node_type_value(target) in _ACCOUNT_RESOURCE_CONTAINMENT_TARGETS
+    )
 
 
 def _contains_children(graph: UnifiedGraph) -> dict[str, list[str]]:
     """Map container_id -> sorted direct containment children (deterministic).
 
-    Walks ``CONTAINS`` and account→``CLOUD_RESOURCE`` ``HOSTS`` edges so cloud
-    resources roll up under their account even when only ``HOSTS`` is present.
+    Walks ``CONTAINS`` and account→``CLOUD_RESOURCE`` ``HOSTS``/``OWNS`` edges
+    so cloud resources roll up under their account even when inventory emits
+    ``OWNS`` instead of ``CONTAINS``.
     Self-loops are ignored. Children are de-duplicated and sorted by id so the
     output is stable across runs regardless of edge insertion order.
     """

--- a/tests/test_graph_rollup.py
+++ b/tests/test_graph_rollup.py
@@ -31,6 +31,10 @@ def _hosts(graph: UnifiedGraph, parent: str, child: str) -> None:
     graph.add_edge(UnifiedEdge(source=parent, target=child, relationship=RelationshipType.HOSTS))
 
 
+def _owns(graph: UnifiedGraph, parent: str, child: str) -> None:
+    graph.add_edge(UnifiedEdge(source=parent, target=child, relationship=RelationshipType.OWNS))
+
+
 def _deep_estate() -> UnifiedGraph:
     """org -> account -> app -> {server, server} -> {package(crit), package(low)}."""
     g = UnifiedGraph(scan_id="estate-scan", tenant_id="default")
@@ -110,6 +114,71 @@ def test_rollup_treats_hosts_as_containment_for_cloud_account_resources() -> Non
     assert top["aggregate"]["descendant_count"] == 1
     assert top["aggregate"]["by_type"]["cloud_resource"] == 1
     assert top["aggregate"]["worst_severity"] == "high"
+
+
+def test_rollup_treats_owns_as_containment_for_cloud_account_resources() -> None:
+    """Cloud inventory emits account→resource as OWNS — roll-up must treat it like CONTAINS."""
+    g = UnifiedGraph(scan_id="owns-scan", tenant_id="default")
+    g.add_node(UnifiedNode(id="account:aws:1", entity_type=EntityType.ACCOUNT, label="prod"))
+    g.add_node(
+        UnifiedNode(
+            id="cloud:aws:s3:bucket",
+            entity_type=EntityType.CLOUD_RESOURCE,
+            label="customer-pii",
+            severity="high",
+        )
+    )
+    _owns(g, "account:aws:1", "cloud:aws:s3:bucket")
+
+    view = rollup_view(g)
+    assert view["summary"]["top_level_count"] == 1
+    top = view["top_level"][0]
+    assert top["id"] == "account:aws:1"
+    assert top["aggregate"]["descendant_count"] == 1
+    assert top["aggregate"]["by_type"]["cloud_resource"] == 1
+
+    drill = drill_down(g, "account:aws:1")
+    assert {child["id"] for child in drill["children"]} == {"cloud:aws:s3:bucket"}
+
+
+def test_rollup_org_account_resource_hierarchy_with_owns() -> None:
+    """Org→account CONTAINS + account→resource OWNS rolls up as a three-level estate."""
+    g = UnifiedGraph(scan_id="org-owns-scan", tenant_id="default")
+    g.add_node(UnifiedNode(id="org:aws:acme", entity_type=EntityType.ORG, label="Acme"))
+    g.add_node(UnifiedNode(id="account:aws:111", entity_type=EntityType.ACCOUNT, label="prod"))
+    g.add_node(
+        UnifiedNode(
+            id="cloud:aws:s3:logs",
+            entity_type=EntityType.CLOUD_RESOURCE,
+            label="logs-bucket",
+            severity="medium",
+        )
+    )
+    g.add_node(
+        UnifiedNode(
+            id="cloud:aws:ec2:bastion",
+            entity_type=EntityType.CLOUD_RESOURCE,
+            label="bastion",
+            severity="high",
+        )
+    )
+    _contains(g, "org:aws:acme", "account:aws:111")
+    _owns(g, "account:aws:111", "cloud:aws:s3:logs")
+    _owns(g, "account:aws:111", "cloud:aws:ec2:bastion")
+
+    view = rollup_view(g)
+    assert view["summary"]["top_level_count"] == 1
+    org = view["top_level"][0]
+    assert org["id"] == "org:aws:acme"
+    assert org["aggregate"]["descendant_count"] == 3
+    assert org["aggregate"]["by_type"]["account"] == 1
+    assert org["aggregate"]["by_type"]["cloud_resource"] == 2
+
+    account_drill = drill_down(g, "account:aws:111")
+    assert {child["id"] for child in account_drill["children"]} == {
+        "cloud:aws:s3:logs",
+        "cloud:aws:ec2:bastion",
+    }
 
 
 def test_rollup_collapses_deep_contains_tree_with_aggregate_counts() -> None:

--- a/tests/test_graph_rollup_load.py
+++ b/tests/test_graph_rollup_load.py
@@ -28,8 +28,44 @@ def test_load_graph_can_filter_edges_for_rollup(tmp_path) -> None:
             conn,
             tenant_id="default",
             scan_id="rollup-load",
-            relationship_types=frozenset({RelationshipType.CONTAINS.value}),
+            relationship_types=frozenset(
+                {
+                    RelationshipType.CONTAINS.value,
+                    RelationshipType.HOSTS.value,
+                    RelationshipType.OWNS.value,
+                }
+            ),
         )
         assert len(containment.edges) == 1
         assert containment.edges[0].relationship == RelationshipType.CONTAINS
         assert not containment.attack_paths
+
+        g2 = UnifiedGraph(scan_id="rollup-owns", tenant_id="default")
+        g2.add_node(UnifiedNode(id="account:aws:1", entity_type=EntityType.ACCOUNT, label="prod"))
+        g2.add_node(
+            UnifiedNode(id="cloud:aws:s3:b", entity_type=EntityType.CLOUD_RESOURCE, label="bucket")
+        )
+        g2.add_edge(
+            UnifiedEdge(
+                source="account:aws:1",
+                target="cloud:aws:s3:b",
+                relationship=RelationshipType.OWNS,
+            )
+        )
+        sqlite_graph_store.save_graph(conn, g2)
+        conn.commit()
+
+        owns_only = sqlite_graph_store.load_graph(
+            conn,
+            tenant_id="default",
+            scan_id="rollup-owns",
+            relationship_types=frozenset(
+                {
+                    RelationshipType.CONTAINS.value,
+                    RelationshipType.HOSTS.value,
+                    RelationshipType.OWNS.value,
+                }
+            ),
+        )
+        assert len(owns_only.edges) == 1
+        assert owns_only.edges[0].relationship == RelationshipType.OWNS


### PR DESCRIPTION
## Summary
- Treat **account → cloud_resource `OWNS`** (how live inventory links resources) as estate containment in `rollup.py`, alongside existing `CONTAINS` and account→resource `HOSTS`.
- Load `OWNS` on `/v1/graph/rollup` filtered graph fetch so roll-up sees inventory edges without full-graph materialization.

Part 1 of #3742 (post-0.94.1). Demo showcase hierarchy already uses `CONTAINS`; this fixes **production** scans that emit `OWNS`.

## Test plan
- [x] `uv run pytest -q tests/test_graph_rollup.py tests/test_graph_rollup_load.py`

## Follow-ups (#3742)
- **PR 2:** Complete live `EXPOSED_TO` paths (ENI, LB entry, network edge chains)
- **PR 3:** Cross-account trust attack paths + graph diff lifecycle for cloud edges


Made with [Cursor](https://cursor.com)