### PR TITLE
feat(findings): first-class scope + domain taxonomy + honest overview counts

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -120,6 +120,41 @@ Used for unified findings outside the SCA / blast-radius path
 | `Asset` | Target of a finding (file, package, cloud resource, K8s resource, container image) |
 | `Finding` | The finding itself — `id`, `type`, `source`, `severity`, `title`, `description`, `asset`, `evidence`, `remediation`, `compliance_tags` |
 
+### Scope + taxonomy (issue #3946)
+
+Every `Finding` (and its `Asset`) carries explicit, optional/nullable **scope**
+so findings can be filtered by where they live, and a derived **security
+domain** so they roll up into exactly one posture lane:
+
+| Field | Meaning |
+|---|---|
+| `provider` | `aws` \| `azure` \| `gcp` \| `snowflake` \| … (None for local/package findings) |
+| `account_ref` | One normalized string: `aws:123456789012`, `azure:<sub-id>`, `gcp:<project-id>`, `snowflake:<account>` |
+| `region` | Cloud region (parsed from the ARN where available) |
+| `environment` | `prod` \| `staging` \| `dev` \| … when known |
+| `security_domain` (derived) | Exactly one of `cspm`, `vuln`, `appsec_sca`, `dspm`, `aispm` |
+
+Scope is populated at ingest by the cloud converters
+(`cloud_cis_check_to_finding`, `snowflake_governance_finding_to_finding`) and
+mirrored between the finding and its asset. `security_domain` is a pure function
+of source + finding type (+ evidence for the cloud data-vs-config split), living
+in `src/agent_bom/finding_scope.py`:
+
+| FindingSource / FindingType | Domain |
+|---|---|
+| `CLOUD_CIS` (CIS benchmark) | `cspm` |
+| `CLOUD_CIS` Snowflake governance (data access) | `dspm` |
+| CVE / malicious package / license (any source) | `vuln` |
+| `SAST`, secret/credential exposure | `appsec_sca` |
+| MCP / proxy / skill / prompt / graph + AI-native types | `aispm` |
+
+A **finding** is raw scanner output; an **issue** is a correlated/deduped
+grouping of findings for display. `GET /v1/findings` accepts optional
+`provider`, `account`, `environment`, and `domain` filters (canonicalized
+server-side, never rejected), and `GET /v1/overview` returns a `coverage` array
+of the five domain lanes whose per-lane severity histogram — including an
+`unrated` bucket for unknown-severity findings — sums to the lane count.
+
 ---
 
 ## 3. Graph taxonomy (`src/agent_bom/graph/types.py`)

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -10300,6 +10300,74 @@
               "title": "Approximate Total",
               "type": "boolean"
             }
