### PR TITLE
fix(ui): consolidate scan entry points + vocabulary (Connect→Scan→Assess)

### DIFF
--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -1098,14 +1098,6 @@ function FragmentRow({
         </td>
         <td className="px-4 py-3">
           <div className="flex justify-end gap-2">
-            <Link
-              href={`/scan?connection=${encodeURIComponent(connection.id)}`}
-              title="Open this account in New Scan with scope summary"
-              className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-1.5 text-xs font-medium text-[var(--foreground)] transition hover:border-emerald-600"
-            >
-              <FileSearch className="h-3.5 w-3.5" />
-              New Scan
-            </Link>
             <button
               onClick={onTest}
               disabled={isBusy || !canManage || !scannable}

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -353,11 +353,13 @@ export default function Dashboard() {
         }
         actions={
           <>
+            {/* Exec pane leads with drill-downs, not an operational scan action
+                (New Scan lives in the nav + empty states for engineers). */}
             <Link
-              href="/scan"
+              href="/compliance"
               className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-500"
             >
-              New Scan <ArrowRight className="h-4 w-4" />
+              Compliance <ArrowRight className="h-4 w-4" />
             </Link>
             <Link
               href="/security-graph"
@@ -374,10 +376,10 @@ export default function Dashboard() {
               </Link>
             ) : (
               <Link
-                href="/compliance"
+                href="/findings"
                 className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] px-3 py-2 text-sm font-medium text-[color:var(--foreground)] hover:border-[color:var(--border-strong)]"
               >
-                Compliance
+                Findings
               </Link>
             )}
           </>

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -357,7 +357,7 @@ export default function Dashboard() {
               href="/scan"
               className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-500"
             >
-              Run scan <ArrowRight className="h-4 w-4" />
+              New Scan <ArrowRight className="h-4 w-4" />
             </Link>
             <Link
               href="/security-graph"
@@ -556,7 +556,7 @@ function EmptyState() {
         href="/scan"
         className="inline-flex items-center gap-1.5 mt-4 px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white rounded-lg text-sm font-medium transition-colors"
       >
-        Run your first scan
+        New Scan
         <ArrowRight className="w-3.5 h-3.5" />
       </Link>
     </div>

--- a/ui/components/coverage-cockpit.tsx
+++ b/ui/components/coverage-cockpit.tsx
@@ -94,22 +94,13 @@ export function CoverageCockpit({
       aria-labelledby="coverage-cockpit-heading"
       className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4"
     >
-      <div className="mb-4 flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <h2 id="coverage-cockpit-heading" className="text-sm font-semibold text-[color:var(--foreground)]">
-            Onboard & coverage
-          </h2>
-          <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
-            Deployment is your control plane. Accounts are onboarded cloud boundaries. Scans are the evidence runs that feed Overview posture.
-          </p>
-        </div>
-        <Link
-          href="/scan"
-          className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-emerald-500"
-        >
-          Run scan
-          <ArrowRight className="h-3.5 w-3.5" />
-        </Link>
+      <div className="mb-4">
+        <h2 id="coverage-cockpit-heading" className="text-sm font-semibold text-[color:var(--foreground)]">
+          Onboard & coverage
+        </h2>
+        <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
+          Deployment is your control plane. Accounts are onboarded cloud boundaries. Scans are the evidence runs that feed Overview posture.
+        </p>
       </div>
 
       <div className="grid gap-3 lg:grid-cols-3">
@@ -164,8 +155,8 @@ export function CoverageCockpit({
               ? `Latest evidence ${latestScanLabel}. Ad-hoc, connected-account, and source runs all land in Jobs.`
               : "No completed scans yet. Start with a connected account or an ad-hoc workstation scan."
           }
-          actionHref="/scan"
-          actionLabel="Start scan"
+          actionHref="/jobs"
+          actionLabel="View jobs"
           secondaryHref="/sources"
           secondaryLabel="Data sources"
         />

--- a/ui/lib/empty-state-actions.ts
+++ b/ui/lib/empty-state-actions.ts
@@ -5,8 +5,10 @@ export const CONNECT_CLOUD_ACTION: PageStateAction = {
   href: "/connections",
 };
 
+// Canonical scan entry point: "New Scan" opens the /scan configurator.
+// (Use "Run scan" only for actions that execute immediately on a scoped target.)
 export const RUN_SCAN_ACTION: PageStateAction = {
-  label: "Run scan",
+  label: "New Scan",
   href: "/scan",
 };
 

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -324,7 +324,7 @@ describe("ConnectionsPage", () => {
     );
   });
 
-  it("deep-links each connection into New Scan with a preselected account", async () => {
+  it("deep-links the connection drawer into New Scan with a preselected account", async () => {
     apiMock.listCloudConnections.mockResolvedValue({
       schema_version: "cloud.connections.v1",
       tenant_id: "tenant-acme",
@@ -338,7 +338,10 @@ describe("ConnectionsPage", () => {
       expect(screen.getByText("Production account")).toBeInTheDocument(),
     );
 
-    expect(screen.getByRole("link", { name: "New Scan" })).toHaveAttribute(
+    fireEvent.click(screen.getByRole("button", { name: "Production account" }));
+    const drawer = await screen.findByRole("dialog", { name: "Production account" });
+
+    expect(within(drawer).getByRole("link", { name: "New Scan" })).toHaveAttribute(
       "href",
       "/scan?connection=conn-1",
     );


### PR DESCRIPTION
Addresses the "Run scan everywhere" redundancy — an audit found 20 scan CTAs across 8 files using 6 different labels for one action. This is the first consolidation pass, aligned to the Wiz/Orca-style workflow stages (Connect → Scan → Assess → drill-down).

**One vocabulary rule:** `New Scan` opens the `/scan` configurator; `Run scan` executes immediately on an already-scoped target (a connected account/source).

This pass:
- **Coverage cockpit** (renders on Overview *and* Connections) dropped the section-header "Run scan" and the Scans-card "Start scan" — together they stacked up to **4 scan CTAs on one screen**. The Cloud-accounts card keeps the single contextual "Scan account"; the Scans card now reads "View jobs".
- Shared empty-state action, Overview header, and Overview empty-state all now read **"New Scan"** (were "Run scan" / "Run your first scan").

Follow-ups in this branch: dedupe the connections row/drawer New-Scan-vs-Run-scan pair, demote the redundant Jobs-header CTA, and unify concept naming (Cloud accounts / Data sources / Scan jobs). UI typechecks clean.