### PR TITLE
fix(secrets): resolve signing PEMs file-first + keyless-lead cloud creds (#3807)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,21 +17,38 @@ SNOWFLAKE_DATABASE=CORTEX_DB
 SNOWFLAKE_SCHEMA=PUBLIC
 
 # AWS Configuration (for Bedrock scanning - future)
+# PREFER keyless auth — the SDK's default credential chain already supports it:
+#   - EKS: IRSA (IAM Roles for Service Accounts) via a projected token
+#   - EC2/ECS: the instance/task role
+#   - Cross-account: an STS AssumeRole profile
+# Set only AWS_REGION (and optionally AWS_PROFILE for a named role/SSO profile).
 AWS_REGION=us-east-1
-AWS_ACCESS_KEY_ID=your-access-key
-AWS_SECRET_ACCESS_KEY=your-secret-key
 AWS_PROFILE=default
+# Last resort only (long-lived static keys) — avoid in production; prefer IRSA /
+# instance roles above. If you must, mount them as secrets rather than inlining:
+# AWS_ACCESS_KEY_ID=your-access-key
+# AWS_SECRET_ACCESS_KEY=your-secret-key
 
 # Azure Configuration (for OpenAI Service scanning - future)
+# PREFER workload identity / managed identity — DefaultAzureCredential picks it up
+# automatically (AKS workload identity, VM/App-Service managed identity). Set only
+# the non-secret identifiers below in that case.
 AZURE_SUBSCRIPTION_ID=your-subscription-id
 AZURE_RESOURCE_GROUP=your-resource-group
 AZURE_TENANT_ID=your-tenant-id
 AZURE_CLIENT_ID=your-client-id
-AZURE_CLIENT_SECRET=your-client-secret
+# Last resort only (service-principal client secret) — prefer managed/workload
+# identity above. If unavoidable, mount it as a secret rather than inlining:
+# AZURE_CLIENT_SECRET=your-client-secret
 
 # Google Cloud Configuration (for ADK scanning - future)
+# PREFER Workload Identity Federation / attached service account — Application
+# Default Credentials resolve these with no key file (GKE Workload Identity, GCE
+# metadata identity). Set only GCP_PROJECT_ID in that case.
 GCP_PROJECT_ID=your-project-id
-GCP_SERVICE_ACCOUNT_KEY=/path/to/service-account.json
+# Last resort only (exported service-account JSON key) — prefer Workload Identity
+# above. If unavoidable, mount the key file as a secret rather than inlining it:
+# GCP_SERVICE_ACCOUNT_KEY=/path/to/service-account.json
 
 # Optional: Logging
 LOG_LEVEL=INFO

--- a/deploy/secrets/README.md
+++ b/deploy/secrets/README.md
@@ -36,7 +36,14 @@ Compose defaults to the real `deploy/secrets/*` paths so a shared stack fails
 closed if a real secret file is missing.
 
 The API reads `AGENT_BOM_*_FILE` mounts (file wins over plain env). Helm may
-still inject via Secret→env; compose/local is file-only.
+still inject via Secret→env; compose/local is file-only. This file-first
+resolution also covers the signing PEMs, so a mounted file works everywhere the
+inline env var did:
+
+- `AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM_FILE` — RSA PEM for the OAuth AS token
+  signing key (unset → ephemeral per-restart key).
+- `AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE` — Ed25519 PEM for
+  compliance-bundle signing (unset → HMAC-SHA256 fallback).
 
 The API never connects as the Postgres bootstrap/admin/superuser role — only
 `agent_bom_app`.

--- a/deploy/supabase/clickhouse/docker-compose.yml
+++ b/deploy/supabase/clickhouse/docker-compose.yml
@@ -2,9 +2,12 @@
 #
 # Usage:
 #   cd deploy/supabase/clickhouse
+#   # Provide the Grafana admin password as a mounted file (never inline env):
+#   printf '%s' "$(openssl rand -hex 24)" > ./secrets/grafana_admin_password
+#   chmod 0400 ./secrets/grafana_admin_password
 #   docker compose up -d
 #   # ClickHouse: http://localhost:8123
-#   # Grafana:    http://localhost:3001 (set GRAFANA_ADMIN_USER and GRAFANA_ADMIN_PASSWORD first)
+#   # Grafana:    http://localhost:3001 (set GRAFANA_ADMIN_USER; password comes from the secret file)
 #
 # Then run scans with analytics enabled:
 #   agent-bom agents --clickhouse-url http://localhost:8123
@@ -40,12 +43,20 @@ services:
     environment:
       GF_INSTALL_PLUGINS: grafana-clickhouse-datasource
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:?set GRAFANA_ADMIN_USER before starting this analytics stack}
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD before starting this analytics stack}
+      # Password is read from a mounted secret file (Grafana's __FILE convention),
+      # never from an interpolated env value.
+      GF_SECURITY_ADMIN_PASSWORD__FILE: /run/secrets/grafana_admin_password
       GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /var/lib/grafana/dashboards/agent-bom.json
