### PR TITLE
fix(compliance): never score unevaluated controls as pass

### DIFF
--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -974,7 +974,13 @@ async def get_compliance_summary(request: Request) -> dict:
         "summary",
     }
     response = {key: full.get(key) for key in summary_keys if key in full}
-    framework_summary: dict[str, dict[str, int]] = {}
+
+    # With zero completed scans nothing was evaluated: every control trivially
+    # lacks findings, so the per-control "pass" statuses and the *_pass counts
+    # from get_compliance would read as all-pass / fully compliant. That is the
+    # same false assurance /v1/compliance guards against with overall_status=
+    # "no_data" — so mirror it here and report not_evaluated instead of pass.
+    no_data = int(full.get("scan_count") or 0) == 0
 
     def _control_status_counts(value: list[object]) -> tuple[int, int, int, int] | None:
         controls = [item for item in value if isinstance(item, dict) and isinstance(item.get("status"), str)]
@@ -985,19 +991,36 @@ async def get_compliance_summary(request: Request) -> dict:
         fail_count = sum(1 for item in controls if item.get("status") == "fail")
         return len(controls), pass_count, warn_count, fail_count
 
+    framework_summary: dict[str, dict[str, int]] = {}
     for key, value in full.items():
         if isinstance(value, list):
             counts = _control_status_counts(value)
             if counts is None:
                 continue
             controls, pass_count, warn_count, fail_count = counts
+            if no_data:
+                pass_count = warn_count = fail_count = 0
             framework_summary[key] = {
                 "controls": controls,
                 "pass": pass_count,
                 "warning": warn_count,
                 "fail": fail_count,
+                "not_evaluated": controls - pass_count - warn_count - fail_count,
             }
     response["frameworks"] = framework_summary
+
+    if no_data:
+        raw_summary = full.get("summary")
+        if isinstance(raw_summary, dict):
+            adjusted: dict[str, Any] = {}
+            for count_key, count_value in raw_summary.items():
+                if count_key.endswith("_pass"):
+                    adjusted[count_key] = 0
+                    adjusted[f"{count_key[:-len('_pass')]}_not_evaluated"] = count_value
+                else:
+                    adjusted[count_key] = count_value
+            response["summary"] = adjusted
+
     return response
 
 

--- a/src/agent_bom/output/compliance_narrative.py
+++ b/src/agent_bom/output/compliance_narrative.py
@@ -104,8 +104,8 @@ class FrameworkNarrative:
 
     framework: str  # display name, e.g. "OWASP Top 10 for LLM"
     slug: str  # e.g. "owasp-llm"
-    status: str  # "passing" | "at_risk" | "failing"
-    score: int  # 0-100
+    status: str  # "passing" | "at_risk" | "failing" | "not_evaluated"
+    score: int  # 0-100, over evaluated controls only (0 when nothing evaluated)
     narrative: str  # 2-3 sentences
     failing_controls: list[ControlNarrative] = field(default_factory=list)
     recommendations: list[str] = field(default_factory=list)
