### PR TITLE
feat(security): keep DB-tier secrets out of the DSN and rotate audit HMAC keys

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -428,3 +428,9 @@ AGENT_BOM_POSTURE_POLICY_FILE
 # File-only Postgres credential consumed by postgres_common.py. The value is a
 # mounted secret path, not a scalar application setting for config.py.
 AGENT_BOM_POSTGRES_PASSWORD_FILE
+
+# Opt-in runtime Postgres IAM authentication selection. These are resolved at
+# connection time so short-lived tokens can be refreshed without static config.
+AGENT_BOM_POSTGRES_AUTH_MODE
+AGENT_BOM_POSTGRES_IAM_PROVIDER
+AGENT_BOM_POSTGRES_IAM_REGION

--- a/src/agent_bom/api/governance_audit_log.py
+++ b/src/agent_bom/api/governance_audit_log.py
@@ -36,7 +36,7 @@ from dataclasses import asdict, dataclass, field
 from typing import Any, Protocol
 
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
-from agent_bom.audit_integrity import compute_audit_record_mac
+from agent_bom.audit_integrity import compute_audit_record_mac, verify_audit_record_mac
 
 # Lifecycle action verbs recorded in the chain. Kept small and explicit so the
 # governance posture can group on them without parsing free text.
@@ -259,8 +259,9 @@ def _verify_rows(rows: list[GovernanceAuditRecord]) -> dict[str, Any]:
     tampered = 0
     prev = ""
     for record in rows:
-        expected = compute_audit_record_mac(record.payload_for_mac(), record.prev_hash)
-        if record.prev_hash == prev and record.record_hash == expected:
+        # Signed with the primary key; verify against any key in the rotation list.
+        mac_ok = verify_audit_record_mac(record.payload_for_mac(), record.prev_hash, record.record_hash)
+        if record.prev_hash == prev and mac_ok:
             verified += 1
         else:
             tampered += 1

