### PR TITLE
fix(compliance): /v1/compliance scores over evaluated controls, not silent passes

### DIFF
--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -302,6 +302,20 @@ def _derive_deployment_context(request: Request, jobs: list[Any]) -> dict[str, A
     }
 
 
+def _evaluated_control_status(sev_breakdown: dict[str, int]) -> str:
+    """Status of a control that HAS mapped findings, by worst severity.
+
+    Mirror of ``compliance_narrative._control_status`` so ``/v1/compliance``, the
+    narrative, and the CLI export agree: critical/high → fail, medium/low →
+    warning, otherwise pass. Keep in sync with that function.
+    """
+    if sev_breakdown.get("critical", 0) > 0 or sev_breakdown.get("high", 0) > 0:
+        return "fail"
+    if sev_breakdown.get("medium", 0) > 0 or sev_breakdown.get("low", 0) > 0:
+        return "warning"
+    return "pass"
+
+
 @router.get("/compliance", tags=["compliance"])
 async def get_compliance(request: Request) -> dict:
     """Aggregate OWASP LLM Top 10, OWASP MCP Top 10, MITRE ATLAS, NIST AI RMF,
@@ -370,11 +384,14 @@ async def get_compliance(request: Request) -> dict:
                 # status per control (mirrors the aggregate no_data top-line).
                 status = "not_assessed"
             elif findings == 0:
-                status = "pass"
-            elif sev_breakdown["critical"] > 0 or sev_breakdown["high"] > 0:
-                status = "fail"
+                # Scan ran but nothing maps to this control — no
+                # vulnerability-derived evidence, so it is not_evaluated, never a
+                # silent pass. Counting these as pass inflated overall_score
+                # toward 100 and contradicted the narrative + CLI export; all
+                # three surfaces now agree.
+                status = "not_evaluated"
             else:
-                status = "warning"
+                status = _evaluated_control_status(sev_breakdown)
 
             controls.append(
                 {
@@ -402,18 +419,25 @@ async def get_compliance(request: Request) -> dict:
         return p, w, f
 
     all_frameworks = list(framework_controls.values())
-    total_controls = sum(len(fw) for fw in all_frameworks)
-    total_pass = sum(_count_statuses(fw)[0] for fw in all_frameworks)
-    any_fail = any(_count_statuses(fw)[2] > 0 for fw in all_frameworks)
-    any_warn = any(_count_statuses(fw)[1] > 0 for fw in all_frameworks)
-    overall_score = round((total_pass / total_controls) * 100, 1) if total_controls > 0 else 100.0
+    status_totals = [_count_statuses(fw) for fw in all_frameworks]
+    total_pass = sum(s[0] for s in status_totals)
+    total_warn = sum(s[1] for s in status_totals)
+    total_fail = sum(s[2] for s in status_totals)
+    # Score over EVALUATED controls only (those with mapped findings). A control
+    # with no findings is not_evaluated, never a silent pass — otherwise every
+    # never-triggered bundled control inflates the score toward 100. Matches the
+    # narrative so a benign/empty estate can't read as "fully compliant".
+    evaluated_controls = total_pass + total_warn + total_fail
+    overall_score = round((total_pass / evaluated_controls) * 100, 1) if evaluated_controls > 0 else 0.0
 
-    if any_fail:
+    if total_fail > 0:
         overall_status = "fail"
-    elif any_warn:
+    elif total_warn > 0:
         overall_status = "warning"
-    else:
+    elif evaluated_controls > 0:
         overall_status = "pass"
+    else:
+        overall_status = "no_data"
 
     # With zero completed scans there is nothing to measure — every control
     # trivially "passes" because no findings map to it. Reporting
@@ -429,15 +453,17 @@ async def get_compliance(request: Request) -> dict:
     aisvs_summary = aisvs["summary"]
     summary: dict[str, int | float] = {}
     for metadata in TAG_MAPPED_FRAMEWORKS:
-        passed, warned, failed = _count_statuses(framework_controls[metadata.output_key])
+        controls_list = framework_controls[metadata.output_key]
+        passed, warned, failed = _count_statuses(controls_list)
         summary[f"{metadata.summary_prefix}_pass"] = passed
         summary[f"{metadata.summary_prefix}_warn"] = warned
         summary[f"{metadata.summary_prefix}_fail"] = failed
-        # On a zero-scan tenant every control is not_assessed (0 pass/warn/fail).
-        # Surface the catalogue size as not_evaluated so consumers can tell an
-        # empty estate apart from a fully-passing one.
-        if scan_count == 0:
-            summary[f"{metadata.summary_prefix}_not_evaluated"] = len(framework_controls[metadata.output_key])
+        # Controls with no mapped findings are not_evaluated (not_assessed on a
+        # zero-scan estate) — surface the count so consumers can tell an
+        # unevaluated control apart from a passing one.
+        not_evaluated = len(controls_list) - passed - warned - failed
+        if not_evaluated:
+            summary[f"{metadata.summary_prefix}_not_evaluated"] = not_evaluated
     summary.update(
         {
             "aisvs_pass": aisvs_summary["pass"],

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -168,7 +168,11 @@ def test_compliance_includes_latest_aisvs_benchmark():
     assert data["summary"]["aisvs_pass"] == 1
     assert data["summary"]["aisvs_fail"] == 1
     assert data["summary"]["aisvs_not_applicable"] == 1
-    assert data["overall_score"] == 100.0
+    # This scan produced only AISVS-benchmark results, no tag-mapped-framework
+    # findings, so the tag-mapped frameworks are not_evaluated — overall_score is
+    # 0.0 / no_data (AISVS results are surfaced separately in aisvs_benchmark).
+    assert data["overall_score"] == 0.0
+    assert data["overall_status"] == "no_data"
 
     _clear_jobs()
 
@@ -254,7 +258,9 @@ def test_compliance_with_findings():
 
     # LLM01 should be pass (no findings)
     lmm01 = next(c for c in data["owasp_llm_top10"] if c["code"] == "LLM01")
-    assert lmm01["status"] == "pass"
+    # No findings map to this control — it is not_evaluated (no evidence), never a
+    # silent pass. Matches the narrative + CLI export.
+    assert lmm01["status"] == "not_evaluated"
     assert lmm01["findings"] == 0
 
     _clear_jobs()
@@ -363,9 +369,12 @@ def test_compliance_summary_counts():
     s = data["summary"]
     # Verify OWASP: 1 fail (LLM05), 9 pass
     assert s["owasp_fail"] == 1
-    assert s["owasp_pass"] == 9
+    # The other 9 controls have no mapped findings → not_evaluated, not a silent
+    # pass (would otherwise inflate the score toward 100).
+    assert s["owasp_pass"] == 0
     assert s["owasp_warn"] == 0
-    assert s["owasp_pass"] + s["owasp_warn"] + s["owasp_fail"] == 10
+    assert s["owasp_not_evaluated"] == 9
+    assert s["owasp_pass"] + s["owasp_warn"] + s["owasp_fail"] + s["owasp_not_evaluated"] == 10
 
     _clear_jobs()
 
@@ -415,8 +424,10 @@ def test_compliance_summary_with_scan_counts_evaluated_controls():
     data = client.get("/v1/compliance/summary", headers=_AUTH_HEADERS).json()
     assert data["scan_count"] == 1
     assert data["summary"]["owasp_fail"] == 1
-    assert data["summary"]["owasp_pass"] == 9
-    assert "owasp_not_evaluated" not in data["summary"]
+    # Never-triggered controls are not_evaluated, not pass — so the evaluated
+    # split is surfaced even on a non-empty scan.
+    assert data["summary"]["owasp_pass"] == 0
+    assert data["summary"]["owasp_not_evaluated"] == 9
     _clear_jobs()
 
 


### PR DESCRIPTION
Pre-tag honesty fix from the accuracy audit — you chose "fix before tag."

## The problem
`/v1/compliance` marked a control with **zero mapped findings** as `pass` and computed `overall_score = pass / total_controls`. On any real scan, the hundreds of never-triggered bundled controls all read as pass → the score inflated toward 100, **contradicting the narrative and CLI export**, which correctly call that state `not_evaluated`. Same class as the historical "100/100 on 0 findings" P0, on the API surface.

## The fix
- A control with **no mapped findings → `not_evaluated`** (never a silent pass).
- Evaluated controls are graded by worst severity via `_evaluated_control_status` — a mirror of `compliance_narrative._control_status` (critical/high → fail, medium/low → warning, else pass), so all three surfaces agree by construction.
- `overall_score` is now computed **over evaluated controls only**; `overall_status` is `no_data` when a scan produced no tag-mapped findings.
- Summary surfaces `*_not_evaluated` on real scans, not just empty ones. `get_compliance_summary` inherits the fix; `get_compliance_by_framework` was already honest (#3879).

## ⚠️ Behavioral change (intended)
**The compliance score reads materially lower on real scans** — it now reflects *evaluated* controls (those with evidence), not catalogue coverage. This is the honest number; the old ~100 was the over-claim. The UI compliance tile displays it unchanged (no UI code change). Please eyeball the new numbers before merging.

## Verification
- mypy clean; **25** compliance + export tests, **504** compliance/posture/overview tests pass (updated the 4 that encoded the old inflated values).