### PR TITLE
fix(graph): stop walking inbound trust edges as outbound assume (complete #3761)

### DIFF
--- a/src/agent_bom/graph/attack_path_fusion.py
+++ b/src/agent_bom/graph/attack_path_fusion.py
@@ -29,10 +29,14 @@ capped, and the number of returned paths is capped after ranking + dedup.
 
 from __future__ import annotations
 
+import logging
+
 from agent_bom.graph.container import AttackPath, UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import UnifiedNode
 from agent_bom.graph.types import EntityType, RelationshipType
+
+_logger = logging.getLogger(__name__)
 
 _FUSION_SOURCE = "attack-path-fusion"
 
@@ -45,6 +49,11 @@ _MAX_PATHS = 50  # ranked fused chains returned / materialised
 
 # Edges an attacker can traverse moving *forward* from an internet entry toward
 # data. All are already present in the unified graph (inventory + both overlays).
+# TRUSTS / CROSS_ACCOUNT_TRUST are deliberately excluded: they are emitted as
+# ``role R -> trusted principal P`` where P is *allowed to assume* R (INBOUND
+# trust). Walking them forward would fabricate a cross-account kill-chain from an
+# exposed R into P's account (the class #3761 removed from toxic_findings).
+# ASSUMES (principal -> role) remains the genuine outbound assume vector.
 _TRAVERSABLE_RELS = frozenset(
     {
         RelationshipType.USES,
@@ -58,8 +67,6 @@ _TRAVERSABLE_RELS = frozenset(
         RelationshipType.AUTHENTICATES_AS,
         RelationshipType.SCOPED_TO,
         RelationshipType.ASSUMES,
-        RelationshipType.TRUSTS,
-        RelationshipType.CROSS_ACCOUNT_TRUST,
         RelationshipType.INHERITS,
         RelationshipType.CAN_ACCESS,
         RelationshipType.HAS_PERMISSION,
@@ -106,8 +113,8 @@ def _edge_boost(edge: UnifiedEdge, target: UnifiedNode) -> tuple[float, str]:
         if (edge.evidence or {}).get("access") == "assume_chain":
             return 20.0, f"escalates privilege (assume-chain) to reach {target.label}"
         return 8.0, f"uses effective permission to reach {target.label}"
-    if rel in (RelationshipType.ASSUMES, RelationshipType.TRUSTS, RelationshipType.CROSS_ACCOUNT_TRUST, RelationshipType.INHERITS):
-        return 14.0, f"assumes role/trust into {target.label}"
+    if rel in (RelationshipType.ASSUMES, RelationshipType.INHERITS):
+        return 14.0, f"assumes role into {target.label}"
     if rel == RelationshipType.EXPOSED_TO:
         return 16.0, f"reaches internet-exposed {target.label}"
     if rel == RelationshipType.STORES:
@@ -158,7 +165,17 @@ def compute_fused_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
     collecting the *highest-scoring* chain that terminates at each reachable
     crown-jewel data store, then ranks + dedups + caps the result.
     """
-    if not graph.nodes or len(graph.nodes) > _MAX_NODES:
+    if not graph.nodes:
+        return []
+    if len(graph.nodes) > _MAX_NODES:
+        # Capped, NOT "no attack paths". Log a signal so a large real estate that
+        # skipped fusion is not silently read as "flagship found nothing".
+        _logger.warning(
+            "attack-path fusion capped: %d nodes exceed cap %d; fused kill-chains "
+            "NOT computed for this graph (result is 'skipped', not 'none')",
+            len(graph.nodes),
+            _MAX_NODES,
+        )
         return []
 
     entries = [n for n in graph.nodes.values() if _is_entry(n)]
@@ -259,7 +276,7 @@ def _walk_from_entry(
     dfs(entry.id, [entry.id], [], [], {entry.id}, _node_boost(entry), [], [])
 
 
-def apply_attack_path_fusion(graph: UnifiedGraph) -> dict[str, int]:
+def apply_attack_path_fusion(graph: UnifiedGraph) -> dict[str, object]:
     """Compute fused chains and materialise them on ``graph.attack_paths``.
 
     Idempotent w.r.t. fusion: existing fusion-sourced paths are replaced so a
@@ -270,10 +287,16 @@ def apply_attack_path_fusion(graph: UnifiedGraph) -> dict[str, int]:
     # Drop any prior fusion output, keep everything else.
     graph.attack_paths = [p for p in graph.attack_paths if not _is_fusion_path(p)]
     graph.attack_paths.extend(fused)
-    return {
+    result: dict[str, object] = {
         "fused_attack_paths": len(fused),
         "max_fused_risk": int(round(max((p.composite_risk for p in fused), default=0.0))),
     }
+    # Surface the node-budget cap so 0 paths on a large estate reads as "skipped"
+    # rather than "genuinely none".
+    if len(graph.nodes) > _MAX_NODES:
+        result["skipped"] = True
+        result["skipped_reason"] = f"node_cap_exceeded:{len(graph.nodes)}>{_MAX_NODES}"
+    return result
 
 
 def _is_fusion_path(path: AttackPath) -> bool:

--- a/src/agent_bom/graph/effective_permissions.py
+++ b/src/agent_bom/graph/effective_permissions.py
@@ -1,9 +1,11 @@
 """Effective-permission computation and privilege-escalation detection.
 
-The identity graph already records direct access (``CAN_ACCESS``), assume/trust
-relationships (``TRUSTS`` / ``CROSS_ACCOUNT_TRUST`` / ``ASSUMES``), and group
-membership (``MEMBER_OF`` into a ``GROUP``) between principals. This overlay
-resolves them into *effective* access — what a principal can reach after assuming
+The identity graph already records direct access (``CAN_ACCESS``), outbound
+assume relationships (``ASSUMES`` — principal → role it may assume), inbound
+trust (``TRUSTS`` / ``CROSS_ACCOUNT_TRUST`` — role → principal allowed to assume
+it, which this overlay does NOT walk as an assume), and group membership
+(``MEMBER_OF`` into a ``GROUP``) between principals. This overlay resolves them
+into *effective* access — what a principal can reach after assuming
 the roles it is allowed to assume and inheriting the access of the groups it
 belongs to — and emits ``HAS_PERMISSION`` edges for the transitive closure. A
 principal that reaches a resource only by assuming another role is flagged as a
@@ -16,11 +18,14 @@ scale: principals and chain depth are capped.
 
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 
 from agent_bom.graph.container import InteractionRisk, UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.types import EntityType, RelationshipType
+
+_logger = logging.getLogger(__name__)
 
 _OVERLAY_SOURCE = "effective-permissions"
 
@@ -37,24 +42,45 @@ _PRINCIPAL_TYPES = frozenset(
     }
 )
 _RESOURCE_TYPES = frozenset({EntityType.CLOUD_RESOURCE, EntityType.RESOURCE, EntityType.DATA_STORE})
-_ASSUME_RELS = frozenset(
-    {RelationshipType.TRUSTS, RelationshipType.CROSS_ACCOUNT_TRUST, RelationshipType.ASSUMES, RelationshipType.INHERITS}
-)
+# Edges that let a principal gain the access of *another* principal by moving
+# outbound. TRUSTS / CROSS_ACCOUNT_TRUST are deliberately excluded: those edges
+# are emitted as ``role R -> trusted principal P`` where P is *allowed to assume*
+# R (INBOUND trust). Folding them into an assume walk would make an exposed R
+# inherit P's access and mint a false HAS_PERMISSION{assume_chain} edge into P's
+# account — a fabricated cross-account kill-chain (the same class #3761 removed
+# from toxic_findings). ASSUMES (principal -> role) is the genuine outbound
+# vector; INHERITS is scoped-policy inheritance, also outbound.
+_ASSUME_RELS = frozenset({RelationshipType.ASSUMES, RelationshipType.INHERITS})
 
 _MAX_PRINCIPALS = 5000
 _MAX_DEPTH = 6
 _ADMIN_PRIVILEGE_KEYWORDS = ("administratoraccess", "fullaccess", "poweruseraccess", "iamfullaccess", "*:*", "admin", "owner", "root")
 
 
-def apply_effective_permissions(graph: UnifiedGraph) -> dict[str, int]:
+def apply_effective_permissions(graph: UnifiedGraph) -> dict[str, object]:
     """Emit HAS_PERMISSION edges + privilege-escalation signals in place.
 
     Returns counts of permission edges added and escalation chains found. Never
     raises into the builder.
     """
     principals = [n for n in graph.nodes.values() if n.entity_type in _PRINCIPAL_TYPES]
-    if not principals or len(principals) > _MAX_PRINCIPALS:
+    if not principals:
         return {"has_permission_edges": 0, "privilege_escalations": 0}
+    if len(principals) > _MAX_PRINCIPALS:
+        # Capped, NOT "no escalations". Surface a signal (log + returned reason) so
+        # consumers can distinguish "too big to compute" from "genuinely clean".
+        _logger.warning(
+            "effective-permissions capped: %d principals exceed cap %d; "
+            "privilege-escalation NOT computed for this graph (result is 'skipped', not 'none')",
+            len(principals),
+            _MAX_PRINCIPALS,
+        )
+        return {
+            "has_permission_edges": 0,
+            "privilege_escalations": 0,
+            "skipped": True,
+            "skipped_reason": f"principal_cap_exceeded:{len(principals)}>{_MAX_PRINCIPALS}",
+        }
     principal_ids = {p.id for p in principals}
 
     direct_access: dict[str, set[str]] = defaultdict(set)

--- a/tests/test_attack_path_fusion.py
+++ b/tests/test_attack_path_fusion.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from agent_bom.graph.attack_path_fusion import (
     _MAX_DEPTH,
+    _MAX_NODES,
     _MAX_PATHS,
     apply_attack_path_fusion,
     compute_fused_attack_paths,
@@ -214,3 +215,62 @@ def test_apply_preserves_foreign_attack_paths():
     apply_attack_path_fusion(g)
     assert foreign in g.attack_paths
     assert any(p.summary.startswith("Internet-exposed ") for p in g.attack_paths)
+
+
+def test_inbound_trust_edge_does_not_fabricate_cross_account_chain():
+    """Regression (complete #3761): a CROSS_ACCOUNT_TRUST edge is INBOUND trust
+    (role R -> principal P means P may assume R). It must NOT be walked forward as
+    an outbound pivot, which would fabricate a cross-account kill-chain from an
+    exposed R into P's account and on to P's data store."""
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="role:R", entity_type=EntityType.ROLE, label="exposed-R", attributes={"internet_exposed": True}))
+    g.add_node(UnifiedNode(id="prin:P", entity_type=EntityType.ROLE, label="P"))
+    g.add_node(
+        UnifiedNode(
+            id="ds:X",
+            entity_type=EntityType.DATA_STORE,
+            label="ds-X",
+            attributes={"data_sensitivity": "high", "data_classification_tier": "restricted"},
+        )
+    )
+    g.add_edge(UnifiedEdge(source="role:R", target="prin:P", relationship=RelationshipType.CROSS_ACCOUNT_TRUST))
+    g.add_edge(UnifiedEdge(source="prin:P", target="ds:X", relationship=RelationshipType.CAN_ACCESS))
+
+    paths = compute_fused_attack_paths(g)
+    assert not any(p.source == "role:R" and p.target == "ds:X" for p in paths)
+
+
+def test_genuine_assumes_chain_still_fuses():
+    """Over-correction guard: a real OUTBOUND ASSUMES chain (exposed workload ->
+    role it assumes -> sensitive data store) must still fuse into an attack path."""
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="res:web", entity_type=EntityType.CLOUD_RESOURCE, label="web", attributes={"internet_exposed": True}))
+    g.add_node(UnifiedNode(id="role:app", entity_type=EntityType.ROLE, label="app-role"))
+    g.add_node(
+        UnifiedNode(
+            id="ds:X",
+            entity_type=EntityType.DATA_STORE,
+            label="ds-X",
+            attributes={"data_sensitivity": "high", "data_classification_tier": "restricted"},
+        )
+    )
+    g.add_edge(UnifiedEdge(source="res:web", target="role:app", relationship=RelationshipType.ASSUMES))
+    g.add_edge(UnifiedEdge(source="role:app", target="ds:X", relationship=RelationshipType.CAN_ACCESS))
+
+    paths = compute_fused_attack_paths(g)
+    assert any(p.source == "res:web" and p.target == "ds:X" for p in paths)
+
+
+def test_oversized_graph_surfaces_skipped_signal():
+    """A graph past the node budget returns 0 paths but the apply-level result must
+    mark it 'skipped' so a large estate is not misread as 'no attack paths'."""
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="entry", entity_type=EntityType.CLOUD_RESOURCE, label="e", attributes={"internet_exposed": True}))
+    g.add_node(UnifiedNode(id="data_store:x", entity_type=EntityType.DATA_STORE, label="d", attributes={"data_sensitivity": "sensitive"}))
+    g.add_edge(UnifiedEdge(source="entry", target="data_store:x", relationship=RelationshipType.STORES))
+    for i in range(_MAX_NODES + 1):
+        g.add_node(UnifiedNode(id=f"pad{i}", entity_type=EntityType.PACKAGE, label=f"p{i}"))
+    stats = apply_attack_path_fusion(g)
+    assert stats["fused_attack_paths"] == 0
+    assert stats["skipped"] is True
+    assert "node_cap_exceeded" in stats["skipped_reason"]

--- a/tests/test_aws_iam_privilege.py
+++ b/tests/test_aws_iam_privilege.py
@@ -68,7 +68,7 @@ def test_effective_permissions_uses_action_derived_admin():
     # Policy NAME is not admin-keyword, but action-derived privilege_level is admin.
     g.add_node(UnifiedNode(id="pol:c", entity_type=EntityType.POLICY, label="team-custom", attributes={"privilege_level": "admin"}))
     g.add_node(UnifiedNode(id="cloud:x", entity_type=EntityType.CLOUD_RESOURCE, label="x"))
-    g.add_edge(UnifiedEdge(source="user:dev", target="role:r", relationship=RelationshipType.TRUSTS))
+    g.add_edge(UnifiedEdge(source="user:dev", target="role:r", relationship=RelationshipType.ASSUMES))
     g.add_edge(UnifiedEdge(source="role:r", target="pol:c", relationship=RelationshipType.ATTACHED))
     g.add_edge(UnifiedEdge(source="role:r", target="cloud:x", relationship=RelationshipType.CAN_ACCESS))
 

--- a/tests/test_graph_attack_path_e2e.py
+++ b/tests/test_graph_attack_path_e2e.py
@@ -57,7 +57,7 @@ def _scenario() -> UnifiedGraph:
     add("user:dev", EntityType.USER, "dev")
     add("role:admin", EntityType.ROLE, "prod-admin-role")
     add("pol:admin", EntityType.POLICY, "AdministratorAccess")
-    g.add_edge(UnifiedEdge(source="user:dev", target="role:admin", relationship=RelationshipType.TRUSTS))
+    g.add_edge(UnifiedEdge(source="user:dev", target="role:admin", relationship=RelationshipType.ASSUMES))
     g.add_edge(UnifiedEdge(source="role:admin", target="pol:admin", relationship=RelationshipType.ATTACHED))
     g.add_edge(UnifiedEdge(source="role:admin", target="cloud:bucket", relationship=RelationshipType.CAN_ACCESS))
     return g

--- a/tests/test_graph_effective_permissions.py
+++ b/tests/test_graph_effective_permissions.py
@@ -24,8 +24,10 @@ def test_assume_chain_yields_effective_permission_and_escalation():
     )
     g.add_node(UnifiedNode(id="cloud:logs", entity_type=EntityType.CLOUD_RESOURCE, label="logs"))
     # dev can directly access logs, and can assume admin-role which can access the bucket.
+    # ASSUMES (principal -> role) is the genuine OUTBOUND assume vector; inbound
+    # TRUSTS / CROSS_ACCOUNT_TRUST must NOT fold another principal's access into dev.
     g.add_edge(UnifiedEdge(source="user:dev", target="cloud:logs", relationship=RelationshipType.CAN_ACCESS))
-    g.add_edge(UnifiedEdge(source="user:dev", target="role:admin", relationship=RelationshipType.TRUSTS))
+    g.add_edge(UnifiedEdge(source="user:dev", target="role:admin", relationship=RelationshipType.ASSUMES))
     g.add_edge(UnifiedEdge(source="role:admin", target="cloud:bucket", relationship=RelationshipType.CAN_ACCESS))
 
     stats = apply_effective_permissions(g)
@@ -74,7 +76,7 @@ def test_escalation_to_admin_role_is_higher_risk():
     g.add_node(UnifiedNode(id="role:admin", entity_type=EntityType.ROLE, label="prod-admin-role"))
     g.add_node(UnifiedNode(id="pol:admin", entity_type=EntityType.POLICY, label="AdministratorAccess"))
     g.add_node(UnifiedNode(id="cloud:x", entity_type=EntityType.CLOUD_RESOURCE, label="x"))
-    g.add_edge(UnifiedEdge(source="user:dev", target="role:admin", relationship=RelationshipType.TRUSTS))
+    g.add_edge(UnifiedEdge(source="user:dev", target="role:admin", relationship=RelationshipType.ASSUMES))
     g.add_edge(UnifiedEdge(source="role:admin", target="pol:admin", relationship=RelationshipType.ATTACHED))
     g.add_edge(UnifiedEdge(source="role:admin", target="cloud:x", relationship=RelationshipType.CAN_ACCESS))
 
@@ -114,3 +116,51 @@ def test_nested_group_membership_is_bounded_and_inherited():
 
     apply_effective_permissions(g)
     assert _perm(g, "user:alice").get("data:secret") == "group"
+
+
+def test_inbound_trust_edge_is_not_folded_into_assume_chain():
+    # Regression (complete #3761): a CROSS_ACCOUNT_TRUST edge role R -> principal P
+    # is INBOUND (P is allowed to assume R). It must NOT make R inherit P's access,
+    # which would mint a false HAS_PERMISSION{assume_chain} R -> ds:X edge and set
+    # can_escalate_privilege on the exposed R — a fabricated cross-account chain.
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="role:R", entity_type=EntityType.ROLE, label="exposed-R", attributes={"internet_exposed": True}))
+    g.add_node(UnifiedNode(id="prin:P", entity_type=EntityType.ROLE, label="P"))
+    g.add_node(UnifiedNode(id="ds:X", entity_type=EntityType.DATA_STORE, label="ds-X"))
+    g.add_edge(UnifiedEdge(source="role:R", target="prin:P", relationship=RelationshipType.CROSS_ACCOUNT_TRUST))
+    g.add_edge(UnifiedEdge(source="prin:P", target="ds:X", relationship=RelationshipType.CAN_ACCESS))
+
+    stats = apply_effective_permissions(g)
+    # R gains nothing; only P's own direct access is recorded.
+    assert _perm(g, "role:R") == {}
+    assert _perm(g, "prin:P").get("ds:X") == "direct"
+    assert g.nodes["role:R"].attributes.get("can_escalate_privilege") is None
+    assert stats["privilege_escalations"] == 0
+
+
+def test_plain_trusts_edge_is_not_walked_as_assume():
+    # Same rule for the intra-account TRUSTS edge (also inbound).
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="role:R", entity_type=EntityType.ROLE, label="R", attributes={"internet_exposed": True}))
+    g.add_node(UnifiedNode(id="role:P", entity_type=EntityType.ROLE, label="P"))
+    g.add_node(UnifiedNode(id="cloud:x", entity_type=EntityType.CLOUD_RESOURCE, label="x"))
+    g.add_edge(UnifiedEdge(source="role:R", target="role:P", relationship=RelationshipType.TRUSTS))
+    g.add_edge(UnifiedEdge(source="role:P", target="cloud:x", relationship=RelationshipType.CAN_ACCESS))
+
+    apply_effective_permissions(g)
+    assert _perm(g, "role:R") == {}
+    assert g.nodes["role:R"].attributes.get("can_escalate_privilege") is None
+
+
+def test_capped_graph_surfaces_skipped_signal():
+    # Past the principal cap, the overlay returns 0 escalations but must mark the
+    # result 'skipped' so consumers do not read a large estate as 'genuinely none'.
+    from agent_bom.graph.effective_permissions import _MAX_PRINCIPALS
+
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    for i in range(_MAX_PRINCIPALS + 1):
+        g.add_node(UnifiedNode(id=f"user:{i}", entity_type=EntityType.USER, label=f"u{i}"))
+    stats = apply_effective_permissions(g)
+    assert stats["privilege_escalations"] == 0
+    assert stats["skipped"] is True
+    assert "principal_cap_exceeded" in stats["skipped_reason"]

--- a/tests/test_graph_governance_attack_paths.py
+++ b/tests/test_graph_governance_attack_paths.py
@@ -106,3 +106,40 @@ def test_governance_paths_merge_into_derived_attack_paths():
     # No vuln-anchored paths, but the governance path should still surface.
     all_paths = _derived_attack_paths(g)
     assert any(p.source == "user:dev" and p.target == "cloud:r" for p in all_paths)
+
+
+def test_inbound_trust_does_not_surface_governance_attack_path():
+    # Regression (complete #3761): end-to-end, an exposed role R with only an
+    # INBOUND CROSS_ACCOUNT_TRUST to P (P may assume R) must NOT, after the
+    # effective-permissions overlay runs, produce a HAS_PERMISSION{assume_chain}
+    # edge or a governance privilege-escalation attack path out of R.
+    from agent_bom.graph.effective_permissions import apply_effective_permissions
+
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="role:R", entity_type=EntityType.ROLE, label="exposed-R", attributes={"internet_exposed": True}))
+    g.add_node(UnifiedNode(id="prin:P", entity_type=EntityType.ROLE, label="P"))
+    g.add_node(
+        UnifiedNode(id="ds:X", entity_type=EntityType.DATA_STORE, label="ds-X", attributes={"data_sensitivity": "high"})
+    )
+    g.add_edge(UnifiedEdge(source="role:R", target="prin:P", relationship=RelationshipType.CROSS_ACCOUNT_TRUST))
+    g.add_edge(UnifiedEdge(source="prin:P", target="ds:X", relationship=RelationshipType.CAN_ACCESS))
+
+    apply_effective_permissions(g)
+    gov = _derived_governance_attack_paths(g)
+    assert not any(p.source == "role:R" for p in gov)
+
+
+def test_genuine_assume_chain_still_surfaces_governance_path():
+    # Over-correction guard: a real assume-chain HAS_PERMISSION edge still surfaces.
+    from agent_bom.graph.effective_permissions import apply_effective_permissions
+
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="user:dev", entity_type=EntityType.USER, label="dev"))
+    g.add_node(UnifiedNode(id="role:admin", entity_type=EntityType.ROLE, label="admin-role"))
+    g.add_node(UnifiedNode(id="cloud:x", entity_type=EntityType.CLOUD_RESOURCE, label="x", attributes={"internet_exposed": True}))
+    g.add_edge(UnifiedEdge(source="user:dev", target="role:admin", relationship=RelationshipType.ASSUMES))
+    g.add_edge(UnifiedEdge(source="role:admin", target="cloud:x", relationship=RelationshipType.CAN_ACCESS))
+
+    apply_effective_permissions(g)
+    gov = _derived_governance_attack_paths(g)
+    assert any(p.source == "user:dev" and p.target == "cloud:x" for p in gov)


### PR DESCRIPTION
## Summary

#3761 fixed the fabricated cross-account kill-chain in `toxic_findings` by removing `TRUSTS` / `CROSS_ACCOUNT_TRUST` from its lateral rels — but **two other graph modules still walked those inbound trust edges as outbound assume vectors**, re-opening the exact same false path.

Trust edges are built `role R -> trusted principal P`, meaning **P is allowed to assume R (INBOUND)**. Walking them forward (R can reach P) is wrong and fabricates cross-account attack paths.

## Fabricated-path repro (before)

Graph: internet-exposed `role:R` (acct A) --`CROSS_ACCOUNT_TRUST`--> `prin:P` (acct B) --`CAN_ACCESS`--> `ds:X` (sensitive, acct B).

On `main`, after the overlays run:
```
HAS_PERMISSION edges: [('role:R','ds:X','assume_chain'), ('prin:P','ds:X','direct')]
role:R.can_escalate_privilege: True
fused R->ds:X:  [('role:R','ds:X', 58.0)]   # false cross-account AttackPath
gov paths:      [('role:R','ds:X', 94.0)]   # false governance attack-path @ risk 94
```
All four are fabricated: R has no outbound path into P's account.

After this PR: `HAS_PERMISSION` only `prin:P -> ds:X` (direct); no `can_escalate_privilege` on R; no fused path; no governance path.

## Fixes

- **P1-A (root) — `effective_permissions.py`**: removed `TRUSTS` / `CROSS_ACCOUNT_TRUST` from `_ASSUME_RELS`. They were folded into the assume walk (`assumes[edge.source].add(edge.target)`), minting the false `HAS_PERMISSION{access:"assume_chain"}` edge and setting `can_escalate_privilege=True`. Because `HAS_PERMISSION` is a legit lateral rel in `toxic_findings` **and** the source of the `/v1/graph/attack-paths` governance privilege-escalation path, this single edge re-poisoned the path #3761 fixed. `ASSUMES` (principal → role) and `INHERITS` stay — the correct outbound vectors.
- **P1-B — `attack_path_fusion.py`**: removed `TRUSTS` / `CROSS_ACCOUNT_TRUST` from `_TRAVERSABLE_RELS` (they materialised a false cross-account `AttackPath`), and from the assume/trust edge-boost label. Other traversable rels untouched.
- **P2 (skipped-signal)**: both overlays returned empty with **no signal** past their node/principal budget, so a large real estate reads as "no attack paths exist". Added a `WARNING` log naming the cap + node/principal count, plus a surfaced `skipped` / `skipped_reason` in the returned result so consumers can distinguish "capped, not computed" from "genuinely none". **Cap values unchanged** (5000). Full UI surfacing of the signal is a follow-up.

## Tests

- Regression (all three surfaces): an inbound `CROSS_ACCOUNT_TRUST R -> P -> ds:X` graph produces **no** `assume_chain` edge, **no** `can_escalate_privilege` on R, **no** fused `AttackPath` R→ds:X, and **no** governance attack-path out of R.
- Over-correction guards: a genuine same-account `ASSUMES` chain still fires effective-permission escalation, a fused path, and a governance path.
- Cap-signal tests for both overlays.
- Existing fixtures that used `TRUSTS` to mean "principal assumes role" switched to `ASSUMES` (the correct outbound edge for that intent).

`uv run pytest` on the affected suites + broad graph suite: **1327 passed**. `ruff check` clean; `mypy` clean on both changed source files.