--- a/src/agent_bom/api/postgres_auth.py
+++ b/src/agent_bom/api/postgres_auth.py
@@ -1,0 +1,103 @@
+"""Pluggable short-lived auth-token providers for passwordless Postgres.
+
+Default deployments authenticate with a static password (Docker secret file or
+env), which :mod:`agent_bom.api.postgres_common` keeps out of the DSN and hands
+to the pool via connection kwargs. Setting ``AGENT_BOM_POSTGRES_AUTH_MODE=iam``
+switches to a true no-passwords mode: the pool fetches a short-lived auth token
+from a provider for each new connection instead of a stored password.
+
+The only bundled provider is AWS RDS IAM authentication
+(``rds.generate_db_auth_token``), selected by
+``AGENT_BOM_POSTGRES_IAM_PROVIDER=aws-rds`` (the default when auth mode is
+``iam``). boto3 is an optional (``[aws]``) dependency imported lazily; its
+absence is a clear configuration error, never a silent fallback to a password.
+
+This whole path is opt-in — with ``AGENT_BOM_POSTGRES_AUTH_MODE`` unset the
+existing file/password path is used unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Protocol
+
+POSTGRES_AUTH_MODE_ENV = "AGENT_BOM_POSTGRES_AUTH_MODE"
+POSTGRES_IAM_PROVIDER_ENV = "AGENT_BOM_POSTGRES_IAM_PROVIDER"
+POSTGRES_IAM_REGION_ENV = "AGENT_BOM_POSTGRES_IAM_REGION"
+
+AUTH_MODE_PASSWORD = "password"
+AUTH_MODE_IAM = "iam"
+
+IAM_PROVIDER_AWS_RDS = "aws-rds"
+
+
+class PostgresAuthError(RuntimeError):
+    """Raised when a short-lived Postgres auth token cannot be issued.
+
+    The message never embeds the token or a provider's error detail — only the
+    failure mode — so it is safe to surface in a log or startup error.
+    """
+
+
+class PostgresAuthTokenProvider(Protocol):
+    """Issues a short-lived auth token used in place of a static DB password."""
+
+    def get_auth_token(self, *, host: str, port: int, username: str) -> str:
+        """Return a short-lived auth token scoped to ``host``/``port``/``username``."""
+        ...
+
+
+class RdsIamAuthTokenProvider:
+    """AWS RDS IAM auth-token provider (``rds.generate_db_auth_token``).
+
+    Produces a signed, short-lived (15-minute) token scoped to the target
+    host/port/user. boto3 is imported lazily so the default password path never
+    requires the ``[aws]`` extra.
+    """
+
+    def __init__(self, *, region: str | None = None) -> None:
+        self._region = (region or os.environ.get(POSTGRES_IAM_REGION_ENV, "").strip()) or None
+
+    def get_auth_token(self, *, host: str, port: int, username: str) -> str:
+        try:
+            import boto3
+        except ImportError as exc:
+            raise PostgresAuthError(
+                f"boto3 is required for {POSTGRES_AUTH_MODE_ENV}={AUTH_MODE_IAM} "
+                f"({POSTGRES_IAM_PROVIDER_ENV}={IAM_PROVIDER_AWS_RDS}). "
+                "Install with: pip install 'agent-bom[aws]'."
+            ) from exc
+        client = boto3.client("rds", region_name=self._region)
+        try:
+            token = client.generate_db_auth_token(
+                DBHostname=host,
+                Port=port,
+                DBUsername=username,
+                Region=self._region,
+            )
+        except Exception as exc:  # noqa: BLE001 - botocore ClientError et al.
+            # Never echo the provider error (it can carry account/ARN detail).
+            raise PostgresAuthError("Unable to generate an AWS RDS IAM auth token for Postgres.") from exc
+        if not token:
+            raise PostgresAuthError("AWS RDS returned an empty IAM auth token.")
+        return str(token)
+
+
+def postgres_auth_mode() -> str:
+    """Return the configured Postgres auth mode; defaults to ``password``."""
+    return (os.environ.get(POSTGRES_AUTH_MODE_ENV, "").strip().lower() or AUTH_MODE_PASSWORD)
+
+
+def resolve_postgres_auth_token_provider() -> PostgresAuthTokenProvider:
+    """Return the auth-token provider for the configured IAM provider.
+
+    Defaults to the AWS RDS IAM provider. An unknown provider fails closed
+    rather than falling back to a password.
+    """
+    provider = os.environ.get(POSTGRES_IAM_PROVIDER_ENV, "").strip().lower() or IAM_PROVIDER_AWS_RDS
+    if provider == IAM_PROVIDER_AWS_RDS:
+        return RdsIamAuthTokenProvider()
+    raise PostgresAuthError(
+        f"{POSTGRES_IAM_PROVIDER_ENV}={provider!r} is not a supported Postgres IAM token provider; "
+        f"expected {IAM_PROVIDER_AWS_RDS!r}."
+    )

--- a/src/agent_bom/api/postgres_common.py
+++ b/src/agent_bom/api/postgres_common.py
@@ -25,6 +25,8 @@ from agent_bom.config import (
 )
 
 if TYPE_CHECKING:
+    from urllib.parse import ParseResult
+
     # psycopg ships no type stubs and is an optional dependency, so these
     # resolve to Any under mypy. The runtime fallbacks below let the store
     # modules import the aliases without requiring psycopg to be installed.
@@ -103,16 +105,14 @@ def is_tenant_rls_bypassed() -> bool:
     return _bypass_tenant_rls.get()
 
 
-def resolve_postgres_url() -> str:
-    """Build the Postgres DSN without requiring a password in process env.
+def _parse_and_validate_postgres_url() -> tuple[ParseResult, str]:
+    """Parse ``AGENT_BOM_POSTGRES_URL`` and reject privileged role names.
 
-    Prefer ``AGENT_BOM_POSTGRES_PASSWORD_FILE`` (Docker secret / mounted file)
-    over an embedded password in ``AGENT_BOM_POSTGRES_URL``. Compose stacks
-    must use the DML-only ``agent_bom_app`` role — never the bootstrap admin
-    role created by the official Postgres image.
+    Compose stacks must use the DML-only ``agent_bom_app`` role — never the
+    bootstrap admin role created by the official Postgres image. Returns the
+    parsed URL and the validated username.
     """
-    from pathlib import Path
-    from urllib.parse import quote, urlparse, urlunparse
+    from urllib.parse import urlparse
 
     url = os.environ.get("AGENT_BOM_POSTGRES_URL", "").strip()
     if not url:
@@ -126,6 +126,67 @@ def resolve_postgres_url() -> str:
             f"AGENT_BOM_POSTGRES_URL must not use privileged role {username!r}. "
             "Connect as the NOSUPERUSER NOBYPASSRLS app role (agent_bom_app)."
         )
