### PR TITLE
fix(output): surface reachability in JSON findings, warn on malformed manifests, tighten typosquat + git-SHA confidence

### DIFF
--- a/src/agent_bom/asset_provenance.py
+++ b/src/agent_bom/asset_provenance.py
@@ -47,6 +47,26 @@ _VERSION_SOURCE_CONFIDENCE = {
     "registry_latest": "low",
     "unknown": "unknown",
 }
+# Version sources where the reported version came from the running/installed
+# host rather than the declared reference — a git ref pinned here is a
+# coincidence, not an exact match.
+_HOST_RESOLVED_VERSION_SOURCES = frozenset(
+    {"installed_package", "runtime_process", "image_sbom", "tool_cache"}
+)
+_GIT_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+
+
+def _looks_like_git_reference(value: Any) -> bool:
+    """Return True when a declared version looks like a git URL or commit SHA."""
+    text = str(value or "").strip()
+    if not text:
+        return False
+    lowered = text.lower()
+    if "git+" in lowered or lowered.startswith(("git@", "git://")):
+        return True
+    return bool(_GIT_SHA_RE.fullmatch(lowered))
+
+
 _VERSION_SOURCE_PRECEDENCE = {
     "runtime_process": 80,
     "image_sbom": 70,
@@ -289,6 +309,18 @@ def package_version_provenance(package: Any, inherited: dict[str, Any] | None = 
         result["floating_reference"] = True
         if _field(package, "floating_reference_reason"):
             result["floating_reference_reason"] = _field(package, "floating_reference_reason")
+
+    # A git URL/SHA declared reference whose reported version came from the host
+    # environment (installed/runtime/image) is not an exact pin — the SHA and the
+    # resolved release are unrelated coincidences. Never let it claim `exact`.
+    if _looks_like_git_reference(declared_version) and version_source in _HOST_RESOLVED_VERSION_SOURCES:
+        result["floating_reference"] = True
+        result.setdefault(
+            "floating_reference_reason",
+            "git URL/SHA reference — reported version resolved from the installed host package, not the pinned ref",
+        )
+        if result["confidence"] == "exact":
+            result["confidence"] = "low"
 
     evidence = _sanitize_version_evidence_list(
         explicit.get("evidence") or _field(package, "version_evidence") or _occurrence_version_evidence(package)

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -2454,6 +2454,7 @@ def scan(
         from agent_bom.graph.blast_reach import (
             apply_dependency_reachability_to_blast_radii,
             apply_symbol_reachability_to_blast_radii,
+            resync_cve_findings_from_blast_radii,
         )
 
         apply_dependency_reachability_to_blast_radii(blast_radii, agents, rescore=True)
@@ -2462,6 +2463,11 @@ def scan(
         # unreachable signal. No-op when no Python entrypoints were analysed.
         if _ast_result_for_reach is not None:
             apply_symbol_reachability_to_blast_radii(blast_radii, _ast_result_for_reach)
+        # The dual-write `report.findings` was materialized before the stamping
+        # above, so its CVE findings still carry null reachability. Re-project the
+        # stamped rows onto them so the JSON `findings[]` view agrees with
+        # `blast_radius[]`, CSV, Parquet, and SARIF.
+        resync_cve_findings_from_blast_radii(report.findings, blast_radii)
     except Exception:  # noqa: BLE001
         # Reachability is best-effort enrichment — don't let it fail the scan.
         pass

--- a/src/agent_bom/cli/options_sources.py
+++ b/src/agent_bom/cli/options_sources.py
@@ -498,7 +498,11 @@ def policy_options(fn):
                     "Use with --fail-on-severity for two-tier CI gates (e.g. --warn-on medium --fail-on-severity critical)."
                 ),
             ),
-            click.option("--fail-on-kev", is_flag=True, help="Exit 1 if any finding appears in CISA KEV (must use --enrich)"),
+            click.option(
+                "--fail-on-kev",
+                is_flag=True,
+                help="Exit 1 if any finding appears in CISA KEV (works offline from the local DB; --enrich not required)",
+            ),
             click.option("--fail-on-malicious", is_flag=True, help="Exit 1 if any package is flagged as known malicious"),
             click.option("--fail-if-ai-risk", is_flag=True, help="Exit 1 if an AI framework package with credentials has vulnerabilities"),
             click.option("--save", "save_report", is_flag=True, help="Save this scan to ~/.agent-bom/history/ for future diffing"),

--- a/src/agent_bom/coverage.py
+++ b/src/agent_bom/coverage.py
@@ -58,6 +58,32 @@ class CoverageWarning:
         return asdict(self)
 
 
+def record_manifest_parse_warning(*, ecosystem: str, path: str, detail: str) -> None:
+    """Record a coverage warning for a manifest that failed to parse.
+
+    A malformed dependency manifest (invalid ``package.json``, unclosed
+    ``pom.xml``, …) otherwise scans to zero packages for that ecosystem with no
+    signal — indistinguishable from a project that genuinely has no
+    dependencies. Emit a structured coverage warning (deduped per path) plus a
+    stderr log so operators know the ecosystem was not actually covered.
+    """
+    warning = CoverageWarning(
+        ecosystem=ecosystem,
+        release=f"{ecosystem}:{path}",
+        reason="manifest_parse_error",
+        detail=detail,
+        package_count=0,
+        advisory_rows=0,
+    )
+    _logger.warning("Manifest not scanned (%s): %s", path, detail)
+    try:
+        from agent_bom.scanners.state import record_coverage_warning
+
+        record_coverage_warning(warning.to_dict())
+    except Exception:  # noqa: BLE001 - warning surfacing must never break a scan
+        pass
+
+
 def _release_key(pkg: "Package") -> Optional[tuple[str, str]]:
     """Return ``(family, db_release_key)`` for an OS package with a known release.
 

--- a/src/agent_bom/graph/blast_reach.py
+++ b/src/agent_bom/graph/blast_reach.py
@@ -26,6 +26,7 @@ from agent_bom.graph.dependency_reach import compute_dependency_reach
 
 if TYPE_CHECKING:
     from agent_bom.ast_models import ASTAnalysisResult
+    from agent_bom.finding import Finding
     from agent_bom.models import Agent, BlastRadius
 
 _logger = logging.getLogger(__name__)
@@ -162,7 +163,52 @@ def apply_symbol_reachability_to_blast_radii(
     return stamped
 
 
+def resync_cve_findings_from_blast_radii(
+    findings: list["Finding"] | None,
+    blast_radii: list["BlastRadius"],
+) -> int:
+    """Re-project stamped reachability from ``blast_radii`` onto CVE findings.
+
+    The CLI dual-write path materializes ``report.findings`` from ``blast_radii``
+    *before* ``apply_dependency_reachability_to_blast_radii`` /
+    ``apply_symbol_reachability_to_blast_radii`` stamp the rows. As a result the
+    JSON ``findings[]`` projection (which reads ``report.findings``) carried
+    ``symbol_reachability`` / ``graph_reachable`` = null while ``blast_radius[]``,
+    CSV, Parquet, and SARIF — all rebuilt fresh from the stamped rows — carried
+    the verdict. Rebuild each CVE finding from its stamped row (matched by
+    canonical id) so every view agrees, without reordering or double-counting.
+
+    Non-CVE findings (secrets, auth posture, prompt-scan, …) and CVE findings
+    with no matching row are left untouched. Returns the number of CVE findings
+    replaced. Best-effort: never raises.
+    """
+    if not findings or not blast_radii:
+        return 0
+    try:
+        from agent_bom.finding import FindingType, blast_radius_to_finding
+
+        fresh_by_id: dict[str, Finding] = {}
+        for br in blast_radii:
+            fresh = blast_radius_to_finding(br)
+            fresh_by_id[fresh.id] = fresh
+
+        replaced = 0
+        for idx, finding in enumerate(findings):
+            if finding.finding_type != FindingType.CVE:
+                continue
+            stamped = fresh_by_id.get(finding.id)
+            if stamped is None:
+                continue
+            findings[idx] = stamped
+            replaced += 1
+        return replaced
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("CVE finding reachability resync skipped: %s", exc)
+        return 0
+
+
 __all__ = [
     "apply_dependency_reachability_to_blast_radii",
     "apply_symbol_reachability_to_blast_radii",
+    "resync_cve_findings_from_blast_radii",
 ]

--- a/src/agent_bom/malicious.py
+++ b/src/agent_bom/malicious.py
@@ -128,6 +128,29 @@ _POPULAR_PACKAGES: dict[str, frozenset[str]] = {
 }
 
 
+# Names at least this long are eligible for the single-substitution catch below.
+# Below this, one edited character is too weak a signal (``core`` vs ``cors``,
+# ``flask`` vs ``flash``) and would create false positives on real packages.
+_EDIT1_MIN_LEN = 6
+
+
+def _single_substitution(a: str, b: str) -> bool:
+    """Return True when equal-length ``a`` and ``b`` differ in exactly one char.
+
+    Restricting to equal length (a pure substitution) avoids flagging legitimate
+    length-shifted neighbours such as ``panda`` vs ``pandas``.
+    """
+    if len(a) != len(b):
+        return False
+    diff = 0
+    for ca, cb in zip(a, b):
+        if ca != cb:
+            diff += 1
+            if diff > 1:
+                return False
+    return diff == 1
+
+
 def check_typosquat(name: str, ecosystem: str, threshold: float = 0.85) -> str | None:
     """Check if a package name looks like a typosquat of a popular package.
 
@@ -159,6 +182,16 @@ def check_typosquat(name: str, ecosystem: str, threshold: float = 0.85) -> str |
 
     if best_ratio >= threshold:
         return best_match
+
+    # A single-character substitution on a short-ish name (``djanga`` vs
+    # ``django``) scores 0.833 < 0.85 and slips past the ratio gate. Catch the
+    # equal-length one-edit case explicitly for names long enough that one edited
+    # character is a strong signal, without lowering the ratio threshold (which
+    # would pull in genuine near-neighbours).
+    if len(normalized) >= _EDIT1_MIN_LEN:
+        for pkg_name in popular:
+            if _single_substitution(normalized, pkg_name.lower()):
+                return pkg_name
     return None
 
 

--- a/src/agent_bom/output/console_render.py
+++ b/src/agent_bom/output/console_render.py
@@ -202,14 +202,19 @@ def print_summary(report: AIBOMReport) -> None:
 
     coverage_warnings = getattr(report, "coverage_warnings", None) or []
     if coverage_warnings:
-        lines = [
-            (
+        def _coverage_line(w: dict) -> str:
+            if w.get("reason") == "manifest_parse_error":
+                return (
+                    f"[bold yellow]⚠ {w.get('release', '?')}[/bold yellow] — "
+                    f"{w.get('detail') or 'manifest failed to parse; ecosystem not scanned'}"
+                )
+            return (
                 f"[bold yellow]⚠ {w.get('release', '?')}[/bold yellow] — "
                 f"{w.get('package_count', 0)} package(s) present, "
                 f"{w.get('advisory_rows', 0)} advisory row(s) in the data source"
             )
-            for w in coverage_warnings
-        ]
+
+        lines = [_coverage_line(w) for w in coverage_warnings]
         body = "\n".join(lines) + (
             "\n\n[dim]Vulnerability coverage for the release(s) above is incomplete — likely "
             "end-of-life and no longer carried by the data source. Results may UNDER-report; a "

--- a/src/agent_bom/parsers/compiled_parsers.py
+++ b/src/agent_bom/parsers/compiled_parsers.py
@@ -663,6 +663,13 @@ def _parse_pom_modules(root_dir: Path, depth: int = 0) -> list[Package]:
         xml_root = tree.getroot()
     except ET.ParseError as exc:
         logger.debug("Failed to parse pom.xml in %s: %s", root_dir, exc)
+        from agent_bom.coverage import record_manifest_parse_warning
+
+        record_manifest_parse_warning(
+            ecosystem="maven",
+            path=str(pom),
+            detail=f"pom.xml failed to parse ({exc}); Maven dependencies were not scanned",
+        )
         return []
 
     # Namespace may or may not be present

--- a/src/agent_bom/parsers/node_parsers.py
+++ b/src/agent_bom/parsers/node_parsers.py
@@ -210,6 +210,14 @@ def parse_npm_packages(directory: Path) -> list[Package]:
                 )
         except (json.JSONDecodeError, KeyError) as exc:
             logger.debug("Failed to parse package-lock.json in %s: %s", directory, exc)
+            if isinstance(exc, json.JSONDecodeError):
+                from agent_bom.coverage import record_manifest_parse_warning
+
+                record_manifest_parse_warning(
+                    ecosystem="npm",
+                    path=str(lock_file),
+                    detail=f"package-lock.json failed to parse ({exc}); npm dependencies were not scanned",
+                )
 
     # Fallback to package.json only
     elif (directory / "package.json").exists():
@@ -258,6 +266,14 @@ def parse_npm_packages(directory: Path) -> list[Package]:
                     )
         except (json.JSONDecodeError, KeyError) as exc:
             logger.debug("Failed to parse package.json in %s: %s", directory, exc)
+            if isinstance(exc, json.JSONDecodeError):
+                from agent_bom.coverage import record_manifest_parse_warning
+
+                record_manifest_parse_warning(
+                    ecosystem="npm",
+                    path=str(directory / "package.json"),
+                    detail=f"package.json failed to parse ({exc}); npm dependencies were not scanned",
+                )
 
     return packages
 

--- a/src/agent_bom/parsers/python_parsers.py
+++ b/src/agent_bom/parsers/python_parsers.py
@@ -17,6 +17,52 @@ from agent_bom.parsers.file_limits import read_json_limited, read_text_limited
 
 logger = logging.getLogger(__name__)
 
+# PEP 508 direct-URL git reference (``flask @ git+https://…/flask.git@<sha>``)
+# and the legacy ``git+https://…#egg=name`` form.
+_GIT_DIRECT_URL_RE = re.compile(r"^(?P<name>[a-zA-Z0-9_.-]+)\s*@\s*(?P<url>\S+)$")
+_GIT_EGG_RE = re.compile(r"[#&]egg=(?P<name>[a-zA-Z0-9_.-]+)")
+
+_GIT_REF_FLOATING_REASON = (
+    "declared as a git URL/SHA reference — a pinned git ref is not a released "
+    "version, so any reported version is resolved from the installed host "
+    "package, not the pinned ref"
+)
+
+
+def _looks_like_git_requirement(url: str) -> bool:
+    lowered = url.lower()
+    return lowered.startswith(("git+", "git@", "git://")) or "git+" in lowered
+
+
+def _git_reference_package(line: str, *, is_direct: bool = True) -> Package | None:
+    """Return a Package for a git-URL requirement line, or None if not one.
+
+    A git reference resolves (at scan time) to whatever the host environment has
+    installed, which is *not* an exact match to the pinned ref. Mark it
+    ``floating_reference`` with lowered confidence so downstream matching does not
+    treat the host-env coincidence as an exact pin.
+    """
+    direct = _GIT_DIRECT_URL_RE.match(line)
+    if direct and _looks_like_git_requirement(direct.group("url")):
+        name, url = direct.group("name"), direct.group("url")
+    elif _looks_like_git_requirement(line):
+        egg = _GIT_EGG_RE.search(line)
+        if not egg:
+            return None
+        name, url = egg.group("name"), line.split()[0]
+    else:
+        return None
+    return Package(
+        name=name,
+        version="unknown",
+        ecosystem="pypi",
+        is_direct=is_direct,
+        declared_version=url,
+        floating_reference=True,
+        floating_reference_reason=_GIT_REF_FLOATING_REASON,
+        version_confidence="low",
+    )
+
 
 def parse_poetry_lock(directory: Path) -> list[Package]:
     """Parse packages from poetry.lock (TOML format).
@@ -208,6 +254,12 @@ def parse_pip_packages(directory: Path) -> list[Package]:
         for line in read_text_limited(req_file).splitlines():
             line = line.strip()
             if not line or line.startswith("#") or line.startswith("-"):
+                continue
+            # Git URL/SHA reference (``flask @ git+…@<sha>``): version can't be
+            # pinned from the ref, so flag it floating rather than dropping it.
+            git_pkg = _git_reference_package(line, is_direct=True)
+            if git_pkg is not None:
+                packages.append(git_pkg)
                 continue
             # Parse name==version, name>=version, etc.
             match = re.match(r"^([a-zA-Z0-9_.-]+)\s*([=<>!~]+)\s*([a-zA-Z0-9_.*+-]+)", line)

--- a/src/agent_bom/secret_scanner.py
+++ b/src/agent_bom/secret_scanner.py
@@ -294,6 +294,25 @@ def _should_scan(path: Path) -> bool:
     return path.suffix.lower() in _SCAN_EXTENSIONS
 
 
+def _is_agent_bom_report(content: str) -> bool:
+    """Return True when *content* is one of agent-bom's own machine reports.
+
+    Re-scanning a previously written report (JSON AI-BOM, SARIF, or the CSV
+    finding export) for secrets flags the report's own numeric payload — scan
+    ids, CVSS scores, timestamps — as PII/credentials, inflating and
+    destabilizing finding counts on repeat scans of a directory that holds prior
+    output. Our own output is never a secret source, so skip it.
+    """
+    head = content[:4096]
+    if '"document_type": "AI-BOM"' in head or '"document_type":"AI-BOM"' in head:
+        return True
+    if '"$schema"' in head and "sarif" in head.lower() and '"runs"' in head:
+        return True
+    return head.startswith("cve_id,package,version,ecosystem,severity") or head.startswith(
+        "﻿cve_id,package,version,ecosystem,severity"
+    )
+
+
 def _scan_file(file_path: Path, rel_path: str, *, detect_entropy: bool = False) -> list[SecretFinding]:
     """Scan a single file for secrets."""
     try:
@@ -302,6 +321,9 @@ def _scan_file(file_path: Path, rel_path: str, *, detect_entropy: bool = False) 
         return []
 
     if len(content) > _MAX_FILE_SIZE:
+        return []
+
+    if _is_agent_bom_report(content):
         return []
 
     findings: list[SecretFinding] = []

--- a/tests/test_asset_discovery_provenance.py
+++ b/tests/test_asset_discovery_provenance.py
@@ -346,3 +346,34 @@ def _blast_radius(vuln: Vulnerability, pkg: Package, server: MCPServer, agent: A
         exposed_credentials=[],
         exposed_tools=[],
     )
+
+
+def test_git_ref_resolved_from_host_never_reports_exact() -> None:
+    """A git URL/SHA declared version resolved from the installed host package
+    must be downgraded from `exact` and flagged floating (host-env coincidence)."""
+    pkg = Package(name="flask", version="3.1.3", ecosystem="pypi")
+    pkg.version_source = "installed_package"
+    pkg.declared_version = "git+https://github.com/pallets/flask.git@a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+
+    vp = package_version_provenance(pkg)
+    assert vp["confidence"] != "exact"
+    assert vp.get("floating_reference") is True
+
+
+def test_bare_commit_sha_declared_never_reports_exact() -> None:
+    pkg = Package(name="flask", version="3.1.3", ecosystem="pypi")
+    pkg.version_source = "installed_package"
+    pkg.declared_version = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+
+    vp = package_version_provenance(pkg)
+    assert vp["confidence"] != "exact"
+
+
+def test_normal_installed_package_still_exact() -> None:
+    pkg = Package(name="flask", version="3.1.3", ecosystem="pypi")
+    pkg.version_source = "installed_package"
+    pkg.declared_version = "3.1.3"
+
+    vp = package_version_provenance(pkg)
+    assert vp["confidence"] == "exact"
+    assert vp.get("floating_reference") is not True

--- a/tests/test_coverage_warning.py
+++ b/tests/test_coverage_warning.py
@@ -224,5 +224,46 @@ def test_osv_fallback_db_keys_for_sparse_release(tmp_path):
     assert keys == {package_db_key(pkg) for pkg in packages}
 
 
+def test_malformed_package_json_records_coverage_warning(tmp_path):
+    from agent_bom.parsers.node_parsers import parse_npm_packages
+    from agent_bom.scanners.state import consume_coverage_warnings
+
+    consume_coverage_warnings()  # clear any prior state
+    (tmp_path / "package.json").write_text('{ "dependencies": { "express": "^4"  BROKEN', encoding="utf-8")
+
+    pkgs = parse_npm_packages(tmp_path)
+    warnings = consume_coverage_warnings()
+
+    assert pkgs == []  # nothing parsed — but the gap must be surfaced
+    assert any(w.get("reason") == "manifest_parse_error" and w.get("ecosystem") == "npm" for w in warnings)
+
+
+def test_malformed_pom_xml_records_coverage_warning(tmp_path):
+    from agent_bom.parsers.compiled_parsers import parse_maven_packages
+    from agent_bom.scanners.state import consume_coverage_warnings
+
+    consume_coverage_warnings()
+    (tmp_path / "pom.xml").write_text("<project><dependencies><dependency><groupId>g</groupId><artifactId>a", encoding="utf-8")
+
+    pkgs = parse_maven_packages(tmp_path)
+    warnings = consume_coverage_warnings()
+
+    assert pkgs == []
+    assert any(w.get("reason") == "manifest_parse_error" and w.get("ecosystem") == "maven" for w in warnings)
+
+
+def test_valid_package_json_records_no_manifest_warning(tmp_path):
+    from agent_bom.parsers.node_parsers import parse_npm_packages
+    from agent_bom.scanners.state import consume_coverage_warnings
+
+    consume_coverage_warnings()
+    (tmp_path / "package.json").write_text('{"dependencies": {"express": "4.18.2"}}', encoding="utf-8")
+
+    parse_npm_packages(tmp_path)
+    warnings = consume_coverage_warnings()
+
+    assert not any(w.get("reason") == "manifest_parse_error" for w in warnings)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_malicious.py
+++ b/tests/test_malicious.py
@@ -105,6 +105,40 @@ def test_typosquat_case_insensitive():
     assert result == "express"
 
 
+def test_typosquat_single_char_substitution_short_name():
+    # `djanga` vs `django` is a single substitution scoring 0.833 < 0.85 — the
+    # ratio gate misses it, the edit-distance-1 catch must not.
+    assert check_typosquat("djanga", "pypi") == "django"
+
+
+def test_typosquat_legit_packages_not_flagged_no_regressions():
+    from agent_bom.malicious import _POPULAR_PACKAGES
+
+    legit_pypi = [
+        "urllib3", "click", "rich", "pytest", "setuptools", "wheel", "certifi",
+        "idna", "six", "jinja2", "werkzeug", "attrs", "packaging", "tqdm",
+        "pyyaml", "typing-extensions", "pytz", "wrapt", "markupsafe", "poetry",
+        "ruff", "mypy", "coverage", "hypothesis", "loguru", "starlette", "anyio",
+        "sniffio", "greenlet", "protobuf",
+    ] + list(_POPULAR_PACKAGES["pypi"])
+    legit_npm = [
+        "react-router", "vite", "rollup", "esbuild", "vitest", "jest", "ts-node",
+        "pnpm", "yarn", "fastify", "koa", "ws", "ioredis", "pino", "winston",
+        "undici", "tslib", "glob", "rimraf", "minimist", "semver", "debug", "ms",
+        "node-fetch",
+    ] + list(_POPULAR_PACKAGES["npm"])
+
+    assert [n for n in legit_pypi if check_typosquat(n, "pypi")] == []
+    assert [n for n in legit_npm if check_typosquat(n, "npm")] == []
+
+
+def test_typosquat_short_names_not_over_flagged():
+    # `core` (len 4) vs `cors` and `flash` (len 5) vs `flask` are legitimate
+    # neighbours below the edit-distance-1 length gate — must stay clean.
+    assert check_typosquat("core", "npm") is None
+    assert check_typosquat("flash", "pypi") is None
+
+
 def test_typosquat_pypi_torch():
     # "torcch" is close to "torch"
     result = check_typosquat("torcch", "pypi")

--- a/tests/test_parser_interop.py
+++ b/tests/test_parser_interop.py
@@ -346,3 +346,39 @@ def test_conda_in_ecosystem_map():
     assert "conda" in ECOSYSTEM_MAP
     # conda maps to PyPI in OSV (conda packages are pip-installable)
     assert ECOSYSTEM_MAP["conda"] == "PyPI"
+
+
+# ── Git URL/SHA requirements ──────────────────────────────────────────────────
+
+
+def test_pip_git_url_requirement_marked_floating_not_exact(tmp_path):
+    """A `name @ git+…@<sha>` requirement must not claim an exact pin.
+
+    The version resolves to whatever the host env has installed, which is not an
+    exact match to the pinned commit; it must be flagged floating with lowered
+    confidence so downstream matching does not trust the coincidence.
+    """
+    (tmp_path / "requirements.txt").write_text(
+        "flask @ git+https://github.com/pallets/flask.git@a1b2c3d4e5f60718293a4b5c6d7e8f9012345678\n"
+        "requests==2.0.0\n",
+        encoding="utf-8",
+    )
+    pkgs = {p.name: p for p in parse_pip_packages(tmp_path)}
+
+    flask = pkgs["flask"]
+    assert flask.floating_reference is True
+    assert flask.version_confidence != "exact"
+    assert "git+" in (flask.declared_version or "")
+
+    # A normal pinned requirement is unaffected.
+    assert pkgs["requests"].floating_reference is False
+
+
+def test_pip_git_egg_requirement_marked_floating(tmp_path):
+    (tmp_path / "requirements.txt").write_text(
+        "git+https://github.com/pallets/flask.git@abcdef1234#egg=flask\n",
+        encoding="utf-8",
+    )
+    pkgs = {p.name: p for p in parse_pip_packages(tmp_path)}
+    assert "flask" in pkgs
+    assert pkgs["flask"].floating_reference is True

--- a/tests/test_secret_scanner.py
+++ b/tests/test_secret_scanner.py
@@ -121,3 +121,21 @@ def test_scan_secrets_warns_on_non_directory(tmp_path: Path):
 
     assert result.total == 0
     assert result.warnings == [f"{target} is not a directory"]
+
+
+def test_scan_secrets_skips_agent_bom_own_reports(tmp_path: Path):
+    """Re-scanning a directory that holds a prior agent-bom report must not flag
+    the report's own numeric payload (scan ids, CVSS, timestamps) as PII."""
+    # A phone-number-like literal inside our own JSON report must be ignored.
+    (tmp_path / "r.json").write_text(
+        '{"document_type": "AI-BOM", "summary": {"phone": "415-555-0132"}}',
+        encoding="utf-8",
+    )
+    # SARIF report form.
+    (tmp_path / "r.sarif").write_text(
+        '{"$schema": "https://json.schemastore.org/sarif-2.1.0.json", "version": "2.1.0", '
+        '"runs": [{"results": [{"message": {"text": "415-555-0132"}}]}]}',
+        encoding="utf-8",
+    )
+    result = scan_secrets(tmp_path)
+    assert result.total == 0

--- a/tests/test_symbol_reachability_export.py
+++ b/tests/test_symbol_reachability_export.py
@@ -92,6 +92,67 @@ def test_sarif_exports_symbol_reachability_fields() -> None:
     assert props["reachable_affected_symbols"] == ["get"]
 
 
+def test_dual_write_findings_resync_carries_reachability_into_json() -> None:
+    """Regression: the CLI materializes `report.findings` *before* the blast_radii
+    are stamped, so the JSON `findings[]` projection carried null reachability
+    while `blast_radius[]`/CSV/Parquet/SARIF carried the verdict. The resync must
+    reconcile them."""
+    from agent_bom.graph.blast_reach import resync_cve_findings_from_blast_radii
+
+    br = _python_br(["get"])
+    # Dual-write: findings built from the row before stamping (the CLI ordering).
+    findings = [blast_radius_to_finding(br)]
+    apply_symbol_reachability_to_blast_radii(
+        [br],
+        ASTAnalysisResult(dependency_symbol_reach=[_reach("requests", "requests", "get")]),
+    )
+    assert findings[0].evidence["symbol_reachability"] is None  # stale before resync
+
+    replaced = resync_cve_findings_from_blast_radii(findings, [br])
+    assert replaced == 1
+
+    payload = to_json(AIBOMReport(agents=[], blast_radii=[br], findings=findings))
+    assert payload["blast_radius"][0]["symbol_reachability"] == FUNCTION_REACHABLE
+    assert payload["findings"][0]["evidence"]["symbol_reachability"] == FUNCTION_REACHABLE
+    # The two views must agree, not merely both be truthy.
+    assert (
+        payload["findings"][0]["evidence"]["symbol_reachability"]
+        == payload["blast_radius"][0]["symbol_reachability"]
+    )
+
+
+def test_all_machine_views_agree_on_reachability_verdict() -> None:
+    """json findings[], blast_radius[], CSV, SARIF (and Parquet when pyarrow is
+    present) must surface the same symbol_reachability verdict for a finding."""
+    import csv as _csv
+    import io
+
+    from agent_bom.output.csv_fmt import to_csv
+
+    br = _stamp_python_br()
+    report = AIBOMReport(agents=[], blast_radii=[br], findings=[blast_radius_to_finding(br)])
+
+    payload = to_json(report)
+    assert payload["findings"][0]["evidence"]["symbol_reachability"] == FUNCTION_REACHABLE
+    assert payload["blast_radius"][0]["symbol_reachability"] == FUNCTION_REACHABLE
+
+    sarif = to_sarif(report)
+    assert sarif["runs"][0]["results"][0]["properties"]["symbol_reachability"] == FUNCTION_REACHABLE
+
+    rows = list(_csv.DictReader(io.StringIO(to_csv(report))))
+    assert rows[0]["symbol_reachability"] == FUNCTION_REACHABLE
+
+    try:
+        import pyarrow.parquet as pq  # noqa: F401
+
+        from agent_bom.output.parquet_fmt import to_arrow_table
+
+        table = to_arrow_table(report)
+        assert table.column("symbol_reachability").to_pylist()[0] == FUNCTION_REACHABLE
+    except ImportError:
+        pass
+
+
 def test_project_paths_for_symbol_reach_dedupes_scan_targets() -> None:
     class _Req:
         agent_projects = ["/tmp/agent-a", "/tmp/agent-b"]


### PR DESCRIPTION
## Summary

Coherent output/reachability fix pass (0.94.3). Every bug below was reproduced by a dogfood run before fixing, and each ships with tests.

### 1. P1 — JSON `findings[]` dropped the reachability verdict (+ cross-format count parity)
`-f json` `findings[].evidence.symbol_reachability` / `graph_reachable` were `null` while `blast_radius[]`, CSV, Parquet, and SARIF all carried the verdict. Root cause: the CLI materializes `report.findings` (dual-write) **before** `apply_*_reachability_to_blast_radii` stamps the rows, so the JSON `findings[]` projection read a stale list. Fix: `resync_cve_findings_from_blast_radii` re-projects the stamped rows onto the CVE findings (matched by canonical id, no reorder / no double-count) right after stamping — so all five views agree.

While reconciling the finding **set** across formats, found and fixed the real cause of the pre-existing `test_scan_finding_count_parity_across_formats` failure: the secret scanner was scanning agent-bom's **own** report artifacts left in the project dir on a repeat scan and flagging their numeric payload (scan ids / CVSS / timestamps) as PII, inflating SARIF's count. Agent-bom reports (AI-BOM JSON / SARIF / CSV export) are now excluded from secret scanning. That test now passes.

### 2. P2 — malformed manifest silently dropped
An invalid `package.json` / `package-lock.json` / `pom.xml` scanned to 0 packages with no signal. Now emits a structured `coverage_warnings` entry (reason `manifest_parse_error`) plus a stderr log, and the console renders it distinctly.

### 3. P2 — typosquat miss on single-char substitutions
`djanga` (vs `django`) scored 0.833 < 0.85 and slipped past the ratio gate. Added an equal-length edit-distance-1 catch, gated to names ≥6 chars, so `djanga`/similar are caught with **no** new false positives (validated against the popular list + a batch of real packages; short neighbours like `core`/`flash` stay clean).

### 4. P2 — git-URL/SHA dep mislabeled `confidence: exact`
`flask @ git+…@<sha>` resolved to the host venv's installed version and claimed `floating_reference: false`, `confidence: exact`. The requirements parser now captures the git ref as `declared_version`, flags `floating_reference: true`, and lowers confidence; `asset_provenance` also downgrades any host-resolved git ref away from `exact`. The prior SHA-bound comparator fix is untouched.

### 5. P3 — stale `--fail-on-kev` help
Said "must use `--enrich`"; KEV works offline from the local DB. Text corrected.

## Tests
Added/extended: reachability export (dual-write resync + five-view parity), malicious (djanga caught, legit batch clean, short-name guard), coverage warnings (npm + maven parse failures), parser interop (git URL floating/non-exact), asset provenance (host-resolved git ref never `exact`), secret scanner (own reports skipped).

Targeted regression sweep: **1478 passed, 4 skipped**. `ruff check` + `mypy` clean on changed files.