### PR TITLE
docs: reconcile drifted capability counts and enforce check-counts in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -941,6 +941,9 @@ jobs:
       - name: Verify README/docs consistency
         run: python scripts/check_release_consistency.py
 
+      - name: Verify doc counts (MCP tools, detectors, pages) match source
+        run: python scripts/check-counts.py
+
       - name: Verify product surface contract
         run: python scripts/check_product_surface_contract.py
 

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -4,7 +4,7 @@ A repo-map for `agent-bom`: where things live, which trees are canonical, and
 how the `src/agent_bom/` package is organized into subsystems. Start here when
 you ask **"where does X live?"**
 
-`agent-bom` is a single pure-Python package (~221K LoC) that exposes one shared
+`agent-bom` is a single pure-Python package (~289K LoC) that exposes one shared
 evidence model through many surfaces: CLI/CI, REST API, MCP server, dashboard,
 and runtime proxy/gateway. The package is intentionally broad — this map groups
 its modules so the breadth reads as a system, not a flat sprawl.
@@ -28,7 +28,7 @@ For the layered architecture and data-flow diagrams, see
 | `sdks/` | Client SDKs: `python`, `go`, `typescript`, `typescript-client`, `shared`. | Yes — typed control-plane clients (not scanner SDKs). |
 | `deploy/` | Helm chart, docker-compose pilot, EKS reference, deployment manifests. | Yes. |
 | `contracts/` | Cross-surface contract fixtures. | Yes. |
-| `docs/openapi/v1.json` | Committed OpenAPI spec — the canonical REST contract (239 paths / 283 operations). | **Yes** — SDK + client contract checks read this. |
+| `docs/openapi/v1.json` | Committed OpenAPI spec — the canonical REST contract (251 paths / 295 operations). | **Yes** — SDK + client contract checks read this. |
 | `scripts/` | Release, deploy, and consistency tooling (e.g. `check_release_consistency.py`). | Yes. |
 | `integrations/` | External tool integrations and examples. | Yes. |
 | `examples/`, `config/`, `security/`, `fuzz/` | Samples, config, security policy, fuzz harnesses. | Support material. |
@@ -39,7 +39,7 @@ For the layered architecture and data-flow diagrams, see
 
 ## `src/agent_bom/` subsystems
 
-The package has ~192 top-level modules plus 22 subpackages. Grouped by the role
+The package has ~223 top-level modules plus 25 subpackages. Grouped by the role
 each plays in the **collect → normalize → serve → enforce** pipeline:
 
 ### 1. Scan layer — collect evidence
@@ -84,7 +84,7 @@ The self-hosted operator surface. Same evidence, multi-tenant, audited.
 
 | Subsystem | Path | Responsibility |
 |---|---|---|
