### PR TITLE
feat(cloud): add AWS IAM evidence contracts

### DIFF
--- a/src/agent_bom/cloud/aws_iam_collector.py
+++ b/src/agent_bom/cloud/aws_iam_collector.py
@@ -1,0 +1,201 @@
+"""Bounded collection of AWS IAM role policy and usage evidence."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Mapping
+
+from agent_bom.cloud.aws_iam_evidence import (
+    EvidenceCompleteness,
+    IamPrincipalEvidence,
+    IamServiceUsageEvidence,
+    NormalizedIamPolicy,
+    UsageEvidenceState,
+    normalize_iam_policy_document,
+)
+
+_DENIED_CODES = {"AccessDenied", "AccessDeniedException", "UnauthorizedOperation"}
+_UNSUPPORTED_CODES = {"NotSupported", "NotSupportedException", "UnsupportedOperation"}
+
+
+def _error_code(exc: Exception) -> str:
+    response = getattr(exc, "response", None)
+    if not isinstance(response, Mapping):
+        return ""
+    error = response.get("Error")
+    if not isinstance(error, Mapping):
+        return ""
+    code = error.get("Code")
+    return code if isinstance(code, str) else ""
+
+
+def _unavailable_policy(diagnostic: str, *, arn: str | None = None) -> NormalizedIamPolicy:
+    return NormalizedIamPolicy(
+        version=None,
+        statements=(),
+        completeness=EvidenceCompleteness.UNAVAILABLE,
+        diagnostics=(diagnostic,),
+        source_policy_arn=arn,
+    )
+
+
+def _pages(client: Any, operation: str, **kwargs: str) -> list[Mapping[str, Any]]:
+    paginator = client.get_paginator(operation)
+    return [page for page in paginator.paginate(**kwargs) if isinstance(page, Mapping)]
+
+
+def _collect_policies(client: Any, role_name: str) -> tuple[tuple[NormalizedIamPolicy, ...], EvidenceCompleteness]:
+    policies: list[NormalizedIamPolicy] = []
+    collection_failed = False
+    try:
+        for page in _pages(client, "list_attached_role_policies", RoleName=role_name):
+            entries = page.get("AttachedPolicies", [])
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, Mapping):
+                    continue
+                arn = entry.get("PolicyArn")
+                if not isinstance(arn, str) or not arn:
+                    policies.append(_unavailable_policy("attached_policy_missing_arn"))
+                    continue
+                try:
+                    metadata = client.get_policy(PolicyArn=arn).get("Policy", {})
+                    version_id = metadata.get("DefaultVersionId") if isinstance(metadata, Mapping) else None
+                    if not isinstance(version_id, str) or not version_id:
+                        policies.append(_unavailable_policy("attached_policy_missing_default_version", arn=arn))
+                        continue
+                    version = client.get_policy_version(PolicyArn=arn, VersionId=version_id)
+                    payload = version.get("PolicyVersion", {})
+                    document = payload.get("Document") if isinstance(payload, Mapping) else None
+                    policies.append(normalize_iam_policy_document(document, source_policy_arn=arn))
+                except Exception:
+                    collection_failed = True
+                    policies.append(_unavailable_policy("attached_policy_read_failed", arn=arn))
+    except Exception:
+        collection_failed = True
+        policies.append(_unavailable_policy("attached_policy_list_failed"))
+
+    try:
+        for page in _pages(client, "list_role_policies", RoleName=role_name):
+            names = page.get("PolicyNames", [])
+            if not isinstance(names, list):
+                continue
+            for name in names:
+                if not isinstance(name, str) or not name:
+                    continue
+                try:
+                    response = client.get_role_policy(RoleName=role_name, PolicyName=name)
+                    policies.append(normalize_iam_policy_document(response.get("PolicyDocument")))
+                except Exception:
+                    collection_failed = True
+                    policies.append(_unavailable_policy("inline_policy_read_failed"))
+    except Exception:
+        collection_failed = True
+        policies.append(_unavailable_policy("inline_policy_list_failed"))
+    if collection_failed:
+        state = EvidenceCompleteness.PARTIAL if any(policy.statements for policy in policies) else EvidenceCompleteness.UNAVAILABLE
+    elif any(policy.completeness is not EvidenceCompleteness.COMPLETE for policy in policies):
+        state = EvidenceCompleteness.PARTIAL
+    else:
+        # Successful empty policy lists are complete evidence: the role has no
+        # attached or inline identity policies.
+        state = EvidenceCompleteness.COMPLETE
+    return tuple(policies), state
+
+
+def _usage_failure(exc: Exception) -> UsageEvidenceState:
+    code = _error_code(exc)
+    if code in _DENIED_CODES:
+        return UsageEvidenceState.ACCESS_DENIED
+    if code in _UNSUPPORTED_CODES:
+        return UsageEvidenceState.NOT_SUPPORTED
+    return UsageEvidenceState.UNAVAILABLE
+
+
+def _collect_access_advisor(
+    client: Any, principal_arn: str, *, max_polls: int
+) -> tuple[tuple[IamServiceUsageEvidence, ...], UsageEvidenceState]:
+    try:
+        started = client.generate_service_last_accessed_details(Arn=principal_arn, Granularity="SERVICE_LEVEL")
+        job_id = started.get("JobId")
+        if not isinstance(job_id, str) or not job_id:
+            return (), UsageEvidenceState.UNAVAILABLE
+        response: Mapping[str, Any] = {}
+        for _ in range(max(1, max_polls)):
+            candidate = client.get_service_last_accessed_details(JobId=job_id)
+            if not isinstance(candidate, Mapping):
+                return (), UsageEvidenceState.UNAVAILABLE
+            response = candidate
+            if response.get("JobStatus") == "COMPLETED":
+                break
+            if response.get("JobStatus") == "FAILED":
+                return (), UsageEvidenceState.UNAVAILABLE
+        else:
+            return (), UsageEvidenceState.PENDING
+        services = response.get("ServicesLastAccessed", [])
+        if not isinstance(services, list):
+            return (), UsageEvidenceState.UNAVAILABLE
+        evidence: list[IamServiceUsageEvidence] = []
+        for service in services:
+            if not isinstance(service, Mapping):
+                continue
+            namespace = service.get("ServiceNamespace")
+            if not isinstance(namespace, str) or not namespace:
+                continue
+            accessed = service.get("LastAuthenticated")
+            region = service.get("LastAuthenticatedRegion")
+            evidence.append(
+                IamServiceUsageEvidence(
+                    service_namespace=namespace,
+                    state=UsageEvidenceState.AVAILABLE,
+                    last_accessed_at=accessed if isinstance(accessed, datetime) else None,
+                    last_accessed_region=region if isinstance(region, str) else None,
+                )
+            )
+        return tuple(evidence), UsageEvidenceState.AVAILABLE
+    except Exception as exc:
+        return (), _usage_failure(exc)
+
+
+def _role_last_used(client: Any, role_name: str) -> IamServiceUsageEvidence | None:
+    try:
+        response = client.get_role(RoleName=role_name)
+    except Exception:
+        return None
+    role = response.get("Role", {})
+    last_used = role.get("RoleLastUsed", {}) if isinstance(role, Mapping) else {}
+    if not isinstance(last_used, Mapping):
+        return None
+    accessed = last_used.get("LastUsedDate")
+    region = last_used.get("Region")
+    return IamServiceUsageEvidence(
+        service_namespace="*",
+        state=UsageEvidenceState.AVAILABLE,
+        last_accessed_at=accessed if isinstance(accessed, datetime) else None,
+        last_accessed_region=region if isinstance(region, str) else None,
+        source="role_last_used",
+    )
+
+
+def collect_iam_role_evidence(
+    client: Any,
+    *,
+    principal_arn: str,
+    role_name: str,
+    max_access_advisor_polls: int = 3,
+) -> IamPrincipalEvidence:
+    """Collect policy and usage facts without interpreting authorization."""
+    policies, policy_state = _collect_policies(client, role_name)
+
+    usage, usage_state = _collect_access_advisor(client, principal_arn, max_polls=max_access_advisor_polls)
+    role_usage = _role_last_used(client, role_name)
+    if role_usage is not None:
+        usage = (*usage, role_usage)
+    return IamPrincipalEvidence(
+        principal_arn=principal_arn,
+        policies=policies,
+        usage=usage,
+        policy_completeness=policy_state,
+        usage_state=usage_state,
+    )

--- a/src/agent_bom/cloud/aws_iam_evidence.py
+++ b/src/agent_bom/cloud/aws_iam_evidence.py
@@ -1,0 +1,168 @@
+"""Normalized, non-secret AWS IAM policy and usage evidence contracts.
+
+This module deliberately does not decide whether an action is allowed. It
+canonicalizes the evidence needed by the policy-simulation and NHI-governance
+layers so deny statements, condition keys, resource scope, and missing
+telemetry cannot be flattened into the existing reachability heuristic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Any, Literal, Mapping
+
+
+class EvidenceCompleteness(StrEnum):
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    UNAVAILABLE = "unavailable"
+
+
+class UsageEvidenceState(StrEnum):
+    AVAILABLE = "available"
+    ACCESS_DENIED = "access_denied"
+    NOT_SUPPORTED = "not_supported"
+    UNAVAILABLE = "unavailable"
+
+
+def _strings(value: Any) -> tuple[str, ...]:
+    values = value if isinstance(value, list) else [value]
+    return tuple(sorted({item.strip() for item in values if isinstance(item, str) and item.strip()}))
+
+
+def _conditions(value: Any) -> tuple[tuple[str, str, tuple[str, ...]], ...]:
+    if not isinstance(value, Mapping):
+        return ()
+    normalized: list[tuple[str, str, tuple[str, ...]]] = []
+    for operator, entries in value.items():
+        if not isinstance(operator, str) or not isinstance(entries, Mapping):
+            continue
+        for key, raw_values in entries.items():
+            if not isinstance(key, str):
+                continue
+            values = _strings(raw_values)
+            if values:
+                normalized.append((operator.strip(), key.strip(), values))
+    return tuple(sorted(normalized))
+
+
+@dataclass(frozen=True)
+class NormalizedIamStatement:
+    effect: Literal["Allow", "Deny"]
+    actions: tuple[str, ...] = ()
+    not_actions: tuple[str, ...] = ()
+    resources: tuple[str, ...] = ()
+    not_resources: tuple[str, ...] = ()
+    conditions: tuple[tuple[str, str, tuple[str, ...]], ...] = ()
+    sid: str | None = None
+
+
+@dataclass(frozen=True)
+class NormalizedIamPolicy:
+    version: str | None
+    statements: tuple[NormalizedIamStatement, ...]
+    completeness: EvidenceCompleteness
+    diagnostics: tuple[str, ...] = ()
+    source_policy_arn: str | None = None
+
+
+def normalize_iam_policy_document(
+    document: Any,
+    *,
+    source_policy_arn: str | None = None,
+) -> NormalizedIamPolicy:
+    """Canonicalize an IAM policy document without raising on provider input."""
+    if not isinstance(document, Mapping):
+        return NormalizedIamPolicy(
+            version=None,
+            statements=(),
+            completeness=EvidenceCompleteness.UNAVAILABLE,
+            diagnostics=("policy_document_not_mapping",),
+            source_policy_arn=source_policy_arn,
+        )
+
+    version_value = document.get("Version")
+    version = version_value.strip() if isinstance(version_value, str) and version_value.strip() else None
+    raw_statements = document.get("Statement", [])
+    if isinstance(raw_statements, Mapping):
+        raw_statements = [raw_statements]
+    if not isinstance(raw_statements, list):
+        raw_statements = []
+
+    statements: list[NormalizedIamStatement] = []
+    diagnostics: list[str] = []
+    for index, raw in enumerate(raw_statements):
+        if not isinstance(raw, Mapping):
+            diagnostics.append(f"statement_{index}_not_mapping")
+            continue
+        effect = raw.get("Effect")
+        if effect not in {"Allow", "Deny"}:
+            diagnostics.append(f"statement_{index}_invalid_effect")
+            continue
+        actions = _strings(raw.get("Action"))
+        not_actions = _strings(raw.get("NotAction"))
+        resources = _strings(raw.get("Resource"))
+        not_resources = _strings(raw.get("NotResource"))
+        if bool(actions) == bool(not_actions):
+            diagnostics.append(f"statement_{index}_requires_exactly_one_action_form")
+            continue
+        if resources and not_resources:
+            diagnostics.append(f"statement_{index}_conflicting_resource_forms")
+            continue
+        sid_value = raw.get("Sid")
+        statements.append(
+            NormalizedIamStatement(
+                effect=effect,
+                actions=actions,
+                not_actions=not_actions,
+                resources=resources,
+                not_resources=not_resources,
+                conditions=_conditions(raw.get("Condition")),
+                sid=sid_value.strip() if isinstance(sid_value, str) and sid_value.strip() else None,
+            )
+        )
+
+    if not statements:
+        completeness = EvidenceCompleteness.UNAVAILABLE
+        if not diagnostics:
+            diagnostics.append("policy_has_no_statements")
+    elif diagnostics:
+        completeness = EvidenceCompleteness.PARTIAL
+    else:
+        completeness = EvidenceCompleteness.COMPLETE
+    return NormalizedIamPolicy(
+        version=version,
+        statements=tuple(statements),
+        completeness=completeness,
+        diagnostics=tuple(diagnostics),
+        source_policy_arn=source_policy_arn,
+    )
+
+
+@dataclass(frozen=True)
+class IamServiceUsageEvidence:
+    service_namespace: str
+    state: UsageEvidenceState
+    last_accessed_at: datetime | None = None
+    last_accessed_region: str | None = None
+    source: Literal["access_advisor", "role_last_used", "credential_report"] = "access_advisor"
+    collected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @property
+    def observed(self) -> bool | None:
+        """True/False only when telemetry exists; None means not assessable."""
+        if self.state is not UsageEvidenceState.AVAILABLE:
+            return None
+        return self.last_accessed_at is not None
+
+
+@dataclass(frozen=True)
+class IamPrincipalEvidence:
+    principal_arn: str
+    policies: tuple[NormalizedIamPolicy, ...] = ()
+    usage: tuple[IamServiceUsageEvidence, ...] = ()
+    policy_completeness: EvidenceCompleteness = EvidenceCompleteness.UNAVAILABLE
+    usage_state: UsageEvidenceState = UsageEvidenceState.UNAVAILABLE
+

