### PR TITLE
Density pass on the Findings table

### DIFF
--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -33,6 +33,7 @@ import {
   serverFindingsSort,
   formatFindingsTotal,
   hasLifecycleMetadata,
+  computeFindingColumns,
   vulnRowKey,
 } from "@/lib/findings-view";
 import {
@@ -48,7 +49,7 @@ import {
 } from "@/lib/findings-lens";
 import { useFindingsLens } from "@/hooks/use-findings-lens";
 import { severityRank } from "@/lib/severity";
-import { Bug, Download, Layers, Loader2, Package, Server, ClipboardCheck } from "lucide-react";
+import { Bug, ChevronDown, ChevronRight, Download, Layers, Loader2, Package, Server, ClipboardCheck } from "lucide-react";
 import { PageLaneHeader } from "@/components/page-lane";
 
 function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
@@ -320,6 +321,15 @@ function FindingsPage() {
   const PAGE_SIZE = 25;
   const useServerPaging = groupBy === "none" && !search.trim();
   const showLifecycleColumns = useMemo(() => hasLifecycleMetadata(vulns), [vulns]);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  const toggleGroup = useCallback((groupLabel: string) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupLabel)) next.delete(groupLabel);
+      else next.add(groupLabel);
+      return next;
+    });
+  }, []);
 
   // URL-as-source-of-truth: when the query string changes (link, back/forward),
   // re-sync the derived filter state so the view matches the address bar instead
@@ -783,6 +793,10 @@ function FindingsPage() {
     return Array.from(groups.entries()).sort((a, b) => b[1].length - a[1].length);
   }, [displayed, groupBy]);
 
