### PR TITLE
feat(auth): dashboard SSO CTA for OIDC auth-code/PKCE

### DIFF
--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -193,14 +193,17 @@ Fleet trust scoring is advisory and evidence-backed. The score combines registry
 | Path | Configure with | Surface | Counts toward the boot-gate / `auth_configured`? |
 | --- | --- | --- | --- |
 | API key (M2M) | `AGENT_BOM_API_KEY` / `AGENT_BOM_API_KEYS` | CLI · API · MCP | Yes |
-| OIDC JWT (bearer) | `AGENT_BOM_OIDC_ISSUER` or `AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON` | API · UI | Yes |
+| OIDC JWT (bearer) | `AGENT_BOM_OIDC_ISSUER` or `AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON` | API · UI (bearer) | Yes |
+| OIDC browser SSO (auth-code + PKCE) | Issuer + `AGENT_BOM_OIDC_CLIENT_ID` + `AGENT_BOM_OIDC_REDIRECT_URI` (optional secret/scopes) | Dashboard `/login` → `/v1/auth/oidc/login` | Yes (signals `oidc_browser` in auth runtime) |
 | SAML SSO (browser) | `AGENT_BOM_SAML_IDP_*` + `AGENT_BOM_SAML_SP_*` | UI (mints a short-lived session API key) | Yes |
 | SCIM bearer (provisioning) | `AGENT_BOM_SCIM_BEARER_TOKEN` | `/scim/v2/*` only | Yes |
-| Trusted reverse proxy | `AGENT_BOM_TRUST_PROXY_AUTH=1` | UI · API | Yes (upstream proxy is the authority) |
+| Trusted reverse proxy | `AGENT_BOM_TRUST_PROXY_AUTH=1` | UI · API | Yes (upstream proxy is the authority; preferred when present) |
 | Browser session cookie | Minted server-side after OIDC/SAML/proxy login | UI | Derived — not a standalone configured path |
 | mTLS (client cert) | `AGENT_BOM_TLS_REQUIRE_CLIENT_CERT=1` | Transport | No — transport posture, not RBAC identity |
 
 A SAML-only deployment is a valid, fail-closed posture: browser users authenticate against the IdP and receive a short-lived session API key, while anonymous requests are still rejected (401) by the API-key middleware, which stays installed whenever any auth path is configured.
+
+**Dashboard OIDC auth-code + PKCE:** when the control plane has an OIDC issuer plus a confidential or public client (`AGENT_BOM_OIDC_CLIENT_ID`, `AGENT_BOM_OIDC_REDIRECT_URI`, optional `AGENT_BOM_OIDC_CLIENT_SECRET` / `AGENT_BOM_OIDC_SCOPES`), the dashboard shows **Sign in with SSO**. That CTA navigates same-origin to `GET /v1/auth/oidc/login`, completes the IdP authorize + callback with PKCE S256, and mints the usual httpOnly browser session + CSRF cookies. Role and tenant claims map through the same OIDC claim contract as bearer JWT verification. Reverse-proxy SSO remains preferred when `AGENT_BOM_TRUST_PROXY_AUTH=1` is set. Laptop-to-gateway MCP PKCE is a separate later surface — not this dashboard path. mTLS remains transport only and never substitutes for user identity.
 
 **Tracing:** every API response includes `X-Request-ID`, `X-Trace-ID`, `X-Span-ID`, and W3C `traceparent`. If your ingress or collector already sends `traceparent`, `tracestate`, or bounded W3C `baggage`, `agent-bom` preserves the upstream trace context and continues the chain. `GET /health` also reports the current tracing contract (`w3c_trace_context`, `w3c_tracestate`, `w3c_baggage`) plus OTLP export state so operators can confirm whether tracing is merely available or actively exported. Set `AGENT_BOM_OTEL_TRACES_ENDPOINT` to export API request spans over OTLP/HTTP, and use `AGENT_BOM_OTEL_TRACES_HEADERS` for collector auth headers when needed.
 
