### PR TITLE
feat(onboarding): AWS read-only connector role — 1-click CloudFormation + org StackSet

### DIFF
--- a/deploy/cloudformation/README.md
+++ b/deploy/cloudformation/README.md
@@ -1,4 +1,18 @@
-# agent-bom one-click AWS scan (CloudFormation)
+# agent-bom AWS onboarding (CloudFormation)
+
+Two onboarding models — pick per how you run agent-bom:
+
+- **Serverless self-scan** (`agent-bom-scan.yaml`, below) — deploy agent-bom *into*
+  the account via CodeBuild; it scans and publishes reports to S3. Best for a
+  standalone, agent-bom-free-of-a-control-plane scan.
+- **Connector role** (`agent-bom-readonly-role.yaml`, [jump ↓](#connector-role--control-plane-assume-role-1-click--org-stackset)) —
+  create a read-only role your **agent-bom control plane assumes** (short-lived
+  STS, no static keys). This is what the connection wizard uses; 1-click per
+  account or an **Organizations StackSet** for the whole org.
+
+---
+
+## Serverless self-scan
 
 Deploy a **read-only**, **serverless** agent-bom scan of your AWS account in one
 command. The stack provisions an AWS CodeBuild project (no EC2 instance — it runs
@@ -137,3 +151,85 @@ accidental stack delete; remove it manually when you no longer need them.
 
 The CodeBuild buildspec is inlined in the template (`ScanProject.Source.BuildSpec`).
 [`buildspec.yml`](./buildspec.yml) is a readable reference copy kept in sync.
+
+---
+
+## Connector role — control-plane assume-role (1-click + org StackSet)
+
+`agent-bom-readonly-role.yaml` creates the read-only IAM role the agent-bom
+**control plane assumes** (`sts:AssumeRole` + an ExternalId) to run read-only
+inventory + CIS scans. No write permissions, no static keys — the control plane
+only holds short-lived STS credentials. This is the role the connection wizard
+registers (Role ARN + ExternalId).
+
+### One account — 1-click Launch Stack
+
+The connection wizard generates a pre-filled CloudFormation console link (region,
+ExternalId, and control-plane principal filled in), so there's no CLI or
+trust-policy copy-paste:
+
+```
+https://console.aws.amazon.com/cloudformation/home?region=<REGION>#/stacks/quickcreate
+  ?templateURL=https://<hosted>/agent-bom-readonly-role.yaml
+  &stackName=agent-bom-readonly
+  &param_ExternalId=<EXTERNAL_ID>
+  &param_TrustedPrincipalArn=<CONTROL_PLANE_PRINCIPAL_ARN>
+```
+
+Review → **Create stack** → copy the **RoleArn** output into the wizard. Or from a
+shell / CloudShell:
+
+```bash
+aws cloudformation deploy \
+  --template-file deploy/cloudformation/agent-bom-readonly-role.yaml \
+  --stack-name agent-bom-readonly \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides ExternalId="$EXTERNAL_ID" TrustedPrincipalArn="$CONTROL_PLANE_PRINCIPAL_ARN"
+```
+
+`TrustedPrincipalArn` is the identity the control plane runs as (hosted: agent-bom's
+control-plane role ARN; self-hosted: the control-plane process's IAM role/user —
+or, for a same-account self-host, the account root ARN, since the ExternalId is
+the guard).
+
+### Whole org — Organizations StackSet (no account-by-account)
+
+Roll the read-only role to **every account in your AWS Organization** in one
+operation, with **auto-deploy** so new accounts enroll automatically. Run from the
+org management account (or a delegated admin) with StackSets trusted access on:
+
+```bash
+aws cloudformation create-stack-set \
+  --stack-set-name agent-bom-readonly \
+  --template-body file://deploy/cloudformation/agent-bom-readonly-role.yaml \
+  --permission-model SERVICE_MANAGED \
+  --auto-deployment Enabled=true,RetainStacksOnAccountRemoval=false \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameters ParameterKey=ExternalId,ParameterValue="$EXTERNAL_ID" \
+               ParameterKey=TrustedPrincipalArn,ParameterValue="$CONTROL_PLANE_PRINCIPAL_ARN"
+
+aws cloudformation create-stack-instances \
+  --stack-set-name agent-bom-readonly \
+  --deployment-targets OrganizationalUnitIds="$ROOT_OU_ID" \
+  --regions us-east-1 \
+  --operation-preferences MaxConcurrentPercentage=100,FailureTolerancePercentage=20
+```
+
+Every account gets an identically-named `agent-bom-readonly` role trusting the same
+control-plane principal + ExternalId, so the control plane can enumerate and scan
+the whole estate. New accounts added to the org/OU onboard automatically. **This
+is the org-scale path — never add accounts one by one.**
+
+### Parameters
+
+| Parameter             | Default                  | Purpose                                                        |
+| --------------------- | ------------------------ | -------------------------------------------------------------- |
+| `TrustedPrincipalArn` | *(required)*             | Control-plane principal allowed to assume the role.           |
+| `ExternalId`          | *(required, NoEcho)*     | Shared secret required on AssumeRole; paste into the wizard.  |
+| `RoleName`            | `agent-bom-readonly`     | Name of the created role.                                     |
+| `PermissionScope`     | `ReadOnlyAndSecurityAudit` | `ReadOnlyAndSecurityAudit` or `SecurityAuditOnly` (tighter). |
+
+Notes: host the template on a stable HTTPS/S3 URL for the Launch-Stack `templateURL`
+(production should pin a versioned S3 object). Azure (ARM/Bicep at management-group)
+and GCP (org-policy / Deployment Manager at folder) equivalents follow the same
+pattern.

--- a/deploy/cloudformation/README.md
+++ b/deploy/cloudformation/README.md
@@ -157,10 +157,13 @@ The CodeBuild buildspec is inlined in the template (`ScanProject.Source.BuildSpe
 ## Connector role — control-plane assume-role (1-click + org StackSet)
 
 `agent-bom-readonly-role.yaml` creates the read-only IAM role the agent-bom
-**control plane assumes** (`sts:AssumeRole` + an ExternalId) to run read-only
-inventory + CIS scans. No write permissions, no static keys — the control plane
-only holds short-lived STS credentials. This is the role the connection wizard
-registers (Role ARN + ExternalId).
+**control plane assumes** (`sts:AssumeRole` + an ExternalId). It is the CloudFormation
+**grant-provisioning** counterpart to the Terraform `connect-aws` module and the
+org fan-out (`AGENT_BOM_AWS_ORG_INVENTORY`) — see
+[`docs/CLOUD_CONNECT.md`](../../docs/CLOUD_CONNECT.md) for the authoritative story
+of **how agent-bom authenticates, what it reads, and why it stays read-only /
+least-privilege / zero-trust** (not repeated here). This template just mints the
+role the wizard registers (Role ARN + ExternalId); no writes, short-lived STS only.
 
 ### One account — 1-click Launch Stack
 

--- a/deploy/cloudformation/agent-bom-readonly-role.yaml
+++ b/deploy/cloudformation/agent-bom-readonly-role.yaml
@@ -1,0 +1,114 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  agent-bom read-only connector role. Creates an IAM role that the agent-bom
+  control plane assumes (via sts:AssumeRole with an ExternalId) to run
+  read-only inventory + CIS scans. No write permissions, no static keys —
+  the control plane receives only short-lived STS credentials. Deploy in one
+  account, or roll out across an AWS Organization with a StackSet (see
+  deploy/cloudformation/README.md).
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: agent-bom connection
+        Parameters:
+          - TrustedPrincipalArn
+          - ExternalId
+          - RoleName
+          - PermissionScope
+    ParameterLabels:
+      TrustedPrincipalArn:
+        default: Control-plane principal allowed to assume this role
+      ExternalId:
+        default: ExternalId (paste this into the agent-bom wizard)
+      RoleName:
+        default: Role name
+      PermissionScope:
+        default: Read-only permission scope
+
+Parameters:
+  TrustedPrincipalArn:
+    Type: String
+    Description: >-
+      ARN of the agent-bom control-plane identity that may assume this role
+      (e.g. the hosted control-plane role ARN, or for a self-hosted control
+      plane the IAM user/role its process runs as). For a same-account
+      self-host you may use the account root ARN
+      (arn:aws:iam::<ACCOUNT_ID>:root) — the ExternalId is the guard.
+    AllowedPattern: "^arn:aws[a-z-]*:(iam|sts)::[0-9]{12}:(root|user/.+|role/.+|assumed-role/.+)$"
+    ConstraintDescription: Must be a valid IAM/STS principal ARN.
+
+  ExternalId:
+    Type: String
+    Description: >-
+      Shared secret required on every AssumeRole call. Generate a random,
+      high-entropy value and paste the SAME value into the agent-bom connection
+      wizard. Rotating it here + in the wizard revokes old sessions.
+    MinLength: 16
+    MaxLength: 1224
+    NoEcho: true
+
+  RoleName:
+    Type: String
+    Description: Name for the created role.
+    Default: agent-bom-readonly
+    AllowedPattern: "^[A-Za-z0-9+=,.@_-]{1,64}$"
+
+  PermissionScope:
+    Type: String
+    Description: >-
+      ReadOnlyAndSecurityAudit attaches both AWS-managed ReadOnlyAccess and
+      SecurityAudit (recommended for full inventory + CIS coverage).
+      SecurityAuditOnly attaches only SecurityAudit (tighter, config-focused).
+    Default: ReadOnlyAndSecurityAudit
+    AllowedValues:
+      - ReadOnlyAndSecurityAudit
+      - SecurityAuditOnly
+
+Conditions:
+  AttachReadOnly: !Equals [!Ref PermissionScope, ReadOnlyAndSecurityAudit]
+
+Resources:
+  AgentBomReadOnlyRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref RoleName
+      Description: Read-only role assumed by the agent-bom control plane for inventory + CIS scans.
+      MaxSessionDuration: 3600
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Ref TrustedPrincipalArn
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                sts:ExternalId: !Ref ExternalId
+      ManagedPolicyArns:
+        !If
+          - AttachReadOnly
+          - - arn:aws:iam::aws:policy/ReadOnlyAccess
+            - arn:aws:iam::aws:policy/SecurityAudit
+          - - arn:aws:iam::aws:policy/SecurityAudit
+      Tags:
+        - Key: app
+          Value: agent-bom
+        - Key: purpose
+          Value: read-only-connector
+
+Outputs:
+  RoleArn:
+    Description: Paste this Role ARN into the agent-bom connection wizard.
+    Value: !GetAtt AgentBomReadOnlyRole.Arn
+  RoleName:
+    Description: The created role name.
+    Value: !Ref RoleName
+  AccountId:
+    Description: This account's ID.
+    Value: !Ref AWS::AccountId
+  Region:
+    Description: Stack region (the role is global; region is where the stack lives).
+    Value: !Ref AWS::Region


### PR DESCRIPTION
First increment of scalable cloud onboarding (#3935), from the live session where connecting account-by-account by hand didn't scale.

- **`deploy/cloudformation/agent-bom-readonly-role.yaml`** — the read-only role the control plane *assumes* (sts:AssumeRole + ExternalId), attaching AWS-managed ReadOnlyAccess + SecurityAudit. No writes, no static keys stored; short-lived STS only. (Complements the existing serverless self-scan template — the README now disambiguates the two models.)
- **1-click**: a CloudFormation **Launch Stack** URL (wizard-generated, pre-filled) creates the role — no CLI, no trust-policy copy-paste.
- **Org-scale**: an **Organizations StackSet** rolls the role to every account with auto-enroll for new ones — never account-by-account.
- Validated: `cfn-lint` clean + `aws cloudformation validate-template` OK.

Follow-ups (in #3935): wire the wizard **Launch Stack** button + carry one ExternalId through the wizard; Azure (ARM/Bicep at management-group) + GCP (org-policy) equivalents; self-host compose defaults.