### PR TITLE
fix(deploy): demo redeploy — ec2 SendCommand ARN + dash-safe remote script

### DIFF
--- a/.github/workflows/demo-redeploy.yml
+++ b/.github/workflows/demo-redeploy.yml
@@ -87,7 +87,10 @@ jobs:
           # NOT expand any of the VM-side shell variables, then splice in only
           # the two runner-provided values via sed.
           cat > remote.sh <<'REMOTE'
-          set -euo pipefail
+          # SSM AWS-RunShellScript executes this under /bin/sh (dash on Ubuntu),
+          # which has no `pipefail` — use POSIX-safe `set -eu` so the script does
+          # not abort at line 1 with "Illegal option -o pipefail".
+          set -eu
           DEPLOY_DIR="__DEPLOY_DIR__"
           RESET_DEMO="__RESET_DEMO__"
           cd "$DEPLOY_DIR"

--- a/deploy/terraform/demo-deploy-oidc/main.tf
+++ b/deploy/terraform/demo-deploy-oidc/main.tf
@@ -32,9 +32,12 @@ locals {
   oidc_provider_arn = var.create_oidc_provider ? aws_iam_openid_connect_provider.github[0].arn : data.aws_iam_openid_connect_provider.github[0].arn
 
   # ARNs SendCommand is scoped to: the AWS-managed shell document plus the one
-  # demo instance. Both are required for a single ssm:SendCommand call.
+  # demo instance. Both are required for a single ssm:SendCommand call. The
+  # instance resource for ssm:SendCommand is the EC2 instance ARN (service
+  # `ec2`, not `ssm`) — IAM evaluates SendCommand against arn:aws:ec2:...:instance/...,
+  # so an ssm-service instance ARN silently fails closed with AccessDenied.
   run_shell_document_arn = "arn:${data.aws_partition.current.partition}:ssm:*::document/AWS-RunShellScript"
-  demo_instance_arn      = "arn:${data.aws_partition.current.partition}:ssm:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/${var.demo_instance_id}"
+  demo_instance_arn      = "arn:${data.aws_partition.current.partition}:ec2:${var.aws_region}:${data.aws_caller_identity.current.account_id}:instance/${var.demo_instance_id}"
 }
 
 data "aws_partition" "current" {}


### PR DESCRIPTION
## Summary
- `ssm:SendCommand`'s instance resource must be the **EC2** instance ARN (`arn:aws:ec2:<region>:<account>:instance/<id>`), not an `ssm`-service ARN. IAM evaluates SendCommand against the ec2 ARN, so the prior `arn:...:ssm:...:instance/...` scoping never matched — every demo redeploy failed closed with `AccessDeniedException` on `ssm:SendCommand`.

## Verification
- Reproduced live: the demo-redeploy workflow's OIDC assume-role succeeded, then SendCommand was denied with exactly this ARN mismatch (`...not authorized to perform: ssm:SendCommand on resource: arn:aws:ec2:...:instance/i-...`). Swapping the service to `ec2` resolves it.
- `terraform fmt -check` clean.

## Notes
Document ARN (`ssm:*::document/AWS-RunShellScript`) and the read-only `GetCommandInvocation` statement are unchanged and correct.