### PR TITLE
feat(brand): BOM manifest mark + agent bill of materials tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/brand/logo-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/brand/logo-light.svg" alt="agent-bom — AI supply-chain and infrastructure security" width="380" />
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/brand/logo-light.svg" alt="agent-bom — AI agent bill of materials" width="380" />
   </picture>
 </p>
 

--- a/docs/VISUAL_LANGUAGE.md
+++ b/docs/VISUAL_LANGUAGE.md
@@ -9,15 +9,17 @@ social cards, CLI splash.
   sentence or in a Title Case heading. Never `Agent-BOM`, `AgentBOM`, or
   `Agent-Bom` (the title-cased `X-Agent-Bom-*` HTTP headers are a separate wire
   convention and are intentionally left as-is).
-- **Tagline (short, for the wordmark/badges):** "AI supply-chain & infrastructure security".
+- **Tagline (short, for the wordmark/badges):** "AI agent bill of materials".
 - **Tagline (full, for prose/meta):** "Security scanner for the AI supply chain and
   infrastructure — from agent to runtime."
 - **Positioning line (README hero):** "Open security scanner and self-hosted control
   plane for AI, MCP, and cloud infrastructure."
-- **Accent:** blue → violet gradient. Light `#2563eb → #7c3aed`; dark `#60a5fa → #a78bfa`.
-  Ink `#1f2937` (light) / `#e6edf3` (dark); muted `#6b7280` / `#8b949e`.
-- **Mark:** a security shield wrapping a three-node supply-chain / blast-radius graph —
-  the product's signature "agent → MCP → package → CVE → blast radius" motif.
+- **Accent (product UI / lockup):** emerald → cyan. Light `#059669 → #0891b2`;
+  dark `#34d399 → #06b6d4` / `#22d3ee`. Ink `#1f2937` (light) / `#e6edf3` (dark);
+  muted `#6b7280` / `#8b949e`.
+- **Mark:** a rounded tile with a BOM manifest card — stacked inventory rows and one
+  finding highlight. Reads as bill-of-materials inventory, not a generic network graph.
+  A/B explorations live in `docs/images/brand/variants/`.
 
 Brand assets live in `docs/images/brand/` (self-contained SVG, no external fonts or
 network refs, light + dark pairs):

--- a/docs/images/brand/logo-dark.svg
+++ b/docs/images/brand/logo-dark.svg
@@ -1,22 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 96" fill="none" role="img" aria-label="agent-bom — AI supply-chain and infrastructure security">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 96" fill="none" role="img" aria-label="agent-bom — AI agent bill of materials">
   <defs>
     <linearGradient id="abg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#60a5fa"/>
-      <stop offset="100%" stop-color="#a78bfa"/>
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#22d3ee"/>
     </linearGradient>
   </defs>
   <g transform="translate(8, 16)">
-    <path d="M32 6 L54 14 V30 C54 43 44 53 32 58 C20 53 10 43 10 30 V14 Z"
-          fill="url(#abg)" fill-opacity="0.16" stroke="url(#abg)" stroke-width="2.5" stroke-linejoin="round"/>
-    <g stroke="url(#abg)" stroke-width="2" stroke-linecap="round">
-      <line x1="32" y1="23" x2="22" y2="39"/>
-      <line x1="32" y1="23" x2="42" y2="39"/>
-      <line x1="22" y1="39" x2="42" y2="39"/>
-    </g>
-    <circle cx="32" cy="23" r="4" fill="url(#abg)"/>
-    <circle cx="22" cy="39" r="3.4" fill="url(#abg)" fill-opacity="0.5" stroke="url(#abg)" stroke-width="1.5"/>
-    <circle cx="42" cy="39" r="3.4" fill="url(#abg)" fill-opacity="0.5" stroke="url(#abg)" stroke-width="1.5"/>
+    <rect x="0" y="0" width="54" height="54" rx="16" fill="#0c1210" stroke="url(#abg)" stroke-width="2"/>
+    <rect x="11" y="10" width="32" height="34" rx="6" fill="#111a17" stroke="url(#abg)" stroke-width="1.5" stroke-opacity="0.55"/>
+    <circle cx="17" cy="19" r="2" fill="#34d399" fill-opacity="0.45"/>
+    <rect x="22" y="17.25" width="16" height="3.5" rx="1.75" fill="#34d399" fill-opacity="0.28"/>
+    <circle cx="17" cy="27" r="2.25" fill="url(#abg)"/>
+    <rect x="22" y="25" width="18" height="4" rx="2" fill="url(#abg)"/>
+    <rect x="42" y="25.5" width="3.5" height="3" rx="1" fill="#f87171"/>
+    <circle cx="17" cy="35" r="2" fill="#06b6d4" fill-opacity="0.45"/>
+    <rect x="22" y="33.25" width="12" height="3.5" rx="1.75" fill="#06b6d4" fill-opacity="0.28"/>
   </g>
