### PR TITLE
fix(image): include aws/azure/gcp SDKs so self-hosted BYOC works (#3832)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,12 @@ COPY pyproject.toml README.md PYPI_README.md LICENSE ./
 COPY src/ ./src/
 COPY deploy/supabase/postgres/ ./deploy/supabase/postgres/
 
-RUN pip install --no-cache-dir --prefix=/install ".[api,snowflake,postgres]"
+# Extras baked into the published control-plane image. Cloud SDKs (aws/azure/gcp)
+# ship by default so self-hosted BYOC (connect an AWS/Azure/GCP account read-only,
+# incl. IRSA/workload-identity) works out of the box (#3832). Override at build
+# time for a lean image, e.g. --build-arg AGENT_BOM_EXTRAS=api,snowflake,postgres.
+ARG AGENT_BOM_EXTRAS=api,snowflake,postgres,aws,azure,gcp
+RUN pip install --no-cache-dir --prefix=/install ".[${AGENT_BOM_EXTRAS}]"
 
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.6-alpine3.23@sha256:02da11a8d221ca167aa07de20b3cd7104c1f01227f4b02b1fa13cf6517280a81

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -589,9 +589,15 @@ def test_dockerfiles_support_proxy_and_ca_contract():
 
 
 def test_primary_api_image_includes_snowflake_extra_for_snowflake_backend():
-    """The default API image must contain Snowflake and Postgres extras for Helm profiles."""
+    """The default API image must bake in Snowflake, Postgres, and cloud BYOC extras.
+
+    The extras are driven by the ``AGENT_BOM_EXTRAS`` build-arg whose default must
+    include the cloud SDKs so self-hosted AWS/Azure/GCP BYOC works out of the box
+    (#3832); the install line must consume that arg.
+    """
     content = (ROOT / "Dockerfile").read_text()
-    assert 'pip install --no-cache-dir --prefix=/install ".[api,snowflake,postgres]"' in content
+    assert "ARG AGENT_BOM_EXTRAS=api,snowflake,postgres,aws,azure,gcp" in content
+    assert 'pip install --no-cache-dir --prefix=/install ".[${AGENT_BOM_EXTRAS}]"' in content
 
 
 def test_runtime_dockerfile_builds_from_repo_source():


### PR DESCRIPTION
## Problem
The published control-plane image `agentbom/agent-bom` installed only `.[api,snowflake,postgres]`, so self-hosted **AWS/Azure/GCP BYOC** (connect a cloud account read-only) returned empty inventory plus an unactionable `pip install 'agent-bom[aws]'` hint — inside a non-root container where that install can't succeed. IRSA / workload-identity was already plumbed through Helm, but boto3 / azure-* / google-cloud-* were never in the image. Closes the main blocker in #3832.

## Fix
Add an `AGENT_BOM_EXTRAS` Docker build-arg defaulting to `api,snowflake,postgres,aws,azure,gcp`. The default published image now supports cloud BYOC out of the box; a lean image is still buildable with `--build-arg AGENT_BOM_EXTRAS=api,snowflake,postgres`.

- `release.yml` needs no change — the ARG default includes cloud extras.
- Not hash-pinned: the app install resolves from `pyproject.toml` (only the runtime-stage pip self-upgrade uses `--require-hashes`, pinning pip only).

## Verification
- `pip install --dry-run` of the combined extras resolves cleanly (159 pkgs, no conflicts).
- `import boto3`, `import azure.identity`, `import google.auth` succeed with the extras (the exact modules the cloud pip-hints gate on).
- `docker build --check` clean; `tests/test_deployment.py` + docker-base-policy tests pass.

## Size tradeoff
Cloud SDKs add ~680 MB uncompressed (201→880 MB; ~200–250 MB compressed layer). Worth it for out-of-the-box BYOC; the build-arg leaves the door open for a future slim tag / separate collector image — tracked in #3835.

Refs #3832, #3835.