+          },
+          {
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 64,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Provider"
+            }
+          },
+          {
+            "in": "query",
+            "name": "account",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 256,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Account"
+            }
+          },
+          {
+            "in": "query",
+            "name": "environment",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 64,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Environment"
+            }
+          },
+          {
+            "in": "query",
+            "name": "domain",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 32,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Domain"
+            }
           }
         ],
         "responses": {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -6757,6 +6757,42 @@ paths:
           default: false
           title: Approximate Total
           type: boolean
+      - in: query
+        name: provider
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Provider
+      - in: query
+        name: account
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 256
+            type: string
+          - type: 'null'
+          title: Account
+      - in: query
+        name: environment
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 64
+            type: string
+          - type: 'null'
+          title: Environment
+      - in: query
+        name: domain
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 32
+            type: string
+          - type: 'null'
+          title: Domain
       responses:
         '200':
           content:

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -38,7 +38,24 @@ router = APIRouter(dependencies=[cast(Any, require_authenticated_permission("rea
 _logger = logging.getLogger(__name__)
 
 _SEVERITY_KEYS = ("critical", "high", "medium", "low")
+# ``unrated`` is the honest home for findings whose severity the histogram does
+# not recognize (empty / "unknown" / vendor-specific). Without it those findings
+# incremented the CVE count but were dropped from the severity strip, producing
+# the "39 CVEs / 0 severities" mismatch. Every severity histogram in this module
+# now carries it so ``sum(severity.values())`` reconciles with the counted total.
+_UNRATED_KEY = "unrated"
+_ALL_SEVERITY_KEYS = (*_SEVERITY_KEYS, _UNRATED_KEY)
 _HUB_SEVERITY_KEYS = ("critical", "high", "medium", "low", "info", "unknown")
+
+# Coverage lanes — the five security domains, in display order (issue #3946).
+_COVERAGE_DOMAINS = ("cspm", "vuln", "appsec_sca", "dspm", "aispm")
+_COVERAGE_LABELS = {
+    "cspm": "CSPM",
+    "vuln": "Vuln mgmt",
+    "appsec_sca": "AppSec / SCA",
+    "dspm": "DSPM",
+    "aispm": "AISPM",
+}
 
 
 def _tenant_id(request: Request) -> str:
@@ -46,7 +63,17 @@ def _tenant_id(request: Request) -> str:
 
 
 def _empty_severity() -> dict[str, int]:
-    return {key: 0 for key in _SEVERITY_KEYS}
+    return {key: 0 for key in _ALL_SEVERITY_KEYS}
+
+
+def _bucket(sev: str | None, severity: dict[str, int]) -> str:
+    """Return the histogram bucket for ``sev`` — an exact match or ``unrated``.
+
+    The single choke point shared by every rollup so a finding is counted in one
+    and only one bucket and no unknown severity is silently dropped.
+    """
+    key = (sev or "").strip().lower()
+    return key if key in _SEVERITY_KEYS else _UNRATED_KEY
 
 
 def _graph_drill_href(
@@ -84,19 +111,25 @@ def _severity_from_summary(
 ) -> dict[str, int]:
     """Rebuild severity histogram from compact scan ``summary`` metadata."""
     severity = _empty_severity()
+    total = int(summary.get("total_vulnerabilities") or summary.get("total_findings") or 0)
     by_sev = (finding_summary or {}).get("by_severity") or {}
     if isinstance(by_sev, dict) and by_sev:
-        for key in _SEVERITY_KEYS:
-            severity[key] = int(by_sev.get(key) or 0)
+        for raw_key, raw_val in by_sev.items():
+            severity[_bucket(str(raw_key), severity)] += int(raw_val or 0)
+        counted = sum(severity.values())
+        # Reconcile with the scalar total so no finding is lost to a severity
+        # band the per-severity map omitted (info/unknown/vendor-specific).
+        if total > counted:
+            severity[_UNRATED_KEY] += total - counted
         return severity
-    severity["critical"] = int(
-        summary.get("critical_unified_findings") or summary.get("critical_findings") or 0
-    )
+    severity["critical"] = int(summary.get("critical_unified_findings") or summary.get("critical_findings") or 0)
     severity["high"] = int(summary.get("high_unified_findings") or 0)
-    total = int(summary.get("total_vulnerabilities") or summary.get("total_findings") or 0)
+    # The remainder are of unknown band (only critical/high are itemized in the
+    # compact summary) — record them as ``unrated`` rather than fabricating a
+    # ``medium`` count. This keeps ``sum(severity) == total``.
     remainder = max(0, total - severity["critical"] - severity["high"])
     if remainder:
-        severity["medium"] = remainder
+        severity[_UNRATED_KEY] = remainder
     return severity
 
 
@@ -114,8 +147,9 @@ def _rollup_from_blast_radius(blast_radius: list[dict[str, Any]]) -> dict[str, A
         if vid:
             seen_ids.add(vid)
         sev = (b.get("severity") or "").lower()
-        if sev in severity:
-            severity[sev] += 1
+        # Always count into exactly one bucket — unknown severities land in
+        # ``unrated`` instead of being dropped (the 39-CVEs / 0-severities bug).
+        severity[_bucket(sev, severity)] += 1
         is_kev = bool(b.get("cisa_kev") or b.get("is_kev"))
         if is_kev:
             kev += 1
@@ -139,11 +173,13 @@ def _rollup_from_blast_radius(blast_radius: list[dict[str, Any]]) -> dict[str, A
         )
 
     top_risks.sort(key=lambda r: r["risk_score"], reverse=True)
+    # One source of truth: the CVE count is the histogram total, so the severity
+    # strip and the headline number can never disagree.
     return {
         "severity": severity,
         "kev": kev,
         "credential_exposed": credential_exposed,
-        "unique_cves": len(seen_ids),
+        "unique_cves": sum(severity.values()),
         "top_risks": top_risks[:10],
     }
 
@@ -152,8 +188,9 @@ def _rollup_from_summary(result: dict[str, Any]) -> dict[str, Any]:
     summary = cast(dict[str, Any], result.get("summary") or {})
     finding_summary = cast(dict[str, Any], result.get("finding_summary") or {})
     severity = _severity_from_summary(summary, finding_summary)
-    total_vulns = int(summary.get("total_vulnerabilities") or summary.get("total_findings") or 0)
-    unique_cves = total_vulns if total_vulns else sum(severity.values())
+    # ``_severity_from_summary`` reconciles the histogram with the scalar total,
+    # so the histogram sum is the single source of truth for the CVE count.
+    unique_cves = sum(severity.values())
     return {
         "severity": severity,
         "kev": 0,
@@ -203,7 +240,7 @@ def _scan_rollup(jobs: list[Any]) -> dict[str, Any]:
         blast_radius = result.get("blast_radius") or []
         if blast_radius:
             partial = _rollup_from_blast_radius(cast(list[dict[str, Any]], blast_radius))
-            for key in _SEVERITY_KEYS:
+            for key in _ALL_SEVERITY_KEYS:
                 severity[key] += partial["severity"][key]
             kev += partial["kev"]
             credential_exposed += partial["credential_exposed"]
@@ -217,7 +254,7 @@ def _scan_rollup(jobs: list[Any]) -> dict[str, Any]:
                             unique_packages += 1
         else:
             partial = _rollup_from_summary(result)
-            for key in _SEVERITY_KEYS:
+            for key in _ALL_SEVERITY_KEYS:
                 severity[key] += partial["severity"][key]
             kev += partial["kev"]
             credential_exposed += partial["credential_exposed"]
@@ -243,6 +280,58 @@ def _scan_rollup(jobs: list[Any]) -> dict[str, Any]:
     }
 
 
+def _row_domain(row: dict[str, Any]) -> str:
+    """Return the security domain for a serialized finding row.
+
+    Prefers the first-class ``security_domain`` field (set by
+    ``Finding.to_dict``); falls back to the source/type mapping for legacy rows.
+    ``vuln`` is the safe default for legacy CVE rows that predate the taxonomy.
+    """
+    from agent_bom.finding_scope import domain_for_row
+
+    return domain_for_row(row) or "vuln"
+
+
+def _domain_rollup(jobs: list[Any]) -> list[dict[str, Any]]:
+    """Group unified findings by security domain into the five coverage lanes.
+
+    Reads each completed scan's unified ``findings`` stream (deduped by finding
+    id across re-scans) and buckets it by ``security_domain``. Each lane carries
+    a severity strip whose values sum to the lane count, so the UI can never
+    render a count that contradicts its severity strip. Empty lanes are still
+    returned at zero so the coverage row is always the same five domains.
+    """
+    lanes: dict[str, dict[str, int]] = {dom: _empty_severity() for dom in _COVERAGE_DOMAINS}
+    counts: dict[str, int] = {dom: 0 for dom in _COVERAGE_DOMAINS}
+    seen: set[str] = set()
+
+    for job in jobs:
+        if getattr(job, "status", None) != JobStatus.DONE or not job.result:
+            continue
+        result = cast(dict[str, Any], job.result)
+        for row in result.get("findings", []) or []:
+            if not isinstance(row, dict):
+                continue
+            identity = str(row.get("id") or row.get("canonical_id") or row.get("cve_id") or id(row))
+            if identity in seen:
+                continue
+            seen.add(identity)
+            dom = _row_domain(row)
+            lanes[dom][_bucket(str(row.get("severity") or ""), lanes[dom])] += 1
+            counts[dom] += 1
+
+    return [
+        {
+            "domain": dom,
+            "label": _COVERAGE_LABELS[dom],
+            "href": f"/findings?domain={dom}",
+            "count": counts[dom],
+            "severity": lanes[dom],
+        }
+        for dom in _COVERAGE_DOMAINS
+    ]
+
+
 def _posture_snapshot(jobs: list[Any]) -> dict[str, Any]:
     """Letter grade + score from the latest completed scan (same as /v1/posture)."""
     for job in jobs:
@@ -257,14 +346,10 @@ def _posture_snapshot(jobs: list[Any]) -> dict[str, Any]:
                 "summary": scorecard.get("summary", ""),
             }
         summary = result.get("summary")
-        if isinstance(summary, dict) and (
-            summary.get("total_vulnerabilities") or summary.get("total_findings")
-        ):
+        if isinstance(summary, dict) and (summary.get("total_vulnerabilities") or summary.get("total_findings")):
             from agent_bom.posture import _score_to_grade
 
-            critical = int(
-                summary.get("critical_unified_findings") or summary.get("critical_findings") or 0
-            )
+            critical = int(summary.get("critical_unified_findings") or summary.get("critical_findings") or 0)
             high = int(summary.get("high_unified_findings") or 0)
             total = int(summary.get("total_vulnerabilities") or summary.get("total_findings") or 0)
             penalty = min(100.0, critical * 12.0 + high * 6.0 + max(0, total - critical - high) * 1.5)
@@ -391,29 +476,44 @@ def _blend_posture_with_hub(
     ingested evidence never launders a failing posture into a passing one.
     """
     hub_total = sum(int(hub_severity.get(k, 0) or 0) for k in _HUB_SEVERITY_KEYS)
-    if hub_total <= 0:
+    scan_total = sum(int(v) for v in scan_severity.values())
+    posture_is_na = posture.get("grade") in (None, "N/A")
+
+    # An existing scorecard/summary posture stays authoritative unless ingested
+    # evidence adds to it — never recompute a graded scan from severity counts
+    # (that would double-penalize and drift the published grade). Only synthesize
+    # a grade from counts when the posture is N/A but findings exist, so the
+    # blurb can never claim "no vulnerabilities" while the counted total > 0.
+    if hub_total <= 0 and not posture_is_na:
+        return posture
+    if hub_total <= 0 and scan_total <= 0:
         return posture
 
     from agent_bom.posture import _score_to_grade
 
     combined_critical = int(scan_severity["critical"]) + int(hub_severity.get("critical", 0) or 0)
     combined_high = int(scan_severity["high"]) + int(hub_severity.get("high", 0) or 0)
-    combined_total = sum(int(v) for v in scan_severity.values()) + hub_total
+    combined_total = scan_total + hub_total
     penalty = min(
         100.0,
         combined_critical * 12.0 + combined_high * 6.0 + max(0, combined_total - combined_critical - combined_high) * 1.5,
     )
     combined_score = max(0.0, round(100.0 - penalty, 1))
 
-    if posture.get("grade") in (None, "N/A"):
+    if posture_is_na:
         final_score = combined_score
     else:
         final_score = min(float(posture.get("score") or 0.0), combined_score)
 
+    if hub_total > 0:
+        summary = f"{combined_total} finding(s) across scans + ingested evidence"
+    else:
+        summary = f"{combined_total} finding(s) from completed scans"
+
     return {
         "grade": _score_to_grade(final_score),
         "score": final_score,
-        "summary": f"{combined_total} finding(s) across scans + ingested evidence",
+        "summary": summary,
     }
 
 
@@ -459,6 +559,7 @@ async def get_overview(request: Request) -> dict[str, Any]:
     jobs = _get_store().list_all(tenant_id=_tenant_id(request))
 
     scan = _scan_rollup(jobs)
+    coverage = _domain_rollup(jobs)
     hub_severity = _hub_severity_snapshot(request)
     posture = _blend_posture_with_hub(_posture_snapshot(jobs), scan["severity"], hub_severity)
     runtime = _runtime_snapshot(request, jobs)
@@ -498,6 +599,9 @@ async def get_overview(request: Request) -> dict[str, Any]:
                 "high": scan["severity"]["high"],
                 "kev": scan["kev"],
                 "packages": scan["unique_packages"],
+                # Full histogram (incl. ``unrated``) so the UI never renders a
+                # metric that contradicts its severity strip.
+                "severity": scan["severity"],
             },
         },
         "code": {
@@ -565,6 +669,7 @@ async def get_overview(request: Request) -> dict[str, Any]:
             "hub_findings": hub_findings,
         },
         "domains": domains,
+        "coverage": coverage,
         "top_risks": scan["top_risks"],
     }
 

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1470,6 +1470,45 @@ _ALLOWED_FINDING_SEVERITIES = (
 )
 
 
+def _canonical_scope_filters(
+    provider: str | None,
+    account: str | None,
+    environment: str | None,
+    domain: str | None,
+) -> dict[str, str]:
+    """Normalize the optional scope/domain filters into an active-filter map.
+
+    Server-side canonicalization (issue #3946): values are lowercased/trimmed
+    and empty inputs dropped. Unknown values are kept (not rejected) so the
+    endpoint never raises on ad-hoc input — an unmatched value simply returns no
+    findings. ``account`` maps to the finding's ``account_ref``.
+    """
+    filters: dict[str, str] = {}
+    if provider and provider.strip():
+        filters["provider"] = provider.strip().lower()
+    if account and account.strip():
+        filters["account_ref"] = account.strip().lower()
+    if environment and environment.strip():
+        filters["environment"] = environment.strip().lower()
+    if domain and domain.strip():
+        filters["domain"] = domain.strip().lower()
+    return filters
+
+
+def _row_matches_scope(row: dict[str, Any], filters: dict[str, str]) -> bool:
+    """Return True when a finding row matches every active scope filter."""
+    from agent_bom.finding_scope import domain_for_row
+
+    for key in ("provider", "account_ref", "environment"):
+        wanted = filters.get(key)
+        if wanted is not None and str(row.get(key) or "").strip().lower() != wanted:
+            return False
+    wanted_domain = filters.get("domain")
+    if wanted_domain is not None and (domain_for_row(row) or "") != wanted_domain:
+        return False
+    return True
+
+
 def _resolve_bulk_findings_total(
     *,
     tenant_id: str,
@@ -1547,9 +1586,9 @@ def _merged_scan_bulk_page(
 ) -> list[dict[str, Any]]:
     """Merge pre-sorted scan findings with bulk hub pages without O(table) work.
 
-  Streams two sorted sources with a two-pointer walk so deep ``offset`` does
-  not require loading ``offset + limit`` bulk rows up front or re-sorting the
-  full combined window in memory.
+    Streams two sorted sources with a two-pointer walk so deep ``offset`` does
+    not require loading ``offset + limit`` bulk rows up front or re-sorting the
+    full combined window in memory.
     """
     scan_i = 0
     bulk_remote_offset = 0
@@ -1633,6 +1672,10 @@ async def list_findings(
     offset: Annotated[int, Query(ge=0)] = 0,
     cursor: Annotated[str | None, Query(max_length=512)] = None,
     approximate_total: bool = False,
+    provider: Annotated[str | None, Query(max_length=64)] = None,
+    account: Annotated[str | None, Query(max_length=256)] = None,
+    environment: Annotated[str | None, Query(max_length=64)] = None,
+    domain: Annotated[str | None, Query(max_length=32)] = None,
 ) -> dict:
     """List vulnerability findings aggregated from completed scan results.
 
@@ -1663,6 +1706,10 @@ async def list_findings(
                 offset,
                 cursor,
                 approximate_total,
+                provider,
+                account,
+                environment,
+                domain,
             )
     except BackpressureRejectedError as exc:
         raise HTTPException(
@@ -1681,6 +1728,10 @@ def _list_findings_impl(
     offset: int,
     cursor: str | None,
     approximate_total: bool,
+    provider: str | None = None,
+    account: str | None = None,
+    environment: str | None = None,
+    domain: str | None = None,
 ) -> dict:
     """Synchronous body of :func:`list_findings` (runs in a worker thread).
 
@@ -1739,9 +1790,7 @@ def _list_findings_impl(
         severity=severity,
         scan_id=scan_id,
     )
-    cached_bulk_total = get_cached_total(
-        cache_key(tenant_id=tenant_id, severity=severity, scan_id=scan_id, origin="bulk_ingest")
-    )
+    cached_bulk_total = get_cached_total(cache_key(tenant_id=tenant_id, severity=severity, scan_id=scan_id, origin="bulk_ingest"))
     if approximate_total or effective_approximate_total:
         # Explicit ``approximate_total=true`` (and the auto-threshold path) must
         # NOT force the O(table) exact COUNT — reuse the cached/approximate total
@@ -1776,6 +1825,9 @@ def _list_findings_impl(
     if severity:
         normalized = severity.lower()
         scan_findings = [item for item in scan_findings if str(item.get("severity", "")).lower() == normalized]
+    scope_filters = _canonical_scope_filters(provider, account, environment, domain)
+    if scope_filters:
+        scan_findings = [item for item in scan_findings if _row_matches_scope(item, scope_filters)]
     scan_findings.sort(key=lambda row: _finding_sort_key(row, sort_key))
 
     store = get_compliance_hub_store()
@@ -1785,7 +1837,11 @@ def _list_findings_impl(
     warnings: list[str] = []
     if cursor and scan_findings:
         warnings.append("cursor pagination applies to bulk-ingested findings only; in-memory scan findings appear on the first page")
-    if callable(bulk_list):
+    # When scope/domain filters are active, page over the fully-materialized
+    # combined list so ``total``/``count`` stay honest (the keyset store path
+    # does not carry the scope predicates). No scope filter -> unchanged fast
+    # path, so existing pagination behavior is byte-for-byte backward compatible.
+    if callable(bulk_list) and not scope_filters:
         if scan_findings and not cursor:
             bulk_result = bulk_list(
                 tenant_id,
@@ -1851,6 +1907,8 @@ def _list_findings_impl(
         if severity:
             normalized = severity.lower()
             bulk_findings = [item for item in bulk_findings if str(item.get("severity", "")).lower() == normalized]
+        if scope_filters:
+            bulk_findings = [item for item in bulk_findings if _row_matches_scope(item, scope_filters)]
         combined = scan_findings + bulk_findings
         combined.sort(key=lambda row: _finding_sort_key(row, sort_key))
         total = len(combined)

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -183,6 +183,14 @@ class Asset:
     identifier: Optional[str] = None  # purl, ARN, image digest, etc.
     location: Optional[str] = None  # file path, URL, cloud region
 
+    # Explicit scope — where this asset lives. Optional/nullable so non-cloud
+    # assets (packages, files) serialize unchanged. ``account_ref`` is a single
+    # normalized string (e.g. ``aws:123456789012``) built by finding_scope.
+    provider: Optional[str] = None  # aws | azure | gcp | snowflake | ...
+    account_ref: Optional[str] = None  # normalized ``<provider>:<account>``
+    region: Optional[str] = None
+    environment: Optional[str] = None  # prod | staging | dev | ...
+
     @property
     def stable_id(self) -> str:
         """Deterministic UUID derived from asset content.
@@ -217,6 +225,14 @@ class Finding:
     source: FindingSource
     asset: Asset
     severity: str  # mirrors Severity enum value; str for forward-compat
+
+    # Explicit scope (issue #3946) — carried on the finding for query/filter
+    # convenience and mirrored onto the asset at ingest. All optional/nullable
+    # so existing findings serialize unchanged.
+    provider: Optional[str] = None  # aws | azure | gcp | snowflake | ...
+    account_ref: Optional[str] = None  # normalized ``<provider>:<account>``
+    region: Optional[str] = None
+    environment: Optional[str] = None  # prod | staging | dev | ...
 
     # Vendor severity (from source scanner) vs normalised CVSS severity
     vendor_severity: Optional[str] = None  # severity as reported by vendor/scanner
@@ -307,6 +323,17 @@ class Finding:
         from agent_bom.graph.severity import normalize_severity
 
         self.severity = normalize_severity(self.severity)
+        # Keep finding scope and asset scope consistent: mirror finding-level
+        # scope down to the asset when the asset does not already carry it (and
+        # lift asset scope up when only the asset was populated). Non-cloud
+        # findings leave every field None, so this is a no-op for them.
+        for _scope_field in ("provider", "account_ref", "region", "environment"):
+            finding_val = getattr(self, _scope_field)
+            asset_val = getattr(self.asset, _scope_field, None)
+            if finding_val is not None and asset_val is None:
+                setattr(self.asset, _scope_field, finding_val)
+            elif finding_val is None and asset_val is not None:
+                setattr(self, _scope_field, asset_val)
         if self.vendor_severity is not None:
             self.vendor_severity = normalize_severity(self.vendor_severity)
         if self.cvss_severity is not None:
@@ -401,6 +428,18 @@ class Finding:
         """Return the best severity value: vendor > cvss > base severity."""
         return self.vendor_severity or self.cvss_severity or self.severity
 
+    @property
+    def security_domain(self) -> str:
+        """Derived posture lane: one of cspm/vuln/appsec_sca/dspm/aispm.
+
+        A pure function of source + finding type (+ evidence for the cloud
+        data-vs-config split), so the overview and findings surfaces route each
+        finding to exactly one coverage lane without double counting.
+        """
+        from agent_bom.finding_scope import security_domain_for
+
+        return security_domain_for(self.source, self.finding_type, self.evidence)
+
     def to_dict(self) -> dict:
         """Return a JSON-serializable finding payload."""
         return {
@@ -417,7 +456,17 @@ class Finding:
                 "stable_id": self.asset.stable_id,
                 "canonical_id": self.asset.canonical_id,
                 "source_ids": self.asset.source_ids,
+                "provider": self.asset.provider,
+                "account_ref": self.asset.account_ref,
+                "region": self.asset.region,
+                "environment": self.asset.environment,
             },
+            # First-class scope + taxonomy (issue #3946)
+            "provider": self.provider,
+            "account_ref": self.account_ref,
+            "region": self.region,
+            "environment": self.environment,
+            "security_domain": self.security_domain,
             "severity": self.severity,
             "effective_severity": self.effective_severity(),
             "vendor_severity": self.vendor_severity,
@@ -731,6 +780,17 @@ def cloud_cis_check_to_finding(check: dict, provider: str) -> "Finding":
     attack = [str(t) for t in (check.get("attack_techniques") or []) if str(t).strip()]
     compliance = [f"CIS-{check_id}"] + [str(t) for t in (check.get("compliance_tags") or []) if str(t).strip()]
     cis_section = sanitize_text(str(check.get("cis_section", "") or ""), max_len=200)
+
+    # Explicit scope (issue #3946): the converter already knows the provider and
+    # the resource id/ARN — parse the account/region out of the ARN, prefer an
+    # explicit ``account_id`` on the check, and normalize into one account ref.
+    from agent_bom.finding_scope import account_ref_from_arn, normalize_account_ref, region_from_arn
+
+    raw_account = str(check.get("account_id") or "").strip() or account_ref_from_arn(primary)
+    account_ref = normalize_account_ref(provider, raw_account)
+    region = sanitize_text(str(check.get("region") or "" or region_from_arn(primary) or ""), max_len=64) or None
+    environment = sanitize_text(str(check.get("environment") or ""), max_len=64) or None
+
     finding = Finding(
         finding_type=FindingType.CIS_FAIL,
         source=FindingSource.CLOUD_CIS,
@@ -739,8 +799,16 @@ def cloud_cis_check_to_finding(check: dict, provider: str) -> "Finding":
             asset_type="cloud_resource",
             identifier=primary,
             location=provider,
+            provider=provider,
+            account_ref=account_ref,
+            region=region,
+            environment=environment,
         ),
         severity=severity,
+        provider=provider,
+        account_ref=account_ref,
+        region=region,
+        environment=environment,
         title=f"CIS {check_id}: {title}",
         description=evidence_text or f"CIS benchmark control {check_id} failed for {provider}.",
         remediation_guidance=recommendation or None,
@@ -781,6 +849,10 @@ def snowflake_governance_finding_to_finding(finding: dict, account: str) -> "Fin
     agent_or_role = sanitize_text(str(finding.get("agent_or_role", "") or ""), max_len=300)
     object_name = sanitize_text(str(finding.get("object_name", "") or ""), max_len=300)
     primary = object_name or agent_or_role or f"snowflake:{account or 'account'}"
+
+    from agent_bom.finding_scope import normalize_account_ref
+
+    account_ref = normalize_account_ref("snowflake", account)
     return Finding(
         finding_type=FindingType.CIS_FAIL,
         source=FindingSource.CLOUD_CIS,
@@ -789,8 +861,12 @@ def snowflake_governance_finding_to_finding(finding: dict, account: str) -> "Fin
             asset_type="cloud_resource",
             identifier=primary,
             location="snowflake",
+            provider="snowflake",
+            account_ref=account_ref,
         ),
         severity=severity,
+        provider="snowflake",
+        account_ref=account_ref,
         title=f"Snowflake governance: {title}",
         description=description or f"Snowflake governance risk ({category}) for {primary}.",
         compliance_tags=[f"SNOWFLAKE-GOVERNANCE-{category.upper()}"],

--- a/src/agent_bom/finding_scope.py
+++ b/src/agent_bom/finding_scope.py
@@ -1,0 +1,168 @@
+"""First-class scope + security-domain taxonomy for findings (issue #3946).
+
+Two concerns live here, both pure and dependency-light so the ``Finding`` model
+and ingest converters can import them without a cycle:
+
+* **Scope** — where a finding lives: ``provider`` (aws/azure/gcp/snowflake/…),
+  ``account_ref`` (a single normalized string such as ``aws:123456789012``),
+  ``region``, and ``environment``. Cloud converters already know the provider
+  and a resource id/ARN; these helpers parse the account/region out of an ARN
+  and normalize the account into one canonical string.
+
+* **Taxonomy** — which security domain a finding belongs to. Every finding maps
+  to exactly one of the five posture lanes so the overview never double-counts a
+  CIS misconfiguration as a CVE. The mapping leads with ``FindingType`` where it
+  is decisive (a dependency CVE is vuln-management regardless of the scan entry
+  point) and falls back to ``FindingSource`` for the runtime/agent signals.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from agent_bom.finding import FindingSource, FindingType
+
+# The five posture lanes. Kept as plain strings (not an enum) so the value can
+# flow through JSON, the API, and the UI without a serialization shim.
+SECURITY_DOMAINS: tuple[str, ...] = ("cspm", "vuln", "appsec_sca", "dspm", "aispm")
+
+# Human labels for the UI coverage lanes (one per domain, 1:1).
+SECURITY_DOMAIN_LABELS: dict[str, str] = {
+    "cspm": "CSPM",
+    "vuln": "Vuln mgmt",
+    "appsec_sca": "AppSec / SCA",
+    "dspm": "DSPM",
+    "aispm": "AISPM",
+}
+
+
+# ---------------------------------------------------------------------------
+# Scope normalization
+# ---------------------------------------------------------------------------
+
+
+def account_ref_from_arn(arn: Optional[str]) -> Optional[str]:
+    """Return the bare account id embedded in an AWS ARN, if present.
+
+    ARN grammar is ``arn:partition:service:region:account-id:resource``. Some
+    services (S3 buckets) leave the account segment empty; those return None.
+    """
+    if not arn or not isinstance(arn, str):
+        return None
+    parts = arn.split(":")
+    if len(parts) < 6 or parts[0] != "arn":
+        return None
+    account = parts[4].strip()
+    return account or None
+
+
+def region_from_arn(arn: Optional[str]) -> Optional[str]:
+    """Return the region segment of an AWS ARN, if present."""
+    if not arn or not isinstance(arn, str):
+        return None
+    parts = arn.split(":")
+    if len(parts) < 6 or parts[0] != "arn":
+        return None
+    region = parts[3].strip()
+    return region or None
+
+
+def normalize_account_ref(provider: Optional[str], account: Optional[str]) -> Optional[str]:
+    """Return a single canonical account reference, e.g. ``aws:123456789012``.
+
+    Idempotent: an already-prefixed value is returned with a normalized provider
+    casing rather than double-prefixed. Empty/None inputs return None so the
+    field stays nullable for non-cloud findings.
+    """
+    prov = (provider or "").strip().lower()
+    acct = (account or "").strip()
+    if not prov or not acct:
+        return None
+    if ":" in acct:
+        head, _, tail = acct.partition(":")
+        if head.strip().lower() == prov and tail.strip():
+            return f"{prov}:{tail.strip()}"
+    return f"{prov}:{acct}"
+
+
+# ---------------------------------------------------------------------------
+# Security-domain taxonomy
+# ---------------------------------------------------------------------------
+
+
+def security_domain_for(
+    source: "FindingSource",
+    finding_type: "FindingType",
+    evidence: Optional[dict] = None,
+) -> str:
+    """Map a finding to exactly one of :data:`SECURITY_DOMAINS`.
+
+    Precedence:
+      1. Cloud posture sources route by data-vs-config: a Snowflake *governance*
+         finding (data access risk, no CIS benchmark marker) is DSPM; every
+         other cloud CIS finding is CSPM.
+      2. ``FindingType`` is decisive for the portable signals — a dependency CVE
+         or malicious package is vuln-management wherever it was discovered; SAST
+         and secret findings are AppSec/SCA.
+      3. Otherwise route by source (container/SBOM/external/filesystem → vuln;
+         everything MCP/agent/runtime/prompt/skill/graph → AISPM).
+    """
+    from agent_bom.finding import FindingSource, FindingType
+
+    ev = evidence or {}
+
+    if source == FindingSource.CLOUD_CIS:
+        provider = str(ev.get("provider") or "").strip().lower()
+        # Snowflake governance findings carry a category + no CIS benchmark tag;
+        # they describe data-access posture, not infra config → DSPM.
+        if provider == "snowflake" and not ev.get("benchmark") and ev.get("category"):
+            return "dspm"
+        return "cspm"
+
+    if finding_type in (
+        FindingType.CVE,
+        FindingType.MALICIOUS_PACKAGE,
+        FindingType.LICENSE,
+    ):
+        return "vuln"
+
+    if finding_type in (FindingType.SAST, FindingType.CREDENTIAL_EXPOSURE):
+        return "appsec_sca"
+
+    if source in (
+        FindingSource.CONTAINER,
+        FindingSource.SBOM,
+        FindingSource.EXTERNAL,
+        FindingSource.FILESYSTEM,
+    ):
+        return "vuln"
+
+    if source in (FindingSource.SAST, FindingSource.SECRET_SCAN):
+        return "appsec_sca"
+
+    # MCP scan, proxy, skill, browser-ext, prompt scan, graph correlation, and
+    # any AI-native finding type (tool drift, injection, cloaking, blocklist,
+    # combination, rate limit) are AI security-posture signals.
+    return "aispm"
+
+
+def domain_for_row(row: dict) -> Optional[str]:
+    """Return the security domain for a serialized finding row, or None.
+
+    Prefers the first-class ``security_domain`` field; falls back to the
+    source/type mapping for legacy rows. Returns None when neither the field nor
+    a recognizable source/type is present, so callers decide the default.
+    """
+    dom = str(row.get("security_domain") or "").strip().lower()
+    if dom in SECURITY_DOMAINS:
+        return dom
+    from agent_bom.finding import FindingSource, FindingType
+
+    try:
+        source = FindingSource(str(row.get("source") or "").upper())
+        ftype = FindingType(str(row.get("finding_type") or "").upper())
+    except ValueError:
+        return None
+    evidence = row.get("evidence") if isinstance(row.get("evidence"), dict) else None
+    return security_domain_for(source, ftype, evidence)

--- a/tests/test_finding_scope.py
+++ b/tests/test_finding_scope.py
@@ -1,0 +1,172 @@
+"""Tests for first-class finding scope + security-domain taxonomy (issue #3946)."""
+
+from __future__ import annotations
+
+from agent_bom.finding import (
+    Asset,
+    Finding,
+    FindingSource,
+    FindingType,
+    cloud_cis_check_to_finding,
+    snowflake_governance_finding_to_finding,
+)
+from agent_bom.finding_scope import (
+    account_ref_from_arn,
+    normalize_account_ref,
+    region_from_arn,
+    security_domain_for,
+)
+
+# ---------------------------------------------------------------------------
+# Account-ref / ARN normalization
+# ---------------------------------------------------------------------------
+
+
+def test_account_ref_from_aws_arn() -> None:
+    arn = "arn:aws:s3:::my-bucket"
+    # S3 ARNs carry no account segment; fall back to None
+    assert account_ref_from_arn(arn) is None
+    ec2 = "arn:aws:ec2:us-east-1:123456789012:instance/i-0abc"
+    assert account_ref_from_arn(ec2) == "123456789012"
+    assert region_from_arn(ec2) == "us-east-1"
+
+
+def test_normalize_account_ref_adds_provider_prefix() -> None:
+    assert normalize_account_ref("aws", "123456789012") == "aws:123456789012"
+    assert normalize_account_ref("azure", "sub-uuid-1") == "azure:sub-uuid-1"
+    assert normalize_account_ref("gcp", "my-project") == "gcp:my-project"
+
+
+def test_normalize_account_ref_idempotent_when_prefixed() -> None:
+    assert normalize_account_ref("aws", "aws:123456789012") == "aws:123456789012"
+    # provider casing is normalized
+    assert normalize_account_ref("AWS", "123456789012") == "aws:123456789012"
+
+
+def test_normalize_account_ref_none_and_empty() -> None:
+    assert normalize_account_ref("aws", None) is None
+    assert normalize_account_ref("aws", "") is None
+    assert normalize_account_ref("", "123") is None
+
+
+# ---------------------------------------------------------------------------
+# FindingSource / FindingType -> security_domain
+# ---------------------------------------------------------------------------
+
+
+def test_domain_cloud_cis_is_cspm() -> None:
+    assert security_domain_for(FindingSource.CLOUD_CIS, FindingType.CIS_FAIL, {"benchmark": "CIS"}) == "cspm"
+
+
+def test_domain_dependency_cve_is_vuln() -> None:
+    assert security_domain_for(FindingSource.MCP_SCAN, FindingType.CVE) == "vuln"
+    assert security_domain_for(FindingSource.SBOM, FindingType.CVE) == "vuln"
+    assert security_domain_for(FindingSource.CONTAINER, FindingType.CVE) == "vuln"
+    assert security_domain_for(FindingSource.MCP_SCAN, FindingType.MALICIOUS_PACKAGE) == "vuln"
+
+
+def test_domain_sast_and_secret_is_appsec_sca() -> None:
+    assert security_domain_for(FindingSource.SAST, FindingType.SAST) == "appsec_sca"
+    assert security_domain_for(FindingSource.SECRET_SCAN, FindingType.CREDENTIAL_EXPOSURE) == "appsec_sca"
+
+
+def test_domain_mcp_agent_signals_are_aispm() -> None:
+    assert security_domain_for(FindingSource.MCP_SCAN, FindingType.TOOL_DRIFT) == "aispm"
+    assert security_domain_for(FindingSource.PROXY, FindingType.EXFILTRATION) == "aispm"
+    assert security_domain_for(FindingSource.SKILL, FindingType.SKILL_RISK) == "aispm"
+    assert security_domain_for(FindingSource.PROMPT_SCAN, FindingType.PROMPT_SECURITY) == "aispm"
+
+
+def test_domain_snowflake_governance_is_dspm() -> None:
+    ev = {"provider": "snowflake", "category": "sensitive-data-access"}
+    assert security_domain_for(FindingSource.CLOUD_CIS, FindingType.CIS_FAIL, ev) == "dspm"
+
+
+def test_domain_is_one_of_the_five() -> None:
+    valid = {"cspm", "vuln", "appsec_sca", "dspm", "aispm"}
+    for source in FindingSource:
+        for ftype in FindingType:
+            assert security_domain_for(source, ftype) in valid
+
+
+# ---------------------------------------------------------------------------
+# Finding / Asset carry scope + domain through serialization
+# ---------------------------------------------------------------------------
+
+
+def test_finding_scope_fields_default_none_and_serialize() -> None:
+    f = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.MCP_SCAN,
+        asset=Asset(name="requests", asset_type="package"),
+        severity="high",
+    )
+    assert f.provider is None
+    assert f.account_ref is None
+    assert f.region is None
+    assert f.environment is None
+    payload = f.to_dict()
+    assert payload["provider"] is None
+    assert payload["account_ref"] is None
+    assert payload["region"] is None
+    assert payload["environment"] is None
+    assert payload["security_domain"] == "vuln"
+    # asset scope block present
+    assert payload["asset"]["provider"] is None
+
+
+def test_finding_scope_fields_serialize_when_set() -> None:
+    f = Finding(
+        finding_type=FindingType.CIS_FAIL,
+        source=FindingSource.CLOUD_CIS,
+        asset=Asset(name="root", asset_type="cloud_resource"),
+        severity="high",
+        provider="aws",
+        account_ref="aws:123456789012",
+        region="us-east-1",
+        environment="prod",
+    )
+    payload = f.to_dict()
+    assert payload["provider"] == "aws"
+    assert payload["account_ref"] == "aws:123456789012"
+    assert payload["region"] == "us-east-1"
+    assert payload["environment"] == "prod"
+    assert payload["security_domain"] == "cspm"
+    assert payload["asset"]["account_ref"] == "aws:123456789012"
+
+
+# ---------------------------------------------------------------------------
+# Ingest converters populate scope
+# ---------------------------------------------------------------------------
+
+
+def test_cloud_cis_converter_threads_scope() -> None:
+    check = {
+        "check_id": "2.1.1",
+        "title": "S3 bucket encryption",
+        "severity": "high",
+        "status": "FAIL",
+        "resource_ids": ["arn:aws:ec2:us-west-2:210987654321:instance/i-1"],
+        "account_id": "210987654321",
+        "benchmark": "CIS",
+    }
+    f = cloud_cis_check_to_finding(check, "aws")
+    assert f.provider == "aws"
+    assert f.account_ref == "aws:210987654321"
+    assert f.region == "us-west-2"
+    assert f.security_domain == "cspm"
+    payload = f.to_dict()
+    assert payload["account_ref"] == "aws:210987654321"
+
+
+def test_snowflake_governance_converter_normalizes_account_and_domain() -> None:
+    raw = {
+        "category": "sensitive-data-access",
+        "severity": "high",
+        "title": "Broad SELECT on PII",
+        "object_name": "DB.SCHEMA.CUSTOMERS",
+    }
+    f = snowflake_governance_finding_to_finding(raw, "xy12345")
+    assert f.provider == "snowflake"
+    assert f.account_ref == "snowflake:xy12345"
+    assert f.security_domain == "dspm"

--- a/tests/test_findings_scope_filter.py
+++ b/tests/test_findings_scope_filter.py
@@ -1,0 +1,124 @@
+"""Scope + domain filter params on GET /v1/findings (issue #3946)."""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore, set_compliance_hub_store
+from agent_bom.api.models import JobStatus
+from agent_bom.api.server import ScanJob, ScanRequest, app, set_job_store
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import _get_store
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+_AUTH = proxy_headers(tenant="default")
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+
+
+def _seed_scan_findings() -> None:
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+    job = ScanJob(
+        job_id="scope-job",
+        tenant_id="default",
+        created_at="2026-02-22T10:00:00Z",
+        request=ScanRequest(),
+    )
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-02-22T10:05:00Z"
+    job.result = {
+        "agents": [],
+        "scan_sources": ["cloud"],
+        "findings": [
+            {
+                "id": "f-aws-prod",
+                "severity": "high",
+                "security_domain": "cspm",
+                "provider": "aws",
+                "account_ref": "aws:111111111111",
+                "environment": "prod",
+                "title": "aws prod misconfig",
+            },
+            {
+                "id": "f-aws-dev",
+                "severity": "medium",
+                "security_domain": "cspm",
+                "provider": "aws",
+                "account_ref": "aws:222222222222",
+                "environment": "dev",
+                "title": "aws dev misconfig",
+            },
+            {
+                "id": "f-gcp-vuln",
+                "severity": "critical",
+                "security_domain": "vuln",
+                "provider": "gcp",
+                "account_ref": "gcp:my-project",
+                "environment": "prod",
+                "title": "gcp cve",
+            },
+        ],
+    }
+    _get_store().put(job)
+
+
+def _ids(resp) -> set[str]:
+    return {f.get("id") for f in resp.json()["findings"]}
+
+
+def test_filter_by_provider() -> None:
+    _seed_scan_findings()
+    client = TestClient(app)
+    resp = client.get("/v1/findings?provider=aws", headers=_AUTH)
+    assert resp.status_code == 200
+    assert _ids(resp) == {"f-aws-prod", "f-aws-dev"}
+
+
+def test_filter_by_account_ref() -> None:
+    _seed_scan_findings()
+    client = TestClient(app)
+    resp = client.get("/v1/findings?account=aws:111111111111", headers=_AUTH)
+    assert resp.status_code == 200
+    assert _ids(resp) == {"f-aws-prod"}
+
+
+def test_filter_by_environment_and_domain() -> None:
+    _seed_scan_findings()
+    client = TestClient(app)
+    resp = client.get("/v1/findings?environment=prod&domain=vuln", headers=_AUTH)
+    assert resp.status_code == 200
+    assert _ids(resp) == {"f-gcp-vuln"}
+
+
+def test_filter_by_domain_cspm() -> None:
+    _seed_scan_findings()
+    client = TestClient(app)
+    resp = client.get("/v1/findings?domain=cspm", headers=_AUTH)
+    assert resp.status_code == 200
+    assert _ids(resp) == {"f-aws-prod", "f-aws-dev"}
+
+
+def test_unknown_filter_values_never_raise() -> None:
+    _seed_scan_findings()
+    client = TestClient(app)
+    # Unknown domain / provider must not 4xx — normalize + return an empty match.
+    resp = client.get("/v1/findings?domain=not-a-domain&provider=", headers=_AUTH)
+    assert resp.status_code == 200
+    assert resp.json()["findings"] == []
+
+
+def test_no_scope_filter_is_backward_compatible() -> None:
+    _seed_scan_findings()
+    client = TestClient(app)
+    resp = client.get("/v1/findings", headers=_AUTH)
+    assert resp.status_code == 200
+    assert len(resp.json()["findings"]) == 3

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -251,6 +251,83 @@ def client_get_overview() -> dict:
     return TestClient(app).get("/v1/overview", headers=_AUTH_HEADERS).json()
 
 
+def test_overview_severity_sum_equals_unique_cves_with_unknown_severity() -> None:
+    """The 39-CVEs / 0-severities bug: unknown-severity findings must not vanish.
+
+    A finding with a severity the histogram doesn't recognize lands in the
+    ``unrated`` bucket, and ``sum(severity.values()) == unique_cves`` holds.
+    """
+    _clear_jobs()
+    _add_done_job(
+        [
+            {"vulnerability_id": "CVE-A", "severity": "critical", "risk_score": 9},
+            {"vulnerability_id": "CVE-B", "severity": "unknown", "risk_score": 5},
+            {"vulnerability_id": "CVE-C", "severity": "", "risk_score": 4},
+        ]
+    )
+    data = client_get_overview()
+    vuln = data["domains"]["vuln"]
+    strip = vuln["detail"]["severity"]
+    assert strip["critical"] == 1
+    assert strip["unrated"] == 2
+    assert sum(strip.values()) == vuln["metric"]
+    assert vuln["metric"] == 3
+
+
+def test_overview_coverage_lanes_map_to_five_domains() -> None:
+    """Coverage lanes are the five security domains, non-overlapping, invariant-clean."""
+    _clear_jobs()
+    from agent_bom.api.server import ScanJob, ScanRequest
+
+    job = ScanJob(
+        job_id="dom-job",
+        tenant_id="default",
+        created_at="2026-02-22T10:00:00Z",
+        request=ScanRequest(),
+    )
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-02-22T10:05:00Z"
+    job.result = {
+        "agents": [],
+        "scan_sources": ["cloud"],
+        "findings": [
+            {"security_domain": "cspm", "severity": "high", "id": "c1"},
+            {"security_domain": "cspm", "severity": "unknown", "id": "c2"},
+            {"security_domain": "vuln", "severity": "critical", "id": "v1"},
+            {"security_domain": "aispm", "severity": "medium", "id": "a1"},
+        ],
+    }
+    _get_store().put(job)
+
+    data = client_get_overview()
+    coverage = {lane["domain"]: lane for lane in data["coverage"]}
+    assert set(coverage) == {"cspm", "vuln", "appsec_sca", "dspm", "aispm"}
+
+    cspm = coverage["cspm"]
+    assert cspm["count"] == 2
+    assert cspm["severity"]["high"] == 1
+    assert cspm["severity"]["unrated"] == 1
+    assert sum(cspm["severity"].values()) == cspm["count"]
+
+    assert coverage["vuln"]["count"] == 1
+    assert coverage["aispm"]["count"] == 1
+    assert coverage["dspm"]["count"] == 0
+    assert coverage["appsec_sca"]["count"] == 0
+    # CIS misconfig went to CSPM, not the vuln lane.
+    assert coverage["vuln"]["severity"]["critical"] == 1
+
+
+def test_overview_posture_blurb_not_no_vulns_when_counted() -> None:
+    """Posture summary must never claim no vulnerabilities when the count > 0."""
+    _clear_jobs()
+    _add_done_job(
+        [{"vulnerability_id": "CVE-X", "severity": "high", "risk_score": 7}],
+    )
+    data = client_get_overview()
+    blurb = str(data["posture"]["summary"]).lower()
+    assert "no vulnerabilit" not in blurb
+
+
 def test_overview_requires_auth(monkeypatch) -> None:
     """Endpoint is read-only but still behind the standard viewer gate."""
     _clear_jobs()

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -251,6 +251,19 @@ function collectUnifiedFindings(findings: UnifiedFinding[]): EnrichedVuln[] {
 }
 
 
+// Security-domain facets (issue #3946). Map 1:1 to the overview coverage lanes
+// so drilling from a coverage lane lands on the matching findings filter.
+const DOMAIN_FILTERS: { key: string; label: string }[] = [
+  { key: "all", label: "All domains" },
+  { key: "cspm", label: "CSPM" },
+  { key: "vuln", label: "Vuln mgmt" },
+  { key: "appsec_sca", label: "AppSec / SCA" },
+  { key: "dspm", label: "DSPM" },
+  { key: "aispm", label: "AISPM" },
+];
+
+const PROVIDER_OPTIONS = ["aws", "azure", "gcp", "snowflake", "databricks"];
+
 export default function FindingsPageWrapper() {
   return (
     <Suspense fallback={
@@ -278,6 +291,11 @@ function FindingsPage() {
   const paramScan = searchParams.get("scan") ?? searchParams.get("scan_id");
   const paramIssueType = searchParams.get("issue");
   const paramLens = searchParams.get("lens");
+  // First-class scope + taxonomy facets (issue #3946), URL-synced.
+  const paramDomain = searchParams.get("domain");
+  const paramProvider = searchParams.get("provider");
+  const paramAccount = searchParams.get("account");
+  const paramEnvironment = searchParams.get("environment");
   const { lens, selectLens, lenses, label: lensLabel, hint: lensHint } = useFindingsLens(paramLens);
 
   const [jobs, setJobs] = useState<JobListItem[]>([]);
@@ -300,6 +318,12 @@ function FindingsPage() {
     }
     return "all";
   });
+  const [domainFilter, setDomainFilter] = useState<string>(
+    paramDomain && DOMAIN_FILTERS.some((d) => d.key === paramDomain) ? paramDomain : "all",
+  );
+  const [providerFilter, setProviderFilter] = useState<string>(paramProvider ?? "");
+  const [accountFilter, setAccountFilter] = useState<string>(paramAccount ?? "");
+  const [environmentFilter, setEnvironmentFilter] = useState<string>(paramEnvironment ?? "");
   const [sortKey, setSortKey] = useState<SortKey>("severity");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
   const [search, setSearch] = useState(paramQuery ?? paramCve ?? paramAgent ?? "");
@@ -375,6 +399,22 @@ function FindingsPage() {
   }, [paramIssueType]);
 
   useEffect(() => {
+    setDomainFilter(paramDomain && DOMAIN_FILTERS.some((d) => d.key === paramDomain) ? paramDomain : "all");
+  }, [paramDomain]);
+
+  useEffect(() => {
+    setProviderFilter(paramProvider ?? "");
+  }, [paramProvider]);
+
+  useEffect(() => {
+    setAccountFilter(paramAccount ?? "");
+  }, [paramAccount]);
+
+  useEffect(() => {
+    setEnvironmentFilter(paramEnvironment ?? "");
+  }, [paramEnvironment]);
+
+  useEffect(() => {
     const params = new URLSearchParams();
     if (filter !== "all") params.set("severity", filter);
     if (issueTypeFilter !== "all") params.set("issue", issueTypeFilter);
@@ -382,11 +422,30 @@ function FindingsPage() {
     if (search.trim()) params.set("q", search.trim());
     if (scope !== "latest") params.set("scope", scope);
     if (groupBy !== "none") params.set("group", groupBy);
+    if (domainFilter !== "all") params.set("domain", domainFilter);
+    if (providerFilter.trim()) params.set("provider", providerFilter.trim());
+    if (accountFilter.trim()) params.set("account", accountFilter.trim());
+    if (environmentFilter.trim()) params.set("environment", environmentFilter.trim());
     if (page > 1) params.set("page", String(page));
     if (paramScan) params.set("scan", paramScan);
     const qs = params.toString();
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
-  }, [filter, issueTypeFilter, lens, search, scope, groupBy, page, paramScan, pathname, router]);
+  }, [
+    filter,
+    issueTypeFilter,
+    lens,
+    search,
+    scope,
+    groupBy,
+    domainFilter,
+    providerFilter,
+    accountFilter,
+    environmentFilter,
+    page,
+    paramScan,
+    pathname,
+    router,
+  ]);
 
   const collectVulns = useCallback((fullJobs: ScanJob[]) => {
     const vulnMap = new Map<string, EnrichedVuln>();
@@ -665,6 +724,10 @@ function FindingsPage() {
           const response = await api.listFindings({
             ...(scanId ? { scanId } : {}),
             ...(filter !== "all" ? { severity: filter } : {}),
+            ...(domainFilter !== "all" ? { domain: domainFilter } : {}),
+            ...(providerFilter.trim() ? { provider: providerFilter.trim() } : {}),
+            ...(accountFilter.trim() ? { account: accountFilter.trim() } : {}),
+            ...(environmentFilter.trim() ? { environment: environmentFilter.trim() } : {}),
             sort: serverFindingsSort(sortKey),
             limit: PAGE_SIZE,
             offset: (page - 1) * PAGE_SIZE,
@@ -697,6 +760,10 @@ function FindingsPage() {
     useServerPaging,
     page,
     filter,
+    domainFilter,
+    providerFilter,
+    accountFilter,
+    environmentFilter,
     sortKey,
   ]);
 
@@ -747,7 +814,7 @@ function FindingsPage() {
   }, [vulns, filter, issueTypeFilter, search, sortKey, sortDir, useServerPaging]);
 
   // Reset page when filters change
-  useEffect(() => { setPage(1); }, [filter, issueTypeFilter, search, sortKey, sortDir, groupBy, scope, paramScan]);
+  useEffect(() => { setPage(1); }, [filter, issueTypeFilter, search, sortKey, sortDir, groupBy, scope, paramScan, domainFilter, providerFilter, accountFilter, environmentFilter]);
 
   const totalPages = useServerPaging
     ? Math.max(1, Math.ceil(findingsTotal / PAGE_SIZE))
@@ -810,6 +877,8 @@ function FindingsPage() {
     findingsTotal,
     useServerPaging && findingsTotalApproximate,
   );
+
+  const cloudScopeActive = Boolean(providerFilter.trim() || accountFilter.trim() || environmentFilter.trim());
 
   const FILTERS: { key: SeverityFilter; label: string; color: string }[] = [
     {
@@ -1042,6 +1111,81 @@ function FindingsPage() {
               <p className="text-xs text-zinc-600">
                 Default stays scoped for speed. Expand to all scans only when you need history-wide findings aggregation.
               </p>
+            </div>
+
+            {/* Security domain + cloud scope facets (issue #3946). Design-token
+                styled so both themes read correctly; URL-synced via state. */}
+            <div className="flex flex-col gap-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3">
+              <div className="flex flex-wrap items-center gap-1">
+                <span className="mr-1 text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+                  Domain
+                </span>
+                {DOMAIN_FILTERS.map(({ key, label }) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setDomainFilter(key)}
+                    className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
+                      domainFilter === key
+                        ? "border-[color:var(--accent-mint)] bg-[color:var(--surface-muted)] text-[color:var(--foreground)]"
+                        : "border-[color:var(--border-subtle)] text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+              <div className="flex flex-wrap items-end gap-3">
+                <label className="flex flex-col gap-1">
+                  <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Cloud</span>
+                  <select
+                    value={providerFilter}
+                    onChange={(e) => setProviderFilter(e.target.value)}
+                    className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-1.5 text-sm text-[color:var(--foreground)] focus:border-[color:var(--border-strong)] focus:outline-none"
+                  >
+                    <option value="">Any provider</option>
+                    {PROVIDER_OPTIONS.map((p) => (
+                      <option key={p} value={p}>
+                        {p.toUpperCase()}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Account</span>
+                  <input
+                    type="text"
+                    placeholder="e.g. aws:123456789012"
+                    value={accountFilter}
+                    onChange={(e) => setAccountFilter(e.target.value)}
+                    className="w-52 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-1.5 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--border-strong)] focus:outline-none"
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Environment</span>
+                  <input
+                    type="text"
+                    placeholder="e.g. prod"
+                    value={environmentFilter}
+                    onChange={(e) => setEnvironmentFilter(e.target.value)}
+                    className="w-40 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-1.5 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--border-strong)] focus:outline-none"
+                  />
+                </label>
+                {(cloudScopeActive || domainFilter !== "all") && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDomainFilter("all");
+                      setProviderFilter("");
+                      setAccountFilter("");
+                      setEnvironmentFilter("");
+                    }}
+                    className="rounded-lg border border-[color:var(--border-subtle)] px-3 py-1.5 text-xs font-medium text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
+                  >
+                    Clear scope
+                  </button>
+                )}
+              </div>
             </div>
 
             {detailLoading && vulns.length > 0 && (

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -39,6 +39,11 @@
   --severity-low: #6ba3ff;
   --severity-low-bg: rgba(107, 163, 255, 0.15);
   --severity-low-border: rgba(107, 163, 255, 0.48);
+  /* Unrated — findings whose severity is unknown/unscored (issue #3946). Neutral
+   * grey so it never reads as a severity band but is still visibly counted. */
+  --severity-unrated: #9aa3b8;
+  --severity-unrated-bg: rgba(154, 163, 184, 0.14);
+  --severity-unrated-border: rgba(154, 163, 184, 0.46);
 
   /* Status — success / warn / danger */
   --status-success: #34d399;
@@ -89,6 +94,9 @@
   --severity-low: #2563eb;
   --severity-low-bg: rgba(37, 99, 235, 0.1);
   --severity-low-border: rgba(37, 99, 235, 0.38);
+  --severity-unrated: #64748b;
+  --severity-unrated-bg: rgba(100, 116, 139, 0.1);
+  --severity-unrated-border: rgba(100, 116, 139, 0.36);
 
   --status-success: #059669;
   --status-success-bg: rgba(5, 150, 105, 0.1);

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -403,6 +403,7 @@ export default function Dashboard() {
         severity={severity}
         issueMatrix={issueMatrix}
         domains={overview?.domains ?? null}
+        coverage={overview?.coverage ?? null}
         topPath={topExposurePath}
         exposurePaths={exposurePaths}
         signals={{

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { ArrowRight, ChevronRight } from "lucide-react";
 
 import type { OverviewResponse } from "@/lib/api";
-import type { ServiceEntry, ServiceId } from "@/lib/api-types";
+import type { OverviewCoverageLane, ServiceEntry, ServiceId } from "@/lib/api-types";
 import { Collapsible } from "@/components/collapsible";
 import { FrameworkIcon } from "@/components/framework-icon";
 import type { SeverityCounts } from "@/lib/dashboard-data";
@@ -141,6 +141,9 @@ export interface OverviewCockpitProps {
   /** Severity × issue-type matrix (CVEs, misconfigs, secrets, identity). */
   issueMatrix?: IssueSeverityMatrix | null | undefined;
   domains: OverviewResponse["domains"] | null;
+  /** Five security-posture coverage lanes (CSPM / Vuln / AppSec-SCA / DSPM /
+   *  AISPM) with reconciled, non-overlapping counts (issue #3946). */
+  coverage?: OverviewCoverageLane[] | null | undefined;
   topPath: ExposurePathView | null;
   exposurePaths: ExposurePathView[];
   signals: {
@@ -170,6 +173,7 @@ export function OverviewCockpit({
   severity,
   issueMatrix = null,
   domains,
+  coverage = null,
   topPath,
   exposurePaths,
   compliance = null,
@@ -221,6 +225,10 @@ export function OverviewCockpit({
           {/* 2 — Cross-lane coverage: the single canonical estate view */}
           <CrossLaneCoverage domains={domains} services={services} />
 
+          {/* 2b — Security coverage lanes: the five posture domains 1:1, each
+              with a reconciled severity strip (sum === count, unrated shown). */}
+          <SecurityCoverageLanes coverage={coverage} />
+
           {/* 3 — Compliance: one honest strip, coverage after first scan */}
           <ComplianceSnapshotPanel compliance={compliance} hasScanEvidence={hasScanEvidence} />
         </Collapsible>
@@ -238,6 +246,84 @@ export function OverviewCockpit({
           agentMeshHref={agents != null && agents > 0 ? "/agents/topology" : null}
         />
       </section>
+    </div>
+  );
+}
+
+// Severity bands shown in a coverage lane's strip, in descending order, plus
+// ``unrated`` for findings whose severity is unknown/unscored (issue #3946).
+const COVERAGE_SEVERITY_BANDS: { key: keyof OverviewCoverageLane["severity"]; label: string; token: string }[] = [
+  { key: "critical", label: "Critical", token: "--severity-critical" },
+  { key: "high", label: "High", token: "--severity-high" },
+  { key: "medium", label: "Medium", token: "--severity-medium" },
+  { key: "low", label: "Low", token: "--severity-low" },
+  { key: "unrated", label: "Unrated", token: "--severity-unrated" },
+];
+
+/**
+ * The five security-posture coverage lanes rendered 1:1 (CSPM / Vuln mgmt /
+ * AppSec-SCA / DSPM / AISPM). Each lane's count is the sum of its severity
+ * strip, so the metric can never contradict the strip. An ``unrated`` chip is
+ * surfaced only when unknown-severity findings are present. All colors come from
+ * design tokens (no hardcoded palette) so light + dark both read correctly.
+ */
+function SecurityCoverageLanes({ coverage }: { coverage?: OverviewCoverageLane[] | null | undefined }) {
+  if (!coverage || coverage.length === 0) return null;
+  return (
+    <div className="mt-4" data-testid="overview-security-coverage">
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--text-tertiary)]">Security coverage</h3>
+      <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
+        {coverage.map((lane) => {
+          const total = COVERAGE_SEVERITY_BANDS.reduce((sum, band) => sum + (lane.severity[band.key] || 0), 0);
+          const bands = COVERAGE_SEVERITY_BANDS.filter((band) => (lane.severity[band.key] || 0) > 0);
+          return (
+            <Link
+              key={lane.domain}
+              href={lane.href}
+              data-testid={`coverage-lane-${lane.domain}`}
+              className="flex flex-col gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3 transition-colors hover:border-[color:var(--border-strong)]"
+            >
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="text-xs font-semibold text-[color:var(--foreground)]">{lane.label}</span>
+                <span className="text-lg font-bold tabular-nums text-[color:var(--foreground)]">{lane.count}</span>
+              </div>
+              {/* Stacked severity strip — widths reflect share of the lane count. */}
+              <div className="flex h-1.5 w-full overflow-hidden rounded-full bg-[color:var(--surface-muted)]">
+                {total > 0 &&
+                  bands.map((band) => (
+                    <span
+                      key={band.key}
+                      className="h-full"
+                      style={{
+                        width: `${((lane.severity[band.key] || 0) / total) * 100}%`,
+                        backgroundColor: `var(${band.token})`,
+                      }}
+                    />
+                  ))}
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {total === 0 ? (
+                  <span className="text-[11px] text-[color:var(--text-tertiary)]">No findings</span>
+                ) : (
+                  bands.map((band) => (
+                    <span
+                      key={band.key}
+                      className="rounded px-1.5 py-0.5 text-[11px] font-medium tabular-nums"
+                      style={{
+                        color: `var(${band.token})`,
+                        backgroundColor: `var(${band.token}-bg)`,
+                        border: `1px solid var(${band.token}-border)`,
+                      }}
+                    >
+                      {band.label} {lane.severity[band.key]}
+                    </span>
+                  ))
+                )}
+              </div>
+            </Link>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2290,6 +2290,25 @@ export interface OverviewDomain {
   detail: Record<string, unknown>;
 }
 
+/** Per-domain severity histogram — includes the honest ``unrated`` bucket so
+ * ``sum(values) === count`` for the lane (issue #3946). */
+export interface CoverageSeverity {
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  unrated: number;
+}
+
+/** One security-posture coverage lane (CSPM / Vuln mgmt / AppSec-SCA / DSPM / AISPM). */
+export interface OverviewCoverageLane {
+  domain: "cspm" | "vuln" | "appsec_sca" | "dspm" | "aispm";
+  label: string;
+  href: string;
+  count: number;
+  severity: CoverageSeverity;
+}
+
 export interface OverviewTopRisk {
   vulnerability_id: string;
   package: string | null;
@@ -2313,7 +2332,9 @@ export interface OverviewResponse {
     credential_exposed: number;
     scans: number;
     latest_scan_at: string | null;
+    hub_findings?: number;
   };
+  coverage?: OverviewCoverageLane[];
   domains: {
     cloud: OverviewDomain;
     vuln: OverviewDomain;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -951,6 +951,12 @@ export const api = {
     limit?: number;
     offset?: number;
     approximateTotal?: boolean;
+    // First-class scope + taxonomy filters (issue #3946). All optional +
+    // backward compatible; the server canonicalizes and never rejects them.
+    provider?: string;
+    account?: string;
+    environment?: string;
+    domain?: string;
   }) => {
     const params = new URLSearchParams();
     if (filters?.scanId) params.set("scan_id", filters.scanId);
@@ -959,6 +965,10 @@ export const api = {
     if (filters?.limit != null) params.set("limit", String(filters.limit));
     if (filters?.offset != null) params.set("offset", String(filters.offset));
     if (filters?.approximateTotal) params.set("approximate_total", "true");
+    if (filters?.provider) params.set("provider", filters.provider);
+    if (filters?.account) params.set("account", filters.account);
+    if (filters?.environment) params.set("environment", filters.environment);
+    if (filters?.domain) params.set("domain", filters.domain);
     const qs = params.toString();
     return get<FindingsResponse>(`/v1/findings${qs ? `?${qs}` : ""}`);
   },

--- a/ui/tests/overview-cockpit.test.tsx
+++ b/ui/tests/overview-cockpit.test.tsx
@@ -85,6 +85,26 @@ describe("OverviewCockpit", () => {
     expect(screen.getByText(/5 of 7 lanes reporting/i)).toBeInTheDocument();
   });
 
+  it("renders the five security coverage lanes with reconciled severity strips", () => {
+    const coverage = [
+      { domain: "cspm" as const, label: "CSPM", href: "/findings?domain=cspm", count: 3, severity: { critical: 1, high: 1, medium: 0, low: 0, unrated: 1 } },
+      { domain: "vuln" as const, label: "Vuln mgmt", href: "/findings?domain=vuln", count: 2, severity: { critical: 2, high: 0, medium: 0, low: 0, unrated: 0 } },
+      { domain: "appsec_sca" as const, label: "AppSec / SCA", href: "/findings?domain=appsec_sca", count: 0, severity: { critical: 0, high: 0, medium: 0, low: 0, unrated: 0 } },
+      { domain: "dspm" as const, label: "DSPM", href: "/findings?domain=dspm", count: 0, severity: { critical: 0, high: 0, medium: 0, low: 0, unrated: 0 } },
+      { domain: "aispm" as const, label: "AISPM", href: "/findings?domain=aispm", count: 1, severity: { critical: 0, high: 0, medium: 1, low: 0, unrated: 0 } },
+    ];
+    render(<OverviewCockpit {...baseProps} domains={sampleDomains} coverage={coverage} />);
+
+    const section = screen.getByTestId("overview-security-coverage");
+    expect(section).toBeInTheDocument();
+    // Each lane links to its domain-filtered findings view.
+    expect(screen.getByTestId("coverage-lane-cspm")).toHaveAttribute("href", "/findings?domain=cspm");
+    // Unrated is surfaced as its own chip when present.
+    expect(screen.getByText(/Unrated 1/)).toBeInTheDocument();
+    // Empty lanes still render (DSPM at zero) so the row is always the five domains.
+    expect(screen.getByTestId("coverage-lane-dspm")).toBeInTheDocument();
+  });
+
   it("keeps connected data sources out of leadership lanes and links to connections", () => {
     render(
       <OverviewCockpit


### PR DESCRIPTION
## Summary

Closes #3946 (refs #3931, #3940). Gives the unified `Finding` model first-class **scope** and a derived **security-domain taxonomy**, and makes the overview counts one honest source of truth.

- **Scope on findings + assets** — optional/nullable `provider`, `account_ref` (single normalized string, e.g. `aws:123456789012`), `region`, `environment` on both `Finding` and `Asset`, mirrored between them. Populated at ingest by `cloud_cis_check_to_finding` and `snowflake_governance_finding_to_finding`: account/region parsed from ARNs, account normalized via `normalize_account_ref`. Existing findings serialize unchanged (all default `None`).
- **Taxonomy** — new `src/agent_bom/finding_scope.py` maps every finding to exactly one of `cspm` / `vuln` / `appsec_sca` / `dspm` / `aispm` via a derived `Finding.security_domain`. A *finding* is raw scanner output; an *issue* stays a lightweight display grouping (no new engine).
- **One source of truth for counts** — fixes the "39 CVEs / 0 severities" bug: `_empty_severity()` gains an `unrated` bucket, a single `_bucket()` helper is shared by `_rollup_from_blast_radius` and `_rollup_from_summary`, and `sum(severity.values()) == unique_cves` holds. Overview gains a `coverage` block of the five domain lanes (CIS misconfigs land in **CSPM**, not Vuln/SCA). The posture blurb never asserts "no vulnerabilities" while the counted total > 0.
- **API** — `GET /v1/findings` gains optional `provider`, `account`, `environment`, `domain` filters, canonicalized server-side (never rejected on unknown input); tenant RLS preserved; default pagination path unchanged.
- **UI** — overview renders the five coverage lanes with reconciled severity strips + an `unrated` chip; findings page adds URL-synced domain + cloud-scope (provider → account → environment) facets. New `--severity-unrated` design token (light + dark); no hardcoded palette in the new controls.
- **Contracts/docs** — regenerated OpenAPI; `docs/DATA_MODEL.md` scope + taxonomy section.

### FindingSource / FindingType → domain mapping

| Input | Domain |
|---|---|
| `CLOUD_CIS` (CIS benchmark) | `cspm` |
| `CLOUD_CIS` Snowflake governance (data-access, no benchmark marker) | `dspm` |
| CVE / malicious package / license (any source, incl. MCP-discovered) | `vuln` |
| `SAST`, credential/secret exposure | `appsec_sca` |
| MCP / proxy / skill / prompt / graph + AI-native finding types | `aispm` |

`sum == count` is enforced by deriving the count from the histogram: both rollups increment exactly one bucket per finding (unknown → `unrated`) and set `unique_cves = sum(severity.values())`; per-lane coverage does the same.

## Verification

Python (all green):
```
uv run pytest tests/test_finding.py tests/test_finding_scope.py tests/test_overview.py tests/test_findings_scope_filter.py
uv run pytest tests/ -k "finding or overview or scan_contract or cloud_cis or cis_benchmark or snowflake or compliance_export or sarif or api_surface"   # 1382 passed
uv run mypy src/agent_bom/finding.py src/agent_bom/finding_scope.py src/agent_bom/api/routes/overview.py src/agent_bom/api/routes/scan.py   # clean
uv run ruff check <changed>   # clean
make preflight   # clean (no drift)
```

UI (from `ui/`, all green):
```
npm ci
npm run typecheck
npm run build          # Compiled successfully
npx vitest run tests/overview-cockpit.test.tsx tests/findings-page.test.tsx tests/cockpits.test.tsx tests/coverage-cockpit.test.tsx   # 19 passed
```

New tests: `tests/test_finding_scope.py`, `tests/test_findings_scope_filter.py`, added overview honest-count/coverage cases in `tests/test_overview.py`, and a coverage-lanes case in `ui/tests/overview-cockpit.test.tsx` — each written to fail before the change.

## Notes

- Scope filters on `GET /v1/findings` route through the fully-materialized combined list so `total`/`count` stay honest; the default (no scope filter) keeps the existing keyset fast path byte-for-byte. Deep keyset pagination *combined with* scope filters is intentionally out of scope here (belongs with the pagination consolidation in #3666).
- DSPM currently has one honest source (Snowflake governance); the lane renders at zero otherwise rather than borrowing counts.
- No graph backfill (#3742) or pagination/API-contract consolidation (#3666) touched.