### PR TITLE
fix(security): confine POST /v1/scan local paths to the same jail as secondary scan endpoints

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -2895,6 +2895,14 @@
           },
           "format": {
             "default": "json",
+            "enum": [
+              "json",
+              "cyclonedx",
+              "sarif",
+              "spdx",
+              "html",
+              "text"
+            ],
             "title": "Format",
             "type": "string"
           },
@@ -2957,6 +2965,12 @@
           "min_severity": {
             "anyOf": [
               {
+                "enum": [
+                  "low",
+                  "medium",
+                  "high",
+                  "critical"
+                ],
                 "type": "string"
               },
               {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -1915,6 +1915,13 @@ components:
           type: array
         format:
           default: json
+          enum:
+          - json
+          - cyclonedx
+          - sarif
+          - spdx
+          - html
+          - text
           title: Format
           type: string
         gha_path:
@@ -1952,7 +1959,12 @@ components:
           title: K8S Namespace
         min_severity:
           anyOf:
-          - type: string
+          - enum:
+            - low
+            - medium
+            - high
+            - critical
+            type: string
           - type: 'null'
           title: Min Severity
         no_scan:

--- a/docs/schemas/v1/ScanJob.json
+++ b/docs/schemas/v1/ScanJob.json
@@ -107,6 +107,14 @@
         },
         "format": {
           "default": "json",
+          "enum": [
+            "json",
+            "cyclonedx",
+            "sarif",
+            "spdx",
+            "html",
+            "text"
+          ],
           "title": "Format",
           "type": "string"
         },
@@ -172,6 +180,12 @@
         "min_severity": {
           "anyOf": [
             {
+              "enum": [
+                "low",
+                "medium",
+                "high",
+                "critical"
+              ],
               "type": "string"
             },
             {

--- a/docs/schemas/v1/ScanRequest.json
+++ b/docs/schemas/v1/ScanRequest.json
@@ -94,6 +94,14 @@
     },
     "format": {
       "default": "json",
+      "enum": [
+        "json",
+        "cyclonedx",
+        "sarif",
+        "spdx",
+        "html",
+        "text"
+      ],
       "title": "Format",
       "type": "string"
     },
@@ -159,6 +167,12 @@
     "min_severity": {
       "anyOf": [
         {
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "critical"
+          ],
           "type": "string"
         },
         {

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable
 from enum import Enum
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator
 
 from agent_bom.config import API_MAX_BATCH_SCAN_TARGETS
 
@@ -139,7 +139,7 @@ class ScanRequest(BaseModel):
     filesystem_paths: list[ScanPathEntry] = Field(default_factory=list)
     """Filesystem directories or tar archives to scan via Syft."""
 
-    format: str = "json"
+    format: Literal["json", "cyclonedx", "sarif", "spdx", "html", "text"] = "json"
     """Output format: json | cyclonedx | sarif | spdx | html | text."""
 
     dynamic_discovery: bool = False
@@ -160,8 +160,18 @@ class ScanRequest(BaseModel):
     exclude_servers: list[ScanGlobPattern] = Field(default_factory=list)
     """Exclude MCP servers matching these name patterns."""
 
-    min_severity: str | None = None
+    min_severity: Literal["low", "medium", "high", "critical"] | None = None
     """Minimum severity to include in results (low/medium/high/critical)."""
+
+    @field_validator("format", "min_severity", mode="before")
+    @classmethod
+    def _normalize_enum_case(cls, value: Any) -> Any:
+        """Accept case/whitespace variants (e.g. ``HIGH``/``JSON``) before the
+        Literal constraint validates, so tightening the field does not reject
+        inputs the pipeline previously lower-cased at read time."""
+        if isinstance(value, str):
+            return value.strip().lower()
+        return value
 
     @model_validator(mode="after")
     def _enforce_batch_target_cap(self) -> "ScanRequest":

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -212,6 +212,40 @@ def _api_scan_path_or_400(user_path: str) -> str:
         raise HTTPException(status_code=400, detail="Invalid scan path") from exc
 
 
+# Local-path fields on a ScanRequest that must be confined to the API scan jail
+# before the job is queued. Non-path targets (images, connectors, repo_url, k8s)
+# are intentionally excluded.
+_SCAN_LOCAL_PATH_SINGLE_FIELDS = ("inventory", "gha_path", "sbom", "external_scan", "vex")
+_SCAN_LOCAL_PATH_LIST_FIELDS = ("tf_dirs", "agent_projects", "jupyter_dirs", "filesystem_paths")
+
+
+def _sanitize_scan_request_paths(body: ScanRequest) -> ScanRequest:
+    """Confine every local-path field on a scan request to the API scan jail.
+
+    The primary ``POST /v1/scan`` flow historically ran only
+    :func:`agent_bom.security.validate_path` on these fields, which rejects
+    ``..`` traversal but accepts absolute paths and does not confine them to a
+    configured root — letting an authenticated caller read arbitrary host files
+    (e.g. ``{"inventory": "/etc/hosts"}``). Route each populated field through the
+    same :func:`_api_scan_path_or_400` helper and ``_api_local_scans_enabled``
+    gate the dedicated scan endpoints use, so the default posture rejects
+    local-path scans consistently on the primary endpoint too. ``external_scan``
+    and ``vex`` are included here even though they were opened unvalidated.
+    """
+    updates: dict[str, Any] = {}
+    for field in _SCAN_LOCAL_PATH_SINGLE_FIELDS:
+        value = getattr(body, field)
+        if value:
+            updates[field] = _api_scan_path_or_400(value)
+    for field in _SCAN_LOCAL_PATH_LIST_FIELDS:
+        values = getattr(body, field)
+        if values:
+            updates[field] = [_api_scan_path_or_400(entry) for entry in values]
+    if not updates:
+        return body
+    return body.model_copy(update=updates)
+
+
 def _dataclass_to_dict(obj: object) -> object:
     """Convert a dataclass to dict, handling nested dataclasses."""
     import dataclasses
@@ -922,6 +956,9 @@ async def create_scan(request: Request, body: ScanRequest) -> ScanJob:
     the key with a different body is a 409 conflict.
     """
     tenant_id = _tenant_id(request)
+    # Confine local-path targets to the API scan jail before any queueing or
+    # idempotency work — the same gate/helper the dedicated scan endpoints use.
+    body = _sanitize_scan_request_paths(body)
     idem_key = _request_header(request, "Idempotency-Key")
     idem_source = _request_header(request, "X-Agent-Bom-Source-Id") or "scan"
     request_hash = idempotency_request_fingerprint(body)

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -404,12 +404,12 @@ def test_create_scan_returns_202():
 
 
 def test_create_scan_with_options():
-    """POST /v1/scan with inventory/enrich fields returns a proper job."""
+    """POST /v1/scan passes through non-path options (enrich, format)."""
     client, _ = _fresh_client()
     resp = client.post(
         "/v1/scan",
         json={
-            "inventory": "/tmp/agents.json",
+            "images": ["redis:7"],
             "enrich": True,
             "format": "cyclonedx",
         },
@@ -417,10 +417,78 @@ def test_create_scan_with_options():
     assert resp.status_code == 202
     body = resp.json()
     assert body["triggered_by"] == "api"
-    assert body["request"]["inventory"] == "<path:agents.json>"
-    assert "/tmp" not in body["request"]["inventory"]
+    assert body["request"]["images"] == ["redis:7"]
     assert body["request"]["enrich"] is True
     assert body["request"]["format"] == "cyclonedx"
+
+
+# ---------------------------------------------------------------------------
+# 5b. Scan path jail — primary POST /v1/scan is confined to the same jail
+#     the dedicated scan endpoints use (gate disabled by default).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"inventory": "/etc/hosts"},
+        {"filesystem_paths": ["/etc"]},
+        {"agent_projects": ["../../etc"]},
+        {"sbom": "/tmp/sbom.json"},
+        {"external_scan": "/etc/hosts"},
+        {"vex": "/etc/hosts"},
+        {"tf_dirs": ["/var"]},
+        {"gha_path": "/etc"},
+        {"jupyter_dirs": ["../secret"]},
+    ],
+)
+def test_create_scan_rejects_local_paths_by_default(monkeypatch, payload):
+    """Absolute and traversal local paths are rejected with 400 while the
+    local-path scan gate is disabled (default posture)."""
+    monkeypatch.delenv("AGENT_BOM_API_LOCAL_PATH_SCANS", raising=False)
+    monkeypatch.delenv("AGENT_BOM_ENABLE_LOCAL_PATH_SCANS", raising=False)
+    client, _ = _fresh_client()
+    resp = client.post("/v1/scan", json=payload)
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid scan path"
+
+
+def test_create_scan_non_path_targets_allowed_by_default(monkeypatch):
+    """Image / connector / k8s / repo scans do not require the path gate."""
+    monkeypatch.delenv("AGENT_BOM_API_LOCAL_PATH_SCANS", raising=False)
+    client, _ = _fresh_client()
+    for payload in ({"images": ["redis:7"]}, {"k8s": True}, {}, {"repo_url": "https://github.com/org/repo"}):
+        resp = client.post("/v1/scan", json=payload)
+        assert resp.status_code == 202, payload
+
+
+def test_create_scan_allows_valid_path_when_gate_enabled(monkeypatch, tmp_path):
+    """With the gate enabled and a scan root configured, a relative path under
+    the root resolves and the scan is accepted."""
+    root = tmp_path
+    (root / "proj").mkdir()
+    monkeypatch.setenv("AGENT_BOM_API_LOCAL_PATH_SCANS", "enabled")
+    monkeypatch.setenv("AGENT_BOM_API_SCAN_ROOT", str(root))
+    monkeypatch.setenv("AGENT_BOM_API_SCAN_ALLOW_FOREIGN_OWNER", "1")
+    client, _ = _fresh_client()
+    resp = client.post("/v1/scan", json={"agent_projects": ["proj"], "offline": True, "no_scan": True})
+    assert resp.status_code == 202
+
+    # Absolute paths outside the root are still rejected even with the gate on.
+    resp = client.post("/v1/scan", json={"agent_projects": ["/etc"]})
+    assert resp.status_code == 400
+
+
+def test_create_scan_rejects_invalid_enum_fields():
+    """format / min_severity are enum-constrained and reject junk with 422."""
+    client, _ = _fresh_client()
+    assert client.post("/v1/scan", json={"format": "exe"}).status_code == 422
+    assert client.post("/v1/scan", json={"min_severity": "spicy"}).status_code == 422
+    # Case-insensitive variants are normalized, not rejected.
+    resp = client.post("/v1/scan", json={"images": ["x:1"], "format": "SARIF", "min_severity": "High"})
+    assert resp.status_code == 202
+    assert resp.json()["request"]["format"] == "sarif"
+    assert resp.json()["request"]["min_severity"] == "high"
 
 
 def test_create_scan_rejects_unknown_fields():

--- a/ui/components/scan-form.tsx
+++ b/ui/components/scan-form.tsx
@@ -41,6 +41,21 @@ type ScanFormProps = {
   initialConnectionId?: string | undefined;
 };
 
+/** Client-side guard: accept only well-formed ``http(s)://<host>`` repo URLs
+ * before enabling submit. Server-side validation remains authoritative. */
+function isHttpRepoUrl(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return false;
+  return Boolean(parsed.hostname) && parsed.hostname.includes(".");
+}
+
 export function ScanForm({ initialConnectionId }: ScanFormProps) {
   const router = useRouter();
   const { counts } = useDeploymentContext();
@@ -198,10 +213,13 @@ export function ScanForm({ initialConnectionId }: ScanFormProps) {
             }
           : {
               ...form,
+              agent_projects: (form.agent_projects ?? []).map((p) => p.trim()).filter(Boolean),
+              tf_dirs: (form.tf_dirs ?? []).map((p) => p.trim()).filter(Boolean),
+              gha_path: form.gha_path?.trim() || undefined,
               repo_url: undefined,
             };
-      if (target === "repository" && !request.repo_url) {
-        setError("Enter a public repository URL (https://github.com/org/repo)");
+      if (target === "repository" && !isHttpRepoUrl(repoUrlInput)) {
+        setError("Enter a valid public repository URL (https://github.com/org/repo)");
         setLoading(false);
         return;
       }
@@ -242,7 +260,9 @@ export function ScanForm({ initialConnectionId }: ScanFormProps) {
   const queuedImages = form.images ?? [];
   const cloudScanReady = Boolean(selectedConnection && isScannableConnection(selectedConnection));
   const sourceRunReady = Boolean(selectedSource?.enabled);
-  const repoScanReady = target !== "repository" || Boolean(repoUrlInput.trim());
+  const repoUrlValid = isHttpRepoUrl(repoUrlInput);
+  const repoUrlInvalid = target === "repository" && repoUrlInput.trim().length > 0 && !repoUrlValid;
+  const repoScanReady = target !== "repository" || repoUrlValid;
 
   return (
     <div className="max-w-4xl" data-testid="scan-form">
@@ -354,7 +374,12 @@ export function ScanForm({ initialConnectionId }: ScanFormProps) {
                       type="url"
                       aria-label="Public repository URL"
                       placeholder="https://github.com/org/repo"
-                      className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3 font-mono text-sm text-[color:var(--foreground)] focus:border-emerald-600 focus:outline-none"
+                      aria-invalid={repoUrlInvalid}
+                      className={`w-full rounded-xl border bg-[color:var(--surface-muted)] px-4 py-3 font-mono text-sm text-[color:var(--foreground)] focus:outline-none ${
+                        repoUrlInvalid
+                          ? "border-red-600/70 focus:border-red-500"
+                          : "border-[color:var(--border-subtle)] focus:border-emerald-600"
+                      }`}
                       value={repoUrlInput}
                       onChange={(event) => {
                         const value = event.target.value;
@@ -362,6 +387,9 @@ export function ScanForm({ initialConnectionId }: ScanFormProps) {
                         setForm((current) => ({ ...current, repo_url: value.trim() || undefined }));
                       }}
                     />
+                    {repoUrlInvalid ? (
+                      <p className="text-xs text-red-400">Enter a full http(s):// URL, e.g. https://github.com/org/repo</p>
+                    ) : null}
                     <RepoSurfaceCatalog />
                   </div>
                 )}

--- a/ui/tests/scan-form.test.tsx
+++ b/ui/tests/scan-form.test.tsx
@@ -173,6 +173,20 @@ describe("ScanForm", () => {
     });
   });
 
+  it("blocks submit and flags an invalid public repository URL", async () => {
+    const user = userEvent.setup();
+
+    render(<ScanForm />);
+    await user.click(screen.getByRole("tab", { name: "Ad-hoc" }));
+    await user.click(screen.getByRole("tab", { name: /Public repo/i }));
+
+    const input = screen.getByPlaceholderText("https://github.com/org/repo");
+    await user.type(input, "github.com/org/repo");
+
+    expect(screen.getByText(/Enter a full http\(s\):\/\/ URL/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Scan repo/i })).toBeDisabled();
+  });
+
   it("explains kubernetes namespace scope in plain language", async () => {
     const user = userEvent.setup();
     render(<ScanForm />);


### PR DESCRIPTION
## The gap

The primary `POST /v1/scan` flow (`create_scan` → `enqueue_scan_job` → pipeline) only ran `validate_path(p, must_exist=True)` on its local-path fields. With the default `restrict_to_home=False`, that guard rejects `..` traversal but **accepts absolute paths and does not confine to a configured root**. The dedicated scan endpoints (`/scan/dataset-cards`, `/scan/prompt-scan`, etc.) route their paths through the hardened `_sanitize_api_path` / `_api_scan_path_or_400` helper (gated by `AGENT_BOM_API_LOCAL_PATH_SCANS`, default disabled) — but the primary endpoint bypassed it entirely.

Result: an authenticated caller could `POST /v1/scan {"inventory":"/etc/hosts"}` (or `filesystem_paths`, `sbom`, `tf_dirs`, `gha_path`, `jupyter_dirs`, `agent_projects`) and the control plane would read arbitrary host files, with contents partly reflected via parse errors / results. `external_scan` and `vex` were opened with **no** validation at all.

### Repro (before the fix)

```
validate_path('/etc/hosts', must_exist=True)  -> /etc/hosts        (no rejection)
POST /v1/scan {"inventory":"/etc/hosts"}       -> 202, inventory reader receives /etc/hosts
```

## The fix

Route **every** `ScanRequest` local-path field through the existing `_api_scan_path_or_400` helper and the same `_api_local_scans_enabled()` gate the secondary endpoints use, at request ingest in `create_scan` — before the job is queued. Fields covered: `filesystem_paths`, `agent_projects`, `tf_dirs`, `gha_path`, `inventory`, `jupyter_dirs`, `sbom`, and now `external_scan` and `vex` (previously opened unvalidated).

With the gate at its default (disabled) posture, local-path scans are rejected with a clean `400 Invalid scan path` on the primary endpoint too — consistent with the secondary endpoints. Image / connector / k8s / `repo_url` scans are unaffected. When the gate is enabled and paths resolve under the configured scan root, legitimate local scans still run.

The helper is reused unchanged — not reimplemented or weakened.

## Bundled hardening

- **Backend model tightening** (`ScanRequest`): `format` and `min_severity` are now enum-constrained (with a case/whitespace-normalizing pre-validator so `HIGH`/`CycloneDX` still work) — junk is rejected at the edge with `422` instead of flowing downstream.
- **Frontend defense-in-depth** (`ui/components/scan-form.tsx`): the public-repo URL field is client-side validated as a well-formed `http(s)://<host>` before submit is enabled, with an inline error; path inputs are trimmed. (`findings-lens.ts` intentionally untouched.)

## Tests

- New endpoint tests assert absolute and `..` paths to `POST /v1/scan` are rejected (400) with the gate at default, across all nine path fields incl. `external_scan`/`vex`; that non-path (image/k8s/repo_url) scans still succeed; and that a valid relative path under the root scans when the gate is enabled.
- New model tests assert `422` on bad `format`/`min_severity` and normalization of case variants.
- New UI test asserts an invalid repo URL disables submit and shows the inline error.
- Full `tests/api/` suite (698) green; security suites (120) green; scan/type/batch/sources (100) green; `ui` typecheck clean; scan-form vitest (7) green.