### PR TITLE
docs: reconcile API-op / route-module / MCP-tool counts for 0.95.0

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,7 +75,7 @@ flowchart TB
     subgraph L5["Control plane - same evidence, multi-tenant + audited"]
         direction TB
         MW["Middleware: auth · RBAC · tenant scope · rate-limit · audit"]
-        API["REST API (283 ops)"]
+        API["REST API (300 ops)"]
         GW["Gateway / MCP server / proxy"]
         MW --> API
         MW --> GW
@@ -155,7 +155,7 @@ flowchart TB
         M4["Max body size"]
     end
     subgraph BE["Backend - FastAPI"]
-        R["283 REST operations across 32 route modules\nplus 2 WebSocket routes"]
+        R["300 REST operations across 36 route modules\nplus 2 WebSocket routes"]
     end
     subgraph ST["Stores - start on SQLite, scale to a cluster without rewrites"]
         S1["SQLite (default / single node)"]

--- a/docs/CODEX_CLI.md
+++ b/docs/CODEX_CLI.md
@@ -20,7 +20,7 @@ command = "agent-bom"
 args = ["mcp", "server"]
 ```
 
-That makes the same 54 `agent-bom` MCP tools available to Codex.
+That makes the same 73 `agent-bom` MCP tools available to Codex.
 
 ## What agent-bom discovers for Codex
 

--- a/docs/CORTEX_CODE.md
+++ b/docs/CORTEX_CODE.md
@@ -41,7 +41,7 @@ Or, if `agent-bom` is already installed:
 }
 ```
 
-This makes the same 47 `agent-bom` MCP tools available in CoCo conversations.
+This makes the same 73 `agent-bom` MCP tools available in CoCo conversations.
 
 ## What agent-bom discovers for Cortex
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (239 paths / 283 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (256 paths / 300 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,7 +47,7 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 
 - Deployment chooser (Docker / Helm / EKS / Postgres):
   [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
-- API contract (283 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- API contract (300 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
 - Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
   [`PERMISSIONS.md`](PERMISSIONS.md)
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the


### PR DESCRIPTION
Final pre-tag count reconciliation against merged main. REST **283→300 ops**, **32→36 route modules** (docs/ARCHITECTURE.md, docs/README.md, docs/START_HERE.md); stale integration-guide MCP tool counts **47/54 → 73** (docs/CORTEX_CODE.md, docs/CODEX_CLI.md). `check-counts.py` + `check_release_consistency.py` green.