### PR TITLE
feat(ui): add top product bar with canonical agent-bom branding

### DIFF
--- a/ui/components/app-shell.tsx
+++ b/ui/components/app-shell.tsx
@@ -19,7 +19,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <DemoEstateLabel />
       <Nav />
       <AuthGate>
-        <main id="main-content" className="lg:pl-[240px] pt-14 lg:pt-0 min-h-screen transition-[padding-left] duration-200">
+        <main id="main-content" className="min-h-screen pt-14 transition-[padding-left] duration-200 lg:pl-[240px]">
           <div className="max-w-[1400px] mx-auto px-4 sm:px-6 lg:px-8 py-6">
             {children}
           </div>

--- a/ui/components/brand-logo.tsx
+++ b/ui/components/brand-logo.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useThemeMode } from "@/lib/theme-mode";
+
+type BrandLogoProps = {
+  className?: string;
+  showWordmark?: boolean;
+  markClassName?: string;
+  wordmarkClassName?: string;
+};
+
+/** Canonical mark + wordmark lockup from docs/images/brand (theme-aware). */
+export function BrandLogo({
+  className = "",
+  showWordmark = true,
+  markClassName = "h-8 w-8",
+  wordmarkClassName = "h-[22px] w-auto",
+}: BrandLogoProps) {
+  const theme = useThemeMode();
+
+  return (
+    <span className={`inline-flex min-w-0 items-center gap-2.5 ${className}`}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={`/brand/mark-${theme}.svg`}
+        alt=""
+        aria-hidden="true"
+        className={`${markClassName} shrink-0 object-contain`}
+      />
+      {showWordmark && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={`/brand/wordmark-${theme}.svg`}
+          alt="agent-bom"
+          className={`${wordmarkClassName} max-w-[9.5rem] shrink-0 object-contain object-left`}
+        />
+      )}
+    </span>
+  );
+}

--- a/ui/components/brand-mark.tsx
+++ b/ui/components/brand-mark.tsx
@@ -1,31 +1,18 @@
 "use client";
 
+import { useThemeMode } from "@/lib/theme-mode";
+
+/** Icon-only canonical mark (dashboard favicon-scale placements). */
 export function BrandMark({ className = "h-8 w-8" }: { className?: string }) {
+  const theme = useThemeMode();
+
   return (
-    <svg
-      viewBox="0 0 64 64"
-      role="img"
-      aria-label="agent-bom logo"
-      className={className}
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <rect x="2" y="2" width="60" height="60" rx="16" fill="url(#agent-bom-bg)" stroke="#124C3A" strokeWidth="2" />
-      <path
-        d="M32 14L44 19V28C44 38.5 38.4 46.4 32 50C25.6 46.4 20 38.5 20 28V19L32 14Z"
-        fill="#0C1713"
-        stroke="#19C37D"
-        strokeWidth="2.5"
-      />
-      <path d="M32 23V36" stroke="#19C37D" strokeWidth="2.5" strokeLinecap="round" />
-      <circle cx="32" cy="41" r="2.5" fill="#19C37D" />
-      <path d="M26.5 28H37.5" stroke="#19C37D" strokeWidth="2.5" strokeLinecap="round" />
-      <defs>
-        <linearGradient id="agent-bom-bg" x1="8" y1="6" x2="58" y2="58" gradientUnits="userSpaceOnUse">
-          <stop stopColor="#0D2A21" />
-          <stop offset="1" stopColor="#07110D" />
-        </linearGradient>
-      </defs>
-    </svg>
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={`/brand/mark-${theme}.svg`}
+      alt=""
+      aria-hidden="true"
+      className={`${className} object-contain`}
+    />
   );
 }

