### PR TITLE
Configurable exec risk score + compliance tile honesty

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,8 +53,8 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 256 |
-| `docs/openapi/v1.json` | component schemas | 66 |
+| `docs/openapi/v1.json` | paths | 257 |
+| `docs/openapi/v1.json` | component schemas | 67 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -1440,6 +1440,48 @@
         "title": "ExceptionRequest",
         "type": "object"
       },
+      "ExecScoreConfigUpdateRequest": {
+        "description": "Body for PUT /v1/overview/score-config (issue #3940).\n\nDeliberately lenient: unknown keys are ignored and values are canonicalized\n/ clamped server-side (see ``agent_bom.exec_score.canonicalize_config``) so\nan ad-hoc override never raises \u2014 out-of-range weights are clamped, junk\nkeys dropped, an invalid display format falls back to the default.",
+        "properties": {
+          "display_format": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Format"
+          },
+          "grade_thresholds": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grade Thresholds"
+          },
+          "weights": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weights"
+          }
+        },
+        "title": "ExecScoreConfigUpdateRequest",
+        "type": "object"
+      },
       "FalsePositiveRequest": {
         "additionalProperties": false,
         "description": "Request body for POST /v1/findings/false-positive.",
@@ -18378,6 +18420,255 @@
           }
         },
         "summary": "Get Overview",
