### PR TITLE
feat(cloud): complete live EXPOSED_TO network paths (#3742 PR 2)

### DIFF
--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -4497,6 +4497,7 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
     # Track (node_id, raw-instance) so the GCP firewall-matching pass can mark
     # exposure by network + target tags/SA (GCP has no per-instance SG-id list).
     instance_nodes: list[tuple[str, dict[str, Any]]] = []
+    internet_facing_lbs: list[tuple[str, str]] = []
     for instance in inventory.get("instances", []) or []:
         if not isinstance(instance, dict):
             continue
@@ -4653,6 +4654,8 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
                         source=account_node_id, target=node_id, relationship=RelationshipType.OWNS, evidence={"source": "cloud-inventory"}
                     )
                 )
+            if coll_key == "elb_load_balancers" and exposed:
+                internet_facing_lbs.append((node_id, _clean_graph_part(item.get("vpc_id"))))
 
     # ── GCP estate breadth (GKE / Cloud Run / Functions / Cloud SQL / VPC /
     # disks / Pub/Sub) → CLOUD_RESOURCE or DATA_STORE, OWNS from the project. ──
@@ -4737,6 +4740,7 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
         sg_node_by_id=sg_node_by_id,
         instance_node_by_id=instance_node_by_id,
     )
+    _link_internet_facing_load_balancers(graph, internet_facing_lbs, instance_nodes)
 
     # ── Management-group hierarchy (org → subscription CONTAINS tree) ──
     _add_management_group_hierarchy(graph, original_inventory, provider=provider, data_sources=data_sources)
@@ -4954,6 +4958,63 @@ _GCP_LB_COLLECTION: tuple[str, str, str, str, str, str] = (
 )
 
 
