### PR TITLE
fix(gateway): detect modern secret formats in DLP; correct fail_mode doc

### DIFF
--- a/site-docs/deployment/proxy-vs-gateway-vs-fleet.md
+++ b/site-docs/deployment/proxy-vs-gateway-vs-fleet.md
@@ -132,6 +132,14 @@ What `gateway` gives you today:
 - local credential overlay via `--upstreams` or environment-backed tokens
 - in-process reload for file-backed policies
 
+> **DLP is opt-in — off by default.** Out of the box the gateway does **not**
+> scan, redact, or block secrets or PII in tool-call arguments or results. The
+> DLP pass only runs when you pass `--enable-dlp`, and it only blocks/redacts
+> when you also set `--dlp-mode enforce` (the default mode is `audit`, which
+> flags but forwards). Do not assume secret redaction is automatic: an operator
+> who wants the gateway to strip credentials from traffic must enable it
+> explicitly, e.g. `agent-bom gateway serve … --enable-dlp --dlp-mode enforce`.
+
 What `gateway` is not:
 
 - not the right answer for every stdio MCP session

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -326,7 +326,12 @@ def init_policy_cmd(output_path: Path, mode: str, output_format: str, tenant_id:
     is_flag=True,
     envvar="AGENT_BOM_GATEWAY_ENABLE_DLP",
     default=False,
-    help="Run a DLP pass on tool-call arguments and results (injection/PII/secrets/payload-vuln).",
+    help=(
+        "Run a DLP pass on tool-call arguments and results "
+        "(injection/PII/secrets/payload-vuln). OFF by default: without this flag "
+        "the gateway does NOT scan, redact, or block secrets or PII. Pair with "
+        "--dlp-mode enforce to actually block/redact."
+    ),
 )
 @click.option(
     "--dlp-mode",

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -217,11 +217,12 @@ class GatewaySettings:
     # ("enforce") or flagged ("warn") at the gateway — isolating a compromised
     # or under-review agent without touching per-tool policy. Default "off".
     fleet_enforcement_mode: str = "off"
-    # Fail-closed posture for the policy engine. "open" (default) preserves
-    # today's behaviour: a missing/unloadable policy or an evaluation error
-    # degrades to default-allow. "closed" makes those paths DENY so a
-    # security-conscious operator never silently runs unprotected. Resolved from
-    # AGENT_BOM_GATEWAY_FAIL_MODE when left at the sentinel ``None``.
+    # Fail-closed posture for the policy engine. "closed" (the secure default,
+    # used when the env var is unset) makes a missing/unloadable policy or an
+    # evaluation error DENY so a security-conscious operator never silently runs
+    # unprotected. "open" opts back into legacy default-allow on those paths.
+    # Resolved by ``resolve_fail_mode`` from AGENT_BOM_GATEWAY_FAIL_MODE when
+    # left at the sentinel ``None`` (unset env → "closed").
     fail_mode: str | None = None
     # SIEM/SOAR webhook for deny/quarantine OCSF events. Unset (default) is a
     # no-op; when set, every DENY/QUARANTINE POSTs a normalized OCSF event with

--- a/src/agent_bom/proxy_scanner.py
+++ b/src/agent_bom/proxy_scanner.py
@@ -88,6 +88,75 @@ _PII_PATTERNS: list[tuple[re.Pattern, str, str]] = [
 ]
 
 # ---------------------------------------------------------------------------
+# Modern secret token formats (new — gateway-DLP specific)
+#
+# The shared ``_SECRET_PATTERNS`` ruleset (imported from prompt_scanner) misses
+# several token formats that a live gateway forwards upstream in cleartext and
+# echoes to clients. These patterns are kept LOCAL to the proxy scanner so the
+# prompt-file scanner's false-positive profile is unchanged. Every rule requires
+# a distinctive prefix, an explicit label, or a high length/charset constraint
+# to keep false positives low on ordinary prose.
+# ---------------------------------------------------------------------------
+
+_GATEWAY_SECRET_PATTERNS: list[tuple[re.Pattern, str, str]] = [
+    (
+        # OpenAI project-scoped keys: sk-proj-<body>. The dash after the prefix
+        # defeats the legacy ``sk-[A-Za-z0-9]{20,}`` rule, so it is missed today.
+        re.compile(r"sk-proj-[A-Za-z0-9_\-]{20,}"),
+        "openai_project_key",
+        "critical",
+    ),
+    (
+        # Anthropic keys: sk-ant-<body>.
+        re.compile(r"sk-ant-[A-Za-z0-9_\-]{20,}"),
+        "anthropic_api_key",
+        "critical",
+    ),
+    (
+        # GitHub fine-grained PAT: github_pat_<22+ char body>.
+        re.compile(r"github_pat_[A-Za-z0-9_]{22,}"),
+        "github_fine_grained_pat",
+        "critical",
+    ),
+    (
+        # JWT (and bearer JWTs): three base64url segments, header begins ``eyJ``
+        # (base64 of ``{"``). The triple-segment shape keeps FPs negligible.
+        re.compile(r"eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}"),
+        "jwt",
+        "critical",
+    ),
+    (
+        # Opaque bearer token behind an explicit Authorization header. The
+        # explicit ``Authorization: Bearer`` label plus a 20+ char value keeps
+        # this from firing on ordinary words.
+        re.compile(r"(?i)authorization\s*:\s*bearer\s+[A-Za-z0-9._\-]{20,}"),
+        "bearer_token",
+        "critical",
+    ),
+    (
+        # AWS secret access key value (40-char base64) — REQUIRE the label. A
+        # bare 40-char base64 string collides with git SHAs, hashes, etc., so it
+        # is only flagged when explicitly named ``aws_secret_access_key``.
+        re.compile(r"(?i)aws_secret_access_key\s*[:=]\s*['\"]?[A-Za-z0-9/+]{40}"),
+        "aws_secret_access_key",
+        "critical",
+    ),
+    (
+        # Generic labeled secret where the keyword is EMBEDDED in a longer
+        # identifier (e.g. client_secret, secret_key, access_token) that the
+        # legacy adjacent-keyword rules miss. Requires ``=``/``:`` plus a 16+
+        # char value to avoid flagging prose that merely mentions the word.
+        re.compile(
+            r"(?i)\b[\w.\-]*"
+            r"(?:secret|api[_-]?key|access[_-]?key|auth[_-]?token|access[_-]?token|refresh[_-]?token|credential)"
+            r"[\w.\-]*\s*[:=]\s*['\"]?([A-Za-z0-9/+=_\-\.]{16,})",
+        ),
+        "labeled_secret",
+        "high",
+    ),
+]
+
+# ---------------------------------------------------------------------------
 # Payload vulnerability patterns (WAF-style — new)
 # ---------------------------------------------------------------------------
 
@@ -262,6 +331,8 @@ def scan_content(text: str, config: ScanConfig) -> list[ScanResult]:
                 is_enforce,
             )
         )