@@ -219,6 +219,7 @@ def _control_remediation_steps(
 def _framework_overall_narrative(
     display_name: str,
     total_controls: int,
+    evaluated_count: int,
     pass_count: int,
     fail_count: int,
     warn_count: int,
@@ -226,18 +227,29 @@ def _framework_overall_narrative(
     score: int,
 ) -> str:
     """2-3 sentence framework-level posture narrative."""
+    if evaluated_count == 0:
+        return (
+            f"No {display_name} controls could be evaluated in this scan: "
+            f"0 of {total_controls} controls have vulnerability-derived evidence. "
+            "This is a coverage gap, not a pass — controls without mapped findings are "
+            f"reported as not-evaluated. Run scans that map findings to {display_name} "
+            "before relying on this posture."
+        )
+
+    plural = "s" if evaluated_count != 1 else ""
     if fail_count == 0 and warn_count == 0:
         return (
-            f"The organisation is fully compliant with {display_name}: "
-            f"all {total_controls} assessed controls are passing. "
-            "No immediate action is required; continue monitoring with regular scans."
+            f"All {evaluated_count} evaluated {display_name} control{plural} are passing "
+            f"({evaluated_count} of {total_controls} controls evaluated; score {score}/100 "
+            "over evaluated controls). Controls with no mapped findings are reported as "
+            "not-evaluated rather than compliant; continue scanning to broaden coverage."
         )
 
     if fail_count == 0:
         return (
             f"{display_name} posture is at risk with {warn_count} control"
             f"{'s' if warn_count > 1 else ''} in warning state "
-            f"(overall score {score}/100). "
+            f"(score {score}/100 over {evaluated_count} evaluated control{plural}). "
             "Medium and low severity findings require remediation within the next maintenance cycle "
             "to prevent status degradation."
         )
@@ -249,7 +261,7 @@ def _framework_overall_narrative(
     return (
         f"{display_name} compliance is failing: {fail_count} control"
         f"{'s' if fail_count > 1 else ''} have critical or high severity findings "
-        f"(overall score {score}/100). "
+        f"(score {score}/100 over {evaluated_count} evaluated control{plural}). "
         f"Failing controls include {ctrl_str}. "
         "Immediate remediation is required — unaddressed critical findings may constitute "
         "a regulatory breach under this framework."
@@ -322,6 +334,7 @@ def _build_framework_narrative(
                 entry["affected_agents"].add(agent)
 
     total_controls = len(control_data)
+    evaluated_count = 0
     pass_count = 0
     warn_count = 0
     fail_count = 0
@@ -329,7 +342,13 @@ def _build_framework_narrative(
     critical_failing_ids: list[str] = []
 
     for code, data in sorted(control_data.items()):
-        status = _control_status(data["severity_breakdown"]) if data["findings"] > 0 else "pass"
+        # A control is only "evaluated" when at least one finding maps to it.
+        # Controls with zero mapped findings carry no vulnerability-derived
+        # evidence, so they are not-evaluated — never counted as a silent pass.
+        if data["findings"] == 0:
+            continue
+        evaluated_count += 1
+        status = _control_status(data["severity_breakdown"])
         pkgs = sorted(data["affected_pkgs"])
         agents = sorted(data["affected_agents"])
 
@@ -354,16 +373,23 @@ def _build_framework_narrative(
                 )
             )
 
-    score = round((pass_count / total_controls) * 100) if total_controls > 0 else 100
+    # Score over EVALUATED controls only. With nothing evaluated there is no
+    # evidence, so the score is 0 (not 100) and the status is not_evaluated —
+    # an empty scan must never read as "fully compliant".
+    score = round((pass_count / evaluated_count) * 100) if evaluated_count > 0 else 0
 
-    if fail_count > 0:
+    if evaluated_count == 0:
+        fw_status = "not_evaluated"
+    elif fail_count > 0:
         fw_status = "failing"
     elif warn_count > 0:
         fw_status = "at_risk"
     else:
         fw_status = "passing"
 
-    narrative = _framework_overall_narrative(display_name, total_controls, pass_count, fail_count, warn_count, critical_failing_ids, score)
+    narrative = _framework_overall_narrative(
+        display_name, total_controls, evaluated_count, pass_count, fail_count, warn_count, critical_failing_ids, score
+    )
     recommendations = _framework_recommendations(display_name, fail_count, warn_count, failing_controls)
 
     return FrameworkNarrative(
@@ -560,6 +586,7 @@ def _build_executive_summary(
     """3-5 sentence executive summary for compliance stakeholders."""
     failing_fws = [fn for fn in framework_narratives if fn.status == "failing"]
     at_risk_fws = [fn for fn in framework_narratives if fn.status == "at_risk"]
+    evaluated_fws = [fn for fn in framework_narratives if fn.status in ("passing", "at_risk", "failing")]
     # Lead: what was scanned
     sentences: list[str] = [
         f"This AI-BOM compliance report covers {total_agents} AI agent"
@@ -588,11 +615,16 @@ def _build_executive_summary(
     elif at_risk_fws:
         fw_names = ", ".join(fn.framework for fn in at_risk_fws[:3])
         sentences.append(
-            f"All frameworks passed without critical failures; however {len(at_risk_fws)} "
+            f"All evaluated frameworks passed without critical failures; however {len(at_risk_fws)} "
             f"{'are' if len(at_risk_fws) > 1 else 'is'} at risk: {fw_names}."
         )
+    elif evaluated_fws:
+        sentences.append(f"All {len(evaluated_fws)} evaluated compliance frameworks are passing with no critical findings.")
     else:
-        sentences.append(f"All {total_fws} assessed compliance frameworks are passing with no critical findings.")
+        sentences.append(
+            f"None of the {total_fws} frameworks could be evaluated — no findings mapped to their "
+            "controls, so compliance posture is unknown rather than compliant."
+        )
 
     # Closing action
     if failing_fws or at_risk_fws:

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -353,6 +353,56 @@ def test_compliance_summary_counts():
     _clear_jobs()
 
 
+def test_compliance_summary_no_scans_reports_not_evaluated():
+    """With no completed scans /v1/compliance/summary must not report all-pass.
+
+    The *_pass counts and per-framework pass counts equalled the control
+    catalogue size even though nothing was evaluated — false full-compliance.
+    Mirror /v1/compliance's no_data contract: report 0 pass / not_evaluated.
+    """
+    _clear_jobs()
+    client = TestClient(app)
+    data = client.get("/v1/compliance/summary", headers=_AUTH_HEADERS).json()
+
+    assert data["scan_count"] == 0
+    assert data["overall_status"] == "no_data"
+    assert data["overall_score"] == 0.0
+
+    for metadata in TAG_MAPPED_FRAMEWORKS:
+        assert data["summary"][f"{metadata.summary_prefix}_pass"] == 0
+        assert data["summary"][f"{metadata.summary_prefix}_not_evaluated"] == metadata.control_count
+
+    for fw in data["frameworks"].values():
+        assert fw["pass"] == 0
+        assert fw["warning"] == 0
+        assert fw["fail"] == 0
+        assert fw["not_evaluated"] == fw["controls"]
+    _clear_jobs()
+
+
+def test_compliance_summary_with_scan_counts_evaluated_controls():
+    """With a real finding the summary still reports honest pass/fail counts."""
+    _clear_jobs()
+    _add_done_job(
+        [
+            {
+                "vulnerability_id": "CVE-2025-2222",
+                "severity": "high",
+                "package": "express",
+                "affected_agents": ["claude-desktop"],
+                "owasp_tags": ["LLM05"],
+            },
+        ]
+    )
+    client = TestClient(app)
+    data = client.get("/v1/compliance/summary", headers=_AUTH_HEADERS).json()
+    assert data["scan_count"] == 1
+    assert data["summary"]["owasp_fail"] == 1
+    assert data["summary"]["owasp_pass"] == 9
+    assert "owasp_not_evaluated" not in data["summary"]
+    _clear_jobs()
+
+
 def test_posture_has_proxy_flips_on_proxy_alert_ingest():
     """audit P1-B: ingesting proxy alerts via /v1/proxy/audit must flip
     the ``has_proxy`` posture flag on /v1/posture/counts.

--- a/tests/test_compliance_narrative.py
+++ b/tests/test_compliance_narrative.py
@@ -132,13 +132,18 @@ def test_unknown_framework_raises_value_error():
 # ─── Framework narrative content ──────────────────────────────────────────────
 
 
-def test_passing_framework_status_when_no_vulns():
+def test_not_evaluated_framework_status_when_no_vulns():
+    """A scan with zero findings has no evidence — it must not read as fully compliant."""
     report = _make_report(blast_radii=[])
     result = generate_compliance_narrative(report, framework="owasp-llm")
     fw = result.framework_narratives[0]
-    assert fw.status == "passing"
-    assert fw.score == 100
+    assert fw.status == "not_evaluated"
+    assert fw.score != 100
+    assert fw.score == 0
     assert fw.failing_controls == []
+    lower = fw.narrative.lower()
+    assert "fully compliant" not in lower
+    assert "not-evaluated" in lower or "not evaluated" in lower or "could be evaluated" in lower
 
 
 def test_failing_framework_status_for_critical_vuln():
@@ -163,6 +168,22 @@ def test_at_risk_framework_status_for_medium_vuln():
     result = generate_compliance_narrative(report, framework="owasp-llm")
     fw = result.framework_narratives[0]
     assert fw.status == "at_risk"
+
+
+def test_score_is_over_evaluated_controls_only():
+    """Score denominator is the evaluated controls, not the whole catalogue.
+
+    Two of ten OWASP controls are evaluated: one passes (finding with no
+    severity) and one warns. Score must be 50 (1 pass / 2 evaluated), not 10
+    (1 pass / 10 catalogue controls).
+    """
+    passing = _make_blast_radius(vuln=_make_vuln(severity=Severity.UNKNOWN), owasp_tags=["LLM05"])
+    warning = _make_blast_radius(vuln=_make_vuln(severity=Severity.MEDIUM), owasp_tags=["LLM01"])
+    report = _make_report(blast_radii=[passing, warning])
+    result = generate_compliance_narrative(report, framework="owasp-llm")
+    fw = result.framework_narratives[0]
+    assert fw.status == "at_risk"
+    assert fw.score == 50
 
 
 def test_framework_score_is_integer_0_to_100():
@@ -403,8 +424,8 @@ def test_multi_framework_tags_affect_multiple_frameworks():
     assert status_by_slug["owasp-mcp"] != "passing"
     assert status_by_slug["nist"] != "passing"
     assert status_by_slug["cmmc"] != "passing"
-    # Untagged framework should be passing
-    assert status_by_slug["soc2"] == "passing"
+    # Untagged framework has no mapped findings → not-evaluated, never a silent pass
+    assert status_by_slug["soc2"] == "not_evaluated"
 
 
 def test_all_framework_slugs_covered():
@@ -440,6 +461,6 @@ def test_same_control_id_does_not_bleed_between_frameworks():
     status_by_slug = {fn.slug: fn.status for fn in result.framework_narratives}
 
     assert status_by_slug["nist-800-53"] == "failing"
-    assert status_by_slug["fedramp"] == "passing"
+    assert status_by_slug["fedramp"] == "not_evaluated"
     assert result.remediation_impact
     assert result.remediation_impact[0].frameworks_impacted == ["NIST 800-53"]

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -32,7 +32,7 @@ import {
 } from "lucide-react";
 import { ComplianceControlDrawer } from "@/components/compliance-control-drawer";
 import { ComplianceControlRow } from "@/components/compliance-control-row";
-import { postureLabel, statusColor } from "@/components/compliance-status";
+import { isNotEvaluated, postureLabel, statusColor } from "@/components/compliance-status";
 import { ComplianceHeatmap } from "@/components/compliance-heatmap";
 import { ComplianceMatrix } from "@/components/compliance-matrix";
 import { CISBenchmarkDetail } from "@/components/cis-benchmark-detail";
@@ -67,8 +67,17 @@ function downloadBlobToFile(blob: Blob, filename: string) {
 function ScoreRing({ score, status }: { score: number; status: string }) {
   const r = 54;
   const circ = 2 * Math.PI * r;
-  const offset = circ - (score / 100) * circ;
-  const color = status === "pass" ? "#34d399" : status === "warning" ? "#facc15" : "#f87171";
+  // A no-evidence scan has nothing to score. Render a neutral, empty ring with
+  // a "Not evaluated" label rather than a red 0% that reads as "failing".
+  const notEvaluated = isNotEvaluated(status);
+  const offset = notEvaluated ? circ : circ - (score / 100) * circ;
+  const color = notEvaluated
+    ? "var(--text-tertiary)"
+    : status === "pass"
+      ? "#34d399"
+      : status === "warning"
+        ? "#facc15"
+        : "#f87171";
 
   return (
     <div className="relative w-32 h-32">
@@ -83,8 +92,19 @@ function ScoreRing({ score, status }: { score: number; status: string }) {
         />
       </svg>
       <div className="absolute inset-0 flex flex-col items-center justify-center">
-        <span className="text-2xl font-bold text-[color:var(--foreground)]">{Math.round(score)}%</span>
-        <span className="text-[10px] text-[color:var(--text-tertiary)] uppercase tracking-wider">Score</span>
+        {notEvaluated ? (
+          <>
+            <span className="text-lg font-bold text-[color:var(--text-secondary)]">—</span>
+            <span className="px-1 text-center text-[9px] leading-tight text-[color:var(--text-tertiary)] uppercase tracking-wider">
+              Not evaluated
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="text-2xl font-bold text-[color:var(--foreground)]">{Math.round(score)}%</span>
+            <span className="text-[10px] text-[color:var(--text-tertiary)] uppercase tracking-wider">Score</span>
+          </>
+        )}
       </div>
     </div>
   );

--- a/ui/components/compliance-status.tsx
+++ b/ui/components/compliance-status.tsx
@@ -5,6 +5,14 @@ import {
   XCircle,
 } from "lucide-react";
 
+// Statuses with no vulnerability-derived evidence to score. The backend emits
+// "no_data" (aggregate /v1/compliance) and "not_evaluated" (per-framework
+// narratives) for scans that mapped no findings — these must read as neutral
+// "Not evaluated", never green "Compliant" or red "Non-compliant".
+export function isNotEvaluated(status: string): boolean {
+  return status === "not_evaluated" || status === "no_data";
+}
+
 export function StatusIcon({ status, className }: { status: string; className?: string }) {
   switch (status) {
     case "pass":
@@ -47,6 +55,9 @@ export function postureLabel(status: string): string {
       return "Needs attention";
     case "fail":
       return "Non-compliant";
+    case "not_evaluated":
+    case "no_data":
+      return "Not evaluated";
     default:
       return "No data";
   }

--- a/ui/tests/compliance-status.test.ts
+++ b/ui/tests/compliance-status.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { isNotEvaluated, postureLabel } from "@/components/compliance-status";
+
+describe("compliance status honesty", () => {
+  it("treats no-evidence statuses as not evaluated", () => {
+    expect(isNotEvaluated("no_data")).toBe(true);
+    expect(isNotEvaluated("not_evaluated")).toBe(true);
+    expect(isNotEvaluated("pass")).toBe(false);
+    expect(isNotEvaluated("fail")).toBe(false);
+  });
+
+  it("labels no-evidence statuses as 'Not evaluated', never Compliant/Non-compliant", () => {
+    expect(postureLabel("no_data")).toBe("Not evaluated");
+    expect(postureLabel("not_evaluated")).toBe("Not evaluated");
+    expect(postureLabel("pass")).toBe("Compliant");
+    expect(postureLabel("fail")).toBe("Non-compliant");
+  });
+});


### PR DESCRIPTION
**P0 — auditor-facing false assurance.** Controls with zero mapped findings carry no vulnerability-derived evidence, yet the compliance-narrative generator counted them as "pass" and computed the score as `pass_count/total_controls`. A scan with no findings claimed full SOC 2 compliance at 100/100 with zero evidence.

Aligned across **API + CLI + UI**:
- **Backend** (`output/compliance_narrative.py`): new `not_evaluated` control state (findings == 0), excluded from `pass_count` and the score denominator; score is computed over *evaluated* controls only. Framework `status` is `not_evaluated` and score `0` when nothing was evaluated — never `passing`/100. Framework + executive narratives reworded to state coverage honestly instead of asserting full compliance.
- **API** (`routes/compliance.py`): `/v1/compliance/summary` no longer emits `*_pass` counts equal to the catalogue size when `scan_count == 0`; it reports `not_evaluated`, consistent with `/v1/compliance`'s existing `no_data` contract. Behavior with real scans is unchanged.
- **UI** (`compliance-status.tsx`, `compliance/page.tsx`): `not_evaluated`/`no_data` renders a neutral "Not evaluated" state (not green "Compliant", not red "0% failing"). Overview tile already guarded on `scans>0`.

**Tests:** 74 backend + 10 UI pass; ruff + eslint clean. A no-findings scan now yields `not_evaluated` (not 100 / not "fully compliant"); a partially-mapped framework scores over evaluated controls only.