### PR TITLE
fix(ui): product taxonomy, density pass, and demo clarity

### DIFF
--- a/ui/app/audit/page.tsx
+++ b/ui/app/audit/page.tsx
@@ -24,6 +24,7 @@ import {
 import { useAuthState } from "@/components/auth-provider";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { KeyLifecyclePanel } from "@/components/key-lifecycle-panel";
+import { PageLaneHeader } from "@/components/page-lane";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -81,7 +82,14 @@ export default function AuditLogPage() {
       setTotal(log.total);
       setIntegrity(integ);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load audit log");
+      const message = e instanceof Error ? e.message : "Failed to load audit log";
+      if (/forbidden|analyst|viewer/i.test(message)) {
+        setError(
+          `Audit log requires analyst role or higher. You're signed in as ${roleLabel}. Sign in with a higher role to view entries.`
+        );
+      } else {
+        setError(message);
+      }
     } finally {
       setLoading(false);
     }
@@ -114,12 +122,12 @@ export default function AuditLogPage() {
   useEffect(() => {
     const timer = window.setTimeout(() => {
       void load();
-      if (!authSessionLoading) {
+      if (!authSessionLoading && canManageKeys) {
         void loadAdmin();
       }
     }, 0);
     return () => window.clearTimeout(timer);
-  }, [authSessionLoading, load, loadAdmin]);
+  }, [authSessionLoading, canManageKeys, load, loadAdmin]);
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
 
@@ -134,37 +142,36 @@ export default function AuditLogPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0">
-          <h1 className="text-2xl font-semibold tracking-tight flex items-center gap-2">
-            <FileText className="w-6 h-6 text-blue-400" />
-            Audit Log
-          </h1>
-          <p className="text-zinc-400 text-sm mt-1">
-            HMAC-signed, tamper-evident log of all system actions
-          </p>
-        </div>
-        <button
-          onClick={() => {
-            void load();
-            void loadAdmin();
-          }}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors"
-        >
-          <RefreshCw className="w-3.5 h-3.5" />
-          Refresh
-        </button>
-      </div>
-
-      <KeyLifecyclePanel
-        loading={adminLoading}
-        error={adminError}
-        policy={authPolicy}
-        keys={keys}
-        onRefresh={loadAdmin}
-        roleLabel={roleLabel}
+      <PageLaneHeader
+        lane="governance"
+        title="Audit Log"
+        subtitle="HMAC-signed, tamper-evident log of scan, policy, and fleet actions."
+        actions={
+          <button
+            onClick={() => {
+              void load();
+              if (canManageKeys) {
+                void loadAdmin();
+              }
+            }}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors"
+          >
+            <RefreshCw className="w-3.5 h-3.5" />
+            Refresh
+          </button>
+        }
       />
+
+      {canManageKeys ? (
+        <KeyLifecyclePanel
+          loading={adminLoading}
+          error={adminError}
+          policy={authPolicy}
+          keys={keys}
+          onRefresh={loadAdmin}
+          roleLabel={roleLabel}
+        />
+      ) : null}
 
       {/* Integrity banner + stats */}
       {integrity && (

--- a/ui/app/cost/page.tsx
+++ b/ui/app/cost/page.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/components/api-offline-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
 import { ChartTooltip } from "@/components/charts";
+import { PageLaneHeader } from "@/components/page-lane";
 
 function classifyApiErrorKind(err: unknown): ApiOfflineKind {
   if (err instanceof ApiAuthError) return "auth";
@@ -490,15 +491,11 @@ export default function CostPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-2">
-        <DollarSign className="h-6 w-6 text-emerald-400" />
-        <div>
-          <h1 className="text-2xl font-semibold text-zinc-100">Cost</h1>
-          <p className="text-sm text-zinc-500">
-            LLM spend, per-agent attribution, and budget enforcement posture.
-          </p>
-        </div>
-      </div>
+      <PageLaneHeader
+        lane="operations"
+        title="AI Spend"
+        subtitle="Model and token cost from proxy/gateway usage — not cloud infrastructure billing."
+      />
 
       <BudgetBanner budget={report.budget} />
 

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -2534,7 +2534,12 @@ function GraphPageInner() {
           )}
         </div>
 
-        <GraphEvaluationSummary evaluation={graphEvaluation} />
+        <details className="mt-3 rounded-xl border border-zinc-800 bg-zinc-950/70">
+          <summary className="cursor-pointer list-none px-3 py-2 text-xs font-medium text-zinc-300 [&::-webkit-details-marker]:hidden">
+            Graph evaluation · score {Math.round(graphEvaluation.score)} ({graphEvaluation.grade})
+          </summary>
+          <GraphEvaluationSummary evaluation={graphEvaluation} />
+        </details>
 
         {/* Snapshot diff + how-to-read default-collapsed so the canvas owns the
             viewport. The four redundant SnapshotMetaCards (Snapshot/Topology/
@@ -2628,19 +2633,26 @@ function GraphPageInner() {
         )}
 
         {graphDiff && (
-          <GraphDriftLegend
-            active={driftLensActive}
-            onToggleActive={(next) => {
-              setDriftLensActive(next);
-              if (!next) setDriftFilter("all");
-            }}
-            filter={driftFilter}
-            onFilterChange={setDriftFilter}
-            counts={drift.counts}
-            criticalCount={drift.critical}
-            comparedLabel={previousSnapshot?.scan_id.slice(0, 12)}
-            attributeSummaries={driftAttributeSummaryList}
-          />
+          <details className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3">
+            <summary className="cursor-pointer list-none text-xs font-medium text-zinc-300 [&::-webkit-details-marker]:hidden">
+              Snapshot drift lens · {drift.critical} critical changes
+            </summary>
+            <div className="mt-3">
+              <GraphDriftLegend
+                active={driftLensActive}
+                onToggleActive={(next) => {
+                  setDriftLensActive(next);
+                  if (!next) setDriftFilter("all");
+                }}
+                filter={driftFilter}
+                onFilterChange={setDriftFilter}
+                counts={drift.counts}
+                criticalCount={drift.critical}
+                comparedLabel={previousSnapshot?.scan_id.slice(0, 12)}
+                attributeSummaries={driftAttributeSummaryList}
+              />
+            </div>
+          </details>
         )}
 
         {driftLensActive && graphDiff ? (
@@ -2652,16 +2664,23 @@ function GraphPageInner() {
           />
         ) : null}
 
-        <GraphEvidenceLegend
-          active={evidenceLensActive}
-          onToggleActive={(next) => {
-            setEvidenceLensActive(next);
-            if (!next) setEvidenceFilter("all");
-          }}
-          filter={evidenceFilter}
-          onFilterChange={setEvidenceFilter}
-          counts={evidenceCounts}
-        />
+        <details className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3">
+          <summary className="cursor-pointer list-none text-xs font-medium text-zinc-300 [&::-webkit-details-marker]:hidden">
+            Evidence lens · {evidenceCounts.all} nodes
+          </summary>
+          <div className="mt-3">
+            <GraphEvidenceLegend
+              active={evidenceLensActive}
+              onToggleActive={(next) => {
+                setEvidenceLensActive(next);
+                if (!next) setEvidenceFilter("all");
+              }}
+              filter={evidenceFilter}
+              onFilterChange={setEvidenceFilter}
+              counts={evidenceCounts}
+            />
+          </div>
+        </details>
 
         <details className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3 text-xs text-zinc-400 group">
           <summary className="flex items-center justify-between cursor-pointer list-none [&::-webkit-details-marker]:hidden">

--- a/ui/app/manifest/page.tsx
+++ b/ui/app/manifest/page.tsx
@@ -28,6 +28,7 @@ import {
   manifestFilterOptions,
   type ManifestFilters,
 } from "@/lib/agent-bom-manifest";
+import { PageLaneHeader } from "@/components/page-lane";
 
 function downloadManifest(manifest: AgentBomManifestResponse) {
   const blob = new Blob([JSON.stringify(manifest, null, 2)], { type: "application/json" });
@@ -183,56 +184,59 @@ export default function AgentBomManifestPage() {
   return (
     <main className="min-h-screen bg-[var(--background)] p-6 text-[var(--foreground)]">
       <div className="mx-auto flex max-w-7xl flex-col gap-6">
-        <header className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-          <div>
-            <p className="text-sm font-medium text-emerald-400">Agent BOM</p>
-            <h1 className="mt-2 text-3xl font-semibold tracking-tight">AI visibility cockpit</h1>
-            <p className="mt-2 max-w-3xl text-sm text-[var(--muted-foreground)]">
-              Tenant-scoped inventory of agents, MCP servers, tools, credential references, ownership, runtime evidence, and graph relationships.
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              onClick={load}
-              className="inline-flex items-center gap-2 rounded-md border border-[var(--border)] px-3 py-2 text-sm hover:bg-[var(--accent)]"
-            >
-              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
-              Refresh
-            </button>
-            <button
-              type="button"
-              disabled={!manifest}
-              onClick={() => manifest && downloadManifest(manifest)}
-              className="inline-flex items-center gap-2 rounded-md border border-[var(--border)] px-3 py-2 text-sm hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <Download className="h-4 w-4" />
-              Download JSON
-            </button>
-          </div>
-        </header>
+        <PageLaneHeader
+          lane="ai-estate"
+          title="Agent BOM"
+          subtitle="Your tenant inventory of agents, MCP servers, tools, and credential references."
+          actions={
+            <>
+              <button
+                type="button"
+                onClick={load}
+                className="inline-flex items-center gap-2 rounded-md border border-[var(--border)] px-3 py-2 text-sm hover:bg-[var(--accent)]"
+              >
+                {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+                Refresh
+              </button>
+              <button
+                type="button"
+                disabled={!manifest}
+                onClick={() => manifest && downloadManifest(manifest)}
+                className="inline-flex items-center gap-2 rounded-md border border-[var(--border)] px-3 py-2 text-sm hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <Download className="h-4 w-4" />
+                Download JSON
+              </button>
+            </>
+          }
+        />
 
         {error ? <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">{error}</div> : null}
 
         {manifest ? (
           <>
-            <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-6">
+            <section className="grid gap-3 sm:grid-cols-3">
               <SummaryCard label="Agents" value={manifest.summary.agents} icon={TerminalSquare} tone="text-blue-300" />
               <SummaryCard label="MCP servers" value={manifest.summary.mcp_servers} icon={Server} tone="text-cyan-300" />
-              <SummaryCard label="Tools" value={manifest.summary.tools} icon={Wrench} tone="text-emerald-300" />
-              <SummaryCard label="Credentials" value={manifest.summary.credential_refs} icon={KeyRound} tone="text-yellow-300" />
-              <SummaryCard label="Runtime seen" value={manifest.summary.runtime_observed_servers} icon={Activity} tone="text-pink-300" />
-              <SummaryCard label="Gateway bound" value={manifest.summary.gateway_registered_servers} icon={Network} tone="text-violet-300" />
+              <SummaryCard label="Credential refs" value={manifest.summary.credential_refs} icon={KeyRound} tone="text-yellow-300" />
             </section>
 
-            <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-6">
-              <SummaryCard label="Owners" value={manifest.visibility.owners} icon={UserRound} tone="text-teal-300" />
-              <SummaryCard label="Unowned agents" value={manifest.visibility.unowned_agents} icon={AlertTriangle} tone="text-yellow-300" />
-              <SummaryCard label="Shadow runtime" value={manifest.visibility.shadow_runtime_servers} icon={Eye} tone="text-red-300" />
-              <SummaryCard label="Untracked runtime" value={manifest.visibility.untracked_runtime_servers} icon={Network} tone="text-orange-300" />
-              <SummaryCard label="Warnings" value={manifest.visibility.servers_with_warnings} icon={AlertTriangle} tone="text-amber-300" />
-              <SummaryCard label="Risky refs" value={manifest.visibility.risky_credential_refs} icon={KeyRound} tone="text-rose-300" />
-            </section>
+            <details className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+              <summary className="cursor-pointer list-none text-sm font-medium text-[var(--foreground)] [&::-webkit-details-marker]:hidden">
+                Extended visibility metrics
+              </summary>
+              <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+                <SummaryCard label="Tools" value={manifest.summary.tools} icon={Wrench} tone="text-emerald-300" />
+                <SummaryCard label="Runtime seen" value={manifest.summary.runtime_observed_servers} icon={Activity} tone="text-pink-300" />
+                <SummaryCard label="Gateway bound" value={manifest.summary.gateway_registered_servers} icon={Network} tone="text-violet-300" />
+                <SummaryCard label="Owners" value={manifest.visibility.owners} icon={UserRound} tone="text-teal-300" />
+                <SummaryCard label="Unowned agents" value={manifest.visibility.unowned_agents} icon={AlertTriangle} tone="text-yellow-300" />
+                <SummaryCard label="Shadow runtime" value={manifest.visibility.shadow_runtime_servers} icon={Eye} tone="text-red-300" />
+                <SummaryCard label="Untracked runtime" value={manifest.visibility.untracked_runtime_servers} icon={Network} tone="text-orange-300" />
+                <SummaryCard label="Warnings" value={manifest.visibility.servers_with_warnings} icon={AlertTriangle} tone="text-amber-300" />
+                <SummaryCard label="Risky refs" value={manifest.visibility.risky_credential_refs} icon={KeyRound} tone="text-rose-300" />
+              </div>
+            </details>
 
             <section className="flex flex-wrap items-center gap-2">
               <BoundaryBadge ok={!manifest.boundaries.stores_credential_values} label="credential values redacted" />
@@ -264,7 +268,7 @@ export default function AgentBomManifestPage() {
               </section>
             ) : null}
 
-            <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(360px,0.9fr)]">
+            <div className="space-y-6">
               <section className="rounded-lg border border-[var(--border)] bg-[var(--card)]">
                 <div className="flex flex-col gap-3 border-b border-[var(--border)] p-4 md:flex-row md:items-center md:justify-between">
                   <div>
@@ -414,7 +418,9 @@ export default function AgentBomManifestPage() {
                       {rows.length === 0 ? (
                         <tr>
                           <td colSpan={11} className="px-4 py-8 text-center text-sm text-[var(--muted-foreground)]">
-                            No MCP servers match these filters. Run <code className="rounded bg-[var(--muted)] px-1.5 py-0.5">agent-bom manifest</code> to generate local evidence, or clear filters to inspect the full tenant manifest.
+                            No MCP servers in this tenant yet. Run{" "}
+                            <code className="rounded bg-[var(--muted)] px-1.5 py-0.5">agent-bom manifest</code> locally to
+                            generate evidence, or clear filters to inspect the full manifest.
                           </td>
                         </tr>
                       ) : null}
@@ -423,7 +429,14 @@ export default function AgentBomManifestPage() {
                 </div>
               </section>
 
-              <MiniGraph manifest={manifest} />
+              <details className="rounded-lg border border-[var(--border)] bg-[var(--card)]">
+                <summary className="cursor-pointer list-none px-4 py-3 text-sm font-medium [&::-webkit-details-marker]:hidden">
+                  Manifest graph · {manifest.graph.stats.nodes} nodes · {manifest.graph.stats.edges} edges
+                </summary>
+                <div className="border-t border-[var(--border)] p-4">
+                  <MiniGraph manifest={manifest} />
+                </div>
+              </details>
             </div>
           </>
         ) : loading ? (

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/lib/api";
 import { TrustStackSignals } from "@/components/trust-stack";
 import { ActivityFeed } from "@/components/activity-feed";
-import { PostureGrade } from "@/components/posture-grade";
 import { AttackPathCard } from "@/components/attack-path-card";
 import { ApiOfflineState } from "@/components/api-offline-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
@@ -346,10 +345,7 @@ export default function Dashboard() {
   if (apiError && !importedReport) return <ApiOfflineState onImport={setImportedReport} kind={apiErrorKind} detail={apiErrorDetail} />;
 
   return (
-    <div className="space-y-8">
-      {/* Scorecard strip — one posture grade + risk score, critical/high, coverage,
-          connect status. Folds the former /overview domain tiles into the home
-          header so `/` opens above the fold with a single command surface. */}
+    <div className="space-y-5">
       <ScorecardStrip
         posture={posture ?? (overview ? { grade: overview.posture.grade, score: overview.posture.score, summary: overview.posture.summary, dimensions: {} } : null)}
         overview={overview}
@@ -359,158 +355,64 @@ export default function Dashboard() {
         summaryReady={summaryReady}
       />
 
-      <section className="relative overflow-hidden rounded-[28px] border border-zinc-800/80 bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.16),transparent_24%),radial-gradient(circle_at_top_right,rgba(239,68,68,0.12),transparent_24%),linear-gradient(180deg,rgba(24,24,27,0.98),rgba(9,9,11,0.96))] p-6 shadow-2xl shadow-black/20">
-        <div className="flex flex-col gap-6 xl:flex-row xl:items-start xl:justify-between">
-          <div className="max-w-3xl">
-            <p className="text-[11px] uppercase tracking-[0.24em] text-emerald-400">Solution overview</p>
-            <h1 className="mt-3 text-3xl font-semibold tracking-tight text-zinc-50 sm:text-4xl">
-              Exposure command center
-            </h1>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-zinc-300">
-              Prioritized AI/MCP exposure paths, active services, credentials, packages, and response work across {effectiveRecentJobs.length} scan{effectiveRecentJobs.length !== 1 ? "s" : ""}, {(displayedAgentCount ?? "—")} agent{displayedAgentCount === 1 ? "" : "s"}, {summaryReady ? displayedPackages : (summaryStats?.total_packages ?? 0)} packages, and {summaryReady ? displayedUniqueCVEs : (summaryStats?.total_vulnerabilities ?? fallbackVulnTotal)} CVEs.
+      <section className="rounded-2xl border border-zinc-800/80 bg-zinc-950/80 p-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0 flex-1">
+            <h1 className="text-2xl font-semibold tracking-tight text-zinc-50">Exposure command center</h1>
+            <p className="mt-1 text-sm text-zinc-400">
+              {(displayedAgentCount ?? "—")} agents · {summaryReady ? displayedPackages : "—"} packages · {summaryReady ? displayedUniqueCVEs : "—"} CVEs
             </p>
-            <p className="mt-5 text-[10px] font-semibold uppercase tracking-[0.22em] text-zinc-500">
-              Active exposure
-            </p>
-            <div className="mt-2 flex flex-wrap gap-2">
-              <div className="rounded-2xl border border-red-500/20 bg-red-500/10 px-3 py-2">
-                <div className="text-[10px] uppercase tracking-[0.18em] text-red-200/70">Actively exploited</div>
-                <div className="mt-1 font-mono text-lg font-semibold text-red-100">{summaryReady ? displayedKevCount : 0}</div>
-              </div>
-              <div className="rounded-2xl border border-amber-500/20 bg-amber-500/10 px-3 py-2">
-                <div className="text-[10px] uppercase tracking-[0.18em] text-amber-200/70">Credential exposed</div>
-                <div className="mt-1 font-mono text-lg font-semibold text-amber-100">{summaryReady ? displayedCredentialExposure : 0}</div>
-              </div>
-              <div className="rounded-2xl border border-sky-500/20 bg-sky-500/10 px-3 py-2">
-                <div className="text-[10px] uppercase tracking-[0.18em] text-sky-200/70">Reachable tools</div>
-                <div className="mt-1 font-mono text-lg font-semibold text-sky-100">{summaryReady ? displayedReachableTools : 0}</div>
-              </div>
+            <div className="mt-3 flex flex-wrap gap-2 text-xs">
+              <MetricChip label="KEV" value={String(summaryReady ? displayedKevCount : 0)} tone="red" />
+              <MetricChip label="Credentials" value={String(summaryReady ? displayedCredentialExposure : 0)} tone="amber" />
+              <MetricChip label="Tools" value={String(summaryReady ? displayedReachableTools : 0)} tone="sky" />
             </div>
           </div>
-          <div className="flex flex-wrap gap-2 xl:justify-end">
-            <Link
-              href="/scan"
-              className="flex items-center gap-2 rounded-xl bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500"
-            >
-              Run scan
-              <ArrowRight className="h-4 w-4" />
+          <div className="flex flex-wrap gap-2">
+            <Link href="/scan" className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500">
+              Run scan <ArrowRight className="h-4 w-4" />
             </Link>
-            <Link
-              href="/security-graph"
-              className="flex items-center gap-2 rounded-xl border border-zinc-700 bg-zinc-900/80 px-4 py-2.5 text-sm font-medium text-zinc-200 transition-colors hover:border-zinc-500 hover:bg-zinc-800"
-            >
-              Open graph
-              <GitBranch className="h-4 w-4" />
+            <Link href="/security-graph" className="inline-flex items-center gap-2 rounded-lg border border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-200 hover:border-zinc-500">
+              Security graph <GitBranch className="h-4 w-4" />
             </Link>
           </div>
         </div>
 
-        <div className="mt-6 grid gap-4 xl:grid-cols-[1.15fr_0.85fr]">
+        <div className="mt-4 grid gap-4 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
           {topExposurePath ? (
-            <div className="rounded-3xl border border-emerald-500/20 bg-emerald-500/[0.06] p-4">
-              <div className="mb-3 flex items-center justify-between gap-3">
-                <div>
-                  <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-emerald-300">Highest priority path</p>
-                  <p className="mt-1 text-sm text-zinc-400">
-                    Start here: this chain connects a finding to the agent/runtime surface that can exercise it.
-                  </p>
-                </div>
-                <span className="rounded-full border border-red-500/25 bg-red-500/10 px-3 py-1 font-mono text-xs font-semibold text-red-200">
-                  Risk {topExposurePath.riskScore.toFixed(1)}
+            <div className="rounded-xl border border-emerald-500/20 bg-emerald-500/[0.06] p-4">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-emerald-300">Top path</p>
+                <span className="rounded-full border border-red-500/25 bg-red-500/10 px-2 py-0.5 font-mono text-xs text-red-200">
+                  {topExposurePath.riskScore.toFixed(1)}
                 </span>
               </div>
-              <AttackPathCard nodes={topExposurePath.nodes} riskScore={topExposurePath.riskScore} href={topExposurePath.href} captureMode />
+              <AttackPathCard nodes={topExposurePath.nodes} riskScore={topExposurePath.riskScore} href={topExposurePath.href} captureMode compact />
             </div>
           ) : (
-            <div className="rounded-3xl border border-zinc-800 bg-zinc-950/70 p-4">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-emerald-300">Estate map</p>
-              <p className="mt-1 max-w-2xl text-sm leading-6 text-zinc-400">
-                No scored exposure path is available yet. The overview stays grounded in discovered environments, agent services, credential boundaries, and scan coverage until findings produce evidence.
-              </p>
-              <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                <Link href="/agents" className="rounded-2xl border border-sky-500/20 bg-sky-500/10 p-4 transition-colors hover:border-sky-400/40">
-                  <p className="text-[10px] uppercase tracking-[0.2em] text-sky-200/70">Agents</p>
-                  <p className="mt-2 font-mono text-2xl font-semibold text-sky-100">{agentsReady ? estateSummary.configuredAgents : "—"}</p>
-                  <p className="mt-1 text-xs text-sky-100/60">configured clients</p>
-                </Link>
-                <Link href="/agents" className="rounded-2xl border border-emerald-500/20 bg-emerald-500/10 p-4 transition-colors hover:border-emerald-400/40">
-                  <p className="text-[10px] uppercase tracking-[0.2em] text-emerald-200/70">Services</p>
-                  <p className="mt-2 font-mono text-2xl font-semibold text-emerald-100">{agentsReady ? estateSummary.servers : "—"}</p>
-                  <p className="mt-1 text-xs text-emerald-100/60">MCP servers</p>
-                </Link>
-                <Link href="/security-graph" className="rounded-2xl border border-amber-500/20 bg-amber-500/10 p-4 transition-colors hover:border-amber-400/40">
-                  <p className="text-[10px] uppercase tracking-[0.2em] text-amber-200/70">Identities</p>
-                  <p className="mt-2 font-mono text-2xl font-semibold text-amber-100">{agentsReady ? estateSummary.credentialedServers : "—"}</p>
-                  <p className="mt-1 text-xs text-amber-100/60">credentialed services</p>
-                </Link>
-                <Link href="/security-graph" className="rounded-2xl border border-fuchsia-500/20 bg-fuchsia-500/10 p-4 transition-colors hover:border-fuchsia-400/40">
-                  <p className="text-[10px] uppercase tracking-[0.2em] text-fuchsia-200/70">Environments</p>
-                  <p className="mt-2 font-mono text-2xl font-semibold text-fuchsia-100">{agentsReady ? estateSummary.environments : "—"}</p>
-                  <p className="mt-1 text-xs text-fuchsia-100/60">observed scopes</p>
-                </Link>
-              </div>
+            <div className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-4 text-sm text-zinc-400">
+              No scored exposure path yet. Run a scan to populate attack-path evidence.
             </div>
           )}
-          <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
-            <Link href="/findings?severity=critical" className="rounded-2xl border border-red-500/20 bg-red-500/10 p-4 transition-colors hover:border-red-400/40">
-              <p className="text-[10px] uppercase tracking-[0.2em] text-red-200/70">Fix queue</p>
-              <p className="mt-2 font-mono text-2xl font-semibold text-red-100">{severity.critical}</p>
-              <p className="mt-1 text-xs text-red-100/60">critical findings</p>
-            </Link>
-            <Link href="/security-graph" className="rounded-2xl border border-amber-500/20 bg-amber-500/10 p-4 transition-colors hover:border-amber-400/40">
-              <p className="text-[10px] uppercase tracking-[0.2em] text-amber-200/70">Identity paths</p>
-              <p className="mt-2 font-mono text-2xl font-semibold text-amber-100">{credentialExposureCount || estateSummary.credentialedServers}</p>
-              <p className="mt-1 text-xs text-amber-100/60">credential-linked services</p>
-            </Link>
-            <Link href="/agents" className="rounded-2xl border border-sky-500/20 bg-sky-500/10 p-4 transition-colors hover:border-sky-400/40">
-              <p className="text-[10px] uppercase tracking-[0.2em] text-sky-200/70">Active services</p>
-              <p className="mt-2 font-mono text-2xl font-semibold text-sky-100">{impactedAgentCount || estateSummary.servers || (displayedAgentCount ?? 0)}</p>
-              <p className="mt-1 text-xs text-sky-100/60">agent-facing services</p>
-            </Link>
+          <div className="grid grid-cols-3 gap-2">
+            <QuickLink href="/findings?severity=critical" label="Critical" value={String(severity.critical)} />
+            <QuickLink href="/security-graph" label="Identity" value={String(credentialExposureCount || estateSummary.credentialedServers)} />
+            <QuickLink href="/agents" label="Services" value={String(impactedAgentCount || estateSummary.servers || (displayedAgentCount ?? 0))} />
           </div>
         </div>
-
-        {posture && doneJobs.length > 0 && (
-          <div className="mt-6">
-            <PostureGrade
-              grade={posture.grade}
-              score={posture.score}
-              dimensions={posture.dimensions}
-              summary={posture.summary}
-              variant="panel"
-              defaultExpanded={false}
-              drilldown
-            />
-          </div>
-        )}
       </section>
 
       {/* Top exposure paths — the fix-first shortlist, kept above the fold. */}
       {(!isLoading) && allBlast.length > 0 && (
-        <details open className="group/attack rounded-[28px] border border-zinc-800/90 bg-zinc-950/70 p-4 shadow-[0_24px_80px_-48px_rgba(16,185,129,0.28)]">
-          <summary className="flex cursor-pointer list-none items-start justify-between gap-4 select-none">
-            <div className="flex items-start gap-3">
-              <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-emerald-500/20 bg-emerald-500/10 text-emerald-300">
-                <GitBranch className="h-4 w-4" />
-              </div>
-              <div>
-                <div className="flex items-center gap-2">
-                  <ChevronRight className="h-4 w-4 text-zinc-500 transition-transform group-open/attack:rotate-90" />
-                  <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-widest">
-                    Exposure Paths
-                  </h2>
-                  <span className="rounded-full border border-zinc-800 bg-zinc-900/90 px-2 py-0.5 font-mono text-[10px] text-zinc-400">
-                    {Math.min(allBlast.length, 5)} shown
-                  </span>
-                </div>
-                <p className="mt-1 max-w-3xl text-xs leading-5 text-zinc-500">
-                  Collapse this list when you want a tighter landing view. Open any path card to jump straight into the focused security graph drilldown.
-                </p>
-              </div>
+        <details className="group/attack rounded-2xl border border-zinc-800/90 bg-zinc-950/70 p-4">
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-4 select-none">
+            <div className="flex items-center gap-2">
+              <ChevronRight className="h-4 w-4 text-zinc-500 transition-transform group-open/attack:rotate-90" />
+              <h2 className="text-sm font-semibold text-zinc-300">Exposure paths</h2>
+              <span className="rounded-full border border-zinc-800 bg-zinc-900/90 px-2 py-0.5 font-mono text-[10px] text-zinc-400">
+                {Math.min(allBlast.length, 5)}
+              </span>
             </div>
-            <span className="hidden rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-emerald-300 md:inline-flex">
-              Clickable drilldowns
-            </span>
           </summary>
           <div className="mt-4 space-y-2">
             {[...allBlast]
@@ -544,27 +446,10 @@ export default function Dashboard() {
       )}
 
       {/* Exposure KPIs — coverage + backlog snapshot. */}
-      <details open className="group/metrics rounded-[28px] border border-zinc-800/90 bg-zinc-950/70 p-4 shadow-[0_24px_80px_-48px_rgba(59,130,246,0.24)]">
-        <summary className="flex cursor-pointer list-none items-start justify-between gap-4 select-none">
-          <div className="flex items-start gap-3">
-            <div className="mt-0.5 flex h-10 w-10 shrink-0 items-center justify-center rounded-2xl border border-sky-500/20 bg-sky-500/10 text-sky-300">
-              <Layers className="h-4 w-4" />
-            </div>
-            <div>
-              <div className="flex items-center gap-2">
-                <ChevronRight className="h-4 w-4 text-zinc-500 transition-transform group-open/metrics:rotate-90" />
-                <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-widest">
-                  Exposure KPIs
-                </h2>
-              </div>
-              <p className="mt-1 max-w-3xl text-xs leading-5 text-zinc-500">
-                Coverage and backlog snapshot for the current scan set: total scans, agents, packages, unique CVEs, and critical findings.
-              </p>
-            </div>
-          </div>
-          <span className="hidden rounded-full border border-zinc-800 bg-zinc-900/90 px-3 py-1 text-[10px] font-semibold uppercase tracking-[0.2em] text-zinc-400 md:inline-flex">
-            5 tiles
-          </span>
+      <details className="group/metrics rounded-2xl border border-zinc-800/90 bg-zinc-950/70 p-4">
+        <summary className="flex cursor-pointer list-none items-center gap-2 select-none">
+          <ChevronRight className="h-4 w-4 text-zinc-500 transition-transform group-open/metrics:rotate-90" />
+          <h2 className="text-sm font-semibold text-zinc-300">Exposure KPIs</h2>
         </summary>
         <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-5">
           <StatCard icon={Layers} label="Total scans" value={summaryReady ? String(effectiveRecentJobs.length) : "—"} color="zinc" href="/jobs" />
@@ -580,8 +465,8 @@ export default function Dashboard() {
           paint. */}
       <div>
         <div className="mb-4 inline-flex rounded-2xl border border-zinc-800 bg-zinc-950/70 p-1">
-          <TabButton icon={LayoutGrid} label="Command center" active={activeTab === "command"} onClick={() => setActiveTab("command")} />
-          <TabButton icon={BarChart3} label="Deep analytics" active={activeTab === "analytics"} onClick={() => setActiveTab("analytics")} />
+          <TabButton icon={LayoutGrid} label="Overview" active={activeTab === "command"} onClick={() => setActiveTab("command")} />
+          <TabButton icon={BarChart3} label="Analytics" active={activeTab === "analytics"} onClick={() => setActiveTab("analytics")} />
         </div>
 
         {activeTab === "command" ? (
@@ -637,6 +522,29 @@ export default function Dashboard() {
 }
 
 // ─── Components ───────────────────────────────────────────────────────────────
+
+function MetricChip({ label, value, tone }: { label: string; value: string; tone: "red" | "amber" | "sky" }) {
+  const toneClass =
+    tone === "red"
+      ? "border-red-500/20 bg-red-500/10 text-red-100"
+      : tone === "amber"
+        ? "border-amber-500/20 bg-amber-500/10 text-amber-100"
+        : "border-sky-500/20 bg-sky-500/10 text-sky-100";
+  return (
+    <span className={`rounded-lg border px-2.5 py-1 font-mono text-xs ${toneClass}`}>
+      {label} {value}
+    </span>
+  );
+}
+
+function QuickLink({ href, label, value }: { href: string; label: string; value: string }) {
+  return (
+    <Link href={href} className="rounded-lg border border-zinc-800 bg-zinc-900/80 p-3 text-center transition hover:border-zinc-600">
+      <p className="text-[10px] uppercase tracking-[0.16em] text-zinc-500">{label}</p>
+      <p className="mt-1 font-mono text-xl font-semibold text-zinc-100">{value}</p>
+    </Link>
+  );
+}
 
 function TabButton({
   icon: Icon,

--- a/ui/app/registry/page.tsx
+++ b/ui/app/registry/page.tsx
@@ -21,6 +21,7 @@ import {
   Tag,
 } from "lucide-react";
 import { api, type RegistryServer } from "@/lib/api";
+import { CatalogBanner, PageLaneHeader } from "@/components/page-lane";
 
 /* ------------------------------------------------------------------ */
 /*  Shared helpers                                                     */
@@ -70,6 +71,7 @@ function DetailSection({ title, icon: Icon, children, accent }: {
 /* ------------------------------------------------------------------ */
 
 type RiskFilter = "all" | "high" | "medium" | "low";
+type RegistryView = "table" | "cards";
 
 function RegistryDetail({ serverId }: { serverId: string }) {
   const router = useRouter();
@@ -289,6 +291,7 @@ function RegistryList() {
   const [search, setSearch] = useState("");
   const [riskFilter, setRiskFilter] = useState<RiskFilter>("all");
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
+  const [viewMode, setViewMode] = useState<RegistryView>("table");
 
   useEffect(() => {
     api
@@ -346,18 +349,17 @@ function RegistryList() {
 
   return (
     <div className="py-6 space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="text-xl font-semibold text-zinc-100">MCP Server Registry</h1>
-        <p className="text-sm text-zinc-500 mt-1">
-          {servers.length} known servers with risk levels, tools, and credential mapping
-        </p>
-      </div>
+      <PageLaneHeader
+        lane="reference"
+        title="MCP Catalog"
+        subtitle={`${servers.length.toLocaleString()} known servers · ${riskCounts.high} high · ${riskCounts.medium} medium risk`}
+        banner={<CatalogBanner />}
+      />
 
       {/* Search + Filters */}
       <div className="space-y-3">
-        <div className="flex items-center gap-3">
-          <div className="relative flex-1 max-w-md">
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="relative min-w-[240px] flex-1 max-w-md">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-500" />
             <input
               type="text"
@@ -385,98 +387,143 @@ function RegistryList() {
               </button>
             ))}
           </div>
-        </div>
 
-        {/* Category filter */}
-        {categories.length > 0 && (
-          <div className="flex items-center gap-1 flex-wrap">
-            <span className="text-[10px] text-zinc-600 uppercase tracking-wider mr-1">Category:</span>
+          {categories.length > 0 && (
+            <label className="flex items-center gap-2 text-xs text-zinc-500">
+              Category
+              <select
+                value={categoryFilter}
+                onChange={(e) => setCategoryFilter(e.target.value)}
+                className="rounded-md border border-zinc-700 bg-zinc-900 px-2 py-1.5 text-xs text-zinc-200"
+              >
+                <option value="all">All categories</option>
+                {categories.map((cat) => (
+                  <option key={cat} value={cat}>
+                    {cat}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          <div className="ml-auto flex items-center gap-1 rounded-md border border-zinc-800 p-0.5">
             <button
-              onClick={() => setCategoryFilter("all")}
-              className={`px-2 py-1 rounded text-[10px] font-medium transition-colors ${
-                categoryFilter === "all"
-                  ? "bg-zinc-700 text-zinc-100"
-                  : "text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300"
+              type="button"
+              onClick={() => setViewMode("table")}
+              className={`rounded px-2.5 py-1 text-[11px] font-medium ${
+                viewMode === "table" ? "bg-zinc-700 text-zinc-100" : "text-zinc-500"
               }`}
             >
-              All
+              Table
             </button>
-            {categories?.map((cat) => (
-              <button
-                key={cat}
-                onClick={() => setCategoryFilter(categoryFilter === cat ? "all" : cat)}
-                className={`px-2 py-1 rounded text-[10px] font-medium transition-colors ${
-                  categoryFilter === cat
-                    ? "bg-zinc-700 text-zinc-100"
-                    : "text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300"
-                }`}
-              >
-                {cat}
-              </button>
-            ))}
+            <button
+              type="button"
+              onClick={() => setViewMode("cards")}
+              className={`rounded px-2.5 py-1 text-[11px] font-medium ${
+                viewMode === "cards" ? "bg-zinc-700 text-zinc-100" : "text-zinc-500"
+              }`}
+            >
+              Cards
+            </button>
           </div>
-        )}
+        </div>
       </div>
 
-      {/* Server Grid */}
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-        {filtered?.map((server) => (
-          <div
-            key={server.id}
-            className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4 hover:border-zinc-600 transition-colors cursor-pointer group"
-            onClick={() => router.push(`/registry?id=${server.id}`)}
-          >
-            {/* Top row */}
-            <div className="flex items-start justify-between mb-2">
-              <div className="flex items-center gap-2 min-w-0">
-                {server.verified ? (
-                  <ShieldCheck className="w-4 h-4 text-emerald-400 shrink-0" />
-                ) : (
-                  <ShieldAlert className="w-4 h-4 text-zinc-500 shrink-0" />
-                )}
-                <span className="font-mono text-sm font-medium text-zinc-200 truncate">
-                  {server.name}
-                </span>
-              </div>
-              <div className="flex items-center gap-1.5 shrink-0">
-                <span
-                  className={`text-[10px] px-1.5 py-0.5 rounded border font-mono uppercase ${riskColor(server.risk_level)}`}
+      {viewMode === "table" ? (
+        <div className="overflow-x-auto rounded-lg border border-zinc-800">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-zinc-900 text-xs uppercase tracking-wide text-zinc-500">
+              <tr>
+                <th className="px-4 py-3 font-medium">Server</th>
+                <th className="px-4 py-3 font-medium">Publisher</th>
+                <th className="px-4 py-3 font-medium">Risk</th>
+                <th className="px-4 py-3 font-medium">Tools</th>
+                <th className="px-4 py-3 font-medium">Creds</th>
+                <th className="px-4 py-3 font-medium">Category</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-zinc-800">
+              {filtered.map((server) => (
+                <tr
+                  key={server.id}
+                  className="cursor-pointer hover:bg-zinc-900/70"
+                  onClick={() => router.push(`/registry?id=${server.id}`)}
                 >
-                  {server.risk_level}
-                </span>
-                <ChevronRight className="w-3.5 h-3.5 text-zinc-600 group-hover:text-zinc-400 transition-colors" />
+                  <td className="px-4 py-3 font-medium text-zinc-200">{server.name}</td>
+                  <td className="px-4 py-3 text-zinc-500">{server.publisher ?? "—"}</td>
+                  <td className="px-4 py-3">
+                    <span className={`text-[10px] px-1.5 py-0.5 rounded border font-mono uppercase ${riskColor(server.risk_level)}`}>
+                      {server.risk_level}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-zinc-400">{server.tools?.length ?? 0}</td>
+                  <td className="px-4 py-3 text-zinc-400">{server.credential_env_vars?.length ?? 0}</td>
+                  <td className="px-4 py-3 text-zinc-500">{server.category ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+          {filtered?.map((server) => (
+            <div
+              key={server.id}
+              className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4 hover:border-zinc-600 transition-colors cursor-pointer group"
+              onClick={() => router.push(`/registry?id=${server.id}`)}
+            >
+              {/* Top row */}
+              <div className="flex items-start justify-between mb-2">
+                <div className="flex items-center gap-2 min-w-0">
+                  {server.verified ? (
+                    <ShieldCheck className="w-4 h-4 text-emerald-400 shrink-0" />
+                  ) : (
+                    <ShieldAlert className="w-4 h-4 text-zinc-500 shrink-0" />
+                  )}
+                  <span className="font-mono text-sm font-medium text-zinc-200 truncate">
+                    {server.name}
+                  </span>
+                </div>
+                <div className="flex items-center gap-1.5 shrink-0">
+                  <span
+                    className={`text-[10px] px-1.5 py-0.5 rounded border font-mono uppercase ${riskColor(server.risk_level)}`}
+                  >
+                    {server.risk_level}
+                  </span>
+                  <ChevronRight className="w-3.5 h-3.5 text-zinc-600 group-hover:text-zinc-400 transition-colors" />
+                </div>
+              </div>
+
+              {/* Description */}
+              {server.description && (
+                <p className="text-xs text-zinc-500 mb-2 line-clamp-2">{server.description}</p>
+              )}
+
+              {/* Stats row */}
+              <div className="flex items-center gap-3 text-[10px] text-zinc-500">
+                {server.packages && server.packages.length > 0 && (
+                  <span className="flex items-center gap-0.5">
+                    <Package className="w-2.5 h-2.5" /> {server.packages[0]!.ecosystem}
+                  </span>
+                )}
+                {server.tools && server.tools.length > 0 && (
+                  <span className="flex items-center gap-0.5">
+                    <Wrench className="w-2.5 h-2.5" /> {server.tools.length} tools
+                  </span>
+                )}
+                {server.credential_env_vars && server.credential_env_vars.length > 0 && (
+                  <span className="flex items-center gap-0.5 text-amber-500">
+                    <KeyRound className="w-2.5 h-2.5" /> {server.credential_env_vars.length} creds
+                  </span>
+                )}
+                {server.category && (
+                  <span className="truncate">{server.category}</span>
+                )}
               </div>
             </div>
-
-            {/* Description */}
-            {server.description && (
-              <p className="text-xs text-zinc-500 mb-2 line-clamp-2">{server.description}</p>
-            )}
-
-            {/* Stats row */}
-            <div className="flex items-center gap-3 text-[10px] text-zinc-500">
-              {server.packages && server.packages.length > 0 && (
-                <span className="flex items-center gap-0.5">
-                  <Package className="w-2.5 h-2.5" /> {server.packages[0]!.ecosystem}
-                </span>
-              )}
-              {server.tools && server.tools.length > 0 && (
-                <span className="flex items-center gap-0.5">
-                  <Wrench className="w-2.5 h-2.5" /> {server.tools.length} tools
-                </span>
-              )}
-              {server.credential_env_vars && server.credential_env_vars.length > 0 && (
-                <span className="flex items-center gap-0.5 text-amber-500">
-                  <KeyRound className="w-2.5 h-2.5" /> {server.credential_env_vars.length} creds
-                </span>
-              )}
-              {server.category && (
-                <span className="truncate">{server.category}</span>
-              )}
-            </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
 
       {filtered.length === 0 && (
         <div className="text-center py-12 text-zinc-500 text-sm">

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -7,7 +7,6 @@ import {
   ArrowRight,
   GitBranch,
   Loader2,
-  Route,
 } from "lucide-react";
 
 import { ApiOfflineState } from "@/components/api-offline-state";
@@ -377,74 +376,50 @@ function SecurityGraphPageContent() {
 
   return (
     <div className="space-y-4">
-      <GraphLensSwitcher />
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <h1 className="text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">Security graph</h1>
+          <p className="mt-1 text-sm text-[color:var(--text-secondary)]">Fix-first investigation — ranked attack paths from persisted graph evidence.</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <GraphEvidenceExportButton
+            scanId={selectedScanId || undefined}
+            filenamePrefix={selectedScanId ? `scan-${selectedScanId}-security-graph` : undefined}
+          />
+          <Link
+            href={fullGraphHref}
+            className="inline-flex items-center gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-4 py-2 text-sm font-medium text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+          >
+            Full graph
+            <GitBranch className="h-4 w-4" />
+          </Link>
+          <Link
+            href="/remediation"
+            className="inline-flex items-center gap-2 rounded-xl border border-emerald-800 bg-emerald-950/40 px-4 py-2 text-sm font-medium text-emerald-300 transition hover:bg-emerald-950/70"
+          >
+            Remediation
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
+      </header>
+
+      <GraphLensSwitcher variant="compact" />
+
       {selectedExposurePath && (
-        <section className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
-          <div className="overflow-hidden rounded-3xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]">
-            <ExposurePathStrip path={selectedExposurePath} />
-            <div className="p-5">
-              <ExposurePathCommandCenter
-                path={selectedExposurePath}
-                actions={selectedFixFirstCard?.next_actions ?? selectedPathActions}
-              />
-            </div>
-          </div>
-          <div className="rounded-3xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
-            <p className="text-[11px] uppercase tracking-[0.2em] text-orange-400">Graph operating mode</p>
-            <h2 className="mt-2 text-base font-semibold text-[color:var(--foreground)]">Fix-first investigation</h2>
-            <p className="mt-2 text-sm leading-6 text-[color:var(--text-secondary)]">
-              This page starts with the highest-risk proven path. Use the queue below to change focus, or open the
-              full lineage graph when you need broader neighbor context.
-            </p>
-            <div className="mt-4 grid gap-2 text-xs">
-              <QuickStat label="Rank" value={`#${selectedExposurePath.rank ?? 1}`} />
-              <QuickStat label="Relationships" value={String(selectedExposurePath.relationships.length)} />
-              <QuickStat label="Evidence source" value={selectedExposurePath.provenance?.source ?? "graph"} />
-            </div>
+        <section className="overflow-hidden rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]">
+          <ExposurePathStrip path={selectedExposurePath} />
+          <div className="p-4">
+            <ExposurePathCommandCenter
+              path={selectedExposurePath}
+              actions={selectedFixFirstCard?.next_actions ?? selectedPathActions}
+            />
           </div>
         </section>
       )}
 
-      <section className="rounded-3xl border border-[color:var(--border-subtle)] bg-[radial-gradient(circle_at_top_left,rgba(16,185,129,0.08),transparent_34%),linear-gradient(180deg,var(--surface),var(--surface-elevated))] p-4 shadow-2xl">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="max-w-3xl">
-            <div className="inline-flex items-center gap-2 rounded-full border border-emerald-900/60 bg-emerald-950/30 px-3 py-1 text-[11px] uppercase tracking-[0.18em] text-emerald-300">
-              <Route className="h-3.5 w-3.5" />
-              Security graph
-            </div>
-            <h1 className="mt-3 text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">
-              Fix-first attack paths without dropping into the full graph canvas
-            </h1>
-            <p className="mt-2 max-w-2xl text-sm leading-6 text-[color:var(--text-secondary)]">
-              This view keeps the highest-risk exploit chains explicit: what finding starts the path, which assets it reaches,
-              which credentials and tools stay exposed, and where to jump next for evidence or remediation.
-            </p>
-          </div>
-
-          <div className="flex flex-wrap items-center gap-2">
-            <GraphEvidenceExportButton
-              scanId={selectedScanId || undefined}
-              filenamePrefix={selectedScanId ? `scan-${selectedScanId}-security-graph` : undefined}
-            />
-            <Link
-              href={fullGraphHref}
-              className="inline-flex items-center gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-4 py-2 text-sm font-medium text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)]"
-            >
-              Open full lineage graph
-              <GitBranch className="h-4 w-4" />
-            </Link>
-            <Link
-              href="/remediation"
-              className="inline-flex items-center gap-2 rounded-xl border border-emerald-800 bg-emerald-950/40 px-4 py-2 text-sm font-medium text-emerald-300 transition hover:bg-emerald-950/70"
-            >
-              Open remediation
-              <ArrowRight className="h-4 w-4" />
-            </Link>
-          </div>
-        </div>
-
-        <div className="mt-4 grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_320px]">
-          <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+      <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+        <div className="grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_220px]">
+          <div>
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
                 <p className="text-[11px] uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">Snapshot</p>
@@ -523,38 +498,25 @@ function SecurityGraphPageContent() {
             )}
           </div>
 
-          <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
-            <p className="text-[11px] uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">Current pressure</p>
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">Posture</p>
             {posture ? (
-              <div className="mt-4">
-                <div className="flex items-end justify-between gap-4">
-                  <div>
-                    <div className="font-mono text-5xl font-semibold text-red-300">{posture.grade}</div>
-                    <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">{posture.summary}</p>
-                  </div>
-                  <div className="text-right">
-                    <div className="font-mono text-2xl text-[color:var(--foreground)]">{posture.score}</div>
-                    <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">score</div>
-                  </div>
+              <div className="mt-3">
+                <div className="flex items-baseline gap-3">
+                  <div className="font-mono text-3xl font-semibold text-red-300">{posture.grade}</div>
+                  <div className="font-mono text-lg text-[color:var(--foreground)]">{posture.score}</div>
                 </div>
-                <div className="mt-4 h-2 overflow-hidden rounded-full bg-[color:var(--surface-muted)]">
-                  <div
-                    className="h-full rounded-full bg-gradient-to-r from-red-500 via-amber-400 to-emerald-400"
-                    style={{ width: `${Math.max(0, Math.min(100, posture.score))}%` }}
-                  />
-                </div>
+                <p className="mt-2 line-clamp-2 text-xs text-[color:var(--text-tertiary)]">{posture.summary}</p>
                 <Link
                   href="/insights"
-                  className="mt-4 inline-flex items-center gap-2 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-1.5 text-xs text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
+                  className="mt-3 inline-flex items-center gap-1 text-xs text-[color:var(--text-secondary)] transition hover:text-[color:var(--foreground)]"
                 >
-                  Open posture details
-                  <ArrowRight className="h-3.5 w-3.5" />
+                  Details
+                  <ArrowRight className="h-3 w-3" />
                 </Link>
               </div>
             ) : (
-              <div className="mt-4 rounded-2xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5 text-sm text-[color:var(--text-secondary)]">
-                Posture scoring is unavailable for this snapshot.
-              </div>
+              <div className="mt-3 text-sm text-[color:var(--text-secondary)]">Unavailable for this snapshot.</div>
             )}
           </div>
         </div>
@@ -630,58 +592,21 @@ function SecurityGraphPageContent() {
         </section>
       ) : (
         <>
-          <section className="rounded-3xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
+          <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
-                <p className="text-[11px] uppercase tracking-[0.2em] text-orange-400">Attack path queue</p>
-                <h2 className="mt-1 text-lg font-semibold text-[color:var(--foreground)]">
-                  {attackPaths.length} ranked fix-first path{attackPaths.length !== 1 ? "s" : ""} in the selected snapshot
+                <h2 className="text-base font-semibold text-[color:var(--foreground)]">
+                  {attackPaths.length} ranked path{attackPaths.length !== 1 ? "s" : ""}
                 </h2>
-                <p className="mt-1 text-sm text-[color:var(--text-tertiary)]">
-                  Ranked by composite risk and operator context so the first screen starts with what to validate, contain, or expand.
-                </p>
-                <p className="mt-2 text-xs text-[color:var(--text-tertiary)]">
-                  Keyboard: focus this queue and use ← / → to step through paths.
-                </p>
                 {focusLabel && (
-                  <p className="mt-2 text-xs text-emerald-300">
-                    Focused from dashboard context: {focusLabel}
-                  </p>
+                  <p className="mt-1 text-xs text-emerald-300">Focused: {focusLabel}</p>
                 )}
-                <div className="mt-3 flex flex-wrap gap-2">
-                  <Link
-                    href={fullGraphHref}
-                    className="inline-flex items-center gap-1 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1 text-[11px] text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-                  >
-                    Full graph
-                    <GitBranch className="h-3 w-3" />
-                  </Link>
-                  <Link
-                    href={buildFindingsHref({ scanId: selectedScanId || undefined })}
-                    className="inline-flex items-center gap-1 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1 text-[11px] text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-                  >
-                    Findings
-                    <ArrowRight className="h-3 w-3" />
-                  </Link>
-                  {hasFocusContext && (
-                    <Link
-                      href={resetFocusHref}
-                      className="inline-flex items-center gap-1 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1 text-[11px] text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-                    >
-                      Clear focus
-                      <ArrowRight className="h-3 w-3" />
-                    </Link>
-                  )}
-                </div>
               </div>
-              <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-4 py-3 text-sm text-[color:var(--text-secondary)]">
-                <div className="text-[11px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">Highest composite risk</div>
-                <div className="mt-1 font-mono text-xl text-red-300">{attackPaths[0]!.composite_risk.toFixed(1)}</div>
-              </div>
+              <div className="font-mono text-lg text-red-300">{attackPaths[0]!.composite_risk.toFixed(1)}</div>
             </div>
 
             <div
-              className="mt-4 grid max-h-[34rem] max-w-full grid-cols-1 gap-3 overflow-y-auto pr-1 outline-none md:grid-cols-2 xl:grid-cols-3"
+              className="mt-4 grid max-h-[28rem] max-w-full grid-cols-1 gap-2 overflow-y-auto pr-1 outline-none md:grid-cols-2 xl:grid-cols-3"
               tabIndex={0}
               onKeyDown={handleAttackPathQueueKeyDown}
               aria-label="Attack path queue"
@@ -716,6 +641,7 @@ function SecurityGraphPageContent() {
                       nodes={pathNodes}
                       riskScore={path.composite_risk}
                       captureMode={captureMode}
+                      compact
                       onClick={() => setSelectedAttackPathKey(key)}
                     />
                     {card && card.risk_reasons.length > 0 && (

--- a/ui/app/sources/page.tsx
+++ b/ui/app/sources/page.tsx
@@ -7,7 +7,6 @@ import {
   ArrowRight,
   CalendarClock,
   Cloud,
-  Database,
   FileCheck2,
   Plus,
   Radio,
@@ -30,6 +29,7 @@ import {
 } from "@/lib/api";
 import { useAuthState } from "@/components/auth-provider";
 import { DemoConnectCard } from "@/components/demo-mode-cta";
+import { useDemoMode } from "@/hooks/use-demo-mode";
 
 type IngestMode = "Direct scan" | "Read-only connector" | "Pushed ingest" | "Runtime" | "Imported artifact";
 
@@ -250,6 +250,7 @@ function summarizeProviders(contracts: DiscoveryProvidersResponse | null) {
 
 export default function SourcesPage() {
   const { session, loading: authLoading, hasCapability } = useAuthState();
+  const { isDemoMode } = useDemoMode();
   const [connectorHealth, setConnectorHealth] = useState<ConnectorHealthResponse[]>([]);
   const [providerContracts, setProviderContracts] = useState<DiscoveryProvidersResponse | null>(null);
   const [schedules, setSchedules] = useState<ScanSchedule[]>([]);
@@ -513,38 +514,39 @@ export default function SourcesPage() {
   }
 
   return (
-    <div className="space-y-6">
-      <section className="rounded-3xl border border-[color:var(--border-subtle)] bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] p-6 shadow-2xl shadow-black/10">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <p className="text-[11px] uppercase tracking-[0.22em] text-emerald-400">Hosted control plane</p>
-            <h1 className="mt-2 text-3xl font-semibold tracking-tight text-[var(--foreground)]">Sources and ingest control</h1>
-            <p className="mt-3 max-w-3xl text-sm leading-6 text-[var(--text-secondary)]">
-              The UI should declare intent and review state. The API owns auth, orchestration, graph, persistence, audit, and policy. Workers,
-              connectors, proxy, and gateway paths do the privileged collection work.
-            </p>
-          </div>
-
-          <div className="flex flex-wrap gap-3">
-            <button
-              onClick={() => refreshControlPlane()}
-              className="inline-flex items-center gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-4 py-2 text-sm text-[var(--foreground)] transition hover:border-[color:var(--border-strong)]"
-            >
-              <RefreshCcw className="h-4 w-4" />
-              Refresh
-            </button>
+    <div className="space-y-5 max-w-5xl">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--foreground)]">Data sources</h1>
+          <p className="mt-1 text-sm text-[var(--text-secondary)]">
+            Register scan targets, review connector health, and manage schedules.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={() => refreshControlPlane()}
+            className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+          >
+            <RefreshCcw className="h-4 w-4" />
+            Refresh
+          </button>
+          {!isDemoMode && (
             <button
               onClick={handleFleetSync}
               disabled={syncingFleet || !canManageFleet}
-              className="inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-3 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <Activity className="h-4 w-4" />
-              {syncingFleet ? "Syncing fleet…" : "Run fleet sync"}
+              {syncingFleet ? "Syncing…" : "Fleet sync"}
             </button>
-          </div>
+          )}
         </div>
+      </header>
 
-        <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+      {isDemoMode && <DemoConnectCard />}
+
+      <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
           <MetricCard
             icon={ShieldCheck}
             label="Auth mode"
@@ -580,7 +582,7 @@ export default function SourcesPage() {
         {error ? <p className="mt-2 text-sm text-red-400">{error}</p> : null}
       </section>
 
-      {roleSummary ? (
+      {roleSummary && !isDemoMode ? (
         <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
           <div className="flex items-start gap-3">
             <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
@@ -600,71 +602,66 @@ export default function SourcesPage() {
         </section>
       ) : null}
 
-      <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="flex items-start gap-3">
-            <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
-              <ShieldCheck className="h-5 w-5 text-emerald-400" />
-            </span>
-            <div>
-              <h2 className="text-base font-semibold text-[var(--foreground)]">Discovery provider trust contracts</h2>
-              <p className="mt-1 max-w-3xl text-sm leading-6 text-[var(--text-secondary)]">
-                These contracts come from the backend provider registry. They show which modes are direct pull, scope-zero push, or skill-mediated,
-                and which read permissions each provider declares before discovery data becomes canonical evidence.
-              </p>
-            </div>
-          </div>
+      <details className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]">
+        <summary className="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-[var(--foreground)] [&::-webkit-details-marker]:hidden">
+          Provider trust contracts
           {providerContracts ? (
-            <div className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-1.5 text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
-              v{providerContracts.contract_version} · {providerContracts.entrypoints_enabled ? "entry points on" : "entry points opt-in"}
+            <span className="ml-2 text-xs font-normal text-[var(--text-tertiary)]">
+              {providerSummary.total} providers · v{providerContracts.contract_version}
+            </span>
+          ) : null}
+        </summary>
+        <div className="space-y-4 border-t border-[color:var(--border-subtle)] p-4">
+          <p className="text-sm text-[var(--text-secondary)]">
+            Backend provider registry: scan modes, declared permissions, and read-only guarantees.
+          </p>
+
+          <div className="grid gap-3 md:grid-cols-4">
+            <ContractStat label="Providers" value={loading ? "Loading…" : String(providerSummary.total)} />
+            <ContractStat label="Read-only" value={loading ? "Loading…" : `${providerSummary.readOnly}/${providerSummary.total}`} />
+            <ContractStat label="Scope-zero modes" value={loading ? "Loading…" : String(providerSummary.scopeZero)} />
+            <ContractStat label="Declared permissions" value={loading ? "Loading…" : String(providerSummary.permissionCount)} />
+          </div>
+
+          {providerContracts?.warnings?.length ? (
+            <div className="rounded-xl border border-amber-900/60 bg-amber-950/20 p-3 text-xs leading-5 text-amber-200">
+              {providerContracts.warnings.slice(0, 2).join(" · ")}
             </div>
           ) : null}
-        </div>
 
-        <div className="mt-5 grid gap-3 md:grid-cols-4">
-          <ContractStat label="Providers" value={loading ? "Loading…" : String(providerSummary.total)} />
-          <ContractStat label="Read-only" value={loading ? "Loading…" : `${providerSummary.readOnly}/${providerSummary.total}`} />
-          <ContractStat label="Scope-zero modes" value={loading ? "Loading…" : String(providerSummary.scopeZero)} />
-          <ContractStat label="Declared permissions" value={loading ? "Loading…" : String(providerSummary.permissionCount)} />
-        </div>
-
-        {providerContracts?.warnings?.length ? (
-          <div className="mt-4 rounded-xl border border-amber-900/60 bg-amber-950/20 p-3 text-xs leading-5 text-amber-200">
-            {providerContracts.warnings.slice(0, 2).join(" · ")}
+          <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
+            {!providerContracts && !loading ? (
+              <div className="rounded-xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-sm text-[var(--text-secondary)]">
+                Provider contracts are unavailable from the API.
+              </div>
+            ) : (
+              (providerContracts?.providers ?? []).slice(0, 12).map((provider) => (
+                <ProviderContractCard key={provider.name} provider={provider} />
+              ))
+            )}
           </div>
-        ) : null}
-
-        <div className="mt-5 grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
-          {!providerContracts && !loading ? (
-            <div className="rounded-2xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-sm text-[var(--text-secondary)]">
-              Provider contracts are unavailable from the API.
-            </div>
-          ) : (
-            (providerContracts?.providers ?? []).slice(0, 12).map((provider) => (
-              <ProviderContractCard key={provider.name} provider={provider} />
-            ))
-          )}
         </div>
-      </section>
+      </details>
 
-      <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
-        <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
-          <div className="flex items-start gap-3">
-            <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
-              <Database className="h-5 w-5 text-emerald-400" />
-            </span>
-            <div>
-              <h2 className="text-base font-semibold text-[var(--foreground)]">Source registry</h2>
-              <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                Each source is a persisted control-plane record with tenant scope, ownership, credential mode, last test, and last run state.
-              </p>
-            </div>
-          </div>
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
+        <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+          <h2 className="text-base font-semibold text-[var(--foreground)]">Source registry</h2>
+          <p className="mt-1 text-sm text-[var(--text-secondary)]">Persisted sources with status, last run, and evidence links.</p>
 
-          <div className="mt-5 space-y-3">
+          <div className="mt-4 space-y-3">
             {sources.length === 0 && !loading ? (
-              <div className="rounded-2xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-sm text-[var(--text-secondary)]">
-                No registered sources yet. Create one here, then test it or run it from the control plane.
+              <div className="rounded-xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-sm text-[var(--text-secondary)]">
+                {isDemoMode ? (
+                  <>
+                    No demo sources registered. Explore{" "}
+                    <Link href="/scan" className="text-emerald-400 hover:text-emerald-300">New Scan</Link>
+                    {" "}or{" "}
+                    <Link href="/jobs" className="text-emerald-400 hover:text-emerald-300">Scan Jobs</Link>
+                    {" "}with sample data.
+                  </>
+                ) : (
+                  "No registered sources yet. Create one to test and run from the control plane."
+                )}
               </div>
             ) : (
               sources.map((source) => {
@@ -784,25 +781,13 @@ export default function SourcesPage() {
           </div>
         </section>
 
-        <section className="space-y-6">
-          <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
-            <div className="flex items-start gap-3">
-              <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
-                <Plus className="h-5 w-5 text-emerald-400" />
-              </span>
-              <div>
-                <h2 className="text-base font-semibold text-[var(--foreground)]">Create source</h2>
-                <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                  Register the source here, then let backend jobs, connectors, proxy, or gateway paths do the collection work.
-                </p>
-              </div>
-            </div>
+        <div className="space-y-5">
+          {!isDemoMode && (
+          <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+            <h2 className="text-base font-semibold text-[var(--foreground)]">Create source</h2>
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">Register a new scan target or connector-backed source.</p>
 
-            <div className="mt-5 empty:hidden">
-              <DemoConnectCard />
-            </div>
-
-            <form className="mt-5 space-y-4" onSubmit={handleCreateSource}>
+            <form className="mt-4 space-y-4" onSubmit={handleCreateSource}>
               <label className="block">
                 <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Display name</span>
                 <input
@@ -884,28 +869,19 @@ export default function SourcesPage() {
               </button>
             </form>
           </section>
+          )}
 
-          <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
-            <div className="flex items-start gap-3">
-              <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
-                <Cloud className="h-5 w-5 text-emerald-400" />
-              </span>
-              <div>
-                <h2 className="text-base font-semibold text-[var(--foreground)]">Connector health</h2>
-                <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                  Read-only integrations are backend-owned. The browser only reviews health and initiates control-plane actions.
-                </p>
-              </div>
-            </div>
-
-            <div className="mt-5 space-y-3">
+          {!isDemoMode && (
+          <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+            <h2 className="text-base font-semibold text-[var(--foreground)]">Connector health</h2>
+            <div className="mt-4 space-y-3">
               {connectorHealth.length === 0 && !loading ? (
-                <div className="rounded-2xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-sm text-[var(--text-secondary)]">
+                <div className="rounded-xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-sm text-[var(--text-secondary)]">
                   No connector health state loaded yet.
                 </div>
               ) : (
                 connectorHealth.map((connector) => (
-                  <div key={connector.connector} className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+                  <div key={connector.connector} className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
                     <div className="flex items-start justify-between gap-3">
                       <div>
                         <h3 className="text-sm font-semibold text-[var(--foreground)]">{connector.connector}</h3>
@@ -918,22 +894,15 @@ export default function SourcesPage() {
               )}
             </div>
           </section>
+          )}
 
-          <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
-            <div className="flex items-start gap-3">
-              <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
-                <CalendarClock className="h-5 w-5 text-emerald-400" />
-              </span>
-              <div>
-                <h2 className="text-base font-semibold text-[var(--foreground)]">Persisted schedules</h2>
-                <p className="mt-1 text-sm text-[var(--text-secondary)]">
-                  Recurring collection belongs to the control plane. This page already reflects real schedule state from the backend.
-                </p>
-              </div>
-            </div>
+          {!isDemoMode && (
+          <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+            <h2 className="text-base font-semibold text-[var(--foreground)]">Schedules</h2>
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">Recurring scans bound to registered sources.</p>
 
-            <div className="mt-5 space-y-3">
-              <form className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4" onSubmit={handleCreateSchedule}>
+            <div className="mt-4 space-y-3">
+              <form className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4" onSubmit={handleCreateSchedule}>
                 <div className="grid gap-4 md:grid-cols-3">
                   <label className="block">
                     <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Source</span>
@@ -1040,24 +1009,16 @@ export default function SourcesPage() {
               )}
             </div>
           </section>
-        </section>
+          )}
+        </div>
       </div>
 
-      <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
-        <div className="flex items-start gap-3">
-          <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
-            <Activity className="h-5 w-5 text-emerald-400" />
-          </span>
-          <div>
-            <h2 className="text-base font-semibold text-[var(--foreground)]">Operating surfaces after ingest</h2>
-            <p className="mt-1 text-sm text-[var(--text-secondary)]">
-              Discovery and ingest are only the front door. Agent-bom also needs clear surfaces for runtime review, fleet operations, policy
-              enforcement, and graph analysis after the data lands.
-            </p>
-          </div>
-        </div>
-
-        <div className="mt-5 grid gap-3 xl:grid-cols-2">
+      {!isDemoMode && (
+      <details className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]">
+        <summary className="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-[var(--foreground)] [&::-webkit-details-marker]:hidden">
+          Related operating surfaces
+        </summary>
+        <div className="grid gap-3 border-t border-[color:var(--border-subtle)] p-4 xl:grid-cols-2">
           {OPERATING_SURFACES.map((surface) => {
             const Icon = surface.icon;
             return (
@@ -1081,7 +1042,8 @@ export default function SourcesPage() {
             );
           })}
         </div>
-      </section>
+      </details>
+      )}
     </div>
   );
 }

--- a/ui/components/app-shell.tsx
+++ b/ui/components/app-shell.tsx
@@ -4,7 +4,6 @@ import { usePathname } from "next/navigation";
 
 import { AuthGate } from "@/components/auth-gate";
 import { DemoEstateLabel } from "@/components/demo-estate-label";
-import { DemoModeBanner } from "@/components/demo-mode-cta";
 import { Nav } from "@/components/nav";
 
 export function AppShell({ children }: { children: React.ReactNode }) {
@@ -22,7 +21,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <AuthGate>
         <main id="main-content" className="lg:pl-[240px] pt-14 lg:pt-0 min-h-screen transition-[padding-left] duration-200">
           <div className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6">
-            <DemoModeBanner />
             {children}
           </div>
         </main>

--- a/ui/components/attack-path-card.tsx
+++ b/ui/components/attack-path-card.tsx
@@ -16,6 +16,7 @@ interface AttackPathCardProps {
   onClick?: () => void;
   href?: string | undefined;
   captureMode?: boolean | undefined;
+  compact?: boolean | undefined;
 }
 
 const NODE_META: Record<AttackPathNode["type"], { icon: LucideIcon; tint: string; ring: string }> = {
@@ -26,7 +27,7 @@ const NODE_META: Record<AttackPathNode["type"], { icon: LucideIcon; tint: string
   credential: { icon: KeyRound, tint: "text-fuchsia-300 bg-fuchsia-500/12", ring: "border-fuchsia-500/25" },
 };
 
-export function AttackPathCard({ nodes, riskScore, onClick, href, captureMode = false }: AttackPathCardProps) {
+export function AttackPathCard({ nodes, riskScore, onClick, href, captureMode = false, compact = false }: AttackPathCardProps) {
   const riskTone =
     riskScore >= 8
       ? "border-red-500/25 bg-red-500/10 text-red-200"
@@ -36,18 +37,25 @@ export function AttackPathCard({ nodes, riskScore, onClick, href, captureMode = 
 
   const cardBody = (
     <>
-      <div className="mb-3 flex items-start justify-between gap-3">
-        <div>
-          <p className="text-[11px] uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">Attack path</p>
-          <p className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">Credential-aware blast radius</p>
+      {!compact && (
+        <div className="mb-3 flex items-start justify-between gap-3">
+          <div>
+            <p className="text-[11px] uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">Attack path</p>
+            <p className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">Credential-aware blast radius</p>
+          </div>
+          <div className={`rounded-xl border px-2.5 py-1 font-mono text-xs font-semibold ${riskTone}`}>
+            <span className="text-[11px] uppercase tracking-[0.14em]">Risk</span>{" "}
+            <span>{riskScore.toFixed(1)}</span>
+          </div>
         </div>
-        <div className={`rounded-xl border px-2.5 py-1 font-mono text-xs font-semibold ${riskTone}`}>
-          <span className="text-[11px] uppercase tracking-[0.14em]">Risk</span>{" "}
-          <span>{riskScore.toFixed(1)}</span>
-        </div>
-      </div>
+      )}
 
-      <div className="flex flex-wrap items-center gap-1.5">
+      <div className={`flex flex-wrap items-center gap-1.5 ${compact ? "justify-between" : ""}`}>
+        {compact && (
+          <div className={`rounded-lg border px-2 py-0.5 font-mono text-[11px] font-semibold ${riskTone}`}>
+            {riskScore.toFixed(1)}
+          </div>
+        )}
         {nodes.map((node, i) => {
           const meta = NODE_META[node.type];
           const Icon = meta.icon;
@@ -100,7 +108,9 @@ export function AttackPathCard({ nodes, riskScore, onClick, href, captureMode = 
   );
 
   const className =
-    `group block w-full rounded-2xl border border-[color:var(--border-subtle)] bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] px-4 py-3 text-left shadow-lg transition-all hover:border-[color:var(--border-strong)] hover:shadow-xl hover:shadow-emerald-500/5 ${
+    `group block w-full rounded-2xl border border-[color:var(--border-subtle)] bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] text-left shadow-lg transition-all hover:border-[color:var(--border-strong)] hover:shadow-xl hover:shadow-emerald-500/5 ${
+      compact ? "px-3 py-2" : "px-4 py-3"
+    } ${
       captureMode ? "" : "hover:-translate-y-0.5"
     }`;
 

--- a/ui/components/demo-mode-cta.tsx
+++ b/ui/components/demo-mode-cta.tsx
@@ -1,57 +1,50 @@
 "use client";
 
-import { ArrowRight, Cloud, Sparkles } from "lucide-react";
+import { ArrowRight, Sparkles } from "lucide-react";
 
 import { useDemoMode } from "@/hooks/use-demo-mode";
 import { getSignInUrl } from "@/lib/runtime-config";
 
-const CTA_LABEL = "Sign in / Get started";
+const CTA_LABEL = "Sign in";
 
 function ctaHref(): string {
   return getSignInUrl();
 }
 
-/**
- * Slim, theme-aware strip shown at the top of app surfaces (dashboard, connect,
- * everywhere the shell renders) when the platform is running in public-demo
- * mode. Explains the sample-data context and funnels the anonymous viewer to
- * the sign-in / get-started flow. Renders nothing outside demo mode.
- */
+/** @deprecated Page banner removed — demo is indicated by watermark + nav/sources CTA only. */
 export function DemoModeBanner() {
+  return null;
+}
+
+/** Compact nav-footer CTA for anonymous demo viewers. */
+export function DemoNavSignIn({ collapsed = false }: { collapsed?: boolean }) {
   const { isDemoMode } = useDemoMode();
 
   if (!isDemoMode) return null;
 
   return (
-    <div
-      data-testid="demo-mode-banner"
-      className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-emerald-500/30 bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] px-4 py-3 shadow-sm shadow-black/5"
+    <a
+      href={ctaHref()}
+      data-testid="demo-nav-sign-in"
+      className={`flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-[12px] font-medium text-emerald-300 transition-colors hover:border-emerald-400/50 hover:bg-emerald-500/15 ${
+        collapsed ? "justify-center px-2" : ""
+      }`}
+      title="Sign in to connect your cloud"
     >
-      <div className="flex items-center gap-3">
-        <span className="grid h-8 w-8 shrink-0 place-items-center rounded-md border border-emerald-500/30 bg-emerald-500/10 text-emerald-300">
-          <Sparkles className="h-4 w-4" aria-hidden="true" />
-        </span>
-        <p className="text-sm leading-5 text-[color:var(--text-secondary)]">
-          <span className="font-semibold text-[color:var(--foreground)]">You&rsquo;re exploring a live demo with sample data.</span>{" "}
-          Connect your own cloud to scan your real estate.
-        </p>
-      </div>
-      <a
-        href={ctaHref()}
-        className="inline-flex shrink-0 items-center gap-2 rounded-md bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
-      >
-        {CTA_LABEL}
-        <ArrowRight className="h-4 w-4" aria-hidden="true" />
-      </a>
-    </div>
+      <Sparkles className="h-4 w-4 shrink-0" aria-hidden="true" />
+      {!collapsed && (
+        <>
+          <span>Demo · Sign in</span>
+          <ArrowRight className="ml-auto h-3.5 w-3.5" aria-hidden="true" />
+        </>
+      )}
+    </a>
   );
 }
 
 /**
- * Card variant for the connect / sources surface. The anonymous demo viewer is
- * read-only and cannot register a real source, so instead of showing a
- * forbidden "Create source" action we present the sign-in funnel. Renders
- * nothing outside demo mode (the normal authenticated form stays in place).
+ * Slim connect funnel for read-only demo tenants. Replaces the full create-source
+ * form on /sources instead of stacking on top of a page banner + watermark.
  */
 export function DemoConnectCard() {
   const { isDemoMode } = useDemoMode();
@@ -61,25 +54,16 @@ export function DemoConnectCard() {
   return (
     <section
       data-testid="demo-connect-card"
-      className="rounded-lg border border-emerald-500/30 bg-[linear-gradient(135deg,var(--surface),var(--surface-elevated))] p-5 shadow-sm shadow-black/5"
+      className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-emerald-500/30 bg-emerald-500/5 px-4 py-3"
     >
-      <div className="flex items-start gap-3">
-        <span className="grid h-10 w-10 shrink-0 place-items-center rounded-md border border-emerald-500/30 bg-emerald-500/10 text-emerald-300">
-          <Cloud className="h-5 w-5" aria-hidden="true" />
-        </span>
-        <div>
-          <h2 className="text-base font-semibold text-[color:var(--foreground)]">Connect your cloud</h2>
-          <p className="mt-1 max-w-2xl text-sm leading-6 text-[color:var(--text-secondary)]">
-            This is a read-only demo estate with sample data, so connecting a real source is disabled here.
-            Sign in to the full product to register your own cloud accounts, registries, and warehouses.
-          </p>
-        </div>
-      </div>
+      <p className="text-sm text-[color:var(--text-secondary)]">
+        <span className="font-medium text-[color:var(--foreground)]">Read-only demo.</span> Sign in to register cloud accounts and data sources.
+      </p>
       <a
         href={ctaHref()}
-        className="mt-4 inline-flex items-center gap-2 rounded-md bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
+        className="inline-flex shrink-0 items-center gap-2 rounded-md bg-emerald-500 px-3 py-1.5 text-sm font-medium text-black transition hover:bg-emerald-400"
       >
-        Connect your cloud — {CTA_LABEL}
+        {CTA_LABEL}
         <ArrowRight className="h-4 w-4" aria-hidden="true" />
       </a>
     </section>

--- a/ui/components/exposure-path-command-center.tsx
+++ b/ui/components/exposure-path-command-center.tsx
@@ -6,10 +6,10 @@ import {
   Bot,
   Bug,
   CheckCircle2,
+  ChevronDown,
   Database,
   KeyRound,
   Package,
-  Route,
   Server,
   ShieldAlert,
   Wrench,
@@ -57,100 +57,82 @@ export function ExposurePathCommandCenter({
   const evidence = path.evidence;
   const primaryAction = actions[0];
   const investigationBrief = buildInvestigationBrief(path, fixLabel);
+  const hopCount = Math.max(0, path.hops.length - 1);
 
   return (
     <div className="space-y-4">
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(220px,280px)]">
-        <div className="min-w-0">
-          <p className="text-[10px] uppercase tracking-[0.2em] text-orange-400">Command center</p>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">Command center</p>
           <h2 className="mt-1 text-lg font-semibold leading-7 text-[color:var(--foreground)] [overflow-wrap:anywhere]">
             {pathDisplayTitle(path)}
           </h2>
-          <p className="mt-2 max-w-4xl text-sm leading-6 text-[color:var(--text-secondary)]">
-            {path.summary ||
-              evidence?.attackVectorSummary ||
-              "Selected exposure path with the entities, relationships, and evidence needed to choose the first fix."}
-          </p>
         </div>
-        <div className="grid min-w-0 grid-cols-2 gap-2 text-xs">
-          <CommandMetric label="Risk" value={path.riskScore.toFixed(1)} tone="red" />
-          <CommandMetric label="Hops" value={String(Math.max(0, path.hops.length - 1))} />
-          <CommandMetric label="Agents" value={String(path.affectedAgents.length)} />
-          <CommandMetric label="Fix" value={fixLabel ?? "triage"} tone={fixLabel ? "green" : "zinc"} />
+        <div className="flex flex-wrap gap-2 text-xs">
+          <MetricPill label="Risk" value={path.riskScore.toFixed(1)} tone="red" />
+          <MetricPill label="Hops" value={String(hopCount)} />
+          <MetricPill label="Agents" value={String(path.affectedAgents.length)} />
+          {fixLabel && <MetricPill label="Fix" value={fixLabel} tone="green" />}
         </div>
       </div>
 
-      <section aria-label="Investigation brief" className="grid gap-2 md:grid-cols-2 xl:grid-cols-4">
+      <div className="flex flex-wrap gap-2">
         {investigationBrief.map((item) => (
-          <div
-            key={item.label}
-            className="min-w-0 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2"
-          >
-            <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">{item.label}</div>
-            <div className="mt-1 text-sm font-semibold leading-5 text-[color:var(--foreground)] [overflow-wrap:anywhere]">
-              {item.value}
-            </div>
-            {item.detail && (
-              <p className="mt-1 text-xs leading-5 text-[color:var(--text-secondary)] [overflow-wrap:anywhere]">
-                {item.detail}
-              </p>
-            )}
-          </div>
+          <BriefChip key={item.label} label={item.label} value={item.value} detail={item.detail} />
         ))}
-      </section>
+      </div>
 
       <section aria-label="Selected exposure path graph">
-        <div className="mb-2 flex items-center gap-2 text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
-          <Route className="h-3.5 w-3.5" />
-          Selected path graph
-        </div>
         <ExposurePathGraph path={path} />
       </section>
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_300px]">
-        <section aria-label="Relationship proof">
-          <div className="mb-2 text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
-            Relationship proof
-          </div>
-          <div className="max-h-64 overflow-y-auto divide-y divide-[color:var(--border-subtle)] rounded-xl border border-[color:var(--border-subtle)]">
-            {path.relationships.slice(0, 5).map((relationship) => (
-              <div key={relationship.id} className="grid gap-2 px-3 py-2 text-xs md:grid-cols-[1fr_auto]">
-                <div className="min-w-0">
-                  <span className="font-mono text-[color:var(--foreground)] [overflow-wrap:anywhere]">{relationship.relationship}</span>
-                  <span className="ml-2 break-all text-[color:var(--text-tertiary)] [overflow-wrap:anywhere]">
-                    {relationship.source} → {relationship.target}
-                  </span>
-                </div>
-                <div className="flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
-                  <span>{relationship.direction ?? "directed"}</span>
-                  <span>{relationship.traversable === false ? "blocked" : "traversable"}</span>
-                  {relationship.confidence && <span>{relationship.confidence}</span>}
-                </div>
-              </div>
-            ))}
-            {path.relationships.length === 0 && (
-              <div className="px-3 py-3 text-xs text-[color:var(--text-secondary)]">No relationship evidence attached.</div>
-            )}
-          </div>
-        </section>
-
-        <aside aria-label="Evidence drawer" className="grid gap-3 sm:grid-cols-2 xl:grid-cols-1">
-          <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">Evidence drawer</div>
-          <EvidenceRow label="Findings" values={path.findings} />
-          <EvidenceRow label="Agents" values={path.affectedAgents} />
-          <EvidenceRow label="Servers" values={path.affectedServers} />
-          <EvidenceRow label="Tools" values={path.reachableTools} emptyLabel="none" />
-          <EvidenceRow label="Credentials" values={path.exposedCredentials} emptyLabel="none" />
-          <div className="rounded-xl border border-[color:var(--border-subtle)] px-3 py-2 text-xs">
-            <div className="flex items-center gap-2 text-[color:var(--text-secondary)]">
-              <ShieldAlert className="h-3.5 w-3.5 text-red-300" />
-              <span>CVSS {evidence?.cvssScore ?? "n/a"}</span>
-              <span>EPSS {typeof evidence?.epssScore === "number" ? evidence.epssScore.toFixed(3) : "n/a"}</span>
-              {evidence?.isKev && <span className="font-semibold text-red-300">KEV</span>}
+      <details className="group rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)]">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-[color:var(--foreground)] [&::-webkit-details-marker]:hidden">
+          <span>Relationship proof & evidence drawer</span>
+          <ChevronDown className="h-4 w-4 shrink-0 text-[color:var(--text-tertiary)] transition-transform group-open:rotate-180" />
+        </summary>
+        <div className="space-y-4 border-t border-[color:var(--border-subtle)] px-4 py-4">
+          <section aria-label="Relationship proof">
+            <div className="mb-2 text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+              Relationship proof
             </div>
-          </div>
-        </aside>
-      </div>
+            <div className="max-h-48 divide-y divide-[color:var(--border-subtle)] overflow-y-auto rounded-xl border border-[color:var(--border-subtle)]">
+              {path.relationships.slice(0, 8).map((relationship) => (
+                <div key={relationship.id} className="grid gap-2 px-3 py-2 text-xs md:grid-cols-[1fr_auto]">
+                  <div className="min-w-0">
+                    <span className="font-mono text-[color:var(--foreground)] [overflow-wrap:anywhere]">{relationship.relationship}</span>
+                    <span className="ml-2 break-all text-[color:var(--text-tertiary)] [overflow-wrap:anywhere]">
+                      {relationship.source} → {relationship.target}
+                    </span>
+                  </div>
+                </div>
+              ))}
+              {path.relationships.length === 0 && (
+                <div className="px-3 py-3 text-xs text-[color:var(--text-secondary)]">No relationship evidence attached.</div>
+              )}
+            </div>
+          </section>
+
+          <aside aria-label="Evidence drawer" className="grid gap-2 sm:grid-cols-2">
+            <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)] sm:col-span-2">
+              Evidence drawer
+            </div>
+            <EvidenceRow label="Findings" values={path.findings} />
+            <EvidenceRow label="Agents" values={path.affectedAgents} />
+            <EvidenceRow label="Servers" values={path.affectedServers} />
+            <EvidenceRow label="Tools" values={path.reachableTools} emptyLabel="none" />
+            <EvidenceRow label="Credentials" values={path.exposedCredentials} emptyLabel="none" />
+            <div className="rounded-xl border border-[color:var(--border-subtle)] px-3 py-2 text-xs sm:col-span-2">
+              <div className="flex flex-wrap items-center gap-2 text-[color:var(--text-secondary)]">
+                <ShieldAlert className="h-3.5 w-3.5 text-red-300" />
+                <span>CVSS {evidence?.cvssScore ?? "n/a"}</span>
+                <span>EPSS {typeof evidence?.epssScore === "number" ? evidence.epssScore.toFixed(3) : "n/a"}</span>
+                {evidence?.isKev && <span className="font-semibold text-red-300">KEV</span>}
+              </div>
+            </div>
+          </aside>
+        </div>
+      </details>
 
       {primaryAction && (
         <Link
@@ -168,38 +150,52 @@ export function ExposurePathCommandCenter({
   );
 }
 
+function MetricPill({
+  label,
+  value,
+  tone = "zinc",
+}: {
+  label: string;
+  value: string;
+  tone?: "red" | "green" | "zinc";
+}) {
+  const toneClass =
+    tone === "red"
+      ? "border-red-500/25 bg-red-500/10 text-red-200"
+      : tone === "green"
+        ? "border-emerald-500/25 bg-emerald-500/10 text-emerald-200"
+        : "border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-[color:var(--foreground)]";
+
+  return (
+    <div className={`rounded-lg border px-2.5 py-1.5 ${toneClass}`}>
+      <span className="text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">{label}</span>{" "}
+      <span className="font-mono font-semibold">{value}</span>
+    </div>
+  );
+}
+
+function BriefChip({ label, value, detail }: { label: string; value: string; detail?: string }) {
+  return (
+    <div
+      className="min-w-[9rem] max-w-full flex-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2"
+      title={detail ? `${label}: ${detail}` : label}
+    >
+      <div className="text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">{label}</div>
+      <div className="mt-0.5 truncate text-sm font-medium text-[color:var(--foreground)]">{value}</div>
+    </div>
+  );
+}
+
 function buildInvestigationBrief(path: ExposurePath, fixLabel: string | undefined) {
   const exposed = firstNonEmpty(path.exposedCredentials, path.reachableTools, path.affectedServers, path.affectedAgents);
   const finding = path.findings[0] ?? path.target.label;
   const proofCount = path.relationships.length;
-  const evidence = path.evidence;
-  const riskSignals = [
-    evidence?.isKev ? "KEV" : "",
-    typeof evidence?.epssScore === "number" ? `EPSS ${evidence.epssScore.toFixed(3)}` : "",
-    typeof evidence?.cvssScore === "number" ? `CVSS ${evidence.cvssScore}` : "",
-  ].filter(Boolean);
 
   return [
-    {
-      label: "What is exposed",
-      value: exposed.value,
-      detail: exposed.label,
-    },
-    {
-      label: "Why it matters",
-      value: finding,
-      detail: riskSignals.length > 0 ? riskSignals.join(" · ") : path.severity || "ranked by graph risk",
-    },
-    {
-      label: "What proves it",
-      value: `${proofCount} relationship${proofCount === 1 ? "" : "s"}`,
-      detail: path.provenance?.source ?? "graph evidence",
-    },
-    {
-      label: "What fixes it",
-      value: fixLabel ?? "triage path",
-      detail: path.fix?.version ? `Target ${path.fix.version}` : primaryFixDetail(path),
-    },
+    { label: "What is exposed", value: exposed.value, detail: exposed.label },
+    { label: "Why it matters", value: finding, detail: path.severity || "ranked by graph risk" },
+    { label: "What proves it", value: `${proofCount} relationship${proofCount === 1 ? "" : "s"}`, detail: path.provenance?.source ?? "graph evidence" },
+    { label: "What fixes it", value: fixLabel ?? "triage path", detail: path.fix?.version ? `Target ${path.fix.version}` : primaryFixDetail(path) },
   ];
 }
 
@@ -228,28 +224,20 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
   const layout = buildPathGraphLayout(path);
 
   return (
-    <div className="overflow-x-auto rounded-2xl border border-[color:var(--border-subtle)] bg-[#05070b]">
+    <div className="overflow-x-auto rounded-xl border border-[color:var(--border-subtle)] bg-[#05070b]">
       <svg
         viewBox={`0 0 ${layout.width} ${layout.height}`}
         role="img"
         aria-label={`Selected exposure path graph for ${pathDisplayTitle(path)}`}
-        className="block h-auto min-w-[760px] md:min-w-0 md:w-full"
+        className="block h-auto min-w-[640px] w-full md:min-w-0"
       >
         <defs>
           <marker id="exposure-arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
             <path d="M0,0 L0,6 L9,3 z" fill="#94a3b8" />
           </marker>
-          <filter id="node-shadow" x="-20%" y="-20%" width="140%" height="140%">
-            <feDropShadow dx="0" dy="10" stdDeviation="10" floodColor="#000000" floodOpacity="0.35" />
-          </filter>
         </defs>
 
         <rect x="0" y="0" width={layout.width} height={layout.height} fill="#05070b" />
-        <g opacity="0.18">
-          {Array.from({ length: 10 }).map((_, index) => (
-            <line key={index} x1="0" y1={34 + index * 38} x2={layout.width} y2={34 + index * 38} stroke="#334155" strokeWidth="1" />
-          ))}
-        </g>
 
         {layout.edges.map((edge) => (
           <path
@@ -257,7 +245,7 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
             d={edge.path}
             fill="none"
             stroke={edge.stroke}
-            strokeWidth="3"
+            strokeWidth="2.5"
             strokeLinecap="round"
             markerEnd="url(#exposure-arrow)"
             opacity="0.88"
@@ -268,8 +256,8 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
 
         {layout.relationshipLabels.map((label) => (
           <g key={label.id} transform={`translate(${label.x} ${label.y})`}>
-            <rect x="-52" y="-11" width="104" height="22" rx="11" fill="#0f172a" stroke="#334155" />
-            <text x="0" y="4" textAnchor="middle" fill="#cbd5e1" fontSize="11" fontFamily="var(--font-mono), monospace">
+            <rect x="-48" y="-10" width="96" height="20" rx="10" fill="#0f172a" stroke="#334155" />
+            <text x="0" y="4" textAnchor="middle" fill="#cbd5e1" fontSize="10" fontFamily="var(--font-mono), monospace">
               {label.text}
             </text>
           </g>
@@ -279,24 +267,18 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
           const style = GRAPH_ROLE_STYLE[node.role] ?? GRAPH_ROLE_STYLE.unknown;
           const meta = ROLE_META[node.role] ?? ROLE_META.unknown;
           return (
-            <g key={`${node.id}-${index}`} transform={`translate(${node.x} ${node.y})`} filter="url(#node-shadow)">
-              <rect width={layout.nodeWidth} height={layout.nodeHeight} rx="14" fill={style.fill} stroke={style.stroke} strokeWidth="2" />
-              <circle cx="18" cy="20" r="5" fill={style.accent} />
-              <text x="32" y="24" fill={style.accent} fontSize="10" fontWeight="700" letterSpacing="2" fontFamily="var(--font-mono), monospace">
+            <g key={`${node.id}-${index}`} transform={`translate(${node.x} ${node.y})`}>
+              <rect width={layout.nodeWidth} height={layout.nodeHeight} rx="12" fill={style.fill} stroke={style.stroke} strokeWidth="2" />
+              <text x="14" y="22" fill={style.accent} fontSize="9" fontWeight="700" letterSpacing="1.5" fontFamily="var(--font-mono), monospace">
                 {meta.label.toUpperCase()}
               </text>
-              <text x="16" y="49" fill={style.text} fontSize="14" fontWeight="700" fontFamily="var(--font-sans), system-ui">
-                {wrapGraphText(node.label, 18, 2).map((line, lineIndex) => (
-                  <tspan key={`${node.id}-line-${lineIndex}`} x="16" dy={lineIndex === 0 ? 0 : 17}>
+              <text x="14" y="44" fill={style.text} fontSize="13" fontWeight="600" fontFamily="var(--font-sans), system-ui">
+                {wrapGraphText(node.label, 16, 2).map((line, lineIndex) => (
+                  <tspan key={`${node.id}-line-${lineIndex}`} x="14" dy={lineIndex === 0 ? 0 : 15}>
                     {line}
                   </tspan>
                 ))}
               </text>
-              {node.severity && (
-                <text x="16" y="79" fill="#94a3b8" fontSize="10" letterSpacing="1.4" fontFamily="var(--font-mono), monospace">
-                  {String(node.severity).toUpperCase()}
-                </text>
-              )}
               <title>{`${meta.label}: ${node.label}`}</title>
             </g>
           );
@@ -308,21 +290,21 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
 
 function buildPathGraphLayout(path: ExposurePath) {
   const width = 920;
-  const nodeWidth = 178;
-  const nodeHeight = 96;
-  const columns = Math.min(3, Math.max(1, path.hops.length));
+  const nodeWidth = 168;
+  const nodeHeight = 72;
+  const columns = Math.min(4, Math.max(1, path.hops.length));
   const rows = Math.max(1, Math.ceil(path.hops.length / columns));
-  const xGap = columns > 1 ? (width - nodeWidth - 64) / (columns - 1) : 0;
-  const yGap = 138;
-  const height = 52 + rows * nodeHeight + (rows - 1) * (yGap - nodeHeight) + 36;
+  const xGap = columns > 1 ? (width - nodeWidth - 48) / (columns - 1) : 0;
+  const yGap = 108;
+  const height = 40 + rows * nodeHeight + (rows - 1) * (yGap - nodeHeight) + 24;
   const nodes = path.hops.map((hop, index) => {
     const row = Math.floor(index / columns);
     const col = index % columns;
     const visualCol = row % 2 === 0 ? col : columns - 1 - col;
     return {
       ...hop,
-      x: 32 + visualCol * xGap,
-      y: 38 + row * yGap,
+      x: 24 + visualCol * xGap,
+      y: 28 + row * yGap,
     };
   });
   const edges = nodes.slice(0, -1).map((source, index) => {
@@ -333,7 +315,7 @@ function buildPathGraphLayout(path: ExposurePath) {
     const endX = target.x;
     const endY = target.y + nodeHeight / 2;
     const sameRow = Math.abs(startY - endY) < 10;
-    const control = sameRow ? Math.max(48, Math.abs(endX - startX) / 2) : 70;
+    const control = sameRow ? Math.max(40, Math.abs(endX - startX) / 2) : 56;
     const pathD = sameRow
       ? `M ${startX} ${startY} C ${startX + control} ${startY}, ${endX - control} ${endY}, ${endX} ${endY}`
       : `M ${source.x + nodeWidth / 2} ${source.y + nodeHeight} C ${source.x + nodeWidth / 2} ${source.y + nodeHeight + control}, ${target.x + nodeWidth / 2} ${target.y - control}, ${target.x + nodeWidth / 2} ${target.y}`;
@@ -344,12 +326,12 @@ function buildPathGraphLayout(path: ExposurePath) {
       stroke: style.stroke,
       label: relationship,
       labelX: sameRow ? (startX + endX) / 2 : (source.x + target.x + nodeWidth) / 2,
-      labelY: sameRow ? startY - 16 : (source.y + target.y + nodeHeight) / 2,
+      labelY: sameRow ? startY - 14 : (source.y + target.y + nodeHeight) / 2,
     };
   });
   const relationshipLabels = edges.map((edge) => ({
     id: `${edge.id}:label`,
-    text: truncateGraphText(edge.label, 14),
+    text: truncateGraphText(edge.label, 12),
     x: edge.labelX,
     y: edge.labelY,
   }));
@@ -395,22 +377,6 @@ function wrapGraphText(value: string, maxLineLength: number, maxLines: number): 
   return lines.length > 0 ? lines : [truncateGraphText(normalized, maxLineLength)];
 }
 
-function CommandMetric({ label, value, tone = "zinc" }: { label: string; value: string; tone?: "red" | "green" | "zinc" }) {
-  const toneClass =
-    tone === "red"
-      ? "border-red-500/25 bg-red-500/10 text-red-200"
-      : tone === "green"
-        ? "border-emerald-500/25 bg-emerald-500/10 text-emerald-200"
-        : "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]";
-
-  return (
-    <div className={`min-w-0 rounded-xl border px-3 py-2 ${toneClass}`}>
-      <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">{label}</div>
-      <div className="mt-1 font-mono text-sm font-semibold leading-5 [overflow-wrap:anywhere]">{value}</div>
-    </div>
-  );
-}
-
 function EvidenceRow({
   label,
   values,
@@ -424,7 +390,7 @@ function EvidenceRow({
     <div className="min-w-0 rounded-xl border border-[color:var(--border-subtle)] px-3 py-2 text-xs">
       <div className="mb-1 text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">{label}</div>
       <div className="flex flex-wrap gap-1.5">
-        {(values.length > 0 ? values : [emptyLabel]).slice(0, 4).map((value) => (
+        {(values.length > 0 ? values : [emptyLabel]).slice(0, 3).map((value) => (
           <span
             key={`${label}-${value}`}
             className="max-w-full rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2 py-0.5 text-[color:var(--text-secondary)] [overflow-wrap:anywhere]"
@@ -432,9 +398,9 @@ function EvidenceRow({
             {value}
           </span>
         ))}
-        {values.length > 4 && (
+        {values.length > 3 && (
           <span className="rounded border border-[color:var(--border-subtle)] px-2 py-0.5 text-[color:var(--text-tertiary)]">
-            +{values.length - 4}
+            +{values.length - 3}
           </span>
         )}
       </div>

--- a/ui/components/exposure-path-strip.tsx
+++ b/ui/components/exposure-path-strip.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { Crosshair, KeyRound, Route, ShieldAlert, Wrench } from "lucide-react";
-import { pathDisplayTitle, pathFixLabel, type ExposurePath } from "@/lib/exposure-path";
+import { pathDisplayTitle, type ExposurePath } from "@/lib/exposure-path";
 
 export function ExposurePathStrip({
   path,
@@ -14,65 +13,26 @@ export function ExposurePathStrip({
   actionLabel?: string | undefined;
   onAction?: (() => void) | undefined;
 }) {
-  const fixLabel = pathFixLabel(path);
-
   return (
-    <div className="flex flex-wrap items-center gap-3 border-b border-[var(--border-subtle)] bg-red-950/20 px-4 py-2.5 text-xs">
-      <div className="flex min-w-[min(100%,24rem)] flex-1 flex-wrap items-center gap-2">
-        <span className="inline-flex shrink-0 items-center gap-1 rounded border border-red-500/40 bg-red-500/10 px-2 py-1 font-semibold uppercase text-red-200">
-          <Crosshair className="h-3.5 w-3.5" />
-          Top exposed path
-        </span>
-        <span className="shrink-0 rounded bg-red-500/15 px-2 py-0.5 font-mono text-[11px] uppercase text-red-200">
-          {path.severity}
-        </span>
-        <span
-          className="min-w-[12rem] flex-1 overflow-hidden break-words text-[var(--text-secondary)] [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] [overflow-wrap:anywhere]"
-          title={path.label}
+    <div className="flex flex-wrap items-center gap-2 border-b border-[var(--border-subtle)] bg-red-950/15 px-4 py-2 text-sm">
+      <span className="shrink-0 rounded border border-red-500/40 bg-red-500/10 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-red-200">
+        {path.severity}
+      </span>
+      <span
+        className="min-w-0 flex-1 truncate font-medium text-[var(--foreground)]"
+        title={path.label}
+      >
+        {pathDisplayTitle(path)}
+      </span>
+      {onAction && actionLabel && (
+        <button
+          type="button"
+          onClick={onAction}
+          className="shrink-0 rounded border border-red-500/30 px-2 py-1 text-xs text-red-200 transition hover:border-red-400 hover:bg-red-500/10"
         >
-          {pathDisplayTitle(path)}
-        </span>
-      </div>
-      <div className="flex min-w-0 flex-wrap items-center gap-2 text-[11px] text-[var(--text-secondary)]">
-        <Metric icon={ShieldAlert} label="risk" value={Math.round(path.riskScore * 10) / 10} />
-        <Metric icon={Route} label="hops" value={Math.max(0, path.hops.length - 1)} />
-        <Metric label="agents" value={path.affectedAgents.length} />
-        {path.reachableTools.length > 0 && <Metric icon={Wrench} label="tools" value={path.reachableTools.length} />}
-        {path.exposedCredentials.length > 0 && (
-          <Metric icon={KeyRound} label="creds" value={path.exposedCredentials.length} />
-        )}
-        {fixLabel && (
-          <span className="min-w-0 break-words [overflow-wrap:anywhere]">
-            fix <b className="text-emerald-300">{fixLabel}</b>
-          </span>
-        )}
-        {onAction && actionLabel && (
-          <button
-            type="button"
-            onClick={onAction}
-            className="rounded border border-red-500/30 px-2 py-1 text-red-200 transition hover:border-red-400 hover:bg-red-500/10"
-          >
-            {active ? "Show all" : actionLabel}
-          </button>
-        )}
-      </div>
+          {active ? "Show all" : actionLabel}
+        </button>
+      )}
     </div>
-  );
-}
-
-function Metric({
-  icon: Icon,
-  label,
-  value,
-}: {
-  icon?: typeof ShieldAlert | undefined;
-  label: string;
-  value: string | number;
-}) {
-  return (
-    <span className="inline-flex shrink-0 items-center gap-1">
-      {Icon && <Icon className="h-3 w-3" />}
-      {label} <b className="text-foreground">{value}</b>
-    </span>
   );
 }

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -40,6 +40,7 @@ import { api } from "@/lib/api";
 import { useAuthState } from "@/components/auth-provider";
 import { BrandMark } from "@/components/brand-mark";
 import { CommandPalette, type CommandPaletteAction } from "@/components/command-palette";
+import { DemoNavSignIn } from "@/components/demo-mode-cta";
 import { ThemeToggle } from "@/components/theme-toggle";
 import {
   deploymentModeLabel,
@@ -59,7 +60,6 @@ interface NavLink {
 
 interface NavGroup {
   label: string;
-  description: string;
   icon: React.ElementType;
   links: NavLink[];
   /**
@@ -82,40 +82,14 @@ function activeGroupForPath(path: string | null): string {
 
 const NAV_GROUPS: NavGroup[] = [
   {
-    label: "Discover",
-    description: "Inventory, coverage, and starting points",
+    label: "Command",
     icon: LayoutDashboard,
-    accent: "#58a6ff", // blue — discovery layer
+    accent: "#58a6ff",
     links: [
       { href: "/", label: "Dashboard", icon: LayoutDashboard },
-      { href: "/agents", label: "Agents", icon: Server },
-      { href: "/manifest", label: "Agent BOM", icon: Waypoints },
-      { href: "/fleet", label: "Fleet", icon: Users },
-      { href: "/registry", label: "Registry", icon: Boxes },
-    ],
-  },
-  {
-    label: "Scan",
-    description: "Choose source mode, run scans, and review findings",
-    icon: Scan,
-    accent: "#f85149", // red — scanning layer
-    links: [
-      { href: "/sources", label: "Data Sources", icon: Database, capability: "sources.manage" },
-      { href: "/connections", label: "Cloud Accounts", icon: Cloud, capability: "scan.run" },
-      { href: "/scan", label: "New Scan", icon: Scan, capability: "scan.run" },
-      { href: "/jobs", label: "Scan Jobs", icon: Clock },
       { href: "/findings", label: "Findings", icon: Bug },
-    ],
-  },
-  {
-    label: "Analyze",
-    description: "One security graph with attack-path, lineage, mesh, and context lenses",
-    icon: GitBranch,
-    accent: "#d29922", // amber — analysis layer
-    links: [
-      // Single graph surface. Lineage / mesh / context are lenses reached from the
-      // in-page lens switcher, not separate nav links (see graph-lens-switcher).
       { href: "/security-graph", label: "Security Graph", icon: Network },
+      { href: "/remediation", label: "Remediation", icon: Wrench },
     ],
     secondary: [
       { href: "/graph", label: "Lineage Lens", icon: GitBranch },
@@ -124,23 +98,40 @@ const NAV_GROUPS: NavGroup[] = [
     ],
   },
   {
-    label: "Protect",
-    description: "Proxy, policy, and runtime enforcement surfaces",
-    icon: Shield,
-    accent: "#f778ba", // pink — enforcement layer
+    label: "AI Estate",
+    icon: Server,
+    accent: "#3fb950",
     links: [
-      { href: "/runtime", label: "Runtime", icon: Shield },
+      { href: "/agents", label: "Agents", icon: Server },
+      { href: "/manifest", label: "Agent BOM", icon: Waypoints },
+      { href: "/fleet", label: "Fleet", icon: Users },
     ],
   },
-  // Govern is split into three tight, single-purpose groups instead of one
-  // eight-deep list with a "More" disclosure. Every former Govern route (plus
-  // the Audit Log moved out of Protect) stays reachable directly in the sidebar,
-  // the command palette, and deep links.
   {
-    label: "Compliance",
-    description: "Evidence, policy governance, and audit export",
+    label: "Cloud & Data",
+    icon: Cloud,
+    accent: "#a371f7",
+    links: [
+      { href: "/connections", label: "Cloud Accounts", icon: Cloud, capability: "scan.run" },
+      { href: "/sources", label: "Data Sources", icon: Database, capability: "sources.manage" },
+      { href: "/scan", label: "New Scan", icon: Scan, capability: "scan.run" },
+      { href: "/identity", label: "Identity", icon: Fingerprint },
+      { href: "/drift", label: "Drift", icon: Radar },
+    ],
+  },
+  {
+    label: "Runtime",
     icon: Shield,
-    accent: "#3fb950", // green — evidence/governance layer
+    accent: "#f778ba",
+    links: [
+      { href: "/runtime", label: "Runtime", icon: Shield },
+      { href: "/traces", label: "Traces", icon: Radio },
+    ],
+  },
+  {
+    label: "Governance",
+    icon: Eye,
+    accent: "#3fb950",
     links: [
       { href: "/compliance", label: "Compliance", icon: Shield },
       { href: "/governance", label: "Governance", icon: Eye, capability: "policy.manage" },
@@ -148,25 +139,19 @@ const NAV_GROUPS: NavGroup[] = [
     ],
   },
   {
-    label: "Operations",
-    description: "Identity, cost, drift, and activity posture",
-    icon: Activity,
-    accent: "#a371f7", // purple — operational posture layer
-    links: [
-      { href: "/identity", label: "Identity", icon: Fingerprint },
-      { href: "/cost", label: "Cost", icon: DollarSign },
-      { href: "/drift", label: "Drift", icon: Radar },
-      { href: "/activity", label: "Activity", icon: Activity },
-    ],
+    label: "Reference",
+    icon: Boxes,
+    accent: "#d29922",
+    links: [{ href: "/registry", label: "MCP Catalog", icon: Boxes }],
   },
   {
-    label: "Remediation",
-    description: "Fix workflow and runtime trace evidence",
-    icon: Wrench,
-    accent: "#db6d28", // orange — remediation/action layer
+    label: "Operations",
+    icon: Activity,
+    accent: "#db6d28",
     links: [
-      { href: "/remediation", label: "Remediation", icon: Wrench },
-      { href: "/traces", label: "Traces", icon: Radio },
+      { href: "/cost", label: "AI Spend", icon: DollarSign },
+      { href: "/jobs", label: "Scan Jobs", icon: Clock },
+      { href: "/activity", label: "Activity", icon: Activity },
     ],
   },
 ];
@@ -177,11 +162,11 @@ const ALL_GROUP_LABELS = NAV_GROUPS.map((group) => group.label);
 // Reuse the canonical nav labels so proof-path tiles don't give the same route
 // a second name (e.g. Findings vs "Queue"). Icons mirror each route's nav icon.
 const PROOF_PATH_LINKS: NavLink[] = [
-  { href: "/findings", label: "Findings", icon: Bug },
   { href: "/security-graph", label: "Security Graph", icon: Network },
   { href: "/runtime", label: "Runtime", icon: Shield },
   { href: "/compliance", label: "Compliance", icon: FileText },
   { href: "/connections", label: "Cloud Accounts", icon: Cloud },
+  { href: "/remediation", label: "Remediation", icon: Wrench },
 ];
 
 // ─── Risk counts for badges ─────────────────────────────────────────────────
@@ -460,7 +445,7 @@ export function Nav() {
           <p className="px-1 pb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">
             Proof path
           </p>
-          <div className="grid grid-cols-2 gap-1">
+          <div className="flex gap-1 overflow-x-auto pb-1 scrollbar-thin">
             {PROOF_PATH_LINKS.map((link) => {
               const Icon = link.icon;
               const active = link.href === "/" ? path === "/" : Boolean(path?.startsWith(link.href));
@@ -468,14 +453,14 @@ export function Nav() {
                 <Link
                   key={link.href}
                   href={link.href}
-                  className={`flex items-center gap-2 rounded-lg border px-2.5 py-2 text-[11px] font-medium transition-colors ${
+                  className={`flex shrink-0 items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-[11px] font-medium whitespace-nowrap transition-colors ${
                     active
                       ? "border-[color:var(--border-strong)] bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
                       : "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
                   }`}
                 >
                   <Icon className="h-3.5 w-3.5 shrink-0" />
-                  <span className="truncate">{link.label}</span>
+                  <span>{link.label}</span>
                 </Link>
               );
             })}
@@ -524,7 +509,7 @@ export function Nav() {
                 }`}
                 style={{ borderLeftColor: group.accent }}
                 aria-expanded={collapsed ? collapsedFlyoutGroup === group.label : isExpanded}
-                aria-label={collapsed ? `${group.label}: ${group.description}` : undefined}
+                aria-label={collapsed ? group.label : undefined}
               >
                 <GroupIcon
                   className={`${collapsed ? "h-5 w-5" : "h-4 w-4"} shrink-0`}
@@ -552,9 +537,6 @@ export function Nav() {
               {/* Group Links */}
               {(isExpanded || collapsed) && !collapsed && (
                 <div className="mx-2 mb-2 mt-1 space-y-0.5 border-l border-[color:var(--border-subtle)] pl-2">
-                  <p className="px-3 pb-1 text-[11px] leading-5 text-[color:var(--text-tertiary)]">
-                    {group.description}
-                  </p>
                   {group.visibleLinks.map(({ href, label, icon: Icon }) => {
                     const active =
                       href === "/"
@@ -687,9 +669,6 @@ export function Nav() {
                         <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-[color:var(--foreground)]">
                           {group.label}
                         </p>
-                        <p className="mt-1 text-[12px] leading-5 text-[color:var(--text-secondary)]">
-                          {group.description}
-                        </p>
                       </div>
                     </div>
                     <div className="space-y-1">
@@ -763,6 +742,7 @@ export function Nav() {
       <div className={`border-t border-[color:var(--border-subtle)] ${collapsed ? "px-2 py-3" : "px-3 py-3"}`}>
         <div className="space-y-2">
           <SessionStatus collapsed={collapsed} loading={authLoading} session={session} />
+          <DemoNavSignIn collapsed={collapsed} />
           <Link
             href={`/help?from=${encodeURIComponent(path ?? "/")}`}
             className={`flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-[12px] text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)] ${collapsed ? "justify-center px-2" : ""}`}

--- a/ui/components/page-lane.tsx
+++ b/ui/components/page-lane.tsx
@@ -1,0 +1,70 @@
+import type { ReactNode } from "react";
+import { PAGE_LANE_META, type PageLane } from "@/lib/page-lanes";
+
+export function PageScopeChip({ lane }: { lane: PageLane }) {
+  const meta = PAGE_LANE_META[lane];
+  return (
+    <span
+      className="inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium"
+      style={{
+        borderColor: `${meta.accent}55`,
+        backgroundColor: `${meta.accent}14`,
+        color: meta.accent,
+      }}
+    >
+      {meta.scope}
+    </span>
+  );
+}
+
+export function PageLaneHeader({
+  lane,
+  title,
+  subtitle,
+  actions,
+  banner,
+}: {
+  lane: PageLane;
+  title: string;
+  subtitle?: string;
+  actions?: ReactNode;
+  banner?: ReactNode;
+}) {
+  const meta = PAGE_LANE_META[lane];
+  return (
+    <div className="space-y-3">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <p
+              className="text-[11px] font-semibold uppercase tracking-[0.16em]"
+              style={{ color: meta.accent }}
+            >
+              {meta.label}
+            </p>
+            <PageScopeChip lane={lane} />
+          </div>
+          <h1 className="mt-1 text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">
+            {title}
+          </h1>
+          {subtitle ? (
+            <p className="mt-1 max-w-2xl text-sm text-[color:var(--text-secondary)]">{subtitle}</p>
+          ) : null}
+        </div>
+        {actions ? (
+          <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div>
+        ) : null}
+      </header>
+      {banner}
+    </div>
+  );
+}
+
+export function CatalogBanner() {
+  return (
+    <div className="rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-xs text-amber-100/90">
+      Reference catalog — known MCP packages and risk metadata. This is not your connected estate; use{" "}
+      <span className="font-medium text-amber-50">Agent BOM</span> for tenant inventory.
+    </div>
+  );
+}

--- a/ui/components/scan-form.tsx
+++ b/ui/components/scan-form.tsx
@@ -4,7 +4,7 @@ import { useState, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { api, type ScanRequest } from "@/lib/api";
-import { ArrowRight, Cloud, Loader2, Plus, Radio, Upload, Workflow, X } from "lucide-react";
+import { ArrowRight, ChevronDown, Loader2, Plus, Upload, X } from "lucide-react";
 
 // ─── Scan Form ──────────────────────────────────────────────────────────────
 
@@ -75,244 +75,229 @@ export function ScanForm() {
     }
   }
 
+  const queuedImages = form.images ?? [];
+
   return (
-    <div className="max-w-2xl">
-      <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight mb-1">New Scan</h1>
-          <p className="text-zinc-400 text-sm">
-            Launch direct scan jobs from this page. Cloud-backed governance feeds, connector-backed discovery, and trace ingest live in separate product
-            surfaces.
+    <div className="max-w-5xl">
+      <header className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <h1 className="text-2xl font-semibold tracking-tight text-zinc-100">New Scan</h1>
+          <p className="mt-1 max-w-2xl text-sm text-zinc-400">
+            Run a direct scan job. Local MCP configs are included automatically.
           </p>
+          <nav aria-label="Related scan surfaces" className="mt-3 flex flex-wrap items-center gap-x-1 gap-y-1 text-xs text-zinc-500">
+            <RelatedLink href="/sources">Data sources</RelatedLink>
+            <span aria-hidden="true">·</span>
+            <RelatedLink href="/governance">Governance</RelatedLink>
+            <span aria-hidden="true">·</span>
+            <RelatedLink href="/traces">Traces</RelatedLink>
+            <span aria-hidden="true">·</span>
+            <RelatedLink href="/jobs">Scan jobs</RelatedLink>
+          </nav>
         </div>
         <Link
           href="/sources"
-          className="inline-flex items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm font-medium text-zinc-200 transition-colors hover:border-zinc-600 hover:bg-zinc-800"
+          className="inline-flex shrink-0 items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm font-medium text-zinc-200 transition-colors hover:border-zinc-600 hover:bg-zinc-800"
         >
-          Explore data sources
+          Connect source
           <ArrowRight className="h-4 w-4" />
         </Link>
-      </div>
+      </header>
 
-      <div className="grid gap-3 md:grid-cols-2 mb-8">
-        <SurfaceCard
-          icon={Workflow}
-          title="Direct scans"
-          description="Local MCP configs, images, Kubernetes, Terraform, GitHub Actions, custom inventory, and Python agent projects start here."
-          badge="This page"
-        />
-        <SurfaceCard
-          icon={Cloud}
-          title="Cloud and governance feeds"
-          description="Snowflake and other cloud-backed governance or activity data are surfaced through the governance and activity pages, not this scan form."
-          href="/governance"
-          action="Open governance"
-        />
-        <SurfaceCard
-          icon={Radio}
-          title="Trace ingest"
-          description="OTLP and runtime-event ingest are handled through the traces surface and the POST /v1/traces API contract."
-          href="/traces"
-          action="Open traces"
-        />
-        <SurfaceCard
-          icon={Cloud}
-          title="Connectors and enterprise sources"
-          description="Connector-backed discovery and SIEM integrations exist in the backend today, but they are not yet exposed as first-class setup flows on this page."
-          badge="API today"
-        />
-      </div>
+      <form onSubmit={handleSubmit} className="grid gap-5 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] lg:items-start">
+        <div className="space-y-5">
+          <Section title="Docker images">
+            <div className="mb-3 flex flex-wrap items-center gap-1">
+              {(["single", "bulk", "upload"] as const).map((mode) => (
+                <button
+                  key={mode}
+                  type="button"
+                  onClick={() => setImageMode(mode)}
+                  className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                    imageMode === mode
+                      ? "bg-zinc-700 text-zinc-100"
+                      : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
+                  }`}
+                >
+                  {mode === "single" ? "One at a time" : mode === "bulk" ? "Bulk paste" : "Upload .txt"}
+                </button>
+              ))}
+            </div>
 
-      <form onSubmit={handleSubmit} className="space-y-6">
-        {/* Auto-discover */}
-        <Section title="Local MCP configs" subtitle="Claude Desktop, Cursor, Windsurf, Cline, VS Code... (auto)">
-          <p className="text-xs text-zinc-500">Always included automatically.</p>
-        </Section>
-
-        {/* Docker images */}
-        <Section title="Docker images" subtitle="--image flag · supports bulk input for enterprise scale">
-          <div className="flex items-center gap-1 mb-3">
-            {(["single", "bulk", "upload"] as const).map((mode) => (
-              <button
-                key={mode}
-                type="button"
-                onClick={() => setImageMode(mode)}
-                className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
-                  imageMode === mode
-                    ? "bg-zinc-700 text-zinc-100"
-                    : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
-                }`}
-              >
-                {mode === "single" ? "One at a time" : mode === "bulk" ? "Bulk paste" : "Upload .txt"}
-              </button>
-            ))}
-          </div>
-
-          {imageMode === "single" && (
-            <ListInput
-              placeholder="nginx:1.25 or ghcr.io/org/app:v1"
-              value={imageInput}
-              onChange={setImageInput}
-              onAdd={() => addToList("images", imageInput, () => setImageInput(""))}
-              items={[]}
-              onRemove={() => {}}
-            />
-          )}
-
-          {imageMode === "bulk" && (
-            <div className="space-y-2">
-              <textarea
-                placeholder={"# One image per line\nnginx:1.25\nredis:7-alpine\nghcr.io/org/app:latest"}
-                value={bulkText}
-                onChange={(e) => setBulkText(e.target.value)}
-                rows={5}
-                className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm font-mono text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:border-emerald-600 resize-y"
+            {imageMode === "single" && (
+              <ListInput
+                placeholder="nginx:1.25 or ghcr.io/org/app:v1"
+                value={imageInput}
+                onChange={setImageInput}
+                onAdd={() => addToList("images", imageInput, () => setImageInput(""))}
+                items={[]}
+                onRemove={() => {}}
               />
-              <button
-                type="button"
-                onClick={applyBulk}
-                disabled={!bulkText.trim()}
-                className="flex items-center gap-1.5 px-3 py-1.5 bg-emerald-700 hover:bg-emerald-600 disabled:opacity-40 disabled:cursor-not-allowed rounded-lg text-xs text-white font-medium transition-colors"
-              >
-                <Plus className="w-3.5 h-3.5" />
-                Add {parseBulkImages(bulkText).length || 0} image{parseBulkImages(bulkText).length !== 1 ? "s" : ""}
-              </button>
-            </div>
-          )}
+            )}
 
-          {imageMode === "upload" && (
-            <div className="space-y-2">
-              <input ref={fileInputRef} type="file" accept=".txt,.csv,.list" onChange={handleFileUpload} className="hidden" />
-              <button
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                className="flex items-center gap-2 px-4 py-3 w-full bg-zinc-800 hover:bg-zinc-700 border border-dashed border-zinc-600 rounded-lg text-sm text-zinc-300 transition-colors justify-center"
-              >
-                <Upload className="w-4 h-4" />
-                Choose .txt file (one image per line)
-              </button>
-              <p className="text-[10px] text-zinc-600">Lines starting with # are ignored. Supports .txt, .csv, .list files.</p>
-            </div>
-          )}
-
-          {(form.images ?? []).length > 0 && (
-            <div className="mt-3 space-y-1.5">
-              <div className="text-xs text-zinc-500 font-medium">
-                {(form.images ?? []).length} image{(form.images ?? []).length !== 1 ? "s" : ""} queued
+            {imageMode === "bulk" && (
+              <div className="space-y-2">
+                <textarea
+                  placeholder={"# One image per line\nnginx:1.25\nredis:7-alpine\nghcr.io/org/app:latest"}
+                  value={bulkText}
+                  onChange={(e) => setBulkText(e.target.value)}
+                  rows={4}
+                  className="w-full resize-y rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-emerald-600 focus:outline-none"
+                />
+                <button
+                  type="button"
+                  onClick={applyBulk}
+                  disabled={!bulkText.trim()}
+                  className="flex items-center gap-1.5 rounded-lg bg-emerald-700 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                  Add {parseBulkImages(bulkText).length || 0} image{parseBulkImages(bulkText).length !== 1 ? "s" : ""}
+                </button>
               </div>
-              <div className="flex flex-wrap gap-2">
-                {(form.images ?? []).map((item, i) => (
-                  <span key={i} className="flex items-center gap-1.5 bg-zinc-800 border border-zinc-700 rounded-lg px-2.5 py-1 text-xs font-mono text-zinc-300">
-                    {item}
-                    <button type="button" onClick={() => removeFromList("images", i)}>
-                      <X className="w-3 h-3 text-zinc-500 hover:text-zinc-300" />
-                    </button>
-                  </span>
-                ))}
+            )}
+
+            {imageMode === "upload" && (
+              <div className="space-y-2">
+                <input ref={fileInputRef} type="file" accept=".txt,.csv,.list" onChange={handleFileUpload} className="hidden" />
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  className="flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-zinc-600 bg-zinc-800 px-4 py-3 text-sm text-zinc-300 transition-colors hover:bg-zinc-700"
+                >
+                  <Upload className="h-4 w-4" />
+                  Choose .txt file
+                </button>
+              </div>
+            )}
+
+            {queuedImages.length > 0 && (
+              <div className="mt-3 space-y-1.5">
+                <div className="text-xs font-medium text-zinc-500">
+                  {queuedImages.length} image{queuedImages.length !== 1 ? "s" : ""} queued
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {queuedImages.map((item, i) => (
+                    <span key={i} className="flex items-center gap-1.5 rounded-lg border border-zinc-700 bg-zinc-800 px-2.5 py-1 font-mono text-xs text-zinc-300">
+                      {item}
+                      <button type="button" onClick={() => removeFromList("images", i)}>
+                        <X className="h-3 w-3 text-zinc-500 hover:text-zinc-300" />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </Section>
+
+          <Section title="Kubernetes cluster">
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                className="h-4 w-4 rounded border-zinc-700 bg-zinc-900 text-emerald-500"
+                checked={form.k8s ?? false}
+                onChange={(e) => setForm((f) => ({ ...f, k8s: e.target.checked }))}
+              />
+              <span className="text-sm text-zinc-300">Scan running pods via kubectl</span>
+            </label>
+            {form.k8s && (
+              <input
+                type="text"
+                placeholder="Namespace (optional)"
+                className="mt-2 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 focus:border-emerald-600 focus:outline-none"
+                value={form.k8s_namespace ?? ""}
+                onChange={(e) => setForm((f) => ({ ...f, k8s_namespace: e.target.value || undefined }))}
+              />
+            )}
+          </Section>
+
+          <Section title="Python agent projects">
+            <ListInput
+              placeholder="/path/to/my-langchain-app"
+              value={apInput}
+              onChange={setApInput}
+              onAdd={() => addToList("agent_projects", apInput, () => setApInput(""))}
+              items={form.agent_projects ?? []}
+              onRemove={(i) => removeFromList("agent_projects", i)}
+            />
+          </Section>
+        </div>
+
+        <div className="space-y-5">
+          <details className="group rounded-xl border border-zinc-800 bg-zinc-900">
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-5 py-4 text-sm font-semibold text-zinc-200 [&::-webkit-details-marker]:hidden">
+              Advanced targets
+              <ChevronDown className="h-4 w-4 text-zinc-500 transition-transform group-open:rotate-180" />
+            </summary>
+            <div className="space-y-5 border-t border-zinc-800 px-5 py-4">
+              <div>
+                <h3 className="mb-2 text-sm font-medium text-zinc-200">Terraform directories</h3>
+                <ListInput
+                  placeholder="/path/to/infra"
+                  value={tfInput}
+                  onChange={setTfInput}
+                  onAdd={() => addToList("tf_dirs", tfInput, () => setTfInput(""))}
+                  items={form.tf_dirs ?? []}
+                  onRemove={(i) => removeFromList("tf_dirs", i)}
+                />
+              </div>
+              <div>
+                <h3 className="mb-2 text-sm font-medium text-zinc-200">GitHub Actions</h3>
+                <input
+                  type="text"
+                  placeholder="/path/to/git/repo"
+                  className="w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 focus:border-emerald-600 focus:outline-none"
+                  value={form.gha_path ?? ""}
+                  onChange={(e) => setForm((f) => ({ ...f, gha_path: e.target.value || undefined }))}
+                />
+              </div>
+              <div>
+                <h3 className="mb-2 text-sm font-medium text-zinc-200">Custom inventory</h3>
+                <input
+                  type="text"
+                  placeholder="/path/to/agents.json"
+                  className="w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 focus:border-emerald-600 focus:outline-none"
+                  value={form.inventory ?? ""}
+                  onChange={(e) => setForm((f) => ({ ...f, inventory: e.target.value || undefined }))}
+                />
               </div>
             </div>
+          </details>
+
+          <Section title="Options">
+            <label className="flex cursor-pointer items-start gap-2">
+              <input
+                type="checkbox"
+                className="mt-0.5 h-4 w-4 rounded border-zinc-700 bg-zinc-900 text-emerald-500"
+                checked={form.enrich ?? false}
+                onChange={(e) => setForm((f) => ({ ...f, enrich: e.target.checked }))}
+              />
+              <span className="text-sm text-zinc-300">
+                Enrich with NVD CVSS, EPSS, and CISA KEV
+                <span className="mt-0.5 block text-xs text-zinc-500">Slower; requires internet</span>
+              </span>
+            </label>
+          </Section>
+
+          {error && (
+            <p className="rounded-lg border border-red-900 bg-red-950 px-4 py-3 text-sm text-red-400">{error}</p>
           )}
-        </Section>
 
-        {/* Kubernetes */}
-        <Section title="Kubernetes cluster" subtitle="--k8s (requires kubectl)">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              className="w-4 h-4 rounded border-zinc-700 bg-zinc-900 text-emerald-500"
-              checked={form.k8s ?? false}
-              onChange={(e) => setForm((f) => ({ ...f, k8s: e.target.checked }))}
-            />
-            <span className="text-sm text-zinc-300">Scan all running pods via kubectl</span>
-          </label>
-          {form.k8s && (
-            <input
-              type="text"
-              placeholder="Namespace (leave empty for all)"
-              className="mt-2 w-full bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 focus:outline-none focus:border-emerald-600"
-              value={form.k8s_namespace ?? ""}
-              onChange={(e) => setForm((f) => ({ ...f, k8s_namespace: e.target.value || undefined }))}
-            />
-          )}
-        </Section>
-
-        {/* Terraform */}
-        <Section title="Terraform directories" subtitle="--tf-dir">
-          <ListInput
-            placeholder="/path/to/infra or infra/prod"
-            value={tfInput}
-            onChange={setTfInput}
-            onAdd={() => addToList("tf_dirs", tfInput, () => setTfInput(""))}
-            items={form.tf_dirs ?? []}
-            onRemove={(i) => removeFromList("tf_dirs", i)}
-          />
-        </Section>
-
-        {/* Python agent projects */}
-        <Section title="Python agent projects" subtitle="--agent-project (LangChain, OpenAI Agents, CrewAI, AutoGen...)">
-          <ListInput
-            placeholder="/path/to/my-langchain-app or ."
-            value={apInput}
-            onChange={setApInput}
-            onAdd={() => addToList("agent_projects", apInput, () => setApInput(""))}
-            items={form.agent_projects ?? []}
-            onRemove={(i) => removeFromList("agent_projects", i)}
-          />
-        </Section>
-
-        {/* GitHub Actions */}
-        <Section title="GitHub Actions" subtitle="--gha (scans .github/workflows/)">
-          <input
-            type="text"
-            placeholder="/path/to/git/repo"
-            className="w-full bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 focus:outline-none focus:border-emerald-600"
-            value={form.gha_path ?? ""}
-            onChange={(e) => setForm((f) => ({ ...f, gha_path: e.target.value || undefined }))}
-          />
-        </Section>
-
-        {/* Inventory file */}
-        <Section title="Custom inventory" subtitle="--inventory (JSON file with custom agents)">
-          <input
-            type="text"
-            placeholder="/path/to/agents.json"
-            className="w-full bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 focus:outline-none focus:border-emerald-600"
-            value={form.inventory ?? ""}
-            onChange={(e) => setForm((f) => ({ ...f, inventory: e.target.value || undefined }))}
-          />
-        </Section>
-
-        {/* Options */}
-        <Section title="Options" subtitle="">
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              className="w-4 h-4 rounded border-zinc-700 bg-zinc-900 text-emerald-500"
-              checked={form.enrich ?? false}
-              onChange={(e) => setForm((f) => ({ ...f, enrich: e.target.checked }))}
-            />
-            <span className="text-sm text-zinc-300">
-              Enrich with NVD CVSS, EPSS, and CISA KEV{" "}
-              <span className="text-zinc-500">(slower, requires internet)</span>
-            </span>
-          </label>
-        </Section>
-
-        {error && (
-          <p className="text-red-400 text-sm bg-red-950 border border-red-900 rounded-lg px-4 py-3">{error}</p>
-        )}
-
-        <button
-          type="submit"
-          disabled={loading}
-          className="flex items-center gap-2 px-6 py-2.5 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
-        >
-          {loading ? (
-            <><Loader2 className="w-4 h-4 animate-spin" /> Starting scan...</>
-          ) : (
-            <>Start scan <ArrowRight className="w-4 h-4" /></>
-          )}
-        </button>
+          <button
+            type="submit"
+            disabled={loading}
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-emerald-600 px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:opacity-50 sm:w-auto"
+          >
+            {loading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" /> Starting scan...
+              </>
+            ) : (
+              <>
+                Start scan <ArrowRight className="h-4 w-4" />
+              </>
+            )}
+          </button>
+        </div>
       </form>
     </div>
   );
@@ -320,55 +305,21 @@ export function ScanForm() {
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-function Section({ title, subtitle, children }: { title: string; subtitle: string; children: React.ReactNode }) {
+function RelatedLink({ href, children }: { href: string; children: React.ReactNode }) {
   return (
-    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
-      <div className="mb-3">
-        <h3 className="text-sm font-semibold text-zinc-200">{title}</h3>
-        {subtitle && <p className="text-xs text-zinc-500 mt-0.5">{subtitle}</p>}
-      </div>
+    <Link href={href} className="text-zinc-400 transition-colors hover:text-emerald-400">
       {children}
-    </div>
+    </Link>
   );
 }
 
-function SurfaceCard({
-  icon: Icon,
-  title,
-  description,
-  href,
-  action,
-  badge,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  title: string;
-  description: string;
-  href?: string | undefined;
-  action?: string | undefined;
-  badge?: string | undefined;
-}) {
-  const content = (
-    <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-4 transition-colors hover:border-zinc-700 hover:bg-zinc-900/80">
-      <div className="flex items-start justify-between gap-3 mb-3">
-        <div className="flex items-center gap-2">
-          <span className="rounded-lg border border-zinc-800 bg-zinc-950 p-2">
-            <Icon className="w-4 h-4 text-emerald-400" />
-          </span>
-          <div>
-            <h3 className="text-sm font-semibold text-zinc-100">{title}</h3>
-            {badge && <p className="text-[11px] uppercase tracking-[0.18em] text-zinc-500 mt-0.5">{badge}</p>}
-          </div>
-        </div>
-        {href && <ArrowRight className="w-4 h-4 text-zinc-500" />}
-      </div>
-      <p className="text-xs leading-5 text-zinc-400">{description}</p>
-      {href && action && <div className="mt-4 text-xs font-medium text-emerald-400">{action}</div>}
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+      <h3 className="mb-3 text-sm font-semibold text-zinc-200">{title}</h3>
+      {children}
     </div>
   );
-
-  if (!href) return content;
-
-  return <Link href={href}>{content}</Link>;
 }
 
 function ListInput({
@@ -387,7 +338,7 @@ function ListInput({
         <input
           type="text"
           placeholder={placeholder}
-          className="flex-1 bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-2 text-sm text-zinc-200 focus:outline-none focus:border-emerald-600"
+          className="flex-1 rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-200 focus:border-emerald-600 focus:outline-none"
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); onAdd(); } }}
@@ -395,19 +346,19 @@ function ListInput({
         <button
           type="button"
           onClick={onAdd}
-          className="flex items-center gap-1 px-3 py-2 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors"
+          className="flex items-center gap-1 rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 transition-colors hover:bg-zinc-700"
         >
-          <Plus className="w-3.5 h-3.5" />
+          <Plus className="h-3.5 w-3.5" />
           Add
         </button>
       </div>
       {items.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {items?.map((item, i) => (
-            <span key={i} className="flex items-center gap-1.5 bg-zinc-800 border border-zinc-700 rounded-lg px-2.5 py-1 text-xs font-mono text-zinc-300">
+            <span key={i} className="flex items-center gap-1.5 rounded-lg border border-zinc-700 bg-zinc-800 px-2.5 py-1 font-mono text-xs text-zinc-300">
               {item}
               <button type="button" onClick={() => onRemove(i)}>
-                <X className="w-3 h-3 text-zinc-500 hover:text-zinc-300" />
+                <X className="h-3 w-3 text-zinc-500 hover:text-zinc-300" />
               </button>
             </span>
           ))}

--- a/ui/e2e/security-graph-cockpit.spec.ts
+++ b/ui/e2e/security-graph-cockpit.spec.ts
@@ -245,13 +245,12 @@ async function routeCockpit(page: Page) {
 }
 
 async function expectCockpitVisible(page: Page) {
-  // Investigation cockpit shell
-  await expect(page.getByRole("heading", { name: "Fix-first investigation" })).toBeVisible();
-  // Exposure-path command center, metrics, and evidence drawer
+  await expect(page.getByRole("heading", { name: "Security graph" })).toBeVisible();
+  await expect(page.getByText("Fix-first investigation")).toBeVisible();
   await expect(page.getByText("Command center", { exact: true })).toBeVisible();
   await expect(page.getByText("Risk", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("Hops", { exact: true }).first()).toBeVisible();
-  await expect(page.getByText("Evidence drawer", { exact: true })).toBeVisible();
+  await expect(page.getByText("Relationship proof & evidence drawer", { exact: true })).toBeVisible();
 }
 
 for (const theme of ["dark", "light"] as const) {

--- a/ui/lib/api-format.ts
+++ b/ui/lib/api-format.ts
@@ -40,7 +40,10 @@ export function severityDot(severity: string): string {
 }
 
 export function formatDate(iso: string): string {
-  return new Date(iso).toLocaleString();
+  if (!iso?.trim()) return "—";
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return "—";
+  return parsed.toLocaleString();
 }
 
 export function isConfigured(agent: Agent): boolean {

--- a/ui/lib/page-lanes.ts
+++ b/ui/lib/page-lanes.ts
@@ -1,0 +1,59 @@
+export type PageLane =
+  | "command"
+  | "ai-estate"
+  | "cloud-data"
+  | "runtime"
+  | "governance"
+  | "reference"
+  | "operations";
+
+export const PAGE_LANE_META: Record<
+  PageLane,
+  { label: string; scope: string; accent: string }
+> = {
+  command: { label: "Command", scope: "Posture & paths", accent: "#58a6ff" },
+  "ai-estate": { label: "AI Estate", scope: "Local · Your agents", accent: "#3fb950" },
+  "cloud-data": { label: "Cloud & Data", scope: "Cloud · Read-only", accent: "#a371f7" },
+  runtime: { label: "Runtime", scope: "Live · Enforced", accent: "#f778ba" },
+  governance: { label: "Governance", scope: "Policy & evidence", accent: "#3fb950" },
+  reference: { label: "Reference", scope: "Catalog · Not yours", accent: "#d29922" },
+  operations: { label: "Operations", scope: "AI usage · Jobs", accent: "#db6d28" },
+};
+
+const PATH_TO_LANE: Record<string, PageLane> = {
+  "/": "command",
+  "/findings": "command",
+  "/security-graph": "command",
+  "/remediation": "command",
+  "/graph": "command",
+  "/mesh": "command",
+  "/context": "command",
+  "/agents": "ai-estate",
+  "/manifest": "ai-estate",
+  "/fleet": "ai-estate",
+  "/connections": "cloud-data",
+  "/sources": "cloud-data",
+  "/scan": "cloud-data",
+  "/identity": "cloud-data",
+  "/drift": "cloud-data",
+  "/runtime": "runtime",
+  "/traces": "runtime",
+  "/compliance": "governance",
+  "/governance": "governance",
+  "/audit": "governance",
+  "/registry": "reference",
+  "/cost": "operations",
+  "/jobs": "operations",
+  "/activity": "operations",
+};
+
+export function laneForPath(path: string): PageLane | null {
+  if (PATH_TO_LANE[path]) {
+    return PATH_TO_LANE[path]!;
+  }
+  const match = Object.keys(PATH_TO_LANE)
+    .filter((prefix) => prefix !== "/")
+    .sort((a, b) => b.length - a.length)
+    .find((prefix) => path.startsWith(prefix));
+  return match ? PATH_TO_LANE[match]! : null;
+}

--- a/ui/tests/demo-mode-cta.test.tsx
+++ b/ui/tests/demo-mode-cta.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AuthProvider } from "@/components/auth-provider";
-import { DemoConnectCard, DemoModeBanner } from "@/components/demo-mode-cta";
+import { DemoConnectCard, DemoModeBanner, DemoNavSignIn } from "@/components/demo-mode-cta";
 
 const originalFetch = global.fetch;
 
@@ -63,62 +63,35 @@ afterEach(() => {
 });
 
 describe("DemoModeBanner", () => {
-  it("shows the connect-your-cloud CTA in public demo mode", async () => {
+  it("renders nothing (banner removed in favor of watermark + nav CTA)", () => {
     mockServer({ unauthenticated_allowed: true, auth_configured: false, authenticated: false });
-
-    render(
+    const { container } = render(
       <AuthProvider>
         <DemoModeBanner />
       </AuthProvider>,
     );
+    expect(container).toBeEmptyDOMElement();
+  });
+});
 
-    const cta = await screen.findByRole("link", { name: /sign in \/ get started/i });
-    expect(cta).toBeInTheDocument();
+describe("DemoNavSignIn", () => {
+  it("shows a compact nav sign-in CTA in public demo mode", async () => {
+    mockServer({ unauthenticated_allowed: true, auth_configured: false, authenticated: false });
+
+    render(
+      <AuthProvider>
+        <DemoNavSignIn />
+      </AuthProvider>,
+    );
+
+    const cta = await screen.findByTestId("demo-nav-sign-in");
     expect(cta).toHaveAttribute("href", "/login");
-    expect(screen.getByTestId("demo-mode-banner")).toBeInTheDocument();
-  });
-
-  it("honors a configured sign-in URL", async () => {
-    mockServer({ unauthenticated_allowed: true, auth_configured: false, authenticated: false });
-    window.__AGENT_BOM_CONFIG__ = { signInUrl: "https://app.example.com/start" };
-
-    render(
-      <AuthProvider>
-        <DemoModeBanner />
-      </AuthProvider>,
-    );
-
-    const cta = await screen.findByRole("link", { name: /sign in \/ get started/i });
-    expect(cta).toHaveAttribute("href", "https://app.example.com/start");
-  });
-
-  it("stays hidden for an authenticated deployment", async () => {
-    mockServer({ unauthenticated_allowed: false, auth_configured: true, authenticated: true });
-
-    render(
-      <AuthProvider>
-        <DemoModeBanner />
-      </AuthProvider>,
-    );
-
-    await waitFor(() => expect(screen.queryByTestId("demo-mode-banner")).not.toBeInTheDocument());
-  });
-
-  it("stays hidden for a signed-in viewer even when the server allows anonymous access", async () => {
-    mockServer({ unauthenticated_allowed: true, auth_configured: false, authenticated: true });
-
-    render(
-      <AuthProvider>
-        <DemoModeBanner />
-      </AuthProvider>,
-    );
-
-    await waitFor(() => expect(screen.queryByTestId("demo-mode-banner")).not.toBeInTheDocument());
+    expect(screen.getByText(/demo · sign in/i)).toBeInTheDocument();
   });
 });
 
 describe("DemoConnectCard", () => {
-  it("renders the connect-surface demo state in demo mode", async () => {
+  it("renders a compact connect-surface demo state in demo mode", async () => {
     mockServer({ unauthenticated_allowed: true, auth_configured: false, authenticated: false });
 
     render(
@@ -128,8 +101,8 @@ describe("DemoConnectCard", () => {
     );
 
     expect(await screen.findByTestId("demo-connect-card")).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /connect your cloud/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /connect your cloud/i })).toHaveAttribute("href", "/login");
+    expect(screen.getByText(/read-only demo/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^sign in$/i })).toHaveAttribute("href", "/login");
   });
 
   it("is absent outside demo mode", async () => {

--- a/ui/tests/exposure-path-command-center.test.tsx
+++ b/ui/tests/exposure-path-command-center.test.tsx
@@ -66,7 +66,7 @@ const basePath: ExposurePath = {
 };
 
 describe("ExposurePathCommandCenter", () => {
-  it("renders the selected exposure path as a command-center investigation", () => {
+  it("renders a compact command center with collapsed evidence by default", () => {
     render(
       <ExposurePathCommandCenter
         path={basePath}
@@ -80,16 +80,8 @@ describe("ExposurePathCommandCenter", () => {
     expect(screen.getByText("Why it matters")).toBeInTheDocument();
     expect(screen.getByText("What proves it")).toBeInTheDocument();
     expect(screen.getByText("What fixes it")).toBeInTheDocument();
-    expect(screen.getByText("Selected path graph")).toBeInTheDocument();
-    expect(screen.getByText("Relationship proof")).toBeInTheDocument();
-    expect(screen.getByText("Evidence drawer")).toBeInTheDocument();
-    expect(screen.getAllByText("uses").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("vulnerable_to").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("DATABASE_URL").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("execute_sql").length).toBeGreaterThan(0);
-    expect(screen.getByText("CVSS 9.8")).toBeInTheDocument();
-    expect(screen.getByText("EPSS 0.834")).toBeInTheDocument();
-    expect(screen.getByText("KEV")).toBeInTheDocument();
+    expect(screen.getByText("Relationship proof & evidence drawer")).toBeInTheDocument();
+    expect(screen.queryByText("Evidence drawer")).not.toBeVisible();
     expect(screen.getByText("Validate the lead finding")).toBeInTheDocument();
   });
 });

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -54,34 +54,31 @@ describe('Nav', () => {
     vi.clearAllMocks()
   })
 
-  it('renders the Discover nav group', () => {
+  it('renders the Command nav group', () => {
     render(<Nav />)
-    expect(screen.getByText('Discover')).toBeInTheDocument()
-    expect(screen.getByText('Inventory, coverage, and starting points')).toBeInTheDocument()
+    expect(screen.getByText('Command')).toBeInTheDocument()
   })
 
-  it('renders the Scan nav group', () => {
+  it('renders the AI Estate nav group', () => {
     render(<Nav />)
-    expect(screen.getByText('Scan')).toBeInTheDocument()
+    expect(screen.getByText('AI Estate')).toBeInTheDocument()
   })
 
-  it('renders the Analyze nav group', () => {
+  it('renders the Cloud & Data nav group', () => {
     render(<Nav />)
-    expect(screen.getByText('Analyze')).toBeInTheDocument()
+    expect(screen.getByText('Cloud & Data')).toBeInTheDocument()
   })
 
-  it('renders the Protect nav group', () => {
+  it('renders the Runtime nav group', () => {
     render(<Nav />)
-    expect(screen.getByText('Protect')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^runtime/i })).toBeInTheDocument()
   })
 
-  it('renders the three Govern groups (Compliance, Operations, Remediation)', () => {
+  it('renders Governance, Reference, and Operations groups', () => {
     render(<Nav />)
-    // 'Compliance'/'Remediation' appear both as a group label and as a page link,
-    // so use getAllByText.
-    expect(screen.getAllByText('Compliance').length).toBeGreaterThan(0)
+    expect(screen.getByText('Governance')).toBeInTheDocument()
+    expect(screen.getByText('Reference')).toBeInTheDocument()
     expect(screen.getByText('Operations')).toBeInTheDocument()
-    expect(screen.getAllByText('Remediation').length).toBeGreaterThan(0)
   })
 
   it('contains link to Dashboard (/)', () => {
@@ -90,44 +87,41 @@ describe('Nav', () => {
     expect(links.length).toBeGreaterThan(0)
   })
 
-  it('contains link to New Scan (/scan)', () => {
+  it('contains link to New Scan (/scan) under Cloud & Data', () => {
     render(<Nav />)
-    fireEvent.click(screen.getByRole('button', { name: /scan/i }))
+    fireEvent.click(screen.getByRole('button', { name: /cloud & data/i }))
     const links = screen.getAllByRole('link', { name: /new scan/i })
     expect(links.some((l) => l.getAttribute('href') === '/scan')).toBe(true)
   })
 
   it('contains link to Data Sources (/sources)', () => {
     render(<Nav />)
-    fireEvent.click(screen.getByRole('button', { name: /scan/i }))
+    fireEvent.click(screen.getByRole('button', { name: /cloud & data/i }))
     const links = screen.getAllByRole('link', { name: /data sources/i })
     expect(links.some((l) => l.getAttribute('href') === '/sources')).toBe(true)
   })
 
-  it('contains link to Scan Jobs (/jobs)', () => {
+  it('contains link to Scan Jobs (/jobs) under Operations', () => {
     render(<Nav />)
-    fireEvent.click(screen.getByRole('button', { name: /scan/i }))
+    fireEvent.click(screen.getByRole('button', { name: /operations/i }))
     const links = screen.getAllByRole('link', { name: /scan jobs/i })
     expect(links.some((l) => l.getAttribute('href') === '/jobs')).toBe(true)
   })
 
-  it('contains link to Findings (/findings)', () => {
+  it('contains link to Findings (/findings) under Command', () => {
     render(<Nav />)
-    fireEvent.click(screen.getByRole('button', { name: /scan/i }))
     const links = screen.getAllByRole('link', { name: /findings/i })
     expect(links.some((l) => l.getAttribute('href') === '/findings')).toBe(true)
   })
 
-  it('contains Remediation link', () => {
+  it('contains Remediation link under Command', () => {
     render(<Nav />)
-    fireEvent.click(screen.getByRole('button', { name: /remediation/i }))
     const links = screen.getAllByRole('link', { name: /remediation/i })
     expect(links.some((l) => l.getAttribute('href') === '/remediation')).toBe(true)
   })
 
-  it('contains Security Graph link', () => {
+  it('contains Security Graph link under Command', () => {
     render(<Nav />)
-    fireEvent.click(screen.getByRole('button', { name: /analyze/i }))
     const links = screen.getAllByRole('link', { name: /security graph/i })
     expect(links.some((l) => l.getAttribute('href') === '/security-graph')).toBe(true)
   })
@@ -135,7 +129,7 @@ describe('Nav', () => {
   it('surfaces curated proof-path links for golden workflows', () => {
     render(<Nav />)
     const hrefs = screen.getAllByRole('link').map((l) => l.getAttribute('href'))
-    expect(hrefs).toContain('/findings')
+    expect(hrefs).toContain('/remediation')
     expect(hrefs).toContain('/security-graph')
     expect(hrefs).toContain('/runtime')
     expect(hrefs).toContain('/compliance')
@@ -143,15 +137,15 @@ describe('Nav', () => {
     expect(screen.getByText(/proof path/i)).toBeInTheDocument()
   })
 
-  it('contains Registry link in Discover', () => {
+  it('contains MCP Catalog link in Reference', () => {
     render(<Nav />)
-    const links = screen.getAllByRole('link', { name: /^registry$/i })
+    fireEvent.click(screen.getByRole('button', { name: /reference/i }))
+    const links = screen.getAllByRole('link', { name: /mcp catalog/i })
     expect(links.some((l) => l.getAttribute('href') === '/registry')).toBe(true)
   })
 
-  it('keeps graph lenses tucked under Analyze instead of primary sidebar links', () => {
+  it('keeps graph lenses tucked under Command instead of primary sidebar links', () => {
     render(<Nav />)
-    fireEvent.click(screen.getByRole('button', { name: /analyze/i }))
     expect(screen.getByText(/more \(3\)/i)).toBeInTheDocument()
     const hrefs = screen.getAllByRole('link').map((l) => l.getAttribute('href'))
     expect(hrefs).toContain('/security-graph')
@@ -168,33 +162,38 @@ describe('Nav', () => {
     expect(hrefs).not.toContain('/overview')
   })
 
-  it('contains Compliance link', () => {
+  it('contains Compliance link under Governance', () => {
     render(<Nav />)
-    fireEvent.click(screen.getByRole('button', { name: /compliance/i }))
+    fireEvent.click(screen.getByRole('button', { name: /governance/i }))
     const links = screen.getAllByRole('link', { name: /^compliance$/i })
     expect(links.some((l) => l.getAttribute('href') === '/compliance')).toBe(true)
   })
 
   it('contains Governance link', () => {
     render(<Nav />)
-    fireEvent.click(screen.getByRole('button', { name: /compliance/i }))
+    fireEvent.click(screen.getByRole('button', { name: /governance/i }))
     const links = screen.getAllByRole('link', { name: /^governance$/i })
     expect(links.some((l) => l.getAttribute('href') === '/governance')).toBe(true)
   })
 
-  it('keeps cost, identity, drift, and activity reachable directly from the Operations group', () => {
+  it('labels cost as AI Spend under Operations', () => {
     render(<Nav />)
     fireEvent.click(screen.getByRole('button', { name: /operations/i }))
-    const hrefs = screen.getAllByRole('link').map((l) => l.getAttribute('href'))
-    expect(hrefs).toContain('/cost')
-    expect(hrefs).toContain('/identity')
-    expect(hrefs).toContain('/drift')
-    expect(hrefs).toContain('/activity')
+    const links = screen.getAllByRole('link', { name: /ai spend/i })
+    expect(links.some((l) => l.getAttribute('href') === '/cost')).toBe(true)
   })
 
-  it('moves the Audit Log into the Compliance group', () => {
+  it('keeps identity and drift under Cloud & Data', () => {
     render(<Nav />)
-    fireEvent.click(screen.getByRole('button', { name: /compliance/i }))
+    fireEvent.click(screen.getByRole('button', { name: /cloud & data/i }))
+    const hrefs = screen.getAllByRole('link').map((l) => l.getAttribute('href'))
+    expect(hrefs).toContain('/identity')
+    expect(hrefs).toContain('/drift')
+  })
+
+  it('moves the Audit Log into the Governance group', () => {
+    render(<Nav />)
+    fireEvent.click(screen.getByRole('button', { name: /governance/i }))
     const links = screen.getAllByRole('link', { name: /audit log/i })
     expect(links.some((l) => l.getAttribute('href') === '/audit')).toBe(true)
   })
@@ -220,18 +219,22 @@ describe('Nav', () => {
 
   it('renders all 7 nav group labels', () => {
     render(<Nav />)
-    // Use getAllByText to handle cases where a label also appears as a page link
-    // (e.g. Compliance, Remediation).
-    const groups = ['Discover', 'Scan', 'Analyze', 'Protect', 'Compliance', 'Operations', 'Remediation']
+    const groups = ['Command', 'AI Estate', 'Cloud & Data', 'Runtime', 'Governance', 'Reference', 'Operations']
     for (const group of groups) {
       expect(screen.getAllByText(group).length).toBeGreaterThan(0)
     }
   })
 
+  it('does not render sidebar group description paragraphs', () => {
+    render(<Nav />)
+    expect(screen.queryByText('Inventory, coverage, and starting points')).not.toBeInTheDocument()
+    expect(screen.queryByText('One security graph with attack-path, lineage, mesh, and context lenses')).not.toBeInTheDocument()
+  })
+
   it('shows page counts for expanded nav groups', async () => {
     render(<Nav />)
     expect(screen.getAllByText('3').length).toBeGreaterThan(0)
-    fireEvent.click(screen.getByRole('button', { name: /analyze/i }))
+    fireEvent.click(screen.getByRole('button', { name: /cloud & data/i }))
     await waitFor(() => {
       expect(screen.getAllByText('5').length).toBeGreaterThan(0)
     })
@@ -240,13 +243,13 @@ describe('Nav', () => {
   it('contains links for all primary pages across all groups', async () => {
     render(<Nav />)
     const expectedByGroup: Record<string, string[]> = {
-      Discover: ['/', '/agents', '/fleet', '/registry'],
-      Scan: ['/sources', '/scan', '/jobs', '/findings'],
-      Analyze: ['/security-graph'],
-      Protect: ['/runtime'],
-      Compliance: ['/compliance', '/governance', '/audit'],
-      Operations: ['/identity', '/cost', '/drift', '/activity'],
-      Remediation: ['/remediation', '/traces'],
+      Command: ['/', '/findings', '/security-graph', '/remediation'],
+      'AI Estate': ['/agents', '/manifest', '/fleet'],
+      'Cloud & Data': ['/connections', '/sources', '/scan', '/identity', '/drift'],
+      Runtime: ['/runtime', '/traces'],
+      Governance: ['/compliance', '/governance', '/audit'],
+      Reference: ['/registry'],
+      Operations: ['/cost', '/jobs', '/activity'],
     }
 
     for (const [group, hrefs] of Object.entries(expectedByGroup)) {
@@ -265,18 +268,11 @@ describe('Nav', () => {
     render(<Nav />)
 
     await waitFor(() => {
-      expect(screen.getByText('Choose source mode, run scans, and review findings')).toBeInTheDocument()
-      expect(screen.getByText('One security graph with attack-path, lineage, mesh, and context lenses')).toBeInTheDocument()
-      expect(screen.getByText('Proxy, policy, and runtime enforcement surfaces')).toBeInTheDocument()
-      expect(screen.getByText('Evidence, policy governance, and audit export')).toBeInTheDocument()
-      expect(screen.getByText('Identity, cost, drift, and activity posture')).toBeInTheDocument()
-      expect(screen.getByText('Fix workflow and runtime trace evidence')).toBeInTheDocument()
+      expect(screen.getAllByRole('link', { name: /dashboard/i }).length).toBeGreaterThan(0)
+      expect(screen.getAllByRole('link', { name: /new scan/i }).length).toBeGreaterThan(0)
+      expect(screen.getAllByRole('link', { name: /runtime/i }).length).toBeGreaterThan(0)
+      expect(screen.getAllByRole('link', { name: /remediation/i }).length).toBeGreaterThan(0)
     })
-
-    expect(screen.getAllByRole('link', { name: /dashboard/i }).length).toBeGreaterThan(0)
-    expect(screen.getAllByRole('link', { name: /new scan/i }).length).toBeGreaterThan(0)
-    expect(screen.getAllByRole('link', { name: /runtime/i }).length).toBeGreaterThan(0)
-    expect(screen.getAllByRole('link', { name: /remediation/i }).length).toBeGreaterThan(0)
   })
 
   it('moves inactive deployment surfaces into Unused capabilities', async () => {
@@ -308,16 +304,23 @@ describe('Nav', () => {
     render(<Nav />)
 
     await waitFor(() => {
-      expect(document.querySelector('summary')).toBeTruthy()
+      expect(screen.getByRole('button', { name: /ai estate/i })).toBeInTheDocument()
     })
 
-    expect(document.querySelector('summary')?.textContent).toContain('Unused in Local')
+    fireEvent.click(screen.getByRole('button', { name: /ai estate/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/unused in local \(1\)/i)).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText(/unused in local \(1\)/i))
+
     const fleetLink = screen.getByRole('link', { name: /^fleet$/i })
     expect(fleetLink).toHaveAttribute('href', '/fleet')
     expect(fleetLink).toHaveAttribute('title', 'Hidden until this deployment mode is detected')
   })
 
-  it('keeps gateway and traces visible for hybrid deployments', async () => {
+  it('keeps runtime and traces visible for hybrid deployments', async () => {
     const { api } = await import('@/lib/api')
     vi.mocked(api.getPostureCounts).mockResolvedValueOnce({
       critical: 0,
@@ -345,12 +348,11 @@ describe('Nav', () => {
 
     render(<Nav />)
 
-    fireEvent.click(screen.getByRole('button', { name: /protect/i }))
+    fireEvent.click(screen.getByRole('button', { name: /runtime/i }))
     await waitFor(() => {
       expect(screen.getAllByRole('link', { name: /^runtime$/i }).some((link) => link.getAttribute('href') === '/runtime')).toBe(true)
     })
 
-    fireEvent.click(screen.getByRole('button', { name: /remediation/i }))
     expect(screen.getAllByRole('link', { name: /^traces$/i }).some((link) => link.getAttribute('href') === '/traces')).toBe(true)
   })
 
@@ -383,8 +385,16 @@ describe('Nav', () => {
     render(<Nav />)
 
     await waitFor(() => {
-      expect(document.querySelector('summary')).toBeTruthy()
+      expect(screen.getByRole('button', { name: /ai estate/i })).toBeInTheDocument()
     })
+
+    fireEvent.click(screen.getByRole('button', { name: /ai estate/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/unused in local/i)).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByText(/unused in local/i))
 
     const agentsLink = screen.getByRole('link', { name: /^agents$/i })
     expect(agentsLink).toHaveAttribute('href', '/agents')

--- a/ui/tests/page-lanes.test.ts
+++ b/ui/tests/page-lanes.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { laneForPath, PAGE_LANE_META } from "@/lib/page-lanes";
+
+describe("page lanes", () => {
+  it("maps primary routes to product lanes", () => {
+    expect(laneForPath("/manifest")).toBe("ai-estate");
+    expect(laneForPath("/registry")).toBe("reference");
+    expect(laneForPath("/cost")).toBe("operations");
+    expect(laneForPath("/connections")).toBe("cloud-data");
+    expect(laneForPath("/security-graph")).toBe("command");
+  });
+
+  it("resolves nested paths by longest prefix", () => {
+    expect(laneForPath("/findings/abc")).toBe("command");
+    expect(laneForPath("/registry?id=foo")).toBe("reference");
+  });
+
+  it("exposes scope chips for every lane", () => {
+    for (const lane of Object.keys(PAGE_LANE_META)) {
+      expect(PAGE_LANE_META[lane as keyof typeof PAGE_LANE_META].scope.length).toBeGreaterThan(3);
+    }
+  });
+});

--- a/ui/tests/scan-form.test.tsx
+++ b/ui/tests/scan-form.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ScanForm } from "@/components/scan-form";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe("ScanForm", () => {
+  it("renders a compact header without surface explainer cards", () => {
+    render(<ScanForm />);
+
+    expect(screen.getByRole("heading", { name: "New Scan" })).toBeInTheDocument();
+    expect(screen.queryByText(/Direct scans/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Connectors and enterprise sources/i)).not.toBeInTheDocument();
+  });
+
+  it("exposes related surfaces as inline links", () => {
+    render(<ScanForm />);
+
+    expect(screen.getByRole("link", { name: "Data sources" })).toHaveAttribute("href", "/sources");
+    expect(screen.getByRole("link", { name: "Governance" })).toHaveAttribute("href", "/governance");
+    expect(screen.getByRole("link", { name: "Traces" })).toHaveAttribute("href", "/traces");
+  });
+
+  it("keeps advanced targets collapsed by default", () => {
+    render(<ScanForm />);
+
+    expect(screen.getByText("Advanced targets")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("/path/to/infra")).not.toBeVisible();
+  });
+
+  it("shows primary scan controls above the fold", () => {
+    render(<ScanForm />);
+
+    expect(screen.getByText("Docker images")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Start scan/i })).toBeInTheDocument();
+  });
+});

--- a/ui/tests/sources-page.test.tsx
+++ b/ui/tests/sources-page.test.tsx
@@ -235,7 +235,7 @@ describe("SourcesPage", () => {
 
     await waitFor(() => expect(screen.getByText("Nightly cloud posture")).toBeInTheDocument());
     expect(apiMock.listDiscoveryProviders).toHaveBeenCalled();
-    expect(screen.getByText("Discovery provider trust contracts")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Provider trust contracts"));
     expect(screen.getAllByText("aws").length).toBeGreaterThan(0);
     expect(screen.getByText("scope-zero")).toBeInTheDocument();
     expect(screen.getAllByText("snowflake").length).toBeGreaterThan(0);
@@ -305,7 +305,7 @@ describe("SourcesPage", () => {
 
     render(<SourcesPage />);
 
-    await waitFor(() => expect(screen.getByText("Persisted schedules")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole("heading", { name: "Schedules" })).toBeInTheDocument());
 
     fireEvent.change(screen.getByLabelText("Schedule source"), { target: { value: "src-1" } });
     fireEvent.change(screen.getByLabelText("Schedule name"), { target: { value: "Recurring AWS run" } });


### PR DESCRIPTION
## Summary
- Re-lanes sidebar navigation by product concept (Command, AI Estate, Cloud & Data, Runtime, Governance, Reference, Operations) and removes group description paragraphs that added noise.
- Adds page scope chips (`PageLaneHeader`) on Agent BOM, MCP Catalog, Audit Log, and AI Spend so users can distinguish owned estate vs reference catalog vs AI usage cost.
- Consolidates prior demo/density work: compact dashboard/scan/security-graph/sources, demo chrome cleanup, `formatDate` crash fix, manifest KPI collapse, registry table-first browse, audit key panel hidden for viewers, graph drift/evidence lenses collapsed by default.

## Test plan
- [x] `cd ui && npm run typecheck`
- [x] `cd ui && npm test -- --run tests/page-lanes.test.ts tests/nav.test.tsx tests/demo-mode-cta.test.tsx tests/sources-page.test.tsx tests/scan-form.test.tsx tests/exposure-path-command-center.test.tsx tests/attack-path-card.test.tsx`
- [ ] Preview deploy: verify nav lanes, `/manifest` (3 KPIs + table), `/registry` (catalog banner + table), `/cost` (AI Spend label), `/audit` (no key panel for viewer)

## Notes
Consolidated PR covering phases A+B+C (partial graph canvas). Follow-up PR can add demo seed data (sources/compliance/connections) once this lands on preview.