### PR TITLE
fix(cli): correct Snowflake connect scan command (points at a removed surface)

### DIFF
--- a/src/agent_bom/cli/_entry_points.py
+++ b/src/agent_bom/cli/_entry_points.py
@@ -122,7 +122,7 @@ _CONNECT_SOURCES: dict[str, _ConnectSource] = {
         inventory_env="SNOWFLAKE_ACCOUNT",
         inventory_value="<your-account-locator>",
         cred_env_vars=("SNOWFLAKE_ACCOUNT", "SNOWFLAKE_USER", "SNOWFLAKE_PRIVATE_KEY_PATH"),
-        scan_command="agent-bom cloud snowflake",
+        scan_command="agent-bom scan --snowflake",
         role_summary="Read-only role (warehouse USAGE + governance views). No DML/DDL grants.",
     ),
 }

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -40,6 +40,22 @@ def test_public_docs_do_not_teach_removed_cli_surfaces() -> None:
         assert command not in combined
 
 
+def test_connect_sources_do_not_teach_removed_cli_surfaces() -> None:
+    # The `connect <provider>` guidance prints a scan command; it must point at a
+    # real surface, not a removed/misleading one (e.g. `agent-bom cloud snowflake`,
+    # which the cloud group does not register — Snowflake uses `scan --snowflake`).
+    from agent_bom.cli._entry_points import _CONNECT_SOURCES
+
+    removed_or_misleading = [
+        "agent-bom generate-sbom",
+        "agent-bom cloud snowflake",
+        "agent-bom cis-benchmark",
+    ]
+    for source in _CONNECT_SOURCES.values():
+        for bad in removed_or_misleading:
+            assert bad not in source.scan_command, f"{source.name} teaches removed surface: {source.scan_command}"
+
+
 def test_documented_primary_commands_are_real_cli_surfaces() -> None:
     runner = CliRunner()
     commands = [


### PR DESCRIPTION
Follow-up from the last-2-day reconciliation. `connect snowflake` printed `Next, run the read-only scan: agent-bom cloud snowflake` — but the cloud group registers **no** `snowflake` subcommand (it's listed in `test_public_docs_do_not_teach_removed_cli_surfaces`'s `removed_or_misleading`). Snowflake is scanned via `agent-bom scan --snowflake`. This shipped to main via #3842.

- Fix `_CONNECT_SOURCES["snowflake"].scan_command` → `agent-bom scan --snowflake`.
- Add `test_connect_sources_do_not_teach_removed_cli_surfaces` so any connect source pointing at a removed/misleading surface fails CI — closes the gap that let this slip through (the existing test only checked docs, not the connect code).

**Tests:** alignment + connect-establish suites 23 pass; ruff clean.