### PR TITLE
fix(api): dedupe /v1/findings to one row per canonical id + normalize identifiers

### DIFF
--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -422,6 +422,127 @@ def _finding_key(finding: dict[str, Any]) -> str:
     return f"{vuln_id}:{package}"
 
 
+def _row_vuln_id(finding: dict[str, Any]) -> str:
+    """Return the CVE/advisory identifier for a finding, source-agnostic.
+
+    The unified stream carries it under ``cve_id`` while the blast-radius and
+    package-vulnerability representations carry the same value under
+    ``vulnerability_id`` — normalizing here lets the three collapse together.
+    """
+    return str(finding.get("cve_id") or finding.get("vulnerability_id") or "").strip()
+
+
+def _package_base_name(finding: dict[str, Any]) -> str:
+    """Return the bare package name (no version) shared across representations.
+
+    Blast-radius rows carry ``pkg@version`` while package-vulnerability rows
+    carry a bare ``package`` + separate ``package_version``; the unified stream
+    encodes it only in the ``"CVE-…: pkg@version"`` title. Strip all three to a
+    common lowercase base so the same vuln+package folds to one canonical group.
+    """
+    package = str(finding.get("package") or finding.get("package_name") or "").strip()
+    if not package:
+        title = str(finding.get("title") or "")
+        if ": " in title:
+            package = title.split(": ", 1)[1].strip()
+    if "@" in package:
+        package = package.split("@", 1)[0]
+    return package.strip().lower()
+
+
+def _canonical_group_key(finding: dict[str, Any]) -> str:
+    """Collapse the three per-CVE representations onto one grouping key.
+
+    Findings that carry a CVE/advisory id group by ``(vuln_id, package_base)``
+    so the ``MCP_SCAN`` (unified), ``blast_radius`` and ``package_vulnerability``
+    rows for the same vulnerability merge into a single list row. Non-CVE
+    findings (posture, malicious-package, etc.) fall back to their stable
+    identity so distinct findings stay distinct.
+    """
+    vuln = _row_vuln_id(finding)
+    if vuln:
+        return f"vuln:{vuln.lower()}:{_package_base_name(finding)}"
+    return f"id:{_finding_identity(finding)}"
+
+
+_EMPTY_FIELD_VALUES: tuple[Any, ...] = (None, "", [], {})
+
+# Descriptive/structural fields safe to backfill from the supplementary
+# (blast-radius / package-vulnerability) representations onto the authoritative
+# unified finding. Reachability and VEX verdicts are deliberately excluded: the
+# unified stream is the source of truth for those and must not be overridden by
+# a coarser blast-radius projection (see the unified-stream-wins contract).
+_SUPPLEMENTARY_BACKFILL_FIELDS: tuple[str, ...] = (
+    "package",
+    "package_name",
+    "package_version",
+    "ecosystem",
+    "summary",
+    "description",
+    "cvss_score",
+    "cvss_vector",
+    "attack_vector",
+    "attack_complexity",
+    "privileges_required",
+    "user_interaction",
+    "network_exploitable",
+    "references",
+    "fixed_version",
+    "epss_score",
+    "affected_agents",
+    "affected_servers",
+    "exposed_credentials",
+    "exposed_tools",
+    "phantom_tools",
+)
+
+
+def _backfill_supplementary_fields(base: dict[str, Any], incoming: dict[str, Any]) -> None:
+    """Fill only empty descriptive fields on ``base`` from ``incoming``.
+
+    Never overrides a value the authoritative row already carries, so the
+    unified finding's identifiers and reachability stay intact while
+    package/CVE metadata from the supplementary representations is preserved.
+    """
+    for field in _SUPPLEMENTARY_BACKFILL_FIELDS:
+        value = incoming.get(field)
+        if value in _EMPTY_FIELD_VALUES:
+            continue
+        if base.get(field) in _EMPTY_FIELD_VALUES:
+            base[field] = value
+
+
+def _normalize_finding_identifiers(finding: dict[str, Any]) -> dict[str, Any]:
+    """Guarantee every list row carries ``cve_id``/``title``/``finding_type``.
+
+    Blast-radius and package-vulnerability rows carry the identifier only under
+    ``vulnerability_id`` and omit ``title``/``finding_type``; normalize those so
+    no row surfaces null identifiers regardless of which representation seeded it.
+    """
+    vuln = finding.get("cve_id") or finding.get("vulnerability_id")
+    if vuln:
+        if not finding.get("cve_id"):
+            finding["cve_id"] = vuln
+        if not finding.get("vulnerability_id"):
+            finding["vulnerability_id"] = vuln
+    if not finding.get("title"):
+        package = finding.get("package") or finding.get("package_name") or ""
+        # Never fall back to summary/description here: those are replay-only,
+        # redacted-on-read fields, and the title is not redacted — deriving it
+        # from them would leak sensitive free-text past _redact_finding_page.
+        if vuln and package:
+            finding["title"] = f"{vuln}: {package}"
+        elif vuln:
+            finding["title"] = str(vuln)
+        elif package:
+            finding["title"] = f"Vulnerability in {package}"
+        else:
+            finding["title"] = str(finding.get("finding_type") or "Finding")
+    if not finding.get("finding_type"):
+        finding["finding_type"] = "CVE" if vuln else "VULNERABILITY"
+    return finding
+
+
 def _finding_from_blast_radius(item: dict[str, Any], job: ScanJob) -> dict[str, Any]:
     vulnerability_id = item.get("vulnerability_id") or item.get("id") or ""
     package = item.get("package") or item.get("package_name") or ""
