### PR TITLE
feat(sast): add CI workflow hardening checks

### DIFF
--- a/docs/PERMISSIONS.md
+++ b/docs/PERMISSIONS.md
@@ -20,8 +20,14 @@ agent-bom reads only what you explicitly ask it to scan:
 | Docker images | `--image` | Image filesystem layers (via container inspection subprocess) |
 | Kubernetes | `--k8s` | Pod specs via `kubectl get pods -o json` (read-only) |
 | Terraform | `--tf-dir` | `.tf` source files (no state files, no `.tfvars`) |
-| GitHub Actions | `--gha` | `.github/workflows/*.yml` files |
+| GitHub Actions | `--gha` | `.github/workflows/*.yml` files; reports AI/credential use plus unpinned remote actions, `pull_request_target`, and missing top-level `permissions:` policies |
 | SBOM files | `--sbom` | CycloneDX/SPDX JSON you provide |
+
+Run `agent-bom agents --gha . --offline` to inspect workflow files without
+network access. Pipeline-hardening gaps appear as scan warnings; pin remote
+actions and reusable workflows to full commit SHAs, avoid executing untrusted
+pull-request code under `pull_request_target`, and declare least-privilege
+top-level `permissions:` before rerunning the same command.
 
 ---
 

--- a/src/agent_bom/cli/options_surfaces.py
+++ b/src/agent_bom/cli/options_surfaces.py
@@ -360,7 +360,8 @@ def iac_sast_options(fn):
                 "gha_path",
                 type=click.Path(exists=True),
                 metavar="REPO",
