### PR TITLE
refactor(ast): dedupe shared scanner primitives into ast_signal_utils

### DIFF
--- a/src/agent_bom/ast_csharp.py
+++ b/src/agent_bom/ast_csharp.py
@@ -24,6 +24,7 @@ from agent_bom.ast_models import (
     _CSharpMethodAnalysis,
     _CSharpToolRegistration,
 )
+from agent_bom.ast_signal_utils import _balanced_segment, _line_number_from_index
 from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol, is_verified_nuget_package
 
 if TYPE_CHECKING:
@@ -67,39 +68,6 @@ _CS_FRAMEWORK_HINTS: dict[str, str] = {
     "modelcontextprotocol": "MCP",
     "microsoft.semantickernel": "SemanticKernel",
 }
-
-
-def _line_number_from_index(source: str, index: int) -> int:
-    return source[:index].count("\n") + 1
-
-
-def _balanced_segment(source: str, open_index: int, *, open_char: str, close_char: str) -> tuple[str, int] | None:
-    if open_index < 0 or open_index >= len(source) or source[open_index] != open_char:
-        return None
-    depth = 0
-    in_quote = ""
-    escaped = False
-    for index in range(open_index, len(source)):
-        char = source[index]
-        if in_quote:
-            if char == "\\" and not escaped:
-                escaped = True
-                continue
-            if char == in_quote and not escaped:
-                in_quote = ""
-            escaped = False
-            continue
-        if char in {'"', "'"}:
-            in_quote = char
-            escaped = False
-            continue
-        if char == open_char:
-            depth += 1
-        elif char == close_char:
-            depth -= 1
-            if depth == 0:
-                return source[open_index : index + 1], index + 1
-    return None
 
 
 def load_nuget_namespace_map(project: Path) -> dict[str, str]:

--- a/src/agent_bom/ast_go.py
+++ b/src/agent_bom/ast_go.py
@@ -18,7 +18,12 @@ from agent_bom.ast_models import (
     _GoFunctionAnalysis,
     _GoToolRegistration,
 )
