### PR TITLE
fix(deploy): reset Postgres app-password GUC so it doesn't persist in cleartext

### DIFF
--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -1175,6 +1175,18 @@ BEGIN
 END
 $$;
 
+-- Clear the app-password GUC now that the role has been created. The init
+-- wrapper stores it via ALTER DATABASE ... SET, which persists the cleartext
+-- password in pg_db_role_setting where any connected role can read it
+-- (readonly→readwrite escalation). RESET drops it so current_setting() returns
+-- empty for every later session. current_database() targets whatever DB the
+-- wrapper set the GUC on (both run against POSTGRES_DB).
+DO $$
+BEGIN
+    EXECUTE format('ALTER DATABASE %I RESET init.app_password', current_database());
+END
+$$;
+
 -- ══════════════════════════════════════════════════════════════════════════════
 -- READ-ONLY ROLE: For dashboards, BI tools, and audit queries
 -- ══════════════════════════════════════════════════════════════════════════════

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -252,6 +252,24 @@ def test_hosted_poc_overlay_keeps_api_and_ui_loopback_only() -> None:
     ]
 
 
+def test_postgres_init_resets_app_password_guc_after_reading_it() -> None:
+    """The init wrapper stores the app password via ALTER DATABASE ... SET
+    init.app_password, which persists in cleartext in pg_db_role_setting.
+    init.sql must RESET it after creating the role so no later session (e.g. a
+    readonly role) can read the password back via current_setting()."""
+    init_sql = (COMPOSE_DIR / "supabase" / "postgres" / "init.sql").read_text(encoding="utf-8")
+
+    read_idx = init_sql.find("current_setting('init.app_password'")
+    assert read_idx != -1, "init.sql must read the app password via current_setting('init.app_password', ...)"
+
+    reset_idx = init_sql.find("RESET init.app_password")
+    assert reset_idx != -1, (
+        "init.sql must RESET init.app_password so the cleartext app password does "
+        "not persist in pg_db_role_setting (readable by any connected role)."
+    )
+    assert reset_idx > read_idx, "the RESET of init.app_password must come after the read that uses it."
+
+
 def test_active_docker_docs_do_not_mount_config_under_root_home() -> None:
     active_docs = [
         ROOT / "docs" / "DEPLOYMENT.md",


### PR DESCRIPTION
The Postgres init wrapper passes the app-role password into init.sql via `ALTER DATABASE ... SET init.app_password`, but nothing ever cleared it. The value stayed in cleartext in the `pg_db_role_setting` catalog, readable by any connected role via `current_setting()` — a readonly→readwrite escalation path.

init.sql now RESETs the GUC (targeting `current_database()`) right after the app role is created, so later sessions read back empty. Adds a guard test asserting the RESET follows the read.

**Tests:** `pytest tests/test_compose_secrets_healthcheck.py` → 27 passed; ruff clean.

**Note for existing deployments:** initdb only runs on first init, so already-provisioned instances should run `ALTER DATABASE <db> RESET init.app_password;` once.

**Follow-up (stronger):** drop the database-scoped GUC entirely by passing the secret with `psql -v app_password=...` and referencing `:'app_password'` in init.sql, so the cleartext never touches the catalog at all.