### PR TITLE
fix(ui): distinguish AI clients from background agents in agent inventory

### DIFF
--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -193,6 +193,22 @@ def _observation_ids(agent: Any, server: Any) -> tuple[str, str | None]:
     return current, legacy
 
 
+def _agent_count_by_class(agents) -> dict[str, int]:
+    """Split discovered agents into AI clients vs background agents (additive).
+
+    Excludes synthetic SBOM/image wrappers. Lets clients render one authoritative
+    breakdown instead of each re-deriving from ``agent_type``.
+    """
+    from agent_bom.models import classify_agent_kind
+
+    counts = {"client": 0, "background": 0}
+    for agent in agents:
+        kind = classify_agent_kind(agent)
+        if kind in counts:
+            counts[kind] += 1
+    return counts
+
+
 def _serialize_agent(
     agent,
     *,
@@ -202,6 +218,11 @@ def _serialize_agent(
     observation_index: dict[str, MCPObservation] | None = None,
 ) -> dict:
     payload = asdict(agent)
+    # Display-only class (AI client/host vs background/framework agent). Additive
+    # field; never renames agent_type or any existing key.
+    from agent_bom.models import classify_agent_kind
+
+    payload["agent_class"] = classify_agent_kind(agent)
     agent_provenance = agent_discovery_provenance(agent)
     payload["discovery_provenance"] = agent_provenance
     payload["mcp_servers"] = []
@@ -436,6 +457,7 @@ def _build_agents_response(tenant_id: str) -> dict[str, Any]:
             for a in agents
         ],
         "count": len(agents),
+        "count_by_class": _agent_count_by_class(agents),
         "warnings": [],
     }
 

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -1053,6 +1053,30 @@ class BlastRadius:
         return sorted(self.package.occurrences, key=lambda occ: (occ.layer_index, occ.layer_id, occ.package_path or ""))
 
 
+def classify_agent_kind(agent: "Agent") -> str:
+    """Display-only classification of a discovered agent record.
+
+    Distinguishes what "agent" actually means to avoid overstating autonomy:
+
+    - ``"client"`` — an AI **client/host** application discovered from config
+      (Cursor, Claude Desktop, VS Code/Copilot, Codex CLI, …). Signalled by a
+      specific ``agent_type`` (not ``CUSTOM``).
+    - ``"background"`` — a **framework/service agent** *definition* discovered
+      from code (CrewAI/LangChain/LangGraph, ``agent_type == CUSTOM`` with a
+      ``source``/name shaped like ``"langchain:orders"``).
+    - ``"synthetic"`` — an SBOM/image ingest wrapper (``agent_type == CUSTOM``
+      with a ``sbom:``/``image:`` name), not a real agent at all.
+
+    Layers vocabulary on top of the existing ``agent_type`` field; changes no
+    stored data, enum value, route, or API key.
+    """
+    if agent.agent_type != AgentType.CUSTOM:
+        return "client"
+    if (agent.name or "").startswith(("sbom:", "image:")):
+        return "synthetic"
+    return "background"
+
+
 @dataclass
 class AIBOMReport:
     """Complete AI-BOM report."""
