### PR TITLE
fix(dx): 0.95.0 DX/UX polish bundle (serve --demo-estate, offline+repo_url guard, per-control no_data, blocklist seed)

### DIFF
--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -190,6 +190,10 @@ class ScanRequest(BaseModel):
         repo_url = (self.repo_url or "").strip()
         if not repo_url:
             return self
+        if self.offline:
+            raise ValueError(
+                "offline mode cannot clone a remote repo_url; drop offline or scan a local path instead"
+            )
         conflicts: list[str] = []
         if self.agent_projects:
             conflicts.append("agent_projects")

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -363,7 +363,13 @@ async def get_compliance(request: Request) -> dict:
                     for agent in br.get("affected_agents", []):
                         affected_agents.add(agent)
 
-            if findings == 0:
+            if scan_count == 0:
+                # No completed scans means no evidence was gathered for this
+                # control. Rendering "pass" here reads as a clean audit when in
+                # fact nothing was measured, so surface an explicit not_assessed
+                # status per control (mirrors the aggregate no_data top-line).
+                status = "not_assessed"
+            elif findings == 0:
                 status = "pass"
             elif sev_breakdown["critical"] > 0 or sev_breakdown["high"] > 0:
                 status = "fail"
@@ -427,6 +433,11 @@ async def get_compliance(request: Request) -> dict:
         summary[f"{metadata.summary_prefix}_pass"] = passed
         summary[f"{metadata.summary_prefix}_warn"] = warned
         summary[f"{metadata.summary_prefix}_fail"] = failed