-from agent_bom.ast_signal_utils import _GUARDRAIL_CALL_PATTERNS, check_prompt_risks, classify_prompt_type
+from agent_bom.ast_signal_utils import (
+    _GUARDRAIL_CALL_PATTERNS,
+    _line_number_from_index,
+    check_prompt_risks,
+    classify_prompt_type,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -225,6 +230,9 @@ def _is_go_dangerous_call_name(call_name: str) -> bool:
 
 
 def _balanced_segment(source: str, open_index: int, *, open_char: str, close_char: str) -> tuple[str, int] | None:
+    # Go-specific override of the shared ast_signal_utils._balanced_segment: Go
+    # has backtick raw string literals (`...`) in which backslashes are literal,
+    # so they need distinct quote handling to avoid miscounting brace/paren depth.
     if open_index < 0 or open_index >= len(source) or source[open_index] != open_char:
         return None
     depth = 0
@@ -251,10 +259,6 @@ def _balanced_segment(source: str, open_index: int, *, open_char: str, close_cha
             if depth == 0:
                 return source[open_index : index + 1], index + 1
     return None
-
-
-def _line_number_from_index(source: str, index: int) -> int:
-    return source[:index].count("\n") + 1
 
 
 def _go_import_aliases(source: str) -> tuple[dict[str, str], set[str], dict[str, str]]:

--- a/src/agent_bom/ast_java.py
+++ b/src/agent_bom/ast_java.py
@@ -24,6 +24,7 @@ from agent_bom.ast_models import (
     _JavaMethodAnalysis,
     _JavaToolRegistration,
 )
+from agent_bom.ast_signal_utils import _balanced_segment, _line_number_from_index
 from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol, is_verified_maven_coord
 
 if TYPE_CHECKING:
@@ -67,39 +68,6 @@ _MAVEN_DEP_RE = re.compile(
     r"<dependency>[\s\S]*?<groupId>(?P<group>[^<]+)</groupId>[\s\S]*?<artifactId>(?P<artifact>[^<]+)</artifactId>",
     re.IGNORECASE,
 )
-
-
-def _line_number_from_index(source: str, index: int) -> int:
-    return source[:index].count("\n") + 1
-
-
-def _balanced_segment(source: str, open_index: int, *, open_char: str, close_char: str) -> tuple[str, int] | None:
-    if open_index < 0 or open_index >= len(source) or source[open_index] != open_char:
-        return None
-    depth = 0
-    in_quote = ""
-    escaped = False
-    for index in range(open_index, len(source)):
-        char = source[index]
-        if in_quote:
-            if char == "\\" and not escaped:
-                escaped = True
-                continue
-            if char == in_quote and not escaped:
-                in_quote = ""
-            escaped = False
-            continue
-        if char in {'"', "'"}:
-            in_quote = char
-            escaped = False
-            continue
-        if char == open_char:
-            depth += 1
-        elif char == close_char:
-            depth -= 1
-            if depth == 0:
-                return source[open_index : index + 1], index + 1
-    return None
 
 
 def _maven_map_from_coord(coord: str) -> dict[str, str]:

--- a/src/agent_bom/ast_php.py
+++ b/src/agent_bom/ast_php.py
@@ -24,6 +24,7 @@ from agent_bom.ast_models import (
     _PhpMethodAnalysis,
     _PhpToolRegistration,
 )
+from agent_bom.ast_signal_utils import _line_number_from_index
 from agent_bom.ast_source_mask import mask_line_comments_and_strings
 from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol, is_verified_composer_package
 
@@ -61,10 +62,6 @@ _PHP_FRAMEWORK_HINTS: dict[str, str] = {
     "modelcontextprotocol": "MCP",
     "mcp": "MCP",
 }
-
-
-def _line_number_from_index(source: str, index: int) -> int:
-    return source[:index].count("\n") + 1
 
 
 def load_composer_package_map(project: Path) -> dict[str, str]:

--- a/src/agent_bom/ast_ruby.py
+++ b/src/agent_bom/ast_ruby.py
@@ -24,6 +24,7 @@ from agent_bom.ast_models import (
     _RubyMethodAnalysis,
     _RubyToolRegistration,
 )
+from agent_bom.ast_signal_utils import _balanced_segment, _line_number_from_index
 from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol, is_verified_ruby_gem
 
 if TYPE_CHECKING:
@@ -67,39 +68,6 @@ _RUBY_FRAMEWORK_HINTS: dict[str, str] = {
     "modelcontextprotocol": "MCP",
     "mcp": "MCP",
 }
-
-
-def _line_number_from_index(source: str, index: int) -> int:
-    return source[:index].count("\n") + 1
-
-
-def _balanced_segment(source: str, open_index: int, *, open_char: str, close_char: str) -> tuple[str, int] | None:
-    if open_index < 0 or open_index >= len(source) or source[open_index] != open_char:
-        return None
-    depth = 0
-    in_quote = ""
-    escaped = False
-    for index in range(open_index, len(source)):
-        char = source[index]
-        if in_quote:
-            if char == "\\" and not escaped:
-                escaped = True
-                continue
-            if char == in_quote and not escaped:
-                in_quote = ""
-            escaped = False
-            continue
-        if char in {'"', "'"}:
-            in_quote = char
-            escaped = False
-            continue
-        if char == open_char:
-            depth += 1
-        elif char == close_char:
-            depth -= 1
-            if depth == 0:
-                return source[open_index : index + 1], index + 1
-    return None
 
 
 def _ruby_constant_for_gem(gem_name: str) -> str:

--- a/src/agent_bom/ast_rust.py
+++ b/src/agent_bom/ast_rust.py
@@ -24,6 +24,7 @@ from agent_bom.ast_models import (
     _RustFunctionAnalysis,
     _RustToolRegistration,
 )
+from agent_bom.ast_signal_utils import _balanced_segment, _line_number_from_index
 from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol, is_external_rust_crate
 
 if TYPE_CHECKING:
@@ -42,39 +43,6 @@ _RUST_FRAMEWORK_HINTS: dict[str, str] = {
     "mcp": "MCP",
     "modelcontextprotocol": "MCP",
 }
-
-
-def _line_number_from_index(source: str, index: int) -> int:
-    return source[:index].count("\n") + 1
-
-
-def _balanced_segment(source: str, open_index: int, *, open_char: str, close_char: str) -> tuple[str, int] | None:
-    if open_index < 0 or open_index >= len(source) or source[open_index] != open_char:
-        return None
-    depth = 0
-    in_quote = ""
-    escaped = False
-    for index in range(open_index, len(source)):
-        char = source[index]
-        if in_quote:
-            if char == "\\" and not escaped:
-                escaped = True
-                continue
-            if char == in_quote and not escaped:
-                in_quote = ""
-            escaped = False
-            continue
-        if char in {'"', "'"}:
-            in_quote = char
-            escaped = False
-            continue
-        if char == open_char:
-            depth += 1
-        elif char == close_char:
-            depth -= 1
-            if depth == 0:
-                return source[open_index : index + 1], index + 1
-    return None
 
 
 def _rust_crate_from_use_path(path: str) -> str | None:

--- a/src/agent_bom/ast_signal_utils.py
+++ b/src/agent_bom/ast_signal_utils.py
@@ -1,8 +1,41 @@
-"""Shared prompt and guardrail signal helpers for AST analyzers."""
+"""Shared prompt, guardrail, and source-scanning helpers for AST analyzers."""
 
 from __future__ import annotations
 
 import re
+
+
+def _line_number_from_index(source: str, index: int) -> int:
+    return source[:index].count("\n") + 1
+
+
+def _balanced_segment(source: str, open_index: int, *, open_char: str, close_char: str) -> tuple[str, int] | None:
+    if open_index < 0 or open_index >= len(source) or source[open_index] != open_char:
+        return None
+    depth = 0
+    in_quote = ""
+    escaped = False
+    for index in range(open_index, len(source)):
+        char = source[index]
+        if in_quote:
+            if char == "\\" and not escaped:
+                escaped = True
+                continue
+            if char == in_quote and not escaped:
+                in_quote = ""
+            escaped = False
+            continue
+        if char in {'"', "'"}:
+            in_quote = char
+            escaped = False
+            continue
+        if char == open_char:
+            depth += 1
+        elif char == close_char:
+            depth -= 1
+            if depth == 0:
+                return source[open_index : index + 1], index + 1
+    return None
 
 _GUARDRAIL_CALL_PATTERNS = re.compile(
     r"\b(?:content_filter|safety_check|moderate|moderation|validate_input|"

--- a/src/agent_bom/ast_swift.py
+++ b/src/agent_bom/ast_swift.py
@@ -24,6 +24,7 @@ from agent_bom.ast_models import (
     _SwiftFunctionAnalysis,
     _SwiftToolRegistration,
 )
+from agent_bom.ast_signal_utils import _line_number_from_index
 from agent_bom.ast_source_mask import mask_line_comments_and_strings
 from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol, is_verified_swift_package
 
@@ -131,10 +132,6 @@ _SWIFT_FRAMEWORK_HINTS: dict[str, str] = {
     "modelcontextprotocol": "MCP",
     "mcp": "MCP",
 }
-
-
-def _line_number_from_index(source: str, index: int) -> int:
-    return source[:index].count("\n") + 1
 
 
 def load_swift_package_map(project: Path) -> dict[str, str]:


### PR DESCRIPTION
Consolidate copy-pasted AST scanner primitives into the shared `ast_signal_utils` module (hardens the scanner-accuracy surface against per-language drift).

- `_line_number_from_index` was byte-identical across 7 language analyzers (ast_csharp, ast_go, ast_java, ast_php, ast_ruby, ast_rust, ast_swift). It now lives once in `ast_signal_utils` and is imported everywhere.
- `_balanced_segment` was duplicated identically across 4 analyzers (csharp, java, ruby, rust); the canonical copy now lives in `ast_signal_utils`.
- `ast_go` keeps a local `_balanced_segment` override — Go has backtick **raw string** literals where backslashes are literal and the string ends only at the next backtick; the common variant would misread quotes/braces inside such raw strings, so unifying Go to it would be a behavior change. The override carries a comment explaining why. (This is the copy that had already silently diverged; it's now deliberate and documented.)

Net: 11 duplicate function copies removed, no functional change beyond the consolidation. **Tests:** AST/reachability suite 510 + per-language parser suite 853 green; ruff clean.