@@ -1163,6 +1187,21 @@ class AIBOMReport:
         specific agent types (CLAUDE_DESKTOP, CURSOR, etc.).
         """
         return any(a.agent_type != AgentType.CUSTOM for a in self.agents)
+
+    @property
+    def agent_class_counts(self) -> dict[str, int]:
+        """Real agents split by display class: AI clients vs background agents.
+
+        Excludes synthetic SBOM/image wrappers. ``client`` = discovered AI
+        host apps; ``background`` = framework/service agent definitions. See
+        :func:`classify_agent_kind`.
+        """
+        counts = {"client": 0, "background": 0}
+        for agent in self.agents:
+            kind = classify_agent_kind(agent)
+            if kind in counts:
+                counts[kind] += 1
+        return counts
 
     def __post_init__(self) -> None:
         if not self.tool_version:

--- a/tests/test_agent_classification.py
+++ b/tests/test_agent_classification.py
@@ -1,0 +1,54 @@
+"""Display-only agent classification: AI clients vs background agents.
+
+Locks the vocabulary fix that stops "N agents" from implying autonomy when
+some records are AI client/host apps (Cursor, Claude Desktop) and others are
+framework/service agent definitions. See ``classify_agent_kind``.
+"""
+
+from __future__ import annotations
+
+from agent_bom.api.routes.discovery import _agent_count_by_class
+from agent_bom.models import Agent, AgentType, AIBOMReport, classify_agent_kind
+
+
+def _agent(name: str, agent_type: AgentType) -> Agent:
+    return Agent(name=name, agent_type=agent_type, config_path="/x")
+
+
+def test_client_apps_classify_as_client() -> None:
+    for t in (AgentType.CURSOR, AgentType.CLAUDE_DESKTOP, AgentType.VSCODE_COPILOT, AgentType.CODEX_CLI):
+        assert classify_agent_kind(_agent("app", t)) == "client"
+
+
+def test_framework_definition_classifies_as_background() -> None:
+    assert classify_agent_kind(_agent("langchain:orders", AgentType.CUSTOM)) == "background"
+    assert classify_agent_kind(_agent("crewai:support", AgentType.CUSTOM)) == "background"
+
+
+def test_sbom_and_image_wrappers_are_synthetic_not_agents() -> None:
+    assert classify_agent_kind(_agent("sbom:requirements.txt", AgentType.CUSTOM)) == "synthetic"
+    assert classify_agent_kind(_agent("image:nginx:1.25", AgentType.CUSTOM)) == "synthetic"
+
+
+def test_report_counts_split_clients_and_background_excluding_synthetic() -> None:
+    report = AIBOMReport(
+        agents=[
+            _agent("cursor", AgentType.CURSOR),
+            _agent("claude-desktop", AgentType.CLAUDE_DESKTOP),
+            _agent("langchain:orders", AgentType.CUSTOM),
+            _agent("crewai:support", AgentType.CUSTOM),
+            _agent("celery:pipeline", AgentType.CUSTOM),
+            _agent("sbom:reqs", AgentType.CUSTOM),  # synthetic — not an agent
+        ]
+    )
+    # Mirrors the seeded demo estate: 2 AI clients + 3 background agents.
+    assert report.agent_class_counts == {"client": 2, "background": 3}
+
+
+def test_api_count_by_class_matches_and_ignores_synthetic() -> None:
+    agents = [
+        _agent("cursor", AgentType.CURSOR),
+        _agent("langchain:orders", AgentType.CUSTOM),
+        _agent("image:nginx", AgentType.CUSTOM),
+    ]
+    assert _agent_count_by_class(agents) == {"client": 1, "background": 1}

--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -8,6 +8,7 @@ import {
   api,
   Agent,
   isConfigured,
+  agentClassCounts,
   type AgentDetailResponse,
   type DiscoveryEnvelope,
   type DiscoveryProvenance,
@@ -214,6 +215,9 @@ function AgentsList() {
 
   const { configured, notConfigured: installedOnly, totalServers, totalPackages, totalCredentials, ecosystems, serversWithCredentials, blockedServers, remoteServers } =
     useAgentStats(agents);
+  // Split real agents into AI clients (host apps) vs background/framework agents,
+  // so the headline doesn't imply e.g. Cursor is an autonomous agent.
+  const agentClasses = agentClassCounts(agents);
 
   const filteredConfigured = configured.filter((a) =>
     !search || a.name.toLowerCase().includes(search.toLowerCase())
@@ -248,7 +252,7 @@ function AgentsList() {
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Agents</h1>
           <p className="text-zinc-400 text-sm mt-1">
-            Discovered agent configurations and attached MCP servers
+            Discovered AI clients/hosts and background agents, with their MCP servers
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -295,8 +299,10 @@ function AgentsList() {
                 <div className="mt-1 text-sm font-semibold text-rose-400">{blockedServers}</div>
               </div>
               <div className="rounded-lg border border-zinc-800 bg-zinc-950/80 px-3 py-2">
-                <div className="text-zinc-500">Configured agents</div>
-                <div className="mt-1 text-sm font-semibold text-emerald-400">{configured.length}</div>
+                <div className="text-zinc-500">AI clients · background</div>
+                <div className="mt-1 text-sm font-semibold text-emerald-400">
+                  {agentClasses.client} · {agentClasses.background}
+                </div>
               </div>
             </div>
           </div>

--- a/ui/lib/api-format.ts
+++ b/ui/lib/api-format.ts
@@ -49,3 +49,32 @@ export function formatDate(iso: string): string {
 export function isConfigured(agent: Agent): boolean {
   return agent.status !== "installed-not-configured";
 }
+
+const AGENT_SYNTHETIC_PREFIXES = ["sbom:", "image:"];
+
+/**
+ * Display class for a discovered agent, distinct from the configured/installed
+ * axis: an AI **client/host** app (Cursor, Claude Desktop, …) vs a **background**
+ * framework/service agent definition (CrewAI/LangChain) vs a synthetic
+ * SBOM/image wrapper. Mirrors the backend `classify_agent_kind`; prefers the
+ * server-provided `agent_class` when present.
+ */
+export function agentClass(agent: Agent): "client" | "background" | "synthetic" {
+  const provided = agent.agent_class;
+  if (provided === "client" || provided === "background" || provided === "synthetic") {
+    return provided;
+  }
+  if (agent.agent_type && agent.agent_type !== "custom") return "client";
+  if (AGENT_SYNTHETIC_PREFIXES.some((p) => (agent.name ?? "").startsWith(p))) return "synthetic";
+  return "background";
+}
+
+/** Real agents (excludes synthetic) split into AI clients vs background agents. */
+export function agentClassCounts(agents: Agent[]): { client: number; background: number } {
+  const counts = { client: 0, background: 0 };
+  for (const agent of agents) {
+    const kind = agentClass(agent);
+    if (kind === "client" || kind === "background") counts[kind] += 1;
+  }
+  return counts;
+}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -697,6 +697,8 @@ export type AgentStatus = "configured" | "installed-not-configured";
 export interface Agent {
   name: string;
   agent_type: string;
+  /** Display class from the API: "client" | "background" | "synthetic" (additive). */
+  agent_class?: string | undefined;
   config_path?: string | undefined;
   source?: string | undefined;
   source_id?: string | undefined;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -1301,4 +1301,4 @@ export const CMMC_PRACTICES: Record<string, string> = {
 // re-exports keep every existing `import { severityColor } from "@/lib/api"`
 // working unchanged so callers don't need to migrate in one big bang.
 
-export { severityColor, severityDot, formatDate, isConfigured } from "./api-format";
+export { severityColor, severityDot, formatDate, isConfigured, agentClass, agentClassCounts } from "./api-format";


### PR DESCRIPTION
## What

Stops "N agents" from implying autonomy. Discovered "agent" records are two different things: **AI clients/hosts** (Cursor, Claude Desktop, VS Code/Copilot, Codex CLI — config-discovered apps) and **background agents** (LangChain/CrewAI framework/service definitions). The distinction already lives in `agent_type`; this layers display vocabulary on top — **no enum value, route, or API key is renamed** (non-breaking).

- `models.classify_agent_kind()` → `client | background | synthetic` (synthetic = `sbom:`/`image:` ingest wrappers, excluded from agent counts).
- `AIBOMReport.agent_class_counts` + **additive** API fields: per-agent `agent_class` in `_serialize_agent`, `count_by_class` on the `/agents` response.
- `/agents` page: subtitle now reads "Discovered AI clients/hosts and background agents…" and the tile shows an **"AI clients · background"** split. UI `agentClass()`/`agentClassCounts()` prefer the API field, fall back to `agent_type`.

The seeded demo now reads truthfully as **2 AI clients + 3 background agents** (was "5 agents").

## Tests
- `tests/test_agent_classification.py` — client/background/synthetic classification + report & API counts (5 pass).
- `typecheck` ✓ · `npm run build` ✓ · agents-page virtualization test ✓.

## Follow-up (not in this PR)
CLI scan-summary lines and a couple of docs still say "N agents"; low-risk copy-only, deferred to avoid snapshot churn.