### PR TITLE
feat(api): opt-in anonymous viewer alongside configured credentials

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -427,7 +427,14 @@ def configure_auth_runtime(
         configured_modes.append("scim_provisioning")
 
     auth_configured = bool(configured_modes)
-    auth_required = auth_configured or not unauthenticated_allowed
+    # An explicit unauthenticated opt-in means anonymous callers are served as
+    # NO_AUTH_ROLE, so authentication is not *required* — even when credentials
+    # are also configured for callers who want to elevate. This keeps the UI
+    # from rendering a login wall when public read-only access is genuinely on.
+    # Presenting a valid credential still authenticates to its role, and an
+    # invalid credential is still rejected; that enforcement lives in
+    # APIKeyMiddleware, not in this introspection surface.
+    auth_required = not unauthenticated_allowed
 
     recommended_ui_mode = "configure_auth"
     if unauthenticated_allowed and not auth_configured:
@@ -947,12 +954,21 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             )
         return sorted(catalog, key=lambda item: (item["scope"], item["method"], item["path_prefix"]))
 
-    def __init__(self, app: ASGIApp, api_key: str) -> None:
+    def __init__(self, app: ASGIApp, api_key: str, allow_unauthenticated: bool = False) -> None:
         super().__init__(app)
         if api_key and not static_api_key_allowed():
             raise RuntimeError(static_api_key_rejection_message())
         self._validate_exempt_paths_against_role_rules()
         self._api_key = api_key
+        # When the operator explicitly opts in, a request that presents NO
+        # credential at all is served as the configured NO_AUTH_ROLE (default
+        # viewer) instead of being rejected with 401; a present-but-invalid
+        # credential is still rejected. This is driven solely by the value
+        # ``configure_api`` resolves (explicit flag combined with
+        # AGENT_BOM_ALLOW_UNAUTHENTICATED_API) and passes in — the middleware
+        # deliberately does NOT re-read the env itself, so it fails closed
+        # unless an operator's configured posture explicitly enables it.
+        self._allow_unauthenticated = bool(allow_unauthenticated)
         self._trusted_proxy_auth = _env_flag("AGENT_BOM_TRUST_PROXY_AUTH")
         self._trusted_proxy_secret = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", "").strip()
         self._trusted_proxy_issuer = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH_ISSUER", "").strip()
@@ -1022,6 +1038,48 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             request.state.scim_subject_id = resolution.user_id
         return resolution.role, None
 
+    @staticmethod
+    def _credential_presented(request: StarletteRequest, auth_header: str) -> bool:
+        """Return true when the caller presented *any* credential material.
+
+        Distinguishes "no credential presented" (eligible for the anonymous
+        NO_AUTH_ROLE fallback when opted in) from "credential presented but
+        we could not turn it into a valid identity" (must be rejected, never
+        silently downgraded to anonymous). A non-empty Authorization header in
+        any scheme, or a non-empty X-API-Key header, counts as presented. The
+        session-cookie and trusted-proxy paths are handled by their own
+        branches before this is consulted.
+        """
+        if auth_header.strip():
+            return True
+        if request.headers.get("x-api-key", "").strip():
+            return True
+        return False
+
+    async def _serve_anonymous(self, request: StarletteRequest, call_next):
+        """Serve a credential-less request as the configured NO_AUTH_ROLE.
+
+        The anonymous identity is subject to the exact same per-route role gate
+        as any other identity, so an anonymous viewer still gets 403 on
+        analyst/admin routes. DEMO_ESTATE clamps NO_AUTH_ROLE to viewer inside
+        ``_no_auth_role`` and remains authoritative here.
+        """
+        from agent_bom.api.auth import Role
+        from agent_bom.rbac import _no_auth_role
+
+        role = _no_auth_role()
+        required = Role(self._required_role(request.method, request.url.path))
+        if not self._role_allows(role, required):
+            return JSONResponse(
+                status_code=403,
+                content={"detail": f"Forbidden — requires {required.value} role, anonymous access has {role.value}"},
+            )
+        request.state.api_key_name = "anonymous"
+        request.state.api_key_role = role.value
+        request.state.tenant_id = getattr(request.state, "tenant_id", None) or "default"
+        request.state.auth_method = "anonymous"
+        return await self._call_with_tenant_context(request, call_next)
+
     async def dispatch(self, request: StarletteRequest, call_next):
         # CORS preflight (OPTIONS) MUST bypass auth: browsers do not attach
         # Authorization headers to preflights (CORS spec / Fetch §3.2.2).