-  <text x="88" y="52" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="800" letter-spacing="-0.5" fill="#e6edf3">agent<tspan fill="url(#abg)">-bom</tspan></text>
-  <text x="90" y="74" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="12.5" font-weight="500" letter-spacing="0.2" fill="#8b949e">AI supply-chain &amp; infrastructure security</text>
+  <text x="88" y="52" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="800" letter-spacing="-0.5" fill="#e6edf3">agent<tspan fill="url(#abg)">·bom</tspan></text>
+  <text x="90" y="74" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="12.5" font-weight="500" letter-spacing="0.2" fill="#8b949e">AI agent bill of materials</text>
 </svg>

--- a/docs/images/brand/logo-light.svg
+++ b/docs/images/brand/logo-light.svg
@@ -1,22 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 96" fill="none" role="img" aria-label="agent-bom — AI supply-chain and infrastructure security">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 96" fill="none" role="img" aria-label="agent-bom — AI agent bill of materials">
   <defs>
     <linearGradient id="abg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#2563eb"/>
-      <stop offset="100%" stop-color="#7c3aed"/>
+      <stop offset="0%" stop-color="#059669"/>
+      <stop offset="100%" stop-color="#0891b2"/>
     </linearGradient>
   </defs>
   <g transform="translate(8, 16)">
-    <path d="M32 6 L54 14 V30 C54 43 44 53 32 58 C20 53 10 43 10 30 V14 Z"
-          fill="url(#abg)" fill-opacity="0.10" stroke="url(#abg)" stroke-width="2.5" stroke-linejoin="round"/>
-    <g stroke="url(#abg)" stroke-width="2" stroke-linecap="round">
-      <line x1="32" y1="23" x2="22" y2="39"/>
-      <line x1="32" y1="23" x2="42" y2="39"/>
-      <line x1="22" y1="39" x2="42" y2="39"/>
-    </g>
-    <circle cx="32" cy="23" r="4" fill="url(#abg)"/>
-    <circle cx="22" cy="39" r="3.4" fill="url(#abg)" fill-opacity="0.45" stroke="url(#abg)" stroke-width="1.5"/>
-    <circle cx="42" cy="39" r="3.4" fill="url(#abg)" fill-opacity="0.45" stroke="url(#abg)" stroke-width="1.5"/>
+    <rect x="0" y="0" width="54" height="54" rx="16" fill="#f8fafc" stroke="url(#abg)" stroke-width="2"/>
+    <rect x="11" y="10" width="32" height="34" rx="6" fill="#ffffff" stroke="url(#abg)" stroke-width="1.5" stroke-opacity="0.65"/>
+    <circle cx="17" cy="19" r="2" fill="#059669" fill-opacity="0.5"/>
+    <rect x="22" y="17.25" width="16" height="3.5" rx="1.75" fill="#059669" fill-opacity="0.22"/>
+    <circle cx="17" cy="27" r="2.25" fill="url(#abg)"/>
+    <rect x="22" y="25" width="18" height="4" rx="2" fill="url(#abg)"/>
+    <rect x="42" y="25.5" width="3.5" height="3" rx="1" fill="#dc2626"/>
+    <circle cx="17" cy="35" r="2" fill="#0891b2" fill-opacity="0.5"/>
+    <rect x="22" y="33.25" width="12" height="3.5" rx="1.75" fill="#0891b2" fill-opacity="0.22"/>
   </g>
-  <text x="88" y="52" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="800" letter-spacing="-0.5" fill="#1f2937">agent<tspan fill="url(#abg)">-bom</tspan></text>
-  <text x="90" y="74" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="12.5" font-weight="500" letter-spacing="0.2" fill="#6b7280">AI supply-chain &amp; infrastructure security</text>
+  <text x="88" y="52" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="800" letter-spacing="-0.5" fill="#1f2937">agent<tspan fill="url(#abg)">·bom</tspan></text>
+  <text x="90" y="74" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="12.5" font-weight="500" letter-spacing="0.2" fill="#6b7280">AI agent bill of materials</text>
 </svg>

--- a/docs/images/brand/mark-light.svg
+++ b/docs/images/brand/mark-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark  manifest card">
   <defs>
     <linearGradient id="abm-chain" x1="12" y1="10" x2="52" y2="54" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#059669"/>
@@ -6,10 +6,12 @@
     </linearGradient>
   </defs>
   <rect x="5" y="5" width="54" height="54" rx="16" fill="#f8fafc" stroke="url(#abm-chain)" stroke-width="2"/>
