### PR TITLE
fix(demo): complete + reliable correlated demo-estate seed (agents, exposure paths, identity)

### DIFF
--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -46,6 +46,33 @@ def _tenant_id(request: Request) -> str:
     return require_request_tenant_id(request)
 
 
+def _discover_agents_with_demo_fallback() -> list[Any]:
+    """Live local-disk discovery, with a demo-estate fallback.
+
+    On a hosted/anonymous demo server there are no local agent configs to
+    discover, so ``discover_all()`` returns nothing and the Agents page + the
+    Overview NHI/agents tile read empty. When (and only when) demo-estate mode is
+    enabled AND live discovery found nothing, fall back to the curated demo
+    inventory so the correlated demo story renders. Real deployments — env unset
+    — always get live discovery only; the fallback is never injected there.
+    """
+    from agent_bom.discovery import discover_all
+
+    agents = discover_all()
+    if agents:
+        return agents
+
+    from agent_bom.demo_estate.bootstrap import demo_estate_enabled
+
+    if not demo_estate_enabled():
+        return agents
+
+    from agent_bom.cli._common import _build_agents_from_inventory
+    from agent_bom.demo import DEMO_INVENTORY
+
+    return _build_agents_from_inventory(DEMO_INVENTORY, "agent-bom --demo")
+
+
 def _merge_strings(*values: list[str]) -> list[str]:
     merged: list[str] = []
     seen: set[str] = set()
