### PR TITLE
fix(cli): harden focused-command formats, unscanned-check gate, friendly findings error, --aws-deep

### DIFF
--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -617,6 +617,10 @@ def check(
     from agent_bom.parsers.os_parsers import enrich_os_package_context
 
     if version == "unknown":
+        # Without a version we cannot query OSV, so NOTHING was actually
+        # checked. This is an incomplete scan, not a clean pass — exit
+        # non-zero (rc=2) so a CI pre-install gate does not treat an
+        # unscanned package as safe.
         message = f"No version specified for {name}; skipping OSV lookup."
         if structured_output:
             _write_check_output(
@@ -626,11 +630,11 @@ def check(
                     ecosystems=[detected_eco],
                     verdict="skipped",
                     message=message,
-                    exit_code=0,
+                    exit_code=2,
                 ),
                 output_path,
                 agent_mode=agent_mode,
-                exit_code=0,
+                exit_code=2,
                 output_format=output_format,
             )
         else:
@@ -641,7 +645,7 @@ def check(
             warn_console = Console(stderr=True, no_color=no_color)
             warn_console.print(f"[bold yellow]⚠ WARNING: no version given for '{name}' — NOT scanned (OSV lookup skipped).[/bold yellow]")
             warn_console.print(f"  This is not a clean result. Re-run with a version: agent-bom check {name}@<version>")
-        sys.exit(0)
+        sys.exit(2)
 
     ecosystems = _resolve_check_ecosystems(name, version, ecosystem, detected_eco)
     pkgs = [Package(name=name, version=version, ecosystem=eco) for eco in ecosystems]

--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -256,6 +256,11 @@ def cloud_group(ctx: click.Context) -> None:
 @click.option("--include-eks", is_flag=True, help="Include EKS workloads (aws only).")
 @click.option("--include-ec2", is_flag=True, help="Include EC2 instances (aws only).")
 @click.option("--include-iam", is_flag=True, help="Enrich identity graph with IAM (aws only).")
+@click.option(
+    "--aws-deep",
+    is_flag=True,
+    help="Full AWS scan: enable EKS, EC2, and IAM discovery at once (convenience alias, aws only).",
+)
 @click.option("--subscription", default=None, help="Azure subscription ID (azure only).")
 @click.option("--project", default=None, help="GCP project ID (gcp only).")
 @click.option("--cis/--no-cis", default=True, show_default=True, help="Run CIS benchmark for each selected provider.")
@@ -281,6 +286,7 @@ def scan_cmd(
     include_eks: bool,
     include_ec2: bool,
     include_iam: bool,
+    aws_deep: bool,
     subscription: Optional[str],
     project: Optional[str],
     cis: bool,
@@ -313,9 +319,9 @@ def scan_cmd(
         aws_region=region,
         aws_profile=profile,
         aws_include_lambda=not skip_lambda,
-        aws_include_eks=include_eks,
-        aws_include_ec2=include_ec2,
-        aws_include_iam=include_iam,
+        aws_include_eks=include_eks or aws_deep,
+        aws_include_ec2=include_ec2 or aws_deep,
+        aws_include_iam=include_iam or aws_deep,
         azure_subscription=subscription,
         gcp_project=project,
         cis=cis,
@@ -334,6 +340,11 @@ def scan_cmd(
 @click.option("--include-eks", is_flag=True, help="Include EKS workloads")
 @click.option("--include-ec2", is_flag=True, help="Include EC2 instances")
 @click.option("--include-iam", is_flag=True, help="Enrich identity graph with IAM role policies and trust principals")
+@click.option(
+    "--aws-deep",
+    is_flag=True,
+    help="Full AWS scan: enable EKS, EC2, and IAM discovery at once (convenience alias).",
+)
 @click.option("--cis", is_flag=True, default=True, help="Run CIS benchmark (default: on)")
 @click.option("--no-cis", is_flag=True, help="Skip CIS benchmark")
 @click.option("--show-passed", is_flag=True, help="List passed CIS checks instead of collapsing them into a count.")
@@ -348,6 +359,7 @@ def aws_cmd(
     include_eks: bool,
     include_ec2: bool,
     include_iam: bool,
+    aws_deep: bool,
     cis: bool,
     no_cis: bool,
     show_passed: bool,
@@ -366,9 +378,9 @@ def aws_cmd(
         aws_region=region,
         aws_profile=profile,
         aws_include_lambda=not skip_lambda,
-        aws_include_eks=include_eks,
-        aws_include_ec2=include_ec2,
-        aws_include_iam=include_iam,
+        aws_include_eks=include_eks or aws_deep,
+        aws_include_ec2=include_ec2 or aws_deep,
+        aws_include_iam=include_iam or aws_deep,
         cis=cis and not no_cis,
         show_passed=show_passed,
         output_format=output_format,

--- a/src/agent_bom/cli/_findings_group.py
+++ b/src/agent_bom/cli/_findings_group.py
@@ -110,8 +110,19 @@ def _print_triage_table(payload: JsonObject) -> None:
 
 
 def _run_request(client: AgentBomClient, callback: Any) -> JsonObject:
+    import httpx
+
     try:
         return callback(client)
+    except httpx.RequestError as exc:
+        # No server listening (or unreachable): give the same friendly
+        # guidance the `fleet` commands print instead of dumping a raw
+        # "[Errno 61] Connection refused" traceback.
+        raise click.ClickException(
+            f"Could not reach the agent-bom API server at {client.base_url}. "
+            "This command requires the API server. Start it with:\n"
+            "  agent-bom api"
+        ) from exc
     except AgentBomApiError as exc:
         raise click.ClickException(f"API request failed with {exc.status_code}: {exc.body[:500]}") from exc
     except ValueError as exc:

--- a/src/agent_bom/cli/_focused_commands.py
+++ b/src/agent_bom/cli/_focused_commands.py
@@ -20,7 +20,25 @@ from typing import Optional
 
 import click
 
+from agent_bom.cli._scan_help import AliasedChoice
+from agent_bom.cli.options_sources import SCAN_OUTPUT_FORMAT_ALIASES, SCAN_OUTPUT_FORMATS
 from agent_bom.graph.severity import severity_at_or_above
+
+
+def _scan_format_option():
+    """`-f/--format` validated against the same formats the `scan` command accepts.
+
+    A bad ``-f`` is rejected with rc=2 (like `scan`), instead of being accepted
+    as a free string that silently bypasses the default fail-on-severity gate.
+    """
+    return click.option(
+        "-f",
+        "--format",
+        "output_format",
+        type=AliasedChoice(SCAN_OUTPUT_FORMATS, aliases=SCAN_OUTPUT_FORMAT_ALIASES),
+        default="console",
+        help="Output format",
+    )
 
 
 def _validate_json_or_console_format(command_name: str, output_format: str) -> str:
@@ -52,11 +70,11 @@ def _has_finding_at_or_above(findings, threshold: str = "high") -> bool:
     "--tar",
     "--image-tar",
     "image_tar",
-    type=click.Path(exists=False, dir_okay=True, file_okay=True, path_type=str),
+    type=click.Path(exists=True, dir_okay=True, file_okay=True, path_type=str),
     help="Scan a docker save / OCI image tarball without a Docker daemon.",
 )
 @click.option("--platform", help="Target platform (e.g. linux/amd64)")
-@click.option("-f", "--format", "output_format", default="console", help="Output format")
+@_scan_format_option()
 @click.option("-o", "--output", "output_path", help="Output file path")
 @click.option("--fail-on-severity", type=click.Choice(["critical", "high", "medium", "low"]))
 @click.option("--enrich", is_flag=True, help="Add NVD CVSS + EPSS + KEV enrichment")
@@ -129,7 +147,7 @@ def image_cmd(
 
 @click.command("fs")
 @click.argument("path")
-@click.option("-f", "--format", "output_format", default="console", help="Output format")
+@_scan_format_option()
 @click.option("-o", "--output", "output_path", help="Output file path")
 @click.option("--fail-on-severity", type=click.Choice(["critical", "high", "medium", "low"]))
 @click.option("--enrich", is_flag=True, help="Add NVD CVSS + EPSS + KEV enrichment")
@@ -192,7 +210,7 @@ def fs_cmd(
 
 @click.command("iac")
 @click.argument("paths", nargs=-1, required=True)
-@click.option("-f", "--format", "output_format", default="console", help="Output format")
+@_scan_format_option()
 @click.option("-o", "--output", "output_path", help="Output file path")
 @click.option("--fail-on-severity", type=click.Choice(["critical", "high", "medium", "low"]))
 @click.option("--quiet", "-q", is_flag=True, help="Minimal output")
@@ -224,7 +242,16 @@ def iac_cmd(
       agent-bom iac . -f sarif -o iac-results.sarif
       agent-bom iac . --k8s-live --k8s-all-namespaces
     """
+    from pathlib import Path as _Path
+
     from agent_bom.cli.agents import scan
+
+    # A missing/typo'd IaC target must never be reported as a clean scan.
+    missing = [p for p in paths if not _Path(p).exists()]
+    if missing:
+        raise click.ClickException(
+            "IaC target(s) not found: " + ", ".join(missing) + ". Check the path(s) and try again."
+        )
 
     effective_fail_on_severity = fail_on_severity
     if effective_fail_on_severity is None and output_format.lower() in {"console", "json"}:
@@ -252,7 +279,7 @@ def iac_cmd(
 @click.command("sbom")
 @click.argument("path", type=click.Path(exists=True, dir_okay=False, readable=True))
 @click.option("--name", "sbom_name", help="Label for the SBOM resource")
-@click.option("-f", "--format", "output_format", default="console", help="Output format")
+@_scan_format_option()
 @click.option("-o", "--output", "output_path", help="Output file path")
 @click.option("--fail-on-severity", type=click.Choice(["critical", "high", "medium", "low"]))
 @click.option("--enrich", is_flag=True, help="Add NVD CVSS + EPSS + KEV enrichment")

--- a/src/agent_bom/cli/_focused_commands.py
+++ b/src/agent_bom/cli/_focused_commands.py
@@ -16,6 +16,7 @@ Usage::
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Optional
 
 import click
@@ -70,7 +71,7 @@ def _has_finding_at_or_above(findings, threshold: str = "high") -> bool:
     "--tar",
     "--image-tar",
     "image_tar",
-    type=click.Path(exists=True, dir_okay=True, file_okay=True, path_type=str),
+    type=click.Path(dir_okay=False, file_okay=True, path_type=str),
     help="Scan a docker save / OCI image tarball without a Docker daemon.",
 )
 @click.option("--platform", help="Target platform (e.g. linux/amd64)")
@@ -124,6 +125,8 @@ def image_cmd(
 
     if bool(image_ref) == bool(image_tar):
         raise click.UsageError("Provide exactly one image reference or --tar/--image-tar path.")
+    if image_tar and not Path(image_tar).expanduser().is_file():
+        raise click.BadParameter(f"Path '{image_tar}' does not exist.", param_hint="--tar")
 
     ctx = click.get_current_context()
     ctx.invoke(
@@ -249,9 +252,7 @@ def iac_cmd(
     # A missing/typo'd IaC target must never be reported as a clean scan.
     missing = [p for p in paths if not _Path(p).exists()]
     if missing:
-        raise click.ClickException(
-            "IaC target(s) not found: " + ", ".join(missing) + ". Check the path(s) and try again."
-        )
+        raise click.ClickException("IaC target(s) not found: " + ", ".join(missing) + ". Check the path(s) and try again.")
 
     effective_fail_on_severity = fail_on_severity
     if effective_fail_on_severity is None and output_format.lower() in {"console", "json"}:

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -389,6 +389,7 @@ def scan(
     aws_include_step_functions: bool,
     aws_include_ec2: bool,
     aws_include_iam: bool,
+    aws_deep: bool,
     aws_ec2_tag: Optional[str],
     aws_cis_benchmark: bool,
     snowflake_cis_benchmark: bool,
@@ -517,6 +518,16 @@ def scan(
     from agent_bom.cli._profiles import apply_scan_profile_defaults
 
     agent_mode = agent_mode or agent_mode_requested()
+
+    # `--aws-deep` is a convenience alias that ORs on every granular AWS
+    # discovery toggle. It never turns anything off, so it composes with any
+    # individually supplied --aws-include-* flag and leaves defaults unchanged
+    # when absent.
+    if aws_deep:
+        aws_include_eks = True
+        aws_include_step_functions = True
+        aws_include_ec2 = True
+        aws_include_iam = True
 
     if _apply_profile_defaults:
         (

--- a/src/agent_bom/cli/options_sources.py
+++ b/src/agent_bom/cli/options_sources.py
@@ -9,6 +9,35 @@ import click
 from agent_bom.cli._scan_help import AliasedChoice
 from agent_bom.cli.options_helpers import _apply
 
+# Canonical `--format` choices accepted by the top-level `scan` command. The
+# focused commands (fs/iac/sbom/image) forward straight to `scan`, so they
+# reuse this exact list to validate `-f/--format` instead of accepting any
+# free string (which silently disabled the fail-on-severity gate).
+SCAN_OUTPUT_FORMATS = [
+    "console",
+    "json",
+    "html",
+    "pdf",
+    "sarif",
+    "cyclonedx",
+    "spdx",
+    "spdx2",
+    "junit",
+    "csv",
+    "parquet",
+    "markdown",
+    "plain",
+    "prometheus",
+    "graph",
+    "graph-html",
+    "mermaid",
+    "svg",
+    "badge",
+]
+# `text` is a deprecated spelling of the canonical `plain`; still accepted,
+# but hidden from the advertised choices.
+SCAN_OUTPUT_FORMAT_ALIASES = {"text": "plain"}
+
 
 def _set_env(var: str):
     """Click callback: mirror a CLI value into ``os.environ`` when provided.
@@ -169,30 +198,8 @@ def output_options(fn):
                 "-f",
                 "output_format",
                 type=AliasedChoice(
-                    [
-                        "console",
-                        "json",
-                        "html",
-                        "pdf",
-                        "sarif",
-                        "cyclonedx",
-                        "spdx",
-                        "spdx2",
-                        "junit",
-                        "csv",
-                        "parquet",
-                        "markdown",
-                        "plain",
-                        "prometheus",
-                        "graph",
-                        "graph-html",
-                        "mermaid",
-                        "svg",
-                        "badge",
-                    ],
-                    # `text` is a deprecated spelling of the canonical `plain`;
-                    # still accepted, but hidden from the advertised choices.
-                    aliases={"text": "plain"},
+                    SCAN_OUTPUT_FORMATS,
+                    aliases=SCAN_OUTPUT_FORMAT_ALIASES,
                 ),
                 default="console",
                 help=(

--- a/src/agent_bom/cli/options_surfaces.py
+++ b/src/agent_bom/cli/options_surfaces.py
@@ -244,6 +244,12 @@ def cloud_options(fn):
             click.option("--aws-include-ec2", is_flag=True, help="Discover EC2 instances by tag (used with --aws)"),
             click.option("--aws-include-iam", is_flag=True, help="Enrich AWS identity graph with IAM role policies and trust principals"),
             click.option(
+                "--aws-deep",
+                is_flag=True,
+                help="Full AWS scan: enable EKS, Step Functions, EC2, and IAM discovery at once "
+                "(convenience alias for --aws-include-eks --aws-include-step-functions --aws-include-ec2 --aws-include-iam).",
+            ),
+            click.option(
                 "--aws-ec2-tag", default=None, metavar="KEY=VALUE", help="EC2 tag filter for --aws-include-ec2 (e.g. 'Environment=ai-prod')"
             ),
             click.option("--azure", "azure_flag", is_flag=True, help="Discover agents from Azure AI Foundry and Container Apps"),

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -522,3 +522,27 @@ def test_check_output_requires_json_format(monkeypatch):
 
     assert result.exit_code == 1
     assert "--format json" in result.output
+
+
+def test_check_without_version_exits_nonzero(monkeypatch):
+    """`check <pkg>` with no @version scans nothing, so it must not exit 0 —
+    a CI pre-install gate must never treat an unscanned package as clean."""
+    _patch_check_scan(monkeypatch, [])
+
+    result = CliRunner().invoke(main, ["check", "somepkg", "--ecosystem", "pypi"])
+
+    assert result.exit_code != 0
+    assert result.exit_code == 2
+    assert "not a clean result" in result.output
+
+
+def test_check_without_version_json_reports_nonzero(monkeypatch):
+    """Structured output for the no-version skip must also carry exit_code=2."""
+    _patch_check_scan(monkeypatch, [])
+
+    result = CliRunner().invoke(main, ["check", "somepkg", "--ecosystem", "pypi", "--format", "json"])
+
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["verdict"] == "skipped"
+    assert payload["exit_code"] == 2

--- a/tests/test_cli_cloud_scan.py
+++ b/tests/test_cli_cloud_scan.py
@@ -585,3 +585,32 @@ class TestCloudAliasKwargsMatchScanSignature:
         assert result.exit_code == 0, result.output
         assert seen, "scan was never invoked"
         self._assert_kwargs_bind(seen[-1])
+
+
+# ── --aws-deep convenience flag ──────────────────────────────────────────────
+
+
+class TestAwsDeep:
+    def test_cloud_scan_aws_deep_sets_all_includes(self, monkeypatch):
+        seen = _capture_scan(monkeypatch)
+        r = CliRunner().invoke(cloud_group, ["scan", "--provider", "aws", "--aws-deep"])
+        assert r.exit_code == 0
+        assert seen[0]["aws_include_eks"] is True
+        assert seen[0]["aws_include_ec2"] is True
+        assert seen[0]["aws_include_iam"] is True
+
+    def test_cloud_aws_alias_deep_sets_all_includes(self, monkeypatch):
+        seen = _capture_scan(monkeypatch)
+        r = CliRunner().invoke(cloud_group, ["aws", "--aws-deep"])
+        assert r.exit_code == 0
+        assert seen[0]["aws_include_eks"] is True
+        assert seen[0]["aws_include_ec2"] is True
+        assert seen[0]["aws_include_iam"] is True
+
+    def test_cloud_scan_without_deep_leaves_includes_off(self, monkeypatch):
+        seen = _capture_scan(monkeypatch)
+        r = CliRunner().invoke(cloud_group, ["scan", "--provider", "aws"])
+        assert r.exit_code == 0
+        assert seen[0]["aws_include_eks"] is False
+        assert seen[0]["aws_include_ec2"] is False
+        assert seen[0]["aws_include_iam"] is False

--- a/tests/test_cli_findings.py
+++ b/tests/test_cli_findings.py
@@ -225,3 +225,45 @@ def test_findings_triage_export_vex_writes_file(monkeypatch, tmp_path) -> None:
     assert "Wrote" in result.output
     assert json.loads(output.read_text(encoding="utf-8"))["schema_version"] == "findings.triage.vex.v1"
     assert fake.calls[0] == ("export_finding_triage_vex", {})
+
+
+class ConnRefusedClient:
+    """Client whose server-backed calls fail as if no API server is listening."""
+
+    base_url = "http://127.0.0.1:8422"
+
+    def __init__(self, **kwargs: Any) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def _refuse(self, *args: Any, **kwargs: Any):
+        import httpx
+
+        raise httpx.ConnectError("[Errno 61] Connection refused")
+
+    list_findings = _refuse
+    list_finding_triage = _refuse
+
+
+def _install_refused_client(monkeypatch) -> None:
+    monkeypatch.setattr("agent_bom.cli._findings_group.AgentBomClient", ConnRefusedClient)
+
+
+def test_findings_list_connection_refused_is_friendly(monkeypatch) -> None:
+    _install_refused_client(monkeypatch)
+    result = CliRunner().invoke(main, ["findings", "list"])
+    assert result.exit_code != 0
+    assert "Connection refused" not in result.output
+    assert "requires the API server" in result.output
+    assert "agent-bom api" in result.output
+
+
+def test_findings_triage_list_connection_refused_is_friendly(monkeypatch) -> None:
+    _install_refused_client(monkeypatch)
+    result = CliRunner().invoke(main, ["findings", "triage", "list"])
+    assert result.exit_code != 0
+    assert "Connection refused" not in result.output
+    assert "requires the API server" in result.output
+    assert "agent-bom api" in result.output

--- a/tests/test_cli_p1_polish.py
+++ b/tests/test_cli_p1_polish.py
@@ -117,7 +117,7 @@ def test_check_no_version_warns_loudly_on_stderr() -> None:
     """A version-less `check` must surface a loud NOT-scanned warning, not a
     silent skip on stdout that reads like a clean result."""
     result = CliRunner().invoke(main, ["check", "requests"])
-    assert result.exit_code == 0
+    assert result.exit_code == 2
     # Click 8.2+ captures stderr separately; the warning must be there.
     assert result.stdout == ""
     assert "WARNING" in result.stderr

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1882,3 +1882,48 @@ def test_scan_positional_with_image_still_routes_to_image(tmp_path):
     assert image_calls == ["alpine:3.19"]
     # Local project discovery was skipped for image scans (no hijack via PATH).
     assert discover_calls == []
+
+
+# ---------------------------------------------------------------------------
+# --aws-deep convenience flag on the top-level scan command
+# ---------------------------------------------------------------------------
+
+
+def _capture_dry_run_plan(monkeypatch):
+    """Capture the kwargs the scan command hands to emit_dry_run_plan.
+
+    --dry-run runs after the --aws-deep flags are resolved but before any
+    real discovery, so the plan kwargs are a faithful, side-effect-free view
+    of the resolved aws_include_* toggles.
+    """
+    seen: dict = {}
+
+    def fake_plan(_con, **kwargs):
+        seen.update(kwargs)
+
+    monkeypatch.setattr("agent_bom.cli.agents.emit_dry_run_plan", fake_plan)
+    return seen
+
+
+def test_scan_aws_deep_enables_all_aws_includes(monkeypatch, tmp_path):
+    seen = _capture_dry_run_plan(monkeypatch)
+    result = _run(
+        ["scan", str(tmp_path), "--aws", "--aws-deep", "--dry-run", "--no-scan", "--no-auto-update-db", "--offline"],
+    )
+    assert result.exit_code == 0, result.output
+    assert seen["aws_include_eks"] is True
+    assert seen["aws_include_step_functions"] is True
+    assert seen["aws_include_ec2"] is True
+    assert seen["aws_include_iam"] is True
+
+
+def test_scan_without_aws_deep_leaves_aws_includes_off(monkeypatch, tmp_path):
+    seen = _capture_dry_run_plan(monkeypatch)
+    result = _run(
+        ["scan", str(tmp_path), "--aws", "--dry-run", "--no-scan", "--no-auto-update-db", "--offline"],
+    )
+    assert result.exit_code == 0, result.output
+    assert seen["aws_include_eks"] is False
+    assert seen["aws_include_step_functions"] is False
+    assert seen["aws_include_ec2"] is False
+    assert seen["aws_include_iam"] is False

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1107,6 +1107,8 @@ def test_scan_sarif_does_not_auto_enable_context_graph(tmp_path):
 
 def test_scan_finding_count_parity_across_formats(tmp_path):
     """json/csv/sarif of the same scan must report identical finding counts (#3643)."""
+    project = tmp_path / "project"
+    project.mkdir()
     out = tmp_path / "out"
     out.mkdir()
 
@@ -1118,7 +1120,7 @@ def test_scan_finding_count_parity_across_formats(tmp_path):
             patch("agent_bom.cli.agents.scan_agents_sync", return_value=br),
             patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=[]),
         ):
-            return _run(["scan", "--project", str(tmp_path), "-f", fmt, "-o", str(path), "--no-auto-update-db"])
+            return _run(["scan", "--project", str(project), "-f", fmt, "-o", str(path), "--no-auto-update-db"])
 
     jf, sf, cf = out / "r.json", out / "r.sarif", out / "r.csv"
     _scan("json", jf)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1288,8 +1288,10 @@ def test_cli_scan_has_image_flag():
     assert "--image" in result.output
 
 
-def test_cli_image_accepts_tarball_without_image_ref(monkeypatch):
+def test_cli_image_accepts_tarball_without_image_ref(monkeypatch, tmp_path):
     seen = []
+    image_tar = tmp_path / "image.tar"
+    image_tar.write_bytes(b"")
 
     def fake_scan(**kwargs):
         seen.append(kwargs)
@@ -1297,11 +1299,11 @@ def test_cli_image_accepts_tarball_without_image_ref(monkeypatch):
     monkeypatch.setattr("agent_bom.cli.agents.scan.callback", fake_scan)
 
     runner = CliRunner()
-    result = runner.invoke(main, ["image", "--tar", "image.tar", "--quiet"])
+    result = runner.invoke(main, ["image", "--tar", str(image_tar), "--quiet"])
 
     assert result.exit_code == 0
     assert seen[0]["images"] == ()
-    assert seen[0]["image_tars"] == ("image.tar",)
+    assert seen[0]["image_tars"] == (str(image_tar),)
     assert seen[0]["_image_only"] is True
     assert seen[0]["no_skill"] is True
 

--- a/tests/test_focused_security_gates.py
+++ b/tests/test_focused_security_gates.py
@@ -249,3 +249,53 @@ def test_image_and_fs_expose_ignore_and_exclude_unfixable():
         assert result.exit_code == 0
         assert "--ignore" in result.output
         assert "--exclude-unfixable" in result.output
+
+
+# ── Focused-command --format validation (CI-gate bypass guard) ───────────────
+
+
+@pytest.mark.parametrize("command", ["fs", "iac", "sbom", "image"])
+def test_focused_bad_format_is_rejected_rc2(command: str, tmp_path: Path):
+    """A bogus -f must be rejected (rc=2) like `scan`, not accepted as a free
+    string that silently disables the default fail-on-severity gate."""
+    target = tmp_path / "target"
+    if command == "sbom":
+        target.write_text("{}", encoding="utf-8")
+        args = [command, str(target), "-f", "bogus"]
+    elif command == "image":
+        args = [command, "nginx:latest", "-f", "bogus"]
+    elif command == "iac":
+        target.write_text("FROM ubuntu:latest\n", encoding="utf-8")
+        args = [command, str(target), "-f", "bogus"]
+    else:  # fs
+        target.mkdir()
+        args = [command, str(target), "-f", "bogus"]
+
+    result = CliRunner().invoke(main, args)
+
+    assert result.exit_code == 2, result.output
+    assert "bogus" in result.output
+
+
+@pytest.mark.parametrize("command", ["fs", "iac", "sbom", "image"])
+def test_focused_valid_format_is_accepted(command: str):
+    """The now-restricted choice must still advertise the shared scan formats."""
+    result = CliRunner().invoke(main, [command, "--help"])
+    assert result.exit_code == 0
+    for fmt in ("console", "json", "sarif"):
+        assert fmt in result.output
+
+
+def test_iac_missing_path_errors_nonzero(tmp_path: Path):
+    """A missing/typo'd IaC path must error, never report a clean pass."""
+    missing = tmp_path / "does-not-exist.tf"
+    result = CliRunner().invoke(main, ["iac", str(missing)])
+    assert result.exit_code != 0
+    assert "no misconfigurations" not in result.output
+
+
+def test_image_missing_tar_errors_nonzero(tmp_path: Path):
+    """A missing --tar image path must be rejected, not silently scanned."""
+    missing = tmp_path / "nope.tar"
+    result = CliRunner().invoke(main, ["image", "--tar", str(missing)])
+    assert result.exit_code == 2


### PR DESCRIPTION
## CLI hardening — focused-command safety, unscanned-check gate, friendly errors, `--aws-deep`

Five coherent CLI-hardening fixes, all reproduced by a dogfood run on `main` before fixing. All changes live in `src/agent_bom/cli/` (+ tests).

### Fixes

**1. P1 — CI-gate bypass via unvalidated `--format` on focused commands.**
`fs`, `iac`, `sbom`, `image` declared `-f/--format` as a free string, so a format typo (`iac Dockerfile -f bogus`) exited `0` even with high-severity findings — the default fail-on-severity gate only fires for `console`/`json`. They now use a shared `AliasedChoice` of the exact formats `scan` accepts (extracted to `SCAN_OUTPUT_FORMATS` / `SCAN_OUTPUT_FORMAT_ALIASES` in `options_sources.py` and reused by both), so a bad `-f` is rejected with `rc=2` and the default gate still fires for any valid format.
- Repro (main): `iac Dockerfile -f bogus` -> `rc=0` with 2 high findings. Fixed: `rc=2`; valid `-f json` still gates -> `rc=1`.

**2. P1 — `iac <nonexistent>` reported "no misconfigurations" and exited 0.**
A missing/typo'd IaC target was treated as a clean scan. `iac` now errors with a clean message and non-zero exit when any target path is missing.
- `fs` (already `rc=1`) and `sbom` (`click.Path(exists=True)` -> `rc=2`) were already guarded and left unchanged.
- `image --tar <missing>` silently continued and exited `0` on main; its `--tar` path now uses `exists=True` (matching `sbom`), rejecting a missing tarball with `rc=2`.

**3. P2 — `check <pkg>` without `@version` exited 0** despite printing "This is not a clean result." A CI pre-install gate passed on an unscanned package. The no-version branch now exits `rc=2` (incomplete scan), in both console and structured/JSON output (`exit_code: 2`).

**4. P2 — `findings list` / `findings triage list` dumped raw `[Errno 61] Connection refused`** with no server running. `_run_request` now catches `httpx.RequestError` and raises friendly guidance ("This command requires the API server. Start it with: `agent-bom api`"), mirroring the `fleet` commands. Covers every server-backed `findings` subcommand.

**5. P2/UX — `--aws-deep` one-flag full AWS scan.** A full AWS scan previously required `--aws-include-ec2 --aws-include-iam --aws-include-eks --aws-include-step-functions`. Added `--aws-deep` to the top-level `scan` command (ORs on all four toggles) and to the `cloud` group (`cloud scan`, `cloud aws` — ORs on eks/ec2/iam, the toggles that surface there). Granular flags are kept; `--aws-deep` only ORs them on and never changes defaults (opt-in). GCP/Azure have no analogous include toggles, so none were added there.

### Tests (CliRunner)
- Bad `-f` on `fs`/`iac`/`sbom`/`image` -> `rc=2` (parametrized); valid formats still advertised.
- `iac <missing>` -> non-zero, never "no misconfigurations"; `image --tar <missing>` -> `rc=2`.
- `check <pkg>` no version -> `rc=2` (console + JSON `exit_code`).
- `findings list` / `findings triage list` connection-refused -> friendly message, no raw traceback.
- `--aws-deep` sets the include kwargs on both the `cloud` group (captured via `scan.callback`) and the top-level `scan` command (captured via `emit_dry_run_plan`); "without deep" leaves them off.

New tests: 19 passing. `ruff check` and `mypy` clean on all changed source files.

Note: `tests/test_cli_scan.py::test_scan_finding_count_parity_across_formats` fails on pristine `origin/main` (verified via stash) — a pre-existing CSV/SARIF parity issue unrelated to this PR.