-  <path d="M32 14v8M32 22l-14 18M32 22l14 18" stroke="url(#abm-chain)" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-  <circle cx="32" cy="14" r="5.5" fill="url(#abm-chain)"/>
-  <circle cx="18" cy="40" r="4.5" fill="#059669" fill-opacity="0.9"/>
-  <circle cx="46" cy="40" r="4.5" fill="#0891b2" fill-opacity="0.9"/>
-  <rect x="24" y="46" width="16" height="3" rx="1.5" fill="#059669" fill-opacity="0.25"/>
-  <rect x="26" y="50" width="12" height="3" rx="1.5" fill="#0891b2" fill-opacity="0.25"/>
+  <rect x="16" y="15" width="32" height="34" rx="6" fill="#ffffff" stroke="url(#abm-chain)" stroke-width="1.5" stroke-opacity="0.65"/>
+  <circle cx="22" cy="24" r="2" fill="#059669" fill-opacity="0.5"/>
+  <rect x="27" y="22.25" width="16" height="3.5" rx="1.75" fill="#059669" fill-opacity="0.22"/>
+  <circle cx="22" cy="32" r="2.25" fill="url(#abm-chain)"/>
+  <rect x="27" y="30" width="18" height="4" rx="2" fill="url(#abm-chain)"/>
+  <rect x="47" y="30.5" width="3.5" height="3" rx="1" fill="#dc2626"/>
+  <circle cx="22" cy="40" r="2" fill="#0891b2" fill-opacity="0.5"/>
+  <rect x="27" y="38.25" width="12" height="3.5" rx="1.75" fill="#0891b2" fill-opacity="0.22"/>
 </svg>

--- a/docs/images/brand/variants/README.md
+++ b/docs/images/brand/variants/README.md
@@ -1,0 +1,12 @@
+# Brand mark variants (A/B)
+
+Explorations for a more BOM-native mark. Canonical product assets remain
+`../mark-{light,dark}.svg` (currently **A — manifest card**).
+
+| File | Concept |
+|---|---|
+| `a-manifest-{light,dark}.svg` | BOM card: stacked inventory rows, one finding highlight |
+| `b-agent-materials-{light,dark}.svg` | Agent prompt block + materials list |
+| `c-brace-bom-{light,dark}.svg` | Code braces framing dependency ticks |
+
+Accent continuity: emerald → cyan (`#34d399` / `#06b6d4` dark; `#059669` / `#0891b2` light).

--- a/docs/images/brand/variants/a-manifest-dark.svg
+++ b/docs/images/brand/variants/a-manifest-dark.svg
@@ -1,19 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark  manifest card">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark — manifest card">
   <defs>
-    <linearGradient id="abm-chain" x1="12" y1="10" x2="52" y2="54" gradientUnits="userSpaceOnUse">
+    <linearGradient id="abm-a" x1="12" y1="10" x2="52" y2="54" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#34d399"/>
       <stop offset="100%" stop-color="#06b6d4"/>
     </linearGradient>
   </defs>
-  <rect x="5" y="5" width="54" height="54" rx="16" fill="#0c1210" stroke="url(#abm-chain)" stroke-width="2"/>
+  <rect x="5" y="5" width="54" height="54" rx="16" fill="#0c1210" stroke="url(#abm-a)" stroke-width="2"/>
   <!-- BOM card -->
-  <rect x="16" y="15" width="32" height="34" rx="6" fill="#111a17" stroke="url(#abm-chain)" stroke-width="1.5" stroke-opacity="0.55"/>
+  <rect x="16" y="15" width="32" height="34" rx="6" fill="#111a17" stroke="url(#abm-a)" stroke-width="1.5" stroke-opacity="0.55"/>
   <!-- row 1 -->
   <circle cx="22" cy="24" r="2" fill="#34d399" fill-opacity="0.45"/>
   <rect x="27" y="22.25" width="16" height="3.5" rx="1.75" fill="#34d399" fill-opacity="0.28"/>
   <!-- row 2 (finding) -->
-  <circle cx="22" cy="32" r="2.25" fill="url(#abm-chain)"/>
-  <rect x="27" y="30" width="18" height="4" rx="2" fill="url(#abm-chain)"/>
+  <circle cx="22" cy="32" r="2.25" fill="url(#abm-a)"/>
+  <rect x="27" y="30" width="18" height="4" rx="2" fill="url(#abm-a)"/>
   <rect x="47" y="30.5" width="3.5" height="3" rx="1" fill="#f87171"/>
   <!-- row 3 -->
   <circle cx="22" cy="40" r="2" fill="#06b6d4" fill-opacity="0.45"/>

