### PR TITLE
fix(inventory): facet-filtered list drops rows past the page limit (P1, pre-tag)

### DIFF
--- a/src/agent_bom/api/inventory_service.py
+++ b/src/agent_bom/api/inventory_service.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any, Awaitable, Callable, Optional
 
-from agent_bom.api.graph_store import MAX_NODE_PAGE_OFFSET
+from agent_bom.api.graph_store import MAX_NODE_PAGE_OFFSET, encode_graph_cursor
 from agent_bom.graph import SEVERITY_RANK, EntityType
 from agent_bom.graph.ocsf import FINDING_ENTITY_TYPES
 from agent_bom.security import sanitize_error
@@ -343,25 +343,36 @@ async def build_asset_list(
         # Offset paging is ambiguous once an in-route facet filter is applied, so
         # facet-filtered listing is cursor-only. Fall back to a fresh scan.
         offset = 0
-    collected: list[dict[str, Any]] = []
+    collected_nodes: list[Any] = []
+    collected_rows: list[dict[str, Any]] = []
     page_cursor = cursor
     exhausted = False
     for _ in range(MAX_FACET_SCAN_PAGES):
         nodes, _total, next_cursor = await _fetch(page_cursor, 0, MAX_PAGE_LIMIT)
         for node in nodes:
             if predicate(node):
-                collected.append(asset_row(node))
+                collected_nodes.append(node)
+                collected_rows.append(asset_row(node))
         page_cursor = next_cursor
         if not next_cursor:
             exhausted = True
             break
-        if len(collected) >= limit:
+        if len(collected_rows) >= limit:
             break
-    page_rows = collected[:limit]
-    # The continuation cursor is the store cursor after the last consumed store
-    # page; the extra collected rows beyond ``limit`` are re-derived on the next
-    # request, keeping the keyset stable without a private buffer.
-    has_more = not exhausted or len(collected) > limit
+    page_rows = collected_rows[:limit]
+    # The continuation cursor MUST resume after the last EMITTED row — not the
+    # store cursor after the last consumed page, which would skip the matches
+    # collected past ``limit`` within that final store page (a silent drop). When
+    # more matches than ``limit`` were collected, mint the keyset cursor from the
+    # boundary emitted node so the next request re-scans from exactly there;
+    # otherwise everything collected was emitted, so resume from the store cursor
+    # (cap hit, more to scan) or stop (store exhausted).
+    if len(collected_rows) > limit:
+        next_cursor_out = encode_graph_cursor(collected_nodes[limit - 1])
+        has_more = True
+    else:
+        next_cursor_out = "" if exhausted else (page_cursor or "")
+        has_more = bool(next_cursor_out)
     return {
         "schema_version": "inventory.assets.v1",
         "tenant_id": tenant_id,
@@ -379,8 +390,8 @@ async def build_asset_list(
             "offset": 0,
             "limit": limit,
             "cursor": cursor or "",
-            "next_cursor": page_cursor or "",
-            "has_more": bool(has_more and page_cursor),
+            "next_cursor": next_cursor_out,
+            "has_more": has_more,
             "facet_filtered": True,
         },
     }

--- a/tests/test_inventory_assets.py
+++ b/tests/test_inventory_assets.py
@@ -202,6 +202,45 @@ def test_list_provider_facet_filter(inventory_store):
     }
 
 
+def test_list_facet_filter_paginates_without_dropping_rows(tmp_path):
+    """Regression: when a facet filter matches more rows than ``limit`` within a
+    single store page, the continuation cursor must resume after the last EMITTED
+    row — not after the last consumed store page (which silently dropped the
+    overflow and mis-reported ``has_more=False``). Paginating must return every
+    matching asset exactly once."""
+    from agent_bom.api.stores import _get_graph_store
+
+    original = _get_graph_store()
+    store = SQLiteGraphStore(tmp_path / "inv-many.db")
+    total = 130
+    g = UnifiedGraph(scan_id="inv-many", tenant_id="default")
+    for i in range(total):
+        g.add_node(_node(f"agent:a{i:03d}", EntityType.AGENT, f"agent-{i:03d}", environment="production"))
+    store.save_graph(g)
+    set_graph_store(store)
+    try:
+        client = TestClient(app)
+        seen: list[str] = []
+        cursor = ""
+        for _ in range(total):  # generous safety cap above any real page count
+            url = "/v1/inventory/assets?environment=production&limit=40"
+            if cursor:
+                url += f"&cursor={cursor}"
+            body = client.get(url).json()
+            assert body["pagination"]["facet_filtered"] is True
+            page = body["assets"]
+            assert len(page) <= 40
+            seen.extend(row["id"] for row in page)
+            pagination = body["pagination"]
+            if not pagination["has_more"] or not pagination["next_cursor"]:
+                break
+            cursor = pagination["next_cursor"]
+        assert len(seen) == total, f"facet pagination dropped rows: got {len(seen)} of {total}"
+        assert len(set(seen)) == total, "facet pagination returned duplicate rows across pages"
+    finally:
+        set_graph_store(original)
+
+
 def test_list_pagination_with_cursor(inventory_store):
     client = TestClient(app)
     seen: set[str] = set()


### PR DESCRIPTION
Pre-release bug-hunt found a **P1** in the new unified inventory (headline 0.95.0 feature): the facet-filtered `/v1/inventory/assets` list — and the `inventory_list` MCP tool — **silently drop matching rows**.

**Cause:** the continuation cursor was set to the store cursor after the last *consumed* store page, so facet matches collected beyond `limit` within that final store page were skipped, and `has_more` reported `False`. Repro: 400 matches, limit 50 → 300 dropped, page reported complete.

**Fix:** when more matches than `limit` are collected, mint the continuation cursor from the **last emitted node** (`encode_graph_cursor`, the same encoder the store uses), so the next request resumes exactly after it and every match is returned once. Adds a multi-page facet regression test (130 matches, limit 40) — **verified it fails on the old logic, passes on the fix**. Ruff clean; full inventory + MCP inventory suite green (24).