### PR TITLE
feat(graph): dependency-driven expand/collapse on exposure attack paths

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 257 |
+| `docs/openapi/v1.json` | paths | 258 |
 | `docs/openapi/v1.json` | component schemas | 67 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -14170,6 +14170,95 @@
         ]
       }
     },
+    "/v1/graph/node/{node_id}/neighbors": {
+      "get": {
+        "description": "Return a bounded set of a node's direct graph neighbors for inline expand.\n\nThis is the read side of the dashboard's progressive-disclosure attack-path\nview: expanding one hop loads only that hop's direct neighbors instead of the\nwhole graph. It is deliberately lazy and bounded \u2014 fan-out is capped by\n``limit`` and a high-degree node reports an honest ``total_neighbors`` with\n``truncated`` set, so the UI can render a \"+N more\" affordance rather than\nexploding the view. Neighbor node metadata (entity type, label, severity)\ntravels with the payload so the client never needs a second round trip per\nneighbor id. An unknown node id returns an empty payload (200, ``found``\nfalse) instead of raising, so a stale client id degrades quietly in-place.",
+        "operationId": "get_graph_node_neighbors_v1_graph_node__node_id__neighbors_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "node_id",
+            "required": true,
+            "schema": {
+              "title": "Node Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Scan ID; latest if omitted",
+            "in": "query",
+            "name": "scan_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Scan ID; latest if omitted",
+              "title": "Scan Id"
+            }
+          },
+          {
+            "description": "Max neighbors returned per expand",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 24,
+              "description": "Max neighbors returned per expand",
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "out=dependencies, in=dependents, both=either",
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "default": "both",
+              "description": "out=dependencies, in=dependents, both=either",
+              "title": "Direction",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Graph Node Neighbors V1 Graph Node  Node Id  Neighbors Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Graph Node Neighbors",
+        "tags": [
+          "graph"
+        ]
+      }
+    },
     "/v1/graph/paths": {
       "get": {
         "description": "Find all attack paths from a source node via BFS.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -9267,6 +9267,76 @@ paths:
       summary: Get Graph Node
       tags:
       - graph
+  /v1/graph/node/{node_id}/neighbors:
+    get:
+      description: "Return a bounded set of a node's direct graph neighbors for inline\
+        \ expand.\n\nThis is the read side of the dashboard's progressive-disclosure\
+        \ attack-path\nview: expanding one hop loads only that hop's direct neighbors\
+        \ instead of the\nwhole graph. It is deliberately lazy and bounded \u2014\
+        \ fan-out is capped by\n``limit`` and a high-degree node reports an honest\
+        \ ``total_neighbors`` with\n``truncated`` set, so the UI can render a \"+N\
+        \ more\" affordance rather than\nexploding the view. Neighbor node metadata\
+        \ (entity type, label, severity)\ntravels with the payload so the client never\
+        \ needs a second round trip per\nneighbor id. An unknown node id returns an\
+        \ empty payload (200, ``found``\nfalse) instead of raising, so a stale client\
+        \ id degrades quietly in-place."
+      operationId: get_graph_node_neighbors_v1_graph_node__node_id__neighbors_get
+      parameters:
+      - in: path
+        name: node_id
+        required: true
+        schema:
+          title: Node Id
+          type: string
+      - description: Scan ID; latest if omitted
+        in: query
+        name: scan_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Scan ID; latest if omitted
+          title: Scan Id
+      - description: Max neighbors returned per expand
+        in: query
+        name: limit
+        required: false
+        schema:
+          default: 24
+          description: Max neighbors returned per expand
+          maximum: 100
+          minimum: 1
+          title: Limit
+          type: integer
+      - description: out=dependencies, in=dependents, both=either
+        in: query
+        name: direction
+        required: false
+        schema:
+          default: both
+          description: out=dependencies, in=dependents, both=either
+          title: Direction
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Graph Node Neighbors V1 Graph Node  Node Id  Neighbors
+                  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Graph Node Neighbors
+      tags:
+      - graph
   /v1/graph/paths:
     get:
       description: Find all attack paths from a source node via BFS.

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -2362,6 +2362,99 @@ async def get_graph_node(
     }
 
 
+@router.get("/graph/node/{node_id}/neighbors", tags=["graph"])
+async def get_graph_node_neighbors(
+    request: Request,
+    node_id: str,
+    scan_id: Optional[str] = Query(None, description="Scan ID; latest if omitted"),
+    limit: int = Query(24, ge=1, le=100, description="Max neighbors returned per expand"),
+    direction: str = Query("both", description="out=dependencies, in=dependents, both=either"),
+) -> dict:
+    """Return a bounded set of a node's direct graph neighbors for inline expand.
+
+    This is the read side of the dashboard's progressive-disclosure attack-path
+    view: expanding one hop loads only that hop's direct neighbors instead of the
+    whole graph. It is deliberately lazy and bounded — fan-out is capped by
+    ``limit`` and a high-degree node reports an honest ``total_neighbors`` with
+    ``truncated`` set, so the UI can render a "+N more" affordance rather than
+    exploding the view. Neighbor node metadata (entity type, label, severity)
+    travels with the payload so the client never needs a second round trip per
+    neighbor id. An unknown node id returns an empty payload (200, ``found``
+    false) instead of raising, so a stale client id degrades quietly in-place.
+    """
+    normalized_direction = direction.strip().lower()
+    if normalized_direction not in {"out", "in", "both"}:
+        normalized_direction = "both"
+
+    tenant = _tenant(request)
+    store = _get_graph_store_or_503()
+    context = await _graph_store_call(
+        store.node_context,
+        scan_id=scan_id or "",
+        tenant_id=tenant,
+        node_id=node_id,
+    )
+    if context is None:
+        return {
+            "node_id": node_id,
+            "scan_id": scan_id or "",
+            "found": False,
+            "direction": normalized_direction,
+            "limit": limit,
+            "total_neighbors": 0,
+            "truncated": False,
+            "neighbors": [],
+            "edges": [],
+        }
+
+    selected_edges: list = []
+    if normalized_direction in {"out", "both"}:
+        selected_edges.extend(context["edges_out"])
+    if normalized_direction in {"in", "both"}:
+        selected_edges.extend(context["edges_in"])
+
+    # Deterministic, de-duplicated neighbor ordering keeps the cap stable across
+    # repeated expands (same class of pagination-drop guard used elsewhere).
+    edges_by_neighbor: dict[str, list] = {}
+    neighbor_ids: list[str] = []
+    seen: set[str] = set()
+    for edge in selected_edges:
+        neighbor_id = edge.target if edge.source == node_id else edge.source
+        if neighbor_id == node_id:
+            continue
+        edges_by_neighbor.setdefault(neighbor_id, []).append(edge)
+        if neighbor_id not in seen:
+            seen.add(neighbor_id)
+            neighbor_ids.append(neighbor_id)
+
+    neighbor_ids.sort()
+    total_neighbors = len(neighbor_ids)
+    bounded_ids = neighbor_ids[:limit]
+    truncated = total_neighbors > len(bounded_ids)
+
+    neighbor_nodes = await _graph_store_call(
+        store.nodes_by_ids,
+        scan_id=scan_id or "",
+        tenant_id=tenant,
+        node_ids=set(bounded_ids),
+    )
+    nodes_by_id = {node.id: node for node in neighbor_nodes}
+    ordered_nodes = [nodes_by_id[node_id_] for node_id_ in bounded_ids if node_id_ in nodes_by_id]
+    bounded_edges = [edge for node_id_ in bounded_ids for edge in edges_by_neighbor.get(node_id_, [])]
+
+    return {
+        "node_id": node_id,
+        "scan_id": scan_id or "",
+        "found": True,
+        "direction": normalized_direction,
+        "limit": limit,
+        "total_neighbors": total_neighbors,
+        "truncated": truncated,
+        "neighbors": [node.to_dict() for node in ordered_nodes],
+        "edges": [edge.to_dict() for edge in bounded_edges],
+    }
+
+
 @router.get("/graph/snapshots", tags=["graph"])
 async def get_graph_snapshots(
     request: Request,

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -2731,6 +2731,94 @@ class TestGraphStoreBackendSelection:
         assert any(call[0] == "node_context" for call in recording_graph_store.calls)
         assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
 
+    def test_graph_node_neighbors_returns_bounded_metadata(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_node(
+            UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a", severity="high")
+        )
+        recording_graph_store.graph.add_node(UnifiedNode(id="pkg:p", entity_type=EntityType.PACKAGE, label="pkg@1.0"))
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES, traversable=True)
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="server:s", target="pkg:p", relationship=RelationshipType.DEPENDS_ON, traversable=True)
+        )
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/node/server:s/neighbors")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["found"] is True
+        assert body["node_id"] == "server:s"
+        assert body["total_neighbors"] == 2
+        assert body["truncated"] is False
+        returned = {node["id"]: node for node in body["neighbors"]}
+        assert set(returned) == {"agent:a", "pkg:p"}
+        # Neighbor metadata (entity_type/label/severity) travels with the payload so
+        # the dashboard can render child nodes without a second round trip per id.
+        assert returned["agent:a"]["entity_type"] == "agent"
+        assert returned["agent:a"]["severity"] == "high"
+        assert {(edge["source_id"], edge["target_id"]) for edge in body["edges"]} == {
+            ("agent:a", "server:s"),
+            ("server:s", "pkg:p"),
+        }
+
+    def test_graph_node_neighbors_caps_fan_out_and_flags_truncation(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:hub", entity_type=EntityType.SERVER, label="hub"))
+        for index in range(5):
+            neighbor_id = f"pkg:p{index}"
+            recording_graph_store.graph.add_node(
+                UnifiedNode(id=neighbor_id, entity_type=EntityType.PACKAGE, label=f"pkg-{index}")
+            )
+            recording_graph_store.graph.add_edge(
+                UnifiedEdge(source="server:hub", target=neighbor_id, relationship=RelationshipType.DEPENDS_ON)
+            )
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/node/server:hub/neighbors", params={"limit": 2})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total_neighbors"] == 5
+        assert len(body["neighbors"]) == 2
+        assert body["truncated"] is True
+        # Bounded set is deterministic so repeated expands are stable.
+        assert [node["id"] for node in body["neighbors"]] == ["pkg:p0", "pkg:p1"]
+
+    def test_graph_node_neighbors_direction_filters_dependents(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="pkg:p", entity_type=EntityType.PACKAGE, label="pkg@1.0"))
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES)
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="server:s", target="pkg:p", relationship=RelationshipType.DEPENDS_ON)
+        )
+        client = TestClient(app)
+
+        out_only = client.get("/v1/graph/node/server:s/neighbors", params={"direction": "out"}).json()
+        assert [node["id"] for node in out_only["neighbors"]] == ["pkg:p"]
+
+        in_only = client.get("/v1/graph/node/server:s/neighbors", params={"direction": "in"}).json()
+        assert [node["id"] for node in in_only["neighbors"]] == ["agent:a"]
+
+    def test_graph_node_neighbors_unknown_node_does_not_raise(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/node/server:ghost/neighbors")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["found"] is False
+        assert body["neighbors"] == []
+        assert body["total_neighbors"] == 0
+
     def test_graph_query_truncates_on_edge_cap(self, recording_graph_store):
         recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
         recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -413,6 +413,7 @@ function SecurityGraphPageContent() {
         <ExposurePathCommandCenter
           path={selectedExposurePath}
           actions={selectedFixFirstCard?.next_actions ?? selectedPathActions}
+          scanId={selectedScanId || undefined}
         />
       ) : null}
 