--- a/docs/images/brand/variants/a-manifest-light.svg
+++ b/docs/images/brand/variants/a-manifest-light.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark — manifest card">
+  <defs>
+    <linearGradient id="abm-a" x1="12" y1="10" x2="52" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#059669"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+  </defs>
+  <rect x="5" y="5" width="54" height="54" rx="16" fill="#f8fafc" stroke="url(#abm-a)" stroke-width="2"/>
+  <rect x="16" y="15" width="32" height="34" rx="6" fill="#ffffff" stroke="url(#abm-a)" stroke-width="1.5" stroke-opacity="0.65"/>
+  <circle cx="22" cy="24" r="2" fill="#059669" fill-opacity="0.5"/>
+  <rect x="27" y="22.25" width="16" height="3.5" rx="1.75" fill="#059669" fill-opacity="0.22"/>
+  <circle cx="22" cy="32" r="2.25" fill="url(#abm-a)"/>
+  <rect x="27" y="30" width="18" height="4" rx="2" fill="url(#abm-a)"/>
+  <rect x="47" y="30.5" width="3.5" height="3" rx="1" fill="#dc2626"/>
+  <circle cx="22" cy="40" r="2" fill="#0891b2" fill-opacity="0.5"/>
+  <rect x="27" y="38.25" width="12" height="3.5" rx="1.75" fill="#0891b2" fill-opacity="0.22"/>
+</svg>

--- a/docs/images/brand/variants/b-agent-materials-dark.svg
+++ b/docs/images/brand/variants/b-agent-materials-dark.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark — agent + materials">
+  <defs>
+    <linearGradient id="abm-b" x1="12" y1="10" x2="52" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+  </defs>
+  <rect x="5" y="5" width="54" height="54" rx="16" fill="#0c1210" stroke="url(#abm-b)" stroke-width="2"/>
+  <!-- agent / prompt block -->
+  <rect x="14" y="16" width="16" height="20" rx="4" fill="#111a17" stroke="url(#abm-b)" stroke-width="1.5"/>
+  <path d="M18 24h8M18 28h5" stroke="url(#abm-b)" stroke-width="1.75" stroke-linecap="round"/>
+  <rect x="18" y="31.5" width="1.75" height="5" rx="0.75" fill="url(#abm-b)"/>
+  <!-- materials list -->
+  <rect x="34" y="18" width="16" height="3.25" rx="1.5" fill="#34d399" fill-opacity="0.35"/>
+  <rect x="34" y="25" width="16" height="3.25" rx="1.5" fill="url(#abm-b)"/>
+  <rect x="34" y="32" width="11" height="3.25" rx="1.5" fill="#06b6d4" fill-opacity="0.35"/>
+  <!-- checksum bar -->
+  <rect x="14" y="44" width="36" height="4" rx="2" fill="url(#abm-b)" fill-opacity="0.35"/>
+</svg>

--- a/docs/images/brand/variants/b-agent-materials-light.svg
+++ b/docs/images/brand/variants/b-agent-materials-light.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark — agent + materials">
+  <defs>
+    <linearGradient id="abm-b" x1="12" y1="10" x2="52" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#059669"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+  </defs>
+  <rect x="5" y="5" width="54" height="54" rx="16" fill="#f8fafc" stroke="url(#abm-b)" stroke-width="2"/>
+  <rect x="14" y="16" width="16" height="20" rx="4" fill="#ffffff" stroke="url(#abm-b)" stroke-width="1.5"/>
+  <path d="M18 24h8M18 28h5" stroke="url(#abm-b)" stroke-width="1.75" stroke-linecap="round"/>
+  <rect x="18" y="31.5" width="1.75" height="5" rx="0.75" fill="url(#abm-b)"/>
+  <rect x="34" y="18" width="16" height="3.25" rx="1.5" fill="#059669" fill-opacity="0.28"/>
+  <rect x="34" y="25" width="16" height="3.25" rx="1.5" fill="url(#abm-b)"/>
+  <rect x="34" y="32" width="11" height="3.25" rx="1.5" fill="#0891b2" fill-opacity="0.28"/>
+  <rect x="14" y="44" width="36" height="4" rx="2" fill="url(#abm-b)" fill-opacity="0.28"/>
+</svg>

--- a/docs/images/brand/variants/c-brace-bom-dark.svg
+++ b/docs/images/brand/variants/c-brace-bom-dark.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark — brace BOM">
+  <defs>
+    <linearGradient id="abm-c" x1="12" y1="10" x2="52" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+  </defs>
+  <rect x="5" y="5" width="54" height="54" rx="16" fill="#0c1210" stroke="url(#abm-c)" stroke-width="2"/>
+  <!-- braces -->
+  <path d="M24 16c-5 0-7 3-7 8v4c0 3-2 4-4 5 2 1 4 2 4 5v4c0 5 2 8 7 8"
+        fill="none" stroke="url(#abm-c)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M40 16c5 0 7 3 7 8v4c0 3 2 4 4 5-2 1-4 2-4 5v4c0 5-2 8-7 8"
+        fill="none" stroke="url(#abm-c)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- dependency ticks -->
+  <rect x="27" y="24" width="10" height="3" rx="1.5" fill="#34d399" fill-opacity="0.4"/>
+  <rect x="26" y="30.5" width="12" height="3.5" rx="1.75" fill="url(#abm-c)"/>
+  <rect x="28" y="37.5" width="8" height="3" rx="1.5" fill="#06b6d4" fill-opacity="0.4"/>
+</svg>