+def _add_exposure_path_edge(
+    graph: UnifiedGraph,
+    *,
+    source: str,
+    target: str,
+    reason: str,
+    weight: float = 6.0,
+) -> None:
+    """Emit a provenance-tagged EXPOSED_TO edge when both endpoints exist."""
+    if source not in graph.nodes or target not in graph.nodes or source == target:
+        return
+    for edge in graph.edges:
+        if edge.source == source and edge.target == target and edge.relationship == RelationshipType.EXPOSED_TO:
+            return
+    graph.add_edge(
+        UnifiedEdge(
+            source=source,
+            target=target,
+            relationship=RelationshipType.EXPOSED_TO,
+            weight=weight,
+            evidence={"source": "cloud-inventory", "reason": reason},
+        )
+    )
+
+
+def _instance_internet_reachable(graph: UnifiedGraph, inst_node_id: str, instance: dict[str, Any]) -> bool:
+    node = graph.nodes.get(inst_node_id)
+    if node is None:
+        return False
+    if node.attributes.get("internet_exposed") or _clean_graph_part(instance.get("public_ip")):
+        return True
+    return any(e.relationship == RelationshipType.EXPOSED_TO and e.target == inst_node_id for e in graph.edges)
+
+
+def _link_internet_facing_load_balancers(
+    graph: UnifiedGraph,
+    load_balancers: list[tuple[str, str]],
+    instance_nodes: list[tuple[str, dict[str, Any]]],
+) -> None:
+    """Link internet-facing LBs to reachable instances in the same VPC."""
+    for lb_node_id, lb_vpc_id in load_balancers:
+        lb_node = graph.nodes.get(lb_node_id)
+        if lb_node is None or not lb_node.attributes.get("internet_exposed"):
+            continue
+        for inst_node_id, instance in instance_nodes:
+            inst_vpc = _clean_graph_part(instance.get("vpc_id"))
+            if lb_vpc_id and inst_vpc and inst_vpc != lb_vpc_id:
+                continue
+            if _instance_internet_reachable(graph, inst_node_id, instance):
+                _add_exposure_path_edge(
+                    graph,
+                    source=lb_node_id,
+                    target=inst_node_id,
+                    reason="internet_facing_load_balancer",
+                )
+
+
 def _add_network_edge_inventory(
     graph: UnifiedGraph,
     inventory: dict[str, Any],
@@ -4979,7 +5040,10 @@ def _add_network_edge_inventory(
     - **Subnets** → ``CLOUD_RESOURCE``; a public subnet is ``internet_exposed``.
     - **ENIs / NICs** → ``CLOUD_RESOURCE`` wired ``PART_OF`` their instance,
       subnet, and security group(s) so the network path is traversable; an ENI
-      carrying a public IP marks its instance internet-reachable.
+      carrying a public IP marks its instance internet-reachable and emits
+      ``EXPOSED_TO`` the instance.
+    - **Elastic/public IPs** → ``EXPOSED_TO`` the attached instance when known.
+    - **Internet-facing API gateways** → ``EXPOSED_TO`` protected frontends.
     - NAT/internet gateways, route tables, network ACLs, VPC endpoints, load
       balancers, and IP addresses → ``CLOUD_RESOURCE`` inventory nodes.
 
@@ -5116,6 +5180,14 @@ def _add_network_edge_inventory(
                 "internet_exposed": True,
             },
         )
+        attached_instance = instance_node_by_id.get(_clean_graph_part(ip.get("attached_to")))
+        if attached_instance:
+            _add_exposure_path_edge(
+                graph,
+                source=node_id,
+                target=attached_instance,
+                reason="elastic_ip_attachment",
+            )
 
     # ── ENIs / NICs → PART_OF instance + subnet + security group(s) ──
     for eni in inventory.get("network_interfaces", []) or []:
@@ -5154,6 +5226,12 @@ def _add_network_edge_inventory(
                 inst_node = graph.nodes.get(instance_node_id)
                 if inst_node is not None:
                     inst_node.attributes["internet_exposed"] = True
+                _add_exposure_path_edge(
+                    graph,
+                    source=node_id,
+                    target=instance_node_id,
+                    reason="eni_public_ip",
+                )
         subnet_node_id = subnet_node_by_id.get(_clean_graph_part(eni.get("subnet_id")))
         if subnet_node_id:
             graph.add_edge(
@@ -5244,6 +5322,17 @@ def _add_network_edge_inventory(
                 )
             )
         _protect(node_id, api.get("protected_targets", []), "api_gateway_frontend")
+        if api.get("internet_exposed"):
+            for target_ref in api.get("protected_targets", []) or []:
+                ref = _clean_graph_part(target_ref)
+                target_node_id = ref_to_node.get(ref)
+                if target_node_id:
+                    _add_exposure_path_edge(
+                        graph,
+                        source=node_id,
+                        target=target_node_id,
+                        reason="internet_facing_api_gateway",
+                    )
 
 
 def _add_inventory_principal(

--- a/tests/cloud/test_cloud_network_edge.py
+++ b/tests/cloud/test_cloud_network_edge.py
@@ -253,13 +253,28 @@ def _aws_inventory() -> dict:
             }
         ],
         "elb_load_balancers": [
-            {"name": "web-alb", "arn": "arn:alb:web", "scheme": "internet-facing", "internet_exposed": True, "location": "us-east-1"}
+            {
+                "name": "web-alb",
+                "arn": "arn:alb:web",
+                "scheme": "internet-facing",
+                "internet_exposed": True,
+                "location": "us-east-1",
+                "vpc_id": "vpc-1",
+            }
         ],
         "web_acls": [
             {"name": "web-acl", "id": "acl-id", "arn": "arn:waf:regional", "scope": "regional", "protected_targets": ["arn:alb:web"]}
         ],
         "api_gateways": [
-            {"name": "rest-api", "id": "rest1", "protocol": "REST", "endpoint": "REGIONAL", "internet_exposed": True, "stages": ["prod"]}
+            {
+                "name": "rest-api",
+                "id": "rest1",
+                "protocol": "REST",
+                "endpoint": "REGIONAL",
+                "internet_exposed": True,
+                "stages": ["prod"],
+                "protected_targets": ["arn:alb:web"],
+            }
         ],
     }
 
@@ -286,10 +301,65 @@ def test_eni_maps_instance_subnet_and_security_group() -> None:
     g = build_unified_graph_from_report({"cloud_inventory": _aws_inventory()})
     edges = {(e.source, e.target, e.relationship.value) for e in g.edges}
     eni_id = "cloud_resource:aws:network:network_interface:eni-1"
+    inst_id = "cloud_resource:aws:ec2:instance:i-1"
     assert eni_id in g.nodes
-    assert (eni_id, "cloud_resource:aws:ec2:instance:i-1", "part_of") in edges
+    assert (eni_id, inst_id, "part_of") in edges
     assert (eni_id, "cloud_resource:aws:network:subnet:subnet-pub", "part_of") in edges
     assert (eni_id, "cloud_resource:aws:ec2:security-group:sg-1", "part_of") in edges
