### PR TITLE
feat(connect): org-scale Azure/GCP onboarding and contributor guidance

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -142,10 +142,10 @@ Minimum verification matrix:
 - Tool-credit prefixes in PR titles, commits, or CHANGELOG entries
   (`[claude]`, `[codex]`, `[copilot]`, `[cursor]`, etc.) — they ship into
   GitHub release notes.
-- Name competitor products in marketing, positioning, release notes, PR titles,
-  or benchmark claims. Talk about capability gaps and our own surfaces there.
-  Functional integration code and supported-upstream docs may name a service
-  when the exact product name is required for users to configure it.
+- Clutter marketing, positioning, release notes, PR titles, or benchmark claims
+  with comparisons to other products — describe our own capabilities and users'
+  needs. Integration code and supported-upstream docs may name a third-party
+  service when the exact name is required for users to configure it.
 - Release with broken imports, red tests, or unreleased `[Unreleased]`
   CHANGELOG entries left after tagging.
 - Claim a file, feature, or behavior exists without reading the code that

--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -24,7 +24,7 @@ modules — keys and public-key material are variables or outputs only.
 |--------|--------------------------------------------|-------------|
 | [`connect-aws`](./connect-aws/) | IAM role/user + AWS-managed `SecurityAudit` (+ `ViewOnlyAccess`); cross-account or OIDC trust | `AGENT_BOM_AWS_INVENTORY=1` |
 | [`connect-azure`](./connect-azure/) | Built-in `Reader` (+ `Security Reader`) RBAC assignment at a subscription / management group | `AGENT_BOM_AZURE_INVENTORY=1` |
-| [`connect-gcp`](./connect-gcp/) | Service account + `roles/viewer` & `roles/iam.securityReviewer`; optional keyless Workload Identity Federation | `AGENT_BOM_GCP_INVENTORY=1` |
+| [`connect-gcp`](./connect-gcp/) | Service account + `roles/viewer` & `roles/iam.securityReviewer` at a project / organization / folder; optional keyless Workload Identity Federation | `AGENT_BOM_GCP_INVENTORY=1` |
 | [`connect-snowflake`](./connect-snowflake/) | `ABOM_READONLY` role + `IMPORTED PRIVILEGES`/`MONITOR USAGE`/warehouse `USAGE` grants + key-pair user | `SNOWFLAKE_*` (see module README) |
 
 ## Keyless-first

--- a/deploy/terraform/connect-gcp/README.md
+++ b/deploy/terraform/connect-gcp/README.md
@@ -6,16 +6,20 @@ same one-model connect pattern as
 `terraform apply` instead of hand-running `gcloud iam` commands.
 
 This is the **only** per-cloud difference in the connect flow: a service account