+        # On a zero-scan tenant every control is not_assessed (0 pass/warn/fail).
+        # Surface the catalogue size as not_evaluated so consumers can tell an
+        # empty estate apart from a fully-passing one.
+        if scan_count == 0:
+            summary[f"{metadata.summary_prefix}_not_evaluated"] = len(framework_controls[metadata.output_key])
     summary.update(
         {
             "aisvs_pass": aisvs_summary["pass"],
@@ -1011,17 +1022,10 @@ async def get_compliance_summary(request: Request) -> dict:
             }
     response["frameworks"] = framework_summary
 
-    if no_data:
-        raw_summary = full.get("summary")
-        if isinstance(raw_summary, dict):
-            adjusted: dict[str, Any] = {}
-            for count_key, count_value in raw_summary.items():
-                if count_key.endswith("_pass"):
-                    adjusted[count_key] = 0
-                    adjusted[f"{count_key[:-len('_pass')]}_not_evaluated"] = count_value
-                else:
-                    adjusted[count_key] = count_value
-            response["summary"] = adjusted
+    # When no_data the aggregate (get_compliance) already emits 0 pass/warn/fail
+    # and a per-framework *_not_evaluated count equal to the catalogue size, so
+    # the pass-through summary above is already honest — no reinterpretation
+    # needed here.
 
     return response
 

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -470,6 +470,13 @@ def _analytics_summary_rows(
     metavar="ROWS",
     help="Maximum rows to flush per ClickHouse batch.",
 )
+@click.option(
+    "--demo-estate",
+    is_flag=True,
+    default=False,
+    envvar="AGENT_BOM_DEMO_ESTATE",
+    help="Seed a labeled demo graph and curated offline findings on first API start.",
+)
 def serve_cmd(
     host: str,
     port: int,
@@ -486,6 +493,7 @@ def serve_cmd(
     analytics_buffered: bool,
     analytics_flush_interval: float,
     analytics_max_batch: int,
+    demo_estate: bool,
 ):
     """Start the API server and serve the dashboard when UI assets are built.
 
@@ -514,6 +522,8 @@ def serve_cmd(
 
     import os as _os
 
+    if demo_estate:
+        _os.environ["AGENT_BOM_DEMO_ESTATE"] = "1"
     if persist:
         _os.environ["AGENT_BOM_DB"] = str(Path(persist).resolve())
     if cors_allow_all:

--- a/src/agent_bom/data/mcp-blocklist.json
+++ b/src/agent_bom/data/mcp-blocklist.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 2,
-  "updated": "2026-04-28",
+  "updated": "2026-07-13",
   "description": "Curated MCP intelligence entries and suspicious-name patterns. Confirmed malicious entries carry references and default enforcement recommendations; heuristic entries remain review-oriented.",
   "policy_contract": {
     "confidence_levels": [
@@ -154,6 +154,121 @@
         "(^|[-_./@])token[-_]?grabber($|[-_./])"
       ],
       "severity": "high",
+      "source": "agent-bom-curated",
+      "references": []
+    },
+    {
+      "id": "suspicious-remote-shell-backdoor-name",
+      "title": "Suspicious remote-shell or backdoor server name",
+      "description": "Server name, registry id, package name, or command contains terms associated with reverse shells, bind shells, or backdoor implants. Malicious MCP packages have shipped reverse-shell payloads; review the server source before enabling it.",
+      "confidence": "heuristic",
+      "default_recommendation": "review",
+      "source_type": "heuristic",
+      "last_verified": "2026-07-13",
+      "remediation_actions": [
+        "review_server_source",
+        "verify_requested_permissions",
+        "audit_host_for_reverse_shell_activity"
+      ],
+      "match_type": "pattern",
+      "patterns": [
+        "(^|[-_./@])(reverse|bind|back)[-_]?shell($|[-_./])",
+        "(^|[-_./@])revshell($|[-_./])",
+        "(^|[-_./@])backconnect($|[-_./])",
+        "(^|[-_./@])backdoor($|[-_./])"
+      ],
+      "severity": "high",
+      "source": "agent-bom-curated",
+      "references": []
+    },
+    {
+      "id": "suspicious-command-and-control-beacon-name",
+      "title": "Suspicious command-and-control beacon server name",
+      "description": "Server name, registry id, package name, or command references common command-and-control or offensive-tooling frameworks. Legitimate MCP servers rarely name themselves after C2 implants.",
+      "confidence": "heuristic",
+      "default_recommendation": "review",
+      "source_type": "heuristic",
+      "last_verified": "2026-07-13",
+      "remediation_actions": [
+        "review_server_source",
+        "isolate_host_from_network",
+        "audit_outbound_connections"
+      ],
+      "match_type": "pattern",
+      "patterns": [
+        "(^|[-_./@])c2[-_]?(beacon|implant|server)($|[-_./])",
+        "(^|[-_./@])command[-_]?and[-_]?control($|[-_./])",
+        "(^|[-_./@])meterpreter($|[-_./])",
+        "(^|[-_./@])cobalt[-_]?strike($|[-_./])"
+      ],
+      "severity": "high",
+      "source": "agent-bom-curated",
+      "references": []
+    },
+    {
+      "id": "suspicious-crypto-wallet-stealer-name",
+      "title": "Suspicious cryptocurrency wallet or key stealer server name",
+      "description": "Server name, registry id, package name, or command references cryptocurrency wallet, seed-phrase, or private-key theft or clipboard-hijacking (clipper) behavior. Supply-chain campaigns have used MCP packages to harvest crypto keys.",
+      "confidence": "heuristic",
+      "default_recommendation": "review",
+      "source_type": "heuristic",
+      "last_verified": "2026-07-13",
+      "remediation_actions": [
+        "review_server_source",
+        "rotate_exposed_credentials",
+        "audit_wallet_and_key_access"
+      ],
+      "match_type": "pattern",
+      "patterns": [
+        "(^|[-_./@])(wallet|seed[-_]?phrase|private[-_]?key)[-_]?(stealer|grabber|drainer)($|[-_./])",
+        "(^|[-_./@])clipboard[-_]?(hijack|clipper)($|[-_./])",
+        "(^|[-_./@])crypto[-_]?(stealer|drainer)($|[-_./])"
+      ],
+      "severity": "high",
+      "source": "agent-bom-curated",
+      "references": []
+    },
+    {
+      "id": "suspicious-keylogger-screencapture-name",
+      "title": "Suspicious keylogger or screen-capture server name",
+      "description": "Server name, registry id, package name, or command references keystroke logging or stealthy screen capture. Such capabilities are unusual for a legitimate MCP tool and warrant review.",
+      "confidence": "heuristic",
+      "default_recommendation": "review",
+      "source_type": "heuristic",
+      "last_verified": "2026-07-13",
+      "remediation_actions": [
+        "review_server_source",
+        "verify_requested_permissions"
+      ],
+      "match_type": "pattern",
+      "patterns": [
+        "(^|[-_./@])key[-_]?(logger|stroke[-_]?logger)($|[-_./])",
+        "(^|[-_./@])screen[-_]?(grabber|capture[-_]?stealth)($|[-_./])"
+      ],
+      "severity": "high",
+      "source": "agent-bom-curated",
+      "references": []
+    },
+    {
+      "id": "suspicious-modelcontextprotocol-typosquat-name",
+      "title": "Suspicious typosquat of the Model Context Protocol namespace",
+      "description": "Package or registry id closely misspells the official 'modelcontextprotocol' namespace. Typosquats of the official namespace are a common vector for impersonating trusted MCP servers.",
+      "confidence": "heuristic",
+      "default_recommendation": "review",
+      "source_type": "heuristic",
+      "last_verified": "2026-07-13",
+      "remediation_actions": [
+        "review_server_source",
+        "confirm_official_namespace"
+      ],
+      "match_type": "pattern",
+      "patterns": [
+        "(^|[-_./@])modlecontextprotocol($|[-_./])",
+        "(^|[-_./@])modelcontextprotoco(al|coll|kol)($|[-_./])",
+        "(^|[-_./@])modelcontextprotocal($|[-_./])",
+        "(^|[-_./@])model[-_]?context[-_]?protcol($|[-_./])"
+      ],
+      "severity": "medium",
       "source": "agent-bom-curated",
       "references": []
     }

--- a/tests/api/test_api_scan_repo_url.py
+++ b/tests/api/test_api_scan_repo_url.py
@@ -21,6 +21,13 @@ def test_scan_request_accepts_repo_url_only() -> None:
     assert req.repo_url == "https://github.com/org/repo"
 
 
+def test_scan_request_repo_url_rejects_offline() -> None:
+    """offline cannot clone a remote repo — reject up front with a clear message
+    instead of failing deep in the pipeline with an opaque subpath error."""
+    with pytest.raises(ValueError, match="offline mode cannot clone a remote repo_url"):
+        ScanRequest(repo_url="https://github.com/org/repo", offline=True)
+
+
 def test_run_scan_sync_clones_repo_url_and_cleans_up(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     cloned = tmp_path / "cloned-repo"
     cloned.mkdir()

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -153,6 +153,23 @@ def test_serve_cmd_non_loopback_never_auto_generates_dev_key(monkeypatch):
     mock_set_dev.assert_called_once_with(None)
 
 
+def test_serve_cmd_demo_estate_sets_env(monkeypatch):
+    """`serve --demo-estate` seeds the demo estate the same way `api --demo-estate` does."""
+    for name in _AUTH_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.delenv("AGENT_BOM_DEMO_ESTATE", raising=False)
+    runner = CliRunner()
+    with (
+        patch("agent_bom.api.server.configure_api"),
+        patch("agent_bom.api.server.set_dev_api_key"),
+        patch("uvicorn.run"),
+    ):
+        result = runner.invoke(serve_cmd, ["--demo-estate"])
+
+    assert result.exit_code == 0
+    assert os.environ.get("AGENT_BOM_DEMO_ESTATE") == "1"
+
+
 # ---------------------------------------------------------------------------
 # api_cmd
 # ---------------------------------------------------------------------------

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -78,15 +78,16 @@ def test_compliance_no_scans():
     assert data["aisvs_benchmark"]["benchmark"]["checks"] == []
     assert data["summary"]["aisvs_pass"] == 0
     assert data["summary"]["aisvs_fail"] == 0
-    # All OWASP controls should be "pass"
+    # With no evidence, every control is not_assessed — not a trivial "pass".
     for c in data["owasp_llm_top10"]:
-        assert c["status"] == "pass"
+        assert c["status"] == "not_assessed"
         assert c["findings"] == 0
     for metadata in TAG_MAPPED_FRAMEWORKS:
         assert len(data[metadata.output_key]) == metadata.control_count
-        assert data["summary"][f"{metadata.summary_prefix}_pass"] == metadata.control_count
+        assert data["summary"][f"{metadata.summary_prefix}_pass"] == 0
         assert data["summary"][f"{metadata.summary_prefix}_warn"] == 0
         assert data["summary"][f"{metadata.summary_prefix}_fail"] == 0
+        assert data["summary"][f"{metadata.summary_prefix}_not_evaluated"] == metadata.control_count
     _clear_jobs()
 
 

--- a/tests/test_mcp_blocklist.py
+++ b/tests/test_mcp_blocklist.py
@@ -271,6 +271,31 @@ def test_bundled_blocklist_matches_suspicious_exfiltration_names() -> None:
         assert match.match_type == "pattern"
 
 
+def test_bundled_blocklist_matches_expanded_heuristic_names() -> None:
+    """The seed ships heuristic name patterns beyond the original exfiltration entry."""
+    blocklist = load_mcp_blocklist()
+    cases = [
+        ("reverse-shell-mcp", "suspicious-remote-shell-backdoor-name"),
+        ("mcp-backdoor", "suspicious-remote-shell-backdoor-name"),
+        ("c2-beacon", "suspicious-command-and-control-beacon-name"),
+        ("wallet-stealer", "suspicious-crypto-wallet-stealer-name"),
+        ("mcp-keylogger", "suspicious-keylogger-screencapture-name"),
+        ("modlecontextprotocol", "suspicious-modelcontextprotocol-typosquat-name"),
+    ]
+
+    for name, expected_entry_id in cases:
+        matches = match_mcp_server(MCPServer(name=name, command="npx", args=["-y", name]), blocklist)
+        assert any(match.entry_id == expected_entry_id for match in matches), name
+
+
+def test_bundled_blocklist_does_not_flag_official_mcp_namespace() -> None:
+    """The typosquat heuristic must not fire on the legitimate namespace."""
+    blocklist = load_mcp_blocklist()
+    legit = MCPServer(name="filesystem", command="npx", args=["-y", "@modelcontextprotocol/server-filesystem"])
+    matches = match_mcp_server(legit, blocklist)
+    assert not [m for m in matches if m.entry_id == "suspicious-modelcontextprotocol-typosquat-name"]
+
+
 def test_bundled_blocklist_keeps_version_specific_mcp_package_pinned() -> None:
     blocklist = load_mcp_blocklist()
 


### PR DESCRIPTION
Lands the **contained** items from the 0.95.0 DX/UX polish bundle (#3889) ahead of the 0.95.0 tag. Non-regressive, demo/tenant-safe.

## Done
1. **`serve --demo-estate`** — the documented primary command lacked the flag `api` already had. Added it (same `AGENT_BOM_DEMO_ESTATE=1` wiring), so `agent-bom serve --demo-estate` seeds the demo graph + curated findings. `src/agent_bom/cli/_server.py`
2. **`offline` + `repo_url` rejected up front** — previously produced an opaque deep-pipeline "not in the subpath" error. `ScanRequest` now raises a clear `offline mode cannot clone a remote repo_url…` at validation time. `src/agent_bom/api/models.py`
3. **Per-control compliance `no_data`** — on a zero-scan estate individual controls rendered `status: "pass"` even though the top-line is `no_data`. Controls now render `not_assessed`; the aggregate summary emits `*_not_evaluated` (= catalogue size) and `/compliance/summary` passes it through honestly instead of reinterpreting `*_pass`. `src/agent_bom/api/routes/compliance.py`
4. **MCP blocklist seed expanded** — grew the bundled seed from 5 to 10 entries with **heuristic, review-only** name patterns (reverse-shell/backdoor, C2 beacons, crypto-key stealers, keyloggers, `modelcontextprotocol` typosquats). Deliberately no `block`/`confirmed_malicious` additions and no fabricated advisories, so there is zero false-block / false-accusation risk. `src/agent_bom/data/mcp-blocklist.json`

## Deferred (still tracked in #3889 — the bigger/riskier items)
- **`/v1/agents` disjoint from estate** (local-disk discovery vs `/v1/inventory`/graph) — reconciling two discovery surfaces is invasive for a pre-tag release.
- **Exec Overview compliance tile** — new posture surface; out of scope for a stable polish pass.
- **Filesystem-scan `N/A` posture grade** — needs MCP posture signals folded into the grade; touches scoring, deferred.

## Tests
- Extended: `test_compliance.py` (aggregate no-scans → `not_assessed` + `*_not_evaluated`), `test_mcp_blocklist.py` (new heuristic patterns match; official namespace does **not** false-positive), `test_cli_server.py` (`serve --demo-estate` sets the env), `test_api_scan_repo_url.py` (offline+repo_url rejected).
- Green: affected suites (75 passed) + compliance/report/demo-estate/api-endpoints (91) + compliance-adjacent smoke (18). `ruff` clean. OpenAPI `--check` matches (dict responses + a validator; no schema change).