### PR TITLE
Unify cloud-scan status stats + clean cloud icon + Glama README polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,29 +43,30 @@
 <details>
 <summary><b>Persona lane detail</b></summary>
 
-- **AppSec / GRC** — SARIF, compliance packs, and audit-ready exports from the
-  same scan that powers the dashboard.
-- **Platform / SRE** — fleet sync, Helm deploy, CI gates, and SBOM output
-  without a separate scanner stack.
-- **Agent builders** — MCP inventory, Shield SDK, and optional runtime proxy or
-  gateway enforcement on the same graph.
-- **Security engineers** — findings queue, attack-path drilldown, and blast-radius
-  context in CLI, API, and UI.
+- **AppSec / GRC** — SARIF, compliance packs, and audit-ready exports from one scan.
+- **Platform / SRE** — fleet sync, Helm deploy, CI gates, SBOM — no separate scanner stack.
+- **Agent builders** — MCP inventory, Shield SDK, optional runtime proxy or gateway enforcement.
+- **Security engineers** — findings queue, attack-path drilldown, blast-radius context in CLI, API, and UI.
 
-Snowflake is a supported connector lane, not the product center.
+**MCP server mode**
 
-MCP server mode advertises 73 MCP tools, 6 resources, and 8 workflow prompts.
-Registry metadata is tracked through the committed Smithery manifest and Glama
-listing; install and liveness checks live in the integration docs.
+- Advertises 73 MCP tools, 6 resources, and 8 workflow prompts.
+- Registry metadata lives in the committed Smithery manifest and Glama listing; install and liveness checks are in the integration docs.
 
 </details>
 
 ## How It Works
 
-Four beats that match the commands and the sidebar: **connect** (read-only
-cloud, data, code, and agent sources) → **scan** (`agents` / CI) → **graph**
-(`ContextGraph` + blast radius) → **serve** (`agent-bom serve` — one pane of
-glass). The Findings page is a posture queue inside serve — not a product lane.
+Four beats that match the commands and the sidebar:
+
+```text
+connect → scan → graph → serve
+```
+
+- **connect** — read-only cloud, data, code, and agent sources.
+- **scan** — `agents` / CI.
+- **graph** — `ContextGraph` + blast radius.
+- **serve** — `agent-bom serve`, one pane of glass; the Findings page is a posture queue here, not a product lane.
 
 <p align="center">
   <picture>
@@ -105,19 +106,9 @@ package -> vulnerability finding -> MCP server -> tools + credential refs -> age
 <details>
 <summary><b>What it is</b> — scanner, ContextGraph, and blast radius</summary>
 
-`agent-bom` is a read-only scanner and self-hosted control plane for local
-projects, agent fleets, MCP runtimes, and cloud estates (AWS, Azure, GCP,
-Snowflake).
-
-**ContextGraph** is agent-bom's unified evidence graph across CLI, API, UI, MCP
-tools, reports, and gateway decisions. Findings, assets, packages, cloud
-resources, identities, agents, MCP servers, credentials, and runtime decisions
-all normalize into that graph so posture, blast radius, and enforcement read
-from the same evidence.
-
-Blast radius is the core idea: a vulnerable package is linked to the MCP server
-that loads it, the tools it exposes, reachable credential references, and the
-agents that can call it — not just a CVE row.
+- **Scanner + control plane** — read-only, self-hosted, over local projects, agent fleets, MCP runtimes, and cloud estates (AWS, Azure, GCP, Snowflake).
+- **ContextGraph** — the unified evidence graph across CLI, API, UI, MCP tools, reports, and gateway decisions. Findings, assets, packages, cloud resources, identities, agents, MCP servers, credentials, and runtime decisions all normalize into it, so posture, blast radius, and enforcement read from one evidence set.
+- **Blast radius** — the core idea: a vulnerable package links to the MCP server that loads it, the tools it exposes, reachable credential references, and the agents that can call it — not just a CVE row.
 
 Coverage depth and honest boundaries:
 [AI infrastructure scanning](docs/AI_INFRASTRUCTURE_SCANNING.md) ·

--- a/glama.json
+++ b/glama.json
@@ -5,7 +5,7 @@
   ],
   "name": "agent-bom",
   "title": "agent-bom",
