### PR TITLE
fix(compliance): wire MITRE ATT&CK to its real bundled catalog (#3882)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -392,7 +392,7 @@ agent-bom ships a curated control set per framework, sized to the AI/MCP/agent t
 | NIST / FedRAMP | 800-53 Rev 5 | 29 controls | ~1,006 | Vulnerability-driven mapping (RA-5, SI-2, etc.); not a complete catalog |
 | NIST / FedRAMP | FedRAMP Moderate | 25 controls | ~325 | Subset of 800-53 controls in the Moderate baseline |
 | MITRE | ATLAS | 65 techniques | ~90 | LLM/AI techniques: prompt injection, jailbreak, supply-chain, exfiltration, agent tool abuse |
-| MITRE | ATT&CK Enterprise | 0 techniques | ~600 | Adversary techniques tagged via CWE → CAPEC → ATT&CK on every blast-radius finding |
+| MITRE | ATT&CK Enterprise | 557 techniques | ~600 | Adversary techniques tagged via CWE → CAPEC → ATT&CK on every blast-radius finding |
 | Regulatory | EU AI Act | 6 articles | ~113 | Articles 5/6/9/10/15/17 (prohibited practices, high-risk classification, risk mgmt, data governance, accuracy/cybersecurity, QMS) |
 | Regulatory | ISO/IEC 27001:2022 | 9 Annex A controls | 93 | Supplier, vulnerability, cryptography, secure-dev, evidence collection |
 | Regulatory | SOC 2 TSC | 9 criteria | ~64 | Common Criteria 6.x / 7.x / 8.x / 9.x (access, monitoring, change mgmt, vendor risk) |

--- a/src/agent_bom/compliance_coverage.py
+++ b/src/agent_bom/compliance_coverage.py
@@ -12,6 +12,7 @@ from agent_bom.cmmc import CMMC_PRACTICES
 from agent_bom.eu_ai_act import EU_AI_ACT
 from agent_bom.fedramp import FEDRAMP_MODERATE
 from agent_bom.iso_27001 import ISO_27001
+from agent_bom.mitre_attack import get_bundled_attack_techniques
 from agent_bom.nist_800_53 import NIST_800_53
 from agent_bom.nist_ai_rmf import NIST_AI_RMF
 from agent_bom.nist_csf import NIST_CSF
@@ -185,7 +186,7 @@ TAG_MAPPED_FRAMEWORKS: tuple[ComplianceFrameworkMetadata, ...] = (
         output_key="mitre_attack",
         summary_prefix="attack",
         tag_field="attack_tags",
-        catalog={},
+        catalog=get_bundled_attack_techniques(),
         report_label="MITRE ATT&CK",
         bundled_unit="techniques",
         source_standard_size="~600",

--- a/src/agent_bom/mitre_attack.py
+++ b/src/agent_bom/mitre_attack.py
@@ -45,6 +45,17 @@ def get_attack_techniques() -> dict[str, str]:
     return {tid: meta["name"] for tid, meta in get_techniques().items()}
 
 
+def get_bundled_attack_techniques() -> dict[str, str]:
+    """Return ``{technique_id: name}`` from the bundled ATT&CK catalog only.
+
+    Deterministic and offline (ignores any synced catalog). Used for disclosing
+    the bundled technique count in compliance coverage metadata and docs.
+    """
+    from agent_bom.mitre_fetch import get_bundled_techniques
+
+    return {tid: meta["name"] for tid, meta in get_bundled_techniques().items()}
+
+
 # Legacy alias kept for callers that import ATTACK_TECHNIQUES directly from
 # this module.  Evaluated lazily to avoid a network call on import.
 class _LazyTechniquesProxy:

--- a/src/agent_bom/mitre_fetch.py
+++ b/src/agent_bom/mitre_fetch.py
@@ -386,6 +386,16 @@ def get_techniques() -> dict[str, dict]:
     return build_catalog().get("techniques", {})
 
 
+def get_bundled_techniques() -> dict[str, dict]:
+    """Return techniques from the bundled catalog only.
+
+    Deterministic and offline: ignores any locally synced catalog so callers
+    that disclose the *bundled* technique count (docs, compliance coverage
+    metadata) get the same figure in every environment.
+    """
+    return _load_bundled_catalog().get("techniques", {})
+
+
 def get_cwe_to_attack() -> dict[str, list[str]]:
     return build_catalog().get("cwe_to_attack", {})
 


### PR DESCRIPTION
## Problem

`compliance_coverage.py` registered the MITRE ATT&CK Enterprise framework in `TAG_MAPPED_FRAMEWORKS` with `catalog={}`. It was advertised alongside the other frameworks but disclosed **0 techniques**, implying coverage that the metadata didn't back — a pre-release honesty bug (#3882).

## Root cause / decision: wire, don't delist

ATT&CK is genuinely implemented, unlike a true empty stub:
- Findings are tagged with `attack_tags` via CWE → CAPEC → ATT&CK (`mitre_attack.py`, `tag_blast_radius` / `tag_cis_check` / `tag_provenance_finding`).
- A **557-technique** normalized ATT&CK/CAPEC catalog ships bundled (`data/mitre_attack_catalog.json`).
- `get_attack_techniques()` / the `ATTACK_TECHNIQUES` proxy already expose it.

The metadata was simply disconnected from the real catalog. Per the issue's guidance, when a populated catalog exists it should be wired in rather than delisted — so this wires it in.

## Change

- Add `get_bundled_techniques()` (mitre_fetch) and `get_bundled_attack_techniques()` (mitre_attack) — read the **bundled** catalog only, so the disclosed count is deterministic and offline (a locally *synced* catalog can't make the committed docs/table drift across environments).
- Point the ATT&CK `catalog` at `get_bundled_attack_techniques()`.
- Regenerate `docs/ARCHITECTURE.md` coverage table: ATT&CK `0 techniques` → `557 techniques`.

Framework membership is unchanged (still 14 tag-mapped frameworks + AISVS benchmark), so `check-counts.py` and `check_release_consistency.py` ("14-framework compliance") stay consistent.

## Verification

- `scripts/check-counts.py` — green
- `scripts/check_release_consistency.py` — green
- `scripts/generate_compliance_coverage_table.py --check` — green (via test)
- `pytest tests/ -k "compliance or framework or attack"` — 511 passed, 1 skipped
- targeted: `test_compliance_coverage`, `test_mitre_attack`, `test_mitre_fetch`, `test_api_data_p1_batch_v0867`, `test_compliance_narrative` — 132 passed
- `ruff check` clean; `mypy` on `compliance_coverage.py` clean
- runtime: ATT&CK metadata now reports `control_count=557` / label `557 techniques`