### PR TITLE
feat(ui): post-scan repo overview with surface chips

### DIFF
--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -587,6 +587,15 @@ def _ast_result_for_symbol_reach(paths: Iterable[str]) -> Any | None:
     return merged
 
 
+def _promote_repo_dependency_inventory(report: Any, ai_inventory: dict[str, Any]) -> None:
+    """Lift nested API dependency inventory to top-level for graph overlay parity with CLI."""
+    if getattr(report, "project_inventory_data", None):
+        return
+    nested = ai_inventory.get("dependency_inventory")
+    if isinstance(nested, dict) and nested:
+        report.project_inventory_data = nested
+
+
 def _run_scan_sync(job: ScanJob) -> None:
     """Run the full scan pipeline in a thread (blocking). Updates job in-place."""
     from contextlib import ExitStack
@@ -954,6 +963,7 @@ def _run_scan_sync(job: ScanJob) -> None:
                     report.iac_findings_data = iac_findings_data
                 if repo_ai_inventory_data is not None:
                     report.ai_inventory_data = repo_ai_inventory_data
+                    _promote_repo_dependency_inventory(report, repo_ai_inventory_data)
                 if repo_sast_data is not None:
                     report.sast_data = repo_sast_data
                 report_json = to_json(report)
@@ -1146,6 +1156,7 @@ def _run_scan_sync(job: ScanJob) -> None:
             report.iac_findings_data = iac_findings_data
         if repo_ai_inventory_data is not None:
             report.ai_inventory_data = repo_ai_inventory_data
+            _promote_repo_dependency_inventory(report, repo_ai_inventory_data)
         if repo_sast_data is not None:
             report.sast_data = repo_sast_data
         if req.vex:

