### PR TITLE
feat(deploy): keyless out-of-box control-plane cloud identity + cross-account connect

### DIFF
--- a/deploy/helm/agent-bom/examples/README.md
+++ b/deploy/helm/agent-bom/examples/README.md
@@ -20,6 +20,7 @@ product split.
 | `oidc-discovery-shim` | `eks-mcp-pilot-values.yaml` + `gateway-upstreams.example.yaml` + `oidc-discovery-shim-values.yaml` | Gateway-hosted `/.well-known/openid-configuration` for legacy IdPs (MCP OAuth interop) |
 | `snowflake-backend` | `eks-snowflake-values.yaml` | Overlay for Snowflake governance and selected store parity, not a claim of full control-plane replacement |
 | `gateway-runtime` | `eks-mcp-pilot-values.yaml` + `gateway-upstreams.example.yaml` | Focused pilot plus central gateway rendering for shared MCP relay/policy |
+| `control-plane-identity` | `control-plane-identity-values.yaml` | Keyless control-plane cloud identity (EKS IRSA / EC2-ECS instance role / AKS + GKE workload identity) that assumes read-only connect roles — zero static keys. See `docs/DEPLOY_PLATFORM.md` "Connect your cloud (zero keys)" |
 
 ## Validate the shipped profiles
 

--- a/deploy/helm/agent-bom/examples/control-plane-identity-values.yaml
+++ b/deploy/helm/agent-bom/examples/control-plane-identity-values.yaml
@@ -1,0 +1,62 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Control-plane identity — KEYLESS, out-of-box cloud connect (zero static keys)
+# ─────────────────────────────────────────────────────────────────────────────
+# The control plane reads a customer cloud by ASSUMING that account's read-only
+# connection role (sts:AssumeRole + ExternalId) — it never stores customer keys.
+# To make that call it needs its OWN cloud identity. This example wires the
+# control-plane workload identity for each target, and none of them use a static
+# access key.
+#
+#   EKS  → IRSA: annotate the ServiceAccount with the scanner/control-plane role
+#          ARN. That role reads THIS account directly and assumes the per-account
+#          connect-aws read-only roles cross-account (org fan-out / hosted
+#          connect). The baseline Terraform module attaches the least-privilege
+#          sts:AssumeRole policy (see deploy/terraform/aws/baseline,
+#          connect_role_arns). On self-managed k8s on EC2/ECS the pod instead
+#          inherits the node instance profile / ECS task role — also keyless, no
+#          annotation needed; grant that role the same sts:AssumeRole.
+#   AKS  → Azure workload identity: set clientId + tenantId; the chart renders the
+#          azure.workload.identity/client-id SA annotation and labels the pod.
+#   GKE  → Workload Identity: annotate the SA with the Google service account and
+#          set impersonateSa to the connect-gcp read-only SA.
+#
+# Read the control plane's identity per target, then create the read-only role in
+# each account trusting THAT identity + ExternalId (deploy/cloudformation or
+# deploy/terraform/connect-*), or run the org StackSet for every account at once.
+# See docs/DEPLOY_PLATFORM.md "Connect your cloud (zero keys)".
+# ─────────────────────────────────────────────────────────────────────────────
+
+controlPlane:
+  enabled: true
+
+# Top-level SA the control-plane pods run as. On EKS this is the identity that
+# assumes the read-only connection roles. Replace with your scanner/control-plane
+# role ARN (platform-eks output: scanner_role_arn), or pass via --set.
+serviceAccount:
+  create: true
+  name: agent-bom
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/agent-bom-scanner
+
+scanner:
+  enabled: true
+  serviceAccount:
+    create: true
+    annotations:
+      # Same keyless identity for the scheduled scan CronJob.
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/agent-bom-scanner
+  cloud:
+    enabled: true
+    aws:
+      inventory: true
+    # AKS — Azure workload identity (keyless). Uncomment and set your IDs.
+    # azure:
+    #   inventory: true
+    #   clientId: "00000000-0000-0000-0000-000000000000"
+    #   tenantId: "11111111-1111-1111-1111-111111111111"
+    # GKE — Workload Identity (keyless). Annotate the SA above with
+    #   iam.gke.io/gcp-service-account: <gsa>@<project>.iam.gserviceaccount.com
+    # and set the connect-gcp read-only SA to impersonate.
+    # gcp:
+    #   inventory: true
+    #   impersonateSa: agent-bom-readonly@PROJECT_ID.iam.gserviceaccount.com

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -110,8 +110,20 @@ scanner:
   cloud:
     enabled: false
     aws:
