### PR TITLE
perf(findings): materialize scan_id + severity index on hub_findings_current

### DIFF
--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -404,14 +404,18 @@ def _upsert_current_finding_sqlite(
         updated_at=now,
     )
     origin_val = str(payload.get("origin") or "")
+    # Materialise the scan filter key: batch_id first, scan_id fallback — the
+    # canonical ``batch_id or scan_id`` the in-memory filter compares against so
+    # every backend agrees and the read rides the (tenant_id, scan_id) index.
+    scan_id_val = str(payload.get("batch_id") or payload.get("scan_id") or "")
     if has_ledger_col:
         conn.execute(
             """
             INSERT INTO hub_findings_current
                 (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
                  cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-                 updated_at, payload, ledger_finding_id, origin)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 updated_at, payload, ledger_finding_id, origin, scan_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(tenant_id, canonical_id) DO UPDATE SET
                 first_seen = MIN(hub_findings_current.first_seen, excluded.first_seen),
                 last_seen = MAX(hub_findings_current.last_seen, excluded.last_seen),
@@ -426,7 +430,8 @@ def _upsert_current_finding_sqlite(
                 updated_at = excluded.updated_at,
                 payload = excluded.payload,
                 ledger_finding_id = excluded.ledger_finding_id,
-                origin = excluded.origin
+                origin = excluded.origin,
+                scan_id = excluded.scan_id
             """,
             (
                 tenant_id,
@@ -445,6 +450,7 @@ def _upsert_current_finding_sqlite(
                 payload_json,
                 ledger_finding_id or None,
                 origin_val,
+                scan_id_val,
             ),
         )
     else:
@@ -453,8 +459,8 @@ def _upsert_current_finding_sqlite(
             INSERT INTO hub_findings_current
                 (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
                  cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-                 updated_at, payload, origin)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 updated_at, payload, origin, scan_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(tenant_id, canonical_id) DO UPDATE SET
                 first_seen = MIN(hub_findings_current.first_seen, excluded.first_seen),
                 last_seen = MAX(hub_findings_current.last_seen, excluded.last_seen),
@@ -468,7 +474,8 @@ def _upsert_current_finding_sqlite(
                 reopened_at = excluded.reopened_at,
                 updated_at = excluded.updated_at,
                 payload = excluded.payload,
-                origin = excluded.origin
+                origin = excluded.origin,
+                scan_id = excluded.scan_id
             """,
             (
                 tenant_id,
@@ -486,6 +493,7 @@ def _upsert_current_finding_sqlite(
                 merged["updated_at"],
                 payload_json,
                 origin_val,
+                scan_id_val,
             ),
         )
 
@@ -533,6 +541,50 @@ def _migrate_current_origin_col_sqlite(conn: sqlite3.Connection) -> None:
         conn.execute("UPDATE hub_findings_current SET origin = COALESCE(json_extract(payload, '$.origin'), '') WHERE origin = ''")
 
 
+def _migrate_current_scan_id_col_sqlite(conn: sqlite3.Connection) -> None:
+    """Promote ``scan_id`` to a real indexed column on ``hub_findings_current``.
+
+    The default ``/v1/findings`` (current-state) reach read filtered ``scan_id``
+    via ``json_extract(payload, '$.batch_id'/'$.scan_id')`` per row — a full-table
+    scan of the tenant, paid twice (COUNT + page). This mirrors the ledger fix
+    (#3641/#3913): backfill a materialised column so the filter rides an index.
+
+    The materialised value matches the canonical in-memory filter
+    (``batch_id or scan_id``): ``batch_id`` takes precedence and ``scan_id`` is
+    the fallback, so pre-migration rows resolve to the exact same key the old
+    per-row json_extract compared against. Idempotent: the guarded ALTER runs
+    once and the backfill only touches empty cells.
+    """
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(hub_findings_current)").fetchall()}
+    if "scan_id" not in cols:
+        conn.execute("ALTER TABLE hub_findings_current ADD COLUMN scan_id TEXT NOT NULL DEFAULT ''")
+        conn.execute(
+            "UPDATE hub_findings_current SET scan_id = "
+            "COALESCE(NULLIF(json_extract(payload, '$.batch_id'), ''), json_extract(payload, '$.scan_id'), '') "
+            "WHERE scan_id = ''"
+        )
+
+
+def _ensure_current_scale_indexes_sqlite(conn: sqlite3.Connection) -> None:
+    """Partial indexes backing the current-state scan_id + severity filters.
+
+    Both are ``WHERE <col> != ''`` partial indexes: the common rows (no scan_id,
+    or an empty severity) stay OUT of the index so an all-empty
+    ``(tenant_id, col)`` index cannot shadow the default reach read as a
+    perfect tenant-equality candidate and force a filesort. Real filters always
+    query a non-empty value, so the partial index still serves them (mirrors the
+    ledger treatment in ``_ensure_scale_indexes``).
+    """
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_scan "
+        "ON hub_findings_current(tenant_id, scan_id) WHERE scan_id != ''"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_severity_ci "
+        "ON hub_findings_current(tenant_id, LOWER(severity)) WHERE severity != ''"
+    )
+
+
 def _ensure_current_lifecycle_sqlite(conn: sqlite3.Connection) -> None:
     from agent_bom.api.finding_lifecycle import (
         _CURRENT_LIFECYCLE_SORT_INDEXES_SQLITE,
@@ -544,7 +596,11 @@ def _ensure_current_lifecycle_sqlite(conn: sqlite3.Connection) -> None:
     # ``(tenant_id, origin, cvss_score DESC, …)`` index can build on pre-existing
     # tables that predate the column.
     _migrate_current_origin_col_sqlite(conn)
+    # Materialise scan_id before its index so the partial index can build on
+    # tables that predate the column (the default /v1/findings scan filter).
+    _migrate_current_scan_id_col_sqlite(conn)
     conn.executescript(_CURRENT_LIFECYCLE_SORT_INDEXES_SQLITE)
+    _ensure_current_scale_indexes_sqlite(conn)
     _migrate_lifecycle_observations_l2_sqlite(conn)
     _migrate_current_ledger_ref_sqlite(conn)
     conn.execute("UPDATE hub_findings_current SET cvss_score = 0 WHERE cvss_score IS NULL")
@@ -1481,12 +1537,20 @@ class SQLiteComplianceHubStore:
             params.append(origin)
         if severity is not None:
             # Match the materialised severity STRING (exact, lowercased) so all
-            # backends agree; ``severity_rank`` stays ORDER-BY-only (#3192).
-            where.append("LOWER(severity) = ?")
+            # backends agree; ``severity_rank`` stays ORDER-BY-only (#3192). The
+            # ``severity != ''`` guard is redundant for any real severity but
+            # lets the partial expression index idx_hub_findings_current_tenant_
+            # severity_ci serve the filter (#3926).
+            where.append("severity != '' AND LOWER(severity) = ?")
             params.append(severity.lower())
         if scan_id is not None:
-            where.append("(CAST(json_extract(payload, '$.batch_id') AS TEXT) = ? OR CAST(json_extract(payload, '$.scan_id') AS TEXT) = ?)")
-            params.extend([scan_id, scan_id])
+            # Materialised column (backfilled from batch_id|scan_id) so the scan
+            # filter and its COUNT(*) ride idx_hub_findings_current_tenant_scan
+            # instead of a per-row json_extract full scan. The ``scan_id != ''``
+            # guard is redundant for any real scan_id but lets SQLite apply the
+            # partial index (it cannot prove a bound param is non-empty) (#3926).
+            where.append("scan_id = ? AND scan_id != ''")
+            params.append(scan_id)
         if cursor:
             keyset_sql, keyset_params = sqlite_keyset_clause(normalized_sort, cursor)
             where.append(keyset_sql.removeprefix(" AND "))

--- a/src/agent_bom/api/finding_lifecycle.py
+++ b/src/agent_bom/api/finding_lifecycle.py
@@ -154,6 +154,7 @@ CREATE TABLE IF NOT EXISTS hub_findings_current (
     payload TEXT NOT NULL,
     ledger_finding_id TEXT,
     origin TEXT NOT NULL DEFAULT '',
+    scan_id TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (tenant_id, canonical_id)
 );
 
@@ -225,6 +226,7 @@ CREATE TABLE IF NOT EXISTS hub_findings_current (
     payload JSONB NOT NULL,
     ledger_finding_id TEXT,
     origin TEXT NOT NULL DEFAULT '',
+    scan_id TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (tenant_id, canonical_id)
 );
 

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -320,6 +320,25 @@ class PostgresComplianceHubStore:
             conn.execute("ALTER TABLE hub_findings_current ADD COLUMN IF NOT EXISTS origin TEXT NOT NULL DEFAULT ''")
             conn.execute("UPDATE hub_findings_current SET origin = COALESCE(payload->>'origin', '') WHERE origin = ''")
             conn.execute(_CURRENT_LIFECYCLE_ORIGIN_INDEX_POSTGRES)
+            # Materialise scan_id (default /v1/findings scan filter) so the read
+            # and its COUNT(*) ride an index instead of a per-row payload->>
+            # extract. Value mirrors the in-memory ``batch_id or scan_id`` key so
+            # every backend agrees. Partial index (WHERE scan_id <> '') keeps the
+            # common no-scan_id rows out so it cannot shadow the default read
+            # (#3926). Idempotent guards.
+            conn.execute("ALTER TABLE hub_findings_current ADD COLUMN IF NOT EXISTS scan_id TEXT NOT NULL DEFAULT ''")
+            conn.execute(
+                "UPDATE hub_findings_current SET scan_id = "
+                "COALESCE(NULLIF(payload->>'batch_id', ''), payload->>'scan_id', '') WHERE scan_id = ''"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_scan "
+                "ON hub_findings_current(tenant_id, scan_id) WHERE scan_id <> ''"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_hub_findings_current_tenant_severity_ci "
+                "ON hub_findings_current(tenant_id, LOWER(severity)) WHERE severity <> ''"
+            )
             _ensure_tenant_rls(conn, "hub_findings_current", "tenant_id")
             _ensure_tenant_rls(conn, "hub_findings_current_observations", "tenant_id")
             ensure_postgres_reference_tables(conn)
@@ -617,14 +636,16 @@ class PostgresComplianceHubStore:
                     updated_at=now,
                 )
                 origin_val = str(payload.get("origin") or "")
+                # Canonical ``batch_id or scan_id`` scan filter key (#3926).
+                scan_id_val = str(payload.get("batch_id") or payload.get("scan_id") or "")
                 if has_ledger_col:
                     conn.execute(
                         """
                         INSERT INTO hub_findings_current
                             (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
                              cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-                             updated_at, payload, ledger_finding_id, origin)
-                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s)
+                             updated_at, payload, ledger_finding_id, origin, scan_id)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s)
                         ON CONFLICT (tenant_id, canonical_id) DO UPDATE SET
                             first_seen = LEAST(hub_findings_current.first_seen, EXCLUDED.first_seen),
                             last_seen = GREATEST(hub_findings_current.last_seen, EXCLUDED.last_seen),
@@ -639,7 +660,8 @@ class PostgresComplianceHubStore:
                             updated_at = EXCLUDED.updated_at,
                             payload = EXCLUDED.payload,
                             ledger_finding_id = EXCLUDED.ledger_finding_id,
-                            origin = EXCLUDED.origin
+                            origin = EXCLUDED.origin,
+                            scan_id = EXCLUDED.scan_id
                         """,
                         (
                             tenant_id,
@@ -658,6 +680,7 @@ class PostgresComplianceHubStore:
                             encode_hub_payload(overlay),
                             ledger_finding_id or None,
                             origin_val,
+                            scan_id_val,
                         ),
                     )
                 else:
@@ -666,8 +689,8 @@ class PostgresComplianceHubStore:
                         INSERT INTO hub_findings_current
                             (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
                              cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-                             updated_at, payload, origin)
-                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s)
+                             updated_at, payload, origin, scan_id)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s)
                         ON CONFLICT (tenant_id, canonical_id) DO UPDATE SET
                             first_seen = LEAST(hub_findings_current.first_seen, EXCLUDED.first_seen),
                             last_seen = GREATEST(hub_findings_current.last_seen, EXCLUDED.last_seen),
@@ -681,7 +704,8 @@ class PostgresComplianceHubStore:
                             reopened_at = EXCLUDED.reopened_at,
                             updated_at = EXCLUDED.updated_at,
                             payload = EXCLUDED.payload,
-                            origin = EXCLUDED.origin
+                            origin = EXCLUDED.origin,
+                            scan_id = EXCLUDED.scan_id
                         """,
                         (
                             tenant_id,
@@ -699,6 +723,7 @@ class PostgresComplianceHubStore:
                             merged["updated_at"],
                             encode_hub_payload(overlay),
                             origin_val,
+                            scan_id_val,
                         ),
                     )
             conn.commit()
