### PR TITLE
ci(demo): automate hosted demo redeploy on release via SSM (#3833)

### DIFF
--- a/.github/workflows/demo-redeploy.yml
+++ b/.github/workflows/demo-redeploy.yml
@@ -33,6 +33,12 @@ jobs:
     name: Redeploy hosted demo via SSM
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Protected environment: this repo is public, so gate every run behind a
+    # required-reviewer approval on the `demo` environment. Even a maintainer's
+    # release/workflow_dispatch pauses for owner approval before any AWS call,
+    # and the AWS trust policy is scoped to this environment's OIDC subject
+    # (repo:<owner>/<repo>:environment:demo) so forks/PRs can never assume it.
+    environment: demo
     permissions:
       id-token: write  # OIDC token to assume the deploy role
       contents: read

--- a/.github/workflows/demo-redeploy.yml
+++ b/.github/workflows/demo-redeploy.yml
@@ -1,0 +1,171 @@
+name: Demo redeploy
+
+# Redeploys the public hosted demo VM after a release (or on manual dispatch).
+#
+# The demo is a single manual AWS VM whose runbook lives in docs/HOSTED_POC.md.
+# All control-plane / Postgres secrets already live on the VM as 0400 file
+# mounts (deploy/secrets/), so this workflow NEVER handles plaintext secrets —
+# it only orchestrates `docker compose` on the VM over AWS SSM Run Command.
+#
+# Auth is short-lived OIDC role assumption (no stored SSH keys, no long-lived
+# AWS access keys). The workflow stays inert until the owner sets the repo
+# vars/secrets documented in docs/HOSTED_POC.md → "Demo redeploy".
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      reset_demo:
+        description: "Reset the demo tenant state after the redeploy"
+        type: boolean
+        default: false
+
+permissions: {}  # all permissions denied by default; the job declares only what it needs
+
+concurrency:
+  # Never let two redeploys race on the same VM.
+  group: demo-redeploy
+  cancel-in-progress: false
+
+jobs:
+  redeploy:
+    name: Redeploy hosted demo via SSM
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      id-token: write  # OIDC token to assume the deploy role
+      contents: read
+    steps:
+      - name: Guard — require DEMO_INSTANCE_ID
+        id: guard
+        env:
+          DEMO_INSTANCE_ID: ${{ vars.DEMO_INSTANCE_ID }}
+        run: |
+          if [ -z "${DEMO_INSTANCE_ID}" ]; then
+            {
+              echo "### Demo redeploy skipped"
+              echo ""
+              echo "\`DEMO_INSTANCE_ID\` is not set, so the hosted-demo redeploy is inert."
+              echo ""
+              echo "To enable it, configure these repo settings:"
+              echo "- **vars.DEMO_INSTANCE_ID** — EC2 instance id of the demo VM (\`i-...\`)"
+              echo "- **vars.AWS_REGION** — region of the demo VM (defaults to \`us-east-1\`)"
+              echo "- **vars.DEMO_DEPLOY_DIR** — repo checkout dir on the VM (defaults to \`/opt/agent-bom\`)"
+              echo "- **secrets.DEMO_DEPLOY_ROLE_ARN** — IAM role ARN the workflow assumes via OIDC"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::notice::DEMO_INSTANCE_ID unset — hosted demo redeploy is inert. See job summary for the vars/secrets to configure."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        if: steps.guard.outputs.configured == 'true'
+        uses: aws-actions/configure-aws-credentials@b47578312673ae6fa5b5096b330d9fbac3d116df # v4.2.1
+        with:
+          role-to-assume: ${{ secrets.DEMO_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+
+      - name: Redeploy over SSM Run Command
+        if: steps.guard.outputs.configured == 'true'
+        env:
+          DEMO_INSTANCE_ID: ${{ vars.DEMO_INSTANCE_ID }}
+          DEMO_DEPLOY_DIR: ${{ vars.DEMO_DEPLOY_DIR || '/opt/agent-bom' }}
+          RESET_DEMO: ${{ inputs.reset_demo || 'false' }}
+          RELEASE_REF: ${{ github.event.release.tag_name || github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Build the remote script with a quoted heredoc so the runner does
+          # NOT expand any of the VM-side shell variables, then splice in only
+          # the two runner-provided values via sed.
+          cat > remote.sh <<'REMOTE'
+          set -euo pipefail
+          DEPLOY_DIR="__DEPLOY_DIR__"
+          RESET_DEMO="__RESET_DEMO__"
+          cd "$DEPLOY_DIR"
+
+          # Optional on-VM env file carries the non-secret URL wiring the
+          # preflight requires (NEXT_PUBLIC_API_URL, CORS_ORIGINS) plus the
+          # smoke/reset admin key. It lives on the VM only — the workflow never
+          # sees or transports any secret material.
+          if [ -f deploy/secrets/redeploy.env ]; then
+            set -a
+            . deploy/secrets/redeploy.env
+            set +a
+          fi
+
+          echo "== git pull =="
+          git pull --ff-only
+
+          echo "== docker compose up =="
+          docker compose \
+            -f deploy/docker-compose.platform.yml \
+            -f deploy/docker-compose.hosted-poc.yml \
+            up -d --build
+
+          echo "== preflight (fail-closed) =="
+          python3 scripts/deploy/hosted_poc_preflight.py --write-postgres-secret
+
+          echo "== smoke =="
+          scripts/deploy/hosted_poc_smoke.sh
+
+          if [ "$RESET_DEMO" = "true" ]; then
+            echo "== demo reset =="
+            scripts/deploy/demo-reset.sh \
+              "${AGENT_BOM_SMOKE_URL:?redeploy.env must set AGENT_BOM_SMOKE_URL to reset}" \
+              "${AGENT_BOM_SMOKE_API_KEY:?redeploy.env must set AGENT_BOM_SMOKE_API_KEY to reset}" \
+              "${AGENT_BOM_DEMO_TENANT:-default}"
+          fi
+
+          echo "== redeploy complete =="
+          REMOTE
+
+          sed -i "s#__DEPLOY_DIR__#${DEMO_DEPLOY_DIR}#g" remote.sh
+          sed -i "s#__RESET_DEMO__#${RESET_DEMO}#g" remote.sh
+
+          # SSM `commands` is a JSON array; pass the whole script as one element.
+          jq -n --rawfile script remote.sh '{commands: [$script]}' > params.json
+
+          echo "Sending redeploy command to ${DEMO_INSTANCE_ID} (ref ${RELEASE_REF}) ..."
+          command_id=$(aws ssm send-command \
+            --instance-ids "${DEMO_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --comment "hosted demo redeploy ${RELEASE_REF}" \
+            --parameters file://params.json \
+            --query "Command.CommandId" \
+            --output text)
+          echo "SSM CommandId: ${command_id}"
+
+          status="Pending"
+          # Poll up to ~20 min (well under the 30 min job timeout) so a long
+          # `--build` finishes but a wedged VM cannot hang the runner forever.
+          for _ in $(seq 1 80); do
+            sleep 15
+            status=$(aws ssm get-command-invocation \
+              --command-id "${command_id}" \
+              --instance-id "${DEMO_INSTANCE_ID}" \
+              --query "Status" --output text 2>/dev/null || echo "Pending")
+            echo "SSM status: ${status}"
+            case "${status}" in
+              Success|Failed|Cancelled|TimedOut) break ;;
+            esac
+          done
+
+          echo "----- remote stdout -----"
+          aws ssm get-command-invocation \
+            --command-id "${command_id}" \
+            --instance-id "${DEMO_INSTANCE_ID}" \
+            --query "StandardOutputContent" --output text || true
+          echo "----- remote stderr -----"
+          aws ssm get-command-invocation \
+            --command-id "${command_id}" \
+            --instance-id "${DEMO_INSTANCE_ID}" \
+            --query "StandardErrorContent" --output text >&2 || true
+
+          if [ "${status}" != "Success" ]; then
+            echo "::error::Hosted demo redeploy failed on the VM (SSM status: ${status}). Preflight/smoke or compose did not pass — the demo was NOT promoted."
+            exit 1
+          fi
+          echo "Hosted demo redeploy succeeded."

--- a/deploy/terraform/demo-deploy-oidc/README.md
+++ b/deploy/terraform/demo-deploy-oidc/README.md
@@ -1,0 +1,73 @@
+# demo-deploy-oidc
+
+Mints the **keyless OIDC role** the `demo-redeploy` GitHub Actions workflow
+(`.github/workflows/demo-redeploy.yml`) assumes to redeploy the public hosted
+demo VM over AWS SSM Run Command. No long-lived AWS access keys, no stored SSH
+keys.
+
+Because the repo is **public**, this module is written so that neither a fork
+nor a pull-request contributor can assume the role:
+
+- The trust policy pins the GitHub OIDC `sub` to **exactly**
+
+  ```
+  repo:<github_repo>:environment:demo
+  ```
+
+  (`StringEquals`, no `:*` wildcard) and `aud` = `sts.amazonaws.com`. Only a
+  workflow run executing in this repo's protected `demo` environment presents
+  that subject. Fork/PR runs get a different `sub` and STS rejects them.
+- The role's permissions are least-privilege: it may `ssm:SendCommand` the
+  `AWS-RunShellScript` document to **one specific instance ARN** and read
+  command status with `ssm:GetCommandInvocation`. No `ec2:*`, no broad `ssm:*`.
+
+## What it creates
+
+- `aws_iam_openid_connect_provider` for `token.actions.githubusercontent.com`
+  (guarded by `create_oidc_provider`; set it to `false` and the module looks up
+  the existing provider instead — AWS allows only one per URL per account).
+- `aws_iam_role` `demo_deploy` with the scoped web-identity trust policy above.
+- An inline policy with just the two SSM actions, `SendCommand` scoped to the
+  shell document + the demo instance ARN.
+
+## One-time apply
+
+```bash
+cd deploy/terraform/demo-deploy-oidc
+
+terraform init
+
+terraform apply \
+  -var 'github_repo=msaad00/agent-bom' \
+  -var 'demo_instance_id=i-0123456789abcdef0' \
+  -var 'aws_region=us-east-1'
+# If the account already has the GitHub OIDC provider:
+#   -var 'create_oidc_provider=false'
+
+terraform output -raw role_arn
+```
+
+## Wire it up
+
+1. **Repo secret** — paste `role_arn` into the repo Actions secret
+   `DEMO_DEPLOY_ROLE_ARN`.
+2. **Repo vars** — set `DEMO_INSTANCE_ID`, `AWS_REGION`, and (optionally)
+   `DEMO_DEPLOY_DIR`. See `docs/HOSTED_POC.md` → "Demo redeploy".
+3. **Protected environment** — in the repo, create an Actions **Environment**
+   named `demo` and add **yourself as a required reviewer**. Optionally restrict
+   its deployment branches/tags to the default branch and `v*.*.*` tags. This
+   makes every `release` / `workflow_dispatch` run **pause for your approval**
+   before any AWS call, and the environment name is what the trust policy above
+   is scoped to — the two defenses reinforce each other.
+
+Once configured, a published release (or a manual dispatch) queues a redeploy
+that waits for your approval, then runs `git pull` → `docker compose up -d
+--build` → fail-closed preflight → smoke on the VM, failing the job if the demo
+is unhealthy.
+
+## Scope note
+
+The trust policy is scoped to this repo's `demo` environment, so **no fork or
+pull request can assume the role**. Rotate nothing here to revoke access —
+delete the `demo` environment or `terraform destroy` this module and the role is
+gone.

--- a/deploy/terraform/demo-deploy-oidc/main.tf
+++ b/deploy/terraform/demo-deploy-oidc/main.tf
@@ -1,0 +1,128 @@
+# demo-deploy-oidc — mints the keyless OIDC role the demo-redeploy GitHub
+# Actions workflow assumes to redeploy the public hosted demo VM.
+#
+# The repo is PUBLIC, so the two things a fork/PR contributor must never be able
+# to do are (1) trigger the deploy and (2) assume this AWS role. (1) is handled
+# in the workflow (release + workflow_dispatch only, gated behind a protected
+# `demo` environment with a required reviewer). (2) is handled HERE: the trust
+# policy pins the OIDC sub to EXACTLY
+#   repo:<github_repo>:environment:<github_environment>
+# (StringEquals, no wildcard), which only the owner-approved environment run can
+# present. Fork/PR runs get a different sub and are rejected by STS.
+#
+# The role can do nothing but send one specific SSM shell document to one
+# specific instance and read command status — no ec2:*, no broad ssm:*.
+
+locals {
+  common_tags = merge(
+    {
+      "agent-bom.io/managed-by" = "terraform"
+      "agent-bom.io/module"     = "demo-deploy-oidc"
+      "agent-bom.io/access"     = "deploy"
+    },
+    var.tags,
+  )
+
+  github_oidc_url = "token.actions.githubusercontent.com"
+
+  # The exact sub the trust policy allows. Scoped to the protected environment,
+  # NOT "repo:<repo>:*" — a wildcard would let any branch/PR/tag ref assume it.
+  github_sub = "repo:${var.github_repo}:environment:${var.github_environment}"
+
+  oidc_provider_arn = var.create_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : data.aws_iam_openid_connect_provider.github[0].arn
+
+  # ARNs SendCommand is scoped to: the AWS-managed shell document plus the one
+  # demo instance. Both are required for a single ssm:SendCommand call.
+  run_shell_document_arn = "arn:${data.aws_partition.current.partition}:ssm:*::document/AWS-RunShellScript"
+  demo_instance_arn      = "arn:${data.aws_partition.current.partition}:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/${var.demo_instance_id}"
+}
+
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+
+# ---------------------------------------------------------------------------
+# GitHub Actions OIDC provider. Created here by default; looked up instead when
+# the account already has one (only one provider per URL is allowed per account).
+# ---------------------------------------------------------------------------
+resource "aws_iam_openid_connect_provider" "github" {
+  count = var.create_oidc_provider ? 1 : 0
+
+  url            = "https://${local.github_oidc_url}"
+  client_id_list = [var.oidc_audience]
+  # Thumbprints are no longer validated by AWS STS for this IAM OIDC IdP, but the
+  # field is still required by the API. GitHub's current Actions root CA thumbprint.
+  thumbprint_list = ["1c58a3a8518e8759bf075b76b750d4f2df264fcd"]
+  tags            = local.common_tags
+}
+
+data "aws_iam_openid_connect_provider" "github" {
+  count = var.create_oidc_provider ? 0 : 1
+  url   = "https://${local.github_oidc_url}"
+}
+
+# ---------------------------------------------------------------------------
+# Trust policy: keyless web-identity assume, pinned to this repo's protected
+# environment. aud must equal sts.amazonaws.com AND sub must equal the exact
+# environment subject — both StringEquals, no wildcards.
+# ---------------------------------------------------------------------------
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [local.oidc_provider_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.github_oidc_url}:aud"
+      values   = [var.oidc_audience]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.github_oidc_url}:sub"
+      values   = [local.github_sub]
+    }
+  }
+}
+
+resource "aws_iam_role" "demo_deploy" {
+  name                 = var.role_name
+  description          = "Keyless OIDC role assumed by the demo-redeploy workflow (scoped to ${local.github_sub}). Can only SSM SendCommand AWS-RunShellScript to the demo instance."
+  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
+  permissions_boundary = var.permissions_boundary_arn != "" ? var.permissions_boundary_arn : null
+  tags                 = local.common_tags
+}
+
+# ---------------------------------------------------------------------------
+# Least-privilege inline policy. SendCommand is resource-scoped to the specific
+# shell document + the specific instance; GetCommandInvocation is read-only
+# status and cannot be resource-scoped, so it stays "*".
+# ---------------------------------------------------------------------------
+data "aws_iam_policy_document" "deploy" {
+  statement {
+    sid     = "SendRunShellToDemoInstance"
+    effect  = "Allow"
+    actions = ["ssm:SendCommand"]
+    resources = [
+      local.run_shell_document_arn,
+      local.demo_instance_arn,
+    ]
+  }
+
+  statement {
+    sid       = "ReadCommandStatus"
+    effect    = "Allow"
+    actions   = ["ssm:GetCommandInvocation"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "deploy" {
+  name   = "${var.role_name}-ssm"
+  role   = aws_iam_role.demo_deploy.id
+  policy = data.aws_iam_policy_document.deploy.json
+}

--- a/deploy/terraform/demo-deploy-oidc/outputs.tf
+++ b/deploy/terraform/demo-deploy-oidc/outputs.tf
@@ -1,0 +1,19 @@
+output "role_arn" {
+  description = "ARN of the deploy role. Paste this into the repo secret DEMO_DEPLOY_ROLE_ARN."
+  value       = aws_iam_role.demo_deploy.arn
+}
+
+output "role_name" {
+  description = "Name of the deploy role."
+  value       = aws_iam_role.demo_deploy.name
+}
+
+output "oidc_provider_arn" {
+  description = "ARN of the GitHub Actions OIDC provider (created or looked up)."
+  value       = local.oidc_provider_arn
+}
+
+output "trusted_oidc_sub" {
+  description = "The exact OIDC sub the trust policy allows. Only a workflow run in this repo's protected environment presents this subject; forks/PRs cannot."
+  value       = local.github_sub
+}

--- a/deploy/terraform/demo-deploy-oidc/variables.tf
+++ b/deploy/terraform/demo-deploy-oidc/variables.tf
@@ -1,0 +1,62 @@
+variable "github_repo" {
+  description = "GitHub \"owner/repo\" allowed to assume the deploy role. The trust policy pins the OIDC sub to repo:<github_repo>:environment:<github_environment>, so ONLY this repo's protected environment can assume the role — forks and pull-request runs (which get a different sub) cannot."
+  type        = string
+  default     = "msaad00/agent-bom"
+
+  validation {
+    condition     = can(regex("^[^/]+/[^/]+$", var.github_repo))
+    error_message = "github_repo must be in \"owner/repo\" form."
+  }
+}
+
+variable "github_environment" {
+  description = "GitHub Actions Environment the deploy job runs in. Must match `environment:` in .github/workflows/demo-redeploy.yml. Create this environment in the repo with a required reviewer (yourself) so every run pauses for approval before touching AWS."
+  type        = string
+  default     = "demo"
+}
+
+variable "create_oidc_provider" {
+  description = "Create the GitHub Actions IAM OIDC provider (token.actions.githubusercontent.com). Set to false if the account already has one — the module then looks it up by URL instead of creating a duplicate (AWS allows only one provider per URL per account)."
+  type        = bool
+  default     = true
+}
+
+variable "role_name" {
+  description = "Name of the deploy role. Its ARN goes into the repo secret DEMO_DEPLOY_ROLE_ARN."
+  type        = string
+  default     = "abom-demo-deploy"
+}
+
+variable "demo_instance_id" {
+  description = "EC2 instance id of the hosted-demo VM (i-...). SendCommand is scoped to exactly this instance's ARN."
+  type        = string
+
+  validation {
+    condition     = can(regex("^i-[0-9a-f]+$", var.demo_instance_id))
+    error_message = "demo_instance_id must look like an EC2 instance id (i-...)."
+  }
+}
+
+variable "aws_region" {
+  description = "Region the demo VM runs in. Used to build the instance ARN that SendCommand is scoped to. Should match vars.AWS_REGION in the workflow."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "oidc_audience" {
+  description = "Expected aud claim on the OIDC token. GitHub's configure-aws-credentials uses sts.amazonaws.com."
+  type        = string
+  default     = "sts.amazonaws.com"
+}
+
+variable "permissions_boundary_arn" {
+  description = "Optional IAM permissions boundary ARN to cap the deploy role. The inline policy is already least-privilege (two SSM actions), so this stays well within any sane boundary."
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Additional tags to apply to created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/deploy/terraform/demo-deploy-oidc/versions.tf
+++ b/deploy/terraform/demo-deploy-oidc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/docs/HOSTED_POC.md
+++ b/docs/HOSTED_POC.md
@@ -223,6 +223,52 @@ Run this checklist before inviting anyone:
 
 If any item fails, treat the POC as not ready for external users.
 
+### Demo redeploy
+
+Redeploying by hand (SSH in, `git pull`, `docker compose up`, rerun preflight +
+smoke) is easy to forget after a release. The `.github/workflows/demo-redeploy.yml`
+workflow automates it without any stored SSH keys or long-lived AWS credentials:
+
+- **Triggers:** every published GitHub release, plus manual `workflow_dispatch`
+  with an optional `reset_demo` boolean.
+- **Transport:** AWS SSM Run Command (`AWS-RunShellScript`) against the demo
+  instance — no inbound SSH. AWS auth is short-lived OIDC role assumption via
+  `aws-actions/configure-aws-credentials`.
+- **Remote steps on the VM:** `git pull --ff-only` → `docker compose -f
+  deploy/docker-compose.platform.yml -f deploy/docker-compose.hosted-poc.yml up
+  -d --build` → `scripts/deploy/hosted_poc_preflight.py --write-postgres-secret`
+  (fail-closed) → `scripts/deploy/hosted_poc_smoke.sh`. The job fails if the
+  preflight or smoke fails, so a bad redeploy never gets promoted silently. When
+  dispatched with `reset_demo=true` it also runs `scripts/deploy/demo-reset.sh`.
+- **No plaintext secrets in CI.** All secret material stays on the VM as the
+  existing `deploy/secrets/` file mounts. The remote script sources an optional
+  on-VM env file `deploy/secrets/redeploy.env` (chmod `0400`, owned by the deploy
+  user) for the non-secret URL wiring the preflight needs and the admin key the
+  smoke/reset need:
+
+  ```bash
+  # /opt/agent-bom/deploy/secrets/redeploy.env  (0400, not committed)
+  NEXT_PUBLIC_API_URL="https://demo.agent-bom.com"
+  CORS_ORIGINS="https://demo.agent-bom.com,http://ui:3000"
+  AGENT_BOM_SMOKE_URL="https://demo.agent-bom.com"
+  AGENT_BOM_SMOKE_API_KEY="<raw admin key>"
+  # AGENT_BOM_DEMO_TENANT="default"   # only needed if reset targets a non-default tenant
+  ```
+
+The workflow is **inert until configured** — if `DEMO_INSTANCE_ID` is unset it
+logs the required settings and exits successfully instead of failing. To enable
+it, set these repo Actions **variables** and **secret**:
+
+| Setting | Kind | Purpose |
+|---|---|---|
+| `DEMO_INSTANCE_ID` | var | EC2 instance id of the demo VM (`i-...`). Gate: unset ⇒ workflow no-ops. |
+| `AWS_REGION` | var | Region of the demo VM. Defaults to `us-east-1` if unset. |
+| `DEMO_DEPLOY_DIR` | var | Repo checkout dir on the VM. Defaults to `/opt/agent-bom`. |
+| `DEMO_DEPLOY_ROLE_ARN` | secret | IAM role ARN the workflow assumes via OIDC. Its trust policy must allow this repo's GitHub OIDC subject, and its permissions must allow `ssm:SendCommand` / `ssm:GetCommandInvocation` on the instance. |
+
+The instance also needs the SSM agent running and an instance profile granting
+`AmazonSSMManagedInstanceCore` so Run Command can reach it.
+
 ## Snowflake Native App lane
 
 Use Snowflake when the buyer wants agent-bom to run inside their Snowflake

--- a/docs/HOSTED_POC.md
+++ b/docs/HOSTED_POC.md
@@ -269,6 +269,26 @@ it, set these repo Actions **variables** and **secret**:
 The instance also needs the SSM agent running and an instance profile granting
 `AmazonSSMManagedInstanceCore` so Run Command can reach it.
 
+#### Public-repo hardening (required)
+
+This repo is public, so fork/PR contributors must never be able to trigger the
+deploy or assume the AWS role. Two independent defenses:
+
+- **Protected environment.** The deploy job declares `environment: demo`. Create
+  a repo Actions **Environment** named `demo` with **yourself as a required
+  reviewer**, and optionally restrict its deployment branches/tags to the default
+  branch and `v*.*.*` tags. Then every `release` / `workflow_dispatch` run
+  **pauses for your approval** before any AWS call. The workflow has **no**
+  `pull_request` / `pull_request_target` trigger — it is release +
+  `workflow_dispatch` only, so PRs cannot start it at all.
+- **Scoped OIDC trust.** Provision the deploy role with the
+  `deploy/terraform/demo-deploy-oidc` module. Its trust policy pins the GitHub
+  OIDC `sub` to **exactly** `repo:<owner>/<repo>:environment:demo` (StringEquals,
+  no wildcard) and grants only `ssm:SendCommand` to the demo instance +
+  `ssm:GetCommandInvocation`. Fork/PR runs present a different `sub` and STS
+  rejects them. `terraform output -raw role_arn` gives the value for
+  `DEMO_DEPLOY_ROLE_ARN`.
+
 ## Snowflake Native App lane
 
 Use Snowflake when the buyer wants agent-bom to run inside their Snowflake

--- a/scripts/check_provisioning_readonly.py
+++ b/scripts/check_provisioning_readonly.py
@@ -56,6 +56,7 @@ PRIVILEGED_MODULES = {
 # can't sneak in unnoticed — it would fail rule 3 until added here on purpose.
 OPERATIONAL_MODULES = {
     "aws/baseline",
+    "demo-deploy-oidc",
     "platform-eks",
     "azure/ingestion",
 }

--- a/tests/test_provisioning_readonly_guard.py
+++ b/tests/test_provisioning_readonly_guard.py
@@ -44,6 +44,15 @@ def test_current_tree_passes() -> None:
     assert "PASS:" in proc.stdout
 
 
+def test_demo_deploy_is_explicitly_operational_and_instance_scoped() -> None:
+    """Demo redeploy may mutate only its own VM, never a connected estate."""
+    assert "demo-deploy-oidc" in GUARD.OPERATIONAL_MODULES
+    content = (ROOT / "deploy" / "terraform" / "demo-deploy-oidc" / "main.tf").read_text()
+    assert 'actions = ["ssm:SendCommand"]' in content
+    assert "local.demo_instance_arn" in content
+    assert '"ssm:*"' not in content
+
+
 # ---------------------------------------------------------------------------
 # Rule 1 — read-only connect modules.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3833.

The public hosted demo is a manually operated AWS VM (runbook: `docs/HOSTED_POC.md`) — after each release someone has to SSH in, pull, `docker compose up`, and rerun preflight + smoke. This adds a workflow that automates the redeploy safely.

**`.github/workflows/demo-redeploy.yml`**
- Runs on `release: [published]` and manual `workflow_dispatch` (optional `reset_demo` boolean).
- Reaches the VM over **AWS SSM Run Command** (no inbound SSH, no stored SSH keys). AWS auth is short-lived **OIDC role assumption** — no long-lived access keys.
- Remote steps: `git pull --ff-only` → `docker compose -f platform -f hosted-poc up -d --build` → `hosted_poc_preflight.py` (fail-closed) → `hosted_poc_smoke.sh`; optional `demo-reset.sh` on dispatch. Job **fails if preflight/smoke fails**, so a broken redeploy is never promoted.
- **No plaintext secrets in CI:** all secret material stays on the VM as the existing `deploy/secrets/` file mounts (plus an optional on-VM `redeploy.env`).
- **Inert until configured:** if `DEMO_INSTANCE_ID` is unset the run logs the required settings and exits green.

Repo conventions: top-level `permissions: {}`, per-job `timeout-minutes`, SHA-pinned actions; passes `scripts/check_workflow_timeouts.py`.

**To enable** (documented in `docs/HOSTED_POC.md` → "Demo redeploy"): vars `DEMO_INSTANCE_ID`, `AWS_REGION`, `DEMO_DEPLOY_DIR`; secret `DEMO_DEPLOY_ROLE_ARN`; on the VM: SSM agent + instance profile.

**Testing:** YAML parses + passes the timeout gate; remote-script generation validated locally. Cannot be exercised end-to-end without the VM + configured OIDC role — first activation should be a manual `workflow_dispatch` to confirm SSM connectivity.