### PR TITLE
feat(onboarding): guided first-run, one carried ExternalId, self-host defaults

### DIFF
--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -35,6 +35,14 @@ services:
       AGENT_BOM_DEPLOYMENT_ENV: pilot-loopback
       AGENT_BOM_DEMO_ESTATE: ${AGENT_BOM_DEMO_ESTATE:-0}
       AGENT_BOM_SKIP_UPDATE_CHECK: "1"
+      # Local no-auth pilots resolve to a role. Default to analyst so a first-run
+      # operator can connect a cloud + run a scan (viewer is read-only and would
+      # 403 on create/scan). DEMO_ESTATE still clamps to viewer for public demos.
+      AGENT_BOM_NO_AUTH_ROLE: ${AGENT_BOM_NO_AUTH_ROLE:-analyst}
+      # Connection-secret at-rest key is auto-seeded to /home/abom/.agent-bom/
+      # connections.key on first run (persisted in the data volume) so creating a
+      # cloud connection does not 503. Set AGENT_BOM_CONNECTIONS_KEY / a managed
+      # provider to bring your own; AGENT_BOM_NO_AUTO_CONNECTIONS_KEY=1 disables it.
     ports:
       - "127.0.0.1:8422:8422"
     volumes:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -89,6 +89,12 @@ services:
       - AGENT_BOM_AUDIT_HMAC_KEY_FILE=/run/secrets/audit_hmac_key
       - AGENT_BOM_REQUIRE_AUDIT_HMAC=${AGENT_BOM_REQUIRE_AUDIT_HMAC:-1}
       - AGENT_BOM_CONNECTIONS_KEY_FILE=/run/secrets/connections_key
+      # Role for any request that reaches the API without an authenticated
+      # identity. This stack ships with API-key auth (above), so unauthenticated
+      # requests fail closed (401) and this never applies — it only takes effect
+      # if an operator removes all auth backends. analyst (not viewer) lets a
+      # no-auth local bring-up connect + scan; viewer is read-only.
+      - AGENT_BOM_NO_AUTH_ROLE=${AGENT_BOM_NO_AUTH_ROLE:-analyst}
       - AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_FILE=/run/secrets/browser_session_signing_key
       - AGENT_BOM_SESSION_COOKIE_SECURE=${AGENT_BOM_SESSION_COOKIE_SECURE:-1}
       - AGENT_BOM_DISABLE_DOCS=1

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -30,6 +30,48 @@ brokered catalog.
 
 ---
 
+## 1c. Control-plane Connections wizard (browser onboarding)
+
+The dashboard **Connections** page runs the same read-only grant flow as a
+three-step wizard: **Provider → Setup → Details**.
+
+- **One ExternalId, carried end-to-end.** For AWS the wizard generates a single
+  high-entropy `sts:ExternalId` **once** and carries it unchanged from Setup into
+  Details. The value embedded in the copy-ready grant script (the one you paste
+  into your trust policy) is the exact value the connection stores — the two can
+  never diverge. "Regenerate" (Setup step only) mints a fresh value and updates
+  both places together; only use it before you have applied the grant. The other
+  providers' secret field is a real credential you paste (Azure client secret,
+  GCP service-account key JSON, Snowflake PEM), encrypted at rest and never
+  returned to the browser.
+- **Roles.** Creating a connection or running a scan needs the **analyst**
+  (Contributor) role or higher; **viewer** is read-only. The wizard and empty
+  states surface your role and, when an action needs a higher one, the concrete
+  way to elevate. Roles are the closed enum in `src/agent_bom/rbac.py`.
+
+### Self-host defaults ("just works" on the shipped compose)
+
+The pilot compose (`deploy/docker-compose.pilot.yml`) is preset so first-run
+connect works without extra flags:
+
+- `AGENT_BOM_NO_AUTH_ROLE=analyst` — a local **no-auth** stack resolves to
+  analyst (not viewer), so you can connect and scan. `AGENT_BOM_DEMO_ESTATE=1`
+  always clamps to read-only viewer for public demos.
+- **Connection encryption key auto-seeded.** On first boot a local/no-auth stack
+  generates a Fernet key at `~/.agent-bom/connections.key` (persisted in the data
+  volume) and wires `AGENT_BOM_CONNECTIONS_KEY_FILE` to it, so creating a
+  connection does not fail closed with `AGENT_BOM_CONNECTIONS_KEY unset` (503).
+  Set `AGENT_BOM_CONNECTIONS_KEY` / `_FILE` or a managed key provider to bring
+  your own; `AGENT_BOM_NO_AUTO_CONNECTIONS_KEY=1` disables auto-seeding.
+
+The production-shaped compose (`deploy/docker-compose.platform.yml`) is
+auth-required and takes every secret — including `connections_key` — from mounted
+Docker secret files (write them with `scripts/deploy/hosted_poc_preflight.py
+--write-secret`; see `deploy/secrets/README.md`). It never auto-seeds and never
+carries plaintext secrets in the compose.
+
+---
+
 ## 1. The approach (why it is safe to point at production)
 
 | Principle | What it means here |

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -132,6 +132,8 @@ AGENT_BOM_CRED_NEAR_EXPIRY_DAYS
 AGENT_BOM_CRED_ROTATION_DAYS
 # Opt-out flag for the zero-config loopback dev API key; when set, `agent-bom serve` stays fail-closed on loopback instead of auto-minting a dev key. Read in cli/_server.py.
 AGENT_BOM_NO_AUTO_DEV_KEY
+# Opt-out flag for the local/no-auth auto-seeded connection encryption key; when set, `agent-bom serve|api` does not write ~/.agent-bom/connections.key and connection creation stays 503 until a key is provided. Read in cli/_server.py.
+AGENT_BOM_NO_AUTO_CONNECTIONS_KEY
 # Dormancy window (days, default 90) before a non-human identity with no recent usage is flagged dormant; read in graph/nhi_governance.py.
 AGENT_BOM_NHI_DORMANT_DAYS
 # Opt-in window (days, default 0 = disabled) after which a dormant agent-bom-issued identity is auto-revoked; read in api/agent_identity_store.py.

--- a/src/agent_bom/api/connection_crypto.py
+++ b/src/agent_bom/api/connection_crypto.py
@@ -78,11 +78,15 @@ next operation re-resolves the rotated list.
 from __future__ import annotations
 
 import base64
+import logging
 import os
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from agent_bom.config import resolved_vault_addr
+
+logger = logging.getLogger(__name__)
 
 CONNECTIONS_KEY_ENV = "AGENT_BOM_CONNECTIONS_KEY"
 CONNECTIONS_KEY_PROVIDER_ENV = "AGENT_BOM_CONNECTIONS_KEY_PROVIDER"
@@ -97,6 +101,9 @@ PROVIDER_VAULT = "vault"
 
 # Default field name inside a Vault KV v2 secret when ``...#field`` is omitted.
 DEFAULT_VAULT_FIELD = "key"
+
+# Filename for an auto-seeded local at-rest key (self-hosted / pilot first run).
+LOCAL_KEY_FILENAME = "connections.key"
 
 # In-process cache of the resolved key material. ``None`` means "not yet
 # resolved"; cleared by :func:`reset_key_cache`. The value may carry a
