### PR TITLE
fix(api): dedupe CIS checks per scan and surface persist failures

### DIFF
--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -1189,7 +1189,21 @@ def _run_scan_sync(job: ScanJob) -> None:
             terminal_status = job.status
         # Persist final state
         store = _get_store()
-        store.put(job)
+        try:
+            store.put(job)
+        except Exception as persist_exc:  # noqa: BLE001
+            # Persistence is the durability boundary. If the store rejects the
+            # final write, this result only ever existed in this process's
+            # memory: it will not survive a restart and will never reach the
+            # compliance/graph reads that load from the store. Reporting it as a
+            # clean success would be a lie, so surface the failure on the job
+            # the caller polls rather than swallowing it in a finally block.
+            _logger.error("Scan result persistence failed job=%s: %s", job.job_id, persist_exc)
+            with lock:
+                job.status = JobStatus.FAILED
+                job.error = f"result not persisted: {sanitize_error(persist_exc)}"
+                job.progress.append(f"Persistence failed: {sanitize_error(persist_exc)}")
+                terminal_status = job.status
         # Default to "retains in memory" so a store that does not declare the
         # attribute (e.g. test mocks, third-party plugins) keeps a usable job
         # result for the caller. Durable stores that fully serialize on put()

--- a/src/agent_bom/api/postgres_job_store.py
+++ b/src/agent_bom/api/postgres_job_store.py
@@ -338,12 +338,26 @@ class PostgresJobStore:
             params.append(int(priority))
         params.extend([max(1, min(int(limit), 500)), max(0, int(offset))])
         with _tenant_connection(self._pool) as conn:
