### PR TITLE
fix(ui): align AI BOM manifest with platform theme and evidence model

### DIFF
--- a/ui/app/manifest/page.tsx
+++ b/ui/app/manifest/page.tsx
@@ -6,21 +6,24 @@ import Link from "next/link";
 import {
   Activity,
   AlertTriangle,
+  Bot,
+  Box,
+  Cloud,
   Download,
-  Eye,
   GitBranch,
   KeyRound,
   Loader2,
-  Network,
   RefreshCw,
   Search,
   Server,
   ShieldCheck,
-  TerminalSquare,
-  UserRound,
-  Wrench,
+  Sparkles,
 } from "lucide-react";
-import { api, type AgentBomManifestResponse } from "@/lib/api";
+
+import { Card, Section } from "@/components/card";
+import { PageLaneHeader } from "@/components/page-lane";
+import { StatCard } from "@/components/stat-card";
+import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import {
   DEFAULT_MANIFEST_FILTERS,
   deriveManifestRows,
@@ -28,37 +31,30 @@ import {
   manifestFilterOptions,
   type ManifestFilters,
 } from "@/lib/agent-bom-manifest";
-import { PageLaneHeader } from "@/components/page-lane";
+import {
+  aiBomScopeLabel,
+  countActiveEvidenceSources,
+  deriveAiBomEvidenceSources,
+  summarizeAiBomEntities,
+  type AiBomEvidenceSource,
+} from "@/lib/ai-bom-evidence";
+import { api, formatDate, type AgentBomManifestResponse } from "@/lib/api";
 
 function downloadManifest(manifest: AgentBomManifestResponse) {
   const blob = new Blob([JSON.stringify(manifest, null, 2)], { type: "application/json" });
   const url = URL.createObjectURL(blob);
   const anchor = document.createElement("a");
   anchor.href = url;
-  anchor.download = `agent-bom-manifest-${manifest.tenant_id ?? "local"}.json`;
+  anchor.download = `ai-bom-${manifest.tenant_id ?? "local"}.json`;
   anchor.click();
   URL.revokeObjectURL(url);
 }
 
-function SummaryCard({
-  label,
-  value,
-  icon: Icon,
-  tone = "text-zinc-300",
-}: {
-  label: string;
-  value: number;
-  icon: ElementType;
-  tone?: string;
-}) {
+function ScopeChip({ label }: { label: string }) {
   return (
-    <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
-      <div className="flex items-center justify-between gap-3">
-        <span className="text-sm text-[var(--muted-foreground)]">{label}</span>
-        <Icon className={`h-4 w-4 ${tone}`} />
-      </div>
-      <div className="mt-3 text-2xl font-semibold tracking-tight text-[var(--foreground)]">{value.toLocaleString()}</div>
-    </div>
+    <span className="inline-flex items-center rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-0.5 text-[11px] font-medium text-emerald-200">
+      {label}
+    </span>
   );
 }
 
@@ -66,7 +62,9 @@ function BoundaryBadge({ ok, label }: { ok: boolean; label: string }) {
   return (
     <span
       className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs ${
-        ok ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300" : "border-yellow-500/30 bg-yellow-500/10 text-yellow-300"
+        ok
+          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
+          : "border-amber-500/30 bg-amber-500/10 text-amber-200"
       }`}
     >
       {ok ? <ShieldCheck className="h-3 w-3" /> : <AlertTriangle className="h-3 w-3" />}
@@ -82,15 +80,60 @@ function DriftStatusBadge({ status }: { status: string }) {
     <span
       className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs ${
         needsReview
-          ? "border-yellow-500/30 bg-yellow-500/10 text-yellow-300"
+          ? "border-amber-500/30 bg-amber-500/10 text-amber-200"
           : aligned
-            ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
-            : "border-[var(--border)] bg-[var(--muted)] text-[var(--muted-foreground)]"
+            ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
+            : "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]"
       }`}
     >
       {needsReview ? <AlertTriangle className="h-3 w-3" /> : <ShieldCheck className="h-3 w-3" />}
       blueprint {status.replaceAll("_", " ")}
     </span>
+  );
+}
+
+function EvidenceSourceCard({ source }: { source: AiBomEvidenceSource }) {
+  const body = (
+    <div
+      className={`rounded-xl border px-3 py-2.5 transition ${
+        source.active
+          ? "border-emerald-600/40 bg-emerald-500/10"
+          : "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] opacity-70"
+      }`}
+    >
+      <div className="text-sm font-medium text-[color:var(--foreground)]">{source.label}</div>
+      <p className="mt-1 text-[11px] leading-5 text-[color:var(--text-secondary)]">{source.detail}</p>
+      <p className="mt-2 text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+        {source.active ? "Evidence flowing" : "Not connected"}
+      </p>
+    </div>
+  );
+
+  if (source.href && source.active) {
+    return <Link href={source.href}>{body}</Link>;
+  }
+  return body;
+}
+
+function MetricTile({
+  label,
+  value,
+  icon: Icon,
+}: {
+  label: string;
+  value: number;
+  icon: ElementType;
+}) {
+  return (
+    <Card className="flex items-center justify-between gap-3 !p-4">
+      <div>
+        <div className="text-[11px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">{label}</div>
+        <div className="mt-2 font-mono text-2xl font-semibold text-[color:var(--foreground)]">
+          {value.toLocaleString()}
+        </div>
+      </div>
+      <Icon className="h-5 w-5 text-[color:var(--text-tertiary)]" />
+    </Card>
   );
 }
 
@@ -100,49 +143,56 @@ function MiniGraph({ manifest }: { manifest: AgentBomManifestResponse }) {
   const columns = Math.min(4, Math.max(1, Math.ceil(Math.sqrt(nodes.length || 1))));
 
   return (
-    <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
+    <div className="space-y-4">
       <div className="flex items-center justify-between gap-3">
         <div>
-          <h2 className="text-sm font-semibold text-[var(--foreground)]">Manifest graph</h2>
-          <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+          <h3 className="text-sm font-semibold text-[color:var(--foreground)]">Reachability graph</h3>
+          <p className="mt-1 text-xs text-[color:var(--text-secondary)]">
             {manifest.graph.stats.nodes} nodes · {manifest.graph.stats.edges} edges
           </p>
         </div>
         <Link
           href="/graph?layers=agent,server,tool,credential"
-          className="inline-flex items-center gap-1 rounded-md border border-[var(--border)] px-2.5 py-1.5 text-xs text-[var(--foreground)] hover:bg-[var(--accent)]"
+          className="inline-flex items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1.5 text-xs text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)]"
         >
-          Open graph <GitBranch className="h-3 w-3" />
+          Open lineage <GitBranch className="h-3 w-3" />
         </Link>
       </div>
 
-      <div className="mt-4 grid gap-3" style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}>
+      <div className="grid gap-3" style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}>
         {nodes.map((node) => (
-          <div key={node.id} className="min-h-20 rounded-md border border-[var(--border)] bg-[var(--background)] p-3">
-            <div className="text-xs uppercase tracking-wide text-[var(--muted-foreground)]">{node.entity_type}</div>
-            <div className="mt-2 truncate text-sm font-medium text-[var(--foreground)]" title={node.label}>
+          <div
+            key={node.id}
+            className="min-h-20 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3"
+          >
+            <div className="text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+              {node.entity_type}
+            </div>
+            <div className="mt-2 truncate text-sm font-medium text-[color:var(--foreground)]" title={node.label}>
               {node.label}
             </div>
           </div>
         ))}
-        {nodes.length === 0 ? <div className="text-sm text-[var(--muted-foreground)]">No manifest graph nodes yet.</div> : null}
+        {nodes.length === 0 ? (
+          <div className="text-sm text-[color:var(--text-secondary)]">No graph nodes in this manifest yet.</div>
+        ) : null}
       </div>
 
-      <div className="mt-4 max-h-48 overflow-auto rounded-md border border-[var(--border)]">
+      <div className="max-h-48 overflow-auto rounded-lg border border-[color:var(--border-subtle)]">
         <table className="w-full text-left text-xs">
-          <thead className="bg-[var(--muted)] text-[var(--muted-foreground)]">
+          <thead className="bg-[color:var(--surface-muted)] text-[color:var(--text-tertiary)]">
             <tr>
               <th className="px-3 py-2 font-medium">Relationship</th>
               <th className="px-3 py-2 font-medium">Source</th>
               <th className="px-3 py-2 font-medium">Target</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-[var(--border)]">
+          <tbody className="divide-y divide-[color:var(--border-subtle)]">
             {edges.map((edge) => (
               <tr key={edge.id}>
-                <td className="px-3 py-2 text-[var(--foreground)]">{edge.relationship}</td>
-                <td className="px-3 py-2 text-[var(--muted-foreground)]">{edge.source}</td>
-                <td className="px-3 py-2 text-[var(--muted-foreground)]">{edge.target}</td>
+                <td className="px-3 py-2 text-[color:var(--foreground)]">{edge.relationship}</td>
+                <td className="px-3 py-2 text-[color:var(--text-secondary)]">{edge.source}</td>
+                <td className="px-3 py-2 text-[color:var(--text-secondary)]">{edge.target}</td>
               </tr>
             ))}
           </tbody>
@@ -153,6 +203,7 @@ function MiniGraph({ manifest }: { manifest: AgentBomManifestResponse }) {
 }
 
 export default function AgentBomManifestPage() {
+  const { counts } = useDeploymentContext();
   const [manifest, setManifest] = useState<AgentBomManifestResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -176,276 +227,278 @@ export default function AgentBomManifestPage() {
   const rows = useMemo(() => filterManifestRows(allRows, filters), [allRows, filters]);
   const options = useMemo(() => manifestFilterOptions(allRows), [allRows]);
   const hasActiveFilters = JSON.stringify(filters) !== JSON.stringify(DEFAULT_MANIFEST_FILTERS);
+  const evidenceSources = useMemo(() => deriveAiBomEvidenceSources(counts, manifest), [counts, manifest]);
+  const entityRollup = useMemo(() => summarizeAiBomEntities(manifest), [manifest]);
+  const activeSources = countActiveEvidenceSources(evidenceSources);
+  const scopeLabel = aiBomScopeLabel(counts, manifest);
 
   const updateFilter = <K extends keyof ManifestFilters>(key: K, value: ManifestFilters[K]) => {
     setFilters((current) => ({ ...current, [key]: value }));
   };
 
   return (
-    <main className="min-h-screen bg-[var(--background)] p-6 text-[var(--foreground)]">
-      <div className="mx-auto flex max-w-7xl flex-col gap-6">
-        <PageLaneHeader
-          lane="ai-estate"
-          title="Agent BOM"
-          subtitle="Your tenant inventory of agents, MCP servers, tools, and credential references."
-          actions={
-            <>
-              <button
-                type="button"
-                onClick={load}
-                className="inline-flex items-center gap-2 rounded-md border border-[var(--border)] px-3 py-2 text-sm hover:bg-[var(--accent)]"
-              >
-                {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
-                Refresh
-              </button>
-              <button
-                type="button"
-                disabled={!manifest}
-                onClick={() => manifest && downloadManifest(manifest)}
-                className="inline-flex items-center gap-2 rounded-md border border-[var(--border)] px-3 py-2 text-sm hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                <Download className="h-4 w-4" />
-                Download JSON
-              </button>
-            </>
-          }
-        />
-
-        {error ? <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-300">{error}</div> : null}
-
-        {manifest ? (
+    <div className="space-y-6">
+      <PageLaneHeader
+        lane="ai-estate"
+        title="AI BOM"
+        subtitle="Reachability-backed inventory from connected agents, cloud accounts, endpoints, and runtime observations — not a static file upload."
+        scopeChip={<ScopeChip label={scopeLabel} />}
+        actions={
           <>
-            <section className="grid gap-3 sm:grid-cols-3">
-              <SummaryCard label="Agents" value={manifest.summary.agents} icon={TerminalSquare} tone="text-blue-300" />
-              <SummaryCard label="MCP servers" value={manifest.summary.mcp_servers} icon={Server} tone="text-cyan-300" />
-              <SummaryCard label="Credential refs" value={manifest.summary.credential_refs} icon={KeyRound} tone="text-yellow-300" />
-            </section>
-
-            <details className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-4">
-              <summary className="cursor-pointer list-none text-sm font-medium text-[var(--foreground)] [&::-webkit-details-marker]:hidden">
-                Extended visibility metrics
-              </summary>
-              <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-                <SummaryCard label="Tools" value={manifest.summary.tools} icon={Wrench} tone="text-emerald-300" />
-                <SummaryCard label="Runtime seen" value={manifest.summary.runtime_observed_servers} icon={Activity} tone="text-pink-300" />
-                <SummaryCard label="Gateway bound" value={manifest.summary.gateway_registered_servers} icon={Network} tone="text-violet-300" />
-                <SummaryCard label="Owners" value={manifest.visibility.owners} icon={UserRound} tone="text-teal-300" />
-                <SummaryCard label="Unowned agents" value={manifest.visibility.unowned_agents} icon={AlertTriangle} tone="text-yellow-300" />
-                <SummaryCard label="Shadow runtime" value={manifest.visibility.shadow_runtime_servers} icon={Eye} tone="text-red-300" />
-                <SummaryCard label="Untracked runtime" value={manifest.visibility.untracked_runtime_servers} icon={Network} tone="text-orange-300" />
-                <SummaryCard label="Warnings" value={manifest.visibility.servers_with_warnings} icon={AlertTriangle} tone="text-amber-300" />
-                <SummaryCard label="Risky refs" value={manifest.visibility.risky_credential_refs} icon={KeyRound} tone="text-rose-300" />
-              </div>
-            </details>
-
-            <section className="flex flex-wrap items-center gap-2">
-              <BoundaryBadge ok={!manifest.boundaries.stores_credential_values} label="credential values redacted" />
-              <BoundaryBadge ok={!manifest.boundaries.stores_raw_prompts} label="raw prompts not persisted" />
-              <DriftStatusBadge status={manifest.blueprint_drift.status} />
-              <span className="text-xs text-[var(--muted-foreground)]">
-                {manifest.schema_version} · {manifest.tenant_id ?? "local"} · {new Date(manifest.generated_at).toLocaleString()}
-              </span>
-            </section>
-
-            {manifest.blueprint_drift.status === "needs_review" ? (
-              <section className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-4">
-                <div className="flex items-start gap-3">
-                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-300" />
-                  <div>
-                    <h2 className="text-sm font-semibold text-yellow-100">Observation-only drift review</h2>
-                    <p className="mt-1 text-xs text-yellow-100/80">
-                      {manifest.blueprint_drift.signal_count} signal(s) from manifest/runtime evidence. This view reports drift candidates; enforcement policy is unchanged.
-                    </p>
-                    <ul className="mt-3 grid gap-2 text-xs text-yellow-100/90">
-                      {manifest.blueprint_drift.signals.slice(0, 4).map((signal) => (
-                        <li key={`${signal.kind}:${signal.entity_id}`} className="rounded-md border border-yellow-500/20 bg-black/10 px-3 py-2">
-                          <span className="font-medium">{signal.kind.replaceAll("_", " ")}</span>: {signal.message}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                </div>
-              </section>
-            ) : null}
-
-            <div className="space-y-6">
-              <section className="rounded-lg border border-[var(--border)] bg-[var(--card)]">
-                <div className="flex flex-col gap-3 border-b border-[var(--border)] p-4 md:flex-row md:items-center md:justify-between">
-                  <div>
-                    <h2 className="text-sm font-semibold">Agent and MCP inventory</h2>
-                    <p className="mt-1 text-xs text-[var(--muted-foreground)]">
-                      {rows.length} of {allRows.length} server rows visible
-                    </p>
-                  </div>
-                  <label className="relative w-full md:w-80">
-                    <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-[var(--muted-foreground)]" />
-                    <input
-                      value={filters.query}
-                      onChange={(event) => updateFilter("query", event.target.value)}
-                      placeholder="Search agents, servers, transports"
-                      className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] py-2 pl-9 pr-3 text-sm outline-none focus:border-emerald-500"
-                    />
-                  </label>
-                </div>
-                <div className="grid gap-3 border-b border-[var(--border)] p-4 md:grid-cols-2 xl:grid-cols-6">
-                  <label className="flex flex-col gap-1 text-xs text-[var(--muted-foreground)]">
-                    Source
-                    <select
-                      value={filters.source}
-                      onChange={(event) => updateFilter("source", event.target.value)}
-                      className="rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
-                    >
-                      <option value="all">All sources</option>
-                      {options.sources.map((source) => (
-                        <option key={source} value={source}>
-                          {source}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <label className="flex flex-col gap-1 text-xs text-[var(--muted-foreground)]">
-                    Owner
-                    <select
-                      value={filters.owner}
-                      onChange={(event) => updateFilter("owner", event.target.value)}
-                      className="rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
-                    >
-                      <option value="all">All owners</option>
-                      {options.owners.map((owner) => (
-                        <option key={owner} value={owner}>
-                          {owner}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <label className="flex flex-col gap-1 text-xs text-[var(--muted-foreground)]">
-                    Risk
-                    <select
-                      value={filters.risk}
-                      onChange={(event) => updateFilter("risk", event.target.value as ManifestFilters["risk"])}
-                      className="rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
-                    >
-                      <option value="all">All risk</option>
-                      <option value="high">High</option>
-                      <option value="medium">Medium</option>
-                      <option value="low">Low</option>
-                    </select>
-                  </label>
-                  <label className="flex flex-col gap-1 text-xs text-[var(--muted-foreground)]">
-                    Freshness
-                    <select
-                      value={filters.freshness}
-                      onChange={(event) => updateFilter("freshness", event.target.value as ManifestFilters["freshness"])}
-                      className="rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
-                    >
-                      <option value="all">All freshness</option>
-                      <option value="seen_24h">Seen 24h</option>
-                      <option value="seen_7d">Seen 7d</option>
-                      <option value="stale">Stale</option>
-                      <option value="unknown">Unknown</option>
-                    </select>
-                  </label>
-                  <label className="flex flex-col gap-1 text-xs text-[var(--muted-foreground)]">
-                    Runtime
-                    <select
-                      value={filters.runtime}
-                      onChange={(event) => updateFilter("runtime", event.target.value as ManifestFilters["runtime"])}
-                      className="rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)]"
-                    >
-                      <option value="all">All runtime</option>
-                      <option value="gateway bound">Gateway bound</option>
-                      <option value="runtime observed">Runtime observed</option>
-                      <option value="shadow runtime">Shadow runtime</option>
-                      <option value="inventory only">Inventory only</option>
-                    </select>
-                  </label>
-                  <div className="flex items-end">
-                    <button
-                      type="button"
-                      disabled={!hasActiveFilters}
-                      onClick={() => setFilters(DEFAULT_MANIFEST_FILTERS)}
-                      className="inline-flex w-full items-center justify-center gap-2 rounded-md border border-[var(--border)] px-3 py-2 text-sm text-[var(--foreground)] hover:bg-[var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      Clear filters
-                    </button>
-                  </div>
-                </div>
-                <div className="overflow-x-auto">
-                  <table className="w-full text-left text-sm">
-                    <thead className="bg-[var(--muted)] text-xs uppercase tracking-wide text-[var(--muted-foreground)]">
-                      <tr>
-                        <th className="px-4 py-3 font-medium">Agent</th>
-                        <th className="px-4 py-3 font-medium">Owner</th>
-                        <th className="px-4 py-3 font-medium">Source</th>
-                        <th className="px-4 py-3 font-medium">Environment</th>
-                        <th className="px-4 py-3 font-medium">MCP server</th>
-                        <th className="px-4 py-3 font-medium">Risk</th>
-                        <th className="px-4 py-3 font-medium">Transport</th>
-                        <th className="px-4 py-3 font-medium">Runtime</th>
-                        <th className="px-4 py-3 font-medium">Tools</th>
-                        <th className="px-4 py-3 font-medium">Credential refs</th>
-                        <th className="px-4 py-3 font-medium">Last seen</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-[var(--border)]">
-                      {rows.map((row, index) => (
-                        <tr key={`${row.id}:${index}`}>
-                          <td className="px-4 py-3 text-[var(--foreground)]">{row.agentName}</td>
-                          <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.owner}</td>
-                          <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.source}</td>
-                          <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.environment}</td>
-                          <td className="px-4 py-3 font-medium text-[var(--foreground)]">{row.name}</td>
-                          <td className="px-4 py-3">
-                            <span
-                              className={`rounded-full px-2 py-1 text-xs ${
-                                row.riskLevel === "high"
-                                  ? "bg-red-500/10 text-red-300"
-                                  : row.riskLevel === "medium"
-                                    ? "bg-yellow-500/10 text-yellow-300"
-                                    : "bg-emerald-500/10 text-emerald-300"
-                              }`}
-                            >
-                              {row.riskLevel}
-                            </span>
-                          </td>
-                          <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.transport}</td>
-                          <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.runtimeState}</td>
-                          <td className="px-4 py-3 text-[var(--foreground)]">{row.toolCount}</td>
-                          <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.credentialRefs.join(", ") || "none"}</td>
-                          <td className="px-4 py-3 text-[var(--muted-foreground)]">{row.lastSeen}</td>
-                        </tr>
-                      ))}
-                      {rows.length === 0 ? (
-                        <tr>
-                          <td colSpan={11} className="px-4 py-8 text-center text-sm text-[var(--muted-foreground)]">
-                            No MCP servers in this tenant yet. Run{" "}
-                            <code className="rounded bg-[var(--muted)] px-1.5 py-0.5">agent-bom manifest</code> locally to
-                            generate evidence, or clear filters to inspect the full manifest.
-                          </td>
-                        </tr>
-                      ) : null}
-                    </tbody>
-                  </table>
-                </div>
-              </section>
-
-              <details className="rounded-lg border border-[var(--border)] bg-[var(--card)]">
-                <summary className="cursor-pointer list-none px-4 py-3 text-sm font-medium [&::-webkit-details-marker]:hidden">
-                  Manifest graph · {manifest.graph.stats.nodes} nodes · {manifest.graph.stats.edges} edges
-                </summary>
-                <div className="border-t border-[var(--border)] p-4">
-                  <MiniGraph manifest={manifest} />
-                </div>
-              </details>
-            </div>
+            <button
+              type="button"
+              onClick={load}
+              className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-sm text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+            >
+              {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+              Refresh
+            </button>
+            <button
+              type="button"
+              disabled={!manifest}
+              onClick={() => manifest && downloadManifest(manifest)}
+              className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-sm text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Download className="h-4 w-4" />
+              Export JSON
+            </button>
           </>
-        ) : loading ? (
-          <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-8 text-sm text-[var(--muted-foreground)]">
-            <Loader2 className="mr-2 inline h-4 w-4 animate-spin" />
-            Loading Agent BOM manifest
-          </div>
-        ) : null}
-      </div>
-    </main>
+        }
+        banner={
+          <Card className="!p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 text-sm font-medium text-[color:var(--foreground)]">
+                  <Sparkles className="h-4 w-4 text-emerald-300" />
+                  Evidence sources
+                </div>
+                <p className="mt-1 max-w-3xl text-sm text-[color:var(--text-secondary)]">
+                  AI BOM rolls up whatever is connected: workstation discovery, fleet ingest, cloud connectors,
+                  Kubernetes scans, and runtime enforcement. Agent runtime rows below are one layer of that estate.
+                </p>
+              </div>
+              <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-right">
+                <div className="font-mono text-xl font-semibold text-emerald-300">{activeSources}</div>
+                <div className="text-[11px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+                  active sources
+                </div>
+              </div>
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+              {evidenceSources.map((source) => (
+                <EvidenceSourceCard key={source.id} source={source} />
+              ))}
+            </div>
+          </Card>
+        }
+      />
+
+      {error ? (
+        <Card className="border-red-500/30 bg-red-500/10 !p-4 text-sm text-red-200">{error}</Card>
+      ) : null}
+
+      {manifest ? (
+        <>
+          <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <MetricTile label="Agents" value={entityRollup.agents} icon={Bot} />
+            <MetricTile label="MCP servers" value={entityRollup.mcpServers} icon={Server} />
+            <MetricTile label="Models" value={entityRollup.models} icon={Sparkles} />
+            <MetricTile label="Packages" value={entityRollup.packages} icon={Box} />
+            <MetricTile label="Cloud assets" value={entityRollup.cloudAssets} icon={Cloud} />
+            <MetricTile label="Credential refs" value={entityRollup.credentials} icon={KeyRound} />
+            <MetricTile label="Findings" value={entityRollup.findings} icon={AlertTriangle} />
+            <MetricTile label="Runtime seen" value={manifest.summary.runtime_observed_servers} icon={Activity} />
+          </section>
+
+          <section className="flex flex-wrap items-center gap-2">
+            <BoundaryBadge ok={!manifest.boundaries.stores_credential_values} label="credential values redacted" />
+            <BoundaryBadge ok={!manifest.boundaries.stores_raw_prompts} label="raw prompts not persisted" />
+            <DriftStatusBadge status={manifest.blueprint_drift.status} />
+            <span className="text-xs text-[color:var(--text-tertiary)]">
+              {manifest.schema_version} · generated {formatDate(manifest.generated_at)}
+            </span>
+          </section>
+
+          {manifest.blueprint_drift.status === "needs_review" ? (
+            <Card className="border-amber-500/30 bg-amber-500/10 !p-4">
+              <div className="flex items-start gap-3">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-200" />
+                <div>
+                  <h2 className="text-sm font-semibold text-amber-50">Observation-only drift review</h2>
+                  <p className="mt-1 text-xs text-amber-100/85">
+                    {manifest.blueprint_drift.signal_count} signal(s) from manifest/runtime evidence. This view reports drift candidates; enforcement policy is unchanged.
+                  </p>
+                </div>
+              </div>
+            </Card>
+          ) : null}
+
+          <Section
+            label="Agent runtime inventory"
+            description="MCP servers, tools, and credential references discovered from agent runtimes. Cloud-managed models and endpoint AI services appear when those connectors are linked."
+            divider
+          >
+            <Card flush className="overflow-hidden">
+              <div className="flex flex-col gap-3 border-b border-[color:var(--border-subtle)] p-4 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <p className="text-sm text-[color:var(--text-secondary)]">
+                    {rows.length} of {allRows.length} server rows visible
+                  </p>
+                </div>
+                <label className="relative w-full md:w-80">
+                  <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-[color:var(--text-tertiary)]" />
+                  <input
+                    value={filters.query}
+                    onChange={(event) => updateFilter("query", event.target.value)}
+                    placeholder="Search agents, servers, transports"
+                    className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] py-2 pl-9 pr-3 text-sm text-[color:var(--foreground)] outline-none focus:border-emerald-600"
+                  />
+                </label>
+              </div>
+
+              <div className="grid gap-3 border-b border-[color:var(--border-subtle)] p-4 md:grid-cols-2 xl:grid-cols-6">
+                {(
+                  [
+                    ["source", "Source", options.sources],
+                    ["owner", "Owner", options.owners],
+                  ] as const
+                ).map(([key, label, values]) => (
+                  <label key={key} className="flex flex-col gap-1 text-xs text-[color:var(--text-tertiary)]">
+                    {label}
+                    <select
+                      value={filters[key]}
+                      onChange={(event) => updateFilter(key, event.target.value)}
+                      className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-sm text-[color:var(--foreground)]"
+                    >
+                      <option value="all">All {label.toLowerCase()}</option>
+                      {values.map((value) => (
+                        <option key={value} value={value}>
+                          {value}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ))}
+                {(
+                  [
+                    ["risk", "Risk", ["all", "high", "medium", "low"]],
+                    ["freshness", "Freshness", ["all", "seen_24h", "seen_7d", "stale", "unknown"]],
+                    ["runtime", "Runtime", ["all", "gateway bound", "runtime observed", "shadow runtime", "inventory only"]],
+                  ] as const
+                ).map(([key, label, values]) => (
+                  <label key={key} className="flex flex-col gap-1 text-xs text-[color:var(--text-tertiary)]">
+                    {label}
+                    <select
+                      value={filters[key]}
+                      onChange={(event) => updateFilter(key, event.target.value as ManifestFilters[typeof key])}
+                      className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-sm text-[color:var(--foreground)]"
+                    >
+                      {values.map((value) => (
+                        <option key={value} value={value}>
+                          {value === "all" ? `All ${label.toLowerCase()}` : value}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ))}
+                <div className="flex items-end">
+                  <button
+                    type="button"
+                    disabled={!hasActiveFilters}
+                    onClick={() => setFilters(DEFAULT_MANIFEST_FILTERS)}
+                    className="inline-flex w-full items-center justify-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-sm text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)] disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Clear filters
+                  </button>
+                </div>
+              </div>
+
+              <div className="overflow-x-auto">
+                <table className="w-full text-left text-sm">
+                  <thead className="bg-[color:var(--surface-muted)] text-[11px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+                    <tr>
+                      {["Agent", "Owner", "Source", "Environment", "MCP server", "Risk", "Transport", "Runtime", "Tools", "Credential refs", "Last seen"].map((heading) => (
+                        <th key={heading} className="px-4 py-3 font-medium">
+                          {heading}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-[color:var(--border-subtle)]">
+                    {rows.map((row, index) => (
+                      <tr key={`${row.id}:${index}`} className="hover:bg-[color:var(--surface-muted)]/60">
+                        <td className="px-4 py-3 text-[color:var(--foreground)]">{row.agentName}</td>
+                        <td className="px-4 py-3 text-[color:var(--text-secondary)]">{row.owner}</td>
+                        <td className="px-4 py-3 text-[color:var(--text-secondary)]">{row.source}</td>
+                        <td className="px-4 py-3 text-[color:var(--text-secondary)]">{row.environment}</td>
+                        <td className="px-4 py-3 font-medium text-[color:var(--foreground)]">{row.name}</td>
+                        <td className="px-4 py-3">
+                          <span
+                            className={`rounded-full px-2 py-1 text-xs ${
+                              row.riskLevel === "high"
+                                ? "bg-red-500/10 text-red-300"
+                                : row.riskLevel === "medium"
+                                  ? "bg-amber-500/10 text-amber-200"
+                                  : "bg-emerald-500/10 text-emerald-200"
+                            }`}
+                          >
+                            {row.riskLevel}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-[color:var(--text-secondary)]">{row.transport}</td>
+                        <td className="px-4 py-3 text-[color:var(--text-secondary)]">{row.runtimeState}</td>
+                        <td className="px-4 py-3 text-[color:var(--foreground)]">{row.toolCount}</td>
+                        <td className="px-4 py-3 text-[color:var(--text-secondary)]">{row.credentialRefs.join(", ") || "none"}</td>
+                        <td className="px-4 py-3 text-[color:var(--text-secondary)]">{row.lastSeen}</td>
+                      </tr>
+                    ))}
+                    {rows.length === 0 ? (
+                      <tr>
+                        <td colSpan={11} className="px-4 py-8 text-center text-sm text-[color:var(--text-secondary)]">
+                          No MCP servers in this tenant yet. Connect cloud accounts or run{" "}
+                          <code className="rounded bg-[color:var(--surface-muted)] px-1.5 py-0.5">agent-bom agents</code>{" "}
+                          to populate AI BOM evidence.
+                        </td>
+                      </tr>
+                    ) : null}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          </Section>
+
+          <details className="group rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]">
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-5 py-4 text-sm font-medium text-[color:var(--foreground)] [&::-webkit-details-marker]:hidden">
+              Extended visibility metrics
+              <span className="text-xs text-[color:var(--text-tertiary)]">operators</span>
+            </summary>
+            <div className="grid gap-3 border-t border-[color:var(--border-subtle)] p-4 sm:grid-cols-2 lg:grid-cols-4">
+              <StatCard label="Tools" value={manifest.summary.tools} accent="info" />
+              <StatCard label="Gateway bound" value={manifest.summary.gateway_registered_servers} />
+              <StatCard label="Owners" value={manifest.visibility.owners} />
+              <StatCard label="Unowned agents" value={manifest.visibility.unowned_agents} accent="medium" />
+              <StatCard label="Shadow runtime" value={manifest.visibility.shadow_runtime_servers} accent="high" />
+              <StatCard label="Untracked runtime" value={manifest.visibility.untracked_runtime_servers} accent="high" />
+              <StatCard label="Warnings" value={manifest.visibility.servers_with_warnings} accent="medium" />
+              <StatCard label="Risky refs" value={manifest.visibility.risky_credential_refs} accent="critical" />
+            </div>
+          </details>
+
+          <details className="group rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]">
+            <summary className="cursor-pointer list-none px-5 py-4 text-sm font-medium text-[color:var(--foreground)] [&::-webkit-details-marker]:hidden">
+              Reachability graph · {manifest.graph.stats.nodes} nodes · {manifest.graph.stats.edges} edges
+            </summary>
+            <div className="border-t border-[color:var(--border-subtle)] p-5">
+              <MiniGraph manifest={manifest} />
+            </div>
+          </details>
+        </>
+      ) : loading ? (
+        <Card className="!p-8 text-sm text-[color:var(--text-secondary)]">
+          <Loader2 className="mr-2 inline h-4 w-4 animate-spin" />
+          Loading AI BOM evidence
+        </Card>
+      ) : null}
+    </div>
   );
 }

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -102,7 +102,7 @@ const NAV_GROUPS: NavGroup[] = [
     icon: Bot,
     links: [
       { href: "/agents", label: "Agents", icon: Bot },
-      { href: "/manifest", label: "Agent BOM", icon: ClipboardList },
+      { href: "/manifest", label: "AI BOM", icon: ClipboardList },
       { href: "/fleet", label: "Fleet", icon: Users },
     ],
   },

--- a/ui/components/page-lane.tsx
+++ b/ui/components/page-lane.tsx
@@ -23,12 +23,14 @@ export function PageLaneHeader({
   subtitle,
   actions,
   banner,
+  scopeChip,
 }: {
   lane: PageLane;
   title: string;
   subtitle?: string;
   actions?: ReactNode;
   banner?: ReactNode;
+  scopeChip?: ReactNode;
 }) {
   const meta = PAGE_LANE_META[lane];
   return (
@@ -42,7 +44,7 @@ export function PageLaneHeader({
             >
               {meta.label}
             </p>
-            <PageScopeChip lane={lane} />
+            {scopeChip ?? <PageScopeChip lane={lane} />}
           </div>
           <h1 className="mt-1 text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">
             {title}

--- a/ui/lib/ai-bom-evidence.ts
+++ b/ui/lib/ai-bom-evidence.ts
@@ -1,0 +1,110 @@
+import type { AgentBomManifestNode, AgentBomManifestResponse, PostureCountsResponse } from "@/lib/api";
+import { deploymentModeLabel } from "@/lib/deployment-context";
+
+export type AiBomEvidenceSource = {
+  id: string;
+  label: string;
+  detail: string;
+  active: boolean;
+  href?: string;
+};
+
+export type AiBomEntityRollup = {
+  agents: number;
+  mcpServers: number;
+  models: number;
+  packages: number;
+  credentials: number;
+  cloudAssets: number;
+  findings: number;
+};
+
+export function aiBomScopeLabel(
+  counts: PostureCountsResponse | null,
+  manifest: AgentBomManifestResponse | null,
+): string {
+  const mode = deploymentModeLabel(counts?.deployment_mode);
+  const tenant = manifest?.tenant_id?.trim() || "default";
+  const source = manifest?.source === "control-plane" ? "control plane" : "local discovery";
+  return `${mode} · tenant ${tenant} · ${source}`;
+}
+
+export function deriveAiBomEvidenceSources(
+  counts: PostureCountsResponse | null,
+  manifest: AgentBomManifestResponse | null,
+): AiBomEvidenceSource[] {
+  const scanSources = new Set((counts?.scan_sources ?? []).map((source) => source.toLowerCase()));
+  const hasCloudScan = ["aws", "azure", "gcp", "snowflake", "databricks"].some((provider) =>
+    [...scanSources].some((source) => source.includes(provider)),
+  );
+
+  return [
+    {
+      id: "workstation",
+      label: "Workstation agents",
+      detail: "Local MCP and agent project discovery",
+      active: Boolean(counts?.has_local_scan || counts?.has_agent_context || manifest?.summary.agents),
+      href: "/agents",
+    },
+    {
+      id: "fleet",
+      label: "Fleet endpoints",
+      detail: "Laptops, VMs, and collectors pushing inventory",
+      active: Boolean(counts?.has_fleet_ingest),
+      href: "/fleet",
+    },
+    {
+      id: "cloud",
+      label: "Cloud AI services",
+      detail: "Connected accounts for models, endpoints, and managed AI",
+      active: hasCloudScan || Boolean(counts?.services && Object.keys(counts.services).length > 0),
+      href: "/connections",
+    },
+    {
+      id: "cluster",
+      label: "Kubernetes",
+      detail: "Cluster scans for pods, images, and runtime AI workloads",
+      active: Boolean(counts?.has_cluster_scan),
+      href: "/scan",
+    },
+    {
+      id: "runtime",
+      label: "Runtime enforcement",
+      detail: "Proxy, gateway, and trace observations",
+      active: Boolean(counts?.has_proxy || counts?.has_gateway || counts?.has_traces),
+      href: "/runtime",
+    },
+    {
+      id: "control-plane",
+      label: "Control-plane manifest",
+      detail: "Tenant-scoped Agent BOM assembled from fleet + runtime stores",
+      active: Boolean(manifest),
+      href: "/manifest",
+    },
+  ];
+}
+
+export function summarizeAiBomEntities(
+  manifest: AgentBomManifestResponse | null,
+): AiBomEntityRollup {
+  const nodes = manifest?.graph.nodes ?? [];
+  const byType = nodes.reduce<Record<string, number>>((acc, node) => {
+    const key = node.entity_type.toLowerCase();
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return {
+    agents: manifest?.summary.agents ?? byType.agent ?? 0,
+    mcpServers: manifest?.summary.mcp_servers ?? byType.server ?? 0,
+    models: byType.model ?? 0,
+    packages: byType.package ?? 0,
+    credentials: manifest?.summary.credential_refs ?? byType.credential ?? 0,
+    cloudAssets: (byType.cloud_resource ?? 0) + (byType.cloudresource ?? 0) + (byType.container ?? 0),
+    findings: (byType.vulnerability ?? 0) + (byType.misconfiguration ?? 0),
+  };
+}
+
+export function countActiveEvidenceSources(sources: AiBomEvidenceSource[]): number {
+  return sources.filter((source) => source.active).length;
+}

--- a/ui/lib/ai-bom-evidence.ts
+++ b/ui/lib/ai-bom-evidence.ts
@@ -1,4 +1,4 @@
-import type { AgentBomManifestNode, AgentBomManifestResponse, PostureCountsResponse } from "@/lib/api";
+import type { AgentBomManifestResponse, PostureCountsResponse } from "@/lib/api";
 import { deploymentModeLabel } from "@/lib/deployment-context";
 
 export type AiBomEvidenceSource = {

--- a/ui/lib/page-lanes.ts
+++ b/ui/lib/page-lanes.ts
@@ -11,8 +11,8 @@ export const PAGE_LANE_META: Record<
   PageLane,
   { label: string; scope: string; accent: string }
 > = {
-  command: { label: "Command", scope: "Posture & paths", accent: "#58a6ff" },
-  "ai-estate": { label: "AI inventory", scope: "Local · Your agents", accent: "#3fb950" },
+  command: { label: "Posture", scope: "Exposure & paths", accent: "#58a6ff" },
+  "ai-estate": { label: "AI inventory", scope: "Tenant AI estate", accent: "#3fb950" },
   "cloud-data": { label: "Cloud & Data", scope: "Cloud · Read-only", accent: "#a371f7" },
   runtime: { label: "Runtime", scope: "Live · Enforced", accent: "#f778ba" },
   governance: { label: "Governance", scope: "Policy & evidence", accent: "#3fb950" },

--- a/ui/tests/ai-bom-evidence.test.ts
+++ b/ui/tests/ai-bom-evidence.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  aiBomScopeLabel,
+  countActiveEvidenceSources,
+  deriveAiBomEvidenceSources,
+  summarizeAiBomEntities,
+} from "@/lib/ai-bom-evidence";
+import type { AgentBomManifestResponse } from "@/lib/api";
+
+const manifestFixture: AgentBomManifestResponse = {
+  schema_version: "agent-bom.manifest/v1",
+  generated_at: "2026-07-10T03:57:48Z",
+  source: "control-plane",
+  tenant_id: "default",
+  summary: {
+    agents: 0,
+    mcp_servers: 9,
+    tools: 42,
+    credential_refs: 3,
+    runtime_observed_servers: 2,
+    gateway_registered_servers: 1,
+  },
+  visibility: {
+    owners: 1,
+    unowned_agents: 0,
+    shadow_runtime_servers: 0,
+    untracked_runtime_servers: 0,
+    servers_with_warnings: 1,
+    risky_credential_refs: 0,
+    risk_signals: {
+      unowned_agent_ids: [],
+      shadow_runtime_server_ids: [],
+      untracked_runtime_server_ids: [],
+      risky_credential_refs: [],
+    },
+  },
+  blueprint_drift: {
+    status: "aligned",
+    mode: "observation_only",
+    fail_behavior: "report_only",
+    signal_count: 0,
+    signals: [],
+  },
+  agents: [],
+  mcp_servers: [],
+  graph: {
+    nodes: [
+      { id: "server:github", entity_type: "server", label: "github", attributes: {} },
+      { id: "pkg:form-data", entity_type: "package", label: "form-data@4.0.0", attributes: {} },
+      { id: "model:gpt-4", entity_type: "model", label: "gpt-4", attributes: {} },
+    ],
+    edges: [],
+    stats: { nodes: 3, edges: 0, relationships: [] },
+  },
+  boundaries: {
+    stores_credential_values: false,
+    stores_raw_prompts: false,
+    credential_value_policy: "names_only",
+  },
+};
+
+describe("ai-bom-evidence", () => {
+  it("builds a deployment-aware scope label instead of a vague local/default chip", () => {
+    expect(
+      aiBomScopeLabel(
+        {
+          critical: 0,
+          high: 0,
+          medium: 0,
+          low: 0,
+          total: 0,
+          kev: 0,
+          compound_issues: 0,
+          deployment_mode: "local",
+        },
+        manifestFixture,
+      ),
+    ).toBe("Local · tenant default · control plane");
+  });
+
+  it("rolls up AI estate entities from the manifest graph", () => {
+    expect(summarizeAiBomEntities(manifestFixture)).toEqual({
+      agents: 0,
+      mcpServers: 9,
+      models: 1,
+      packages: 1,
+      credentials: 3,
+      cloudAssets: 0,
+      findings: 0,
+    });
+  });
+
+  it("marks connected evidence sources from deployment posture", () => {
+    const sources = deriveAiBomEvidenceSources(
+      {
+        critical: 0,
+        high: 0,
+        medium: 0,
+        low: 0,
+        total: 1,
+        kev: 0,
+        compound_issues: 0,
+        deployment_mode: "hybrid",
+        has_local_scan: true,
+        has_fleet_ingest: true,
+        has_proxy: true,
+        scan_sources: ["aws", "agent_discovery"],
+      },
+      manifestFixture,
+    );
+
+    expect(countActiveEvidenceSources(sources)).toBeGreaterThanOrEqual(4);
+    expect(sources.find((source) => source.id === "cloud")?.active).toBe(true);
+    expect(sources.find((source) => source.id === "control-plane")?.active).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Rethemes `/manifest` onto shared platform tokens (`--surface`, `--border-subtle`, `Card`, `StatCard`) — the old page used undefined shadcn vars (`--border`, `--card`, `--muted-foreground`) and looked off-brand.
- Reframes the surface as **AI BOM**: reachability-backed evidence from connected workstations, fleet, cloud, Kubernetes, and runtime — with **Agent runtime inventory** as one layer, not the whole story.
- Adds an **Evidence sources** panel driven by deployment posture + manifest source, plus entity rollups (agents, models, packages, cloud assets, findings).
- Replaces misleading `Local · Your agents` / raw `default` scope with `Local · tenant default · control plane` style context; nav label becomes **AI BOM**.

## Verification
- `cd ui && npm run typecheck`
- `cd ui && npm test -- --run tests/ai-bom-evidence.test.ts tests/agent-bom-manifest.test.ts`

## Notes
Cloud-managed model inventory still depends on connected accounts and scan evidence — this PR makes that contract visible in the UI. Deeper AI-service ingestion can extend the same `ai-bom-evidence` helper without another page rewrite.