### PR TITLE
docs(readme): add read-only live demo link to the hero row

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 <p align="center">Headless agent primitives and human cockpit surfaces over one shared evidence model.</p>
 
 <p align="center">
+  <a href="https://demo.agent-bom.com"><b>Live demo</b></a> (read-only sandbox) ·
   <a href="https://msaad00.github.io/agent-bom/">Docs</a> ·
   <a href="docs/FIRST_RUN.md">First Run</a> ·
   <a href="site-docs/deployment/overview.md">Self-host</a> ·


### PR DESCRIPTION
Adds a hero **Live demo** link to the always-on anonymous sandbox at demo.agent-bom.com (read-only estate, verified healthy), next to Docs. Labeled 'read-only sandbox' so it reads as a try-it demo, not managed SaaS; Self-host stays in the row as the real path.