+            # Each scan inserts a fresh set of rows keyed by its own scan_id
+            # (the table is insert-only, deleted only per scan_id). Without a
+            # latest-per-check filter, the compliance surface would stack every
+            # historical scan's checks and show the same (cloud, check_id) N
+            # times after N scans. DISTINCT ON collapses each logical check to
+            # its most recent measurement; the outer query then restores the
+            # caller's measured_at/priority ordering and applies pagination.
             rows = conn.execute(
                 f"""SELECT scan_id, team_id, cloud, check_id, title, status, severity, cis_section, evidence,
                           resource_ids, remediation, fix_cli, fix_console, effort, priority, guardrails,
                           requires_human_review, measured_at
-                   FROM cis_benchmark_checks
-                   WHERE {" AND ".join(clauses)}
+                   FROM (
+                       SELECT DISTINCT ON (cloud, check_id)
+                              scan_id, team_id, cloud, check_id, title, status, severity, cis_section, evidence,
+                              resource_ids, remediation, fix_cli, fix_console, effort, priority, guardrails,
+                              requires_human_review, measured_at
+                       FROM cis_benchmark_checks
+                       WHERE {" AND ".join(clauses)}
+                       ORDER BY cloud, check_id, measured_at DESC
+                   ) latest
                    ORDER BY measured_at DESC, priority ASC, cloud, check_id
                    LIMIT %s OFFSET %s""",  # nosec B608 - clauses are fixed fragments, values are parameters.
                 params,

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -522,7 +522,19 @@ async def list_cis_benchmark_checks(
         and (priority is None or int(row["priority"]) == priority)
     ]
     filtered.sort(key=lambda row: (str(row.get("measured_at") or ""), -int(row.get("priority") or 0)), reverse=True)
-    return {"checks": filtered[safe_offset : safe_offset + safe_limit], "count": len(filtered), "source": "scan_jobs"}
+    # Collapse to the latest measurement per logical (cloud, check_id) so this
+    # in-memory fallback matches the columnar store's DISTINCT ON dedup: without
+    # it, N scans of the same cloud would stack N copies of each check. Rows are
+    # already sorted newest-first, so the first occurrence wins.
+    deduped: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    for row in filtered:
+        key = (str(row.get("cloud") or ""), str(row.get("check_id") or ""))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(row)
+    return {"checks": deduped[safe_offset : safe_offset + safe_limit], "count": len(deduped), "source": "scan_jobs"}
 
 
 def _coerce_cis_row(row: dict[str, Any]) -> dict[str, Any]:

--- a/tests/api/test_api_pipeline_image_contract.py
+++ b/tests/api/test_api_pipeline_image_contract.py
@@ -94,6 +94,35 @@ def test_api_pipeline_dry_run_skips_discovery_scan_and_side_effects(monkeypatch)
     assert store.jobs[-1].job_id == "dry-run-123"
 
 
+def test_api_pipeline_persistence_failure_is_surfaced_not_silent_success(monkeypatch):
+    """A store.put() failure must not be reported as a clean success.
+
+    The result only ever lived in this process's memory; if persistence
+    raises, the job the caller polls must reflect the failure (so the result
+    does not silently evaporate on restart or go missing from durable reads).
+    """
+
+    class _FailingStore:
+        retains_job_objects_in_memory = True
+
+        def put(self, _job: ScanJob) -> None:
+            raise RuntimeError("postgres unavailable")
+
+    store = _FailingStore()
+    job = ScanJob(
+        job_id="persist-fail-123",
+        created_at="2026-03-25T12:00:00Z",
+        request=ScanRequest(images=["agentbom/agent-bom:latest"], dry_run=True),
+    )
+    monkeypatch.setattr("agent_bom.api.pipeline._get_store", lambda: store)
+
+    _run_scan_sync(job)
+
+    assert job.status == JobStatus.FAILED
+    assert job.error is not None and "not persisted" in job.error
+    assert any("Persistence failed" in line for line in job.progress)
+
+
 def test_api_pipeline_no_scan_skips_vulnerability_scan_and_result_side_effects(monkeypatch):
     store = _DummyStore()
     job = ScanJob(

--- a/tests/test_compliance_report.py
+++ b/tests/test_compliance_report.py
@@ -195,6 +195,62 @@ def test_list_cis_checks_filters_scan_job_fallback():
     assert body["checks"][0]["remediation"]["priority"] == 1
 
 
+def _seed_cis_scan(job_id: str, completed_at: str, status: str, tenant_id: str = "tenant-alpha") -> ScanJob:
+    """A completed scan carrying a single AWS CIS check 1.5 with a given status/time."""
+    job = ScanJob(
+        job_id=job_id,
+        tenant_id=tenant_id,
+        status=JobStatus.DONE,
+        created_at=completed_at,
+        completed_at=completed_at,
+        request=ScanRequest(),
+    )
+    job.result = {
+        "scan_id": job_id,
+        "cis_benchmark": {
+            "checks": [
+                {
+                    "check_id": "1.5",
+                    "title": "Ensure MFA is enabled for the root user",
+                    "status": status,
+                    "severity": "high",
+                    "cis_section": "1 - Identity and Access Management",
+                    "evidence": f"status={status}",
+                    "resource_ids": ["root"],
+                    "remediation": {"priority": 1},
+                }
+            ]
+        },
+    }
+    return job
+
+
+def test_list_cis_checks_fallback_dedupes_repeat_scans_to_latest():
+    """Two scans of the same cloud must not stack duplicate check_id rows.
+
+    The insert-only CIS table keys rows by scan_id, so N scans of one cloud
+    would otherwise surface the same (cloud, check_id) N times. The in-memory
+    fallback must collapse to the latest measurement, mirroring the columnar
+    store's DISTINCT ON dedup.
+    """
+    store = InMemoryJobStore()
+    set_job_store(store)
+    store.put(_seed_cis_scan("scan-old", "2026-01-01T00:00:00Z", status="fail"))
+    store.put(_seed_cis_scan("scan-new", "2026-02-01T00:00:00Z", status="pass"))
+
+    class _NoAnalytics:
+        def query_cis_benchmark_checks(self, **_kwargs):
+            return []
+
+    set_analytics_store(_NoAnalytics())
+    body = asyncio.run(compliance_routes.list_cis_benchmark_checks(_request("tenant-alpha"), cloud="aws"))
+    assert body["source"] == "scan_jobs"
+    aws_15 = [row for row in body["checks"] if row["check_id"] == "1.5"]
+    assert len(aws_15) == 1  # one logical check, not one-per-scan
+    assert aws_15[0]["status"] == "pass"  # latest scan wins
+    assert body["count"] == 1
+
+
 def test_list_cis_checks_prefers_columnar_store():
     class _ColumnarStore(InMemoryJobStore):
         def query_cis_benchmark_checks(self, tenant_id: str, **kwargs):

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -71,6 +71,62 @@ def test_postgres_job_store_real_roundtrip_and_tenant_filter():
     assert any(item.job_id == job_id for item in results)
 
 
+def test_postgres_cis_checks_dedupe_latest_per_check_across_scans():
+    """Re-scanning a cloud must surface one row per check, not one-per-scan.
+
+    ``cis_benchmark_checks`` is insert-only and keyed by scan_id, so two scans
+    of the same cloud persist two copies of every (cloud, check_id). The read
+    path must collapse to the most recent measurement via DISTINCT ON.
+    """
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_store import PostgresJobStore
+    from agent_bom.api.server import JobStatus, ScanJob, ScanRequest
+
+    store = PostgresJobStore()
+    suffix = uuid4().hex
+    tenant_id = f"tenant-{suffix}"
+
+    def _cis_job(job_id: str, completed_at: str, status: str) -> ScanJob:
+        job = ScanJob(
+            job_id=job_id,
+            tenant_id=tenant_id,
+            status=JobStatus.DONE,
+            created_at=completed_at,
+            completed_at=completed_at,
+            request=ScanRequest(format="json"),
+        )
+        job.result = {
+            "scan_id": job_id,
+            "cis_benchmark": {
+                "checks": [
+                    {
+                        "check_id": "1.5",
+                        "title": "Ensure MFA is enabled for the root user",
+                        "status": status,
+                        "severity": "high",
+                        "cis_section": "1 - IAM",
+                        "evidence": f"status={status}",
+                        "resource_ids": ["root"],
+                        "remediation": {"priority": 1},
+                    }
+                ]
+            },
+        }
+        return job
+
+    token = set_current_tenant(tenant_id)
+    try:
+        store.put(_cis_job(f"scan-old-{suffix}", "2026-01-01T00:00:00Z", "fail"))
+        store.put(_cis_job(f"scan-new-{suffix}", "2026-02-01T00:00:00Z", "pass"))
+        rows = store.query_cis_benchmark_checks(tenant_id, cloud="aws")
+    finally:
+        reset_current_tenant(token)
+
+    aws_15 = [row for row in rows if row["check_id"] == "1.5"]
+    assert len(aws_15) == 1  # not one-per-scan
+    assert aws_15[0]["status"] == "pass"  # latest measurement wins
+
+
 def test_postgres_audit_log_real_roundtrip_and_schema_marker():
     from agent_bom.api.audit_log import AuditEntry
     from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant


### PR DESCRIPTION
## Summary

Two Postgres correctness fixes on the scan → ingest → read path, both verified real on `main` before changing.

### 1. CIS posted-scan duplication (wrong result)

`cis_benchmark_checks` is insert-only and deleted only per `scan_id` (`_replace_cis_checks` deletes `WHERE scan_id = %s`). Each scan gets a new `job_id`, so re-scanning the same cloud stacks a fresh set of rows on top of the old ones. `query_cis_benchmark_checks` selected `ORDER BY measured_at DESC, priority ASC, cloud, check_id` with **no latest-scan filter**, so the compliance surface showed the same `(cloud, check_id)` **N times after N scans**.

- **Fix:** `query_cis_benchmark_checks` now wraps a `DISTINCT ON (cloud, check_id) … ORDER BY cloud, check_id, measured_at DESC` inner query to keep only the most recent measurement per logical check, with the caller's `measured_at`/`priority` ordering and `LIMIT`/`OFFSET` restored on the outer query. All existing WHERE filters (tenant, cloud, status, priority) are preserved.
- The compliance route's in-memory `scan_jobs` fallback had the identical bug (it stacked rows from every completed job); it now applies the same latest-per-`(cloud, check_id)` collapse so both read paths agree.
- The time-bucketed `aggregate_cis_benchmark_checks` trends path is intentionally left untouched — showing every scan over time is correct there.

### 2. Persist fail-open-to-memory (durability)

`_run_scan_sync`'s `finally` block called `store.put(job)` with no error handling. If Postgres was unavailable the job was already `DONE` and readable in the in-memory cache, so `GET /v1/scan/{id}` returned a success that never persisted — it evaporated on restart and never reached compliance/graph reads.

- **Fix:** the `store.put` call is wrapped. On failure it logs at error level and marks the job `FAILED` with a `result not persisted: …` error (plus a progress line) instead of reporting a silent clean success. The request is not crashed and the failure is not swallowed.

## Tests

- `test_list_cis_checks_fallback_dedupes_repeat_scans_to_latest` — two scans of one cloud yield **one** row per `check_id`, latest wins (runs locally).
- `test_postgres_cis_checks_dedupe_latest_per_check_across_scans` — real-Postgres DISTINCT ON contract (gated on `AGENT_BOM_POSTGRES_URL`, runs in CI).
- `test_api_pipeline_persistence_failure_is_surfaced_not_silent_success` — a raising `store.put` marks the job `FAILED`, not a clean success.

Local run: `816 passed, 5 skipped` for `-k "cis or job_store or persist or pipeline"`; `ruff` + `mypy` clean on changed files.