### PR TITLE
fix(ui): dedupe live-investigation panel, graph readability, HUD mark polish, overview consolidation

### DIFF
--- a/docs/images/brand/mark-dark.svg
+++ b/docs/images/brand/mark-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark — BOM with detailed agent in the O">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark — BOM with an agent HUD in the O">
   <defs>
     <linearGradient id="abm" x1="8" y1="6" x2="56" y2="58" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#34d399"/>
@@ -8,28 +8,14 @@
   <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#0c1210" stroke="url(#abm)" stroke-width="2"/>
   <!-- B -->
   <path fill="url(#abm)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
-  <!-- Detailed agent as the O: helmet + visor + side sensors + jaw + antenna -->
-  <circle cx="32" cy="30.2" r="12.2" fill="none" stroke="url(#abm)" stroke-width="2.2"/>
-  <!-- helmet fill -->
-  <path fill="#111a17" stroke="url(#abm)" stroke-width="1.15"
-        d="M22.8 30.2c0-5.1 4.1-9.2 9.2-9.2s9.2 4.1 9.2 9.2c0 2.55-1.05 4.85-2.7 6.5l-1.4 1.35c-.7.65-1.7 1.05-2.75 1.05h-4.7c-1.05 0-2.05-.4-2.75-1.05l-1.4-1.35a9.15 9.15 0 0 1-2.7-6.5z"/>
-  <!-- visor band -->
-  <rect x="24.2" y="26.2" width="15.6" height="5.2" rx="2.2" fill="#0c1210" stroke="url(#abm)" stroke-width="1"/>
-  <!-- eyes -->
-  <rect x="25.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#34d399"/>
-  <rect x="33.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#06b6d4"/>
-  <!-- eye glow dots -->
-  <circle cx="27.2" cy="28.8" r="0.7" fill="#ecfdf5"/>
-  <circle cx="35.2" cy="28.8" r="0.7" fill="#ecfeff"/>
-  <!-- jaw / status bar -->
-  <path d="M26.2 35.4h11.6" fill="none" stroke="url(#abm)" stroke-width="1.8" stroke-linecap="round"/>
-  <path d="M28.2 37.6h7.6" fill="none" stroke="#06b6d4" stroke-width="1.2" stroke-linecap="round" opacity="0.7"/>
-  <!-- side sensors -->
-  <path d="M21.4 29.2h1.8M40.8 29.2h1.8" stroke="url(#abm)" stroke-width="1.5" stroke-linecap="round"/>
-  <!-- antenna -->
-  <path d="M32 18.8V13.8" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
-  <circle cx="32" cy="12.2" r="2.1" fill="url(#abm)"/>
-  <circle cx="32" cy="12.2" r="0.85" fill="#0c1210"/>
+  <!-- O as the agent HUD: ring + antenna + visor + status bar (one consistent stroke system) -->
+  <circle cx="32" cy="30.2" r="12" fill="#0f1a17" stroke="url(#abm)" stroke-width="2.4"/>
+  <path d="M32 18.2V14" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
+  <circle cx="32" cy="12.4" r="2" fill="url(#abm)"/>
+  <rect x="24.6" y="26" width="14.8" height="6.6" rx="3.3" fill="#0b1512" stroke="url(#abm)" stroke-width="1.6"/>
+  <rect x="26.9" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#34d399"/>
+  <rect x="33.2" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#22d3ee"/>
+  <path d="M27.6 36h8.8" stroke="url(#abm)" stroke-width="1.8" stroke-linecap="round"/>
   <!-- M -->
   <path fill="url(#abm)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
   <!-- materials ticks -->

--- a/docs/images/brand/mark-light.svg
+++ b/docs/images/brand/mark-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark — BOM with detailed agent in the O">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark — BOM with an agent HUD in the O">
   <defs>
     <linearGradient id="abm" x1="8" y1="6" x2="56" y2="58" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#059669"/>
@@ -8,23 +8,17 @@
   <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#f8fafc" stroke="url(#abm)" stroke-width="2"/>
   <!-- B -->
   <path fill="url(#abm)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
-  <!-- Detailed agent as the O -->
-  <circle cx="32" cy="30.2" r="12.2" fill="none" stroke="url(#abm)" stroke-width="2.2"/>
-  <path fill="#ecfdf5" stroke="url(#abm)" stroke-width="1.15"
-        d="M22.8 30.2c0-5.1 4.1-9.2 9.2-9.2s9.2 4.1 9.2 9.2c0 2.55-1.05 4.85-2.7 6.5l-1.4 1.35c-.7.65-1.7 1.05-2.75 1.05h-4.7c-1.05 0-2.05-.4-2.75-1.05l-1.4-1.35a9.15 9.15 0 0 1-2.7-6.5z"/>
-  <rect x="24.2" y="26.2" width="15.6" height="5.2" rx="2.2" fill="#f8fafc" stroke="url(#abm)" stroke-width="1"/>
-  <rect x="25.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#059669"/>
-  <rect x="33.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#0891b2"/>
-  <circle cx="27.2" cy="28.8" r="0.7" fill="#ffffff"/>
-  <circle cx="35.2" cy="28.8" r="0.7" fill="#ffffff"/>
-  <path d="M26.2 35.4h11.6" fill="none" stroke="url(#abm)" stroke-width="1.8" stroke-linecap="round"/>
-  <path d="M28.2 37.6h7.6" fill="none" stroke="#0891b2" stroke-width="1.2" stroke-linecap="round" opacity="0.7"/>
-  <path d="M21.4 29.2h1.8M40.8 29.2h1.8" stroke="url(#abm)" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M32 18.8V13.8" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
-  <circle cx="32" cy="12.2" r="2.1" fill="url(#abm)"/>
-  <circle cx="32" cy="12.2" r="0.85" fill="#f8fafc"/>
+  <!-- O as the agent HUD: ring + antenna + visor + status bar (one consistent stroke system) -->
+  <circle cx="32" cy="30.2" r="12" fill="#ecfdf5" stroke="url(#abm)" stroke-width="2.4"/>
+  <path d="M32 18.2V14" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
+  <circle cx="32" cy="12.4" r="2" fill="url(#abm)"/>
+  <rect x="24.6" y="26" width="14.8" height="6.6" rx="3.3" fill="#ffffff" stroke="url(#abm)" stroke-width="1.6"/>
+  <rect x="26.9" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#059669"/>
+  <rect x="33.2" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#0891b2"/>
+  <path d="M27.6 36h8.8" stroke="url(#abm)" stroke-width="1.8" stroke-linecap="round"/>
   <!-- M -->
   <path fill="url(#abm)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