-      # Sets AGENT_BOM_AWS_INVENTORY=1. Auth = IRSA (serviceAccount.annotations
-      # eks.amazonaws.com/role-arn -> the connect-aws read-only role).
+      # Sets AGENT_BOM_AWS_INVENTORY=1. Keyless control-plane identity, in order
+      # of preference:
+      #   - EKS: IRSA — set serviceAccount.annotations
+      #     eks.amazonaws.com/role-arn to the scanner/control-plane role. That
+      #     role reads THIS account directly and, cross-account, assumes each
+      #     connect-aws read-only role via sts:AssumeRole (org fan-out / hosted
+      #     connect). The baseline module attaches the least-privilege
+      #     sts:AssumeRole policy; see deploy/terraform/aws/baseline
+      #     (connect_role_arns).
+      #   - Self-managed k8s on EC2 / ECS: the pod inherits the node instance
+      #     profile or ECS task role from the AWS SDK default chain — still
+      #     keyless, no annotation needed. Give that role sts:AssumeRole on the
+      #     connect roles the same way.
+      # NEVER static access keys.
       inventory: false
       allRegions: false       # AGENT_BOM_AWS_ALL_REGIONS
       regions: ""             # AGENT_BOM_AWS_REGIONS (comma list, e.g. "us-east-1,eu-west-1")

--- a/deploy/terraform/aws/baseline/README.md
+++ b/deploy/terraform/aws/baseline/README.md
@@ -17,6 +17,14 @@ Helm owns the `agent-bom` workloads inside the cluster.
 - IAM roles and policies for scanner + backup IRSA
 - Secrets Manager secret containers / generated secret references
 
+The scanner IRSA role is the **keyless control-plane cloud identity**. Besides
+reading the account it runs in, it is granted a least-privilege `sts:AssumeRole`
+policy (`connect_role_arns`, default `agent-bom-readonly*` / `abom-readonly*`) so
+it can assume the read-only connection role in **other** accounts — the keyless
+path behind AWS Organizations fan-out and hosted connect. Only `sts:AssumeRole`
+is granted; the connection role's own trust policy + ExternalId are the
+reciprocal guard. Set `connect_role_arns = []` to disable cross-account assume.
+
 ## What Helm still owns
 
 - Deployments, CronJobs, Services, Ingress, HPAs, PDBs

--- a/deploy/terraform/aws/baseline/main.tf
+++ b/deploy/terraform/aws/baseline/main.tf
@@ -65,6 +65,41 @@ resource "aws_iam_role_policy_attachment" "scanner" {
   policy_arn = aws_iam_policy.scanner.arn
 }
 