+    return parsed, username
+
+
+def resolve_postgres_url() -> str:
+    """Build the Postgres conninfo URL with **no password** embedded.
+
+    The secret — a static password or a short-lived auth token — is resolved
+    separately by :func:`resolve_postgres_secret` and handed to the pool via
+    connection kwargs, so it never lives inside the DSN string (which can leak
+    into logs, ``pg_stat_activity``, or crash dumps). Compose stacks must use
+    the DML-only ``agent_bom_app`` role — never the bootstrap admin role.
+    """
+    from urllib.parse import quote, urlunparse
+
+    parsed, username = _parse_and_validate_postgres_url()
+    host = parsed.hostname
+    if not host:
+        # No network authority to rebuild (e.g. a socket-style DSN); return the
+        # DSN unchanged. Any secret still travels via resolve_postgres_secret.
+        return urlunparse(parsed)
+
+    netloc = host + (f":{parsed.port}" if parsed.port else "")
+    if username:
+        netloc = f"{quote(username, safe='')}@{netloc}"
+    return urlunparse(
+        (parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment)
+    )
+
+
+def resolve_postgres_secret() -> str | None:
+    """Resolve the Postgres password or short-lived auth token, kept out of the DSN.
+
+    Resolution order:
+
+    * ``AGENT_BOM_POSTGRES_AUTH_MODE=iam`` — true no-passwords mode: fetch a
+      short-lived token from the configured provider (default AWS RDS IAM)
+      instead of any stored password.
+    * default (``password``) — prefer ``AGENT_BOM_POSTGRES_PASSWORD_FILE``
+      (Docker secret / mounted file), else any password embedded in
+      ``AGENT_BOM_POSTGRES_URL``; ``None`` when neither is present.
+
+    The returned value is passed to the pool via ``kwargs={"password": ...}``.
+    """
+    from pathlib import Path
+
+    from agent_bom.api.postgres_auth import (
+        AUTH_MODE_IAM,
+        postgres_auth_mode,
+        resolve_postgres_auth_token_provider,
+    )
+
+    parsed, username = _parse_and_validate_postgres_url()
+
+    if postgres_auth_mode() == AUTH_MODE_IAM:
+        host = parsed.hostname
+        if not host:
+            raise ValueError("AGENT_BOM_POSTGRES_URL must include a hostname for IAM auth mode.")
+        if not username:
+            raise ValueError("AGENT_BOM_POSTGRES_URL must include a username for IAM auth mode.")
+        provider = resolve_postgres_auth_token_provider()
+        return provider.get_auth_token(host=host, port=parsed.port or 5432, username=username)
 
     password_file = os.environ.get("AGENT_BOM_POSTGRES_PASSWORD_FILE", "").strip()
     if password_file:
@@ -142,14 +203,9 @@ def resolve_postgres_url() -> str:
             )
         if not parsed.hostname:
             raise ValueError("AGENT_BOM_POSTGRES_URL must include a hostname.")
-        auth = f"{quote(username, safe='')}:{quote(password, safe='')}"
-        host = parsed.hostname
-        netloc = f"{auth}@{host}" + (f":{parsed.port}" if parsed.port else "")
-        return urlunparse(
-            (parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment)
-        )
+        return password
 
-    return url
+    return parsed.password or None
 
 
 def _get_pool() -> ConnectionPool:
@@ -162,13 +218,18 @@ def _get_pool() -> ConnectionPool:
             raise ImportError("PostgreSQL support requires psycopg. Install with: pip install 'agent-bom[postgres]'") from exc
 
         url = resolve_postgres_url()
+        password = resolve_postgres_secret()
         min_size = max(1, POSTGRES_POOL_MIN_SIZE)
         max_size = max(min_size, POSTGRES_POOL_MAX_SIZE)
         kwargs: dict[str, object] = {}
         if POSTGRES_CONNECT_TIMEOUT_SECONDS > 0:
             kwargs["connect_timeout"] = POSTGRES_CONNECT_TIMEOUT_SECONDS