-| API | `api/` | FastAPI app. `routes/` (32 route modules; 283 REST operations + 2 WebSocket), `middleware.py` (4 layers), and `*_store.py`/`postgres_*.py` persistence (SQLite default, Postgres for clusters, optional Snowflake/ClickHouse). |
+| API | `api/` | FastAPI app. `routes/` (34 route modules; 295 REST operations + 2 WebSocket), `middleware.py` (4 layers), and `*_store.py`/`postgres_*.py` persistence (SQLite default, Postgres for clusters, optional Snowflake/ClickHouse). |
 | MCP server | `mcp_server*.py`, `mcp_tools/` | FastMCP server advertising 70 tools, 6 resources, 8 prompts (mostly read-only; 3 Shield write actions fail closed). |
 | Runtime enforcement | `proxy*.py`, `gateway*.py`, `firewall*.py`, `shield.py`, `runtime/`, `enforcement.py` | MCP traffic proxy, secure-by-default gateway, inline firewall, Shield enforcement. **Spread by design** — see [Runtime enforcement spread](#runtime-enforcement-spread). |
 | Auth / tenancy | `rbac.py`, `permissions.py`, `entitlements.py`, `mcp_tenant.py`, `api/auth.py`, `api/oidc.py` | RBAC roles, tenant scoping, API keys, OIDC/SAML/SCIM. |
@@ -104,7 +104,7 @@ The self-hosted operator surface. Same evidence, multi-tenant, audited.
 
 | Subsystem | Path | Responsibility |
 |---|---|---|
-| CLI | `cli/` | Click entry point. 48 top-level commands (plus an inline `upgrade`) across 7 help categories. See [`docs/CLI_MAP.md`](docs/CLI_MAP.md). |
+| CLI | `cli/` | Click entry point. 60 top-level commands across 7 help categories. See [`docs/CLI_MAP.md`](docs/CLI_MAP.md). |
 
 ---
 

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -115,7 +115,7 @@ helm upgrade --install agent-bom deploy/helm/agent-bom \
 - **Blast radius + attack-path fusion** — multi-hop exposure paths over one unified `ContextGraph`, from package → finding → MCP server → credentials → connected agents
 - **CWE-aware impact** — RCE shows credential exposure, DoS does not; symbol-level CVE reachability joins CWE/CVE/CPE advisory context when OSV/GHSA carry affected symbols (Python, npm, Go)
 - **Portable outputs** — SARIF, CycloneDX, SPDX, OCSF, HTML, graph, JSON, ZIP evidence bundles, and more
-- **MCP server mode** — 69 MCP tools, 6 resources, and 6 workflow prompts exposed to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
+- **MCP server mode** — 70 MCP tools, 6 resources, and 8 workflow prompts exposed to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
 - **Skill bundle identity** — stable bundle hashes for skill and instruction file review
 - **Dependency confusion detection** — flags internal naming patterns
 - **VEX generation** — auto-triage with CWE/CVE/CPE-aware reachability (package + function-level when advisory symbols exist)

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Summary:
 
 ```text
 MCP security tools       70 tools · 6 resources · 8 workflow prompts
-REST API                 283 ops · OpenAPI docs/openapi/v1.json
+REST API                 295 ops · OpenAPI docs/openapi/v1.json
 Runtime proxy / gateway  stdio policy · HTTP/SSE relay · KPI rollup
 Full manifest            docs/AGENT_CAPABILITY.md
 ```

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -17,7 +17,7 @@ attack paths, compliance tags, and runtime audit chain.
 | Area | Shipped today |
 |---|---|
 | MCP security tools | 70 tools, 6 resources, 8 workflow prompts |
-| REST API | 283 operations across 32 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| REST API | 295 operations across 34 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/scripts/check-counts.py
+++ b/scripts/check-counts.py
@@ -115,6 +115,7 @@ print()
 
 SURFACES = [
     "README.md",
+    "PYPI_README.md",
     "DOCKER_HUB_README.md",
     "docs/ARCHITECTURE.md",
     "pyproject.toml",


### PR DESCRIPTION
Hardcoded counts across the docs had drifted from the source of truth, and `scripts/check-counts.py` claimed "CI enforcement" while running in no workflow and skipping PYPI_README entirely — so the two published front doors (README vs PYPI_README) even contradicted each other on MCP tool counts.

**Real numbers (recomputed from code/specs):** MCP 70 tools / 6 resources / 8 prompts · REST 251 paths / 295 operations · ~289K LoC · 34 route modules · ~223 top-level modules + 25 subpackages · 60 CLI commands.

**Doc fixes:**
- PYPI_README: 69→70 MCP tools, 6→8 workflow prompts (now matches README)
- README + AGENT_CAPABILITY: 283→295 REST operations
- PROJECT_STRUCTURE: ~221K→~289K LoC, 239/283→251/295 paths/ops, ~192/22→~223/25 modules/subpackages, 32→34 route modules, 48→60 CLI commands

**Enforcement:** `check-counts.py` now also scans PYPI_README.md, and the `lint` CI job invokes it, so future drift fails CI. `python scripts/check-counts.py` exits 0. No product-code change.