### PR TITLE
fix(correctness): close post-merge audit gaps

### DIFF
--- a/src/agent_bom/api/postgres_common.py
+++ b/src/agent_bom/api/postgres_common.py
@@ -11,10 +11,10 @@ from __future__ import annotations
 import inspect
 import logging
 import os
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from agent_bom.config import (
     ALLOW_SUPERUSER_DB,
@@ -231,22 +231,31 @@ def _get_pool() -> ConnectionPool:
         if auth_mode == AUTH_MODE_IAM:
             import psycopg
 
-            class IamAuthConnection(psycopg.Connection):
-                """Resolve a fresh short-lived IAM token for every connection."""
+            base_connect: Callable[..., object] = getattr(
+                psycopg.Connection.connect, "__func__", psycopg.Connection.connect
+            )
 
-                @classmethod
-                def connect(  # type: ignore[override]
-                    cls, conninfo: str = "", **connect_kwargs: object
-                ) -> object:
-                    connect_kwargs["password"] = resolve_postgres_secret()
-                    return super().connect(conninfo, **connect_kwargs)  # type: ignore[arg-type]
+            def connect_with_iam_token(
+                cls: type[object], conninfo: str = "", **connect_kwargs: object
+            ) -> object:
+                """Resolve a fresh short-lived IAM token for every connection."""
+                connect_kwargs["password"] = resolve_postgres_secret()
+                return base_connect(cls, conninfo, **connect_kwargs)
+
+            # Construct the optional psycopg subclass dynamically so importing
+            # this module remains dependency-free in non-Postgres installs.
+            iam_auth_connection_class = type(
+                "IamAuthConnection",
+                (psycopg.Connection,),
+                {"connect": classmethod(connect_with_iam_token)},
+            )
 
             _pool = psycopg_pool.ConnectionPool(
                 conninfo=url,
                 min_size=min_size,
                 max_size=max_size,
                 kwargs=kwargs,
-                connection_class=IamAuthConnection,
+                connection_class=iam_auth_connection_class,
             )
         else:
             _pool = psycopg_pool.ConnectionPool(
@@ -255,9 +264,8 @@ def _get_pool() -> ConnectionPool:
                 max_size=max_size,
                 kwargs=kwargs,
             )
-    pool = cast(ConnectionPool, _pool)
-    _guard_rls_capable_role(pool)
-    return pool
+    _guard_rls_capable_role(_pool)
+    return _pool
 
 
 def _guard_rls_capable_role(pool: ConnectionPool) -> None:

--- a/src/agent_bom/api/postgres_common.py
+++ b/src/agent_bom/api/postgres_common.py
@@ -14,7 +14,7 @@ import os
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from agent_bom.config import (
     ALLOW_SUPERUSER_DB,
@@ -150,9 +150,7 @@ def resolve_postgres_url() -> str:
     netloc = host + (f":{parsed.port}" if parsed.port else "")
     if username:
         netloc = f"{quote(username, safe='')}@{netloc}"
-    return urlunparse(
-        (parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment)
-    )
+    return urlunparse((parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment))
 
 
 def resolve_postgres_secret() -> str | None:
@@ -198,8 +196,7 @@ def resolve_postgres_secret() -> str | None:
             raise ValueError(f"AGENT_BOM_POSTGRES_PASSWORD_FILE is empty: {password_file}")
         if not username:
             raise ValueError(
-                "AGENT_BOM_POSTGRES_URL must include a username when using "
-                "AGENT_BOM_POSTGRES_PASSWORD_FILE (expected agent_bom_app)."
+                "AGENT_BOM_POSTGRES_URL must include a username when using AGENT_BOM_POSTGRES_PASSWORD_FILE (expected agent_bom_app)."
             )
         if not parsed.hostname:
             raise ValueError("AGENT_BOM_POSTGRES_URL must include a hostname.")
@@ -217,8 +214,11 @@ def _get_pool() -> ConnectionPool:
         except ImportError as exc:
             raise ImportError("PostgreSQL support requires psycopg. Install with: pip install 'agent-bom[postgres]'") from exc
 
+        from agent_bom.api.postgres_auth import AUTH_MODE_IAM, postgres_auth_mode
+
         url = resolve_postgres_url()
-        password = resolve_postgres_secret()
+        auth_mode = postgres_auth_mode()
+        password = resolve_postgres_secret() if auth_mode != AUTH_MODE_IAM else None
         min_size = max(1, POSTGRES_POOL_MIN_SIZE)
         max_size = max(min_size, POSTGRES_POOL_MAX_SIZE)
         kwargs: dict[str, object] = {}
@@ -228,14 +228,36 @@ def _get_pool() -> ConnectionPool:
             # Keep the secret out of the conninfo/DSN; psycopg forwards these
             # per-connection kwargs to libpq for every new connection.
             kwargs["password"] = password
-        _pool = psycopg_pool.ConnectionPool(
-            conninfo=url,
-            min_size=min_size,
-            max_size=max_size,
-            kwargs=kwargs,
-        )
-    _guard_rls_capable_role(_pool)
-    return _pool
+        if auth_mode == AUTH_MODE_IAM:
+            import psycopg
+
+            class IamAuthConnection(psycopg.Connection):
+                """Resolve a fresh short-lived IAM token for every connection."""
+
+                @classmethod
+                def connect(  # type: ignore[override]
+                    cls, conninfo: str = "", **connect_kwargs: object
+                ) -> object:
+                    connect_kwargs["password"] = resolve_postgres_secret()
+                    return super().connect(conninfo, **connect_kwargs)  # type: ignore[arg-type]
+
+            _pool = psycopg_pool.ConnectionPool(
+                conninfo=url,
+                min_size=min_size,
+                max_size=max_size,
+                kwargs=kwargs,
+                connection_class=IamAuthConnection,
+            )
+        else:
+            _pool = psycopg_pool.ConnectionPool(
+                conninfo=url,
+                min_size=min_size,
+                max_size=max_size,
+                kwargs=kwargs,
+            )
+    pool = cast(ConnectionPool, _pool)
+    _guard_rls_capable_role(pool)
+    return pool
 
 
 def _guard_rls_capable_role(pool: ConnectionPool) -> None:
@@ -254,9 +276,7 @@ def _guard_rls_capable_role(pool: ConnectionPool) -> None:
         return
     try:
         with pool.connection() as conn:
-            cursor = conn.execute(
-                "SELECT rolsuper, rolbypassrls, rolname FROM pg_roles WHERE rolname = current_user"
-            )
+            cursor = conn.execute("SELECT rolsuper, rolbypassrls, rolname FROM pg_roles WHERE rolname = current_user")
             row = cursor.fetchone() if cursor is not None else None
     except Exception:
         # Best-effort probe: a transient connect error or a store mock without a
@@ -273,9 +293,7 @@ def _guard_rls_capable_role(pool: ConnectionPool) -> None:
     if not (rolsuper or rolbypassrls):
         return
 
-    attrs = " and ".join(
-        label for label, present in (("SUPERUSER", rolsuper), ("BYPASSRLS", rolbypassrls)) if present
-    )
+    attrs = " and ".join(label for label, present in (("SUPERUSER", rolsuper), ("BYPASSRLS", rolbypassrls)) if present)
     message = (
         f"Postgres role {role_name!r} has {attrs}, which bypasses FORCE ROW LEVEL SECURITY "
         "and silently disables agent-bom tenant isolation — cross-tenant reads/writes would "

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -304,7 +304,10 @@ def init_policy_cmd(output_path: Path, mode: str, output_format: str, tenant_id:
     "--oauth-as-issuer",
     envvar="AGENT_BOM_GATEWAY_OAUTH_AS_ISSUER",
     default=None,
-    help="Public issuer base URL for the OAuth AS (defaults to the request URL when unset).",
+    help=(
+        "Public issuer base URL for the OAuth AS. Required for non-loopback listeners; "
+        "loopback development may derive it from the request URL."
+    ),
 )
 @click.option(
     "--a2a-mutual-auth-enforcement",

--- a/tests/test_db_secret_handling.py
+++ b/tests/test_db_secret_handling.py
@@ -82,9 +82,7 @@ def test_get_pool_password_via_kwargs_not_dsn(monkeypatch, tmp_path):
 
 def test_resolve_postgres_url_strips_embedded_password(monkeypatch):
     """A password embedded directly in the URL is moved to the secret resolver."""
-    monkeypatch.setenv(
-        "AGENT_BOM_POSTGRES_URL", "postgresql://agent_bom_app:inline-pw@postgres:5432/agent_bom"
-    )
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://agent_bom_app:inline-pw@postgres:5432/agent_bom")
     monkeypatch.delenv("AGENT_BOM_POSTGRES_PASSWORD_FILE", raising=False)
     monkeypatch.delenv("AGENT_BOM_POSTGRES_AUTH_MODE", raising=False)
 
@@ -244,9 +242,7 @@ def test_resolve_postgres_secret_iam_mode(monkeypatch):
     capture: dict = {}
     _install_fake_boto3(monkeypatch, token="iam-token", capture=capture)
 
-    monkeypatch.setenv(
-        "AGENT_BOM_POSTGRES_URL", "postgresql://agent_bom_app@db.example.com:5432/agent_bom"
-    )
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://agent_bom_app@db.example.com:5432/agent_bom")
     monkeypatch.setenv("AGENT_BOM_POSTGRES_AUTH_MODE", "iam")
     monkeypatch.setenv("AGENT_BOM_POSTGRES_IAM_REGION", "eu-west-1")
     monkeypatch.delenv("AGENT_BOM_POSTGRES_IAM_PROVIDER", raising=False)
@@ -257,6 +253,45 @@ def test_resolve_postgres_secret_iam_mode(monkeypatch):
     assert capture["DBHostname"] == "db.example.com"
     assert capture["Region"] == "eu-west-1"
     assert "iam-token" not in postgres_common.resolve_postgres_url()
+
+
+def test_iam_pool_resolves_fresh_token_for_each_connection(monkeypatch):
+    """Pool replacement connections must not reuse an expired RDS IAM token."""
+    postgres_common.reset_pool()
+    tokens = iter(["token-1", "token-2"])
+    captured: dict[str, object] = {}
+
+    class FakeConnection:
+        calls: list[tuple[str, dict[str, object]]] = []
+
+        @classmethod
+        def connect(cls, conninfo="", **kwargs):
+            cls.calls.append((conninfo, kwargs))
+            return object()
+
+    class FakePool:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        def connection(self):
+            return _RoleConnection()
+
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://agent_bom_app@db.example:5432/agent_bom")
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_AUTH_MODE", "iam")
+    monkeypatch.setattr(postgres_common, "resolve_postgres_secret", lambda: next(tokens))
+    monkeypatch.setitem(sys.modules, "psycopg", types.SimpleNamespace(Connection=FakeConnection))
+    monkeypatch.setitem(sys.modules, "psycopg_pool", types.SimpleNamespace(ConnectionPool=FakePool))
+
+    try:
+        postgres_common._get_pool()
+        connection_class = captured["connection_class"]
+        connection_class.connect("postgresql://agent_bom_app@db.example:5432/agent_bom")
+        connection_class.connect("postgresql://agent_bom_app@db.example:5432/agent_bom")
+    finally:
+        postgres_common.reset_pool()
+
+    assert [call[1]["password"] for call in FakeConnection.calls] == ["token-1", "token-2"]
+    assert "password" not in captured["kwargs"]
 
 
 def test_password_mode_is_default(monkeypatch):

--- a/tests/test_iceberg_catalog.py
+++ b/tests/test_iceberg_catalog.py
@@ -165,8 +165,8 @@ def test_round_trip_against_fake_catalog() -> None:
     assert fake.namespaces == [("lake",)]
     assert "lake.cves" in fake.tables
     table = fake.tables["lake.cves"]
-    # schema handed to Iceberg must match the shared 27-col Parquet schema
-    assert len(table.schema) == 27
+    # schema handed to Iceberg must match the shared 28-col Parquet schema
+    assert len(table.schema) == 28
     assert table.schema.names[0] == "cve_id"
     assert len(table.appended) == 1
     assert table.appended[0].num_rows == 1

--- a/tests/test_mitre_fetch.py
+++ b/tests/test_mitre_fetch.py
@@ -293,6 +293,7 @@ def test_build_catalog_uses_bundled_by_default(tmp_path, monkeypatch):
     bundled_file = tmp_path / "bundled.json"
     bundled_file.write_text(json.dumps(_catalog("bundled-v1", source="bundled")))
     monkeypatch.setattr("agent_bom.mitre_fetch._BUNDLED_CATALOG_PATH", bundled_file)
+    monkeypatch.setattr("agent_bom.mitre_fetch._DEFAULT_SYNC_PATH", tmp_path / "missing-synced.json")
     monkeypatch.delenv("AGENT_BOM_MITRE_CATALOG_PATH", raising=False)
     monkeypatch.delenv("AGENT_BOM_MITRE_CATALOG_MODE", raising=False)
 
@@ -377,6 +378,7 @@ def test_get_catalog_metadata_exposes_counts(tmp_path, monkeypatch):
     bundled_file = tmp_path / "bundled.json"
     bundled_file.write_text(json.dumps(_catalog("bundled-v1", source="bundled")))
     monkeypatch.setattr("agent_bom.mitre_fetch._BUNDLED_CATALOG_PATH", bundled_file)
+    monkeypatch.setattr("agent_bom.mitre_fetch._DEFAULT_SYNC_PATH", tmp_path / "missing-synced.json")
     monkeypatch.delenv("AGENT_BOM_MITRE_CATALOG_PATH", raising=False)
 
     metadata = get_catalog_metadata()

--- a/ui/app/audit/page.tsx
+++ b/ui/app/audit/page.tsx
@@ -93,7 +93,7 @@ export default function AuditLogPage() {
     } finally {
       setLoading(false);
     }
-  }, [actionFilter, resourceFilter, page]);
+  }, [actionFilter, resourceFilter, page, roleLabel]);
 
   const loadAdmin = useCallback(async () => {
     if (authSessionLoading) {

--- a/ui/app/gateway/GatewayFeedPanel.tsx
+++ b/ui/app/gateway/GatewayFeedPanel.tsx
@@ -156,7 +156,7 @@ export function GatewayFeedPanel({ onActivity }: { onActivity?: () => void }) {
       clearTimeout(reconnectTimer);
       ws?.close();
     };
-  }, []);
+  }, [onActivity]);
 
   const filtered = actionFilter ? events.filter((e) => e.action_type === actionFilter) : events;
 

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -40,6 +40,10 @@ export type OverviewComplianceSnapshot = {
   frameworks: OverviewComplianceFramework[];
 };
 
