### PR TITLE
fix(cli): cloud scan alias crashes with TypeError (aws_include_lambda)

### DIFF
--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -176,7 +176,11 @@ def _run_cloud_scan(
         aws=aws_on,
         aws_region=aws_region,
         aws_profile=aws_profile,
-        aws_include_lambda=aws_include_lambda,
+        # The target ``scan`` command exposes lambda discovery as the negative
+        # flag ``no_aws_lambda`` (--no-aws-lambda), not ``aws_include_lambda`` —
+        # passing the wrong keyword raised TypeError and broke every
+        # ``cloud scan/aws/azure/gcp`` invocation.
+        no_aws_lambda=not aws_include_lambda,
         aws_include_eks=aws_include_eks,
         aws_include_ec2=aws_include_ec2,
         aws_include_iam=aws_include_iam,

--- a/tests/test_cli_cloud_scan.py
+++ b/tests/test_cli_cloud_scan.py
@@ -541,3 +541,47 @@ class TestRequestedProviderHardFailExits:
             quiet=True,
         )
         assert code == 1
+
+
+# ── regression: cloud aliases must call scan() with kwargs it actually accepts ──
+
+
+class TestCloudAliasKwargsMatchScanSignature:
+    """Guards the ``cloud`` group → ``scan`` invocation against keyword drift.
+
+    Regression for the 0.94.2 break where ``_run_cloud_scan`` passed
+    ``aws_include_lambda`` (the target ``scan`` command exposes ``no_aws_lambda``),
+    raising ``TypeError`` on every ``cloud scan/aws/azure/gcp`` run. The prior
+    tests missed it because they patched ``scan.callback`` with a permissive
+    ``**kwargs`` fake that swallowed the bad keyword. Here we bind the captured
+    kwargs against the REAL signature so any future rename fails loudly.
+    """
+
+    def _real_scan_signature(self):
+        import inspect
+
+        import agent_bom.cli.agents as agents
+
+        return inspect.signature(agents.scan.callback)
+
+    def _assert_kwargs_bind(self, kwargs: dict) -> None:
+        # Raises TypeError if the kwargs don't match scan()'s real parameters.
+        self._real_scan_signature().bind(**kwargs)
+        assert "no_aws_lambda" in kwargs
+        assert "aws_include_lambda" not in kwargs
+
+    def test_cloud_aws_alias_invokes_scan_cleanly(self, monkeypatch):
+        seen = _capture_scan(monkeypatch)
+        _all_configured(monkeypatch, {"aws"})
+        result = CliRunner().invoke(cloud_group, ["aws", "--region", "us-east-2"])
+        assert result.exit_code == 0, result.output
+        assert seen, "scan was never invoked"
+        self._assert_kwargs_bind(seen[-1])
+
+    def test_cloud_scan_provider_all_invokes_scan_cleanly(self, monkeypatch):
+        seen = _capture_scan(monkeypatch)
+        _all_configured(monkeypatch, {"aws", "gcp"})
+        result = CliRunner().invoke(cloud_group, ["scan", "--provider", "all"])
+        assert result.exit_code == 0, result.output
+        assert seen, "scan was never invoked"
+        self._assert_kwargs_bind(seen[-1])


### PR DESCRIPTION
**P1 — the entire `cloud` CLI group is broken in 0.94.2.** `agent-bom cloud scan/aws/azure/gcp` all crash:
```
TypeError: scan() got an unexpected keyword argument 'aws_include_lambda'
```
`_run_cloud_scan` invokes the top-level `scan` command passing `aws_include_lambda`, but that command exposes lambda discovery as `--no-aws-lambda` (param `no_aws_lambda`). Fix: pass `no_aws_lambda=not aws_include_lambda`.

**Why tests missed it:** `test_cli_cloud_scan` patched `scan.callback` with a `**kwargs` fake that swallowed the bad keyword. Added a regression that binds the captured kwargs against the **real** `scan` signature (via `inspect.signature().bind()`), so any future keyword drift fails loudly. 29 tests pass.

**Not affected:** top-level `agent-bom scan --aws …` (different path) and the API/server `/v1/scan` (uses the pipeline directly) both work. Only the CLI `cloud` alias group. Warrants a 0.94.3 patch.