### PR TITLE
polish: MCP-catalog freshness line + client/background agent copy

### DIFF
--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -61,7 +61,7 @@ What to look for:
 |---|---|---|
 | `Demo mode` | Uses the bundled curated sample instead of your workstation config. | The first run is reproducible and safe to share in a bug report or sales demo. |
 | `Offline mode` | Uses the bundled demo advisory DB and no network calls. | The command does not depend on live OSV/GHSA/network availability or a pre-synced local DB. |
-| `2 agent(s)` | Loads sample agent surfaces such as Cursor and Claude Desktop. | Findings are tied to AI agents, not only package names. |
+| `2 agent(s)` | Loads sample **AI client/host** surfaces such as Cursor and Claude Desktop (distinct from background/framework agents). | Findings are tied to AI clients and agents, not only package names. |
 | `12 packages` | Extracts Python and npm package evidence behind MCP servers. | The scan proves supply-chain inventory before reporting risk. |
 | `11 vulnerabilities` | Matches vulnerable demo package versions against curated advisory-backed ranges. | The findings are advisory-backed; they are not invented demo rows. |
 | severity summary | Groups findings by critical/high/medium/low. | Operators can immediately prioritize the highest-risk fixes. |

--- a/src/agent_bom/api/routes/connectors.py
+++ b/src/agent_bom/api/routes/connectors.py
@@ -114,11 +114,31 @@ async def connector_health(name: str) -> dict:
 # ─── Registry endpoints ──────────────────────────────────────────────────────
 
 
+def _load_registry_meta() -> dict:
+    """Freshness/provenance metadata from the bundled registry (top-level keys)."""
+    import json as _json
+
+    registry_path = _Path(__file__).parent.parent.parent / "mcp_registry.json"
+    if not registry_path.exists():
+        return {}
+    try:
+        raw = _json.loads(registry_path.read_text())
+    except (_json.JSONDecodeError, OSError):
+        return {}
+    return {
+        "updated": raw.get("_updated"),
+        "total_servers": raw.get("_total_servers"),
+        "sources": raw.get("_sources", []),
+        "source_url": raw.get("_source"),
+        "schema_version": raw.get("_schema_version"),
+    }
+
+
 @router.get("/registry", tags=["registry"])
 async def list_registry() -> dict:
     """List all known MCP servers from the agent-bom registry."""
     servers = _load_registry()
-    return {"servers": servers, "count": len(servers)}
+    return {"servers": servers, "count": len(servers), "meta": _load_registry_meta()}
 
 
 @router.get("/registry/{server_id:path}", tags=["registry"])

--- a/src/agent_bom/cli/_inventory.py
+++ b/src/agent_bom/cli/_inventory.py
@@ -186,7 +186,19 @@ def validate(inventory_file: str):
         agents = payload.get("agents", [])
         total_servers = sum(len(a.get("mcp_servers", [])) for a in agents)
         total_packages = sum(len(s.get("packages", [])) for a in agents for s in a.get("mcp_servers", []))
-        console.print(f"\n  [green]✓ Valid[/green] — {len(agents)} agent(s), {total_servers} server(s), {total_packages} package(s)")
+        # Split AI clients/hosts (specific agent_type) from background/framework
+        # agents (agent_type == custom), excluding synthetic sbom:/image: wrappers
+        # — mirrors models.classify_agent_kind so the count doesn't imply autonomy.
+        clients = sum(1 for a in agents if a.get("agent_type") and a.get("agent_type") != "custom")
+        background = sum(
+            1
+            for a in agents
+            if a.get("agent_type") == "custom" and not str(a.get("name") or "").startswith(("sbom:", "image:"))
+        )
+        breakdown = f" ({clients} client(s), {background} background)" if (clients or background) else ""
+        console.print(
+            f"\n  [green]✓ Valid[/green] — {len(agents)} agent(s){breakdown}, {total_servers} server(s), {total_packages} package(s)"
+        )
         console.print(f"\n  [dim]Scan exact inventory with:[/dim] agent-bom scan --inventory {inventory_file} --inventory-only")
     else:
         console.print(f"\n  [red]✗ Invalid — {len(errors)} error(s):[/red]\n")

--- a/ui/app/registry/page.tsx
+++ b/ui/app/registry/page.tsx
@@ -295,6 +295,12 @@ function RegistryDetail({ serverId }: { serverId: string }) {
 function RegistryList() {
   const router = useRouter();
   const [servers, setServers] = useState<RegistryServer[]>([]);
+  const [meta, setMeta] = useState<{
+    updated?: string | null;
+    total_servers?: number | null;
+    sources?: string[];
+    source_url?: string | null;
+  } | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
@@ -305,7 +311,10 @@ function RegistryList() {
   useEffect(() => {
     api
       .listRegistry()
-      .then((res) => setServers(res.servers))
+      .then((res) => {
+        setServers(res.servers);
+        setMeta(res.meta ?? null);
+      })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
   }, []);
@@ -361,9 +370,20 @@ function RegistryList() {
       <PageLaneHeader
         lane="reference"
         title="MCP Catalog"
-        subtitle={`${servers.length.toLocaleString()} known servers · capability risk (not CVE status) · ${riskCounts.high} high · ${riskCounts.medium} medium`}
+        subtitle={`${(meta?.total_servers ?? servers.length).toLocaleString()} known servers · capability risk (not CVE status) · ${riskCounts.high} high · ${riskCounts.medium} medium`}
         banner={<CatalogBanner />}
       />
+
+      {meta && (meta.updated || meta.sources?.length) ? (
+        <p className="-mt-3 text-xs text-zinc-500">
+          Synced from{" "}
+          {meta.sources?.includes("mcp-official")
+            ? "the official MCP registry"
+            : meta.sources?.join(", ") || "curated sources"}
+          {meta.updated ? ` · updated ${meta.updated}` : ""}
+          {typeof meta.total_servers === "number" ? ` · ${meta.total_servers.toLocaleString()} servers` : ""}
+        </p>
+      ) : null}
 
       {/* Search + Filters */}
       <div className="space-y-3">

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1731,9 +1731,18 @@ export interface RegistryServer {
   risk_justification?: string | undefined;
 }
 
+export interface RegistryMeta {
+  updated?: string | null;
+  total_servers?: number | null;
+  sources?: string[];
+  source_url?: string | null;
+  schema_version?: string | null;
+}
+
 export interface RegistryResponse {
   servers: RegistryServer[];
   count: number;
+  meta?: RegistryMeta;
 }
 
 export interface ControlNarrative {


### PR DESCRIPTION
Two small clarity items agreed for after the terminology + hardening PRs.

## MCP-catalog freshness (the "keep it, make freshness visible" follow-up)
- `/v1/registry` now returns a `meta` block (`updated`, `total_servers`, `sources`, `source_url`, `schema_version`) from the bundled registry.
- The **MCP Catalog** page shows a provenance line: *"Synced from the official MCP registry · updated <date> · N servers."* Freshness is now visible, answering the "is it current / made-up?" question — and the catalog already auto-syncs (weekly chore job; currently 967 servers, updated 2026-07-13).

## Client-vs-agent copy (deferred CLI/docs from the terminology PR)
- CLI `inventory validate` summary now splits `N agent(s) (C client(s), B background)` — mirrors `models.classify_agent_kind`, excludes synthetic `sbom:`/`image:` wrappers, so a raw count doesn't imply autonomy.
- `docs/FIRST_RUN.md` sharpens AI-client vs background-agent vocabulary.

## Verification
- mypy clean; 321 registry/connectors/inventory tests pass; UI typecheck clean.