+
+
+def test_eni_public_ip_emits_exposed_to_instance() -> None:
+    g = build_unified_graph_from_report({"cloud_inventory": _aws_inventory()})
+    eni_id = "cloud_resource:aws:network:network_interface:eni-1"
+    inst_id = "cloud_resource:aws:ec2:instance:i-1"
+    exposed = [
+        e
+        for e in g.edges
+        if e.relationship == RelationshipType.EXPOSED_TO and e.source == eni_id and e.target == inst_id
+    ]
+    assert exposed
+    assert exposed[0].evidence.get("reason") == "eni_public_ip"
+
+
+def test_elastic_ip_emits_exposed_to_attached_instance() -> None:
+    payload = _aws_inventory()
+    payload["ip_addresses"] = [{"address": "52.9.9.9", "kind": "elastic", "attached_to": "i-1"}]
+    g = build_unified_graph_from_report({"cloud_inventory": payload})
+    ip_id = "cloud_resource:aws:network:ip_address:52.9.9.9"
+    inst_id = "cloud_resource:aws:ec2:instance:i-1"
+    exposed = [
+        e
+        for e in g.edges
+        if e.relationship == RelationshipType.EXPOSED_TO and e.source == ip_id and e.target == inst_id
+    ]
+    assert exposed
+    assert exposed[0].evidence.get("reason") == "elastic_ip_attachment"
+
+
+def test_internet_facing_lb_emits_exposed_to_reachable_instance() -> None:
+    g = build_unified_graph_from_report({"cloud_inventory": _aws_inventory()})
+    lb_id = "cloud_resource:aws:elbv2:load_balancer:web-alb"
+    inst_id = "cloud_resource:aws:ec2:instance:i-1"
+    exposed = [
+        e
+        for e in g.edges
+        if e.relationship == RelationshipType.EXPOSED_TO and e.source == lb_id and e.target == inst_id
+    ]
+    assert exposed
+    assert exposed[0].evidence.get("reason") == "internet_facing_load_balancer"
+
+
+def test_internet_facing_api_gateway_emits_exposed_to_frontend() -> None:
+    g = build_unified_graph_from_report({"cloud_inventory": _aws_inventory()})
+    api_id = "api_gateway:aws:rest1"
+    alb_id = "cloud_resource:aws:elbv2:load_balancer:web-alb"
+    exposed = [
+        e
+        for e in g.edges
+        if e.relationship == RelationshipType.EXPOSED_TO and e.source == api_id and e.target == alb_id
+    ]
+    assert exposed
+    assert exposed[0].evidence.get("reason") == "internet_facing_api_gateway"
 
 
 def _exposed_vuln_graph(*, protected: bool) -> UnifiedGraph:

