### PR TITLE
fix: pre-release graph-accuracy + anonymous-viewer hardening

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1068,6 +1068,13 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         from agent_bom.rbac import _no_auth_role
 
         role = _no_auth_role()
+        # Combined mode: when credentials (a static API key or any stored keys)
+        # are also configured, the anonymous fallback is strictly read-only —
+        # otherwise NO_AUTH_ROLE=admin would hand an unauthenticated caller admin
+        # (they could mint admin keys). NO_AUTH_ROLE elevation only applies to a
+        # pure no-auth deployment with no credentials configured at all.
+        if role != Role.VIEWER and (self._api_key or get_key_store().has_keys()):
+            role = Role.VIEWER
         required = Role(self._required_role(request.method, request.url.path))
         if not self._role_allows(role, required):
             return JSONResponse(

--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -2416,7 +2416,11 @@ def _discover_network_edge(
                         "vpc_id": str(acl.get("VpcId", "") or ""),
                         "is_default": bool(acl.get("IsDefault")),
                         "subnet_ids": subnet_ids,
-                        "internet_exposed": bool(network_exposure),
+                        # The AWS default NACL is allow-all inbound by design, so
+                        # its permissive rules alone are not internet exposure —
+                        # only flag non-default NACLs (downstream public-subnet
+                        # gate is the primary guard).
+                        "internet_exposed": bool(network_exposure) and not bool(acl.get("IsDefault")),
                         "network_exposure": network_exposure,
                         "location": region,
                         "account_id": account_id or "",

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -496,7 +496,15 @@ def _executemany_batched(
 @contextmanager
 def open_graph_db(db_path: str | Path) -> Generator[sqlite3.Connection, None, None]:
     """Open (or create) a graph database with schema initialisation."""
-    conn = sqlite3.connect(str(db_path), timeout=10)
+    target = str(db_path)
+    # Create the parent directory up front: on a fresh deploy (new volume /
+    # container, offline) ``~/.agent-bom/db`` may not exist yet, and
+    # ``sqlite3.connect`` does not create missing parents — it raises
+    # "unable to open database file", which silently leaves the seeded demo
+    # estate with an empty graph. ``:memory:`` has no parent to create.
+    if target != ":memory:":
+        Path(target).parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(target, timeout=10)
     conn.row_factory = sqlite3.Row
     try:
         _init_db(conn)

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -5489,6 +5489,12 @@ def _wire_network_entry_exposure_paths(
             continue
         for sn_id in nacl.get("subnet_ids", []) or []:
             sn_clean = _clean_graph_part(sn_id)
+            # A permissive NACL only implies internet reachability when the
+            # subnet is actually public (has an IGW route). A permissive NACL on
+            # a private subnet is not internet exposure — skip it to avoid a
+            # false EXPOSED_TO edge. Mirrors the IGW branch's public gate above.
+            if sn_clean not in public_subnet_ids:
+                continue
             sn_node = subnet_node_by_id.get(sn_clean)
             if sn_node:
                 _add_exposure_path_edge(

--- a/src/agent_bom/graph/toxic_findings.py
+++ b/src/agent_bom/graph/toxic_findings.py
@@ -59,13 +59,16 @@ _PRINCIPAL_TYPES = frozenset(
 )
 
 # Edges that move a principal toward effective control of a resource.
+# NOTE: CROSS_ACCOUNT_TRUST / TRUSTS are deliberately excluded. Those edges are
+# emitted as role R -> principal P where P is *allowed to assume* R, i.e. they
+# encode INBOUND trust (P -> R capability). Walking them as outbound pivots would
+# falsely claim an exposed R can move laterally INTO P's account. The genuine
+# outbound vectors are ASSUMES / CAN_ACCESS / HAS_PERMISSION.
 _LATERAL_RELS = frozenset(
     {
         RelationshipType.ASSUMES,
         RelationshipType.CAN_ACCESS,
         RelationshipType.HAS_PERMISSION,
-        RelationshipType.CROSS_ACCOUNT_TRUST,
-        RelationshipType.TRUSTS,
     }
 )
 

--- a/tests/api/test_api_hardening.py
+++ b/tests/api/test_api_hardening.py
@@ -284,6 +284,26 @@ class TestAnonymousViewerAlongsideCredentials:
         finally:
             self._restore(monkeypatch, original_store)
 
+    def test_flag_on_combined_mode_clamps_no_auth_admin_to_viewer(self, monkeypatch):
+        """Combined mode (credentials configured + anonymous allowed) must clamp
+        the anonymous fallback to viewer even when AGENT_BOM_NO_AUTH_ROLE=admin.
+
+        Without the clamp, NO_AUTH_ROLE=admin would hand an unauthenticated caller
+        admin — they could then mint admin keys. This is the footgun, and it must
+        be closed independently of DEMO_ESTATE.
+        """
+        original_store = self._configure(monkeypatch, allow_unauthenticated=True, no_auth_role="admin")
+        try:
+            client = TestClient(app)
+            me = client.get("/v1/auth/me")
+            assert me.status_code == 200
+            assert me.json()["role"] == "viewer"
+            assert me.json()["auth_method"] == "anonymous"
+            # The clamped anonymous caller cannot mint an admin (or any) key.
+            assert client.post("/v1/auth/keys", json={"name": "escalate", "role": "admin"}).status_code == 403
+        finally:
+            self._restore(monkeypatch, original_store)
+
     def test_flag_on_session_discovery_reports_auth_not_required(self, monkeypatch):
         original_store = self._configure(monkeypatch, allow_unauthenticated=True)
         try:

--- a/tests/test_graph_cloud_edge_lifecycle.py
+++ b/tests/test_graph_cloud_edge_lifecycle.py
@@ -179,6 +179,15 @@ def _cross_account_foothold_inventory() -> dict:
                 "iam_instance_profile": "arn:aws:iam::111122223333:role/cross-account-role",
             }
         ],
+        "network_interfaces": [
+            {
+                "id": "eni-1",
+                "instance_id": "i-foothold",
+                "vpc_id": "vpc-1",
+                "subnet_id": "subnet-1",
+                "public_ip": "52.1.2.3",
+            }
+        ],
         "security_groups": [
             {
                 "group_id": "sg-1",
@@ -231,13 +240,33 @@ def test_inventory_instance_profile_assumes_role_and_marks_exposed() -> None:
 
 def test_inventory_public_foothold_triggers_public_permission_lateral() -> None:
     graph = build_unified_graph_from_report({"cloud_inventory": _cross_account_foothold_inventory()})
+    instance_id = "cloud_resource:aws:ec2:instance:i-foothold"
     role_id = "role:aws:arn:aws:iam::111122223333:role/cross-account-role"
     external_account_id = "account:aws:210987654321"
 
     hits = [f for f in build_toxic_combination_findings(graph) if f.evidence.get("rule_id") == "PUBLIC_PERMISSION_LATERAL"]
-    assert hits, "expected PUBLIC_PERMISSION_LATERAL from exposed role with cross-account trust"
-    assert role_id in hits[0].evidence["node_ids"]
-    assert external_account_id in hits[0].evidence["node_ids"]
+
+    # True positive: an internet-exposed instance can pivot to the same-account
+    # admin role it is allowed to assume (a genuine outbound lateral move).
+    assert hits, "expected PUBLIC_PERMISSION_LATERAL from exposed foothold to same-account role"
+    same_account = [f for f in hits if instance_id in f.evidence["node_ids"] and role_id in f.evidence["node_ids"]]
+    assert same_account, "expected same-account instance→role lateral finding"
+
+    # Regression guard: the role→external-account edge is INBOUND trust (the
+    # external account is allowed to assume the role, not vice-versa). It must
+    # NOT be walked as an outbound pivot, so no lateral finding may claim the
+    # exposed role moves INTO the external account.
+    assert not any(external_account_id in f.evidence["node_ids"] for f in hits), (
+        "cross-account trust is inbound and must not fabricate a lateral pivot into the trusting account"
+    )
+    # The trust edge itself is still present in the graph — we stopped walking
+    # it as a lateral vector, we did not delete the relationship.
+    assert any(
+        edge.source == role_id
+        and edge.target == external_account_id
+        and edge.relationship == RelationshipType.CROSS_ACCOUNT_TRUST
+        for edge in graph.edges
+    )
 
 
 def test_inventory_fusion_reaches_sensitive_data_store() -> None:

--- a/tests/test_graph_store_mkdir.py
+++ b/tests/test_graph_store_mkdir.py
@@ -1,0 +1,28 @@
+"""open_graph_db must create missing parent directories on a fresh deploy.
+
+Regression guard: sqlite3.connect does not create missing parent dirs, so a
+seeded demo estate on a fresh volume (no ~/.agent-bom/db) crashed to an empty
+graph with "unable to open database file".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_bom.db.graph_store import open_graph_db
+
+
+def test_open_graph_db_creates_missing_parent_dirs(tmp_path: Path) -> None:
+    db_path = tmp_path / "nested" / "deeper" / "graph.db"
+    assert not db_path.parent.exists()
+
+    with open_graph_db(db_path) as conn:
+        assert conn.execute("SELECT 1").fetchone()[0] == 1
+
+    assert db_path.parent.is_dir()
+    assert db_path.exists()
+
+
+def test_open_graph_db_memory_target_is_unaffected() -> None:
+    with open_graph_db(":memory:") as conn:
+        assert conn.execute("SELECT 1").fetchone()[0] == 1

--- a/tests/test_toxic_findings.py
+++ b/tests/test_toxic_findings.py
@@ -119,9 +119,23 @@ def _graph_agent_reaches_privileged() -> UnifiedGraph:
 def _graph_public_permission_lateral() -> UnifiedGraph:
     entry = _node("role:public_fn", EntityType.ROLE, severity="medium", internet_exposed=True)
     other = _node("account:prod", EntityType.ACCOUNT, severity="high")
+    # ASSUMES is a genuine OUTBOUND lateral capability: the exposed role can
+    # assume into account:prod. (CROSS_ACCOUNT_TRUST is inbound and must NOT
+    # count as lateral — see test_cross_account_trust_is_not_lateral.)
     return _graph(
         [entry, other],
-        [_edge("role:public_fn", "account:prod", RelationshipType.CROSS_ACCOUNT_TRUST)],
+        [_edge("role:public_fn", "account:prod", RelationshipType.ASSUMES)],
+    )
+
+
+def _graph_cross_account_trust_only() -> UnifiedGraph:
+    entry = _node("role:public_fn", EntityType.ROLE, severity="medium", internet_exposed=True)
+    other = _node("account:external", EntityType.ACCOUNT, severity="high")
+    # role -> account CROSS_ACCOUNT_TRUST encodes that the external account may
+    # assume the role (INBOUND). It is not an outbound pivot the role can walk.
+    return _graph(
+        [entry, other],
+        [_edge("role:public_fn", "account:external", RelationshipType.CROSS_ACCOUNT_TRUST)],
     )
 
 
@@ -228,6 +242,14 @@ def test_public_permission_lateral_rule():
     # max component = high (account) → critical.
     assert f.severity == "critical"
     assert "account:prod" in f.evidence["node_ids"]
+
+
+def test_cross_account_trust_is_not_lateral():
+    """Regression: a role→account CROSS_ACCOUNT_TRUST edge is INBOUND trust
+    (the account may assume the role), so an internet-exposed role must NOT be
+    reported as pivoting laterally into the trusting account."""
+    findings = build_toxic_combination_findings(_graph_cross_account_trust_only())
+    assert _by_rule(findings, "PUBLIC_PERMISSION_LATERAL") == []
 
 
 def test_severity_escalation_one_tier_above_max():


### PR DESCRIPTION
Three surgical pre-release correctness/security fixes. Each has an exact root cause and a test that now asserts the corrected behavior.

## Fix 1 — False EXPOSED_TO from permissive / default NACLs (P1, over-claim)
`_wire_network_entry_exposure_paths` emitted `EXPOSED_TO` `nacl→subnet` and `nacl→instance` for **every** subnet associated with a permissive NACL, gated only on the NACL being `internet_exposed`. A permissive NACL on a **private** subnet (no IGW route) is not internet reachability — the sibling IGW branch already restricts to public subnets.

- `graph/builder.py`: in the NACL loop, `continue` when the subnet is not in `public_subnet_ids` before drawing the subnet/instance edges (reuses the exact set the IGW branch builds from `is_public` subnets).
- `cloud/aws_inventory.py` (defense-in-depth): the AWS **default** NACL is allow-all inbound by design, so its permissive rules alone no longer set `internet_exposed` (`bool(network_exposure) and not is_default`). The builder public-subnet gate remains the primary guard.

## Fix 2 — Inverted cross-account trust direction (P1, fabricated kill-chains)
`CROSS_ACCOUNT_TRUST` / `TRUSTS` edges are `role R → principal P` where **P is allowed to assume R** (inbound trust, P→R capability). They were in `_LATERAL_RELS`, so an internet-exposed R was falsely reported as pivoting **into** P's account.

- `graph/toxic_findings.py`: removed `CROSS_ACCOUNT_TRUST` and `TRUSTS` from `_LATERAL_RELS` with a comment explaining they are inbound and must not be walked as outbound pivots. Genuine outbound vectors (`ASSUMES`, `CAN_ACCESS`, `HAS_PERMISSION`) are unchanged. The trust edges are still built in the graph — they are simply no longer treated as lateral movement.

## Fix 3 — Anonymous → admin footgun in combined mode (P2, security)
`_serve_anonymous` set `role = _no_auth_role()`, which honors `AGENT_BOM_NO_AUTH_ROLE` (can be admin/analyst) and was only clamped by `DEMO_ESTATE`. When credentials are **also** configured (a static key or stored keys), `NO_AUTH_ROLE=admin` handed an unauthenticated caller admin — enough to mint admin keys.

- `api/middleware.py`: after resolving `role`, clamp to `VIEWER` when `self._api_key or get_key_store().has_keys()`. `NO_AUTH_ROLE` elevation now applies only to a pure no-auth deployment (no credentials configured at all).

## Test changes
- `tests/test_toxic_findings.py`: the `PUBLIC_PERMISSION_LATERAL` fixture now uses a genuine outbound `ASSUMES` role→account edge (true positive still fires); added `test_cross_account_trust_is_not_lateral` asserting a trust-only graph produces no lateral finding.
- `tests/test_graph_cloud_edge_lifecycle.py`: the public-foothold fixture gains a public-IP ENI so the internet-exposed instance→same-account-role lateral (true positive) fires; the test now asserts the false cross-account pivot is gone while the `CROSS_ACCOUNT_TRUST` edge still exists in the graph.
- `tests/api/test_api_hardening.py`: added combined-mode clamp test — keys configured + `NO_AUTH_ROLE=admin` + no credential → anonymous caller is `viewer` and `POST /v1/auth/keys` → 403.

## Verification
- `ruff check` and `mypy` clean on the four changed source files.
- Full runs green: `tests/test_toxic_findings.py`, `tests/test_graph_cloud_edge_lifecycle.py`, `tests/test_graph_builder.py`, `tests/cloud` (594), `tests/api/test_api_hardening.py`, attack-path fusion/e2e.