### PR TITLE
feat(brand): agent HUD in the O, not emoji smile

### DIFF
--- a/docs/VISUAL_LANGUAGE.md
+++ b/docs/VISUAL_LANGUAGE.md
@@ -9,7 +9,7 @@ tagline under the nav lockup — the wordmark is enough.
 | Layer | Canonical form | Where |
 |---|---|---|
 | **Product name** | `agent-bom` | CLI, packages, URLs, docs titles, UI wordmark `alt`, metadata |
-| **Mark (logo)** | **BOM** with agent face in the **O** | Favicon, nav icon, avatars, social icon-only |
+| **Mark (logo)** | **BOM** with agent HUD in the **O** | Favicon, nav icon, avatars, social icon-only |
 | **Wordmark** | `agent·bom` | Nav lockup beside the mark |
 | **Spoken nickname** | “BOM” | Optional in conversation / tight chrome — never as the sole product name in docs, CLI, or packages |
 
@@ -35,11 +35,11 @@ tagline under the nav lockup — the wordmark is enough.
 - **Accent (product UI / lockup):** emerald → cyan. Light `#059669 → #0891b2`;
   dark `#34d399 → #06b6d4` / `#22d3ee`. Ink `#1f2937` (light) / `#e6edf3` (dark);
   muted `#6b7280` / `#8b949e`.