@@ -748,12 +773,18 @@ class PostgresComplianceHubStore:
             params.append(origin)
         if severity is not None:
             # Match the materialised severity STRING (exact, lowercased) so all
-            # backends agree; ``severity_rank`` stays ORDER-BY-only (#3192).
-            where.append("LOWER(severity) = %s")
+            # backends agree; ``severity_rank`` stays ORDER-BY-only (#3192). The
+            # ``severity <> ''`` guard lets the partial expression index
+            # idx_hub_findings_current_tenant_severity_ci serve the filter (#3926).
+            where.append("severity <> '' AND LOWER(severity) = %s")
             params.append(severity.lower())
         if scan_id is not None:
-            where.append("(payload->>'batch_id' = %s OR payload->>'scan_id' = %s)")
-            params.extend([scan_id, scan_id])
+            # Materialised column (backfilled from batch_id|scan_id) so the scan
+            # filter + COUNT(*) ride idx_hub_findings_current_tenant_scan instead
+            # of a per-row payload->> extract. The ``scan_id <> ''`` guard lets the
+            # partial index apply (a bound param is not provably non-empty) (#3926).
+            where.append("scan_id <> '' AND scan_id = %s")
+            params.append(scan_id)
         if cursor:
             keyset_sql, keyset_params = postgres_keyset_clause(normalized_sort, cursor)
             where.append(keyset_sql.removeprefix(" AND "))

