### PR TITLE
ci(azure-ingestion): skip scheduled run when Azure OIDC is not configured

### DIFF
--- a/.github/workflows/azure-ingestion.yml
+++ b/.github/workflows/azure-ingestion.yml
@@ -27,6 +27,15 @@ concurrency:
 jobs:
   ingest:
     name: Azure scan and API ingest
+    # Optional scheduled integration: only run when this repo has Azure OIDC
+    # federation configured. On repos/forks without the Azure variables set,
+    # the job is SKIPPED (neutral) instead of failing the daily schedule red.
+    # Set vars.AGENT_BOM_AZURE_CLIENT_ID/TENANT_ID/SUBSCRIPTION_ID (+ an Azure
+    # federated credential trusting this repo) to activate live ingestion.
+    if: >-
+      ${{ vars.AGENT_BOM_AZURE_CLIENT_ID != ''
+          && vars.AGENT_BOM_AZURE_TENANT_ID != ''
+          && vars.AGENT_BOM_AZURE_SUBSCRIPTION_ID != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:


### PR DESCRIPTION
Resolves the red **Azure Ingestion** scheduled workflow flagged in the release audit. It failed at *Validate Azure OIDC configuration* because `vars.AGENT_BOM_AZURE_*` aren't set on this repo — a **deployment-config gap, not a code failure** (the Azure scan feature is verified healthy). Gates the job on the Azure OIDC variables so an unconfigured repo **skips (neutral)** instead of failing red daily; setting the vars + an Azure federated credential still activates live scheduled ingestion. Unblocks a green release run without over-claiming Azure ingestion is live.