+function hasEvaluatedCompliance(compliance: OverviewComplianceSnapshot | null | undefined): boolean {
+  return Boolean(compliance?.frameworks.some((framework) => framework.total > 0));
+}
+
 export interface OverviewCockpitProps {
   grade: string;
   score?: number | undefined;
@@ -97,7 +101,7 @@ export function OverviewCockpit({
   const activeDomains = domainList.filter((domain) => domain.status !== "idle").length;
   const coverage = domainList.length > 0 ? Math.round((activeDomains / domainList.length) * 100) : null;
   const complianceScore =
-    summaryReady && scans != null && scans > 0 && compliance != null && compliance.overallScore > 0
+    summaryReady && scans != null && scans > 0 && compliance != null && hasEvaluatedCompliance(compliance)
       ? `${Math.round(compliance.overallScore)}%`
       : undefined;
 
@@ -200,7 +204,7 @@ function ComplianceSnapshotPanel({
   defaultOpen?: boolean | undefined;
 }) {
   const frameworks = (compliance?.frameworks ?? []).slice(0, 8);
-  const evidenceReady = hasScanEvidence && compliance != null && compliance.overallScore > 0;
+  const evidenceReady = hasScanEvidence && compliance != null && hasEvaluatedCompliance(compliance);
   const failing = evidenceReady ? frameworks.filter((item) => item.fail > 0).length : 0;
   const statusTone =
     !evidenceReady

--- a/ui/tests/overview-cockpit.test.tsx
+++ b/ui/tests/overview-cockpit.test.tsx
@@ -119,6 +119,24 @@ describe("OverviewCockpit", () => {
     expect(screen.getByText(/Empty estates do not show pass tiles/i)).toBeInTheDocument();
   });
 
+  it("shows evaluated compliance when every control fails and the score is zero", () => {
+    render(
+      <OverviewCockpit
+        {...baseProps}
+        compliance={{
+          overallScore: 0,
+          overallStatus: "fail",
+          frameworks: [{ id: "cis", label: "CIS Controls v8", pass: 0, warn: 0, fail: 10, total: 10 }],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Compliance 0%")).toBeInTheDocument();
+    expect(screen.getByText("CIS Controls v8")).toBeInTheDocument();
+    expect(screen.getByText(/0% overall · 1 framework need attention/i)).toBeInTheDocument();
+    expect(screen.queryByText(/coverage appears after the first completed scan/i)).not.toBeInTheDocument();
+  });
+
   it("lets operators collapse overview sections", async () => {
     const user = userEvent.setup();
     render(


### PR DESCRIPTION
## Summary

- refresh short-lived Postgres IAM credentials for every physical pool connection while keeping secrets out of the DSN
- distinguish evaluated 0% compliance from missing evidence and clear the remaining dashboard hook warnings
- isolate MITRE catalog tests from operator state, align the Iceberg schema lock, and correct OAuth issuer guidance

## Verification

- `uv run --extra api --extra dev --extra postgres pytest -q tests/test_db_secret_handling.py tests/test_mitre_fetch.py tests/test_iceberg_catalog.py tests/test_postgres_store.py` (121 passed, 1 skipped)
- `uv run ruff check src/agent_bom/api/postgres_common.py tests/test_db_secret_handling.py tests/test_mitre_fetch.py tests/test_iceberg_catalog.py src/agent_bom/cli/_gateway.py`
- `uv run mypy src/agent_bom/api/postgres_common.py`
- `make preflight`
- `cd ui && npm run verify:toolchain && npm run lint && npm run typecheck`
- `cd ui && npm test -- --run` (90 files, 440 tests)
- `cd ui && npm run build`
- full backend run: 13,404 passed, 35 skipped, 1 pre-existing order-dependent failure in `tests/api/test_api_pipeline_image_contract.py::test_api_pipeline_persists_clickhouse_analytics`; the test passes in isolation and this diff does not touch the pipeline

## Notes

Postgres IAM remains opt-in and fail-closed. Password mode is unchanged. IAM token generation errors remain sanitized by the provider boundary.