### PR TITLE
fix(findings): match severity filter on string column for backend parity

### DIFF
--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -1053,10 +1053,13 @@ class SQLiteComplianceHubStore:
         if "severity_rank" not in cols:
             self._conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN severity_rank INTEGER NOT NULL DEFAULT 0")
             self._conn.execute(
+                # Mirror severity_policy_rank() so backfilled ranks match new
+                # writes: info==low==1, none==0, everything unknown==-1 (#3192).
                 "UPDATE compliance_hub_findings SET severity_rank = CASE "
                 "LOWER(COALESCE(json_extract(payload, '$.severity'), '')) "
                 "WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 "
-                "ELSE 0 END WHERE severity_rank = 0"
+                "WHEN 'info' THEN 1 WHEN 'informational' THEN 1 WHEN 'none' THEN 0 "
+                "ELSE -1 END WHERE severity_rank = 0"
             )
         if "cvss_score" not in cols:
             self._conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN cvss_score REAL NOT NULL DEFAULT 0")
@@ -1285,8 +1288,11 @@ class SQLiteComplianceHubStore:
             where.append("origin = ?")
             params.append(origin)
         if severity is not None:
-            where.append("severity_rank = ?")
-            params.append(severity_policy_rank(severity))
+            # Filter on the materialised severity STRING (exact match, lowercased)
+            # so every backend agrees. ``severity_rank`` collapses info==low and
+            # is kept for ORDER BY only (#3192).
+            where.append("LOWER(severity) = ?")
+            params.append(severity.lower())
         if scan_id is not None:
             where.append("CAST(json_extract(payload, '$.scan_id') AS TEXT) = ?")
             params.append(scan_id)
@@ -1440,8 +1446,10 @@ class SQLiteComplianceHubStore:
             where.append("origin = ?")
             params.append(origin)
         if severity is not None:
-            where.append("severity_rank = ?")
-            params.append(severity_policy_rank(severity))
+            # Match the materialised severity STRING (exact, lowercased) so all
+            # backends agree; ``severity_rank`` stays ORDER-BY-only (#3192).
+            where.append("LOWER(severity) = ?")
+            params.append(severity.lower())
         if scan_id is not None:
             where.append("(CAST(json_extract(payload, '$.batch_id') AS TEXT) = ? OR CAST(json_extract(payload, '$.scan_id') AS TEXT) = ?)")
             params.extend([scan_id, scan_id])

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -252,9 +252,12 @@ class PostgresComplianceHubStore:
             conn.execute("UPDATE compliance_hub_findings SET severity = COALESCE(payload->>'severity', '') WHERE severity = ''")
             conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN IF NOT EXISTS severity_rank INTEGER NOT NULL DEFAULT 0")
             conn.execute(
+                # Mirror severity_policy_rank() so backfilled ranks match new
+                # writes: info==low==1, none==0, everything unknown==-1 (#3192).
                 "UPDATE compliance_hub_findings SET severity_rank = CASE LOWER(COALESCE(payload->>'severity', '')) "
                 "WHEN 'critical' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 "
-                "ELSE 0 END WHERE severity_rank = 0"
+                "WHEN 'info' THEN 1 WHEN 'informational' THEN 1 WHEN 'none' THEN 0 "
+                "ELSE -1 END WHERE severity_rank = 0"
             )
             conn.execute("ALTER TABLE compliance_hub_findings ADD COLUMN IF NOT EXISTS cvss_score DOUBLE PRECISION NOT NULL DEFAULT 0")
             conn.execute(
@@ -457,10 +460,11 @@ class PostgresComplianceHubStore:
             where.append("origin = %s")
             params.append(origin)
         if severity is not None:
-            from agent_bom.graph.severity import severity_policy_rank
-
-            where.append("severity_rank = %s")
-            params.append(severity_policy_rank(severity))
+            # Filter on the materialised severity STRING (exact, lowercased) so
+            # every backend agrees; ``severity_rank`` collapses info==low and is
+            # kept for ORDER BY only (#3192).
+            where.append("LOWER(severity) = %s")
+            params.append(severity.lower())
         if scan_id is not None:
             where.append("payload->>'scan_id' = %s")
             params.append(scan_id)
@@ -732,7 +736,6 @@ class PostgresComplianceHubStore:
         cursor: str | None = None,
     ) -> FindingCursorPage:
         from agent_bom.api.finding_lifecycle import enriched_finding_payload