+    secrets:
+      - grafana_admin_password
     volumes:
       - grafana-data:/var/lib/grafana
       - ./grafana-provisioning:/etc/grafana/provisioning:ro
       - ./grafana-dashboard.json:/var/lib/grafana/dashboards/agent-bom.json:ro
+
+secrets:
+  grafana_admin_password:
+    file: ${GRAFANA_ADMIN_PASSWORD_FILE:-./secrets/grafana_admin_password}
 
 volumes:
   clickhouse-data:

--- a/docs/COMPLIANCE_SIGNING.md
+++ b/docs/COMPLIANCE_SIGNING.md
@@ -24,8 +24,11 @@ openssl pkey -in agent-bom-evidence-key.pem -pubout -out agent-bom-evidence-pub.
 ```
 
 Deploy the server with the **private** key mounted as
-`AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM` (PEM string, PKCS#8). On a
-Helm install:
+`AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM` (PEM string, PKCS#8). The value
+resolves file-first: set `AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE` to
+a mounted secret path (Docker/Compose secrets) and the file wins over the inline
+env var — preferred for compose/local so the PEM never lands in `.env` or process
+env. On a Helm install (Secret→env is fine):
 
 ```yaml
 controlPlane:

--- a/src/agent_bom/api/compliance_signing.py
+++ b/src/agent_bom/api/compliance_signing.py
@@ -181,7 +181,9 @@ def _load_ed25519_signer() -> _Ed25519Signer | None:
     global _signer_cache, _signer_init_error
     if _signer_cache is not None:
         return _signer_cache
-    pem = os.environ.get(_ED25519_ENV_VAR)
+    from agent_bom.api.secret_source import resolve_secret
+
+    pem = resolve_secret(_ED25519_ENV_VAR)
     if not pem:
         return None
     if _signer_init_error is not None:

--- a/src/agent_bom/api/oauth_as.py
+++ b/src/agent_bom/api/oauth_as.py
@@ -118,10 +118,11 @@ def _scope_str(scopes: set[str]) -> str:
 class OAuthSigningKey:
     """RSA signing key for access tokens, with a JWKS view for validation.
 
-    Loads a PEM private key from ``AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM`` when set
-    (so issued tokens survive a restart and are shared across replicas); else
-    generates an ephemeral RSA-2048 key and warns that tokens are invalidated on
-    restart. The ``kid`` is the RFC 7638 JWK thumbprint so it is stable for a
+    Loads a PEM private key from ``AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM`` (or the
+    file-first ``AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM_FILE`` mounted-secret variant)
+    when set (so issued tokens survive a restart and are shared across replicas);
+    else generates an ephemeral RSA-2048 key and warns that tokens are invalidated
+    on restart. The ``kid`` is the RFC 7638 JWK thumbprint so it is stable for a
     given key.
     """
 
@@ -129,7 +130,9 @@ class OAuthSigningKey:
         from cryptography.hazmat.primitives import serialization
         from cryptography.hazmat.primitives.asymmetric import rsa
 
-        pem = private_pem if private_pem is not None else os.environ.get("AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM", "").strip()
+        from agent_bom.api.secret_source import resolve_secret
+
+        pem = private_pem if private_pem is not None else resolve_secret("AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM").strip()
         if pem:
             self._private_key = serialization.load_pem_private_key(pem.encode("utf-8"), password=None)
             self._ephemeral = False

--- a/tests/test_compliance_signing.py
+++ b/tests/test_compliance_signing.py
@@ -82,6 +82,7 @@ def _seed_tagged_scan(tenant_id: str = "tenant-alpha") -> InMemoryJobStore:
 @pytest.fixture
 def clean_signer_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.delenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", raising=False)
