### PR TITLE
fix(deploy): SPCS native-app install blockers + deploy hardening

### DIFF
--- a/deploy/docker-compose.product.yml
+++ b/deploy/docker-compose.product.yml
@@ -22,8 +22,9 @@ version: "3.8"
 #   - NO_AUTH_ROLE is NOT set         there is no implicit unauthenticated role
 #   - Postgres URL REQUIRES the non-superuser app role (agent_bom_app), so the
 #     RLS superuser guard (#3665) is satisfied by least privilege, not by the
-#     AGENT_BOM_ALLOW_SUPERUSER_DB escape hatch. The `:?` guards fail closed
-#     when the operator has not provisioned the DML-only role.
+#     AGENT_BOM_ALLOW_SUPERUSER_DB escape hatch. The user defaults to the fixed
+#     `agent_bom_app` role name; the password `:?` guard fails closed until the
+#     operator has provisioned that DML-only role.
 #   - Session cookies stay Secure because Caddy terminates public TLS on 443 and
 #     proxies to the loopback-bound API/UI (see deploy/caddy/Caddyfile.hosted-poc).
 #
@@ -39,9 +40,13 @@ version: "3.8"
 services:
   api:
     environment:
-      # Fail closed unless the DML-only, NOSUPERUSER/NOBYPASSRLS app role created
-      # by deploy/supabase/postgres/init.sql is provisioned. No admin fallback.
-      - AGENT_BOM_POSTGRES_URL=postgresql://${POSTGRES_APP_USER:?set POSTGRES_APP_USER=agent_bom_app}:${POSTGRES_APP_PASSWORD:?set POSTGRES_APP_PASSWORD to the app-role password}@postgres:5432/${POSTGRES_DB:-agent_bom}
+      # Connect as the DML-only, NOSUPERUSER/NOBYPASSRLS app role that
+      # deploy/supabase/postgres/init.sql creates. That role name is hardcoded to
+      # `agent_bom_app` in init.sql, so POSTGRES_APP_USER MUST be `agent_bom_app`
+      # — it defaults to exactly that and there is no reason to override it. The
+      # password has no default and fails closed: provision the role first. No
+      # admin/superuser fallback.
+      - AGENT_BOM_POSTGRES_URL=postgresql://${POSTGRES_APP_USER:-agent_bom_app}:${POSTGRES_APP_PASSWORD:?set POSTGRES_APP_PASSWORD to the agent_bom_app role password from init.sql}@postgres:5432/${POSTGRES_DB:-agent_bom}
       # Anti-demo guards: opposite of docker-compose.hosted-poc.yml.
       - AGENT_BOM_DEMO_ESTATE=0
       - AGENT_BOM_ALLOW_UNAUTHENTICATED_API=0

--- a/deploy/snowflake/native-app/manifest.yml
+++ b/deploy/snowflake/native-app/manifest.yml
@@ -186,7 +186,8 @@ external_access_integrations:
       enabled: false
       egress_destinations:
         - registry.npmjs.org
+        - api.npmjs.org
         - pypi.org
-        - files.pythonhosted.org
-        - repo1.maven.org
         - proxy.golang.org
+        - sum.golang.org
+        - search.maven.org

--- a/deploy/snowflake/native-app/scripts/setup.sql
+++ b/deploy/snowflake/native-app/scripts/setup.sql
@@ -10,6 +10,14 @@ CREATE APPLICATION ROLE IF NOT EXISTS app_user;
 CREATE SCHEMA IF NOT EXISTS core;
 GRANT USAGE ON SCHEMA core TO APPLICATION ROLE app_user;
 
+-- 2b. Core DCM schema (V001__core_schema.sql)
+-- Materialises the full internal schema — including the compliance-hub tables
+-- (core.compliance_hub_findings, core.findings_by_framework) that the Phase 2
+-- proc and posture view below depend on. Runs before the inline DDL so its
+-- superset table definitions win; the CREATE TABLE IF NOT EXISTS statements
+-- that follow become no-ops. Must run after app_user exists (grants inside).
+EXECUTE IMMEDIATE FROM 'dcm/V001__core_schema.sql';
+
 -- 3. Tables
 CREATE TABLE IF NOT EXISTS core.scan_jobs (
     job_id VARCHAR PRIMARY KEY,
@@ -256,7 +264,10 @@ BEGIN
             reference('osv_dev'),
             reference('cisa_kev'),
             reference('first_epss'),
-            reference('github_ghsa')
+            reference('github_ghsa'),
+            reference('nvd_api'),
+            reference('deps_dev'),
+            reference('package_registries')
         )
         MIN_INSTANCES = 1
         MAX_INSTANCES = 1