--- a/docs/images/brand/variants/c-brace-bom-light.svg
+++ b/docs/images/brand/variants/c-brace-bom-light.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark — brace BOM">
+  <defs>
+    <linearGradient id="abm-c" x1="12" y1="10" x2="52" y2="54" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#059669"/>
+      <stop offset="100%" stop-color="#0891b2"/>
+    </linearGradient>
+  </defs>
+  <rect x="5" y="5" width="54" height="54" rx="16" fill="#f8fafc" stroke="url(#abm-c)" stroke-width="2"/>
+  <path d="M24 16c-5 0-7 3-7 8v4c0 3-2 4-4 5 2 1 4 2 4 5v4c0 5 2 8 7 8"
+        fill="none" stroke="url(#abm-c)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M40 16c5 0 7 3 7 8v4c0 3 2 4 4 5-2 1-4 2-4 5v4c0 5-2 8-7 8"
+        fill="none" stroke="url(#abm-c)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="27" y="24" width="10" height="3" rx="1.5" fill="#059669" fill-opacity="0.35"/>
+  <rect x="26" y="30.5" width="12" height="3.5" rx="1.75" fill="url(#abm-c)"/>
+  <rect x="28" y="37.5" width="8" height="3" rx="1.5" fill="#0891b2" fill-opacity="0.35"/>
+</svg>

--- a/docs/images/logo-dark.svg
+++ b/docs/images/logo-dark.svg
@@ -1,22 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 96" fill="none" role="img" aria-label="agent-bom — AI supply-chain and infrastructure security">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 96" fill="none" role="img" aria-label="agent-bom — AI agent bill of materials">
   <defs>
     <linearGradient id="abg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#60a5fa"/>
-      <stop offset="100%" stop-color="#a78bfa"/>
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#22d3ee"/>
     </linearGradient>
   </defs>
   <g transform="translate(8, 16)">
-    <path d="M32 6 L54 14 V30 C54 43 44 53 32 58 C20 53 10 43 10 30 V14 Z"
-          fill="url(#abg)" fill-opacity="0.16" stroke="url(#abg)" stroke-width="2.5" stroke-linejoin="round"/>
-    <g stroke="url(#abg)" stroke-width="2" stroke-linecap="round">
-      <line x1="32" y1="23" x2="22" y2="39"/>
-      <line x1="32" y1="23" x2="42" y2="39"/>
-      <line x1="22" y1="39" x2="42" y2="39"/>
-    </g>
-    <circle cx="32" cy="23" r="4" fill="url(#abg)"/>
-    <circle cx="22" cy="39" r="3.4" fill="url(#abg)" fill-opacity="0.5" stroke="url(#abg)" stroke-width="1.5"/>
-    <circle cx="42" cy="39" r="3.4" fill="url(#abg)" fill-opacity="0.5" stroke="url(#abg)" stroke-width="1.5"/>
+    <rect x="0" y="0" width="54" height="54" rx="16" fill="#0c1210" stroke="url(#abg)" stroke-width="2"/>
+    <rect x="11" y="10" width="32" height="34" rx="6" fill="#111a17" stroke="url(#abg)" stroke-width="1.5" stroke-opacity="0.55"/>
+    <circle cx="17" cy="19" r="2" fill="#34d399" fill-opacity="0.45"/>
+    <rect x="22" y="17.25" width="16" height="3.5" rx="1.75" fill="#34d399" fill-opacity="0.28"/>
+    <circle cx="17" cy="27" r="2.25" fill="url(#abg)"/>
+    <rect x="22" y="25" width="18" height="4" rx="2" fill="url(#abg)"/>
+    <rect x="42" y="25.5" width="3.5" height="3" rx="1" fill="#f87171"/>
+    <circle cx="17" cy="35" r="2" fill="#06b6d4" fill-opacity="0.45"/>
+    <rect x="22" y="33.25" width="12" height="3.5" rx="1.75" fill="#06b6d4" fill-opacity="0.28"/>
   </g>
-  <text x="88" y="52" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="800" letter-spacing="-0.5" fill="#e6edf3">agent<tspan fill="url(#abg)">-bom</tspan></text>
-  <text x="90" y="74" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="12.5" font-weight="500" letter-spacing="0.2" fill="#8b949e">AI supply-chain &amp; infrastructure security</text>
+  <text x="88" y="52" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="800" letter-spacing="-0.5" fill="#e6edf3">agent<tspan fill="url(#abg)">·bom</tspan></text>
+  <text x="90" y="74" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="12.5" font-weight="500" letter-spacing="0.2" fill="#8b949e">AI agent bill of materials</text>
 </svg>

--- a/docs/images/logo-light.svg
+++ b/docs/images/logo-light.svg
@@ -1,22 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 96" fill="none" role="img" aria-label="agent-bom — AI supply-chain and infrastructure security">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 96" fill="none" role="img" aria-label="agent-bom — AI agent bill of materials">
   <defs>
     <linearGradient id="abg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#2563eb"/>
