### PR TITLE
feat(cloud): network entry EXPOSED_TO paths (#3742 PR 4)

### DIFF
--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -2314,6 +2314,7 @@ def _discover_network_edge(
                     "name": igw_id,
                     "vpc_id": vpc_ids[0] if vpc_ids else "",
                     "kind": "internet-gateway",
+                    "internet_exposed": True,
                     "location": region,
                     "account_id": account_id or "",
                 }
@@ -2383,12 +2384,40 @@ def _discover_network_edge(
                 acl_id = str(acl.get("NetworkAclId", "") or "")
                 if not acl_id:
                     continue
+                subnet_ids = sorted(
+                    {
+                        str(assoc.get("SubnetId", "") or "")
+                        for assoc in acl.get("Associations", []) or []
+                        if isinstance(assoc, dict) and assoc.get("SubnetId")
+                    }
+                )
+                network_exposure: list[dict[str, Any]] = []
+                for entry in acl.get("Entries", []) or []:
+                    if not isinstance(entry, dict) or entry.get("Egress"):
+                        continue
+                    if str(entry.get("RuleAction", "")).lower() != "allow":
+                        continue
+                    cidr = str(entry.get("CidrBlock", "") or entry.get("Ipv6CidrBlock", "") or "")
+                    if cidr not in ("0.0.0.0/0", "::/0"):
+                        continue
+                    network_exposure.append(
+                        {
+                            "cidr": cidr,
+                            "from_port": entry.get("PortRange", {}).get("From") if isinstance(entry.get("PortRange"), dict) else None,
+                            "to_port": entry.get("PortRange", {}).get("To") if isinstance(entry.get("PortRange"), dict) else None,
+                            "protocol": str(entry.get("Protocol", "") or ""),
+                            "scope": "internet",
+                        }
+                    )
                 out["network_acls"].append(
                     {
                         "id": acl_id,
                         "name": acl_id,
                         "vpc_id": str(acl.get("VpcId", "") or ""),
                         "is_default": bool(acl.get("IsDefault")),
+                        "subnet_ids": subnet_ids,
+                        "internet_exposed": bool(network_exposure),
+                        "network_exposure": network_exposure,
                         "location": region,
                         "account_id": account_id or "",
                     }

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -5155,6 +5155,8 @@ def _add_network_edge_inventory(
                     "vpc_id": _clean_graph_part(item.get("vpc_id")),
                     "internet_exposed": bool(item.get("internet_exposed")),
                     "has_internet_route": bool(item.get("has_internet_route")),
+                    "subnet_ids": list(item.get("subnet_ids", []) or []),
+                    "network_exposure": list(item.get("network_exposure", []) or []),
                 },
             )
 
@@ -5267,6 +5269,19 @@ def _add_network_edge_inventory(
             attrs={"resource_id": _clean_graph_part(acl.get("arn")) or acl_id, "scope": _clean_graph_part(acl.get("scope"))},
         )
         _protect(node_id, acl.get("protected_targets", []), "waf_web_acl_association")
+        waf_node = graph.nodes.get(node_id)
+        if waf_node is not None:
+            waf_node.attributes["internet_exposed"] = True
+        for target_ref in acl.get("protected_targets", []) or []:
+            ref = _clean_graph_part(target_ref)
+            target_node_id = ref_to_node.get(ref)
+            if target_node_id:
+                _add_exposure_path_edge(
+                    graph,
+                    source=node_id,
+                    target=target_node_id,
+                    reason="waf_internet_entry",
+                )
 
     # ── API gateways → API_GATEWAY nodes (+ Azure API Management) + PROTECTS ──
     api_gateway_items = list(inventory.get("api_gateways", []) or [])
@@ -5332,6 +5347,114 @@ def _add_network_edge_inventory(
                         source=node_id,
                         target=target_node_id,
                         reason="internet_facing_api_gateway",
+                    )
+
+    _wire_network_entry_exposure_paths(
+        graph,
+        inventory,
+        provider=provider,
+        subnet_node_by_id=subnet_node_by_id,
+        instance_node_by_id=instance_node_by_id,
+    )
+
+
+def _wire_network_entry_exposure_paths(
+    graph: UnifiedGraph,
+    inventory: dict[str, Any],
+    *,
+    provider: str,
+    subnet_node_by_id: dict[str, str],
+    instance_node_by_id: dict[str, str],
+) -> None:
+    """Link IGW / public subnet / permissive NACL nodes to reachable instances."""
+    public_subnet_ids = {
+        sn_id
+        for sn in inventory.get("subnets", []) or []
+        if isinstance(sn, dict)
+        for sn_id in [_clean_graph_part(sn.get("id"))]
+        if sn_id and sn.get("is_public")
+    }
+    igw_by_vpc: dict[str, str] = {}
+    for igw in inventory.get("internet_gateways", []) or []:
+        if not isinstance(igw, dict):
+            continue
+        kind = _clean_graph_part(igw.get("kind")) or "internet-gateway"
+        if kind != "internet-gateway":
+            continue
+        ident = _clean_graph_part(igw.get("id"))
+        vpc_id = _clean_graph_part(igw.get("vpc_id"))
+        if not ident or not vpc_id:
+            continue
+        node_id = f"cloud_resource:{provider}:network:internet_gateway:{ident}"
+        if node_id in graph.nodes:
+            graph.nodes[node_id].attributes["internet_exposed"] = True
+            igw_by_vpc[vpc_id] = node_id
+
+    for vpc_id, igw_node in igw_by_vpc.items():
+        for sn in inventory.get("subnets", []) or []:
+            if not isinstance(sn, dict):
+                continue
+            sn_id = _clean_graph_part(sn.get("id"))
+            if sn_id not in public_subnet_ids or _clean_graph_part(sn.get("vpc_id")) != vpc_id:
+                continue
+            sn_node = subnet_node_by_id.get(sn_id)
+            if sn_node:
+                _add_exposure_path_edge(
+                    graph,
+                    source=igw_node,
+                    target=sn_node,
+                    reason="internet_gateway_public_subnet",
+                )
+
+    for sn_id in public_subnet_ids:
+        sn_node = subnet_node_by_id.get(sn_id)
+        if not sn_node:
+            continue
+        for instance in inventory.get("instances", []) or []:
+            if not isinstance(instance, dict):
+                continue
+            if _clean_graph_part(instance.get("subnet_id")) != sn_id:
+                continue
+            inst_node = instance_node_by_id.get(_clean_graph_part(instance.get("instance_id")))
+            if inst_node:
+                _add_exposure_path_edge(
+                    graph,
+                    source=sn_node,
+                    target=inst_node,
+                    reason="public_subnet_instance",
+                )
+
+    for nacl in inventory.get("network_acls", []) or []:
+        if not isinstance(nacl, dict) or not nacl.get("internet_exposed"):
+            continue
+        ident = _clean_graph_part(nacl.get("id"))
+        if not ident:
+            continue
+        nacl_node = f"cloud_resource:{provider}:network:network_acl:{ident}"
+        if nacl_node not in graph.nodes:
+            continue
+        for sn_id in nacl.get("subnet_ids", []) or []:
+            sn_clean = _clean_graph_part(sn_id)
+            sn_node = subnet_node_by_id.get(sn_clean)
+            if sn_node:
+                _add_exposure_path_edge(
+                    graph,
+                    source=nacl_node,
+                    target=sn_node,
+                    reason="permissive_network_acl",
+                )
+            for instance in inventory.get("instances", []) or []:
+                if not isinstance(instance, dict):
+                    continue
+                if _clean_graph_part(instance.get("subnet_id")) != sn_clean:
+                    continue
+                inst_node = instance_node_by_id.get(_clean_graph_part(instance.get("instance_id")))
+                if inst_node:
+                    _add_exposure_path_edge(
+                        graph,
+                        source=nacl_node,
+                        target=inst_node,
+                        reason="permissive_network_acl_instance",
                     )
 
 

--- a/tests/cloud/test_cloud_network_edge.py
+++ b/tests/cloud/test_cloud_network_edge.py
@@ -79,7 +79,26 @@ class _Ec2Client:
             "describe_vpc_endpoints": [
                 {"VpcEndpoints": [{"VpcEndpointId": "vpce-1", "ServiceName": "com.amazonaws.s3", "VpcId": "vpc-1"}]}
             ],
-            "describe_network_acls": [{"NetworkAcls": [{"NetworkAclId": "acl-1", "VpcId": "vpc-1", "IsDefault": True}]}],
+            "describe_network_acls": [
+                {
+                    "NetworkAcls": [
+                        {
+                            "NetworkAclId": "acl-1",
+                            "VpcId": "vpc-1",
+                            "IsDefault": True,
+                            "Associations": [{"SubnetId": "subnet-pub"}],
+                            "Entries": [
+                                {
+                                    "Egress": False,
+                                    "RuleAction": "allow",
+                                    "CidrBlock": "0.0.0.0/0",
+                                    "Protocol": "-1",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            ],
         }
         return _Paginator(pages.get(op, []))
 
@@ -240,6 +259,28 @@ def _aws_inventory() -> dict:
         "instances": [{"instance_id": "i-1", "name": "web", "vpc_id": "vpc-1", "subnet_id": "subnet-pub", "security_group_ids": ["sg-1"]}],
         "security_groups": [{"group_id": "sg-1", "name": "open", "vpc_id": "vpc-1", "internet_exposed": True, "network_exposure": []}],
         "subnets": [{"id": "subnet-pub", "name": "pub", "vpc_id": "vpc-1", "cidr": "10.0.1.0/24", "is_public": True}],
+        "internet_gateways": [
+            {
+                "id": "igw-1",
+                "name": "igw-1",
+                "vpc_id": "vpc-1",
+                "kind": "internet-gateway",
+                "internet_exposed": True,
+            }
+        ],
+        "network_acls": [
+            {
+                "id": "acl-open",
+                "name": "acl-open",
+                "vpc_id": "vpc-1",
+                "subnet_ids": ["subnet-pub"],
+                "internet_exposed": True,
+                "network_exposure": [{"scope": "internet", "cidr": "0.0.0.0/0"}],
+            }
+        ],
+        "buckets": [],
+        "roles": [],
+        "users": [],
         "network_interfaces": [
             {
                 "id": "eni-1",
@@ -360,6 +401,48 @@ def test_internet_facing_api_gateway_emits_exposed_to_frontend() -> None:
     ]
     assert exposed
     assert exposed[0].evidence.get("reason") == "internet_facing_api_gateway"
+
+
+def test_waf_emits_internet_entry_exposed_to_frontend() -> None:
+    g = build_unified_graph_from_report({"cloud_inventory": _aws_inventory()})
+    waf_id = "cloud_resource:aws:waf:web_acl:acl-id"
+    alb_id = "cloud_resource:aws:elbv2:load_balancer:web-alb"
+    exposed = [
+        e
+        for e in g.edges
+        if e.relationship == RelationshipType.EXPOSED_TO and e.source == waf_id and e.target == alb_id
+    ]
+    assert exposed
+    assert exposed[0].evidence.get("reason") == "waf_internet_entry"
+    assert g.nodes[waf_id].attributes.get("internet_exposed") is True
+
+
+def test_internet_gateway_public_subnet_and_instance_paths() -> None:
+    g = build_unified_graph_from_report({"cloud_inventory": _aws_inventory()})
+    igw_id = "cloud_resource:aws:network:internet_gateway:igw-1"
+    subnet_id = "cloud_resource:aws:network:subnet:subnet-pub"
+    inst_id = "cloud_resource:aws:ec2:instance:i-1"
+    reasons = {
+        (e.source, e.target): (e.evidence or {}).get("reason")
+        for e in g.edges
+        if e.relationship == RelationshipType.EXPOSED_TO
+    }
+    assert reasons.get((igw_id, subnet_id)) == "internet_gateway_public_subnet"
+    assert reasons.get((subnet_id, inst_id)) == "public_subnet_instance"
+
+
+def test_permissive_network_acl_exposed_to_subnet_and_instance() -> None:
+    g = build_unified_graph_from_report({"cloud_inventory": _aws_inventory()})
+    nacl_id = "cloud_resource:aws:network:network_acl:acl-open"
+    subnet_id = "cloud_resource:aws:network:subnet:subnet-pub"
+    inst_id = "cloud_resource:aws:ec2:instance:i-1"
+    reasons = {
+        (e.source, e.target): (e.evidence or {}).get("reason")
+        for e in g.edges
+        if e.relationship == RelationshipType.EXPOSED_TO
+    }
+    assert reasons.get((nacl_id, subnet_id)) == "permissive_network_acl"
+    assert reasons.get((nacl_id, inst_id)) == "permissive_network_acl_instance"
 
 
 def _exposed_vuln_graph(*, protected: bool) -> UnifiedGraph:


### PR DESCRIPTION
## Summary
- Wire internet gateway → public subnet → instance, permissive NACL reachability, and WAF internet-entry `EXPOSED_TO` edges (alongside existing `PROTECTS`).
- Enrich AWS NACL inventory with subnet associations and open ingress rule detection.

## Verification
- `uv run pytest -q tests/cloud/test_cloud_network_edge.py` (17 passed)

## Notes
- Closes the network-inventory `EXPOSED_TO` row for #3742 (ENI/LB/API GW landed in #3744).

Made with [Cursor](https://cursor.com)