### PR TITLE
fix(graph): honor AGENT_BOM_STATE_DIR and stale-aware demo seed

### DIFF
--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -255,11 +255,20 @@ def default_graph_db_path() -> Path:
     Preference order:
     1. ``AGENT_BOM_GRAPH_DB`` explicit graph database path
     2. ``AGENT_BOM_DB`` shared SQLite database used by the API
-    3. ``~/.agent-bom/db/graph.db`` local default
+    3. ``AGENT_BOM_STATE_DIR`` per-process state dir (``<state>/db/graph.db``)
+    4. ``~/.agent-bom/db/graph.db`` local default
+
+    Honoring ``AGENT_BOM_STATE_DIR`` mirrors ``api.durable_store`` so the graph
+    snapshot lands in the same isolated state dir an operator (or the test
+    suite's conftest) redirects state to — instead of always writing the real
+    ``~/.agent-bom/db/graph.db`` and accumulating cross-run/test pollution.
     """
     configured = os.environ.get("AGENT_BOM_GRAPH_DB") or os.environ.get("AGENT_BOM_DB")
     if configured:
         return Path(configured).expanduser()
+    state_dir = os.environ.get("AGENT_BOM_STATE_DIR")
+    if state_dir:
+        return Path(state_dir).expanduser() / "db" / "graph.db"
     return Path.home() / ".agent-bom" / "db" / "graph.db"
 
 

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -115,9 +115,10 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
     graph_store = _get_graph_store()
     summary: dict[str, Any] = {"enabled": True, "tenant_id": tenant_id, "seeded": False}
 
-    # Graph seed is isolated: a pre-existing (possibly stale) snapshot early-returns
-    # here, and any failure must NOT block the findings/scan or identity seeding
-    # below — those are what make posture + NHI reliably non-empty on every start.
+    # Graph seed is isolated and stale-aware: a real scan is left untouched, a
+    # current demo seed is a no-op, and a stale demo seed is refreshed (see
+    # seed_showcase_graph_if_empty). Any failure must NOT block the findings/scan
+    # or identity seeding below — those keep posture + NHI non-empty on start.
     graph_seeded = False
     try:
         graph_seeded = seed_showcase_graph_if_empty(graph_store, tenant_id=tenant_id)

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -589,15 +589,72 @@ def finalize_showcase_snapshot(graph: UnifiedGraph, *, profile: ShowcaseProfile)
         blocked_tool.attributes["evidence_tier"] = "runtime_blocked"
 
 
+def _existing_snapshots(
+    graph_store: GraphStoreProtocol, tenant_id: str
+) -> list[dict[str, Any]]:
+    """Return the tenant's snapshots (scan_id + created_at) for staleness checks.
+
+    Prefers ``list_snapshots`` so we can tell a real scan and a stale demo seed
+    apart. Minimal stores that only expose ``latest_snapshot_id`` degrade to a
+    single-entry view with an unknown ``created_at`` (which reads as stale).
+    """
+    list_snapshots = getattr(graph_store, "list_snapshots", None)
+    if callable(list_snapshots):
+        try:
+            return list(list_snapshots(tenant_id=tenant_id))
+        except Exception:  # noqa: BLE001 — fall back rather than block seeding
+            _logger.warning("showcase seed could not list snapshots", exc_info=True)
+    latest_snapshot_id = getattr(graph_store, "latest_snapshot_id", None)
+    if callable(latest_snapshot_id):
+        scan_id = latest_snapshot_id(tenant_id=tenant_id)
+        if scan_id:
+            return [{"scan_id": scan_id, "created_at": ""}]
+    return []
+
+
+def _showcase_seed_is_current(snapshots: list[dict[str, Any]]) -> bool:
+    """True when both showcase snapshots are present at the expected timestamps."""
+    created_at_by_id = {
+        str(row.get("scan_id")): str(row.get("created_at") or "") for row in snapshots
+    }
+    return (
+        created_at_by_id.get(SHOWCASE_SCAN_ID) == SHOWCASE_CURRENT_CREATED_AT
+        and created_at_by_id.get(SHOWCASE_BASELINE_SCAN_ID) == SHOWCASE_BASELINE_CREATED_AT
+    )
+
+
 def seed_showcase_graph_if_empty(
     graph_store: GraphStoreProtocol,
     *,
     tenant_id: str = SHOWCASE_TENANT,
 ) -> bool:
-    """Persist baseline + current showcase snapshots when the tenant has none yet."""
-    latest_snapshot_id = getattr(graph_store, "latest_snapshot_id", None)
-    if callable(latest_snapshot_id) and latest_snapshot_id(tenant_id=tenant_id):
+    """Persist baseline + current showcase snapshots, stale-aware (issue #3964).
+
+    Seeding is gated on *what* already occupies the tenant, not merely whether
+    anything does:
+
+    * A real (non-showcase) scan is never shadowed — if any snapshot has a
+      scan id outside the showcase set, a fresh scan owns the graph and the demo
+      seed is skipped. The read path already defaults to the newest snapshot, so
+      the fresh scan stays the one served.
+    * A *current* showcase seed (both snapshots at the expected ``created_at``)
+      is idempotent — nothing is rewritten.
+    * A *stale* showcase seed (missing baseline, or an out-of-date ``created_at``
+      left by an older build / polluted DB) is cleared and re-seeded so
+      ``--demo-estate`` boots on today's curated estate.
+    """
+    showcase_ids = {SHOWCASE_SCAN_ID, SHOWCASE_BASELINE_SCAN_ID}
+    snapshots = _existing_snapshots(graph_store, tenant_id)
+    if any(str(row.get("scan_id")) not in showcase_ids for row in snapshots):
         return False
+    if snapshots and _showcase_seed_is_current(snapshots):
+        return False
+    if snapshots:
+        # Only stale showcase snapshots remain (no real scan reached here); wipe
+        # them so the refreshed seed does not leave orphaned nodes/edges behind.
+        delete_tenant = getattr(graph_store, "delete_tenant", None)
+        if callable(delete_tenant):
+            delete_tenant(tenant_id=tenant_id)
 
     # One shared, enriched identity estate feeds both snapshots so the persisted
     # MANAGED_IDENTITY node ids match the live identity store the API re-projects.

--- a/tests/test_graph_store_state_dir.py
+++ b/tests/test_graph_store_state_dir.py
@@ -1,0 +1,61 @@
+"""``default_graph_db_path`` must honor ``AGENT_BOM_STATE_DIR``.
+
+Without this the graph snapshot always lands in the real ``~/.agent-bom/db``
+even when an operator (or the test suite's conftest) redirects state off
+``$HOME`` via ``AGENT_BOM_STATE_DIR`` — leaking demo/test snapshots into the
+user's home dir and shadowing fresh scans with accumulated pollution.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_bom.db.graph_store import default_graph_db_path
+
+
+def test_state_dir_places_graph_db_under_state_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv("AGENT_BOM_GRAPH_DB", raising=False)
+    monkeypatch.delenv("AGENT_BOM_DB", raising=False)
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path))
+
+    resolved = default_graph_db_path()
+
+    assert resolved == tmp_path / "db" / "graph.db"
+    # The real home dir is never referenced when a state dir is configured.
+    assert Path.home() not in resolved.parents
+
+
+def test_explicit_graph_db_overrides_state_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    explicit = tmp_path / "explicit-graph.db"
+    monkeypatch.setenv("AGENT_BOM_GRAPH_DB", str(explicit))
+    monkeypatch.setenv("AGENT_BOM_DB", str(tmp_path / "shared.db"))
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path / "state"))
+
+    assert default_graph_db_path() == explicit
+
+
+def test_shared_db_overrides_state_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    shared = tmp_path / "shared.db"
+    monkeypatch.delenv("AGENT_BOM_GRAPH_DB", raising=False)
+    monkeypatch.setenv("AGENT_BOM_DB", str(shared))
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(tmp_path / "state"))
+
+    assert default_graph_db_path() == shared
+
+
+def test_home_default_only_when_nothing_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AGENT_BOM_GRAPH_DB", raising=False)
+    monkeypatch.delenv("AGENT_BOM_DB", raising=False)
+    monkeypatch.delenv("AGENT_BOM_STATE_DIR", raising=False)
+
+    assert default_graph_db_path() == Path.home() / ".agent-bom" / "db" / "graph.db"