-      <stop offset="100%" stop-color="#7c3aed"/>
+      <stop offset="0%" stop-color="#059669"/>
+      <stop offset="100%" stop-color="#0891b2"/>
     </linearGradient>
   </defs>
   <g transform="translate(8, 16)">
-    <path d="M32 6 L54 14 V30 C54 43 44 53 32 58 C20 53 10 43 10 30 V14 Z"
-          fill="url(#abg)" fill-opacity="0.10" stroke="url(#abg)" stroke-width="2.5" stroke-linejoin="round"/>
-    <g stroke="url(#abg)" stroke-width="2" stroke-linecap="round">
-      <line x1="32" y1="23" x2="22" y2="39"/>
-      <line x1="32" y1="23" x2="42" y2="39"/>
-      <line x1="22" y1="39" x2="42" y2="39"/>
-    </g>
-    <circle cx="32" cy="23" r="4" fill="url(#abg)"/>
-    <circle cx="22" cy="39" r="3.4" fill="url(#abg)" fill-opacity="0.45" stroke="url(#abg)" stroke-width="1.5"/>
-    <circle cx="42" cy="39" r="3.4" fill="url(#abg)" fill-opacity="0.45" stroke="url(#abg)" stroke-width="1.5"/>
+    <rect x="0" y="0" width="54" height="54" rx="16" fill="#f8fafc" stroke="url(#abg)" stroke-width="2"/>
+    <rect x="11" y="10" width="32" height="34" rx="6" fill="#ffffff" stroke="url(#abg)" stroke-width="1.5" stroke-opacity="0.65"/>
+    <circle cx="17" cy="19" r="2" fill="#059669" fill-opacity="0.5"/>
+    <rect x="22" y="17.25" width="16" height="3.5" rx="1.75" fill="#059669" fill-opacity="0.22"/>
+    <circle cx="17" cy="27" r="2.25" fill="url(#abg)"/>
+    <rect x="22" y="25" width="18" height="4" rx="2" fill="url(#abg)"/>
+    <rect x="42" y="25.5" width="3.5" height="3" rx="1" fill="#dc2626"/>
+    <circle cx="17" cy="35" r="2" fill="#0891b2" fill-opacity="0.5"/>
+    <rect x="22" y="33.25" width="12" height="3.5" rx="1.75" fill="#0891b2" fill-opacity="0.22"/>
   </g>
-  <text x="88" y="52" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="800" letter-spacing="-0.5" fill="#1f2937">agent<tspan fill="url(#abg)">-bom</tspan></text>
-  <text x="90" y="74" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="12.5" font-weight="500" letter-spacing="0.2" fill="#6b7280">AI supply-chain &amp; infrastructure security</text>
+  <text x="88" y="52" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="800" letter-spacing="-0.5" fill="#1f2937">agent<tspan fill="url(#abg)">·bom</tspan></text>
+  <text x="90" y="74" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="12.5" font-weight="500" letter-spacing="0.2" fill="#6b7280">AI agent bill of materials</text>
 </svg>

--- a/site-docs/assets/brand/mark-mono.svg
+++ b/site-docs/assets/brand/mark-mono.svg
@@ -1,12 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom">
-  <path d="M32 6 L54 14 V30 C54 43 44 53 32 58 C20 53 10 43 10 30 V14 Z"
-        fill="#ffffff" fill-opacity="0.14" stroke="#ffffff" stroke-width="2.5" stroke-linejoin="round"/>
-  <g stroke="#ffffff" stroke-width="2" stroke-linecap="round">
-    <line x1="32" y1="23" x2="22" y2="39"/>
-    <line x1="32" y1="23" x2="42" y2="39"/>
-    <line x1="22" y1="39" x2="42" y2="39"/>
-  </g>
-  <circle cx="32" cy="23" r="4" fill="#ffffff"/>
-  <circle cx="22" cy="39" r="3.4" fill="#ffffff" fill-opacity="0.55" stroke="#ffffff" stroke-width="1.5"/>
-  <circle cx="42" cy="39" r="3.4" fill="#ffffff" fill-opacity="0.55" stroke="#ffffff" stroke-width="1.5"/>
+  <rect x="5" y="5" width="54" height="54" rx="16" fill="#ffffff" fill-opacity="0.12" stroke="#ffffff" stroke-width="2"/>
+  <rect x="16" y="15" width="32" height="34" rx="6" fill="#ffffff" fill-opacity="0.08" stroke="#ffffff" stroke-width="1.5" stroke-opacity="0.7"/>
+  <circle cx="22" cy="24" r="2" fill="#ffffff" fill-opacity="0.45"/>
+  <rect x="27" y="22.25" width="16" height="3.5" rx="1.75" fill="#ffffff" fill-opacity="0.35"/>
+  <circle cx="22" cy="32" r="2.25" fill="#ffffff"/>
+  <rect x="27" y="30" width="18" height="4" rx="2" fill="#ffffff"/>
+  <rect x="47" y="30.5" width="3.5" height="3" rx="1" fill="#ffffff" fill-opacity="0.85"/>
+  <circle cx="22" cy="40" r="2" fill="#ffffff" fill-opacity="0.45"/>
+  <rect x="27" y="38.25" width="12" height="3.5" rx="1.75" fill="#ffffff" fill-opacity="0.35"/>
 </svg>

