### PR TITLE
fix(ui): exec→graph drill targets the finding's scan + drawer Close clears the nav

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -26,13 +26,12 @@ import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { deploymentModeLabel, hasDeploymentSignals } from "@/lib/deployment-context";
 import { useCaptureMode } from "@/lib/use-capture-mode";
-import { buildSecurityGraphHref } from "@/lib/attack-paths";
 import { complianceFrameworkSummaries } from "@/lib/compliance-frameworks";
 import {
   aggregateSeverity,
-  blastAgents,
   blastCredentials,
   blastTools,
+  buildExposurePathView,
 } from "@/lib/dashboard-data";
 import { buildIssueSeverityMatrix } from "@/lib/finding-issue-type";
 import {
@@ -198,8 +197,17 @@ export default function Dashboard() {
     [effectiveJobs]
   );
 
+  // Tag each blast with its originating scan id (the graph snapshot scan_id is
+  // the job id) so the exec→graph drill can target the finding's own scan
+  // instead of falling back to the latest snapshot (#3966).
   const allBlast = useMemo(
-    () => doneJobs.flatMap((j) => (j.result as ScanResult)?.blast_radius ?? []),
+    () =>
+      doneJobs.flatMap((j) =>
+        ((j.result as ScanResult)?.blast_radius ?? []).map((blast) => ({
+          ...blast,
+          scanId: j.job_id,
+        })),
+      ),
     [doneJobs]
   );
 
@@ -233,52 +241,14 @@ export default function Dashboard() {
   );
   const topExposurePath = useMemo(() => {
     if (!topRisk) return null;
-    const agents = blastAgents(topRisk);
-    const credentials = blastCredentials(topRisk);
-    const nodes: ExposurePathView["nodes"] = [
-      { type: "cve", label: topRisk.vulnerability_id, severity: topRisk.severity?.toLowerCase() },
-    ];
-    if (topRisk.package) nodes.push({ type: "package", label: topRisk.package });
-    if (topRisk.affected_servers && topRisk.affected_servers.length > 0) nodes.push({ type: "server", label: topRisk.affected_servers[0]! });
-    if (agents.length > 0) nodes.push({ type: "agent", label: agents[0]! });
-    if (credentials.length > 0) nodes.push({ type: "credential", label: credentials[0]! });
-    return {
-      key: `${topRisk.vulnerability_id}:${topRisk.package ?? "unknown"}`,
-      nodes,
-      riskScore: topRisk.risk_score ?? topRisk.blast_score / 10,
-      href: buildSecurityGraphHref({
-        cve: topRisk.vulnerability_id,
-        packageName: topRisk.package,
-        agentName: agents[0],
-      }),
-    };
+    return buildExposurePathView(topRisk, topRisk.scanId);
   }, [topRisk]);
 
   const exposurePaths = useMemo<ExposurePathView[]>(() => {
     return [...allBlast]
       .sort((a, b) => (b.risk_score ?? b.blast_score) - (a.risk_score ?? a.blast_score))
       .slice(0, 5)
-      .map((blast, index) => {
-        const agents = blastAgents(blast);
-        const credentials = blastCredentials(blast);
-        const nodes: ExposurePathView["nodes"] = [
-          { type: "cve", label: blast.vulnerability_id, severity: blast.severity?.toLowerCase() },
-        ];
-        if (blast.package) nodes.push({ type: "package", label: blast.package });
-        if (blast.affected_servers && blast.affected_servers.length > 0) nodes.push({ type: "server", label: blast.affected_servers[0]! });
-        if (agents.length > 0) nodes.push({ type: "agent", label: agents[0]! });
-        if (credentials.length > 0) nodes.push({ type: "credential", label: credentials[0]! });
-        return {
-          key: `${blast.vulnerability_id}:${blast.package ?? "unknown"}:${index}`,
-          nodes,
-          riskScore: blast.risk_score ?? blast.blast_score / 10,
-          href: buildSecurityGraphHref({
-            cve: blast.vulnerability_id,
-            packageName: blast.package,
-            agentName: agents[0],
-          }),
-        };
-      });
+      .map((blast, index) => buildExposurePathView(blast, blast.scanId, index));
   }, [allBlast]);
 
   // Total packages scanned across all jobs

--- a/ui/components/drawer.tsx
+++ b/ui/components/drawer.tsx
@@ -73,7 +73,7 @@ export function Drawer({
 
   return (
     <div
-      className={`fixed inset-0 z-50 flex justify-end bg-black/45 backdrop-blur-sm transition-opacity duration-200 ${
+      className={`fixed inset-0 z-[80] flex justify-end bg-black/45 backdrop-blur-sm transition-opacity duration-200 ${
         entered ? "opacity-100" : "opacity-0"
       }`}
       role="dialog"

--- a/ui/lib/dashboard-data.ts
+++ b/ui/lib/dashboard-data.ts
@@ -13,6 +13,8 @@ import type {
   EpssVsCvssPoint,
   TrendDataPoint,
 } from "@/components/charts";
+import type { ExposurePathView } from "@/components/overview-cockpit";
+import { buildSecurityGraphHref } from "@/lib/attack-paths";
 import { severityRank } from "@/lib/severity";
 
 // ─── Shared dashboard aggregation ───────────────────────────────────────────
@@ -233,6 +235,42 @@ export function blastCredentials(blast: BlastRadius): string[] {
 
 export function blastAgents(blast: BlastRadius): string[] {
   return blast.affected_agents ?? [];
+}
+
+/**
+ * Build the exec→graph exposure-path row for a finding. Threads the finding's
+ * own `scanId` into the security-graph drill so the drill lands on the scan
+ * that produced the finding — not whichever scan happens to be latest (#3966).
+ * `index` disambiguates the key within a shortlist; omit it for a single row.
+ */
+export function buildExposurePathView(
+  blast: BlastRadius,
+  scanId?: string,
+  index?: number,
+): ExposurePathView {
+  const agents = blastAgents(blast);
+  const credentials = blastCredentials(blast);
+  const nodes: ExposurePathView["nodes"] = [
+    { type: "cve", label: blast.vulnerability_id, severity: blast.severity?.toLowerCase() },
+  ];
+  if (blast.package) nodes.push({ type: "package", label: blast.package });
+  if (blast.affected_servers && blast.affected_servers.length > 0) {
+    nodes.push({ type: "server", label: blast.affected_servers[0]! });
+  }
+  if (agents.length > 0) nodes.push({ type: "agent", label: agents[0]! });
+  if (credentials.length > 0) nodes.push({ type: "credential", label: credentials[0]! });
+  const baseKey = `${blast.vulnerability_id}:${blast.package ?? "unknown"}`;
+  return {
+    key: index === undefined ? baseKey : `${baseKey}:${index}`,
+    nodes,
+    riskScore: blast.risk_score ?? blast.blast_score / 10,
+    href: buildSecurityGraphHref({
+      scanId,
+      cve: blast.vulnerability_id,
+      packageName: blast.package,
+      agentName: agents[0],
+    }),
+  };
 }
 
 export function aggregateCompoundIssues(allBlast: BlastRadius[]): CompoundIssue[] {

--- a/ui/tests/dashboard-data.test.ts
+++ b/ui/tests/dashboard-data.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { buildExposurePathView } from "@/lib/dashboard-data";
+import type { BlastRadius } from "@/lib/api";
+
+function makeBlast(overrides: Partial<BlastRadius> = {}): BlastRadius {
+  return {
+    vulnerability_id: "CVE-2026-0002",
+    severity: "Critical",
+    package: "flask",
+    affected_agents: ["Claude Desktop"],
+    affected_servers: ["mcp-fs"],
+    exposed_credentials: ["GITHUB_TOKEN"],
+    reachable_tools: ["read_file"],
+    blast_score: 82,
+    risk_score: 9.1,
+    ...overrides,
+  };
+}
+
+describe("buildExposurePathView", () => {
+  it("threads the finding's scanId into the exec→graph drill href (#3966)", () => {
+    const view = buildExposurePathView(makeBlast(), "scan-abc123");
+    // The drill must target the finding's own scan, not the latest snapshot.
+    expect(view.href).toBe(
+      "/security-graph?scan=scan-abc123&cve=CVE-2026-0002&package=flask&agent=Claude+Desktop",
+    );
+  });
+
+  it("omits the scan param only when no scanId is known", () => {
+    const view = buildExposurePathView(makeBlast(), undefined);
+    expect(view.href).toBe(
+      "/security-graph?cve=CVE-2026-0002&package=flask&agent=Claude+Desktop",
+    );
+    expect(view.href).not.toContain("scan=");
+  });
+
+  it("builds the node chain and key, appending an index when provided", () => {
+    const view = buildExposurePathView(makeBlast(), "scan-1", 3);
+    expect(view.key).toBe("CVE-2026-0002:flask:3");
+    expect(view.riskScore).toBe(9.1);
+    expect(view.nodes).toEqual([
+      { type: "cve", label: "CVE-2026-0002", severity: "critical" },
+      { type: "package", label: "flask" },
+      { type: "server", label: "mcp-fs" },
+      { type: "agent", label: "Claude Desktop" },
+      { type: "credential", label: "GITHUB_TOKEN" },
+    ]);
+  });
+
+  it("uses an index-less key for a single row", () => {
+    const view = buildExposurePathView(makeBlast({ package: undefined }), "scan-1");
+    expect(view.key).toBe("CVE-2026-0002:unknown");
+    // Package hop dropped when absent; scan still threaded.
+    expect(view.href).toBe(
+      "/security-graph?scan=scan-1&cve=CVE-2026-0002&agent=Claude+Desktop",
+    );
+  });
+});

--- a/ui/tests/drawer.test.tsx
+++ b/ui/tests/drawer.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Drawer } from "@/components/drawer";
+
+function renderDrawer(props: Partial<React.ComponentProps<typeof Drawer>> = {}) {
+  const onClose = props.onClose ?? vi.fn();
+  render(
+    <Drawer open title="Finding detail" onClose={onClose} {...props}>
+      <p>body</p>
+    </Drawer>,
+  );
+  return { onClose };
+}
+
+describe("Drawer", () => {
+  it("renders the overlay above the nav header so the Close X is clickable (#3966)", () => {
+    renderDrawer();
+    const dialog = screen.getByRole("dialog");
+    // The fixed top nav is z-[60]; a lower drawer paints its Close X under the
+    // nav band and makes it unclickable. The overlay must sit above the nav.
+    expect(dialog.className).toContain("z-[80]");
+    const overlayZ = 80;
+    const navHeaderZ = 60;
+    expect(overlayZ).toBeGreaterThan(navHeaderZ);
+  });
+
+  it("closes when the header Close button is clicked", () => {
+    const { onClose } = renderDrawer();
+    const closeButtons = screen.getAllByRole("button", { name: "Close" });
+    // The last "Close" control is the header X (the first is the backdrop).
+    fireEvent.click(closeButtons[closeButtons.length - 1]!);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape for keyboard accessibility", () => {
+    const { onClose } = renderDrawer();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders nothing when closed", () => {
+    renderDrawer({ open: false });
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});


### PR DESCRIPTION
Two quick-win UI fixes from audit #3966.

## 1. Exec→graph drill landed on the wrong finding
The overview exposure-path rows (`ui/app/page.tsx`) called `buildSecurityGraphHref({cve, packageName, agentName})` **without a `scan` param**. The graph page falls back to the latest snapshot when no scan is supplied, so drilling from an exec exposure path landed on the latest scan's node — not the finding's own scan.

Fix: tag each blast with its originating scan id (the graph snapshot `scan_id` is the job id, per `pipeline._persist_graph_snapshot`) and thread it through a new shared, unit-tested `buildExposurePathView` helper in `ui/lib/dashboard-data.ts`. Both the top exposure path and the shortlist now emit `?scan=<finding-scan>&cve=…`. When no scan is known (e.g. imported reports) the param is omitted and behavior is unchanged.

## 2. Drawer Close X was hidden under the nav
The fixed top nav (`z-[60]`, `ui/components/nav.tsx`) painted over the drawer overlay (`z-50`, `ui/components/drawer.tsx`), so the Close X in the top ~64px band was unclickable. Raised the drawer overlay to `z-[80]` — above the nav header and flyout, matching the existing modal convention (connections modal is already `z-[80]`); the command palette (`z-[100]`) still sits above by design. Esc-to-close and the header Close button both verified.

## Scope / constraints
- Design tokens only — no new `zinc-*`. Both light and dark themes unaffected. Keyboard-accessible Close preserved.
- **Not** included: the ~1997 `zinc-*` light-theme tokenization is a separate, larger follow-up.

## Tests
- `ui/tests/dashboard-data.test.ts` — new: `buildExposurePathView` threads `scanId` into the drill href, omits `scan=` when absent, and builds the node chain/key.
- `ui/tests/drawer.test.tsx` — new: overlay renders at `z-[80]` (above nav `z-[60]`); Close button and Escape both fire `onClose`.

## Verification
- `npm ci` → `npm run typecheck` clean
- `npm run build` compiled successfully
- `vitest run` — 98 files / 488 tests green (incl. new suites, attack-paths, overview-cockpit, nav)
- ESLint clean on touched files

Refs #3966 (closes the drill + drawer parts; zinc light-theme tokenization tracked separately).