--- a/deploy/snowflake/native-app/service-spec.yaml
+++ b/deploy/snowflake/native-app/service-spec.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom
-      image: /db/schema/agent_bom_repo/agent-bom:v0_89_2
+      image: /db/schema/agent_bom_repo/agent-bom:v0_94_1
       env:
         AGENT_BOM_STORE_BACKEND: snowflake
         AGENT_BOM_SNOWFLAKE_NATIVE_APP: "1"
@@ -22,7 +22,7 @@ spec:
           cpu: 2
 
     - name: agent-bom-ui
-      image: /db/schema/agent_bom_repo/agent-bom-ui:v0_89_2
+      image: /db/schema/agent_bom_repo/agent-bom-ui:v0_94_1
       env:
         NEXT_PUBLIC_API_URL: "http://localhost:8422"
         NODE_ENV: production

--- a/deploy/terraform/connect-azure/README.md
+++ b/deploy/terraform/connect-azure/README.md
@@ -103,6 +103,16 @@ Azure network I/O.
 | `federated_credential_issuer` | `""` | OIDC issuer. **Required when the credential is created.** |
 | `federated_credential_subject` | `""` | Exact subject (no wildcard). **Required when the credential is created.** |
 | `federated_credential_audience` | `api://AzureADTokenExchange` | Token-exchange audience. |
+| `assign_key_vault_reader` | `false` | **Opt-in** data-plane read: built-in `Key Vault Reader` for CIS 8.1/8.2 (key/secret expiry metadata). RBAC-model vaults only. Off by default, matching the AWS S3/deep-scan opt-in pattern. |
+| `assign_acr_pull` | `false` | **Opt-in** data-plane read: built-in `AcrPull` for ACR image SBOM/CVE extraction. Off by default, matching the AWS S3/deep-scan opt-in pattern. |
+
+## Known coverage limitations
+
+- **Access-policy-model Key Vaults need a different grant.** `Key Vault Reader`
+  only reads data-plane metadata on **RBAC-model** vaults. Vaults using the
+  legacy **access-policy** permission model require a `List` access policy on
+  keys/secrets instead (not managed here); CIS 8.1/8.2 read as silently-empty
+  on those vaults until that policy is added out-of-band.
 
 ## Outputs
 