--- a/src/agent_bom/cloud/aws_iam_evidence.py
+++ b/src/agent_bom/cloud/aws_iam_evidence.py
@@ -24,6 +24,7 @@ class UsageEvidenceState(StrEnum):
     AVAILABLE = "available"
     ACCESS_DENIED = "access_denied"
     NOT_SUPPORTED = "not_supported"
+    PENDING = "pending"
     UNAVAILABLE = "unavailable"
 
 
@@ -165,4 +166,3 @@ class IamPrincipalEvidence:
     usage: tuple[IamServiceUsageEvidence, ...] = ()
     policy_completeness: EvidenceCompleteness = EvidenceCompleteness.UNAVAILABLE
     usage_state: UsageEvidenceState = UsageEvidenceState.UNAVAILABLE
-

--- a/tests/test_aws_iam_collector.py
+++ b/tests/test_aws_iam_collector.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from agent_bom.cloud.aws_iam_collector import collect_iam_role_evidence
+from agent_bom.cloud.aws_iam_evidence import EvidenceCompleteness, UsageEvidenceState
+
+
+class ProviderError(Exception):
+    def __init__(self, code: str) -> None:
+        self.response = {"Error": {"Code": code}}
+
+
+class Paginator:
+    def __init__(self, pages: list[dict[str, Any]]) -> None:
+        self.pages = pages
+
+    def paginate(self, **kwargs: str) -> list[dict[str, Any]]:
+        return self.pages
+
+
+class IamClient:
+    job_status = "COMPLETED"
+
+    def get_paginator(self, operation: str) -> Paginator:
+        pages = {
+            "list_attached_role_policies": [{"AttachedPolicies": [{"PolicyArn": "arn:aws:iam::aws:policy/ReadOnlyAccess"}]}],
+            "list_role_policies": [{"PolicyNames": ["bounded-inline"]}],
+        }
+        return Paginator(pages[operation])
+
+    def get_policy(self, **kwargs: str) -> dict[str, Any]:
+        return {"Policy": {"DefaultVersionId": "v4"}}
+
+    def get_policy_version(self, **kwargs: str) -> dict[str, Any]:
+        return {"PolicyVersion": {"Document": {"Statement": {"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"}}}}
+
+    def get_role_policy(self, **kwargs: str) -> dict[str, Any]:
+        return {"PolicyDocument": {"Statement": {"Effect": "Deny", "Action": "s3:DeleteObject", "Resource": "*"}}}
+
+    def generate_service_last_accessed_details(self, **kwargs: str) -> dict[str, str]:
+        return {"JobId": "job-1"}
+
+    def get_service_last_accessed_details(self, **kwargs: str) -> dict[str, Any]:
+        return {
+            "JobStatus": self.job_status,
+            "ServicesLastAccessed": [
+                {
+                    "ServiceNamespace": "s3",
+                    "LastAuthenticated": datetime(2026, 7, 1, tzinfo=timezone.utc),
+                    "LastAuthenticatedRegion": "us-east-1",
+                },
+                {"ServiceNamespace": "kms"},
+            ],
+        }
+
+    def get_role(self, **kwargs: str) -> dict[str, Any]:
+        return {
+            "Role": {
+                "RoleLastUsed": {
+                    "LastUsedDate": datetime(2026, 7, 2, tzinfo=timezone.utc),
+                    "Region": "us-west-2",
+                }
+            }
+        }
+
+
+def test_collects_attached_inline_and_usage_evidence() -> None:
+    evidence = collect_iam_role_evidence(IamClient(), principal_arn="arn:aws:iam::123456789012:role/scanner", role_name="scanner")
+
+    assert evidence.policy_completeness is EvidenceCompleteness.COMPLETE
+    assert len(evidence.policies) == 2
+    assert evidence.policies[0].source_policy_arn == "arn:aws:iam::aws:policy/ReadOnlyAccess"
+    assert evidence.policies[1].statements[0].effect == "Deny"
+    assert evidence.usage_state is UsageEvidenceState.AVAILABLE
+    assert [(item.service_namespace, item.observed) for item in evidence.usage] == [
+        ("s3", True),
+        ("kms", False),
+        ("*", True),
+    ]
+
+
+def test_access_advisor_denied_is_not_clean_or_unused() -> None:
+    client = IamClient()
+
+    def denied(**kwargs: str) -> dict[str, str]:
+        raise ProviderError("AccessDenied")
+
+    client.generate_service_last_accessed_details = denied  # type: ignore[method-assign]
+    evidence = collect_iam_role_evidence(client, principal_arn="arn:aws:iam::123456789012:role/scanner", role_name="scanner")
+
+    assert evidence.usage_state is UsageEvidenceState.ACCESS_DENIED
+    assert all(item.source == "role_last_used" for item in evidence.usage)
+
+
+def test_access_advisor_pending_is_bounded_and_explicit() -> None:
+    client = IamClient()
+    client.job_status = "IN_PROGRESS"
+    evidence = collect_iam_role_evidence(
+        client,
+        principal_arn="arn:aws:iam::123456789012:role/scanner",
+        role_name="scanner",
+        max_access_advisor_polls=2,
+    )
+
+    assert evidence.usage_state is UsageEvidenceState.PENDING
+
+
+def test_policy_read_failure_makes_collection_partial_without_exception_text() -> None:
+    client = IamClient()
+
+    def failed(**kwargs: str) -> dict[str, Any]:
+        raise RuntimeError("secret account path")
+
+    client.get_policy_version = failed  # type: ignore[method-assign]
+    evidence = collect_iam_role_evidence(client, principal_arn="arn:aws:iam::123456789012:role/scanner", role_name="scanner")
+
+    assert evidence.policy_completeness is EvidenceCompleteness.PARTIAL
+    assert evidence.policies[0].diagnostics == ("attached_policy_read_failed",)
+    assert "secret" not in repr(evidence)
+
+
+def test_successful_empty_policy_lists_are_complete_evidence() -> None:
+    client = IamClient()
+
+    def empty(operation: str) -> Paginator:
+        page = {"AttachedPolicies": []} if operation == "list_attached_role_policies" else {"PolicyNames": []}
+        return Paginator([page])
+
+    client.get_paginator = empty  # type: ignore[method-assign]
+    evidence = collect_iam_role_evidence(client, principal_arn="arn:aws:iam::123456789012:role/empty", role_name="empty")
+
+    assert evidence.policies == ()
+    assert evidence.policy_completeness is EvidenceCompleteness.COMPLETE

