### PR TITLE
docs(readme): make Glama-facing README scannable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,29 +43,30 @@
 <details>
 <summary><b>Persona lane detail</b></summary>
 
-- **AppSec / GRC** — SARIF, compliance packs, and audit-ready exports from the
-  same scan that powers the dashboard.
-- **Platform / SRE** — fleet sync, Helm deploy, CI gates, and SBOM output
-  without a separate scanner stack.
-- **Agent builders** — MCP inventory, Shield SDK, and optional runtime proxy or
-  gateway enforcement on the same graph.
-- **Security engineers** — findings queue, attack-path drilldown, and blast-radius
-  context in CLI, API, and UI.
+- **AppSec / GRC** — SARIF, compliance packs, and audit-ready exports from one scan.
+- **Platform / SRE** — fleet sync, Helm deploy, CI gates, SBOM — no separate scanner stack.
+- **Agent builders** — MCP inventory, Shield SDK, optional runtime proxy or gateway enforcement.
+- **Security engineers** — findings queue, attack-path drilldown, blast-radius context in CLI, API, and UI.
 
-Snowflake is a supported connector lane, not the product center.
+**MCP server mode**
 
-MCP server mode advertises 73 MCP tools, 6 resources, and 8 workflow prompts.
-Registry metadata is tracked through the committed Smithery manifest and Glama
-listing; install and liveness checks live in the integration docs.
+- Advertises 73 MCP tools, 6 resources, and 8 workflow prompts.
+- Registry metadata lives in the committed Smithery manifest and Glama listing; install and liveness checks are in the integration docs.
 
 </details>
 
 ## How It Works
 
-Four beats that match the commands and the sidebar: **connect** (read-only
-cloud, data, code, and agent sources) → **scan** (`agents` / CI) → **graph**
-(`ContextGraph` + blast radius) → **serve** (`agent-bom serve` — one pane of
-glass). The Findings page is a posture queue inside serve — not a product lane.
+Four beats that match the commands and the sidebar:
+
+```text
+connect → scan → graph → serve
+```
+
+- **connect** — read-only cloud, data, code, and agent sources.
+- **scan** — `agents` / CI.
+- **graph** — `ContextGraph` + blast radius.
+- **serve** — `agent-bom serve`, one pane of glass; the Findings page is a posture queue here, not a product lane.
 
 <p align="center">
   <picture>
@@ -105,19 +106,9 @@ package -> vulnerability finding -> MCP server -> tools + credential refs -> age
 <details>
 <summary><b>What it is</b> — scanner, ContextGraph, and blast radius</summary>
 
-`agent-bom` is a read-only scanner and self-hosted control plane for local
-projects, agent fleets, MCP runtimes, and cloud estates (AWS, Azure, GCP,
-Snowflake).
-
-**ContextGraph** is agent-bom's unified evidence graph across CLI, API, UI, MCP
-tools, reports, and gateway decisions. Findings, assets, packages, cloud
-resources, identities, agents, MCP servers, credentials, and runtime decisions
-all normalize into that graph so posture, blast radius, and enforcement read
-from the same evidence.
-
-Blast radius is the core idea: a vulnerable package is linked to the MCP server
-that loads it, the tools it exposes, reachable credential references, and the
-agents that can call it — not just a CVE row.
+- **Scanner + control plane** — read-only, self-hosted, over local projects, agent fleets, MCP runtimes, and cloud estates (AWS, Azure, GCP, Snowflake).
+- **ContextGraph** — the unified evidence graph across CLI, API, UI, MCP tools, reports, and gateway decisions. Findings, assets, packages, cloud resources, identities, agents, MCP servers, credentials, and runtime decisions all normalize into it, so posture, blast radius, and enforcement read from one evidence set.
+- **Blast radius** — the core idea: a vulnerable package links to the MCP server that loads it, the tools it exposes, reachable credential references, and the agents that can call it — not just a CVE row.
 
 Coverage depth and honest boundaries:
 [AI infrastructure scanning](docs/AI_INFRASTRUCTURE_SCANNING.md) ·

--- a/glama.json
+++ b/glama.json
@@ -5,7 +5,7 @@
   ],
   "name": "agent-bom",
   "title": "agent-bom",
-  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 70 read-first MCP tools for headless security agents.",
+  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 73 read-first MCP tools for headless security agents.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

The repo `README.md` — which the Glama listing renders — read as prose walls, especially **How It Works** and **Who It's For**. This restructures those into scannable bullets and a visual pipeline without changing any facts, counts, commands, links, or tables.

**Tightened**
- **How It Works** — the four-beat prose sentence becomes a `connect → scan → graph → serve` fenced pipeline plus one-line bullets per beat.
- **Who It's For** — persona bullets trimmed of filler; the MCP-metadata paragraph folded into two bullets.
- **What it is** — the ContextGraph / blast-radius prose converted to bullets.

**Removed**
- The redundant standalone sentence "Snowflake is a supported connector lane, not the product center." The Cloud table (four connectors) and the "posture queue … not a product lane" line already make the point.

## Verification
- `python scripts/check_release_consistency.py` → passed.
- `pre-commit run --files README.md` → green (release-surface-consistency, end-of-file, hygiene all pass).
- Re-grepped every gated token: canonical tagline, all four `img.shields.io/*` badges, `docs/images/demo-latest.gif`, `73 MCP tools, 6 resources, and 8 workflow prompts`, `uses: msaad00/agent-bom@v0.95.0`, every `docs/…` and `site-docs/…`/`deploy/…` link, and every `agent-bom …` command — all still present.

## Notes
- No version numbers, tool/resource/prompt counts, command syntax, doc paths, or asserted strings changed.
- No images or binary assets added; honest-boundaries and trust claims unchanged.