@@ -374,10 +401,9 @@ def _persist_agent_observations(
 
 
 def _build_agents_response(tenant_id: str) -> dict[str, Any]:
-    from agent_bom.discovery import discover_all
     from agent_bom.parsers import extract_packages
 
-    agents = discover_all()
+    agents = _discover_agents_with_demo_fallback()
     for agent in agents:
         for server in agent.mcp_servers:
             if not server.packages:
@@ -454,11 +480,10 @@ async def get_agent_mesh(request: Request) -> dict:
     as an interactive graph.
     """
     try:
-        from agent_bom.discovery import discover_all
         from agent_bom.output.agent_mesh import build_agent_mesh
         from agent_bom.parsers import extract_packages
 
-        agents = discover_all()
+        agents = _discover_agents_with_demo_fallback()
         for agent in agents:
             for server in agent.mcp_servers:
                 if not server.packages:

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -9,7 +9,11 @@ from typing import Any
 
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.pipeline import _now
-from agent_bom.demo_estate.showcase_graph import SHOWCASE_TENANT, seed_showcase_graph_if_empty
+from agent_bom.demo_estate.showcase_graph import (
+    SHOWCASE_TENANT,
+    seed_showcase_graph_if_empty,
+    seed_showcase_identities,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -111,8 +115,25 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
     graph_store = _get_graph_store()
     summary: dict[str, Any] = {"enabled": True, "tenant_id": tenant_id, "seeded": False}
 
-    graph_seeded = seed_showcase_graph_if_empty(graph_store, tenant_id=tenant_id)
+    # Graph seed is isolated: a pre-existing (possibly stale) snapshot early-returns
+    # here, and any failure must NOT block the findings/scan or identity seeding
+    # below — those are what make posture + NHI reliably non-empty on every start.
+    graph_seeded = False
+    try:
+        graph_seeded = seed_showcase_graph_if_empty(graph_store, tenant_id=tenant_id)
+    except Exception:
+        _logger.warning("demo estate graph seeding failed", exc_info=True)
+        summary["graph_error"] = True
     summary["graph_seeded"] = graph_seeded
+
+    # Seed the live agent-identity store (NHI estate) independently of the graph
+    # snapshot so the NHI/Identity overview tile and the nhi-governance posture
+    # survive a restart even when the graph already exists. Idempotent.
+    try:
+        summary["identities"] = seed_showcase_identities(tenant_id=tenant_id)
+    except Exception:
+        _logger.warning("demo estate identity seeding failed", exc_info=True)
+        summary["identity_error"] = True
 
     # Seed the runtime gateway feed (proxy alerts + metrics + firewall
     # decisions) so the gateway/proxy/runtime dashboards show the AI-firewall in

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Literal
 
 from agent_bom.api.agent_identity_store import (
+    AgentIdentity,
+    AgentJITGrant,
     InMemoryAgentIdentityStore,
-    issue_identity,
-    issue_jit_grant,
 )
 from agent_bom.graph.cnapp_overlay import apply_cnapp_overlay
 from agent_bom.graph.container import UnifiedGraph
@@ -27,6 +29,196 @@ SHOWCASE_SCAN_ID = "showcase"
 SHOWCASE_BASELINE_SCAN_ID = "showcase-baseline"
 SHOWCASE_BASELINE_CREATED_AT = "2026-06-01T12:00:00+00:00"
 SHOWCASE_CURRENT_CREATED_AT = "2026-06-08T12:00:00+00:00"
+
+_logger = logging.getLogger(__name__)
+
+# Deterministic non-human-identity estate for the demo. Identity ids are stable
+# across restarts so the persisted MANAGED_IDENTITY graph nodes and the live
+# identity store agree — the governance overlay re-runs at request time and must
+# not inject a *second*, duplicate set of identities. Each row is shaped to tell
+# one clear NHI-governance story:
+#   * an over-granted but owned + active identity (standing tool scopes it never
+#     uses → right-size),
+#   * a dormant + orphaned admin identity that reaches an exposed resource (the
+#     textbook worst case → deprovision), and
+#   * clean, owned, least-privilege identities for contrast.
+_DEMO_IDENTITIES: tuple[dict[str, Any], ...] = (
+    {
+        "slug": "cursor",
+        "agent_label": "Cursor IDE Agent",
+        "role": "prod-admin",
+        "owner": "platform-team@corp",
+        "owner_type": "team",
+        "allowed_tools": ["run_shell", "exec_command", "read_file", "execute_sql", "query_vectors"],
+        "last_used_days": 1,
+    },
+    {
+        "slug": "support-copilot",
+        "agent_label": "Support Copilot",
+        "role": "support-admin",
+        "owner": "",  # orphaned — no accountable owner
+        "owner_type": "",
+        "allowed_tools": ["send_email", "create_ticket", "search_tickets"],
+        "last_used_days": None,  # never observed → dormant
+        "privileged": True,
+        "internet_exposed": True,
+    },
+    {
+        "slug": "data-pipeline",
+        "agent_label": "Data Pipeline Agent",
+        "role": "data-pipeline",
+        "owner": "data-eng@corp",
+        "owner_type": "team",
+        "allowed_tools": [],  # least privilege — access is JIT-granted
+        "last_used_days": 2,
+    },
+    {
+        "slug": "langchain-service",
+        "agent_label": "LangChain Service Agent",
+        "role": "service",
+        "owner": "ml-platform@corp",
+        "owner_type": "team",
+        "allowed_tools": [],
+        "last_used_days": 3,
+    },
+    {
+        "slug": "claude-desktop",
+        "agent_label": "Claude Desktop Agent",
+        "role": "agent",
+        "owner": "",  # orphaned
+        "owner_type": "",
+        "allowed_tools": [],
+        "last_used_days": None,  # dormant
+    },
+)
+
+# JIT grants that light up ACCESS_GRANT nodes for the least-privilege identities.
+_DEMO_JIT_GRANTS: tuple[tuple[str, str], ...] = (
+    ("cursor", "run_shell"),
+    ("data-pipeline", "execute_sql"),
+    ("langchain-service", "eval_expression"),
+)
+
+
+def _demo_identity_id(slug: str) -> str:
+    return f"demo-nhi-{slug}"
+
+
+def demo_identity_records(tenant_id: str = SHOWCASE_TENANT) -> tuple[list[AgentIdentity], list[AgentJITGrant]]:
+    """Return the deterministic enriched demo identities + JIT grants.
+
+    Single source of truth shared by the persisted graph seed and the live
+    identity-store seed so both carry identical ids and attributes.
+    """
+    now = datetime.now(timezone.utc)
+    issued_at = (now - timedelta(days=120)).isoformat()
+    expires_at = (now + timedelta(days=90)).isoformat()
+
+    identities: list[AgentIdentity] = []
+    by_slug: dict[str, str] = {}
+    for spec in _DEMO_IDENTITIES:
+        slug = str(spec["slug"])
+        identity_id = _demo_identity_id(slug)
+        by_slug[slug] = identity_id
+        last_used_days = spec.get("last_used_days")
+        last_used_at = "" if last_used_days is None else (now - timedelta(days=int(last_used_days))).isoformat()
+        identities.append(
+            AgentIdentity(
+                identity_id=identity_id,
+                agent_id=str(spec["agent_label"]),
+                tenant_id=tenant_id,
+                token_hash=f"demo-nhi-hash-{slug}",
+                token_prefix="demo",
+                role=str(spec.get("role") or "agent"),
+                blueprint_id=str(spec["agent_label"]),
+                status="active",
+                issued_at=issued_at,
+                expires_at=expires_at,
+                allowed_tools=list(spec.get("allowed_tools") or []),
+                owner=str(spec.get("owner") or ""),
+                owner_type=str(spec.get("owner_type") or ""),
+                last_used_at=last_used_at,
+            )
+        )
+
+    grants: list[AgentJITGrant] = []
+    approved_at = (now - timedelta(hours=2)).isoformat()
+    grant_expiry = (now + timedelta(hours=1)).isoformat()
+    for slug, tool_name in _DEMO_JIT_GRANTS:
+        identity_id = by_slug.get(slug)
+        if not identity_id:
+            continue
+        grants.append(
+            AgentJITGrant(
+                grant_id=f"demo-jit-{slug}-{tool_name}",
+                identity_id=identity_id,
+                agent_id=next(str(s["agent_label"]) for s in _DEMO_IDENTITIES if s["slug"] == slug),
+                tenant_id=tenant_id,
+                tool_name=tool_name,
+                status="active",
+                requested_at=approved_at,
+                requested_by="oncall@corp",
+                approved_at=approved_at,
+                approved_by="oncall@corp",
+                starts_at=approved_at,
+                expires_at=grant_expiry,
+                ticket_id=f"OPS-{slug.upper()}",
+            )
+        )
+    return identities, grants
+
+
+def build_demo_identity_store(tenant_id: str = SHOWCASE_TENANT) -> InMemoryAgentIdentityStore:
+    """A throwaway identity store pre-loaded with the demo NHI estate."""
+    store = InMemoryAgentIdentityStore()
+    identities, grants = demo_identity_records(tenant_id)
+    for identity in identities:
+        store.put(identity)
+    for grant in grants:
+        store.put_jit_grant(grant)
+    return store
+
+
+def seed_showcase_identities(tenant_id: str = SHOWCASE_TENANT) -> dict[str, Any]:
+    """Populate the LIVE agent-identity store with the demo NHI estate.
+
+    Idempotent and independent of the graph seed so the NHI/Identity overview
+    tile and the ``/v1/*/nhi/governance`` posture survive a restart even when the
+    graph snapshot already exists. Only ever runs under demo-estate mode.
+    """
+    from agent_bom.api.agent_identity_store import get_agent_identity_store
+
+    store = get_agent_identity_store()
+    existing = {i.identity_id for i in store.list(tenant_id, include_inactive=True, limit=1000)}
+    if any(iid.startswith("demo-nhi-") for iid in existing):
+        return {"seeded": False, "reason": "identities_present", "count": len(existing)}
+
+    identities, grants = demo_identity_records(tenant_id)
+    for identity in identities:
+        store.put(identity)
+    for grant in grants:
+        store.put_jit_grant(grant)
+    return {"seeded": True, "identities": len(identities), "jit_grants": len(grants)}
+
+
+def _annotate_demo_identity_risk(graph: UnifiedGraph) -> None:
+    """Pin privilege / exposure signals the identity record cannot carry.
+
+    ``AgentIdentity`` has no privilege or internet-exposure field, so the
+    governance evaluator would otherwise only see dormancy/ownership. Stamp the
+    curated signals directly onto the persisted MANAGED_IDENTITY node so the demo
+    surfaces at least one clearly high/critical NHI (a dormant, orphaned, admin
+    identity). Node ids are deterministic; safe to call on any showcase snapshot.
+    """
+    for spec in _DEMO_IDENTITIES:
+        node = graph.nodes.get(f"managed_identity:{_demo_identity_id(str(spec['slug']))}")
+        if node is None:
+            continue
+        if spec.get("privileged"):
+            node.attributes["privilege_level"] = "admin"
+            node.attributes["is_admin"] = True
+        if spec.get("internet_exposed"):
+            node.attributes["internet_exposed"] = True
 
 
 class _DriftIncident:
@@ -57,6 +249,7 @@ def build_showcase_graph(
     tenant_id: str = SHOWCASE_TENANT,
     scan_id: str = SHOWCASE_SCAN_ID,
     profile: ShowcaseProfile = "current",
+    identity_store: InMemoryAgentIdentityStore | None = None,
 ) -> tuple[UnifiedGraph, InMemoryAgentIdentityStore, _DriftStore]:
     is_baseline = profile == "baseline"
     g = UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id)
@@ -297,20 +490,10 @@ def build_showcase_graph(
         node("tool:legacy-chat-server:send_message", EntityType.TOOL, "send_message")
         edge("server:legacy-chat-server", "tool:legacy-chat-server:send_message", RelationshipType.PROVIDES_TOOL)
 
-    store = InMemoryAgentIdentityStore()
-    _jit_tools = {"cursor": "run_shell", "data-pipeline": "execute_sql", "langchain-service": "eval_expression"}
-    for aid, label in agents.items():
-        idn, _ = issue_identity(store, agent_id=label, tenant_id=tenant_id, allowed_tools=[])
-        if aid in _jit_tools:
-            issue_jit_grant(
-                store,
-                identity_id=idn.identity_id,
-                agent_id=label,
-                tenant_id=tenant_id,
-                tool_name=_jit_tools[aid],
-                ttl_seconds=3600,
-                approved_by="oncall@corp",
-            )
+    # Enriched, deterministic NHI estate (owner / last_used / standing scopes) so
+    # the governance overlay projects a real identity story. Shared with the live
+    # identity-store seed via ``demo_identity_records`` so ids/attributes match.
+    store = identity_store if identity_store is not None else build_demo_identity_store(tenant_id)
 
     drift = _DriftStore(
         [
@@ -416,10 +599,15 @@ def seed_showcase_graph_if_empty(
     if callable(latest_snapshot_id) and latest_snapshot_id(tenant_id=tenant_id):
         return False
 
+    # One shared, enriched identity estate feeds both snapshots so the persisted
+    # MANAGED_IDENTITY node ids match the live identity store the API re-projects.
+    identity_records = build_demo_identity_store(tenant_id)
+
     baseline_graph, baseline_identity, baseline_drift = build_showcase_graph(
         tenant_id=tenant_id,
         scan_id=SHOWCASE_BASELINE_SCAN_ID,
         profile="baseline",
+        identity_store=identity_records,
     )
     baseline_graph.created_at = SHOWCASE_BASELINE_CREATED_AT
     apply_showcase_overlays(
@@ -429,12 +617,15 @@ def seed_showcase_graph_if_empty(
         drift_store=baseline_drift,
     )
     finalize_showcase_snapshot(baseline_graph, profile="baseline")
+    _annotate_demo_identity_risk(baseline_graph)
+    _materialize_showcase_attack_paths(baseline_graph)
     graph_store.save_graph(baseline_graph)
 
     current_graph, identity_store, drift_store = build_showcase_graph(
         tenant_id=tenant_id,
         scan_id=SHOWCASE_SCAN_ID,
         profile="current",
+        identity_store=identity_records,
     )
     current_graph.created_at = SHOWCASE_CURRENT_CREATED_AT
     apply_showcase_overlays(
@@ -444,5 +635,28 @@ def seed_showcase_graph_if_empty(
         drift_store=drift_store,
     )
     finalize_showcase_snapshot(current_graph, profile="current")
+    _annotate_demo_identity_risk(current_graph)
+    _materialize_showcase_attack_paths(current_graph)
     graph_store.save_graph(current_graph)
     return True
+
+
+def _materialize_showcase_attack_paths(graph: UnifiedGraph) -> None:
+    """Persist derived attack paths so the materialized exposure-path queue is
+    non-empty for the demo.
+
+    ``/v1/graph/attack-paths`` derives paths on the fly, but
+    ``/v1/graph/exposure-paths`` reads the materialized ``attack_paths`` table
+    populated from ``graph.attack_paths`` at save time. The showcase graph never
+    set that, so exposure paths came back empty. Reuse the exact same deriver the
+    attack-path endpoint uses (pure seed-shaping — no algorithm change) and pin
+    the hero chains onto the snapshot before it is saved.
+    """
+    if graph.attack_paths:
+        return
+    try:
+        from agent_bom.api.routes.graph import _derived_attack_paths
+
+        graph.attack_paths = _derived_attack_paths(graph)
+    except Exception:  # noqa: BLE001 — never block the snapshot save on path shaping
+        _logger.warning("demo estate attack-path materialization failed", exc_info=True)

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -145,13 +145,13 @@ def demo_identity_records(tenant_id: str = SHOWCASE_TENANT) -> tuple[list[AgentI
     approved_at = (now - timedelta(hours=2)).isoformat()
     grant_expiry = (now + timedelta(hours=1)).isoformat()
     for slug, tool_name in _DEMO_JIT_GRANTS:
-        identity_id = by_slug.get(slug)
-        if not identity_id:
+        grant_identity_id = by_slug.get(slug)
+        if not grant_identity_id:
             continue
         grants.append(
             AgentJITGrant(
                 grant_id=f"demo-jit-{slug}-{tool_name}",
-                identity_id=identity_id,
+                identity_id=grant_identity_id,
                 agent_id=next(str(s["agent_label"]) for s in _DEMO_IDENTITIES if s["slug"] == slug),
                 tenant_id=tenant_id,
                 tool_name=tool_name,

--- a/src/agent_bom/graph/governance_overlay.py
+++ b/src/agent_bom/graph/governance_overlay.py
@@ -119,6 +119,13 @@ def apply_governance_overlay(
                     "expires_at": identity.expires_at,
                     "allowed_tools": list(identity.allowed_tools),
                     "scope_bound": bool(identity.allowed_tools),
+                    # Surface the accountability + usage fields the NHI governance
+                    # evaluator reads so ownership/dormancy verdicts reflect the
+                    # real identity record instead of defaulting every identity to
+                    # orphaned + never-observed.
+                    "owner": getattr(identity, "owner", "") or "",
+                    "owner_type": getattr(identity, "owner_type", "") or "",
+                    "last_used_at": getattr(identity, "last_used_at", "") or "",
                 },
             )
         )

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -429,3 +429,110 @@ def test_demo_estate_bootstrap_is_idempotent(demo_estate_client: TestClient) -> 
     assert second.get("reason") == "demo_jobs_present"
     again = demo_estate_client.get("/v1/jobs", headers={"X-Agent-Bom-Role": "admin"}).json()
     assert again.get("total") == first.get("total")
+
+
+def test_demo_estate_exposure_paths_materialized(demo_estate_client: TestClient) -> None:
+    """The materialized exposure-path queue (read by /v1/graph/exposure-paths) is
+    non-empty and headlines the seeded hero chains."""
+    payload = demo_estate_client.get(
+        "/v1/graph/exposure-paths", headers=ADMIN, params={"limit": 10}
+    ).json()
+    assert payload.get("count", 0) >= 3, payload
+    assert payload.get("total", 0) >= 3, payload
+
+    findings = {f for p in payload.get("paths", []) for f in (p.get("findings") or [])}
+    creds = {c for p in payload.get("paths", []) for c in (p.get("exposedCredentials") or [])}
+    tools = {t for p in payload.get("paths", []) for t in (p.get("reachableTools") or [])}
+    # The PyYAML RCE → run_shell → AWS-secret hero chain materializes.
+    assert "CVE-2020-14343" in findings, findings
+    assert "AWS_SECRET_ACCESS_KEY" in creds, creds
+    assert "run_shell" in tools, tools
+
+
+def test_demo_estate_nhi_governance_tells_a_story(demo_estate_client: TestClient) -> None:
+    """NHI governance evaluates the seeded identities and surfaces at least one
+    over-granted, one dormant/orphaned, and one clearly high/critical identity."""
+    posture = demo_estate_client.get("/v1/graph/nhi/governance", headers=ADMIN).json()
+    assert posture.get("evaluated", 0) >= 5, posture
+    counts = posture.get("counts") or {}
+    assert counts.get("over_granted", 0) >= 1, counts
+    assert counts.get("dormant", 0) >= 1, counts
+    assert counts.get("orphaned", 0) >= 1, counts
+    bands = counts.get("by_risk_band") or {}
+    assert (bands.get("critical", 0) + bands.get("high", 0)) >= 1, bands
+
+    # A dormant + orphaned admin identity is the headline risk.
+    worst = (posture.get("identities") or [])[0]
+    assert worst.get("is_dormant") and worst.get("is_orphaned"), worst
+    assert worst.get("risk_band") in {"high", "critical"}, worst
+
+
+def test_demo_estate_overview_identity_tile_populated(demo_estate_client: TestClient) -> None:
+    """The Overview NHI/Identity tile reads the live identity store, which the
+    demo seed populates, so it is no longer 0/idle."""
+    overview = demo_estate_client.get("/v1/overview").json()
+    identity = overview["domains"]["identity"]
+    assert identity["metric"] >= 5, identity
+    assert identity["detail"]["managed_identities"] >= 5, identity
+    assert identity["status"] != "idle", identity
+
+
+def test_demo_estate_agents_fall_back_to_demo_inventory(
+    demo_estate_client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On a hosted server local discovery is empty; the demo estate falls back to
+    the curated inventory so /v1/agents + /v1/agents/mesh are non-empty and
+    correlated with the graph agents."""
+    import agent_bom.discovery as discovery_mod
+
+    monkeypatch.setattr(discovery_mod, "discover_all", lambda: [])
+    from agent_bom.api.routes.discovery import _clear_agents_response_cache_for_tests
+
+    _clear_agents_response_cache_for_tests()
+
+    agents = demo_estate_client.get("/v1/agents", headers=ADMIN).json()
+    names = {a.get("name") for a in agents.get("agents", [])}
+    assert agents.get("count", 0) >= 5, agents
+    assert {"cursor", "langchain-service", "support-copilot"} <= names, names
+
+    mesh = demo_estate_client.get("/v1/agents/mesh", headers=ADMIN).json()
+    assert len(mesh.get("nodes") or []) >= 5, mesh
+
+
+def test_demo_estate_agents_no_fallback_without_demo_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env unset ⇒ live discovery only; the demo inventory is never injected."""
+    monkeypatch.delenv("AGENT_BOM_DEMO_ESTATE", raising=False)
+    import agent_bom.discovery as discovery_mod
+    from agent_bom.api.routes.discovery import _discover_agents_with_demo_fallback
+
+    monkeypatch.setattr(discovery_mod, "discover_all", lambda: [])
+    assert _discover_agents_with_demo_fallback() == []
+
+
+def test_demo_estate_scan_findings_restored_after_restart(
+    demo_estate_client: TestClient,
+) -> None:
+    """A restart resets the in-memory job store; demo mode must re-seed the scan
+    so posture + findings are restored (the graph snapshot already persists)."""
+    from agent_bom.api import stores as api_stores
+    from agent_bom.demo_estate.bootstrap import (
+        _tenant_has_demo_jobs,
+        maybe_bootstrap_demo_estate,
+    )
+    from agent_bom.demo_estate.showcase_graph import SHOWCASE_TENANT
+
+    before = demo_estate_client.get("/v1/findings", headers=ADMIN, params={"limit": 3}).json()
+    assert before.get("total", 0) > 0
+
+    # Simulate a process restart: the in-memory job store is recreated empty
+    # while the persisted graph snapshot survives.
+    api_stores._store = None
+    assert not _tenant_has_demo_jobs(api_stores._get_store(), SHOWCASE_TENANT)
+
+    summary = maybe_bootstrap_demo_estate()
+    assert summary.get("seeded") is True, summary
+
+    after = demo_estate_client.get("/v1/findings", headers=ADMIN, params={"limit": 3}).json()
+    assert after.get("total", 0) == before.get("total", 0), (before.get("total"), after.get("total"))


### PR DESCRIPTION
## Problem

The seeded/anonymous demo (`AGENT_BOM_DEMO_ESTATE=1`) rendered a broken or empty
story on several lanes, so the Overview and drill-downs did not show ONE
fully-correlated estate. Re-verified in clean isolated state.

## Gaps & fixes

**1. `/v1/agents` + `/v1/agents/mesh` empty on hosted demo.** They do live
local-disk discovery (`discover_all()`), which finds nothing on a hosted server,
so the Agents page and the Overview NHI/agents tile read empty. Added a strictly
demo-gated fallback (`_discover_agents_with_demo_fallback`): when demo mode is on
AND live discovery is empty, build agents from the curated `DEMO_INVENTORY`. Env
unset ⇒ live discovery only — the fallback is never injected into real
deployments.

**2. `/v1/graph/exposure-paths` returned 0.** It reads the materialized
`attack_paths` table (populated from `graph.attack_paths` at save time), which
the seed never set — even though `/v1/graph/attack-paths` already derived paths
on the fly. The seed now materializes `graph.attack_paths` via the exact same
deriver (`_derived_attack_paths`) before save. Pure seed-shaping; no attack-path
algorithm change.

**3. NHI/identity governance had no story + Overview NHI/Identity tile read 0.**
The seed used a throwaway identity store, so the live store (read by the overview
tile and by the request-time governance overlay) stayed empty. Now a
deterministic, enriched NHI estate is seeded into the live identity store
(owner, last_used, standing tool scopes) and shared with the persisted graph
nodes so ids match (no duplicate identities when the overlay re-projects at
request time). The governance overlay also propagates `owner`/`owner_type`/
`last_used_at` onto `MANAGED_IDENTITY` nodes — a general correctness fix so real
identities no longer all default to orphaned + never-observed. One demo identity
is a dormant, orphaned admin reaching an exposed resource (critical).

**4. Seed reliability.** Identity + scan/findings seeding now run independently
of the graph seed on every startup. Graph seeding is exception-isolated, so a
stale or failing snapshot can no longer abort findings/identity seeding, and the
in-memory scan job re-seeds deterministically after a restart. The graph seed
early-return on a pre-existing snapshot no longer blocks the findings/identity
seed.

## Verification (clean isolated state: temp graph DB + state dir)

| Lane | Before | After | After restart |
|---|---|---|---|
| `/v1/overview` posture | F 37.0 | F 37.0 | F 37.0 |
| Overview NHI/Identity tile | **0 / idle** | **5 / ok** | **5 / ok** |
| Overview Vuln/SCA | 15 | 15 | 15 |
| `/v1/findings` total | 49 | 49 | 49 |
| `/v1/agents` (hosted, empty local discovery) | **0** | **5 correlated** | — |
| `/v1/graph/exposure-paths` count / total | **0 / 0** | **10 / 23** | **10 / 23** |
| `/v1/graph/nhi/governance` evaluated | 5 (all medium, over_granted 0) | **5; over_granted 2, dormant 2, orphaned 2, 1 critical** | same |
| `/v1/compliance/summary` overall_score | 32.1 | 32.1 | 32.1 |

Exposure-paths hero chain (rank 1, risk 100, critical): `CVE-2020-14343` →
`run_shell` → `AWS_SECRET_ACCESS_KEY`. NHI headline: **Support Copilot** —
dormant + orphaned admin, risk 86 (critical).

Non-demo path (env unset) confirmed to do live discovery only (no demo injection).

## Tests

Added to `tests/test_demo_estate_bootstrap.py`: exposure-paths materialization
(hero chain), NHI governance story, Overview identity tile, agents demo fallback
(+ no-fallback without demo mode), and findings-restored-after-restart. Suites
green: demo-estate (24), graph governance overlay / nhi / attack-paths /
attack-path e2e, nhi lifecycle, discovery envelope, agent-detail, api-hardening.

## Files

- `src/agent_bom/demo_estate/showcase_graph.py` — deterministic enriched NHI
  estate (`demo_identity_records`, `build_demo_identity_store`,
  `seed_showcase_identities`, `_annotate_demo_identity_risk`), shared identity
  store across snapshots, `_materialize_showcase_attack_paths`.
- `src/agent_bom/demo_estate/bootstrap.py` — independent, exception-isolated
  graph / identity / scan seeding.
- `src/agent_bom/api/routes/discovery.py` — demo-gated agents fallback.
- `src/agent_bom/graph/governance_overlay.py` — propagate owner/last_used onto
  managed-identity nodes.
- `tests/test_demo_estate_bootstrap.py` — new coverage.
