### PR TITLE
fix(brand): minimal-head agent mark for small-size readability

### DIFF
--- a/docs/images/brand/mark-dark.svg
+++ b/docs/images/brand/mark-dark.svg
@@ -8,14 +8,13 @@
   <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#0c1210" stroke="url(#abm)" stroke-width="2"/>
   <!-- B -->
   <path fill="url(#abm)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
-  <!-- O as the agent HUD: ring + antenna + visor + status bar (one consistent stroke system) -->
+  <!-- O as the agent HUD: ring-as-head + antenna + two eyes + mouth (readable at small sizes) -->
   <circle cx="32" cy="30.2" r="12" fill="#0f1a17" stroke="url(#abm)" stroke-width="2.4"/>
-  <path d="M32 18.2V14" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
-  <circle cx="32" cy="12.4" r="2" fill="url(#abm)"/>
-  <rect x="24.6" y="26" width="14.8" height="6.6" rx="3.3" fill="#0b1512" stroke="url(#abm)" stroke-width="1.6"/>
-  <rect x="26.9" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#34d399"/>
-  <rect x="33.2" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#22d3ee"/>
-  <path d="M27.6 36h8.8" stroke="url(#abm)" stroke-width="1.8" stroke-linecap="round"/>
+  <path d="M32 18.4V13.5" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
+  <circle cx="32" cy="11.9" r="2.1" fill="url(#abm)"/>
+  <circle cx="28" cy="28.9" r="2.7" fill="#34d399"/>
+  <circle cx="36" cy="28.9" r="2.7" fill="#22d3ee"/>
+  <path d="M28.3 35.4h7.4" stroke="url(#abm)" stroke-width="1.9" stroke-linecap="round"/>
   <!-- M -->
   <path fill="url(#abm)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
   <!-- materials ticks -->

--- a/docs/images/brand/mark-light.svg
+++ b/docs/images/brand/mark-light.svg
@@ -8,14 +8,13 @@
   <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#f8fafc" stroke="url(#abm)" stroke-width="2"/>
   <!-- B -->
   <path fill="url(#abm)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
-  <!-- O as the agent HUD: ring + antenna + visor + status bar (one consistent stroke system) -->
+  <!-- O as the agent HUD: ring-as-head + antenna + two eyes + mouth (readable at small sizes) -->
   <circle cx="32" cy="30.2" r="12" fill="#ecfdf5" stroke="url(#abm)" stroke-width="2.4"/>
-  <path d="M32 18.2V14" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
-  <circle cx="32" cy="12.4" r="2" fill="url(#abm)"/>
-  <rect x="24.6" y="26" width="14.8" height="6.6" rx="3.3" fill="#ffffff" stroke="url(#abm)" stroke-width="1.6"/>
-  <rect x="26.9" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#059669"/>
-  <rect x="33.2" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#0891b2"/>
-  <path d="M27.6 36h8.8" stroke="url(#abm)" stroke-width="1.8" stroke-linecap="round"/>
+  <path d="M32 18.4V13.5" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
+  <circle cx="32" cy="11.9" r="2.1" fill="url(#abm)"/>
+  <circle cx="28" cy="28.9" r="2.7" fill="#059669"/>
+  <circle cx="36" cy="28.9" r="2.7" fill="#0891b2"/>
+  <path d="M28.3 35.4h7.4" stroke="url(#abm)" stroke-width="1.9" stroke-linecap="round"/>
   <!-- M -->
   <path fill="url(#abm)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
   <!-- materials ticks -->

--- a/ui/public/brand/mark-dark.svg
+++ b/ui/public/brand/mark-dark.svg
@@ -8,14 +8,13 @@
   <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#0c1210" stroke="url(#abm)" stroke-width="2"/>
   <!-- B -->
   <path fill="url(#abm)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
-  <!-- O as the agent HUD: ring + antenna + visor + status bar (one consistent stroke system) -->
+  <!-- O as the agent HUD: ring-as-head + antenna + two eyes + mouth (readable at small sizes) -->
   <circle cx="32" cy="30.2" r="12" fill="#0f1a17" stroke="url(#abm)" stroke-width="2.4"/>
-  <path d="M32 18.2V14" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
-  <circle cx="32" cy="12.4" r="2" fill="url(#abm)"/>
-  <rect x="24.6" y="26" width="14.8" height="6.6" rx="3.3" fill="#0b1512" stroke="url(#abm)" stroke-width="1.6"/>
-  <rect x="26.9" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#34d399"/>
-  <rect x="33.2" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#22d3ee"/>
-  <path d="M27.6 36h8.8" stroke="url(#abm)" stroke-width="1.8" stroke-linecap="round"/>
+  <path d="M32 18.4V13.5" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
+  <circle cx="32" cy="11.9" r="2.1" fill="url(#abm)"/>
+  <circle cx="28" cy="28.9" r="2.7" fill="#34d399"/>
+  <circle cx="36" cy="28.9" r="2.7" fill="#22d3ee"/>
+  <path d="M28.3 35.4h7.4" stroke="url(#abm)" stroke-width="1.9" stroke-linecap="round"/>
   <!-- M -->
   <path fill="url(#abm)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
   <!-- materials ticks -->

--- a/ui/public/brand/mark-light.svg
+++ b/ui/public/brand/mark-light.svg
@@ -8,14 +8,13 @@
   <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#f8fafc" stroke="url(#abm)" stroke-width="2"/>
   <!-- B -->
   <path fill="url(#abm)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
-  <!-- O as the agent HUD: ring + antenna + visor + status bar (one consistent stroke system) -->
+  <!-- O as the agent HUD: ring-as-head + antenna + two eyes + mouth (readable at small sizes) -->
   <circle cx="32" cy="30.2" r="12" fill="#ecfdf5" stroke="url(#abm)" stroke-width="2.4"/>
-  <path d="M32 18.2V14" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
-  <circle cx="32" cy="12.4" r="2" fill="url(#abm)"/>
-  <rect x="24.6" y="26" width="14.8" height="6.6" rx="3.3" fill="#ffffff" stroke="url(#abm)" stroke-width="1.6"/>
-  <rect x="26.9" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#059669"/>
-  <rect x="33.2" y="27.9" width="3.9" height="2.8" rx="1.4" fill="#0891b2"/>
-  <path d="M27.6 36h8.8" stroke="url(#abm)" stroke-width="1.8" stroke-linecap="round"/>
+  <path d="M32 18.4V13.5" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
+  <circle cx="32" cy="11.9" r="2.1" fill="url(#abm)"/>
+  <circle cx="28" cy="28.9" r="2.7" fill="#059669"/>
+  <circle cx="36" cy="28.9" r="2.7" fill="#0891b2"/>
+  <path d="M28.3 35.4h7.4" stroke="url(#abm)" stroke-width="1.9" stroke-linecap="round"/>
   <!-- M -->
   <path fill="url(#abm)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
   <!-- materials ticks -->


### PR DESCRIPTION
The nav/app mark (`mark-{dark,light}.svg`, used in the sidebar at ~36px and the favicon) used a boxed visor + two square eyes that muddy together at small sizes and read as unclear. Replace the face with a **minimal head** — the ring is the head, antenna + two bold round eyes + a mouth — legibly an agent at 20-36px. The large README lockup (`logo-*.svg`, detailed helmet visor) is unchanged.

Follow-up: regenerate `ui/app/favicon.ico` from the minimal-head mark (needs raster tooling).