--- a/ui/components/demo-estate-label.tsx
+++ b/ui/components/demo-estate-label.tsx
@@ -19,7 +19,7 @@ export function DemoEstateLabel() {
     <div
       id="demo-estate-watermark"
       className={`pointer-events-none fixed z-[120] max-w-[min(18rem,calc(100vw-1.5rem))] truncate rounded-full border border-emerald-500/40 bg-[color:var(--surface-elevated)]/95 px-3 py-1 font-medium uppercase tracking-[0.1em] text-emerald-200 shadow-md shadow-black/20 ${
-        captureMode ? "right-5 top-3 text-[11px]" : "bottom-4 right-4 text-[11px]"
+        captureMode ? "right-5 top-16 text-[11px]" : "bottom-4 right-4 text-[11px]"
       }`}
       aria-hidden="true"
     >

--- a/ui/components/login-panel.tsx
+++ b/ui/components/login-panel.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { KeyRound, Loader2, ShieldCheck } from "lucide-react";
 
 import { useAuthState } from "@/components/auth-provider";
+import { BrandLogo } from "@/components/brand-logo";
 import { api } from "@/lib/api";
 import { userFacingApiErrorMessage } from "@/lib/api-errors";
 import { clearSessionApiKey } from "@/lib/auth";
@@ -89,8 +90,8 @@ export function LoginPanel({
       <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-10">
         <div className="w-full max-w-md rounded-3xl border border-zinc-800 bg-zinc-950/80 p-8 shadow-2xl shadow-black/20">
           <div className="mb-6 text-center">
-            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl border border-emerald-900/60 bg-emerald-950/30">
-              <ShieldCheck className="h-6 w-6 text-emerald-400" />
+            <div className="mx-auto mb-4 flex justify-center">
+              <BrandLogo />
             </div>
             <h1 className="text-xl font-semibold tracking-tight text-zinc-100">{title}</h1>
             <p className="mt-1 text-sm text-zinc-400">Enter your API key to access the dashboard.</p>

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -38,7 +38,7 @@ import {
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { useAuthState } from "@/components/auth-provider";
-import { BrandMark } from "@/components/brand-mark";
+import { BrandLogo } from "@/components/brand-logo";
 import { CommandPalette, type CommandPaletteAction } from "@/components/command-palette";
 import { DemoNavSignIn } from "@/components/demo-mode-cta";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -382,28 +382,19 @@ export function Nav() {
 
   const sidebarContent = (
     <>
-      {/* Logo */}
+      {/* Sidebar controls */}
       <div
         className={`border-b border-[color:var(--border-subtle)] ${
           collapsed
-            ? "flex h-20 flex-col items-center justify-center gap-2 px-2 py-2"
-            : "flex h-14 items-center justify-between px-4"
+            ? "flex h-11 items-center justify-center px-2"
+            : "flex h-11 items-center justify-between px-3"
         }`}
       >
-        <Link href="/" className="flex items-center gap-2.5 group min-w-0">
-          <BrandMark className="h-8 w-8 shrink-0 transition-transform duration-200 group-hover:scale-[1.03]" />
-          {!collapsed && (
-            <div className="min-w-0">
-              <span className="font-semibold text-sm text-[color:var(--foreground)] block truncate">agent-bom</span>
-              <span className="text-[10px] text-[color:var(--text-secondary)] font-mono block">AI Supply Chain</span>
-              {counts?.deployment_mode && (
-                <span className="mt-1 inline-flex rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2 py-0.5 text-[9px] font-mono uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
-                  {deploymentModeLabel(counts.deployment_mode)} Mode
-                </span>
-              )}
-            </div>
-          )}
-        </Link>
+        {!collapsed && (
+          <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">
+            Navigate
+          </span>
+        )}
         <button
           onClick={() => setCollapsed((value) => !value)}
           className="hidden rounded-md p-1.5 text-[color:var(--text-secondary)] transition-colors hover:bg-[color:var(--surface-elevated)] hover:text-[color:var(--foreground)] lg:flex"
@@ -760,42 +751,62 @@ export function Nav() {
 
   return (
     <>
+      {/* Product chrome — Snowflake-style top bar with canonical agent-bom lockup */}
+      <header className="fixed inset-x-0 top-0 z-[60] flex h-14 items-center gap-3 border-b border-[color:var(--border-subtle)] bg-[color:var(--surface)]/95 px-4 backdrop-blur-sm">
+        <Link href="/" className="group flex min-w-0 items-center transition-opacity hover:opacity-90">
+          <BrandLogo className="transition-transform duration-200 group-hover:scale-[1.01]" />
+        </Link>
+        {counts?.deployment_mode && (
+          <span className="hidden rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-0.5 text-[10px] font-mono uppercase tracking-[0.16em] text-[color:var(--text-tertiary)] sm:inline-flex">
+            {deploymentModeLabel(counts.deployment_mode)}
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            onClick={() => setSearchOpen(true)}
+            className="hidden items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-1.5 text-xs text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)] lg:flex"
+            title="Search pages (⌘K)"
+          >
+            <Search className="h-3.5 w-3.5" />
+            <span>Search</span>
+            <kbd className="ml-1 rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--text-secondary)]">
+              ⌘K
+            </kbd>
+          </button>
+          <ThemeToggle compact />
+          <ApiStatus collapsed={false} />
+          <button
+            onClick={() => setMobileOpen(!mobileOpen)}
+            className="rounded-lg p-2 text-[color:var(--text-secondary)] transition-colors hover:bg-[color:var(--surface-elevated)] hover:text-[color:var(--foreground)] lg:hidden"
+            aria-label={mobileOpen ? "Close navigation menu" : "Open navigation menu"}
+          >
+            {mobileOpen ? (
+              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            ) : (
+              <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            )}
+          </button>
+        </div>
+      </header>
+
       {/* Desktop Sidebar */}
       <aside
-        className={`hidden lg:flex flex-col fixed left-0 top-0 bottom-0 z-40 bg-[color:var(--surface)] border-r border-[color:var(--border-subtle)] transition-[width] duration-200 ${
+        className={`hidden lg:flex flex-col fixed left-0 top-14 bottom-0 z-40 bg-[color:var(--surface)] border-r border-[color:var(--border-subtle)] transition-[width] duration-200 ${
           collapsed ? "w-[60px]" : "w-[240px]"
         }`}
       >
         {sidebarContent}
       </aside>
 
-      {/* Mobile Top Bar */}
-      <div className="lg:hidden fixed top-0 left-0 right-0 z-50 h-14 bg-[color:var(--surface)] backdrop-blur-sm border-b border-[color:var(--border-subtle)] flex items-center justify-between px-4">
-        <Link href="/" className="flex items-center gap-2 group">
-          <BrandMark className="h-7 w-7" />
-          <span className="font-semibold text-sm text-[color:var(--foreground)]">agent-bom</span>
-        </Link>
-        <div className="flex items-center gap-2">
-          <ThemeToggle compact />
-          <ApiStatus collapsed={false} />
-          <button
-            onClick={() => setMobileOpen(!mobileOpen)}
-            className="p-2 rounded-lg text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] hover:bg-[color:var(--surface-elevated)] transition-colors"
-          >
-            {mobileOpen ? (
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" /></svg>
-            ) : (
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" /></svg>
-            )}
-          </button>
-        </div>
-      </div>
-
       {/* Mobile Drawer Overlay */}
       {mobileOpen && (
         <>
           <div className="lg:hidden fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" onClick={() => setMobileOpen(false)} />
-          <aside className="lg:hidden fixed left-0 top-0 bottom-0 z-50 w-[260px] bg-[color:var(--surface)] border-r border-[color:var(--border-subtle)] flex flex-col animate-slide-in">
+          <aside className="lg:hidden fixed left-0 top-14 bottom-0 z-50 w-[260px] bg-[color:var(--surface)] border-r border-[color:var(--border-subtle)] flex flex-col animate-slide-in">
             {sidebarContent}
           </aside>
         </>

--- a/ui/components/theme-toggle.tsx
+++ b/ui/components/theme-toggle.tsx
@@ -3,20 +3,14 @@
 import { Moon, Sun } from "lucide-react";
 import { useSyncExternalStore } from "react";
 
+import {
+  getThemeModeServerSnapshot,
+  readThemeMode,
+  subscribeThemeMode,
+  type ThemeMode,
+} from "@/lib/theme-mode";
+
 const THEME_STORAGE_KEY = "agent-bom-theme";
-
-type ThemeMode = "dark" | "light";
-
-function readTheme(): ThemeMode {
-  if (typeof window === "undefined") return "dark";
-  try {
-    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
-    if (stored === "light" || stored === "dark") return stored;
-  } catch {
-    // Ignore storage failures and fall back to the current root theme.
-  }
-  return document.documentElement.dataset.theme === "light" ? "light" : "dark";
-}
 
 function applyTheme(theme: ThemeMode) {
   const root = document.documentElement;
@@ -31,22 +25,15 @@ function applyTheme(theme: ThemeMode) {
 }
 
 function subscribe(onChange: () => void) {
-  if (typeof window === "undefined") return () => {};
-  const handleChange = () => onChange();
-  window.addEventListener("storage", handleChange);
-  window.addEventListener("agent-bom-theme-change", handleChange);
-  return () => {
-    window.removeEventListener("storage", handleChange);
-    window.removeEventListener("agent-bom-theme-change", handleChange);
-  };
+  return subscribeThemeMode(onChange);
 }
 
 function getServerSnapshot(): ThemeMode {
-  return "dark";
+  return getThemeModeServerSnapshot();
 }
 
 export function ThemeToggle({ compact = false, className = "" }: { compact?: boolean; className?: string }) {
-  const theme = useSyncExternalStore(subscribe, readTheme, getServerSnapshot);
+  const theme = useSyncExternalStore(subscribe, readThemeMode, getServerSnapshot);
 
   const nextTheme = theme === "dark" ? "light" : "dark";
   const label = theme === "dark" ? "Switch to light theme" : "Switch to dark theme";

--- a/ui/lib/theme-mode.ts
+++ b/ui/lib/theme-mode.ts
@@ -1,0 +1,35 @@
+import { useSyncExternalStore } from "react";
+
+const THEME_STORAGE_KEY = "agent-bom-theme";
+
+export type ThemeMode = "dark" | "light";
+
+export function readThemeMode(): ThemeMode {
+  if (typeof window === "undefined") return "dark";
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === "light" || stored === "dark") return stored;
+  } catch {
+    // Ignore storage failures and fall back to the current root theme.
+  }
+  return document.documentElement.dataset.theme === "light" ? "light" : "dark";
+}
+
+export function subscribeThemeMode(onChange: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const handleChange = () => onChange();
+  window.addEventListener("storage", handleChange);
+  window.addEventListener("agent-bom-theme-change", handleChange);
+  return () => {
+    window.removeEventListener("storage", handleChange);
+    window.removeEventListener("agent-bom-theme-change", handleChange);
+  };
+}
+
+export function getThemeModeServerSnapshot(): ThemeMode {
+  return "dark";
+}
+
+export function useThemeMode(): ThemeMode {
+  return useSyncExternalStore(subscribeThemeMode, readThemeMode, getThemeModeServerSnapshot);
+}

--- a/ui/public/brand/mark-dark.svg
+++ b/ui/public/brand/mark-dark.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark">
+  <defs>
+    <linearGradient id="abm" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <path d="M32 6 L54 14 V30 C54 43 44 53 32 58 C20 53 10 43 10 30 V14 Z"
+        fill="url(#abm)" fill-opacity="0.16" stroke="url(#abm)" stroke-width="2.5" stroke-linejoin="round"/>
+  <g stroke="url(#abm)" stroke-width="2" stroke-linecap="round">
+    <line x1="32" y1="23" x2="22" y2="39"/>
+    <line x1="32" y1="23" x2="42" y2="39"/>
+    <line x1="22" y1="39" x2="42" y2="39"/>
+  </g>
+  <circle cx="32" cy="23" r="4" fill="url(#abm)"/>
+  <circle cx="22" cy="39" r="3.4" fill="url(#abm)" fill-opacity="0.5" stroke="url(#abm)" stroke-width="1.5"/>
+  <circle cx="42" cy="39" r="3.4" fill="url(#abm)" fill-opacity="0.5" stroke="url(#abm)" stroke-width="1.5"/>
+</svg>

--- a/ui/public/brand/mark-light.svg
+++ b/ui/public/brand/mark-light.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark">
+  <defs>
+    <linearGradient id="abm" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2563eb"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+  </defs>
+  <path d="M32 6 L54 14 V30 C54 43 44 53 32 58 C20 53 10 43 10 30 V14 Z"
+        fill="url(#abm)" fill-opacity="0.10" stroke="url(#abm)" stroke-width="2.5" stroke-linejoin="round"/>
+  <g stroke="url(#abm)" stroke-width="2" stroke-linecap="round">
+    <line x1="32" y1="23" x2="22" y2="39"/>
+    <line x1="32" y1="23" x2="42" y2="39"/>
+    <line x1="22" y1="39" x2="42" y2="39"/>
+  </g>
+  <circle cx="32" cy="23" r="4" fill="url(#abm)"/>
+  <circle cx="22" cy="39" r="3.4" fill="url(#abm)" fill-opacity="0.45" stroke="url(#abm)" stroke-width="1.5"/>
+  <circle cx="42" cy="39" r="3.4" fill="url(#abm)" fill-opacity="0.45" stroke="url(#abm)" stroke-width="1.5"/>
+</svg>

--- a/ui/public/brand/wordmark-dark.svg
+++ b/ui/public/brand/wordmark-dark.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 56" fill="none" role="img" aria-label="agent-bom">
+  <defs>
+    <linearGradient id="abw" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="100%" stop-color="#a78bfa"/>
+    </linearGradient>
+  </defs>
+  <text x="4" y="40" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="38" font-weight="800" letter-spacing="-0.5" fill="#e6edf3">agent<tspan fill="url(#abw)">-bom</tspan></text>
+</svg>

--- a/ui/public/brand/wordmark-light.svg
+++ b/ui/public/brand/wordmark-light.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 56" fill="none" role="img" aria-label="agent-bom">
+  <defs>
+    <linearGradient id="abw" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#2563eb"/>
+      <stop offset="100%" stop-color="#7c3aed"/>
+    </linearGradient>
+  </defs>
+  <text x="4" y="40" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="38" font-weight="800" letter-spacing="-0.5" fill="#1f2937">agent<tspan fill="url(#abw)">-bom</tspan></text>
+</svg>

--- a/ui/tests/brand-logo.test.tsx
+++ b/ui/tests/brand-logo.test.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BrandLogo } from "@/components/brand-logo";
+
+vi.mock("@/lib/theme-mode", () => ({
+  useThemeMode: () => "dark",
+}));
+
+describe("BrandLogo", () => {
+  it("renders canonical mark and wordmark assets for the active theme", () => {
+    const { container } = render(<BrandLogo />);
+    const images = container.querySelectorAll("img");
+    expect(images).toHaveLength(2);
+    expect(images[0]?.getAttribute("src")).toBe("/brand/mark-dark.svg");
+    expect(images[1]?.getAttribute("src")).toBe("/brand/wordmark-dark.svg");
+    expect(images[1]).toHaveAttribute("alt", "agent-bom");
+  });
+
+  it("can hide the wordmark for compact placements", () => {
+    const { container } = render(<BrandLogo showWordmark={false} />);
+    const images = container.querySelectorAll("img");
+    expect(images).toHaveLength(1);
+    expect(images[0]).toHaveAttribute("src", "/brand/mark-dark.svg");
+  });
+});

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -212,9 +212,10 @@ describe('Nav', () => {
     expect(within(palette).getByRole('link', { name: /context lens/i })).toHaveAttribute('href', '/context')
   })
 
-  it('renders the agent-bom brand text', () => {
-    render(<Nav />)
-    expect(screen.getAllByText('agent-bom').length).toBeGreaterThan(0)
+  it('renders the canonical agent-bom brand lockup in the top bar', () => {
+    const { container } = render(<Nav />)
+    const wordmark = container.querySelector('img[alt="agent-bom"]')
+    expect(wordmark).toHaveAttribute('src', '/brand/wordmark-dark.svg')
   })
 
   it('renders all 7 nav group labels', () => {


### PR DESCRIPTION
## Summary
- Ship canonical brand assets under `ui/public/brand/` (mark + wordmark, light/dark).
- Add `BrandLogo` lockup and a fixed top product bar on desktop and mobile (mark + `agent-bom` wordmark left; search/theme/health right).
- Remove duplicate sidebar logo block; sidebar is navigation-only below the top bar.
- Use the same lockup on the login screen.

## Verification
- `cd ui && npm run lint`
- `cd ui && npm run typecheck`
- `cd ui && npm test -- --run tests/brand-logo.test.tsx tests/nav.test.tsx`
- `cd ui && npm run build`
- `cd ui && npm run bundle:check`

## Notes
- `cd ui && npm run verify:toolchain` was not run locally because this machine has Node 25.9.0 while the project requires `>=22 <25`; CI runs the canonical Node 24 toolchain.