--- a/tests/test_aws_iam_evidence.py
+++ b/tests/test_aws_iam_evidence.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from agent_bom.cloud.aws_iam_evidence import (
+    EvidenceCompleteness,
+    IamServiceUsageEvidence,
+    UsageEvidenceState,
+    normalize_iam_policy_document,
+)
+
+
+def test_normalizes_allow_deny_resource_and_conditions_deterministically() -> None:
+    policy = normalize_iam_policy_document(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "ScopedRead",
+                    "Effect": "Allow",
+                    "Action": ["s3:GetObject", "s3:ListBucket", "s3:GetObject"],
+                    "Resource": ["arn:aws:s3:::example/*", "arn:aws:s3:::example"],
+                    "Condition": {
+                        "StringEquals": {"aws:PrincipalOrgID": "o-example"},
+                        "IpAddress": {"aws:SourceIp": ["10.0.0.0/8"]},
+                    },
+                },
+                {"Effect": "Deny", "NotAction": "iam:Get*", "NotResource": "arn:aws:s3:::public/*"},
+            ],
+        },
+        source_policy_arn="arn:aws:iam::123456789012:policy/example",
+    )
+
+    assert policy.completeness is EvidenceCompleteness.COMPLETE
+    assert policy.statements[0].actions == ("s3:GetObject", "s3:ListBucket")
+    assert policy.statements[0].resources == ("arn:aws:s3:::example", "arn:aws:s3:::example/*")
+    assert policy.statements[0].conditions == (
+        ("IpAddress", "aws:SourceIp", ("10.0.0.0/8",)),
+        ("StringEquals", "aws:PrincipalOrgID", ("o-example",)),
+    )
+    assert policy.statements[1].effect == "Deny"
+    assert policy.statements[1].not_actions == ("iam:Get*",)
+
+
+def test_invalid_provider_statements_are_partial_not_exceptions() -> None:
+    policy = normalize_iam_policy_document(
+        {
+            "Statement": [
+                {"Effect": "Maybe", "Action": "s3:*"},
+                {"Effect": "Allow", "Action": "s3:GetObject", "NotAction": "s3:DeleteObject"},
+                {"Effect": "Allow", "Action": "ec2:Describe*", "Resource": "*"},
+            ]
+        }
+    )
+
+    assert policy.completeness is EvidenceCompleteness.PARTIAL
+    assert len(policy.statements) == 1
+    assert policy.diagnostics == (
+        "statement_0_invalid_effect",
+        "statement_1_requires_exactly_one_action_form",
+    )
+
+
+def test_non_mapping_policy_is_unavailable() -> None:
+    policy = normalize_iam_policy_document("not-a-document")
+    assert policy.completeness is EvidenceCompleteness.UNAVAILABLE
+    assert policy.statements == ()
+    assert policy.diagnostics == ("policy_document_not_mapping",)
+
+
+def test_usage_evidence_preserves_unknown_instead_of_inventing_dormancy() -> None:
+    denied = IamServiceUsageEvidence(service_namespace="s3", state=UsageEvidenceState.ACCESS_DENIED)
+    never_used = IamServiceUsageEvidence(service_namespace="iam", state=UsageEvidenceState.AVAILABLE)
+    used = IamServiceUsageEvidence(
+        service_namespace="lambda",
+        state=UsageEvidenceState.AVAILABLE,
+        last_accessed_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+    )
+
+    assert denied.observed is None
+    assert never_used.observed is False
+    assert used.observed is True