-- **Mark (locked):** **BOM** wordmark-as-icon where the **O** is an agent face
-  (eyes + antenna). Canonical product mark — do not replace with lettermarks or
-  clipboard variants. Reads as bill-of-materials + agent in one glyph. Same mark
-  appears in the dashboard lockup and the CLI no-args splash
-  (`agent_bom.output.brand_tokens`).
+- **Mark (locked):** **BOM** wordmark-as-icon where the **O** is an agent HUD
+  (visor slots + status bar + antenna — not an emoji smile). Canonical product
+  mark — do not replace with lettermarks or clipboard variants. Reads as
+  bill-of-materials + agent in one glyph. Same mark appears in the dashboard
+  lockup and the CLI no-args splash (`agent_bom.output.brand_tokens`).
 
 
 Brand assets live in `docs/images/brand/` (self-contained SVG, no external fonts or

--- a/docs/images/brand/logo-dark.svg
+++ b/docs/images/brand/logo-dark.svg
@@ -9,9 +9,9 @@
     <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#0c1210" stroke="url(#abg)" stroke-width="2.4"/>
     <path fill="url(#abg)" d="M8 17.5h7.2c3.55 0 5.7 1.85 5.7 4.55 0 1.85-1 3.2-2.65 3.85 1.95.75 3.2 2.25 3.2 4.55 0 2.95-2.35 4.8-6.25 4.8H8V17.5zm3.55 3v4.55h2.7c1.65 0 2.6-.8 2.6-2.25s-1.05-2.3-2.85-2.3h-2.45zm0 7.35v4.85h3.05c1.8 0 2.9-.9 2.9-2.45s-1.05-2.4-2.95-2.4H11.55z"/>
     <circle cx="32" cy="31" r="11" fill="none" stroke="url(#abg)" stroke-width="2.6"/>
-    <circle cx="27.9" cy="29.4" r="2.15" fill="#34d399"/>
-    <circle cx="36.1" cy="29.4" r="2.15" fill="#22d3ee"/>
-    <path d="M29.2 35.2c1.05 1.2 2.3 1.8 3.8 1.8s2.75-.6 3.8-1.8" fill="none" stroke="url(#abg)" stroke-width="1.7" stroke-linecap="round"/>
+    <rect x="24.1" y="27.5" width="5.4" height="3.4" rx="1" fill="#34d399"/>
+    <rect x="34.5" y="27.5" width="5.4" height="3.4" rx="1" fill="#22d3ee"/>
+    <path d="M27.2 35.6h9.6" fill="none" stroke="url(#abg)" stroke-width="1.9" stroke-linecap="round"/>
     <path d="M32 20V15.4" stroke="url(#abg)" stroke-width="2.3" stroke-linecap="round"/>
     <circle cx="32" cy="13.7" r="1.75" fill="url(#abg)"/>
     <path fill="url(#abg)" d="M44.8 17.5h3.55l3.7 11.4 3.7-11.4H59.3v19.2h-3.2V28.4L52.5 36.7h-2.85l-3.4-8.3v8.3h-3.2V17.5h1.75z"/>

--- a/docs/images/brand/logo-light.svg
+++ b/docs/images/brand/logo-light.svg
@@ -9,9 +9,9 @@
     <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#f8fafc" stroke="url(#abg)" stroke-width="2.4"/>
     <path fill="url(#abg)" d="M8 17.5h7.2c3.55 0 5.7 1.85 5.7 4.55 0 1.85-1 3.2-2.65 3.85 1.95.75 3.2 2.25 3.2 4.55 0 2.95-2.35 4.8-6.25 4.8H8V17.5zm3.55 3v4.55h2.7c1.65 0 2.6-.8 2.6-2.25s-1.05-2.3-2.85-2.3h-2.45zm0 7.35v4.85h3.05c1.8 0 2.9-.9 2.9-2.45s-1.05-2.4-2.95-2.4H11.55z"/>
     <circle cx="32" cy="31" r="11" fill="none" stroke="url(#abg)" stroke-width="2.6"/>
-    <circle cx="27.9" cy="29.4" r="2.15" fill="#059669"/>
-    <circle cx="36.1" cy="29.4" r="2.15" fill="#0891b2"/>
-    <path d="M29.2 35.2c1.05 1.2 2.3 1.8 3.8 1.8s2.75-.6 3.8-1.8" fill="none" stroke="url(#abg)" stroke-width="1.7" stroke-linecap="round"/>
+    <rect x="24.1" y="27.5" width="5.4" height="3.4" rx="1" fill="#059669"/>
+    <rect x="34.5" y="27.5" width="5.4" height="3.4" rx="1" fill="#0891b2"/>
+    <path d="M27.2 35.6h9.6" fill="none" stroke="url(#abg)" stroke-width="1.9" stroke-linecap="round"/>
     <path d="M32 20V15.4" stroke="url(#abg)" stroke-width="2.3" stroke-linecap="round"/>
     <circle cx="32" cy="13.7" r="1.75" fill="url(#abg)"/>
     <path fill="url(#abg)" d="M44.8 17.5h3.55l3.7 11.4 3.7-11.4H59.3v19.2h-3.2V28.4L52.5 36.7h-2.85l-3.4-8.3v8.3h-3.2V17.5h1.75z"/>

--- a/docs/images/brand/mark-dark.svg
+++ b/docs/images/brand/mark-dark.svg
@@ -5,15 +5,15 @@
       <stop offset="100%" stop-color="#06b6d4"/>
     </linearGradient>
   </defs>
-  <!-- Canonical locked mark: BOM with agent face in the O -->
+  <!-- Canonical locked mark: BOM with agent HUD in the O (not emoji smile) -->
   <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#0c1210" stroke="url(#abm)" stroke-width="2"/>
   <!-- B -->
   <path fill="url(#abm)" d="M8 17.5h7.2c3.55 0 5.7 1.85 5.7 4.55 0 1.85-1 3.2-2.65 3.85 1.95.75 3.2 2.25 3.2 4.55 0 2.95-2.35 4.8-6.25 4.8H8V17.5zm3.55 3v4.55h2.7c1.65 0 2.6-.8 2.6-2.25s-1.05-2.3-2.85-2.3h-2.45zm0 7.35v4.85h3.05c1.8 0 2.9-.9 2.9-2.45s-1.05-2.4-2.95-2.4H11.55z"/>
-  <!-- Agent O -->
+  <!-- Agent O: letter ring + HUD visor slots + status bar + antenna -->
   <circle cx="32" cy="31" r="11" fill="none" stroke="url(#abm)" stroke-width="2.6"/>
-  <circle cx="27.9" cy="29.4" r="2.15" fill="#34d399"/>
-  <circle cx="36.1" cy="29.4" r="2.15" fill="#06b6d4"/>
-  <path d="M29.2 35.2c1.05 1.2 2.3 1.8 3.8 1.8s2.75-.6 3.8-1.8" fill="none" stroke="url(#abm)" stroke-width="1.7" stroke-linecap="round"/>
+  <rect x="24.1" y="27.5" width="5.4" height="3.4" rx="1" fill="#34d399"/>
+  <rect x="34.5" y="27.5" width="5.4" height="3.4" rx="1" fill="#06b6d4"/>
+  <path d="M27.2 35.6h9.6" fill="none" stroke="url(#abm)" stroke-width="1.9" stroke-linecap="round"/>
   <path d="M32 20V15.4" stroke="url(#abm)" stroke-width="2.3" stroke-linecap="round"/>
   <circle cx="32" cy="13.7" r="1.75" fill="url(#abm)"/>
   <!-- M -->

--- a/docs/images/brand/mark-light.svg
+++ b/docs/images/brand/mark-light.svg
@@ -5,12 +5,13 @@
       <stop offset="100%" stop-color="#0891b2"/>
     </linearGradient>
   </defs>
+  <!-- Canonical locked mark: BOM with agent HUD in the O (not emoji smile) -->
   <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#f8fafc" stroke="url(#abm)" stroke-width="2"/>
   <path fill="url(#abm)" d="M8 17.5h7.2c3.55 0 5.7 1.85 5.7 4.55 0 1.85-1 3.2-2.65 3.85 1.95.75 3.2 2.25 3.2 4.55 0 2.95-2.35 4.8-6.25 4.8H8V17.5zm3.55 3v4.55h2.7c1.65 0 2.6-.8 2.6-2.25s-1.05-2.3-2.85-2.3h-2.45zm0 7.35v4.85h3.05c1.8 0 2.9-.9 2.9-2.45s-1.05-2.4-2.95-2.4H11.55z"/>
   <circle cx="32" cy="31" r="11" fill="none" stroke="url(#abm)" stroke-width="2.6"/>
-  <circle cx="27.9" cy="29.4" r="2.15" fill="#059669"/>
-  <circle cx="36.1" cy="29.4" r="2.15" fill="#0891b2"/>
-  <path d="M29.2 35.2c1.05 1.2 2.3 1.8 3.8 1.8s2.75-.6 3.8-1.8" fill="none" stroke="url(#abm)" stroke-width="1.7" stroke-linecap="round"/>
+  <rect x="24.1" y="27.5" width="5.4" height="3.4" rx="1" fill="#059669"/>
+  <rect x="34.5" y="27.5" width="5.4" height="3.4" rx="1" fill="#0891b2"/>
+  <path d="M27.2 35.6h9.6" fill="none" stroke="url(#abm)" stroke-width="1.9" stroke-linecap="round"/>
   <path d="M32 20V15.4" stroke="url(#abm)" stroke-width="2.3" stroke-linecap="round"/>
   <circle cx="32" cy="13.7" r="1.75" fill="url(#abm)"/>
   <path fill="url(#abm)" d="M44.8 17.5h3.55l3.7 11.4 3.7-11.4H59.3v19.2h-3.2V28.4L52.5 36.7h-2.85l-3.4-8.3v8.3h-3.2V17.5h1.75z"/>

--- a/docs/images/brand/variants/README.md
+++ b/docs/images/brand/variants/README.md
@@ -4,7 +4,8 @@
 Do not ship a product rename to bare “BOM”.
 
 Canonical mark is **locked**: `../mark-{light,dark}.svg` —
-**BOM with agent O** (bill-of-materials wordmark where O is the agent face).
+**BOM with agent O** (bill-of-materials wordmark where O is an agent HUD:
+visor slots, status bar, antenna — not a smiley).
 
 Do not promote alternatives into the product UI without an explicit brand
 decision. Optional historical sketches may remain under this folder for archive

--- a/site-docs/assets/brand/mark-mono.svg
+++ b/site-docs/assets/brand/mark-mono.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark">
   <path fill="#FFFFFF" d="M8 17.5h7.2c3.55 0 5.7 1.85 5.7 4.55 0 1.85-1 3.2-2.65 3.85 1.95.75 3.2 2.25 3.2 4.55 0 2.95-2.35 4.8-6.25 4.8H8V17.5zm3.55 3v4.55h2.7c1.65 0 2.6-.8 2.6-2.25s-1.05-2.3-2.85-2.3h-2.45zm0 7.35v4.85h3.05c1.8 0 2.9-.9 2.9-2.45s-1.05-2.4-2.95-2.4H11.55z"/>
   <circle cx="32" cy="31" r="11" fill="none" stroke="#FFFFFF" stroke-width="2.6"/>
-  <circle cx="27.9" cy="29.4" r="2.15" fill="#FFFFFF"/>
-  <circle cx="36.1" cy="29.4" r="2.15" fill="#FFFFFF"/>
-  <path d="M29.2 35.2c1.05 1.2 2.3 1.8 3.8 1.8s2.75-.6 3.8-1.8" fill="none" stroke="#FFFFFF" stroke-width="1.7" stroke-linecap="round"/>
+  <rect x="24.1" y="27.5" width="5.4" height="3.4" rx="1" fill="#FFFFFF"/>
+  <rect x="34.5" y="27.5" width="5.4" height="3.4" rx="1" fill="#FFFFFF"/>
+  <path d="M27.2 35.6h9.6" fill="none" stroke="#FFFFFF" stroke-width="1.9" stroke-linecap="round"/>
   <path d="M32 20V15.4" stroke="#FFFFFF" stroke-width="2.3" stroke-linecap="round"/>
   <circle cx="32" cy="13.7" r="1.75" fill="#FFFFFF"/>
   <path fill="#FFFFFF" d="M44.8 17.5h3.55l3.7 11.4 3.7-11.4H59.3v19.2h-3.2V28.4L52.5 36.7h-2.85l-3.4-8.3v8.3h-3.2V17.5h1.75z"/>

--- a/site-docs/assets/brand/mark.svg
+++ b/site-docs/assets/brand/mark.svg
@@ -2,9 +2,9 @@
   <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#0c1210"/>
   <path fill="#34d399" d="M8 17.5h7.2c3.55 0 5.7 1.85 5.7 4.55 0 1.85-1 3.2-2.65 3.85 1.95.75 3.2 2.25 3.2 4.55 0 2.95-2.35 4.8-6.25 4.8H8V17.5zm3.55 3v4.55h2.7c1.65 0 2.6-.8 2.6-2.25s-1.05-2.3-2.85-2.3h-2.45zm0 7.35v4.85h3.05c1.8 0 2.9-.9 2.9-2.45s-1.05-2.4-2.95-2.4H11.55z"/>
   <circle cx="32" cy="31" r="11" fill="none" stroke="#34d399" stroke-width="2.6"/>
-  <circle cx="27.9" cy="29.4" r="2.15" fill="#34d399"/>
-  <circle cx="36.1" cy="29.4" r="2.15" fill="#22d3ee"/>
-  <path d="M29.2 35.2c1.05 1.2 2.3 1.8 3.8 1.8s2.75-.6 3.8-1.8" fill="none" stroke="#34d399" stroke-width="1.7" stroke-linecap="round"/>
+  <rect x="24.1" y="27.5" width="5.4" height="3.4" rx="1" fill="#34d399"/>
+  <rect x="34.5" y="27.5" width="5.4" height="3.4" rx="1" fill="#22d3ee"/>
+  <path d="M27.2 35.6h9.6" fill="none" stroke="#34d399" stroke-width="1.9" stroke-linecap="round"/>
   <path d="M32 20V15.4" stroke="#34d399" stroke-width="2.3" stroke-linecap="round"/>
   <circle cx="32" cy="13.7" r="1.75" fill="#34d399"/>
   <path fill="#22d3ee" d="M44.8 17.5h3.55l3.7 11.4 3.7-11.4H59.3v19.2h-3.2V28.4L52.5 36.7h-2.85l-3.4-8.3v8.3h-3.2V17.5h1.75z"/>

--- a/src/agent_bom/output/brand_tokens.py
+++ b/src/agent_bom/output/brand_tokens.py
@@ -1,6 +1,6 @@
 """Shared product brand tokens for terminal + lane labels.
 
-Product name is always ``agent-bom``. The mark is BOM-with-agent-O (logo only).
+Product name is always ``agent-bom``. The mark is BOM with an agent HUD in the O.
 See ``docs/VISUAL_LANGUAGE.md``.
 """
 
@@ -14,15 +14,15 @@ POSITIONING_SHORT = "Open security scanner for AI infrastructure"
 TAGLINE_CHAIN = "agent → MCP server → packages → CVEs → blast radius"
 DOCS_URL = "https://github.com/msaad00/agent-bom"
 
-# Terminal mark: BOM with agent face in the O (antenna + eyes).
+# Terminal mark: BOM with agent HUD in the O (visor + antenna cue).
 _MARK_UNICODE = (
     "  ┌───────────┐",
-    "  │ B  ◉  M  │",
+    "  │ B [=o=] M │",
     "  └───────────┘",
 )
 _MARK_ASCII = (
     "  +-----------+",
-    "  | B  .o.  M |",
+    "  | B [=o=] M |",
     "  +-----------+",
 )
 

--- a/ui/components/brand-logo.tsx
+++ b/ui/components/brand-logo.tsx
@@ -3,11 +3,12 @@
 import { useThemeMode } from "@/lib/theme-mode";
 
 /** Bump when mark/wordmark SVGs change so browsers drop stale caches. */
-const BRAND_ASSET_REV = "v8";
+const BRAND_ASSET_REV = "v9";
 
 /**
- * Product name is always `agent-bom`. The mark is BOM-with-agent-O (logo only).
- * No lockup tagline — the wordmark is enough. See docs/VISUAL_LANGUAGE.md.
+ * Product name is always `agent-bom`. The mark is BOM with an agent HUD in the O
+ * (visor slots + status bar + antenna — not an emoji smile). No lockup tagline.
+ * See docs/VISUAL_LANGUAGE.md.
  */
 
 type BrandLogoProps = {

--- a/ui/public/brand/mark-dark.svg
+++ b/ui/public/brand/mark-dark.svg
@@ -5,15 +5,15 @@
       <stop offset="100%" stop-color="#06b6d4"/>
     </linearGradient>
   </defs>
-  <!-- Canonical locked mark: BOM with agent face in the O -->
+  <!-- Canonical locked mark: BOM with agent HUD in the O (not emoji smile) -->
   <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#0c1210" stroke="url(#abm)" stroke-width="2"/>
   <!-- B -->
   <path fill="url(#abm)" d="M8 17.5h7.2c3.55 0 5.7 1.85 5.7 4.55 0 1.85-1 3.2-2.65 3.85 1.95.75 3.2 2.25 3.2 4.55 0 2.95-2.35 4.8-6.25 4.8H8V17.5zm3.55 3v4.55h2.7c1.65 0 2.6-.8 2.6-2.25s-1.05-2.3-2.85-2.3h-2.45zm0 7.35v4.85h3.05c1.8 0 2.9-.9 2.9-2.45s-1.05-2.4-2.95-2.4H11.55z"/>
-  <!-- Agent O -->
+  <!-- Agent O: letter ring + HUD visor slots + status bar + antenna -->
   <circle cx="32" cy="31" r="11" fill="none" stroke="url(#abm)" stroke-width="2.6"/>
-  <circle cx="27.9" cy="29.4" r="2.15" fill="#34d399"/>
-  <circle cx="36.1" cy="29.4" r="2.15" fill="#06b6d4"/>
-  <path d="M29.2 35.2c1.05 1.2 2.3 1.8 3.8 1.8s2.75-.6 3.8-1.8" fill="none" stroke="url(#abm)" stroke-width="1.7" stroke-linecap="round"/>
+  <rect x="24.1" y="27.5" width="5.4" height="3.4" rx="1" fill="#34d399"/>
+  <rect x="34.5" y="27.5" width="5.4" height="3.4" rx="1" fill="#06b6d4"/>
+  <path d="M27.2 35.6h9.6" fill="none" stroke="url(#abm)" stroke-width="1.9" stroke-linecap="round"/>
   <path d="M32 20V15.4" stroke="url(#abm)" stroke-width="2.3" stroke-linecap="round"/>
   <circle cx="32" cy="13.7" r="1.75" fill="url(#abm)"/>
   <!-- M -->

--- a/ui/public/brand/mark-light.svg
+++ b/ui/public/brand/mark-light.svg
@@ -5,12 +5,13 @@
       <stop offset="100%" stop-color="#0891b2"/>
     </linearGradient>
   </defs>
+  <!-- Canonical locked mark: BOM with agent HUD in the O (not emoji smile) -->
   <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#f8fafc" stroke="url(#abm)" stroke-width="2"/>
   <path fill="url(#abm)" d="M8 17.5h7.2c3.55 0 5.7 1.85 5.7 4.55 0 1.85-1 3.2-2.65 3.85 1.95.75 3.2 2.25 3.2 4.55 0 2.95-2.35 4.8-6.25 4.8H8V17.5zm3.55 3v4.55h2.7c1.65 0 2.6-.8 2.6-2.25s-1.05-2.3-2.85-2.3h-2.45zm0 7.35v4.85h3.05c1.8 0 2.9-.9 2.9-2.45s-1.05-2.4-2.95-2.4H11.55z"/>
   <circle cx="32" cy="31" r="11" fill="none" stroke="url(#abm)" stroke-width="2.6"/>
-  <circle cx="27.9" cy="29.4" r="2.15" fill="#059669"/>
-  <circle cx="36.1" cy="29.4" r="2.15" fill="#0891b2"/>
-  <path d="M29.2 35.2c1.05 1.2 2.3 1.8 3.8 1.8s2.75-.6 3.8-1.8" fill="none" stroke="url(#abm)" stroke-width="1.7" stroke-linecap="round"/>
+  <rect x="24.1" y="27.5" width="5.4" height="3.4" rx="1" fill="#059669"/>
+  <rect x="34.5" y="27.5" width="5.4" height="3.4" rx="1" fill="#0891b2"/>
+  <path d="M27.2 35.6h9.6" fill="none" stroke="url(#abm)" stroke-width="1.9" stroke-linecap="round"/>
   <path d="M32 20V15.4" stroke="url(#abm)" stroke-width="2.3" stroke-linecap="round"/>
   <circle cx="32" cy="13.7" r="1.75" fill="url(#abm)"/>
   <path fill="url(#abm)" d="M44.8 17.5h3.55l3.7 11.4 3.7-11.4H59.3v19.2h-3.2V28.4L52.5 36.7h-2.85l-3.4-8.3v8.3h-3.2V17.5h1.75z"/>


### PR DESCRIPTION
## Summary
- Mark O uses HUD visor slots + flat status bar + antenna instead of round eyes + smile (reads as agent, not emoji).
- Synced `ui/public/brand`, `docs/images/brand` (mark + lockup), `site-docs/assets/brand`, CLI splash mark, and visual-language docs.
- Wordmark `agent·bom` unchanged — still the right lockup.

## Verification
- `uv run pytest tests/test_cli_brand.py -q`
- `cd ui && npm test -- --run brand-logo`

## Notes
- Hard-refresh dashboard to pick up `?v9` asset rev on `BrandLogo`.

Made with [Cursor](https://cursor.com)