@@ -139,13 +146,19 @@ def connections_key_configured() -> bool:
     """
     if _RESOLVED_KEY is not None:
         return True
+    from agent_bom.api.secret_source import secret_is_configured
+
     provider = _provider()
+    # env / aws-kms carry the key material in AGENT_BOM_CONNECTIONS_KEY, which may
+    # be supplied either directly or via the mounted-file ``*_FILE`` form (Docker
+    # secrets on the shipped compose). Honor both so a file-only deployment does
+    # not fail closed with a spurious 503.
     if provider == PROVIDER_ENV:
-        return bool(os.environ.get(CONNECTIONS_KEY_ENV, "").strip())
+        return secret_is_configured(CONNECTIONS_KEY_ENV)
     if provider == PROVIDER_AWS_SECRETS:
         return bool(os.environ.get(CONNECTIONS_KEY_REF_ENV, "").strip())
     if provider == PROVIDER_AWS_KMS:
-        return bool(os.environ.get(CONNECTIONS_KEY_ENV, "").strip())
+        return secret_is_configured(CONNECTIONS_KEY_ENV)
     if provider == PROVIDER_VAULT:
         return bool(
             resolved_vault_addr()
@@ -366,6 +379,43 @@ def encrypt_secret(plaintext: str) -> str:
     fernet = _fernet()
     token = fernet.encrypt(plaintext.encode("utf-8"))
     return str(token.decode("ascii"))
+
+
+def seed_local_connection_key(directory: Path) -> Path:
+    """Generate and persist a Fernet key for a local/no-auth first run.
+
+    Writes a fresh base64 ``Fernet`` key to ``directory/connections.key`` with
+    ``0600`` permissions and returns the path. An existing key is never
+    overwritten so ciphertext stays decryptable across restarts (the file lives
+    on the persistent state volume). The key material is never logged.
+
+    This is the "just works" self-hosted default: the CLI wires
+    ``AGENT_BOM_CONNECTIONS_KEY_FILE`` at boot to the returned path so a fresh
+    pilot can create a connection without a 503. It is intentionally *only*
+    called for a local, unauthenticated stack — managed key providers and
+    authenticated deployments own their own key material.
+    """
+    from cryptography.fernet import Fernet
+
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / LOCAL_KEY_FILENAME
+    if path.exists():
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+        return path
+    key = Fernet.generate_key()
+    try:
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        # Lost a race with a concurrent boot — the existing key is authoritative.
+        return path
+    try:
+        os.write(fd, key)
+    finally:
+        os.close(fd)
+    return path
 
 
 def decrypt_secret(token: str) -> str:

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -317,6 +317,53 @@ def _should_auto_generate_dev_key(*, host: str, api_key: str | None, allow_insec
     return True
 
 
+def _maybe_seed_local_connection_key(*, host: str, allow_insecure_no_auth: bool) -> str | None:
+    """Auto-seed an at-rest connection encryption key for a local/no-auth stack.
+
+    Fail-closed by construction. Fires only when *all* of these hold:
+
+    - the deployment is clearly local: a loopback bind, or an explicit
+      ``--allow-insecure-no-auth`` local-demo override;
+    - the default ``env`` key provider is in effect (a managed provider owns its
+      own key material and must never be shadowed by a local file);
+    - no connection key is already configured (env, ``*_FILE``, or a prior seed);
+    - the ``AGENT_BOM_NO_AUTO_CONNECTIONS_KEY`` opt-out is unset.
+
+    Otherwise this is a no-op and connection creation keeps its existing
+    behaviour (a 503 until the operator provides ``AGENT_BOM_CONNECTIONS_KEY``).
+
+    The key is written to ``~/.agent-bom/connections.key`` so it survives
+    restarts and previously-stored ciphertext stays decryptable. On success the
+    process-local ``AGENT_BOM_CONNECTIONS_KEY_FILE`` is pointed at the file and
+    the resolver cache is reset. Any failure degrades silently to the prior
+    fail-closed behaviour rather than blocking boot.
+    """
+    if _env_truthy("AGENT_BOM_NO_AUTO_CONNECTIONS_KEY"):
+        return None
+    if not (_is_loopback_host(host) or allow_insecure_no_auth):
+        return None
+    from agent_bom.api.connection_crypto import (
+        CONNECTIONS_KEY_ENV,
+        CONNECTIONS_KEY_PROVIDER_ENV,
+        connections_key_configured,
+        reset_key_cache,
+        seed_local_connection_key,
+    )
+
+    provider = os.environ.get(CONNECTIONS_KEY_PROVIDER_ENV, "env").strip().lower() or "env"
+    if provider != "env":
+        return None
+    if connections_key_configured():
+        return None
+    try:
+        path = seed_local_connection_key(Path.home() / ".agent-bom")
+    except Exception:  # noqa: BLE001 - never block boot; stay fail-closed on connect
+        return None
+    os.environ[f"{CONNECTIONS_KEY_ENV}_FILE"] = str(path)
+    reset_key_cache()
+    return str(path)
+
+
 def _api_auth_summary(
     *,
     host: str,
@@ -544,6 +591,8 @@ def serve_cmd(
     _enforce_control_plane_listener_posture(host)
     tls_kwargs = _uvicorn_tls_kwargs()
 
+    seeded_connection_key = _maybe_seed_local_connection_key(host=host, allow_insecure_no_auth=allow_insecure_no_auth)
+
     # Zero-config loopback: when bound to loopback with no auth configured and no
     # opt-out, mint an ephemeral dev key so the dashboard loads without flags.
     # Non-loopback binds never reach here unauthenticated (see the gate above),
@@ -594,6 +643,12 @@ def serve_cmd(
         ),
     ]
     _emit_runtime_summary("agent-bom serve", rows)
+    if seeded_connection_key:
+        click.echo(
+            f"  Connection secrets: auto-sealed at rest with a locally generated key ({seeded_connection_key}).\n"
+            "  Set AGENT_BOM_CONNECTIONS_KEY / _FILE or a managed provider to bring your own; "
+            "AGENT_BOM_NO_AUTO_CONNECTIONS_KEY=1 disables auto-seeding.\n"
+        )
     if dev_api_key:
         click.secho(
             f"  Dev API key (loopback only): {dev_api_key}",
@@ -804,6 +859,8 @@ def api_cmd(
     _enforce_control_plane_listener_posture(host)
     tls_kwargs = _uvicorn_tls_kwargs()
 
+    seeded_connection_key = _maybe_seed_local_connection_key(host=host, allow_insecure_no_auth=allow_insecure_no_auth)
+
     origins = cors_origins.split(",") if cors_origins else None
     configure_api(
         cors_origins=origins,
@@ -848,6 +905,12 @@ def api_cmd(
         ),
     ]
     _emit_runtime_summary("agent-bom API", rows)
+    if seeded_connection_key:
+        click.echo(
+            f"  Connection secrets: auto-sealed at rest with a locally generated key ({seeded_connection_key}).\n"
+            "  Set AGENT_BOM_CONNECTIONS_KEY / _FILE or a managed provider to bring your own; "
+            "AGENT_BOM_NO_AUTO_CONNECTIONS_KEY=1 disables auto-seeding.\n"
+        )
 
     uvicorn.run(
         "agent_bom.api.server:app",

--- a/tests/test_connection_key_autoseed.py
+++ b/tests/test_connection_key_autoseed.py
@@ -1,0 +1,111 @@
+"""Self-host first-run: auto-seed the at-rest connection encryption key.
+
+Pins the #3935 "self-host defaults just work" contract: a local/no-auth stack
+seeds a Fernet key on first boot so creating a cloud connection does not 503 on
+``AGENT_BOM_CONNECTIONS_KEY unset`` — while staying fail-closed everywhere that
+is not clearly a local, unauthenticated bring-up.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from agent_bom.api import connection_crypto
+from agent_bom.api.connection_crypto import (
+    LOCAL_KEY_FILENAME,
+    decrypt_secret,
+    encrypt_secret,
+    seed_local_connection_key,
+)
+from agent_bom.cli._server import _maybe_seed_local_connection_key
+
+_KEY_ENV = "AGENT_BOM_CONNECTIONS_KEY"
+_KEY_FILE_ENV = "AGENT_BOM_CONNECTIONS_KEY_FILE"
+_PROVIDER_ENV = "AGENT_BOM_CONNECTIONS_KEY_PROVIDER"
+_OPT_OUT_ENV = "AGENT_BOM_NO_AUTO_CONNECTIONS_KEY"
+_REF_ENV = "AGENT_BOM_CONNECTIONS_KEY_REF"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    for name in (_KEY_ENV, _KEY_FILE_ENV, _PROVIDER_ENV, _OPT_OUT_ENV, _REF_ENV):
+        monkeypatch.delenv(name, raising=False)
+    # Path.home() -> tmp so seeds land in an isolated state dir.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    connection_crypto.reset_key_cache()
+    yield
+    connection_crypto.reset_key_cache()
+
+
+def test_seed_writes_valid_fernet_key_with_locked_down_perms(tmp_path: Path):
+    path = seed_local_connection_key(tmp_path / "state")
+    assert path.name == LOCAL_KEY_FILENAME
+    assert path.is_file()
+    # 0600 — owner read/write only.
+    mode = stat.S_IMODE(path.stat().st_mode)
+    assert mode == 0o600, oct(mode)
+    from cryptography.fernet import Fernet
+
+    Fernet(path.read_bytes())  # constructs iff the material is a valid key
+
+
+def test_seed_is_idempotent_and_never_overwrites(tmp_path: Path):
+    directory = tmp_path / "state"
+    first = seed_local_connection_key(directory)
+    original = first.read_bytes()
+    second = seed_local_connection_key(directory)
+    assert second == first
+    # A second call must preserve the existing key so prior ciphertext still
+    # decrypts across restarts.
+    assert second.read_bytes() == original
+
+
+def test_loopback_seed_enables_encrypt_decrypt_roundtrip(monkeypatch: pytest.MonkeyPatch):
+    assert not connection_crypto.connections_key_configured()
+    seeded = _maybe_seed_local_connection_key(host="127.0.0.1", allow_insecure_no_auth=False)
+    assert seeded is not None
+    assert os.environ[_KEY_FILE_ENV] == seeded
+    assert connection_crypto.connections_key_configured()
+    token = encrypt_secret("external-id-abc")
+    assert decrypt_secret(token) == "external-id-abc"
+
+
+def test_insecure_no_auth_nonloopback_seeds(monkeypatch: pytest.MonkeyPatch):
+    # The pilot compose binds 0.0.0.0 inside the container with
+    # --allow-insecure-no-auth; that local bring-up should still seed.
+    seeded = _maybe_seed_local_connection_key(host="0.0.0.0", allow_insecure_no_auth=True)
+    assert seeded is not None
+    assert connection_crypto.connections_key_configured()
+
+
+def test_nonloopback_without_override_does_not_seed(monkeypatch: pytest.MonkeyPatch):
+    seeded = _maybe_seed_local_connection_key(host="0.0.0.0", allow_insecure_no_auth=False)
+    assert seeded is None
+    assert _KEY_FILE_ENV not in os.environ
+    assert not connection_crypto.connections_key_configured()
+
+
+def test_opt_out_disables_seeding(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(_OPT_OUT_ENV, "1")
+    assert _maybe_seed_local_connection_key(host="127.0.0.1", allow_insecure_no_auth=True) is None
+    assert not connection_crypto.connections_key_configured()
+
+
+def test_managed_provider_is_never_shadowed(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(_PROVIDER_ENV, "aws-secrets")
+    assert _maybe_seed_local_connection_key(host="127.0.0.1", allow_insecure_no_auth=True) is None
+    assert _KEY_FILE_ENV not in os.environ
+
+
+def test_already_configured_key_is_left_untouched(monkeypatch: pytest.MonkeyPatch):
+    from cryptography.fernet import Fernet
+
+    monkeypatch.setenv(_KEY_ENV, Fernet.generate_key().decode("ascii"))
+    connection_crypto.reset_key_cache()
+    assert _maybe_seed_local_connection_key(host="127.0.0.1", allow_insecure_no_auth=True) is None
+    assert _KEY_FILE_ENV not in os.environ

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -67,6 +67,12 @@ import {
 import { serviceEntry } from "@/lib/service-registry";
 import { RUN_SCAN_ACTION } from "@/lib/empty-state-actions";
 import { vendorLogo } from "@/lib/vendor-logos";
+import { FirstRunJourney } from "@/components/first-run-journey";
+import {
+  PermissionDeniedNotice,
+  RoleBadge,
+  RolePermissionsPanel,
+} from "@/components/role-access";
 
 // ── Provider catalog ──────────────────────────────────────────────────────────
 // Every option maps its wizard fields onto the connection's role_ref (plaintext
@@ -755,12 +761,24 @@ export default function ConnectionsPage() {
 
       {message ? <p className="text-sm text-emerald-400">{message}</p> : null}
       {!canManage ? (
-        <p className="text-sm text-amber-300">
-          Your role can review connections but cannot create, scan, or delete them.
-        </p>
+        <PermissionDeniedNotice
+          session={session}
+          needed="analyst"
+          action="connect a cloud account, run a scan, or delete a connection"
+        />
       ) : null}
 
+      <FirstRunJourney
+        connectionsCount={connections.length}
+        scanCount={counts?.scan_count ?? 0}
+        findingsCount={counts?.total ?? 0}
+        canManage={canManage}
+        session={session}
+        onConnect={() => openWizard("aws")}
+      />
+
       <div className="flex flex-wrap items-center gap-2">
+        <RoleBadge session={session} />
         <ServiceStateChip
           serviceId="cloud_accounts"
           entry={cloudService}
@@ -890,6 +908,8 @@ export default function ConnectionsPage() {
           )}
         </div>
       </Card>
+
+      <RolePermissionsPanel session={session} />
 
       <ConnectionDetailDrawer
         connection={connections.find((c) => c.id === detailId) ?? null}
@@ -1751,6 +1771,31 @@ function AddConnectionWizard({
     [form.provider],
   );
 
+  // AWS is the only provider whose "secret" is an ExternalId that agent-bom
+  // mints (the customer bakes it into their role's trust policy). It must be
+  // generated exactly once and carried unchanged through Setup → Details so the
+  // value shown in the grant script the user copies is the value the connection
+  // stores. The other providers' secretField is a real credential the user
+  // pastes, so no generation happens there.
+  const isAws = provider.value === "aws";
+
+  // Generate the single AWS ExternalId once, the first time AWS is active.
+  useEffect(() => {
+    if (!isAws) return;
+    setGeneratedExternalId((current) => current || generateConnectionExternalId());
+  }, [isAws]);
+
+  // Keep the submitted external_id in lockstep with the carried ExternalId so
+  // Setup, Details, and the created connection can never diverge.
+  useEffect(() => {
+    if (!isAws || !generatedExternalId) return;
+    setForm((current) =>
+      current.external_id === generatedExternalId
+        ? current
+        : { ...current, external_id: generatedExternalId },
+    );
+  }, [isAws, generatedExternalId]);
+
   function update<K extends keyof WizardForm>(field: K, value: WizardForm[K]) {
     setForm((current) => ({ ...current, [field]: value }));
   }
@@ -1766,8 +1811,10 @@ function AddConnectionWizard({
     setForm((current) => {
       // Re-selecting the already-active provider must not wipe entered fields.
       if (current.provider === value) return current;
+      // Drop any carried ExternalId; the effect re-mints one iff the new
+      // provider is AWS. Reset provider-specific fields so a previous
+      // provider's params don't leak.
       setGeneratedExternalId("");
-      // Reset provider-specific fields so a previous provider's params don't leak.
       return {
         ...current,
         provider: value,
@@ -1780,25 +1827,23 @@ function AddConnectionWizard({
   }
 
   function goNext() {
-    if (step === 1 && generatedExternalId && !form.external_id.trim()) {
-      update("external_id", generatedExternalId);
-    }
     setStep((current) => (current + 1) as 0 | 1 | 2);
   }
 
-  function handleGenerateExternalId() {
+  // Explicit, deliberate re-mint. Updates the carried id and the submitted
+  // external_id together so they stay identical; the operator must re-copy the
+  // grant script and re-apply the trust policy after regenerating.
+  function handleRegenerateExternalId() {
     const value = generateConnectionExternalId();
     setGeneratedExternalId(value);
-    if (step === 2 || !form.external_id.trim()) {
-      update("external_id", value);
-    }
+    setForm((current) => ({ ...current, external_id: value }));
   }
 
   const providerMeta = cloudProviderMeta(provider.value);
   const deployScript = buildGrantScript(
     provider.value,
     grantMethod,
-    generatedExternalId || form.external_id || undefined,
+    isAws ? generatedExternalId || undefined : undefined,
   );
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -1988,31 +2033,40 @@ function AddConnectionWizard({
                       {deployScript || provider.cli}
                     </pre>
                   </div>
-                  {provider.value === "aws" ? (
+                  {isAws ? (
                     <div className="mt-4 rounded-lg border border-emerald-900/50 bg-emerald-950/20 p-3">
                       <div className="flex flex-wrap items-center justify-between gap-2">
                         <p className="text-[11px] font-medium text-emerald-200">
                           External ID for trust policy
                         </p>
-                        <button
-                          type="button"
-                          onClick={handleGenerateExternalId}
-                          className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-700/60 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-200 transition hover:border-emerald-500"
-                        >
-                          <Fingerprint className="h-3 w-3" />
-                          Generate external ID
-                        </button>
+                        <div className="flex items-center gap-1.5">
+                          {generatedExternalId ? (
+                            <CopyTextButton text={generatedExternalId} label="Copy ID" />
+                          ) : null}
+                          <button
+                            type="button"
+                            onClick={handleRegenerateExternalId}
+                            className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-700/60 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-200 transition hover:border-emerald-500"
+                          >
+                            <RefreshCcw className="h-3 w-3" />
+                            Regenerate
+                          </button>
+                        </div>
                       </div>
                       {generatedExternalId ? (
-                        <p className="mt-2 break-all font-mono text-[11px] text-[var(--foreground)]">
+                        <p
+                          data-testid="wizard-external-id"
+                          className="mt-2 break-all font-mono text-[11px] text-[var(--foreground)]"
+                        >
                           {generatedExternalId}
                         </p>
-                      ) : (
-                        <p className="mt-2 text-[11px] text-[var(--text-tertiary)]">
-                          Generate a high-entropy ExternalId before applying the grant
-                          (CLI, CloudShell, or Terraform). It pre-fills the secret field on the next step.
-                        </p>
-                      )}
+                      ) : null}
+                      <p className="mt-2 text-[11px] text-[var(--text-tertiary)]">
+                        This exact ID is embedded in the grant script above and is
+                        what the connection stores — apply it as the trust policy
+                        ExternalId. It carries to the next step unchanged; do not
+                        regenerate after you have applied the grant.
+                      </p>
                     </div>
                   ) : null}
                   <div className="mt-3 flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1.5">
@@ -2076,18 +2130,26 @@ function AddConnectionWizard({
                     <span className="text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
                       {provider.secretField.label}
                     </span>
-                    {provider.value === "aws" ? (
-                      <button
-                        type="button"
-                        onClick={handleGenerateExternalId}
-                        className="inline-flex items-center gap-1 rounded-lg border border-emerald-700/60 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-200 transition hover:border-emerald-500"
-                      >
-                        <Fingerprint className="h-3 w-3" />
-                        Generate
-                      </button>
+                    {isAws ? (
+                      <span className="inline-flex items-center gap-1 text-[10px] font-medium text-emerald-300">
+                        <CheckCircle2 className="h-3 w-3" /> Carried from setup
+                      </span>
                     ) : null}
                   </span>
-                  {provider.secretField.multiline ? (
+                  {isAws ? (
+                    // AWS: the single generated ExternalId, read-only, identical
+                    // to the value in the Setup grant script. Never a fresh mint
+                    // here — that would not match the applied trust policy.
+                    <div className="flex items-center justify-between gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2">
+                      <code
+                        data-testid="wizard-external-id-details"
+                        className="min-w-0 break-all font-mono text-sm text-[var(--foreground)]"
+                      >
+                        {form.external_id}
+                      </code>
+                      <CopyTextButton text={form.external_id} label="Copy" />
+                    </div>
+                  ) : provider.secretField.multiline ? (
                     <textarea
                       autoComplete="off"
                       rows={5}
@@ -2111,7 +2173,10 @@ function AddConnectionWizard({
                     />
                   )}
                   <span className="mt-1.5 inline-flex items-center gap-1.5 text-[11px] text-[var(--text-tertiary)]">
-                    <Lock className="h-3 w-3" /> {provider.secretField.hint}
+                    <Lock className="h-3 w-3" />{" "}
+                    {isAws
+                      ? "Matches the ExternalId in your trust policy. Stored encrypted at rest; regenerate on the Setup step only if you have not applied the grant yet."
+                      : provider.secretField.hint}
                   </span>
                 </label>
                 {provider.usesRegions ? (

--- a/ui/components/first-run-journey.tsx
+++ b/ui/components/first-run-journey.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowRight, CheckCircle2, Circle, Plug, ScanSearch, Sparkles } from "lucide-react";
+
+import type { AuthMeResponse } from "@/lib/api";
+import { PermissionDeniedNotice } from "@/components/role-access";
+
+type StepStatus = "done" | "current" | "todo";
+
+interface JourneyStep {
+  id: "connect" | "scan" | "results";
+  title: string;
+  detail: string;
+  icon: typeof Plug;
+  status: StepStatus;
+}
+
+function statusOf(done: boolean, isCurrent: boolean): StepStatus {
+  if (done) return "done";
+  return isCurrent ? "current" : "todo";
+}
+
+/**
+ * Guided connect → scan → see-results path for a fresh instance. Honest: a step
+ * is "done" only when the real estate says so (a connection exists, a scan has
+ * run, findings landed). No fabricated progress. Renders nothing once the whole
+ * journey is complete so it never clutters a populated instance.
+ */
+export function FirstRunJourney({
+  connectionsCount,
+  scanCount,
+  findingsCount,
+  canManage,
+  session,
+  onConnect,
+}: {
+  connectionsCount: number;
+  scanCount: number;
+  findingsCount: number;
+  canManage: boolean;
+  session: AuthMeResponse | null;
+  onConnect: () => void;
+}) {
+  const connected = connectionsCount > 0;
+  const scanned = scanCount > 0;
+  const hasResults = findingsCount > 0;
+
+  if (connected && scanned && hasResults) return null;
+
+  // The current step is the first incomplete one.
+  const currentId: JourneyStep["id"] = !connected
+    ? "connect"
+    : !scanned
+      ? "scan"
+      : "results";
+
+  const steps: JourneyStep[] = [
+    {
+      id: "connect",
+      title: "Connect a source",
+      detail:
+        "Add a read-only cloud account, or register a repo, image, IaC, or MCP source. Secrets are encrypted at rest.",
+      icon: Plug,
+      status: statusOf(connected, currentId === "connect"),
+    },
+    {
+      id: "scan",
+      title: "Run a scan",
+      detail:
+        "Launch a read-only inventory + CIS scan on the connection, or run a local scan for repo / image / IaC evidence.",
+      icon: ScanSearch,
+      status: statusOf(scanned, currentId === "scan"),
+    },
+    {
+      id: "results",
+      title: "See results",
+      detail:
+        "Findings, the security graph, and compliance populate from your first scan — each one links straight to its evidence.",
+      icon: Sparkles,
+      status: statusOf(hasResults, currentId === "results"),
+    },
+  ];
+
+  const completed = steps.filter((s) => s.status === "done").length;
+
+  return (
+    <section
+      data-testid="first-run-journey"
+      className="rounded-2xl border border-[color:var(--border-subtle)] bg-[linear-gradient(160deg,var(--surface-elevated),var(--surface))] p-5"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-base font-semibold text-[var(--foreground)]">
+            Get to your first findings
+          </h2>
+          <p className="mt-1 text-sm text-[var(--text-secondary)]">
+            Three steps from an empty instance to correlated evidence. We only
+            check a step off once it has actually happened.
+          </p>
+        </div>
+        <span className="shrink-0 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2.5 py-0.5 text-[11px] font-medium text-[var(--text-secondary)]">
+          {completed} of {steps.length} done
+        </span>
+      </div>
+
+      <ol className="mt-4 space-y-3">
+        {steps.map((step, index) => {
+          const Icon = step.icon;
+          const isCurrent = step.status === "current";
+          return (
+            <li
+              key={step.id}
+              data-testid={`journey-step-${step.id}`}
+              data-status={step.status}
+              className={`rounded-xl border p-4 transition ${
+                isCurrent
+                  ? "border-emerald-500/50 bg-emerald-500/10"
+                  : "border-[color:var(--border-subtle)] bg-[color:var(--surface)]"
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                <span className="mt-0.5 shrink-0">
+                  {step.status === "done" ? (
+                    <CheckCircle2 className="h-5 w-5 text-emerald-400" />
+                  ) : isCurrent ? (
+                    <span className="flex h-5 w-5 items-center justify-center rounded-full border border-emerald-500 text-[11px] font-semibold text-emerald-300">
+                      {index + 1}
+                    </span>
+                  ) : (
+                    <Circle className="h-5 w-5 text-[var(--text-tertiary)]" />
+                  )}
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="inline-flex items-center gap-2 text-sm font-semibold text-[var(--foreground)]">
+                    <Icon className="h-4 w-4 text-emerald-400" />
+                    {step.title}
+                    {step.status === "done" ? (
+                      <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-200">
+                        Done
+                      </span>
+                    ) : null}
+                  </p>
+                  <p className="mt-1 text-[13px] leading-6 text-[var(--text-secondary)]">
+                    {step.detail}
+                  </p>
+
+                  {isCurrent ? (
+                    <JourneyAction
+                      step={step.id}
+                      canManage={canManage}
+                      session={session}
+                      onConnect={onConnect}
+                    />
+                  ) : null}
+                </div>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}
+
+function JourneyAction({
+  step,
+  canManage,
+  session,
+  onConnect,
+}: {
+  step: JourneyStep["id"];
+  canManage: boolean;
+  session: AuthMeResponse | null;
+  onConnect: () => void;
+}) {
+  // Connect and scan both require the analyst/contributor role. A viewer sees
+  // the concrete elevation path instead of a dead button.
+  if (!canManage && (step === "connect" || step === "scan")) {
+    return (
+      <PermissionDeniedNotice
+        session={session}
+        needed="analyst"
+        action={step === "connect" ? "connect a source" : "run a scan"}
+        className="mt-3"
+      />
+    );
+  }
+
+  if (step === "connect") {
+    return (
+      <div className="mt-3 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={onConnect}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-medium text-black transition hover:bg-emerald-400"
+        >
+          <Plug className="h-3.5 w-3.5" />
+          Connect cloud account
+        </button>
+        <Link
+          href="/sources"
+          className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-1.5 text-xs font-medium text-[var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+        >
+          Register a source
+          <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+    );
+  }
+
+  if (step === "scan") {
+    return (
+      <div className="mt-3 flex flex-wrap gap-2">
+        <span className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-200">
+          <ScanSearch className="h-3.5 w-3.5" />
+          Use “Run scan” on your connection below
+        </span>
+        <Link
+          href="/scan"
+          className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-1.5 text-xs font-medium text-[var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+        >
+          New local scan
+          <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-3 flex flex-wrap gap-2">
+      <Link
+        href="/findings"
+        className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-medium text-black transition hover:bg-emerald-400"
+      >
+        Open findings
+        <ArrowRight className="h-3.5 w-3.5" />
+      </Link>
+      <Link
+        href="/security-graph"
+        className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-1.5 text-xs font-medium text-[var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+      >
+        Open graph
+        <ArrowRight className="h-3.5 w-3.5" />
+      </Link>
+    </div>
+  );
+}

--- a/ui/components/role-access.tsx
+++ b/ui/components/role-access.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { Check, Eye, Lock, ShieldCheck, TriangleAlert, Wrench, X } from "lucide-react";
+
+import type { AuthMeResponse } from "@/lib/api";
+import {
+  ROLE_LADDER,
+  type RoleId,
+  normalizeRoleId,
+  roleElevationGuidance,
+} from "@/lib/roles";
+
+const ROLE_ICON: Record<RoleId, typeof Eye> = {
+  viewer: Eye,
+  analyst: Wrench,
+  admin: ShieldCheck,
+};
+
+function activeRoleId(session: AuthMeResponse | null): RoleId | null {
+  return normalizeRoleId(session?.role_summary?.role ?? session?.role ?? null);
+}
+
+/** Compact chip naming the caller's current role. */
+export function RoleBadge({ session }: { session: AuthMeResponse | null }) {
+  const roleId = activeRoleId(session);
+  const entry = ROLE_LADDER.find((r) => r.id === roleId);
+  if (!entry) return null;
+  const Icon = ROLE_ICON[entry.id];
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-0.5 text-[11px] font-medium text-[var(--text-secondary)]">
+      <Icon className="h-3 w-3 text-emerald-400" />
+      Your role · {entry.label}
+    </span>
+  );
+}
+
+/**
+ * Actionable, non-403 permission notice. Names the current role, what the
+ * blocked action needs, and the concrete lever to elevate — self-host env var
+ * or an admin grant — instead of a raw "Role 'viewer' does not have 'scan'".
+ */
+export function PermissionDeniedNotice({
+  session,
+  needed = "analyst",
+  action = "connect a cloud account or run a scan",
+  className = "",
+}: {
+  session: AuthMeResponse | null;
+  needed?: RoleId;
+  action?: string;
+  className?: string;
+}) {
+  const roleId = activeRoleId(session);
+  const current = ROLE_LADDER.find((r) => r.id === roleId);
+  const authRequired = Boolean(session?.auth_required);
+  const guidance = roleElevationGuidance({ authRequired, needed });
+  const neededLabel = ROLE_LADDER.find((r) => r.id === needed)?.label ?? "Contributor";
+
+  return (
+    <div
+      role="note"
+      className={`rounded-xl border border-amber-500/25 bg-amber-500/10 p-4 text-sm text-amber-100 ${className}`}
+    >
+      <p className="inline-flex items-center gap-2 font-medium">
+        <TriangleAlert className="h-4 w-4 shrink-0" />
+        {current
+          ? `Your ${current.label} role is read-only for this action.`
+          : "This action needs a higher role."}
+      </p>
+      <p className="mt-1.5 text-[13px] leading-6 text-amber-100/90">
+        To {action} you need the {neededLabel} role or higher.
+      </p>
+      <p className="mt-3 text-[12px] font-semibold uppercase tracking-[0.12em] text-amber-200/90">
+        {guidance.title}
+      </p>
+      <ul className="mt-1.5 space-y-1 text-[13px] leading-6 text-amber-100/90">
+        {guidance.steps.map((step) => (
+          <li key={step} className="flex items-start gap-2">
+            <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-amber-300/80" />
+            <span>{step}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+/**
+ * The viewer / contributor / admin ladder with the caller's current role
+ * highlighted. Static ladder mirrors rbac.py; the live capability facts come
+ * from the session's role_summary when present.
+ */
+export function RolePermissionsPanel({ session }: { session: AuthMeResponse | null }) {
+  const roleId = activeRoleId(session);
+  return (
+    <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
+      <div className="flex items-start gap-3">
+        <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
+          <Lock className="h-5 w-5 text-emerald-400" />
+        </span>
+        <div className="min-w-0">
+          <h2 className="text-base font-semibold text-[var(--foreground)]">
+            Roles &amp; permissions
+          </h2>
+          <p className="mt-1 text-sm text-[var(--text-secondary)]">
+            Three roles gate the control plane. Viewer reads; Contributor connects
+            and scans; Admin manages keys, policy, and fleet. Your role decides
+            which actions are enabled below.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-3 md:grid-cols-3">
+        {ROLE_LADDER.map((entry) => {
+          const Icon = ROLE_ICON[entry.id];
+          const active = entry.id === roleId;
+          return (
+            <div
+              key={entry.id}
+              aria-current={active ? "true" : undefined}
+              data-testid={`role-card-${entry.id}`}
+              className={`flex h-full flex-col rounded-xl border p-3 transition ${
+                active
+                  ? "border-emerald-500/60 bg-emerald-500/10"
+                  : "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)]"
+              }`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="inline-flex items-center gap-2 text-sm font-semibold text-[var(--foreground)]">
+                  <Icon className="h-4 w-4 text-emerald-400" />
+                  {entry.label}
+                </span>
+                {active ? (
+                  <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-200">
+                    You
+                  </span>
+                ) : null}
+              </div>
+              <p className="mt-2 text-[12px] leading-5 text-[var(--text-secondary)]">
+                {entry.summary}
+              </p>
+              <ul className="mt-3 space-y-1 text-[12px] leading-5">
+                {entry.can.map((item) => (
+                  <li key={item} className="flex items-start gap-1.5 text-[var(--text-secondary)]">
+                    <Check className="mt-0.5 h-3 w-3 shrink-0 text-emerald-400" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+                {entry.cannot.map((item) => (
+                  <li key={item} className="flex items-start gap-1.5 text-[var(--text-tertiary)]">
+                    <X className="mt-0.5 h-3 w-3 shrink-0 text-[var(--text-tertiary)]" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/ui/e2e/connections-screenshot.spec.ts
+++ b/ui/e2e/connections-screenshot.spec.ts
@@ -104,11 +104,13 @@ test("captures connections page and wizard", async ({ page }, testInfo) => {
   const dialog = page.getByRole("dialog", { name: "Add cloud account" });
   await expect(dialog).toBeVisible();
   await dialog.getByRole("button", { name: "Next", exact: true }).click();
+  const setupExternalId = (await dialog.getByTestId("wizard-external-id").textContent())?.trim();
+  expect(setupExternalId).toMatch(/^[a-f0-9]{32}$/);
   await dialog.getByRole("button", { name: "Next", exact: true }).click();
   await expect(page.getByText("Read-only connection · step 3 of 3")).toBeVisible();
   await dialog.getByPlaceholder("Production account").fill("Production account");
   await dialog.getByPlaceholder(/arn:aws:iam/).fill("arn:aws:iam::123456789012:role/agent-bom-readonly");
-  await dialog.getByPlaceholder("••••••••••••").fill("example-external-id");
+  await expect(dialog.getByTestId("wizard-external-id-details")).toHaveText(setupExternalId!);
   await dialog.getByPlaceholder("us-east-1, us-west-2").fill("us-east-1, us-west-2");
   await expect(dialog.getByText("A display name is required.")).toHaveCount(0);
   await page.screenshot({ path: ".screenshots/connections-wizard.png" });

--- a/ui/lib/roles.ts
+++ b/ui/lib/roles.ts
@@ -1,0 +1,120 @@
+// Honest, code-true role model for the dashboard.
+//
+// Mirrors the closed role enum and permission matrix in
+// `src/agent_bom/rbac.py` (viewer / analyst / admin). The live per-session
+// capabilities come from `/v1/auth/me` (`role_summary`); this module supplies
+// the *ladder* — what each of the three roles can and cannot do — plus the
+// elevation guidance the API cannot infer, so a user who hits a 403 knows the
+// concrete next step instead of a raw "Role 'viewer' does not have 'scan'".
+
+export type RoleId = "viewer" | "analyst" | "admin";
+
+export interface RoleLadderEntry {
+  id: RoleId;
+  /** UI-facing label. analyst surfaces as "Contributor" (matches rbac display names). */
+  label: string;
+  /** The raw role value the API reports (what a 403 message names). */
+  value: RoleId;
+  summary: string;
+  can: string[];
+  cannot: string[];
+}
+
+const RANK: Record<RoleId, number> = { viewer: 1, analyst: 2, admin: 3 };
+
+export const ROLE_LADDER: RoleLadderEntry[] = [
+  {
+    id: "viewer",
+    label: "Viewer",
+    value: "viewer",
+    summary: "Read-only across inventory, findings, graph, compliance, and audit.",
+    can: [
+      "View inventory, findings, graph, posture, compliance, and audit",
+      "Open evidence and export what is already scanned",
+    ],
+    cannot: [
+      "Connect a cloud account or source",
+      "Run or schedule scans",
+      "Create exceptions, keys, policy, or fleet writes",
+    ],
+  },
+  {
+    id: "analyst",
+    label: "Contributor",
+    value: "analyst",
+    summary: "Everything a viewer sees, plus connect, scan, and evidence workflows.",
+    can: [
+      "Connect cloud accounts and manage sources + schedules",
+      "Run read-only scans and push runtime evidence",
+      "Create exception / false-positive workflows",
+    ],
+    cannot: [
+      "Create, rotate, or revoke API keys",
+      "Change protected admin policy, fleet writes, or break-glass state",
+    ],
+  },
+  {
+    id: "admin",
+    label: "Admin",
+    value: "admin",
+    summary: "Full control-plane administration and protected writes.",
+    can: [
+      "Everything a contributor can do",
+      "Manage API keys, gateway policy, and fleet sync",
+      "Approve exceptions and protected break-glass actions",
+    ],
+    cannot: [],
+  },
+];
+
+export function normalizeRoleId(value: string | null | undefined): RoleId | null {
+  const raw = (value ?? "").trim().toLowerCase();
+  if (raw === "viewer" || raw === "analyst" || raw === "admin") return raw;
+  // rbac's UI display name for analyst is "contributor".
+  if (raw === "contributor") return "analyst";
+  return null;
+}
+
+export function roleRank(value: string | null | undefined): number {
+  const id = normalizeRoleId(value);
+  return id ? RANK[id] : 0;
+}
+
+/** analyst + admin can connect/scan (the `scan` permission in rbac.py). */
+export function roleCanConnect(value: string | null | undefined): boolean {
+  return roleRank(value) >= RANK.analyst;
+}
+
+export interface ElevationGuidance {
+  title: string;
+  steps: string[];
+}
+
+/**
+ * Concrete, honest guidance for raising the effective role. The path differs
+ * for an authenticated deployment vs a local unauthenticated (self-host) one —
+ * agent-bom never self-elevates, so we point at the real lever.
+ */
+export function roleElevationGuidance(opts: {
+  authRequired: boolean;
+  needed?: RoleId;
+}): ElevationGuidance {
+  const needed = opts.needed ?? "analyst";
+  const neededLabel = ROLE_LADDER.find((r) => r.id === needed)?.label ?? "Contributor";
+  if (opts.authRequired) {
+    return {
+      title: `Ask an admin to grant ${neededLabel} access`,
+      steps: [
+        "Your role comes from your API key or SSO group mapping, not from this UI.",
+        `An admin assigns ${neededLabel} (${needed}) to your identity; sign in again to pick it up.`,
+      ],
+    };
+  }
+  return {
+    title: `Grant this local instance ${neededLabel} access`,
+    steps: [
+      `Set AGENT_BOM_NO_AUTH_ROLE=${needed} on the API and restart (the shipped pilot compose already defaults to analyst).`,
+      "AGENT_BOM_DEMO_ESTATE=1 always clamps to read-only viewer for public demos.",
+    ],
+  };
+}

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -102,8 +102,14 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+function openAwsWizard(): HTMLElement {
+  // The header "Add cloud account" button opens the wizard defaulted to AWS.
+  fireEvent.click(screen.getByRole("button", { name: "Add cloud account" }));
+  return screen.getByRole("dialog", { name: "Add cloud account" });
+}
+
 describe("ConnectionsPage", () => {
-  it("creates a connection through the wizard and lists it with has_external_id, never rendering the secret", async () => {
+  it("carries one AWS ExternalId from setup through details into create", async () => {
     apiMock.createCloudConnection.mockResolvedValue(CREATED_RECORD);
     // After create, the list refresh returns the new connection.
     apiMock.listCloudConnections
@@ -128,36 +134,50 @@ describe("ConnectionsPage", () => {
       ).toBeInTheDocument(),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Add cloud account" }));
-    // Step 0 -> 1 -> 2. Advancing must NOT trigger a premature form submit.
-    fireEvent.click(screen.getByRole("button", { name: /Next/ }));
-    fireEvent.click(screen.getByRole("button", { name: /Next/ }));
+    const wizard = openAwsWizard();
+
+    // Step 0 -> 1 (Setup). Advancing must NOT trigger a premature form submit.
+    fireEvent.click(within(wizard).getByRole("button", { name: /Next/ }));
+    // A single ExternalId is generated once and shown in the trust-policy panel
+    // and embedded in the grant script the user copies.
+    const setupId = within(wizard)
+      .getByTestId("wizard-external-id")
+      .textContent!.trim();
+    expect(setupId).toMatch(/^[a-f0-9]{32}$/);
+    expect(within(wizard).getByText(/EXTERNAL_ID=/)).toBeInTheDocument();
+
+    // Step 1 -> 2 (Details). The carried ExternalId must be identical — never
+    // a fresh mint that would not match the applied trust policy.
+    fireEvent.click(within(wizard).getByRole("button", { name: /Next/ }));
     expect(screen.queryByText("A display name is required.")).toBeNull();
     expect(apiMock.createCloudConnection).not.toHaveBeenCalled();
 
-    fireEvent.change(screen.getByPlaceholderText("Production account"), {
+    const detailsId = within(wizard)
+      .getByTestId("wizard-external-id-details")
+      .textContent!.trim();
+    expect(detailsId).toBe(setupId);
+
+    fireEvent.change(within(wizard).getByPlaceholderText("Production account"), {
       target: { value: "Production account" },
     });
-    fireEvent.change(screen.getByPlaceholderText(/arn:aws:iam/), {
+    fireEvent.change(within(wizard).getByPlaceholderText(/arn:aws:iam/), {
       target: { value: "arn:aws:iam::123456789012:role/agent-bom-readonly" },
     });
-    const secretInput = screen.getByPlaceholderText(
-      "••••••••••••",
-    ) as HTMLInputElement;
-    expect(secretInput.type).toBe("password");
-    fireEvent.change(secretInput, { target: { value: SECRET } });
-    fireEvent.change(screen.getByPlaceholderText("us-east-1, us-west-2"), {
+    fireEvent.change(within(wizard).getByPlaceholderText("us-east-1, us-west-2"), {
       target: { value: "us-east-1" },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: "Create connection" }));
+    fireEvent.click(
+      within(wizard).getByRole("button", { name: "Create connection" }),
+    );
 
+    // The stored ExternalId is exactly the value shown in setup + details.
     await waitFor(() =>
       expect(apiMock.createCloudConnection).toHaveBeenCalledWith({
         provider: "aws",
         display_name: "Production account",
         role_ref: "arn:aws:iam::123456789012:role/agent-bom-readonly",
-        external_id: SECRET,
+        external_id: setupId,
         regions: ["us-east-1"],
         // AWS has no provider-specific params, so auth_params is an empty map.
         auth_params: {},
@@ -169,13 +189,9 @@ describe("ConnectionsPage", () => {
       expect(screen.getByText("Production account")).toBeInTheDocument(),
     );
     expect(screen.getByText("Secret configured")).toBeInTheDocument();
-
-    // The plaintext secret must not be present anywhere in the rendered DOM.
-    expect(document.body.textContent).not.toContain(SECRET);
-    expect(document.querySelector(`input[value="${SECRET}"]`)).toBeNull();
   });
 
-  it("generates an AWS external ID in the wizard and pre-fills the secret field", async () => {
+  it("regenerating the AWS ExternalId updates setup and details together", async () => {
     render(<ConnectionsPage />);
 
     await waitFor(() =>
@@ -184,22 +200,25 @@ describe("ConnectionsPage", () => {
       ).toBeInTheDocument(),
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Add cloud account" }));
-    fireEvent.click(screen.getByRole("button", { name: /Next/ }));
+    const wizard = openAwsWizard();
+    fireEvent.click(within(wizard).getByRole("button", { name: /Next/ }));
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Generate external ID" }),
-    );
+    const firstId = within(wizard)
+      .getByTestId("wizard-external-id")
+      .textContent!.trim();
 
-    const generated = screen.getByText(/^[a-f0-9]{32}$/);
-    expect(generated).toBeInTheDocument();
+    fireEvent.click(within(wizard).getByRole("button", { name: "Regenerate" }));
+    const regeneratedId = within(wizard)
+      .getByTestId("wizard-external-id")
+      .textContent!.trim();
+    expect(regeneratedId).toMatch(/^[a-f0-9]{32}$/);
+    expect(regeneratedId).not.toBe(firstId);
 
-    fireEvent.click(screen.getByRole("button", { name: /Next/ }));
-
-    const secretInput = screen.getByPlaceholderText(
-      "••••••••••••",
-    ) as HTMLInputElement;
-    expect(secretInput.value).toBe(generated.textContent);
+    // The Details step reflects the regenerated value — the two never diverge.
+    fireEvent.click(within(wizard).getByRole("button", { name: /Next/ }));
+    expect(
+      within(wizard).getByTestId("wizard-external-id-details").textContent!.trim(),
+    ).toBe(regeneratedId);
   });
 
   it("maps provider-specific GCP fields to role_ref / external_id / auth_params", async () => {
@@ -249,6 +268,12 @@ describe("ConnectionsPage", () => {
         auth_params: { project_id: "proj-123" },
       }),
     );
+
+    // The pasted credential is dropped from state on success and never rendered.
+    await waitFor(() =>
+      expect(document.body.textContent).not.toContain(SECRET),
+    );
+    expect(document.querySelector(`textarea[value="${SECRET}"]`)).toBeNull();
   });
 
   it("runs a read-only scan and shows inventory counts + CIS pass rate", async () => {

--- a/ui/tests/first-run-journey.test.tsx
+++ b/ui/tests/first-run-journey.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FirstRunJourney } from "@/components/first-run-journey";
+import type { AuthMeResponse } from "@/lib/api";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+function session(overrides: Partial<AuthMeResponse> = {}): AuthMeResponse {
+  return {
+    authenticated: true,
+    auth_required: false,
+    configured_modes: [],
+    recommended_ui_mode: "no_auth",
+    auth_method: "no_auth",
+    subject: null,
+    tenant_id: "default",
+    role: "analyst",
+    role_summary: null,
+    memberships: [],
+    request_id: null,
+    trace_id: null,
+    span_id: null,
+    ...overrides,
+  };
+}
+
+describe("FirstRunJourney", () => {
+  it("marks connect as current on a fresh instance and exposes the connect action", () => {
+    const onConnect = vi.fn();
+    render(
+      <FirstRunJourney
+        connectionsCount={0}
+        scanCount={0}
+        findingsCount={0}
+        canManage
+        session={session()}
+        onConnect={onConnect}
+      />,
+    );
+
+    expect(screen.getByTestId("first-run-journey")).toBeInTheDocument();
+    expect(screen.getByText("0 of 3 done")).toBeInTheDocument();
+    expect(screen.getByTestId("journey-step-connect")).toHaveAttribute(
+      "data-status",
+      "current",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Connect cloud account/ }));
+    expect(onConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("checks a step off only when the estate really has it (honest progress)", () => {
+    render(
+      <FirstRunJourney
+        connectionsCount={2}
+        scanCount={0}
+        findingsCount={0}
+        canManage
+        session={session()}
+        onConnect={vi.fn()}
+      />,
+    );
+    // Connected is real → done; scan is the current step; results still todo.
+    expect(screen.getByText("1 of 3 done")).toBeInTheDocument();
+    expect(screen.getByTestId("journey-step-connect")).toHaveAttribute("data-status", "done");
+    expect(screen.getByTestId("journey-step-scan")).toHaveAttribute("data-status", "current");
+    expect(screen.getByTestId("journey-step-results")).toHaveAttribute("data-status", "todo");
+  });
+
+  it("disappears once the whole journey is complete (no clutter on a live instance)", () => {
+    const { container } = render(
+      <FirstRunJourney
+        connectionsCount={1}
+        scanCount={3}
+        findingsCount={12}
+        canManage
+        session={session()}
+        onConnect={vi.fn()}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a viewer the elevation path instead of a dead connect button", () => {
+    render(
+      <FirstRunJourney
+        connectionsCount={0}
+        scanCount={0}
+        findingsCount={0}
+        canManage={false}
+        session={session({ role: "viewer", auth_required: false })}
+        onConnect={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Connect cloud account/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/AGENT_BOM_NO_AUTH_ROLE=analyst/)).toBeInTheDocument();
+  });
+});

--- a/ui/tests/role-access.test.tsx
+++ b/ui/tests/role-access.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  PermissionDeniedNotice,
+  RoleBadge,
+  RolePermissionsPanel,
+} from "@/components/role-access";
+import type { AuthMeResponse } from "@/lib/api";
+
+function session(overrides: Partial<AuthMeResponse> = {}): AuthMeResponse {
+  return {
+    authenticated: true,
+    auth_required: true,
+    configured_modes: [],
+    recommended_ui_mode: "api_key",
+    auth_method: "api_key",
+    subject: "svc",
+    tenant_id: "default",
+    role: "viewer",
+    role_summary: null,
+    memberships: [],
+    request_id: null,
+    trace_id: null,
+    span_id: null,
+    ...overrides,
+  };
+}
+
+describe("RolePermissionsPanel", () => {
+  it("renders the viewer/contributor/admin ladder and highlights the active role", () => {
+    render(<RolePermissionsPanel session={session({ role: "analyst" })} />);
+    expect(screen.getByText("Roles & permissions")).toBeInTheDocument();
+    expect(screen.getByTestId("role-card-viewer")).toBeInTheDocument();
+    expect(screen.getByTestId("role-card-admin")).toBeInTheDocument();
+
+    const contributor = screen.getByTestId("role-card-analyst");
+    // analyst is the active role → flagged as "You".
+    expect(contributor).toHaveAttribute("aria-current", "true");
+    expect(within(contributor).getByText("You")).toBeInTheDocument();
+    // Viewer card is not the active one.
+    expect(screen.getByTestId("role-card-viewer")).not.toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+  });
+
+  it("maps the analyst role_summary onto the Contributor card", () => {
+    render(
+      <RolePermissionsPanel
+        session={session({
+          role: "analyst",
+          role_summary: {
+            role: "analyst",
+            ui_role: "contributor",
+            display_name: "Contributor",
+            description: "",
+            capabilities: ["scan.run"],
+            capability_matrix: [],
+            can_see: [],
+            can_do: [],
+            cannot_do: [],
+          },
+        })}
+      />,
+    );
+    expect(screen.getByTestId("role-card-analyst")).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+  });
+});
+
+describe("RoleBadge", () => {
+  it("names the current role", () => {
+    render(<RoleBadge session={session({ role: "admin" })} />);
+    expect(screen.getByText(/Your role · Admin/)).toBeInTheDocument();
+  });
+
+  it("renders nothing without a resolvable role", () => {
+    const { container } = render(<RoleBadge session={session({ role: null })} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("PermissionDeniedNotice", () => {
+  it("points an authenticated viewer at an admin grant, not a raw 403", () => {
+    render(<PermissionDeniedNotice session={session({ role: "viewer" })} />);
+    expect(screen.getByText(/read-only for this action/i)).toBeInTheDocument();
+    expect(screen.getByText(/Ask an admin to grant Contributor access/i)).toBeInTheDocument();
+    // Honest: no fabricated "self-elevate" affordance.
+    expect(screen.queryByText(/AGENT_BOM_NO_AUTH_ROLE/)).toBeNull();
+  });
+
+  it("gives a self-host operator the concrete env-var lever", () => {
+    render(
+      <PermissionDeniedNotice
+        session={session({ role: "viewer", auth_required: false })}
+      />,
+    );
+    expect(screen.getByText(/AGENT_BOM_NO_AUTH_ROLE=analyst/)).toBeInTheDocument();
+    expect(screen.getByText(/AGENT_BOM_DEMO_ESTATE/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Closes the onboarding + first-run gaps left after the AWS CloudFormation (#3939) and Azure/GCP terraform (#3944) landed. Builds **only the remaining parts** of #3935 and all of #3936.

Closes #3936
Closes #3935
Refs #3931

### #3935 — one ExternalId, carried through the wizard
The wizard used to mint a *new* ExternalId on the Details step that would not match a role the user already created in AWS. Now the AWS ExternalId is generated **once** and carried unchanged Setup → Details; the value in the copy-ready grant script is exactly the value the connection stores. The per-step mint-new button is gone — "Regenerate" (Setup only) updates the grant script and the stored value together.

### #3935 — self-host defaults that just work
- Pilot + platform compose default `AGENT_BOM_NO_AUTH_ROLE=analyst` so a local no-auth stack can connect + scan (viewer is read-only; `AGENT_BOM_DEMO_ESTATE` still clamps to viewer).
- Local/no-auth stacks **auto-seed** a Fernet key at `~/.agent-bom/connections.key` on first boot (persisted, `0600`, fail-closed everywhere else), so first-run connect no longer 503s on `AGENT_BOM_CONNECTIONS_KEY unset`. Opt out with `AGENT_BOM_NO_AUTO_CONNECTIONS_KEY=1`. No plaintext in compose.
- Fixed a latent bug: `connections_key_configured()` ignored the `*_FILE` secret form, so the file-mounted **platform** stack would have failed closed spuriously too.

### #3936 — guided first-run + role clarity
- `FirstRunJourney`: honest connect → scan → see-results guide built on the existing empty-state primitives. A step is only "done" when the estate really has it; the whole guide disappears once complete (no fake progress, no clutter).
- `RolePermissionsPanel` + `RoleBadge` + `PermissionDeniedNotice`: surface the viewer / analyst / admin ladder (true to `rbac.py`) and, when an action needs a higher role, the concrete elevation lever (self-host env var, or "ask an admin") instead of a raw `Role 'viewer' does not have 'scan'` 403.

### Already-done vs newly-built
- **Already merged (not touched):** AWS 1-click CFN + StackSet (#3939), Azure/GCP org-scale terraform (#3944).
- **New here:** the four items above.

### Scope
Does **not** touch `ui/components/nav.tsx` (owned by a parallel PR this round).

## Verification
- `pytest` touched suites (connection-key auto-seed, compose, preflight, connection/cli) — green
- `ruff` + `mypy` on touched Python — clean
- `make preflight` — green (new env var allowlisted)
- UI `npm ci` → `typecheck` → `lint` (0 errors) → `build` → `vitest` full **468 passed**
- `docker compose config` validates for platform + pilot