### PR TITLE
feat(identity): harden OAuth-AS issuer, JWT aud/iss binding, deprovision by owner

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -669,6 +669,17 @@
             "title": "Name",
             "type": "string"
           },
+          "owner": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner"
+          },
           "role": {
             "default": "viewer",
             "title": "Role",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -462,6 +462,11 @@ components:
         name:
           title: Name
           type: string
+        owner:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Owner
         role:
           default: viewer
           title: Role

--- a/docs/schemas/v1/CreateKeyRequest.json
+++ b/docs/schemas/v1/CreateKeyRequest.json
@@ -17,6 +17,18 @@
       "title": "Name",
       "type": "string"
     },
+    "owner": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Owner"
+    },
     "role": {
       "default": "viewer",
       "title": "Role",

--- a/src/agent_bom/agent_identity.py
+++ b/src/agent_bom/agent_identity.py
@@ -120,8 +120,34 @@ def _resolve_jwks_uri(policy: dict) -> str | None:
     return None
 
 
-def _verify_jwt_signature(token: str, jwks_uri: str) -> tuple[bool, str | None]:
+def _resolve_expected_aud_iss(policy: dict) -> tuple[str | None, str | None]:
+    """Return the ``(expected_audience, expected_issuer)`` the policy pins.
+
+    Audience accepts ``expected_audience``/``audience``; issuer accepts
+    ``expected_issuer``/``oidc_issuer``. Any value is enforced during JWT decode
+    so a validly-signed token minted for a different aud/iss is rejected. Absent
+    values leave the corresponding claim unenforced (back-compatible).
+    """
+    aud = policy.get("expected_audience") or policy.get("audience")
+    iss = policy.get("expected_issuer") or policy.get("oidc_issuer")
+    aud_str = str(aud).strip() if isinstance(aud, str) and aud.strip() else None
+    iss_str = str(iss).strip() if isinstance(iss, str) and iss.strip() else None
+    return aud_str, iss_str
+
+
+def _verify_jwt_signature(
+    token: str,
+    jwks_uri: str,
+    *,
+    expected_audience: str | None = None,
+    expected_issuer: str | None = None,
+) -> tuple[bool, str | None]:
     """Cryptographically verify a JWT signature using a JWKS endpoint.
+
+    When ``expected_audience`` / ``expected_issuer`` are provided the ``aud`` /
+    ``iss`` claims are pinned during decode, so a validly-signed token minted for
+    a different audience or issuer is rejected (audience-confusion defense). When
+    they are ``None`` the corresponding claim is not enforced (back-compatible).
 
     Returns (verified, error_message).  On library-unavailable or network
     failure, returns (False, reason) so the caller can decide whether to
@@ -165,14 +191,27 @@ def _verify_jwt_signature(token: str, jwks_uri: str) -> tuple[bool, str | None]:
                 public_key = ECAlgorithm.from_jwk(json.dumps(jwk))  # type: ignore[assignment]
             else:
                 continue
-            # Verify signature only; expiry is checked separately
+            # Verify signature (expiry is checked separately by the caller).
+            # aud/iss are pinned when the policy provides expected values so a
+            # token minted for a different audience/issuer is rejected.
+            decode_kwargs: dict[str, Any] = {
+                "algorithms": [alg],
+                "options": {"verify_exp": False, "verify_aud": expected_audience is not None},
+            }
+            if expected_audience is not None:
+                decode_kwargs["audience"] = expected_audience
+            if expected_issuer is not None:
+                decode_kwargs["issuer"] = expected_issuer
             pyjwt.decode(
                 token,
                 public_key,  # type: ignore[arg-type]
-                algorithms=[alg],
-                options={"verify_exp": False, "verify_aud": False},
+                **decode_kwargs,
             )
             return True, None
+        except (pyjwt.InvalidAudienceError, pyjwt.InvalidIssuerError) as claim_err:
+            # Signature is valid but the token targets a different aud/iss —
+            # fail closed immediately; other keys cannot change the claim.
+            return False, f"JWT claim mismatch: {claim_err}"
         except (ValueError, KeyError, TypeError, pyjwt.PyJWTError):
             continue
 
@@ -272,7 +311,13 @@ def resolve_agent_id(token: str, policy: dict) -> tuple[str, str | None]:
         # enforced mode, a JWT without verification policy is not an identity.
         jwks_uri = _resolve_jwks_uri(policy)
         if jwks_uri:
-            verified, sig_err = _verify_jwt_signature(token, jwks_uri)
+            expected_audience, expected_issuer = _resolve_expected_aud_iss(policy)
+            verified, sig_err = _verify_jwt_signature(
+                token,
+                jwks_uri,
+                expected_audience=expected_audience,
+                expected_issuer=expected_issuer,
+            )
             if not verified:
                 return ANONYMOUS, f"JWT signature invalid: {sig_err}"
         elif policy.get("require_agent_identity"):

--- a/src/agent_bom/api/auth.py
+++ b/src/agent_bom/api/auth.py
@@ -36,6 +36,10 @@ class ApiKey:
     rotation_overlap_until: str | None = None
     replacement_key_id: str | None = None
     scim_subject_id: str | None = None
+    # Stable identifier of the user this key was issued on behalf of (SCIM
+    # user_id / user_name / external_id). Lets deprovisioning revoke free-form
+    # CI keys whose ``name`` doesn't match the departing user.
+    owner: str | None = None
 
     def __post_init__(self) -> None:
         if not self.created_at:
@@ -126,6 +130,7 @@ class ApiKey:
             "rotation_overlap_until": self.rotation_overlap_until,
             "replacement_key_id": self.replacement_key_id,
             "scim_subject_id": self.scim_subject_id,
+            "owner": self.owner,
             "state": self.lifecycle_state(now=current),
             "overlap_seconds_remaining": overlap_remaining_seconds,
         }
@@ -352,6 +357,7 @@ def create_api_key(
     scopes: list[str] | None = None,
     tenant_id: str = "default",
     scim_subject_id: str | None = None,
+    owner: str | None = None,
 ) -> tuple[str, ApiKey]:
     """Generate a new API key.
 
@@ -367,6 +373,7 @@ def create_api_key(
         scopes=scopes,
         tenant_id=tenant_id,
         scim_subject_id=scim_subject_id,
+        owner=owner,
     )
 
 
@@ -378,11 +385,13 @@ def create_api_key_record(
     scopes: list[str] | None = None,
     tenant_id: str = "default",
     scim_subject_id: str | None = None,
+    owner: str | None = None,
 ) -> ApiKey:
     """Create a stored API key record for an operator-supplied raw key."""
     salt = os.urandom(16)
     key_hash = _derive_key(raw_key, salt)
     normalized_expiry = normalize_api_key_expiry(expires_at)
+    owner_normalized = owner.strip() if isinstance(owner, str) and owner.strip() else None
     return ApiKey(
         key_id=secrets.token_hex(8),
         key_hash=key_hash,
@@ -394,6 +403,7 @@ def create_api_key_record(
         scopes=scopes or [],
         tenant_id=tenant_id,
         scim_subject_id=scim_subject_id,
+        owner=owner_normalized,
     )
 
 

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -740,6 +740,9 @@ class CreateKeyRequest(BaseModel):
     expires_at: str | None = None
     scopes: list[str] = Field(default_factory=list)
     scim_subject_id: str | None = None
+    # User this key is issued on behalf of (e.g. a SCIM user_id/user_name). Lets
+    # deprovisioning revoke free-form CI keys that don't name the departing user.
+    owner: str | None = None
 
 
 class RotateKeyRequest(BaseModel):

--- a/src/agent_bom/api/oauth_as.py
+++ b/src/agent_bom/api/oauth_as.py
@@ -262,8 +262,14 @@ class OAuthAuthorizationServer:
         token_ttl_seconds: int = _DEFAULT_TOKEN_TTL,
         code_ttl_seconds: int = _DEFAULT_CODE_TTL,
         supported_scopes: list[str] | None = None,
+        allow_host_derived_issuer: bool = True,
     ) -> None:
         self._configured_issuer = issuer.rstrip("/") if issuer else None
+        # When False, the issuer is never derived (TOFU-cached) from the
+        # client-controlled request base URL. A non-loopback listener without an
+        # explicit issuer would otherwise let the first caller poison token
+        # ``iss`` and RFC 8414 metadata via a spoofed ``Host`` header.
+        self._allow_host_derived_issuer = bool(allow_host_derived_issuer)
         self._observed_issuer: str | None = None
         self.signing_key = signing_key or OAuthSigningKey()
         self.token_ttl_seconds = max(60, min(int(token_ttl_seconds), _MAX_TOKEN_TTL))
@@ -278,6 +284,15 @@ class OAuthAuthorizationServer:
     def resolve_issuer(self, request_base_url: str | None = None) -> str:
         if self._configured_issuer:
             return self._configured_issuer
+        if not self._allow_host_derived_issuer:
+            # Fail closed: refuse to derive the issuer from a client-controlled
+            # base URL on a listener that has not opted into host derivation.
+            raise OAuthError(
+                "server_error",
+                "OAuth AS issuer is not configured; set AGENT_BOM_GATEWAY_OAUTH_AS_ISSUER "
+                "(--oauth-as-issuer) to the public base URL",
+                status=500,
+            )
         if self._observed_issuer:
             return self._observed_issuer
         base = (request_base_url or "").rstrip("/")
@@ -696,7 +711,10 @@ def build_oauth_as_router(server: OAuthAuthorizationServer):
 
     @router.get("/.well-known/oauth-authorization-server")
     async def authorization_server_metadata(request: Request) -> JSONResponse:
-        return JSONResponse(server.metadata(_request_base_url(request)))
+        try:
+            return JSONResponse(server.metadata(_request_base_url(request)))
+        except OAuthError as exc:
+            return JSONResponse(exc.to_dict(), status_code=exc.status)
 
     @router.get("/oauth/jwks.json")
     async def jwks(_request: Request) -> JSONResponse:

--- a/src/agent_bom/api/postgres_access.py
+++ b/src/agent_bom/api/postgres_access.py
@@ -81,10 +81,17 @@ class PostgresKeyStore:
                     ) THEN
                         ALTER TABLE api_keys ADD COLUMN scim_subject_id TEXT;
                     END IF;
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'api_keys' AND column_name = 'owner'
+                    ) THEN
+                        ALTER TABLE api_keys ADD COLUMN owner TEXT;
+                    END IF;
                 END
                 $$;
             """)
             conn.execute("CREATE INDEX IF NOT EXISTS idx_api_keys_scim_subject ON api_keys(team_id, scim_subject_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_api_keys_owner ON api_keys(team_id, owner)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_api_keys_team ON api_keys(team_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys(key_prefix)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_api_keys_active ON api_keys(team_id, revoked)")
@@ -109,6 +116,7 @@ class PostgresKeyStore:
             rotation_overlap_until=row[11],
             replacement_key_id=row[12],
             scim_subject_id=row[13] if len(row) > 13 else None,
+            owner=row[14] if len(row) > 14 else None,
         )
 
     def add(self, key: ApiKey) -> None:
@@ -118,9 +126,9 @@ class PostgresKeyStore:
                    (
                      key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes,
                      created_at, expires_at, revoked_at, rotation_overlap_until, replacement_key_id,
-                     scim_subject_id, revoked
+                     scim_subject_id, owner, revoked
                    )
-                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE)
                    ON CONFLICT (key_id) DO UPDATE SET
                      key_hash = EXCLUDED.key_hash,
                      key_salt = EXCLUDED.key_salt,
@@ -135,6 +143,7 @@ class PostgresKeyStore:
                      rotation_overlap_until = EXCLUDED.rotation_overlap_until,
                      replacement_key_id = EXCLUDED.replacement_key_id,
                      scim_subject_id = EXCLUDED.scim_subject_id,
+                     owner = EXCLUDED.owner,
                      revoked = FALSE""",
                 (
                     key.key_id,
@@ -151,6 +160,7 @@ class PostgresKeyStore:
                     key.rotation_overlap_until,
                     key.replacement_key_id,
                     key.scim_subject_id,
+                    key.owner,
                 ),
             )
             conn.commit()