@@ -1065,6 +1123,14 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             proxy_response = await self._try_proxy_header_auth(request, call_next)
             if proxy_response is not None:
                 return proxy_response
+            # No API key, no session cookie, no trusted-proxy attestation. If the
+            # operator opted into anonymous read-only access AND no credential
+            # was presented in any form, serve the request as NO_AUTH_ROLE
+            # instead of 401. A present-but-malformed credential (e.g. an
+            # unsupported Authorization scheme) must NOT silently downgrade to
+            # anonymous — it is treated as a presented credential and rejected.
+            if self._allow_unauthenticated and not self._credential_presented(request, auth):
+                return await self._serve_anonymous(request, call_next)
             return JSONResponse(
                 status_code=401,
                 content={"detail": "Unauthorized — provide API key via Authorization: Bearer <key> or X-API-Key header"},

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -786,8 +786,15 @@ def configure_api(
     # (capping unauthenticated floods before auth), then body-size, then auth
     # before the tenant-scoped rate limiter, which needs tenant/auth state.
     _replace_middleware(RateLimitMiddleware, scan_rpm=_rate_limit_rpm, read_rpm=_rate_limit_rpm * 5)
+    # ``auth_required`` is ``auth_configured or not allow_unauthenticated`` so the
+    # middleware is still installed whenever any credential is configured — even
+    # with the unauthenticated opt-in on. In that combined mode it authenticates
+    # valid credentials to their role and lets credential-less callers fall
+    # through to NO_AUTH_ROLE (via ``allow_unauthenticated``); a present-but-
+    # invalid credential is still rejected. Only the pure no-auth mode (nothing
+    # configured + opt-in) removes the middleware entirely.
     if auth_required:
-        _replace_middleware(APIKeyMiddleware, api_key=api_key)
+        _replace_middleware(APIKeyMiddleware, api_key=api_key, allow_unauthenticated=allow_unauthenticated)
     else:
         app.user_middleware = [m for m in app.user_middleware if m.cls is not APIKeyMiddleware]
     _replace_middleware(MaxBodySizeMiddleware)

--- a/tests/api/test_api_cloud_surface_parity.py
+++ b/tests/api/test_api_cloud_surface_parity.py
@@ -17,7 +17,7 @@ import os
 
 from starlette.testclient import TestClient
 
-from agent_bom.api.server import app
+from agent_bom.api.server import app, configure_api
 
 PROXY_SECRET = "test-proxy-secret-with-32-plus-bytes"
 
@@ -45,13 +45,21 @@ def teardown_module() -> None:
 # --------------------------------------------------------------------------- #
 
 
-def test_cloud_inventory_requires_authenticated_context() -> None:
+def test_cloud_inventory_requires_authenticated_context(monkeypatch) -> None:
+    # The shared harness enables the anonymous opt-in by default; this contract
+    # asserts fail-closed auth, so disable it and rebuild the middleware.
+    monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
+    configure_api(api_key=None)
     client = TestClient(app)
     resp = client.get("/v1/cloud/aws/inventory")
     assert resp.status_code == 401
 
 
-def test_cloud_cis_requires_authenticated_context() -> None:
+def test_cloud_cis_requires_authenticated_context(monkeypatch) -> None:
+    # The shared harness enables the anonymous opt-in by default; this contract
+    # asserts fail-closed auth, so disable it and rebuild the middleware.
+    monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
+    configure_api(api_key=None)
     client = TestClient(app)
     resp = client.get("/v1/cloud/aws/cis-benchmark")
     assert resp.status_code == 401

--- a/tests/api/test_api_compliance_auth.py
+++ b/tests/api/test_api_compliance_auth.py
@@ -6,7 +6,7 @@ from starlette.testclient import TestClient
 
 from agent_bom.api import stores as _stores
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
-from agent_bom.api.server import app
+from agent_bom.api.server import app, configure_api
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.api.stores import set_job_store
 
@@ -35,7 +35,11 @@ def teardown_module() -> None:
     os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", None)
 
 
-def test_posture_requires_authenticated_context() -> None:
+def test_posture_requires_authenticated_context(monkeypatch) -> None:
+    # The shared harness enables the anonymous opt-in by default; this contract
+    # asserts fail-closed auth, so disable it and rebuild the middleware.
+    monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
+    configure_api(api_key=None)
     client = TestClient(app)
     resp = client.get("/v1/posture")
     assert resp.status_code == 401
@@ -70,7 +74,11 @@ def test_posture_proxy_auth_requires_tenant_header() -> None:
     assert "X-Agent-Bom-Tenant-ID" in resp.json()["detail"]
 
 
-def test_compliance_export_requires_authenticated_context() -> None:
+def test_compliance_export_requires_authenticated_context(monkeypatch) -> None:
+    # The shared harness enables the anonymous opt-in by default; this contract
+    # asserts fail-closed auth, so disable it and rebuild the middleware.
+    monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
+    configure_api(api_key=None)
     client = TestClient(app)
     resp = client.get("/v1/compliance")
     assert resp.status_code == 401
@@ -89,7 +97,11 @@ def test_compliance_export_accepts_trusted_proxy_headers() -> None:
     assert body["tenant_id"] == "tenant-alpha"
 
 
-def test_aisvs_compliance_requires_authenticated_context() -> None:
+def test_aisvs_compliance_requires_authenticated_context(monkeypatch) -> None:
+    # The shared harness enables the anonymous opt-in by default; this contract
+    # asserts fail-closed auth, so disable it and rebuild the middleware.
+    monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
+    configure_api(api_key=None)
     client = TestClient(app)
     resp = client.get("/v1/compliance/aisvs")
     assert resp.status_code == 401

--- a/tests/api/test_api_hardening.py
+++ b/tests/api/test_api_hardening.py
@@ -135,6 +135,9 @@ def test_direct_asgi_import_configures_static_api_key_from_env(monkeypatch):
     """Raw uvicorn imports must honor AGENT_BOM_API_KEY without the CLI wrapper."""
     raw_key = "raw-uvicorn-static-key"
     monkeypatch.setenv("AGENT_BOM_API_KEY", raw_key)
+    # Assert fail-closed credentialed auth; the shared harness enables the
+    # anonymous opt-in by default, so disable it for this posture.
+    monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
     configure_api_from_env()
     try:
         client = TestClient(app)
@@ -153,6 +156,9 @@ def test_direct_asgi_import_configures_rbac_api_keys_from_env(monkeypatch):
     set_key_store(KeyStore())
     monkeypatch.setattr("agent_bom.api.server._env_api_keys_seeded", False)
     monkeypatch.setenv("AGENT_BOM_API_KEYS", f"{raw_admin}:admin,{raw_viewer}:viewer")
+    # Assert fail-closed credentialed auth; the shared harness enables the
+    # anonymous opt-in by default, so disable it for this posture.
+    monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
     configure_api_from_env()
     try:
         client = TestClient(app)
@@ -167,6 +173,131 @@ def test_direct_asgi_import_configures_rbac_api_keys_from_env(monkeypatch):
         set_key_store(original_store)
         monkeypatch.setattr("agent_bom.api.server._env_api_keys_seeded", False)
         configure_api(api_key=None)
+
+
+class TestAnonymousViewerAlongsideCredentials:
+    """Opt-in anonymous read-only surface coexisting with configured credentials.
+
+    AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1 must let a credential-less caller act
+    as NO_AUTH_ROLE (default viewer) even while API keys are configured, without
+    weakening any credentialed path: valid keys still authenticate to their
+    role, and present-but-invalid credentials are still rejected.
+    """
+
+    _RAW_ADMIN = "raw-anon-coexist-admin-key"
+
+    def _configure(self, monkeypatch, *, allow_unauthenticated: bool, no_auth_role: str = "viewer"):
+        original_store = get_key_store()
+        set_key_store(KeyStore())
+        monkeypatch.setattr("agent_bom.api.server._env_api_keys_seeded", False)
+        monkeypatch.setenv("AGENT_BOM_API_KEYS", f"{self._RAW_ADMIN}:admin")
+        # conftest pins AGENT_BOM_NO_AUTH_ROLE=admin session-wide for legacy
+        # unauthenticated tests; pin the product default (viewer) here so these
+        # cases assert the shipped anonymous role rather than the test harness.
+        monkeypatch.setenv("AGENT_BOM_NO_AUTH_ROLE", no_auth_role)
+        if allow_unauthenticated:
+            monkeypatch.setenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", "1")
+        else:
+            monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
+        configure_api_from_env()
+        return original_store
+
+    @staticmethod
+    def _restore(monkeypatch, original_store):
+        monkeypatch.delenv("AGENT_BOM_API_KEYS", raising=False)
+        set_key_store(original_store)
+        monkeypatch.setattr("agent_bom.api.server._env_api_keys_seeded", False)
+        configure_api(api_key=None)
+
+    def test_flag_on_no_credential_serves_viewer(self, monkeypatch):
+        original_store = self._configure(monkeypatch, allow_unauthenticated=True)
+        try:
+            client = TestClient(app)
+            resp = client.get("/v1/auth/me")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["role"] == "viewer"
+            assert body["auth_method"] == "anonymous"
+        finally:
+            self._restore(monkeypatch, original_store)
+
+    def test_flag_on_valid_admin_key_authenticates_admin(self, monkeypatch):
+        original_store = self._configure(monkeypatch, allow_unauthenticated=True)
+        try:
+            client = TestClient(app)
+            me = client.get("/v1/auth/me", headers={"Authorization": f"Bearer {self._RAW_ADMIN}"})
+            assert me.status_code == 200
+            assert me.json()["role"] == "admin"
+            # A protected admin write still succeeds with the admin key …
+            created = client.post(
+                "/v1/auth/keys",
+                json={"name": "spawned", "role": "viewer"},
+                headers={"Authorization": f"Bearer {self._RAW_ADMIN}"},
+            )
+            assert created.status_code == 201
+            # … while the anonymous viewer is forbidden from the same write.
+            assert client.post("/v1/auth/keys", json={"name": "nope", "role": "viewer"}).status_code == 403
+        finally:
+            self._restore(monkeypatch, original_store)
+
+    def test_flag_on_invalid_credential_is_rejected_not_anonymous(self, monkeypatch):
+        original_store = self._configure(monkeypatch, allow_unauthenticated=True)
+        try:
+            client = TestClient(app)
+            # Bad bearer key, unsupported scheme, and bad X-API-Key must all 401 —
+            # a presented-but-invalid credential must never fall through to viewer.
+            assert client.get("/v1/auth/me", headers={"Authorization": "Bearer totally-wrong-key"}).status_code == 401
+            assert client.get("/v1/auth/me", headers={"Authorization": "Basic dXNlcjpwYXNz"}).status_code == 401
+            assert client.get("/v1/auth/me", headers={"X-API-Key": "totally-wrong-key"}).status_code == 401
+        finally:
+            self._restore(monkeypatch, original_store)
+
+    def test_flag_off_no_credential_still_401(self, monkeypatch):
+        """Default (flag OFF) fails closed exactly as before — no regression."""
+        original_store = self._configure(monkeypatch, allow_unauthenticated=False)
+        try:
+            client = TestClient(app)
+            assert client.get("/v1/auth/me").status_code == 401
+            # A valid credential still works under the default posture.
+            assert client.get("/v1/auth/me", headers={"Authorization": f"Bearer {self._RAW_ADMIN}"}).status_code == 200
+            assert client.get("/health").json()["auth_required"] is True
+        finally:
+            self._restore(monkeypatch, original_store)
+
+    def test_flag_on_demo_estate_clamps_anonymous_to_viewer(self, monkeypatch):
+        """DEMO_ESTATE clamps the anonymous NO_AUTH_ROLE to viewer, winning over
+        an operator-set AGENT_BOM_NO_AUTH_ROLE=admin."""
+        import agent_bom.config as config
+
+        monkeypatch.setenv("AGENT_BOM_DEMO_ESTATE", "1")
+        monkeypatch.setattr(config, "DEMO_ESTATE", True)
+        # NO_AUTH_ROLE=admin would grant admin anonymously, but DEMO_ESTATE must
+        # clamp to viewer regardless.
+        original_store = self._configure(monkeypatch, allow_unauthenticated=True, no_auth_role="admin")
+        try:
+            client = TestClient(app)
+            me = client.get("/v1/auth/me")
+            assert me.status_code == 200
+            assert me.json()["role"] == "viewer"
+            # The clamped anonymous viewer cannot reach an admin write.
+            assert client.post("/v1/auth/keys", json={"name": "z", "role": "viewer"}).status_code == 403
+        finally:
+            self._restore(monkeypatch, original_store)
+
+    def test_flag_on_session_discovery_reports_auth_not_required(self, monkeypatch):
+        original_store = self._configure(monkeypatch, allow_unauthenticated=True)
+        try:
+            client = TestClient(app)
+            health = client.get("/health").json()
+            assert health["auth_required"] is False
+            assert health["auth_configured"] is True
+            assert health["unauthenticated_allowed"] is True
+            # Authenticated users are still pointed at the right elevation path.
+            me = client.get("/v1/auth/me").json()
+            assert me["auth_required"] is False
+            assert me["recommended_ui_mode"] == "session_api_key"
+        finally:
+            self._restore(monkeypatch, original_store)
 
 
 def test_create_api_key_record_verifies_operator_supplied_key():
@@ -444,6 +575,9 @@ def test_configured_app_cors_preflight_survives_auth_and_rate_limit(monkeypatch)
         monkeypatch.delenv("AGENT_BOM_TRUST_PROXY_AUTH", raising=False)
         monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
         monkeypatch.delenv("AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT", raising=False)
+        # This test asserts fail-closed auth for a credentialed real request; the
+        # shared harness enables the anonymous opt-in by default, so disable it.
+        monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
         configure_api(
             cors_origins=["http://localhost:3000"],
             api_key="test-key-cors",

--- a/tests/api/test_api_operator_policy.py
+++ b/tests/api/test_api_operator_policy.py
@@ -886,6 +886,10 @@ def test_metrics_requires_authenticated_access(monkeypatch: pytest.MonkeyPatch) 
 def test_auth_debug_reports_runtime_auth_modes(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
     monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", PROXY_SECRET)
+    # This case asserts auth_required is True for a configured-auth posture; the
+    # shared harness enables the anonymous opt-in by default (which correctly
+    # reports auth_required=False), so disable it here.
+    monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
     _reload_config()
     _server_mod.configure_api(api_key=None)
 

--- a/tests/api/test_api_privacy.py
+++ b/tests/api/test_api_privacy.py
@@ -13,7 +13,7 @@ from agent_bom.api.models import JobStatus, ScanJob, ScanRequest, SourceKind, So
 from agent_bom.api.policy_store import GatewayPolicy, InMemoryPolicyStore
 from agent_bom.api.routes.privacy import delete_tenant_data, export_tenant_data
 from agent_bom.api.schedule_store import InMemoryScheduleStore, ScanSchedule
-from agent_bom.api.server import app
+from agent_bom.api.server import app, configure_api
 from agent_bom.api.source_store import InMemorySourceStore
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.api.stores import (
@@ -138,7 +138,11 @@ def test_tenant_data_export_is_tenant_scoped_and_redacts_source_secrets(tenant_s
     assert "retained_immutable_hmac_chain" == response["retention"]["audit_log"]
 
 
-def test_tenant_data_http_endpoint_requires_authenticated_admin(tenant_stores) -> None:
+def test_tenant_data_http_endpoint_requires_authenticated_admin(tenant_stores, monkeypatch) -> None:
+    # The shared harness enables the anonymous opt-in by default; this contract
+    # asserts fail-closed auth, so disable it and rebuild the middleware.
+    monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
+    configure_api(api_key=None)
     client = TestClient(app)
 
     unauthenticated = client.get("/v1/tenant/tenant-a/data")

--- a/tests/test_graph_rollup.py
+++ b/tests/test_graph_rollup.py
@@ -351,8 +351,11 @@ def test_rollup_endpoint_rejects_bad_severity(tmp_path) -> None:
 
 
 def test_rollup_endpoint_requires_auth_when_key_configured(monkeypatch) -> None:
-    # With an API key configured, an unauthenticated request must be rejected
-    # by the same middleware that guards the sibling graph routes.
+    # With an API key configured and no anonymous opt-in, an unauthenticated
+    # request must be rejected by the same middleware that guards the sibling
+    # graph routes. (The shared test harness enables the anonymous opt-in by
+    # default; this test asserts the fail-closed credentialed posture.)
+    monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
     api_server.configure_api(api_key="rollup-secret-key")
     try:
         client = TestClient(app)

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from starlette.testclient import TestClient
 
-from agent_bom.api.server import JobStatus, _get_store, app
+from agent_bom.api.server import JobStatus, _get_store, app, configure_api
 from agent_bom.api.store import InMemoryJobStore
 from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
 
@@ -175,9 +175,13 @@ def test_overview_reads_compacted_scan_summary() -> None:
     assert data["domains"]["cloud"]["metric"] == 87
 
 
-def test_overview_requires_auth() -> None:
+def test_overview_requires_auth(monkeypatch) -> None:
     """Endpoint is read-only but still behind the standard viewer gate."""
     _clear_jobs()
+    # The shared harness enables the anonymous opt-in by default; this contract
+    # asserts fail-closed auth, so disable it and rebuild the middleware.
+    monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
+    configure_api(api_key=None)
     client = TestClient(app)
     resp = client.get("/v1/overview")
     assert resp.status_code in (401, 403)


### PR DESCRIPTION
## What
`AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1` (default **OFF**) now serves a credential-less caller as `NO_AUTH_ROLE` (default `viewer`) **even when API keys / OIDC / trusted-proxy are also configured** — so a public read-only surface can coexist with key-based elevation. Previously, the moment any credential was configured, `auth_configured` forced `auth_required` and anonymous requests got 401, which blocked the hosted demo and any public-read deployment.

## Behavior
- `auth_required` now tracks the opt-in, not merely 'any auth configured' — so the UI no longer renders a login wall when anonymous access is genuinely on.
- `APIKeyMiddleware` distinguishes **no credential presented** (served as `NO_AUTH_ROLE`) from **credential presented but invalid** (still rejected — never silently downgraded).
- Anonymous identity still passes the per-route role gate (403 on analyst/admin routes); the `DEMO_ESTATE` viewer clamp stays authoritative.
- Middleware never re-reads the env — it uses only the value `configure_api` resolves — so it **fails closed** unless the operator's posture explicitly enables it.

## No-regression guarantee
With the flag **OFF** (production default), behavior is byte-for-byte unchanged: configured auth ⇒ 401 for anonymous. Auth-contract tests assert this explicitly (they `delenv` the opt-in the test harness sets by default).

## Test matrix (tests/api/test_api_hardening.py::TestAnonymousViewerAlongsideCredentials + touched contract tests)
1. flag ON + keys + no credential → 200 as viewer (`auth_method=anonymous`)
2. flag ON + keys + valid key → authenticated to its role
3. flag ON + keys + invalid key → rejected (not anonymous)
4. flag OFF + keys + no credential → 401 (unchanged)
5. DEMO_ESTATE clamp holds → viewer

Unblocks the hosted demo (anonymous → read-only viewer over the synthetic estate) without deleting persisted keys.