-  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 70 read-first MCP tools for headless security agents.",
+  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 73 read-first MCP tools for headless security agents.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -350,6 +350,29 @@ def _cis_summary(cis_dict: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _annotate_inventory_counts(inventory: Any) -> None:
+    """Add UI-facing count fields to a persisted raw inventory payload in place.
+
+    The persisted ``cloud_inventory`` keeps the raw provider resource lists the
+    graph builder ingests, but those carry no top-level counts. The Scan-jobs
+    pipeline panel and scan-result view read ``resource_count`` / ``identity_count``
+    (with a ``node_summary`` fallback), so without these a completed cloud-connection
+    scan surfaced empty resource/identity stats. Enrich the payload (non-destructive
+    — raw lists are preserved) with the same counts ``_summarize_inventory_payload``
+    computes so those stats populate honestly.
+    """
+    if not isinstance(inventory, dict):
+        return
+    if "resource_count" in inventory and "identity_count" in inventory:
+        return
+    from agent_bom.mcp_tools.posture import _summarize_inventory_payload
+
+    summary = _summarize_inventory_payload(str(inventory.get("provider") or ""), inventory)
+    inventory.setdefault("resource_count", summary["resource_count"])
+    inventory.setdefault("identity_count", summary["identity_count"])
+    inventory.setdefault("node_summary", summary["node_summary"])
+
+
 def _persist_connection_report(record: CloudConnectionRecord, tenant_id: str, report: Any) -> str:
     """Persist a brokered-scan report through the existing scan/graph stores.
 
@@ -363,6 +386,7 @@ def _persist_connection_report(record: CloudConnectionRecord, tenant_id: str, re
     from agent_bom.output import to_json
 
     report_json = to_json(report)
+    _annotate_inventory_counts(report_json.get("cloud_inventory"))
     now = _now()
     job = ScanJob(
         job_id=report.scan_id,

--- a/tests/cloud/test_cloud_connections.py
+++ b/tests/cloud/test_cloud_connections.py
@@ -1074,7 +1074,9 @@ def test_broker_secret_failure_does_not_leak(monkeypatch: pytest.MonkeyPatch) ->
 _BROKER_SESSION_SENTINEL = object()
 
 
-def _install_scan_mocks(monkeypatch: pytest.MonkeyPatch, *, fail: bool = False) -> dict[str, Any]:
+def _install_scan_mocks(
+    monkeypatch: pytest.MonkeyPatch, *, fail: bool = False, inventory: dict[str, Any] | None = None
+) -> dict[str, Any]:
     """Patch the broker + AWS inventory/CIS the scan route reuses.
 
     Captures the session each discovery call receives so a test can assert the
@@ -1093,6 +1095,8 @@ def _install_scan_mocks(monkeypatch: pytest.MonkeyPatch, *, fail: bool = False) 
     def _fake_inventory(region: str | None = None, force: bool = False, session: Any = None, **kwargs: Any) -> dict[str, Any]:
         calls["inventory_session"] = session
         calls["inventory_force"] = force
+        if inventory is not None:
+            return inventory
         return {
             "provider": "aws",
             "status": "ok",
@@ -1181,6 +1185,43 @@ def test_scan_launch_brokers_runs_persists_and_marks_active(monkeypatch: pytest.
     assert listing["connections"][0]["last_scan_id"] == scan_id
     # No secret anywhere in the response surface.
     assert "super-secret-external-id" not in str(body)
+
+
+def test_scan_persists_inventory_counts_for_dashboard(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A completed cloud-connection scan must persist resource/identity counts so the
+    Scan-jobs pipeline panel and scan-result view surface real stats (not empty)."""
+    inventory = {
+        "provider": "aws",
+        "status": "ok",
+        "account_id": "123456789012",
+        "region": "us-east-1",
+        "buckets": [{"name": "b1"}, {"name": "b2"}],
+        "instances": [{"id": "i-1"}],
+        "security_groups": [{"id": "sg-1"}],
+        "roles": [{"name": "r1"}, {"name": "r2"}, {"name": "r3"}],
+        "users": [{"name": "u1"}],
+        "warnings": [],
+    }
+    _install_scan_mocks(monkeypatch, inventory=inventory)
+    client = TestClient(_app())
+    cid = _seed_connection("tenant-alpha")
+
+    resp = client.post(f"/v1/cloud/connections/{cid}/scan", headers=_proxy_headers(tenant="tenant-alpha"))
+    assert resp.status_code == 200
+    scan_id = resp.json()["scan_id"]
+
+    from agent_bom.api.stores import _get_store
+
+    job = _get_store().get(scan_id, "tenant-alpha")
+    assert job is not None and job.result is not None
+    persisted = job.result["cloud_inventory"]
+    # Raw provider lists preserved for the graph builder …
+    assert persisted["buckets"] == inventory["buckets"]
+    # … and enriched with UI-facing counts (buckets+instances+security_groups = 4 resources,
+    # roles+users = 4 identities).
+    assert persisted["resource_count"] == 4
+    assert persisted["identity_count"] == 4
+    assert isinstance(persisted["node_summary"], dict)
 
 
 def test_scan_failure_marks_error_without_secret(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -34,7 +34,7 @@ import {
   Radar,
   Bot,
   Boxes,
-  Cloud,
+  Plug,
   ClipboardList,
   FileCheck,
   Layers,
@@ -52,6 +52,28 @@ import {
   navLinkNeedsSetup,
 } from "@/lib/deployment-context";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
+
+// A clean, symmetric cloud mark (the lucide `Cloud` glyph reads lopsided at
+// sidebar sizes). Uses `currentColor` so the per-group tint classes apply, and
+// mirrors lucide's 24×24 stroke conventions so it sizes with `h-*`/`w-*`.
+function CloudGlyph({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={24}
+      height={24}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.9}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M5 18a3.5 3.5 0 0 1 1.2-6.6a5 5 0 0 1 11.6 0a3.5 3.5 0 0 1 1.2 6.6Z" />
+    </svg>
+  );
+}
 
 // ─── Navigation Structure ──────────────────────────────────────────────────
 
@@ -109,9 +131,9 @@ const NAV_GROUPS: NavGroup[] = [
   },
   {
     label: "Cloud & Data",
-    icon: Cloud,
+    icon: CloudGlyph,
     links: [
-      { href: "/connections", label: "Connections", icon: Cloud, capability: "inventory.read" },
+      { href: "/connections", label: "Connections", icon: Plug, capability: "inventory.read" },
       { href: "/sources", label: "Data Sources", icon: Database, capability: "sources.manage" },
       { href: "/scan", label: "New Scan", icon: Scan, capability: "scan.run" },
       { href: "/identity", label: "Identity", icon: Fingerprint },


### PR DESCRIPTION
Closes #3933. Refs #3931.

One UI-polish PR bundling the #3933 residual, feedback item J (cloud icon), and the held Glama README polish.

## 1. #3933 residual — cloud-scan result stats (resources / identities)
#3941 already made the Scan-jobs pipeline DAG live/interactive and, for a finished cloud-connection scan that emits no per-stage step events, synthesizes `6/6` done with a status banner plus CIS pass-rate and findings chips. What it could not surface was **resources / identities**: a completed cloud-connection scan persists the *raw* provider inventory payload (buckets / instances / roles lists) with no top-level `resource_count` / `identity_count`, so both the DAG panel and the scan-result view read absent fields and rendered empty resource/identity stats for an otherwise successful scan.

`_persist_connection_report` now enriches the persisted inventory in place — non-destructive, the raw lists stay for the graph builder — with the same `resource_count` / `identity_count` / `node_summary` the summarizer computes. AWS / Azure / GCP connection scans now surface honest resource + identity counts alongside the CIS pass-rate and findings.

Note: cloud-connection scans run synchronously and are persisted already-`done`, so there is no intermediate "running" job to animate — live per-stage progress already works for the streaming scan pipeline (#3941), and mapping connection scans onto live stages remains the deeper follow-up #3941 flagged.

## 2. Cloud icon (feedback J)
The lucide `Cloud` glyph read lopsided and was used three times in the sidebar. Replaced the "Cloud & Data" group mark with a clean, mirror-symmetric cloud vector (`currentColor`, tokenized tint) and gave the Connections item its own `Plug` icon, so the cloud mark is no longer tripled.

## 3. Glama README polish (folded in)
Cherry-picked the two held commits — scannable Glama-facing README + `glama.json` tool count 70→73 — so they ride in this PR instead of standing alone. `check_release_consistency` stays green.

## Verification
- Python: `pytest tests/cloud/test_cloud_connections.py` 75 passed (new `test_scan_persists_inventory_counts_for_dashboard`); `ruff` + `mypy` clean on the touched route.
- UI: `npm ci` → `npm run typecheck` clean → `npm run build` compiled → `vitest` scan-pipeline-progress + scan-result-cloud-evidence 6 passed; `eslint` 0 errors.
- `python scripts/check_release_consistency.py` passed.

Design tokens only (no `zinc-*`), light + dark; status stays honest (no fake green stages).