--- a/tests/test_pipeline_repo_inventory_promote.py
+++ b/tests/test_pipeline_repo_inventory_promote.py
@@ -1,0 +1,25 @@
+"""Promote nested API dependency inventory for graph overlay parity."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent_bom.api.pipeline import _promote_repo_dependency_inventory
+
+
+def test_promote_repo_dependency_inventory_lifts_nested_dict() -> None:
+    report = SimpleNamespace(project_inventory_data=None)
+    _promote_repo_dependency_inventory(
+        report,
+        {"dependency_inventory": {"directories": [{"path": "src"}], "package_count": 3}},
+    )
+    assert report.project_inventory_data["package_count"] == 3
+
+
+def test_promote_repo_dependency_inventory_keeps_existing_top_level() -> None:
+    report = SimpleNamespace(project_inventory_data={"package_count": 9})
+    _promote_repo_dependency_inventory(
+        report,
+        {"dependency_inventory": {"package_count": 1}},
+    )
+    assert report.project_inventory_data["package_count"] == 9

--- a/ui/components/repo-scan-overview-panel.tsx
+++ b/ui/components/repo-scan-overview-panel.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import Link from "next/link";
+import { FolderTree, GitBranch, Info } from "lucide-react";
+
+import type { ScanResult } from "@/lib/api-types";
+import {
+  deriveRepoSurfaceEvidence,
+  repoGraphHref,
+  repoInventoryStats,
+} from "@/lib/repo-scan-overview";
+
+export function RepoScanOverviewPanel({
+  scanId,
+  repoUrl,
+  result,
+}: {
+  scanId: string;
+  repoUrl: string;
+  result: ScanResult;
+}) {
+  const surfaces = deriveRepoSurfaceEvidence(result);
+  const foundCount = surfaces.filter((surface) => surface.state === "found").length;
+  const stats = repoInventoryStats(result);
+
+  return (
+    <section
+      className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4"
+      data-testid="repo-scan-overview"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+            Repo overview
+          </p>
+          <h2 className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">Static inventory from this clone</h2>
+          <p className="mt-1 break-all font-mono text-xs text-[color:var(--text-secondary)]">{repoUrl}</p>
+          <p className="mt-2 max-w-2xl text-xs text-[color:var(--text-tertiary)]">
+            Public URLs need no token. Private repos use a server-side{" "}
+            <code className="text-[color:var(--text-secondary)]">AGENT_BOM_REPO_SCAN_TOKEN</code> or a local{" "}
+            <code className="text-[color:var(--text-secondary)]">--project</code> path — static parse only, not dynamic
+            app testing.
+          </p>
+        </div>
+        <Link
+          href={repoGraphHref(scanId)}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-700/40 bg-emerald-950/30 px-3 py-1.5 text-xs font-medium text-emerald-200 hover:border-emerald-500/50"
+        >
+          <GitBranch className="h-3.5 w-3.5" />
+          Open folder graph
+        </Link>
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-4">
+        <Mini label="Surfaces with evidence" value={String(foundCount)} />
+        <Mini label="Directories" value={stats.directories != null ? String(stats.directories) : "—"} />
+        <Mini label="Packages" value={stats.packages != null ? String(stats.packages) : "—"} />
+        <Mini label="Lockfiles" value={stats.lockfiles != null ? String(stats.lockfiles) : "—"} />
+      </div>
+
+      <div className="mt-4">
+        <div className="mb-2 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">
+          <FolderTree className="h-3 w-3" />
+          Surface coverage
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {surfaces.map((surface) => (
+            <span
+              key={surface.id}
+              title={surface.detail}
+              className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] ${
+                surface.state === "found"
+                  ? "border-emerald-600/40 bg-emerald-500/10 text-emerald-100"
+                  : "border-dashed border-[color:var(--border-subtle)] text-[color:var(--text-tertiary)]"
+              }`}
+            >
+              <span
+                className={`h-1.5 w-1.5 rounded-full ${
+                  surface.state === "found" ? "bg-emerald-400" : "bg-[color:var(--border-strong)]"
+                }`}
+                aria-hidden
+              />
+              {surface.label}
+            </span>
+          ))}
+        </div>
+        <p className="mt-2 flex items-start gap-1.5 text-[11px] text-[color:var(--text-tertiary)]">
+          <Info className="mt-0.5 h-3 w-3 shrink-0" />
+          Solid chips have evidence in this result. Dashed chips are in the catalog but produced no signal on this clone.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function Mini({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2">
+      <p className="text-[10px] uppercase tracking-wide text-[color:var(--text-tertiary)]">{label}</p>
+      <p className="mt-0.5 font-mono text-sm font-semibold text-[color:var(--foreground)]">{value}</p>
+    </div>
+  );
+}

--- a/ui/components/scan-result.tsx
+++ b/ui/components/scan-result.tsx
@@ -6,6 +6,7 @@ import { api, type ScanJob, type ScanJobStatus, type ScanResult, type BlastRadiu
 import { useScanStream } from "@/lib/use-scan-stream";
 import { mergePipelineSteps, parsePipelineStepsFromProgress } from "@/lib/scan-pipeline-progress";
 import { ScanPipeline } from "@/components/scan-pipeline";
+import { RepoScanOverviewPanel } from "@/components/repo-scan-overview-panel";
 import { SeverityBadge } from "@/components/severity-badge";
 import { StatCard } from "@/components/stat-card";
 import {
@@ -102,6 +103,10 @@ export function ScanResultView({ id }: { id: string }) {
   const summary = result?.summary;
   const blastRadius = result?.blast_radius ?? [];
   const cloudEvidence = result ? summarizeCloudEvidence(result) : null;
+  const repoUrl =
+    typeof job?.request?.repo_url === "string" && job.request.repo_url.trim()
+      ? job.request.repo_url.trim()
+      : null;
 
   async function handleExport(format: GraphExportFormat = "json") {
     setExporting(true);
@@ -209,6 +214,8 @@ export function ScanResultView({ id }: { id: string }) {
           <MiniStat label="Critical" value={summary.critical_findings} accent="red" />
         </div>
       )}
+
+      {repoUrl && result ? <RepoScanOverviewPanel scanId={id} repoUrl={repoUrl} result={result} /> : null}
 
       {cloudEvidence ? <CloudEvidencePanel evidence={cloudEvidence} /> : null}
 

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -93,6 +93,12 @@ export interface ScanResult {
   gcp_cis_benchmark?: unknown | undefined;
   snowflake_cis_benchmark?: unknown | undefined;
   databricks_cis_benchmark?: unknown | undefined;
+  /** Static repo extras (API clone / CLI project path). */
+  ai_inventory?: Record<string, unknown> | undefined;
+  project_inventory?: Record<string, unknown> | undefined;
+  skill_audit?: Record<string, unknown> | undefined;
+  iac_findings?: unknown | undefined;
+  sast?: Record<string, unknown> | undefined;
 }
 
 export interface GraphPagination {

--- a/ui/lib/repo-scan-overview.ts
+++ b/ui/lib/repo-scan-overview.ts
@@ -1,0 +1,151 @@
+/**
+ * Post-scan repo overview: which static surfaces produced evidence on this job.
+ * Catalog labels come from REPO_SCAN_SURFACES; state is evidence-backed, not a DAST claim.
+ */
+
+import type { ScanResult } from "@/lib/api-types";
+import { REPO_SCAN_SURFACES, type RepoScanSurface } from "@/lib/repo-scan-surfaces";
+
+export type RepoSurfaceEvidenceState = "found" | "idle";
+
+export type RepoSurfaceEvidence = {
+  id: string;
+  label: string;
+  detail: string;
+  state: RepoSurfaceEvidenceState;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value != null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function nonempty(value: unknown): boolean {
+  if (value == null) return false;
+  if (Array.isArray(value)) return value.length > 0;
+  if (typeof value === "object") return Object.keys(value as object).length > 0;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (typeof value === "number") return value > 0;
+  return Boolean(value);
+}
+
+/** Prefer top-level project_inventory; fall back to nested AI inventory (API repo path). */
+export function resolveProjectInventory(result: ScanResult | null | undefined): Record<string, unknown> | null {
+  if (!result) return null;
+  const top = asRecord((result as ScanResult & { project_inventory?: unknown }).project_inventory);
+  if (top) return top;
+  const ai = asRecord((result as ScanResult & { ai_inventory?: unknown }).ai_inventory);
+  return asRecord(ai?.dependency_inventory);
+}
+
+export function repoGraphHref(scanId: string): string {
+  const layers = "directory,source_file,config_file,package,framework,vulnerability";
+  return `/graph?scan_id=${encodeURIComponent(scanId)}&layers=${encodeURIComponent(layers)}`;
+}
+
+/**
+ * Map completed scan result extras onto the honest surface catalog.
+ * Surfaces without evidence stay idle (catalog only) — never claim a scan ran them dynamically.
+ */
+export function deriveRepoSurfaceEvidence(result: ScanResult | null | undefined): RepoSurfaceEvidence[] {
+  const ai = asRecord((result as ScanResult & { ai_inventory?: unknown } | undefined)?.ai_inventory);
+  const inventory = resolveProjectInventory(result);
+  const skillAudit = asRecord((result as ScanResult & { skill_audit?: unknown } | undefined)?.skill_audit);
+  const iac = (result as ScanResult & { iac_findings?: unknown } | undefined)?.iac_findings;
+  const sast = asRecord((result as ScanResult & { sast?: unknown } | undefined)?.sast);
+  const agents = result?.agents ?? [];
+  const warnings = result?.warnings ?? [];
+  const warningBlob = warnings.join(" ").toLowerCase();
+
+  const found = new Set<string>();
+
+  if (nonempty(inventory) || (result?.summary?.total_packages ?? 0) > 0) {
+    found.add("dependencies");
+  }
+  if (nonempty(ai?.secrets) || /secret/.test(warningBlob)) {
+    found.add("secrets");
+  }
+  if (nonempty(ai?.weak_crypto) || /weak.?crypto|md5|sha-1/.test(warningBlob)) {
+    found.add("weak-crypto");
+  }
+  if (
+    nonempty(ai?.sdk_imports) ||
+    nonempty(ai?.components) ||
+    nonempty(ai?.models) ||
+    nonempty(ai?.observability) ||
+    (typeof ai?.total_components === "number" && ai.total_components > 0)
+  ) {
+    found.add("ai-inventory");
+  }
+  if (nonempty(skillAudit) || nonempty(ai?.skills)) {
+    found.add("skills");
+  }
+  if (nonempty(iac)) {
+    found.add("iac");
+    const iacText = JSON.stringify(iac).toLowerCase();
+    if (iacText.includes("terraform") || iacText.includes("hcl")) {
+      found.add("terraform");
+    }
+    if (iacText.includes("github") && iacText.includes("action")) {
+      found.add("github-actions");
+    }
+  }
+  if (
+    sast != null &&
+    (nonempty(sast.findings) ||
+      nonempty(sast.results) ||
+      (typeof sast.count === "number" && sast.count > 0))
+  ) {
+    found.add("sast");
+  }
+  if (agents.some((agent) => (agent.mcp_servers?.length ?? 0) > 0)) {
+    found.add("mcp-config");
+  }
+  if (
+    agents.some((agent) => {
+      const type = (agent.agent_type || "").toLowerCase();
+      return type.includes("lang") || type.includes("crew") || type.includes("autogen") || type.includes("framework");
+    }) ||
+    nonempty(ai?.frameworks)
+  ) {
+    found.add("agent-frameworks");
+  }
+  if (nonempty(ai?.notebooks) || /jupyter|\.ipynb/.test(JSON.stringify(ai ?? {}))) {
+    found.add("jupyter");
+  }
+  if (nonempty(ai?.ingestion) || nonempty(ai?.data_pipelines)) {
+    found.add("ingestion");
+  }
+
+  // Connectors are never part of git repo scans — always idle here.
+  return REPO_SCAN_SURFACES.filter((surface) => surface.id !== "connectors").map((surface: RepoScanSurface) => ({
+    id: surface.id,
+    label: surface.label,
+    detail: surface.detail,
+    state: found.has(surface.id) ? ("found" as const) : ("idle" as const),
+  }));
+}
+
+export function repoInventoryStats(result: ScanResult | null | undefined): {
+  directories: number | null;
+  packages: number | null;
+  lockfiles: number | null;
+} {
+  const inventory = resolveProjectInventory(result);
+  if (!inventory) {
+    return {
+      directories: null,
+      packages: result?.summary?.total_packages ?? null,
+      lockfiles: null,
+    };
+  }
+  const dirs = inventory.directories ?? inventory.dirs;
+  const packages = inventory.package_count ?? inventory.packages ?? result?.summary?.total_packages;
+  const lockfiles = inventory.lockfiles ?? inventory.lockfile_count;
+  return {
+    directories: Array.isArray(dirs) ? dirs.length : typeof dirs === "number" ? dirs : null,
+    packages: typeof packages === "number" ? packages : Array.isArray(packages) ? packages.length : null,
+    lockfiles: Array.isArray(lockfiles) ? lockfiles.length : typeof lockfiles === "number" ? lockfiles : null,
+  };
+}

--- a/ui/tests/repo-scan-overview.test.ts
+++ b/ui/tests/repo-scan-overview.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import type { ScanResult } from "@/lib/api-types";
+import {
+  deriveRepoSurfaceEvidence,
+  repoGraphHref,
+  resolveProjectInventory,
+} from "@/lib/repo-scan-overview";
+
+describe("repo-scan-overview", () => {
+  it("resolves nested dependency inventory from API repo scans", () => {
+    const result = {
+      agents: [],
+      blast_radius: [],
+      ai_inventory: {
+        dependency_inventory: { directories: ["src", "tests"], package_count: 12 },
+        secrets: { findings: [{ id: "1" }] },
+      },
+    } as ScanResult;
+
+    expect(resolveProjectInventory(result)?.package_count).toBe(12);
+    const surfaces = deriveRepoSurfaceEvidence(result);
+    expect(surfaces.find((s) => s.id === "dependencies")?.state).toBe("found");
+    expect(surfaces.find((s) => s.id === "secrets")?.state).toBe("found");
+    expect(surfaces.find((s) => s.id === "connectors")).toBeUndefined();
+  });
+
+  it("builds a folder-layer graph deep link for the scan", () => {
+    expect(repoGraphHref("job-abc")).toContain("scan_id=job-abc");
+    expect(repoGraphHref("job-abc")).toContain("directory");
+    expect(repoGraphHref("job-abc")).toContain("framework");
+  });
+});


### PR DESCRIPTION
## Summary
- Post-scan **Repo overview** on `/scan?id=` when `repo_url` is present: stats, surface coverage chips, graph deep-link.
- Honest private-token / static-only copy (no DAST claims).
- Promote API `ai_inventory.dependency_inventory` → `project_inventory` so folder graph overlays match CLI.

Closes #3806

## Verification
- `uv run pytest tests/test_pipeline_repo_inventory_promote.py -q`
- `cd ui && npm test -- --run repo-scan-overview`
- `cd ui && npm run typecheck`