### PR TITLE
feat(cli): connect can establish and verify a read-only cloud connection (#3832)

### DIFF
--- a/src/agent_bom/cli/_entry_points.py
+++ b/src/agent_bom/cli/_entry_points.py
@@ -290,9 +290,9 @@ _CONNECT_FIELDS: dict[str, tuple[_ConnectField, ...]] = {
 }
 
 
-def _connect_options(source: _ConnectSource) -> list[click.Option]:
+def _connect_options(source: _ConnectSource) -> list[click.Parameter]:
     """Build the Click options for one provider's establish + verify flags."""
-    options: list[click.Option] = []
+    options: list[click.Parameter] = []
     for field in _CONNECT_FIELDS[source.name]:
         decls = [field.flag, field.param]
         if field.kind == "regions":
@@ -333,8 +333,8 @@ def _resolve_connect_inputs(source: _ConnectSource, kwargs: dict[str, object]) -
     for field in _CONNECT_FIELDS[source.name]:
         value = kwargs.get(field.param)
         if field.kind == "regions":
-            if value:
-                regions = [str(item) for item in value]  # type: ignore[union-attr]
+            if isinstance(value, (tuple, list)) and value:
+                regions = [str(item) for item in value]
                 supplied = True
             continue
         if not value:

--- a/src/agent_bom/cli/_entry_points.py
+++ b/src/agent_bom/cli/_entry_points.py
@@ -205,13 +205,24 @@ def _list_connect_sources() -> None:
 )
 @click.pass_context
 def connect_group(ctx: click.Context) -> None:
-    """Read-only onboard a cloud or data source.
+    """Read-only onboard a cloud or data source — describe, or establish + verify.
 
     \b
-    Prints the exact read-only setup for a source (CLI, CloudShell, or
-    Terraform grant + opt-in inventory env var), then reports whether local
-    credentials are already detectable. agent-bom never mutates the target
-    and does no network I/O until you opt in.
+    With no connection flags, `connect <source>` prints the exact read-only
+    setup (CLI, CloudShell, or Terraform grant + opt-in inventory env var) and
+    reports whether local credentials are detectable — no network I/O.
+
+    \b
+    Given connection params (e.g. aws --role-arn/--external-id/--region) it goes
+    further and actually establishes + verifies a read-only connection using the
+    SAME broker and schema as the API:
+      * locally (default): broker a short-lived read-only credential and run a
+        trivial read-only probe (e.g. AWS sts:GetCallerIdentity) to prove it;
+      * with --server/--api-key: register the connection with a running control
+        plane (POST /v1/cloud/connections) and run its /test — the identical
+        connection the UI/API create.
+    The secret (--external-id / client secret / key) is write-only: never
+    printed, never logged.
 
     \b
     Sources:
@@ -227,24 +238,320 @@ def connect_group(ctx: click.Context) -> None:
         _list_connect_sources()
 
 
