### PR TITLE
chore(deps): group cloud + AI provider SDK bumps in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,20 @@ updates:
       - "dependencies"
       - "python"
     open-pull-requests-limit: 10
+    groups:
+      # Keep the BYOC cloud + AI provider SDKs current together, so new provider
+      # APIs land and deprecations are picked up without a swarm of individual
+      # PRs. boto3/botocore are data-driven (new AWS APIs arrive via bumps).
+      cloud-and-ai-sdks:
+        patterns:
+          - "boto3"
+          - "botocore"
+          - "azure-*"
+          - "google-*"
+          - "snowflake-*"
+          - "huggingface*"
+          - "litellm"
+          - "ollama"
 
   - package-ecosystem: "npm"
     directory: "/ui"


### PR DESCRIPTION
boto3/botocore/azure-*/google-*/snowflake-*/huggingface*/litellm/ollama now bump as one grouped PR instead of scattered individual ones, so new provider APIs land and deprecations get picked up promptly. Part of the currency strategy in #3835.