+  // Auto-hide columns that are entirely empty/N/A across the filtered set — for
+  // CIS/misconfiguration scans CVSS, EPSS, Packages and Fix are pure noise.
+  const visibleColumns = useMemo(() => computeFindingColumns(displayed), [displayed]);
+
   const counts = useMemo(() => {
     const c = { critical: 0, high: 0, medium: 0, low: 0 };
     for (const v of vulns) {
@@ -1070,31 +1084,47 @@ function FindingsPage() {
                 // so users know they're seeing a slice.
                 const visibleGroupVulns = groupVulns.slice(0, PAGE_SIZE);
                 const groupOverflow = groupVulns.length - visibleGroupVulns.length;
+                const collapsed = collapsedGroups.has(groupLabel);
                 return (
                   <div key={groupLabel}>
-                    <div className="flex items-center gap-2 mb-2">
+                    <button
+                      type="button"
+                      onClick={() => toggleGroup(groupLabel)}
+                      aria-expanded={!collapsed}
+                      className="flex w-full items-center gap-2 mb-2 text-left transition-colors group"
+                    >
+                      {collapsed ? (
+                        <ChevronRight className="h-4 w-4 text-zinc-500 group-hover:text-zinc-300" />
+                      ) : (
+                        <ChevronDown className="h-4 w-4 text-zinc-500 group-hover:text-zinc-300" />
+                      )}
                       <h3 className="text-sm font-semibold text-zinc-300">{groupLabel}</h3>
                       <span className="text-xs font-mono text-zinc-600 bg-zinc-800 rounded px-1.5 py-0.5">
                         {groupVulns.length}
                       </span>
-                    </div>
-                    <FindingsQueueTable
-                      vulns={visibleGroupVulns}
-                      sortKey={sortKey}
-                      sortDir={sortDir}
-                      handleSort={handleSort}
-                      suppressed={suppressed}
-                      onMarkFP={handleMarkFP}
-                      selectedId={selectedId}
-                      onSelect={setSelectedId}
-                      showLifecycle={showLifecycleColumns}
-                    />
-                    {groupOverflow > 0 && (
-                      <p className="mt-2 text-xs text-zinc-600">
-                        Showing first {PAGE_SIZE} of {groupVulns.length} —
-                        narrow with the search box or switch to the flat
-                        view (Group: none) for full pagination.
-                      </p>
+                    </button>
+                    {!collapsed && (
+                      <>
+                        <FindingsQueueTable
+                          vulns={visibleGroupVulns}
+                          sortKey={sortKey}
+                          sortDir={sortDir}
+                          handleSort={handleSort}
+                          suppressed={suppressed}
+                          onMarkFP={handleMarkFP}
+                          selectedId={selectedId}
+                          onSelect={setSelectedId}
+                          showLifecycle={showLifecycleColumns}
+                          columns={visibleColumns}
+                        />
+                        {groupOverflow > 0 && (
+                          <p className="mt-2 text-xs text-zinc-600">
+                            Showing first {PAGE_SIZE} of {groupVulns.length} —
+                            narrow with the search box or switch to the flat
+                            view (Group: none) for full pagination.
+                          </p>
+                        )}
+                      </>
                     )}
                   </div>
                 );
@@ -1111,6 +1141,7 @@ function FindingsPage() {
               selectedId={selectedId}
               onSelect={setSelectedId}
               showLifecycle={showLifecycleColumns}
+              columns={visibleColumns}
             />
           )}
 

--- a/ui/components/findings-queue.tsx
+++ b/ui/components/findings-queue.tsx
@@ -3,13 +3,22 @@
 import { ChevronDown, ChevronRight, ChevronUp, ExternalLink, ShieldOff } from "lucide-react";
 
 import { severityColor, severityDot } from "@/lib/api";
-import type { EnrichedVuln, SortKey } from "@/lib/findings-view";
+import type { EnrichedVuln, FindingColumnVisibility, SortKey } from "@/lib/findings-view";
 import {
+  findingSecondaryText,
   findingStatusClass,
   findingStatusLabel,
   formatFindingTimestamp,
   vulnRowKey,
 } from "@/lib/findings-view";
+
+const ALL_COLUMNS_VISIBLE: FindingColumnVisibility = {
+  cvss: true,
+  epss: true,
+  packages: true,
+  agents: true,
+  fix: true,
+};
 
 function ReachabilityBadge({
   reachable,
@@ -111,6 +120,7 @@ export function FindingsQueueTable({
   selectedId,
   onSelect,
   showLifecycle = false,
+  columns = ALL_COLUMNS_VISIBLE,
 }: {
   vulns: EnrichedVuln[];
   sortKey: SortKey;
@@ -121,6 +131,7 @@ export function FindingsQueueTable({
   selectedId: string | null;
   onSelect: (vulnId: string | null) => void;
   showLifecycle?: boolean;
+  columns?: FindingColumnVisibility;
 }) {
   return (
     <div className="border border-zinc-800 rounded-xl overflow-hidden overflow-x-auto">
@@ -139,15 +150,25 @@ export function FindingsQueueTable({
                 <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Last seen</th>
               </>
             ) : null}
-            <th className="text-left px-4 py-3">
-              <SortButton label="CVSS" field="cvss" current={sortKey} dir={sortDir} onClick={handleSort} />
-            </th>
-            <th className="text-left px-4 py-3">
-              <SortButton label="EPSS" field="epss" current={sortKey} dir={sortDir} onClick={handleSort} />
-            </th>
-            <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Packages</th>
-            <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Agents</th>
-            <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Fix</th>
+            {columns.cvss ? (
+              <th className="text-left px-4 py-3">
+                <SortButton label="CVSS" field="cvss" current={sortKey} dir={sortDir} onClick={handleSort} />
+              </th>
+            ) : null}
+            {columns.epss ? (
+              <th className="text-left px-4 py-3">
+                <SortButton label="EPSS" field="epss" current={sortKey} dir={sortDir} onClick={handleSort} />
+              </th>
+            ) : null}
+            {columns.packages ? (
+              <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Packages</th>
+            ) : null}
+            {columns.agents ? (
+              <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Agents</th>
+            ) : null}
+            {columns.fix ? (
+              <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Fix</th>
+            ) : null}
             <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Actions</th>
           </tr>
         </thead>
@@ -155,6 +176,7 @@ export function FindingsQueueTable({
           {vulns?.map((v) => {
             const rowKey = vulnRowKey(v);
             const isSelected = selectedId === rowKey || selectedId === v.id;
+            const secondary = findingSecondaryText(v);
             return (
               <tr
                 key={rowKey}
@@ -203,9 +225,9 @@ export function FindingsQueueTable({
                             hops={v.graph_min_hop_distance}
                           />
                         </div>
-                        {(v.summary ?? v.description) && (
+                        {secondary && (
                           <p className="text-xs text-zinc-600 mt-0.5 ml-3.5 line-clamp-1 max-w-xs">
-                            {v.summary ?? v.description}
+                            {secondary}
                           </p>
                         )}
                       </div>
@@ -230,31 +252,41 @@ export function FindingsQueueTable({
                       </td>
                     </>
                   ) : null}
-                  <td className="px-4 py-3 text-xs font-mono text-zinc-400">
-                    {renderScoreValue(v.cvss_score, "CVSS not published by the current advisory")}
-                  </td>
-                  <td className="px-4 py-3 text-xs font-mono text-zinc-400">
-                    {renderPercentValue(v.epss_score, "EPSS not available for this advisory")}
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex flex-wrap gap-1">
-                      {v.packages.slice(0, 3).map((p) => (
-                        <span key={p} className="text-xs font-mono bg-zinc-800 border border-zinc-700 rounded px-1.5 py-0.5 text-zinc-400">
-                          {p}
-                        </span>
-                      ))}
-                      {v.packages.length > 3 && (
-                        <span className="text-xs text-zinc-600">+{v.packages.length - 3}</span>
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 text-xs text-zinc-500">
-                    {v.agents.slice(0, 2).join(", ")}
-                    {v.agents.length > 2 && <span className="text-zinc-600"> +{v.agents.length - 2}</span>}
-                  </td>
-                  <td className="px-4 py-3 text-xs font-mono text-emerald-500">
-                    {v.fixed_version ?? "N/A"}
-                  </td>
+                  {columns.cvss ? (
+                    <td className="px-4 py-3 text-xs font-mono text-zinc-400">
+                      {renderScoreValue(v.cvss_score, "CVSS not published by the current advisory")}
+                    </td>
+                  ) : null}
+                  {columns.epss ? (
+                    <td className="px-4 py-3 text-xs font-mono text-zinc-400">
+                      {renderPercentValue(v.epss_score, "EPSS not available for this advisory")}
+                    </td>
+                  ) : null}
+                  {columns.packages ? (
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-1">
+                        {v.packages.slice(0, 3).map((p) => (
+                          <span key={p} className="text-xs font-mono bg-zinc-800 border border-zinc-700 rounded px-1.5 py-0.5 text-zinc-400">
+                            {p}
+                          </span>
+                        ))}
+                        {v.packages.length > 3 && (
+                          <span className="text-xs text-zinc-600">+{v.packages.length - 3}</span>
+                        )}
+                      </div>
+                    </td>
+                  ) : null}
+                  {columns.agents ? (
+                    <td className="px-4 py-3 text-xs text-zinc-500">
+                      {v.agents.slice(0, 2).join(", ")}
+                      {v.agents.length > 2 && <span className="text-zinc-600"> +{v.agents.length - 2}</span>}
+                    </td>
+                  ) : null}
+                  {columns.fix ? (
+                    <td className="px-4 py-3 text-xs font-mono text-emerald-500">
+                      {v.fixed_version ?? "N/A"}
+                    </td>
+                  ) : null}
                   <td className="px-4 py-3">
                     {suppressed.has(v.id) ? (
                       <span className="text-xs font-medium px-2 py-0.5 rounded border bg-zinc-800 border-zinc-700 text-zinc-400">

--- a/ui/lib/findings-view.ts
+++ b/ui/lib/findings-view.ts
@@ -128,3 +128,80 @@ export function uniqueStrings(items: Array<string | null | undefined>) {
 export function vulnRowKey(vuln: EnrichedVuln): string {
   return vuln.finding_id ?? vuln.id;
 }
+
+/**
+ * Placeholder package name used when a finding has no real package (CIS /
+ * misconfiguration rows carry the asset itself). Treated as "empty" so the
+ * Packages column can auto-hide when every row is just this stand-in.
+ */
+const PLACEHOLDER_PACKAGE = "asset";
+
+/**
+ * Secondary (grey) line for a findings row. Findings frequently set the summary
+ * to the same string as the title (`id`) — for CIS/misconfig rows the title and
+ * summary are identical, so the row printed the label twice. Return the summary
+ * only when it carries information the title doesn't; if it's the same string or
+ * a truncation of the title (or vice versa), return null so the echo is dropped.
+ */
+export function findingSecondaryText(vuln: EnrichedVuln): string | null {
+  const secondary = (vuln.summary ?? vuln.description ?? "").trim();
+  if (!secondary) return null;
+  const primary = (vuln.id ?? "").trim();
+  if (!primary) return secondary;
+  const p = primary.toLowerCase();
+  const s = secondary.toLowerCase();
+  if (p === s) return null;
+  // One is a truncated prefix of the other — still the same text, drop it.
+  if (p.startsWith(s) || s.startsWith(p)) return null;
+  return secondary;
+}
+
+export interface FindingColumnVisibility {
+  cvss: boolean;
+  epss: boolean;
+  packages: boolean;
+  agents: boolean;
+  fix: boolean;
+}
+
+/**
+ * Auto-hide columns that are entirely empty/N/A across the current (filtered)
+ * result set. CIS/misconfiguration findings leave CVSS, EPSS and Fix as "N/A"
+ * and only carry the placeholder "asset" package, so those columns are pure
+ * noise for posture-only scans. A column stays visible when at least one row
+ * carries a real value. Falls back to all-visible for an empty set so headers
+ * don't flicker between renders.
+ */
+export function computeFindingColumns(rows: EnrichedVuln[]): FindingColumnVisibility {
+  if (rows.length === 0) {
+    return { cvss: true, epss: true, packages: true, agents: true, fix: true };
+  }
+  const columns: FindingColumnVisibility = {
+    cvss: false,
+    epss: false,
+    packages: false,
+    agents: false,
+    fix: false,
+  };
+  for (const row of rows) {
+    if (!columns.cvss && typeof row.cvss_score === "number" && Number.isFinite(row.cvss_score)) {
+      columns.cvss = true;
+    }
+    if (!columns.epss && typeof row.epss_score === "number" && Number.isFinite(row.epss_score)) {
+      columns.epss = true;
+    }
+    if (!columns.packages && row.packages.some((p) => p.trim() && p.trim().toLowerCase() !== PLACEHOLDER_PACKAGE)) {
+      columns.packages = true;
+    }
+    if (!columns.agents && row.agents.some((a) => a.trim())) {
+      columns.agents = true;
+    }
+    if (!columns.fix && Boolean(row.fixed_version?.trim())) {
+      columns.fix = true;
+    }
+    if (columns.cvss && columns.epss && columns.packages && columns.agents && columns.fix) {
+      break;
+    }
+  }
+  return columns;
+}


### PR DESCRIPTION
## Summary

A focused density pass on the Findings queue for #3934, based on a live session where the table read as tall and repetitive on real scan data (especially CIS/misconfiguration findings).

- **Duplicate title line removed.** Each row printed its title twice — the CVE/label line, then a grey subtitle that repeated the same string (often just a truncation). The subtitle now renders only when it carries information the title doesn't (`findingSecondaryText`), roughly halving row height for CIS/misconfig findings.
- **Empty columns auto-hide.** `computeFindingColumns` inspects the current filtered result set and renders CVSS / EPSS / Packages / Agents / Fix only when at least one row carries a real value. Posture-only scans (all-N/A scores, placeholder `asset` package) no longer show dead columns. Applies consistently across grouped and flat views.
- **Collapsible groups.** When grouping by Severity / Package / Agent, each group header now has a chevron toggle (defaults expanded).

Filter toolbar, lenses, drawer, pagination, server paging, and data shape are unchanged. No API calls changed.

## Verification (from `ui/`)

- `npm ci` — clean install (no symlinked `node_modules`)
- `npm run typecheck` — clean
- `npm run build` — compiled successfully
- `npx vitest run tests/findings-page.test.tsx tests/findings-view.test.ts` — 7 passed (no assertion changes needed)
- eslint on changed files — clean

Closes #3934