-        from agent_bom.graph.severity import severity_policy_rank
 
         normalized_sort = sort if sort in ("effective_reach", "cvss", "severity", "ordinal") else "effective_reach"
         where = ["tenant_id = %s"]
@@ -744,8 +747,10 @@ class PostgresComplianceHubStore:
             where.append("origin = %s")
             params.append(origin)
         if severity is not None:
-            where.append("severity_rank = %s")
-            params.append(severity_policy_rank(severity))
+            # Match the materialised severity STRING (exact, lowercased) so all
+            # backends agree; ``severity_rank`` stays ORDER-BY-only (#3192).
+            where.append("LOWER(severity) = %s")
+            params.append(severity.lower())
         if scan_id is not None:
             where.append("(payload->>'batch_id' = %s OR payload->>'scan_id' = %s)")
             params.extend([scan_id, scan_id])

--- a/tests/test_compliance_hub_store_pagination.py
+++ b/tests/test_compliance_hub_store_pagination.py
@@ -114,6 +114,40 @@ def test_list_page_severity_filter_pushed_down(seeded_store) -> None:
     assert all(r["severity"] == "critical" for r in rows)
 
 
+@pytest.mark.parametrize("kind", ["memory", "sqlite"])
+def test_list_page_severity_filter_info_low_parity(kind, tmp_path) -> None:
+    """``severity=low`` must return ONLY low (not info), and ``severity=info``
+    only info, identically on every backend.
+
+    ``severity_policy_rank`` collapses info==low==1, so a rank-based filter
+    conflated the two on the SQL backends while the in-memory backend
+    string-matched — different results per backend (P1). The filter now matches
+    the materialised severity STRING, so all backends agree.
+    """
+    store = _make_store(kind, tmp_path)
+    tenant = "tenant-parity"
+    store.add(
+        tenant,
+        [
+            {"id": "sev-low", "source": "s", "origin": "bulk_ingest", "severity": "low"},
+            {"id": "sev-info", "source": "s", "origin": "bulk_ingest", "severity": "info"},
+            {"id": "sev-unknown", "source": "s", "origin": "bulk_ingest", "severity": "unknown"},
+        ],
+    )
+
+    low_rows, low_total = store.list_page(tenant, limit=100, offset=0, severity="low")
+    assert low_total == 1
+    assert [r["id"] for r in low_rows] == ["sev-low"]
+
+    info_rows, info_total = store.list_page(tenant, limit=100, offset=0, severity="info")
+    assert info_total == 1
+    assert [r["id"] for r in info_rows] == ["sev-info"]
+
+    unknown_rows, unknown_total = store.list_page(tenant, limit=100, offset=0, severity="unknown")
+    assert unknown_total == 1
+    assert [r["id"] for r in unknown_rows] == ["sev-unknown"]
+
+
 def test_list_page_scan_id_filter_pushed_down(seeded_store) -> None:
     store, tenant = seeded_store
     rows, total = store.list_page(tenant, limit=1000, offset=0, scan_id="scan-a")


### PR DESCRIPTION
**P1 — the severity filter conflated `info` with `low` and returned different results per backend.** Both SQL backends filtered `severity_rank = severity_policy_rank(severity)`, and the policy order maps INFO==LOW==1, so `severity=low` on SQLite/Postgres returned both low AND info rows while the in-memory backend string-matched and returned only low. `severity=info`/`unknown` filters could also miss legacy rows (migration backfill wrote `info→0` while new writes use `info→1`).

- Filter on the materialised `severity` **string** column (exact, lowercased) in both SQL `list_page` paths and both cursor paths, matching the in-memory backend. `severity_rank` is kept for ORDER BY only.
- Align the `severity_rank` migration backfill CASE with `severity_policy_rank` so ranks stay consistent between backfilled and freshly-written rows.
- Adds a cross-backend parity test asserting `severity=low` returns only low (and `info`/`unknown` only their own rows) on both in-memory and SQLite.

The UI findings filter calls the API, so it inherits the corrected semantics; the CLI's `--fail-on-severity` threshold path is unaffected.

**Tests:** 87 pass (pagination parity + severity-sort regressions); ruff clean. No schema/DDL change — only a WHERE predicate + the values written by an existing one-time backfill.