+  <!-- materials ticks -->
   <rect x="10" y="48.5" width="12" height="2.4" rx="1.2" fill="#059669" fill-opacity="0.4"/>
   <rect x="26" y="48.5" width="12" height="2.4" rx="1.2" fill="url(#abm)"/>
   <rect x="42" y="48.5" width="12" height="2.4" rx="1.2" fill="#0891b2" fill-opacity="0.4"/>

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -677,7 +677,7 @@ export default function ConnectionsPage() {
             />
           ) : (
             <div className="overflow-x-auto rounded-xl border border-[color:var(--border-subtle)]">
-              <table className="w-full min-w-[880px] border-collapse text-left text-sm">
+              <table className="w-full min-w-[1040px] border-collapse text-left text-sm">
                 <thead>
                   <tr className="border-b border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[11px] uppercase tracking-[0.16em] text-[var(--text-tertiary)]">
                     <th className="px-4 py-3 font-medium">Account</th>
@@ -1005,10 +1005,13 @@ function FragmentRow({
     <>
       <tr className="border-b border-[color:var(--border-subtle)] last:border-b-0 align-top">
         <td className="px-4 py-3">
-          <p className="font-medium text-[var(--foreground)]">
+          <p className="max-w-[220px] truncate font-medium text-[var(--foreground)]" title={connection.display_name}>
             {connection.display_name}
           </p>
-          <p className="mt-0.5 break-all font-mono text-[11px] text-[var(--text-tertiary)]">
+          <p
+            className="mt-0.5 max-w-[220px] truncate font-mono text-[11px] text-[var(--text-tertiary)]"
+            title={connection.role_ref}
+          >
             {connection.role_ref}
           </p>
           <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
@@ -1033,15 +1036,15 @@ function FragmentRow({
           </div>
         </td>
         <td className="px-4 py-3">
-          <span className="inline-flex items-center gap-2 text-[var(--text-secondary)]">
-            <ProviderLogo provider={connection.provider} className="h-4 w-4" />
+          <span className="inline-flex items-center gap-2 whitespace-nowrap text-[var(--text-secondary)]">
+            <ProviderLogo provider={connection.provider} className="h-4 w-4 shrink-0" />
             {providerLabel(connection.provider)}
           </span>
         </td>
         <td className="px-4 py-3">
           <StatusPill status={connection.status} />
         </td>
-        <td className="px-4 py-3 text-[var(--text-secondary)]">
+        <td className="whitespace-nowrap px-4 py-3 text-[var(--text-secondary)]">
           {formatWhen(connection.last_scan_at)}
         </td>
         <td className="px-4 py-3">

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -427,17 +427,6 @@ function SecurityGraphPageContent() {
         />
       )}
 
-      {graphData && selectedAttackPath && (
-        <SecurityGraphInvestigation
-          graph={graphData as UnifiedGraphData}
-          attackPath={selectedAttackPath}
-          focusMode={investigationFocusMode}
-          onFocusModeChange={setInvestigationFocusMode}
-          fullGraphHref={fullGraphHref}
-          loading={loadingGraph}
-        />
-      )}
-
       <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="min-w-0 flex-1">

--- a/ui/components/brand-logo.tsx
+++ b/ui/components/brand-logo.tsx
@@ -3,7 +3,7 @@
 import { useThemeMode } from "@/lib/theme-mode";
 
 /** Bump when mark/wordmark SVGs change so browsers drop stale caches. */
-const BRAND_ASSET_REV = "v9";
+const BRAND_ASSET_REV = "v10";
 
 /**
  * Product name is always `agent-bom`. The mark is BOM with an agent HUD in the O

--- a/ui/components/exposure-path-command-center.tsx
+++ b/ui/components/exposure-path-command-center.tsx
@@ -223,15 +223,21 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
             strokeLinecap="round"
             markerEnd="url(#exposure-arrow)"
             opacity="0.88"
-          >
-            <title>{edge.label}</title>
-          </path>
+          />
         ))}
 
         {layout.relationshipLabels.map((label) => (
           <g key={label.id} transform={`translate(${label.x} ${label.y})`}>
-            <rect x="-48" y="-10" width="96" height="20" rx="10" fill="#0f172a" stroke="#334155" />
-            <text x="0" y="4" textAnchor="middle" fill="#cbd5e1" fontSize="10" fontFamily="var(--font-mono), monospace">
+            <rect
+              x={-label.width / 2}
+              y="-11"
+              width={label.width}
+              height="22"
+              rx="11"
+              fill="#0f172a"
+              stroke="#334155"
+            />
+            <text x="0" y="4" textAnchor="middle" fill="#cbd5e1" fontSize="11" fontFamily="var(--font-mono), monospace">
               {label.text}
             </text>
           </g>
@@ -277,22 +283,30 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
 }
 
 function buildPathGraphLayout(path: ExposurePath) {
-  const width = 980;
-  const nodeWidth = 196;
-  const nodeHeight = 78;
+  // Geometry note: nodes are spaced with a generous horizontal gap so the
+  // relationship pill sits centred in the clear channel between two node boxes
+  // — never overlapping a node or getting clipped at the container edge. The
+  // SVG scales to its container via viewBox, so a wider board just renders a
+  // little smaller; it never crowds the labels.
+  const nodeWidth = 188;
+  const nodeHeight = 76;
+  const marginX = 28;
+  const marginY = 30;
+  const columnGap = 132;
+  const rowGap = 116;
   const columns = Math.min(4, Math.max(1, path.hops.length));
   const rows = Math.max(1, Math.ceil(path.hops.length / columns));
-  const xGap = columns > 1 ? (width - nodeWidth - 48) / (columns - 1) : 0;
-  const yGap = 108;
-  const height = 40 + rows * nodeHeight + (rows - 1) * (yGap - nodeHeight) + 24;
+  const pitchX = nodeWidth + columnGap;
+  const width = marginX * 2 + columns * nodeWidth + (columns - 1) * columnGap;
+  const height = marginY * 2 + rows * nodeHeight + (rows - 1) * (rowGap - nodeHeight);
   const nodes = path.hops.map((hop, index) => {
     const row = Math.floor(index / columns);
     const col = index % columns;
     const visualCol = row % 2 === 0 ? col : columns - 1 - col;
     return {
       ...hop,
-      x: 24 + visualCol * xGap,
-      y: 28 + row * yGap,
+      x: marginX + visualCol * pitchX,
+      y: marginY + row * rowGap,
     };
   });
   const edges = nodes.slice(0, -1).map((source, index) => {
@@ -312,16 +326,18 @@ function buildPathGraphLayout(path: ExposurePath) {
       id: `${source.id}->${target.id}`,
       path: pathD,
       stroke: style.stroke,
-      label: relationship,
-      labelX: sameRow ? (startX + endX) / 2 : (source.x + target.x + nodeWidth) / 2,
-      labelY: sameRow ? startY - 14 : (source.y + target.y + nodeHeight) / 2,
+      label: truncateGraphText(relationship, 16),
+      // Centre the pill on the edge line, mid-channel between the two nodes.
+      labelX: sameRow ? (startX + endX) / 2 : source.x + nodeWidth / 2,
+      labelY: sameRow ? startY : (source.y + nodeHeight + target.y) / 2,
     };
   });
   const relationshipLabels = edges.map((edge) => ({
     id: `${edge.id}:label`,
-    text: truncateGraphText(edge.label, 12),
+    text: edge.label,
     x: edge.labelX,
     y: edge.labelY,
+    width: Math.max(50, Math.round(edge.label.length * 6.6 + 22)),
   }));
 
   return { width, height, nodeWidth, nodeHeight, nodes, edges, relationshipLabels };

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 
-import type { OverviewDomain, OverviewResponse } from "@/lib/api";
+import type { OverviewResponse } from "@/lib/api";
 import type { ServiceEntry, ServiceId } from "@/lib/api-types";
 import { Collapsible } from "@/components/collapsible";
 import { FrameworkIcon } from "@/components/framework-icon";
@@ -16,7 +16,6 @@ import {
   type IssueType,
   type SeverityBand,
 } from "@/lib/finding-issue-type";
-import { SERVICE_META, serviceStateLabel } from "@/lib/service-registry";
 
 export interface ExposurePathView {
   nodes: { type: "cve" | "package" | "server" | "agent" | "credential"; label: string; severity?: string }[];
@@ -83,35 +82,22 @@ export function OverviewCockpit({
   kev,
   credentials,
   agents,
-  cves,
   scans,
+  latestScan,
   summaryReady,
   severity,
   issueMatrix = null,
   domains,
   topPath,
   exposurePaths,
-  signals,
   compliance = null,
   services = null,
 }: OverviewCockpitProps) {
-  const domainList = domains ? Object.values(domains) : [];
-  const activeDomains = domainList.filter((domain) => domain.status !== "idle").length;
-  const coverage = domainList.length > 0 ? Math.round((activeDomains / domainList.length) * 100) : null;
+  const hasScanEvidence = Boolean(summaryReady && scans && scans > 0);
   const complianceScore =
-    summaryReady && scans != null && scans > 0 && compliance != null && hasEvaluatedCompliance(compliance)
+    hasScanEvidence && compliance != null && hasEvaluatedCompliance(compliance)
       ? `${Math.round(compliance.overallScore)}%`
       : undefined;
-
-  // Connected estate — real/zero surfaces that exist independent of any scan, so
-  // the exec read is never just "Awaiting scan".
-  const cloudAccounts = services?.cloud_accounts?.count ?? 0;
-  const liveServices = signals.activeServices;
-  const estateBits: string[] = [];
-  if (agents != null && agents > 0) estateBits.push(`${agents} agent${agents === 1 ? "" : "s"}`);
-  if (cloudAccounts > 0) estateBits.push(`${cloudAccounts} cloud account${cloudAccounts === 1 ? "" : "s"}`);
-  if (liveServices > 0) estateBits.push(`${liveServices} live service${liveServices === 1 ? "" : "s"}`);
-  const connectedSummary = estateBits.length > 0 ? `${estateBits.join(" · ")} connected` : null;
 
   return (
     <div className="space-y-4">
@@ -121,18 +107,19 @@ export function OverviewCockpit({
             Command center
           </p>
           <p className="mt-1 text-xs text-[color:var(--text-secondary)]">
-            Posture, open issues, compliance, and the connected estate — one exec read.
+            Posture and open issues across every lane — one exec read.
           </p>
         </div>
 
-        <div className="grid gap-5 lg:grid-cols-[auto_minmax(0,1fr)_auto] lg:items-start">
+        {/* 1 — Posture headline + open issues by severity */}
+        <div className="grid gap-5 lg:grid-cols-[auto_minmax(0,1fr)] lg:items-start">
           <PostureHero
             grade={grade}
             score={score}
             summary={postureSummary}
             critical={critical}
             high={high}
-            connectedSummary={connectedSummary}
+            latestScan={latestScan}
           />
           <SeverityIssueStrip
             summaryReady={summaryReady}
@@ -144,55 +131,16 @@ export function OverviewCockpit({
             severity={severity}
             matrix={issueMatrix}
           />
-          <div className="min-w-[9rem]">
-            <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
-              Connected estate
-            </p>
-            <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs lg:grid-cols-1">
-              <MetaLine label="Agents" value={agents != null ? String(agents) : "—"} href="/agents" />
-              <MetaLine label="Cloud accts" value={String(cloudAccounts)} href="/connections" />
-              <MetaLine label="Live services" value={String(liveServices)} href="/connections" />
-              <MetaLine label="CVEs" value={summaryReady && cves != null ? String(cves) : "—"} href={findingsHref({ issue: "vulnerability" })} />
-              <MetaLine label="Scans" value={summaryReady && scans != null ? String(scans) : "—"} href="/jobs" />
-            </div>
-          </div>
         </div>
 
-        <ComplianceSnapshotPanel compliance={compliance} hasScanEvidence={Boolean(summaryReady && scans && scans > 0)} />
-        <ActivatedServicesPanel services={services} activeCount={signals.activeServices} />
+        {/* 2 — Cross-lane coverage: the single canonical estate view */}
+        <CrossLaneCoverage domains={domains} services={services} />
 
-        {domainList.length > 0 ? (
-          <Collapsible
-            bare
-            className="mt-4 border-t border-[color:var(--border-subtle)]"
-            title="Domain coverage"
-            subtitle={
-              coverage != null ? `${coverage}% domains reporting signal` : "Cross-domain posture roll-up"
-            }
-            count={domainList.length}
-            scrollMaxHeight="14rem"
-            defaultOpen
-            actions={
-              <div className="flex flex-wrap justify-end gap-1.5 text-[10px]">
-                <SignalChip
-                  label="Cred exposure"
-                  value={summaryReady && credentials != null ? String(credentials) : "—"}
-                />
-                <SignalChip label="Tools" value={summaryReady && signals.tools != null ? String(signals.tools) : "—"} />
-                <SignalChip label="Services" value={summaryReady ? String(signals.activeServices) : "—"} />
-                <SignalChip label="Connect" value={signals.connected ? "Live" : "Setup"} highlight={signals.connected} />
-              </div>
-            }
-          >
-            <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-7">
-              {domainList.map((domain) => (
-                <DomainCard key={domain.href + domain.label} domain={domain} />
-              ))}
-            </div>
-          </Collapsible>
-        ) : null}
+        {/* 3 — Compliance: one honest strip, coverage after first scan */}
+        <ComplianceSnapshotPanel compliance={compliance} hasScanEvidence={hasScanEvidence} />
       </section>
 
+      {/* 4 — Top risks: the hero exposure path */}
       <section className="min-h-0">
         <TopRisksPanel
           topPath={topPath}
@@ -205,6 +153,100 @@ export function OverviewCockpit({
         />
       </section>
     </div>
+  );
+}
+
+type CoverageTile = {
+  key: string;
+  label: string;
+  metric: number | string;
+  metricLabel: string;
+  status: "ok" | "warn" | "critical" | "idle";
+  href: string;
+};
+
+function CrossLaneCoverage({
+  domains,
+  services,
+}: {
+  domains: OverviewResponse["domains"] | null;
+  services: Partial<Record<ServiceId, ServiceEntry>> | null | undefined;
+}) {
+  const domainList = domains ? Object.values(domains) : [];
+  const tiles: CoverageTile[] = domainList.map((domain) => ({
+    key: `${domain.href}:${domain.label}`,
+    label: domain.label,
+    metric: domain.metric,
+    metricLabel: domain.metric_label,
+    status: domain.status,
+    href: domain.graph_href ?? domain.href,
+  }));
+
+  // Fold in connected surfaces that no domain lane already represents (e.g. data
+  // sources) so the estate reads in ONE grid — never a duplicate pill strip.
+  const dataSources = services?.data_sources;
+  if (
+    dataSources &&
+    (dataSources.state === "live" || dataSources.state === "connected") &&
+    dataSources.count > 0
+  ) {
+    tiles.push({
+      key: "data_sources",
+      label: "Data sources",
+      metric: dataSources.count,
+      metricLabel: "connected",
+      status: "ok",
+      href: "/sources",
+    });
+  }
+
+  if (tiles.length === 0) return null;
+  const reporting = tiles.filter((tile) => tile.status !== "idle").length;
+
+  return (
+    <section
+      className="mt-5 border-t border-[color:var(--border-subtle)] pt-4"
+      data-testid="overview-cross-lane-coverage"
+    >
+      <div className="mb-2.5 flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+            Cross-lane coverage
+          </p>
+          <p className="mt-0.5 text-xs text-[color:var(--text-secondary)]">
+            {reporting} of {tiles.length} lanes reporting · click a lane to drill in
+          </p>
+        </div>
+        <Link
+          href="/connections"
+          className="inline-flex items-center gap-1 text-xs text-emerald-500 hover:text-emerald-400"
+        >
+          Connections <ArrowRight className="h-3 w-3" />
+        </Link>
+      </div>
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {tiles.map((tile) => (
+          <CoverageTileCard key={tile.key} tile={tile} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function CoverageTileCard({ tile }: { tile: CoverageTile }) {
+  const tone = domainStatusTone(tile.status);
+  return (
+    <Link
+      href={tile.href}
+      className="flex flex-col gap-1 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3.5 py-3 transition hover:border-[color:var(--border-strong)]"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="truncate text-xs font-medium text-[color:var(--foreground)]">{tile.label}</span>
+        <span className={`h-2 w-2 shrink-0 rounded-full ${tone.dot}`} aria-hidden="true" />
+      </div>
+      <span className={`font-mono text-xl font-semibold ${tone.text}`}>{tile.metric}</span>
+      <span className="truncate text-[10px] text-[color:var(--text-tertiary)]">{tile.metricLabel}</span>
+    </Link>
   );
 }
 
@@ -300,78 +342,6 @@ function ComplianceSnapshotPanel({
         </div>
       )}
     </Collapsible>
-  );
-}
-
-function ActivatedServicesPanel({
-  services,
-  activeCount,
-}: {
-  services: Partial<Record<ServiceId, ServiceEntry>> | null | undefined;
-  activeCount: number;
-}) {
-  const rows = (Object.entries(SERVICE_META) as [ServiceId, (typeof SERVICE_META)[ServiceId]][]).map(
-    ([id, meta]) => {
-      const entry = services?.[id] ?? { state: "locked" as const, count: 0 };
-      return { id, entry, meta };
-    },
-  );
-  const liveRows = rows.filter(({ entry }) => entry.state === "live" || entry.state === "connected");
-  const lockedCount = rows.length - liveRows.length;
-
-  return (
-    <div
-      className="mt-4 border-t border-[color:var(--border-subtle)] pt-4"
-      data-testid="overview-activated-services"
-    >
-      <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-        <div>
-          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
-            Live surfaces
-          </p>
-          <p className="mt-0.5 text-xs text-[color:var(--text-secondary)]">
-            {activeCount > 0
-              ? `${activeCount} live · ${lockedCount} not connected`
-              : "Connect cloud, data, or runtime to activate surfaces"}
-          </p>
-        </div>
-        <Link href="/connections" className="inline-flex items-center gap-1 text-xs text-emerald-500 hover:text-emerald-400">
-          Connections <ArrowRight className="h-3 w-3" />
-        </Link>
-      </div>
-      <div className="flex flex-wrap gap-1.5">
-        {rows.map(({ id, entry, meta }) => {
-          const live = entry.state === "live" || entry.state === "connected";
-          return (
-            <Link
-              key={id}
-              href={meta.unlockHref}
-              className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] transition ${
-                live
-                  ? "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--foreground)] hover:border-[color:var(--border-strong)]"
-                  : "border-dashed border-[color:var(--border-subtle)] text-[color:var(--text-tertiary)] hover:border-[color:var(--border-strong)]"
-              }`}
-              title={serviceStateLabel(entry.state)}
-            >
-              <span
-                className={`h-1.5 w-1.5 rounded-full ${
-                  entry.state === "live"
-                    ? "bg-emerald-400"
-                    : entry.state === "connected"
-                      ? "bg-sky-400"
-                      : "bg-[color:var(--border-strong)]"
-                }`}
-                aria-hidden="true"
-              />
-              {meta.label}
-              {live && entry.count > 0 ? (
-                <span className="tabular-nums text-[color:var(--text-tertiary)]">{entry.count}</span>
-              ) : null}
-            </Link>
-          );
-        })}
-      </div>
-    </div>
   );
 }
 
@@ -480,14 +450,14 @@ function PostureHero({
   summary,
   critical,
   high,
-  connectedSummary,
+  latestScan,
 }: {
   grade: string;
   score?: number | undefined;
   summary?: string | undefined;
   critical: number;
   high: number;
-  connectedSummary?: string | null | undefined;
+  latestScan: string | null;
 }) {
   const tone =
     grade === "A" || grade === "B"
@@ -495,6 +465,7 @@ function PostureHero({
       : grade === "C" || grade === "D"
         ? "text-amber-500"
         : "text-red-500";
+  const graded = typeof score === "number" && grade !== "N/A" && grade !== "—";
 
   return (
     <div className="flex items-center gap-4">
@@ -506,20 +477,18 @@ function PostureHero({
           Risk posture
         </p>
         <p className="mt-1 text-lg font-semibold text-[color:var(--foreground)]">
-          {typeof score === "number" ? `Score ${score}` : "Awaiting scan"}
+          {graded ? `Score ${score}` : "Awaiting scan"}
         </p>
-        {typeof score === "number" && grade !== "N/A" && grade !== "—" ? (
-          <p className="mt-0.5 text-[10px] text-[color:var(--text-tertiary)]">
-            Latest completed scan
-          </p>
-        ) : null}
+        <p className="mt-0.5 text-[10px] text-[color:var(--text-tertiary)]">
+          {latestScan ? `Last scan · ${latestScan}` : "No completed scans"}
+        </p>
         <p className="mt-0.5 line-clamp-2 text-xs text-[color:var(--text-secondary)]">
-          {typeof score === "number"
+          {graded
             ? summary ??
               (critical > 0
                 ? `${critical} critical · ${high} high in the current snapshot.`
                 : "Rolled up across connected surfaces.")
-            : connectedSummary ?? "Connect a surface or run a scan to grade posture."}
+            : "Connect a surface or run a scan to grade posture."}
         </p>
       </div>
     </div>
@@ -719,58 +688,7 @@ function SeverityIssueStrip({
   );
 }
 
-function MetaLine({ label, value, href }: { label: string; value: string; href?: string | undefined }) {
-  const content = (
-    <div className="flex items-center justify-between gap-2">
-      <span className="text-[color:var(--text-tertiary)]">{label}</span>
-      <span className="font-medium text-[color:var(--foreground)]">{value}</span>
-    </div>
-  );
-  return href ? <Link href={href} className="block rounded hover:bg-[color:var(--surface-muted)]">{content}</Link> : content;
-}
-
-function SignalChip({
-  label,
-  value,
-  highlight,
-}: {
-  label: string;
-  value: string;
-  highlight?: boolean | undefined;
-}) {
-  return (
-    <span
-      className={`rounded-full border px-2.5 py-1 ${
-        highlight
-          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
-          : "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]"
-      }`}
-    >
-      <span className="text-[color:var(--text-tertiary)]">{label}</span> {value}
-    </span>
-  );
-}
-
-function DomainCard({ domain }: { domain: OverviewDomain }) {
-  const tone = domainStatusTone(domain.status);
-  return (
-    <Link
-      href={domain.graph_href ?? domain.href}
-      className="flex items-center justify-between gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2.5 transition hover:border-[color:var(--border-strong)]"
-    >
-      <div className="min-w-0">
-        <p className="truncate text-xs font-medium text-[color:var(--foreground)]">{domain.label}</p>
-        <p className="truncate text-[10px] text-[color:var(--text-tertiary)]">{domain.metric_label}</p>
-      </div>
-      <div className="flex shrink-0 items-center gap-2">
-        <span className={`font-mono text-sm font-semibold ${tone.text}`}>{domain.metric}</span>
-        <span className={`h-2 w-2 rounded-full ${tone.dot}`} />
-      </div>
-    </Link>
-  );
-}
-
-function domainStatusTone(status: OverviewDomain["status"]): { dot: string; text: string } {
+function domainStatusTone(status: CoverageTile["status"]): { dot: string; text: string } {
   switch (status) {
     case "critical":
       return { dot: "bg-red-500", text: "text-red-400" };

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -85,8 +85,6 @@ export function OverviewCockpit({
   agents,
   cves,
   scans,
-  latestScan,
-  mode,
   summaryReady,
   severity,
   issueMatrix = null,
@@ -105,6 +103,16 @@ export function OverviewCockpit({
       ? `${Math.round(compliance.overallScore)}%`
       : undefined;
 
+  // Connected estate — real/zero surfaces that exist independent of any scan, so
+  // the exec read is never just "Awaiting scan".
+  const cloudAccounts = services?.cloud_accounts?.count ?? 0;
+  const liveServices = signals.activeServices;
+  const estateBits: string[] = [];
+  if (agents != null && agents > 0) estateBits.push(`${agents} agent${agents === 1 ? "" : "s"}`);
+  if (cloudAccounts > 0) estateBits.push(`${cloudAccounts} cloud account${cloudAccounts === 1 ? "" : "s"}`);
+  if (liveServices > 0) estateBits.push(`${liveServices} live service${liveServices === 1 ? "" : "s"}`);
+  const connectedSummary = estateBits.length > 0 ? `${estateBits.join(" · ")} connected` : null;
+
   return (
     <div className="space-y-4">
       <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 lg:p-5">
@@ -112,8 +120,8 @@ export function OverviewCockpit({
           <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
             Command center
           </p>
-          <p className="mt-1 max-w-2xl text-xs text-[color:var(--text-secondary)]">
-            Posture, open issues, and compliance from the latest completed scan — plus live services you’ve activated. Use Findings, Compliance, and Security graph for deeper work.
+          <p className="mt-1 text-xs text-[color:var(--text-secondary)]">
+            Posture, open issues, compliance, and the connected estate — one exec read.
           </p>
         </div>
 
@@ -124,6 +132,7 @@ export function OverviewCockpit({
             summary={postureSummary}
             critical={critical}
             high={high}
+            connectedSummary={connectedSummary}
           />
           <SeverityIssueStrip
             summaryReady={summaryReady}
@@ -135,12 +144,17 @@ export function OverviewCockpit({
             severity={severity}
             matrix={issueMatrix}
           />
-          <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs lg:grid-cols-1">
-            <MetaLine label="Agents" value={summaryReady && agents != null ? String(agents) : "—"} href="/agents" />
-            <MetaLine label="CVEs" value={summaryReady && cves != null ? String(cves) : "—"} href={findingsHref({ issue: "vulnerability" })} />
-            <MetaLine label="Scans" value={summaryReady && scans != null ? String(scans) : "—"} href="/jobs" />
-            <MetaLine label="Last scan" value={latestScan ?? "—"} />
-            <MetaLine label="Mode" value={mode} />
+          <div className="min-w-[9rem]">
+            <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+              Connected estate
+            </p>
+            <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs lg:grid-cols-1">
+              <MetaLine label="Agents" value={agents != null ? String(agents) : "—"} href="/agents" />
+              <MetaLine label="Cloud accts" value={String(cloudAccounts)} href="/connections" />
+              <MetaLine label="Live services" value={String(liveServices)} href="/connections" />
+              <MetaLine label="CVEs" value={summaryReady && cves != null ? String(cves) : "—"} href={findingsHref({ issue: "vulnerability" })} />
+              <MetaLine label="Scans" value={summaryReady && scans != null ? String(scans) : "—"} href="/jobs" />
+            </div>
           </div>
         </div>
 
@@ -393,7 +407,7 @@ function TopRisksPanel({
   return (
     <Collapsible
       title="Top risks"
-      subtitle="Business-readable priorities — open Findings or Security graph for detail"
+      subtitle="Highest-risk exposure paths"
       defaultOpen
       scrollMaxHeight="28rem"
       actions={
@@ -466,12 +480,14 @@ function PostureHero({
   summary,
   critical,
   high,
+  connectedSummary,
 }: {
   grade: string;
   score?: number | undefined;
   summary?: string | undefined;
   critical: number;
   high: number;
+  connectedSummary?: string | null | undefined;
 }) {
   const tone =
     grade === "A" || grade === "B"
@@ -498,10 +514,12 @@ function PostureHero({
           </p>
         ) : null}
         <p className="mt-0.5 line-clamp-2 text-xs text-[color:var(--text-secondary)]">
-          {summary ??
-            (critical > 0
-              ? `${critical} critical and ${high} high findings in the current scan snapshot.`
-              : "Roll-up from the latest completed scan across connected surfaces — cloud, runtime, identity, and inventory.")}
+          {typeof score === "number"
+            ? summary ??
+              (critical > 0
+                ? `${critical} critical · ${high} high in the current snapshot.`
+                : "Rolled up across connected surfaces.")
+            : connectedSummary ?? "Connect a surface or run a scan to grade posture."}
         </p>
       </div>
     </div>
@@ -575,7 +593,7 @@ function SeverityIssueStrip({
             Open issues
           </p>
           <p className="mt-0.5 text-[11px] text-[color:var(--text-secondary)]">
-            Severity across CVEs, misconfigs, secrets, and identity
+            By severity · CVE, misconfig, secret, identity
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-1.5">

--- a/ui/components/security-graph-investigation.tsx
+++ b/ui/components/security-graph-investigation.tsx
@@ -108,7 +108,11 @@ export function SecurityGraphInvestigation({
     });
   }, [activeGraph]);
 
-  const layout = useGraphLayout("dagre-lr", flow.nodes, flow.edges);
+  const layout = useGraphLayout("dagre-lr", flow.nodes, flow.edges, {
+    // Wider rank/node separation keeps the AGENT → SERVER → PACKAGE → FINDING
+    // chain legible: node boxes never touch and edges have room to read.
+    dagreLr: { rankSep: 128, nodeSep: 48 },
+  });
   const displayEdges = useMemo(() => readableGraphEdges(layout.edges), [layout.edges]);
   const legendItems = useMemo(
     () => legendItemsForVisibleGraph(layout.nodes, displayEdges),

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2305,6 +2305,8 @@ export interface OverviewResponse {
   };
   domains: {
     cloud: OverviewDomain;
+    vuln: OverviewDomain;
+    code: OverviewDomain;
     runtime: OverviewDomain;
     cost: OverviewDomain;
     identity: OverviewDomain;

--- a/ui/public/brand/mark-dark.svg
+++ b/ui/public/brand/mark-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark — BOM with detailed agent in the O">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark — BOM with an agent HUD in the O">
   <defs>
     <linearGradient id="abm" x1="8" y1="6" x2="56" y2="58" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#34d399"/>
@@ -8,28 +8,14 @@
   <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#0c1210" stroke="url(#abm)" stroke-width="2"/>
   <!-- B -->
   <path fill="url(#abm)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
-  <!-- Detailed agent as the O: helmet + visor + side sensors + jaw + antenna -->
-  <circle cx="32" cy="30.2" r="12.2" fill="none" stroke="url(#abm)" stroke-width="2.2"/>
-  <!-- helmet fill -->
-  <path fill="#111a17" stroke="url(#abm)" stroke-width="1.15"
-        d="M22.8 30.2c0-5.1 4.1-9.2 9.2-9.2s9.2 4.1 9.2 9.2c0 2.55-1.05 4.85-2.7 6.5l-1.4 1.35c-.7.65-1.7 1.05-2.75 1.05h-4.7c-1.05 0-2.05-.4-2.75-1.05l-1.4-1.35a9.15 9.15 0 0 1-2.7-6.5z"/>
-  <!-- visor band -->
-  <rect x="24.2" y="26.2" width="15.6" height="5.2" rx="2.2" fill="#0c1210" stroke="url(#abm)" stroke-width="1"/>
-  <!-- eyes -->
-  <rect x="25.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#34d399"/>
-  <rect x="33.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#06b6d4"/>
-  <!-- eye glow dots -->
-  <circle cx="27.2" cy="28.8" r="0.7" fill="#ecfdf5"/>
-  <circle cx="35.2" cy="28.8" r="0.7" fill="#ecfeff"/>
-  <!-- jaw / status bar -->
-  <path d="M26.2 35.4h11.6" fill="none" stroke="url(#abm)" stroke-width="1.8" stroke-linecap="round"/>
-  <path d="M28.2 37.6h7.6" fill="none" stroke="#06b6d4" stroke-width="1.2" stroke-linecap="round" opacity="0.7"/>
-  <!-- side sensors -->
-  <path d="M21.4 29.2h1.8M40.8 29.2h1.8" stroke="url(#abm)" stroke-width="1.5" stroke-linecap="round"/>
-  <!-- antenna -->
-  <path d="M32 18.8V13.8" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
-  <circle cx="32" cy="12.2" r="2.1" fill="url(#abm)"/>
-  <circle cx="32" cy="12.2" r="0.85" fill="#0c1210"/>
+  <!-- O as the agent HUD: ring + antenna + visor + status bar (one consistent stroke system) -->
+  <circle cx="32" cy="30.2" r="12" fill="#0f1a17" stroke="url(#abm)" stroke-width="2.4"/>
+  <path d="M32 18.2V14" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
+  <circle cx="32" cy="12.4" r="2" fill="url(#abm)"/>
+  <rect x="24.6" y="26" width="14.8" height="6.6" rx="3.3" fill="#0b1512" stroke="url(#abm)" stroke-width="1.6"/>
+  <rect x="26.9" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#34d399"/>
+  <rect x="33.2" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#22d3ee"/>
+  <path d="M27.6 36h8.8" stroke="url(#abm)" stroke-width="1.8" stroke-linecap="round"/>
   <!-- M -->
   <path fill="url(#abm)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
   <!-- materials ticks -->

--- a/ui/public/brand/mark-light.svg
+++ b/ui/public/brand/mark-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark — BOM with detailed agent in the O">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark — BOM with an agent HUD in the O">
   <defs>
     <linearGradient id="abm" x1="8" y1="6" x2="56" y2="58" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#059669"/>
@@ -8,23 +8,17 @@
   <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#f8fafc" stroke="url(#abm)" stroke-width="2"/>
   <!-- B -->
   <path fill="url(#abm)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
-  <!-- Detailed agent as the O -->
-  <circle cx="32" cy="30.2" r="12.2" fill="none" stroke="url(#abm)" stroke-width="2.2"/>
-  <path fill="#ecfdf5" stroke="url(#abm)" stroke-width="1.15"
-        d="M22.8 30.2c0-5.1 4.1-9.2 9.2-9.2s9.2 4.1 9.2 9.2c0 2.55-1.05 4.85-2.7 6.5l-1.4 1.35c-.7.65-1.7 1.05-2.75 1.05h-4.7c-1.05 0-2.05-.4-2.75-1.05l-1.4-1.35a9.15 9.15 0 0 1-2.7-6.5z"/>
-  <rect x="24.2" y="26.2" width="15.6" height="5.2" rx="2.2" fill="#f8fafc" stroke="url(#abm)" stroke-width="1"/>
-  <rect x="25.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#059669"/>
-  <rect x="33.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#0891b2"/>
-  <circle cx="27.2" cy="28.8" r="0.7" fill="#ffffff"/>
-  <circle cx="35.2" cy="28.8" r="0.7" fill="#ffffff"/>
-  <path d="M26.2 35.4h11.6" fill="none" stroke="url(#abm)" stroke-width="1.8" stroke-linecap="round"/>
-  <path d="M28.2 37.6h7.6" fill="none" stroke="#0891b2" stroke-width="1.2" stroke-linecap="round" opacity="0.7"/>
-  <path d="M21.4 29.2h1.8M40.8 29.2h1.8" stroke="url(#abm)" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M32 18.8V13.8" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
-  <circle cx="32" cy="12.2" r="2.1" fill="url(#abm)"/>
-  <circle cx="32" cy="12.2" r="0.85" fill="#f8fafc"/>
+  <!-- O as the agent HUD: ring + antenna + visor + status bar (one consistent stroke system) -->
+  <circle cx="32" cy="30.2" r="12" fill="#ecfdf5" stroke="url(#abm)" stroke-width="2.4"/>
+  <path d="M32 18.2V14" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
+  <circle cx="32" cy="12.4" r="2" fill="url(#abm)"/>
+  <rect x="24.6" y="26" width="14.8" height="6.6" rx="3.3" fill="#ffffff" stroke="url(#abm)" stroke-width="1.6"/>
+  <rect x="26.9" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#059669"/>
+  <rect x="33.2" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#0891b2"/>
+  <path d="M27.6 36h8.8" stroke="url(#abm)" stroke-width="1.8" stroke-linecap="round"/>
   <!-- M -->
   <path fill="url(#abm)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
+  <!-- materials ticks -->
   <rect x="10" y="48.5" width="12" height="2.4" rx="1.2" fill="#059669" fill-opacity="0.4"/>
   <rect x="26" y="48.5" width="12" height="2.4" rx="1.2" fill="url(#abm)"/>
   <rect x="42" y="48.5" width="12" height="2.4" rx="1.2" fill="#0891b2" fill-opacity="0.4"/>

--- a/ui/tests/overview-cockpit.test.tsx
+++ b/ui/tests/overview-cockpit.test.tsx
@@ -3,6 +3,27 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
 import { OverviewCockpit } from "@/components/overview-cockpit";
+import type { OverviewResponse } from "@/lib/api";
+
+function domain(
+  label: string,
+  metric: number,
+  metricLabel: string,
+  status: OverviewResponse["domains"]["cloud"]["status"],
+  href: string,
+): OverviewResponse["domains"]["cloud"] {
+  return { label, href, metric, metric_label: metricLabel, status, detail: {} };
+}
+
+const sampleDomains: OverviewResponse["domains"] = {
+  cloud: domain("Cloud posture", 3, "accounts connected", "ok", "/connections"),
+  vuln: domain("Vuln / SCA", 15, "open CVEs", "critical", "/findings?issue=vulnerability"),
+  code: domain("Code / repo", 0, "repo scans", "idle", "/scan"),
+  runtime: domain("Runtime", 2, "active surfaces", "ok", "/gateway"),
+  cost: domain("LLM Cost", 0, "USD tracked", "idle", "/cost"),
+  identity: domain("NHI / Identity", 8, "identities + agents", "ok", "/identity"),
+  ops: domain("Ops", 1, "completed scans", "ok", "/jobs"),
+};
 
 describe("OverviewCockpit", () => {
   const baseProps = {
@@ -43,6 +64,38 @@ describe("OverviewCockpit", () => {
     expect(screen.getByText("Risk posture")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "CISO" })).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Agent mesh/i })).toHaveAttribute("href", "/agents/topology");
+    // De-dup: the old redundant "Connected estate" list and "Live surfaces" pill
+    // strip are gone — the cross-lane grid is the single estate view.
+    expect(screen.queryByText("Connected estate")).not.toBeInTheDocument();
+    expect(screen.queryByText("Live surfaces")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("overview-activated-services")).not.toBeInTheDocument();
+  });
+
+  it("renders one canonical cross-lane coverage grid without repeating signals", () => {
+    render(<OverviewCockpit {...baseProps} domains={sampleDomains} />);
+
+    const grid = screen.getByTestId("overview-cross-lane-coverage");
+    expect(grid).toBeInTheDocument();
+    // Every lane appears exactly once — no triple-render of the same number.
+    expect(screen.getByText("Cloud posture")).toBeInTheDocument();
+    expect(screen.getAllByText("Cloud posture")).toHaveLength(1);
+    expect(screen.getByText("Vuln / SCA")).toBeInTheDocument();
+    expect(screen.getByText("NHI / Identity")).toBeInTheDocument();
+    // 5 of 7 lanes report signal (code + cost are idle).
+    expect(screen.getByText(/5 of 7 lanes reporting/i)).toBeInTheDocument();
+  });
+
+  it("folds a connected data source into the coverage grid as one extra tile", () => {
+    render(
+      <OverviewCockpit
+        {...baseProps}
+        domains={sampleDomains}
+        services={{ data_sources: { state: "connected", count: 2 } }}
+      />,
+    );
+
+    expect(screen.getByText("Data sources")).toBeInTheDocument();
+    expect(screen.getByText(/6 of 8 lanes reporting/i)).toBeInTheDocument();
   });
 
   it("surfaces risk themes and links into findings / compliance", () => {
@@ -60,10 +113,11 @@ describe("OverviewCockpit", () => {
     );
   });
 
-  it("shows compliance and compact live-surface chips when evidence exists", () => {
+  it("shows compliance and open-issue chips when evidence exists", () => {
     render(
       <OverviewCockpit
         {...baseProps}
+        domains={sampleDomains}
         compliance={{
           overallScore: 72,
           overallStatus: "warning",
@@ -71,11 +125,6 @@ describe("OverviewCockpit", () => {
             { id: "owasp-llm", label: "OWASP LLM Top 10", pass: 8, warn: 1, fail: 1, total: 10 },
             { id: "cis", label: "CIS Controls v8", pass: 10, warn: 0, fail: 0, total: 10 },
           ],
-        }}
-        services={{
-          cloud_accounts: { state: "live", count: 2 },
-          compliance: { state: "connected", count: 1 },
-          fleet: { state: "locked", count: 0 },
         }}
         issueMatrix={{
           vulnerability: { critical: 1, high: 4, medium: 2, low: 0 },
@@ -91,15 +140,23 @@ describe("OverviewCockpit", () => {
 
     expect(screen.getByTestId("overview-compliance-snapshot")).toBeInTheDocument();
     expect(screen.getByText("OWASP LLM Top 10")).toBeInTheDocument();
-    expect(screen.getByTestId("overview-activated-services")).toBeInTheDocument();
-    expect(screen.getByText("Live surfaces")).toBeInTheDocument();
-    expect(screen.getByText("Cloud accounts")).toBeInTheDocument();
     expect(screen.getByTestId("overview-severity-issue-strip")).toBeInTheDocument();
     expect(screen.getByText("Open issues")).toBeInTheDocument();
     expect(screen.getByText("Misconfig 4")).toBeInTheDocument();
     expect(screen.getByText("KEV 1")).toBeInTheDocument();
     expect(screen.getByText("Secrets 8")).toBeInTheDocument();
     expect(screen.getByText("Compliance 72%")).toBeInTheDocument();
+  });
+
+  it("surfaces the last scan time and an honest zero-state", () => {
+    const { rerender } = render(<OverviewCockpit {...baseProps} />);
+    expect(screen.getByText(/Last scan · Jul 9, 10:45 PM/i)).toBeInTheDocument();
+
+    rerender(
+      <OverviewCockpit {...baseProps} grade="—" score={undefined} scans={0} latestScan={null} />,
+    );
+    expect(screen.getByText("No completed scans")).toBeInTheDocument();
+    expect(screen.getByText(/Connect a surface or run a scan to grade posture/i)).toBeInTheDocument();
   });
 
   it("does not show green compliance pass tiles without scan evidence", () => {

--- a/ui/tests/overview-command-center.test.tsx
+++ b/ui/tests/overview-command-center.test.tsx
@@ -62,6 +62,22 @@ const BASE_PROPS = {
         status: "idle" as const,
         detail: {},
       },
+      vuln: {
+        label: "Vuln / SCA",
+        href: "/findings?issue=vulnerability",
+        metric: 0,
+        metric_label: "open CVEs",
+        status: "idle" as const,
+        detail: {},
+      },
+      code: {
+        label: "Code / repo",
+        href: "/scan",
+        metric: 0,
+        metric_label: "repo scans",
+        status: "idle" as const,
+        detail: {},
+      },
       runtime: {
         label: "Runtime",
         href: "/runtime",


### PR DESCRIPTION
Four UI polish fixes (design bar: Wiz/Orca/Endor — clean, uncluttered, persona-first):
- **Dedupe:** the security-graph page rendered the "Live investigation" panel **twice** (identical `<SecurityGraphInvestigation>` blocks). Removed the leftover.
- **Graph readability:** the exposure-path graph's relationship pills ("Uses/Depends On/Vulnerable") overlapped and clipped the node boxes. Widened node spacing (~132px channel), sized each pill to its text, centred it on the edge line, removed a redundant hover tooltip, and added board margins so nothing clips. Also widened dagre spacing on the investigation graph.
- **Logo:** cleaner agent-HUD mark — one consistent stroke system, tidier visor/eyes/antenna, no sub-pixel strokes — crisp at 32px and larger. Mirrored to `docs/images/brand`; asset rev bumped to drop caches.
- **Overview:** the exec Overview now surfaces the **connected estate** (agents, cloud accounts, live services) first-class and **un-gated** from a completed scan — never just "Awaiting scan"; findings/compliance roll-ups layer on post-scan. Trimmed verbose copy for a denser, cleaner read; honest zero-states preserved.

tsc + eslint clean; overview/exposure-path/cockpit vitest green (17 tests).

**Eyeball before merge** (couldn't render in a browser): graph pill spacing at `/security-graph` (both narrow + wide), and the HUD mark at 32px in light + dark.