### PR TITLE
fix(tests): restore release lint hygiene

### DIFF
--- a/tests/api/test_repo_tree_scan.py
+++ b/tests/api/test_repo_tree_scan.py
@@ -88,7 +88,7 @@ def test_scan_cloned_repo_tree_discovers_jupyter_notebooks(tmp_path: Path) -> No
     (tmp_path / "analysis.ipynb").write_text(json.dumps(notebook), encoding="utf-8")
 
     agents: list = []
-    result = scan_cloned_repo_tree(str(tmp_path), agents=agents, warnings=[])
+    scan_cloned_repo_tree(str(tmp_path), agents=agents, warnings=[])
 
     assert any(agent.source == "jupyter" or "jupyter" in agent.name.lower() for agent in agents)
 

--- a/tests/cloud/test_cloud_aws.py
+++ b/tests/cloud/test_cloud_aws.py
@@ -285,7 +285,10 @@ def test_discover_continues_when_sts_account_resolution_is_denied():
             "foundationModel": "anthropic.claude-3-sonnet",
         }
     }
-    mock_session.client.side_effect = lambda service, **_kwargs: {"sts": mock_sts, "bedrock-agent": mock_bedrock}.get(service, _empty_boto_stub())
+    mock_session.client.side_effect = lambda service, **_kwargs: {
+        "sts": mock_sts,
+        "bedrock-agent": mock_bedrock,
+    }.get(service, _empty_boto_stub())
 
     with patch.dict(sys.modules, {"boto3": mock_boto3, "botocore": mock_botocore, "botocore.exceptions": mock_botocore.exceptions}):
         from agent_bom.cloud import aws

--- a/tests/test_azure_keyvault_cis_denied.py
+++ b/tests/test_azure_keyvault_cis_denied.py
@@ -22,10 +22,12 @@ class _Vault:
 
 
 class _KVMgmt:
-    class vaults:
+    class Vaults:
         @staticmethod
         def list():
             return [_Vault("v1"), _Vault("v2")]
+
+    vaults = Vaults
 
 
 class _DeniedKeyClient:
@@ -98,7 +100,7 @@ class _RbacVault:
 class _RbacKVMgmt:
     """Management client whose vaults are all RBAC-model."""
 
-    class vaults:
+    class Vaults:
         @staticmethod
         def list():
             return [_RbacVault("v1"), _RbacVault("v2")]
@@ -107,6 +109,8 @@ class _RbacKVMgmt:
         def get(resource_group, vault_name):
             props = type("P", (), {"enable_rbac_authorization": True})()
             return type("V", (), {"properties": props})()
+
+    vaults = Vaults
 
 
 def test_cis_8_4_all_rbac_vaults_denied_is_error_not_pass(monkeypatch):

--- a/tests/test_findings_mixed_merge.py
+++ b/tests/test_findings_mixed_merge.py
@@ -7,11 +7,11 @@ from uuid import uuid4
 from starlette.testclient import TestClient
 
 from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore, set_compliance_hub_store
+from agent_bom.api.models import JobStatus
 from agent_bom.api.routes.scan import _finding_sort_key, _merged_scan_bulk_page
 from agent_bom.api.server import ScanJob, ScanRequest, app, set_job_store
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.api.stores import _get_store
-from agent_bom.api.models import JobStatus
 from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
 
 


### PR DESCRIPTION
## Summary
- Remove unused test assignment and preserve scan result assertions.
- Wrap the AWS mock callback, normalize test helper class names, and sort imports.

## Verification
- `uv run ruff check src tests`
- `uv run pytest -q tests/api/test_repo_tree_scan.py tests/cloud/test_cloud_aws.py tests/test_azure_keyvault_cis_denied.py tests/test_findings_mixed_merge.py` (19 passed, 1 skipped)