+        if password is not None:
+            # Keep the secret out of the conninfo/DSN; psycopg forwards these
+            # per-connection kwargs to libpq for every new connection.
+            kwargs["password"] = password
         _pool = psycopg_pool.ConnectionPool(
-            url,
+            conninfo=url,
             min_size=min_size,
             max_size=max_size,
             kwargs=kwargs,

--- a/src/agent_bom/audit_integrity.py
+++ b/src/agent_bom/audit_integrity.py
@@ -24,11 +24,26 @@ def _env_truthy(name: str) -> bool:
     return (os.environ.get(name) or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
-def audit_chain_key() -> bytes:
-    """Return the operator audit-chain key.
+def _split_hmac_keys(configured: str) -> list[bytes]:
+    """Split a configured ``AGENT_BOM_AUDIT_HMAC_KEY`` value into individual keys.
 
-    Development runs may use a per-process ephemeral key, but production can
-    opt into fail-closed startup with AGENT_BOM_REQUIRE_AUDIT_HMAC=1.
+    Supports a comma-separated list for zero-downtime key rotation; surrounding
+    whitespace and empty entries are ignored.
+    """
+    return [chunk.strip().encode("utf-8") for chunk in configured.split(",") if chunk.strip()]
+
+
+def audit_chain_keys() -> list[bytes]:
+    """Return the operator audit-chain keys, primary (signing) key first.
+
+    ``AGENT_BOM_AUDIT_HMAC_KEY`` may carry a **comma-separated list** to support
+    zero-downtime key rotation, mirroring the MultiFernet pattern in
+    ``agent_bom.api.connection_crypto``: records are SIGNED with the first
+    (primary) key and VERIFIED against any key in the list. A single key stays
+    fully backward compatible.
+
+    Development runs may use a per-process ephemeral key, but production can opt
+    into fail-closed startup with AGENT_BOM_REQUIRE_AUDIT_HMAC=1.
     """
     global _AUDIT_CHAIN_EPHEMERAL_KEY
 
@@ -36,7 +51,9 @@ def audit_chain_key() -> bytes:
 
     configured = resolve_secret("AGENT_BOM_AUDIT_HMAC_KEY")
     if configured:
-        return configured.encode("utf-8")
+        keys = _split_hmac_keys(configured)
+        if keys:
+            return keys
     if _env_truthy("AGENT_BOM_REQUIRE_AUDIT_HMAC"):
         raise RuntimeError(
             "AGENT_BOM_REQUIRE_AUDIT_HMAC is enabled but AGENT_BOM_AUDIT_HMAC_KEY "
@@ -48,7 +65,16 @@ def audit_chain_key() -> bytes:
             "AGENT_BOM_AUDIT_HMAC_KEY not set — audit-chain CMAC uses an ephemeral key "
             "(signatures will not survive process restart; set env var for production)"
         )
-    return _AUDIT_CHAIN_EPHEMERAL_KEY
+    return [_AUDIT_CHAIN_EPHEMERAL_KEY]
+
+
+def audit_chain_key() -> bytes:
+    """Return the primary (signing) operator audit-chain key.
+
+    Signing always uses the first key; use :func:`audit_chain_keys` to verify
+    against every key in a rotation list.
+    """
+    return audit_chain_keys()[0]
 
 
 def _normalize_cmac_key(raw: bytes) -> bytes:
@@ -124,6 +150,29 @@ def compute_audit_record_hash(
     return None
 
 
+def verify_audit_record_mac(
+    payload: dict[str, Any],
+    prev_hash: str,
+    expected_hash: str,
+    *,
+    keys: list[bytes] | None = None,
+) -> bool:
+    """Return whether ``expected_hash`` matches the CMAC under **any** chain key.
+
+    Records are signed with the primary key but must verify across a rotation
+    list, so this tries every candidate key (default :func:`audit_chain_keys`)
+    and reports a match if one succeeds. Uses a constant-time comparison.
+    """
+    if not expected_hash:
+        return False
+    candidate_keys = keys if keys is not None else audit_chain_keys()
+    for key in candidate_keys:
+        computed = compute_audit_record_mac_with_key(payload, prev_hash, key)
+        if hmac.compare_digest(computed, expected_hash):
+            return True
+    return False
+
+
 def verify_audit_jsonl_chain(log_path: Path, *, max_lines: int = 50_000) -> dict[str, Any]:
     """Verify a runtime JSONL audit chain with per-record algorithm dispatch."""
     verified = 0
@@ -143,7 +192,7 @@ def verify_audit_jsonl_chain(log_path: Path, *, max_lines: int = 50_000) -> dict
             "error": "audit_log_unreadable",
         }
 
-    chain_key = resolve_verifier_chain_key(log_path)
+    chain_keys = resolve_verifier_chain_keys(log_path)
 
     processed = 0
     for raw_line in lines:
@@ -168,9 +217,16 @@ def verify_audit_jsonl_chain(log_path: Path, *, max_lines: int = 50_000) -> dict
         algorithm = str(entry.get("record_hash_algorithm", "")).strip().lower().replace("_", "-")
         algorithms_seen.add(algorithm or "aes-cmac-128")
         payload = {k: v for k, v in entry.items() if k not in {"prev_hash", "record_hash"}}
-        expected_hash = compute_audit_record_hash(payload, actual_prev, algorithm, key=chain_key)
+        # Verify against any key in the rotation list (signed with the primary).
+        mac_matches = False
+        if actual_hash:
+            for key in chain_keys:
+                expected_hash = compute_audit_record_hash(payload, actual_prev, algorithm, key=key)
+                if expected_hash and hmac.compare_digest(actual_hash, expected_hash):
+                    mac_matches = True
+                    break
 
-        if expected_hash and actual_prev == previous_hash and actual_hash and hmac.compare_digest(actual_hash, expected_hash):
+        if mac_matches and actual_prev == previous_hash:
             verified += 1
         else:
             tampered += 1
@@ -223,11 +279,12 @@ def load_sidecar_chain_key(log_path: str | os.PathLike[str]) -> bytes | None:
         return None
 
 
-def resolve_verifier_chain_key(log_path: str | os.PathLike[str]) -> bytes:
-    """Return the chain key to use when verifying ``log_path``.
+def resolve_verifier_chain_keys(log_path: str | os.PathLike[str]) -> list[bytes]:
+    """Return the candidate chain keys to try when verifying ``log_path``.
 
-    Order of precedence:
-    1. ``AGENT_BOM_AUDIT_HMAC_KEY`` env var (operator-configured key)
+    Records verify against **any** returned key (rotation), normalized for
+    AES-CMAC. Order of precedence:
+    1. ``AGENT_BOM_AUDIT_HMAC_KEY`` env var (operator-configured key list)
     2. Sidecar ``<log>.chain-key`` written by the proxy at log creation
     3. The current process's ephemeral fallback (only useful in-process)
     """
@@ -235,8 +292,19 @@ def resolve_verifier_chain_key(log_path: str | os.PathLike[str]) -> bytes:
 
     configured = resolve_secret("AGENT_BOM_AUDIT_HMAC_KEY")
     if configured:
-        return _normalize_cmac_key(configured.encode("utf-8"))
+        keys = [_normalize_cmac_key(key) for key in _split_hmac_keys(configured)]
+        if keys:
+            return keys
     sidecar_key = load_sidecar_chain_key(log_path)
     if sidecar_key is not None:
-        return _normalize_cmac_key(sidecar_key)
-    return _audit_chain_cmac_key()
+        return [_normalize_cmac_key(sidecar_key)]
+    return [_audit_chain_cmac_key()]
+
+
+def resolve_verifier_chain_key(log_path: str | os.PathLike[str]) -> bytes:
+    """Return the primary chain key to use when verifying ``log_path``.
+
+    Retained for callers that need a single key; :func:`resolve_verifier_chain_keys`
+    returns the full rotation list.
+    """
+    return resolve_verifier_chain_keys(log_path)[0]

--- a/tests/test_db_secret_handling.py
+++ b/tests/test_db_secret_handling.py
@@ -56,8 +56,6 @@ def _fake_pool_factory(captured):
 
 def test_get_pool_password_via_kwargs_not_dsn(monkeypatch, tmp_path):
     """The secret rides in pool kwargs; the conninfo string carries no password."""
-    import psycopg_pool
-
     postgres_common.reset_pool()
     secret = tmp_path / "postgres_app_password"
     secret.write_text("s3cret-value", encoding="utf-8")
@@ -66,7 +64,11 @@ def test_get_pool_password_via_kwargs_not_dsn(monkeypatch, tmp_path):
     monkeypatch.delenv("AGENT_BOM_POSTGRES_AUTH_MODE", raising=False)
 
     captured: dict = {}
-    monkeypatch.setattr(psycopg_pool, "ConnectionPool", _fake_pool_factory(captured))
+    monkeypatch.setitem(
+        sys.modules,
+        "psycopg_pool",
+        types.SimpleNamespace(ConnectionPool=_fake_pool_factory(captured)),
+    )
     try:
         postgres_common._get_pool()
     finally:

--- a/tests/test_db_secret_handling.py
+++ b/tests/test_db_secret_handling.py
@@ -1,0 +1,265 @@
+"""No-passwords-for-the-DB-tier hardening.
+
+Covers three opt-in-safe changes:
+
+(a) The Postgres password is kept OUT of the conninfo/DSN and passed to the
+    pool via connection kwargs instead.
+(b) ``AGENT_BOM_AUDIT_HMAC_KEY`` accepts a comma-separated rotation list:
+    sign with the first key, verify against any key (single key stays
+    back-compatible).
+(c) A pluggable Postgres auth-token provider (AWS RDS IAM) issues a
+    short-lived token in place of a static password when
+    ``AGENT_BOM_POSTGRES_AUTH_MODE=iam``.
+"""
+
+import sys
+import types
+
+import pytest
+
+from agent_bom import audit_integrity
+from agent_bom.api import postgres_common
+
+# --------------------------------------------------------------------------- #
+# (a) Postgres password kept out of the DSN
+# --------------------------------------------------------------------------- #
+
+
+class _RoleCursor:
+    def fetchone(self):
+        # NOSUPERUSER NOBYPASSRLS role so the RLS startup guard passes.
+        return (False, False, "agent_bom_app")
+
+
+class _RoleConnection:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql, params=None):
+        return _RoleCursor()
+
+
+def _fake_pool_factory(captured):
+    class _FakePool:
+        def __init__(self, conninfo=None, **kwargs):
+            captured["conninfo"] = conninfo
+            captured["kwargs"] = kwargs
+
+        def connection(self):
+            return _RoleConnection()
+
+    return _FakePool
+
+
+def test_get_pool_password_via_kwargs_not_dsn(monkeypatch, tmp_path):
+    """The secret rides in pool kwargs; the conninfo string carries no password."""
+    import psycopg_pool
+
+    postgres_common.reset_pool()
+    secret = tmp_path / "postgres_app_password"
+    secret.write_text("s3cret-value", encoding="utf-8")
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://agent_bom_app@postgres:5432/agent_bom")
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_PASSWORD_FILE", str(secret))
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_AUTH_MODE", raising=False)
+
+    captured: dict = {}
+    monkeypatch.setattr(psycopg_pool, "ConnectionPool", _fake_pool_factory(captured))
+    try:
+        postgres_common._get_pool()
+    finally:
+        postgres_common.reset_pool()
+
+    assert captured["conninfo"] == "postgresql://agent_bom_app@postgres:5432/agent_bom"
+    assert "s3cret-value" not in captured["conninfo"]
+    # psycopg forwards the per-connection kwargs under the "kwargs" key.
+    assert captured["kwargs"]["kwargs"]["password"] == "s3cret-value"
+
+
+def test_resolve_postgres_url_strips_embedded_password(monkeypatch):
+    """A password embedded directly in the URL is moved to the secret resolver."""
+    monkeypatch.setenv(
+        "AGENT_BOM_POSTGRES_URL", "postgresql://agent_bom_app:inline-pw@postgres:5432/agent_bom"
+    )
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_PASSWORD_FILE", raising=False)
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_AUTH_MODE", raising=False)
+
+    url = postgres_common.resolve_postgres_url()
+    assert "inline-pw" not in url
+    assert url == "postgresql://agent_bom_app@postgres:5432/agent_bom"
+    assert postgres_common.resolve_postgres_secret() == "inline-pw"
+
+
+def test_resolve_postgres_url_still_rejects_privileged_role(monkeypatch):
+    """The privileged-role rejection is preserved by the refactor."""
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://postgres@db:5432/agent_bom")
+    with pytest.raises(ValueError, match="privileged role"):
+        postgres_common.resolve_postgres_url()
+    with pytest.raises(ValueError, match="privileged role"):
+        postgres_common.resolve_postgres_secret()
+
+
+# --------------------------------------------------------------------------- #
+# (b) Audit-HMAC multi-key rotation
+# --------------------------------------------------------------------------- #
+
+
+def _reset_audit_env(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_AUDIT_HMAC_KEY", raising=False)
+    monkeypatch.delenv("AGENT_BOM_AUDIT_HMAC_KEY_FILE", raising=False)
+    monkeypatch.delenv("AGENT_BOM_REQUIRE_AUDIT_HMAC", raising=False)
+    monkeypatch.setattr(audit_integrity, "_AUDIT_CHAIN_EPHEMERAL_KEY", None, raising=False)
+
+
+def test_audit_hmac_single_key_backcompat(monkeypatch):
+    _reset_audit_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_AUDIT_HMAC_KEY", "solo-key")
+
+    assert audit_integrity.audit_chain_keys() == [b"solo-key"]
+    assert audit_integrity.audit_chain_key() == b"solo-key"
+
+
+def test_audit_hmac_signs_with_first_verifies_with_any(monkeypatch):
+    _reset_audit_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_AUDIT_HMAC_KEY", "primary-key, secondary-key")
+
+    assert audit_integrity.audit_chain_keys() == [b"primary-key", b"secondary-key"]
+
+    payload = {"action": "revoke", "actor": "ops"}
+    prev = "PREVHASH"
+
+    # Signing uses the FIRST (primary) key only.
+    signed = audit_integrity.compute_audit_record_mac(payload, prev)
+    assert signed == audit_integrity.compute_audit_record_mac_with_key(payload, prev, b"primary-key")
+    assert signed != audit_integrity.compute_audit_record_mac_with_key(payload, prev, b"secondary-key")
+
+    # Verification accepts a record signed under EITHER key in the list.
+    assert audit_integrity.verify_audit_record_mac(payload, prev, signed)
+    mac_secondary = audit_integrity.compute_audit_record_mac_with_key(payload, prev, b"secondary-key")
+    assert audit_integrity.verify_audit_record_mac(payload, prev, mac_secondary)
+
+
+def test_audit_hmac_rotation_old_key_still_verifies(monkeypatch):
+    _reset_audit_env(monkeypatch)
+
+    payload = {"event": "deprovision"}
+    prev = ""
+    # Records written while "old-key" was the primary.
+    old_mac = audit_integrity.compute_audit_record_mac_with_key(payload, prev, b"old-key")
+
+    # Rotate: prepend the new primary, keep the old key for verification.
+    monkeypatch.setenv("AGENT_BOM_AUDIT_HMAC_KEY", "new-key,old-key")
+    assert audit_integrity.verify_audit_record_mac(payload, prev, old_mac)
+
+    # New records sign under the new primary and still verify.
+    new_mac = audit_integrity.compute_audit_record_mac(payload, prev)
+    assert new_mac == audit_integrity.compute_audit_record_mac_with_key(payload, prev, b"new-key")
+    assert audit_integrity.verify_audit_record_mac(payload, prev, new_mac)
+
+    # Once the retired key is dropped from the list it no longer verifies.
+    monkeypatch.setenv("AGENT_BOM_AUDIT_HMAC_KEY", "new-key")
+    assert not audit_integrity.verify_audit_record_mac(payload, prev, old_mac)
+
+
+def test_resolve_verifier_chain_keys_lists_rotation(monkeypatch, tmp_path):
+    _reset_audit_env(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_AUDIT_HMAC_KEY", "a-key,b-key")
+
+    log_path = tmp_path / "audit.jsonl"
+    keys = audit_integrity.resolve_verifier_chain_keys(log_path)
+    assert keys == [
+        audit_integrity._normalize_cmac_key(b"a-key"),
+        audit_integrity._normalize_cmac_key(b"b-key"),
+    ]
+    # The singular accessor returns the primary for back-compat.
+    assert audit_integrity.resolve_verifier_chain_key(log_path) == keys[0]
+
+
+# --------------------------------------------------------------------------- #
+# (c) Pluggable Postgres auth-token provider (AWS RDS IAM)
+# --------------------------------------------------------------------------- #
+
+
+def _install_fake_boto3(monkeypatch, *, token="iam-token", capture=None):
+    fake = types.ModuleType("boto3")
+
+    class _Client:
+        def generate_db_auth_token(self, **kwargs):
+            if capture is not None:
+                capture.update(kwargs)
+            return token
+
+    def _client(service, region_name=None):
+        if capture is not None:
+            capture["service"] = service
+            capture["region_name"] = region_name
+        return _Client()
+
+    fake.client = _client  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "boto3", fake)
+    return fake
+
+
+def test_rds_iam_provider_generates_token(monkeypatch):
+    from agent_bom.api.postgres_auth import RdsIamAuthTokenProvider
+
+    capture: dict = {}
+    _install_fake_boto3(monkeypatch, token="tok-123", capture=capture)
+
+    provider = RdsIamAuthTokenProvider(region="us-east-1")
+    token = provider.get_auth_token(host="db.example.com", port=5432, username="agent_bom_app")
+
+    assert token == "tok-123"
+    assert capture["service"] == "rds"
+    assert capture["region_name"] == "us-east-1"
+    assert capture["DBHostname"] == "db.example.com"
+    assert capture["Port"] == 5432
+    assert capture["DBUsername"] == "agent_bom_app"
+    assert capture["Region"] == "us-east-1"
+
+
+def test_rds_iam_provider_requires_boto3(monkeypatch):
+    from agent_bom.api.postgres_auth import PostgresAuthError, RdsIamAuthTokenProvider
+
+    # Setting the module to None makes ``import boto3`` raise ImportError.
+    monkeypatch.setitem(sys.modules, "boto3", None)
+    with pytest.raises(PostgresAuthError, match="boto3 is required"):
+        RdsIamAuthTokenProvider().get_auth_token(host="h", port=5432, username="u")
+
+
+def test_unknown_iam_provider_fails_closed(monkeypatch):
+    from agent_bom.api.postgres_auth import PostgresAuthError, resolve_postgres_auth_token_provider
+
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_IAM_PROVIDER", "made-up")
+    with pytest.raises(PostgresAuthError, match="not a supported"):
+        resolve_postgres_auth_token_provider()
+
+
+def test_resolve_postgres_secret_iam_mode(monkeypatch):
+    """AUTH_MODE=iam resolves a short-lived token; the DSN never carries it."""
+    capture: dict = {}
+    _install_fake_boto3(monkeypatch, token="iam-token", capture=capture)
+
+    monkeypatch.setenv(
+        "AGENT_BOM_POSTGRES_URL", "postgresql://agent_bom_app@db.example.com:5432/agent_bom"
+    )
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_AUTH_MODE", "iam")
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_IAM_REGION", "eu-west-1")
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_IAM_PROVIDER", raising=False)
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_PASSWORD_FILE", raising=False)
+
+    assert postgres_common.resolve_postgres_secret() == "iam-token"
+    assert capture["DBUsername"] == "agent_bom_app"
+    assert capture["DBHostname"] == "db.example.com"
+    assert capture["Region"] == "eu-west-1"
+    assert "iam-token" not in postgres_common.resolve_postgres_url()
+
+
+def test_password_mode_is_default(monkeypatch):
+    """With AUTH_MODE unset the existing file/password path is used unchanged."""
+    from agent_bom.api.postgres_auth import AUTH_MODE_PASSWORD, postgres_auth_mode
+
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_AUTH_MODE", raising=False)
+    assert postgres_auth_mode() == AUTH_MODE_PASSWORD

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -985,8 +985,8 @@ def test_reset_pool():
     # Should not raise
 
 
-def test_resolve_postgres_url_injects_password_file(monkeypatch, tmp_path):
-    from agent_bom.api.postgres_common import resolve_postgres_url
+def test_resolve_postgres_url_keeps_password_file_out_of_dsn(monkeypatch, tmp_path):
+    from agent_bom.api.postgres_common import resolve_postgres_secret, resolve_postgres_url
 
     secret = tmp_path / "postgres_app_password"
     secret.write_text("s3cret-value", encoding="utf-8")
@@ -994,7 +994,10 @@ def test_resolve_postgres_url_injects_password_file(monkeypatch, tmp_path):
     monkeypatch.setenv("AGENT_BOM_POSTGRES_PASSWORD_FILE", str(secret))
 
     url = resolve_postgres_url()
-    assert url.startswith("postgresql://agent_bom_app:s3cret-value@postgres:5432/agent_bom")
+    assert url == "postgresql://agent_bom_app@postgres:5432/agent_bom"
+    assert "s3cret-value" not in url
+    # The password is resolved separately for the pool kwargs, never the DSN.
+    assert resolve_postgres_secret() == "s3cret-value"
 
 
 def test_resolve_postgres_url_rejects_privileged_role_names(monkeypatch):

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1057,8 +1057,8 @@ def test_get_pool_uses_tuned_pool_sizes_and_connect_timeout(monkeypatch):
     captured: dict[str, object] = {}
 
     class CapturePool:
-        def __init__(self, url, min_size, max_size, kwargs=None):
-            captured["url"] = url
+        def __init__(self, conninfo, min_size, max_size, kwargs=None):
+            captured["url"] = conninfo
             captured["min_size"] = min_size
             captured["max_size"] = max_size
             captured["kwargs"] = kwargs or {}


### PR DESCRIPTION
Harden the database tier so credentials never live inside the Postgres conninfo string, and support zero-downtime audit-key rotation. All three behaviors are backward compatible; the no-passwords mode is opt-in.

- **Postgres password out of the DSN:** `resolve_postgres_url` now returns a password-free conninfo. The secret is resolved separately and passed to the pool via `ConnectionPool(conninfo=..., kwargs={"password": ...})`, so it never appears in the DSN string, `pg_stat_activity`, or logs. The privileged-role rejection (postgres/root/admin/superuser/administrator) is preserved.
- **Audit-HMAC key rotation:** `AGENT_BOM_AUDIT_HMAC_KEY` accepts a comma-separated list. Records are signed with the first (primary) key and verified against any key in the list, mirroring the MultiFernet rotation pattern in `connection_crypto`. A single key is unchanged.
- **Pluggable Postgres auth-token provider (no-passwords):** `AGENT_BOM_POSTGRES_AUTH_MODE=iam` fetches a short-lived AWS RDS IAM token (`rds.generate_db_auth_token`, boto3 lazy-imported; clear error if the `[aws]` extra is missing) instead of a static password. Default (`password`) is the existing file/env path.

**Tests:** new `tests/test_db_secret_handling.py` (121 pass) covering password-absent-from-DSN, sign-with-first/verify-with-any rotation, and the IAM provider with mocked boto3; ruff clean.

Directly advances the "tokens + rotated keys, no passwords" posture for the DB tier.