### PR TITLE
feat(cloud): per-account end-to-end drill view (#3931)

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 258 |
+| `docs/openapi/v1.json` | paths | 259 |
 | `docs/openapi/v1.json` | component schemas | 67 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 257 |
+| `docs/openapi/v1.json` | paths | 258 |
 | `docs/openapi/v1.json` | component schemas | 67 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -6384,6 +6384,99 @@
         ]
       }
     },
+    "/v1/cloud/accounts/{account_ref}/summary": {
+      "get": {
+        "description": "Per-account, end-to-end posture drill for one cloud account (issue #3931).\n\nReturns findings by security domain (each severity strip summing to its lane\ncount), stored CIS/compliance pass-rate, an asset count, and an\nidentity/role count \u2014 everything scoped to ``account_ref`` (e.g.\n``aws:123456789012``). Read-only: composes the #3946 rollup + scope filters\nover already-ingested evidence and never triggers a provider scan.\n\nCanonicalized + tenant-scoped; a malformed or unknown account returns an\nhonest empty summary (all five lanes at zero, ``pass_rate: null``) rather\nthan raising. The read runs off the event loop under the shared findings\nbackpressure guard so a burst of account views cannot starve ``/health``.",
+        "operationId": "cloud_account_summary_v1_cloud_accounts__account_ref__summary_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "account_ref",
+            "required": true,
+            "schema": {
+              "title": "Account Ref",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Cloud Account Summary V1 Cloud Accounts  Account Ref  Summary Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Cloud Account Summary",
+        "tags": [
+          "cloud"
+        ]
+      }
+    },
     "/v1/cloud/connections": {
       "get": {
         "description": "List the authenticated tenant's connections (non-secret metadata only).",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -4206,6 +4206,69 @@ paths:
       summary: Cis Benchmark Trends
       tags:
       - compliance
+  /v1/cloud/accounts/{account_ref}/summary:
+    get:
+      description: "Per-account, end-to-end posture drill for one cloud account (issue\
+        \ #3931).\n\nReturns findings by security domain (each severity strip summing\
+        \ to its lane\ncount), stored CIS/compliance pass-rate, an asset count, and\
+        \ an\nidentity/role count \u2014 everything scoped to ``account_ref`` (e.g.\n\
+        ``aws:123456789012``). Read-only: composes the #3946 rollup + scope filters\n\
+        over already-ingested evidence and never triggers a provider scan.\n\nCanonicalized\
+        \ + tenant-scoped; a malformed or unknown account returns an\nhonest empty\
+        \ summary (all five lanes at zero, ``pass_rate: null``) rather\nthan raising.\
+        \ The read runs off the event loop under the shared findings\nbackpressure\
+        \ guard so a burst of account views cannot starve ``/health``."
+      operationId: cloud_account_summary_v1_cloud_accounts__account_ref__summary_get
+      parameters:
+      - in: path
+        name: account_ref
+        required: true
+        schema:
+          title: Account Ref
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Cloud Account Summary V1 Cloud Accounts  Account Ref  Summary
+                  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Cloud Account Summary
+      tags:
+      - cloud
   /v1/cloud/connections:
     get:
       description: List the authenticated tenant's connections (non-secret metadata

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -26,11 +26,14 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any
+from typing import Any, cast
+from urllib.parse import urlencode
 
+import anyio.to_thread
 from fastapi import APIRouter, HTTPException, Query, Request
 
 from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
 from agent_bom.rbac import require_authenticated_permission
 
 router = APIRouter(tags=["cloud"])
@@ -39,6 +42,33 @@ _logger = logging.getLogger(__name__)
 # Reuse the same RBAC gate the sibling scan/identity routes use. Cloud scanning is
 # a scan-class action, so it maps to the "scan" permission ({admin, analyst}).
 _SCAN_DEP = require_authenticated_permission("scan")
+# The per-account drill summary is a read-only aggregation over already-ingested
+# evidence — it never triggers a provider scan — so it maps to the "read" gate
+# (all authenticated roles), like /v1/overview.
+_READ_DEP = require_authenticated_permission("read")
+
+# Bound the per-account read so one account view can never walk an unbounded
+# number of rows on a huge tenant. Mirrors the intent of the findings-list
+# backpressure guard; a sargable account-scoped GROUP BY in the hub store is a
+# follow-up for million-row tenants (see PR notes).
+_ACCOUNT_SUMMARY_MAX_ROWS = 50_000
+
+# Asset-type buckets used to derive an honest identity/role count from the
+# account's finding assets (deeper IAM/grant enumeration is a follow-up).
+_IDENTITY_ASSET_TYPES = frozenset(
+    {"user", "service_account", "identity", "iam_user", "principal", "machine_identity", "nhi"}
+)
+_ROLE_ASSET_TYPES = frozenset({"role", "iam_role", "cloud_role"})
+
+# Provider -> the result keys (new + legacy) that carry a stored CIS benchmark
+# side block. Matches the mapping the graph builder reads (#3946).
+_CIS_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("aws", ("cis_benchmark", "cis_benchmark_data")),
+    ("azure", ("azure_cis_benchmark", "azure_cis_benchmark_data")),
+    ("gcp", ("gcp_cis_benchmark", "gcp_cis_benchmark_data")),
+    ("snowflake", ("snowflake_cis_benchmark", "snowflake_cis_benchmark_data")),
+    ("databricks", ("databricks_cis_benchmark", "databricks_cis_benchmark_data")),
+)
 
 _INVENTORY_PROVIDERS = ("aws", "azure", "gcp")
 _CIS_PROVIDERS = ("aws", "azure", "gcp")
@@ -292,3 +322,312 @@ async def cloud_cis_benchmark(
         # Full diagnostics to the server log only; client gets a generic message.
         _logger.exception("Cloud CIS benchmark failed")
         raise HTTPException(status_code=500, detail="Cloud CIS benchmark failed; see server logs.") from exc
+
+
+# ---------------------------------------------------------------------------
+# Per-account drill summary (issue #3931)
+#
+# "Show me this cloud account end-to-end" — a single read-only aggregation over
+# already-ingested findings + stored CIS benchmark blocks, scoped to one
+# provider+account. It composes the exact rollup + scope filters #3946 shipped
+# (never re-implements counting) and never triggers a live provider scan.
+# ---------------------------------------------------------------------------
+
+
+def _split_account_ref(raw: str | None) -> tuple[str, str, str]:
+    """Return ``(canonical_ref, provider, bare_account)`` for a path param.
+
+    Canonicalized (trimmed, provider lowercased) so ``AWS:1234`` and ``aws:1234``
+    collapse. A value with no ``<provider>:<account>`` shape yields an empty
+    provider/account so the endpoint returns an honest empty summary rather than
+    raising — the same never-raise contract the #3946 scope filters hold.
+    """
+    text = (raw or "").strip()
+    provider, sep, account = text.partition(":")
+    provider = provider.strip().lower()
+    account = account.strip()
+    if not sep or not provider or not account:
+        return "", "", ""
+    return f"{provider}:{account}", provider, account
+
+
+def _account_findings_href(account_ref: str, provider: str, *, domain: str | None = None) -> str:
+    """Build a /findings deep-link pre-filtered to this account (and domain)."""
+    params: dict[str, str] = {}
+    if provider:
+        params["provider"] = provider
+    if account_ref:
+        params["account"] = account_ref
+    if domain:
+        params["domain"] = domain
+    query = urlencode(params)
+    return f"/findings?{query}" if query else "/findings"
+
+
+def _cis_block_account_id(data: dict[str, Any]) -> str:
+    """Pull the account/subscription/project id out of a stored CIS block."""
+    for key in ("account_id", "subscription_id", "aws_account_id", "project_id"):
+        value = str(data.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _cis_counts(data: dict[str, Any]) -> tuple[int, int]:
+    """Return ``(passed, failed)`` for a CIS block, computing from checks if absent."""
+    passed = data.get("passed")
+    failed = data.get("failed")
+    if isinstance(passed, int) and isinstance(failed, int):
+        return passed, failed
+    p = f = 0
+    for check in data.get("checks", []) or []:
+        if not isinstance(check, dict):
+            continue
+        status = str(check.get("status", "")).upper()
+        if status == "PASS":
+            p += 1
+        elif status == "FAIL":
+            f += 1
+    return p, f
+
+
+def _compliance_for_account(
+    jobs_newest_first: list[Any], provider: str, wanted_ref: str
+) -> dict[str, Any]:
+    """Aggregate stored CIS pass-rate for the account (newest run per provider).
+
+    Only blocks whose normalized account matches ``wanted_ref`` are counted; a
+    block with no resolvable account id is admitted only when its provider equals
+    the requested account's provider (the view is provider-scoped anyway), so a
+    different account's run can never leak into this account's pass-rate. Honest
+    empty (``pass_rate: null``) when no benchmark run exists for the account.
+    """
+    from agent_bom.finding_scope import normalize_account_ref
+
+    benchmarks: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    total_passed = total_failed = 0
+
+    for job in jobs_newest_first:
+        result = cast(dict[str, Any], getattr(job, "result", None) or {})
+        for prov, keys in _CIS_SECTIONS:
+            if provider and prov != provider:
+                continue
+            data: dict[str, Any] | None = None
+            for key in keys:
+                candidate = result.get(key)
+                if isinstance(candidate, dict) and candidate:
+                    data = candidate
+                    break
+            if data is None:
+                continue
+            block_provider = str(data.get("provider") or data.get("cloud_provider") or prov).strip().lower() or prov
+            account_id = _cis_block_account_id(data)
+            block_ref = normalize_account_ref(block_provider, account_id) if account_id else ""
+            if block_ref:
+                if block_ref.lower() != wanted_ref:
+                    continue
+            elif not provider or block_provider != provider:
+                # No account id and no confident provider match — skip to stay honest.
+                continue
+            marker = f"{block_provider}:{block_ref or account_id or 'provider-scope'}"
+            if marker in seen:
+                continue  # newest run already recorded for this provider/account
+            seen.add(marker)
+            passed, failed = _cis_counts(data)
+            evaluated = passed + failed
+            total_passed += passed
+            total_failed += failed
+            benchmarks.append(
+                {
+                    "provider": block_provider,
+                    "benchmark": str(data.get("benchmark") or "CIS"),
+                    "passed": passed,
+                    "failed": failed,
+                    "evaluated": evaluated,
+                    "pass_rate": round(passed / evaluated * 100, 1) if evaluated else None,
+                }
+            )
+
+    evaluated = total_passed + total_failed
+    return {
+        "evaluated": evaluated,
+        "passed": total_passed,
+        "failed": total_failed,
+        "pass_rate": round(total_passed / evaluated * 100, 1) if evaluated else None,
+        "benchmarks": benchmarks,
+    }
+
+
+def _build_account_summary(tenant_id: str, raw_account_ref: str) -> dict[str, Any]:
+    """Compose the per-account drill payload from stored evidence (sync body).
+
+    Runs in a worker thread (see the route). Reuses the #3946 domain rollup
+    buckets, the #3946 scope filters, and the shared scan-store helpers so no
+    counting logic is re-implemented here.
+    """
+    from agent_bom.api.routes.overview import (
+        _ALL_SEVERITY_KEYS,
+        _COVERAGE_DOMAINS,
+        _COVERAGE_LABELS,
+        _bucket,
+        _empty_severity,
+        _row_domain,
+    )
+    from agent_bom.api.routes.scan import (
+        _bulk_ingested_findings_for_tenant,
+        _canonical_scope_filters,
+        _completed_jobs_for_tenant,
+        _finding_identity,
+        _row_matches_scope,
+    )
+
+    canonical_ref, provider, account = _split_account_ref(raw_account_ref)
+
+    lanes: dict[str, dict[str, int]] = {dom: _empty_severity() for dom in _COVERAGE_DOMAINS}
+    counts: dict[str, int] = {dom: 0 for dom in _COVERAGE_DOMAINS}
+    total_severity = _empty_severity()
+    regions: set[str] = set()
+    environments: set[str] = set()
+    asset_ids: set[str] = set()
+    identity_ids: set[str] = set()
+    role_ids: set[str] = set()
+    processed = 0
+    truncated = False
+
+    jobs = _completed_jobs_for_tenant(tenant_id)
+    jobs_newest_first = sorted(
+        jobs,
+        key=lambda job: (getattr(job, "completed_at", "") or "", getattr(job, "created_at", "") or "", job.job_id),
+        reverse=True,
+    )
+
+    if canonical_ref:
+        # Dedupe findings across re-scans (latest occurrence of each id wins),
+        # exactly like the findings-list default view, then fold bulk-ingested
+        # rows in under the same identity so a finding seen twice counts once.
+        filters = _canonical_scope_filters(None, canonical_ref, None, None)
+        deduped: dict[str, dict[str, Any]] = {}
+        for job in sorted(
+            jobs,
+            key=lambda job: (getattr(job, "completed_at", "") or "", getattr(job, "created_at", "") or "", job.job_id),
+        ):
+            for row in cast(dict[str, Any], getattr(job, "result", None) or {}).get("findings", []) or []:
+                if isinstance(row, dict):
+                    deduped[_finding_identity(row)] = row
+        for row in _bulk_ingested_findings_for_tenant(tenant_id):
+            if isinstance(row, dict):
+                deduped.setdefault(_finding_identity(row), row)
+
+        for row in deduped.values():
+            if not _row_matches_scope(row, filters):
+                continue
+            if processed >= _ACCOUNT_SUMMARY_MAX_ROWS:
+                truncated = True
+                break
+            processed += 1
+            dom = _row_domain(row)
+            bucket = _bucket(str(row.get("severity") or ""), lanes[dom])
+            lanes[dom][bucket] += 1
+            counts[dom] += 1
+            total_severity[bucket] += 1
+            region = str(row.get("region") or "").strip()
+            if region:
+                regions.add(region)
+            environment = str(row.get("environment") or "").strip()
+            if environment:
+                environments.add(environment)
+            raw_asset = row.get("asset")
+            asset: dict[str, Any] = raw_asset if isinstance(raw_asset, dict) else {}
+            identifier = str(asset.get("identifier") or asset.get("name") or "").strip()
+            asset_type = str(asset.get("asset_type") or "").strip().lower()
+            if identifier:
+                asset_ids.add(identifier)
+                if asset_type in _IDENTITY_ASSET_TYPES:
+                    identity_ids.add(identifier)
+                if asset_type in _ROLE_ASSET_TYPES:
+                    role_ids.add(identifier)
+
+    compliance = (
+        _compliance_for_account(jobs_newest_first, provider, canonical_ref)
+        if canonical_ref
+        else {"evaluated": 0, "passed": 0, "failed": 0, "pass_rate": None, "benchmarks": []}
+    )
+    compliance["href"] = _account_findings_href(canonical_ref, provider, domain="cspm")
+
+    findings_total = sum(counts.values())
+    domains = [
+        {
+            "domain": dom,
+            "label": _COVERAGE_LABELS[dom],
+            "count": counts[dom],
+            "severity": {key: lanes[dom][key] for key in _ALL_SEVERITY_KEYS},
+            "href": _account_findings_href(canonical_ref, provider, domain=dom),
+        }
+        for dom in _COVERAGE_DOMAINS
+    ]
+
+    return {
+        "schema_version": "cloud.account.summary.v1",
+        "tenant_id": tenant_id,
+        "account_ref": canonical_ref,
+        "provider": provider,
+        "account": account,
+        "regions": sorted(regions),
+        "environments": sorted(environments),
+        "findings_total": findings_total,
+        "severity": {key: total_severity[key] for key in _ALL_SEVERITY_KEYS},
+        "domains": domains,
+        "compliance": compliance,
+        "assets": {
+            "count": len(asset_ids),
+            "href": f"/inventory/assets?provider={provider}" if provider else "/inventory/assets",
+            "note": "Distinct assets referenced by findings in this account.",
+        },
+        "identities": {
+            "count": len(identity_ids),
+            "roles": len(role_ids),
+            "note": "Derived from finding assets; full IAM role/grant enumeration is a follow-up.",
+        },
+        "drill": {
+            "findings_href": _account_findings_href(canonical_ref, provider),
+            "graph_href": f"/graph?provider={provider}" if provider else "/graph",
+        },
+        "truncated": truncated,
+        "empty": findings_total == 0 and compliance["evaluated"] == 0,
+        "note": (
+            "Read-only aggregation over already-ingested findings and stored CIS benchmark runs, "
+            "scoped to this provider+account. No live provider scan is triggered."
+        ),
+    }
+
+
+@router.get("/cloud/accounts/{account_ref}/summary")
+async def cloud_account_summary(
+    request: Request,
+    account_ref: str,
+    _role: Any = _READ_DEP,
+) -> dict[str, Any]:
+    """Per-account, end-to-end posture drill for one cloud account (issue #3931).
+
+    Returns findings by security domain (each severity strip summing to its lane
+    count), stored CIS/compliance pass-rate, an asset count, and an
+    identity/role count — everything scoped to ``account_ref`` (e.g.
+    ``aws:123456789012``). Read-only: composes the #3946 rollup + scope filters
+    over already-ingested evidence and never triggers a provider scan.
+
+    Canonicalized + tenant-scoped; a malformed or unknown account returns an
+    honest empty summary (all five lanes at zero, ``pass_rate: null``) rather
+    than raising. The read runs off the event loop under the shared findings
+    backpressure guard so a burst of account views cannot starve ``/health``.
+    """
+    tenant_id = _tenant(request)
+    try:
+        async with adaptive_backpressure("findings"):
+            return await anyio.to_thread.run_sync(_build_account_summary, tenant_id, account_ref)
+    except BackpressureRejectedError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail=exc.to_dict(),
+            headers={"Retry-After": str(exc.retry_after_seconds)},
+        ) from exc

--- a/tests/test_cloud_account_summary.py
+++ b/tests/test_cloud_account_summary.py
@@ -1,0 +1,202 @@
+"""Per-account cloud drill summary — GET /v1/cloud/accounts/{account_ref}/summary.
+
+Read-only aggregation over already-ingested findings + stored CIS benchmark
+blocks, scoped to one provider+account (issue #3931). Reuses the #3946 scope
+filters and the #3946 domain rollup; never triggers a live provider scan.
+"""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore, set_compliance_hub_store
+from agent_bom.api.models import JobStatus
+from agent_bom.api.server import ScanJob, ScanRequest, app, set_job_store
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import _get_store
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+_AUTH = proxy_headers(tenant="default")
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+
+
+def _seed() -> None:
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+    job = ScanJob(
+        job_id="acct-job",
+        tenant_id="default",
+        created_at="2026-02-22T10:00:00Z",
+        request=ScanRequest(),
+    )
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-02-22T10:05:00Z"
+    job.result = {
+        "agents": [],
+        "scan_sources": ["cloud"],
+        "findings": [
+            {
+                "id": "f-aws-prod-cspm",
+                "severity": "high",
+                "security_domain": "cspm",
+                "provider": "aws",
+                "account_ref": "aws:111111111111",
+                "region": "us-east-1",
+                "environment": "prod",
+                "title": "aws prod misconfig",
+                "asset": {"identifier": "arn:aws:s3:::bucket", "asset_type": "cloud_resource"},
+            },
+            {
+                "id": "f-aws-prod-vuln",
+                "severity": "critical",
+                "security_domain": "vuln",
+                "provider": "aws",
+                "account_ref": "aws:111111111111",
+                "region": "us-east-1",
+                "environment": "prod",
+                "title": "aws prod cve",
+            },
+            {
+                "id": "f-aws-prod-iam",
+                "severity": "medium",
+                "security_domain": "aispm",
+                "provider": "aws",
+                "account_ref": "aws:111111111111",
+                "environment": "prod",
+                "title": "aws prod role risk",
+                "asset": {"identifier": "role/admin", "asset_type": "role"},
+            },
+            {
+                "id": "f-aws-dev-cspm",
+                "severity": "medium",
+                "security_domain": "cspm",
+                "provider": "aws",
+                "account_ref": "aws:222222222222",
+                "environment": "dev",
+                "title": "aws dev misconfig",
+            },
+        ],
+        # Stored CIS benchmark side block for the prod account: 8 pass / 2 fail.
+        "cis_benchmark_data": {
+            "benchmark": "CIS AWS Foundations",
+            "provider": "aws",
+            "account_id": "111111111111",
+            "passed": 8,
+            "failed": 2,
+            "evaluated": 10,
+            "pass_rate": 80.0,
+            "checks": [],
+        },
+    }
+    _get_store().put(job)
+
+
+def test_summary_scopes_to_account_and_reconciles_severity() -> None:
+    _seed()
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/accounts/aws:111111111111/summary", headers=_AUTH)
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["schema_version"] == "cloud.account.summary.v1"
+    assert body["provider"] == "aws"
+    assert body["account"] == "111111111111"
+    assert body["account_ref"] == "aws:111111111111"
+    # Only the three prod-account findings; the dev-account one is excluded.
+    assert body["findings_total"] == 3
+    assert body["empty"] is False
+    # Top-level severity strip sums to the counted total (honest invariant).
+    assert sum(body["severity"].values()) == body["findings_total"]
+    assert "us-east-1" in body["regions"]
+    assert "prod" in body["environments"]
+
+
+def test_summary_domains_are_five_lanes_each_reconciled() -> None:
+    _seed()
+    client = TestClient(app)
+    body = client.get("/v1/cloud/accounts/aws:111111111111/summary", headers=_AUTH).json()
+
+    lanes = {lane["domain"]: lane for lane in body["domains"]}
+    assert set(lanes) == {"cspm", "vuln", "appsec_sca", "dspm", "aispm"}
+    assert lanes["cspm"]["count"] == 1
+    assert lanes["vuln"]["count"] == 1
+    assert lanes["aispm"]["count"] == 1
+    assert lanes["dspm"]["count"] == 0
+    # Every lane's severity strip sums to its own count.
+    for lane in body["domains"]:
+        assert sum(lane["severity"].values()) == lane["count"]
+    # Drill links carry the #3946 scope filter params for this account.
+    assert "account=aws%3A111111111111" in lanes["cspm"]["href"] or "account=aws:111111111111" in lanes["cspm"]["href"]
+    assert "domain=cspm" in lanes["cspm"]["href"]
+
+
+def test_summary_surfaces_stored_cis_pass_rate() -> None:
+    _seed()
+    client = TestClient(app)
+    body = client.get("/v1/cloud/accounts/aws:111111111111/summary", headers=_AUTH).json()
+
+    comp = body["compliance"]
+    assert comp["evaluated"] == 10
+    assert comp["passed"] == 8
+    assert comp["failed"] == 2
+    assert comp["pass_rate"] == 80.0
+    assert any(b["provider"] == "aws" for b in comp["benchmarks"])
+
+
+def test_summary_counts_assets_and_roles_from_findings() -> None:
+    _seed()
+    client = TestClient(app)
+    body = client.get("/v1/cloud/accounts/aws:111111111111/summary", headers=_AUTH).json()
+    # Two findings carry an asset (bucket + role); one is a role identity.
+    assert body["assets"]["count"] == 2
+    assert body["identities"]["roles"] == 1
+
+
+def test_unknown_account_never_raises_and_is_empty() -> None:
+    _seed()
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/accounts/aws:999999999999/summary", headers=_AUTH)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["findings_total"] == 0
+    assert body["empty"] is True
+    assert body["compliance"]["pass_rate"] is None
+    # All five lanes still present at zero.
+    assert len(body["domains"]) == 5
+
+
+def test_malformed_account_ref_never_raises() -> None:
+    _seed()
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/accounts/not-an-account/summary", headers=_AUTH)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["provider"] == ""
+    assert body["findings_total"] == 0
+    assert body["empty"] is True
+
+
+def test_summary_is_tenant_scoped() -> None:
+    _seed()
+    client = TestClient(app)
+    other = proxy_headers(tenant="tenant-beta")
+    body = client.get("/v1/cloud/accounts/aws:111111111111/summary", headers=other).json()
+    # The seeded job belongs to tenant default; another tenant sees nothing.
+    assert body["findings_total"] == 0
+    assert body["empty"] is True
+
+
+def test_case_insensitive_account_match() -> None:
+    _seed()
+    client = TestClient(app)
+    body = client.get("/v1/cloud/accounts/AWS:111111111111/summary", headers=_AUTH).json()
+    assert body["findings_total"] == 3

--- a/ui/app/accounts/[ref]/page.tsx
+++ b/ui/app/accounts/[ref]/page.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import {
+  ArrowRight,
+  Boxes,
+  Cloud,
+  KeyRound,
+  ListChecks,
+  MapPin,
+  ShieldCheck,
+} from "lucide-react";
+
+import { api } from "@/lib/api";
+import type { AccountSummaryDomain, AccountSummaryResponse } from "@/lib/api-types";
+import { PageLaneHeader } from "@/components/page-lane";
+import { PageLoadingState, PageEmptyState } from "@/components/states/page-state";
+import { ApiOfflineState, type ApiOfflineKind } from "@/components/api-offline-state";
+import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
+import { providerDisplayName } from "@/lib/scan-scope";
+
+function classifyApiErrorKind(err: unknown): ApiOfflineKind {
+  if (err instanceof ApiAuthError) return "auth";
+  if (err instanceof ApiForbiddenError) return "forbidden";
+  return "network";
+}
+
+// Severity bands shown in a lane's strip, in descending order, plus ``unrated``
+// for findings whose severity is unknown/unscored (issue #3946). Colors come
+// from design tokens so light + dark both read correctly.
+const SEVERITY_BANDS: {
+  key: keyof AccountSummaryDomain["severity"];
+  label: string;
+  token: string;
+}[] = [
+  { key: "critical", label: "Critical", token: "--severity-critical" },
+  { key: "high", label: "High", token: "--severity-high" },
+  { key: "medium", label: "Medium", token: "--severity-medium" },
+  { key: "low", label: "Low", token: "--severity-low" },
+  { key: "unrated", label: "Unrated", token: "--severity-unrated" },
+];
+
+function ScopeChip({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2 py-0.5 text-[11px] font-medium text-[color:var(--text-secondary)]">
+      {children}
+    </span>
+  );
+}
+
+function StatTile({
+  icon: Icon,
+  label,
+  value,
+  sub,
+  href,
+  tone = "neutral",
+}: {
+  icon: React.ElementType;
+  label: string;
+  value: string;
+  sub?: string;
+  href?: string;
+  tone?: "neutral" | "warn" | "danger" | "ok";
+}) {
+  const toneVar =
+    tone === "danger"
+      ? "var(--status-danger)"
+      : tone === "warn"
+        ? "var(--status-warn)"
+        : tone === "ok"
+          ? "var(--status-success)"
+          : "var(--text-secondary)";
+  const inner = (
+    <div className="flex min-h-full flex-col rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4">
+      <div className="mb-1 flex items-center gap-2">
+        <Icon className="h-4 w-4" style={{ color: toneVar }} />
+        <span className="text-xs text-[color:var(--text-tertiary)]">{label}</span>
+      </div>
+      <p className="text-2xl font-bold tabular-nums text-[color:var(--foreground)]" style={{ color: tone === "neutral" ? undefined : toneVar }}>
+        {value}
+      </p>
+      {sub ? <p className="mt-0.5 text-[11px] text-[color:var(--text-tertiary)]">{sub}</p> : null}
+    </div>
+  );
+  return href ? (
+    <Link href={href} className="transition-colors hover:opacity-90">
+      {inner}
+    </Link>
+  ) : (
+    inner
+  );
+}
+
+function DomainLane({ lane }: { lane: AccountSummaryDomain }) {
+  const total = SEVERITY_BANDS.reduce((sum, band) => sum + (lane.severity[band.key] || 0), 0);
+  const bands = SEVERITY_BANDS.filter((band) => (lane.severity[band.key] || 0) > 0);
+  return (
+    <Link
+      href={lane.href}
+      data-testid={`account-lane-${lane.domain}`}
+      className="flex flex-col gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3 transition-colors hover:border-[color:var(--border-strong)]"
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-xs font-semibold text-[color:var(--foreground)]">{lane.label}</span>
+        <span className="text-lg font-bold tabular-nums text-[color:var(--foreground)]">{lane.count}</span>
+      </div>
+      <div className="flex h-1.5 w-full overflow-hidden rounded-full bg-[color:var(--surface-muted)]">
+        {total > 0 &&
+          bands.map((band) => (
+            <span
+              key={band.key}
+              className="h-full"
+              style={{
+                width: `${((lane.severity[band.key] || 0) / total) * 100}%`,
+                backgroundColor: `var(${band.token})`,
+              }}
+            />
+          ))}
+      </div>
+      <div className="flex flex-wrap gap-1">
+        {total === 0 ? (
+          <span className="text-[11px] text-[color:var(--text-tertiary)]">No findings</span>
+        ) : (
+          bands.map((band) => (
+            <span
+              key={band.key}
+              className="rounded px-1.5 py-0.5 text-[11px] font-medium tabular-nums"
+              style={{
+                color: `var(${band.token})`,
+                backgroundColor: `var(${band.token}-bg)`,
+                border: `1px solid var(${band.token}-border)`,
+              }}
+            >
+              {band.label} {lane.severity[band.key]}
+            </span>
+          ))
+        )}
+      </div>
+    </Link>
+  );
+}
+
+function ComplianceHealth({ summary }: { summary: AccountSummaryResponse }) {
+  const { compliance } = summary;
+  const hasRun = compliance.evaluated > 0 && compliance.pass_rate != null;
+  const pct = compliance.pass_rate ?? 0;
+  const tone = !hasRun ? "muted" : pct >= 90 ? "ok" : pct >= 70 ? "warn" : "danger";
+  const barColor =
+    tone === "ok"
+      ? "var(--status-success)"
+      : tone === "warn"
+        ? "var(--status-warn)"
+        : tone === "danger"
+          ? "var(--status-danger)"
+          : "var(--text-tertiary)";
+  return (
+    <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <ShieldCheck className="h-4 w-4 text-[color:var(--text-secondary)]" />
+        <h2 className="text-sm font-semibold text-[color:var(--foreground)]">CIS / compliance health</h2>
+      </div>
+      {!hasRun ? (
+        <p className="text-sm text-[color:var(--text-tertiary)]">
+          No stored CIS benchmark run for this account yet. Run a CIS benchmark for this account to populate a
+          pass-rate — the CSPM lane above still counts open misconfiguration findings.
+        </p>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-baseline justify-between gap-2">
+            <span className="text-3xl font-bold tabular-nums" style={{ color: barColor }}>
+              {pct.toFixed(1)}%
+            </span>
+            <span className="text-xs text-[color:var(--text-tertiary)]">
+              {compliance.passed} passed · {compliance.failed} failed · {compliance.evaluated} evaluated
+            </span>
+          </div>
+          <div className="mt-3 h-2.5 overflow-hidden rounded-full bg-[color:var(--surface-muted)]">
+            <div className="h-full transition-all duration-700" style={{ width: `${Math.min(100, pct)}%`, backgroundColor: barColor }} />
+          </div>
+          {compliance.benchmarks.length > 0 ? (
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {compliance.benchmarks.map((b) => (
+                <span
+                  key={`${b.provider}:${b.benchmark}`}
+                  className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2 py-0.5 text-[11px] text-[color:var(--text-secondary)]"
+                >
+                  {b.benchmark} · {b.pass_rate != null ? `${b.pass_rate.toFixed(0)}%` : "n/a"}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </>
+      )}
+      <Link
+        href={compliance.href}
+        className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)]"
+      >
+        View misconfiguration findings
+        <ArrowRight className="h-3 w-3" />
+      </Link>
+    </section>
+  );
+}
+
+export default function AccountDrillPage() {
+  const params = useParams<{ ref: string }>();
+  const rawRef = Array.isArray(params.ref) ? params.ref[0] : params.ref;
+  const accountRef = useMemo(() => {
+    try {
+      return decodeURIComponent(rawRef ?? "");
+    } catch {
+      return rawRef ?? "";
+    }
+  }, [rawRef]);
+
+  const [summary, setSummary] = useState<AccountSummaryResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [errorKind, setErrorKind] = useState<ApiOfflineKind>("network");
+
+  useEffect(() => {
+    if (!accountRef) {
+      setLoading(false);
+      return;
+    }
+    let mounted = true;
+    setLoading(true);
+    api
+      .getCloudAccountSummary(accountRef)
+      .then((data) => {
+        if (!mounted) return;
+        setSummary(data);
+        setError(null);
+      })
+      .catch((err) => {
+        if (!mounted) return;
+        setError(err?.message ?? "Failed to load account summary");
+        setErrorKind(classifyApiErrorKind(err));
+      })
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [accountRef]);
+
+  if (loading) {
+    return (
+      <PageLoadingState
+        title="Loading account posture"
+        detail="Aggregating findings, compliance, and identities for this cloud account."
+      />
+    );
+  }
+  if (error) {
+    return <ApiOfflineState title="Account summary unavailable" detail={error} kind={errorKind} />;
+  }
+  if (!summary) return null;
+
+  const providerLabel = summary.provider ? providerDisplayName(summary.provider) : "Cloud";
+  const criticalHigh = (summary.severity.critical || 0) + (summary.severity.high || 0);
+
+  return (
+    <div className="space-y-6">
+      <PageLaneHeader
+        lane="cloud-data"
+        title={summary.account ? `${providerLabel} · ${summary.account}` : "Cloud account"}
+        subtitle={
+          summary.account_ref
+            ? `End-to-end read-only posture for ${summary.account_ref}. Findings, compliance, and identities in one pane.`
+            : "This account reference could not be parsed. Use a canonical reference such as aws:123456789012."
+        }
+        actions={
+          <div className="flex flex-wrap items-center gap-1.5">
+            <ScopeChip>
+              <Cloud className="h-3 w-3" />
+              {providerLabel}
+            </ScopeChip>
+            {summary.regions.slice(0, 4).map((region) => (
+              <ScopeChip key={region}>
+                <MapPin className="h-3 w-3" />
+                {region}
+              </ScopeChip>
+            ))}
+            {summary.environments.map((env) => (
+              <ScopeChip key={env}>{env}</ScopeChip>
+            ))}
+          </div>
+        }
+      />
+
+      {summary.empty ? (
+        <PageEmptyState
+          title="No evidence for this account yet"
+          detail={
+            summary.provider
+              ? `No findings or CIS benchmark runs are recorded for ${summary.account_ref}. Connect and scan this account to populate its posture.`
+              : "Provide a canonical account reference like aws:123456789012 (provider:account)."
+          }
+          icon={Cloud}
+        />
+      ) : (
+        <>
+          {/* Leadership altitude — the account at a glance. */}
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-5">
+            <StatTile
+              icon={ListChecks}
+              label="Open findings"
+              value={summary.findings_total.toLocaleString()}
+              href={summary.drill.findings_href}
+            />
+            <StatTile
+              icon={ListChecks}
+              label="Critical + High"
+              value={criticalHigh.toLocaleString()}
+              tone={summary.severity.critical > 0 ? "danger" : criticalHigh > 0 ? "warn" : "ok"}
+              href={summary.drill.findings_href}
+            />
+            <StatTile
+              icon={ShieldCheck}
+              label="CIS pass-rate"
+              value={summary.compliance.pass_rate != null ? `${summary.compliance.pass_rate.toFixed(0)}%` : "—"}
+              sub={summary.compliance.evaluated > 0 ? `${summary.compliance.evaluated} controls` : "no run yet"}
+              tone={
+                summary.compliance.pass_rate == null
+                  ? "neutral"
+                  : summary.compliance.pass_rate >= 90
+                    ? "ok"
+                    : summary.compliance.pass_rate >= 70
+                      ? "warn"
+                      : "danger"
+              }
+              href={summary.compliance.href}
+            />
+            <StatTile
+              icon={Boxes}
+              label="Assets"
+              value={summary.assets.count.toLocaleString()}
+              sub="referenced by findings"
+              href={summary.assets.href}
+            />
+            <StatTile
+              icon={KeyRound}
+              label="Identities / roles"
+              value={`${summary.identities.count} / ${summary.identities.roles}`}
+              sub="from findings"
+            />
+          </div>
+
+          {/* Engineer altitude — domain lanes with drill-in links. */}
+          <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+            <h2 className="mb-3 text-sm font-semibold text-[color:var(--foreground)]">Findings by security domain</h2>
+            <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
+              {summary.domains.map((lane) => (
+                <DomainLane key={lane.domain} lane={lane} />
+              ))}
+            </div>
+          </section>
+
+          <ComplianceHealth summary={summary} />
+
+          <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-xs font-semibold uppercase tracking-wide text-[color:var(--text-tertiary)]">Drill in</span>
+              <Link
+                href={summary.drill.findings_href}
+                className="inline-flex items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2.5 py-1 text-[11px] font-medium text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)]"
+              >
+                All findings for this account
+                <ArrowRight className="h-3 w-3" />
+              </Link>
+              <Link
+                href={summary.drill.graph_href}
+                className="inline-flex items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2.5 py-1 text-[11px] font-medium text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)]"
+              >
+                Open in graph
+                <ArrowRight className="h-3 w-3" />
+              </Link>
+            </div>
+            {summary.truncated ? (
+              <p className="mt-2 text-[11px] text-[color:var(--status-warn)]">
+                Showing a bounded sample of this account&apos;s findings. Use the findings view for the full, paged list.
+              </p>
+            ) : null}
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2409,6 +2409,55 @@ export interface OverviewResponse {
   top_risks: OverviewTopRisk[];
 }
 
+/** One security-domain lane on the per-account drill summary (#3931). Its
+ * severity strip sums to ``count`` (same honest invariant as the overview). */
+export interface AccountSummaryDomain {
+  domain: "cspm" | "vuln" | "appsec_sca" | "dspm" | "aispm";
+  label: string;
+  count: number;
+  severity: CoverageSeverity;
+  /** Pre-filtered /findings deep-link (provider + account + domain). */
+  href: string;
+}
+
+/** One stored CIS benchmark run folded into the account's compliance health. */
+export interface AccountSummaryBenchmark {
+  provider: string;
+  benchmark: string;
+  passed: number;
+  failed: number;
+  evaluated: number;
+  pass_rate: number | null;
+}
+
+/** GET /v1/cloud/accounts/{account_ref}/summary — per-account end-to-end drill. */
+export interface AccountSummaryResponse {
+  schema_version: string;
+  tenant_id: string;
+  account_ref: string;
+  provider: string;
+  account: string;
+  regions: string[];
+  environments: string[];
+  findings_total: number;
+  severity: CoverageSeverity;
+  domains: AccountSummaryDomain[];
+  compliance: {
+    evaluated: number;
+    passed: number;
+    failed: number;
+    pass_rate: number | null;
+    benchmarks: AccountSummaryBenchmark[];
+    href: string;
+  };
+  assets: { count: number; href: string; note: string };
+  identities: { count: number; roles: number; note: string };
+  drill: { findings_href: string; graph_href: string };
+  truncated: boolean;
+  empty: boolean;
+  note: string;
+}
+
 export interface EnrichmentSourcePosture {
   source: string;
   status: "ok" | "stale" | "degraded" | "unknown" | string;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -27,6 +27,7 @@ import type {
   AgentBomManifestResponse,
   PostureCountsResponse,
   OverviewResponse,
+  AccountSummaryResponse,
   ScoreConfigRuntime,
   ScoreConfigUpdate,
   RemediationItem,
@@ -117,6 +118,9 @@ import type {
   CloudConnectionScanResponse
 } from "./api-types";
 export type {
+  AccountSummaryResponse,
+  AccountSummaryDomain,
+  AccountSummaryBenchmark,
   JobStatus,
   ScanRequest,
   StepStatus,
@@ -789,6 +793,10 @@ export const api = {
 
   /** Cross-domain posture snapshot for the unified overview landing page */
   getOverview: () => get<OverviewResponse>("/v1/overview"),
+
+  /** Per-account, end-to-end posture drill for one cloud account (#3931) */
+  getCloudAccountSummary: (accountRef: string) =>
+    get<AccountSummaryResponse>(`/v1/cloud/accounts/${encodeURIComponent(accountRef)}/summary`),
 
   /** Configurable exec risk-score model + display config for this tenant (#3940) */
   getScoreConfig: () => get<ScoreConfigRuntime>("/v1/overview/score-config"),

--- a/ui/tests/account-drill.test.tsx
+++ b/ui/tests/account-drill.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import AccountDrillPage from "@/app/accounts/[ref]/page";
+import { api } from "@/lib/api";
+import type { AccountSummaryResponse } from "@/lib/api-types";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ ref: "aws:111111111111" }),
+}));
+
+function emptySeverity() {
+  return { critical: 0, high: 0, medium: 0, low: 0, unrated: 0 };
+}
+
+function summary(overrides: Partial<AccountSummaryResponse> = {}): AccountSummaryResponse {
+  return {
+    schema_version: "cloud.account.summary.v1",
+    tenant_id: "default",
+    account_ref: "aws:111111111111",
+    provider: "aws",
+    account: "111111111111",
+    regions: ["us-east-1"],
+    environments: ["prod"],
+    findings_total: 3,
+    severity: { critical: 1, high: 1, medium: 1, low: 0, unrated: 0 },
+    domains: [
+      { domain: "cspm", label: "CSPM", count: 1, severity: { ...emptySeverity(), high: 1 }, href: "/findings?provider=aws&account=aws%3A111111111111&domain=cspm" },
+      { domain: "vuln", label: "Vuln mgmt", count: 1, severity: { ...emptySeverity(), critical: 1 }, href: "/findings?provider=aws&account=aws%3A111111111111&domain=vuln" },
+      { domain: "appsec_sca", label: "AppSec / SCA", count: 0, severity: emptySeverity(), href: "/findings?provider=aws&account=aws%3A111111111111&domain=appsec_sca" },
+      { domain: "dspm", label: "DSPM", count: 0, severity: emptySeverity(), href: "/findings?provider=aws&account=aws%3A111111111111&domain=dspm" },
+      { domain: "aispm", label: "AISPM", count: 1, severity: { ...emptySeverity(), medium: 1 }, href: "/findings?provider=aws&account=aws%3A111111111111&domain=aispm" },
+    ],
+    compliance: {
+      evaluated: 10,
+      passed: 8,
+      failed: 2,
+      pass_rate: 80.0,
+      benchmarks: [{ provider: "aws", benchmark: "CIS AWS Foundations", passed: 8, failed: 2, evaluated: 10, pass_rate: 80.0 }],
+      href: "/findings?provider=aws&account=aws%3A111111111111&domain=cspm",
+    },
+    assets: { count: 2, href: "/inventory/assets?provider=aws", note: "" },
+    identities: { count: 0, roles: 1, note: "" },
+    drill: { findings_href: "/findings?provider=aws&account=aws%3A111111111111", graph_href: "/graph?provider=aws" },
+    truncated: false,
+    empty: false,
+    note: "",
+    ...overrides,
+  };
+}
+
+describe("AccountDrillPage", () => {
+  it("renders header, all five domain lanes, and CIS pass-rate with drill links", async () => {
+    vi.spyOn(api, "getCloudAccountSummary").mockResolvedValue(summary());
+    render(<AccountDrillPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /AWS · 111111111111/i })).toBeInTheDocument();
+    });
+    // Five domain lanes, each drill-linked and pre-filtered by account.
+    for (const label of ["CSPM", "Vuln mgmt", "AppSec / SCA", "DSPM", "AISPM"]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    const cspmLane = screen.getByTestId("account-lane-cspm");
+    expect(cspmLane).toHaveAttribute("href", expect.stringContaining("domain=cspm"));
+    expect(cspmLane).toHaveAttribute("href", expect.stringContaining("account=aws%3A111111111111"));
+    // Compliance health surfaces the stored pass-rate.
+    expect(screen.getByText("80.0%")).toBeInTheDocument();
+    expect(screen.getByText(/8 passed · 2 failed · 10 evaluated/)).toBeInTheDocument();
+  });
+
+  it("shows an honest empty state when the account has no evidence", async () => {
+    vi.spyOn(api, "getCloudAccountSummary").mockResolvedValue(
+      summary({ findings_total: 0, empty: true, compliance: { evaluated: 0, passed: 0, failed: 0, pass_rate: null, benchmarks: [], href: "/findings" } }),
+    );
+    render(<AccountDrillPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/No evidence for this account yet/i)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

A per-vendor / per-account **drill view** — "show me this cloud account end-to-end" — built on the first-class scope + `security_domain` taxonomy from #3946. One read, two altitudes: a leadership-readable summary over engineer drill-in links, all scoped to a single provider+account.

- **API** — `GET /v1/cloud/accounts/{account_ref}/summary` (read-gated, tenant-scoped/RLS, off the event loop under the shared findings backpressure guard). For one provider+account (`aws:123456789012`) it returns:
  - findings **by `security_domain`** (five lanes always present) with an honest severity breakdown — each lane's strip sums to its count, and the top-level severity strip sums to `findings_total` (the same reconciliation invariant #3946 holds).
  - **CIS / compliance health** — pass-rate aggregated from the stored `*_cis_benchmark_data` side blocks, matched to the account (newest run per provider), `pass_rate: null` when no run exists.
  - **asset count** and **identity / role count** derived from the account's finding assets.
  - It **composes** the #3946 domain rollup (`_domain_rollup` buckets) and scope filters (`_canonical_scope_filters` / `_row_matches_scope`) plus the shared scan-store helpers — no counting logic is re-implemented. Canonicalizes the account ref, **never raises** on malformed/unknown input (honest empty summary), bounds the read, and **triggers no live provider scan**.

- **UI** — a URL-addressable drill view at **`/accounts/[ref]`**: header (provider + account + region/env chips), a leadership stat row (open findings, critical+high, CIS pass-rate, assets, identities/roles), engineer-altitude domain lanes with severity strips, and a compliance-health panel — each with **drill links** into `/findings` pre-filtered by the #3946 `account` / `provider` / `domain` query params. Design tokens only (no `zinc-*`), light + dark, honest empty states, reuses `PageLaneHeader` and the page-state primitives.

## Verification

- `pytest tests/test_cloud_account_summary.py` — **8 passed** (scope, five-lane reconciliation, stored CIS pass-rate, asset/role counts, unknown/malformed never-raise, tenant isolation, case-insensitive match). Related scope/finding suites green.
- `mypy` + `ruff` clean on the changed backend; `make preflight` green (regenerated + committed `docs/openapi/v1.{json,yaml}` and the data-model atlas — path count 257→258).
- UI: `npm ci` → `npm run typecheck` → `npm run build` (route builds as `/accounts/[ref]`) → `eslint` → `vitest tests/account-drill.test.tsx` (**2 passed**) — all green.

## Notes / follow-ups

- **Entry-point link is deliberately deferred**: the connections table does not yet link to `/accounts/[ref]` — that wiring is a follow-up (scope-guarded file, owned by concurrent work).
- **Per-account data surfaced today**: findings-by-domain + severity (scan + bulk evidence), account-matched CIS pass-rate, distinct assets referenced by findings, and identities/roles inferred from finding asset types.
- **Needs deeper cloud reads (follow-up)**: full IAM **role / grant / privilege** enumeration and a complete per-account asset inventory (graph store has no account facet yet); a sargable account-scoped `GROUP BY` in the hub store for million-row tenants (the v1 read is bounded + capped).

Toward the per-vendor drill-view north-star in #3931.