-def _make_connect_subcommand(source: _ConnectSource) -> click.Command:
-    @click.command(
-        source.name,
-        help=(
-            f"Read-only onboarding for {source.title}.\n\n"
-            f"Prints CLI, CloudShell, and Terraform grant options "
-            f"({source.terraform_module} / {source.provision_path}), the "
-            f"opt-in inventory env var ({source.inventory_env}), and the scan command, "
-            f"then reports whether local credentials are detectable. Read-only — nothing "
-            f"is created or modified in your account."
-        ),
+# ── Establish + verify: shared schema (CloudConnectionCreate) + shared broker ──
+#
+# Each provider exposes provider-appropriate flags that map onto the *canonical*
+# ``CloudConnectionCreate`` fields (role_ref / external_id / regions / auth_params)
+# so the CLI never invents a divergent connection shape. ``secret`` fields carry
+# the single write-only secret and are never echoed.
+
+
+@dataclass(frozen=True)
+class _ConnectField:
+    """One provider flag and how it maps onto the canonical connection schema.
+
+    ``kind`` selects the canonical target: ``role_ref`` and ``secret`` set the
+    two required columns, ``secret_file`` reads the secret from a file path,
+    ``regions`` is a repeatable list, and ``auth_param`` writes into the
+    non-secret ``auth_params`` blob under ``auth_key``.
+    """
+
+    flag: str
+    param: str
+    kind: str
+    help: str
+    auth_key: str = ""
+
+
+_CONNECT_FIELDS: dict[str, tuple[_ConnectField, ...]] = {
+    "aws": (
+        _ConnectField("--role-arn", "role_arn", "role_ref", "IAM role ARN to assume, read-only (the connection role_ref)."),
+        _ConnectField("--external-id", "external_id", "secret", "STS ExternalId — write-only secret; never printed or logged."),
+        _ConnectField("--region", "regions", "regions", "Region to scan (repeatable)."),
+    ),
+    "azure": (
+        _ConnectField("--client-id", "client_id", "role_ref", "App/service-principal client id (the connection role_ref)."),
+        _ConnectField("--client-secret", "client_secret", "secret", "Client secret — write-only; never printed or logged."),
+        _ConnectField("--tenant-id", "tenant_id", "auth_param", "Azure AD tenant id.", auth_key="tenant_id"),
+        _ConnectField("--subscription-id", "subscription_id", "auth_param", "Azure subscription id.", auth_key="subscription_id"),
+    ),
+    "gcp": (
+        _ConnectField("--service-account", "service_account", "role_ref", "Service-account email (the connection role_ref)."),
+        _ConnectField("--key-file", "key_file", "secret_file", "Path to the service-account key JSON — write-only; never printed."),
+        _ConnectField("--project", "project", "auth_param", "GCP project id.", auth_key="project_id"),
+    ),
+    "snowflake": (
+        _ConnectField("--account", "account", "role_ref", "Snowflake account or account/user (the connection role_ref)."),
+        _ConnectField("--private-key-file", "private_key_file", "secret_file", "Path to the PEM private key — write-only; never printed."),
+        _ConnectField("--user", "user", "auth_param", "Snowflake user.", auth_key="user"),
+        _ConnectField("--role", "role", "auth_param", "Snowflake role.", auth_key="role"),
+        _ConnectField("--warehouse", "warehouse", "auth_param", "Snowflake warehouse.", auth_key="warehouse"),
+    ),
+}
+
+
+def _connect_options(source: _ConnectSource) -> list[click.Option]:
+    """Build the Click options for one provider's establish + verify flags."""
+    options: list[click.Option] = []
+    for field in _CONNECT_FIELDS[source.name]:
+        decls = [field.flag, field.param]
+        if field.kind == "regions":
+            options.append(click.Option(decls, multiple=True, help=field.help))
+        elif field.kind == "secret_file":
+            options.append(click.Option(decls, type=click.Path(exists=True, dir_okay=False), help=field.help))
+        else:
+            options.append(click.Option(decls, help=field.help))
+    options.extend(
+        [
+            click.Option(["--display-name"], help="Human label for the connection (defaults to the provider name)."),
+            click.Option(["--server"], help="Control-plane base URL to register the connection with (uses the API)."),
+            click.Option(["--api-key"], help="API key for --server registration."),
+            click.Option(["--tenant"], help="Control-plane tenant id for --server registration."),
+            click.Option(
+                ["--scan", "do_scan"],
+                is_flag=True,
+                help="After establishing, trigger a scan (server /scan, else local scan guidance).",
+            ),
+        ]
     )
-    def _cmd() -> None:
+    return options
+
+
+def _resolve_connect_inputs(source: _ConnectSource, kwargs: dict[str, object]) -> tuple[str, str, list[str], dict[str, str], bool]:
+    """Map raw Click kwargs onto canonical (role_ref, external_id, regions, auth_params).
+
+    Returns the four canonical pieces plus ``supplied`` — whether any connection
+    param was given at all (if not, the caller keeps the informational default).
+    ``secret_file`` fields are read from disk here; the secret content is never
+    returned to the caller as anything but the ``external_id`` value.
+    """
+    role_ref = ""
+    external_id = ""
+    regions: list[str] = []
+    auth_params: dict[str, str] = {}
+    supplied = False
+    for field in _CONNECT_FIELDS[source.name]:
+        value = kwargs.get(field.param)
+        if field.kind == "regions":
+            if value:
+                regions = [str(item) for item in value]  # type: ignore[union-attr]
+                supplied = True
+            continue
+        if not value:
+            continue
+        supplied = True
+        if field.kind == "role_ref":
+            role_ref = str(value)
+        elif field.kind == "secret":
+            external_id = str(value)
+        elif field.kind == "secret_file":
+            from pathlib import Path
+
+            external_id = Path(str(value)).read_text(encoding="utf-8")
+        elif field.kind == "auth_param":
+            auth_params[field.auth_key] = str(value)
+    return role_ref, external_id, regions, auth_params, supplied
+
+
+def _readonly_probe(provider: str, brokered: object, regions: list[str]) -> str:
+    """Run a trivial, bounded, read-only call against a brokered credential.
+
+    Proves the read-only credential actually works. Returns a short, non-secret
+    description of what the probe saw (e.g. the AWS account id) — never the
+    connection secret.
+    """
+    if provider == "aws":
+        identity = brokered.client("sts").get_caller_identity()  # type: ignore[attr-defined]
+        account = str(identity.get("Account") or "").strip()
+        return f"AWS account {account}" if account else "AWS caller identity confirmed"
+    if provider == "azure":
+        # Bounded token acquisition against ARM — read-only, no resource calls.
+        brokered.get_token("https://management.azure.com/.default")  # type: ignore[attr-defined]
+        return "Azure Reader credential acquired a management token"
+    if provider == "gcp":
+        import google.auth.transport.requests as _ga_requests
+
+        brokered.refresh(_ga_requests.Request())  # type: ignore[attr-defined]
+        return "GCP read-only service-account credential refreshed"
+    if provider == "snowflake":
+        try:
+            cursor = brokered.cursor()  # type: ignore[attr-defined]
+            cursor.execute("SELECT CURRENT_VERSION()")
+            cursor.fetchone()
+        finally:
+            try:
+                brokered.close()  # type: ignore[attr-defined]
+            except Exception:  # noqa: BLE001 - close best-effort
+                pass
+        return "Snowflake read-only key-pair connection opened"
+    return "credential brokered"
+
+
+def _local_verify(
+    con: object,
+    source: _ConnectSource,
+    *,
+    role_ref: str,
+    external_id: str,
+    regions: list[str],
+    auth_params: dict[str, str],
+    display_name: str,
+    do_scan: bool,
+) -> None:
+    """Broker a read-only credential in-process and prove it with a bounded probe.
+
+    Standalone — needs no control plane. Degrades gracefully with an install hint
+    when the provider SDK extra is missing. The secret is never printed.
+    """
+    from rich.markup import escape
+
+    from agent_bom.cloud.base import CloudDiscoveryError
+    from agent_bom.cloud.connection_broker import ConnectionBrokerError, broker_session
+    from agent_bom.cloud.connection_request import ephemeral_connection_record
+
+    con.print(f"[dim]Verifying a read-only {source.title} connection locally (no server)...[/dim]")  # type: ignore[attr-defined]
+    try:
+        with ephemeral_connection_record(
+            provider=source.name,
+            display_name=display_name,
+            role_ref=role_ref,
+            external_id=external_id,
+            regions=regions,
+            auth_params=auth_params,
+        ) as record:
+            brokered = broker_session(record, session_name="agent-bom-cli-verify")
+            detail = _readonly_probe(source.name, brokered, regions)
+    except CloudDiscoveryError as exc:
+        # Missing SDK extra — the broker's own install hint is already actionable.
+        # Escape so the ``[extra]`` in the hint is not swallowed as rich markup.
+        con.print(f"[yellow]Cannot verify locally:[/yellow] {escape(str(exc))}")  # type: ignore[attr-defined]
+        return
+    except (ConnectionBrokerError, Exception) as exc:  # noqa: BLE001 - broker/provider failure
+        from agent_bom.security import sanitize_error
+
+        con.print(f"[red]Verification failed:[/red] {escape(sanitize_error(exc, generic=True))}")  # type: ignore[attr-defined]
+        return
+
+    con.print(f"[green]Verified[/green] read-only credentials — {escape(detail)}.")  # type: ignore[attr-defined]
+    if do_scan:
+        con.print(f"[dim]Next, run the read-only scan:[/dim] [cyan]{source.scan_command}[/cyan]")  # type: ignore[attr-defined]
+
+
+def _register_via_server(
+    con: object,
+    source: _ConnectSource,
+    *,
+    role_ref: str,
+    external_id: str,
+    regions: list[str],
+    auth_params: dict[str, str],
+    display_name: str,
+    server: str,
+    api_key: str,
+    tenant: str,
+    do_scan: bool,
+) -> None:
+    """Register the connection with a control plane, then run its /test (and /scan).
+
+    Uses the API client + the SAME ``CloudConnectionCreate`` schema, so this is
+    the identical connection the UI/API create. The secret is sent for at-rest
+    encryption server-side and is never printed by the CLI.
+    """
+    from agent_bom.client import AgentBomApiError, AgentBomClient
+
+    client = AgentBomClient(base_url=server, api_key=api_key, tenant_id=tenant or None)
+    try:
+        created = client.create_cloud_connection(
+            provider=source.name,
+            display_name=display_name,
+            role_ref=role_ref,
+            external_id=external_id,
+            regions=regions,
+            auth_params=auth_params,
+        )
+        connection_id = str(created.get("id") or "")
+        con.print(f"[green]Registered[/green] {source.title} connection [bold]{connection_id}[/bold] on {server}.")  # type: ignore[attr-defined]
+        test = client.test_cloud_connection(connection_id)
+        con.print(f"[green]Test:[/green] read-only broker check -> {test.get('status', 'ok')}.")  # type: ignore[attr-defined]
+        if do_scan:
+            scan = client.scan_cloud_connection(connection_id)
+            con.print(f"[green]Scan:[/green] launched (scan_id {scan.get('scan_id', '?')}).")  # type: ignore[attr-defined]
+    except AgentBomApiError as exc:
+        con.print(f"[red]Control plane rejected the request ({exc.status_code}).[/red] See server logs for detail.")  # type: ignore[attr-defined]
+    finally:
+        client.close()
+
+
+def _make_connect_subcommand(source: _ConnectSource) -> click.Command:
+    def _cmd(**kwargs: object) -> None:
         from rich.console import Console
 
-        _render_connect_guidance(Console(), source)
+        con = Console()
+        role_ref, external_id, regions, auth_params, supplied = _resolve_connect_inputs(source, kwargs)
+        if not supplied:
+            # Back-compat: no connection flags -> unchanged informational output.
+            _render_connect_guidance(con, source)
+            return
 
-    return _cmd
+        display_name = str(kwargs.get("display_name") or "").strip() or f"{source.title} (read-only)"
+        server = str(kwargs.get("server") or "").strip()
+        api_key = str(kwargs.get("api_key") or "").strip()
+        tenant = str(kwargs.get("tenant") or "").strip()
+        do_scan = bool(kwargs.get("do_scan"))
+
+        if not role_ref or not external_id:
+            secret_flag = next(f.flag for f in _CONNECT_FIELDS[source.name] if f.kind in ("secret", "secret_file"))
+            role_flag = next(f.flag for f in _CONNECT_FIELDS[source.name] if f.kind == "role_ref")
+            con.print(f"[red]To establish a connection, provide both {role_flag} and {secret_flag}.[/red]")
+            raise click.exceptions.Exit(2)
+
+        if server or api_key:
+            if not server or not api_key:
+                con.print("[red]--server and --api-key are both required to register with a control plane.[/red]")
+                raise click.exceptions.Exit(2)
+            _register_via_server(
+                con,
+                source,
+                role_ref=role_ref,
+                external_id=external_id,
+                regions=regions,
+                auth_params=auth_params,
+                display_name=display_name,
+                server=server,
+                api_key=api_key,
+                tenant=tenant,
+                do_scan=do_scan,
+            )
+        else:
+            _local_verify(
+                con,
+                source,
+                role_ref=role_ref,
+                external_id=external_id,
+                regions=regions,
+                auth_params=auth_params,
+                display_name=display_name,
+                do_scan=do_scan,
+            )
+
+    command = click.Command(
+        source.name,
+        callback=_cmd,
+        params=_connect_options(source),
+        help=(
+            f"Read-only onboarding for {source.title}.\n\n"
+            f"With no connection flags: prints CLI, CloudShell, and Terraform grant "
+            f"options ({source.terraform_module} / {source.provision_path}), the opt-in "
+            f"inventory env var ({source.inventory_env}), and the scan command, then reports "
+            f"whether local credentials are detectable.\n\n"
+            f"With connection flags (e.g. {_CONNECT_FIELDS[source.name][0].flag} + the write-only "
+            f"secret): establishes + verifies a read-only connection using the same broker and "
+            f"CloudConnectionCreate schema as the API — locally by default, or against a control "
+            f"plane with --server/--api-key. Read-only; nothing is created or modified in your account."
+        ),
+        context_settings={"help_option_names": ["-h", "--help"]},
+    )
+    return command
 
 
 for _source in _CONNECT_SOURCES.values():

--- a/src/agent_bom/client.py
+++ b/src/agent_bom/client.py
@@ -492,6 +492,47 @@ class AgentBomClient:
 
         return self._request("GET", "/v1/intel/sources")
 
+    def create_cloud_connection(
+        self,
+        *,
+        provider: str,
+        display_name: str,
+        role_ref: str,
+        external_id: str,
+        regions: Sequence[str] | None = None,
+        auth_params: Mapping[str, str] | None = None,
+        scan_interval_minutes: int | None = None,
+    ) -> JsonObject:
+        """Register a read-only cloud connection with the control plane.
+
+        Builds the body via the shared request-builder so the fields match the
+        API's ``CloudConnectionCreate`` schema exactly. ``external_id`` is the
+        single write-only secret — it is sent so the server can encrypt it at
+        rest and is never returned in the response (and must never be logged).
+        """
+        from agent_bom.cloud.connection_request import build_connection_create_body
+
+        body = build_connection_create_body(
+            provider=provider,
+            display_name=display_name,
+            role_ref=role_ref,
+            external_id=external_id,
+            regions=regions,
+            auth_params=auth_params,
+            scan_interval_minutes=scan_interval_minutes,
+        )
+        return self._request("POST", "/v1/cloud/connections", json=body)
+
+    def test_cloud_connection(self, connection_id: str) -> JsonObject:
+        """Validate a connection's brokered read-only credential (no scan)."""
+
+        return self._request("POST", f"/v1/cloud/connections/{_quote_path(connection_id)}/test")
+
+    def scan_cloud_connection(self, connection_id: str) -> JsonObject:
+        """Launch a read-only scan for a stored connection via the broker."""
+
+        return self._request("POST", f"/v1/cloud/connections/{_quote_path(connection_id)}/scan")
+
     def _request(
         self,
         method: str,

--- a/src/agent_bom/cloud/connection_request.py
+++ b/src/agent_bom/cloud/connection_request.py
@@ -1,0 +1,127 @@
+"""Shared request-builder for read-only cloud connections.
+
+Single source of truth for the ``CloudConnectionCreate`` field mapping used by
+*both* the ``agent-bom connect`` CLI verb and the control-plane API. Keeping the
+field names here means the CLI's local-verify and server-register paths cannot
+drift from the API's ``CloudConnectionCreate`` schema — the CLI never invents a
+divergent connection shape.
+
+Two helpers:
+
+- :func:`build_connection_create_body` builds the JSON body the API client POSTs
+  to ``/v1/cloud/connections``. Its keys are exactly the ``CloudConnectionCreate``
+  fields (``provider``/``display_name``/``role_ref``/``external_id``/``regions``/
+  ``auth_params``/``scan_interval_minutes``).
+- :func:`ephemeral_connection_record` yields an in-process
+  :class:`~agent_bom.api.connection_store.CloudConnectionRecord` whose secret is
+  encrypted with the *same* :mod:`agent_bom.api.connection_crypto` the server
+  uses, so the *same* :func:`~agent_bom.cloud.connection_broker.broker_session`
+  can materialize a read-only credential for a standalone local verify. The
+  record never leaves the process and the secret is never printed.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agent_bom.api.connection_store import CloudConnectionRecord
+
+
+def build_connection_create_body(
+    *,
+    provider: str,
+    display_name: str,
+    role_ref: str,
+    external_id: str,
+    regions: Sequence[str] | None = None,
+    auth_params: Mapping[str, str] | None = None,
+    scan_interval_minutes: int | None = None,
+) -> dict[str, Any]:
+    """Build the ``CloudConnectionCreate`` request body (API-schema field names).
+
+    ``external_id`` is the single write-only secret — it is included in the body
+    (the server encrypts it at rest) but callers must never log or print it.
+    Optional-but-empty fields (regions/auth_params/scan_interval_minutes) are
+    omitted so the body stays minimal and matches the pydantic defaults.
+    """
+    body: dict[str, Any] = {
+        "provider": provider,
+        "display_name": display_name,
+        "role_ref": role_ref,
+        "external_id": external_id,
+    }
+    if regions:
+        body["regions"] = list(regions)
+    if auth_params:
+        body["auth_params"] = {str(k): str(v) for k, v in auth_params.items()}
+    if scan_interval_minutes is not None:
+        body["scan_interval_minutes"] = scan_interval_minutes
+    return body
+
+
+@contextmanager
+def ephemeral_connection_record(
+    *,
+    provider: str,
+    display_name: str,
+    role_ref: str,
+    external_id: str,
+    regions: Sequence[str] | None = None,
+    auth_params: Mapping[str, str] | None = None,
+) -> Iterator[CloudConnectionRecord]:
+    """Yield an ephemeral connection record for a standalone local verify.
+
+    The secret is encrypted through the same :mod:`connection_crypto` contract the
+    server uses so the same broker can decrypt it. When no connections key is
+    configured (the common standalone case) a throwaway Fernet key is generated
+    for the lifetime of the context and torn down on exit; if a real key *is*
+    configured it is reused untouched. The record is in-process only — it is never
+    persisted, returned over the API, or logged, and the secret is never printed.
+    """
+    from cryptography.fernet import Fernet
+
+    from agent_bom.api import connection_crypto as cc
+    from agent_bom.api.connection_store import CloudConnectionRecord
+
+    use_ephemeral_key = not cc.connections_key_configured()
+    prev_key = os.environ.get(cc.CONNECTIONS_KEY_ENV)
+    prev_provider = os.environ.get(cc.CONNECTIONS_KEY_PROVIDER_ENV)
+
+    if use_ephemeral_key:
+        os.environ[cc.CONNECTIONS_KEY_ENV] = Fernet.generate_key().decode("ascii")
+        # Force the plain env key provider so no managed-provider network call runs.
+        os.environ.pop(cc.CONNECTIONS_KEY_PROVIDER_ENV, None)
+        cc.reset_key_cache()
+    try:
+        external_id_encrypted = cc.encrypt_secret(external_id)
+        record = CloudConnectionRecord(
+            id=f"cli-local-{uuid.uuid4()}",
+            tenant_id="cli-local",
+            provider=provider,
+            display_name=display_name,
+            role_ref=role_ref,
+            external_id_encrypted=external_id_encrypted,
+            regions=list(regions or []),
+            auth_params={str(k): str(v) for k, v in (auth_params or {}).items()},
+        )
+        yield record
+    finally:
+        if use_ephemeral_key:
+            if prev_key is None:
+                os.environ.pop(cc.CONNECTIONS_KEY_ENV, None)
+            else:
+                os.environ[cc.CONNECTIONS_KEY_ENV] = prev_key
+            if prev_provider is None:
+                os.environ.pop(cc.CONNECTIONS_KEY_PROVIDER_ENV, None)
+            else:
+                os.environ[cc.CONNECTIONS_KEY_PROVIDER_ENV] = prev_provider
+            # Drop the throwaway key from the in-process cache.
+            cc.reset_key_cache()
+
+
+__all__ = ["build_connection_create_body", "ephemeral_connection_record"]

--- a/tests/test_cli_connect_establish.py
+++ b/tests/test_cli_connect_establish.py
@@ -1,0 +1,296 @@
+"""`agent-bom connect <provider>` establish + verify behavior.
+
+Covers the four behaviors the connect-polish work guarantees:
+
+* the informational default (no connection flags) is unchanged / back-compatible;
+* local verify succeeds and fails cleanly with a mocked boto3/STS;
+* the server-register path sends the *same* ``CloudConnectionCreate`` schema the
+  API expects, via the API client;
+* the connection secret (external_id / client secret / key) is never printed.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+SECRET = "super-secret-external-id"
+
+
+# ── Fake boto3 so local verify runs the real broker without a real AWS call ────
+
+
+def _make_fake_boto3(*, assume_fails: bool = False) -> types.ModuleType:
+    class FakeStsClient:
+        def assume_role(self, **kwargs: object) -> dict[str, object]:
+            # The broker must present the decrypted ExternalId, never anything else.
+            assert kwargs["ExternalId"] == SECRET
+            if assume_fails:
+                raise RuntimeError("AccessDenied assuming role")
+            return {"Credentials": {"AccessKeyId": "AKIA", "SecretAccessKey": "sk", "SessionToken": "tok"}}
+
+        def get_caller_identity(self) -> dict[str, str]:
+            return {"Account": "123456789012", "Arn": "arn:aws:sts::123456789012:assumed-role/ro/x"}
+
+    class FakeSession:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def client(self, _service: str) -> FakeStsClient:
+            return FakeStsClient()
+
+    module = types.ModuleType("boto3")
+    module.client = lambda *_a, **_k: FakeStsClient()  # type: ignore[attr-defined]
+    module.Session = FakeSession  # type: ignore[attr-defined]
+    return module
+
+
+@pytest.fixture
+def fake_boto3(monkeypatch: pytest.MonkeyPatch):
+    def _install(*, assume_fails: bool = False) -> None:
+        monkeypatch.setitem(sys.modules, "boto3", _make_fake_boto3(assume_fails=assume_fails))
+
+    return _install
+
+
+def _main():
+    from agent_bom.cli import main
+
+    return main
+
+
+# ── (a) informational default unchanged ───────────────────────────────────────
+
+
+class TestInformationalDefault:
+    @pytest.mark.parametrize("provider", ["aws", "azure", "gcp", "snowflake"])
+    def test_no_flags_prints_readonly_guidance(self, provider: str) -> None:
+        r = CliRunner().invoke(_main(), ["connect", provider])
+        assert r.exit_code == 0
+        assert "Provision the read-only grant" in r.output
+        # The establish path must not run without connection flags.
+        assert "Verifying a read-only" not in r.output
+        assert "Registered" not in r.output
+
+    def test_help_documents_establish_and_verify(self) -> None:
+        r = CliRunner().invoke(_main(), ["connect", "--help"])
+        assert r.exit_code == 0
+        assert "establish" in r.output.lower()
+
+    def test_aws_help_exposes_schema_flags(self) -> None:
+        r = CliRunner().invoke(_main(), ["connect", "aws", "--help"])
+        assert r.exit_code == 0
+        for flag in ("--role-arn", "--external-id", "--region", "--server", "--api-key", "--scan"):
+            assert flag in r.output
+
+
+# ── (b) local verify success + failure ────────────────────────────────────────
+
+
+class TestLocalVerify:
+    def test_success_probes_readonly_and_hides_secret(self, fake_boto3) -> None:
+        fake_boto3()
+        r = CliRunner().invoke(
+            _main(),
+            ["connect", "aws", "--role-arn", "arn:aws:iam::123456789012:role/ro", "--external-id", SECRET, "--region", "us-east-1"],
+        )
+        assert r.exit_code == 0
+        assert "Verified" in r.output
+        assert "123456789012" in r.output  # non-secret probe result
+        assert SECRET not in r.output
+
+    def test_failure_is_clean_and_hides_secret(self, fake_boto3) -> None:
+        fake_boto3(assume_fails=True)
+        r = CliRunner().invoke(
+            _main(),
+            ["connect", "aws", "--role-arn", "arn:aws:iam::1:role/ro", "--external-id", SECRET],
+        )
+        assert r.exit_code == 0
+        assert "Verification failed" in r.output
+        assert SECRET not in r.output
+
+    def test_scan_flag_prints_local_scan_guidance(self, fake_boto3) -> None:
+        fake_boto3()
+        r = CliRunner().invoke(
+            _main(),
+            ["connect", "aws", "--role-arn", "arn:aws:iam::1:role/ro", "--external-id", SECRET, "--scan"],
+        )
+        assert r.exit_code == 0
+        assert "agent-bom scan --aws" in r.output
+
+    def test_missing_secret_is_rejected(self) -> None:
+        r = CliRunner().invoke(_main(), ["connect", "aws", "--role-arn", "arn:aws:iam::1:role/ro"])
+        assert r.exit_code != 0
+        assert "--external-id" in r.output
+
+    def test_missing_sdk_degrades_with_install_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from agent_bom.cloud.base import CloudDiscoveryError
+
+        def _raise(*_a: object, **_k: object) -> None:
+            raise CloudDiscoveryError("boto3 is required to broker AWS connections. Install with: pip install 'agent-bom[aws]'")
+
+        monkeypatch.setattr("agent_bom.cloud.connection_broker.broker_session", _raise)
+        r = CliRunner().invoke(
+            _main(),
+            ["connect", "aws", "--role-arn", "arn:aws:iam::1:role/ro", "--external-id", SECRET],
+        )
+        assert r.exit_code == 0
+        assert "Cannot verify locally" in r.output
+        assert "agent-bom[aws]" in r.output
+        assert SECRET not in r.output
+
+
+# ── (c) API-register path uses the SAME CloudConnectionCreate schema ───────────
+
+
+class _FakeClient:
+    instances: list[_FakeClient] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.create_kwargs: dict[str, object] | None = None
+        self.tested: list[str] = []
+        self.scanned: list[str] = []
+        self.closed = False
+        _FakeClient.instances.append(self)
+
+    def create_cloud_connection(self, **kwargs: object) -> dict[str, object]:
+        self.create_kwargs = kwargs
+        return {"id": "conn-9", "provider": kwargs.get("provider")}
+
+    def test_cloud_connection(self, connection_id: str) -> dict[str, object]:
+        self.tested.append(connection_id)
+        return {"status": "ok"}
+
+    def scan_cloud_connection(self, connection_id: str) -> dict[str, object]:
+        self.scanned.append(connection_id)
+        return {"scan_id": "scan-1"}
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class TestServerRegister:
+    def test_register_and_test_send_schema_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _FakeClient.instances = []
+        monkeypatch.setattr("agent_bom.client.AgentBomClient", _FakeClient)
+        r = CliRunner().invoke(
+            _main(),
+            [
+                "connect", "aws",
+                "--role-arn", "arn:aws:iam::123456789012:role/ro",
+                "--external-id", SECRET,
+                "--region", "us-east-1",
+                "--server", "https://cp.example.com",
+                "--api-key", "k-123",
+                "--tenant", "tenant-a",
+            ],
+        )
+        assert r.exit_code == 0, r.output
+        assert "Registered" in r.output
+        assert "conn-9" in r.output
+        assert SECRET not in r.output
+
+        client = _FakeClient.instances[-1]
+        assert client.kwargs["base_url"] == "https://cp.example.com"
+        assert client.kwargs["api_key"] == "k-123"
+        assert client.kwargs["tenant_id"] == "tenant-a"
+        assert client.create_kwargs == {
+            "provider": "aws",
+            "display_name": "Amazon Web Services (read-only)",
+            "role_ref": "arn:aws:iam::123456789012:role/ro",
+            "external_id": SECRET,
+            "regions": ["us-east-1"],
+            "auth_params": {},
+        }
+        assert client.tested == ["conn-9"]
+        assert client.scanned == []
+        assert client.closed is True
+
+    def test_scan_flag_triggers_server_scan(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _FakeClient.instances = []
+        monkeypatch.setattr("agent_bom.client.AgentBomClient", _FakeClient)
+        r = CliRunner().invoke(
+            _main(),
+            [
+                "connect", "aws",
+                "--role-arn", "arn:aws:iam::1:role/ro",
+                "--external-id", SECRET,
+                "--server", "https://cp.example.com",
+                "--api-key", "k",
+                "--scan",
+            ],
+        )
+        assert r.exit_code == 0, r.output
+        assert _FakeClient.instances[-1].scanned == ["conn-9"]
+        assert "Scan:" in r.output
+
+    def test_server_without_api_key_is_rejected(self) -> None:
+        r = CliRunner().invoke(
+            _main(),
+            ["connect", "aws", "--role-arn", "arn:aws:iam::1:role/ro", "--external-id", SECRET, "--server", "https://cp"],
+        )
+        assert r.exit_code != 0
+        assert "--server and --api-key are both required" in r.output
+
+
+# ── Schema/client consistency: CLI body == CloudConnectionCreate ───────────────
+
+
+class TestSchemaConsistency:
+    def test_builder_body_matches_create_schema(self) -> None:
+        from agent_bom.api.routes.cloud_connections import CloudConnectionCreate
+        from agent_bom.cloud.connection_request import build_connection_create_body
+
+        body = build_connection_create_body(
+            provider="aws",
+            display_name="d",
+            role_ref="r",
+            external_id="s",
+            regions=["us-east-1"],
+            auth_params={"k": "v"},
+            scan_interval_minutes=60,
+        )
+        assert set(body) <= set(CloudConnectionCreate.model_fields)
+        # The body must validate against the API's own request model.
+        CloudConnectionCreate(**body)
+
+    def test_client_posts_create_body_to_v1_route(self) -> None:
+        from agent_bom.api.routes.cloud_connections import CloudConnectionCreate
+        from agent_bom.client import AgentBomClient
+
+        captured: dict[str, object] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            captured["method"] = request.method
+            captured["json"] = json.loads(request.content)
+            return httpx.Response(201, json={"id": "conn-1", "provider": "aws"})
+
+        client = AgentBomClient(
+            base_url="http://cp",
+            api_key="k",
+            tenant_id="t",
+            transport=httpx.MockTransport(handler),
+        )
+        try:
+            client.create_cloud_connection(
+                provider="aws",
+                display_name="d",
+                role_ref="r",
+                external_id=SECRET,
+                regions=["us-east-1"],
+            )
+        finally:
+            client.close()
+
+        assert captured["method"] == "POST"
+        assert str(captured["url"]).endswith("/v1/cloud/connections")
+        body = captured["json"]
+        assert body["external_id"] == SECRET
+        CloudConnectionCreate(**body)  # type: ignore[arg-type]


### PR DESCRIPTION
`agent-bom connect <provider>` was informational only — it printed grant options and the scan command but never created or tested a connection, while the API already had a full connection lifecycle. This makes `connect` actionable without diverging from the API.

- No connection flags → **unchanged** read-only onboarding guidance (back-compatible).
- With provider flags (aws `--role-arn`/`--external-id`/`--region`, and azure/gcp/snowflake equivalents) → **local verify**: broker a short-lived read-only credential and run a trivial bounded read-only probe (e.g. AWS `sts:GetCallerIdentity`) to prove it. Works standalone, no server; degrades with an `agent-bom[<extra>]` install hint when the SDK is missing.
- With `--server`/`--api-key` → **register** the connection with a control plane (`POST /v1/cloud/connections`) then `POST /test` (and `/scan` with `--scan`) — the identical connection the UI/API create.

**CLI and API share one connection model:** the same `CloudConnectionCreate` schema (via a small shared request-builder) and the same `connection_broker`. The connection secret (`external_id` etc.) is **write-only everywhere** — never printed or logged. Adds `create/test/scan_cloud_connection` to the Python client.

**Tests:** 16 new + 176 regression pass; ruff + mypy clean. Refs #3832.