### PR TITLE
fix(api): dedupe in-memory findings view, calm graph backpressure, validate findings sort/severity + results push

### DIFF
--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -555,12 +555,45 @@ async def ingest_traces(request: Request, body: dict) -> dict:
         raise HTTPException(status_code=500, detail=sanitize_error(exc)) from exc
 
 
+# Extra (non-declared) keys that still mark a payload as a real pushed report.
+# ``PushPayload`` is ``extra="allow"`` so the full scan report rides through, but
+# that also let arbitrary junk validate into an empty ScanJob. A genuine push
+# always sets at least one declared field (source_id/agents/blast_radii/…) or
+# carries one of these canonical report keys.
+_RECOGNIZED_PUSH_EXTRA_KEYS = frozenset(
+    {
+        "blast_radius",
+        "scan_id",
+        "summary",
+        "posture_scorecard",
+        "findings",
+        "packages",
+        "vulnerabilities",
+        "agent_projects",
+        "report",
+        "observed_at",
+    }
+)
+
+
 @router.post("/results/push", tags=["push"], status_code=201)
 async def receive_push(request: Request, body: PushPayload) -> dict:
     """Receive pushed scan results from a CLI instance.
 
     Stores as a completed ScanJob with source metadata.
     """
+    # ``model_fields_set`` includes ``extra="allow"`` keys, so intersect with the
+    # declared fields to see whether the client set a real push field.
+    provided_declared = body.model_fields_set & set(type(body).model_fields)
+    extra_keys = set(body.model_extra or {})
+    if not provided_declared and not (extra_keys & _RECOGNIZED_PUSH_EXTRA_KEYS):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "results push payload missing recognized fields; expected at least one of "
+                "source_id, agents, blast_radii, warnings, summary"
+            ),
+        )
     tenant_id = _tenant_id(request)
     job = ScanJob(
         job_id=str(uuid.uuid4()),

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -365,6 +365,18 @@ def _scan_source_labels(job: ScanJob) -> list[str]:
     return labels or ["local-agents"]
 
 
+def _finding_identity(finding: dict[str, Any]) -> str:
+    """Stable identity used to collapse the default findings view.
+
+    Prefers the finding ``id`` (what Postgres' ``hub_findings_current`` keys on)
+    and falls back to the vuln:package content key when a scan row omits ``id``.
+    """
+    raw_id = finding.get("id")
+    if raw_id:
+        return str(raw_id)
+    return _finding_key(finding)
+
+
 def _finding_key(finding: dict[str, Any]) -> str:
     vuln_id = finding.get("vulnerability_id") or finding.get("cve_id") or finding.get("id") or finding.get("title") or ""
     raw_asset = finding.get("asset")
@@ -1277,6 +1289,16 @@ async def list_jobs(
 
 
 _ALLOWED_FINDING_SORTS = ("effective_reach", "cvss", "severity")
+_ALLOWED_FINDING_SEVERITIES = (
+    "critical",
+    "high",
+    "medium",
+    "low",
+    "info",
+    "informational",
+    "none",
+    "unknown",
+)
 
 
 def _resolve_bulk_findings_total(
@@ -1468,7 +1490,18 @@ async def list_findings(
     tenant_id = _tenant_id(request)
     sort_key = sort.lower().strip() if isinstance(sort, str) else "effective_reach"
     if sort_key not in _ALLOWED_FINDING_SORTS:
-        sort_key = "effective_reach"
+        # Silently falling back masked typos as "wrong order"; reject clearly.
+        raise HTTPException(
+            status_code=422,
+            detail=f"invalid sort '{sort}'; accepted values: {', '.join(_ALLOWED_FINDING_SORTS)}",
+        )
+    if severity is not None and severity.strip().lower() not in _ALLOWED_FINDING_SEVERITIES:
+        # A bogus severity previously returned an empty 200 that reads as
+        # "no findings" — a trap. Reject with the accepted set instead.
+        raise HTTPException(
+            status_code=422,
+            detail=f"invalid severity '{severity}'; accepted values: {', '.join(_ALLOWED_FINDING_SEVERITIES)}",
+        )
     if cursor and offset:
         raise HTTPException(status_code=400, detail="cursor and offset are mutually exclusive")
     if cursor:
@@ -1504,13 +1537,25 @@ async def list_findings(
     else:
         include_bulk_total = not cursor and cached_bulk_total is None
 
-    scan_findings: list[dict[str, Any]] = []
-    for job in _completed_jobs_for_tenant(tenant_id):
+    # Default (no ``scan_id``) view collapses to the current state per finding:
+    # re-scanning a project emits the same finding ``id`` under a fresh
+    # ``scan_id``, and the in-memory store retains every completed job. Without
+    # deduping, ``total`` inflated by one full copy per re-scan (Postgres reads
+    # ``hub_findings_current`` which already dedupes). Iterate jobs oldest-first
+    # so the latest occurrence of each finding id wins; ``?scan_id=`` still
+    # returns that scan's rows verbatim.
+    deduped: dict[str, dict[str, Any]] = {}
+    for job in sorted(
+        _completed_jobs_for_tenant(tenant_id),
+        key=lambda job: (job.completed_at or "", job.created_at or "", job.job_id),
+    ):
         if scan_id and job.job_id != scan_id:
             continue
         if job.child_job_ids and job.job_id != scan_id:
             continue
-        scan_findings.extend(_iter_scan_findings(job))
+        for row in _iter_scan_findings(job):
+            deduped[_finding_identity(row)] = row
+    scan_findings: list[dict[str, Any]] = list(deduped.values())
     if severity:
         normalized = severity.lower()
         scan_findings = [item for item in scan_findings if str(item.get("severity", "")).lower() == normalized]

--- a/src/agent_bom/backpressure.py
+++ b/src/agent_bom/backpressure.py
@@ -119,6 +119,17 @@ class BackpressureController:
 _CONTROLLERS: dict[str, BackpressureController] = {}
 _CONTROLLERS_LOCK = Lock()
 
+# Default p99 cooldown threshold per path. A path's own honest latency must sit
+# *below* its threshold or a normal single request counts as overload and trips
+# the shared cooldown, 429-storming every route on that controller. The graph
+# path builds a full unified graph on a cold snapshot (~2.6s) and a single GET
+# fans out into several store+compute samples, so the generic 2500ms budget
+# false-trips on cold traffic. Give ``graph`` explicit headroom above its honest
+# build latency; genuinely degraded builds (well past this ceiling) and the
+# concurrency limit still shed real overload.
+_DEFAULT_P99_THRESHOLD_MS: dict[str, int] = {"graph": 12_000}
+_GENERIC_P99_THRESHOLD_MS = 2500
+
 
 def _percentile(values: list[float], percentile: float) -> float:
     if not values:
@@ -159,7 +170,14 @@ def _controller_for(path: str) -> BackpressureController:
         controller = BackpressureController(
             path=path,
             max_concurrency=_env_int(_path_env_key(path, "CONCURRENCY"), 8, minimum=1, maximum=1024),
-            p99_threshold_ms=float(_env_int(_path_env_key(path, "P99_MS"), 2500, minimum=1, maximum=120_000)),
+            p99_threshold_ms=float(
+                _env_int(
+                    _path_env_key(path, "P99_MS"),
+                    _DEFAULT_P99_THRESHOLD_MS.get(path, _GENERIC_P99_THRESHOLD_MS),
+                    minimum=1,
+                    maximum=120_000,
+                )
+            ),
             cooldown_seconds=_env_int(_path_env_key(path, "COOLDOWN_SECONDS"), 10, minimum=1, maximum=3600),
             min_samples=_env_int(_path_env_key(path, "MIN_SAMPLES"), 20, minimum=1, maximum=10_000),
         )

--- a/tests/test_api_surface_0943.py
+++ b/tests/test_api_surface_0943.py
@@ -1,0 +1,282 @@
+"""API-surface regressions for the 0.94.3 fix pass.
+
+1. ``/v1/findings`` default view must dedupe by finding id (latest scan wins) so
+   ``total`` does not inflate one full copy per re-scan against the in-memory
+   store (Postgres reads the already-deduped ``hub_findings_current``).
+2. The shared ``graph`` backpressure controller must not false-trip its p99
+   cooldown on a cold full build's honest latency (~2.6s), 429-storming every
+   ``/v1/graph*`` route.
+3. Invalid ``sort`` / ``severity`` on ``/v1/findings`` must 422, not silently
+   fall back (wrong order) or return an empty 200 (reads as "no findings").
+4. ``/v1/results/push`` must reject junk payloads with 422 instead of minting an
+   empty ScanJob.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import (
+    InMemoryComplianceHubStore,
+    set_compliance_hub_store,
+)
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.server import app
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import set_graph_store, set_job_store
+from agent_bom.backpressure import _controller_for, reset_backpressure_for_tests
+
+TENANT = "default"
+
+
+def _make_findings(count: int) -> list[dict]:
+    return [
+        {
+            "id": f"CVE-2025-{i:04d}:pkg{i}",
+            "vulnerability_id": f"CVE-2025-{i:04d}",
+            "package": f"pkg{i}",
+            "severity": ("critical", "high", "medium", "low")[i % 4],
+            "cvss_score": float(i % 10),
+        }
+        for i in range(count)
+    ]
+
+
+def _seed_repeated_scans(store: InMemoryJobStore, *, scans: int, findings: list[dict]) -> str:
+    """Simulate re-scanning the same project ``scans`` times."""
+    last_scan_id = ""
+    for n in range(scans):
+        job_id = str(uuid.uuid4())
+        last_scan_id = job_id
+        store.put(
+            ScanJob(
+                job_id=job_id,
+                tenant_id=TENANT,
+                status=JobStatus.DONE,
+                created_at=f"2026-07-{n + 1:02d}T00:00:00Z",
+                completed_at=f"2026-07-{n + 1:02d}T00:01:00Z",
+                request=ScanRequest(agent_projects=["/tmp/proj"], offline=True),
+                result={"findings": [dict(f) for f in findings]},
+            )
+        )
+    return last_scan_id
+
+
+@pytest.fixture
+def client_with_scans():
+    job_store = InMemoryJobStore()
+    set_job_store(job_store)
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+    findings = _make_findings(106)
+    last_scan_id = _seed_repeated_scans(job_store, scans=6, findings=findings)
+    yield TestClient(app), last_scan_id, len(findings)
+
+
+# ── Fix 1: default findings view dedupes across re-scans ─────────────────────
+
+
+def test_default_findings_view_dedupes_across_rescans(client_with_scans) -> None:
+    client, _last_scan_id, unique = client_with_scans
+
+    resp = client.get("/v1/findings?limit=1000")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    ids = [f["id"] for f in body["findings"]]
+    assert len(ids) == len(set(ids)), "default view leaked duplicate finding ids across scans"
+    assert len(ids) == unique
+    assert body["total"] == unique
+    assert body["count"] == unique
+
+
+def test_scan_id_filter_still_returns_that_scan(client_with_scans) -> None:
+    client, last_scan_id, unique = client_with_scans
+
+    resp = client.get(f"/v1/findings?limit=1000&scan_id={last_scan_id}")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == unique
+    assert body["count"] == unique
+    assert body["scan_id"] == last_scan_id
+
+
+# ── Fix 3: invalid sort / severity are rejected ──────────────────────────────
+
+
+def test_invalid_sort_is_rejected(client_with_scans) -> None:
+    client, _last, _unique = client_with_scans
+
+    resp = client.get("/v1/findings?sort=not_a_field")
+
+    assert resp.status_code == 422
+    assert "not_a_field" in resp.json()["detail"]
+    assert "effective_reach" in resp.json()["detail"]
+
+
+def test_invalid_severity_is_rejected(client_with_scans) -> None:
+    client, _last, _unique = client_with_scans
+
+    resp = client.get("/v1/findings?severity=BOGUS")
+
+    assert resp.status_code == 422
+    assert "BOGUS" in resp.json()["detail"]
+
+
+@pytest.mark.parametrize("sort", ["effective_reach", "cvss", "severity"])
+def test_valid_sorts_still_pass(client_with_scans, sort) -> None:
+    client, _last, unique = client_with_scans
+    resp = client.get(f"/v1/findings?sort={sort}")
+    assert resp.status_code == 200
+    assert resp.json()["sort"] == sort
+    assert resp.json()["total"] == unique
+
+
+@pytest.mark.parametrize("severity", ["critical", "HIGH", "medium", "low"])
+def test_valid_severities_still_pass(client_with_scans, severity) -> None:
+    client, _last, _unique = client_with_scans
+    resp = client.get(f"/v1/findings?severity={severity}")
+    assert resp.status_code == 200
+    normalized = severity.lower()
+    assert all(f["severity"].lower() == normalized for f in resp.json()["findings"])
+
+
+# ── Fix 4: /v1/results/push rejects junk ─────────────────────────────────────
+
+
+def test_results_push_junk_is_rejected() -> None:
+    set_job_store(InMemoryJobStore())
+    client = TestClient(app)
+
+    resp = client.post("/v1/results/push", json={"garbage": "value", "foo": 123})
+
+    assert resp.status_code == 422
+
+
+def test_results_push_empty_object_is_rejected() -> None:
+    set_job_store(InMemoryJobStore())
+    client = TestClient(app)
+
+    resp = client.post("/v1/results/push", json={})
+
+    assert resp.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"source_id": "collector-1", "agents": []},
+        {"agents": []},
+        {"scan_id": "s-1", "blast_radius": []},
+        {"summary": {"total_packages": 3}},
+    ],
+)
+def test_results_push_real_payloads_accepted(payload) -> None:
+    set_job_store(InMemoryJobStore())
+    client = TestClient(app)
+
+    resp = client.post("/v1/results/push", json=payload)
+
+    assert resp.status_code == 201
+    assert resp.json()["status"] == "stored"
+
+
+# ── Fix 2: graph backpressure does not false-trip on cold build latency ──────
+
+
+@pytest.fixture
+def _reset_bp(monkeypatch):
+    for suffix in ("CONCURRENCY", "P99_MS", "COOLDOWN_SECONDS", "MIN_SAMPLES"):
+        monkeypatch.delenv(f"AGENT_BOM_BACKPRESSURE_GRAPH_{suffix}", raising=False)
+    monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_ENABLED", raising=False)
+    reset_backpressure_for_tests()
+    yield
+    reset_backpressure_for_tests()
+
+
+def test_graph_controller_threshold_clears_honest_build_latency(_reset_bp) -> None:
+    controller = _controller_for("graph")
+
+    # Honest cold full build ~2.6s must sit below the p99 cooldown threshold.
+    assert controller.p99_threshold_ms >= 2600
+
+
+def test_cold_graph_full_builds_do_not_trip_cooldown(_reset_bp) -> None:
+    controller = _controller_for("graph")
+
+    # Replay several cold /v1/graph requests: each fans out into cheap store
+    # reads plus one ~2.6s full-build compute sample. Under the old 2500ms
+    # default this tripped the shared cooldown after ~3 requests and 429'd every
+    # graph route; the raised threshold must keep the controller closed.
+    for _ in range(8):
+        for _ in range(7):
+            controller.try_enter()
+            controller.exit(5.0)
+        controller.try_enter()
+        controller.exit(2600.0)
+
+    posture = controller.describe()
+    assert posture["state"] == "closed"
+    assert posture["rejected"] == 0
+
+
+def test_graph_cold_sweep_and_burst_no_429(_reset_bp, tmp_path) -> None:
+    from agent_bom.api.graph_store import SQLiteGraphStore
+    from agent_bom.graph import (
+        EntityType,
+        RelationshipType,
+        UnifiedEdge,
+        UnifiedGraph,
+        UnifiedNode,
+    )
+
+    store = SQLiteGraphStore(tmp_path / "graph.db")
+    graph = UnifiedGraph(scan_id="cold-scan", tenant_id=TENANT)
+    graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+    graph.add_node(UnifiedNode(id="server:a:fs", entity_type=EntityType.SERVER, label="mcp-fs"))
+    graph.add_node(
+        UnifiedNode(
+            id="vuln:CVE-2024-1",
+            entity_type=EntityType.VULNERABILITY,
+            label="CVE-2024-1",
+            severity="critical",
+            risk_score=9.0,
+        )
+    )
+    graph.add_edge(UnifiedEdge(source="agent:a", target="server:a:fs", relationship=RelationshipType.USES))
+    graph.add_edge(
+        UnifiedEdge(
+            source="server:a:fs",
+            target="vuln:CVE-2024-1",
+            relationship=RelationshipType.VULNERABLE_TO,
+            weight=8.0,
+        )
+    )
+    store.save_graph(graph)
+    set_graph_store(store)
+
+    # Prime the shared controller with honest cold-build latencies (~2.6s each),
+    # as real full builds would record. The sweep and burst below must still
+    # return 200, proving normal graph latency no longer sheds cheap reads.
+    controller = _controller_for("graph")
+    for _ in range(controller.min_samples):
+        controller.try_enter()
+        controller.exit(2600.0)
+
+    client = TestClient(app)
+
+    sweep = [
+        "/v1/graph",
+        "/v1/graph/agents",
+        "/v1/graph/snapshots",
+        "/v1/graph",
+        "/v1/graph/agents",
+    ]
+    for path in sweep:
+        assert client.get(path).status_code != 429, f"cold sweep 429'd on {path}"
+
+    burst = [client.get("/v1/graph") for _ in range(8)]
+    assert all(r.status_code != 429 for r in burst), "modest graph burst 429'd"


### PR DESCRIPTION
## Summary

Coherent API-surface fix pass (0.94.3). Four route-level defects, each reproduced against the in-memory store via a dogfood run (uvicorn on 127.0.0.1) before fixing.

### 1. P1 — `/v1/findings` default view duplicated finding ids; `total` inflated per re-scan
The in-memory read path concatenated findings from **every** completed job, so re-scanning a project emitted the same finding `id` once per scan (6 scans → `total` 636, 106 unique). Postgres reads the deduped `hub_findings_current`; the in-memory default read now matches by collapsing to the latest occurrence per finding id (jobs iterated oldest-first so the newest scan wins). `?scan_id=` filtering is unchanged and still returns that scan's rows verbatim.

### 2. P2 — graph backpressure 429-stormed on cold start
A single `/v1/graph` full build (~2.6s) exceeded the shared `graph` controller's generic `p99_threshold_ms=2500`, and each request fanned out into several store+compute samples, so ~3 cold requests tripped a 10s cooldown that 429'd **all** `/v1/graph*` routes. Fix gives the `graph` path explicit p99 headroom (12s) above its honest build latency via a per-path default (env override still respected). The concurrency limit and genuine-overload shedding are untouched — backpressure is not disabled, just stopped from false-tripping on normal graph latency.

### 3. P2 — invalid `sort`/`severity` silently ignored
`?sort=not_a_field` fell back silently (wrong order); `?severity=BOGUS` returned an empty 200 that reads as "no findings". Both now return **422** naming the bad value and the accepted set, matching the existing pagination validation. Valid values are unaffected.

### 4. P2 — `/v1/results/push` accepted arbitrary JSON
`PushPayload` is `extra="allow"` with all-default fields, so junk (`{"garbage":...}`) validated into an empty `ScanJob`. The route now requires at least one recognized field (a declared push field or a canonical report key) and returns **422** for junk.

## Tests
New `tests/test_api_surface_0943.py` (TestClient): repeated scans → default `/v1/findings` returns unique ids + correct total; `?scan_id=` intact; graph cold sweep + modest burst → no 429 (plus a controller-level lock that cold ~2.6s builds don't open the cooldown); invalid sort/severity → 422; results/push junk/empty → 422, real payloads → 201.

- New file: 20 tests pass.
- Regression sweep green: `test_backpressure`, `test_graph_api`, `test_findings_read_path_3641`, `test_findings_read_scale`, `test_api_tenant_isolation`, `test_ingest_idempotency`, `test_scan_contract`, `test_finding_lifecycle`, `test_cli_findings`, `test_findings_mixed_merge`, `test_findings_bulk_api`, `test_api_scan_findings_wiring`, `test_compliance_hub_api`, `test_push` (208 passed).
- `ruff check` + `mypy` clean on changed source files.
- Live-verified over HTTP on 127.0.0.1: bad sort/severity → 422, valid → 200; junk/empty push → 422, valid → 201; `/v1/graph` → 200; posture endpoint shows `graph` threshold 12000ms, state closed, 0 rejected.