@@ -213,6 +216,11 @@ export AGENT_BOM_OIDC_ROLE_CLAIM="agent_bom_role"
 export AGENT_BOM_OIDC_TENANT_CLAIM="tenant_id"      # or a custom claim like org_slug
 # export AGENT_BOM_OIDC_ALLOW_DEFAULT_TENANT=1      # only for explicit single-tenant compatibility mode
 # export AGENT_BOM_OIDC_REQUIRED_NONCE="replace-me"  # optional when your IdP flow emits nonce
+# Dashboard SSO (auth-code + PKCE) — in addition to bearer verification:
+# export AGENT_BOM_OIDC_CLIENT_ID="agent-bom-dashboard"
+# export AGENT_BOM_OIDC_REDIRECT_URI="https://cp.example/v1/auth/oidc/callback"
+# export AGENT_BOM_OIDC_CLIENT_SECRET="..."         # optional for confidential clients
+# export AGENT_BOM_OIDC_SCOPES="openid profile email"
 ```
 
 That keeps API roles and tenant boundaries aligned with the upstream identity provider. Missing tenant claims now fail closed by default instead of silently falling back to a shared tenant; `AGENT_BOM_OIDC_ALLOW_DEFAULT_TENANT=1` is the explicit compatibility escape hatch for single-tenant deployments.
@@ -373,8 +381,9 @@ payloads, that is not provided today; scope it explicitly rather than assuming i
 
 The browser UI exposes a dedicated sign-in surface at `/login`. Unauthenticated
 users are redirected there with a `returnTo` query parameter so they can resume
-the page they requested after establishing a browser session or completing
-upstream OIDC at the reverse proxy.
+the page they requested after establishing a browser session — via reverse-proxy
+SSO, first-party OIDC auth-code/PKCE (**Sign in with SSO** → `/v1/auth/oidc/login`),
+or API-key exchange.
 
 First command for a pilot operator:
 

--- a/docs/adr/006-ui-auth-model.md
+++ b/docs/adr/006-ui-auth-model.md
@@ -10,26 +10,30 @@ The packaged dashboard shipped without a defined browser authentication model. T
 
 ## Decision
 
-The control-plane UI uses two supported browser auth modes:
+The control-plane UI uses these supported browser auth modes:
 
-1. Recommended for enterprise: same-origin reverse-proxy OIDC or SSO session. The reverse proxy terminates browser auth, keeps the session cookie, and injects trusted `X-Agent-Bom-Role` and `X-Agent-Bom-Tenant-ID` headers to the backend. `AGENT_BOM_TRUST_PROXY_AUTH=1` must be enabled on the API for this mode.
-2. Fallback for local and single-user pilots: a short-lived API key entered into the dashboard. The UI exchanges it for a same-origin `httpOnly` browser session cookie and never stores or forwards the raw key from browser storage.
+1. Recommended when available: same-origin reverse-proxy OIDC or SSO session. The reverse proxy terminates browser auth, keeps the session cookie, and injects trusted `X-Agent-Bom-Role` and `X-Agent-Bom-Tenant-ID` headers to the backend. `AGENT_BOM_TRUST_PROXY_AUTH=1` must be enabled on the API for this mode.
+2. First-party dashboard OIDC: authorization-code + PKCE (`GET /v1/auth/oidc/login` → IdP → `/v1/auth/oidc/callback`). The API verifies the ID token, maps role/tenant claims into the existing RBAC model, and mints the same httpOnly browser session + CSRF cookies used elsewhere. Auth runtime exposes `oidc_browser` so `/login` can show **Sign in with SSO** without guessing from bearer-only OIDC.
+3. Fallback for local and single-user pilots: a short-lived API key entered into the dashboard. The UI exchanges it for a same-origin `httpOnly` browser session cookie and never stores or forwards the raw key from browser storage.
 
-The UI always sends `credentials: "include"` over same-origin fetch/EventSource URLs so same-origin proxy sessions work without custom browser configuration and browser credentials cannot be redirected through runtime config. A global auth gate now blocks dashboard routes until one of the supported auth modes succeeds.
+mTLS (client certificates) is a transport posture between proxy/gateway and control plane — not a browser user identity.
+
+The UI always sends `credentials: "include"` over same-origin fetch/EventSource URLs so same-origin proxy sessions and first-party OIDC sessions work without custom browser configuration and browser credentials cannot be redirected through runtime config. A global auth gate now blocks dashboard routes until one of the supported auth modes succeeds.
 
 ## Consequences
 
 ### Positive
 
 - The browser auth story is explicit and consistent across backend, runtime config, and UI behavior.
-- Enterprise ingress can use OIDC without exposing raw API keys to end users.
+- Enterprise ingress can use reverse-proxy SSO or first-party OIDC without exposing raw API keys to end users.
 - Single-user pilots still have an explicit API-key exchange without a browser-readable bearer-token cache.
 
 ### Negative
 
-- Multi-user browser access still depends on an external reverse proxy or the API browser-session cookie flow.
+- Multi-user browser access depends on reverse proxy, first-party OIDC client configuration, or the API browser-session cookie flow.
 - Proxy-auth mode trusts headers and must only be enabled behind a hardened ingress that strips spoofed client headers.
 
 ### Neutral
 
 - The dashboard no longer treats unauthenticated production deployments as undefined behavior; it shows an auth gate instead.
+- Gateway / laptop MCP PKCE remains a separate later surface; this ADR covers the control-plane dashboard path only.

--- a/site-docs/deployment/enterprise-auth-and-tenancy.md
+++ b/site-docs/deployment/enterprise-auth-and-tenancy.md
@@ -47,9 +47,13 @@ support data, see
 - **SAML is intentionally narrow.**
   It is an assertion-verification path that returns a short-lived API key. It is
   not a full browser session framework with logout/session federation depth.
-- **OIDC is strongest on the control-plane API today.**
-  Per-user OAuth2 auth-code / PKCE for laptop-to-gateway flows is still a later
-  runtime surface.
+- **Dashboard OIDC auth-code / PKCE is available; gateway laptop PKCE is later.**
+  The control-plane dashboard can complete first-party OIDC login via
+  `/v1/auth/oidc/login` (PKCE S256) when `AGENT_BOM_OIDC_CLIENT_ID` and
+  `AGENT_BOM_OIDC_REDIRECT_URI` are set alongside the issuer. Per-user OAuth2
+  auth-code / PKCE for laptop-to-gateway MCP flows remains a later runtime
+  surface. Reverse-proxy SSO is still preferred when present. mTLS is transport
+  posture only — not user identity.
 - **Good enterprise posture still depends on good IdP mapping.**
   Claim naming, tenant binding, and deployment configuration matter almost as
   much as the code paths.
@@ -64,9 +68,11 @@ support data, see
 | Mode | Best for | Tenant source | Role source | Notes |
 |---|---|---|---|---|
 | API key | machine-to-machine, automation, internal service accounts | key metadata | key metadata | hashed at rest; role hierarchy enforced in middleware |
-| OIDC | browser/API users behind corporate IdP | JWT tenant claim or tenant-bound issuer | JWT role claim / groups | issuer + audience verified; tenant defaults fail closed by default |
+| OIDC bearer JWT | API callers with corporate IdP tokens | JWT tenant claim or tenant-bound issuer | JWT role claim / groups | issuer + audience verified; tenant defaults fail closed by default |
+| OIDC browser SSO | Dashboard users without a reverse-proxy identity bridge | same OIDC tenant claim contract | same OIDC role claim / groups | auth-code + PKCE; mints httpOnly session cookie; auth runtime mode `oidc_browser` |
 | SAML | enterprises that need SAML IdP compatibility | SAML attribute | SAML attribute | assertion is verified, then converted into a short-lived API key |
-| Trusted proxy | same-origin ingress or auth gateway in front of API | `X-Agent-Bom-Tenant-ID` | `X-Agent-Bom-Role` | only when `AGENT_BOM_TRUST_PROXY_AUTH=1` |
+| Trusted proxy | same-origin ingress or auth gateway in front of API | `X-Agent-Bom-Tenant-ID` | `X-Agent-Bom-Role` | only when `AGENT_BOM_TRUST_PROXY_AUTH=1`; preferred when present |
+| mTLS | proxy/gateway → API transport | n/a | n/a | not an identity path |
 
 ## RBAC model
 
@@ -311,8 +317,9 @@ The practical rule is:
 
 So a seamless self-hosted browser experience looks like this:
 
-1. the user authenticates through trusted proxy OIDC, direct OIDC bearer, or a
-   narrower fallback such as a short-lived or session-only API key
+1. the user authenticates through trusted proxy OIDC, first-party dashboard OIDC
+   (auth-code + PKCE), direct OIDC bearer, or a narrower fallback such as a
+   short-lived or session-only API key
 2. the API resolves subject, role, tenant, and request trace context
 3. the UI adapts to that state
 4. the API still enforces every request server-side

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -416,12 +416,15 @@ def configure_auth_runtime(
     trusted_proxy_enabled: bool,
     scim_enabled: bool = False,
     saml_enabled: bool = False,
+    oidc_browser_enabled: bool = False,
     unauthenticated_allowed: bool = False,
 ) -> None:
     """Track the active auth modes for operator/UI introspection surfaces."""
     configured_modes: list[str] = []
     if trusted_proxy_enabled:
         configured_modes.append("trusted_proxy")
+    if oidc_browser_enabled:
+        configured_modes.append("oidc_browser")
     if oidc_enabled:
         configured_modes.append("oidc_bearer")
     if api_key_configured:
@@ -445,7 +448,10 @@ def configure_auth_runtime(
     if unauthenticated_allowed and not auth_configured:
         recommended_ui_mode = "no_auth"
     elif trusted_proxy_enabled:
+        # Reverse-proxy SSO remains preferred when present.
         recommended_ui_mode = "reverse_proxy_oidc"
+    elif oidc_browser_enabled:
+        recommended_ui_mode = "oidc_browser"
     elif oidc_enabled:
         recommended_ui_mode = "oidc_bearer"
     elif saml_enabled or api_key_configured:

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -746,10 +746,12 @@ def configure_api(
     runtime_key_store_configured = _seed_runtime_api_key(api_key)
 
     from agent_bom.api.oidc import oidc_enabled_from_env
+    from agent_bom.api.oidc_browser import oidc_browser_enabled_from_env
     from agent_bom.api.saml import saml_enabled_from_env
     from agent_bom.api.scim import scim_enabled_from_env
 
     oidc_enabled = oidc_enabled_from_env()
+    oidc_browser_enabled = oidc_browser_enabled_from_env()
     scim_enabled = scim_enabled_from_env()
     saml_enabled = saml_enabled_from_env()
     trusted_proxy_enabled = os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH", "").strip().lower() in {"1", "true", "yes", "on"}
@@ -758,6 +760,7 @@ def configure_api(
         or env_key_store_configured
         or runtime_key_store_configured
         or oidc_enabled
+        or oidc_browser_enabled
         or trusted_proxy_enabled
         or scim_enabled
         or saml_enabled
@@ -774,6 +777,7 @@ def configure_api(
     configure_auth_runtime(
         api_key_configured=bool(api_key or env_key_store_configured or runtime_key_store_configured),
         oidc_enabled=oidc_enabled,
+        oidc_browser_enabled=oidc_browser_enabled,
         trusted_proxy_enabled=trusted_proxy_enabled,
         scim_enabled=scim_enabled,
         saml_enabled=saml_enabled,

--- a/tests/api/test_api_oidc_browser.py
+++ b/tests/api/test_api_oidc_browser.py
@@ -143,3 +143,68 @@ def test_oidc_browser_config_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AGENT_BOM_OIDC_ALLOW_DEFAULT_TENANT", "1")
     cfg = OIDCBrowserConfig.from_env()
     assert cfg.enabled is True
+
+
+def test_auth_runtime_exposes_oidc_browser_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.api.middleware import configure_auth_runtime, get_auth_runtime_status
+
+    configure_auth_runtime(
+        api_key_configured=True,
+        oidc_enabled=True,
+        oidc_browser_enabled=True,
+        trusted_proxy_enabled=False,
+    )
+    status = get_auth_runtime_status()
+    assert "oidc_browser" in status["configured_modes"]
+    assert "oidc_bearer" in status["configured_modes"]
+    assert status["recommended_ui_mode"] == "oidc_browser"
+
+    configure_auth_runtime(
+        api_key_configured=True,
+        oidc_enabled=True,
+        oidc_browser_enabled=True,
+        trusted_proxy_enabled=True,
+    )
+    status = get_auth_runtime_status()
+    assert status["recommended_ui_mode"] == "reverse_proxy_oidc"
+
+
+def test_oidc_callback_happy_path_mints_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_OIDC_ISSUER", "https://issuer.example")
+    monkeypatch.setenv("AGENT_BOM_OIDC_CLIENT_ID", "dashboard-client")
+    monkeypatch.setenv("AGENT_BOM_OIDC_REDIRECT_URI", "https://cp.example/v1/auth/oidc/callback")
+    monkeypatch.setenv("AGENT_BOM_OIDC_ALLOW_DEFAULT_TENANT", "1")
+    monkeypatch.setenv("AGENT_BOM_BROWSER_SESSION_SIGNING_KEY", "test-browser-session-signing-key")
+
+    state = enterprise._new_oidc_login_state()
+    sealed = seal_pkce_cookie(code_verifier="verifier-value", nonce="nonce-value")
+    import asyncio
+
+    with (
+        patch(
+            "agent_bom.api.oidc_browser.exchange_code_for_tokens",
+            return_value={"id_token": "fake.jwt.token"},
+        ),
+        patch(
+            "agent_bom.api.oidc_browser.verify_browser_id_token",
+            return_value={
+                "email": "analyst@example.com",
+                "sub": "oidc-sub-1",
+                "agent_bom_role": "analyst",
+            },
+        ),
+    ):
+        response = asyncio.run(
+            enterprise.oidc_browser_callback(
+                _request(path="/v1/auth/oidc/callback", cookies={"agent_bom_oidc_pkce": sealed}),
+                code="auth-code",
+                state=state,
+            )
+        )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/"
+    cookies = response.headers.getlist("set-cookie")
+    assert any("agent_bom_session=" in c for c in cookies)
+    assert any("agent_bom_csrf=" in c for c in cookies)
+    assert any("agent_bom_oidc_pkce=" in c and "Max-Age=0" in c for c in cookies)

--- a/tests/api/test_api_operator_policy.py
+++ b/tests/api/test_api_operator_policy.py
@@ -242,7 +242,13 @@ def test_auth_policy_surface_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "default_overlap_seconds" in body["api_key"]
     assert "max_overlap_seconds" in body["api_key"]
     assert body["rate_limit_key"]["status"] in {"ok", "ephemeral", "unknown_age", "rotation_due", "max_age_exceeded"}
-    assert body["ui"]["recommended_mode"] in {"no_auth", "reverse_proxy_oidc", "oidc_bearer", "session_api_key"}
+    assert body["ui"]["recommended_mode"] in {
+        "no_auth",
+        "reverse_proxy_oidc",
+        "oidc_browser",
+        "oidc_bearer",
+        "session_api_key",
+    }
     assert body["ui"]["browser_session"] == "signed_http_only_cookie"
     assert body["ui"]["session_storage_fallback"] == "disabled"
     assert body["audit_hmac"]["rotation_tracking_supported"] is True

--- a/ui/components/login-panel.tsx
+++ b/ui/components/login-panel.tsx
@@ -10,6 +10,7 @@ import { userFacingApiErrorMessage } from "@/lib/api-errors";
 import { clearSessionApiKey } from "@/lib/auth";
 
 const AUTH_FAILURE_MESSAGE = "That API key wasn't accepted — check it and try again.";
+const OIDC_BROWSER_LOGIN_PATH = "/v1/auth/oidc/login";
 
 function isAuthFailure(message: string): boolean {
   const normalized = message.toLowerCase();
@@ -79,7 +80,11 @@ export function LoginPanel({
 
   if (!error || isAuthFailure(error)) {
     const configuredModes = session?.configured_modes ?? [];
-    const ssoConfigured = configuredModes.includes("trusted_proxy") || configuredModes.includes("oidc_bearer");
+    const browserOidcConfigured = configuredModes.includes("oidc_browser");
+    const trustedProxyConfigured = configuredModes.includes("trusted_proxy");
+    const oidcBearerConfigured = configuredModes.includes("oidc_bearer");
+    const proxyOrBearerHint = !browserOidcConfigured && (trustedProxyConfigured || oidcBearerConfigured);
+    const showApiKeyDivider = browserOidcConfigured || proxyOrBearerHint;
     const authError = error && isAuthFailure(error) ? AUTH_FAILURE_MESSAGE : null;
     const shownError = formError ?? authError;
 
@@ -91,13 +96,37 @@ export function LoginPanel({
               <BrandLogo />
             </div>
             <h1 className="text-xl font-semibold tracking-tight text-zinc-100">{title}</h1>
-            <p className="mt-1 text-sm text-zinc-400">Enter your API key to access the dashboard.</p>
+            <p className="mt-1 text-sm text-zinc-400">
+              {browserOidcConfigured
+                ? "Sign in with SSO, or use an API key as a fallback."
+                : "Enter your API key to access the dashboard."}
+            </p>
           </div>
 
-          {ssoConfigured ? (
+          {browserOidcConfigured ? (
+            <div className="mb-6">
+              <a
+                href={OIDC_BROWSER_LOGIN_PATH}
+                className="flex w-full items-center justify-center rounded-xl bg-emerald-500 px-4 py-2.5 text-sm font-medium text-zinc-950 transition hover:bg-emerald-400"
+              >
+                Sign in with SSO
+              </a>
+              {showApiKeyDivider ? (
+                <div className="mt-6 flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-zinc-600">
+                  <span className="h-px flex-1 bg-zinc-800" />
+                  or use an API key
+                  <span className="h-px flex-1 bg-zinc-800" />
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+
+          {proxyOrBearerHint ? (
             <div className="mb-6">
               <p className="rounded-2xl border border-zinc-800 bg-zinc-900/60 px-4 py-3 text-center text-sm text-zinc-400">
-                Single sign-on is handled by your identity provider or reverse proxy.
+                {trustedProxyConfigured
+                  ? "Single sign-on is handled by your reverse proxy. Continue there, or use an API key below."
+                  : "Single sign-on is handled by your identity provider or reverse proxy."}
               </p>
               <div className="mt-6 flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-zinc-600">
                 <span className="h-px flex-1 bg-zinc-800" />
@@ -148,7 +177,7 @@ export function LoginPanel({
                 className="w-full rounded-xl border border-zinc-700 bg-zinc-950 py-2.5 pl-9 pr-3 font-mono text-sm text-zinc-100 outline-none ring-0 placeholder:text-zinc-600 focus:border-emerald-500"
                 placeholder="Paste your API key"
                 autoComplete="off"
-                autoFocus
+                autoFocus={!browserOidcConfigured}
               />
             </div>
             <p className="mt-2 text-xs leading-5 text-zinc-500">
@@ -161,7 +190,11 @@ export function LoginPanel({
             <button
               type="submit"
               disabled={!apiKey.trim()}
-              className="mt-5 w-full rounded-xl bg-emerald-500 px-4 py-2.5 text-sm font-medium text-zinc-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-zinc-800 disabled:text-zinc-500"
+              className={
+                browserOidcConfigured
+                  ? "mt-5 w-full rounded-xl border border-zinc-700 bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-100 transition hover:border-zinc-500 hover:bg-zinc-800 disabled:cursor-not-allowed disabled:border-zinc-800 disabled:bg-zinc-950 disabled:text-zinc-600"
+                  : "mt-5 w-full rounded-xl bg-emerald-500 px-4 py-2.5 text-sm font-medium text-zinc-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-zinc-800 disabled:text-zinc-500"
+              }
             >
               Sign in
             </button>
@@ -193,9 +226,9 @@ export function LoginPanel({
             </div>
           </form>
 
-          {!ssoConfigured ? (
+          {!browserOidcConfigured && !proxyOrBearerHint ? (
             <p className="mt-6 border-t border-zinc-900 pt-4 text-center text-xs text-zinc-600">
-              Setting up single sign-on? Configure a reverse proxy or OIDC issuer in your deployment.
+              Setting up single sign-on? Configure browser OIDC, a reverse proxy, or an OIDC issuer in your deployment.
             </p>
           ) : null}
         </div>

--- a/ui/tests/login-page.test.tsx
+++ b/ui/tests/login-page.test.tsx
@@ -65,13 +65,48 @@ describe("LoginPage", () => {
     expect(screen.getByText("Enter your API key to access the dashboard.")).toBeInTheDocument();
     expect(screen.getByLabelText("API key")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /sign in with sso/i })).not.toBeInTheDocument();
     // First-run help points operators at the env var, no raw mode identifiers leak.
     expect(screen.getByText("AGENT_BOM_API_KEYS")).toBeInTheDocument();
     expect(screen.queryByText("Configured auth modes")).not.toBeInTheDocument();
     expect(screen.queryByText("session_api_key")).not.toBeInTheDocument();
   });
 
-  it("shows the SSO-handled hint (no fake button) when a proxy/OIDC mode is configured", async () => {
+  it("shows Sign in with SSO when browser OIDC is configured", async () => {
+    apiMock.getAuthMe.mockReset();
+    apiMock.getAuthMe.mockResolvedValue({
+      authenticated: false,
+      auth_required: true,
+      configured_modes: ["oidc_browser", "oidc_bearer", "api_key"],
+      recommended_ui_mode: "oidc_browser",
+      auth_method: null,
+      subject: null,
+      role: null,
+      tenant_id: "default",
+      role_summary: null,
+      memberships: [],
+      request_id: null,
+      trace_id: null,
+      span_id: null,
+    });
+
+    render(
+      <AuthProvider>
+        <LoginPage />
+      </AuthProvider>,
+    );
+
+    const ssoLink = await screen.findByRole("link", { name: /sign in with sso/i });
+    expect(ssoLink).toHaveAttribute("href", "/v1/auth/oidc/login");
+    expect(screen.getByText("Sign in with SSO, or use an API key as a fallback.")).toBeInTheDocument();
+    expect(screen.getByLabelText("API key")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
+    expect(
+      screen.queryByText("Single sign-on is handled by your identity provider or reverse proxy."),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the reverse-proxy SSO hint (no fake button) when trusted_proxy is configured", async () => {
     apiMock.getAuthMe.mockReset();
     apiMock.getAuthMe.mockResolvedValue({
       authenticated: false,
@@ -96,9 +131,11 @@ describe("LoginPage", () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByText("Single sign-on is handled by your identity provider or reverse proxy.")).toBeInTheDocument(),
+      expect(
+        screen.getByText("Single sign-on is handled by your reverse proxy. Continue there, or use an API key below."),
+      ).toBeInTheDocument(),
     );
-    expect(screen.queryByRole("button", { name: /continue with sso/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /sign in with sso/i })).not.toBeInTheDocument();
     expect(screen.getByLabelText("API key")).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- Expose `oidc_browser` in auth-runtime `configured_modes` / `recommended_ui_mode` when `OIDCBrowserConfig.enabled`, so the dashboard can show a real SSO CTA without guessing from bearer-only OIDC.
- Login panel: primary **Sign in with SSO** → same-origin `/v1/auth/oidc/login` (full navigation) when browser OIDC is configured; API-key fallback retained; reverse-proxy hint kept for `trusted_proxy`.
- Enterprise docs + ADR-006: honest dashboard auth-code/PKCE path; gateway laptop PKCE still later; mTLS remains transport, not identity.

Closes #3804.

## Verification
- `uv run pytest tests/api/test_api_oidc_browser.py -q` (12 passed)
- `cd ui && npm test -- --run tests/login-page.test.tsx` (5 passed)
- `make preflight` not required (no OpenAPI/route contract changes)

## Notes
- Foundation for browser OIDC login/callback already merged in #3849; this PR is the UI + runtime signal + docs surface.
- Reverse-proxy SSO remains preferred when `AGENT_BOM_TRUST_PROXY_AUTH=1`.
- Out of scope: logout/IdP-initiated, LDAP, CSRF/session trust-model changes, gateway MCP PKCE.


Made with [Cursor](https://cursor.com)