### PR TITLE
fix(ui): posture nav, scan targets, and security-graph polish

### DIFF
--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -316,8 +316,8 @@ function SecurityGraphPageContent() {
   }, [graphLoadError]);
 
   const loadingGraphMessage = focusLabel
-    ? `Loading attack-path candidates for ${focusLabel} from the persisted graph.`
-    : "Loading attack-path candidates from the persisted graph.";
+    ? `Loading paths for ${focusLabel}…`
+    : "Loading exposure paths…";
 
   useEffect(() => {
     setFocusApplied(false);
@@ -379,7 +379,9 @@ function SecurityGraphPageContent() {
       <header className="flex flex-wrap items-start justify-between gap-4">
         <div className="min-w-0">
           <h1 className="text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">Security graph</h1>
-          <p className="mt-1 text-sm text-[color:var(--text-secondary)]">Ranked attack paths from persisted graph evidence.</p>
+          <p className="mt-1 text-sm text-[color:var(--text-secondary)]">
+            Ranked exposure paths from your latest graph snapshot.
+          </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <GraphEvidenceExportButton
@@ -407,7 +409,7 @@ function SecurityGraphPageContent() {
 
       {selectedExposurePath && (
         <section className="overflow-hidden rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]">
-          <ExposurePathStrip path={selectedExposurePath} />
+          <ExposurePathStrip path={selectedExposurePath} showTitle={false} />
           <div className="p-4">
             <ExposurePathCommandCenter
               path={selectedExposurePath}
@@ -418,29 +420,47 @@ function SecurityGraphPageContent() {
       )}
 
       <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
-        <div className="grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_220px]">
-          <div>
-            <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-3">
               <div>
                 <p className="text-[11px] uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">Snapshot</p>
                 <h2 className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">
-                  {selectedSnapshot ? `Scan ${selectedSnapshot.scan_id.slice(0, 8)}…` : "No persisted graph snapshot yet"}
+                  {selectedSnapshot ? `Scan ${selectedSnapshot.scan_id.slice(0, 8)}…` : "No graph snapshot yet"}
                 </h2>
                 {selectedSnapshot && (
                   <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
-                    Persisted {formatDate(selectedSnapshot.created_at)} · {selectedSnapshot.node_count} nodes · {selectedSnapshot.edge_count} edges
+                    {formatDate(selectedSnapshot.created_at)} · {selectedSnapshot.node_count} nodes · {selectedSnapshot.edge_count} edges
                   </p>
                 )}
               </div>
-              {loadingSnapshots && (
-                <span className="inline-flex items-center gap-2 text-xs text-sky-400">
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  loading snapshots
-                </span>
+              {posture && (
+                <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2">
+                  <p className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">Posture</p>
+                  <div className="mt-1 flex items-baseline gap-2">
+                    <span className="font-mono text-xl font-semibold text-red-300">{posture.grade}</span>
+                    <span className="font-mono text-sm text-[color:var(--foreground)]">{posture.score}</span>
+                  </div>
+                </div>
               )}
             </div>
+            {loadingSnapshots && (
+              <span className="mt-2 inline-flex items-center gap-2 text-xs text-sky-400">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                loading snapshots
+              </span>
+            )}
+          </div>
+          {fixFirstView && (
+            <div className="flex flex-wrap gap-2 text-xs">
+              <QuickStat label="Matched paths" value={String(fixFirstView.summary.matched_paths)} tone="blue" />
+              <QuickStat label="Covered findings" value={String(fixFirstView.summary.covered_findings)} tone="amber" />
+              <QuickStat label="Highest risk" value={fixFirstView.summary.highest_risk.toFixed(1)} tone="red" />
+            </div>
+          )}
+        </div>
 
-            {snapshots.length > 0 ? (
+        {snapshots.length > 0 ? (
               <>
                 <div className="mt-4 flex flex-wrap gap-2">
                   {displayedSnapshots.map((snapshot) => {
@@ -489,37 +509,6 @@ function SecurityGraphPageContent() {
               )
             )}
 
-            {fixFirstView && (
-              <div className="mt-4 grid gap-3 border-t border-[color:var(--border-subtle)] pt-4 sm:grid-cols-3">
-                <QuickStat label="Matched paths" value={String(fixFirstView.summary.matched_paths)} tone="blue" />
-                <QuickStat label="Covered findings" value={String(fixFirstView.summary.covered_findings)} tone="amber" />
-                <QuickStat label="Highest risk" value={fixFirstView.summary.highest_risk.toFixed(1)} tone="red" />
-              </div>
-            )}
-          </div>
-
-          <div>
-            <p className="text-[11px] uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">Posture</p>
-            {posture ? (
-              <div className="mt-3">
-                <div className="flex items-baseline gap-3">
-                  <div className="font-mono text-3xl font-semibold text-red-300">{posture.grade}</div>
-                  <div className="font-mono text-lg text-[color:var(--foreground)]">{posture.score}</div>
-                </div>
-                <p className="mt-2 line-clamp-2 text-xs text-[color:var(--text-tertiary)]">{posture.summary}</p>
-                <Link
-                  href="/insights"
-                  className="mt-3 inline-flex items-center gap-1 text-xs text-[color:var(--text-secondary)] transition hover:text-[color:var(--foreground)]"
-                >
-                  Details
-                  <ArrowRight className="h-3 w-3" />
-                </Link>
-              </div>
-            ) : (
-              <div className="mt-3 text-sm text-[color:var(--text-secondary)]">Unavailable for this snapshot.</div>
-            )}
-          </div>
-        </div>
       </section>
 
       {loadingGraph ? (

--- a/ui/components/exposure-path-strip.tsx
+++ b/ui/components/exposure-path-strip.tsx
@@ -7,23 +7,32 @@ export function ExposurePathStrip({
   active = false,
   actionLabel,
   onAction,
+  showTitle = true,
 }: {
   path: ExposurePath;
   active?: boolean;
   actionLabel?: string | undefined;
   onAction?: (() => void) | undefined;
+  showTitle?: boolean;
 }) {
   return (
     <div className="flex flex-wrap items-center gap-2 border-b border-[var(--border-subtle)] bg-red-950/15 px-4 py-2 text-sm">
       <span className="shrink-0 rounded border border-red-500/40 bg-red-500/10 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-red-200">
         {path.severity}
       </span>
-      <span
-        className="min-w-0 flex-1 truncate font-medium text-[var(--foreground)]"
-        title={path.label}
-      >
-        {pathDisplayTitle(path)}
-      </span>
+      {typeof path.riskScore === "number" && Number.isFinite(path.riskScore) && (
+        <span className="shrink-0 rounded border border-orange-500/30 bg-orange-500/10 px-2 py-0.5 font-mono text-[11px] text-orange-200">
+          risk {path.riskScore.toFixed(1)}
+        </span>
+      )}
+      {showTitle ? (
+        <span
+          className="min-w-0 flex-1 truncate font-medium text-[var(--foreground)]"
+          title={path.label}
+        >
+          {pathDisplayTitle(path)}
+        </span>
+      ) : null}
       {onAction && actionLabel && (
         <button
           type="button"

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -66,7 +66,7 @@ interface NavGroup {
   icon: React.ElementType;
   links: NavLink[];
   /**
-   * Graph lens destinations grouped under Command with an explicit subheader
+   * Graph lens destinations grouped under Posture with an explicit subheader
    * (not a generic "More" bucket).
    */
   secondary?: NavLink[];
@@ -83,7 +83,7 @@ function activeGroupForPath(path: string | null): string {
 
 const NAV_GROUPS: NavGroup[] = [
   {
-    label: "Command",
+    label: "Posture",
     icon: LayoutGrid,
     links: [
       { href: "/", label: "Overview", icon: LayoutGrid },
@@ -181,7 +181,7 @@ const NAV_LINK_ICON_CLASS: Record<string, string> = {
 };
 
 const NAV_GROUP_ICON_CLASS: Record<string, string> = {
-  Command: "text-sky-400",
+  Posture: "text-sky-400",
   "AI inventory": "text-emerald-400",
   "Cloud & Data": "text-purple-400",
   Runtime: "text-pink-400",
@@ -745,7 +745,10 @@ export function Nav() {
           />
         </Link>
         {counts?.deployment_mode && (
-          <span className="hidden rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-0.5 text-[10px] font-mono uppercase tracking-[0.16em] text-[color:var(--text-tertiary)] sm:inline-flex">
+          <span
+            className="hidden rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-0.5 text-[10px] font-mono uppercase tracking-[0.16em] text-[color:var(--text-tertiary)] sm:inline-flex"
+            title={`${deploymentModeLabel(counts.deployment_mode)} deployment — evidence scope for this control plane`}
+          >
             {deploymentModeLabel(counts.deployment_mode)}
           </span>
         )}
@@ -966,7 +969,7 @@ function ApiStatus({ collapsed }: { collapsed: boolean }) {
   if (collapsed) {
     return (
       <div className="flex justify-center">
-        <span className={`w-2 h-2 rounded-full ${dotColor}`} title={status === "online" ? `API ${version}` : status} />
+        <span className={`w-2 h-2 rounded-full ${dotColor}`} title={status === "online" ? `Control plane online · v${version}` : status} />
       </div>
     );
   }
@@ -975,7 +978,7 @@ function ApiStatus({ collapsed }: { collapsed: boolean }) {
     <div className="flex items-center gap-2 px-2 py-1.5 rounded-lg text-xs text-[color:var(--text-secondary)]">
       <span className={`w-1.5 h-1.5 rounded-full ${dotColor} shrink-0`} />
       <span className="truncate">
-        {status === "online" ? `API ${version}` : status === "offline" ? "API Offline" : "Connecting..."}
+        {status === "online" ? `Control plane · v${version}` : status === "offline" ? "Control plane offline" : "Connecting…"}
       </span>
     </div>
   );

--- a/ui/components/scan-form.tsx
+++ b/ui/components/scan-form.tsx
@@ -1,17 +1,36 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { api, type ScanRequest } from "@/lib/api";
-import { ArrowRight, ChevronDown, Loader2, Plus, Upload, X } from "lucide-react";
+import {
+  ArrowRight,
+  Bot,
+  ChevronDown,
+  Cloud,
+  Container,
+  Loader2,
+  Plus,
+  Server,
+  Upload,
+  X,
+} from "lucide-react";
 
-// ─── Scan Form ──────────────────────────────────────────────────────────────
+import { useDeploymentContext } from "@/hooks/use-deployment-context";
+import { api, type ScanRequest } from "@/lib/api";
+import { deploymentModeLabel } from "@/lib/deployment-context";
+
+type ScanTarget = "cloud" | "workstation" | "containers" | "kubernetes";
 
 export function ScanForm() {
   const router = useRouter();
+  const { counts } = useDeploymentContext();
+  const deploymentMode = counts?.deployment_mode ?? "local";
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [target, setTarget] = useState<ScanTarget>(
+    deploymentMode === "local" ? "workstation" : "cloud",
+  );
   const [form, setForm] = useState<ScanRequest>({
     enrich: false,
     k8s: false,
@@ -20,11 +39,26 @@ export function ScanForm() {
     agent_projects: [],
   });
   const [imageInput, setImageInput] = useState("");
-  const [imageMode, setImageMode] = useState<"single" | "bulk" | "upload">("single");
+  const [showBulkImages, setShowBulkImages] = useState(false);
   const [bulkText, setBulkText] = useState("");
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [tfInput, setTfInput] = useState("");
   const [apInput, setApInput] = useState("");
+
+  const deploymentLabel = deploymentModeLabel(deploymentMode);
+  const deploymentHint = useMemo(() => {
+    switch (deploymentMode) {
+      case "fleet":
+        return "Fleet control plane — connect cloud accounts for continuous coverage, or run ad-hoc workstation scans.";
+      case "cluster":
+        return "Cluster control plane — prioritize Kubernetes and connected cloud accounts.";
+      case "hybrid":
+        return "Hybrid deployment — cloud connectors plus workstation and cluster scans share one graph.";
+      case "local":
+      default:
+        return "Local control plane — scans run on this machine against paths and kube context you provide.";
+    }
+  }, [deploymentMode]);
 
   function addToList(key: "images" | "tf_dirs" | "agent_projects", value: string, reset: () => void) {
     if (!value.trim()) return;
@@ -79,52 +113,114 @@ export function ScanForm() {
 
   return (
     <div className="max-w-5xl">
-      <header className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <header className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
-          <h1 className="text-2xl font-semibold tracking-tight text-zinc-100">New Scan</h1>
-          <p className="mt-1 max-w-2xl text-sm text-zinc-400">
-            Run a direct scan job. Local MCP configs are included automatically.
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">New Scan</h1>
+            <span className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-0.5 text-[10px] font-mono uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">
+              {deploymentLabel}
+            </span>
+          </div>
+          <p className="mt-1 max-w-2xl text-sm text-[color:var(--text-secondary)]">
+            Choose a scan target. Cloud connectors run continuously; direct scans are for ad-hoc evidence on this control plane.
           </p>
-          <nav aria-label="Related scan surfaces" className="mt-3 flex flex-wrap items-center gap-x-1 gap-y-1 text-xs text-zinc-500">
+          <nav aria-label="Related scan surfaces" className="mt-3 flex flex-wrap items-center gap-x-1 gap-y-1 text-xs text-[color:var(--text-tertiary)]">
             <RelatedLink href="/sources">Data sources</RelatedLink>
             <span aria-hidden="true">·</span>
-            <RelatedLink href="/governance">Governance</RelatedLink>
-            <span aria-hidden="true">·</span>
-            <RelatedLink href="/traces">Traces</RelatedLink>
+            <RelatedLink href="/connections">Cloud accounts</RelatedLink>
             <span aria-hidden="true">·</span>
             <RelatedLink href="/jobs">Scan jobs</RelatedLink>
           </nav>
         </div>
         <Link
-          href="/sources"
-          className="inline-flex shrink-0 items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm font-medium text-zinc-200 transition-colors hover:border-zinc-600 hover:bg-zinc-800"
+          href="/connections"
+          className="inline-flex shrink-0 items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-sm font-medium text-[color:var(--foreground)] transition-colors hover:border-[color:var(--border-strong)]"
         >
-          Connect source
+          Connect cloud account
           <ArrowRight className="h-4 w-4" />
         </Link>
       </header>
 
+      <div className="mb-5 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3 text-sm text-[color:var(--text-secondary)]">
+        <span className="font-medium text-[color:var(--foreground)]">{deploymentLabel} control plane.</span>{" "}
+        {deploymentHint}
+      </div>
+
+      <div className="mb-5 flex flex-wrap gap-2">
+        {(
+          [
+            { id: "cloud" as const, label: "Cloud accounts", icon: Cloud, hint: "AWS · Azure · GCP connectors" },
+            { id: "workstation" as const, label: "Workstation", icon: Bot, hint: "Agent projects on this machine" },
+            { id: "containers" as const, label: "Containers", icon: Container, hint: "OCI images and registries" },
+            { id: "kubernetes" as const, label: "Kubernetes", icon: Server, hint: "Pods in current kube context" },
+          ] as const
+        ).map((option) => {
+          const Icon = option.icon;
+          const active = target === option.id;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => setTarget(option.id)}
+              className={`min-w-[9.5rem] rounded-xl border px-3 py-2.5 text-left transition ${
+                active
+                  ? "border-emerald-600/50 bg-emerald-500/10 text-[color:var(--foreground)]"
+                  : "border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)]"
+              }`}
+            >
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <Icon className="h-4 w-4 shrink-0" />
+                {option.label}
+              </div>
+              <p className="mt-1 text-[11px] text-[color:var(--text-tertiary)]">{option.hint}</p>
+            </button>
+          );
+        })}
+      </div>
+
       <form onSubmit={handleSubmit} className="grid gap-5 lg:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)] lg:items-start">
         <div className="space-y-5">
-          <Section title="Docker images">
-            <div className="mb-3 flex flex-wrap items-center gap-1">
-              {(["single", "bulk", "upload"] as const).map((mode) => (
-                <button
-                  key={mode}
-                  type="button"
-                  onClick={() => setImageMode(mode)}
-                  className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-                    imageMode === mode
-                      ? "bg-zinc-700 text-zinc-100"
-                      : "text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200"
-                  }`}
+          {target === "cloud" && (
+            <Section title="Cloud account scan">
+              <p className="text-sm text-[color:var(--text-secondary)]">
+                Connect a cloud account once, then schedule recurring inventory and posture scans from the control plane.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Link
+                  href="/connections"
+                  className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-emerald-500"
                 >
-                  {mode === "single" ? "One at a time" : mode === "bulk" ? "Bulk paste" : "Upload .txt"}
-                </button>
-              ))}
-            </div>
+                  Open cloud accounts
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+                <Link
+                  href="/sources"
+                  className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] px-4 py-2 text-sm text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+                >
+                  Register data source
+                </Link>
+              </div>
+            </Section>
+          )}
 
-            {imageMode === "single" && (
+          {target === "workstation" && (
+            <Section title="Python agent projects">
+              <p className="mb-3 text-xs text-[color:var(--text-tertiary)]">
+                Scan LangChain, CrewAI, or custom agent repos on this workstation. MCP configs in the project are discovered automatically.
+              </p>
+              <ListInput
+                placeholder="/path/to/my-langchain-app"
+                value={apInput}
+                onChange={setApInput}
+                onAdd={() => addToList("agent_projects", apInput, () => setApInput(""))}
+                items={form.agent_projects ?? []}
+                onRemove={(i) => removeFromList("agent_projects", i)}
+              />
+            </Section>
+          )}
+
+          {target === "containers" && (
+            <Section title="Container images">
               <ListInput
                 placeholder="nginx:1.25 or ghcr.io/org/app:v1"
                 value={imageInput}
@@ -133,104 +229,107 @@ export function ScanForm() {
                 items={[]}
                 onRemove={() => {}}
               />
-            )}
+              <button
+                type="button"
+                onClick={() => setShowBulkImages((current) => !current)}
+                className="mt-3 inline-flex items-center gap-1.5 text-xs text-[color:var(--text-secondary)] transition hover:text-[color:var(--foreground)]"
+              >
+                <ChevronDown className={`h-3.5 w-3.5 transition-transform ${showBulkImages ? "rotate-180" : ""}`} />
+                Add multiple images
+              </button>
+              {showBulkImages && (
+                <div className="mt-3 space-y-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3">
+                  <textarea
+                    placeholder={"# One image per line\nnginx:1.25\nredis:7-alpine"}
+                    value={bulkText}
+                    onChange={(e) => setBulkText(e.target.value)}
+                    rows={4}
+                    className="w-full resize-y rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 font-mono text-sm text-[color:var(--foreground)] placeholder:text-[color:var(--text-tertiary)] focus:border-emerald-600 focus:outline-none"
+                  />
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={applyBulk}
+                      disabled={!bulkText.trim()}
+                      className="flex items-center gap-1.5 rounded-lg bg-emerald-700 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      Add {parseBulkImages(bulkText).length || 0} image{parseBulkImages(bulkText).length !== 1 ? "s" : ""}
+                    </button>
+                    <input ref={fileInputRef} type="file" accept=".txt,.csv,.list" onChange={handleFileUpload} className="hidden" />
+                    <button
+                      type="button"
+                      onClick={() => fileInputRef.current?.click()}
+                      className="flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] px-3 py-1.5 text-xs text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)]"
+                    >
+                      <Upload className="h-3.5 w-3.5" />
+                      Import list file
+                    </button>
+                  </div>
+                </div>
+              )}
+              {queuedImages.length > 0 && (
+                <div className="mt-3 space-y-1.5">
+                  <div className="text-xs font-medium text-[color:var(--text-tertiary)]">
+                    {queuedImages.length} image{queuedImages.length !== 1 ? "s" : ""} queued
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {queuedImages.map((item, i) => (
+                      <span key={i} className="flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1 font-mono text-xs text-[color:var(--foreground)]">
+                        {item}
+                        <button type="button" onClick={() => removeFromList("images", i)}>
+                          <X className="h-3 w-3 text-[color:var(--text-tertiary)] hover:text-[color:var(--foreground)]" />
+                        </button>
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </Section>
+          )}
 
-            {imageMode === "bulk" && (
-              <div className="space-y-2">
-                <textarea
-                  placeholder={"# One image per line\nnginx:1.25\nredis:7-alpine\nghcr.io/org/app:latest"}
-                  value={bulkText}
-                  onChange={(e) => setBulkText(e.target.value)}
-                  rows={4}
-                  className="w-full resize-y rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 font-mono text-sm text-zinc-200 placeholder:text-zinc-600 focus:border-emerald-600 focus:outline-none"
+          {target === "kubernetes" && (
+            <Section title="Kubernetes cluster">
+              <label className="flex cursor-pointer items-center gap-2">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-emerald-500"
+                  checked={form.k8s ?? false}
+                  onChange={(e) => setForm((f) => ({ ...f, k8s: e.target.checked }))}
                 />
-                <button
-                  type="button"
-                  onClick={applyBulk}
-                  disabled={!bulkText.trim()}
-                  className="flex items-center gap-1.5 rounded-lg bg-emerald-700 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  <Plus className="h-3.5 w-3.5" />
-                  Add {parseBulkImages(bulkText).length || 0} image{parseBulkImages(bulkText).length !== 1 ? "s" : ""}
-                </button>
-              </div>
-            )}
-
-            {imageMode === "upload" && (
-              <div className="space-y-2">
-                <input ref={fileInputRef} type="file" accept=".txt,.csv,.list" onChange={handleFileUpload} className="hidden" />
-                <button
-                  type="button"
-                  onClick={() => fileInputRef.current?.click()}
-                  className="flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-zinc-600 bg-zinc-800 px-4 py-3 text-sm text-zinc-300 transition-colors hover:bg-zinc-700"
-                >
-                  <Upload className="h-4 w-4" />
-                  Choose .txt file
-                </button>
-              </div>
-            )}
-
-            {queuedImages.length > 0 && (
-              <div className="mt-3 space-y-1.5">
-                <div className="text-xs font-medium text-zinc-500">
-                  {queuedImages.length} image{queuedImages.length !== 1 ? "s" : ""} queued
+                <span className="text-sm text-[color:var(--foreground)]">Scan running pods via current kubectl context</span>
+              </label>
+              {form.k8s && (
+                <div className="mt-3 space-y-1.5">
+                  <label htmlFor="k8s-namespace-filter" className="text-xs font-medium text-[color:var(--text-secondary)]">
+                    Namespace filter
+                  </label>
+                  <input
+                    id="k8s-namespace-filter"
+                    type="text"
+                    placeholder="All namespaces"
+                    className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 text-sm text-[color:var(--foreground)] focus:border-emerald-600 focus:outline-none"
+                    value={form.k8s_namespace ?? ""}
+                    onChange={(e) => setForm((f) => ({ ...f, k8s_namespace: e.target.value || undefined }))}
+                  />
+                  <p className="text-xs text-[color:var(--text-tertiary)]">
+                    Leave blank to scan every namespace visible in your current kube context. Enter one namespace name to limit scope.
+                  </p>
                 </div>
-                <div className="flex flex-wrap gap-2">
-                  {queuedImages.map((item, i) => (
-                    <span key={i} className="flex items-center gap-1.5 rounded-lg border border-zinc-700 bg-zinc-800 px-2.5 py-1 font-mono text-xs text-zinc-300">
-                      {item}
-                      <button type="button" onClick={() => removeFromList("images", i)}>
-                        <X className="h-3 w-3 text-zinc-500 hover:text-zinc-300" />
-                      </button>
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-          </Section>
-
-          <Section title="Kubernetes cluster">
-            <label className="flex cursor-pointer items-center gap-2">
-              <input
-                type="checkbox"
-                className="h-4 w-4 rounded border-zinc-700 bg-zinc-900 text-emerald-500"
-                checked={form.k8s ?? false}
-                onChange={(e) => setForm((f) => ({ ...f, k8s: e.target.checked }))}
-              />
-              <span className="text-sm text-zinc-300">Scan running pods via kubectl</span>
-            </label>
-            {form.k8s && (
-              <input
-                type="text"
-                placeholder="Namespace (optional)"
-                className="mt-2 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 focus:border-emerald-600 focus:outline-none"
-                value={form.k8s_namespace ?? ""}
-                onChange={(e) => setForm((f) => ({ ...f, k8s_namespace: e.target.value || undefined }))}
-              />
-            )}
-          </Section>
-
-          <Section title="Python agent projects">
-            <ListInput
-              placeholder="/path/to/my-langchain-app"
-              value={apInput}
-              onChange={setApInput}
-              onAdd={() => addToList("agent_projects", apInput, () => setApInput(""))}
-              items={form.agent_projects ?? []}
-              onRemove={(i) => removeFromList("agent_projects", i)}
-            />
-          </Section>
+              )}
+            </Section>
+          )}
         </div>
 
         <div className="space-y-5">
-          <details className="group rounded-xl border border-zinc-800 bg-zinc-900">
-            <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-5 py-4 text-sm font-semibold text-zinc-200 [&::-webkit-details-marker]:hidden">
+          <details className="group rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]">
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-5 py-4 text-sm font-semibold text-[color:var(--foreground)] [&::-webkit-details-marker]:hidden">
               Advanced targets
-              <ChevronDown className="h-4 w-4 text-zinc-500 transition-transform group-open:rotate-180" />
+              <ChevronDown className="h-4 w-4 text-[color:var(--text-tertiary)] transition-transform group-open:rotate-180" />
             </summary>
-            <div className="space-y-5 border-t border-zinc-800 px-5 py-4">
+            <div className="space-y-5 border-t border-[color:var(--border-subtle)] px-5 py-4">
               <div>
-                <h3 className="mb-2 text-sm font-medium text-zinc-200">Terraform directories</h3>
+                <h3 className="mb-2 text-sm font-medium text-[color:var(--foreground)]">Terraform directories</h3>
                 <ListInput
                   placeholder="/path/to/infra"
                   value={tfInput}
@@ -241,21 +340,21 @@ export function ScanForm() {
                 />
               </div>
               <div>
-                <h3 className="mb-2 text-sm font-medium text-zinc-200">GitHub Actions</h3>
+                <h3 className="mb-2 text-sm font-medium text-[color:var(--foreground)]">GitHub Actions</h3>
                 <input
                   type="text"
                   placeholder="/path/to/git/repo"
-                  className="w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 focus:border-emerald-600 focus:outline-none"
+                  className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 text-sm text-[color:var(--foreground)] focus:border-emerald-600 focus:outline-none"
                   value={form.gha_path ?? ""}
                   onChange={(e) => setForm((f) => ({ ...f, gha_path: e.target.value || undefined }))}
                 />
               </div>
               <div>
-                <h3 className="mb-2 text-sm font-medium text-zinc-200">Custom inventory</h3>
+                <h3 className="mb-2 text-sm font-medium text-[color:var(--foreground)]">Custom inventory</h3>
                 <input
                   type="text"
                   placeholder="/path/to/agents.json"
-                  className="w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 focus:border-emerald-600 focus:outline-none"
+                  className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 text-sm text-[color:var(--foreground)] focus:border-emerald-600 focus:outline-none"
                   value={form.inventory ?? ""}
                   onChange={(e) => setForm((f) => ({ ...f, inventory: e.target.value || undefined }))}
                 />
@@ -267,13 +366,13 @@ export function ScanForm() {
             <label className="flex cursor-pointer items-start gap-2">
               <input
                 type="checkbox"
-                className="mt-0.5 h-4 w-4 rounded border-zinc-700 bg-zinc-900 text-emerald-500"
+                className="mt-0.5 h-4 w-4 rounded border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-emerald-500"
                 checked={form.enrich ?? false}
                 onChange={(e) => setForm((f) => ({ ...f, enrich: e.target.checked }))}
               />
-              <span className="text-sm text-zinc-300">
+              <span className="text-sm text-[color:var(--foreground)]">
                 Enrich with NVD CVSS, EPSS, and CISA KEV
-                <span className="mt-0.5 block text-xs text-zinc-500">Slower; requires internet</span>
+                <span className="mt-0.5 block text-xs text-[color:var(--text-tertiary)]">Slower; requires internet</span>
               </span>
             </label>
           </Section>
@@ -284,13 +383,15 @@ export function ScanForm() {
 
           <button
             type="submit"
-            disabled={loading}
-            className="flex w-full items-center justify-center gap-2 rounded-lg bg-emerald-600 px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:opacity-50 sm:w-auto"
+            disabled={loading || target === "cloud"}
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-emerald-600 px-6 py-2.5 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
           >
             {loading ? (
               <>
                 <Loader2 className="h-4 w-4 animate-spin" /> Starting scan...
               </>
+            ) : target === "cloud" ? (
+              <>Use cloud accounts for scheduled scans</>
             ) : (
               <>
                 Start scan <ArrowRight className="h-4 w-4" />
@@ -303,11 +404,9 @@ export function ScanForm() {
   );
 }
 
-// ─── Helpers ────────────────────────────────────────────────────────────────
-
 function RelatedLink({ href, children }: { href: string; children: React.ReactNode }) {
   return (
-    <Link href={href} className="text-zinc-400 transition-colors hover:text-emerald-400">
+    <Link href={href} className="text-[color:var(--text-secondary)] transition-colors hover:text-emerald-400">
       {children}
     </Link>
   );
@@ -315,8 +414,8 @@ function RelatedLink({ href, children }: { href: string; children: React.ReactNo
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
-      <h3 className="mb-3 text-sm font-semibold text-zinc-200">{title}</h3>
+    <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
+      <h3 className="mb-3 text-sm font-semibold text-[color:var(--foreground)]">{title}</h3>
       {children}
     </div>
   );
@@ -338,7 +437,7 @@ function ListInput({
         <input
           type="text"
           placeholder={placeholder}
-          className="flex-1 rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-sm text-zinc-200 focus:border-emerald-600 focus:outline-none"
+          className="flex-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-sm text-[color:var(--foreground)] focus:border-emerald-600 focus:outline-none"
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); onAdd(); } }}
@@ -346,7 +445,7 @@ function ListInput({
         <button
           type="button"
           onClick={onAdd}
-          className="flex items-center gap-1 rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-300 transition-colors hover:bg-zinc-700"
+          className="flex items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs text-[color:var(--foreground)] transition-colors hover:border-[color:var(--border-strong)]"
         >
           <Plus className="h-3.5 w-3.5" />
           Add
@@ -354,11 +453,11 @@ function ListInput({
       </div>
       {items.length > 0 && (
         <div className="flex flex-wrap gap-2">
-          {items?.map((item, i) => (
-            <span key={i} className="flex items-center gap-1.5 rounded-lg border border-zinc-700 bg-zinc-800 px-2.5 py-1 font-mono text-xs text-zinc-300">
+          {items.map((item, i) => (
+            <span key={i} className="flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1 font-mono text-xs text-[color:var(--foreground)]">
               {item}
               <button type="button" onClick={() => onRemove(i)}>
-                <X className="h-3 w-3 text-zinc-500 hover:text-zinc-300" />
+                <X className="h-3 w-3 text-[color:var(--text-tertiary)] hover:text-[color:var(--foreground)]" />
               </button>
             </span>
           ))}

--- a/ui/e2e/scan-export.spec.ts
+++ b/ui/e2e/scan-export.spec.ts
@@ -179,6 +179,7 @@ test("scan flow reaches result view and exports graph JSON", async ({ page }) =>
   // no actionable error.
   await page.waitForLoadState("networkidle");
 
+  await page.getByRole("button", { name: /containers/i }).click();
   const imageInput = page.getByPlaceholder("nginx:1.25 or ghcr.io/org/app:v1");
   try {
     await expect(imageInput, "image input must be visible after hydration").toBeVisible({ timeout: 15_000 });

--- a/ui/lib/exposure-path.ts
+++ b/ui/lib/exposure-path.ts
@@ -129,9 +129,19 @@ export function highestExposureSeverity(paths: ExposurePath[]): ExposureSeverity
 
 export function pathDisplayTitle(path: ExposurePath): string {
   const finding = path.findings[0] || path.target.label;
-  const dependency = path.dependencyContext?.packageName
-    ? `${path.dependencyContext.packageName}${path.dependencyContext.packageVersion ? `@${path.dependencyContext.packageVersion}` : ""}`
-    : "";
+  const rawPackage = path.dependencyContext?.packageName ?? "";
+  let dependency = "";
+  if (rawPackage) {
+    const at = rawPackage.lastIndexOf("@");
+    if (at > 0 && !path.dependencyContext?.packageVersion) {
+      dependency = rawPackage;
+    } else if (path.dependencyContext?.packageVersion) {
+      const baseName = at > 0 ? rawPackage.slice(0, at) : rawPackage;
+      dependency = `${baseName}@${path.dependencyContext.packageVersion}`;
+    } else {
+      dependency = rawPackage;
+    }
+  }
   const agent = path.affectedAgents[0] || path.source.label;
   return [agent, dependency, finding].filter(Boolean).join(" -> ") || path.label;
 }

--- a/ui/tests/exposure-path.test.ts
+++ b/ui/tests/exposure-path.test.ts
@@ -38,6 +38,19 @@ describe("ExposurePath", () => {
     expect(pathDisplayTitle(path({}))).toBe("analyst-agent -> werkzeug@2.2.2 -> CVE-2026-0001");
   });
 
+  it("does not duplicate package versions when the package label already includes one", () => {
+    expect(
+      pathDisplayTitle(
+        path({
+          dependencyContext: {
+            packageName: "form-data@4.0.0",
+            serverName: "github",
+          },
+        }),
+      ),
+    ).toBe("analyst-agent -> form-data@4.0.0 -> CVE-2026-0001");
+  });
+
   it("prefers fix versions for compact remediation labels", () => {
     expect(pathFixLabel(path({ fix: { label: "Upgrade werkzeug", version: "2.2.3" } }))).toBe("2.2.3");
     expect(pathFixLabel(path({ fix: { label: "Rotate credential" } }))).toBe("Rotate credential");

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -59,9 +59,9 @@ describe('Nav', () => {
     vi.clearAllMocks()
   })
 
-  it('renders the Command nav group', () => {
+  it('renders the Posture nav group', () => {
     renderExpandedNav()
-    expect(screen.getByText('Command')).toBeInTheDocument()
+    expect(screen.getByText('Posture')).toBeInTheDocument()
   })
 
   it('renders the AI inventory nav group', () => {
@@ -113,19 +113,19 @@ describe('Nav', () => {
     expect(links.some((l) => l.getAttribute('href') === '/jobs')).toBe(true)
   })
 
-  it('contains link to Findings (/findings) under Command', () => {
+  it('contains link to Findings (/findings) under Posture', () => {
     renderExpandedNav()
     const links = screen.getAllByRole('link', { name: /findings/i })
     expect(links.some((l) => l.getAttribute('href') === '/findings')).toBe(true)
   })
 
-  it('contains Remediation link under Command', () => {
+  it('contains Remediation link under Posture', () => {
     renderExpandedNav()
     const links = screen.getAllByRole('link', { name: /remediation/i })
     expect(links.some((l) => l.getAttribute('href') === '/remediation')).toBe(true)
   })
 
-  it('contains Security Graph link under Command', () => {
+  it('contains Security Graph link under Posture', () => {
     renderExpandedNav()
     const links = screen.getAllByRole('link', { name: /security graph/i })
     expect(links.some((l) => l.getAttribute('href') === '/security-graph')).toBe(true)
@@ -143,7 +143,7 @@ describe('Nav', () => {
     fireEvent.click(screen.getByRole('button', { name: /open navigation menu/i }))
 
     const drawer = screen.getByLabelText('Mobile navigation')
-    expect(within(drawer).getByText('Command')).toBeInTheDocument()
+    expect(within(drawer).getByText('Posture')).toBeInTheDocument()
     expect(within(drawer).getByRole('link', { name: /findings/i })).toHaveAttribute(
       'href',
       '/findings'
@@ -170,7 +170,7 @@ describe('Nav', () => {
     expect(links.some((l) => l.getAttribute('href') === '/registry')).toBe(true)
   })
 
-  it('keeps graph lenses tucked under Command instead of primary sidebar links', () => {
+  it('keeps graph lenses tucked under Posture instead of primary sidebar links', () => {
     renderExpandedNav()
     expect(screen.getByText(/graph lenses/i)).toBeInTheDocument()
     const hrefs = screen.getAllByRole('link').map((l) => l.getAttribute('href'))
@@ -247,7 +247,7 @@ describe('Nav', () => {
 
   it('renders all 7 nav group labels', () => {
     renderExpandedNav()
-    const groups = ['Command', 'AI inventory', 'Cloud & Data', 'Runtime', 'Governance', 'Reference', 'Operations']
+    const groups = ['Posture', 'AI inventory', 'Cloud & Data', 'Runtime', 'Governance', 'Reference', 'Operations']
     for (const group of groups) {
       expect(screen.getAllByText(group).length).toBeGreaterThan(0)
     }
@@ -271,7 +271,7 @@ describe('Nav', () => {
   it('contains links for all primary pages across all groups', async () => {
     renderExpandedNav()
     const expectedByGroup: Record<string, string[]> = {
-      Command: ['/', '/findings', '/security-graph', '/remediation'],
+      Posture: ['/', '/findings', '/security-graph', '/remediation'],
       'AI inventory': ['/agents', '/manifest', '/fleet'],
       'Cloud & Data': ['/connections', '/sources', '/scan', '/identity', '/drift'],
       Runtime: ['/runtime', '/traces'],

--- a/ui/tests/scan-form.test.tsx
+++ b/ui/tests/scan-form.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { ScanForm } from "@/components/scan-form";
@@ -7,34 +8,48 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
+vi.mock("@/hooks/use-deployment-context", () => ({
+  useDeploymentContext: () => ({
+    counts: {
+      deployment_mode: "local",
+      scan_count: 1,
+      has_local_scan: true,
+    },
+    loading: false,
+    error: null,
+  }),
+}));
+
 describe("ScanForm", () => {
-  it("renders a compact header without surface explainer cards", () => {
+  it("renders deployment-aware scan targets instead of a single image upload surface", () => {
     render(<ScanForm />);
 
     expect(screen.getByRole("heading", { name: "New Scan" })).toBeInTheDocument();
-    expect(screen.queryByText(/Direct scans/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/Connectors and enterprise sources/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Local")).toBeInTheDocument();
+    expect(screen.getByText("Local control plane.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Cloud accounts/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Workstation/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Containers/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Kubernetes/i })).toBeInTheDocument();
+    expect(screen.queryByText("Upload .txt")).not.toBeInTheDocument();
   });
 
-  it("exposes related surfaces as inline links", () => {
+  it("routes cloud scans to connectors instead of starting a direct job", async () => {
+    const user = userEvent.setup();
     render(<ScanForm />);
 
-    expect(screen.getByRole("link", { name: "Data sources" })).toHaveAttribute("href", "/sources");
-    expect(screen.getByRole("link", { name: "Governance" })).toHaveAttribute("href", "/governance");
-    expect(screen.getByRole("link", { name: "Traces" })).toHaveAttribute("href", "/traces");
+    await user.click(screen.getByRole("button", { name: /Cloud accounts/i }));
+    expect(screen.getByRole("link", { name: /Open cloud accounts/i })).toHaveAttribute("href", "/connections");
+    expect(screen.getByRole("button", { name: /Use cloud accounts for scheduled scans/i })).toBeDisabled();
   });
 
-  it("keeps advanced targets collapsed by default", () => {
+  it("explains kubernetes namespace scope in plain language", async () => {
+    const user = userEvent.setup();
     render(<ScanForm />);
 
-    expect(screen.getByText("Advanced targets")).toBeInTheDocument();
-    expect(screen.queryByPlaceholderText("/path/to/infra")).not.toBeVisible();
-  });
-
-  it("shows primary scan controls above the fold", () => {
-    render(<ScanForm />);
-
-    expect(screen.getByText("Docker images")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Start scan/i })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Kubernetes/i }));
+    await user.click(screen.getByRole("checkbox", { name: /Scan running pods/i }));
+    expect(screen.getByLabelText("Namespace filter")).toBeInTheDocument();
+    expect(screen.getByText(/Leave blank to scan every namespace/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Rename sidebar **Command → Posture** and soften top-bar control-plane status copy (deployment badge tooltip + `Control plane · v…`).
- Fix duplicate package titles in exposure paths; hide strip title when the command center already shows the path headline.
- Tighten Security Graph snapshot/posture header (inline grade + path stats, shorter loading copy).
- Replace primitive New Scan form with deployment-aware target pickers (Cloud / Workstation / Containers / Kubernetes), clear **Local** context, and plain-language namespace scope.

## Verification
- `cd ui && npm run lint` — 0 errors (2 pre-existing hook warnings)
- `cd ui && npm run typecheck` — passed
- `cd ui && npm test -- --run` — 367 passed
- `cd ui && npm run build` — passed
- `cd ui && npx playwright test` — 11 passed

## Notes
Quick-wins PR (1/2). Graph investigation focus mode ships in follow-up PR `feat/ui-security-graph-focus`.

