### PR TITLE
fix(ui): demo-estate badge no longer covers dashboard cards

### DIFF
--- a/ui/components/demo-estate-label.tsx
+++ b/ui/components/demo-estate-label.tsx
@@ -21,7 +21,7 @@ export function DemoEstateLabel() {
       className={`pointer-events-none fixed z-[120] rounded-full border border-emerald-500/40 bg-[color:var(--surface-elevated)]/95 px-3 py-1 font-medium uppercase tracking-[0.1em] text-emerald-200 shadow-md shadow-black/20 ${
         captureMode
           ? "right-5 top-3 text-[11px]"
-          : "right-5 top-[3.75rem] text-xs"
+          : "bottom-4 right-4 text-[11px]"
       }`}
       aria-hidden="true"
     >


### PR DESCRIPTION
The "Demo data — simulated estate" pill was pinned top-right and overlapped the top metric-card row (visible on the live demo). Moved the live placement to the bottom-right corner; screenshot-capture placement unchanged. One-line position change.