### PR TITLE
fix(ui): unblock main E2E graph selector drift

### DIFF
--- a/ui/e2e/scan-export.spec.ts
+++ b/ui/e2e/scan-export.spec.ts
@@ -179,7 +179,9 @@ test("scan flow reaches result view and exports graph JSON", async ({ page }) =>
   // no actionable error.
   await page.waitForLoadState("networkidle");
 
-  await page.getByRole("button", { name: /containers/i }).click();
+  // New Scan uses source tabs + ad-hoc target tabs (not a free-standing Containers button).
+  await page.getByRole("tab", { name: /^Ad-hoc$/i }).click();
+  await page.getByRole("tab", { name: /Containers/i }).click();
   const imageInput = page.getByPlaceholder("nginx:1.25 or ghcr.io/org/app:v1");
   try {
     await expect(imageInput, "image input must be visible after hydration").toBeVisible({ timeout: 15_000 });

--- a/ui/e2e/security-graph-cockpit.spec.ts
+++ b/ui/e2e/security-graph-cockpit.spec.ts
@@ -249,8 +249,8 @@ async function expectCockpitVisible(page: Page) {
   await expect(
     page.getByRole("heading", { name: /Claude Desktop.*form-data.*CVE-2025-7783/ }),
   ).toBeVisible();
-  // Evidence is progressive disclosure ("Evidence & relationships" summary), not a bare label.
-  await expect(page.getByText(/Evidence/)).toBeVisible();
+  // Progressive disclosure summary — avoid /Evidence/ which also matches "Evidence drawer".
+  await expect(page.getByText("Evidence & relationships")).toBeVisible();
   await expect(page.getByText("Risk", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("Hops", { exact: true }).first()).toBeVisible();
 }

--- a/ui/e2e/security-graph-cockpit.spec.ts
+++ b/ui/e2e/security-graph-cockpit.spec.ts
@@ -249,7 +249,8 @@ async function expectCockpitVisible(page: Page) {
   await expect(
     page.getByRole("heading", { name: /Claude Desktop.*form-data.*CVE-2025-7783/ }),
   ).toBeVisible();
-  await expect(page.getByText("Evidence", { exact: true })).toBeVisible();
+  // Evidence is progressive disclosure ("Evidence & relationships" summary), not a bare label.
+  await expect(page.getByText(/Evidence/)).toBeVisible();
   await expect(page.getByText("Risk", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("Hops", { exact: true }).first()).toBeVisible();
 }


### PR DESCRIPTION
## Summary
- Fixes release-blocker [#3789](https://github.com/msaad00/agent-bom/issues/3789): main `UI Validate` failed on Playwright E2E after #3787 graph chrome changes.
- Lineage legend assertion no longer requires a persistent **Hide legend** button (dock/details chrome is valid).
- Security-graph cockpit path heading matches display labels (`Claude Desktop…`) instead of raw node ids.

## Verification
- Diff is the same e2e selector hardening already proven on #3788 (`b9e8ee711`).
- Unit tests were green on the failing main run (404 passed); only E2E selectors were red.

## Notes
- Scoped hotfix for main — does not wait on the larger #3788 UI PR.
- Closes #3789


Made with [Cursor](https://cursor.com)