--- a/deploy/terraform/connect-azure/variables.tf
+++ b/deploy/terraform/connect-azure/variables.tf
@@ -74,12 +74,12 @@ variable "federated_credential_audience" {
 
 variable "assign_key_vault_reader" {
   type        = bool
-  default     = true
-  description = "Assign the built-in 'Key Vault Reader' role so CIS 8.1/8.2 (key/secret expiry) can read vault data-plane metadata. Reader alone cannot, and the check would otherwise be unevaluable. RBAC-model vaults only."
+  default     = false
+  description = "Opt-in data-plane read: assign the built-in 'Key Vault Reader' role so CIS 8.1/8.2 (key/secret expiry) can read vault data-plane metadata. Reader alone cannot, and the check would otherwise be unevaluable. RBAC-model vaults only. Off by default so vault-metadata read is opt-in, matching the AWS S3/deep-scan pattern; set true to enable CIS 8.1/8.2."
 }
 
 variable "assign_acr_pull" {
   type        = bool
-  default     = true
-  description = "Assign the built-in 'AcrPull' role so agent-bom can pull ACR images for SBOM/CVE extraction. Reader cannot pull image content."
+  default     = false
+  description = "Opt-in data-plane read: assign the built-in 'AcrPull' role so agent-bom can pull ACR images for SBOM/CVE extraction. Reader cannot pull image content. Off by default so image-content read is opt-in, matching the AWS S3/deep-scan pattern; set true to enable ACR SBOM extraction."
 }

--- a/deploy/terraform/connect-gcp/README.md
+++ b/deploy/terraform/connect-gcp/README.md
@@ -101,6 +101,15 @@ network I/O.
 | `wif_attribute_condition` | `""` | Scoped CEL condition. **Required when WIF is on** (empty is rejected). |
 | `wif_allowed_audiences` | `[]` | Pinned audiences. **Required (≥1) when WIF is on.** |
 | `wif_principal_set` | `""` | `principalSet://` member allowed to impersonate the SA. **Required when WIF is on.** |
+| `assign_artifact_registry_reader` | `false` | **Opt-in** data-plane read: `roles/artifactregistry.reader` for GAR image pull (SBOM/CVE extraction). Off by default so image-content read is opt-in, matching the AWS S3/deep-scan pattern. |
+
+## Known coverage limitations
+
+- **Org-level CIS checks need org/folder scope.** This module binds IAM at the
+  **project** level. CIS benchmarks that assert org-wide posture (e.g.
+  org-policy and folder-level controls) require an organization or folder IAM
+  binding that is out of scope here; run those with an org/folder-scoped
+  principal or they surface as silently-empty at project scope.
 
 ## Outputs
 

--- a/deploy/terraform/connect-gcp/variables.tf
+++ b/deploy/terraform/connect-gcp/variables.tf
@@ -78,6 +78,6 @@ variable "wif_principal_set" {
 
 variable "assign_artifact_registry_reader" {
   type        = bool
-  default     = true
-  description = "Grant roles/artifactregistry.reader so agent-bom can pull GAR images (downloadArtifacts) for SBOM/CVE extraction. Primitive viewer does not guarantee image pull."
+  default     = false
+  description = "Opt-in data-plane read: grant roles/artifactregistry.reader so agent-bom can pull GAR images (downloadArtifacts) for SBOM/CVE extraction. Primitive viewer does not guarantee image pull. Off by default so image-content read is opt-in, matching the AWS S3/deep-scan pattern; set true to enable GAR SBOM extraction."
 }

--- a/deploy/terraform/platform-eks/README.md
+++ b/deploy/terraform/platform-eks/README.md
@@ -72,8 +72,15 @@ terraform output ui_url
 | `image_tag` | `""` | Override the API/UI image tag (empty = chart default) |
 | `extra_helm_values` | `""` | Raw YAML merged last into the Helm release |
 | `create_aws_connect_role` | `false` | Mint the read-only role the scanner assumes |
+| `report_export_bucket` | `""` | Existing S3 bucket for async report export. When set, mints a dedicated API IRSA role (least-privilege `s3:` on that bucket only), wires it onto the API service account, and turns on S3 export. Empty = disabled |
 
 See `variables.tf` for the full list.
+
+The API pod runs the async report exporter, which needs `s3:PutObject`. Without
+`report_export_bucket` the API service account inherits the scanner IRSA role,
+which has no `s3:` actions — so S3 export (if enabled by hand) would fail
+`AccessDenied`. Setting `report_export_bucket` provisions a separate, minimal
+role scoped to only that bucket and binds it to the `-api` service account.
 
 ## Outputs
 
@@ -85,6 +92,7 @@ See `variables.tf` for the full list.
 | `scanner_role_arn` | IRSA role bound to the scanner service account |
 | `backup_bucket_name` | S3 bucket for the packaged Postgres backups |
 | `connect_role_arn` | Read-only role the scanner assumes (when enabled) |
+| `report_export_role_arn` | API IRSA role for S3 report export (when `report_export_bucket` is set) |
 
 ## Composition notes
 

--- a/deploy/terraform/platform-eks/main.tf
+++ b/deploy/terraform/platform-eks/main.tf
@@ -131,6 +131,24 @@ locals {
     image   = { tag = local.effective_image_tag }
     uiImage = { tag = local.effective_image_tag }
   }
+
+  # Optional S3 report-export overlay. Binds the dedicated API IRSA role onto
+  # the API service account and turns on S3 export, only when a bucket is set.
+  report_values = local.report_export_enabled ? {
+    controlPlane = {
+      api = {
+        serviceAccount = {
+          annotations = {
+            "eks.amazonaws.com/role-arn" = aws_iam_role.report_export[0].arn
+          }
+        }
+        env = [
+          { name = "AGENT_BOM_REPORT_S3_BUCKET", value = var.report_export_bucket },
+          { name = "AGENT_BOM_REPORT_S3_REGION", value = coalesce(var.report_export_bucket_region, var.region) },
+        ]
+      }
+    }
+  } : {}
 }
 
 ###############################################################################
@@ -253,11 +271,13 @@ resource "helm_release" "control_plane" {
   atomic        = true
   recreate_pods = false
 
-  # Precedence (low -> high): baseline wiring, image tag, ingress, user extras.
+  # Precedence (low -> high): baseline wiring, image tag, ingress, report
+  # export, user extras.
   values = compact([
     yamlencode(local.baseline_values),
     length(local.image_values) > 0 ? yamlencode(local.image_values) : "",
     length(local.ingress_values) > 0 ? yamlencode(local.ingress_values) : "",
+    length(local.report_values) > 0 ? yamlencode(local.report_values) : "",
     var.extra_helm_values,
   ])
 
@@ -283,4 +303,89 @@ module "connect_aws" {
   attach_view_only_access = true
 
   tags = var.tags
+}
+
+###############################################################################
+# 5. Optional API IRSA role for S3 report-artifact export (#3512)
+#
+# The async report exporter (report_artifact_store.py) runs in the API pod and
+# calls s3:PutObject on AGENT_BOM_REPORT_S3_BUCKET. The API service account
+# (agent-bom-api) otherwise inherits the scanner IRSA role, which has zero s3:
+# actions — so S3 export fails AccessDenied. When a report bucket is supplied we
+# mint a dedicated, least-privilege role trusted only by the API SA and wire it
+# below. Gated on var.report_export_bucket so default deploys are unaffected.
+###############################################################################
+
+locals {
+  report_export_enabled    = var.report_export_bucket != ""
+  oidc_provider_hostpath   = replace(local.oidc_issuer_url, "https://", "")
+  api_service_account_name = "${var.name}-api"
+  report_bucket_arn        = "arn:aws:s3:::${var.report_export_bucket}"
+}
+
+data "aws_iam_policy_document" "report_export_assume_role" {
+  count = local.report_export_enabled ? 1 : 0
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [local.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider_hostpath}:sub"
+      values   = ["system:serviceaccount:${var.namespace}:${local.api_service_account_name}"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider_hostpath}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "report_export" {
+  count = local.report_export_enabled ? 1 : 0
+
+  statement {
+    sid       = "ListReportBucket"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket", "s3:GetBucketLocation"]
+    resources = [local.report_bucket_arn]
+  }
+
+  statement {
+    sid       = "ReadWriteReportObjects"
+    effect    = "Allow"
+    actions   = ["s3:PutObject", "s3:GetObject"]
+    resources = ["${local.report_bucket_arn}/*"]
+  }
+}
+
+resource "aws_iam_role" "report_export" {
+  count = local.report_export_enabled ? 1 : 0
+
+  name               = "${var.name}-api-report-export"
+  assume_role_policy = data.aws_iam_policy_document.report_export_assume_role[0].json
+  tags               = var.tags
+}
+
+resource "aws_iam_policy" "report_export" {
+  count = local.report_export_enabled ? 1 : 0
+
+  name   = "${var.name}-api-report-export"
+  policy = data.aws_iam_policy_document.report_export[0].json
+  tags   = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "report_export" {
+  count = local.report_export_enabled ? 1 : 0
+
+  role       = aws_iam_role.report_export[0].name
+  policy_arn = aws_iam_policy.report_export[0].arn
 }

--- a/deploy/terraform/platform-eks/outputs.tf
+++ b/deploy/terraform/platform-eks/outputs.tf
@@ -51,6 +51,11 @@ output "connect_role_arn" {
   value       = var.create_aws_connect_role ? module.connect_aws[0].role_arn : ""
 }
 
+output "report_export_role_arn" {
+  description = "IRSA role ARN bound to the API service account for S3 report export (empty unless report_export_bucket is set)."
+  value       = local.report_export_enabled ? aws_iam_role.report_export[0].arn : ""
+}
+
 locals {
   reach_with_domain = <<-EOT
     Platform is reachable at https://${var.domain} once DNS resolves to your

--- a/deploy/terraform/platform-eks/variables.tf
+++ b/deploy/terraform/platform-eks/variables.tf
@@ -192,3 +192,27 @@ variable "create_aws_connect_role" {
   type        = bool
   default     = false
 }
+
+###############################################################################
+# Optional S3 report-artifact export (async report download via presigned URL)
+###############################################################################
+
+variable "report_export_bucket" {
+  description = <<-EOT
+    Name of an existing S3 bucket for async report-artifact export (#3512). When
+    non-empty, this module mints a dedicated IRSA role trusted only by the
+    control-plane API service account (system:serviceaccount:<namespace>:<name>-api),
+    grants it s3:PutObject/GetObject/ListBucket scoped to this bucket, wires the
+    role ARN onto controlPlane.api.serviceAccount, and sets AGENT_BOM_REPORT_S3_BUCKET
+    on the API. Leave empty (default) to disable S3 export — default deploys are
+    unaffected and the API keeps the scanner IRSA role, which has no s3: actions.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "report_export_bucket_region" {
+  description = "Region of report_export_bucket. Empty falls back to var.region."
+  type        = string
+  default     = ""
+}

--- a/site-docs/deployment/postgres-provisioning.md
+++ b/site-docs/deployment/postgres-provisioning.md
@@ -122,6 +122,34 @@ For Postgres-backed deployments, a successful authenticated request does this:
 That means Postgres is not just a passive storage backend; it participates in
 tenant enforcement.
 
+## Upgrading a pre-existing Postgres volume (superuser crash-loop)
+
+The RLS role guard refuses to start the API when the connection role has
+`SUPERUSER` or `BYPASSRLS`, because either attribute silently voids tenant
+isolation. Fresh installs are fine: `deploy/supabase/postgres/init.sql` strips
+`SUPERUSER`/`BYPASSRLS` from the `agent_bom` owner and provisions the DML-only
+`agent_bom_app` role automatically.
+
+`init.sql` only runs on **first** cluster init (an empty data directory). If you
+created your `postgres-data` volume before that de-superuser block shipped, the
+`agent_bom` role is still a `SUPERUSER`, and upgrading to a build with the guard
+will fail closed on boot — the API pod crash-loops with a
+`RlsRolePrivilegeError` and no automatic escape.
+
+Fix it once, on the existing database, before rolling the new image:
+
+```sql
+-- run as a superuser against the existing database, one time
+ALTER ROLE agent_bom NOSUPERUSER NOBYPASSRLS;
+```
+
+Then point `AGENT_BOM_POSTGRES_URL` at the least-privilege `agent_bom_app` role
+(the intended production connection role). As a temporary stopgap only — for a
+single-tenant or local/dev deployment where tenant isolation is not required —
+you may instead set `AGENT_BOM_ALLOW_SUPERUSER_DB=1` to downgrade the hard
+failure to a warning. Do not use that flag in a multi-tenant deployment: it
+leaves cross-tenant reads/writes possible.
+
 ## Operational checklist
 
 Before calling the deployment production-ready:

--- a/tests/test_snowflake_native_app.py
+++ b/tests/test_snowflake_native_app.py
@@ -128,10 +128,11 @@ def test_no_eai_egresses_to_unexpected_destinations(manifest: dict):
         "api.deps.dev",
         "deps.dev",
         "registry.npmjs.org",
+        "api.npmjs.org",
         "pypi.org",
-        "files.pythonhosted.org",
-        "repo1.maven.org",
         "proxy.golang.org",
+        "sum.golang.org",
+        "search.maven.org",
     }
     for eai in manifest.get("external_access_integrations", []):
         body = next(iter(eai.values()))


### PR DESCRIPTION
One coherent deploy PR. All changes are under `deploy/` and `site-docs/deployment/`. Terraform for the three touched modules passes `terraform validate` and `terraform fmt`.

## SPCS native-app install blockers

### 1. Image tag drift (blocks install)
`native-app/service-spec.yaml` pinned `agent-bom` / `agent-bom-ui` to `v0_89_2`, but `manifest.yml` bundles `v0_94_1` (and the scanner/mcp specs already use `v0_94_1`). Snowflake resolves the CREATE SERVICE image against the bundled digests, so the stale tags would fail to install. Both are now `v0_94_1`. Re-grepped `deploy/snowflake/`: no other stale tags remain.

### 2. EAI allowlist too narrow (silent-empty enrichment)
The scanner `CREATE SERVICE` bound only `osv_dev`, `cisa_kev`, `first_epss`, `github_ghsa`, even though `nvd_api`, `deps_dev` and `package_registries` are declared in `manifest.yml`. Without them the container has no egress for NVD CVSS enrichment, deps.dev transitive resolution, or registry lookups — they silently return empty. Added the three `reference()` entries. Verified every `reference()` in `setup.sql` (7 total) has a matching `external_access_integrations` entry in `manifest.yml`.

### 3. DCM schema init (verified real)
`setup.sql` ran `dcm/V002__compliance_proc.sql` but never `V001__core_schema.sql`. V002 depends on V001's `compliance_hub_findings` / `findings_by_framework` tables, and its `compliance_posture` view selects from `findings_by_framework` — so install would hard-fail on a missing relation. Added `EXECUTE IMMEDIATE FROM 'dcm/V001__core_schema.sql'` right after the app role + schema are created (so V001's grants resolve and its superset table definitions land before the inline `CREATE TABLE IF NOT EXISTS` no-ops, and before V002).

### 4. Package-registry host allowlist (verified against src)
Grepped the resolver/version/integrity code for the hosts it actually contacts and reconciled `manifest.yml`:
- Added `sum.golang.org` (Go checksum DB — used alongside `proxy.golang.org`), `search.maven.org` (Maven Central lookup) and `api.npmjs.org` (npm downloads).
- Removed `repo1.maven.org` (never contacted — code uses `search.maven.org`) and `files.pythonhosted.org` (never contacted).
- Kept `registry.npmjs.org`, `pypi.org`, `proxy.golang.org` (all confirmed contacted).

## Deploy hardening

### A. product.yml role-name friction
`init.sql` hardcodes the app role name `agent_bom_app`, so `POSTGRES_APP_USER` must be exactly that. Defaulted it to `agent_bom_app` and spelled out the constraint in the comment. The password keeps its fail-closed `:?` guard (no default).

### B. Upgrade-path superuser crash-loop (docs)
Operators whose `postgres-data` volume predates the de-superuser block in `init.sql` keep a `SUPERUSER` owner role; on upgrade the RLS guard hard-fails with no escape hatch. Added an "Upgrading a pre-existing Postgres volume" note to `site-docs/deployment/postgres-provisioning.md` with the one-time fix (`ALTER ROLE agent_bom NOSUPERUSER NOBYPASSRLS;`) and the `AGENT_BOM_ALLOW_SUPERUSER_DB=1` stopgap. Docs only.

### C. Terraform data-plane grants default-on
`connect-gcp` (`assign_artifact_registry_reader`) and `connect-azure` (`assign_key_vault_reader`, `assign_acr_pull`) defaulted to `true`, unlike the opt-in AWS S3 deep-scan grant. Flipped all three defaults to `false` so image/vault content read is opt-in everywhere, and updated the variable descriptions + module READMEs.

### D. EKS API S3-export IRSA (opt-in)
The async report exporter runs in the API pod and calls `s3:PutObject` on the report bucket, but the API service account (`agent-bom-api`) inherits the scanner IRSA role, which has zero `s3:` actions → `AccessDenied` when export is on. Added an opt-in `report_export_bucket` variable to `platform-eks`; when set, it mints a dedicated least-privilege IRSA role (`s3:PutObject`/`GetObject`/`ListBucket` scoped to that bucket, trusted only by `system:serviceaccount:<ns>:<name>-api`), wires it onto `controlPlane.api.serviceAccount`, and sets `AGENT_BOM_REPORT_S3_BUCKET`. Gated so default deploys are unaffected.

### E. Coverage-limitation notes
Added one-line "Known coverage limitations" notes: GCP project-scope IAM cannot evaluate org-level CIS (needs org/folder binding); Azure `Key Vault Reader` only covers RBAC-model vaults (access-policy vaults need a List access policy). Docs only — no code.