--- a/ui/components/exposure-path-command-center.tsx
+++ b/ui/components/exposure-path-command-center.tsx
@@ -15,6 +15,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { pathDisplayTitle, pathFixLabel, type ExposureEntityRole, type ExposurePath } from "@/lib/exposure-path";
+import { ExposurePathNeighborExplorer } from "@/components/exposure-path-neighbor-explorer";
 
 export interface ExposurePathCommandAction {
   title: string;
@@ -49,9 +50,11 @@ const GRAPH_ROLE_STYLE: Record<ExposureEntityRole, { fill: string; stroke: strin
 export function ExposurePathCommandCenter({
   path,
   actions = [],
+  scanId,
 }: {
   path: ExposurePath;
   actions?: ExposurePathCommandAction[] | undefined;
+  scanId?: string | undefined;
 }) {
   const fixLabel = pathFixLabel(path);
   const evidence = path.evidence;
@@ -102,6 +105,8 @@ export function ExposurePathCommandCenter({
         <section aria-label="Selected exposure path graph" className="rounded-2xl border border-[color:var(--border-subtle)] bg-[#05070b] p-1">
           <ExposurePathGraph path={path} />
         </section>
+
+        <ExposurePathNeighborExplorer path={path} scanId={scanId} />
 
         <details className="group rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)]/70">
           <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-[color:var(--foreground)] [&::-webkit-details-marker]:hidden">

--- a/ui/components/exposure-path-neighbor-explorer.tsx
+++ b/ui/components/exposure-path-neighbor-explorer.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import type { LucideIcon } from "lucide-react";
+import { Bot, Bug, ChevronRight, Database, KeyRound, Loader2, Package, Server, ShieldAlert, Wrench } from "lucide-react";
+import { api, type GraphNodeNeighborsResponse } from "@/lib/api";
+import type { UnifiedNode } from "@/lib/graph-schema";
+import { exposureRoleForEntityType } from "@/lib/attack-paths";
+import { formatExposureEntityDisplay } from "@/lib/entity-display";
+import type { ExposureEntityRole, ExposurePath } from "@/lib/exposure-path";
+
+/**
+ * Progressive-disclosure layer for the exposure path. The command-center graph
+ * renders the fixed Agent→Server→Package→Finding chain; this explorer lets an
+ * analyst expand any package/server/agent hop to pull that node's *direct*
+ * graph neighbors inline — the dependencies and dependents that never fit in
+ * the fixed chain — then collapse them again. Neighbors are lazy-loaded on
+ * expand (one hop, one level at a time) and fan-out is bounded so a
+ * high-degree hub never explodes the view.
+ */
+
+const EXPANDABLE_ROLES: ReadonlySet<ExposureEntityRole> = new Set(["agent", "server", "package"]);
+const NEIGHBOR_LIMIT = 12;
+
+const ROLE_STYLE: Record<ExposureEntityRole, { icon: LucideIcon; chip: string; accent: string }> = {
+  agent: { icon: Bot, chip: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200", accent: "text-emerald-300" },
+  server: { icon: Server, chip: "border-sky-500/30 bg-sky-500/10 text-sky-200", accent: "text-sky-300" },
+  package: { icon: Package, chip: "border-amber-500/30 bg-amber-500/10 text-amber-200", accent: "text-amber-300" },
+  finding: { icon: Bug, chip: "border-red-500/30 bg-red-500/10 text-red-200", accent: "text-red-300" },
+  credential: { icon: KeyRound, chip: "border-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-200", accent: "text-fuchsia-300" },
+  tool: { icon: Wrench, chip: "border-purple-500/30 bg-purple-500/10 text-purple-200", accent: "text-purple-300" },
+  environment: { icon: Database, chip: "border-cyan-500/30 bg-cyan-500/10 text-cyan-200", accent: "text-cyan-300" },
+  cluster: { icon: Database, chip: "border-indigo-500/30 bg-indigo-500/10 text-indigo-200", accent: "text-indigo-300" },
+  unknown: {
+    icon: ShieldAlert,
+    chip: "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[color:var(--text-secondary)]",
+    accent: "text-[color:var(--text-tertiary)]",
+  },
+};
+
+type NeighborLoadState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; data: GraphNodeNeighborsResponse };
+
+interface NeighborEntry {
+  id: string;
+  role: ExposureEntityRole;
+  title: string;
+  subtitle?: string | undefined;
+  relationship: string;
+  kind: "dependency" | "dependent";
+}
+
+function humanizeRelationship(value: string): string {
+  return value
+    .replace(/[_:]+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function neighborRefFromNode(node: UnifiedNode): { role: ExposureEntityRole; title: string; subtitle?: string | undefined } {
+  const role = exposureRoleForEntityType(String(node.entity_type));
+  const display = formatExposureEntityDisplay(node.label, role, node.attributes ?? {});
+  return { role, title: display.title, subtitle: display.subtitle };
+}
+
+function toNeighborEntries(hopId: string, data: GraphNodeNeighborsResponse): NeighborEntry[] {
+  const relationshipByNeighbor = new Map<string, { relationship: string; kind: "dependency" | "dependent" }>();
+  for (const edge of data.edges) {
+    if (edge.source === hopId && edge.target !== hopId) {
+      relationshipByNeighbor.set(edge.target, { relationship: edge.relationship, kind: "dependency" });
+    } else if (edge.target === hopId && edge.source !== hopId) {
+      // Keep an out-edge classification if we already have one; only fill in when absent.
+      if (!relationshipByNeighbor.has(edge.source)) {
+        relationshipByNeighbor.set(edge.source, { relationship: edge.relationship, kind: "dependent" });
+      }
+    }
+  }
+
+  return data.neighbors.map((node) => {
+    const ref = neighborRefFromNode(node);
+    const edgeInfo = relationshipByNeighbor.get(node.id);
+    return {
+      id: node.id,
+      role: ref.role,
+      title: ref.title,
+      subtitle: ref.subtitle,
+      relationship: humanizeRelationship(edgeInfo?.relationship ?? "related"),
+      kind: edgeInfo?.kind ?? "dependency",
+    };
+  });
+}
+
+function NeighborChip({ entry }: { entry: NeighborEntry }) {
+  const style = ROLE_STYLE[entry.role] ?? ROLE_STYLE.unknown;
+  const Icon = style.icon;
+  return (
+    <div className={`flex min-w-0 items-center gap-2 rounded-lg border px-2.5 py-1.5 ${style.chip}`}>
+      <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <div className="min-w-0">
+        <p className="truncate text-[11px] font-medium text-[color:var(--foreground)]">{entry.title}</p>
+        <p className="truncate text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+          {entry.relationship}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function HopRow({ hop, scanId }: { hop: ExposurePath["hops"][number]; scanId?: string | undefined }) {
+  const [expanded, setExpanded] = useState(false);
+  const [load, setLoad] = useState<NeighborLoadState | null>(null);
+  const style = ROLE_STYLE[hop.role] ?? ROLE_STYLE.unknown;
+  const Icon = style.icon;
+  const expandable = EXPANDABLE_ROLES.has(hop.role);
+
+  const fetchNeighbors = useCallback(async () => {
+    setLoad({ status: "loading" });
+    try {
+      const data = await api.getGraphNodeNeighbors(hop.id, { scanId, limit: NEIGHBOR_LIMIT, direction: "both" });
+      setLoad({ status: "ready", data });
+    } catch (error) {
+      setLoad({ status: "error", message: error instanceof Error ? error.message : "Could not load neighbors" });
+    }
+  }, [hop.id, scanId]);
+
+  const onToggle = useCallback(() => {
+    setExpanded((prev) => {
+      const next = !prev;
+      // Lazy-load once, on first expand; cached afterwards so collapse/expand is free.
+      if (next && load === null) void fetchNeighbors();
+      return next;
+    });
+  }, [fetchNeighbors, load]);
+
+  const entries = useMemo(
+    () => (load?.status === "ready" ? toNeighborEntries(hop.id, load.data) : []),
+    [hop.id, load],
+  );
+  const dependencies = entries.filter((entry) => entry.kind === "dependency");
+  const dependents = entries.filter((entry) => entry.kind === "dependent");
+  const moreCount =
+    load?.status === "ready" && load.data.truncated ? Math.max(0, load.data.total_neighbors - load.data.neighbors.length) : 0;
+
+  return (
+    <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)]/60">
+      <div className="flex items-center gap-2 px-3 py-2">
+        <span className={`flex items-center gap-2 rounded-lg border px-2.5 py-1.5 ${style.chip}`}>
+          <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+          <span className="min-w-0">
+            <span className="block truncate text-[11px] font-medium text-[color:var(--foreground)]">{hop.label}</span>
+            <span className="block text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">{hop.role}</span>
+          </span>
+        </span>
+        <span className="flex-1" />
+        {expandable ? (
+          <button
+            type="button"
+            onClick={onToggle}
+            aria-expanded={expanded}
+            aria-label={expanded ? `Collapse neighbors of ${hop.label}` : `Expand neighbors of ${hop.label}`}
+            className="flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2.5 py-1.5 text-[11px] font-medium text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
+          >
+            <ChevronRight
+              className={`h-3.5 w-3.5 shrink-0 transition-transform ${expanded ? "rotate-90" : ""}`}
+              aria-hidden="true"
+            />
+            <span>{expanded ? "Hide neighbors" : "Expand neighbors"}</span>
+          </button>
+        ) : (
+          <span className="text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">leaf</span>
+        )}
+      </div>
+
+      {expanded && (
+        <div className="space-y-3 border-t border-[color:var(--border-subtle)] px-3 py-3">
+          {load?.status === "loading" && (
+            <div className="flex items-center gap-2 text-[11px] text-[color:var(--text-secondary)]">
+              <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+              Loading neighbors…
+            </div>
+          )}
+          {load?.status === "error" && (
+            <div className="text-[11px] text-red-400">Could not load neighbors: {load.message}</div>
+          )}
+          {load?.status === "ready" && entries.length === 0 && (
+            <div className="text-[11px] text-[color:var(--text-secondary)]">No direct graph neighbors recorded for this node.</div>
+          )}
+          {load?.status === "ready" && dependencies.length > 0 && (
+            <NeighborGroup label="Dependencies" entries={dependencies} />
+          )}
+          {load?.status === "ready" && dependents.length > 0 && (
+            <NeighborGroup label="Dependents" entries={dependents} />
+          )}
+          {moreCount > 0 && (
+            <p className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">
+              +{moreCount} more neighbor{moreCount === 1 ? "" : "s"} not shown
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function NeighborGroup({ label, entries }: { label: string; entries: NeighborEntry[] }) {
+  return (
+    <div className="space-y-1.5">
+      <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">{label}</div>
+      <div className="flex flex-wrap gap-1.5">
+        {entries.map((entry) => (
+          <NeighborChip key={`${entry.kind}-${entry.id}`} entry={entry} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ExposurePathNeighborExplorer({ path, scanId }: { path: ExposurePath; scanId?: string | undefined }) {
+  const hops = path.hops;
+  if (hops.length === 0) return null;
+  const anyExpandable = hops.some((hop) => EXPANDABLE_ROLES.has(hop.role));
+  if (!anyExpandable) return null;
+
+  return (
+    <section aria-label="Expand path neighbors" className="space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">Expand path neighbors</div>
+        <div className="text-[10px] text-[color:var(--text-tertiary)]">Direct dependencies &amp; dependents · loaded on demand</div>
+      </div>
+      <div className="space-y-2">
+        {hops.map((hop) => (
+          <HopRow key={hop.id} hop={hop} scanId={scanId} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -307,6 +307,20 @@ export interface GraphNodeDetailResponse {
   impact: GraphImpactResponse;
 }
 
+export type GraphNeighborDirection = "out" | "in" | "both";
+
+export interface GraphNodeNeighborsResponse {
+  node_id: string;
+  scan_id: string;
+  found: boolean;
+  direction: GraphNeighborDirection;
+  limit: number;
+  total_neighbors: number;
+  truncated: boolean;
+  neighbors: UnifiedNode[];
+  edges: UnifiedEdge[];
+}
+
 export interface GraphRollupAggregate {
   descendant_count: number;
   by_type: Record<string, number>;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -16,6 +16,8 @@ import type {
   GraphQueryRequest,
   GraphQueryResponse,
   GraphNodeDetailResponse,
+  GraphNodeNeighborsResponse,
+  GraphNeighborDirection,
   GraphImpactResponse,
   GraphRollupResponse,
   GraphSearchResponse,
@@ -137,6 +139,8 @@ export type {
   GraphQueryResponse,
   GraphImpactResponse,
   GraphNodeDetailResponse,
+  GraphNodeNeighborsResponse,
+  GraphNeighborDirection,
   GraphSearchResponse,
   GraphSemanticClusterKind,
   GraphSemanticClusterExpansion,
@@ -729,6 +733,21 @@ export const api = {
     if (scanId) params.set("scan_id", scanId);
     const qs = params.toString();
     return get<GraphNodeDetailResponse>(`/v1/graph/node/${encodeURIComponent(nodeId)}${qs ? `?${qs}` : ""}`);
+  },
+
+  /** Lazily load a bounded set of one node's direct graph neighbors for inline expand */
+  getGraphNodeNeighbors: (
+    nodeId: string,
+    options?: { scanId?: string | undefined; limit?: number | undefined; direction?: GraphNeighborDirection | undefined },
+  ) => {
+    const params = new URLSearchParams();
+    if (options?.scanId) params.set("scan_id", options.scanId);
+    if (options?.limit != null) params.set("limit", String(options.limit));
+    if (options?.direction) params.set("direction", options.direction);
+    const qs = params.toString();
+    return get<GraphNodeNeighborsResponse>(
+      `/v1/graph/node/${encodeURIComponent(nodeId)}/neighbors${qs ? `?${qs}` : ""}`,
+    );
   },
 
   /** Compute the blast radius (reverse-BFS impact) of a node */

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -112,7 +112,7 @@ export function toAttackCardNodes(path: AttackPath, nodeById: Map<string, Unifie
   return nodes;
 }
 
-function exposureRoleForEntityType(entityType: string): ExposureEntityRole {
+export function exposureRoleForEntityType(entityType: string): ExposureEntityRole {
   switch (entityType) {
     case EntityType.VULNERABILITY:
     case EntityType.MISCONFIGURATION:

--- a/ui/tests/exposure-path-neighbor-explorer.test.tsx
+++ b/ui/tests/exposure-path-neighbor-explorer.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ExposurePathNeighborExplorer } from "@/components/exposure-path-neighbor-explorer";
+import type { GraphNodeNeighborsResponse } from "@/lib/api";
+import type { ExposurePath } from "@/lib/exposure-path";
+import type { UnifiedEdge, UnifiedNode } from "@/lib/graph-schema";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    getGraphNodeNeighbors: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: apiMock,
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+function node(id: string, entityType: string, label: string): UnifiedNode {
+  return { id, entity_type: entityType, label, attributes: {} } as unknown as UnifiedNode;
+}
+
+function edge(source: string, target: string, relationship: string): UnifiedEdge {
+  return { id: `${source}->${target}`, source, target, relationship } as unknown as UnifiedEdge;
+}
+
+const path: ExposurePath = {
+  id: "path-1",
+  label: "analyst-agent -> database -> werkzeug",
+  riskScore: 9.1,
+  severity: "critical",
+  source: { id: "agent:analyst", label: "analyst-agent", role: "agent" },
+  target: { id: "vuln:werkzeug:CVE", label: "CVE", role: "finding" },
+  hops: [
+    { id: "agent:analyst", label: "analyst-agent", role: "agent" },
+    { id: "server:database", label: "database", role: "server" },
+    { id: "pkg:werkzeug", label: "werkzeug@2.2.2", role: "package" },
+    { id: "vuln:werkzeug:CVE", label: "CVE", role: "finding" },
+  ],
+  relationships: [],
+  nodeIds: ["agent:analyst", "server:database", "pkg:werkzeug", "vuln:werkzeug:CVE"],
+  edgeIds: [],
+  findings: ["CVE"],
+  affectedAgents: ["analyst-agent"],
+  affectedServers: ["database"],
+  reachableTools: [],
+  exposedCredentials: [],
+};
+
+describe("ExposurePathNeighborExplorer", () => {
+  it("lazy-loads and reveals a hop's neighbors on expand, then hides them on collapse", async () => {
+    const response: GraphNodeNeighborsResponse = {
+      node_id: "server:database",
+      scan_id: "scan-1",
+      found: true,
+      direction: "both",
+      limit: 12,
+      total_neighbors: 2,
+      truncated: false,
+      neighbors: [
+        node("pkg:werkzeug", "package", "werkzeug@2.2.2"),
+        node("agent:analyst", "agent", "analyst-agent"),
+      ],
+      edges: [
+        edge("server:database", "pkg:werkzeug", "depends_on"),
+        edge("agent:analyst", "server:database", "uses"),
+      ],
+    };
+    apiMock.getGraphNodeNeighbors.mockResolvedValue(response);
+
+    render(<ExposurePathNeighborExplorer path={path} scanId="scan-1" />);
+
+    // Nothing is fetched until the analyst expands a hop.
+    expect(apiMock.getGraphNodeNeighbors).not.toHaveBeenCalled();
+
+    const expandButton = screen.getByRole("button", { name: /Expand neighbors of database/i });
+    fireEvent.click(expandButton);
+
+    await waitFor(() => expect(screen.getByText("Dependencies")).toBeInTheDocument());
+    expect(apiMock.getGraphNodeNeighbors).toHaveBeenCalledWith("server:database", {
+      scanId: "scan-1",
+      limit: 12,
+      direction: "both",
+    });
+    expect(screen.getByText("Dependents")).toBeInTheDocument();
+    expect(screen.getByText("werkzeug")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Collapse neighbors of database/i })).toBeInTheDocument();
+
+    // Collapsing hides the revealed neighbors without refetching.
+    fireEvent.click(screen.getByRole("button", { name: /Collapse neighbors of database/i }));
+    await waitFor(() => expect(screen.queryByText("Dependencies")).not.toBeInTheDocument());
+
+    // Re-expanding is served from cache (no second network call).
+    fireEvent.click(screen.getByRole("button", { name: /Expand neighbors of database/i }));
+    await waitFor(() => expect(screen.getByText("Dependencies")).toBeInTheDocument());
+    expect(apiMock.getGraphNodeNeighbors).toHaveBeenCalledTimes(1);
+  });
+
+  it("honestly reports a bounded fan-out with a +N more affordance", async () => {
+    apiMock.getGraphNodeNeighbors.mockResolvedValue({
+      node_id: "pkg:werkzeug",
+      scan_id: "scan-1",
+      found: true,
+      direction: "both",
+      limit: 12,
+      total_neighbors: 40,
+      truncated: true,
+      neighbors: [node("pkg:dep0", "package", "dep-0")],
+      edges: [edge("pkg:werkzeug", "pkg:dep0", "depends_on")],
+    } satisfies GraphNodeNeighborsResponse);
+
+    render(<ExposurePathNeighborExplorer path={path} scanId="scan-1" />);
+    fireEvent.click(screen.getByRole("button", { name: /Expand neighbors of werkzeug/i }));
+
+    await waitFor(() => expect(screen.getByText(/\+39 more neighbors not shown/i)).toBeInTheDocument());
+  });
+
+  it("does not offer an expand control for leaf finding hops", () => {
+    render(<ExposurePathNeighborExplorer path={path} scanId="scan-1" />);
+    expect(screen.queryByRole("button", { name: /Expand neighbors of CVE/i })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

The security-graph **Top Exposed Path** command center rendered a fixed-depth `Agent → Server → Package → Finding` chain. Cards were clickable (drill to a drawer) but you could not expand a node to see its transitive dependencies / graph neighbors inline, then collapse. This adds dependency-driven progressive disclosure on the attack path (addresses the attack-path expand/collapse ask in the graph-UX epic #3931).

- Expand any **package / server / agent** hop to reveal its **direct dependencies and dependents** inline as child node chips; collapse to hide them.
- Neighbors are **lazy-loaded on first expand** and cached across collapse/expand — the whole graph is never preloaded.
- Depth is capped at **one level per expand**; fan-out is bounded (default 12) with an honest **"+N more"** when a high-degree hub is truncated.
- Neighbor chips reuse the existing role styling and design tokens (light + dark, no hardcoded `zinc-*`). The existing SVG overview and drill-to-drawer are unchanged.

### Neighbors endpoint

Reused the graph store's existing tenant-scoped primitives rather than adding backend surface per node type. Added one minimal read-only route `GET /v1/graph/node/{id}/neighbors` built on the existing `node_context` + `nodes_by_ids` methods (already implemented across sqlite / postgres / neptune backends, so no per-backend changes). It is:

- **Bounded** — fan-out capped by `limit` (1–100, default 24 API / 12 UI), deterministic neighbor ordering so caps are stable across repeated expands, and a truthful `total_neighbors` + `truncated`.
- **Lazy & tenant-scoped** — one hop at a time, scoped via the request tenant.
- **Non-raising on bad input** — an unknown node id returns an empty payload (`200`, `found: false`) instead of a 404, so a stale client id degrades quietly in-place.
- **Self-describing** — neighbor node metadata (entity type, label, severity) travels with the payload, avoiding a round trip per neighbor id.

## Verification

Backend:
- `pytest tests/test_graph_api.py` — 59 passed (4 new: bounded metadata, fan-out cap + truncation, direction filter, unknown-node no-raise).
- `ruff` + `mypy` on `graph.py` — clean.
- `make preflight` — green (regenerated `docs/openapi/v1.{json,yaml}` and the data-model atlas path count 257 → 258).

UI:
- `npm ci` → `npm run typecheck` — clean.
- `vitest` (explorer + command-center + attack-path-card) — 22 passed (lazy load, expand/collapse, cache reuse, "+N more", leaf hops offer no expand control).
- `npm run build` — succeeds.
- `eslint` on changed files — clean.

## Notes

- Interactive expand lives on the **ExposurePathCommandCenter** surface (the richest one, which already carries hop ids + `scanId`). The compact `AttackPathCard` chip chain was left as-is because it only carries `{type,label,severity}`, not node ids/scan context needed to fetch neighbors.
- **Follow-up (intentionally not started):** deeper graph-layout work — zoom / pan / auto-layout and multi-level in-canvas expansion on the SVG. This v1 keeps a bounded, one-level-per-expand HTML explorer beside the SVG overview.