### PR DESCRIPTION
## Summary

- add canonical AWS IAM policy evidence contracts that preserve Allow/Deny, Action/NotAction, Resource/NotResource, condition operators/keys, and policy provenance
- normalize malformed provider input into explicit complete/partial/unavailable evidence without raising or silently discarding the whole document
- add Access Advisor/role-last-used/credential-report usage contracts whose unavailable states remain unassessed instead of being interpreted as dormant

Foundation PR for #3888. This does **not** claim that IAM policy simulation or AWS telemetry collection is shipped yet; collector, evaluator, and graph lock-in follow as separate PRs.

## Verification

- `uv run pytest -q tests/test_aws_iam_evidence.py tests/test_graph_effective_permissions.py tests/test_graph_nhi_governance.py` (22 passed)
- `uv run ruff check src/agent_bom/cloud/aws_iam_evidence.py tests/test_aws_iam_evidence.py`
- `uv run mypy src/agent_bom/cloud/aws_iam_evidence.py`
- `uv run agent-bom agents --demo --offline --quiet --format json --output /tmp/agent-bom-3888-foundation.json`
- `git diff --check`

## Notes

- no policy allow/deny verdicts are produced in this PR
- no provider credentials or policy secrets are persisted
- missing telemetry is represented as unknown, not unused