### PR TITLE
fix(ui): un-crash Runtime + Lineage pages, unique findings keys, light-mode + version fixes

### DIFF
--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -68,37 +68,37 @@ function downloadBlobToFile(blob: Blob, filename: string) {
 
 function statusColor(status: string): string {
   switch (status) {
-    case "pass":    return "text-emerald-400";
-    case "warning": return "text-yellow-400";
-    case "fail":    return "text-red-400";
-    default:        return "text-zinc-400";
+    case "pass":    return "text-emerald-600 dark:text-emerald-400";
+    case "warning": return "text-yellow-600 dark:text-yellow-400";
+    case "fail":    return "text-red-600 dark:text-red-400";
+    default:        return "text-[color:var(--text-secondary)]";
   }
 }
 
 function statusBg(status: string): string {
   switch (status) {
-    case "pass":    return "bg-emerald-950 border-emerald-800";
-    case "warning": return "bg-yellow-950 border-yellow-800";
-    case "fail":    return "bg-red-950 border-red-800";
-    default:        return "bg-zinc-900 border-zinc-800";
+    case "pass":    return "bg-emerald-50 border-emerald-300 dark:bg-emerald-950 dark:border-emerald-800";
+    case "warning": return "bg-yellow-50 border-yellow-300 dark:bg-yellow-950 dark:border-yellow-800";
+    case "fail":    return "bg-red-50 border-red-300 dark:bg-red-950 dark:border-red-800";
+    default:        return "bg-[color:var(--surface)] border-[color:var(--border-subtle)]";
   }
 }
 
 function StatusIcon({ status, className }: { status: string; className?: string }) {
   switch (status) {
-    case "pass":    return <CheckCircle className={`${className ?? "w-4 h-4"} text-emerald-400`} />;
-    case "warning": return <AlertTriangle className={`${className ?? "w-4 h-4"} text-yellow-400`} />;
-    case "fail":    return <XCircle className={`${className ?? "w-4 h-4"} text-red-400`} />;
-    default:        return <Shield className={`${className ?? "w-4 h-4"} text-zinc-400`} />;
+    case "pass":    return <CheckCircle className={`${className ?? "w-4 h-4"} text-emerald-600 dark:text-emerald-400`} />;
+    case "warning": return <AlertTriangle className={`${className ?? "w-4 h-4"} text-yellow-600 dark:text-yellow-400`} />;
+    case "fail":    return <XCircle className={`${className ?? "w-4 h-4"} text-red-600 dark:text-red-400`} />;
+    default:        return <Shield className={`${className ?? "w-4 h-4"} text-[color:var(--text-secondary)]`} />;
   }
 }
 
 function PostureIcon({ status }: { status: string }) {
   switch (status) {
-    case "pass":    return <ShieldCheck className="w-10 h-10 text-emerald-400" />;
-    case "warning": return <ShieldAlert className="w-10 h-10 text-yellow-400" />;
-    case "fail":    return <ShieldX className="w-10 h-10 text-red-400" />;
-    default:        return <Shield className="w-10 h-10 text-zinc-400" />;
+    case "pass":    return <ShieldCheck className="w-10 h-10 text-emerald-600 dark:text-emerald-400" />;
+    case "warning": return <ShieldAlert className="w-10 h-10 text-yellow-600 dark:text-yellow-400" />;
+    case "fail":    return <ShieldX className="w-10 h-10 text-red-600 dark:text-red-400" />;
+    default:        return <Shield className="w-10 h-10 text-[color:var(--text-secondary)]" />;
   }
 }
 
@@ -122,7 +122,7 @@ function ScoreRing({ score, status }: { score: number; status: string }) {
   return (
     <div className="relative w-32 h-32">
       <svg viewBox="0 0 120 120" className="w-full h-full -rotate-90">
-        <circle cx="60" cy="60" r={r} fill="none" stroke="#27272a" strokeWidth="8" />
+        <circle cx="60" cy="60" r={r} fill="none" stroke="var(--border-strong)" strokeWidth="8" />
         <circle
           cx="60" cy="60" r={r} fill="none"
           stroke={color} strokeWidth="8"
@@ -132,8 +132,8 @@ function ScoreRing({ score, status }: { score: number; status: string }) {
         />
       </svg>
       <div className="absolute inset-0 flex flex-col items-center justify-center">
-        <span className="text-2xl font-bold text-zinc-100">{Math.round(score)}%</span>
-        <span className="text-[10px] text-zinc-500 uppercase tracking-wider">Score</span>
+        <span className="text-2xl font-bold text-[color:var(--foreground)]">{Math.round(score)}%</span>
+        <span className="text-[10px] text-[color:var(--text-tertiary)] uppercase tracking-wider">Score</span>
       </div>
     </div>
   );
@@ -153,10 +153,10 @@ function FrameworkBar({
   return (
     <div className="space-y-1.5">
       <div className="flex items-center justify-between">
-        <span className="text-sm font-medium text-zinc-300">{label}</span>
-        <span className="text-xs text-zinc-500">{p}/{total} pass</span>
+        <span className="text-sm font-medium text-[color:var(--text-secondary)]">{label}</span>
+        <span className="text-xs text-[color:var(--text-tertiary)]">{p}/{total} pass</span>
       </div>
-      <div className="h-2.5 rounded-full bg-zinc-800 overflow-hidden flex">
+      <div className="h-2.5 rounded-full bg-[color:var(--surface-muted)] overflow-hidden flex">
         {p > 0 && (
           <div className="bg-emerald-500 transition-all duration-700" style={{ width: `${pPct}%` }} />
         )}
@@ -167,7 +167,7 @@ function FrameworkBar({
           <div className="bg-red-500 transition-all duration-700" style={{ width: `${fPct}%` }} />
         )}
       </div>
-      <div className="flex gap-4 text-xs text-zinc-500">
+      <div className="flex gap-4 text-xs text-[color:var(--text-tertiary)]">
         <span className="flex items-center gap-1">
           <span className="w-2 h-2 rounded-full bg-emerald-500" /> {p} pass
         </span>
@@ -204,22 +204,22 @@ function ControlCard({ control, catalog }: { control: ComplianceControl; catalog
           <StatusIcon status={control.status} className="w-5 h-5 mt-0.5 shrink-0" />
           <div className="min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
-              <span className="font-mono text-sm font-semibold text-zinc-200">{control.code}</span>
+              <span className="font-mono text-sm font-semibold text-[color:var(--foreground)]">{control.code}</span>
               <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
                 control.status === "pass"
-                  ? "bg-emerald-900/60 text-emerald-300"
+                  ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/60 dark:text-emerald-300"
                   : control.status === "warning"
-                  ? "bg-yellow-900/60 text-yellow-300"
-                  : "bg-red-900/60 text-red-300"
+                  ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/60 dark:text-yellow-300"
+                  : "bg-red-100 text-red-700 dark:bg-red-900/60 dark:text-red-300"
               }`}>
                 {control.status === "pass" ? "Pass" : control.status === "warning" ? "Needs Attention" : "Fail"}
               </span>
             </div>
-            <p className="text-sm text-zinc-400 mt-1 leading-snug">{name}</p>
+            <p className="text-sm text-[color:var(--text-secondary)] mt-1 leading-snug">{name}</p>
           </div>
         </div>
         {control.findings > 0 && (
-          <span className="text-xs font-mono px-2 py-1 rounded bg-zinc-800 text-zinc-300 shrink-0">
+          <span className="text-xs font-mono px-2 py-1 rounded bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] shrink-0">
             {control.findings} finding{control.findings !== 1 ? "s" : ""}
           </span>
         )}
@@ -227,7 +227,7 @@ function ControlCard({ control, catalog }: { control: ComplianceControl; catalog
 
       {/* Severity dots */}
       {hasSev && (
-        <div className="flex gap-3 mt-3 ml-8 text-xs text-zinc-500">
+        <div className="flex gap-3 mt-3 ml-8 text-xs text-[color:var(--text-tertiary)]">
           {sev.critical > 0 && (
             <span className="flex items-center gap-1">
               <span className="w-2 h-2 rounded-full bg-red-500" /> {sev.critical} critical
@@ -256,7 +256,7 @@ function ControlCard({ control, catalog }: { control: ComplianceControl; catalog
         <div className="mt-3 ml-8">
           <button
             onClick={() => setExpanded(!expanded)}
-            className="flex items-center gap-1 text-xs text-zinc-500 hover:text-zinc-300 transition-colors"
+            className="flex items-center gap-1 text-xs text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)] transition-colors"
           >
             {expanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
             Details
@@ -265,12 +265,12 @@ function ControlCard({ control, catalog }: { control: ComplianceControl; catalog
             <div className="mt-2 space-y-2">
               {control.affected_packages.length > 0 && (
                 <div>
-                  <div className="flex items-center gap-1.5 text-xs text-zinc-500 mb-1">
+                  <div className="flex items-center gap-1.5 text-xs text-[color:var(--text-tertiary)] mb-1">
                     <Package className="w-3 h-3" /> Affected Packages
                   </div>
                   <div className="flex flex-wrap gap-1.5">
                     {control.affected_packages?.map((pkg) => (
-                      <span key={pkg} className="text-xs px-2 py-0.5 rounded bg-zinc-800 text-zinc-300 font-mono">
+                      <span key={pkg} className="text-xs px-2 py-0.5 rounded bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] font-mono">
                         {pkg}
                       </span>
                     ))}
@@ -279,12 +279,12 @@ function ControlCard({ control, catalog }: { control: ComplianceControl; catalog
               )}
               {control.affected_agents.length > 0 && (
                 <div>
-                  <div className="flex items-center gap-1.5 text-xs text-zinc-500 mb-1">
+                  <div className="flex items-center gap-1.5 text-xs text-[color:var(--text-tertiary)] mb-1">
                     <Server className="w-3 h-3" /> Affected Agents
                   </div>
                   <div className="flex flex-wrap gap-1.5">
                     {control.affected_agents?.map((agent) => (
-                      <span key={agent} className="text-xs px-2 py-0.5 rounded bg-zinc-800 text-zinc-300">
+                      <span key={agent} className="text-xs px-2 py-0.5 rounded bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]">
                         {agent}
                       </span>
                     ))}
@@ -343,7 +343,7 @@ function FrameworkSection({
   const warningCount = controls.filter((control) => control.status === "warning").length;
 
   return (
-    <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40">
+    <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)]">
       <button
         onClick={() => setOpen((value) => !value)}
         className="flex w-full items-center justify-between gap-4 px-5 py-4 text-left"
@@ -351,25 +351,25 @@ function FrameworkSection({
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <h2 className={`text-lg font-semibold ${accentClass}`}>{title}</h2>
-            {subtitle ? <span className="text-xs text-zinc-500">{subtitle}</span> : null}
+            {subtitle ? <span className="text-xs text-[color:var(--text-tertiary)]">{subtitle}</span> : null}
           </div>
-          <div className="mt-2 flex flex-wrap gap-3 text-xs text-zinc-500">
+          <div className="mt-2 flex flex-wrap gap-3 text-xs text-[color:var(--text-tertiary)]">
             <span>{controls.length} controls</span>
             <span>{failCount} fail</span>
             <span>{warningCount} warning</span>
             {visibleControls.length !== controls.length ? <span>{visibleControls.length} shown</span> : null}
           </div>
         </div>
-        {open ? <ChevronDown className="h-4 w-4 text-zinc-500" /> : <ChevronRight className="h-4 w-4 text-zinc-500" />}
+        {open ? <ChevronDown className="h-4 w-4 text-[color:var(--text-tertiary)]" /> : <ChevronRight className="h-4 w-4 text-[color:var(--text-tertiary)]" />}
       </button>
       {open ? (
-        <div className="border-t border-zinc-800 px-5 py-5">
+        <div className="border-t border-[color:var(--border-subtle)] px-5 py-5">
           {controls.length === 0 && emptyMessage ? (
-            <div className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-5 text-sm text-zinc-500">
+            <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5 text-sm text-[color:var(--text-tertiary)]">
               {emptyMessage}
             </div>
           ) : visibleControls.length === 0 ? (
-            <div className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-5 text-sm text-zinc-500">
+            <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5 text-sm text-[color:var(--text-tertiary)]">
               No controls match the current filters.
             </div>
           ) : (
@@ -488,7 +488,7 @@ function CompliancePageContent() {
       id: "owasp-llm",
       title: "OWASP LLM Top 10",
       subtitle: "2025 Edition",
-      accentClass: "text-zinc-200",
+      accentClass: "text-[color:var(--foreground)]",
       controls: data.owasp_llm_top10,
       catalog: OWASP_LLM_TOP10,
     },
@@ -496,7 +496,7 @@ function CompliancePageContent() {
       id: "owasp-mcp",
       title: "OWASP MCP Top 10",
       subtitle: "MCP security risks",
-      accentClass: hasMcp ? "text-zinc-200" : "text-zinc-500",
+      accentClass: hasMcp ? "text-[color:var(--foreground)]" : "text-[color:var(--text-tertiary)]",
       controls: hasMcp ? data.owasp_mcp_top10 : [],
       catalog: OWASP_MCP_TOP10,
       emptyMessage: "MCP-specific controls appear after a scan with MCP server context.",
@@ -505,7 +505,7 @@ function CompliancePageContent() {
       id: "atlas",
       title: "MITRE ATLAS",
       subtitle: "Adversarial ML techniques",
-      accentClass: "text-zinc-200",
+      accentClass: "text-[color:var(--foreground)]",
       controls: data.mitre_atlas,
       catalog: MITRE_ATLAS,
     },
@@ -513,7 +513,7 @@ function CompliancePageContent() {
       id: "nist-ai-rmf",
       title: "NIST AI RMF 1.0",
       subtitle: "Govern / Map / Measure / Manage",
-      accentClass: "text-zinc-200",
+      accentClass: "text-[color:var(--foreground)]",
       controls: data.nist_ai_rmf,
       catalog: NIST_AI_RMF,
     },
@@ -521,7 +521,7 @@ function CompliancePageContent() {
       id: "owasp-agentic",
       title: "OWASP Agentic Top 10",
       subtitle: "2026 Edition",
-      accentClass: hasMcp ? "text-zinc-200" : "text-zinc-500",
+      accentClass: hasMcp ? "text-[color:var(--foreground)]" : "text-[color:var(--text-tertiary)]",
       controls: hasMcp ? data.owasp_agentic_top10 : [],
       catalog: OWASP_AGENTIC_TOP10,
       emptyMessage: "Agentic controls appear after a scan with agent and MCP context.",
@@ -530,7 +530,7 @@ function CompliancePageContent() {
       id: "eu-ai-act",
       title: "EU AI Act",
       subtitle: "Regulation (EU) 2024/1689",
-      accentClass: "text-zinc-200",
+      accentClass: "text-[color:var(--foreground)]",
       controls: data.eu_ai_act,
       catalog: EU_AI_ACT,
     },
@@ -538,7 +538,7 @@ function CompliancePageContent() {
       id: "nist-csf",
       title: "NIST CSF 2.0",
       subtitle: "Cybersecurity Framework",
-      accentClass: "text-zinc-200",
+      accentClass: "text-[color:var(--foreground)]",
       controls: data.nist_csf,
       catalog: NIST_CSF,
     },
@@ -546,7 +546,7 @@ function CompliancePageContent() {
       id: "iso27001",
       title: "ISO/IEC 27001:2022",
       subtitle: "Annex A controls",
-      accentClass: "text-zinc-200",
+      accentClass: "text-[color:var(--foreground)]",
       controls: data.iso_27001,
       catalog: ISO_27001,
     },
@@ -554,7 +554,7 @@ function CompliancePageContent() {
       id: "soc2",
       title: "SOC 2",
       subtitle: "Trust Services Criteria",
-      accentClass: "text-zinc-200",
+      accentClass: "text-[color:var(--foreground)]",
       controls: data.soc2,
       catalog: SOC2_TSC,
     },
@@ -562,7 +562,7 @@ function CompliancePageContent() {
       id: "cis",
       title: "CIS Controls v8",
       subtitle: "Critical security controls",
-      accentClass: "text-zinc-200",
+      accentClass: "text-[color:var(--foreground)]",
       controls: data.cis_controls,
       catalog: CIS_CONTROLS,
     },
@@ -570,7 +570,7 @@ function CompliancePageContent() {
       id: "cmmc",
       title: "CMMC 2.0",
       subtitle: "Level 2 practices",
-      accentClass: "text-zinc-200",
+      accentClass: "text-[color:var(--foreground)]",
       controls: data.cmmc,
       catalog: CMMC_PRACTICES,
     },
@@ -579,7 +579,7 @@ function CompliancePageContent() {
   return (
     <div className="space-y-8">
       {/* ── Posture Header ─────────────────────────────────────────────── */}
-      <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-6">
+      <div className="bg-[color:var(--surface)] border border-[color:var(--border-subtle)] rounded-2xl p-6">
         <div className="flex items-center gap-6">
           <ScoreRing score={data.overall_score} status={data.overall_status} />
           <div className="flex-1 space-y-2">
@@ -589,12 +589,12 @@ function CompliancePageContent() {
                 <h1 className={`text-xl font-bold ${statusColor(data.overall_status)}`}>
                   {postureLabel(data.overall_status)}
                 </h1>
-                <p className="text-sm text-zinc-500">
+                <p className="text-sm text-[color:var(--text-tertiary)]">
                   AI Supply Chain Compliance Posture
                 </p>
               </div>
             </div>
-            <div className="flex gap-6 text-xs text-zinc-500">
+            <div className="flex gap-6 text-xs text-[color:var(--text-tertiary)]">
               <span>
                 {data.scan_count} scan{data.scan_count !== 1 ? "s" : ""} analyzed
               </span>
@@ -608,7 +608,7 @@ function CompliancePageContent() {
               onClick={() => void handleExportPack()}
               disabled={exporting}
               title="Download a signed evidence pack covering every framework"
-              className="flex items-center gap-1.5 rounded-lg border border-emerald-800 bg-emerald-950/40 px-3 py-2 text-sm font-medium text-emerald-300 transition-colors hover:bg-emerald-900/40 disabled:opacity-50"
+              className="flex items-center gap-1.5 rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 transition-colors hover:bg-emerald-100 disabled:opacity-50 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
               data-testid="compliance-export-pack"
             >
               {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
@@ -623,28 +623,28 @@ function CompliancePageContent() {
         {/* Compliance Hub aggregate (#1044) — surfaces external ingest counts
             alongside the native posture so the page tells one unified story. */}
         {hubPosture && hubPosture.totals.combined > 0 ? (
-          <div className="mt-6 rounded-xl border border-emerald-900/40 bg-emerald-950/20 p-4">
+          <div className="mt-6 rounded-xl border border-emerald-300 bg-emerald-50 p-4 dark:border-emerald-900/40 dark:bg-emerald-950/20">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
               <div className="space-y-1">
-                <div className="text-xs uppercase tracking-[0.24em] text-emerald-400">Compliance Hub</div>
-                <div className="text-sm text-zinc-200">
+                <div className="text-xs uppercase tracking-[0.24em] text-emerald-600 dark:text-emerald-400">Compliance Hub</div>
+                <div className="text-sm text-[color:var(--foreground)]">
                   {hubPosture.totals.combined.toLocaleString()} finding{hubPosture.totals.combined !== 1 ? "s" : ""} across all sources
                   {hubPosture.totals.hub > 0 ? (
                     <>
-                      {" "}<span className="text-emerald-400">({hubPosture.totals.hub.toLocaleString()} ingested external)</span>
+                      {" "}<span className="text-emerald-600 dark:text-emerald-400">({hubPosture.totals.hub.toLocaleString()} ingested external)</span>
                     </>
                   ) : null}
                 </div>
-                <div className="text-xs text-zinc-500">
+                <div className="text-xs text-[color:var(--text-tertiary)]">
                   Native: {hubPosture.totals.native.toLocaleString()} · Hub-ingested: {hubPosture.totals.hub.toLocaleString()}
                   {Object.keys(hubPosture.framework_counts.combined).length > 0 ? (
                     <> · Frameworks lit: {Object.keys(hubPosture.framework_counts.combined).length}</>
                   ) : null}
                 </div>
               </div>
-              <div className="text-xs text-zinc-500 lg:max-w-sm">
+              <div className="text-xs text-[color:var(--text-tertiary)] lg:max-w-sm">
                 Import SARIF / CycloneDX / CSV / JSON via{" "}
-                <code className="rounded bg-zinc-900 px-1.5 py-0.5 text-zinc-300">POST /v1/compliance/ingest</code>{" "}
+                <code className="rounded bg-[color:var(--surface)] px-1.5 py-0.5 text-[color:var(--text-secondary)]">POST /v1/compliance/ingest</code>{" "}
                 — every external finding is auto-mapped to the same framework set as native scans.
               </div>
             </div>
@@ -653,47 +653,47 @@ function CompliancePageContent() {
 
         {/* Framework mini-cards */}
         {mitreCatalog ? (
-          <div className="mt-6 rounded-xl border border-zinc-800 bg-zinc-950/70 p-4">
+          <div className="mt-6 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
               <div className="space-y-1">
                 <div className="text-xs uppercase tracking-[0.24em] text-cyan-400">MITRE ATT&CK catalog</div>
-                <div className="text-sm text-zinc-300">
+                <div className="text-sm text-[color:var(--text-secondary)]">
                   {mitreCatalog.attack_version || "unknown version"} · {mitreCatalog.technique_count} techniques · {mitreCatalog.cwe_mapping_count} CWE mappings
                 </div>
-                <div className="text-xs text-zinc-500">
+                <div className="text-xs text-[color:var(--text-tertiary)]">
                   Source: {mitreCatalog.source}
                   {mitreCatalog.updated_at ? ` · updated ${formatDate(mitreCatalog.updated_at)}` : ""}
                 </div>
               </div>
-              <div className="text-xs text-zinc-500 lg:max-w-sm">
+              <div className="text-xs text-[color:var(--text-tertiary)] lg:max-w-sm">
                 Bundled by default for deterministic scans. Refresh explicitly with{" "}
-                <code className="rounded bg-zinc-900 px-1.5 py-0.5 text-zinc-300">agent-bom db update-frameworks</code>{" "}
+                <code className="rounded bg-[color:var(--surface)] px-1.5 py-0.5 text-[color:var(--text-secondary)]">agent-bom db update-frameworks</code>{" "}
                 when you want a newer upstream snapshot.
               </div>
             </div>
           </div>
         ) : null}
         {atlasCatalog ? (
-          <div className="mt-3 rounded-xl border border-zinc-800 bg-zinc-950/70 p-4">
+          <div className="mt-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4">
             <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
               <div className="space-y-1">
                 <div className="text-xs uppercase tracking-[0.24em] text-fuchsia-400">MITRE ATLAS catalog</div>
-                <div className="text-sm text-zinc-300">
+                <div className="text-sm text-[color:var(--text-secondary)]">
                   {atlasCatalog.atlas_version || "unknown version"} ·{" "}
                   {typeof atlasCatalog.curated_count === "number"
                     ? `${atlasCatalog.curated_count} curated / ${atlasCatalog.technique_count} upstream`
                     : `${atlasCatalog.technique_count} techniques`}{" "}
                   · {atlasCatalog.tactic_count} tactics
                 </div>
-                <div className="text-xs text-zinc-500">
+                <div className="text-xs text-[color:var(--text-tertiary)]">
                   Source: {atlasCatalog.source}
                   {atlasCatalog.updated_at ? ` · updated ${formatDate(atlasCatalog.updated_at)}` : ""}
                 </div>
               </div>
-              <div className="text-xs text-zinc-500 lg:max-w-sm">
+              <div className="text-xs text-[color:var(--text-tertiary)] lg:max-w-sm">
                 Curated tag surface stays load-bearing for tagging precision; the bundled
                 upstream catalog powers coverage rollups. Refresh explicitly with{" "}
-                <code className="rounded bg-zinc-900 px-1.5 py-0.5 text-zinc-300">
+                <code className="rounded bg-[color:var(--surface)] px-1.5 py-0.5 text-[color:var(--text-secondary)]">
                   agent-bom db update-frameworks --framework atlas
                 </code>
                 .
@@ -703,24 +703,24 @@ function CompliancePageContent() {
         ) : null}
 
         <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-6">
-          <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
-            <div className="text-xs text-zinc-500 mb-1">OWASP LLM Top 10</div>
+          <div className="bg-[color:var(--surface-elevated)] rounded-xl p-4 border border-[color:var(--border-subtle)]">
+            <div className="text-xs text-[color:var(--text-tertiary)] mb-1">OWASP LLM Top 10</div>
             <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold text-zinc-100">{s.owasp_pass}</span>
-              <span className="text-sm text-zinc-500">/ 10 pass</span>
+              <span className="text-2xl font-bold text-[color:var(--foreground)]">{s.owasp_pass}</span>
+              <span className="text-sm text-[color:var(--text-tertiary)]">/ 10 pass</span>
             </div>
             <div className="flex gap-2 mt-2 text-xs">
               {s.owasp_fail > 0 && <span className="text-red-400">{s.owasp_fail} fail</span>}
               {s.owasp_warn > 0 && <span className="text-yellow-400">{s.owasp_warn} warn</span>}
             </div>
           </div>
-          <div className={`bg-zinc-950 rounded-xl p-4 border border-zinc-800 ${!hasMcp ? "opacity-40" : ""}`}>
+          <div className={`bg-[color:var(--surface-elevated)] rounded-xl p-4 border border-[color:var(--border-subtle)] ${!hasMcp ? "opacity-40" : ""}`}>
             <div className="text-xs text-amber-500/80 mb-1">OWASP MCP Top 10</div>
             {hasMcp ? (
               <>
                 <div className="flex items-baseline gap-2">
-                  <span className="text-2xl font-bold text-zinc-100">{s.owasp_mcp_pass}</span>
-                  <span className="text-sm text-zinc-500">/ 10 pass</span>
+                  <span className="text-2xl font-bold text-[color:var(--foreground)]">{s.owasp_mcp_pass}</span>
+                  <span className="text-sm text-[color:var(--text-tertiary)]">/ 10 pass</span>
                 </div>
                 <div className="flex gap-2 mt-2 text-xs">
                   {s.owasp_mcp_fail > 0 && <span className="text-red-400">{s.owasp_mcp_fail} fail</span>}
@@ -728,38 +728,38 @@ function CompliancePageContent() {
                 </div>
               </>
             ) : (
-              <div className="text-xs text-zinc-600 mt-1">No MCP servers detected</div>
+              <div className="text-xs text-[color:var(--text-tertiary)] mt-1">No MCP servers detected</div>
             )}
           </div>
-          <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
-            <div className="text-xs text-zinc-500 mb-1">MITRE ATLAS</div>
+          <div className="bg-[color:var(--surface-elevated)] rounded-xl p-4 border border-[color:var(--border-subtle)]">
+            <div className="text-xs text-[color:var(--text-tertiary)] mb-1">MITRE ATLAS</div>
             <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold text-zinc-100">{s.atlas_pass}</span>
-              <span className="text-sm text-zinc-500">/ {data.mitre_atlas.length} pass</span>
+              <span className="text-2xl font-bold text-[color:var(--foreground)]">{s.atlas_pass}</span>
+              <span className="text-sm text-[color:var(--text-tertiary)]">/ {data.mitre_atlas.length} pass</span>
             </div>
             <div className="flex gap-2 mt-2 text-xs">
               {s.atlas_fail > 0 && <span className="text-red-400">{s.atlas_fail} fail</span>}
               {s.atlas_warn > 0 && <span className="text-yellow-400">{s.atlas_warn} warn</span>}
             </div>
           </div>
-          <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
-            <div className="text-xs text-zinc-500 mb-1">NIST AI RMF</div>
+          <div className="bg-[color:var(--surface-elevated)] rounded-xl p-4 border border-[color:var(--border-subtle)]">
+            <div className="text-xs text-[color:var(--text-tertiary)] mb-1">NIST AI RMF</div>
             <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold text-zinc-100">{s.nist_pass}</span>
-              <span className="text-sm text-zinc-500">/ {data.nist_ai_rmf.length} pass</span>
+              <span className="text-2xl font-bold text-[color:var(--foreground)]">{s.nist_pass}</span>
+              <span className="text-sm text-[color:var(--text-tertiary)]">/ {data.nist_ai_rmf.length} pass</span>
             </div>
             <div className="flex gap-2 mt-2 text-xs">
               {s.nist_fail > 0 && <span className="text-red-400">{s.nist_fail} fail</span>}
               {s.nist_warn > 0 && <span className="text-yellow-400">{s.nist_warn} warn</span>}
             </div>
           </div>
-          <div className={`bg-zinc-950 rounded-xl p-4 border border-zinc-800 ${!hasMcp ? "opacity-40" : ""}`}>
+          <div className={`bg-[color:var(--surface-elevated)] rounded-xl p-4 border border-[color:var(--border-subtle)] ${!hasMcp ? "opacity-40" : ""}`}>
             <div className="text-xs text-fuchsia-500/80 mb-1">OWASP Agentic Top 10</div>
             {hasMcp ? (
               <>
                 <div className="flex items-baseline gap-2">
-                  <span className="text-2xl font-bold text-zinc-100">{s.owasp_agentic_pass}</span>
-                  <span className="text-sm text-zinc-500">/ 10 pass</span>
+                  <span className="text-2xl font-bold text-[color:var(--foreground)]">{s.owasp_agentic_pass}</span>
+                  <span className="text-sm text-[color:var(--text-tertiary)]">/ 10 pass</span>
                 </div>
                 <div className="flex gap-2 mt-2 text-xs">
                   {s.owasp_agentic_fail > 0 && <span className="text-red-400">{s.owasp_agentic_fail} fail</span>}
@@ -767,69 +767,69 @@ function CompliancePageContent() {
                 </div>
               </>
             ) : (
-              <div className="text-xs text-zinc-600 mt-1">No agents detected</div>
+              <div className="text-xs text-[color:var(--text-tertiary)] mt-1">No agents detected</div>
             )}
           </div>
-          <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
+          <div className="bg-[color:var(--surface-elevated)] rounded-xl p-4 border border-[color:var(--border-subtle)]">
             <div className="text-xs text-blue-500/80 mb-1">EU AI Act</div>
             <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold text-zinc-100">{s.eu_ai_act_pass}</span>
-              <span className="text-sm text-zinc-500">/ {data.eu_ai_act.length} pass</span>
+              <span className="text-2xl font-bold text-[color:var(--foreground)]">{s.eu_ai_act_pass}</span>
+              <span className="text-sm text-[color:var(--text-tertiary)]">/ {data.eu_ai_act.length} pass</span>
             </div>
             <div className="flex gap-2 mt-2 text-xs">
               {s.eu_ai_act_fail > 0 && <span className="text-red-400">{s.eu_ai_act_fail} fail</span>}
               {s.eu_ai_act_warn > 0 && <span className="text-yellow-400">{s.eu_ai_act_warn} warn</span>}
             </div>
           </div>
-          <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
+          <div className="bg-[color:var(--surface-elevated)] rounded-xl p-4 border border-[color:var(--border-subtle)]">
             <div className="text-xs text-teal-500/80 mb-1">NIST CSF 2.0</div>
             <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold text-zinc-100">{s.nist_csf_pass}</span>
-              <span className="text-sm text-zinc-500">/ {data.nist_csf.length} pass</span>
+              <span className="text-2xl font-bold text-[color:var(--foreground)]">{s.nist_csf_pass}</span>
+              <span className="text-sm text-[color:var(--text-tertiary)]">/ {data.nist_csf.length} pass</span>
             </div>
             <div className="flex gap-2 mt-2 text-xs">
               {s.nist_csf_fail > 0 && <span className="text-red-400">{s.nist_csf_fail} fail</span>}
               {s.nist_csf_warn > 0 && <span className="text-yellow-400">{s.nist_csf_warn} warn</span>}
             </div>
           </div>
-          <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
+          <div className="bg-[color:var(--surface-elevated)] rounded-xl p-4 border border-[color:var(--border-subtle)]">
             <div className="text-xs text-sky-500/80 mb-1">ISO 27001</div>
             <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold text-zinc-100">{s.iso_27001_pass}</span>
-              <span className="text-sm text-zinc-500">/ {data.iso_27001.length} pass</span>
+              <span className="text-2xl font-bold text-[color:var(--foreground)]">{s.iso_27001_pass}</span>
+              <span className="text-sm text-[color:var(--text-tertiary)]">/ {data.iso_27001.length} pass</span>
             </div>
             <div className="flex gap-2 mt-2 text-xs">
               {s.iso_27001_fail > 0 && <span className="text-red-400">{s.iso_27001_fail} fail</span>}
               {s.iso_27001_warn > 0 && <span className="text-yellow-400">{s.iso_27001_warn} warn</span>}
             </div>
           </div>
-          <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
+          <div className="bg-[color:var(--surface-elevated)] rounded-xl p-4 border border-[color:var(--border-subtle)]">
             <div className="text-xs text-indigo-500/80 mb-1">SOC 2</div>
             <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold text-zinc-100">{s.soc2_pass}</span>
-              <span className="text-sm text-zinc-500">/ {data.soc2.length} pass</span>
+              <span className="text-2xl font-bold text-[color:var(--foreground)]">{s.soc2_pass}</span>
+              <span className="text-sm text-[color:var(--text-tertiary)]">/ {data.soc2.length} pass</span>
             </div>
             <div className="flex gap-2 mt-2 text-xs">
               {s.soc2_fail > 0 && <span className="text-red-400">{s.soc2_fail} fail</span>}
               {s.soc2_warn > 0 && <span className="text-yellow-400">{s.soc2_warn} warn</span>}
             </div>
           </div>
-          <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
+          <div className="bg-[color:var(--surface-elevated)] rounded-xl p-4 border border-[color:var(--border-subtle)]">
             <div className="text-xs text-lime-500/80 mb-1">CIS Controls v8</div>
             <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold text-zinc-100">{s.cis_pass}</span>
-              <span className="text-sm text-zinc-500">/ {data.cis_controls.length} pass</span>
+              <span className="text-2xl font-bold text-[color:var(--foreground)]">{s.cis_pass}</span>
+              <span className="text-sm text-[color:var(--text-tertiary)]">/ {data.cis_controls.length} pass</span>
             </div>
             <div className="flex gap-2 mt-2 text-xs">
               {s.cis_fail > 0 && <span className="text-red-400">{s.cis_fail} fail</span>}
               {s.cis_warn > 0 && <span className="text-yellow-400">{s.cis_warn} warn</span>}
             </div>
           </div>
-          <div className="bg-zinc-950 rounded-xl p-4 border border-zinc-800">
+          <div className="bg-[color:var(--surface-elevated)] rounded-xl p-4 border border-[color:var(--border-subtle)]">
             <div className="text-xs text-rose-500/80 mb-1">CMMC 2.0</div>
             <div className="flex items-baseline gap-2">
-              <span className="text-2xl font-bold text-zinc-100">{s.cmmc_pass}</span>
-              <span className="text-sm text-zinc-500">/ {data.cmmc.length} pass</span>
+              <span className="text-2xl font-bold text-[color:var(--foreground)]">{s.cmmc_pass}</span>
+              <span className="text-sm text-[color:var(--text-tertiary)]">/ {data.cmmc.length} pass</span>
             </div>
             <div className="flex gap-2 mt-2 text-xs">
               {s.cmmc_fail > 0 && <span className="text-red-400">{s.cmmc_fail} fail</span>}
@@ -846,7 +846,7 @@ function CompliancePageContent() {
           className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
             viewMode === "detail"
               ? "bg-emerald-600 text-white"
-              : "bg-zinc-800 text-zinc-400 hover:text-zinc-200 border border-zinc-700"
+              : "bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] border border-[color:var(--border-strong)]"
           }`}
         >
           <List className="w-3.5 h-3.5" />
@@ -857,7 +857,7 @@ function CompliancePageContent() {
           className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
             viewMode === "heatmap"
               ? "bg-emerald-600 text-white"
-              : "bg-zinc-800 text-zinc-400 hover:text-zinc-200 border border-zinc-700"
+              : "bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] border border-[color:var(--border-strong)]"
           }`}
         >
           <Grid3X3 className="w-3.5 h-3.5" />
@@ -868,7 +868,7 @@ function CompliancePageContent() {
           className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
             viewMode === "matrix"
               ? "bg-emerald-600 text-white"
-              : "bg-zinc-800 text-zinc-400 hover:text-zinc-200 border border-zinc-700"
+              : "bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] border border-[color:var(--border-strong)]"
           }`}
         >
           <Scan className="w-3.5 h-3.5" />
@@ -887,8 +887,8 @@ function CompliancePageContent() {
       <>
 
       {/* ── Framework Coverage Bars ────────────────────────────────────── */}
-      <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-6 space-y-5">
-        <h2 className="text-sm font-semibold text-zinc-300 uppercase tracking-wider">Framework Coverage</h2>
+      <div className="bg-[color:var(--surface)] border border-[color:var(--border-subtle)] rounded-2xl p-6 space-y-5">
+        <h2 className="text-sm font-semibold text-[color:var(--text-secondary)] uppercase tracking-wider">Framework Coverage</h2>
         <FrameworkBar label="OWASP LLM Top 10" pass={s.owasp_pass} warn={s.owasp_warn} fail={s.owasp_fail} total={10} />
         <FrameworkBar label="MITRE ATLAS" pass={s.atlas_pass} warn={s.atlas_warn} fail={s.atlas_fail} total={data.mitre_atlas.length} />
         {hasMcp && <FrameworkBar label="OWASP MCP Top 10" pass={s.owasp_mcp_pass} warn={s.owasp_mcp_warn} fail={s.owasp_mcp_fail} total={10} />}
@@ -909,21 +909,21 @@ function CompliancePageContent() {
         <FrameworkBar label="CMMC 2.0" pass={s.cmmc_pass} warn={s.cmmc_warn} fail={s.cmmc_fail} total={data.cmmc.length} />
       </div>
 
-      <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+      <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div>
-            <h2 className="text-sm font-semibold text-zinc-200">Control explorer</h2>
-            <p className="mt-1 text-xs text-zinc-500">Filter once, then expand only the frameworks you need.</p>
+            <h2 className="text-sm font-semibold text-[color:var(--foreground)]">Control explorer</h2>
+            <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">Filter once, then expand only the frameworks you need.</p>
           </div>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
             <div className="relative min-w-[240px]">
-              <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-600" />
+              <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[color:var(--text-tertiary)]" />
               <input
                 type="text"
                 value={controlQuery}
                 onChange={(e) => setControlQuery(e.target.value)}
                 placeholder="Search control, package, or agent"
-                className="w-full rounded-lg border border-zinc-700 bg-zinc-950 py-2 pl-9 pr-3 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500"
+                className="w-full rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface-elevated)] py-2 pl-9 pr-3 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:outline-none focus:border-[color:var(--border-strong)]"
               />
             </div>
             <div className="flex items-center gap-1">
@@ -933,8 +933,8 @@ function CompliancePageContent() {
                   onClick={() => setStatusFilter(value)}
                   className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
                     statusFilter === value
-                      ? "bg-zinc-800 text-zinc-100"
-                      : "text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300"
+                      ? "bg-[color:var(--surface-muted)] text-[color:var(--foreground)]"
+                      : "text-[color:var(--text-tertiary)] hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--text-secondary)]"
                   }`}
                 >
                   {value === "all" ? "All" : value === "pass" ? "Passing" : value === "warning" ? "Warnings" : "Failing"}

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -33,6 +33,7 @@ import {
   serverFindingsSort,
   formatFindingsTotal,
   hasLifecycleMetadata,
+  vulnRowKey,
 } from "@/lib/findings-view";
 import { severityRank } from "@/lib/severity";
 import { Bug, Download, Layers, Loader2, Package, Server, ClipboardCheck } from "lucide-react";
@@ -181,6 +182,7 @@ function collectUnifiedFindings(findings: UnifiedFinding[]): EnrichedVuln[] {
     const sourceLabel = uniqueStrings([finding.source, finding.finding_type, ...(finding.scan_sources ?? [])]);
     return {
       id: findingLabel,
+      finding_id: finding.id,
       severity: normalizedSeverity(finding.effective_severity ?? finding.severity),
       summary: raw.attack_vector_summary ?? finding.title ?? finding.description,
       description: finding.description ?? finding.title,
@@ -708,7 +710,10 @@ function FindingsPage() {
     ? displayed
     : displayed.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
   const selectedVuln = useMemo(
-    () => displayed.find((vuln) => vuln.id === selectedId) ?? vulns.find((vuln) => vuln.id === selectedId) ?? null,
+    () =>
+      displayed.find((vuln) => vulnRowKey(vuln) === selectedId || vuln.id === selectedId) ??
+      vulns.find((vuln) => vulnRowKey(vuln) === selectedId || vuln.id === selectedId) ??
+      null,
     [displayed, selectedId, vulns],
   );
   const triageByKey = useMemo(() => {

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -98,6 +98,7 @@ import {
 import { evaluateGraphUx } from "@/lib/graph-ux-evaluation";
 import {
   api,
+  ApiRateLimitError,
   type GraphDiffResponse,
   type GraphEdgeChangesResponse,
   type GraphNodeDetailResponse,
@@ -105,7 +106,7 @@ import {
   type GraphSnapshot,
   type UnifiedGraphResponse,
 } from "@/lib/api";
-import type { GraphRollupResponse } from "@/lib/api-types";
+import type { GraphDiffNode, GraphRollupResponse } from "@/lib/api-types";
 import { buildRollupFlowGraph } from "@/lib/graph-rollup-view";
 import { buildUnifiedFlowGraph } from "@/lib/unified-graph-flow";
 import {
@@ -680,6 +681,7 @@ function GraphPageInner() {
   const [loadingGraph, setLoadingGraph] = useState(false);
   const [loadingDiff, setLoadingDiff] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [rateLimited, setRateLimited] = useState(false);
   const [diffError, setDiffError] = useState<string | null>(null);
   const [graphDiff, setGraphDiff] = useState<GraphDiffResponse | null>(null);
   const [edgeChanges, setEdgeChanges] = useState<GraphEdgeChangesResponse | null>(
@@ -800,7 +802,10 @@ function GraphPageInner() {
           });
         }
       })
-      .catch((e) => setError(e.message))
+      .catch((e) => {
+        setRateLimited(e instanceof ApiRateLimitError);
+        setError(e.message);
+      })
       .finally(() => setLoadingSnapshots(false));
   }, []);
 
@@ -2167,10 +2172,22 @@ function GraphPageInner() {
     return (
       <div className="flex flex-col items-center justify-center h-[80vh] text-zinc-400 gap-3">
         <AlertTriangle className="w-8 h-8 text-amber-500" />
-        <p className="text-sm">Could not load the unified graph</p>
-        <p className="text-xs text-zinc-500">
-          Run a scan first so the API can persist graph snapshots.
-        </p>
+        {rateLimited ? (
+          <>
+            <p className="text-sm">Graph temporarily rate-limited</p>
+            <p className="text-xs text-zinc-500">
+              The API is shedding load (HTTP 429). Wait a moment and retry — your
+              snapshots are still there.
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="text-sm">Could not load the unified graph</p>
+            <p className="text-xs text-zinc-500">
+              Run a scan first so the API can persist graph snapshots.
+            </p>
+          </>
+        )}
       </div>
     );
   }
@@ -3481,7 +3498,24 @@ function DiffLoadingGrid() {
   );
 }
 
-function DiffPreview({ label, items }: { label: string; items: string[] }) {
+type DiffPreviewItem = GraphDiffNode | string;
+
+function diffItemKey(item: DiffPreviewItem): string {
+  return typeof item === "string" ? item : item.id;
+}
+
+function diffItemLabel(item: DiffPreviewItem): string {
+  if (typeof item === "string") return item;
+  return item.label || item.id;
+}
+
+export function DiffPreview({
+  label,
+  items,
+}: {
+  label: string;
+  items: DiffPreviewItem[];
+}) {
   const visible = items.slice(0, 5);
   return (
     <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-3">
@@ -3496,10 +3530,10 @@ function DiffPreview({ label, items }: { label: string; items: string[] }) {
       <div className="mt-2 space-y-1">
         {visible.map((item) => (
           <p
-            key={`${label}-${item}`}
+            key={`${label}-${diffItemKey(item)}`}
             className="truncate font-mono text-[11px] text-zinc-300"
           >
-            {item}
+            {diffItemLabel(item)}
           </p>
         ))}
         {items.length > visible.length && (

--- a/ui/app/proxy/ProxyDashboard.tsx
+++ b/ui/app/proxy/ProxyDashboard.tsx
@@ -528,9 +528,7 @@ export default function ProxyDashboard() {
                       </span>
                     </div>
                     <span className="text-[10px] text-zinc-600 shrink-0 ml-3">
-                      {alert.ts
-                        ? formatDate(new Date(alert.ts * 1000).toISOString())
-                        : ""}
+                      {alert.ts ? formatDate(alert.ts) : ""}
                     </span>
                   </div>
                 ))}

--- a/ui/components/cis-benchmark-detail.tsx
+++ b/ui/components/cis-benchmark-detail.tsx
@@ -63,9 +63,9 @@ function statusBadge(status: string): { label: string; className: string; Icon: 
     case "error":
       return { label: "Error", className: "text-orange-400 border-orange-500/30 bg-orange-500/10", Icon: AlertTriangle };
     case "not_applicable":
-      return { label: "N/A", className: "text-zinc-500 border-zinc-700 bg-zinc-800/40", Icon: ChevronRight };
+      return { label: "N/A", className: "text-[color:var(--text-tertiary)] border-[color:var(--border-strong)] bg-[color:var(--surface-muted)]/40", Icon: ChevronRight };
     default:
-      return { label: status || "Unknown", className: "text-zinc-400 border-zinc-700 bg-zinc-800/40", Icon: ChevronRight };
+      return { label: status || "Unknown", className: "text-[color:var(--text-secondary)] border-[color:var(--border-strong)] bg-[color:var(--surface-muted)]/40", Icon: ChevronRight };
   }
 }
 
@@ -80,7 +80,7 @@ function severityClass(severity: string): string {
     case "low":
       return "text-sky-300 border-sky-500/40 bg-sky-500/10";
     default:
-      return "text-zinc-400 border-zinc-700 bg-zinc-800/40";
+      return "text-[color:var(--text-secondary)] border-[color:var(--border-strong)] bg-[color:var(--surface-muted)]/40";
   }
 }
 
@@ -108,7 +108,7 @@ function CopyableFixCli({ check }: { check: CISBenchmarkCheck }) {
 
   if (!cli) {
     return (
-      <div className="text-xs text-zinc-500">
+      <div className="text-xs text-[color:var(--text-tertiary)]">
         No copy-pasteable CLI fix — use the console path below.
       </div>
     );
@@ -116,7 +116,7 @@ function CopyableFixCli({ check }: { check: CISBenchmarkCheck }) {
 
   return (
     <div className="space-y-1.5">
-      <div className="flex items-center gap-2 text-xs text-zinc-500">
+      <div className="flex items-center gap-2 text-xs text-[color:var(--text-tertiary)]">
         <Terminal className="h-3.5 w-3.5" />
         <span>Fix (CLI)</span>
         {check.requires_human_review ? (
@@ -130,7 +130,7 @@ function CopyableFixCli({ check }: { check: CISBenchmarkCheck }) {
         ) : null}
       </div>
       <div className="flex items-start gap-2">
-        <pre className="flex-1 overflow-x-auto rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 text-xs text-zinc-200">
+        <pre className="flex-1 overflow-x-auto rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-xs text-[color:var(--foreground)]">
           <code>{cli}</code>
         </pre>
         <button
@@ -149,7 +149,7 @@ function CopyableFixCli({ check }: { check: CISBenchmarkCheck }) {
           className={`mt-0.5 inline-flex items-center gap-1 rounded-md border px-2 py-1.5 text-xs transition-colors ${
             check.requires_human_review
               ? "border-amber-500/40 text-amber-300 hover:bg-amber-500/10"
-              : "border-zinc-700 text-zinc-300 hover:bg-zinc-800"
+              : "border-[color:var(--border-strong)] text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-muted)]"
           }`}
         >
           <Copy className="h-3.5 w-3.5" />
@@ -171,7 +171,7 @@ function CheckCard({ check }: { check: CISBenchmarkCheck }) {
   const docs = check.remediation?.docs;
 
   return (
-    <div className="rounded-xl border border-zinc-800 bg-zinc-950/60">
+    <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)]">
       <button
         type="button"
         onClick={() => setOpen((value) => !value)}
@@ -179,8 +179,8 @@ function CheckCard({ check }: { check: CISBenchmarkCheck }) {
       >
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="font-mono text-xs text-zinc-400">{check.check_id}</span>
-            <span className="text-sm font-medium text-zinc-100">{check.title}</span>
+            <span className="font-mono text-xs text-[color:var(--text-secondary)]">{check.check_id}</span>
+            <span className="text-sm font-medium text-[color:var(--foreground)]">{check.title}</span>
           </div>
           <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
             <span className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[11px] font-medium ${badge.className}`}>
@@ -190,7 +190,7 @@ function CheckCard({ check }: { check: CISBenchmarkCheck }) {
             <span className={`rounded border px-1.5 py-0.5 text-[11px] font-medium capitalize ${severityClass(check.severity)}`}>
               {check.severity}
             </span>
-            <span className="rounded border border-zinc-700 bg-zinc-800/40 px-1.5 py-0.5 text-[11px] font-medium text-zinc-300">
+            <span className="rounded border border-[color:var(--border-strong)] bg-[color:var(--surface-muted)]/40 px-1.5 py-0.5 text-[11px] font-medium text-[color:var(--text-secondary)]">
               {priorityLabel(check.priority)}
             </span>
             {check.requires_human_review ? (
@@ -209,16 +209,16 @@ function CheckCard({ check }: { check: CISBenchmarkCheck }) {
             ))}
           </div>
         </div>
-        {open ? <ChevronDown className="mt-1 h-4 w-4 shrink-0 text-zinc-500" /> : <ChevronRight className="mt-1 h-4 w-4 shrink-0 text-zinc-500" />}
+        {open ? <ChevronDown className="mt-1 h-4 w-4 shrink-0 text-[color:var(--text-tertiary)]" /> : <ChevronRight className="mt-1 h-4 w-4 shrink-0 text-[color:var(--text-tertiary)]" />}
       </button>
       {open ? (
-        <div className="space-y-3 border-t border-zinc-800 px-4 py-3">
-          {check.evidence ? <p className="text-xs text-zinc-400">{check.evidence}</p> : null}
+        <div className="space-y-3 border-t border-[color:var(--border-subtle)] px-4 py-3">
+          {check.evidence ? <p className="text-xs text-[color:var(--text-secondary)]">{check.evidence}</p> : null}
           <CopyableFixCli check={check} />
           {check.fix_console ? (
-            <div className="text-xs text-zinc-400">
-              <span className="text-zinc-500">Console path: </span>
-              <span className="text-zinc-200">{check.fix_console}</span>
+            <div className="text-xs text-[color:var(--text-secondary)]">
+              <span className="text-[color:var(--text-tertiary)]">Console path: </span>
+              <span className="text-[color:var(--foreground)]">{check.fix_console}</span>
             </div>
           ) : null}
           {docs ? (
@@ -253,14 +253,14 @@ function FilterPills<T extends string | number>({
 }) {
   return (
     <div className="flex flex-wrap items-center gap-1.5">
-      <span className="text-[11px] uppercase tracking-wider text-zinc-600">{label}</span>
+      <span className="text-[11px] uppercase tracking-wider text-[color:var(--text-tertiary)]">{label}</span>
       {options.map((option) => (
         <button
           key={String(option)}
           type="button"
           onClick={() => onChange(option)}
           className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-            value === option ? "bg-zinc-800 text-zinc-100" : "text-zinc-500 hover:bg-zinc-800 hover:text-zinc-300"
+            value === option ? "bg-[color:var(--surface-muted)] text-[color:var(--foreground)]" : "text-[color:var(--text-tertiary)] hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--text-secondary)]"
           }`}
         >
           {render(option)}
@@ -341,18 +341,18 @@ export function CISBenchmarkDetail() {
 
   if (loading) {
     return (
-      <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5" aria-busy="true">
+      <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5" aria-busy="true">
         <SectionHeader />
-        <p className="mt-3 text-sm text-zinc-500">Loading cloud CIS benchmark checks…</p>
+        <p className="mt-3 text-sm text-[color:var(--text-tertiary)]">Loading cloud CIS benchmark checks…</p>
       </section>
     );
   }
 
   if (error) {
     return (
-      <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+      <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5">
         <SectionHeader />
-        <div className="mt-3 flex items-start gap-2 rounded-xl border border-zinc-800 bg-zinc-950/70 p-4 text-sm text-zinc-400">
+        <div className="mt-3 flex items-start gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4 text-sm text-[color:var(--text-secondary)]">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
           <span>{error}</span>
         </div>
@@ -363,9 +363,9 @@ export function CISBenchmarkDetail() {
   const total = checks?.length ?? 0;
   if (total === 0) {
     return (
-      <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+      <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5">
         <SectionHeader />
-        <div className="mt-3 rounded-xl border border-zinc-800 bg-zinc-950/70 p-5 text-sm text-zinc-500">
+        <div className="mt-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5 text-sm text-[color:var(--text-tertiary)]">
           No cloud CIS benchmark checks yet. Run a cloud scan (AWS, Azure, GCP, Snowflake, or Databricks)
           to populate per-check remediation.
         </div>
@@ -374,9 +374,9 @@ export function CISBenchmarkDetail() {
   }
 
   return (
-    <section id="cloud-cis-benchmarks" className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+    <section id="cloud-cis-benchmarks" className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5">
       <SectionHeader count={total} />
-      <div className="mt-4 flex flex-col gap-3 rounded-xl border border-zinc-800 bg-zinc-950/40 p-3 lg:flex-row lg:flex-wrap lg:items-center lg:gap-5">
+      <div className="mt-4 flex flex-col gap-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3 lg:flex-row lg:flex-wrap lg:items-center lg:gap-5">
         <FilterPills
           label="Cloud"
           options={cloudOptions}
@@ -409,12 +409,12 @@ export function CISBenchmarkDetail() {
 
       <div className="mt-4 space-y-2">
         {visible.length === 0 ? (
-          <div className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-5 text-sm text-zinc-500">
+          <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5 text-sm text-[color:var(--text-tertiary)]">
             No checks match the current filters ({total} total).
           </div>
         ) : (
           <>
-            <div className="text-xs text-zinc-500">
+            <div className="text-xs text-[color:var(--text-tertiary)]">
               {visible.length} of {total} checks shown
             </div>
             {visible.map((check) => (
@@ -432,8 +432,8 @@ function SectionHeader({ count }: { count?: number | undefined }) {
     <div className="flex items-center gap-2">
       <Cloud className="h-4 w-4 text-cyan-400" />
       <div>
-        <h2 className="text-lg font-semibold text-zinc-100">Cloud CIS Benchmark Drill-down</h2>
-        <p className="text-xs text-zinc-500">
+        <h2 className="text-lg font-semibold text-[color:var(--foreground)]">Cloud CIS Benchmark Drill-down</h2>
+        <p className="text-xs text-[color:var(--text-tertiary)]">
           Failed AWS / Azure / GCP / Snowflake / Databricks checks behind CIS Controls v8, with fix guidance.
           {typeof count === "number" ? ` ${count} checks.` : null}
         </p>

--- a/ui/components/compliance-heatmap.tsx
+++ b/ui/components/compliance-heatmap.tsx
@@ -29,7 +29,7 @@ function cellColor(status: string): string {
     case "pass":    return "#34d399";
     case "warning": return "#facc15";
     case "fail":    return "#f87171";
-    default:        return "#27272a";
+    default:        return "var(--border-strong)";
   }
 }
 
@@ -51,13 +51,13 @@ export function ComplianceHeatmap({ data }: ComplianceHeatmapProps) {
   );
 
   return (
-    <div className="bg-zinc-900 border border-zinc-800 rounded-2xl p-6 overflow-x-auto relative">
-      <h3 className="text-sm font-semibold text-zinc-300 uppercase tracking-wider mb-4">
+    <div className="bg-[color:var(--surface)] border border-[color:var(--border-subtle)] rounded-2xl p-6 overflow-x-auto relative">
+      <h3 className="text-sm font-semibold text-[color:var(--text-secondary)] uppercase tracking-wider mb-4">
         Compliance Heatmap
       </h3>
 
       {/* Legend */}
-      <div className="flex gap-4 mb-4 text-xs text-zinc-500">
+      <div className="flex gap-4 mb-4 text-xs text-[color:var(--text-tertiary)]">
         <span className="flex items-center gap-1.5">
           <span className="w-3 h-3 rounded" style={{ backgroundColor: "#34d399" }} /> Pass
         </span>
@@ -68,7 +68,7 @@ export function ComplianceHeatmap({ data }: ComplianceHeatmapProps) {
           <span className="w-3 h-3 rounded" style={{ backgroundColor: "#f87171" }} /> Fail
         </span>
         <span className="flex items-center gap-1.5">
-          <span className="w-3 h-3 rounded" style={{ backgroundColor: "#27272a" }} /> N/A
+          <span className="w-3 h-3 rounded" style={{ backgroundColor: "var(--border-strong)" }} /> N/A
         </span>
       </div>
 
@@ -78,7 +78,7 @@ export function ComplianceHeatmap({ data }: ComplianceHeatmapProps) {
           return (
             <div key={fw.field} className="flex items-center gap-3">
               {/* Framework label */}
-              <div className="w-44 shrink-0 text-xs text-zinc-400 font-medium truncate" title={fw.label}>
+              <div className="w-44 shrink-0 text-xs text-[color:var(--text-secondary)] font-medium truncate" title={fw.label}>
                 {fw.label}
               </div>
 
@@ -101,7 +101,7 @@ export function ComplianceHeatmap({ data }: ComplianceHeatmapProps) {
                   <div
                     key={`empty-${i}`}
                     className="w-7 h-7 rounded"
-                    style={{ backgroundColor: "#27272a" }}
+                    style={{ backgroundColor: "var(--border-strong)" }}
                   />
                 ))}
               </div>
@@ -113,7 +113,7 @@ export function ComplianceHeatmap({ data }: ComplianceHeatmapProps) {
       {/* Tooltip */}
       {tooltip && (
         <div
-          className="fixed z-50 px-3 py-1.5 rounded-lg bg-zinc-800 border border-zinc-700 text-xs text-zinc-200 shadow-xl pointer-events-none"
+          className="fixed z-50 px-3 py-1.5 rounded-lg bg-[color:var(--surface-muted)] border border-[color:var(--border-strong)] text-xs text-[color:var(--foreground)] shadow-xl pointer-events-none"
           style={{
             left: tooltip.x,
             top: tooltip.y - 40,
@@ -121,7 +121,7 @@ export function ComplianceHeatmap({ data }: ComplianceHeatmapProps) {
           }}
         >
           <span className="font-mono font-semibold">{tooltip.code}</span>
-          <span className="text-zinc-500 mx-1.5">&middot;</span>
+          <span className="text-[color:var(--text-tertiary)] mx-1.5">&middot;</span>
           <span>{statusLabel(tooltip.status)}</span>
         </div>
       )}

--- a/ui/components/compliance-matrix.tsx
+++ b/ui/components/compliance-matrix.tsx
@@ -92,7 +92,7 @@ const columns = [
   col.accessor("framework", {
     header: "Framework",
     cell: (info) => (
-      <span className="text-xs font-medium text-zinc-400">
+      <span className="text-xs font-medium text-[color:var(--text-secondary)]">
         {info.getValue()}
       </span>
     ),
@@ -101,7 +101,7 @@ const columns = [
   col.accessor("code", {
     header: "Control",
     cell: (info) => (
-      <span className="font-mono text-xs font-semibold text-zinc-200">
+      <span className="font-mono text-xs font-semibold text-[color:var(--foreground)]">
         {info.getValue()}
       </span>
     ),
@@ -109,7 +109,7 @@ const columns = [
   col.accessor("name", {
     header: "Description",
     cell: (info) => (
-      <span className="text-xs text-zinc-400 leading-snug">
+      <span className="text-xs text-[color:var(--text-secondary)] leading-snug">
         {info.getValue()}
       </span>
     ),
@@ -140,7 +140,7 @@ const columns = [
       const v = info.getValue();
       return (
         <span
-          className={`font-mono text-xs ${v > 0 ? "text-zinc-200" : "text-zinc-700"}`}
+          className={`font-mono text-xs ${v > 0 ? "text-[color:var(--foreground)]" : "text-[color:var(--text-tertiary)]"}`}
         >
           {v}
         </span>
@@ -156,7 +156,7 @@ const columns = [
           {v}
         </span>
       ) : (
-        <span className="text-zinc-700">—</span>
+        <span className="text-[color:var(--text-tertiary)]">—</span>
       );
     },
   }),
@@ -169,7 +169,7 @@ const columns = [
           {v}
         </span>
       ) : (
-        <span className="text-zinc-700">—</span>
+        <span className="text-[color:var(--text-tertiary)]">—</span>
       );
     },
   }),
@@ -180,7 +180,7 @@ const columns = [
       return v > 0 ? (
         <span className="font-mono text-xs text-yellow-400">{v}</span>
       ) : (
-        <span className="text-zinc-700">—</span>
+        <span className="text-[color:var(--text-tertiary)]">—</span>
       );
     },
   }),
@@ -191,7 +191,7 @@ const columns = [
       return v > 0 ? (
         <span className="font-mono text-xs text-blue-400">{v}</span>
       ) : (
-        <span className="text-zinc-700">—</span>
+        <span className="text-[color:var(--text-tertiary)]">—</span>
       );
     },
   }),
@@ -199,9 +199,9 @@ const columns = [
     header: "Packages",
     cell: (info) => {
       const pkgs = info.getValue();
-      if (pkgs.length === 0) return <span className="text-zinc-700">—</span>;
+      if (pkgs.length === 0) return <span className="text-[color:var(--text-tertiary)]">—</span>;
       return (
-        <span className="text-xs text-zinc-500" title={pkgs.join(", ")}>
+        <span className="text-xs text-[color:var(--text-tertiary)]" title={pkgs.join(", ")}>
           {pkgs.length} pkg{pkgs.length !== 1 ? "s" : ""}
         </span>
       );
@@ -266,19 +266,19 @@ export function ComplianceMatrix({ data }: { data: ComplianceResponse }) {
       <div className="flex flex-wrap items-center gap-3">
         {/* Search */}
         <div className="relative flex-1 min-w-[200px] max-w-sm">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-zinc-500" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-[color:var(--text-tertiary)]" />
           <input
             type="text"
             placeholder="Search controls..."
             value={globalFilter}
             onChange={(e) => setGlobalFilter(e.target.value)}
-            className="w-full bg-zinc-900 border border-zinc-800 rounded-lg pl-9 pr-3 py-2 text-xs text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-600"
+            className="w-full bg-[color:var(--surface)] border border-[color:var(--border-subtle)] rounded-lg pl-9 pr-3 py-2 text-xs text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:outline-none focus:border-[color:var(--border-strong)]"
           />
         </div>
 
         {/* Framework filter */}
         <div className="flex items-center gap-1">
-          <Filter className="w-3.5 h-3.5 text-zinc-500" />
+          <Filter className="w-3.5 h-3.5 text-[color:var(--text-tertiary)]" />
           <select
             value={activeFramework}
             onChange={(e) => {
@@ -288,7 +288,7 @@ export function ComplianceMatrix({ data }: { data: ComplianceResponse }) {
                 return val ? [...without, { id: "framework", value: val }] : without;
               });
             }}
-            className="bg-zinc-900 border border-zinc-800 rounded-lg px-2 py-1.5 text-xs text-zinc-300 focus:outline-none focus:border-zinc-600"
+            className="bg-[color:var(--surface)] border border-[color:var(--border-subtle)] rounded-lg px-2 py-1.5 text-xs text-[color:var(--text-secondary)] focus:outline-none focus:border-[color:var(--border-strong)]"
           >
             <option value="">All frameworks</option>
             {frameworks?.map((f) => (
@@ -313,7 +313,7 @@ export function ComplianceMatrix({ data }: { data: ComplianceResponse }) {
               className={`px-2.5 py-1 rounded-lg text-[10px] font-medium border transition-colors ${
                 activeStatus === s
                   ? "bg-emerald-600 text-white border-emerald-600"
-                  : "bg-zinc-900 text-zinc-400 border-zinc-800 hover:border-zinc-600"
+                  : "bg-[color:var(--surface)] text-[color:var(--text-secondary)] border-[color:var(--border-subtle)] hover:border-[color:var(--border-strong)]"
               }`}
             >
               {s === "" ? "All" : s === "pass" ? "Pass" : s === "warning" ? "Warn" : "Fail"}
@@ -324,7 +324,7 @@ export function ComplianceMatrix({ data }: { data: ComplianceResponse }) {
         {/* Export */}
         <button
           onClick={() => exportCsv(table.getFilteredRowModel().rows?.map((r) => r.original))}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 border border-zinc-700 rounded-lg text-xs text-zinc-300 hover:text-zinc-100 hover:border-zinc-600 transition-colors ml-auto"
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-[color:var(--surface-muted)] border border-[color:var(--border-strong)] rounded-lg text-xs text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] hover:border-[color:var(--border-strong)] transition-colors ml-auto"
         >
           <Download className="w-3.5 h-3.5" />
           CSV
@@ -332,27 +332,27 @@ export function ComplianceMatrix({ data }: { data: ComplianceResponse }) {
       </div>
 
       {/* Count */}
-      <div className="text-xs text-zinc-600">
+      <div className="text-xs text-[color:var(--text-tertiary)]">
         {table.getFilteredRowModel().rows.length} of {rows.length} controls
       </div>
 
       {/* Table */}
-      <div className="border border-zinc-800 rounded-xl overflow-hidden">
+      <div className="border border-[color:var(--border-subtle)] rounded-xl overflow-hidden">
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
-            <thead className="bg-zinc-900 border-b border-zinc-800">
+            <thead className="bg-[color:var(--surface)] border-b border-[color:var(--border-subtle)]">
               {table.getHeaderGroups().map((hg) => (
                 <tr key={hg.id}>
                   {hg.headers?.map((header) => (
                     <th
                       key={header.id}
-                      className="text-left px-3 py-2.5 text-[10px] font-medium text-zinc-500 uppercase tracking-wider whitespace-nowrap"
+                      className="text-left px-3 py-2.5 text-[10px] font-medium text-[color:var(--text-tertiary)] uppercase tracking-wider whitespace-nowrap"
                     >
                       {header.isPlaceholder ? null : (
                         <button
                           className={`flex items-center gap-1 ${
                             header.column.getCanSort()
-                              ? "cursor-pointer select-none hover:text-zinc-300"
+                              ? "cursor-pointer select-none hover:text-[color:var(--text-secondary)]"
                               : ""
                           }`}
                           onClick={header.column.getToggleSortingHandler()}
@@ -379,11 +379,11 @@ export function ComplianceMatrix({ data }: { data: ComplianceResponse }) {
                 </tr>
               ))}
             </thead>
-            <tbody className="divide-y divide-zinc-800/50 bg-zinc-950">
+            <tbody className="divide-y divide-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)]">
               {table.getRowModel().rows?.map((row) => (
                 <tr
                   key={row.id}
-                  className="hover:bg-zinc-900/50 transition-colors"
+                  className="hover:bg-[color:var(--surface)]/50 transition-colors"
                 >
                   {row.getVisibleCells().map((cell) => (
                     <td key={cell.id} className="px-3 py-2.5">

--- a/ui/components/findings-queue.tsx
+++ b/ui/components/findings-queue.tsx
@@ -8,6 +8,7 @@ import {
   findingStatusClass,
   findingStatusLabel,
   formatFindingTimestamp,
+  vulnRowKey,
 } from "@/lib/findings-view";
 
 function ReachabilityBadge({
@@ -152,12 +153,13 @@ export function FindingsQueueTable({
         </thead>
         <tbody className="divide-y divide-zinc-800 bg-zinc-950">
           {vulns?.map((v) => {
-            const isSelected = selectedId === v.id;
+            const rowKey = vulnRowKey(v);
+            const isSelected = selectedId === rowKey || selectedId === v.id;
             return (
               <tr
-                key={v.id}
+                key={rowKey}
                 className={`cursor-pointer transition-colors ${isSelected ? "bg-zinc-900/90 ring-1 ring-inset ring-emerald-900/60" : "hover:bg-zinc-900"}`}
-                onClick={() => onSelect(v.id)}
+                onClick={() => onSelect(rowKey)}
               >
                 <td className="px-4 py-3">
                   <div className="flex items-start gap-2">
@@ -165,7 +167,7 @@ export function FindingsQueueTable({
                       type="button"
                       onClick={(event) => {
                         event.stopPropagation();
-                        onSelect(v.id);
+                        onSelect(rowKey);
                       }}
                       className="mt-0.5 rounded p-0.5 text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-300"
                       aria-label={`Open details for ${v.id}`}
@@ -179,7 +181,7 @@ export function FindingsQueueTable({
                             type="button"
                             onClick={(event) => {
                               event.stopPropagation();
-                              onSelect(v.id);
+                              onSelect(rowKey);
                             }}
                             className="font-mono text-xs text-zinc-200 transition-colors hover:text-emerald-400"
                           >

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -849,7 +849,7 @@ function SessionStatus({
 
   if (!session?.authenticated) {
     return (
-      <div className="rounded-lg border border-amber-900/60 bg-amber-950/20 px-3 py-2 text-[12px] text-amber-300">
+      <div className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-[12px] text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/20 dark:text-amber-200">
         Sign-in required for protected control-plane actions
       </div>
     );

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -453,9 +453,29 @@ export interface GraphChangeKindIndex {
   edges: Record<string, GraphChangeKind>;
 }
 
+/**
+ * Rich node record emitted by `/v1/graph/diff` for added/removed nodes.
+ * Shape mirrors the backend `node_diff_metadata`, plus a `change_kind` tag
+ * the route attaches for the drift lens.
+ */
+export interface GraphDiffNode {
+  id: string;
+  entity_type: string;
+  label: string;
+  status: string;
+  severity: string;
+  severity_id: number;
+  risk_score: number;
+  attributes?: Record<string, unknown> | undefined;
+  compliance_tags?: string[] | undefined;
+  change_kind?: string | undefined;
+}
+
 export interface GraphDiffResponse {
-  nodes_added: string[];
-  nodes_removed: string[];
+  /** Added/removed nodes are full node objects. */
+  nodes_added: GraphDiffNode[];
+  nodes_removed: GraphDiffNode[];
+  /** Changed nodes are emitted as bare node-id strings. */
   nodes_changed: string[];
   edges_added: [string, string, string][];
   edges_removed: [string, string, string][];
@@ -2478,7 +2498,8 @@ export interface ProxyStatusResponse {
 }
 
 export interface ProxyAlert {
-  ts: number;
+  /** ISO-8601 timestamp string (e.g. "2026-07-06T15:10:00+00:00"). */
+  ts: string;
   severity: string;
   detector: string;
   tool_name: string;

--- a/ui/lib/findings-view.ts
+++ b/ui/lib/findings-view.ts
@@ -1,6 +1,14 @@
 import type { Vulnerability } from "@/lib/api";
 
 export interface EnrichedVuln extends Vulnerability {
+  /**
+   * Unique per-finding identifier (UUID). Distinct from `id`, which carries the
+   * vulnerability label (CVE/GHSA) shown to users. The same CVE can affect many
+   * assets, so `id` is NOT unique across rows — use `finding_id` for React keys
+   * and per-row selection. Absent for legacy scan/graph paths that already
+   * merge one row per CVE.
+   */
+  finding_id?: string | undefined;
   packages: string[];
   agents: string[];
   sources: string[];
@@ -109,4 +117,13 @@ export function hasLifecycleMetadata(rows: EnrichedVuln[]): boolean {
 
 export function uniqueStrings(items: Array<string | null | undefined>) {
   return [...new Set(items.filter((item): item is string => Boolean(item && item.trim())).map((item) => item.trim()))];
+}
+
+/**
+ * Stable, unique React key / selection identity for a findings row. Prefers the
+ * per-finding UUID (`finding_id`) so the same CVE across multiple assets renders
+ * as distinct rows; falls back to `id` for legacy paths that merge per CVE.
+ */
+export function vulnRowKey(vuln: EnrichedVuln): string {
+  return vuln.finding_id ?? vuln.id;
 }

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -50,6 +50,10 @@ const nextConfig: NextConfig = {
           destination: `${API_URL}/health`,
         },
         {
+          source: "/version",
+          destination: `${API_URL}/version`,
+        },
+        {
           source: "/ws/:path*",
           destination: `${API_URL}/ws/:path*`,
         },

--- a/ui/tests/findings-page.test.tsx
+++ b/ui/tests/findings-page.test.tsx
@@ -142,4 +142,34 @@ describe("FindingsPage", () => {
       expect(screen.queryByRole("dialog", { name: "Finding details for CVE-2026-1234" })).not.toBeInTheDocument();
     });
   });
+
+  it("renders the same CVE across multiple assets as distinct rows with unique keys", async () => {
+    // Regression: rows were keyed by the CVE label, so one CVE affecting N
+    // assets collapsed to a single key — React warned and could drop rows.
+    // Each unified finding carries its own UUID, so keys must stay unique.
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    apiMock.listFindings.mockResolvedValue({
+      total: 3,
+      findings: [
+        { id: "uuid-1", severity: "high", cve_id: "CVE-2020-14343", title: "PyYAML RCE", asset: { name: "agent-alpha" } },
+        { id: "uuid-2", severity: "high", cve_id: "CVE-2020-14343", title: "PyYAML RCE", asset: { name: "agent-beta" } },
+        { id: "uuid-3", severity: "high", cve_id: "CVE-2020-14343", title: "PyYAML RCE", asset: { name: "agent-gamma" } },
+      ],
+    });
+
+    render(<FindingsPage />);
+
+    expect(await screen.findByText("Findings queue")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("button", { name: "Open details for CVE-2020-14343" }).length,
+      ).toBe(3);
+    });
+
+    const duplicateKeyWarning = consoleError.mock.calls.some((call) =>
+      String(call[0] ?? "").includes("same key"),
+    );
+    expect(duplicateKeyWarning).toBe(false);
+    consoleError.mockRestore();
+  });
 });

--- a/ui/tests/findings-view.test.ts
+++ b/ui/tests/findings-view.test.ts
@@ -5,6 +5,7 @@ import {
   findingStatusLabel,
   formatFindingTimestamp,
   hasLifecycleMetadata,
+  vulnRowKey,
   type EnrichedVuln,
 } from "@/lib/findings-view";
 
@@ -41,5 +42,21 @@ describe("findings lifecycle helpers", () => {
   it("detects lifecycle metadata on enriched rows", () => {
     expect(hasLifecycleMetadata([sampleVuln()])).toBe(false);
     expect(hasLifecycleMetadata([sampleVuln({ lifecycle_status: "open", last_seen: "2026-07-01T00:00:00Z" })])).toBe(true);
+  });
+});
+
+describe("vulnRowKey", () => {
+  it("prefers the unique per-finding id so the same CVE keeps distinct keys", () => {
+    // Same CVE label affecting two assets must yield two distinct row keys,
+    // otherwise React collapses/drops rows (regression: duplicate keys).
+    const a = sampleVuln({ id: "CVE-2020-14343", finding_id: "uuid-a" });
+    const b = sampleVuln({ id: "CVE-2020-14343", finding_id: "uuid-b" });
+    expect(vulnRowKey(a)).toBe("uuid-a");
+    expect(vulnRowKey(b)).toBe("uuid-b");
+    expect(vulnRowKey(a)).not.toBe(vulnRowKey(b));
+  });
+
+  it("falls back to the vulnerability id when no finding id is present", () => {
+    expect(vulnRowKey(sampleVuln({ id: "CVE-2026-0001" }))).toBe("CVE-2026-0001");
   });
 });

--- a/ui/tests/graph-diff-preview.test.tsx
+++ b/ui/tests/graph-diff-preview.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DiffPreview } from "@/app/graph/graph-page-client";
+import type { GraphDiffNode } from "@/lib/api-types";
+
+// graph-page-client pulls next/navigation at module scope; stub the hooks so the
+// import resolves even though DiffPreview itself never calls them.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  usePathname: () => "/graph",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+function node(overrides: Partial<GraphDiffNode>): GraphDiffNode {
+  return {
+    id: "node-1",
+    entity_type: "package",
+    label: "requests@2.0",
+    status: "active",
+    severity: "high",
+    severity_id: 3,
+    risk_score: 7.5,
+    change_kind: "new",
+    ...overrides,
+  };
+}
+
+describe("DiffPreview", () => {
+  it("renders rich node objects by label without throwing (was: objects as React child)", () => {
+    // Regression: /v1/graph/diff returns node OBJECTS for added/removed; the old
+    // type said string[] and rendered {item}, crashing the Lineage canvas with
+    // "Objects are not valid as a React child".
+    const nodes = [
+      node({ id: "a", label: "requests@2.0" }),
+      node({ id: "b", label: "flask@1.1" }),
+    ];
+    expect(() => render(<DiffPreview label="Added" items={nodes} />)).not.toThrow();
+    expect(screen.getByText("requests@2.0")).toBeInTheDocument();
+    expect(screen.getByText("flask@1.1")).toBeInTheDocument();
+  });
+
+  it("still renders bare node-id strings (the nodes_changed shape)", () => {
+    render(<DiffPreview label="Changed" items={["graph:node:xyz", "graph:node:abc"]} />);
+    expect(screen.getByText("graph:node:xyz")).toBeInTheDocument();
+    expect(screen.getByText("graph:node:abc")).toBeInTheDocument();
+  });
+
+  it("falls back to id when a node has no label", () => {
+    render(<DiffPreview label="Removed" items={[node({ id: "only-id", label: "" })]} />);
+    expect(screen.getByText("only-id")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes surfaced by a live UI dogfood for 0.94.3. Two flagship pages hard-crash (likely live on the demo). Surgical diffs; no app-wide theme rewrite.

## P0 — `/runtime` hard-crashes ("Invalid time value")
- **Repro:** `/v1/proxy/alerts` returns `ts` as an ISO-8601 **string** (backend `proxy.py` emits `datetime.now(timezone.utc).isoformat()`). `ProxyDashboard.tsx` did `new Date(alert.ts * 1000).toISOString()` → `string * 1000 = NaN` → `new Date(NaN).toISOString()` throws → the whole Runtime page (default proxy tab) dies whenever any alert exists (always in demo).
- **Fix:** use the existing `formatDate(alert.ts)` (ts is already ISO). Corrected `ProxyAlert.ts` type `number → string`, which also makes any future `alert.ts * 1000` a **compile-time error**. Confirmed this was the only numeric-timestamp assumption on that page (gateway tab's `last_seen_ts`/`timestamp` are genuine float epochs — left as-is).

## P0 — `/graph` Lineage canvas crashes ("Objects are not valid as a React child … change_kind")
- **Repro:** `/v1/graph/diff` returns node **objects** for `nodes_added`/`nodes_removed` (and bare id **strings** for `nodes_changed`), each tagged with `change_kind` by the route. The stale type `GraphDiffResponse.nodes_added/removed/changed: string[]` + `DiffPreview` rendering `{item}` crashed the Lineage lens and the security-graph Asset-Drift lens (both route through `DiffPreview`).
- **Fix:** new `GraphDiffNode` type reflecting the real backend shape (verified in `db/graph_store.py` + `api/postgres_graph.py` diff emitters + the `_tag_diff_change_kinds` route); `DiffPreview` renders `item.label` keyed by `item.id` and still handles the `nodes_changed` string entries.

## P1 — `/findings` duplicate React keys (rows dropped/duplicated)
- **Repro:** rows were keyed by `finding.cve_id || finding.title || finding.id`, so the same CVE across multiple assets collapsed to one key (React warns; e.g. CVE-2020-14343 rendered 3× under one key).
- **Fix:** carry the unique per-finding UUID as `finding_id` and key/select rows via a new `vulnRowKey` helper. The CVE stays the **display label / OSV link / triage id / CVE deep-link** (no triage/OSV regressions), only the React key + per-row selection move to the UUID.

## P2 (cheap, included)
- **Nav "Sign-in required" box** was near-invisible in light mode (`text-amber-300` on `bg-amber-950/20`) — now theme-aware.
- **`/help` "Version: unknown"** — `/version` wasn't in the Next rewrites (only `/v1/*`, `/health`, `/ws/*`). Added `/version` to the proxy rewrites (backend already serves it).
- **`/graph` empty-state** now distinguishes HTTP 429 backpressure ("temporarily rate-limited") from the genuine "run a scan first" case.

## P2 light-theme — worst offender only
- **`/compliance`** (a Proof-Path page) rendered its whole content area as a dark slab in light mode. Rethemed the page and its **inline** widgets (CIS benchmark detail, heatmap, matrix) from hardcoded `zinc-*`/dark hex to theme tokens, with light/dark treatments for the semantic status colors.
- **Follow-up (tracked):** completing light-theme across the other pages (agents / cost / identity / etc.) is out of scope for this PR.

## Tests
- `vulnRowKey` uniqueness + fallback (unit).
- Findings render test: the same CVE across 3 assets renders 3 distinct rows with no duplicate-key React error.
- `DiffPreview` object-render + string-render + label-fallback tests.

## Checks
- `npm run typecheck` — clean
- `npm run lint` — 0 errors (1 pre-existing warning in untouched `GatewayFeedPanel.tsx`)
- `npm test -- --run` — 351 passed (345 baseline + 6 new)