### PR TITLE
fix(secrets): make proxy signing keys file-first

### DIFF
--- a/docs/COMPLIANCE_SIGNING.md
+++ b/docs/COMPLIANCE_SIGNING.md
@@ -41,9 +41,9 @@ controlPlane:
       - name: evidence-signing
         mountPath: /run/secrets/agent-bom
         readOnly: true
-  env:
-    - name: AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE
-      value: /run/secrets/agent-bom/private.pem
+    env:
+      - name: AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE
+        value: /run/secrets/agent-bom/private.pem
 ```
 
 The server logs at startup:

--- a/docs/COMPLIANCE_SIGNING.md
+++ b/docs/COMPLIANCE_SIGNING.md
@@ -23,21 +23,27 @@ openssl genpkey -algorithm ed25519 -out agent-bom-evidence-key.pem
 openssl pkey -in agent-bom-evidence-key.pem -pubout -out agent-bom-evidence-pub.pem
 ```
 
-Deploy the server with the **private** key mounted as
-`AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM` (PEM string, PKCS#8). The value
-resolves file-first: set `AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE` to
-a mounted secret path (Docker/Compose secrets) and the file wins over the inline
-env var — preferred for compose/local so the PEM never lands in `.env` or process
-env. On a Helm install (Secret→env is fine):
+Deploy the server with the **private** key as a mounted file and set
+`AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE` to that path. File-first
+resolution keeps the PEM out of `.env`, Pod environment, and process listings.
+The inline `..._PEM` variable remains compatibility-only.
+
+On Helm, mount the Secret instead of projecting its contents into an environment variable:
 
 ```yaml
 controlPlane:
+  api:
+    extraVolumes:
+      - name: evidence-signing
+        secret:
+          secretName: agent-bom-evidence-signing
+    extraVolumeMounts:
+      - name: evidence-signing
+        mountPath: /run/secrets/agent-bom
+        readOnly: true
   env:
-    - name: AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM
-      valueFrom:
-        secretKeyRef:
-          name: agent-bom-evidence-signing
-          key: private.pem
+    - name: AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE
+      value: /run/secrets/agent-bom/private.pem
 ```
 
 The server logs at startup:
@@ -103,7 +109,7 @@ full response body. Tampering with any byte invalidates the signature.
 ## Key rotation
 
 1. Generate a new key pair.
-2. Update `AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM` on the server and redeploy.
+2. Replace the mounted private-key file and redeploy.
 3. Auditors re-fetch `/v1/compliance/verification-key` and pin the new `key_id`.
 4. Bundles signed with the old key remain verifiable against the old public key — retain it offline for the evidence retention window your framework requires.
 

--- a/site-docs/deployment/eks-mcp-pilot.md
+++ b/site-docs/deployment/eks-mcp-pilot.md
@@ -190,8 +190,9 @@ kubectl -n agent-bom create secret generic agent-bom-control-plane \
   --from-literal=AGENT_BOM_POSTGRES_URL="$AGENT_BOM_POSTGRES_URL" \
   --from-literal=AGENT_BOM_API_KEY="$API_KEY" \
   --from-literal=AGENT_BOM_AUDIT_HMAC_KEY="$AUDIT_HMAC_KEY" \
-  --from-literal=AGENT_BOM_REQUIRE_AUDIT_HMAC="1" \
-  --from-file=AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM=/tmp/evidence-priv.pem
+  --from-literal=AGENT_BOM_REQUIRE_AUDIT_HMAC="1"
+kubectl -n agent-bom create secret generic agent-bom-evidence-signing \
+  --from-file=private.pem=/tmp/evidence-priv.pem
 rm /tmp/evidence-priv.pem
 
 # 3. Helm install with the focused pilot values

--- a/site-docs/deployment/runtime-operations.md
+++ b/site-docs/deployment/runtime-operations.md
@@ -18,7 +18,7 @@ same self-hosted `agent-bom` deployment.
 
 ## Proxy policy-cache signing key rotation
 
-When `AGENT_BOM_PROXY_POLICY_CACHE_ED25519_PRIVATE_KEY_PEM` is set, each proxy
+When `AGENT_BOM_PROXY_POLICY_CACHE_ED25519_PRIVATE_KEY_PEM_FILE` points to a mounted key, each proxy
 persists its cached gateway policy bundle together with an Ed25519 signature and
 fails closed if the signature is missing, tampered, or produced by a different
 key.
@@ -47,15 +47,15 @@ openssl genpkey -algorithm ed25519 -out /tmp/proxy-policy-cache-ed25519.pem
 openssl pkey -in /tmp/proxy-policy-cache-ed25519.pem -pubout -out /tmp/proxy-policy-cache-ed25519.pub
 ```
 
-Update the secret or environment source that backs
-`AGENT_BOM_PROXY_POLICY_CACHE_ED25519_PRIVATE_KEY_PEM`.
+Update the mounted secret file referenced by
+`AGENT_BOM_PROXY_POLICY_CACHE_ED25519_PRIVATE_KEY_PEM_FILE`.
 
 For Kubernetes, that usually means updating the Secret referenced by the proxy
 or sidecar deployment:
 
 ```bash
 kubectl -n agent-bom create secret generic agent-bom-proxy-policy-signing \
-  --from-file=AGENT_BOM_PROXY_POLICY_CACHE_ED25519_PRIVATE_KEY_PEM=/tmp/proxy-policy-cache-ed25519.pem \
+  --from-file=private.pem=/tmp/proxy-policy-cache-ed25519.pem \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
@@ -96,7 +96,7 @@ Default cache paths:
 
 ### Rotation checklist
 
-- rotate the secret value that backs `AGENT_BOM_PROXY_POLICY_CACHE_ED25519_PRIVATE_KEY_PEM`
+- rotate the mounted file referenced by `AGENT_BOM_PROXY_POLICY_CACHE_ED25519_PRIVATE_KEY_PEM_FILE`
 - perform rolling restarts while the control plane is reachable
 - confirm proxies can still pull policy and start cleanly
 - archive the public key if your change process requires evidence of the new key

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -79,6 +79,13 @@ _PROXY_TRACER = get_tracer("agent_bom.proxy")
 _PROXY_POLICY_CACHE_SIGNING_ENV_VAR = "AGENT_BOM_PROXY_POLICY_CACHE_ED25519_PRIVATE_KEY_PEM"
 
 
+def _proxy_policy_cache_signing_pem() -> str:
+    """Resolve the cache-signing PEM file-first without retaining it in process env."""
+    from agent_bom.api.secret_source import resolve_secret
+
+    return resolve_secret(_PROXY_POLICY_CACHE_SIGNING_ENV_VAR).strip()
+
+
 async def _read_bounded_line(reader: asyncio.StreamReader, *, max_bytes: int = _MAX_MESSAGE_BYTES) -> bytes | None:
     """Read one newline-delimited message without accepting an oversized line."""
     try:
@@ -513,7 +520,7 @@ def _load_gateway_policy_cache_signer() -> _GatewayPolicyCacheSigner | None:
     global _gateway_policy_cache_signer, _gateway_policy_cache_signer_error
     if _gateway_policy_cache_signer is not None:
         return _gateway_policy_cache_signer
-    pem = os.environ.get(_PROXY_POLICY_CACHE_SIGNING_ENV_VAR, "").strip()
+    pem = _proxy_policy_cache_signing_pem()
     if not pem:
         return None
     if _gateway_policy_cache_signer_error is not None:
@@ -570,7 +577,7 @@ def _load_cached_gateway_policies(
         return None, None
 
     signer = _load_gateway_policy_cache_signer()
-    if os.environ.get(_PROXY_POLICY_CACHE_SIGNING_ENV_VAR, "").strip():
+    if _proxy_policy_cache_signing_pem():
         if signer is None:
             logger.warning("Ignoring gateway policy cache %s because cache signing is misconfigured", cache_path)
             return None, None

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -524,12 +524,31 @@ def test_gateway_policy_cache_round_trip_requires_valid_signature_when_enabled(t
 
     signature_path = _gateway_policy_cache_signature_path(cache_path)
     assert signature_path.exists()
-
     loaded_policies, loaded_etag = _load_cached_gateway_policies(cache_path, max_age_seconds=60)
     assert loaded_etag == "etag-signed"
     assert loaded_policies is not None
     assert loaded_policies[0].policy_id == "p1"
 
+
+def test_gateway_policy_cache_signing_key_resolves_from_file_first(tmp_path: Path, monkeypatch):
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    key_file = tmp_path / "proxy-policy-signing.pem"
+    key_file.write_bytes(
+        Ed25519PrivateKey.generate().private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+    monkeypatch.setenv("AGENT_BOM_PROXY_POLICY_CACHE_ED25519_PRIVATE_KEY_PEM", "invalid-inline-value")
+    monkeypatch.setenv("AGENT_BOM_PROXY_POLICY_CACHE_ED25519_PRIVATE_KEY_PEM_FILE", str(key_file))
+    _reset_gateway_policy_cache_signer_for_tests()
+
+    from agent_bom.proxy import _load_gateway_policy_cache_signer
+
+    assert _load_gateway_policy_cache_signer() is not None
 
 def test_gateway_policy_cache_rejects_signature_mismatch(tmp_path: Path, monkeypatch):
     cache_path = tmp_path / "gateway-policies.json"


### PR DESCRIPTION
## Summary

- resolve proxy policy-cache Ed25519 signing keys through the shared file-first secret boundary
- add a regression proving mounted files override compatibility-only inline PEM values
- replace remaining compliance/proxy Kubernetes guidance with mounted Secret files and rotation instructions

Closes #3807

## Verification

- `uv run --extra api --extra dev pytest -q tests/test_proxy.py -k gateway_policy_cache` (9 passed)
- `uv run ruff check src/agent_bom/proxy.py tests/test_proxy.py`
- `python scripts/check_exception_sanitization.py`
- `make preflight`
- `git diff --check`

## Notes

Inline PEM variables remain backward-compatible. Mounted `*_FILE` values win. Invalid configured signing keys continue to fail closed for cached policy use.