### PR TITLE
feat(image): decode legacy RPM databases natively

### DIFF
--- a/site-docs/features/scanning.md
+++ b/site-docs/features/scanning.md
@@ -56,6 +56,22 @@ agent-bom image python:3.12-slim
 ```
 
 Uses agent-bom's native image scanning pipeline to enumerate OS and language packages within container images.
+The native parser reads Debian dpkg, Alpine apk, modern SQLite RPM databases,
+and legacy RPM BerkeleyDB/NDB databases without requiring a scanner binary.
+Malformed legacy RPM databases fail the scan instead of producing a clean
+zero-package result.
+
+The default OS result remains precision-first and reports distro-confirmed
+advisories. To include unfixed, pending, no-DSA, and end-of-life distro
+advisories for an exhaustive review, run:
+
+```bash
+AGENT_BOM_INCLUDE_UNFIXED=1 agent-bom image python:3.12-slim
+```
+
+The artifact is the same findings report with lower-confidence unfixed distro
+rows included; review their match-confidence tier before using them as a CI
+block. Language-package coverage is unaffected by this switch.
 
 ## IaC and cloud posture
 

--- a/src/agent_bom/image.py
+++ b/src/agent_bom/image.py
@@ -43,10 +43,8 @@ from agent_bom.security import validate_image_ref
 
 _logger = logging.getLogger(__name__)
 _PLATFORM_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*){1,2}$")
-# Legacy rpm databases (BerkeleyDB ``Packages`` / NDB ``Packages.db``) are not
-# decoded natively yet — only the modern ``rpmdb.sqlite``. Older RHEL/CentOS/UBI
-# images ship one of these, so a tar that yields nothing else is partial
-# coverage, not an extraction failure.
+# Legacy RPM database paths decoded by the same native header-record parser as
+# OCI layers. Kept here for the flattened ``docker export`` fallback.
 _LEGACY_RPMDB_PATHS = ("var/lib/rpm/Packages", "var/lib/rpm/Packages.db")
 
 
@@ -632,19 +630,17 @@ def _packages_from_tar(tar_path: Path) -> list[Package]:
                 except Exception:
                     _logger.debug("Failed to parse Alpine apk db from container")
 
-            # --- RHEL/Fedora: rpm database ---
-            # The docker-export fallback can only read plaintext sources. Older
-            # RHEL/CentOS/UBI images keep packages in a BerkeleyDB ``Packages``
-            # file (or the NDB ``Packages.db``) we cannot decode yet; when one is
-            # present and no installed-rpms manifest covers it, warn so the empty
-            # result reads as partial coverage rather than a clean scan.
+            # --- RHEL/Fedora: legacy BerkeleyDB/NDB rpm database ---
             legacy_rpmdb = next((p for p in _LEGACY_RPMDB_PATHS if p in names), None)
             if legacy_rpmdb and "var/log/installed-rpms" not in names:
-                _logger.warning(
-                    "Legacy rpm database at /%s is not yet supported — OS package "
-                    "coverage from this image is incomplete",
-                    legacy_rpmdb,
-                )
+                from agent_bom.oci_parser import OCIParseError, _query_legacy_rpmdb
+
+                try:
+                    decoded_rpms = _query_legacy_rpmdb(tf, legacy_rpmdb)
+                except OCIParseError:
+                    raise ImageScanError("Legacy RPM database could not be decoded safely") from None
+                for rpm_name, rpm_ver in decoded_rpms:
+                    _add(rpm_name, rpm_ver, "rpm", f"pkg:rpm/redhat/{rpm_name}@{rpm_ver}")
 
             rpm_manifest = "var/log/installed-rpms"
             if rpm_manifest in names:
@@ -709,16 +705,6 @@ def _packages_from_tar(tar_path: Path) -> list[Package]:
     return packages
 
 
-def _tar_contains_legacy_rpmdb(tar_path: Path) -> str | None:
-    """Return the legacy rpmdb path if the tar carries an unparsed BerkeleyDB/NDB rpm db."""
-    try:
-        with tarfile.open(tar_path, "r") as tf:
-            names = set(tf.getnames())
-    except (tarfile.TarError, OSError):
-        return None
-    return next((p for p in _LEGACY_RPMDB_PATHS if p in names), None)
-
-
 def _scan_with_docker(image_ref: str, platform: Optional[str] = None) -> list[Package]:
     """Scan a Docker image natively and fail if no packages can be extracted."""
     from agent_bom.oci_parser import OCIParseError, scan_oci
@@ -777,20 +763,6 @@ def _scan_with_docker(image_ref: str, platform: Optional[str] = None) -> list[Pa
             packages = _packages_from_tar(tar_path)
             if packages:
                 return packages
-
-            # Distinguish a real extraction failure from a known coverage gap.
-            # A legacy BerkeleyDB/NDB rpm database (/var/lib/rpm/Packages) we
-            # cannot decode yet is correct-but-partial, so report 0 with a
-            # warning instead of failing the whole scan.
-            legacy_rpmdb = _tar_contains_legacy_rpmdb(tar_path)
-            if legacy_rpmdb:
-                _logger.warning(
-                    "Image %s uses a legacy rpm database at /%s that is not yet "
-                    "supported — reporting 0 packages; OS coverage is incomplete",
-                    image_ref,
-                    legacy_rpmdb,
-                )
-                return []
 
         raise ImageScanError(
             f"Native image scan extracted 0 packages from {image_ref}. This is likely an extraction or parser failure, not a clean scan."

--- a/src/agent_bom/oci_parser.py
+++ b/src/agent_bom/oci_parser.py
@@ -16,7 +16,7 @@ Package ecosystems extracted from each layer filesystem:
 - Node: ``node_modules/*/package.json``
 - Debian/Ubuntu: ``var/lib/dpkg/status``
 - Alpine Linux: ``lib/apk/db/installed``
-- RPM: ``var/lib/rpm/rpmdb.sqlite`` (sqlite3) + ``var/log/installed-rpms`` (log manifest)
+- RPM: modern SQLite plus legacy BerkeleyDB/NDB package databases and ``var/log/installed-rpms``
 - Java: ``*.jar``/``*.war``/``*.ear`` → ``META-INF/maven/*/pom.properties`` or ``META-INF/MANIFEST.MF``
 - Go binaries: embedded buildinfo (``\xff Go buildinf:`` magic, dep lines)
 - Ruby: ``**/specifications/*.gemspec`` (regex name/version extraction)
@@ -241,13 +241,12 @@ _GEMSPEC_VER_RE = re.compile(r'\.version\s*=\s*(?:Gem::Version\.new\()?["\']([^"
 
 # RPM sqlite: database path candidates in a container layer
 _RPM_SQLITE_PATHS = ("var/lib/rpm/rpmdb.sqlite", "./var/lib/rpm/rpmdb.sqlite")
-# Legacy rpm databases we cannot decode natively yet: the BerkeleyDB ``Packages``
-# file (RPM < 4.16, RHEL/CentOS <= 8, many older UBI images) and the NDB
-# ``Packages.db``. Tracked so a layer carrying one of these emits a coverage
-# warning instead of silently reporting zero RPMs.
+# Legacy RPM database paths: BerkeleyDB ``Packages`` (RPM < 4.16,
+# RHEL/CentOS <= 8 and older UBI images) and NDB ``Packages.db``.
 _RPM_BDB_PATHS = ("var/lib/rpm/Packages", "./var/lib/rpm/Packages")
 _RPM_NDB_PATHS = ("var/lib/rpm/Packages.db", "./var/lib/rpm/Packages.db")
 _RPM_MANIFEST_PATHS = ("var/log/installed-rpms", "./var/log/installed-rpms")
+_MAX_LEGACY_RPMDB_BYTES = 512 * 1024 * 1024
 # RPM header magic (8 bytes)
 _RPM_HDR_MAGIC = b"\x8e\xad\xe8\x01\x00\x00\x00\x00"
 _RPMTAG_NAME = 1000
@@ -474,6 +473,58 @@ def _parse_rpm_header_blob(blob: bytes) -> Optional[tuple[str, str]]:
         return None
 
 
+def _parse_legacy_rpmdb_bytes(database: bytes) -> list[tuple[str, str]]:
+    """Extract embedded RPM header records from BerkeleyDB or NDB payloads.
+
+    Both legacy backends store canonical RPM header blobs as record values. The
+    database page/index format is backend-specific, but the value format is not:
+    every package header starts with ``_RPM_HDR_MAGIC`` and carries bounded index
+    and data lengths. Scanning for those self-describing records avoids a native
+    BerkeleyDB dependency while preserving exact RPM name/version/release data.
+    """
+    packages: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    cursor = 0
+    while True:
+        start = database.find(_RPM_HDR_MAGIC, cursor)
+        if start < 0:
+            break
+        cursor = start + len(_RPM_HDR_MAGIC)
+        if start + 16 > len(database):
+            continue
+        try:
+            nindex, hsize = struct.unpack_from(">II", database, start + 8)
+        except struct.error:
+            continue
+        if nindex > 100_000 or hsize > _MAX_LEGACY_RPMDB_BYTES:
+            continue
+        record_size = 16 + nindex * 16 + hsize
+        end = start + record_size
+        if record_size < 16 or end > len(database):
+            continue
+        parsed = _parse_rpm_header_blob(database[start:end])
+        if parsed is None or parsed[0] == "gpg-pubkey" or parsed in seen:
+            continue
+        seen.add(parsed)
+        packages.append(parsed)
+        cursor = end
+    return packages
+
+
+def _query_legacy_rpmdb(layer_tf: tarfile.TarFile, database_path: str) -> list[tuple[str, str]]:
+    """Read and decode one bounded BerkeleyDB/NDB package database member."""
+    member = _safe_getmember(layer_tf, database_path)
+    if member is None or not member.isfile() or member.size > _MAX_LEGACY_RPMDB_BYTES:
+        raise OCIParseError("Legacy RPM database is missing, invalid, or exceeds the 512 MiB safety limit")
+    source = _safe_extractfile(layer_tf, database_path)
+    if source is None:
+        raise OCIParseError("Legacy RPM database could not be read safely")
+    packages = _parse_legacy_rpmdb_bytes(source.read())
+    if not packages:
+        raise OCIParseError("Legacy RPM database contains no valid package header records")
+    return packages
+
+
 # ─── Package extraction from a layer filesystem ───────────────────────────────
 
 
@@ -618,8 +669,7 @@ def _extract_packages_from_layer(
         packages: Mutable list of packages — updated in place.
         deleted_paths: Set of paths deleted in LATER layers (whiteouts already processed).
         layer: Layer provenance metadata for this concrete tar blob.
-        warnings: Optional mutable list — coverage gaps (e.g. an unsupported
-            legacy rpm database) are appended here for the caller to surface.
+        warnings: Optional mutable list for non-fatal parser diagnostics.
 
     Returns:
         Set of paths marked as whiteout in THIS layer (for caller to accumulate).
@@ -872,28 +922,26 @@ def _extract_packages_from_layer(
             _logger.debug("Failed to parse rpmdb.sqlite")
         break
 
-    # --- Legacy rpm database coverage gap (BerkeleyDB / NDB) ---
-    # Only the modern ``rpmdb.sqlite`` (RPM >= 4.16) is decoded above. Older
-    # RHEL/CentOS/UBI images keep packages in the BerkeleyDB ``Packages`` file
-    # (or the NDB ``Packages.db``), which we cannot read yet. If a layer carries
-    # one of those and no rpmdb.sqlite / installed-rpms manifest to fall back on,
-    # the layer would silently contribute zero RPMs — surface a clear coverage
-    # warning so operators know the result is partial, not clean.
-    if warnings is not None:
-        has_parsable_rpm = any(
-            p in names and not _is_deleted(p) for p in (*_RPM_SQLITE_PATHS, *_RPM_MANIFEST_PATHS)
+    # --- Legacy rpm database (BerkeleyDB / NDB) ---
+    has_modern_rpm_source = any(
+        p in names and not _is_deleted(p) for p in (*_RPM_SQLITE_PATHS, *_RPM_MANIFEST_PATHS)
+    )
+    if not has_modern_rpm_source:
+        legacy_rpmdb = next(
+            (p for p in (*_RPM_BDB_PATHS, *_RPM_NDB_PATHS) if p in names and not _is_deleted(p)),
+            None,
         )
-        if not has_parsable_rpm:
-            legacy_rpmdb = next(
-                (p for p in (*_RPM_BDB_PATHS, *_RPM_NDB_PATHS) if p in names and not _is_deleted(p)),
-                None,
-            )
-            if legacy_rpmdb:
-                fmt = "NDB" if legacy_rpmdb.endswith("Packages.db") else "BerkeleyDB"
-                normalized = legacy_rpmdb[2:] if legacy_rpmdb.startswith("./") else legacy_rpmdb
-                warnings.append(
-                    f"Legacy {fmt} rpm database at /{normalized} is not yet supported — "
-                    "OS package coverage for this image is incomplete"
+        if legacy_rpmdb:
+            for rpm_name, rpm_ver in _query_legacy_rpmdb(layer_tf, legacy_rpmdb):
+                _add_package(
+                    packages_by_key,
+                    packages,
+                    rpm_name,
+                    rpm_ver,
+                    "rpm",
+                    f"pkg:rpm/redhat/{rpm_name}@{rpm_ver}",
+                    layer=layer,
+                    package_path=legacy_rpmdb,
                 )
 
     # --- Java: JARs via META-INF/maven/*/pom.properties or MANIFEST.MF ---

--- a/tests/test_medium_hardening.py
+++ b/tests/test_medium_hardening.py
@@ -219,25 +219,46 @@ glibc-2.34-83.el9.x86_64
     assert "5.2.26" in bash.version
 
 
-def test_legacy_bdb_rpmdb_warns_and_does_not_fail(caplog):
-    """A legacy BerkeleyDB rpm db yields no fatal error, just a coverage warning."""
-    import logging
+def test_flattened_legacy_bdb_rpmdb_is_decoded_natively():
+    """The docker-export fallback decodes legacy RPM headers without warnings."""
+    import struct
 
     from agent_bom.image import _packages_from_tar
+    from agent_bom.oci_parser import (
+        _RPM_HDR_MAGIC,
+        _RPM_TYPE_STRING,
+        _RPMTAG_NAME,
+        _RPMTAG_RELEASE,
+        _RPMTAG_VERSION,
+    )
 
-    # A BerkeleyDB ``Packages`` file we cannot decode — arbitrary binary bytes.
-    bdb_blob = "\x00\x06\x15\x61 legacy berkeleydb rpm packages \x00\x00"
-    tar_bytes = _make_tar_with_file("var/lib/rpm/Packages", bdb_blob)
+    strings = {
+        _RPMTAG_NAME: b"bash\x00",
+        _RPMTAG_VERSION: b"4.4.20\x00",
+        _RPMTAG_RELEASE: b"5.el8\x00",
+    }
+    data = b""
+    offsets: dict[int, int] = {}
+    for tag, value in strings.items():
+        offsets[tag] = len(data)
+        data += value
+    header = _RPM_HDR_MAGIC + struct.pack(">II", len(strings), len(data))
+    for tag in strings:
+        header += struct.pack(">IIII", tag, _RPM_TYPE_STRING, offsets[tag], 1)
+    database = b"berkeley-page\x00" + header + data
+
+    buf = BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        info = tarfile.TarInfo(name="var/lib/rpm/Packages")
+        info.size = len(database)
+        tf.addfile(info, BytesIO(database))
 
     with tempfile.NamedTemporaryFile(suffix=".tar") as tmp:
-        tmp.write(tar_bytes)
+        tmp.write(buf.getvalue())
         tmp.flush()
-        with caplog.at_level(logging.WARNING, logger="agent_bom.image"):
-            packages = _packages_from_tar(tmp.name)
+        packages = _packages_from_tar(tmp.name)
 
-    # No fatal error, and no phantom rpm packages invented from the binary db.
-    assert [p for p in packages if p.ecosystem == "rpm"] == []
-    assert any("legacy rpm database" in r.getMessage().lower() for r in caplog.records)
+    assert [(p.name, p.version) for p in packages if p.ecosystem == "rpm"] == [("bash", "4.4.20-5.el8")]
 
 
 def _make_tar_with_files(files: dict[str, str]) -> bytes:

--- a/tests/test_oci_parser.py
+++ b/tests/test_oci_parser.py
@@ -888,20 +888,38 @@ def test_rpm_sqlite_gpg_pubkey_skipped():
     assert any(p.name == "bash" for p in result.packages)
 
 
-def test_legacy_bdb_rpmdb_emits_coverage_warning():
-    """A BerkeleyDB ``Packages`` db produces a coverage warning, not silent zero RPMs."""
-    # Arbitrary binary blob standing in for an undecodable BerkeleyDB rpm db.
-    tar = _make_docker_save_tar([{"var/lib/rpm/Packages": b"\x00\x06\x15\x61 legacy bdb \x00"}])
+def test_legacy_bdb_rpmdb_extracts_embedded_package_headers():
+    """BerkeleyDB page bytes yield their canonical embedded RPM headers."""
+    database = (
+        b"\x00\x06\x15\x61berkeley-page-metadata\x00"
+        + _make_rpm_header_blob("bash", "4.4.20", "5.el8")
+        + b"\x00page-boundary\x00"
+        + _make_rpm_header_blob("curl", "7.61.1", "34.el8")
+    )
+    tar = _make_docker_save_tar([{"var/lib/rpm/Packages": database}])
     result = parse_oci_tarball(tar)
-    assert not any(p.ecosystem == "rpm" for p in result.packages)
-    assert any("BerkeleyDB" in w and "not yet supported" in w for w in result.warnings)
+    versions = {p.name: p.version for p in result.packages if p.ecosystem == "rpm"}
+    assert versions == {"bash": "4.4.20-5.el8", "curl": "7.61.1-34.el8"}
+    assert result.warnings == []
 
 
-def test_legacy_ndb_rpmdb_emits_coverage_warning():
-    """An NDB ``Packages.db`` db produces a coverage warning tagged NDB."""
-    tar = _make_docker_save_tar([{"var/lib/rpm/Packages.db": b"\x00\x00\x00 legacy ndb \x00"}])
+def test_legacy_ndb_rpmdb_extracts_package_headers_and_skips_pubkeys():
+    database = (
+        b"ndb-slot-table\x00"
+        + _make_rpm_header_blob("openssl-libs", "1.1.1k", "14.el8")
+        + _make_rpm_header_blob("gpg-pubkey", "deadbeef", "1")
+    )
+    tar = _make_docker_save_tar([{"var/lib/rpm/Packages.db": database}])
     result = parse_oci_tarball(tar)
-    assert any("NDB" in w and "not yet supported" in w for w in result.warnings)
+    rpm_packages = [p for p in result.packages if p.ecosystem == "rpm"]
+    assert [(p.name, p.version) for p in rpm_packages] == [("openssl-libs", "1.1.1k-14.el8")]
+    assert result.warnings == []
+
+
+def test_malformed_legacy_rpmdb_fails_closed():
+    tar = _make_docker_save_tar([{"var/lib/rpm/Packages": b"not an rpm package database"}])
+    with pytest.raises(OCIParseError, match="no valid package header records"):
+        parse_oci_tarball(tar)
 
 
 def test_modern_sqlite_rpmdb_emits_no_legacy_warning():


### PR DESCRIPTION
## Summary

- decode embedded RPM header records from legacy BerkeleyDB `Packages` and NDB `Packages.db` databases with a bounded native parser
- apply the same decoder to OCI layers and the flattened `docker export` fallback
- fail closed on malformed/oversized legacy databases instead of returning zero packages or an unsupported/partial warning
- document precision-first distro findings and the existing `AGENT_BOM_INCLUDE_UNFIXED=1` exhaustive OS mode

Closes #3881.

## Verification

- `uv run pytest -q tests/test_oci_parser.py tests/test_image_scan_parity.py tests/test_medium_hardening.py tests/test_image_auth.py` (110 passed)
- `uv run ruff check src/agent_bom/oci_parser.py src/agent_bom/image.py tests/test_oci_parser.py tests/test_medium_hardening.py`
- `uv run mypy src/agent_bom/oci_parser.py src/agent_bom/image.py`
- `uv run agent-bom agents --demo --offline --quiet --format json --output /tmp/agent-bom-3881-demo.json`
- `git diff --check`

## Notes

- no external `rpm`, BerkeleyDB, or scanner binary is required
- valid legacy databases emit normal RPM package inventory with exact `version-release`
- malformed legacy databases terminate parsing rather than presenting incomplete results as clean