--- a/site-docs/assets/brand/mark.svg
+++ b/site-docs/assets/brand/mark.svg
@@ -1,18 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark">
   <defs>
-    <linearGradient id="abm" x1="0" y1="0" x2="1" y2="1">
+    <linearGradient id="abm" x1="12" y1="10" x2="52" y2="54" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#2563eb"/>
       <stop offset="100%" stop-color="#7c3aed"/>
     </linearGradient>
   </defs>
-  <path d="M32 6 L54 14 V30 C54 43 44 53 32 58 C20 53 10 43 10 30 V14 Z"
-        fill="url(#abm)" fill-opacity="0.10" stroke="url(#abm)" stroke-width="2.5" stroke-linejoin="round"/>
-  <g stroke="url(#abm)" stroke-width="2" stroke-linecap="round">
-    <line x1="32" y1="23" x2="22" y2="39"/>
-    <line x1="32" y1="23" x2="42" y2="39"/>
-    <line x1="22" y1="39" x2="42" y2="39"/>
-  </g>
-  <circle cx="32" cy="23" r="4" fill="url(#abm)"/>
-  <circle cx="22" cy="39" r="3.4" fill="url(#abm)" fill-opacity="0.45" stroke="url(#abm)" stroke-width="1.5"/>
-  <circle cx="42" cy="39" r="3.4" fill="url(#abm)" fill-opacity="0.45" stroke="url(#abm)" stroke-width="1.5"/>
+  <rect x="5" y="5" width="54" height="54" rx="16" fill="#f8fafc" stroke="url(#abm)" stroke-width="2"/>
+  <rect x="16" y="15" width="32" height="34" rx="6" fill="#ffffff" stroke="url(#abm)" stroke-width="1.5" stroke-opacity="0.65"/>
+  <circle cx="22" cy="24" r="2" fill="#2563eb" fill-opacity="0.45"/>
+  <rect x="27" y="22.25" width="16" height="3.5" rx="1.75" fill="#2563eb" fill-opacity="0.22"/>
+  <circle cx="22" cy="32" r="2.25" fill="url(#abm)"/>
+  <rect x="27" y="30" width="18" height="4" rx="2" fill="url(#abm)"/>
+  <rect x="47" y="30.5" width="3.5" height="3" rx="1" fill="#dc2626"/>
+  <circle cx="22" cy="40" r="2" fill="#7c3aed" fill-opacity="0.45"/>
+  <rect x="27" y="38.25" width="12" height="3.5" rx="1.75" fill="#7c3aed" fill-opacity="0.22"/>
 </svg>

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -1,7 +1,7 @@
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/brand/logo-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/brand/logo-light.svg" alt="agent-bom — AI supply-chain and infrastructure security" width="380">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/brand/logo-light.svg" alt="agent-bom — AI agent bill of materials" width="380">
   </picture>
 </p>
 

--- a/ui/components/brand-logo.tsx
+++ b/ui/components/brand-logo.tsx
@@ -2,7 +2,7 @@
 
 import { useThemeMode } from "@/lib/theme-mode";
 