-                help="Repository root to scan GitHub Actions workflows for AI usage and credential exposure. "
+                help="Repository root to scan GitHub Actions workflows for AI usage, credential exposure, "
+                "unpinned actions, pull_request_target risk, and missing permissions policies. "
                 "Auto-detected when scanning --project or --repo if .github/workflows exists.",
             ),
             click.option(

--- a/src/agent_bom/github_actions.py
+++ b/src/agent_bom/github_actions.py
@@ -5,6 +5,8 @@ Scans ``.github/workflows/*.yml`` files to discover:
 - **AI SDK usage** in ``run:`` steps (openai, anthropic, langchain, etc.)
 - **Third-party AI actions** (e.g. ``openai/openai-github-action``)
 - **pip / npm packages** installed in workflow steps that are AI-related
+- **pipeline hardening gaps**: unpinned actions, ``pull_request_target``, and
+  workflows without an explicit top-level ``permissions:`` policy
 
 Treats each workflow file as a synthetic agent entry so blast radius
 analysis can show which CI pipelines are using AI with credential exposure.
@@ -67,6 +69,7 @@ _AI_RUN_PATTERNS = [
 # pip install / npm install AI packages in run steps
 _PIP_RE = re.compile(r"pip\s+install\s+([^\n&;]+)", re.IGNORECASE)
 _NPM_RE = re.compile(r"npm\s+(?:install|i)\s+([^\n&;]+)", re.IGNORECASE)
+_FULL_COMMIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}(?:[0-9a-fA-F]{24})?$")
 
 # NOTE: These are *ecosystem-specific* package lists for detecting AI SDK
 # installs in GitHub Actions workflow run-steps.  They are intentionally
@@ -202,6 +205,68 @@ def _extract_workflow_info(content: str) -> dict:
     return result
 
 
+def _strip_yaml_scalar(value: str) -> str:
+    """Return a simple scalar without a trailing comment or quote wrapper."""
+    scalar = value.split("#", 1)[0].strip()
+    if len(scalar) >= 2 and scalar[0] == scalar[-1] and scalar[0] in {'"', "'"}:
+        scalar = scalar[1:-1].strip()
+    return scalar
+
+
+def _workflow_hardening_warnings(content: str, filename: str, used_actions: list[str]) -> list[str]:
+    """Return conservative pipeline-security warnings for one workflow.
+
+    This remains a zero-dependency, line-level audit. Local actions and Docker
+    references are not remote supply-chain downloads and therefore do not need
+    a Git commit pin. Remote reusable workflows use the same ``owner/repo@ref``
+    syntax as actions and are checked as well.
+    """
+    warnings: list[str] = []
+    active_lines = [line for line in content.splitlines() if line.strip() and not line.lstrip().startswith("#")]
+
+    has_top_level_permissions = any(re.match(r"^permissions\s*:", line) for line in active_lines)
+    if not has_top_level_permissions:
+        warnings.append(
+            f"CI hardening in {filename}: missing top-level permissions: policy; "
+            "declare least-privilege GITHUB_TOKEN permissions"
+        )
+
+    has_pull_request_target = False
+    for index, line in enumerate(active_lines):
+        on_match = re.match(r"^on\s*:\s*(.*)$", line)
+        if on_match is None:
+            continue
+        inline_events = on_match.group(1)
+        if re.search(r"\bpull_request_target\b", inline_events):
+            has_pull_request_target = True
+            break
+        for event_line in active_lines[index + 1 :]:
+            if event_line == event_line.lstrip():
+                break
+            if re.match(r"^\s+pull_request_target\s*:", event_line):
+                has_pull_request_target = True
+                break
+        break
+    if has_pull_request_target:
+        warnings.append(
+            f"CI hardening in {filename}: pull_request_target runs in the base-repository "
+            "security context; do not execute untrusted pull-request code"
+        )
+
+    for raw_action in used_actions:
+        action = _strip_yaml_scalar(raw_action)
+        if not action or action.startswith(("./", "../", "docker://")):
+            continue
+        revision = action.rsplit("@", 1)[1] if "@" in action else ""
+        if not _FULL_COMMIT_SHA_RE.fullmatch(revision):
+            warnings.append(
+                f"CI hardening in {filename}: unpinned action {action}; pin remote actions "
+                "and reusable workflows to a full commit SHA"
+            )
+
+    return warnings
+
+
 # ─── Public API ───────────────────────────────────────────────────────────────
 
 
@@ -247,6 +312,7 @@ def scan_github_actions(repo_path: str) -> tuple[list[Agent], list[str]]:
             continue
 
         info = _extract_workflow_info(content)
+        warnings.extend(_workflow_hardening_warnings(content, wf_path.name, info["used_actions"]))
 
         # ── Check AI env vars ────────────────────────────────────────────────
         ai_env_keys: list[str] = [k for k in info["env_vars"] if _AI_ENV_NAMES.search(k)]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1952,7 +1952,7 @@ jobs:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       NORMAL_VAR: "hello"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
 """)
     agents, warnings = scan_github_actions(str(tmp_path))
     assert len(agents) == 1
@@ -1961,7 +1961,8 @@ jobs:
     server = agent.mcp_servers[0]
     assert server.has_credentials
     assert "OPENAI_API_KEY" in server.env
-    assert len(warnings) == 1
+    assert any("AI credentials exposed" in warning for warning in warnings)
+    assert any("missing top-level permissions" in warning for warning in warnings)
 
 
 def test_gha_no_ai_workflow_not_flagged(tmp_path):
@@ -1977,12 +1978,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567
       - run: pytest tests/
 """)
     agents, warnings = scan_github_actions(str(tmp_path))
     assert agents == []
-    assert warnings == []
+    assert warnings == [
+        "CI hardening in ci.yml: missing top-level permissions: policy; "
+        "declare least-privilege GITHUB_TOKEN permissions"
+    ]
 
 
 def test_gha_detects_ai_sdk_in_run_step(tmp_path):
@@ -2015,6 +2019,57 @@ def test_gha_no_workflows_dir(tmp_path):
     from agent_bom.github_actions import scan_github_actions
 
     agents, warnings = scan_github_actions(str(tmp_path))
+    assert agents == []
+    assert warnings == []
+
+
+def test_gha_flags_standard_pipeline_hardening_gaps(tmp_path):
+    """All workflows get general CI hardening checks, not only AI workflows."""
+    from agent_bom.github_actions import scan_github_actions
+
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "unsafe.yml").write_text("""
+name: Unsafe PR workflow
+on:
+  pull_request_target:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: org/reusable/.github/workflows/test.yml@main
+      - uses: ./local-action
+""")
+
+    agents, warnings = scan_github_actions(str(tmp_path))
+
+    assert agents == []
+    assert any("missing top-level permissions" in warning for warning in warnings)
+    assert any("pull_request_target" in warning for warning in warnings)
+    assert any("unpinned action actions/checkout@v4" in warning for warning in warnings)
+    assert any("unpinned action org/reusable/.github/workflows/test.yml@main" in warning for warning in warnings)
+    assert not any("local-action" in warning for warning in warnings)
+
+
+def test_gha_accepts_sha_pins_and_explicit_permissions(tmp_path):
+    from agent_bom.github_actions import scan_github_actions
+
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "safe.yml").write_text("""
+name: Safe workflow
+on: pull_request
+permissions: {}
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0123456789abcdef0123456789abcdef01234567 # v4
+""")
+
+    agents, warnings = scan_github_actions(str(tmp_path))
+
     assert agents == []
     assert warnings == []
 


### PR DESCRIPTION
## Summary

- scan every GitHub Actions workflow for unpinned remote actions and reusable workflows
- flag `pull_request_target` and missing top-level `permissions:` policies
- keep SAST provenance explicitly Semgrep-powered and document the offline command-to-warning workflow

Closes #3887.

## Verification

- `uv run pytest -q tests/test_core.py -k 'gha_' tests/test_repo_auto_detect.py` (7 passed)
- `uv run ruff check src/agent_bom/github_actions.py src/agent_bom/cli/options_surfaces.py tests/test_core.py`
- `uv run mypy src/agent_bom/github_actions.py`
- `uv run agent-bom agents --gha . --offline --no-discover --format json --output /tmp/agent-bom-3887-smoke.json --quiet`
- `git diff --check`

## Notes

- local actions and `docker://` references are excluded from remote commit-pin findings
- this remains a read-only, zero-network workflow-file audit