+    monkeypatch.delenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE", raising=False)
     monkeypatch.delenv("AGENT_BOM_COMPLIANCE_SIGNING_LAST_ROTATED", raising=False)
     monkeypatch.delenv("AGENT_BOM_COMPLIANCE_SIGNING_ROTATION_DAYS", raising=False)
     monkeypatch.delenv("AGENT_BOM_COMPLIANCE_SIGNING_MAX_AGE_DAYS", raising=False)
@@ -121,6 +122,45 @@ def test_ed25519_activated_when_env_set(monkeypatch: pytest.MonkeyPatch, clean_s
     # Raw Ed25519 signature is 64 bytes = 128 hex chars
     assert len(sig.signature_hex) == 128
     public_key.verify(bytes.fromhex(sig.signature_hex), payload)  # raises on bad sig
+
+
+def test_ed25519_activated_from_mounted_file(
+    monkeypatch: pytest.MonkeyPatch, clean_signer_env: None, tmp_path
+) -> None:
+    # File-first: `*_FILE` points at a mounted secret; the inline var stays unset.
+    pem, public_key = _generate_ed25519_pem()
+    pem_file = tmp_path / "compliance_ed25519.pem"
+    pem_file.write_text(pem)
+    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE", str(pem_file))
+    reset_signer_cache_for_tests()
+
+    algorithm, key_id, reported_pem = describe_current_signer()
+    assert algorithm == "Ed25519"
+    assert key_id is not None and len(key_id) == 16
+    assert reported_pem is not None and "PUBLIC KEY" in reported_pem
+
+    payload = b'{"hello":"file"}'
+    sig = sign_compliance_bundle(payload)
+    assert sig.algorithm == "Ed25519"
+    public_key.verify(bytes.fromhex(sig.signature_hex), payload)
+
+
+def test_file_variant_takes_precedence_over_inline_env(
+    monkeypatch: pytest.MonkeyPatch, clean_signer_env: None, tmp_path
+) -> None:
+    # When both are set, the mounted file wins (resolve_secret is file-first).
+    file_pem, file_public_key = _generate_ed25519_pem()
+    inline_pem, _ = _generate_ed25519_pem()
+    pem_file = tmp_path / "compliance_ed25519.pem"
+    pem_file.write_text(file_pem)
+    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", inline_pem)
+    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE", str(pem_file))
+    reset_signer_cache_for_tests()
+
+    payload = b'{"hello":"precedence"}'
+    sig = sign_compliance_bundle(payload)
+    # Signature verifies under the FILE key, not the inline one.
+    file_public_key.verify(bytes.fromhex(sig.signature_hex), payload)
 
 
 def test_bundle_roundtrip_verifies_with_verification_key_endpoint(monkeypatch: pytest.MonkeyPatch, clean_signer_env: None) -> None:

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -110,8 +110,8 @@ def test_dockerfile_sse_does_not_opt_into_insecure_public_mode():
     assert "AGENT_BOM_MCP_BEARER_TOKEN" in content
 
 
-def test_clickhouse_grafana_compose_has_no_default_admin_password():
-    """Analytics compose must not publish admin/admin or bind public ports."""
+def test_clickhouse_grafana_compose_reads_admin_password_from_secret_file():
+    """Analytics compose must use a mounted password file and local ports."""
     import yaml
 
     path = ROOT / "deploy" / "supabase" / "clickhouse" / "docker-compose.yml"
@@ -121,8 +121,10 @@ def test_clickhouse_grafana_compose_has_no_default_admin_password():
 
     assert grafana["environment"]["GF_SECURITY_ADMIN_USER"] != "admin"
     assert "GRAFANA_ADMIN_USER:?" in grafana["environment"]["GF_SECURITY_ADMIN_USER"]
-    assert grafana["environment"]["GF_SECURITY_ADMIN_PASSWORD"] != "admin"
-    assert "GRAFANA_ADMIN_PASSWORD:?" in grafana["environment"]["GF_SECURITY_ADMIN_PASSWORD"]
+    assert "GF_SECURITY_ADMIN_PASSWORD" not in grafana["environment"]
+    assert grafana["environment"]["GF_SECURITY_ADMIN_PASSWORD__FILE"] == "/run/secrets/grafana_admin_password"
+    assert "grafana_admin_password" in grafana["secrets"]
+    assert "GRAFANA_ADMIN_PASSWORD_FILE" in data["secrets"]["grafana_admin_password"]["file"]
     assert grafana["ports"] == ["127.0.0.1:3001:3000"]
     assert clickhouse["ports"] == ["127.0.0.1:8123:8123", "127.0.0.1:9000:9000"]
 

--- a/tests/test_oauth_as.py
+++ b/tests/test_oauth_as.py
@@ -12,6 +12,7 @@ import base64
 import hashlib
 import secrets
 
+import pytest
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
@@ -342,3 +343,61 @@ def test_validate_token_rejects_foreign_token() -> None:
     # A token signed by server_a does not validate against server_b's key.
     assert server_b.validate_token(tokens["access_token"]) is None
     assert server_a.validate_token(tokens["access_token"]) is not None
+
+
+# ── Signing-key source (env / mounted-file resolution) ────────────────────────
+
+_OAUTH_PEM_ENV = "AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM"
+
+
+def _rsa_private_pem() -> str:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+
+
+def test_signing_key_ephemeral_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(_OAUTH_PEM_ENV, raising=False)
+    monkeypatch.delenv(f"{_OAUTH_PEM_ENV}_FILE", raising=False)
+    key = OAuthSigningKey()
+    assert key.ephemeral is True
+
+
+def test_signing_key_loads_from_inline_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(f"{_OAUTH_PEM_ENV}_FILE", raising=False)
+    pem = _rsa_private_pem()
+    monkeypatch.setenv(_OAUTH_PEM_ENV, pem)
+    key = OAuthSigningKey()
+    assert key.ephemeral is False
+
+
+def test_signing_key_loads_from_mounted_file(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    # File-first: `*_FILE` points at a mounted secret; the inline var stays unset.
+    monkeypatch.delenv(_OAUTH_PEM_ENV, raising=False)
+    pem = _rsa_private_pem()
+    pem_file = tmp_path / "oauth_as.pem"
+    pem_file.write_text(pem)
+    monkeypatch.setenv(f"{_OAUTH_PEM_ENV}_FILE", str(pem_file))
+    key = OAuthSigningKey()
+    assert key.ephemeral is False
+
+
+def test_signing_key_file_takes_precedence_over_inline_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    file_pem = _rsa_private_pem()
+    inline_pem = _rsa_private_pem()
+    pem_file = tmp_path / "oauth_as.pem"
+    pem_file.write_text(file_pem)
+    monkeypatch.setenv(_OAUTH_PEM_ENV, inline_pem)
+    monkeypatch.setenv(f"{_OAUTH_PEM_ENV}_FILE", str(pem_file))
+    # The mounted file wins: the loaded key matches the FILE kid, not the inline one.
+    file_kid = OAuthSigningKey(private_pem=file_pem).kid
+    resolved_kid = OAuthSigningKey().kid
+    assert resolved_kid == file_kid


### PR DESCRIPTION
Closes the **#3807(a)** P1: the OAuth-AS RSA signing key and the compliance Ed25519 signing key were read as inline `os.environ` blobs, bypassing the file-first `resolve_secret()` helper — so mounted-secret (`*_FILE`) deployments couldn't supply them and operators were pushed to put PEMs in env/.env.

- Route both PEMs through `resolve_secret()`: `AGENT_BOM_OAUTH_AS_PRIVATE_KEY_PEM(_FILE)` and `AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM(_FILE)`. File wins over env; unset still yields the ephemeral-RSA (OAuth) / HMAC (compliance) fallback; inline env retained for back-compat.
- Tests cover file load, unset fallback, inline env, and file-over-env precedence.

Plus low-risk #3807 hardening:
- `.env.example` now leads AWS/Azure/GCP with IRSA / workload-identity / STS AssumeRole and demotes static creds to commented last-resort.
- ClickHouse/Grafana compose uses `GF_SECURITY_ADMIN_PASSWORD__FILE` + a `secrets:` mount.
- `deploy/secrets/README.md` and `docs/COMPLIANCE_SIGNING.md` document the `_FILE` variants.

Deferred (P2-4): migrating servicenow/slack/jira/proxy-webhook tokens to `resolve_secret` — out of scope here.

**Tests:** 33 pass (oauth_as, compliance_signing, secret_source); ruff clean. Refs #3807.