-with project IAM bindings **`roles/viewer`** + **`roles/iam.securityReviewer`** —
-both read-only predefined roles. No write permission is granted. The connector
-calls only `list`/`get` APIs.
+bound to **`roles/viewer`** + **`roles/iam.securityReviewer`** — both read-only
+predefined roles. No write permission is granted. The connector calls only
+`list`/`get` APIs. The roles bind at the **project** by default, or **org-wide /
+folder-wide** (`iam_binding_scope`) for fleet/mass onboarding — see
+[Fleet onboarding](#fleet-onboarding-orgfolder-scope) below.
 
 ## What it creates
 
 - A read-only **service account** with a **unique, non-guessable account_id**
   (`abom-readonly-<random hex>@<project>.iam…` by default).
-- Project IAM bindings: **`roles/viewer`** (inventory) and
-  **`roles/iam.securityReviewer`** (read-only IAM policy access for CIEM/posture).
+- IAM bindings for **`roles/viewer`** (inventory) and
+  **`roles/iam.securityReviewer`** (read-only IAM policy access for CIEM/posture),
+  at the **project** (default), **organization**, or **folder** scope
+  (`iam_binding_scope`).
 - **Optionally** (variable-gated) a **Workload Identity Federation** pool +
   OIDC provider, and an impersonation binding, so an external identity can
   assume the SA **keylessly** — no SA key is ever created.
@@ -75,10 +79,36 @@ module "agent_bom_connect" {
 }
 ```
 
+### Fleet onboarding (org/folder scope)
+
+For a fleet scan, bind the same two read-only roles once at the **organization**
+(or **folder**) instead of per project — the GCP analogue of the AWS
+Organizations StackSet and the Azure management-group scope. A single apply then
+covers every project the `AGENT_BOM_GCP_ALL_PROJECTS` fan-out reaches. The SA
+still lives in `project_id`; only the grant scope changes. Still strictly
+read-only.
+
+```hcl
+module "agent_bom_connect" {
+  source     = "github.com/<org>/agent-bom//deploy/terraform/connect-gcp"
+  project_id = "sa-host-project" # where the SA is created
+
+  iam_binding_scope = "organization"
+  organization_id   = "123456789012" # numeric org ID, no "organizations/" prefix
+}
+```
+
+Use `iam_binding_scope = "folder"` with `folder_id = "folders/123456789012"` for
+a narrower, folder-wide grant. Org/folder-level bindings need
+`roles/resourcemanager.organizationAdmin` (or folder admin) on whoever runs the
+apply — grant scope is set by the org, not by agent-bom. See
+[`docs/CLOUD_CONNECT.md`](../../../docs/CLOUD_CONNECT.md) §5 for the fan-out env.
+
 ## After apply
 
 ```bash
 export AGENT_BOM_GCP_INVENTORY=1          # opt-in, default-off
+export AGENT_BOM_GCP_ALL_PROJECTS=1       # fan out across org/folders/projects
 # Authenticate keylessly via WIF / SA impersonation using the SA email below,
 # or `gcloud auth application-default login`.
 agent-bom agents --preset enterprise --gcp
@@ -93,7 +123,10 @@ network I/O.
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `project_id` | — | Project to scope the grant to. |
+| `project_id` | — | Project that hosts the service account (and the grant scope when `iam_binding_scope = "project"`). |
+| `iam_binding_scope` | `project` | Where to bind the read-only roles: `project`, `organization`, or `folder`. Org/folder is the fleet/mass-onboarding path. |
+| `organization_id` | `""` | Numeric org ID. **Required when `iam_binding_scope = "organization"`** (empty is rejected). |
+| `folder_id` | `""` | Folder ID (`folders/…` or numeric). **Required when `iam_binding_scope = "folder"`** (empty is rejected). |
 | `service_account_id` | `""` | Fixed account_id override. Empty → auto-generated unique account_id. |
 | `service_account_id_prefix` | `abom-readonly` | Prefix for the auto-generated unique account_id. |
 | `enable_workload_identity_federation` | `false` | Create a keyless WIF pool/provider. |
@@ -105,13 +138,14 @@ network I/O.
 
 ## Known coverage limitations
 
-- **Org-level CIS checks need org/folder scope.** This module binds IAM at the
-  **project** level. CIS benchmarks that assert org-wide posture (e.g.
-  org-policy and folder-level controls) require an organization or folder IAM
-  binding that is out of scope here; run those with an org/folder-scoped
-  principal or they surface as silently-empty at project scope.
+- **Org-level CIS checks need org/folder scope.** At the default **project**
+  scope, CIS benchmarks that assert org-wide posture (e.g. org-policy and
+  folder-level controls) read as silently-empty. Set
+  `iam_binding_scope = "organization"` (or `"folder"`) so the same read-only
+  roles bind org/folder-wide and those checks evaluate.
 
 ## Outputs
 
 `service_account_email`, `service_account_name`, `granted_roles`,
-`workload_identity_pool_name`, `workload_identity_provider_name`.
+`iam_binding_scope`, `workload_identity_pool_name`,
+`workload_identity_provider_name`.

--- a/deploy/terraform/connect-gcp/main.tf
+++ b/deploy/terraform/connect-gcp/main.tf
@@ -1,8 +1,13 @@
 # connect-gcp — mints the read-only grant agent-bom's GCP connector needs.
 #
-# The ONLY per-cloud difference: a service account with project IAM bindings
+# The ONLY per-cloud difference: a service account with IAM bindings
 # roles/viewer + roles/iam.securityReviewer — both read-only predefined roles.
 # No write permission is granted. agent-bom calls only list/get APIs.
+#
+# The roles bind at the project by default, or org-wide / folder-wide
+# (iam_binding_scope) for fleet onboarding — the GCP analogue of the AWS
+# Organizations StackSet and the Azure management-group scope, so one apply
+# covers every project the AGENT_BOM_GCP_ALL_PROJECTS fan-out reaches.
 #
 # Keyless by default: this module creates NO service-account key. Use Workload
 # Identity Federation (variable-gated below) since many orgs disable SA keys.
@@ -16,6 +21,14 @@ resource "random_id" "sa_suffix" {
 
 locals {
   service_account_id = var.service_account_id != "" ? var.service_account_id : "${var.service_account_id_prefix}-${random_id.sa_suffix.hex}"
+
+  # The two read-only predefined roles the connector needs, bound as a set so
+  # the same grant applies verbatim at whichever scope the operator picks.
+  read_roles = toset(["roles/viewer", "roles/iam.securityReviewer"])
+
+  bind_project = var.iam_binding_scope == "project"
+  bind_org     = var.iam_binding_scope == "organization"
+  bind_folder  = var.iam_binding_scope == "folder"
 }
 
 resource "google_service_account" "this" {
@@ -25,18 +38,61 @@ resource "google_service_account" "this" {
   description  = "Read-only service account assumed by agent-bom (viewer + securityReviewer). No write permissions."
 }
 
-# roles/viewer — read-only visibility over project resources (inventory).
-resource "google_project_iam_member" "viewer" {
+# roles/viewer (inventory) + roles/iam.securityReviewer (read-only IAM policy
+# access for CIEM/posture), bound at the chosen scope. Default: project.
+resource "google_project_iam_member" "readonly" {
+  for_each = local.bind_project ? local.read_roles : toset([])
+
   project = var.project_id
-  role    = "roles/viewer"
+  role    = each.value
   member  = "serviceAccount:${google_service_account.this.email}"
 }
 
-# roles/iam.securityReviewer — read-only access to IAM policies for CIEM/posture.
-resource "google_project_iam_member" "security_reviewer" {
-  project = var.project_id
-  role    = "roles/iam.securityReviewer"
-  member  = "serviceAccount:${google_service_account.this.email}"
+# Org-wide grant (fleet onboarding): covers every folder/project under the org,
+# the GCP analogue of the AWS Organizations StackSet. Still read-only.
+resource "google_organization_iam_member" "readonly" {
+  for_each = local.bind_org ? local.read_roles : toset([])
+
+  org_id = var.organization_id
+  role   = each.value
+  member = "serviceAccount:${google_service_account.this.email}"
+
+  lifecycle {
+    precondition {
+      condition     = trimspace(var.organization_id) != ""
+      error_message = "iam_binding_scope = \"organization\" requires organization_id (the numeric GCP organization ID, e.g. \"123456789012\")."
+    }
+  }
+}
+
+# Folder-wide grant (fleet onboarding, narrower blast radius than org): covers
+# every project under the folder. Still read-only.
+resource "google_folder_iam_member" "readonly" {
+  for_each = local.bind_folder ? local.read_roles : toset([])
+
+  folder = var.folder_id
+  role   = each.value
+  member = "serviceAccount:${google_service_account.this.email}"
+
+  lifecycle {
+    precondition {
+      condition     = trimspace(var.folder_id) != ""
+      error_message = "iam_binding_scope = \"folder\" requires folder_id (e.g. \"folders/123456789012\" or \"123456789012\")."
+    }
+  }
+}
+
+# Preserve state for existing project-scope deployments across the rename from
+# the two named resources to the for_each'd google_project_iam_member.readonly,
+# so an in-place upgrade re-keys the bindings instead of destroying/recreating.
+moved {
+  from = google_project_iam_member.viewer
+  to   = google_project_iam_member.readonly["roles/viewer"]
+}
+
+moved {
+  from = google_project_iam_member.security_reviewer
+  to   = google_project_iam_member.readonly["roles/iam.securityReviewer"]
 }
 
 # ---------------------------------------------------------------------------

--- a/deploy/terraform/connect-gcp/outputs.tf
+++ b/deploy/terraform/connect-gcp/outputs.tf
@@ -9,8 +9,13 @@ output "service_account_name" {
 }
 
 output "granted_roles" {
-  description = "Predefined read-only roles bound to the service account at the project."
+  description = "Predefined read-only roles bound to the service account at the configured scope."
   value       = ["roles/viewer", "roles/iam.securityReviewer"]
+}
+
+output "iam_binding_scope" {
+  description = "Where the read-only roles were bound: project, organization, or folder."
+  value       = var.iam_binding_scope
 }
 
 output "workload_identity_pool_name" {

--- a/deploy/terraform/connect-gcp/variables.tf
+++ b/deploy/terraform/connect-gcp/variables.tf
@@ -21,6 +21,36 @@ variable "service_account_display_name" {
   default     = "agent-bom read-only scanner"
 }
 
+# --- IAM binding scope (project / org / folder — the fleet-onboarding path) ---
+# The service account always lives in project_id; iam_binding_scope only decides
+# WHERE the two read-only roles are granted. "organization"/"folder" is the GCP
+# analogue of the AWS Organizations StackSet and the Azure management-group
+# scope: one apply covers every project the AGENT_BOM_GCP_ALL_PROJECTS fan-out
+# reaches, so onboarding is not per-project. Still strictly read-only.
+
+variable "iam_binding_scope" {
+  description = "Where to bind the read-only roles (roles/viewer + roles/iam.securityReviewer). \"project\" (default) binds at project_id only. \"organization\" binds org-wide via organization_id (covers every folder/project under the org). \"folder\" binds folder-wide via folder_id (covers every project under the folder). Org/folder is the fleet/mass-onboarding path for AGENT_BOM_GCP_ALL_PROJECTS — a single grant instead of a per-project apply."
+  type        = string
+  default     = "project"
+
+  validation {
+    condition     = contains(["project", "organization", "folder"], var.iam_binding_scope)
+    error_message = "iam_binding_scope must be one of project, organization, folder."
+  }
+}
+
+variable "organization_id" {
+  description = "Numeric GCP organization ID (e.g. \"123456789012\", no \"organizations/\" prefix). Required when iam_binding_scope = \"organization\". Binds the read-only roles org-wide so one apply covers every folder/project under the org (fleet onboarding). Empty is rejected at plan time when the org scope is selected."
+  type        = string
+  default     = ""
+}
+
+variable "folder_id" {
+  description = "GCP folder ID (e.g. \"folders/123456789012\" or \"123456789012\"). Required when iam_binding_scope = \"folder\". Binds the read-only roles folder-wide (covers every project under the folder) — a narrower blast radius than the org scope. Empty is rejected at plan time when the folder scope is selected."
+  type        = string
+  default     = ""
+}
+
 # --- Optional Workload Identity Federation (keyless) -------------------------
 # Many orgs disable SA key creation, so keyless federation is the default-safe
 # path. When enabled, an external identity (e.g. the agent-bom hosted scanner,

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -186,6 +186,14 @@ and scans each independently — partitioned in the graph by account so thousand
 of subscriptions stay separable. A defensive `AGENT_BOM_AZURE_MAX_SUBSCRIPTIONS`
 cap (default 500) bounds blast radius.
 
+> **Mass-onboarding grant.** Rather than assigning `Reader` per subscription,
+> assign it **once at a management group** (the tenant root covers everything)
+> so a single assignment covers every subscription under it — the Azure analogue
+> of the AWS Organizations StackSet (§3) and the GCP org/folder binding (§5). The
+> `connect-azure` module does this with `scope_override` set to a management-group
+> ID (`/providers/Microsoft.Management/managementGroups/<id>`); the assignment
+> stays read-only (`Reader` + optional `Security Reader`).
+
 **SDK fragility, handled:** Azure SDKs are per-service distributions, so each is
 imported under `try/except ImportError` and degrades to a warning if absent —
 one missing package never crashes a scan.
@@ -232,10 +240,19 @@ organization → folders → projects hierarchy, runs each project scan separate
 and writes graph nodes under the right org/folder/project parent so exposures
 stay drillable at tenant scale. `AGENT_BOM_GCP_MAX_PROJECTS` bounds the run.
 
+> **Mass-onboarding grant.** Rather than granting the two read-only roles per
+> project, bind them **once at the organization or folder** so a single grant
+> covers every project the fan-out reaches — the GCP analogue of the AWS
+> Organizations StackSet (§3) and the Azure management-group scope (§4). The
+> `connect-gcp` module does this with `iam_binding_scope = "organization"` (or
+> `"folder"`); the binding stays strictly read-only (`roles/viewer` +
+> `roles/iam.securityReviewer`).
+
 **Secure-by-default provisioning** (`deploy/terraform/connect-gcp`): the module
 mints a unique read-only service account and binds only `roles/viewer` plus
-`roles/iam.securityReviewer`. Optional Workload Identity Federation is locked to
-a scoped `attribute_condition`, pinned audiences, and a specific
+`roles/iam.securityReviewer` — at the project by default, or org/folder-wide via
+`iam_binding_scope` for fleet onboarding. Optional Workload Identity Federation
+is locked to a scoped `attribute_condition`, pinned audiences, and a specific
 `principalSet`; broad wildcard federation is rejected.
 
 **Why read-only is enough:** the connector uses list/get style APIs and IAM


### PR DESCRIPTION
## Summary

- add organization/folder-scoped read-only GCP onboarding and document Azure management-group onboarding
- preserve existing project-level GCP grants through Terraform moved blocks
- use brand-neutral wording in the public contributor guidelines
- supersede #3943 with its guideline commit retained separately in this branch

## Verification

- `python scripts/check_provisioning_readonly.py`
- `uv run pytest -q tests/test_provisioning_readonly_guard.py` (18 passed)
- `git diff --check origin/main...HEAD`

## Notes

The onboarding implementation and contributor-guideline wording remain separate commits for auditability.