--- a/tests/test_showcase_graph_seeding.py
+++ b/tests/test_showcase_graph_seeding.py
@@ -1,0 +1,92 @@
+"""``seed_showcase_graph_if_empty`` must be *stale-aware*, not merely empty-aware.
+
+Regression coverage for #3964: a polluted graph DB (25 accumulated snapshots +
+an out-of-date demo seed) must not shadow a fresh scan, and a stale showcase
+seed must be refreshed on ``--demo-estate`` boot instead of early-returning.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.demo_estate.showcase_graph import (
+    SHOWCASE_BASELINE_SCAN_ID,
+    SHOWCASE_CURRENT_CREATED_AT,
+    SHOWCASE_SCAN_ID,
+    SHOWCASE_TENANT,
+    seed_showcase_graph_if_empty,
+)
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> SQLiteGraphStore:
+    return SQLiteGraphStore(db_path=tmp_path / "graph.db")
+
+
+def _snapshot_created_at(store: SQLiteGraphStore) -> dict[str, str]:
+    return {
+        row["scan_id"]: row["created_at"]
+        for row in store.list_snapshots(tenant_id=SHOWCASE_TENANT)
+    }
+
+
+def _minimal_graph(*, scan_id: str, created_at: str) -> UnifiedGraph:
+    graph = UnifiedGraph(scan_id=scan_id, tenant_id=SHOWCASE_TENANT, created_at=created_at)
+    graph.add_node(
+        UnifiedNode(id="agent:probe", entity_type=EntityType.AGENT, label="Probe")
+    )
+    return graph
+
+
+def test_seeds_when_empty(store: SQLiteGraphStore) -> None:
+    assert seed_showcase_graph_if_empty(store) is True
+
+    created = _snapshot_created_at(store)
+    assert created.get(SHOWCASE_SCAN_ID) == SHOWCASE_CURRENT_CREATED_AT
+    assert SHOWCASE_BASELINE_SCAN_ID in created
+    assert store.latest_snapshot_id(tenant_id=SHOWCASE_TENANT) == SHOWCASE_SCAN_ID
+
+
+def test_idempotent_when_current(store: SQLiteGraphStore) -> None:
+    assert seed_showcase_graph_if_empty(store) is True
+    # A fresh seed is not re-written on the next boot.
+    assert seed_showcase_graph_if_empty(store) is False
+    scan_ids = [row["scan_id"] for row in store.list_snapshots(tenant_id=SHOWCASE_TENANT)]
+    assert scan_ids.count(SHOWCASE_SCAN_ID) == 1
+    assert scan_ids.count(SHOWCASE_BASELINE_SCAN_ID) == 1
+
+
+def test_reseeds_when_stale(store: SQLiteGraphStore) -> None:
+    # A stale demo seed: right scan id, mismatched created_at (an older build's
+    # timestamp), no baseline. Recent enough to survive retention purge.
+    store.save_graph(
+        _minimal_graph(scan_id=SHOWCASE_SCAN_ID, created_at="2026-07-13T00:00:00+00:00")
+    )
+    assert store.list_snapshots(tenant_id=SHOWCASE_TENANT), "precondition: stale seed present"
+
+    assert seed_showcase_graph_if_empty(store) is True
+
+    created = _snapshot_created_at(store)
+    assert created.get(SHOWCASE_SCAN_ID) == SHOWCASE_CURRENT_CREATED_AT
+    assert SHOWCASE_BASELINE_SCAN_ID in created
+
+
+def test_does_not_shadow_a_real_scan(store: SQLiteGraphStore) -> None:
+    # A real scan lands with a non-showcase scan id and a current timestamp.
+    store.save_graph(
+        _minimal_graph(scan_id="aws-scan-2026-07-14", created_at="2026-07-14T09:00:00+00:00")
+    )
+
+    assert seed_showcase_graph_if_empty(store) is False
+
+    scan_ids = {row["scan_id"] for row in store.list_snapshots(tenant_id=SHOWCASE_TENANT)}
+    assert scan_ids == {"aws-scan-2026-07-14"}
+    assert scan_ids.isdisjoint({SHOWCASE_SCAN_ID, SHOWCASE_BASELINE_SCAN_ID})
+    # The fresh scan remains the graph the read path defaults to.
+    assert store.latest_snapshot_id(tenant_id=SHOWCASE_TENANT) == "aws-scan-2026-07-14"


### PR DESCRIPTION
Closes #3964.

## Problem
After a real AWS scan the Security Graph showed 25 accumulated snapshots plus a stale demo seed instead of the fresh scan, and the local `~/.agent-bom/db/graph.db` had grown to hundreds of MB of test/demo pollution. Two root causes:

1. **State dir ignored.** `default_graph_db_path` honored only `AGENT_BOM_GRAPH_DB` / `AGENT_BOM_DB`, never `AGENT_BOM_STATE_DIR` — unlike `api.durable_store`. So every run and the whole test suite wrote the real `~/.agent-bom/db/graph.db` even when state was redirected off `$HOME` (the conftest sets `AGENT_BOM_STATE_DIR` but not `AGENT_BOM_GRAPH_DB`), accumulating cross-run/test snapshots.
2. **Seed-if-empty, not seed-if-stale.** `seed_showcase_graph_if_empty` early-returned on *any* existing snapshot, so a polluted DB booted `--demo-estate` on stale seed data.

## Fix
- `default_graph_db_path` now honors `AGENT_BOM_STATE_DIR` (`<state>/db/graph.db`), keeping the `AGENT_BOM_GRAPH_DB` / `AGENT_BOM_DB` overrides ahead of it — matching `durable_store`'s precedence. This also stops the test suite from polluting the real home graph DB.
- `seed_showcase_graph_if_empty` is now stale-aware:
  - a real (non-showcase) scan is **never** shadowed (skip seeding),
  - a current demo seed is a no-op,
  - a stale demo seed (missing baseline or out-of-date `created_at`) is cleared and re-seeded.
- Note on "default to latest scan": the read path already selects the newest snapshot by `created_at DESC`, and the showcase seed is pinned to fixed past timestamps, so a fresh scan (today) is naturally the one served — no separate change needed here.

## Tests (TDD)
- `tests/test_graph_store_state_dir.py` — state-dir precedence + the real home dir is untouched when a state dir is configured.
- `tests/test_showcase_graph_seeding.py` — seeds when empty; idempotent when current; re-seeds when stale; does **not** shadow a real scan.

## Verification
- New suites pass; existing `test_demo_estate_bootstrap.py` (24) + `test_graph_store_mkdir.py` pass.
- `mypy` + `ruff` clean on changed files; `make preflight` green.