-const TAGLINE = "AI supply-chain security";
+const TAGLINE = "AI agent bill of materials";
 
 type BrandLogoProps = {
   className?: string;

--- a/ui/public/brand/mark-dark.svg
+++ b/ui/public/brand/mark-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark  manifest card">
   <defs>
     <linearGradient id="abm-chain" x1="12" y1="10" x2="52" y2="54" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#34d399"/>
@@ -6,10 +6,16 @@
     </linearGradient>
   </defs>
   <rect x="5" y="5" width="54" height="54" rx="16" fill="#0c1210" stroke="url(#abm-chain)" stroke-width="2"/>
-  <path d="M32 14v8M32 22l-14 18M32 22l14 18" stroke="url(#abm-chain)" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-  <circle cx="32" cy="14" r="5.5" fill="url(#abm-chain)"/>
-  <circle cx="18" cy="40" r="4.5" fill="#34d399" fill-opacity="0.85"/>
-  <circle cx="46" cy="40" r="4.5" fill="#06b6d4" fill-opacity="0.85"/>
-  <rect x="24" y="46" width="16" height="3" rx="1.5" fill="#34d399" fill-opacity="0.35"/>
-  <rect x="26" y="50" width="12" height="3" rx="1.5" fill="#06b6d4" fill-opacity="0.35"/>
+  <!-- BOM card -->
+  <rect x="16" y="15" width="32" height="34" rx="6" fill="#111a17" stroke="url(#abm-chain)" stroke-width="1.5" stroke-opacity="0.55"/>
+  <!-- row 1 -->
+  <circle cx="22" cy="24" r="2" fill="#34d399" fill-opacity="0.45"/>
+  <rect x="27" y="22.25" width="16" height="3.5" rx="1.75" fill="#34d399" fill-opacity="0.28"/>
+  <!-- row 2 (finding) -->
+  <circle cx="22" cy="32" r="2.25" fill="url(#abm-chain)"/>
+  <rect x="27" y="30" width="18" height="4" rx="2" fill="url(#abm-chain)"/>
+  <rect x="47" y="30.5" width="3.5" height="3" rx="1" fill="#f87171"/>
+  <!-- row 3 -->
+  <circle cx="22" cy="40" r="2" fill="#06b6d4" fill-opacity="0.45"/>
+  <rect x="27" y="38.25" width="12" height="3.5" rx="1.75" fill="#06b6d4" fill-opacity="0.28"/>
 </svg>

--- a/ui/public/brand/mark-light.svg
+++ b/ui/public/brand/mark-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark  manifest card">
   <defs>
     <linearGradient id="abm-chain" x1="12" y1="10" x2="52" y2="54" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#059669"/>
@@ -6,10 +6,12 @@
     </linearGradient>
   </defs>
   <rect x="5" y="5" width="54" height="54" rx="16" fill="#f8fafc" stroke="url(#abm-chain)" stroke-width="2"/>
-  <path d="M32 14v8M32 22l-14 18M32 22l14 18" stroke="url(#abm-chain)" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
-  <circle cx="32" cy="14" r="5.5" fill="url(#abm-chain)"/>
-  <circle cx="18" cy="40" r="4.5" fill="#059669" fill-opacity="0.9"/>
-  <circle cx="46" cy="40" r="4.5" fill="#0891b2" fill-opacity="0.9"/>
-  <rect x="24" y="46" width="16" height="3" rx="1.5" fill="#059669" fill-opacity="0.25"/>
-  <rect x="26" y="50" width="12" height="3" rx="1.5" fill="#0891b2" fill-opacity="0.25"/>
+  <rect x="16" y="15" width="32" height="34" rx="6" fill="#ffffff" stroke="url(#abm-chain)" stroke-width="1.5" stroke-opacity="0.65"/>
+  <circle cx="22" cy="24" r="2" fill="#059669" fill-opacity="0.5"/>
+  <rect x="27" y="22.25" width="16" height="3.5" rx="1.75" fill="#059669" fill-opacity="0.22"/>
+  <circle cx="22" cy="32" r="2.25" fill="url(#abm-chain)"/>
+  <rect x="27" y="30" width="18" height="4" rx="2" fill="url(#abm-chain)"/>
+  <rect x="47" y="30.5" width="3.5" height="3" rx="1" fill="#dc2626"/>
+  <circle cx="22" cy="40" r="2" fill="#0891b2" fill-opacity="0.5"/>
+  <rect x="27" y="38.25" width="12" height="3.5" rx="1.75" fill="#0891b2" fill-opacity="0.22"/>
 </svg>

--- a/ui/tests/brand-logo.test.tsx
+++ b/ui/tests/brand-logo.test.tsx
@@ -26,6 +26,6 @@ describe("BrandLogo", () => {
 
   it("renders the canonical tagline when requested", () => {
     const { getByText } = render(<BrandLogo showTagline />);
-    expect(getByText("AI supply-chain security")).toBeInTheDocument();
+    expect(getByText("AI agent bill of materials")).toBeInTheDocument();
   });
 });

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -277,7 +277,7 @@ describe('Nav', () => {
     const { container } = render(<Nav />)
     const wordmark = container.querySelector('img[alt="agent-bom"]')
     expect(wordmark).toHaveAttribute('src', '/brand/wordmark-dark.svg')
-    expect(screen.getByText('AI supply-chain security')).toBeInTheDocument()
+    expect(screen.getByText('AI agent bill of materials')).toBeInTheDocument()
   })
 
   it('renders all 7 nav group labels', () => {


### PR DESCRIPTION
## Summary
- Replace the generic node-tree mark with a **BOM manifest card** (inventory rows + finding highlight)
- Tagline → **AI agent bill of materials** (UI lockup, README/site-docs alts, VISUAL_LANGUAGE)
- Keep A/B explorations in `docs/images/brand/variants/` (A live, B agent+materials, C braces)

## Test plan
- [x] `npm test -- --run tests/brand-logo.test.tsx tests/nav.test.tsx`
- [ ] Spot-check sidebar mark in light/dark
- [ ] Prefer B or C? swap canonical mark from variants/

Made with [Cursor](https://cursor.com)