@@ -186,7 +196,7 @@ class PostgresKeyStore:
                 """SELECT
                        key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes,
                        created_at, expires_at, revoked_at, rotation_overlap_until, replacement_key_id,
-                       scim_subject_id
+                       scim_subject_id, owner
                    FROM api_keys
                    WHERE key_id = %s""",
                 (key_id,),
@@ -198,7 +208,7 @@ class PostgresKeyStore:
             SELECT
                 key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes,
                 created_at, expires_at, revoked_at, rotation_overlap_until, replacement_key_id,
-                scim_subject_id
+                scim_subject_id, owner
             FROM api_keys
             WHERE TRUE
         """
@@ -219,7 +229,7 @@ class PostgresKeyStore:
                     """SELECT
                            key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes,
                            created_at, expires_at, revoked_at, rotation_overlap_until, replacement_key_id,
-                           scim_subject_id
+                           scim_subject_id, owner
                        FROM api_keys
                        WHERE key_prefix = %s""",
                     (prefix,),

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -552,6 +552,7 @@ async def create_key(request: Request, req: CreateKeyRequest) -> dict:
             scopes=req.scopes,
             tenant_id=tenant_id,
             scim_subject_id=resolve_scim_subject_binding(request, req.scim_subject_id),
+            owner=req.owner,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
@@ -576,6 +577,7 @@ async def create_key(request: Request, req: CreateKeyRequest) -> dict:
         "tenant_id": api_key.tenant_id,
         "created_at": api_key.created_at,
         "expires_at": api_key.expires_at,
+        "owner": api_key.owner,
         "message": "Store the raw_key securely — it will not be shown again.",
     }
 
@@ -617,6 +619,7 @@ async def rotate_key(
             scopes=list(current_key.scopes),
             tenant_id=current_key.tenant_id,
             scim_subject_id=current_key.scim_subject_id,
+            owner=current_key.owner,
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc

--- a/src/agent_bom/api/scim.py
+++ b/src/agent_bom/api/scim.py
@@ -402,6 +402,12 @@ def scim_error_body(*, status_code: int, detail: str) -> dict[str, Any]:
 def _scim_key_matches_user(key: Any, *, subjects: set[str], subjects_lower: set[str], subject_ids: set[str]) -> bool:
     if key.scim_subject_id and key.scim_subject_id in subject_ids:
         return True
+    # Free-form CI keys created via POST /v1/auth/keys carry no scim_subject_id
+    # but record the user they were issued for as ``owner`` — match on it so a
+    # departing user's tokens are revoked even when the key name is arbitrary.
+    owner = getattr(key, "owner", None)
+    if owner and (owner in subject_ids or owner in subjects or owner.lower() in subjects_lower):
+        return True
     if key.name in subjects or key.name.lower() in subjects_lower:
         return True
     return False

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -502,8 +502,21 @@ def serve_cmd(
     if enable_oauth_as:
         from agent_bom.api.oauth_as import OAuthAuthorizationServer
 
-        oauth_as = OAuthAuthorizationServer(issuer=oauth_as_issuer)
-        click.echo(f"OAuth 2.1 AS enabled (issuer={oauth_as_issuer or '<derived from request>'})")
+        host_is_loopback = _is_loopback_host(host)
+        if not oauth_as_issuer and not host_is_loopback:
+            # Deriving the issuer from the client Host header on a non-loopback
+            # listener lets the first caller poison token `iss` and RFC 8414
+            # metadata (Host-header TOFU). Require an explicit issuer instead.
+            raise click.ClickException(
+                f"OAuth 2.1 AS on non-loopback host {host!r} requires an explicit issuer. "
+                "Set --oauth-as-issuer / AGENT_BOM_GATEWAY_OAUTH_AS_ISSUER to the public base URL "
+                "(e.g. https://gateway.example.com). Deriving it from the request Host header is unsafe."
+            )
+        oauth_as = OAuthAuthorizationServer(
+            issuer=oauth_as_issuer,
+            allow_host_derived_issuer=host_is_loopback,
+        )
+        click.echo(f"OAuth 2.1 AS enabled (issuer={oauth_as_issuer or '<derived from loopback request>'})")
 
     oidc_discovery_shim = None
     try:

--- a/tests/test_identity_governance_3687.py
+++ b/tests/test_identity_governance_3687.py
@@ -110,3 +110,48 @@ def test_scim_revoke_removes_free_form_named_key_with_subject_binding(monkeypatc
         assert bound.is_revoked()
     finally:
         set_key_store(KeyStore())
+
+
+def test_scim_revoke_removes_free_form_key_by_owner(monkeypatch) -> None:
+    # A CI token minted via POST /v1/auth/keys with an arbitrary name and no
+    # scim_subject_id must still be revoked when its owner is deprovisioned.
+    store = KeyStore()
+    set_key_store(store)
+    monkeypatch.setattr("agent_bom.api.auth.get_key_store", lambda: store)
+    try:
+        ci_key = create_api_key_record(
+            "abom_test_owner_key_1234567890123",
+            name="jenkins-nightly",  # name does not identify the user
+            role=Role.ANALYST,
+            tenant_id="default",
+            owner="alice",  # bound to the departing user by owner only
+        )
+        store.add(ci_key)
+        assert ci_key.scim_subject_id is None
+        user = SimpleNamespace(user_id="user-xyz", user_name="alice", external_id=None)
+        revoked = revoke_credentials_for_scim_user("default", user)
+        assert revoked == 1
+        assert ci_key.is_revoked()
+    finally:
+        set_key_store(KeyStore())
+
+
+def test_scim_revoke_leaves_unrelated_owner_key(monkeypatch) -> None:
+    store = KeyStore()
+    set_key_store(store)
+    monkeypatch.setattr("agent_bom.api.auth.get_key_store", lambda: store)
+    try:
+        other = create_api_key_record(
+            "abom_test_other_key_1234567890123",
+            name="jenkins-nightly",
+            role=Role.ANALYST,
+            tenant_id="default",
+            owner="bob",
+        )
+        store.add(other)
+        user = SimpleNamespace(user_id="user-xyz", user_name="alice", external_id=None)
+        revoked = revoke_credentials_for_scim_user("default", user)
+        assert revoked == 0
+        assert not other.is_revoked()
+    finally:
+        set_key_store(KeyStore())

--- a/tests/test_jwks_identity.py
+++ b/tests/test_jwks_identity.py
@@ -231,3 +231,89 @@ def test_check_identity_required_jwt_without_verification_policy_blocks():
     assert agent_id == ANONYMOUS
     assert block is not None
     assert "signature verification required" in block
+
+
+# ─── F2: aud/iss binding in JWT verification ──────────────────────────────────
+
+
+def _signing_key():
+    from agent_bom.api.oauth_as import OAuthSigningKey
+
+    return OAuthSigningKey()
+
+
+def _signed_identity_jwt(key, *, sub="agent-x", aud="service-b", iss="https://issuer-b"):
+    now = int(time.time())
+    return key.sign({"sub": sub, "aud": aud, "iss": iss, "iat": now, "exp": now + 3600})
+
+
+def test_verify_jwt_wrong_audience_rejected_when_pinned():
+    key = _signing_key()
+    token = _signed_identity_jwt(key, aud="service-b")
+    with patch("agent_bom.agent_identity._fetch_jwks", return_value=key.jwks()):
+        verified, err = _verify_jwt_signature(
+            token, "https://idp/jwks", expected_audience="service-a", expected_issuer="https://issuer-b"
+        )
+    assert not verified
+    assert err and "claim mismatch" in err
+
+
+def test_verify_jwt_wrong_issuer_rejected_when_pinned():
+    key = _signing_key()
+    token = _signed_identity_jwt(key, iss="https://issuer-b")
+    with patch("agent_bom.agent_identity._fetch_jwks", return_value=key.jwks()):
+        verified, err = _verify_jwt_signature(
+            token, "https://idp/jwks", expected_audience="service-b", expected_issuer="https://issuer-a"
+        )
+    assert not verified
+    assert err and "claim mismatch" in err
+
+
+def test_verify_jwt_matching_aud_iss_accepted():
+    key = _signing_key()
+    token = _signed_identity_jwt(key)
+    with patch("agent_bom.agent_identity._fetch_jwks", return_value=key.jwks()):
+        verified, err = _verify_jwt_signature(
+            token, "https://idp/jwks", expected_audience="service-b", expected_issuer="https://issuer-b"
+        )
+    assert verified
+    assert err is None
+
+
+def test_resolve_agent_id_rejects_audience_confusion():
+    key = _signing_key()
+    token = _signed_identity_jwt(key, sub="agent-x", aud="service-b", iss="https://issuer-b")
+    policy = {
+        "jwks_uri": "https://idp/jwks",
+        "expected_audience": "service-a",
+        "expected_issuer": "https://issuer-b",
+    }
+    with patch("agent_bom.agent_identity._fetch_jwks", return_value=key.jwks()):
+        agent_id, err = resolve_agent_id(token, policy)
+    assert agent_id == ANONYMOUS
+    assert err and "signature invalid" in err
+
+
+def test_resolve_agent_id_accepts_matching_aud_iss():
+    key = _signing_key()
+    token = _signed_identity_jwt(key, sub="agent-x", aud="service-b", iss="https://issuer-b")
+    policy = {
+        "jwks_uri": "https://idp/jwks",
+        "expected_audience": "service-b",
+        "expected_issuer": "https://issuer-b",
+    }
+    with patch("agent_bom.agent_identity._fetch_jwks", return_value=key.jwks()):
+        agent_id, err = resolve_agent_id(token, policy)
+    assert err is None
+    assert agent_id == "agent-x"
+
+
+def test_resolve_agent_id_backcompat_no_expected_aud_iss():
+    # Without pinned aud/iss the token still validates on signature alone.
+    key = _signing_key()
+    token = _signed_identity_jwt(key, sub="agent-x", aud="anything", iss="https://whatever")
+    policy = {"jwks_uri": "https://idp/jwks"}
+    with patch("agent_bom.agent_identity._fetch_jwks", return_value=key.jwks()):
+        agent_id, err = resolve_agent_id(token, policy)
+    assert err is None
+    assert agent_id == "agent-x"

--- a/tests/test_oauth_as.py
+++ b/tests/test_oauth_as.py
@@ -401,3 +401,53 @@ def test_signing_key_file_takes_precedence_over_inline_env(
     file_kid = OAuthSigningKey(private_pem=file_pem).kid
     resolved_kid = OAuthSigningKey().kid
     assert resolved_kid == file_kid
+
+
+# ── F1: issuer must not be Host-header-influenced when unconfigured ────────────
+
+
+def test_issuer_derivation_disabled_fails_closed_and_ignores_host() -> None:
+    # A server that does not allow host-derived issuers (non-loopback listener
+    # without an explicit issuer) must refuse to derive `iss` from the client
+    # base URL rather than TOFU-cache an attacker-controlled Host.
+    server = OAuthAuthorizationServer(issuer=None, allow_host_derived_issuer=False)
+    try:
+        server.resolve_issuer("https://evil.example")
+        raise AssertionError("expected OAuthError when issuer derivation is disabled")
+    except OAuthError as exc:
+        assert exc.status == 500
+        assert exc.error == "server_error"
+    # A second attempt with a different Host is likewise refused — nothing was
+    # cached from the first (spoofed) request.
+    try:
+        server.resolve_issuer("https://also-evil.example")
+        raise AssertionError("expected OAuthError on repeat")
+    except OAuthError:
+        pass
+
+
+def test_metadata_endpoint_fails_closed_when_issuer_unconfigured_non_loopback() -> None:
+    server = OAuthAuthorizationServer(issuer=None, allow_host_derived_issuer=False)
+    app = FastAPI()
+    app.include_router(build_oauth_as_router(server))
+    client = TestClient(app)
+    resp = client.get(
+        "/.well-known/oauth-authorization-server",
+        headers={"Host": "evil.example"},
+    )
+    assert resp.status_code == 500
+    assert resp.json()["error"] == "server_error"
+
+
+def test_explicit_issuer_is_never_overridden_by_host() -> None:
+    server = OAuthAuthorizationServer(issuer="https://gw.example", allow_host_derived_issuer=False)
+    assert server.resolve_issuer("https://evil.example") == "https://gw.example"
+    assert server.metadata("https://evil.example")["issuer"] == "https://gw.example"
+
+
+def test_loopback_dev_still_derives_issuer_from_request() -> None:
+    # Back-compat: loopback dev keeps deriving (and TOFU-caching) the issuer.
+    server = OAuthAuthorizationServer(issuer=None, allow_host_derived_issuer=True)
+    assert server.resolve_issuer("http://127.0.0.1:8080") == "http://127.0.0.1:8080"
+    # First observed value is stable even if a later request presents another host.
+    assert server.resolve_issuer("http://other.host") == "http://127.0.0.1:8080"

--- a/ui/components/key-lifecycle-panel.tsx
+++ b/ui/components/key-lifecycle-panel.tsx
@@ -205,6 +205,7 @@ export function KeyLifecyclePanel({
     name: "",
     role: "viewer",
     expiresAt: "",
+    owner: "",
   });
   const [rotateForm, setRotateForm] = useState({
     name: "",
@@ -261,6 +262,7 @@ export function KeyLifecyclePanel({
         name: createForm.name.trim(),
         role: createForm.role,
         expires_at: toIsoOrNull(createForm.expiresAt),
+        owner: createForm.owner.trim() || undefined,
       };
       const created = await api.createKey(body);
       setIssuedSecret({
@@ -269,7 +271,7 @@ export function KeyLifecyclePanel({
         detail: created.message,
       });
       setCreateOpen(false);
-      setCreateForm({ name: "", role: "viewer", expiresAt: "" });
+      setCreateForm({ name: "", role: "viewer", expiresAt: "", owner: "" });
       await onRefresh();
     } catch (nextError) {
       setFormError(nextError instanceof Error ? nextError.message : "Failed to create API key");
@@ -459,6 +461,18 @@ export function KeyLifecyclePanel({
               onChange={(event) => setCreateForm((current) => ({ ...current, expiresAt: event.target.value }))}
               className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-emerald-500"
             />
+          </label>
+          <label className="space-y-2 text-sm text-zinc-300 md:col-span-3">
+            <span>Owner (optional)</span>
+            <input
+              value={createForm.owner}
+              onChange={(event) => setCreateForm((current) => ({ ...current, owner: event.target.value }))}
+              className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-emerald-500"
+              placeholder="user@example.com or SCIM user id"
+            />
+            <span className="block text-xs text-zinc-500">
+              Bind this key to a user so it is revoked when that user is deprovisioned.
+            </span>
           </label>
           <div className="md:col-span-3 flex items-center justify-between gap-3">
             <p className="text-xs text-zinc-500">
@@ -920,6 +934,7 @@ export function KeyLifecyclePanel({
                           <div className="text-xs text-zinc-500">
                             {key.key_prefix} · {sessionKey ? "session key" : "service key"}
                           </div>
+                          {key.owner ? <div className="text-xs text-zinc-500">owner: {key.owner}</div> : null}
                         </td>
                         <td className="py-3 text-zinc-300">{key.role}</td>
                         <td className="py-3">

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1487,6 +1487,7 @@ export interface ApiKeyRecord {
   revoked_at: string | null;
   rotation_overlap_until: string | null;
   replacement_key_id: string | null;
+  owner?: string | null | undefined;
   state: ApiKeyLifecycleState;
   overlap_seconds_remaining: number | null;
 }
@@ -1500,6 +1501,7 @@ export interface CreateApiKeyRequest {
   role: string;
   expires_at?: string | null | undefined;
   scopes?: string[] | undefined;
+  owner?: string | null | undefined;
 }
 
 export interface CreateApiKeyResponse extends ApiKeyRecord {


### PR DESCRIPTION
Three identity-stack hardening fixes from the identity audit (fail-closed, back-compatible where possible), aligned across **API + CLI + UI**.

- **F1 — OAuth-AS issuer no longer Host-header-influenced when unconfigured.** The broker AS previously TOFU-cached its issuer from the client-controlled request base URL, so the first caller could poison RFC 8414 metadata and token `iss` with a spoofed `Host`. A non-loopback listener without an explicit issuer now fails closed at startup; `resolve_issuer` refuses to derive from the request. Loopback dev keeps deriving.
- **F2 — Bind aud/iss in agent-identity JWT verification.** Verification ran with `verify_aud=False` and no issuer, accepting tokens minted for another audience/service. `aud`/`iss` are pinned during decode when gateway policy provides expected values (audience-confusion defense); unset keeps prior behavior.
- **F3 — Deprovision revokes free-form CI keys by owner.** A key created via `POST /v1/auth/keys` with an arbitrary name and no `scim_subject_id` survived its owner's deprovisioning. Keys now carry an `owner` (persisted via idempotent nullable Postgres column), matched by SCIM revoke alongside `scim_subject_id`/name. Key-management UI gains an optional Owner field + display.

**Tests:** 209 pass (oauth_as, jwks_identity, identity_governance, agent_identity, auth, gateway_oauth_broker, …); ruff clean.

⚠️ **Release-note / breaking change (F1):** running `gateway serve --enable-oauth-as` on a **non-loopback** host now requires `--oauth-as-issuer` / `AGENT_BOM_GATEWAY_OAUTH_AS_ISSUER`; deployments that relied on silent Host-derivation will fail to start until an explicit issuer is set. This is the intended fail-closed behavior.