### PR TITLE
perf(findings): shed heavy /v1/findings reads with 429 under saturation (#3884)

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -10205,7 +10205,7 @@
     },
     "/v1/findings": {
       "get": {
-        "description": "List vulnerability findings aggregated from completed scan results.\n\nThe heavy work \u2014 dedup/sort of in-memory scan findings plus synchronous\nstore reads \u2014 runs in a worker thread so a single deep read cannot block\nthe event loop and freeze unrelated requests (e.g. ``/health``) under load.\n``anyio.to_thread.run_sync`` propagates the current context, and the tenant\nscope is read from ``request.state`` and passed explicitly to the store, so\nbehavior is identical to running inline.",
+        "description": "List vulnerability findings aggregated from completed scan results.\n\nThe heavy work \u2014 dedup/sort of in-memory scan findings plus synchronous\nstore reads \u2014 runs in a worker thread so a single deep read cannot block\nthe event loop and freeze unrelated requests (e.g. ``/health``) under load.\n``anyio.to_thread.run_sync`` propagates the current context, and the tenant\nscope is read from ``request.state`` and passed explicitly to the store, so\nbehavior is identical to running inline.\n\nThe read is additionally guarded by adaptive backpressure (the same shared\nprimitive the graph route uses): the in-memory default hub copies and\nre-sorts the whole current-state table per request, so a burst of deep\n``?sort=cvss`` reads at scale can pile up worker threads and starve\n``/health`` and unrelated endpoints. Under genuine saturation the guard\nsheds excess reads with ``429 + Retry-After`` instead of degrading every\nroute. Normal single-reader load never trips it.",
         "operationId": "list_findings_v1_findings_get",
         "parameters": [
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -6690,7 +6690,14 @@ paths:
         the event loop and freeze unrelated requests (e.g. ``/health``) under load.\n\
         ``anyio.to_thread.run_sync`` propagates the current context, and the tenant\n\
         scope is read from ``request.state`` and passed explicitly to the store, so\n\
-        behavior is identical to running inline."
+        behavior is identical to running inline.\n\nThe read is additionally guarded\
+        \ by adaptive backpressure (the same shared\nprimitive the graph route uses):\
+        \ the in-memory default hub copies and\nre-sorts the whole current-state table\
+        \ per request, so a burst of deep\n``?sort=cvss`` reads at scale can pile\
+        \ up worker threads and starve\n``/health`` and unrelated endpoints. Under\
+        \ genuine saturation the guard\nsheds excess reads with ``429 + Retry-After``\
+        \ instead of degrading every\nroute. Normal single-reader load never trips\
+        \ it."
       operationId: list_findings_v1_findings_get
       parameters:
       - in: query

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -65,6 +65,7 @@ from agent_bom.api.stores import (
 )
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.api.tenant_quota import enforce_active_scan_quota, enforce_retained_jobs_quota, tenant_quota_guard
+from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
 from agent_bom.canonical_ids import canonical_finding_id
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.security import sanitize_error
@@ -1513,18 +1514,34 @@ async def list_findings(
     ``anyio.to_thread.run_sync`` propagates the current context, and the tenant
     scope is read from ``request.state`` and passed explicitly to the store, so
     behavior is identical to running inline.
+
+    The read is additionally guarded by adaptive backpressure (the same shared
+    primitive the graph route uses): the in-memory default hub copies and
+    re-sorts the whole current-state table per request, so a burst of deep
+    ``?sort=cvss`` reads at scale can pile up worker threads and starve
+    ``/health`` and unrelated endpoints. Under genuine saturation the guard
+    sheds excess reads with ``429 + Retry-After`` instead of degrading every
+    route. Normal single-reader load never trips it.
     """
-    return await anyio.to_thread.run_sync(
-        _list_findings_impl,
-        request,
-        severity,
-        scan_id,
-        sort,
-        limit,
-        offset,
-        cursor,
-        approximate_total,
-    )
+    try:
+        async with adaptive_backpressure("findings"):
+            return await anyio.to_thread.run_sync(
+                _list_findings_impl,
+                request,
+                severity,
+                scan_id,
+                sort,
+                limit,
+                offset,
+                cursor,
+                approximate_total,
+            )
+    except BackpressureRejectedError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail=exc.to_dict(),
+            headers={"Retry-After": str(exc.retry_after_seconds)},
+        ) from exc
 
 
 def _list_findings_impl(

--- a/src/agent_bom/backpressure.py
+++ b/src/agent_bom/backpressure.py
@@ -127,7 +127,16 @@ _CONTROLLERS_LOCK = Lock()
 # false-trips on cold traffic. Give ``graph`` explicit headroom above its honest
 # build latency; genuinely degraded builds (well past this ceiling) and the
 # concurrency limit still shed real overload.
-_DEFAULT_P99_THRESHOLD_MS: dict[str, int] = {"graph": 12_000}
+#
+# ``findings`` gets the same treatment. The in-memory default hub copies and
+# re-sorts the entire current-state table in Python per request, so an honest
+# deep ``?sort=cvss`` read at millions of rows can legitimately take several
+# seconds. Below the generic 2500ms budget a single well-behaved deep read
+# would trip the shared cooldown and 429-storm every reader — shedding under
+# normal single-user load, not overload. Give it headroom above its honest
+# latency; the concurrency limit still sheds a genuine pile-up of concurrent
+# deep reads (the event-loop-starvation case this guard exists to prevent).
+_DEFAULT_P99_THRESHOLD_MS: dict[str, int] = {"graph": 12_000, "findings": 12_000}
 _GENERIC_P99_THRESHOLD_MS = 2500
 
 

--- a/tests/api/test_api_scan_findings_wiring.py
+++ b/tests/api/test_api_scan_findings_wiring.py
@@ -131,3 +131,63 @@ def test_scan_vuln_flows_to_findings_and_attack_paths(wired_client):
     assert paths, "expected at least one derived attack path for the known vuln"
     path_vuln_ids = {vid for path in paths for vid in (path.get("vuln_ids") or [])}
     assert KNOWN_CVE in path_vuln_ids, f"known vuln missing from attack paths: {path_vuln_ids}"
+
+
+def test_findings_read_sheds_with_429_when_backpressure_opens(wired_client, monkeypatch):
+    """A saturated in-memory findings read path sheds with 429 + Retry-After.
+
+    The default hub copies and re-sorts the whole current-state table per
+    request, so a burst of deep reads can starve ``/health``. Under genuine
+    overload the shared adaptive-backpressure guard sheds excess reads instead
+    of degrading every route. Mirrors the graph route's shed contract.
+    """
+    import time
+
+    from agent_bom.api.routes import scan as scan_routes
+    from agent_bom.backpressure import reset_backpressure_for_tests
+
+    monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_FINDINGS_P99_MS", "1")
+    monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_FINDINGS_MIN_SAMPLES", "1")
+    monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_FINDINGS_COOLDOWN_SECONDS", "30")
+    reset_backpressure_for_tests()
+
+    original_impl = scan_routes._list_findings_impl
+
+    def _slow_impl(*args, **kwargs):
+        time.sleep(0.01)
+        return original_impl(*args, **kwargs)
+
+    monkeypatch.setattr(scan_routes, "_list_findings_impl", _slow_impl)
+
+    try:
+        # First read completes and records a latency above the 1ms ceiling,
+        # tripping the p99 cooldown; the next read must shed.
+        warm = wired_client.get("/v1/findings")
+        assert warm.status_code == 200
+
+        shed = wired_client.get("/v1/findings")
+        assert shed.status_code == 429
+        body = shed.json()["detail"]
+        assert body["path"] == "findings"
+        assert body["reason"] == "p99_latency_threshold"
+        assert int(shed.headers["Retry-After"]) >= 1
+    finally:
+        reset_backpressure_for_tests()
+
+
+def test_findings_read_not_shed_under_normal_load(wired_client):
+    """Default budgets never trip on ordinary single-reader traffic."""
+    from agent_bom.backpressure import describe_backpressure_posture, reset_backpressure_for_tests
+
+    reset_backpressure_for_tests()
+    try:
+        for _ in range(5):
+            resp = wired_client.get("/v1/findings")
+            assert resp.status_code == 200
+        posture = describe_backpressure_posture()
+        findings = next((p for p in posture["paths"] if p["path"] == "findings"), None)
+        assert findings is not None
+        assert findings["state"] == "closed"
+        assert findings["rejected"] == 0
+    finally:
+        reset_backpressure_for_tests()


### PR DESCRIPTION
## Summary

Fixes #3884 (P2, pre-0.95.0).

The default in-memory hub's `list_current_page` copies and re-sorts the entire current-state table in Python per request, so heavy `/v1/findings` reads at scale (`sort=cvss` ~5s @ 1M) under concurrency pile up worker threads and starve the event loop — even `/health` degraded to ~5s under 8 concurrent readers, failing slow with no 5xx. The `/v1/graph` route already sheds excess load via the shared adaptive-backpressure primitive; `/v1/findings` had none.

## Change

- Wire the existing shared `adaptive_backpressure("findings")` guard around the findings read (`list_findings`), translating `BackpressureRejectedError` into `429 + Retry-After` — mirroring the graph route's `_graph_store_call` shed contract exactly. No new concurrency system.
- Give the `findings` controller p99 headroom (12s, same reasoning as `graph`) so an honest single deep read at millions of rows does not false-trip the shared cooldown. Normal single-reader load is unchanged; only genuine saturation (concurrency cap or degraded p99) sheds.
- `inventory/summary` already runs under the graph backpressure guard via `_store_call`, so no change needed there.

Behavior is off the fast path: enabled by default, tunable via `AGENT_BOM_BACKPRESSURE_FINDINGS_*` env, and disabled entirely with `AGENT_BOM_BACKPRESSURE_ENABLED=0`. Postgres remains the real scale backend; this bounds the in-memory default's known cliff.

## Tests

- `test_findings_read_sheds_with_429_when_backpressure_opens` — saturated read sheds with 429, `detail.path == "findings"`, `Retry-After >= 1`.
- `test_findings_read_not_shed_under_normal_load` — 5 ordinary reads stay 200, controller `state == closed`, `rejected == 0`.
- Full findings + api + graph + backpressure suites green (783 passed); ruff clean.