### PR TITLE
fix(ci): isolate dashboard no-ui route tests

### DIFF
--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -207,6 +207,8 @@ def test_root_uses_hash_manifest_csp_when_bundled(tmp_path: Path, monkeypatch):
 
 def test_direct_dashboard_html_static_file_strips_csp_meta(tmp_path: Path, monkeypatch):
     """Direct static-export HTML files should use the same CSP stripping as SPA fallback."""
+    monkeypatch.delenv("AGENT_BOM_NO_UI", raising=False)
+
     package_root = tmp_path / "agent_bom"
     api_dir = package_root / "api"
     api_dir.mkdir(parents=True)
@@ -238,6 +240,8 @@ def test_direct_dashboard_html_static_file_strips_csp_meta(tmp_path: Path, monke
 
 def test_dashboard_extensionless_route_serves_static_export_page(tmp_path: Path, monkeypatch):
     """Next static-export routes such as /mesh should serve mesh.html, not index.html."""
+    monkeypatch.delenv("AGENT_BOM_NO_UI", raising=False)
+
     package_root = tmp_path / "agent_bom"
     api_dir = package_root / "api"
     api_dir.mkdir(parents=True)
@@ -275,6 +279,8 @@ def test_dashboard_extensionless_route_serves_static_export_page(tmp_path: Path,
 
 def test_dashboard_client_routes_fall_back_to_app_shell(tmp_path: Path, monkeypatch):
     """Client-only dashboard routes such as /dashboard and /settings serve the SPA shell."""
+    monkeypatch.delenv("AGENT_BOM_NO_UI", raising=False)
+
     package_root = tmp_path / "agent_bom"
     api_dir = package_root / "api"
     api_dir.mkdir(parents=True)


### PR DESCRIPTION
Summary
- Clear AGENT_BOM_NO_UI inside dashboard mount tests that construct a fake bundled ui_dist.
- Prevent release/full-suite Alpine runs from inheriting REST-only process state and falsely returning 404 for SPA fallback routes.

Verification
- AGENT_BOM_NO_UI=1 uv run pytest -q tests/api/test_api_endpoints.py::test_dashboard_client_routes_fall_back_to_app_shell
- uv run pytest -q tests/test_serve_command.py::test_serve_no_ui_sets_rest_only_env tests/api/test_api_endpoints.py::test_dashboard_client_routes_fall_back_to_app_shell tests/api/test_api_endpoints.py tests/test_surface_freshness.py
- uv run ruff check tests/api/test_api_endpoints.py
- git diff --check HEAD~1..HEAD

Notes
- Follow-up for the Alpine failure observed while fixing #3762 after that PR merged.