@@ -648,8 +769,6 @@ def _graph_export_response(result: dict[str, Any], *, format: str, mermaid_limit
 
 def _iter_scan_findings(job: ScanJob) -> list[dict[str, Any]]:
     result = job.result or {}
-    findings: list[dict[str, Any]] = []
-    seen: set[str] = set()
     reach = _effective_reach_lookup(job)
     from agent_bom.finding_runtime_evidence import (
         attach_runtime_evidence_to_finding,
@@ -685,35 +804,44 @@ def _iter_scan_findings(job: ScanJob) -> list[dict[str, Any]]:
         row.setdefault("framework_tags", compliance_tags_from_finding_row(row))
         return attach_runtime_evidence_to_finding(row, runtime_index, incidents=incidents)
 
+    # Collapse the three per-vulnerability representations (unified ``findings``
+    # stream, ``blast_radius`` projection, nested ``package_vulnerability``) onto
+    # one row per canonical id. The unified stream is processed first and stays
+    # authoritative; later representations only backfill descriptive fields the
+    # unified row is missing (package/CVE metadata) — never reachability or VEX,
+    # so the unified-stream-wins contract holds. This keeps ``/v1/findings`` in
+    # step with the overview count instead of emitting one row per representation.
+    grouped: dict[str, dict[str, Any]] = {}
+    order: list[str] = []
+
+    def _absorb(row: dict[str, Any]) -> None:
+        key = _canonical_group_key(row)
+        existing = grouped.get(key)
+        if existing is None:
+            grouped[key] = row
+            order.append(key)
+            return
+        _backfill_supplementary_fields(existing, row)
+
     for item in result.get("findings", []) or []:
         if not isinstance(item, dict):
             continue
         row = dict(item)
         row.setdefault("scan_id", job.job_id)
         row.setdefault("scan_sources", _scan_source_labels(job))
-        key = _finding_key(row)
-        if key in seen:
-            continue
-        seen.add(key)
-        findings.append(_attach_reach(row))
+        _absorb(_attach_reach(row))
 
     for item in result.get("blast_radius", []) or result.get("blast_radii", []) or []:
         if not isinstance(item, dict):
             continue
-        row = _finding_from_blast_radius(item, job)
-        key = _finding_key(row)
-        if key in seen:
-            continue
-        seen.add(key)
-        findings.append(_attach_reach(row))
+        _absorb(_attach_reach(_finding_from_blast_radius(item, job)))
 
     for row in _iter_package_findings(job):
-        key = _finding_key(row)
-        if key in seen:
-            continue
-        seen.add(key)
-        findings.append(_attach_reach(row))
+        _absorb(_attach_reach(row))
 
+    findings = [grouped[key] for key in order]
+    for row in findings:
+        _normalize_finding_identifiers(row)
     return findings
 
 

--- a/tests/api/test_api_scan_vex_parity.py
+++ b/tests/api/test_api_scan_vex_parity.py
@@ -78,6 +78,119 @@ def test_iter_scan_findings_prefers_unified_stream_over_blast_radius():
     assert rows[0].get("symbol_reachability") != "reachable"
 
 
+def test_iter_scan_findings_collapses_three_representations_to_canonical():
+    """Regression for #3883: the unified/blast/package trio for one CVE folds
+    to a single list row that carries non-null cve_id/title/finding_type, with
+    package metadata backfilled but reachability left to the unified stream."""
+    job = _scan_job()
+    job.result = {
+        "agents": [
+            {
+                "name": "agent-x",
+                "mcp_servers": [
+                    {
+                        "name": "srv",
+                        "packages": [
+                            {
+                                "name": "requests",
+                                "version": "2.28.0",
+                                "ecosystem": "pypi",
+                                "vulnerabilities": [
+                                    {
+                                        "id": "CVE-2024-9999",
+                                        "severity": "high",
+                                        "summary": "boom",
+                                        "cvss_score": 7.5,
+                                        "fixed_version": "2.31.0",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        # Unified stream: the richest representation, already normalized.
+        "findings": [
+            {
+                "id": "b1e2c3d4-0000-0000-0000-000000000001",
+                "cve_id": "CVE-2024-9999",
+                "title": "CVE-2024-9999: requests@2.28.0",
+                "finding_type": "CVE",
+                "severity": "high",
+                "match_confidence_tier": "high",
+                "evidence": {"symbol_reachability": "unreachable"},
+                "asset": {"name": "srv", "asset_type": "mcp_server"},
+            }
+        ],
+        # Blast-radius projection: identifier only under vulnerability_id, no
+        # title/finding_type, plus a coarser (over-claiming) reachability signal.
+        "blast_radius": [
+            {
+                "vulnerability_id": "CVE-2024-9999",
+                "package": "requests@2.28.0",
+                "severity": "high",
+                "symbol_reachability": "reachable",
+                "graph_reachable": True,
+            }
+        ],
+    }
+
+    rows = _iter_scan_findings(job)
+
+    # One row per canonical id — not three representations.
+    cve_rows = [r for r in rows if (r.get("cve_id") or r.get("vulnerability_id")) == "CVE-2024-9999"]
+    assert len(cve_rows) == 1
+    row = cve_rows[0]
+
+    # Every identifier is populated (no null cve_id / title / finding_type).
+    assert row["cve_id"] == "CVE-2024-9999"
+    assert row["title"] == "CVE-2024-9999: requests@2.28.0"
+    assert row["finding_type"] == "CVE"
+
+    # Package + descriptive metadata backfilled from the supplementary reps.
+    assert row.get("package")
+    assert row.get("ecosystem") == "pypi"
+    assert row.get("fixed_version") == "2.31.0"
+
+    # Unified stream stays authoritative for reachability/confidence — the
+    # blast-radius "reachable" claim must not override the unified verdict.
+    assert row["match_confidence_tier"] == "high"
+    assert row["evidence"]["symbol_reachability"] == "unreachable"
+    assert row.get("symbol_reachability") != "reachable"
+
+    # Invariant across the whole page: no null identifiers, no duplicate groups.
+    assert all(r.get("title") for r in rows)
+    assert all(r.get("finding_type") for r in rows)
+    assert all(r.get("cve_id") for r in rows if r.get("finding_type") == "CVE")
+    from agent_bom.api.routes.scan import _canonical_group_key
+
+    keys = [_canonical_group_key(r) for r in rows]
+    assert len(keys) == len(set(keys))
+
+
+def test_iter_scan_findings_normalizes_blast_only_finding_identifiers():
+    """A vuln present only as a blast-radius row still surfaces cve_id/title/
+    finding_type after normalization (no null identifiers)."""
+    job = _scan_job()
+    job.result = {
+        "blast_radius": [
+            {
+                "vulnerability_id": "CVE-2024-8888",
+                "package": "urllib3@1.26.0",
+                "severity": "high",
+            }
+        ]
+    }
+    rows = _iter_scan_findings(job)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["cve_id"] == "CVE-2024-8888"
+    assert row["vulnerability_id"] == "CVE-2024-8888"
+    assert row["title"] == "CVE-2024-8888: urllib3@1.26.0"
+    assert row["finding_type"] == "CVE"
+
+
 def test_api_pipeline_ingests_external_scan(monkeypatch, tmp_path):
     class _DummyStore:
         def __init__(self) -> None:


### PR DESCRIPTION
Closes #3883.

## Problem
`GET /v1/findings` emitted **three representations per CVE** — the unified `MCP_SCAN` finding, the `blast_radius` projection, and the nested `package_vulnerability` row — producing **49 rows for 15 CVEs**, contradicting the overview's "15 open CVEs". `_iter_scan_findings` deduped on `_finding_key`, whose package component diverges across the three shapes (asset name vs `pkg@version` vs bare `pkg`), so the trio never collapsed. ~30 of the rows returned `cve_id=null / title=null / finding_type=null` because those identifiers live only under `vulnerability_id`/`package` on the supplementary representations.

## Fix
- Collapse the three representations onto a canonical `(vuln_id, package_base)` group key so each vulnerability surfaces as a **single** list row.
- The unified stream stays **authoritative**: supplementary reps only backfill *empty* descriptive fields (package/CVE metadata) — **never reachability or VEX verdicts** — preserving the unified-stream-wins contract (`test_iter_scan_findings_prefers_unified_stream_over_blast_radius`).
- Normalize every returned row to carry `cve_id` (from `vulnerability_id`), `title`, and `finding_type`.
- Title fallback deliberately avoids `summary`/`description` so replay-only redacted free-text can't leak into the non-redacted `title`.

## Before / after (seeded demo estate)
| | before | after |
|---|---|---|
| `/v1/findings` total | 49 | **19** (15 CVE-typed + 4 non-CVE posture) |
| rows with null `title`/`finding_type` | 30 | **0** |
| CVE-typed rows | — | **15** (matches overview `domains/vuln/metric = 15`, "open CVEs") |
| duplicate canonical groups | 34 | **0** |

## Consumers verified consistent
- `/v1/overview` "15 open CVEs" now aligns with the 15 CVE-typed rows.
- `/v1/inventory`, compliance native-hub list, and the trace-explorer read the deduped rows (all benefit from no triple-counting).
- SARIF/CycloneDX exports build from the raw scan report (not `_iter_scan_findings`) and are unaffected.

## Tests
- New: `test_iter_scan_findings_collapses_three_representations_to_canonical` (one row per canonical id, non-null identifiers, package backfilled, reachability not overridden) and `test_iter_scan_findings_normalizes_blast_only_finding_identifiers`.
- Green: `tests/api/` (735), compliance/observability (189), redaction isolation test, OpenAPI + v1-schema drift `--check`, ruff check, mypy.