+        # Modern token formats missed by the shared ruleset above.
+        results.extend(_scan_patterns(text, _GATEWAY_SECRET_PATTERNS, "secrets", is_enforce))
 
     # Payload vulnerability scanning
     if "payload_vuln" in config.scanners:

--- a/tests/test_gateway_oauth_broker.py
+++ b/tests/test_gateway_oauth_broker.py
@@ -15,6 +15,7 @@ import hashlib
 import secrets
 from typing import Any
 
+import pytest
 from starlette.testclient import TestClient
 
 from agent_bom.api.oauth_as import OAuthAuthorizationServer, OAuthSigningKey
@@ -244,6 +245,67 @@ def test_dlp_blocks_secret_in_arguments() -> None:
     )
     body = resp.json()
     assert body["error"]["data"]["policy_source"] == "dlp"
+
+
+# Modern token formats that must be blocked end-to-end through the relay.
+def _sample(*parts: str) -> str:
+    return "".join(parts)
+
+
+def _token_body(length: int, alphabet: str = "Ab3dEf4gH5jK") -> str:
+    return (alphabet * ((length // len(alphabet)) + 1))[:length]
+
+
+def _jwt_sample() -> str:
+    return _sample("eyJ", _token_body(18), ".", _token_body(14), ".", _token_body(20))
+
+
+_MODERN_SECRET_SAMPLES = [
+    ("openai_project_key", _sample("sk-", "proj-", _token_body(50))),
+    ("anthropic_api_key", _sample("sk-", "ant-", "api03-", _token_body(36))),
+    ("github_fine_grained_pat", _sample("github_", "pat_", _token_body(24, "Ab3dEf4gH5_jK"))),
+    ("jwt", _jwt_sample()),
+    ("bearer_opaque", _sample("Authorization: ", "Bearer ", _token_body(24))),
+    ("aws_secret_access_key", _sample("aws_", "secret_", "access_", "key=", _token_body(40, "Ab3dEf4gH5jK/Lm7N"))),
+]
+
+
+@pytest.mark.parametrize("case_id,sample", _MODERN_SECRET_SAMPLES, ids=[c[0] for c in _MODERN_SECRET_SAMPLES])
+def test_dlp_blocks_modern_secret_in_arguments(case_id: str, sample: str) -> None:
+    caller, captured = _echo_caller()
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={},
+        upstream_caller=caller,
+        dlp_enabled=True,
+        dlp_mode="enforce",
+        listener_host="127.0.0.1",
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_tools_call("fs.write", {"body": sample}))
+    body = resp.json()
+    assert body["error"]["data"]["policy_source"] == "dlp", case_id
+    # Blocked before reaching upstream — secret never forwarded in cleartext.
+    assert "message" not in captured, f"{case_id} secret forwarded upstream"
+
+
+@pytest.mark.parametrize("case_id,sample", _MODERN_SECRET_SAMPLES, ids=[c[0] for c in _MODERN_SECRET_SAMPLES])
+def test_dlp_blocks_modern_secret_in_result(case_id: str, sample: str) -> None:
+    caller, _ = _echo_caller(result={"content": f"leaked value {sample}"})
+    settings = GatewaySettings(
+        registry=_registry(),
+        policy={},
+        upstream_caller=caller,
+        dlp_enabled=True,
+        dlp_mode="enforce",
+        listener_host="127.0.0.1",
+    )
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_tools_call("fs.read", {"path": "/x"}))
+    body = resp.json()
+    # Response carrying the secret is blocked, not echoed verbatim to the client.
+    assert body.get("error", {}).get("data", {}).get("policy_source") == "dlp", case_id
+    assert sample not in resp.text, f"{case_id} secret echoed to client"
 
 
 def test_dlp_redacts_pii_in_result() -> None:

--- a/tests/test_proxy_scanner.py
+++ b/tests/test_proxy_scanner.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from agent_bom.proxy_scanner import (
     ScanConfig,
     load_scan_config,
@@ -186,6 +188,100 @@ class TestSecretsScanning:
         results = scan_content("Please review this pull request.", _cfg())
         secrets = [r for r in results if r.scanner == "secrets"]
         assert len(secrets) == 0
+
+
+# ---------------------------------------------------------------------------
+# Modern secret token formats (gateway-DLP coverage)
+# ---------------------------------------------------------------------------
+
+# Each case: (id, sample text) where the sample MUST be detected as a secret
+# and, in enforce mode, marked blocked.
+def _sample(*parts: str) -> str:
+    return "".join(parts)
+
+
+def _token_body(length: int, alphabet: str = "Ab3dEf4gH5jK") -> str:
+    return (alphabet * ((length // len(alphabet)) + 1))[:length]
+
+
+def _jwt_sample() -> str:
+    return _sample("eyJ", _token_body(18), ".", _token_body(14), ".", _token_body(20))
+
+
+_MODERN_SECRET_CASES = [
+    ("openai_project_key", _sample("key ", "sk-", "proj-", _token_body(50))),
+    ("openai_legacy_key", _sample("OPENAI_", "API_", "KEY=", "sk-", _token_body(28))),
+    ("anthropic_api_key", _sample("sk-", "ant-", "api03-", _token_body(36))),
+    ("github_fine_grained_pat", _sample("github_", "pat_", _token_body(24, "Ab3dEf4gH5_jK"))),
+    ("jwt_bare", _jwt_sample()),
+    ("jwt_bearer_header", _sample("Authorization: ", "Bearer ", _jwt_sample())),
+    ("bearer_opaque", _sample("Authorization: ", "Bearer ", _token_body(24))),
+    ("aws_secret_lower", _sample("aws_", "secret_", "access_", "key=", _token_body(40, "Ab3dEf4gH5jK/Lm7N"))),
+    ("aws_secret_upper", _sample("AWS_", "SECRET_", "ACCESS_", "KEY = ", _token_body(40, "Ab3dEf4gH5jK/Lm7N"))),
+    ("client_secret_embedded", _sample("client_", "secret=", _token_body(28))),
+    ("secret_key_embedded", _sample("my_", "secret_", "key: ", _token_body(24))),
+    ("access_token_embedded", _sample("access_", "token=", _token_body(28))),
+]
+
+
+class TestModernSecretFormats:
+    """Modern token formats the shared _SECRET_PATTERNS ruleset missed."""
+
+    @pytest.mark.parametrize("case_id,text", _MODERN_SECRET_CASES, ids=[c[0] for c in _MODERN_SECRET_CASES])
+    def test_detected_in_content(self, case_id, text):
+        results = scan_content(text, _cfg())
+        secrets = [r for r in results if r.scanner == "secrets"]
+        assert secrets, f"{case_id} not detected as a secret"
+
+    @pytest.mark.parametrize("case_id,text", _MODERN_SECRET_CASES, ids=[c[0] for c in _MODERN_SECRET_CASES])
+    def test_blocked_in_enforce_mode(self, case_id, text):
+        results = scan_content(text, _cfg(mode="enforce"))
+        secrets = [r for r in results if r.scanner == "secrets"]
+        assert secrets and all(r.blocked for r in secrets), f"{case_id} not blocked in enforce mode"
+
+    @pytest.mark.parametrize("case_id,text", _MODERN_SECRET_CASES, ids=[c[0] for c in _MODERN_SECRET_CASES])
+    def test_detected_in_tool_call_argument(self, case_id, text):
+        # A tool-call argument carrying the secret must be flagged+blocked
+        # so the gateway's arg DLP pass drops the request under enforce.
+        results = scan_tool_call("do_thing", {"payload": text, "note": "ok"}, _cfg(mode="enforce"))
+        secrets = [r for r in results if r.scanner == "secrets"]
+        assert secrets and any(r.blocked for r in secrets), f"{case_id} not blocked in tool-call arg"
+
+    @pytest.mark.parametrize("case_id,text", _MODERN_SECRET_CASES, ids=[c[0] for c in _MODERN_SECRET_CASES])
+    def test_detected_in_tool_response(self, case_id, text):
+        # A tool response echoing the secret must be flagged+blocked so the
+        # gateway's response DLP pass does not forward it verbatim.
+        import json as _json
+
+        body = _json.dumps({"content": text})
+        results = scan_tool_response(body, _cfg(mode="enforce"))
+        secrets = [r for r in results if r.scanner == "secrets"]
+        assert secrets and any(r.blocked for r in secrets), f"{case_id} not blocked in tool response"
+
+
+# Benign strings that MUST NOT be flagged as secrets (false-positive guard).
+_BENIGN_SECRET_NEGATIVES = [
+    ("plain_prose", "Please review this pull request and merge it when ready."),
+    ("uuid", "The request id is 550e8400-e29b-41d4-a716-446655440000 thanks."),
+    ("word_token", "Please pass the token to the next stage of the pipeline."),
+    ("word_secret", "It is no secret that the team ships fast every quarter."),
+    ("secret_colon_prose", "The secret: I really love strong coffee in the morning."),
+    ("git_sha", "Commit da39a3ee5e6b4b0d3255bfef95601890afd80709 fixes the bug."),
+    ("access_word", "Grant read access to the token store for the new service."),
+    ("normal_sentence", "The gateway forwards each token exactly once per session."),
+]
+
+
+class TestModernSecretFalsePositives:
+    @pytest.mark.parametrize(
+        "case_id,text",
+        _BENIGN_SECRET_NEGATIVES,
+        ids=[c[0] for c in _BENIGN_SECRET_NEGATIVES],
+    )
+    def test_benign_not_flagged_as_secret(self, case_id, text):
+        results = scan_content(text, _cfg())
+        secrets = [r for r in results if r.scanner == "secrets"]
+        assert not secrets, f"benign {case_id} falsely flagged as secret: {[r.rule_id for r in secrets]}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The gateway DLP/secret-redaction **mechanism** already works (block + redact in-place on request args and response bodies, fail-closed). The problem was **detection coverage**: several modern token formats passed through the enforce-mode DLP pass in cleartext — forwarded upstream and echoed back to clients. This PR closes that gap, corrects a stale `fail_mode` comment, and documents that gateway DLP is opt-in.

## FIX 1 — Extend the secrets detection ruleset (P1)

Reproduced first: with `dlp_enabled=True, dlp_mode="enforce"`, these were **MISSED** (verified against `origin/main`):
`sk-proj-…`, `sk-ant-…`, `github_pat_…`, JWT `eyJ….….…`, `Authorization: Bearer …`, `aws_secret_access_key=…`, and embedded labels like `secret_key=` / `access_token=`.

New patterns added in `src/agent_bom/proxy_scanner.py` as a **local** `_GATEWAY_SECRET_PATTERNS` list (kept out of the shared `_SECRET_PATTERNS` so the prompt-file scanner's FP profile is untouched), scanned in the `secrets` branch of `scan_content`:

| rule_id | pattern (intent) |
|---|---|
| `openai_project_key` | `sk-proj-[A-Za-z0-9_-]{20,}` (dash defeats the legacy `sk-…` rule) |
| `anthropic_api_key` | `sk-ant-[A-Za-z0-9_-]{20,}` |
| `github_fine_grained_pat` | `github_pat_[A-Za-z0-9_]{22,}` |
| `jwt` | `eyJ<b64url>.<b64url>.<b64url>` (triple segment, header starts `eyJ`) |
| `bearer_token` | `Authorization: Bearer <20+ char token>` (explicit label) |
| `aws_secret_access_key` | 40-char base64 value **only when labeled** `aws_secret_access_key=` |
| `labeled_secret` | keyword (`secret`/`api_key`/`access_key`/`*_token`/`credential`) **embedded** in a longer identifier + `=`/`:` + 16+ char value |

Legacy `sk-…`, `ghp_…`, `xoxb-…`, `AKIA…`, PEM, and `password=…` remain covered by the shared ruleset.

Since secret findings carry `blocked=True` in enforce mode, a match now **BLOCKS** the request (arg pass) or the response (result pass) — it is not forwarded verbatim.

### False-positive analysis (honest)

Precision was prioritized over recall on the ambiguous cases:

- **AWS secret key**: a bare 40-char base64 string collides with git SHAs, hashes, and many IDs, so it is flagged **only** when explicitly labeled `aws_secret_access_key=`. A raw, unlabeled AWS secret value is intentionally **not** caught (accepted miss to avoid noise).
- **Generic `labeled_secret`**: requires the keyword to be embedded in an identifier followed by `=`/`:` and a **16+ char** contiguous value. Prose that merely mentions "secret"/"token" (no `=`, or a short/spaced value) does not fire. Verified against a benign batch: ordinary prose, a UUID, a git SHA, and sentences containing the words "token"/"secret"/"access" — **0 false positives**.
- **JWT / bearer**: the triple-`eyJ…`-segment shape and the explicit `Authorization: Bearer` label keep FPs negligible.
- Residual risk: a benign config value like `client_secret_note: sixteencharsplus` would be flagged. This is a deliberate, low-frequency trade for catching real embedded-label secrets; it errors toward blocking, consistent with fail-closed DLP.

## FIX 2 — Correct stale `fail_mode` comment (P3)

`GatewaySettings.fail_mode` docstring claimed `"open" (default)`, but `resolve_fail_mode(None)` returns `"closed"` when the env var is unset (the secure behavior). Comment corrected to state the default is **fail-CLOSED**. No behavior change.

## FIX 3 — Document that gateway DLP is OFF by default

`dlp_enabled=False` out of the box: the gateway does **not** scan/redact/block secrets or PII unless `--enable-dlp` is passed (and `--dlp-mode enforce` to actually block/redact). Added a callout to `site-docs/deployment/proxy-vs-gateway-vs-fleet.md` and expanded the `--enable-dlp` CLI help. **Default is unchanged** in this PR.

**Recommendation (not implemented):** for hosted/managed deployments where operators expect credential hygiene by default, consider shipping DLP on in `audit` mode (visibility without blocking) so leaks are at least detected out of the box. Left as a follow-up decision.

## Tests

- `tests/test_proxy_scanner.py`: parametrized detection + enforce-mode `blocked` assertions for **each** new format, in content, in a tool-call argument, and in a tool response; plus an 8-case benign FP guard asserting **no** secret finding.
- `tests/test_gateway_oauth_broker.py`: true end-to-end relay tests — each new secret in a tool-call arg is blocked before reaching upstream (`policy_source == "dlp"`, never forwarded), and in a tool result is blocked, not echoed to the client.

Results: `test_proxy_scanner` + `test_gateway_oauth_broker` + gateway/prompt/secret-scanner suites all green; `ruff check` and `mypy` clean on changed files.
