### PR TITLE
docs+ui: release-align nav label, stale counts, CHANGELOG date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.95.0] - 2026-07-12
+## [0.95.0] - 2026-07-13
 
 Enterprise auth, cloud-connect, and interop release: browser OIDC SSO, actionable cloud connections, compliance honesty, refreshed dashboard/branding, and a large security-hardening batch on top of 0.94.2.
 

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -17,7 +17,7 @@ attack paths, compliance tags, and runtime audit chain.
 | Area | Shipped today |
 |---|---|
 | MCP security tools | 73 tools, 6 resources, 8 workflow prompts |
-| REST API | 283 operations across 32 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| REST API | 300 operations across 36 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -111,7 +111,7 @@ const NAV_GROUPS: NavGroup[] = [
     label: "Cloud & Data",
     icon: Cloud,
     links: [
-      { href: "/connections", label: "Cloud Accounts", icon: Cloud, capability: "inventory.read" },
+      { href: "/connections", label: "Connections", icon: Cloud, capability: "inventory.read" },
       { href: "/sources", label: "Data Sources", icon: Database, capability: "sources.manage" },
       { href: "/scan", label: "New Scan", icon: Scan, capability: "scan.run" },
       { href: "/identity", label: "Identity", icon: Fingerprint },


### PR DESCRIPTION
Pre-release consistency cleanup from the audit (all P2 nits, no code behavior change).

- **nav**: `/connections` relabelled **"Cloud Accounts" → "Connections"** — the page is now the unified connector gallery (cloud + code + AI + data, #3901); the old label undersold it and blurred against the adjacent Data Sources entry.
- **docs/AGENT_CAPABILITY.md**: stale REST API metric **283 ops / 32 route modules → 300 ops / 36 route modules** (matches `docs/openapi/v1.json` + PRODUCT_METRICS).
- **CHANGELOG.md**: 0.95.0 dated **2026-07-13** (tag day).

Left as-is (verified correct/intentional): the "36 route modules" counts elsewhere include `__init__.py` by definition; SDK versions are independently versioned.