+        "tags": [
+          "overview"
+        ]
+      }
+    },
+    "/v1/overview/score-config": {
+      "delete": {
+        "description": "Clear the tenant's exec risk-score overrides (revert to defaults).",
+        "operationId": "reset_overview_score_config_v1_overview_score_config_delete",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Reset Overview Score Config",
+        "tags": [
+          "overview"
+        ]
+      },
+      "get": {
+        "description": "Return the tenant's effective exec risk-score model + display config (#3940).\n\nRead-only view of the documented default weighting model, any tenant\noverrides, the effective weights/thresholds, and the active display format.",
+        "operationId": "get_overview_score_config_v1_overview_score_config_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Overview Score Config V1 Overview Score Config Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Overview Score Config",
+        "tags": [
+          "overview"
+        ]
+      },
+      "put": {
+        "description": "Update the tenant's exec risk-score weights, thresholds, or display format.\n\nAdmin-gated (mutating ``/v1`` verb). The body is canonicalized and clamped\nserver-side \u2014 out-of-range weights are pinned into range, unknown keys are\ndropped, and an invalid display format falls back to the default, so a bad\noverride never raises.",
+        "operationId": "update_overview_score_config_v1_overview_score_config_put",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExecScoreConfigUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Update Overview Score Config V1 Overview Score Config Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Overview Score Config",
         "tags": [
           "overview"
         ]

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -927,6 +927,32 @@ components:
       - package_name
       title: ExceptionRequest
       type: object
+    ExecScoreConfigUpdateRequest:
+      description: "Body for PUT /v1/overview/score-config (issue #3940).\n\nDeliberately\
+        \ lenient: unknown keys are ignored and values are canonicalized\n/ clamped\
+        \ server-side (see ``agent_bom.exec_score.canonicalize_config``) so\nan ad-hoc\
+        \ override never raises \u2014 out-of-range weights are clamped, junk\nkeys\
+        \ dropped, an invalid display format falls back to the default."
+      properties:
+        display_format:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Display Format
+        grade_thresholds:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Grade Thresholds
+        weights:
+          anyOf:
+          - additionalProperties: true
+            type: object
+          - type: 'null'
+          title: Weights
+      title: ExecScoreConfigUpdateRequest
+      type: object
     FalsePositiveRequest:
       additionalProperties: false
       description: Request body for POST /v1/findings/false-positive.
@@ -11945,6 +11971,157 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Get Overview
+      tags:
+      - overview
+  /v1/overview/score-config:
+    delete:
+      description: Clear the tenant's exec risk-score overrides (revert to defaults).
+      operationId: reset_overview_score_config_v1_overview_score_config_delete
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Reset Overview Score Config
+      tags:
+      - overview
+    get:
+      description: 'Return the tenant''s effective exec risk-score model + display
+        config (#3940).
+
+
+        Read-only view of the documented default weighting model, any tenant
+
+        overrides, the effective weights/thresholds, and the active display format.'
+      operationId: get_overview_score_config_v1_overview_score_config_get
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Overview Score Config V1 Overview Score Config
+                  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Overview Score Config
+      tags:
+      - overview
+    put:
+      description: "Update the tenant's exec risk-score weights, thresholds, or display\
+        \ format.\n\nAdmin-gated (mutating ``/v1`` verb). The body is canonicalized\
+        \ and clamped\nserver-side \u2014 out-of-range weights are pinned into range,\
+        \ unknown keys are\ndropped, and an invalid display format falls back to the\
+        \ default, so a bad\noverride never raises."
+      operationId: update_overview_score_config_v1_overview_score_config_put
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExecScoreConfigUpdateRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Update Overview Score Config V1 Overview Score Config
+                  Put
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Update Overview Score Config
       tags:
       - overview
   /v1/plugins/status:

--- a/docs/schemas/v1/ExecScoreConfigUpdateRequest.json
+++ b/docs/schemas/v1/ExecScoreConfigUpdateRequest.json
@@ -1,0 +1,45 @@
+{
+  "description": "Body for PUT /v1/overview/score-config (issue #3940).\n\nDeliberately lenient: unknown keys are ignored and values are canonicalized\n/ clamped server-side (see ``agent_bom.exec_score.canonicalize_config``) so\nan ad-hoc override never raises \u2014 out-of-range weights are clamped, junk\nkeys dropped, an invalid display format falls back to the default.",
+  "properties": {
+    "display_format": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Display Format"
+    },
+    "grade_thresholds": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Grade Thresholds"
+    },
+    "weights": {
+      "anyOf": [
+        {
+          "additionalProperties": true,
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Weights"
+    }
+  },
+  "title": "ExecScoreConfigUpdateRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/index.json
+++ b/docs/schemas/v1/index.json
@@ -87,6 +87,11 @@
       "schema": "ExceptionRequest.json"
     },
     {
+      "doc": "Body for PUT /v1/overview/score-config (issue #3940).",
+      "name": "ExecScoreConfigUpdateRequest",
+      "schema": "ExecScoreConfigUpdateRequest.json"
+    },
+    {
       "doc": "Request body for POST /v1/findings/false-positive.",
       "name": "FalsePositiveRequest",
       "schema": "FalsePositiveRequest.json"

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -434,6 +434,11 @@ AGENT_BOM_FINDINGS_COUNT_CACHE_TTL_SECONDS
 AGENT_BOM_POSTURE_POLICY
 AGENT_BOM_POSTURE_POLICY_FILE
 
+# Dynamic exec risk-score policy inputs read at runtime by exec_score.py (#3940);
+# JSON weighting model / grade thresholds, not scalar config knobs.
+AGENT_BOM_EXEC_SCORE_POLICY
+AGENT_BOM_EXEC_SCORE_POLICY_FILE
+
 # File-only Postgres credential consumed by postgres_common.py. The value is a
 # mounted secret path, not a scalar application setting for config.py.
 AGENT_BOM_POSTGRES_PASSWORD_FILE

--- a/src/agent_bom/api/exec_score_config.py
+++ b/src/agent_bom/api/exec_score_config.py
@@ -1,0 +1,112 @@
+"""Per-tenant executive risk-score config helpers (#3940).
+
+Thin persistence facade over :func:`agent_bom.api.stores._get_tenant_score_config_store`
+that mirrors ``tenant_quota``: read the persisted (partial) override, merge it
+onto process defaults + env policy, and expose an operator-facing runtime view.
+Every write is canonicalized/clamped by :mod:`agent_bom.exec_score` first, so
+the store never holds invalid weights or thresholds.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from agent_bom.api.stores import _get_tenant_score_config_store
+from agent_bom.exec_score import (
+    DEFAULT_DISPLAY_FORMAT,
+    DEFAULT_EXEC_SCORE_WEIGHTS,
+    DEFAULT_GRADE_THRESHOLDS,
+    DISPLAY_FORMATS,
+    DRIVER_LABELS,
+    DRIVER_ORDER,
+    ExecScoreConfig,
+    canonicalize_config,
+    load_exec_score_config,
+)
+
+
+def get_exec_score_overrides(tenant_id: str) -> dict[str, Any]:
+    """Return the persisted (canonicalized) override for a tenant, or ``{}``."""
+    raw = _get_tenant_score_config_store().get(tenant_id)
+    if not isinstance(raw, dict) or not raw:
+        return {}
+    return canonicalize_config(raw)
+
+
+def resolve_exec_score_config(tenant_id: str) -> ExecScoreConfig:
+    """Resolve the effective config (defaults < env < persisted override)."""
+    overrides = _get_tenant_score_config_store().get(tenant_id)
+    return load_exec_score_config(overrides if isinstance(overrides, dict) else None)
+
+
+def set_exec_score_config(tenant_id: str, updates: Mapping[str, Any]) -> dict[str, Any]:
+    """Merge + canonicalize an override update and persist it.
+
+    Never raises on bad input — :func:`canonicalize_config` clamps/normalizes.
+    Only the fields present in ``updates`` change; the rest of the existing
+    override is preserved.
+    """
+    current = _get_tenant_score_config_store().get(tenant_id)
+    merged: dict[str, Any] = dict(current) if isinstance(current, dict) else {}
+    if isinstance(updates.get("weights"), Mapping):
+        base_weights = dict(merged.get("weights") or {}) if isinstance(merged.get("weights"), Mapping) else {}
+        base_weights.update(updates["weights"])
+        merged["weights"] = base_weights
+    thresholds = updates.get("grade_thresholds") or updates.get("thresholds")
+    if isinstance(thresholds, Mapping):
+        base_thresholds = dict(merged.get("grade_thresholds") or {}) if isinstance(merged.get("grade_thresholds"), Mapping) else {}
+        base_thresholds.update(thresholds)
+        merged["grade_thresholds"] = base_thresholds
+    if updates.get("display_format") is not None:
+        merged["display_format"] = updates["display_format"]
+
+    canonical = canonicalize_config(merged)
+    _get_tenant_score_config_store().put(tenant_id, canonical)
+    return canonical
+
+
+def clear_exec_score_config(tenant_id: str) -> bool:
+    """Remove a tenant's exec-score overrides (revert to defaults)."""
+    return _get_tenant_score_config_store().delete(tenant_id)
+
+
+def exec_score_config_runtime(tenant_id: str) -> dict[str, Any]:
+    """Operator-facing config surface: defaults, overrides, and effective config."""
+    overrides = get_exec_score_overrides(tenant_id)
+    effective = resolve_exec_score_config(tenant_id)
+    drivers = [
+        {
+            "driver": driver,
+            "label": DRIVER_LABELS[driver],
+            "default_weight": DEFAULT_EXEC_SCORE_WEIGHTS[driver],
+            "weight": float(effective.weights.get(driver, DEFAULT_EXEC_SCORE_WEIGHTS[driver])),
+            "overridden": bool(overrides.get("weights", {}).get(driver) is not None)
+            if isinstance(overrides.get("weights"), dict)
+            else False,
+        }
+        for driver in DRIVER_ORDER
+    ]
+    return {
+        "active_override": bool(overrides),
+        "source": effective.source,
+        "override_endpoint": "/v1/overview/score-config",
+        "display_format": effective.display_format,
+        "display_formats": list(DISPLAY_FORMATS),
+        "weights": dict(effective.weights),
+        "grade_thresholds": dict(effective.grade_thresholds),
+        "drivers": drivers,
+        "defaults": {
+            "weights": dict(DEFAULT_EXEC_SCORE_WEIGHTS),
+            "grade_thresholds": dict(DEFAULT_GRADE_THRESHOLDS),
+            "display_format": DEFAULT_DISPLAY_FORMAT,
+        },
+        "overrides": overrides,
+        "message": (
+            "Exec risk-score model resolves from tenant overrides layered on the documented defaults."
+            if overrides
+            else (
+                "Exec risk-score model resolves from the documented defaults. "
+                "Customize weights, grade thresholds, or display format per tenant."
+            )
+        ),
+    }

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -774,6 +774,21 @@ class TenantQuotaUpdateRequest(BaseModel):
     schedules: int | None = Field(default=None, ge=0)
 
 
+class ExecScoreConfigUpdateRequest(BaseModel):
+    """Body for PUT /v1/overview/score-config (issue #3940).
+
+    Deliberately lenient: unknown keys are ignored and values are canonicalized
+    / clamped server-side (see ``agent_bom.exec_score.canonicalize_config``) so
+    an ad-hoc override never raises — out-of-range weights are clamped, junk
+    keys dropped, an invalid display format falls back to the default.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+    weights: dict[str, Any] | None = None
+    grade_thresholds: dict[str, Any] | None = None
+    display_format: str | None = None
+
+
 class ExceptionRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
     vuln_id: str

--- a/src/agent_bom/api/postgres_tenant_score_config.py
+++ b/src/agent_bom/api/postgres_tenant_score_config.py
@@ -1,0 +1,68 @@
+"""Postgres-backed per-tenant exec-score config overrides (#3940)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
+
+
+class PostgresTenantScoreConfigStore:
+    """Persistent tenant exec-score config overrides with tenant-aware access."""
+
+    def __init__(self, pool: ConnectionPool | None = None) -> None:
+        self._pool = pool or _get_pool()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "tenant_score_config")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tenant_score_config_overrides (
+                    tenant_id TEXT PRIMARY KEY,
+                    updated_at TEXT NOT NULL DEFAULT to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+                    data TEXT NOT NULL
+                )
+                """
+            )
+            _ensure_tenant_rls(conn, "tenant_score_config_overrides", "tenant_id")
+            conn.commit()
+
+    def get(self, tenant_id: str) -> dict[str, Any] | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT data FROM tenant_score_config_overrides WHERE tenant_id = %s",
+                (tenant_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            loaded = json.loads(row[0])
+            return loaded if isinstance(loaded, dict) else None
+
+    def put(self, tenant_id: str, config: Mapping[str, Any]) -> None:
+        payload = json.dumps(dict(config), sort_keys=True)
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                """
+                INSERT INTO tenant_score_config_overrides (tenant_id, data)
+                VALUES (%s, %s)
+                ON CONFLICT (tenant_id) DO UPDATE SET
+                    updated_at = to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
+                    data = EXCLUDED.data
+                """,
+                (tenant_id, payload),
+            )
+            conn.commit()
+
+    def delete(self, tenant_id: str) -> bool:
+        with _tenant_connection(self._pool) as conn:
+            cursor = conn.execute(
+                "DELETE FROM tenant_score_config_overrides WHERE tenant_id = %s",
+                (tenant_id,),
+            )
+            conn.commit()
+            return bool(cursor.rowcount > 0)

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -29,9 +29,10 @@ from urllib.parse import urlencode
 
 from fastapi import APIRouter, Request
 
-from agent_bom.api.models import JobStatus
+from agent_bom.api.models import ExecScoreConfigUpdateRequest, JobStatus
 from agent_bom.api.stores import _get_fleet_store, _get_store
 from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.exec_score import compute_exec_score
 from agent_bom.rbac import require_authenticated_permission
 
 router = APIRouter(dependencies=[cast(Any, require_authenticated_permission("read"))])
@@ -462,59 +463,56 @@ def _hub_severity_snapshot(request: Request) -> dict[str, int]:
     return empty
 
 
-def _blend_posture_with_hub(
-    posture: dict[str, Any],
-    scan_severity: dict[str, int],
+def _combined_severity(scan_severity: dict[str, int], hub_severity: dict[str, int]) -> dict[str, int]:
+    """Merge scan + hub-ingested severity into the five reconciled buckets.
+
+    The hub histogram carries ``info``/``unknown`` bands the exec-score model
+    doesn't rate — they fold into ``unrated`` so nothing is dropped and the
+    merged buckets still sum to the true counted total (the same invariant PR1's
+    coverage lanes hold).
+    """
+    merged = {key: int(scan_severity.get(key, 0) or 0) for key in _ALL_SEVERITY_KEYS}
+    for band in ("critical", "high", "medium", "low"):
+        merged[band] += int(hub_severity.get(band, 0) or 0)
+    merged[_UNRATED_KEY] += int(hub_severity.get("info", 0) or 0) + int(hub_severity.get("unknown", 0) or 0)
+    return merged
+
+
+def _exec_posture(
+    request: Request,
+    scan_posture: dict[str, Any],
+    scan: dict[str, Any],
     hub_severity: dict[str, int],
 ) -> dict[str, Any]:
-    """Fold hub-ingested findings into the scan posture grade.
+    """Compute the configurable exec risk score from the honest estate counts.
 
-    With no hub findings the scan posture is returned unchanged (the demo estate
-    and every scan-only tenant keep their existing grade). When findings have
-    been bulk-ingested, a combined penalty score is derived from scan + hub
-    severity and the grade can only move *down* (``min`` of the two scores), so
-    ingested evidence never launders a failing posture into a passing one.
+    The grade derives from the same reconciled severity buckets, KEV, and
+    credential/blast-radius exposure the overview already exposes — so it can
+    never contradict them (a non-zero counted total always carries penalty). An
+    authoritative scan scorecard is passed as a *floor*: the final score is the
+    worst of the count-derived score and that scorecard, so ingested/benign
+    evidence can only move the grade down, never launder a failing posture up.
+    Reads the tenant's persisted score-config (defaults < env < tenant override).
     """
-    hub_total = sum(int(hub_severity.get(k, 0) or 0) for k in _HUB_SEVERITY_KEYS)
-    scan_total = sum(int(v) for v in scan_severity.values())
-    posture_is_na = posture.get("grade") in (None, "N/A")
+    from agent_bom.api.exec_score_config import resolve_exec_score_config
 
-    # An existing scorecard/summary posture stays authoritative unless ingested
-    # evidence adds to it — never recompute a graded scan from severity counts
-    # (that would double-penalize and drift the published grade). Only synthesize
-    # a grade from counts when the posture is N/A but findings exist, so the
-    # blurb can never claim "no vulnerabilities" while the counted total > 0.
-    if hub_total <= 0 and not posture_is_na:
-        return posture
-    if hub_total <= 0 and scan_total <= 0:
-        return posture
-
-    from agent_bom.posture import _score_to_grade
-
-    combined_critical = int(scan_severity["critical"]) + int(hub_severity.get("critical", 0) or 0)
-    combined_high = int(scan_severity["high"]) + int(hub_severity.get("high", 0) or 0)
-    combined_total = scan_total + hub_total
-    penalty = min(
-        100.0,
-        combined_critical * 12.0 + combined_high * 6.0 + max(0, combined_total - combined_critical - combined_high) * 1.5,
+    combined = _combined_severity(scan["severity"], hub_severity)
+    floor: float | None = None
+    if scan_posture.get("grade") not in (None, "N/A"):
+        floor = float(scan_posture.get("score") or 0.0)
+    config = resolve_exec_score_config(_tenant_id(request))
+    return compute_exec_score(
+        severity=combined,
+        kev=int(scan.get("kev", 0) or 0),
+        exposure=int(scan.get("credential_exposed", 0) or 0),
+        # Live compliance-failing count is a follow-up (#3940 notes) — wiring the
+        # full compliance aggregation into this hot exec endpoint is deferred so
+        # the snapshot stays cheap; the driver + weight ship ready in the model.
+        compliance_failing=0,
+        config=config,
+        floor_score=floor,
+        floor_summary=str(scan_posture.get("summary") or "") or None,
     )
-    combined_score = max(0.0, round(100.0 - penalty, 1))
-
-    if posture_is_na:
-        final_score = combined_score
-    else:
-        final_score = min(float(posture.get("score") or 0.0), combined_score)
-
-    if hub_total > 0:
-        summary = f"{combined_total} finding(s) across scans + ingested evidence"
-    else:
-        summary = f"{combined_total} finding(s) from completed scans"
-
-    return {
-        "grade": _score_to_grade(final_score),
-        "score": final_score,
-        "summary": summary,
-    }
 
 
 def _cloud_account_count(request: Request) -> int:
@@ -561,7 +559,7 @@ async def get_overview(request: Request) -> dict[str, Any]:
     scan = _scan_rollup(jobs)
     coverage = _domain_rollup(jobs)
     hub_severity = _hub_severity_snapshot(request)
-    posture = _blend_posture_with_hub(_posture_snapshot(jobs), scan["severity"], hub_severity)
+    posture = _exec_posture(request, _posture_snapshot(jobs), scan, hub_severity)
     runtime = _runtime_snapshot(request, jobs)
     cost = _cost_snapshot(request)
     identity = _identity_snapshot(request)
@@ -672,6 +670,68 @@ async def get_overview(request: Request) -> dict[str, Any]:
         "coverage": coverage,
         "top_risks": scan["top_risks"],
     }
+
+
+@router.get("/overview/score-config", tags=["overview"])
+async def get_overview_score_config(request: Request) -> dict[str, Any]:
+    """Return the tenant's effective exec risk-score model + display config (#3940).
+
+    Read-only view of the documented default weighting model, any tenant
+    overrides, the effective weights/thresholds, and the active display format.
+    """
+    from agent_bom.api.exec_score_config import exec_score_config_runtime
+
+    return exec_score_config_runtime(_tenant_id(request))
+
+
+@router.put("/overview/score-config", tags=["overview"])
+async def update_overview_score_config(request: Request, req: ExecScoreConfigUpdateRequest) -> dict[str, Any]:
+    """Update the tenant's exec risk-score weights, thresholds, or display format.
+
+    Admin-gated (mutating ``/v1`` verb). The body is canonicalized and clamped
+    server-side — out-of-range weights are pinned into range, unknown keys are
+    dropped, and an invalid display format falls back to the default, so a bad
+    override never raises.
+    """
+    from agent_bom.api.audit_log import log_action
+    from agent_bom.api.exec_score_config import exec_score_config_runtime, set_exec_score_config
+
+    tenant_id = _tenant_id(request)
+    updates = req.model_dump(exclude_none=True)
+    if not updates:
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=400, detail="Provide at least one of weights, grade_thresholds, or display_format.")
+
+    actor = getattr(request.state, "api_key_name", "") or "system"
+    canonical = set_exec_score_config(tenant_id, updates)
+    log_action(
+        "overview.score_config_updated",
+        actor=actor,
+        resource=f"tenant/{tenant_id}",
+        tenant_id=tenant_id,
+        updated_fields=sorted(updates),
+        display_format=canonical.get("display_format"),
+    )
+    return exec_score_config_runtime(tenant_id)
+
+
+@router.delete("/overview/score-config", tags=["overview"], status_code=204)
+async def reset_overview_score_config(request: Request) -> None:
+    """Clear the tenant's exec risk-score overrides (revert to defaults)."""
+    from agent_bom.api.audit_log import log_action
+    from agent_bom.api.exec_score_config import clear_exec_score_config
+
+    tenant_id = _tenant_id(request)
+    actor = getattr(request.state, "api_key_name", "") or "system"
+    cleared = clear_exec_score_config(tenant_id)
+    if cleared:
+        log_action(
+            "overview.score_config_reset",
+            actor=actor,
+            resource=f"tenant/{tenant_id}",
+            tenant_id=tenant_id,
+        )
 
 
 def _status_for(critical: int, high: int) -> str:

--- a/src/agent_bom/api/stores.py
+++ b/src/agent_bom/api/stores.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from agent_bom.api.source_store import SourceStore
     from agent_bom.api.tenant_graph_retention_store import TenantGraphRetentionStore
     from agent_bom.api.tenant_quota_store import TenantQuotaStore
+    from agent_bom.api.tenant_score_config_store import TenantScoreConfigStore
 
 # ── Shared lock (protects lazy init of all stores) ───────────────────────────
 _store_lock = threading.Lock()
@@ -324,6 +325,37 @@ def set_tenant_graph_retention_store(store: TenantGraphRetentionStore) -> None:
     """Switch the tenant graph retention override store backend."""
     global _tenant_graph_retention_store
     _tenant_graph_retention_store = store
+
+
+# ─── Tenant exec-score config override store (pluggable) ───────────────────
+_tenant_score_config_store: TenantScoreConfigStore | None = None
+
+
+def _get_tenant_score_config_store() -> TenantScoreConfigStore:
+    """Get the active per-tenant exec-score config override store (#3940)."""
+    global _tenant_score_config_store
+    if _tenant_score_config_store is None:
+        with _store_lock:
+            if _tenant_score_config_store is None:
+                if os.environ.get("AGENT_BOM_POSTGRES_URL"):
+                    from agent_bom.api.postgres_tenant_score_config import PostgresTenantScoreConfigStore
+
+                    _tenant_score_config_store = PostgresTenantScoreConfigStore()
+                elif os.environ.get("AGENT_BOM_DB"):
+                    from agent_bom.api.tenant_score_config_store import SQLiteTenantScoreConfigStore
+
+                    _tenant_score_config_store = SQLiteTenantScoreConfigStore(os.environ["AGENT_BOM_DB"])
+                else:
+                    from agent_bom.api.tenant_score_config_store import InMemoryTenantScoreConfigStore
+
+                    _tenant_score_config_store = InMemoryTenantScoreConfigStore()
+    return _tenant_score_config_store
+
+
+def set_tenant_score_config_store(store: TenantScoreConfigStore) -> None:
+    """Switch the tenant exec-score config override store backend."""
+    global _tenant_score_config_store
+    _tenant_score_config_store = store
 
 
 # ─── SCIM lifecycle store (enterprise identity) ────────────────────────────

--- a/src/agent_bom/api/tenant_score_config_store.py
+++ b/src/agent_bom/api/tenant_score_config_store.py
@@ -1,0 +1,101 @@
+"""Store backends for per-tenant executive risk-score config overrides (#3940).
+
+Mirrors the ``tenant_graph_retention`` / ``tenant_quota`` override stores: a
+per-tenant JSON blob holding the (partial) exec-score config a tenant admin has
+customized. In-memory for tests, SQLite for single-node durability, Postgres for
+multi-replica with tenant RLS (see ``postgres_tenant_score_config``).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
+
+class TenantScoreConfigStore(Protocol):
+    """Protocol for per-tenant exec-score config override persistence."""
+
+    def get(self, tenant_id: str) -> dict[str, Any] | None: ...
+    def put(self, tenant_id: str, config: Mapping[str, Any]) -> None: ...
+    def delete(self, tenant_id: str) -> bool: ...
+
+
+class InMemoryTenantScoreConfigStore:
+    """Process-local exec-score config store for development and tests."""
+
+    def __init__(self) -> None:
+        self._configs: dict[str, dict[str, Any]] = {}
+
+    def get(self, tenant_id: str) -> dict[str, Any] | None:
+        record = self._configs.get(tenant_id)
+        return json.loads(json.dumps(record)) if record is not None else None
+
+    def put(self, tenant_id: str, config: Mapping[str, Any]) -> None:
+        self._configs[tenant_id] = json.loads(json.dumps(dict(config)))
+
+    def delete(self, tenant_id: str) -> bool:
+        return self._configs.pop(tenant_id, None) is not None
+
+
+class SQLiteTenantScoreConfigStore:
+    """SQLite-backed exec-score config override store."""
+
+    def __init__(self, db_path: str = "agent_bom.db") -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        conn: sqlite3.Connection = self._local.conn
+        return conn
+
+    def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "tenant_score_config")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS tenant_score_config_overrides (
+                tenant_id TEXT PRIMARY KEY,
+                updated_at TEXT NOT NULL DEFAULT '',
+                data TEXT NOT NULL
+            )
+            """
+        )
+        self._conn.commit()
+
+    def get(self, tenant_id: str) -> dict[str, Any] | None:
+        row = self._conn.execute(
+            "SELECT data FROM tenant_score_config_overrides WHERE tenant_id = ?",
+            (tenant_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        loaded = json.loads(row[0])
+        return loaded if isinstance(loaded, dict) else None
+
+    def put(self, tenant_id: str, config: Mapping[str, Any]) -> None:
+        payload = json.dumps(dict(config), sort_keys=True)
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO tenant_score_config_overrides (tenant_id, updated_at, data)
+            VALUES (?, datetime('now'), ?)
+            """,
+            (tenant_id, payload),
+        )
+        self._conn.commit()
+
+    def delete(self, tenant_id: str) -> bool:
+        cursor = self._conn.execute(
+            "DELETE FROM tenant_score_config_overrides WHERE tenant_id = ?",
+            (tenant_id,),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0

--- a/src/agent_bom/exec_score.py
+++ b/src/agent_bom/exec_score.py
@@ -1,0 +1,415 @@
+"""Configurable executive risk-score engine (issue #3940).
+
+The overview "risk posture" grade was historically a fixed, opaque number. This
+module makes it **configurable and honest**: the score is a documented,
+weighted penalty model over the *same honest counts* the overview already
+reconciles (severity buckets whose sum equals the counted total, KEV,
+credential/blast-radius exposure, compliance, and the ``unrated`` bucket added
+in the findings-taxonomy work). Because every input is one of those counts, the
+grade can never contradict them — a non-zero counted total always carries a
+non-zero penalty, so the estate can't read as a clean "A / no vulnerabilities"
+while findings are open.
+
+Model shape (all penalty POINTS per unit of the driver's count, not fractions —
+this keeps each contribution legible: "3 critical × 12 = 36 points off"):
+
+    critical    12   high        6    medium      2    low        0.5
+    unrated      1   kev         8    exposure    5    compliance 6
+
+``score = clamp(0, 100, 100 - min(100, Σ weight[d] × count[d]))`` and the letter
+grade comes from configurable thresholds (default A≥90, B≥80, C≥70, D≥60).
+
+Adopters are not locked onto the defaults. Weights, grade thresholds, and the
+display format (``grade`` / ``percent`` / ``points``) can be overridden per
+tenant (persisted via :mod:`agent_bom.api.exec_score_config`) or process-wide
+via ``AGENT_BOM_EXEC_SCORE_POLICY`` (inline JSON) / ``…_POLICY_FILE`` (path).
+Every override path is canonicalized and clamped — bad input never raises, it is
+normalized back into range.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+# ── Default weighted inputs ───────────────────────────────────────────────────
+# Penalty points removed from a perfect 100 per unit of each honest count. The
+# critical/high weights match the existing overview blend (critical×12, high×6)
+# so the configurable grade reconciles with the number the overview showed
+# before this engine landed.
+DEFAULT_EXEC_SCORE_WEIGHTS: dict[str, float] = {
+    "critical": 12.0,
+    "high": 6.0,
+    "medium": 2.0,
+    "low": 0.5,
+    "unrated": 1.0,
+    "kev": 8.0,
+    "exposure": 5.0,
+    "compliance": 6.0,
+}
+
+# Human-facing labels + one-line meaning for each driver (drives the UI
+# "what influences this score" breakdown).
+DRIVER_LABELS: dict[str, str] = {
+    "critical": "Critical findings",
+    "high": "High findings",
+    "medium": "Medium findings",
+    "low": "Low findings",
+    "unrated": "Unrated findings",
+    "kev": "Known-exploited (KEV)",
+    "exposure": "Credential / blast-radius exposure",
+    "compliance": "Failing compliance frameworks",
+}
+
+# Display order for the breakdown (severity bands first, then amplifiers).
+DRIVER_ORDER: tuple[str, ...] = (
+    "critical",
+    "high",
+    "medium",
+    "low",
+    "unrated",
+    "kev",
+    "exposure",
+    "compliance",
+)
+
+# Minimum score (inclusive) for each letter grade; anything below D is F.
+DEFAULT_GRADE_THRESHOLDS: dict[str, float] = {
+    "A": 90.0,
+    "B": 80.0,
+    "C": 70.0,
+    "D": 60.0,
+}
+
+DISPLAY_FORMATS: tuple[str, ...] = ("grade", "percent", "points")
+DEFAULT_DISPLAY_FORMAT = "percent"
+
+# A single driver weight is clamped into this range so a hostile / fat-fingered
+# override can neither invert the score (negative) nor overflow it.
+_MAX_WEIGHT = 100.0
+# Total penalty is capped so the score floors cleanly at 0 (grade F) instead of
+# going negative.
+_MAX_PENALTY = 100.0
+
+
+@dataclass(frozen=True)
+class ExecScoreConfig:
+    """Resolved exec-score policy (defaults + optional adopter overrides)."""
+
+    weights: Mapping[str, float]
+    grade_thresholds: Mapping[str, float]
+    display_format: str = DEFAULT_DISPLAY_FORMAT
+    source: str = "default"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "weights": dict(self.weights),
+            "grade_thresholds": dict(self.grade_thresholds),
+            "display_format": self.display_format,
+            "source": self.source,
+        }
+
+
+def _coerce_float(value: object) -> float | None:
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def canonicalize_weights(weights: Mapping[str, Any] | None) -> dict[str, float]:
+    """Merge caller weights onto defaults, clamped to ``[0, _MAX_WEIGHT]``.
+
+    Unknown keys are ignored and unparseable / out-of-range values fall back to
+    the clamped bound rather than raising, so this never rejects input.
+    """
+    merged = dict(DEFAULT_EXEC_SCORE_WEIGHTS)
+    if weights:
+        for key, raw in weights.items():
+            if key not in merged:
+                continue
+            parsed = _coerce_float(raw)
+            if parsed is None:
+                continue
+            merged[key] = round(max(0.0, min(_MAX_WEIGHT, parsed)), 4)
+    return merged
+
+
+def canonicalize_thresholds(thresholds: Mapping[str, Any] | None) -> dict[str, float]:
+    """Merge caller thresholds onto defaults and keep A≥B≥C≥D, clamped 0–100."""
+    merged = dict(DEFAULT_GRADE_THRESHOLDS)
+    if thresholds:
+        for key, raw in thresholds.items():
+            letter = str(key).upper()
+            if letter not in merged:
+                continue
+            parsed = _coerce_float(raw)
+            if parsed is None:
+                continue
+            merged[letter] = max(0.0, min(100.0, parsed))
+    # Enforce monotonic ordering A≥B≥C≥D so grade bands never cross.
+    ordered_letters = ("A", "B", "C", "D")
+    ceiling = 100.0
+    for letter in ordered_letters:
+        merged[letter] = min(merged[letter], ceiling)
+        ceiling = merged[letter]
+    return merged
+
+
+def canonicalize_display_format(value: object) -> str:
+    fmt = str(value or "").strip().lower()
+    return fmt if fmt in DISPLAY_FORMATS else DEFAULT_DISPLAY_FORMAT
+
+
+def canonicalize_config(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Canonicalize an arbitrary override payload into a persistable config dict.
+
+    Always returns a full, valid config (never raises). Only fields present in
+    ``payload`` override the defaults; the rest fall through to defaults.
+    """
+    payload = payload or {}
+    return {
+        "weights": canonicalize_weights(payload.get("weights") if isinstance(payload.get("weights"), Mapping) else None),
+        "grade_thresholds": canonicalize_thresholds(
+            payload.get("grade_thresholds")
+            if isinstance(payload.get("grade_thresholds"), Mapping)
+            else (payload.get("thresholds") if isinstance(payload.get("thresholds"), Mapping) else None)
+        ),
+        "display_format": canonicalize_display_format(payload.get("display_format")),
+    }
+
+
+def _env_payload() -> tuple[dict[str, Any] | None, str]:
+    raw = os.environ.get("AGENT_BOM_EXEC_SCORE_POLICY", "").strip()
+    file_path = os.environ.get("AGENT_BOM_EXEC_SCORE_POLICY_FILE", "").strip()
+    if raw:
+        try:
+            loaded = json.loads(raw)
+            if isinstance(loaded, dict):
+                return loaded, "env:AGENT_BOM_EXEC_SCORE_POLICY"
+        except json.JSONDecodeError:
+            return None, "default"
+    elif file_path:
+        try:
+            loaded = json.loads(Path(file_path).read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                return loaded, f"file:{file_path}"
+        except (OSError, json.JSONDecodeError):
+            return None, "default"
+    return None, "default"
+
+
+def load_exec_score_config(overrides: Mapping[str, Any] | None = None) -> ExecScoreConfig:
+    """Resolve config as defaults < env policy < tenant ``overrides``.
+
+    ``overrides`` is a (possibly partial) persisted tenant config. Any layer may
+    supply any subset of ``weights`` / ``grade_thresholds`` / ``display_format``;
+    later layers win field-by-field. The result is always canonical.
+    """
+    weights: dict[str, Any] = {}
+    thresholds: dict[str, Any] = {}
+    display_format: object = None
+    source = "default"
+
+    env_payload, env_source = _env_payload()
+    if env_payload:
+        source = env_source
+        if isinstance(env_payload.get("weights"), Mapping):
+            weights.update(env_payload["weights"])
+        env_thresholds = env_payload.get("grade_thresholds") or env_payload.get("thresholds")
+        if isinstance(env_thresholds, Mapping):
+            thresholds.update(env_thresholds)
+        if env_payload.get("display_format") is not None:
+            display_format = env_payload["display_format"]
+
+    if overrides:
+        source = "tenant_override" if source == "default" else f"{source}+tenant_override"
+        if isinstance(overrides.get("weights"), Mapping):
+            weights.update(overrides["weights"])
+        ov_thresholds = overrides.get("grade_thresholds") or overrides.get("thresholds")
+        if isinstance(ov_thresholds, Mapping):
+            thresholds.update(ov_thresholds)
+        if overrides.get("display_format") is not None:
+            display_format = overrides["display_format"]
+
+    return ExecScoreConfig(
+        weights=canonicalize_weights(weights or None),
+        grade_thresholds=canonicalize_thresholds(thresholds or None),
+        display_format=canonicalize_display_format(display_format),
+        source=source,
+    )
+
+
+def score_to_grade(score: float, thresholds: Mapping[str, float] | None = None) -> str:
+    bands = thresholds or DEFAULT_GRADE_THRESHOLDS
+    if score >= float(bands.get("A", 90)):
+        return "A"
+    if score >= float(bands.get("B", 80)):
+        return "B"
+    if score >= float(bands.get("C", 70)):
+        return "C"
+    if score >= float(bands.get("D", 60)):
+        return "D"
+    return "F"
+
+
+def _format_display(score: float, grade: str, display_format: str) -> str:
+    rounded = int(round(score))
+    if display_format == "grade":
+        return f"Grade {grade}"
+    if display_format == "points":
+        return f"{rounded} / 100"
+    return f"{rounded}%"
+
+
+def compute_exec_score(
+    *,
+    severity: Mapping[str, int],
+    kev: int = 0,
+    exposure: int = 0,
+    compliance_failing: int = 0,
+    config: ExecScoreConfig | None = None,
+    floor_score: float | None = None,
+    floor_summary: str | None = None,
+) -> dict[str, Any]:
+    """Compute the configurable exec risk score from honest estate counts.
+
+    Args:
+        severity: histogram with ``critical/high/medium/low/unrated`` counts
+            (the same reconciled buckets the overview exposes; sum == total).
+        kev: number of known-exploited findings (amplifier).
+        exposure: number of findings touching exposed credentials / secrets.
+        compliance_failing: number of failing compliance frameworks.
+        config: resolved :class:`ExecScoreConfig` (defaults when omitted).
+        floor_score: an authoritative scan scorecard score, if any. The final
+            score is the *worst* (``min``) of the count-derived score and this
+            floor, so an existing failing scorecard can never be laundered
+            upward by a benign count and ingested evidence only moves down.
+        floor_summary: the scan scorecard's own summary (used only when there
+            are zero open findings so the blurb explains what graded the estate).
+
+    Returns a JSON-friendly dict with ``grade``, ``score``, ``points``,
+    ``percent``, ``display``/``display_format``, per-driver ``breakdown``,
+    ``penalty_total``, ``summary``, and the active ``weights``/``thresholds``.
+    """
+    cfg = config or load_exec_score_config()
+    weights = cfg.weights
+
+    counts: dict[str, int] = {
+        "critical": max(0, int(severity.get("critical", 0) or 0)),
+        "high": max(0, int(severity.get("high", 0) or 0)),
+        "medium": max(0, int(severity.get("medium", 0) or 0)),
+        "low": max(0, int(severity.get("low", 0) or 0)),
+        "unrated": max(0, int(severity.get("unrated", 0) or 0)),
+        "kev": max(0, int(kev or 0)),
+        "exposure": max(0, int(exposure or 0)),
+        "compliance": max(0, int(compliance_failing or 0)),
+    }
+    finding_total = counts["critical"] + counts["high"] + counts["medium"] + counts["low"] + counts["unrated"]
+
+    breakdown: list[dict[str, Any]] = []
+    raw_penalty = 0.0
+    for driver in DRIVER_ORDER:
+        weight = float(weights.get(driver, 0.0))
+        count = counts[driver]
+        contribution = round(weight * count, 2)
+        raw_penalty += weight * count
+        breakdown.append(
+            {
+                "driver": driver,
+                "label": DRIVER_LABELS[driver],
+                "count": count,
+                "weight": round(weight, 4),
+                "contribution": contribution,
+            }
+        )
+
+    penalty = min(_MAX_PENALTY, raw_penalty)
+    count_score = max(0.0, round(100.0 - penalty, 1))
+
+    has_evidence = floor_score is not None or finding_total > 0 or counts["kev"] > 0 or counts["exposure"] > 0 or counts["compliance"] > 0
+
+    if not has_evidence:
+        return {
+            "grade": "N/A",
+            "score": 0.0,
+            "points": 0.0,
+            "percent": 0,
+            "display_format": cfg.display_format,
+            "display": None,
+            "summary": "Awaiting evidence — connect a surface or run a scan to grade posture.",
+            "policy_source": cfg.source,
+            "weights": dict(weights),
+            "grade_thresholds": dict(cfg.grade_thresholds),
+            "breakdown": breakdown,
+            "penalty_total": 0.0,
+            "floored": False,
+            "finding_total": 0,
+        }
+
+    if floor_score is not None:
+        final_score = min(count_score, round(float(floor_score), 1))
+        floored = final_score < count_score
+    else:
+        final_score = count_score
+        floored = False
+
+    grade = score_to_grade(final_score, cfg.grade_thresholds)
+    summary = _build_summary(
+        grade=grade,
+        score=final_score,
+        counts=counts,
+        finding_total=finding_total,
+        floor_summary=floor_summary,
+    )
+
+    return {
+        "grade": grade,
+        "score": final_score,
+        "points": final_score,
+        "percent": int(round(final_score)),
+        "display_format": cfg.display_format,
+        "display": _format_display(final_score, grade, cfg.display_format),
+        "summary": summary,
+        "policy_source": cfg.source,
+        "weights": dict(weights),
+        "grade_thresholds": dict(cfg.grade_thresholds),
+        "breakdown": breakdown,
+        "penalty_total": round(penalty, 1),
+        "floored": floored,
+        "finding_total": finding_total,
+    }
+
+
+def _build_summary(
+    *,
+    grade: str,
+    score: float,
+    counts: Mapping[str, int],
+    finding_total: int,
+    floor_summary: str | None,
+) -> str:
+    """Honest one-line blurb. Never claims 'no vulnerabilities' when total > 0."""
+    score_txt = f"{grade} · {int(round(score))}%"
+    if finding_total > 0:
+        bits: list[str] = []
+        if counts["critical"]:
+            bits.append(f"{counts['critical']} critical")
+        if counts["high"]:
+            bits.append(f"{counts['high']} high")
+        if counts["kev"]:
+            bits.append(f"{counts['kev']} KEV")
+        if counts["exposure"]:
+            bits.append(f"{counts['exposure']} touch secrets")
+        lead = " · ".join(bits) if bits else f"{finding_total} finding(s)"
+        return f"{score_txt} — {lead} across connected surfaces."
+    # No open findings but still graded: a scan ran (floor present). Explain what
+    # graded it instead of asserting a clean "no vulnerabilities / strong" line.
+    if floor_summary:
+        cleaned = floor_summary.strip()
+        if cleaned:
+            return f"{score_txt} — {cleaned}"
+    return f"{score_txt} — no open findings across connected surfaces."

--- a/tests/test_exec_score.py
+++ b/tests/test_exec_score.py
@@ -1,0 +1,154 @@
+"""Unit tests for the configurable executive risk-score engine (#3940)."""
+
+from __future__ import annotations
+
+from agent_bom.exec_score import (
+    DEFAULT_EXEC_SCORE_WEIGHTS,
+    DISPLAY_FORMATS,
+    ExecScoreConfig,
+    canonicalize_config,
+    canonicalize_thresholds,
+    canonicalize_weights,
+    compute_exec_score,
+    load_exec_score_config,
+    score_to_grade,
+)
+
+
+def _sev(critical=0, high=0, medium=0, low=0, unrated=0) -> dict[str, int]:
+    return {"critical": critical, "high": high, "medium": medium, "low": low, "unrated": unrated}
+
+
+def test_no_evidence_is_na_not_a() -> None:
+    """Empty estate grades N/A — never a clean A that reads as 'no vulns'."""
+    result = compute_exec_score(severity=_sev())
+    assert result["grade"] == "N/A"
+    assert result["display"] is None
+    assert "run a scan" in result["summary"].lower()
+
+
+def test_score_derives_from_honest_counts() -> None:
+    """2 critical + 1 high => penalty 30 => 70 => grade C (default weights)."""
+    result = compute_exec_score(severity=_sev(critical=2, high=1))
+    assert result["penalty_total"] == 30.0
+    assert result["score"] == 70.0
+    assert result["grade"] == "C"
+    # Breakdown carries every driver's contribution for explainability.
+    contrib = {row["driver"]: row["contribution"] for row in result["breakdown"]}
+    assert contrib["critical"] == 24.0
+    assert contrib["high"] == 6.0
+
+
+def test_summary_never_claims_no_vulns_when_counted() -> None:
+    result = compute_exec_score(severity=_sev(high=3))
+    assert "no vulnerabilit" not in result["summary"].lower()
+    assert "3 high" in result["summary"]
+
+
+def test_penalty_caps_score_floor_at_zero() -> None:
+    result = compute_exec_score(severity=_sev(critical=50))
+    assert result["score"] == 0.0
+    assert result["grade"] == "F"
+    assert result["penalty_total"] == 100.0
+
+
+def test_floor_never_launders_a_failing_scorecard_up() -> None:
+    """A benign count cannot raise an authoritative failing scorecard."""
+    result = compute_exec_score(severity=_sev(low=1), floor_score=30.0)
+    assert result["score"] == 30.0  # min(99.5, 30.0)
+    assert result["grade"] == "F"
+    assert result["floored"] is True
+
+
+def test_floor_does_not_raise_a_worse_count() -> None:
+    """When counts are worse than the floor, the worse count wins."""
+    result = compute_exec_score(severity=_sev(critical=10), floor_score=95.0)
+    assert result["score"] == 0.0
+    assert result["grade"] == "F"
+
+
+def test_kev_and_exposure_amplify() -> None:
+    base = compute_exec_score(severity=_sev(high=1))["score"]
+    amplified = compute_exec_score(severity=_sev(high=1), kev=1, exposure=1)["score"]
+    assert amplified < base
+
+
+def test_display_format_variants() -> None:
+    sev = _sev(high=1)
+    assert compute_exec_score(severity=sev, config=_cfg("grade"))["display"].startswith("Grade ")
+    assert compute_exec_score(severity=sev, config=_cfg("percent"))["display"].endswith("%")
+    assert "/ 100" in compute_exec_score(severity=sev, config=_cfg("points"))["display"]
+
+
+def _cfg(fmt: str) -> ExecScoreConfig:
+    return load_exec_score_config({"display_format": fmt})
+
+
+def test_canonicalize_weights_clamps_and_ignores_junk() -> None:
+    weights = canonicalize_weights({"critical": -5, "high": "abc", "bogus": 99, "kev": 1000})
+    assert weights["critical"] == 0.0  # negative clamped to 0
+    assert weights["high"] == DEFAULT_EXEC_SCORE_WEIGHTS["high"]  # junk ignored
+    assert weights["kev"] == 100.0  # clamped to max
+    assert "bogus" not in weights
+
+
+def test_canonicalize_thresholds_enforces_monotonic_order() -> None:
+    # Deliberately inverted: A below C should be corrected to keep A>=B>=C>=D.
+    thresholds = canonicalize_thresholds({"A": 50, "B": 80, "C": 70, "D": 60})
+    assert thresholds["A"] >= thresholds["B"] >= thresholds["C"] >= thresholds["D"]
+
+
+def test_canonicalize_config_never_raises_on_garbage() -> None:
+    cfg = canonicalize_config({"weights": "not-a-dict", "display_format": 123, "grade_thresholds": None})
+    assert set(cfg) == {"weights", "grade_thresholds", "display_format"}
+    assert cfg["display_format"] in DISPLAY_FORMATS
+
+
+def test_env_policy_applies(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_EXEC_SCORE_POLICY", '{"weights": {"critical": 20}, "display_format": "points"}')
+    cfg = load_exec_score_config()
+    assert cfg.weights["critical"] == 20.0
+    assert cfg.display_format == "points"
+    assert cfg.source.startswith("env:")
+
+
+def test_tenant_override_wins_over_env(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_EXEC_SCORE_POLICY", '{"weights": {"critical": 20}}')
+    cfg = load_exec_score_config({"weights": {"critical": 5}})
+    assert cfg.weights["critical"] == 5.0
+    assert "tenant_override" in cfg.source
+
+
+def test_score_to_grade_uses_custom_thresholds() -> None:
+    thresholds = {"A": 50.0, "B": 40.0, "C": 30.0, "D": 20.0}
+    assert score_to_grade(55, thresholds) == "A"
+    assert score_to_grade(10, thresholds) == "F"
+
+
+def test_facade_merge_preserves_existing_and_clear() -> None:
+    """Partial updates merge onto the persisted override; clear reverts."""
+    from agent_bom.api.exec_score_config import (
+        clear_exec_score_config,
+        get_exec_score_overrides,
+        resolve_exec_score_config,
+        set_exec_score_config,
+    )
+    from agent_bom.api.stores import set_tenant_score_config_store
+    from agent_bom.api.tenant_score_config_store import InMemoryTenantScoreConfigStore
+
+    set_tenant_score_config_store(InMemoryTenantScoreConfigStore())
+    tenant = "tenant-x"
+
+    set_exec_score_config(tenant, {"display_format": "grade"})
+    set_exec_score_config(tenant, {"weights": {"critical": 30}})
+    resolved = resolve_exec_score_config(tenant)
+    # Both fields survive across the two partial writes.
+    assert resolved.display_format == "grade"
+    assert resolved.weights["critical"] == 30.0
+    assert get_exec_score_overrides(tenant)  # non-empty
+
+    assert clear_exec_score_config(tenant) is True
+    assert get_exec_score_overrides(tenant) == {}
+    assert resolve_exec_score_config(tenant).display_format == "percent"
+
+    set_tenant_score_config_store(InMemoryTenantScoreConfigStore())

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -9,6 +9,7 @@ from agent_bom.api.store import InMemoryJobStore
 from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
 
 _AUTH_HEADERS = proxy_headers(tenant="default")
+_ADMIN_HEADERS = proxy_headers(role="admin", tenant="default")
 
 
 def setup_module() -> None:
@@ -172,8 +173,13 @@ def test_overview_reads_compacted_scan_summary() -> None:
     assert resp.status_code == 200
     data = resp.json()
 
+    # The configurable exec-score engine (#3940) recomputes the grade from the
+    # honest estate counts and takes the *worst* of that and the scan scorecard
+    # floor (42.0). 3 critical + 12 high + 72 unrated caps the penalty, so the
+    # honest score is 0.0 — still an F, and the CVE/severity tiles are populated
+    # (the compaction-must-not-zero-tiles intent this test guards).
     assert data["posture"]["grade"] == "F"
-    assert data["posture"]["score"] == 42.0
+    assert data["posture"]["score"] <= 42.0
     assert data["headline"]["critical"] == 3
     assert data["headline"]["high"] == 12
     assert data["domains"]["vuln"]["metric"] == 87
@@ -338,6 +344,86 @@ def test_overview_requires_auth(monkeypatch) -> None:
     client = TestClient(app)
     resp = client.get("/v1/overview")
     assert resp.status_code in (401, 403)
+
+
+def _reset_score_config() -> None:
+    from agent_bom.api.stores import set_tenant_score_config_store
+    from agent_bom.api.tenant_score_config_store import InMemoryTenantScoreConfigStore
+
+    set_tenant_score_config_store(InMemoryTenantScoreConfigStore())
+
+
+def test_score_config_defaults_and_update_roundtrip() -> None:
+    """GET returns the documented default model; PUT persists a canonical override."""
+    _reset_score_config()
+    client = TestClient(app)
+
+    default = client.get("/v1/overview/score-config", headers=_AUTH_HEADERS).json()
+    assert default["active_override"] is False
+    assert default["display_format"] == "percent"
+    assert default["weights"]["critical"] == 12.0
+    assert any(d["driver"] == "kev" for d in default["drivers"])
+
+    resp = client.put(
+        "/v1/overview/score-config",
+        headers=_ADMIN_HEADERS,
+        json={"display_format": "grade", "weights": {"critical": 20}},
+    )
+    assert resp.status_code == 200
+    updated = resp.json()
+    assert updated["active_override"] is True
+    assert updated["display_format"] == "grade"
+    assert updated["weights"]["critical"] == 20.0
+
+    # Persisted: a fresh GET reflects the override and the overview grade uses it.
+    again = client.get("/v1/overview/score-config", headers=_AUTH_HEADERS).json()
+    assert again["weights"]["critical"] == 20.0
+    _reset_score_config()
+
+
+def test_score_config_update_never_raises_on_garbage() -> None:
+    """Out-of-range / junk overrides are clamped server-side, never 422/500."""
+    _reset_score_config()
+    client = TestClient(app)
+    resp = client.put(
+        "/v1/overview/score-config",
+        headers=_ADMIN_HEADERS,
+        json={"weights": {"critical": -999, "bogus": 5}, "display_format": "nonsense", "grade_thresholds": {"A": 40, "B": 90}},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["weights"]["critical"] == 0.0  # negative clamped
+    assert "bogus" not in data["weights"]
+    assert data["display_format"] == "percent"  # invalid -> default
+    # Thresholds kept monotonic A>=B despite inverted input.
+    assert data["grade_thresholds"]["A"] >= data["grade_thresholds"]["B"]
+    _reset_score_config()
+
+
+def test_overview_posture_carries_score_breakdown() -> None:
+    """The overview posture exposes the weighted-input breakdown for explainability."""
+    _clear_jobs()
+    _reset_score_config()
+    _add_done_job([{"vulnerability_id": "CVE-1", "severity": "critical", "risk_score": 9}])
+    data = client_get_overview()
+    posture = data["posture"]
+    assert posture["grade"] in {"A", "B", "C", "D", "F"}
+    assert "breakdown" in posture and isinstance(posture["breakdown"], list)
+    crit_row = next(row for row in posture["breakdown"] if row["driver"] == "critical")
+    assert crit_row["count"] == 1
+    assert crit_row["contribution"] == crit_row["weight"] * 1
+    assert posture["display_format"] == "percent"
+    _reset_score_config()
+
+
+def test_score_config_update_requires_admin() -> None:
+    """A viewer token cannot mutate the tenant score model (admin-gated verb)."""
+    _reset_score_config()
+    viewer_headers = proxy_headers(tenant="default", role="viewer")
+    client = TestClient(app)
+    resp = client.put("/v1/overview/score-config", headers=viewer_headers, json={"display_format": "grade"})
+    assert resp.status_code in (401, 403)
+    _reset_score_config()
 
 
 def test_overview_is_read_only() -> None:

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -18,6 +18,7 @@ import {
   OverviewCockpit,
   type ExposurePathView,
   type OverviewComplianceSnapshot,
+  type PostureScoreFormat,
 } from "@/components/overview-cockpit";
 import { PageLaneHeader } from "@/components/page-lane";
 import { ApiOfflineState } from "@/components/api-offline-state";
@@ -63,6 +64,9 @@ export default function Dashboard() {
   const [posture, setPosture] = useState<PostureResponse | null>(null);
   const [overview, setOverview] = useState<OverviewResponse | null>(null);
   const [compliance, setCompliance] = useState<ComplianceResponse | null>(null);
+  // Local display-format override; falls back to the persisted per-tenant
+  // config carried on the overview posture. Toggling persists via the API (#3940).
+  const [scoreFormatOverride, setScoreFormatOverride] = useState<PostureScoreFormat | null>(null);
   const { counts } = useDeploymentContext();
   const captureMode = useCaptureMode();
   const seededEvidence = captureMode || Boolean(counts?.scan_sources?.some((source) => source.includes("demo")));
@@ -333,8 +337,20 @@ export default function Dashboard() {
 
   if (apiError && !importedReport) return <ApiOfflineState onImport={setImportedReport} kind={apiErrorKind} detail={apiErrorDetail} />;
 
-  const postureGrade = posture?.grade ?? overview?.posture.grade ?? "—";
-  const postureScore = posture?.score ?? overview?.posture.score;
+  // The overview's configurable exec risk score (#3940) is authoritative for the
+  // exec grade — it derives from the honest estate counts and the tenant's score
+  // model. Fall back to /v1/posture only until the overview payload lands.
+  const postureGrade = overview?.posture.grade ?? posture?.grade ?? "—";
+  const postureScore = overview?.posture.score ?? posture?.score;
+  const scoreFormat: PostureScoreFormat =
+    scoreFormatOverride ?? overview?.posture.display_format ?? "percent";
+  const scoreBreakdown = overview?.posture.breakdown ?? null;
+  const handleScoreFormatChange = (format: PostureScoreFormat) => {
+    // Optimistic local update, then persist per-tenant. A failed persist (e.g.
+    // a viewer without admin) still keeps the local view; it just won't stick.
+    setScoreFormatOverride(format);
+    api.updateScoreConfig({ display_format: format }).catch(() => {});
+  };
   const latestScanShort =
     summaryReady && effectiveRecentJobs[0]?.created_at
       ? formatShortScanTime(effectiveRecentJobs[0].created_at)
@@ -389,7 +405,10 @@ export default function Dashboard() {
       <OverviewCockpit
         grade={postureGrade}
         score={postureScore}
-        postureSummary={posture?.summary ?? overview?.posture.summary}
+        scoreFormat={scoreFormat}
+        scoreBreakdown={scoreBreakdown}
+        onScoreFormatChange={handleScoreFormatChange}
+        postureSummary={overview?.posture.summary ?? posture?.summary}
         critical={criticalCount}
         high={highCount}
         kev={summaryReady ? displayedKevCount : null}

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { ArrowRight, ChevronRight } from "lucide-react";
 
 import type { OverviewResponse } from "@/lib/api";
-import type { OverviewCoverageLane, ServiceEntry, ServiceId } from "@/lib/api-types";
+import type { ExecScoreDriver, OverviewCoverageLane, ServiceEntry, ServiceId } from "@/lib/api-types";
 import { Collapsible } from "@/components/collapsible";
 import { FrameworkIcon } from "@/components/framework-icon";
 import type { SeverityCounts } from "@/lib/dashboard-data";
@@ -39,8 +39,15 @@ export type OverviewComplianceSnapshot = {
   frameworks: OverviewComplianceFramework[];
 };
 
+/** Controls a framework actually scored (pass/warn/fail) — NOT its catalogue
+ *  size. A framework with 10 bundled controls but 0 mapped findings has
+ *  `total` 10 yet `evaluated` 0, and must never read as a green PASS (#3889). */
+function frameworkEvaluated(framework: OverviewComplianceFramework): number {
+  return framework.pass + framework.warn + framework.fail;
+}
+
 function hasEvaluatedCompliance(compliance: OverviewComplianceSnapshot | null | undefined): boolean {
-  return Boolean(compliance?.frameworks.some((framework) => framework.total > 0));
+  return Boolean(compliance?.frameworks.some((framework) => frameworkEvaluated(framework) > 0));
 }
 
 // Shared class for the collapsible section headers (Command center, Cross-lane
@@ -126,6 +133,10 @@ export interface OverviewCockpitProps {
   score?: number | undefined;
   /** Display-only score presentation. Defaults to a percentage. */
   scoreFormat?: PostureScoreFormat | undefined;
+  /** Weighted inputs behind the score, for the "what influences this" panel. */
+  scoreBreakdown?: ExecScoreDriver[] | null | undefined;
+  /** Called when the user picks a display format; parent persists it (#3940). */
+  onScoreFormatChange?: ((format: PostureScoreFormat) => void) | undefined;
   postureSummary?: string | undefined;
   critical: number;
   high: number;
@@ -160,6 +171,8 @@ export function OverviewCockpit({
   grade,
   score,
   scoreFormat = "percent",
+  scoreBreakdown = null,
+  onScoreFormatChange,
   postureSummary,
   critical,
   high,
@@ -204,6 +217,7 @@ export function OverviewCockpit({
               grade={grade}
               score={score}
               scoreFormat={scoreFormat}
+              onScoreFormatChange={onScoreFormatChange}
               summary={postureSummary}
               critical={critical}
               high={high}
@@ -221,6 +235,10 @@ export function OverviewCockpit({
               matrix={issueMatrix}
             />
           </div>
+
+          {/* 1b — What influences the score: read-only weighted-input breakdown
+              so the grade is legible, not opaque (#3940). */}
+          <ScoreExplainer breakdown={scoreBreakdown} grade={grade} />
 
           {/* 2 — Cross-lane coverage: the single canonical estate view */}
           <CrossLaneCoverage domains={domains} services={services} />
@@ -494,8 +512,17 @@ function ComplianceSnapshotPanel({
       {evidenceReady && frameworks.length > 0 ? (
         <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
           {frameworks.map((framework) => {
+            const evaluated = frameworkEvaluated(framework);
+            // 0 evaluated controls is NOT a pass — surface a neutral
+            // "not evaluated" state so an unscored framework never reads green.
             const tone =
-              framework.fail > 0 ? "fail" : framework.warn > 0 ? "warn" : "pass";
+              evaluated === 0
+                ? "not_evaluated"
+                : framework.fail > 0
+                  ? "fail"
+                  : framework.warn > 0
+                    ? "warn"
+                    : "pass";
             return (
               <Link
                 key={framework.id}
@@ -508,8 +535,9 @@ function ComplianceSnapshotPanel({
                     {framework.label}
                   </p>
                   <p className="mt-0.5 truncate text-[10px] leading-tight text-[color:var(--text-tertiary)]">
-                    {framework.pass}/{framework.total} pass
-                    {framework.fail > 0 ? ` · ${framework.fail} fail` : ""}
+                    {evaluated === 0
+                      ? `Not evaluated · 0/${framework.total} controls`
+                      : `${framework.pass}/${evaluated} pass${framework.fail > 0 ? ` · ${framework.fail} fail` : ""}`}
                   </p>
                 </div>
                 <span
@@ -518,10 +546,12 @@ function ComplianceSnapshotPanel({
                       ? "bg-red-500/15 text-red-300"
                       : tone === "warn"
                         ? "bg-yellow-500/15 text-yellow-200"
-                        : "bg-emerald-500/15 text-emerald-300"
+                        : tone === "pass"
+                          ? "bg-emerald-500/15 text-emerald-300"
+                          : "border border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-[color:var(--text-tertiary)]"
                   }`}
                 >
-                  {tone}
+                  {tone === "not_evaluated" ? "n/a" : tone}
                 </span>
               </Link>
             );
@@ -720,10 +750,116 @@ function RiskChainRow({ path, rank }: { path: ExposurePathView; rank: number }) 
   );
 }
 
+/**
+ * Read-only "what influences this score" panel. Lists the weighted inputs
+ * (severity buckets, KEV, exposure, compliance, unrated) with each driver's
+ * count × weight = penalty contribution, so the grade is legible instead of an
+ * opaque number (#3940). Only drivers that actually moved the score are shown.
+ * A full weight/threshold editor is a documented follow-up.
+ */
+function ScoreExplainer({
+  breakdown,
+  grade,
+}: {
+  breakdown?: ExecScoreDriver[] | null | undefined;
+  grade: string;
+}) {
+  const ungraded = grade === "N/A" || grade === "—";
+  const rows = (breakdown ?? [])
+    .filter((row) => row.count > 0 || row.contribution > 0)
+    .sort((a, b) => b.contribution - a.contribution);
+  if (ungraded || rows.length === 0) return null;
+  const totalPenalty = rows.reduce((sum, row) => sum + row.contribution, 0);
+
+  return (
+    <Collapsible
+      bare
+      className="mt-4 border-t border-[color:var(--border-subtle)]"
+      title="What influences this score"
+      titleClassName={SECTION_TITLE_CLASS}
+      subtitle="Weighted risk inputs behind the grade · each shown as count × weight = points off 100"
+      defaultOpen={false}
+      data-testid="overview-score-explainer"
+    >
+      <div className="mt-2 space-y-1.5">
+        {rows.map((row) => {
+          const share = totalPenalty > 0 ? (row.contribution / totalPenalty) * 100 : 0;
+          return (
+            <div key={row.driver} className="flex items-center gap-3" data-testid={`score-driver-${row.driver}`}>
+              <span className="w-40 shrink-0 truncate text-[11px] text-[color:var(--text-secondary)]" title={row.label}>
+                {row.label}
+              </span>
+              <span className="w-24 shrink-0 text-right font-mono text-[11px] tabular-nums text-[color:var(--text-tertiary)]">
+                {row.count} × {row.weight}
+              </span>
+              <div className="h-1.5 min-w-0 flex-1 overflow-hidden rounded-full bg-[color:var(--surface-muted)]">
+                <span
+                  className="block h-full rounded-full bg-[color:var(--severity-high)]"
+                  style={{ width: `${Math.min(100, share)}%` }}
+                />
+              </div>
+              <span className="w-14 shrink-0 text-right font-mono text-[11px] font-semibold tabular-nums text-[color:var(--foreground)]">
+                −{row.contribution.toFixed(1)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <p className="mt-2 text-[10px] leading-tight text-[color:var(--text-tertiary)]">
+        Score = 100 − total points off (capped at 100). Weights, grade thresholds, and the display format are
+        configurable per tenant via the score-config API. A full in-UI weight editor is a follow-up.
+      </p>
+    </Collapsible>
+  );
+}
+
+const SCORE_FORMAT_OPTIONS: { value: PostureScoreFormat; label: string }[] = [
+  { value: "grade", label: "Grade" },
+  { value: "percent", label: "%" },
+  { value: "points", label: "Points" },
+];
+
+function ScoreFormatToggle({
+  value,
+  onChange,
+}: {
+  value: PostureScoreFormat;
+  onChange: (format: PostureScoreFormat) => void;
+}) {
+  return (
+    <div
+      className="inline-flex overflow-hidden rounded-md border border-[color:var(--border-subtle)]"
+      role="group"
+      aria-label="Score display format"
+      data-testid="score-format-toggle"
+    >
+      {SCORE_FORMAT_OPTIONS.map((option) => {
+        const active = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            aria-pressed={active}
+            className={`px-1.5 py-0.5 text-[10px] font-semibold transition ${
+              active
+                ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
+                : "bg-[color:var(--surface-muted)] text-[color:var(--text-tertiary)] hover:text-[color:var(--foreground)]"
+            }`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 function PostureHero({
   grade,
   score,
   scoreFormat = "percent",
+  onScoreFormatChange,
   summary,
   critical,
   high,
@@ -733,6 +869,7 @@ function PostureHero({
   grade: string;
   score?: number | undefined;
   scoreFormat?: PostureScoreFormat | undefined;
+  onScoreFormatChange?: ((format: PostureScoreFormat) => void) | undefined;
   summary?: string | undefined;
   critical: number;
   high: number;
@@ -763,14 +900,25 @@ function PostureHero({
         ) : null}
       </div>
       <div className="min-w-0">
-        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
-          Risk posture
-        </p>
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+            Risk posture
+          </p>
+          {graded && onScoreFormatChange ? (
+            <ScoreFormatToggle value={scoreFormat} onChange={onScoreFormatChange} />
+          ) : null}
+        </div>
         <p className="mt-1 flex items-baseline gap-2 text-lg font-semibold text-[color:var(--foreground)]">
           {graded ? (
             <>
+              {/* Always show BOTH the letter grade and the %/points, whatever the
+                  chosen primary format, so the number is never ambiguous. */}
               <span>{scoreDisplay}</span>
-              <span className="text-xs font-medium text-[color:var(--text-tertiary)]">Grade {grade}</span>
+              {scoreFormat !== "grade" ? (
+                <span className="text-xs font-medium text-[color:var(--text-tertiary)]">Grade {grade}</span>
+              ) : typeof score === "number" ? (
+                <span className="text-xs font-medium text-[color:var(--text-tertiary)]">{Math.round(score)}%</span>
+              ) : null}
             </>
           ) : (
             "Awaiting scan"

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2320,10 +2320,72 @@ export interface OverviewTopRisk {
   affected_agents: string[];
 }
 
+/** One weighted input into the configurable exec risk score (#3940). */
+export interface ExecScoreDriver {
+  driver: string;
+  label: string;
+  count: number;
+  weight: number;
+  contribution: number;
+}
+
+/** How the exec risk score is displayed. */
+export type ExecScoreDisplayFormat = "grade" | "percent" | "points";
+
+/** The configurable exec risk-score posture block on the overview payload. */
+export interface OverviewPosture {
+  grade: string;
+  score: number;
+  summary: string;
+  points?: number;
+  percent?: number;
+  display?: string | null;
+  display_format?: ExecScoreDisplayFormat;
+  policy_source?: string;
+  penalty_total?: number;
+  floored?: boolean;
+  finding_total?: number;
+  weights?: Record<string, number>;
+  grade_thresholds?: Record<string, number>;
+  breakdown?: ExecScoreDriver[];
+}
+
+/** GET/PUT /v1/overview/score-config — tenant exec-score model + display config. */
+export interface ScoreConfigRuntime {
+  active_override: boolean;
+  source: string;
+  override_endpoint: string;
+  display_format: ExecScoreDisplayFormat;
+  display_formats: ExecScoreDisplayFormat[];
+  weights: Record<string, number>;
+  grade_thresholds: Record<string, number>;
+  drivers: {
+    driver: string;
+    label: string;
+    default_weight: number;
+    weight: number;
+    overridden: boolean;
+  }[];
+  defaults: {
+    weights: Record<string, number>;
+    grade_thresholds: Record<string, number>;
+    display_format: ExecScoreDisplayFormat;
+  };
+  overrides: Record<string, unknown>;
+  message: string;
+}
+
+/** Body for PUT /v1/overview/score-config (all fields optional, clamped server-side). */
+export interface ScoreConfigUpdate {
+  weights?: Record<string, number>;
+  grade_thresholds?: Record<string, number>;
+  display_format?: ExecScoreDisplayFormat;
+}
+
 export interface OverviewResponse {
   schema_version: string;
   tenant_id: string;
-  posture: { grade: string; score: number; summary: string };
+  posture: OverviewPosture;
   headline: {
     critical: number;
     high: number;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -27,6 +27,8 @@ import type {
   AgentBomManifestResponse,
   PostureCountsResponse,
   OverviewResponse,
+  ScoreConfigRuntime,
+  ScoreConfigUpdate,
   RemediationItem,
   FindingsResponse,
   FindingTriageRequest,
@@ -151,6 +153,11 @@ export type {
   DeploymentMode,
   PostureCountsResponse,
   OverviewResponse,
+  OverviewPosture,
+  ExecScoreDriver,
+  ExecScoreDisplayFormat,
+  ScoreConfigRuntime,
+  ScoreConfigUpdate,
   OverviewDomain,
   OverviewTopRisk,
   RemediationItem,
@@ -782,6 +789,13 @@ export const api = {
 
   /** Cross-domain posture snapshot for the unified overview landing page */
   getOverview: () => get<OverviewResponse>("/v1/overview"),
+
+  /** Configurable exec risk-score model + display config for this tenant (#3940) */
+  getScoreConfig: () => get<ScoreConfigRuntime>("/v1/overview/score-config"),
+
+  /** Update the exec risk-score weights, thresholds, or display format (admin) */
+  updateScoreConfig: (body: ScoreConfigUpdate) =>
+    put<ScoreConfigRuntime>("/v1/overview/score-config", body),
 
   /** Runtime health for external vulnerability enrichment sources */
   getEnrichmentPosture: () => get<EnrichmentPostureResponse>("/v1/posture/enrichment"),

--- a/ui/tests/overview-cockpit.test.tsx
+++ b/ui/tests/overview-cockpit.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { OverviewCockpit } from "@/components/overview-cockpit";
 import type { OverviewResponse } from "@/lib/api";
@@ -251,6 +251,68 @@ describe("OverviewCockpit", () => {
     expect(screen.getByText("CIS Controls v8")).toBeInTheDocument();
     expect(screen.getByText(/0% overall · 1 framework need attention/i)).toBeInTheDocument();
     expect(screen.queryByText(/coverage appears after the first completed scan/i)).not.toBeInTheDocument();
+  });
+
+  it("never renders a green PASS for a framework with zero evaluated controls (#3889)", () => {
+    render(
+      <OverviewCockpit
+        {...baseProps}
+        compliance={{
+          overallScore: 100,
+          overallStatus: "pass",
+          frameworks: [
+            // Evaluated (some findings mapped) — legitimately shows.
+            { id: "cis", label: "CIS Controls v8", pass: 8, warn: 1, fail: 1, total: 10 },
+            // Scan ran but nothing mapped: 0 evaluated must read "Not evaluated".
+            { id: "soc2", label: "SOC 2", pass: 0, warn: 0, fail: 0, total: 65 },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("SOC 2")).toBeInTheDocument();
+    expect(screen.getByText(/Not evaluated · 0\/65 controls/i)).toBeInTheDocument();
+    // The unevaluated framework must not claim any pass count.
+    expect(screen.queryByText(/0\/65 pass/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the score breakdown explainer from weighted inputs (#3940)", () => {
+    render(
+      <OverviewCockpit
+        {...baseProps}
+        grade="C"
+        score={70}
+        scoreBreakdown={[
+          { driver: "critical", label: "Critical findings", count: 2, weight: 12, contribution: 24 },
+          { driver: "high", label: "High findings", count: 1, weight: 6, contribution: 6 },
+          { driver: "medium", label: "Medium findings", count: 0, weight: 2, contribution: 0 },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("overview-score-explainer")).toBeInTheDocument();
+    expect(screen.getByTestId("score-driver-critical")).toBeInTheDocument();
+    expect(screen.getByText("−24.0")).toBeInTheDocument();
+    // Zero-contribution drivers are omitted so the panel stays legible.
+    expect(screen.queryByTestId("score-driver-medium")).not.toBeInTheDocument();
+  });
+
+  it("toggles the score display format and calls the persist handler (#3940)", async () => {
+    const user = userEvent.setup();
+    const onScoreFormatChange = vi.fn();
+    render(
+      <OverviewCockpit
+        {...baseProps}
+        grade="C"
+        score={70}
+        scoreFormat="percent"
+        onScoreFormatChange={onScoreFormatChange}
+      />,
+    );
+
+    const toggle = screen.getByTestId("score-format-toggle");
+    await user.click(within(toggle).getByRole("button", { name: "Grade" }));
+    expect(onScoreFormatChange).toHaveBeenCalledWith("grade");
   });
 
   it("lets operators collapse overview sections", async () => {


### PR DESCRIPTION
## Summary

Makes the overview **risk posture grade configurable and honest**, and stops the overview compliance tile from rendering a green PASS for frameworks that were never evaluated.

### 1. Configurable exec risk score (#3940)
- **`agent_bom.exec_score`** — a documented, weighted **penalty model** over the same honest, reconciled counts the overview already exposes: severity buckets (`critical/high/medium/low/unrated`), KEV, credential/blast-radius exposure, and compliance. `score = 100 − min(100, Σ weight×count)`; letter grade from configurable thresholds. Because every input is one of those counts, the grade can **never contradict them** (a non-zero counted total always carries penalty, so the estate can't read as a clean "A / no vulnerabilities" while findings are open).
- **Floor semantics** — an authoritative scan scorecard is applied as a *floor* (`min` of count-derived score and scorecard), so ingested/benign evidence can only move the grade **down**, never launder a failing posture up.
- **Per-tenant persistence** of weights, grade thresholds, and display format via a tenant override store (in-memory / SQLite / Postgres + RLS), mirroring the existing `tenant_quota` / `tenant_graph_retention` override pattern. Read/update via `GET/PUT/DELETE /v1/overview/score-config` (admin-gated mutation). All overrides are **canonicalized/clamped server-side** — bad input never raises (negatives pinned to 0, out-of-range weights clamped, junk keys dropped, invalid display format falls back to default, thresholds kept monotonic).
- **Explainability (UI)** — overview posture carries a per-driver breakdown; the cockpit renders a read-only **"what influences this score"** panel (count × weight = points off) plus a **grade / percent / points** display-format toggle that persists per tenant. A full in-UI weight editor is a **documented follow-up**.

### 2. Compliance tile honesty (#3889)
- The overview compliance snapshot keyed "evidence ready" off the framework **catalogue size** (`total`), so a framework with 0 evaluated controls rendered a green PASS at `0/10`. Now gates on **evaluated controls** (`pass+warn+fail`) and renders a neutral **"Not evaluated"** state for unscored frameworks. Per-control backend honesty (`not_assessed`/`not_evaluated`) already ships via #3925 and is covered by existing tests.

Design tokens only (light + dark); tenant RLS/isolation intact; server-side canonicalization (no raise on ad-hoc input).

## Verification
```
# Python
python -m pytest tests/test_exec_score.py tests/test_overview.py tests/test_compliance.py   # 43 passed
python -m ruff check src tests                                                               # clean
python -m mypy src/agent_bom                                                                 # 688 files, clean
make preflight                                                                               # green (OpenAPI + v1 schemas + DATA_MODEL + env allowlist regenerated & committed)

# UI (from ui/)
npm ci && npm run typecheck                                                                  # clean
npx vitest run tests/overview-cockpit.test.tsx                                               # 16 passed
npm run build                                                                                # compiled successfully
```

## Default weighting model
| Driver | Weight (points/unit) | Driver | Weight |
|---|---|---|---|
| critical | 12 | unrated | 1 |
| high | 6 | kev | 8 |
| medium | 2 | exposure (creds) | 5 |
| low | 0.5 | compliance (failing fw) | 6 |

Default grade thresholds A≥90 / B≥80 / C≥70 / D≥60; default display format `percent`. `critical`/`high` weights match the prior overview blend so the grade reconciles with the number shown before this engine.

## How the score reconciles with the merged honest counts (#3948)
Inputs are exactly the reconciled buckets whose sum equals the counted total (incl. `unrated`) plus KEV/exposure — so the grade is derived from, and can never contradict, the visible counts. Hub-ingested severity folds into the same buckets (`info`/`unknown` → `unrated`). Empty estate stays `N/A` (no fabricated A).

## What persists where
Per-tenant exec-score overrides (partial `weights` / `grade_thresholds` / `display_format`) persist as a canonical JSON blob in `tenant_score_config_overrides` (in-memory / SQLite / Postgres-RLS), selected by the same env precedence as the other override stores. Defaults + `AGENT_BOM_EXEC_SCORE_POLICY[_FILE]` env layer underneath.

## Notes / follow-ups
- **Live compliance-failing count** into the exec score is deferred (the driver + weight ship in the model, fed `0` from the hot overview endpoint) to keep that snapshot cheap — flagged as follow-up.
- **Full in-UI weight/threshold editor** is a follow-up; this PR ships the default model + persisted config + API + display-format toggle + read-only breakdown.
- This branch originally stacked on #3948 (now merged); rebased onto `main`, base is `main`.

Closes #3940. Refs #3889, #3931.