### PR TITLE
docs(release): combine demo, provider onboarding, and SDK maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,20 @@ updates:
       - "dependencies"
       - "python"
     open-pull-requests-limit: 10
+    groups:
+      # Keep the BYOC cloud + AI provider SDKs current together, so new provider
+      # APIs land and deprecations are picked up without a swarm of individual
+      # PRs. boto3/botocore are data-driven (new AWS APIs arrive via bumps).
+      cloud-and-ai-sdks:
+        patterns:
+          - "boto3"
+          - "botocore"
+          - "azure-*"
+          - "google-*"
+          - "snowflake-*"
+          - "huggingface*"
+          - "litellm"
+          - "ollama"
 
   - package-ecosystem: "npm"
     directory: "/ui"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 <p align="center">Headless agent primitives and human cockpit surfaces over one shared evidence model.</p>
 
 <p align="center">
+  <a href="https://demo.agent-bom.com"><b>Live demo</b></a> (read-only sandbox) ·
   <a href="https://msaad00.github.io/agent-bom/">Docs</a> ·
   <a href="docs/FIRST_RUN.md">First Run</a> ·
   <a href="site-docs/deployment/overview.md">Self-host</a> ·

--- a/docs/DEPLOY_QUICKSTART.md
+++ b/docs/DEPLOY_QUICKSTART.md
@@ -298,7 +298,27 @@ scripts/deploy/install.sh connect gcp
 scripts/deploy/install.sh connect snowflake
 ```
 
-Each module prints outputs (role ARN, external ID, etc.). Register them:
+The wrapper calls `agent-bom connect <provider>`. With no flags it prints the
+exact read-only grant to paste into your cloud shell; add the connection flags
+and it establishes **and verifies** the credential in-process, and with
+`--server/--api-key` it registers the identical connection the UI/API create
+(`POST /v1/cloud/connections` → test). Append `--scan` to launch inventory the
+moment it verifies.
+
+| Provider | Read-only grant | Establish + verify | Scan |
+|----------|-----------------|--------------------|------|
+| **AWS** | IAM `SecurityAudit` (+ `ViewOnlyAccess`) — List/Describe/Get only | `agent-bom connect aws --role-arn <arn> --external-id <id> --region <r>` | `agent-bom scan --aws` |
+| **Azure** | Service principal with built-in `Reader` role | `agent-bom connect azure --client-id <id> --client-secret <s> --tenant-id <t> --subscription-id <sub>` | `agent-bom scan --azure` |
+| **GCP** | Service account with `roles/viewer` (+ `roles/iam.securityReviewer`) | `agent-bom connect gcp --service-account <email> --key-file <json> --project <id>` | `agent-bom scan --gcp` |
+| **Snowflake** | Read-only role — warehouse `USAGE` + governance views, no DML/DDL | `agent-bom connect snowflake --account <acct> --user <u> --private-key-file <pem> --role <role> --warehouse <wh>` | `agent-bom scan --snowflake` |
+
+Grants come from the read-only `connect-*` Terraform modules under
+[`deploy/terraform/`](../deploy/terraform/) (`connect-aws`, `connect-azure`,
+`connect-gcp`, `connect-snowflake`) or the paste-ready recipes under
+[`scripts/provision/`](../scripts/provision/). Secrets (`--external-id`, client
+secret, key files) are write-only — never printed or logged.
+
+Register the printed role/principal:
 
 - **API:** `POST /v1/cloud/connections` → test → scan
 - **Helm:** `scanner.cloud.<provider>.inventory=true` in values


### PR DESCRIPTION
## Summary

- add the read-only live demo link to the README hero row
- document per-provider read-only grants, connection verification, and scan commands for AWS, Azure, GCP, and Snowflake
- group cloud and AI provider SDK updates into one Dependabot pull request

Supersedes #3852, #3853, and #3854.

## Verification

- `uv tool run --from mkdocs==1.6.1 --with mkdocs-material==9.7.5 --with mkdocstrings==1.0.3 --with mkdocstrings-python==2.0.3 mkdocs build --strict`
- `uv run pytest -q tests/test_docker_base_policy.py tests/test_version_accuracy.py` (44 passed)
- `python scripts/check_release_consistency.py`
- `python scripts/check_product_surface_contract.py`
- Dependabot YAML parse and exact group-pattern assertion
- live demo returned HTTP 200
- provider flags and scan commands verified against CLI help
- `git diff --check origin/main...HEAD`

## Notes

The canceled checks on the three source PRs were superseded workflow runs, not observed code or test failures. This combined branch starts a single clean CI run.