+# ---------------------------------------------------------------------------
+# Cross-account connect: let the keyless control-plane (scanner) identity
+# sts:AssumeRole the read-only connection roles in OTHER accounts. Without this
+# the scanner can only read the account it runs in — org fan-out
+# (AGENT_BOM_AWS_ORG_INVENTORY) and hosted connect both need to assume a
+# read-only role in each target account. Least-privilege: the ONLY action
+# granted is sts:AssumeRole, scoped to the connection-role resource ARNs; the
+# connection role's own trust policy + ExternalId are the reciprocal guard. No
+# static keys — the assumed session is short-lived STS. Set connect_role_arns
+# to [] to disable cross-account assume entirely.
+# ---------------------------------------------------------------------------
+data "aws_iam_policy_document" "scanner_assume_connect" {
+  count = length(var.connect_role_arns) > 0 ? 1 : 0
+
+  statement {
+    sid       = "AssumeReadOnlyConnectionRoles"
+    effect    = "Allow"
+    actions   = ["sts:AssumeRole"]
+    resources = var.connect_role_arns
+  }
+}
+
+resource "aws_iam_policy" "scanner_assume_connect" {
+  count  = length(var.connect_role_arns) > 0 ? 1 : 0
+  name   = "${var.name}-scanner-assume-connect"
+  policy = data.aws_iam_policy_document.scanner_assume_connect[0].json
+  tags   = local.common_tags
+}
+
+resource "aws_iam_role_policy_attachment" "scanner_assume_connect" {
+  count      = length(var.connect_role_arns) > 0 ? 1 : 0
+  role       = aws_iam_role.scanner.name
+  policy_arn = aws_iam_policy.scanner_assume_connect[0].arn
+}
+
 data "aws_iam_policy_document" "backup_assume_role" {
   statement {
     effect  = "Allow"

--- a/deploy/terraform/aws/baseline/outputs.tf
+++ b/deploy/terraform/aws/baseline/outputs.tf
@@ -7,6 +7,11 @@ output "scanner_role_arn" {
   value       = aws_iam_role.scanner.arn
 }
 
+output "scanner_assume_connect_policy_arn" {
+  description = "IAM policy ARN granting the scanner sts:AssumeRole on the read-only connection roles cross-account (empty when connect_role_arns = [])."
+  value       = length(var.connect_role_arns) > 0 ? aws_iam_policy.scanner_assume_connect[0].arn : ""
+}
+
 output "backup_role_arn" {
   description = "IRSA role ARN for the Postgres backup CronJob service account."
   value       = var.create_backup_bucket ? aws_iam_role.backup[0].arn : null

--- a/deploy/terraform/aws/baseline/variables.tf
+++ b/deploy/terraform/aws/baseline/variables.tf
@@ -26,6 +26,26 @@ variable "cluster_oidc_issuer_url" {
   type        = string
 }
 
+variable "connect_role_arns" {
+  description = <<-EOT
+    ARNs (or ARN patterns) of the read-only connection roles the control-plane
+    scanner identity may assume cross-account via sts:AssumeRole. This is what
+    lets the keyless scanner read OTHER accounts (AWS Organizations fan-out /
+    hosted connect), not only the account it runs in. Least-privilege: the only
+    action granted is sts:AssumeRole, scoped to these resource ARNs; the
+    connection role's own trust policy + ExternalId are the reciprocal guard.
+    Defaults match the role names minted by connect-aws and the CloudFormation
+    connector template (agent-bom-readonly*, abom-readonly*). Narrow to explicit
+    ARNs for a tighter blast radius, or set to [] to disable cross-account
+    assume entirely.
+  EOT
+  type        = list(string)
+  default = [
+    "arn:aws:iam::*:role/agent-bom-readonly*",
+    "arn:aws:iam::*:role/abom-readonly*",
+  ]
+}
+
 variable "vpc_id" {
   description = "VPC ID that hosts the EKS cluster and RDS instance."
   type        = string

--- a/deploy/terraform/platform-eks/README.md
+++ b/deploy/terraform/platform-eks/README.md
@@ -71,7 +71,8 @@ terraform output ui_url
 | `domain` | `""` | Public hostname for the UI/API ingress; empty = no ingress, use port-forward |
 | `image_tag` | `""` | Override the API/UI image tag (empty = chart default) |
 | `extra_helm_values` | `""` | Raw YAML merged last into the Helm release |
-| `create_aws_connect_role` | `false` | Mint the read-only role the scanner assumes |
+| `create_aws_connect_role` | `false` | Mint the read-only role the scanner assumes (same-account) |
+| `connect_role_arns` | `["arn:aws:iam::*:role/agent-bom-readonly*", "arn:aws:iam::*:role/abom-readonly*"]` | Read-only connection roles the scanner IRSA role may `sts:AssumeRole` **cross-account** (org fan-out / hosted connect). Least-privilege: only `sts:AssumeRole`, scoped to these ARNs. Set `[]` to disable |
 | `report_export_bucket` | `""` | Existing S3 bucket for async report export. When set, mints a dedicated API IRSA role (least-privilege `s3:` on that bucket only), wires it onto the API service account, and turns on S3 export. Empty = disabled |
 
 See `variables.tf` for the full list.
@@ -92,6 +93,7 @@ role scoped to only that bucket and binds it to the `-api` service account.
 | `scanner_role_arn` | IRSA role bound to the scanner service account |
 | `backup_bucket_name` | S3 bucket for the packaged Postgres backups |
 | `connect_role_arn` | Read-only role the scanner assumes (when enabled) |
+| `scanner_assume_connect_policy_arn` | Policy letting the scanner assume read-only connect roles cross-account (empty when `connect_role_arns = []`) |
 | `report_export_role_arn` | API IRSA role for S3 report export (when `report_export_bucket` is set) |
 
 ## Composition notes

--- a/deploy/terraform/platform-eks/main.tf
+++ b/deploy/terraform/platform-eks/main.tf
@@ -173,6 +173,10 @@ module "baseline" {
   db_multi_az            = var.db_multi_az
   db_deletion_protection = var.db_deletion_protection
 
+  # Keyless cross-account read: the scanner IRSA role may sts:AssumeRole the
+  # read-only connection roles in target accounts (org fan-out / hosted connect).
+  connect_role_arns = var.connect_role_arns
+
   tags = var.tags
 }
 

--- a/deploy/terraform/platform-eks/outputs.tf
+++ b/deploy/terraform/platform-eks/outputs.tf
@@ -46,6 +46,11 @@ output "backup_bucket_name" {
   value       = module.baseline.backup_bucket_name
 }
 
+output "scanner_assume_connect_policy_arn" {
+  description = "IAM policy ARN letting the scanner identity assume read-only connection roles cross-account (empty when connect_role_arns = [])."
+  value       = module.baseline.scanner_assume_connect_policy_arn
+}
+
 output "connect_role_arn" {
   description = "Read-only IAM role ARN the scanner assumes to inventory this AWS account (empty unless create_aws_connect_role = true)."
   value       = var.create_aws_connect_role ? module.connect_aws[0].role_arn : ""

--- a/deploy/terraform/platform-eks/variables.tf
+++ b/deploy/terraform/platform-eks/variables.tf
@@ -193,6 +193,24 @@ variable "create_aws_connect_role" {
   default     = false
 }
 
+variable "connect_role_arns" {
+  description = <<-EOT
+    ARNs / ARN patterns of the read-only connection roles the control-plane
+    scanner may assume cross-account (AWS Organizations fan-out, hosted connect).
+    Passed to the baseline module, which attaches a least-privilege
+    sts:AssumeRole policy to the scanner IRSA role — the keyless control-plane
+    identity can then read OTHER accounts, not only the one it runs in. Defaults
+    match the connect-aws / CloudFormation connector role names
+    (agent-bom-readonly*, abom-readonly*). Set to [] to disable cross-account
+    assume.
+  EOT
+  type        = list(string)
+  default = [
+    "arn:aws:iam::*:role/agent-bom-readonly*",
+    "arn:aws:iam::*:role/abom-readonly*",
+  ]
+}
+
 ###############################################################################
 # Optional S3 report-artifact export (async report download via presigned URL)
 ###############################################################################

--- a/docs/DEPLOY_PLATFORM.md
+++ b/docs/DEPLOY_PLATFORM.md
@@ -193,6 +193,87 @@ enterprise customer-owned install path.
 
 ---
 
+## Connect your cloud (zero keys)
+
+Once the control plane is up (any tier above), connecting an account is four
+steps and **never** involves a static access key or your laptop's base identity.
+The control plane reads a customer cloud by **assuming that account's read-only
+role** (`sts:AssumeRole` + ExternalId); it only needs its own workload identity
+to make that call. That identity is provisioned automatically by the deploy.
+
+**(a) Deploy the control plane — it gets a keyless identity automatically.**
+
+| Target | Control-plane identity (keyless) | Provisioned by |
+|--------|----------------------------------|----------------|
+| EKS | IRSA role on the scanner/control-plane ServiceAccount | `platform-eks` / `aws/baseline` (`scanner_role_arn`) |
+| Self-managed k8s on EC2 / ECS | Node instance profile / ECS task role (AWS SDK default chain) | your node/task role — grant it `sts:AssumeRole` on the connect roles |
+| AKS | Azure workload identity federated to the pod SA | `connect-azure` + Helm `cloud.azure.clientId/tenantId` |
+| GKE | GCP Workload Identity; the KSA impersonates the read-only SA | `connect-gcp` + Helm `cloud.gcp.impersonateSa` |
+
+On EKS the scanner IRSA role is minted with a least-privilege `sts:AssumeRole`
+policy scoped to the connection-role name pattern (`agent-bom-readonly*` /
+`abom-readonly*`) so it can assume those roles in **any** target account —
+`aws/baseline` variable `connect_role_arns`. Narrow it to explicit ARNs, or set
+`[]` to disable cross-account assume.
+
+**(b) Read the control plane's identity ARN — this is what target accounts trust.**
+
+```bash
+# EKS one-apply
+terraform -chdir=deploy/terraform/platform-eks output -raw scanner_role_arn
+# aws/baseline standalone
+terraform -chdir=deploy/terraform/aws/baseline output -raw scanner_role_arn
+```
+
+For EC2/ECS it is the node instance-profile / ECS task role ARN; for AKS/GCP it
+is the workload-identity principal your `connect-azure` / `connect-gcp` apply
+prints. This is the value the read-only role in each target account will trust.
+
+**(c) In each target account, create the read-only role trusting THAT identity + ExternalId.**
+
+One account (Terraform or the 1-click CloudFormation Launch Stack the wizard
+generates):
+
+```bash
+cd deploy/terraform/connect-aws
+terraform apply -var 'trusted_principal_arns=["<CONTROL_PLANE_IDENTITY_ARN>"]'
+terraform output role_arn               # hand to the wizard
+terraform output -raw external_id       # confused-deputy guard
+```
+
+All accounts at once — the AWS Organizations **StackSet** with auto-deploy, so
+new accounts enroll automatically (never account-by-account):
+
+```bash
+aws cloudformation create-stack-set \
+  --stack-set-name agent-bom-readonly \
+  --template-body file://deploy/cloudformation/agent-bom-readonly-role.yaml \
+  --permission-model SERVICE_MANAGED \
+  --auto-deployment Enabled=true,RetainStacksOnAccountRemoval=false \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameters ParameterKey=ExternalId,ParameterValue="$EXTERNAL_ID" \
+               ParameterKey=TrustedPrincipalArn,ParameterValue="<CONTROL_PLANE_IDENTITY_ARN>"
+```
+
+See [`deploy/cloudformation/README.md`](../deploy/cloudformation/README.md) for
+the full StackSet flow, and [`connect-*`](../deploy/terraform/) for the Azure
+management-group and GCP org/folder equivalents.
+
+**(d) Connect in the UI.** Open **Connections**, paste the `role_arn` +
+`ExternalId`, and scan. The control plane assumes the role with short-lived STS
+— no key ever leaves the target account, nothing is mutated.
+
+> **Zero-key throughout.** The one exception to workload identity is Snowflake,
+> which has no cloud workload identity and uses key-pair (never password) auth
+> supplied via a Secret reference. Everything else is keyless. The
+> laptop/local-credential path (`aws sso login`, `az login`,
+> `gcloud auth application-default login`) exists for **dev only** — never wire a
+> personal base identity into a running control plane.
+
+Full read-only contract (what is read, why it stays least-privilege) lives in
+[`CLOUD_CONNECT.md`](CLOUD_CONNECT.md); the identity model is in
+[`SECURITY_ARCHITECTURE.md` § Control-plane identity](SECURITY_ARCHITECTURE.md#control-plane-identity).
+
 ## Choosing a tier
 
 | Need | Tier |

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -56,6 +56,51 @@ Cloud scanning never moves customer data out of the account. The contract:
   any leftover temp resources (tagged by the scanner) after a hard crash, so a
   failed run leaves nothing behind. No volume bytes leave the account.
 
+### Control-plane identity
+
+The control plane never stores a customer's cloud keys. It reads a customer
+account by **assuming that account's read-only connection role** (AWS
+`sts:AssumeRole` with an ExternalId; Azure/GCP federated equivalents) and
+receives only short-lived credentials. To make that call the control plane needs
+its *own* cloud identity, and that identity is a **workload identity per target
+— never a static access key**:
+
+| Target | Control-plane identity | Keyless mechanism |
+|--------|------------------------|-------------------|
+| EKS | Scanner IRSA role | Projected SA token → STS `AssumeRoleWithWebIdentity` |
+| Self-managed k8s on EC2 / ECS | Node instance profile / ECS task role | AWS SDK default credential chain |
+| AKS | Azure workload identity | Federated pod SA token → Entra ID |
+| GKE | GCP Workload Identity | KSA → impersonated read-only service account |
+
+- **Assumes connection roles, cross-account.** The scanner identity is granted a
+  least-privilege `sts:AssumeRole` policy scoped to the connection-role name
+  pattern (`agent-bom-readonly*` / `abom-readonly*`), so it can assume the
+  read-only role in each target account for AWS Organizations fan-out and hosted
+  connect. Only `sts:AssumeRole` is granted — no other action, no broader
+  resource. Provisioned by `deploy/terraform/aws/baseline`
+  (`connect_role_arns`); set it to `[]` to disable cross-account assume.
+- **ExternalId is the reciprocal guard.** Every connection role's trust policy
+  requires a high-entropy `sts:ExternalId`, always enforced, closing the
+  confused-deputy gap even though the assume permission is scoped by name
+  pattern.
+- **Least-privilege, both sides.** The assumed role carries only read-only
+  managed policies (`SecurityAudit` / `ViewOnlyAccess` and equivalents); the
+  assuming identity carries only `sts:AssumeRole`. Neither side is ever
+  root/admin.
+- **No static keys.** No long-lived access key is created for the control-plane
+  identity in any supported path. Snowflake is the lone exception (no cloud
+  workload identity): it uses key-pair auth via a Secret reference, never a
+  password.
+- **Local/dev path is dev-only.** Running the control plane or CLI against your
+  own laptop credentials (`aws sso login`, `az login`,
+  `gcloud auth application-default login`) is supported for development and
+  one-off operator scans, but a personal base identity must never be wired into
+  a long-running hosted control plane — use the workload identity above.
+
+The end-to-end onboarding walk-through (read the identity ARN, create the trust
+in each account or via the org StackSet, connect in the UI) is in
+[`DEPLOY_PLATFORM.md` § Connect your cloud (zero keys)](DEPLOY_PLATFORM.md#connect-your-cloud-zero-keys).
+
 ### Network Enforcement
 
 - All external calls use HTTPS with full TLS certificate verification (`verify=True`)


### PR DESCRIPTION
## Summary

Make the control plane's **cloud identity** provisioned and documented so a real
deployment connects clouds with **zero manual base identity and zero static
keys**. The control plane reads a customer cloud by *assuming* that account's
read-only role (`sts:AssumeRole` + ExternalId) — it never stores customer keys —
so it only needs its own keyless workload identity to make that call.

**Gap found and fixed:** the scanner IRSA role minted by `aws/baseline` attached
only the direct-read policy, which has **no `sts:AssumeRole`**. So the keyless
control-plane identity could read only the account it runs in; AWS Organizations
fan-out and hosted connect (assume a read-only role in each target account) both
failed. This PR grants a scoped `sts:AssumeRole`.

### Terraform (the load-bearing change)
- `aws/baseline`: attach a **least-privilege `sts:AssumeRole`** policy to the
  scanner IRSA role, scoped to the connection-role name pattern
  (`agent-bom-readonly*` / `abom-readonly*`) via a new `connect_role_arns`
  variable (default on; `[]` disables). Only `sts:AssumeRole` is granted — no
  broader action, never admin. The connection role's own trust policy +
  ExternalId remain the reciprocal guard. New output
  `scanner_assume_connect_policy_arn`.
- `platform-eks`: pass `connect_role_arns` through to baseline, expose the
  output, document in README.

### Non-EKS keyless identity paths (documented + configurable)
- EKS → scanner IRSA role • self-managed k8s on EC2/ECS → node instance profile
  / ECS task role (AWS SDK default chain) • AKS → Azure workload identity • GKE →
  Workload Identity. Documented in `values.yaml`, a new
  `examples/control-plane-identity-values.yaml`, and the docs. No static keys in
  any path (Snowflake key-pair via Secret reference is the sole non-workload-identity exception).

### Docs
- `DEPLOY_PLATFORM.md`: guided **"Connect your cloud (zero keys)"** section —
  deploy (identity auto-provisioned) → read the identity ARN per target → create
  the read-only role in each account trusting that identity + ExternalId, or run
  the org **StackSet** for all accounts at once → connect in the UI. Cross-links
  the CloudFormation StackSet and `connect-*` modules.
- `SECURITY_ARCHITECTURE.md`: **"Control-plane identity"** section — workload
  identity per target, assumes connection roles, ExternalId, least-privilege, no
  static keys, and the laptop/dev path is explicitly dev-only.

## Verification
- `terraform validate` + `fmt -check -recursive`: **clean** on `aws/baseline`
  and `platform-eks` (one pre-existing `aws_region.name` deprecation warning,
  unrelated).
- `helm lint` + `helm template` with `control-plane-identity-values.yaml`:
  **clean**; the keyless role-arn annotation renders on the control-plane and
  scanner ServiceAccounts.
- Internal doc links + anchors resolve.
- No secrets in any file; no Python/contract changes.

## Notes
- The connect **wizard** "trust the control-plane identity" UI change (surfacing
  the identity ARN to paste into the trust policy) is a **separate follow-up**,
  per the onboarding epic — this PR is deploy configs + docs only.
- Cross-account assume is default-on with the documented name pattern for
  out-of-box "just works"; operators can narrow `connect_role_arns` to explicit
  ARNs or disable it.