### PR TITLE
perf(inventory): serve inventory/summary breakdown from cached snapshot counts (#3885)

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -1309,23 +1309,36 @@ class SQLiteGraphStore:
                 params.extend(sev_params)
             where_sql = " AND ".join(node_where)
 
-            # Unfiltered node/edge totals are already materialised on the snapshot
-            # row at write time. Re-deriving them here re-scans graph_edges with a
-            # double id-membership subquery (seconds at 500k edges), so read the
-            # stored counts and only fall back to COUNT(*) when the snapshot row is
-            # missing or the counts were never populated. Any active entity-type or
-            # severity filter narrows the set, so the recompute path still runs.
+            # Unfiltered node/edge totals AND the entity-type / severity breakdowns
+            # are materialised on the snapshot row at write time. Re-deriving them
+            # here re-scans graph_nodes with two GROUP BYs (1-2s at 500k-1M nodes)
+            # plus a double id-membership edge subquery, so read the stored values
+            # and only fall back to the live queries when the snapshot row is missing
+            # or the cached breakdown was never populated (older snapshots). Any
+            # active entity-type or severity filter narrows the set, so the recompute
+            # path still runs.
             filters_active = bool(entity_types) or bool(min_severity_rank)
             stored_node_count: int | None = None
             stored_edge_count: int | None = None
+            cached_node_types: dict[str, int] | None = None
+            cached_severity_counts: dict[str, int] | None = None
             if not filters_active:
                 snap_row = conn.execute(
-                    "SELECT node_count, edge_count FROM graph_snapshots WHERE scan_id = ? AND tenant_id = ?",
+                    "SELECT node_count, edge_count, risk_summary, node_type_counts "
+                    "FROM graph_snapshots WHERE scan_id = ? AND tenant_id = ?",
                     (effective_scan_id, tenant_id),
                 ).fetchone()
                 if snap_row is not None:
                     stored_node_count = snap_row[0] if snap_row[0] is not None else None
                     stored_edge_count = snap_row[1] if snap_row[1] is not None else None
+                    # node_type_counts is NULL for snapshots written before the
+                    # breakdown was materialised — fall back to the live GROUP BY
+                    # for those. risk_summary already carries the severity counts.
+                    if snap_row[3] is not None:
+                        cached_node_types = {str(k): int(v) for k, v in json.loads(snap_row[3]).items()}
+                        cached_severity_counts = {
+                            str(k): int(v) for k, v in json.loads(snap_row[2] or "{}").items() if k
+                        }
 
             if stored_node_count is not None:
                 total_nodes = stored_node_count
@@ -1334,14 +1347,22 @@ class SQLiteGraphStore:
                     f"SELECT COUNT(*) FROM graph_nodes WHERE {where_sql}",  # nosec B608 - where_sql is built from static clause fragments
                     params,
                 ).fetchone()[0]
-            node_type_rows = conn.execute(
-                f"SELECT entity_type, COUNT(*) FROM graph_nodes WHERE {where_sql} GROUP BY entity_type",  # nosec B608 - where_sql is built from static clause fragments
-                params,
-            ).fetchall()
-            severity_rows = conn.execute(
-                f"SELECT severity, COUNT(*) FROM graph_nodes WHERE {where_sql} AND severity <> '' GROUP BY severity",  # nosec B608 - where_sql is built from static clause fragments
-                params,
-            ).fetchall()
+            if cached_node_types is not None:
+                node_types = cached_node_types
+            else:
+                node_type_rows = conn.execute(
+                    f"SELECT entity_type, COUNT(*) FROM graph_nodes WHERE {where_sql} GROUP BY entity_type",  # nosec B608 - where_sql is built from static clause fragments
+                    params,
+                ).fetchall()
+                node_types = {str(row[0]): int(row[1]) for row in node_type_rows}
+            if cached_severity_counts is not None:
+                severity_counts = cached_severity_counts
+            else:
+                severity_rows = conn.execute(
+                    f"SELECT severity, COUNT(*) FROM graph_nodes WHERE {where_sql} AND severity <> '' GROUP BY severity",  # nosec B608 - where_sql is built from static clause fragments
+                    params,
+                ).fetchall()
+                severity_counts = {str(row[0]): int(row[1]) for row in severity_rows}
             if stored_edge_count is not None:
                 total_edges = stored_edge_count
             else:
@@ -1377,8 +1398,8 @@ class SQLiteGraphStore:
             return {
                 "total_nodes": int(total_nodes or 0),
                 "total_edges": int(total_edges or 0),
-                "node_types": {str(row[0]): int(row[1]) for row in node_type_rows},
-                "severity_counts": {str(row[0]): int(row[1]) for row in severity_rows},
+                "node_types": node_types,
+                "severity_counts": severity_counts,
                 "relationship_types": {str(row[0]): int(row[1]) for row in rel_rows},
                 "attack_path_count": int((attack_row[0] if attack_row else 0) or 0),
                 "interaction_risk_count": int((interaction_row[0] if interaction_row else 0) or 0),

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -139,6 +139,7 @@ CREATE TABLE IF NOT EXISTS graph_snapshots (
     node_count      INTEGER DEFAULT 0,
     edge_count      INTEGER DEFAULT 0,
     risk_summary    TEXT DEFAULT '{}',
+    node_type_counts TEXT DEFAULT NULL,
     PRIMARY KEY (scan_id, tenant_id)
 );
 CREATE INDEX IF NOT EXISTS idx_gs_recent ON graph_snapshots(tenant_id, created_at DESC);
@@ -296,6 +297,12 @@ def _init_db(conn: sqlite3.Connection, *, backfill_legacy_tenants: bool = True) 
     conn.execute("UPDATE graph_edges SET valid_from = first_seen WHERE valid_from = '' OR valid_from IS NULL")
     conn.execute("UPDATE graph_edges SET source_scan_id = scan_id WHERE source_scan_id = '' OR source_scan_id IS NULL")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_ge_tenant_valid ON graph_edges(tenant_id, valid_from, valid_to)")
+    # Materialise the per-snapshot entity-type breakdown so inventory/summary
+    # reads a cached count instead of a per-request GROUP BY over every node.
+    # NULL marks pre-migration snapshots, which fall back to the live GROUP BY.
+    snapshot_columns = {row["name"] for row in conn.execute("PRAGMA table_info(graph_snapshots)").fetchall()}
+    if "node_type_counts" not in snapshot_columns:
+        conn.execute("ALTER TABLE graph_snapshots ADD COLUMN node_type_counts TEXT DEFAULT NULL")
     if backfill_legacy_tenants:
         _backfill_empty_tenant_ids(conn)
     conn.commit()
@@ -748,10 +755,26 @@ def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
         )
 
     # ── Snapshot ──