--- a/tests/test_findings_current_sargable_3926.py
+++ b/tests/test_findings_current_sargable_3926.py
@@ -1,0 +1,153 @@
+"""Sargability of the default ``/v1/findings`` (current-state) scan_id + severity
+filters (#3926).
+
+Follow-up to #3641/#3913: the ledger table already rode materialised
+``scan_id``/``LOWER(severity)`` indexes, but ``hub_findings_current`` — the
+default reach read — still filtered ``scan_id`` via
+``json_extract(payload,'$.batch_id'/'$.scan_id')`` and severity via an
+unindexed ``LOWER(severity)``. These regressions assert the current-state path
+now rides the new partial indexes and preserves the exact filter semantics.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from agent_bom.api.compliance_hub_store import SQLiteComplianceHubStore
+
+
+def _findings(count: int, *, batch_id: str, severity: str = "high") -> list[dict]:
+    return [
+        {
+            "id": f"{batch_id}:{ordinal}",
+            "title": f"Finding {ordinal}",
+            "severity": severity,
+            "cvss_score": float(ordinal % 10),
+            "origin": "bulk_ingest",
+            "source": "test_3926",
+            "batch_id": batch_id,
+            "bulk_ordinal": ordinal,
+        }
+        for ordinal in range(1, count + 1)
+    ]
+
+
+def _seed(tmp_path, *, a: int = 40, b: int = 60) -> SQLiteComplianceHubStore:
+    store = SQLiteComplianceHubStore(str(tmp_path / "hub.db"))
+    tenant = "t-3926"
+    rows_a = _findings(a, batch_id="scan-a", severity="critical")
+    rows_b = _findings(b, batch_id="scan-b", severity="Medium")
+    store.add(tenant, rows_a + rows_b)
+    store.upsert_current_batch(tenant, rows_a, observed_at="2026-07-06T00:00:00Z", batch_id="scan-a", source="test_3926")
+    store.upsert_current_batch(tenant, rows_b, observed_at="2026-07-06T01:00:00Z", batch_id="scan-b", source="test_3926")
+    return store
+
+
+# ── scan_id is a real, backfilled, indexed column ────────────────────────────
+
+
+def test_scan_id_count_uses_index_not_json_scan(tmp_path) -> None:
+    store = _seed(tmp_path)
+    conn = store._conn
+    plan = conn.execute(
+        "EXPLAIN QUERY PLAN SELECT COUNT(*) FROM hub_findings_current WHERE tenant_id=? AND scan_id=? AND scan_id != ''",
+        ("t-3926", "scan-a"),
+    ).fetchall()
+    detail = " | ".join(row[3] for row in plan)
+    assert "idx_hub_findings_current_tenant_scan" in detail, detail
+    assert "SCAN hub_findings_current" not in detail, detail
+
+
+def test_scan_id_filter_returns_only_matching_batch(tmp_path) -> None:
+    store = _seed(tmp_path)
+    a_rows, a_total, _ = store.list_current_page("t-3926", limit=1000, scan_id="scan-a")
+    b_rows, b_total, _ = store.list_current_page("t-3926", limit=1000, scan_id="scan-b")
+    assert a_total == 40 and b_total == 60
+    assert all(r.get("batch_id") == "scan-a" for r in a_rows)
+    assert all(r.get("batch_id") == "scan-b" for r in b_rows)
+    # An unknown scan id matches nothing.
+    _, none_total, _ = store.list_current_page("t-3926", limit=1000, scan_id="scan-x")
+    assert none_total == 0
+
+
+def test_scan_id_falls_back_to_payload_scan_id_when_no_batch_id(tmp_path) -> None:
+    """Parity with the old ``batch_id OR scan_id`` filter: a payload carrying only
+    ``scan_id`` (no batch_id) is still matched via the materialised column."""
+    store = SQLiteComplianceHubStore(str(tmp_path / "hub2.db"))
+    payload = {
+        "id": "only-scan:1",
+        "title": "Finding",
+        "severity": "high",
+        "origin": "bulk_ingest",
+        "source": "test_3926",
+        "scan_id": "sc-only",
+    }
+    store.add("t", [payload])
+    store.upsert_current_batch("t", [payload], observed_at="2026-07-06T00:00:00Z", batch_id="sc-only", source="test_3926")
+    rows, total, _ = store.list_current_page("t", limit=10, scan_id="sc-only")
+    assert total == 1 and rows[0]["id"] == "only-scan:1"
+
+
+# ── LOWER(severity) rides the partial expression index ───────────────────────
+
+
+def test_severity_count_uses_expression_index(tmp_path) -> None:
+    store = _seed(tmp_path)
+    conn = store._conn
+    plan = conn.execute(
+        "EXPLAIN QUERY PLAN SELECT COUNT(*) FROM hub_findings_current "
+        "WHERE tenant_id=? AND severity != '' AND LOWER(severity)=?",
+        ("t-3926", "critical"),
+    ).fetchall()
+    detail = " | ".join(row[3] for row in plan)
+    assert "idx_hub_findings_current_tenant_severity_ci" in detail, detail
+    assert "SCAN hub_findings_current" not in detail, detail
+
+
+def test_severity_filter_is_case_insensitive(tmp_path) -> None:
+    store = _seed(tmp_path)
+    # Seed stored "Medium" (mixed case) — a lowercase filter must still match.
+    rows, total, _ = store.list_current_page("t-3926", limit=1000, severity="medium")
+    assert total == 60
+    assert all(str(r.get("severity")).lower() == "medium" for r in rows)
+
+
+# ── migration backfills the column on pre-existing tables ────────────────────
+
+
+def test_scan_id_column_backfilled_for_preexisting_rows(tmp_path) -> None:
+    """A DB whose current table predates the scan_id column is migrated + backfilled
+    from ``batch_id`` (preferred) or ``scan_id`` (fallback)."""
+    db = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE hub_findings_current (
+            tenant_id TEXT NOT NULL, canonical_id TEXT NOT NULL,
+            first_seen TEXT NOT NULL, last_seen TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'open', severity TEXT NOT NULL DEFAULT '',
+            severity_rank INTEGER NOT NULL DEFAULT 0, cvss_score REAL,
+            effective_reach_score REAL NOT NULL DEFAULT 0, scan_count INTEGER NOT NULL DEFAULT 1,
+            resolved_at TEXT, reopened_at TEXT, updated_at TEXT NOT NULL, payload TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, canonical_id)
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO hub_findings_current (tenant_id, canonical_id, first_seen, last_seen, updated_at, payload) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("t", "c1", "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", '{"batch_id": "b-legacy"}'),
+            ("t", "c2", "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", "2026-01-01T00:00:00Z", '{"scan_id": "s-legacy"}'),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    store = SQLiteComplianceHubStore(db)
+    conn2 = store._conn
+    cols = {r[1] for r in conn2.execute("PRAGMA table_info(hub_findings_current)").fetchall()}
+    assert "scan_id" in cols
+    got = dict(conn2.execute("SELECT canonical_id, scan_id FROM hub_findings_current").fetchall())
+    assert got["c1"] == "b-legacy"  # batch_id preferred
+    assert got["c2"] == "s-legacy"  # scan_id fallback


### PR DESCRIPTION
Closes #3926.

## Problem
`#3920` materialized a `scan_id` column + partial index and a case-insensitive severity expression index on the **ledger** table `compliance_hub_findings` (backs `/v1/compliance`), but left `hub_findings_current` — the default `/v1/findings` path — on the old shape. `list_current_page` filtered `scan_id` via `json_extract(payload,'$.batch_id'/'$.scan_id')` (Postgres `payload->>`) and severity via an unindexed `LOWER(severity)`, so a filtered read scanned every current row of the tenant, paid twice (COUNT + page).

## What shipped
Same treatment as the ledger fix, applied to `hub_findings_current` on **both** SQLite and Postgres:

- **Materialized `scan_id` column** — backfilled as `COALESCE(NULLIF(batch_id,''), scan_id)`, i.e. the canonical `batch_id or scan_id` key the in-memory reference filter (`_filter_current_rows`) compares against. Every ingested current row already stamps `payload.batch_id` (`scan.py:352`), so pre-migration rows resolve to the exact same value the old per-row `json_extract` compared — verified filter parity.
- **Partial indexes**:
  - `idx_hub_findings_current_tenant_scan ON (tenant_id, scan_id) WHERE scan_id != ''`
  - `idx_hub_findings_current_tenant_severity_ci ON (tenant_id, LOWER(severity)) WHERE severity != ''`
  
  Partial so the common no-scan_id / empty-severity rows stay out of the index and cannot shadow the default reach read as a perfect tenant-equality candidate (the same planner-shadowing guard used on the ledger).
- **Write path** — both upsert branches (ledger + non-ledger, SQLite + Postgres) persist `scan_id` and update it on conflict (latest-observation wins, matching the current-state semantics of the old json_extract filter).
- **Read path** — `scan_id = ? AND scan_id != ''` and `severity != '' AND LOWER(severity) = ?`; the `!= ''` guard lets the planner apply the partial index (a bound parameter isn't provably non-empty).
- Migrations are idempotent guarded ALTERs with a backfill on empty cells, mirroring the existing `origin` column migration; `scan_id` also added to the base `CREATE TABLE` for fresh installs.

No API route or Pydantic model changed (the `scan_id` query param already existed), so no OpenAPI/atlas regeneration is required.

## Verification
- `EXPLAIN QUERY PLAN` confirms the scan filter rides `idx_hub_findings_current_tenant_scan` (covering) and the severity filter rides `idx_hub_findings_current_tenant_severity_ci`, while the default reach read still uses `idx_hub_findings_current_tenant_reach` (partial indexes do not shadow it).
- New regression suite `tests/test_findings_current_sargable_3926.py`: index-usage EXPLAIN, filter correctness (batch_id + scan_id fallback, case-insensitive severity), and migration/backfill on a pre-column table.
- `ruff check` clean; `mypy` clean on changed files.

Note on environment: this session's egress policy blocks PyPI, so the project dependencies could not be installed to run the full `pytest`/`ruff format`/`mypy` suite here — the SQL index-usage and filter semantics were validated with a standalone stdlib `sqlite3` harness, and `ruff check` + best-effort `mypy` were run against the standalone tools. CI runs the full gate.


---
_Generated by [Claude Code](https://claude.ai/code/session_015fs8L8TktdEg4YghqbvDvm)_