### PR TITLE
Make Scan-jobs pipeline DAG live, interactive, and honest

### DIFF
--- a/ui/app/jobs/page.tsx
+++ b/ui/app/jobs/page.tsx
@@ -99,6 +99,7 @@ function JobsPageContent() {
   const [statusFilter, setStatusFilter] = useState<string>("all");
   const [page, setPage] = useState(1);
   const [expandedJobId, setExpandedJobId] = useState<string | null>(null);
+  const [workflowOpen, setWorkflowOpen] = useState(true);
   const PAGE_SIZE = 25;
 
   useEffect(() => {
@@ -252,31 +253,49 @@ function JobsPageContent() {
                 </span>
               </div>
             </div>
-            <Link
-              href="/sources"
-              className="inline-flex items-center gap-1.5 self-start rounded-lg border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:border-zinc-600 hover:text-zinc-100"
-            >
-              Manage sources
-            </Link>
+            <div className="flex items-center gap-2 self-start">
+              <button
+                type="button"
+                onClick={() => setWorkflowOpen((open) => !open)}
+                aria-expanded={workflowOpen}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:border-zinc-600 hover:text-zinc-100"
+              >
+                {workflowOpen ? (
+                  <ChevronDown className="h-3.5 w-3.5" />
+                ) : (
+                  <ChevronRight className="h-3.5 w-3.5" />
+                )}
+                {workflowOpen ? "Hide pipeline" : "Show pipeline"}
+              </button>
+              <Link
+                href="/sources"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:border-zinc-600 hover:text-zinc-100"
+              >
+                Manage sources
+              </Link>
+            </div>
           </div>
 
-          {featuredJob ? (
-            <JobPipelinePanel
-              jobId={featuredJob.job_id}
-              status={featuredJob.status}
-              createdAt={featuredJob.created_at}
-              completedAt={featuredJob.completed_at}
-            />
-          ) : (
-            <div className="rounded-xl border border-dashed border-zinc-800 bg-zinc-900/30 p-4">
-              <p className="text-sm text-zinc-400">
-                Run a scan to see the live six-stage pipeline DAG with per-step timing and activity.
-              </p>
-              <div className="mt-4">
-                <ScanPipeline steps={new Map()} className="h-[180px]" />
+          {workflowOpen ? (
+            featuredJob ? (
+              <JobPipelinePanel
+                jobId={featuredJob.job_id}
+                status={featuredJob.status}
+                createdAt={featuredJob.created_at}
+                completedAt={featuredJob.completed_at}
+                summary={featuredJob.summary}
+              />
+            ) : (
+              <div className="rounded-xl border border-dashed border-zinc-800 bg-zinc-900/30 p-4">
+                <p className="text-sm text-zinc-400">
+                  Run a scan to see the live six-stage pipeline DAG with per-step timing and activity.
+                </p>
+                <div className="mt-4">
+                  <ScanPipeline steps={new Map()} className="h-[180px]" />
+                </div>
               </div>
-            </div>
-          )}
+            )
+          ) : null}
         </section>
       )}
 
@@ -435,6 +454,7 @@ function JobsPageContent() {
                             status={job.status}
                             createdAt={job.created_at}
                             completedAt={job.completed_at}
+                            summary={job.summary}
                           />
                         </td>
                       </tr>

--- a/ui/components/job-pipeline-panel.tsx
+++ b/ui/components/job-pipeline-panel.tsx
@@ -2,34 +2,241 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { ExternalLink, Loader2 } from "lucide-react";
+import {
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  Loader2,
+  XCircle,
+} from "lucide-react";
 
 import { ScanPipeline } from "@/components/scan-pipeline";
-import { api, PIPELINE_STEPS, type JobStatus, type ScanJob } from "@/lib/api";
+import {
+  api,
+  PIPELINE_STEPS,
+  type JobStatus,
+  type ScanJob,
+  type Summary,
+} from "@/lib/api";
 import { useScanStream } from "@/lib/use-scan-stream";
 import {
   formatDurationMs,
   mergePipelineSteps,
   parsePipelineStepsFromProgress,
   summarizePipeline,
+  synthesizePipelineSteps,
 } from "@/lib/scan-pipeline-progress";
+
+// ── Result-stat extraction (defensive; cloud fields arrive as `unknown`) ─────
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+interface ResultStat {
+  key: string;
+  label: string;
+  value: string;
+}
+
+function cloudResourceCount(inventory: unknown): number | null {
+  if (Array.isArray(inventory)) {
+    let total = 0;
+    let seen = false;
+    for (const item of inventory) {
+      if (!isRecord(item)) continue;
+      const n = asNumber(item.resource_count);
+      if (n != null) {
+        total += n;
+        seen = true;
+      }
+    }
+    return seen ? total : null;
+  }
+  if (isRecord(inventory)) return asNumber(inventory.resource_count);
+  return null;
+}
+
+function cloudIdentityCount(inventory: unknown): number | null {
+  if (Array.isArray(inventory)) {
+    let total = 0;
+    let seen = false;
+    for (const item of inventory) {
+      if (!isRecord(item)) continue;
+      const n = asNumber(item.identity_count);
+      if (n != null) {
+        total += n;
+        seen = true;
+      }
+    }
+    return seen ? total : null;
+  }
+  if (isRecord(inventory)) return asNumber(inventory.identity_count);
+  return null;
+}
+
+function cisPassRate(benchmark: unknown): number | null {
+  if (!isRecord(benchmark)) return null;
+  const raw = asNumber(benchmark.pass_rate);
+  if (raw == null) return null;
+  // Backends emit either 0–1 or 0–100; normalize to a percentage.
+  return raw <= 1 ? raw * 100 : raw;
+}
+
+function deriveResultStats(
+  job: ScanJob | null,
+  fallback: Summary | undefined,
+): ResultStat[] {
+  const summary = job?.result?.summary ?? fallback;
+  const stats: ResultStat[] = [];
+
+  if (summary) {
+    stats.push({
+      key: "findings",
+      label: "findings",
+      value: String(summary.total_vulnerabilities ?? 0),
+    });
+    if ((summary.critical_findings ?? 0) > 0) {
+      stats.push({
+        key: "critical",
+        label: "critical",
+        value: String(summary.critical_findings),
+      });
+    }
+    if ((summary.total_packages ?? 0) > 0) {
+      stats.push({
+        key: "packages",
+        label: "packages",
+        value: String(summary.total_packages),
+      });
+    }
+  }
+
+  const result = job?.result;
+  if (result) {
+    const resources = cloudResourceCount(result.cloud_inventory);
+    if (resources != null) {
+      stats.push({ key: "resources", label: "resources", value: String(resources) });
+    }
+    const identities = cloudIdentityCount(result.cloud_inventory);
+    if (identities != null) {
+      stats.push({ key: "identities", label: "identities", value: String(identities) });
+    }
+    const passRate =
+      cisPassRate(result.cis_benchmark) ??
+      cisPassRate(result.azure_cis_benchmark) ??
+      cisPassRate(result.gcp_cis_benchmark) ??
+      cisPassRate(result.snowflake_cis_benchmark) ??
+      cisPassRate(result.databricks_cis_benchmark);
+    if (passRate != null) {
+      stats.push({ key: "cis", label: "CIS pass", value: `${passRate.toFixed(0)}%` });
+    }
+  }
+
+  return stats;
+}
+
+// Which evidence surfaces are most relevant to drill into from a given stage.
+function stageLinks(stepId: string, jobId: string): { href: string; label: string }[] {
+  const encoded = encodeURIComponent(jobId);
+  switch (stepId) {
+    case "scanning":
+    case "enrichment":
+      return [{ href: `/findings?scan=${encoded}`, label: "Findings" }];
+    case "analysis":
+      return [
+        { href: `/security-graph?scan=${encoded}`, label: "Graph" },
+        { href: `/findings?scan=${encoded}`, label: "Findings" },
+      ];
+    case "output":
+      return [{ href: `/compliance?scan=${encoded}`, label: "Compliance" }];
+    default:
+      return [];
+  }
+}
+
+// ── Status banner ────────────────────────────────────────────────────────────
+
+function StatusBanner({
+  status,
+  streaming,
+  synthesized,
+  error,
+}: {
+  status: JobStatus;
+  streaming: boolean;
+  synthesized: boolean;
+  error?: string | undefined;
+}) {
+  const active = status === "running" || status === "pending";
+  const failed = status === "failed";
+  const done = status === "done";
+
+  const tone = failed
+    ? "border-red-500/40 bg-red-500/10 text-red-300"
+    : active
+      ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-300"
+      : done
+        ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-300"
+        : "border-[var(--border-subtle)] bg-[var(--surface)] text-[var(--text-secondary)]";
+
+  const icon = failed ? (
+    <XCircle className="h-4 w-4" />
+  ) : active ? (
+    <Loader2 className="h-4 w-4 animate-spin" />
+  ) : (
+    <CheckCircle2 className="h-4 w-4" />
+  );
+
+  const label = failed
+    ? error || "Scan failed"
+    : active
+      ? streaming
+        ? "Scan running — live"
+        : "Scan running"
+      : done
+        ? synthesized
+          ? "Scan complete (stages summarized)"
+          : "Scan complete"
+        : status;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium ${tone}`}
+    >
+      {icon}
+      {label}
+    </span>
+  );
+}
+
+// ── Panel ────────────────────────────────────────────────────────────────────
 
 export function JobPipelinePanel({
   jobId,
   status,
   createdAt,
   completedAt,
+  summary: listSummary,
   className,
 }: {
   jobId: string;
   status: JobStatus;
   createdAt: string;
   completedAt?: string | undefined;
+  summary?: Summary | undefined;
   className?: string;
 }) {
   const [job, setJob] = useState<ScanJob | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [selectedStepId, setSelectedStepId] = useState<string | null>(null);
+  const [detailsOpen, setDetailsOpen] = useState(true);
 
   const isActive = status === "pending" || status === "running";
   const { pipelineSteps: liveSteps, streaming, messages } = useScanStream(jobId, {
@@ -58,10 +265,13 @@ export function JobPipelinePanel({
     };
   }, [jobId]);
 
-  const steps = useMemo(() => {
+  const { steps, synthesized } = useMemo(() => {
     const persisted = parsePipelineStepsFromProgress(job?.progress ?? []);
-    return mergePipelineSteps(persisted, liveSteps);
-  }, [job?.progress, liveSteps]);
+    const merged = mergePipelineSteps(persisted, liveSteps);
+    // A finished job with no step events (e.g. cloud-connection scans) is
+    // shown as 6/6 done rather than an all-pending "0/6".
+    return synthesizePipelineSteps(merged, status);
+  }, [job?.progress, liveSteps, status]);
 
   const summary = useMemo(
     () =>
@@ -72,6 +282,11 @@ export function JobPipelinePanel({
         status,
       }),
     [steps, createdAt, completedAt, job, status],
+  );
+
+  const resultStats = useMemo(
+    () => (status === "done" ? deriveResultStats(job, listSummary) : []),
+    [status, job, listSummary],
   );
 
   const recentMessages = useMemo(() => {
@@ -89,33 +304,57 @@ export function JobPipelinePanel({
     return merged.slice(-4);
   }, [job?.progress, messages]);
 
+  const selectedStep = selectedStepId ? steps.get(selectedStepId) : undefined;
+  const selectedMeta = selectedStepId
+    ? PIPELINE_STEPS.find((step) => step.id === selectedStepId)
+    : undefined;
+
   return (
     <div
-      className={`rounded-xl border border-zinc-800 bg-zinc-950/80 p-4 ${className ?? ""}`}
+      className={`rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)] p-4 ${className ?? ""}`}
       data-testid={`job-pipeline-${jobId}`}
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
+        <div className="min-w-0">
           <p className="text-[10px] font-semibold uppercase tracking-[0.22em] text-emerald-400">
             Scan pipeline DAG
           </p>
-          <p className="mt-1 text-sm text-zinc-300">
-            {summary.currentStepLabel
-              ? `${summary.currentStepLabel} · ${status}`
-              : `${summary.completedSteps}/${summary.totalSteps} stages complete`}
-            {streaming ? " · live" : null}
-          </p>
+          <div className="mt-1.5 flex flex-wrap items-center gap-2">
+            <StatusBanner
+              status={status}
+              streaming={streaming}
+              synthesized={synthesized}
+              error={job?.error}
+            />
+            <span className="text-sm text-[var(--text-secondary)]">
+              {summary.currentStepLabel
+                ? summary.currentStepLabel
+                : `${summary.completedSteps}/${summary.totalSteps} stages complete`}
+            </span>
+          </div>
+          {resultStats.length > 0 ? (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {resultStats.map((stat) => (
+                <span
+                  key={stat.key}
+                  className="rounded-md border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-2 py-0.5 font-mono text-[11px] text-[var(--text-secondary)]"
+                >
+                  <span className="text-[var(--foreground)]">{stat.value}</span> {stat.label}
+                </span>
+              ))}
+            </div>
+          ) : null}
         </div>
-        <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-500">
+        <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--text-tertiary)]">
           <span>
             Wall clock{" "}
-            <span className="font-mono text-zinc-300">
+            <span className="font-mono text-[var(--text-secondary)]">
               {formatDurationMs(summary.wallClockMs)}
             </span>
           </span>
           <Link
             href={`/scan?id=${encodeURIComponent(jobId)}`}
-            className="inline-flex items-center gap-1 rounded-md border border-zinc-700 px-2 py-1 text-[11px] font-medium text-zinc-300 hover:border-zinc-600 hover:text-zinc-100"
+            className="inline-flex items-center gap-1 rounded-md border border-[var(--border-subtle)] px-2 py-1 text-[11px] font-medium text-[var(--text-secondary)] hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
           >
             Full scan
             <ExternalLink className="h-3 w-3" />
@@ -124,59 +363,151 @@ export function JobPipelinePanel({
       </div>
 
       {loading && steps.size === 0 ? (
-        <div className="mt-4 flex items-center gap-2 text-sm text-zinc-500">
+        <div className="mt-4 flex items-center gap-2 text-sm text-[var(--text-tertiary)]">
           <Loader2 className="h-4 w-4 animate-spin" />
           Loading persisted pipeline events…
         </div>
       ) : null}
       {error ? <p className="mt-3 text-sm text-amber-300">{error}</p> : null}
 
-      <div className="mt-4">
-        <ScanPipeline steps={steps} className="h-[200px]" />
+      {/* DAG + drill-in detail side panel */}
+      <div className="mt-4 flex flex-col gap-3 lg:flex-row">
+        <ScanPipeline
+          steps={steps}
+          className="h-[220px] flex-1 rounded-lg border border-[var(--border-subtle)]"
+          selectedStepId={selectedStepId}
+          onStepClick={(stepId) =>
+            setSelectedStepId((current) => (current === stepId ? null : stepId))
+          }
+        />
+        {selectedStepId ? (
+          <aside className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-3 lg:w-64">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <p className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                  {selectedStepId}
+                </p>
+                <p className="text-sm font-semibold text-[var(--foreground)]">
+                  {selectedMeta?.label ?? selectedStepId}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setSelectedStepId(null)}
+                className="rounded p-1 text-[var(--text-tertiary)] hover:bg-[var(--surface)] hover:text-[var(--foreground)]"
+                aria-label="Close stage detail"
+              >
+                <XCircle className="h-4 w-4" />
+              </button>
+            </div>
+            <p className="mt-2 text-[11px] capitalize text-[var(--text-secondary)]">
+              Status: {selectedStep?.status ?? "pending"}
+            </p>
+            {selectedStep?.message ? (
+              <p className="mt-1 text-[11px] leading-5 text-[var(--text-tertiary)]">
+                {selectedStep.message}
+              </p>
+            ) : null}
+            {selectedStepId && summary.stepDurationsMs[selectedStepId] != null ? (
+              <p className="mt-1 font-mono text-[11px] text-[var(--text-tertiary)]">
+                {formatDurationMs(summary.stepDurationsMs[selectedStepId])}
+              </p>
+            ) : null}
+            {selectedStep?.stats && Object.keys(selectedStep.stats).length > 0 ? (
+              <div className="mt-2 flex flex-wrap gap-1">
+                {Object.entries(selectedStep.stats).map(([k, v]) => (
+                  <span
+                    key={k}
+                    className="rounded-md border border-[var(--border-subtle)] bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--text-secondary)]"
+                  >
+                    {v} {k}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+            {stageLinks(selectedStepId, jobId).length > 0 ? (
+              <div className="mt-3 flex flex-wrap gap-1.5">
+                {stageLinks(selectedStepId, jobId).map((link) => (
+                  <Link
+                    key={link.label}
+                    href={link.href}
+                    className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-[11px] font-medium text-[var(--text-secondary)] hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
+                  >
+                    {link.label}
+                  </Link>
+                ))}
+              </div>
+            ) : null}
+          </aside>
+        ) : null}
       </div>
 
-      <div className="mt-3 grid gap-3 lg:grid-cols-2">
-        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
-            Stage timing
-          </p>
-          <dl className="mt-2 space-y-1.5">
-            {PIPELINE_STEPS.map((step) => {
-              const duration = summary.stepDurationsMs[step.id];
-              const stepStatus = steps.get(step.id)?.status ?? "pending";
-              return (
-                <div key={step.id} className="flex items-center justify-between gap-3 text-xs">
-                  <dt className="text-zinc-400">{step.label}</dt>
-                  <dd className="font-mono text-zinc-300">
-                    {duration != null
-                      ? formatDurationMs(duration)
-                      : stepStatus === "running"
-                        ? "running…"
-                        : "—"}
-                  </dd>
-                </div>
-              );
-            })}
-          </dl>
-        </div>
-        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-500">
-            Recent activity
-          </p>
-          {recentMessages.length > 0 ? (
-            <ul className="mt-2 space-y-1 text-[11px] leading-5 text-zinc-400">
-              {recentMessages.map((message, index) => (
-                <li key={`${jobId}-msg-${index}`} className="truncate">
-                  {message}
-                </li>
-              ))}
-            </ul>
+      {/* Collapsible timing + activity */}
+      <div className="mt-3">
+        <button
+          type="button"
+          onClick={() => setDetailsOpen((open) => !open)}
+          aria-expanded={detailsOpen}
+          className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
+        >
+          {detailsOpen ? (
+            <ChevronDown className="h-3.5 w-3.5" />
           ) : (
-            <p className="mt-2 text-[11px] text-zinc-600">
-              Step messages appear here as the pipeline runs.
-            </p>
+            <ChevronRight className="h-3.5 w-3.5" />
           )}
-        </div>
+          Timing & activity
+        </button>
+
+        {detailsOpen ? (
+          <div className="mt-3 grid gap-3 lg:grid-cols-2">
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-3">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                Stage timing
+              </p>
+              <dl className="mt-2 space-y-1.5">
+                {PIPELINE_STEPS.map((step) => {
+                  const duration = summary.stepDurationsMs[step.id];
+                  const stepStatus = steps.get(step.id)?.status ?? "pending";
+                  return (
+                    <div
+                      key={step.id}
+                      className="flex items-center justify-between gap-3 text-xs"
+                    >
+                      <dt className="text-[var(--text-secondary)]">{step.label}</dt>
+                      <dd className="font-mono text-[var(--text-secondary)]">
+                        {duration != null
+                          ? formatDurationMs(duration)
+                          : stepStatus === "running"
+                            ? "running…"
+                            : stepStatus === "done"
+                              ? "done"
+                              : "—"}
+                      </dd>
+                    </div>
+                  );
+                })}
+              </dl>
+            </div>
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] p-3">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                Recent activity
+              </p>
+              {recentMessages.length > 0 ? (
+                <ul className="mt-2 space-y-1 text-[11px] leading-5 text-[var(--text-secondary)]">
+                  {recentMessages.map((message, index) => (
+                    <li key={`${jobId}-msg-${index}`} className="truncate">
+                      {message}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-2 text-[11px] text-[var(--text-tertiary)]">
+                  Step messages appear here as the pipeline runs.
+                </p>
+              )}
+            </div>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/ui/components/scan-pipeline.tsx
+++ b/ui/components/scan-pipeline.tsx
@@ -2,13 +2,15 @@
 
 /**
  * Scan Pipeline DAG — shows scan execution stages as a React Flow graph
- * with live status updates from SSE step events.
+ * with live status updates from SSE step events. Interactive: pan / zoom /
+ * drag / select, with click-to-drill-in on any stage.
  */
 
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import {
   ReactFlow,
   Background,
+  Controls,
   Handle,
   Position,
   ReactFlowProvider,
@@ -46,6 +48,7 @@ interface PipelineNodeData {
   startedAt?: string | undefined;
   completedAt?: string | undefined;
   progressPct?: number | undefined;
+  selected?: boolean | undefined;
 }
 
 const STEP_ICONS: Record<string, React.ElementType> = {
@@ -57,6 +60,8 @@ const STEP_ICONS: Record<string, React.ElementType> = {
   output: FileText,
 };
 
+// Neutral (non-severity) surfaces use design tokens so the DAG tracks the
+// active theme; running/done/failed keep their semantic emerald/red hues.
 const STATUS_STYLES: Record<
   StepStatus,
   {
@@ -67,34 +72,34 @@ const STATUS_STYLES: Record<
   }
 > = {
   pending: {
-    border: "border-zinc-700",
-    bg: "bg-zinc-900",
+    border: "border-[var(--border-subtle)]",
+    bg: "bg-[var(--surface)]",
     icon: Clock,
-    iconColor: "text-zinc-500",
+    iconColor: "text-[var(--text-tertiary)]",
   },
   running: {
     border: "border-emerald-500 animate-pulse",
-    bg: "bg-emerald-950/50",
+    bg: "bg-emerald-500/15",
     icon: Loader2,
     iconColor: "text-emerald-400 animate-spin",
   },
   done: {
-    border: "border-emerald-600",
-    bg: "bg-emerald-950/30",
+    border: "border-emerald-500/80",
+    bg: "bg-emerald-500/10",
     icon: CheckCircle,
     iconColor: "text-emerald-400",
   },
   failed: {
-    border: "border-red-600",
-    bg: "bg-red-950/30",
+    border: "border-red-500/80",
+    bg: "bg-red-500/12",
     icon: XCircle,
     iconColor: "text-red-400",
   },
   skipped: {
-    border: "border-zinc-700",
-    bg: "bg-zinc-900/50",
+    border: "border-[var(--border-subtle)]",
+    bg: "bg-[var(--surface-muted)]",
     icon: SkipForward,
-    iconColor: "text-zinc-600",
+    iconColor: "text-[var(--text-tertiary)]",
   },
 };
 
@@ -123,25 +128,35 @@ function PipelineNode({ data }: { data: PipelineNodeData }) {
 
   return (
     <div
-      className={`rounded-2xl border-2 ${style.border} ${style.bg} min-w-[176px] max-w-[208px] overflow-hidden shadow-lg shadow-black/20`}
+      className={`rounded-2xl border-2 ${style.border} ${style.bg} min-w-[176px] max-w-[208px] cursor-pointer overflow-hidden shadow-lg shadow-[var(--shadow-color)] transition-shadow ${
+        data.selected ? "ring-2 ring-emerald-400/70 ring-offset-1 ring-offset-transparent" : ""
+      }`}
     >
-      <Handle type="target" position={Position.Left} className="!bg-zinc-600" />
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="!bg-[var(--border-strong)]"
+      />
 
-      <div className="border-b border-white/5 bg-white/[0.03] px-3 py-2">
+      <div className="border-b border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2">
         <div className="flex items-center gap-2">
-          <div className="flex h-7 w-7 items-center justify-center rounded-xl bg-zinc-950/60 ring-1 ring-white/5">
-            <StepIcon className="h-4 w-4 text-zinc-300 shrink-0" />
+          <div className="flex h-7 w-7 items-center justify-center rounded-xl bg-[var(--surface)] ring-1 ring-[var(--border-subtle)]">
+            <StepIcon className="h-4 w-4 shrink-0 text-[var(--text-secondary)]" />
           </div>
           <div className="min-w-0">
-            <div className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">{data.stepId}</div>
-            <span className="block truncate text-sm font-semibold text-zinc-100">{data.label}</span>
+            <div className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+              {data.stepId}
+            </div>
+            <span className="block truncate text-sm font-semibold text-[var(--foreground)]">
+              {data.label}
+            </span>
           </div>
           <StatusIcon className={`ml-auto h-3.5 w-3.5 ${style.iconColor}`} />
         </div>
       </div>
 
       <div className="px-3 py-2.5">
-        <p className="text-[10px] leading-tight text-zinc-500">
+        <p className="text-[10px] leading-tight text-[var(--text-tertiary)]">
           {data.status !== "pending"
             ? data.message
             : STEP_DESCRIPTIONS[data.stepId] ?? data.description}
@@ -152,7 +167,7 @@ function PipelineNode({ data }: { data: PipelineNodeData }) {
             {Object.entries(data.stats).map(([k, v]) => (
               <span
                 key={k}
-                className="rounded-lg border border-zinc-700 bg-zinc-950/70 px-1.5 py-0.5 font-mono text-[9px] text-zinc-400"
+                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[9px] text-[var(--text-secondary)]"
               >
                 {v} {k}
               </span>
@@ -161,7 +176,7 @@ function PipelineNode({ data }: { data: PipelineNodeData }) {
         )}
 
         {data.progressPct != null && data.status === "running" && (
-          <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-zinc-800">
+          <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[var(--surface-muted)]">
             <div
               className="h-full bg-emerald-500 transition-all duration-300"
               style={{ width: `${data.progressPct}%` }}
@@ -170,14 +185,16 @@ function PipelineNode({ data }: { data: PipelineNodeData }) {
         )}
 
         {duration && (
-          <p className="mt-1 font-mono text-[9px] text-zinc-600">{duration}s</p>
+          <p className="mt-1 font-mono text-[9px] text-[var(--text-tertiary)]">
+            {duration}s
+          </p>
         )}
       </div>
 
       <Handle
         type="source"
         position={Position.Right}
-        className="!bg-zinc-600"
+        className="!bg-[var(--border-strong)]"
       />
     </div>
   );
@@ -190,9 +207,21 @@ const nodeTypes = { pipelineStep: PipelineNode };
 interface ScanPipelineProps {
   steps: Map<string, StepEvent>;
   className?: string | undefined;
+  /** Currently drilled-in step (adds a selection ring). */
+  selectedStepId?: string | null | undefined;
+  /** Fired when a stage node is clicked, for drill-in panels. */
+  onStepClick?: ((stepId: string) => void) | undefined;
+  /** Enable pan/zoom/drag/select + on-canvas controls. Defaults to true. */
+  interactive?: boolean | undefined;
 }
 
-function ScanPipelineInner({ steps, className }: ScanPipelineProps) {
+function ScanPipelineInner({
+  steps,
+  className,
+  selectedStepId,
+  onStepClick,
+  interactive = true,
+}: ScanPipelineProps) {
   const { rawNodes, rawEdges } = useMemo(() => {
     const rawNodes: Node[] = PIPELINE_STEPS?.map((step) => ({
       id: step.id,
@@ -208,6 +237,7 @@ function ScanPipelineInner({ steps, className }: ScanPipelineProps) {
         startedAt: steps.get(step.id)?.started_at,
         completedAt: steps.get(step.id)?.completed_at,
         progressPct: steps.get(step.id)?.progress_pct,
+        selected: selectedStepId === step.id,
       } satisfies PipelineNodeData,
     }));
 
@@ -221,6 +251,7 @@ function ScanPipelineInner({ steps, className }: ScanPipelineProps) {
         source: prevId,
         target: step.id,
         type: "default",
+        // Motion only while something is actively running.
         animated: prevStatus === "running" || curStatus === "running",
         style: {
           stroke:
@@ -228,14 +259,14 @@ function ScanPipelineInner({ steps, className }: ScanPipelineProps) {
               ? "#10b981"
               : curStatus === "failed"
                 ? "#ef4444"
-                : "#3f3f46",
+                : "var(--border-strong)",
           strokeWidth: 2,
         },
       };
     });
 
     return { rawNodes, rawEdges };
-  }, [steps]);
+  }, [steps, selectedStepId]);
 
   const { nodes, edges } = useGraphLayout("sankey", rawNodes, rawEdges, {
     sankey: {
@@ -245,6 +276,13 @@ function ScanPipelineInner({ steps, className }: ScanPipelineProps) {
       rowGap: 20,
     },
   });
+
+  const handleNodeClick = useCallback(
+    (_event: React.MouseEvent, node: Node) => {
+      onStepClick?.(node.id);
+    },
+    [onStepClick],
+  );
 
   return (
     <div className={`h-[180px] ${className ?? ""}`}>
@@ -256,14 +294,21 @@ function ScanPipelineInner({ steps, className }: ScanPipelineProps) {
         fitViewOptions={{ padding: 0.2 }}
         minZoom={0.4}
         maxZoom={1.5}
-        panOnDrag={false}
-        zoomOnScroll={false}
-        nodesDraggable={false}
+        panOnDrag={interactive}
+        zoomOnScroll={interactive}
+        nodesDraggable={interactive}
         nodesConnectable={false}
-        elementsSelectable={false}
+        elementsSelectable={interactive}
+        onNodeClick={handleNodeClick}
         proOptions={{ hideAttribution: true }}
       >
-        <Background color="#27272a" gap={16} />
+        <Background color="var(--border-subtle)" gap={16} />
+        {interactive ? (
+          <Controls
+            showInteractive={false}
+            className="!border !border-[var(--border-subtle)] !bg-[var(--surface)] !shadow-md"
+          />
+        ) : null}
       </ReactFlow>
     </div>
   );

--- a/ui/lib/scan-pipeline-progress.ts
+++ b/ui/lib/scan-pipeline-progress.ts
@@ -30,6 +30,36 @@ export function mergePipelineSteps(
   return merged;
 }
 
+/**
+ * Cloud-connection scans (and other non-pipeline jobs) finish without ever
+ * emitting the six-stage `step` events, which used to leave a completed job
+ * reading "0/6 stages complete" in an all-pending gray DAG. When a job has
+ * genuinely finished (`done`) but carries no per-stage events, mark all six
+ * stages as done so the DAG honestly reflects a completed run. Jobs that did
+ * stream real step events keep their true per-stage states untouched.
+ *
+ * Returns `synthesized: true` when the stages were inferred rather than
+ * observed, so callers can label the timeline as summarized.
+ */
+export function synthesizePipelineSteps(
+  steps: Map<string, StepEvent>,
+  status: JobStatus,
+): { steps: Map<string, StepEvent>; synthesized: boolean } {
+  if (steps.size > 0 || status !== "done") {
+    return { steps, synthesized: false };
+  }
+  const synthesized = new Map<string, StepEvent>();
+  for (const step of PIPELINE_STEPS) {
+    synthesized.set(step.id, {
+      type: "step",
+      step_id: step.id,
+      status: "done",
+      message: "Completed",
+    });
+  }
+  return { steps: synthesized, synthesized: true };
+}
+
 export function formatDurationMs(ms: number | null | undefined): string {
   if (ms == null || ms < 0 || Number.isNaN(ms)) return "—";
   if (ms < 1000) return `${Math.round(ms)}ms`;

--- a/ui/tests/scan-pipeline-progress.test.ts
+++ b/ui/tests/scan-pipeline-progress.test.ts
@@ -6,6 +6,7 @@ import {
   mergePipelineSteps,
   parsePipelineStepsFromProgress,
   summarizePipeline,
+  synthesizePipelineSteps,
 } from "@/lib/scan-pipeline-progress";
 
 describe("scan-pipeline-progress", () => {
@@ -98,5 +99,40 @@ describe("scan-pipeline-progress", () => {
       created_at: "2026-06-27T00:00:00Z",
       completed_at: "2026-06-27T00:00:30Z",
     })).toBe(30_000);
+  });
+
+  it("synthesizes all six stages as done for a finished job with no step events", () => {
+    const { steps, synthesized } = synthesizePipelineSteps(new Map(), "done");
+    expect(synthesized).toBe(true);
+    expect(steps.size).toBe(6);
+    for (const step of steps.values()) {
+      expect(step.status).toBe("done");
+    }
+
+    const summary = summarizePipeline(steps, {
+      created_at: "2026-06-27T00:00:00Z",
+      completed_at: "2026-06-27T00:00:05Z",
+      status: "done",
+    });
+    expect(summary.completedSteps).toBe(6);
+    expect(summary.currentStepLabel).toBeNull();
+  });
+
+  it("leaves real step events untouched and does not synthesize while running", () => {
+    const real = parsePipelineStepsFromProgress([
+      JSON.stringify({
+        type: "step",
+        step_id: "discovery",
+        status: "done",
+        message: "Found 3 agents",
+      }),
+    ]);
+    const done = synthesizePipelineSteps(real, "done");
+    expect(done.synthesized).toBe(false);
+    expect(done.steps.size).toBe(1);
+
+    const running = synthesizePipelineSteps(new Map(), "running");
+    expect(running.synthesized).toBe(false);
+    expect(running.steps.size).toBe(0);
   });
 });


### PR DESCRIPTION
Closes the "dead DAG" symptoms from a live session where a cloud scan **succeeded** but the Scan-jobs page read `0/6 stages complete · 0ms`, timings `—`, empty activity, and the graph felt dark/static/non-interactive.

Refs #3933 (and layout item #3931/#F).

## What changed

**Interactivity** (`scan-pipeline.tsx`)
- Unlocked pan / zoom / drag / select; added ReactFlow `<Controls/>`, kept `<Background/>`.
- `onNodeClick` → drill-in: clicking a stage opens a side panel with its status, message, stats, duration, and context links (findings / graph / compliance) for that stage. Selected node gets a ring.

**Never "0/6" for a finished job** (`scan-pipeline-progress.ts`, `job-pipeline-panel.tsx`)
- New pure helper `synthesizePipelineSteps`: when a job is `done` but emitted **no** per-stage step events (cloud-connection scans don't emit the six-stage pipeline), all six stages render as **done** → `6/6` + success state instead of all-pending gray. Jobs that streamed real step events keep their true per-stage states; running/pending jobs are never synthesized.
- Status banner: running → done / failed, with a "stages summarized" note when synthesized.
- Result stats chips on completion: findings / critical / packages, plus cloud resources / identities / CIS pass-rate (defensively extracted from the scan result).

**State-driven motion & color**
- Motion (pulse / spin / animated edges) only while running; static when idle/done. Raised dark-mode contrast on nodes and edges.

**Layout** (`jobs/page.tsx`)
- Featured pipeline section is now collapsible (default open) via a Hide/Show toggle, so the job list reaches above the fold. Timing + activity fold away inside the panel (kept side-by-side `grid-cols-2`).

**Tokenize**
- Replaced hardcoded `zinc-*` in `job-pipeline-panel.tsx` and `scan-pipeline.tsx` with the CSS design tokens (`--surface*`, `--border-*`, `--foreground`, `--text-secondary/tertiary`) so light theme renders correctly; semantic emerald/red/amber retained.

## Constraints honored
- Reuses `useScanStream`, `useGraphLayout`, and the `scan-pipeline-progress` helpers.
- No API / SSE contract changes.
- Works for both active (streaming) and completed jobs.

## Verification
- `npm ci` (clean install) → `npm run typecheck` clean → `npm run build` (`next build --webpack`) compiled successfully.
- `vitest tests/scan-pipeline-progress.test.ts` → 5/5 pass (2 new tests cover synthesis + the "don't synthesize while running / don't clobber real events" guards).

## Follow-up (noted, deferred)
Fully mapping live cloud-scan progress onto the six stages — instead of synthesizing them at completion — is a deeper follow-up.