+    # Materialise the entity-type and severity breakdowns alongside the node/edge
+    # totals so inventory/summary serves them from this row instead of running a
+    # GROUP BY over every node per request (O(N) → O(1)). ``risk_summary`` already
+    # carries the severity breakdown; ``node_type_counts`` adds the entity types.
     stats = graph.stats()
     conn.execute(
-        "INSERT OR REPLACE INTO graph_snapshots VALUES (?, ?, ?, ?, ?, ?)",
-        (scan, tenant, now, stats["total_nodes"], stats["total_edges"], json.dumps(stats.get("severity_counts", {}))),
+        """
+        INSERT OR REPLACE INTO graph_snapshots
+            (scan_id, tenant_id, created_at, node_count, edge_count, risk_summary, node_type_counts)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            scan,
+            tenant,
+            now,
+            stats["total_nodes"],
+            stats["total_edges"],
+            json.dumps(stats.get("severity_counts", {})),
+            json.dumps(stats.get("node_types", {})),
+        ),
     )
 
     conn.commit()

--- a/tests/test_graph_scale_quickwins.py
+++ b/tests/test_graph_scale_quickwins.py
@@ -94,6 +94,84 @@ def test_snapshot_stats_filtered_recomputes_and_ignores_stored_count(tmp_path):
     assert stats["total_edges"] == 0
 
 
+# ── inventory/summary breakdown: entity-type / severity counts are cached ─────
+
+
+def test_snapshot_stats_reads_cached_breakdown(tmp_path):
+    store = SQLiteGraphStore(tmp_path / "graph.db")
+    store.save_graph(_small_graph())
+
+    # Tamper the materialised breakdown. A cached read returns the sentinels; a
+    # live GROUP BY over graph_nodes would ignore them and return the real counts.
+    conn = sqlite3.connect(store._db_path)
+    conn.execute(
+        "UPDATE graph_snapshots SET node_type_counts = ?, risk_summary = ? WHERE scan_id = 'scale-scan'",
+        ('{"agent": 41}', '{"critical": 42}'),
+    )
+    conn.commit()
+    conn.close()
+
+    stats = store.snapshot_stats(tenant_id="default", scan_id="scale-scan")
+    assert stats["node_types"] == {"agent": 41}
+    assert stats["severity_counts"] == {"critical": 42}
+
+
+def test_cached_breakdown_matches_live_group_by(tmp_path):
+    """The cached entity-type/severity breakdown must equal the live GROUP BY."""
+    store = SQLiteGraphStore(tmp_path / "graph.db")
+    store.save_graph(_small_graph())
+
+    cached = store.snapshot_stats(tenant_id="default", scan_id="scale-scan")
+
+    # Force the fallback path by dropping the materialised breakdown, then
+    # recompute from graph_nodes directly.
+    conn = sqlite3.connect(store._db_path)
+    conn.execute("UPDATE graph_snapshots SET node_type_counts = NULL WHERE scan_id = 'scale-scan'")
+    conn.commit()
+    conn.close()
+
+    live = store.snapshot_stats(tenant_id="default", scan_id="scale-scan")
+
+    assert cached["node_types"] == live["node_types"] == {"agent": 1, "server": 1, "vulnerability": 1}
+    assert cached["severity_counts"] == live["severity_counts"] == {"critical": 1}
+
+
+def test_snapshot_stats_breakdown_falls_back_when_cache_null(tmp_path):
+    store = SQLiteGraphStore(tmp_path / "graph.db")
+    store.save_graph(_small_graph())
+
+    # Pre-migration snapshots have a NULL breakdown but a populated risk_summary;
+    # both node_types and severity_counts must still come from the live GROUP BY.
+    conn = sqlite3.connect(store._db_path)
+    conn.execute(
+        "UPDATE graph_snapshots SET node_type_counts = NULL, risk_summary = ? WHERE scan_id = 'scale-scan'",
+        ('{"critical": 999}',),
+    )
+    conn.commit()
+    conn.close()
+
+    stats = store.snapshot_stats(tenant_id="default", scan_id="scale-scan")
+    assert stats["node_types"] == {"agent": 1, "server": 1, "vulnerability": 1}
+    assert stats["severity_counts"] == {"critical": 1}
+
+
+def test_snapshot_stats_filtered_breakdown_recomputes(tmp_path):
+    store = SQLiteGraphStore(tmp_path / "graph.db")
+    store.save_graph(_small_graph())
+
+    # A stale cached breakdown must never leak into a filtered request.
+    conn = sqlite3.connect(store._db_path)
+    conn.execute(
+        "UPDATE graph_snapshots SET node_type_counts = ? WHERE scan_id = 'scale-scan'",
+        ('{"agent": 999}',),
+    )
+    conn.commit()
+    conn.close()
+
+    stats = store.snapshot_stats(tenant_id="default", scan_id="scale-scan", entity_types={"vulnerability"})
+    assert stats["node_types"] == {"vulnerability": 1}
+
+
 # ── FIX 3: deep OFFSET pagination is capped in favour of cursor= ──────────────
 
 


### PR DESCRIPTION
## Summary

Fixes #3885 (P2 perf, pre-0.95.0). `/v1/inventory/summary` ran `GROUP BY entity_type` + `GROUP BY severity` over **every** node per call (`snapshot_stats` in `api/graph_store.py`) → ~1.0s @ 500k nodes, ~2.2s @ 1M.

This materialises the entity-type breakdown on the snapshot row at write time and serves it from cache, turning the summary breakdown from O(N) into a constant-time row read.

## Change

- **`db/graph_store.py`**
  - `graph_snapshots` gains a nullable `node_type_counts TEXT` column (the severity breakdown is already persisted in `risk_summary`).
  - `save_graph` writes the entity-type counts (`stats["node_types"]`) alongside the existing node/edge totals, using named columns.
  - In-place `ALTER TABLE ... ADD COLUMN` migration in `_init_db`, matching the existing edge/attack-path migration pattern, so pre-existing databases stay queryable.
- **`api/graph_store.py` `snapshot_stats`**
  - For unfiltered calls, reads `node_type_counts` + `risk_summary` from the snapshot row and skips the two per-request GROUP BYs.
  - Falls back to the live GROUP BY when the cached breakdown is `NULL` (older snapshots) or when an entity-type / severity filter narrows the set.
- Response shape is unchanged (`node_types`, `severity_counts` keys identical).

## Verification

- Cached breakdown proven equal to a live GROUP BY (new test + end-to-end seed of 1,000 and 300k nodes).
- **Latency**: 300k nodes → 85ms/call (live) to 20ms/call (cached), 4.2x; scales to constant as node count grows (the two node GROUP BYs are eliminated).
- New tests in `tests/test_graph_scale_quickwins.py`: cached breakdown is read (not recomputed), cached == live GROUP BY, NULL-cache fallback, and filtered requests never leak the cached breakdown.
- Suites GREEN: graph / inventory / api / postgres / retention / demo-bootstrap. `ruff` + `mypy` clean.

## Deferred (tracked in #3885)

- `graph/rollup` (4.9s@500k / 12.9s@1M) and the graph `relationships` full-load — the bigger/riskier items. Left untouched to keep this PR minimal and contained pre-tag. The relationship-type GROUP BY inside `snapshot_stats` (edge side) is unrelated to `inventory/summary` and is part of that deferred work.
- Postgres store parity: `snapshot_stats` there runs against an indexed real DB where the GROUP BY is cheap; not changed here.