--- a/tests/test_graph_cloud_edge_lifecycle.py
+++ b/tests/test_graph_cloud_edge_lifecycle.py
@@ -1,0 +1,161 @@
+"""Cloud inventory graph edges: cross-account trust + scheduled-scan drift (#3742)."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from starlette.testclient import TestClient
+
+from agent_bom.api import stores as api_stores
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.api.server import app
+from agent_bom.api.stores import set_graph_store
+from agent_bom.db.graph_store import changed_edges_between_scans, diff_snapshots, save_graph
+from agent_bom.graph.builder import build_unified_graph_from_report
+from agent_bom.graph.types import EntityType, RelationshipType
+from tests.test_graph_api import _init_db
+
+
+def _minimal_aws_inventory(*, sg_exposed: bool) -> dict:
+    return {
+        "provider": "aws",
+        "status": "ok",
+        "account_id": "111122223333",
+        "region": "us-east-1",
+        "instances": [
+            {
+                "instance_id": "i-1",
+                "name": "web",
+                "vpc_id": "vpc-1",
+                "subnet_id": "subnet-1",
+                "security_group_ids": ["sg-1"],
+            }
+        ],
+        "security_groups": [
+            {
+                "group_id": "sg-1",
+                "name": "web-sg",
+                "vpc_id": "vpc-1",
+                "internet_exposed": sg_exposed,
+                "network_exposure": (
+                    [{"scope": "internet", "from_port": 443, "to_port": 443, "protocol": "tcp"}]
+                    if sg_exposed
+                    else []
+                ),
+            }
+        ],
+        "buckets": [],
+        "roles": [],
+        "users": [],
+    }
+
+
+def test_inventory_emits_cross_account_trust_edges() -> None:
+    payload = {
+        "provider": "aws",
+        "status": "ok",
+        "account_id": "111122223333",
+        "region": "us-east-1",
+        "instances": [],
+        "security_groups": [],
+        "buckets": [],
+        "users": [],
+        "roles": [
+            {
+                "name": "cross-account-role",
+                "arn": "arn:aws:iam::111122223333:role/cross-account-role",
+                "principal_type": "role",
+                "privilege_level": "admin",
+                "policies": [],
+                "trust_principals": [
+                    {
+                        "principal_type": "account",
+                        "principal_id": "210987654321",
+                        "principal_name": "210987654321",
+                        "relationship": "cross_account_trust",
+                    }
+                ],
+            }
+        ],
+    }
+    graph = build_unified_graph_from_report({"cloud_inventory": payload})
+    role_id = "role:aws:arn:aws:iam::111122223333:role/cross-account-role"
+    external_account_id = "account:aws:210987654321"
+
+    assert role_id in graph.nodes
+    assert external_account_id in graph.nodes
+    assert graph.nodes[external_account_id].entity_type == EntityType.ACCOUNT
+    assert any(
+        edge.source == role_id
+        and edge.target == external_account_id
+        and edge.relationship == RelationshipType.CROSS_ACCOUNT_TRUST
+        for edge in graph.edges
+    )
+
+
+def test_cloud_inventory_snapshots_diff_exposed_edges(tmp_path) -> None:
+    """Scheduled scans surface EXPOSED_TO lifecycle changes between snapshots."""
+    conn = sqlite3.connect(tmp_path / "cloud-edge-diff.db")
+    conn.row_factory = sqlite3.Row
+    _init_db(conn)
+
+    baseline = build_unified_graph_from_report(
+        {"cloud_inventory": _minimal_aws_inventory(sg_exposed=False)}
+    )
+    baseline.scan_id = "cloud-scan-baseline"
+    baseline.created_at = "2026-06-01T12:00:00+00:00"
+    save_graph(conn, baseline)
+
+    current = build_unified_graph_from_report(
+        {"cloud_inventory": _minimal_aws_inventory(sg_exposed=True)}
+    )
+    current.scan_id = "cloud-scan-current"
+    current.created_at = "2026-06-08T12:00:00+00:00"
+    save_graph(conn, current)
+
+    sg_id = "cloud_resource:aws:ec2:security-group:sg-1"
+    inst_id = "cloud_resource:aws:ec2:instance:i-1"
+
+    diff = diff_snapshots(conn, "cloud-scan-baseline", "cloud-scan-current", tenant_id="default")
+    assert diff["edges_added"], "expected new edges when SG exposure opens"
+    added_keys = {(row[0], row[1], row[2]) for row in diff["edges_added"]}
+    assert (sg_id, inst_id, "exposed_to") in added_keys
+
+    changes = changed_edges_between_scans(
+        conn,
+        "cloud-scan-baseline",
+        "cloud-scan-current",
+        tenant_id="default",
+    )
+    assert changes["summary"]["added"] >= 1
+    assert any(
+        edge["source_id"] == sg_id
+        and edge["target_id"] == inst_id
+        and edge["relationship"] == "exposed_to"
+        for edge in changes["edges_added"]
+    )
+
+    store = SQLiteGraphStore(tmp_path / "cloud-edge-diff.db")
+    original = api_stores._graph_store
+    try:
+        set_graph_store(store)
+        client = TestClient(app)
+        diff_resp = client.get(
+            "/v1/graph/diff",
+            params={"old": "cloud-scan-baseline", "new": "cloud-scan-current"},
+        )
+        assert diff_resp.status_code == 200
+        diff_body = diff_resp.json()
+        index = diff_body.get("change_kind_index") or {}
+        assert index.get("edges", {}).get(f"{sg_id}|{inst_id}|exposed_to") == "new"
+
+        changes_resp = client.get(
+            "/v1/graph/edges/changes",
+            params={"old": "cloud-scan-baseline", "new": "cloud-scan-current"},
+        )
+        assert changes_resp.status_code == 200
+        changes_body = changes_resp.json()
+        assert changes_body["summary"]["added"] >= 1
+    finally:
+        set_graph_store(original)
+        conn.close()


### PR DESCRIPTION
## Summary
- Emit provenance-tagged `EXPOSED_TO` edges from ENIs with public IPs, elastic IP attachments, internet-facing load balancers (same-VPC reachable instances), and internet-facing API gateway frontends.
- Extends live network-edge inventory wiring in `builder.py` — no demo-only edges.

Part 2 of #3742. Stacks after #3743 (account→resource roll-up) when merged; independent otherwise.

## Test plan
- [x] `uv run pytest -q tests/cloud/test_cloud_network_edge.py`

## Follow-up
- PR 3: cross-account trust + cloud edge graph diff lifecycle tests


Made with [Cursor](https://cursor.com)