### PR TITLE
fix(ui): ranked exposure-path cards render the full correlated chain

### DIFF
--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -37,8 +37,10 @@ import {
   buildFindingsHref,
   buildGraphInvestigationHref,
   buildSecurityGraphHref,
+  descriptiveAttackPathTitle,
   investigationRootForAttackPath,
   matchesAttackPathFocus,
+  rankedAttackPathRows,
   recommendedAttackPathActions,
   moveAttackPathSelection,
   toAttackCardNodes,
@@ -609,38 +611,45 @@ function SecurityGraphPageContent() {
               onKeyDown={handleAttackPathQueueKeyDown}
               aria-label="Attack path queue"
             >
-              {visibleAttackPaths.map((path) => {
-                const key = attackPathKey(path);
-                const card = cardByPathKey.get(key);
+              {rankedAttackPathRows(visibleAttackPaths, fixFirstCards).map(({ path, card, rank, key }) => {
+                const selectionKey = attackPathKey(path);
                 const pathNodes = toAttackCardNodes(path, graphNodeById);
                 if (pathNodes.length === 0) return null;
-                const active = selectedAttackPath ? attackPathKey(selectedAttackPath) === key : false;
+                const active = selectedAttackPath ? attackPathKey(selectedAttackPath) === selectionKey : false;
+                const title = descriptiveAttackPathTitle(card?.title, pathNodes);
                 return (
                   <div
                     key={key}
                     className={`min-w-0 rounded-2xl border bg-[color:var(--surface-elevated)] p-3 transition ${
                       active
-                        ? "border-orange-400/70 ring-2 ring-orange-400/70 ring-offset-2 ring-offset-zinc-950"
+                        ? "border-orange-400/70 ring-2 ring-orange-400/70 ring-offset-2 ring-offset-[color:var(--surface)]"
                         : "border-[color:var(--border-subtle)]"
                     }`}
                   >
-                    {card && (
-                      <div className="mb-3 flex items-start justify-between gap-3">
-                        <div>
-                          <div className="text-[11px] uppercase tracking-[0.18em] text-orange-300">#{card.rank} fix first</div>
-                          <div className="mt-1 text-sm font-semibold leading-5 text-[color:var(--foreground)]">{card.title}</div>
-                        </div>
-                        <div className="rounded-full border border-red-900/60 bg-red-950/30 px-2 py-1 font-mono text-[11px] text-red-200">
-                          {card.attack_path.composite_risk.toFixed(1)}
+                    <div className="mb-3 flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="text-[11px] uppercase tracking-[0.18em] text-orange-300">#{rank} fix first</div>
+                        <div
+                          title={title}
+                          className="mt-1 text-sm font-semibold leading-5 text-[color:var(--foreground)] [overflow-wrap:anywhere]"
+                        >
+                          {title}
                         </div>
                       </div>
-                    )}
+                      <div className="shrink-0 rounded-xl border border-red-900/60 bg-red-950/30 px-2.5 py-1 text-right">
+                        <div className="text-[9px] font-semibold uppercase tracking-[0.14em] text-red-300/80">Path risk</div>
+                        <div className="font-mono text-sm font-semibold leading-4 text-red-200">
+                          {path.composite_risk.toFixed(1)}
+                        </div>
+                      </div>
+                    </div>
                     <AttackPathCard
                       nodes={pathNodes}
                       riskScore={path.composite_risk}
                       captureMode={captureMode}
                       compact
-                      onClick={() => setSelectedAttackPathKey(key)}
+                      showRiskBadge={false}
+                      onClick={() => setSelectedAttackPathKey(selectionKey)}
                     />
                     {card && card.risk_reasons.length > 0 && (
                       <div className="mt-3 flex flex-wrap gap-1.5">

--- a/ui/components/attack-path-card.tsx
+++ b/ui/components/attack-path-card.tsx
@@ -2,10 +2,10 @@
 
 import Link from "next/link";
 import type { LucideIcon } from "lucide-react";
-import { ArrowRight, Bot, Bug, ChevronRight, KeyRound, Package, Server } from "lucide-react";
+import { ArrowRight, Bot, Bug, ChevronRight, Database, Fingerprint, KeyRound, Package, Server, ShieldAlert, Wrench } from "lucide-react";
 
 interface AttackPathNode {
-  type: "cve" | "package" | "server" | "agent" | "credential";
+  type: "cve" | "package" | "server" | "agent" | "credential" | "tool" | "data" | "identity" | "entity";
   label: string;
   severity?: string | undefined;
 }
@@ -17,6 +17,7 @@ interface AttackPathCardProps {
   href?: string | undefined;
   captureMode?: boolean | undefined;
   compact?: boolean | undefined;
+  showRiskBadge?: boolean | undefined;
 }
 
 const NODE_META: Record<AttackPathNode["type"], { icon: LucideIcon; tint: string; ring: string }> = {
@@ -25,9 +26,25 @@ const NODE_META: Record<AttackPathNode["type"], { icon: LucideIcon; tint: string
   server: { icon: Server, tint: "text-sky-300 bg-sky-500/12", ring: "border-sky-500/25" },
   agent: { icon: Bot, tint: "text-emerald-300 bg-emerald-500/12", ring: "border-emerald-500/25" },
   credential: { icon: KeyRound, tint: "text-fuchsia-300 bg-fuchsia-500/12", ring: "border-fuchsia-500/25" },
+  tool: { icon: Wrench, tint: "text-purple-300 bg-purple-500/12", ring: "border-purple-500/25" },
+  data: { icon: Database, tint: "text-cyan-300 bg-cyan-500/12", ring: "border-cyan-500/25" },
+  identity: { icon: Fingerprint, tint: "text-indigo-300 bg-indigo-500/12", ring: "border-indigo-500/25" },
+  entity: {
+    icon: ShieldAlert,
+    tint: "text-[color:var(--text-secondary)] bg-[color:var(--surface-elevated)]",
+    ring: "border-[color:var(--border-subtle)]",
+  },
 };
 
-export function AttackPathCard({ nodes, riskScore, onClick, href, captureMode = false, compact = false }: AttackPathCardProps) {
+export function AttackPathCard({
+  nodes,
+  riskScore,
+  onClick,
+  href,
+  captureMode = false,
+  compact = false,
+  showRiskBadge = true,
+}: AttackPathCardProps) {
   const riskTone =
     riskScore >= 8
       ? "border-red-500/25 bg-red-500/10 text-red-200"
@@ -51,7 +68,7 @@ export function AttackPathCard({ nodes, riskScore, onClick, href, captureMode = 
       )}
 
       <div className={`flex flex-wrap items-center gap-1.5 ${compact ? "justify-between" : ""}`}>
-        {compact && (
+        {compact && showRiskBadge && (
           <div className={`rounded-lg border px-2 py-0.5 font-mono text-[11px] font-semibold ${riskTone}`}>
             {riskScore.toFixed(1)}
           </div>
@@ -77,8 +94,11 @@ export function AttackPathCard({ nodes, riskScore, onClick, href, captureMode = 
                 <Icon className="h-3.5 w-3.5 shrink-0" />
                 <div className="min-w-0">
                   <p
+                    title={node.label}
                     className={`text-[11px] font-medium text-[color:var(--foreground)] ${
-                      captureMode ? "max-w-[13rem] whitespace-normal break-words leading-4" : "max-w-[120px] truncate"
+                      captureMode
+                        ? "max-w-[13rem] whitespace-normal break-words leading-4"
+                        : "max-w-[16rem] whitespace-normal break-words leading-4 [overflow-wrap:anywhere]"
                     }`}
                   >
                     {node.label}

--- a/ui/components/exposure-path-command-center.tsx
+++ b/ui/components/exposure-path-command-center.tsx
@@ -32,7 +32,7 @@ const ROLE_META: Record<ExposureEntityRole, { label: string; icon: LucideIcon; t
   tool: { label: "Tool", icon: Wrench, tint: "border-purple-500/30 bg-purple-500/10 text-purple-200" },
   environment: { label: "Environment", icon: Database, tint: "border-cyan-500/30 bg-cyan-500/10 text-cyan-200" },
   cluster: { label: "Cluster", icon: Database, tint: "border-indigo-500/30 bg-indigo-500/10 text-indigo-200" },
-  unknown: { label: "Entity", icon: ShieldAlert, tint: "border-zinc-500/30 bg-zinc-500/10 text-zinc-200" },
+  unknown: { label: "Entity", icon: ShieldAlert, tint: "border-slate-500/30 bg-slate-500/10 text-slate-200" },
 };
 
 const GRAPH_ROLE_STYLE: Record<ExposureEntityRole, { fill: string; stroke: string; text: string; accent: string }> = {
@@ -44,7 +44,7 @@ const GRAPH_ROLE_STYLE: Record<ExposureEntityRole, { fill: string; stroke: strin
   tool: { fill: "#2e1065", stroke: "#a855f7", text: "#f3e8ff", accent: "#c084fc" },
   environment: { fill: "#164e63", stroke: "#06b6d4", text: "#cffafe", accent: "#22d3ee" },
   cluster: { fill: "#312e81", stroke: "#6366f1", text: "#e0e7ff", accent: "#818cf8" },
-  unknown: { fill: "#27272a", stroke: "#71717a", text: "#f4f4f5", accent: "#a1a1aa" },
+  unknown: { fill: "#1e293b", stroke: "#64748b", text: "#f1f5f9", accent: "#94a3b8" },
 };
 
 export function ExposurePathCommandCenter({
@@ -77,8 +77,9 @@ export function ExposurePathCommandCenter({
               <span className="rounded-full border border-red-500/35 bg-red-500/12 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-red-200">
                 {String(path.severity)} risk
               </span>
-              <span className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-0.5 font-mono text-[11px] text-[color:var(--foreground)]">
-                {path.riskScore.toFixed(1)}
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-0.5 text-[11px] text-[color:var(--foreground)]">
+                <span className="text-[9px] font-semibold uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Path risk</span>
+                <span className="font-mono">{path.riskScore.toFixed(1)}</span>
               </span>
               {evidence?.isKev ? (
                 <span className="rounded-full border border-amber-500/35 bg-amber-500/10 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-200">
@@ -95,7 +96,7 @@ export function ExposurePathCommandCenter({
             </p>
           </div>
           <div className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
-            <MetricPill label="Risk" value={path.riskScore.toFixed(1)} tone="red" />
+            <MetricPill label="Path risk" value={path.riskScore.toFixed(1)} tone="red" />
             <MetricPill label="Hops" value={String(hopCount)} />
             <MetricPill label="Agents" value={String(path.affectedAgents.length)} />
             {fixLabel ? <MetricPill label="Fix" value={fixLabel} tone="green" /> : null}

--- a/ui/e2e/security-graph-cockpit.spec.ts
+++ b/ui/e2e/security-graph-cockpit.spec.ts
@@ -251,7 +251,7 @@ async function expectCockpitVisible(page: Page) {
   ).toBeVisible();
   // Progressive disclosure summary — avoid /Evidence/ which also matches "Evidence drawer".
   await expect(page.getByText("Evidence & relationships")).toBeVisible();
-  await expect(page.getByText("Risk", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("Path risk", { exact: true }).first()).toBeVisible();
   await expect(page.getByText("Hops", { exact: true }).first()).toBeVisible();
 }
 

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -14,10 +14,17 @@ import {
 } from "./exposure-path";
 
 export type AttackPathCardNode = {
-  type: "cve" | "package" | "server" | "agent" | "credential";
+  type: "cve" | "package" | "server" | "agent" | "credential" | "tool" | "data" | "identity" | "entity";
   label: string;
   severity?: string | undefined;
 };
+
+export interface RankedAttackPathRow<C> {
+  path: AttackPath;
+  card: C | undefined;
+  rank: number;
+  key: string;
+}
 
 export type AttackPathFocus = {
   cve?: string | undefined;
@@ -92,24 +99,99 @@ export function mapAttackPathNodeType(entityType: string): AttackPathCardNode["t
   }
 }
 
+/**
+ * Total mapping for chain rendering — unlike {@link mapAttackPathNodeType},
+ * this never returns null. Every hop on a correlated exposure path must render
+ * so the card shows the full `entry → … → sensitive data → finding` chain, not
+ * a single surviving node. Data stores, tools, identities, and gateways are the
+ * crown-jewel and blast-radius hops that made the older mapping collapse.
+ */
+export function mapAttackPathChainType(entityType: string): AttackPathCardNode["type"] {
+  switch (entityType) {
+    case EntityType.VULNERABILITY:
+    case EntityType.MISCONFIGURATION:
+      return "cve";
+    case EntityType.PACKAGE:
+      return "package";
+    case EntityType.SERVER:
+    case EntityType.CONTAINER:
+    case EntityType.CLOUD_RESOURCE:
+    case EntityType.API_GATEWAY:
+    case EntityType.APPLICATION:
+      return "server";
+    case EntityType.AGENT:
+      return "agent";
+    case EntityType.USER:
+    case EntityType.GROUP:
+    case EntityType.SERVICE_ACCOUNT:
+    case EntityType.SERVICE_PRINCIPAL:
+    case EntityType.ROLE:
+    case EntityType.FEDERATED_IDENTITY:
+    case EntityType.MANAGED_IDENTITY:
+    case EntityType.ACCOUNT:
+      return "identity";
+    case EntityType.CREDENTIAL:
+    case EntityType.CREDENTIAL_REF:
+      return "credential";
+    case EntityType.TOOL:
+    case EntityType.TOOL_CALL:
+      return "tool";
+    case EntityType.DATA_STORE:
+    case EntityType.DATASET:
+      return "data";
+    default:
+      return "entity";
+  }
+}
+
 export function toAttackCardNodes(path: AttackPath, nodeById: Map<string, UnifiedNode>): AttackPathCardNode[] {
   const nodes: AttackPathCardNode[] = [];
   for (const hop of path.hops) {
     const node = nodeById.get(hop);
     if (!node) continue;
-    const type = mapAttackPathNodeType(String(node.entity_type));
-    if (!type) continue;
+    const entityType = String(node.entity_type);
     nodes.push({
-      type,
-      label: formatExposureEntityTitle(
-        node.label,
-        type === "cve" ? "finding" : type,
-        node.attributes ?? {},
-      ),
+      type: mapAttackPathChainType(entityType),
+      label: formatExposureEntityTitle(node.label, exposureRoleForEntityType(entityType), node.attributes ?? {}),
       severity: node.severity,
     });
   }
   return nodes;
+}
+
+const GENERIC_PATH_TITLE = /^exposure path\b/i;
+
+/**
+ * Prefer a descriptive backend title, but when the API falls back to the
+ * generic "Exposure path" (a path with no finding id), synthesise a concrete
+ * "entry → crown-jewel" title from the correlated chain endpoints so every card
+ * reads differently and scannably.
+ */
+export function descriptiveAttackPathTitle(cardTitle: string | undefined, nodes: AttackPathCardNode[]): string {
+  const trimmed = (cardTitle ?? "").trim();
+  if (trimmed && !GENERIC_PATH_TITLE.test(trimmed)) return trimmed;
+  const labels = nodes.map((node) => node.label.trim()).filter(Boolean);
+  if (labels.length === 0) return trimmed || "Exposure path";
+  const first = labels[0]!;
+  const last = labels[labels.length - 1]!;
+  if (labels.length === 1 || first === last) return first;
+  return `${first} → ${last}`;
+}
+
+/**
+ * Pair each sorted path with its fix-first card by position and stamp a rank
+ * that equals the row's index in the sorted list. This is the single source of
+ * truth for rank so duplicate ranks (#6 three times) — caused by looking rank up
+ * through a lossy `source::target::hops` key that collides across distinct
+ * paths — can never happen. The composite `key` is guaranteed unique per row.
+ */
+export function rankedAttackPathRows<C>(paths: AttackPath[], cards: readonly C[] = []): RankedAttackPathRow<C>[] {
+  return paths.map((path, index) => ({
+    path,
+    card: cards[index],
+    rank: index + 1,
+    key: `${attackPathKey(path)}::${index}`,
+  }));
 }
 
 export function exposureRoleForEntityType(entityType: string): ExposureEntityRole {

--- a/ui/tests/attack-path-card.test.tsx
+++ b/ui/tests/attack-path-card.test.tsx
@@ -137,4 +137,41 @@ describe('AttackPathCard', () => {
     )
     expect(screen.getByText('ANTHROPIC_KEY')).toBeInTheDocument()
   })
+
+  it('renders the full correlated chain including data-store, tool, and identity hops', () => {
+    const chain = [
+      { type: 'identity' as const, label: 'billing-service-account' },
+      { type: 'server' as const, label: 'Postgres connector' },
+      { type: 'tool' as const, label: 'execute_sql' },
+      { type: 'data' as const, label: 'customers-pii' },
+    ]
+    const { getAllByText } = render(<AttackPathCard nodes={chain} riskScore={8.2} compact />)
+    expect(screen.getByText('billing-service-account')).toBeInTheDocument()
+    expect(screen.getByText('execute_sql')).toBeInTheDocument()
+    expect(screen.getByText('customers-pii')).toBeInTheDocument()
+    // 4 nodes → 3 chain connectors, so the whole path is visible, not a single node.
+    expect(getAllByText('→')).toHaveLength(3)
+  })
+
+  it('hides the internal risk badge when showRiskBadge is false', () => {
+    render(
+      <AttackPathCard nodes={[{ type: 'data' as const, label: 'customers-pii' }]} riskScore={4.6} compact showRiskBadge={false} />
+    )
+    expect(screen.queryByText('4.6')).not.toBeInTheDocument()
+  })
+
+  it('shows the internal risk badge in compact mode by default', () => {
+    render(
+      <AttackPathCard nodes={[{ type: 'data' as const, label: 'customers-pii' }]} riskScore={4.6} compact />
+    )
+    expect(screen.getByText('4.6')).toBeInTheDocument()
+  })
+
+  it('exposes the full entity name via a title tooltip instead of hard-truncating it', () => {
+    const longLabel = 'S3 Bucket: abom-demo-customers-pii-longbucketname'
+    render(<AttackPathCard nodes={[{ type: 'data' as const, label: longLabel }]} riskScore={7.0} compact />)
+    const labelEl = screen.getByText(longLabel)
+    expect(labelEl).toHaveAttribute('title', longLabel)
+    expect(labelEl.className).not.toContain('truncate')
+  })
 })

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -6,11 +6,14 @@ import {
   buildGraphInvestigationHref,
   buildSecurityGraphHref,
   decodeGraphInvestigationParams,
+  descriptiveAttackPathTitle,
   investigationRootForAttackPath,
   labelsForAttackPathType,
+  mapAttackPathChainType,
   mapAttackPathNodeType,
   matchesAttackPathFocus,
   moveAttackPathSelection,
+  rankedAttackPathRows,
   recommendedInteractionRiskActions,
   recommendedAttackPathActions,
   summarizeInteractionRisks,
@@ -100,11 +103,23 @@ describe("attack path helpers", () => {
     expect(mapAttackPathNodeType(EntityType.TOOL)).toBeNull();
   });
 
-  it("drops unknown hops and preserves severity for supported nodes", () => {
+  it("maps every entity type into a chain node type without dropping hops", () => {
+    expect(mapAttackPathChainType(EntityType.VULNERABILITY)).toBe("cve");
+    expect(mapAttackPathChainType(EntityType.PACKAGE)).toBe("package");
+    expect(mapAttackPathChainType(EntityType.CLOUD_RESOURCE)).toBe("server");
+    expect(mapAttackPathChainType(EntityType.AGENT)).toBe("agent");
+    expect(mapAttackPathChainType(EntityType.SERVICE_ACCOUNT)).toBe("identity");
+    expect(mapAttackPathChainType(EntityType.CREDENTIAL)).toBe("credential");
+    expect(mapAttackPathChainType(EntityType.TOOL)).toBe("tool");
+    expect(mapAttackPathChainType(EntityType.DATA_STORE)).toBe("data");
+    expect(mapAttackPathChainType(EntityType.ENVIRONMENT)).toBe("entity");
+  });
+
+  it("renders the full correlated chain — including tool and data-store hops the old mapping dropped", () => {
     const path: AttackPath = {
       source: "cve-1",
-      target: "agent-1",
-      hops: ["cve-1", "tool-1", "agent-1"],
+      target: "data-1",
+      hops: ["cve-1", "tool-1", "agent-1", "data-1"],
       edges: [],
       composite_risk: 7.8,
       summary: "mixed path",
@@ -177,12 +192,76 @@ describe("attack path helpers", () => {
           dimensions: {},
         },
       ],
+      [
+        "data-1",
+        {
+          id: "data-1",
+          entity_type: EntityType.DATA_STORE,
+          label: "customers-pii",
+          category_uid: 5,
+          class_uid: 4001,
+          type_uid: 0,
+          status: "active",
+          risk_score: 8,
+          severity: "critical",
+          severity_id: 5,
+          first_seen: "2026-04-14T00:00:00Z",
+          last_seen: "2026-04-14T00:00:00Z",
+          attributes: {},
+          compliance_tags: [],
+          data_sources: [],
+          dimensions: {},
+        },
+      ],
     ]);
 
     expect(toAttackCardNodes(path, nodes)).toEqual([
       { type: "cve", label: "CVE-2026-0002", severity: "critical" },
+      { type: "tool", label: "Run Shell", severity: "high" },
       { type: "agent", label: "Claude Desktop", severity: "high" },
+      { type: "data", label: "Customers Pii", severity: "critical" },
     ]);
+  });
+
+  it("keeps a descriptive backend title but replaces the generic 'Exposure path' with chain endpoints", () => {
+    const nodes = [
+      { type: "identity" as const, label: "billing-service-account" },
+      { type: "server" as const, label: "Postgres connector" },
+      { type: "data" as const, label: "customers-pii" },
+    ];
+    expect(descriptiveAttackPathTitle("CVE-2026-0002 via analyst-agent", nodes)).toBe(
+      "CVE-2026-0002 via analyst-agent",
+    );
+    expect(descriptiveAttackPathTitle("Exposure path", nodes)).toBe("billing-service-account → customers-pii");
+    expect(descriptiveAttackPathTitle("Exposure path via analyst-agent", nodes)).toBe(
+      "billing-service-account → customers-pii",
+    );
+    expect(descriptiveAttackPathTitle(undefined, [{ type: "data" as const, label: "customers-pii" }])).toBe(
+      "customers-pii",
+    );
+    expect(descriptiveAttackPathTitle(undefined, [])).toBe("Exposure path");
+  });
+
+  it("stamps unique 1..N ranks by sorted position even when path keys collide", () => {
+    const collidingPath = (composite: number): AttackPath => ({
+      source: "s",
+      target: "t",
+      hops: ["s", "t"],
+      edges: [],
+      composite_risk: composite,
+      summary: "same key different path",
+      credential_exposure: [],
+      tool_exposure: [],
+      vuln_ids: [],
+    });
+    const paths = [collidingPath(9.9), collidingPath(9.9), collidingPath(9.9)];
+    const cards = [{ rank: 6, title: "a" }, { rank: 2, title: "b" }, { rank: 6, title: "c" }];
+
+    const rows = rankedAttackPathRows(paths, cards);
+
+    expect(rows.map((row) => row.rank)).toEqual([1, 2, 3]);
+    expect(new Set(rows.map((row) => row.key)).size).toBe(3);
+    expect(rows.map((row) => row.card?.title)).toEqual(["a", "b", "c"]);
   });
 
   it("builds a focused security-graph href from canonical context", () => {


### PR DESCRIPTION
## Problem

The Security-Graph **ranked exposure-path cards** — the correlation moat (`finding → asset → identity → path → data`) — rendered uselessly in a live session:

- each card showed a **single node** (`S3 Bucket: Abom De…`, truncated), not the path;
- **ranks duplicated** — three cards all read `#6 FIX FIRST` (order #6/#2/#3/#6/#6);
- the **title was generic** — "Exposure path" five times;
- the header score (46.0) sat next to unlabeled node numbers with no reconciliation.

## Root causes

- **Single node:** `toAttackCardNodes` dropped every hop whose entity type wasn't one of five allowlisted kinds. Data stores, tools, identities, and gateways — the crown-jewel and blast-radius hops — were silently filtered out, collapsing the chain to whatever survived. The API already returns the full hop chain (`attack_path.hops` + `nodes`, and `exposure_path.hops`); this was purely a render-side filter.
- **Duplicate ranks:** rank was read from a card looked up through a lossy `source::target::hops` key that collides across distinct paths, and the React key collided too, so one card's rank rendered repeatedly.
- **Generic title:** the backend emits `"Exposure path"` when a path has no finding id.

## Fix

- **Full correlated chain per card** — new total `mapAttackPathChainType` maps *every* entity type (adds tool, data, identity, gateway, generic), so the card shows `entry → … → sensitive data → finding`. New chip icons/tints for the added roles.
- **Unique 1..N ranks** — `rankedAttackPathRows` pairs each sorted path with its fix-first card by position and stamps rank from the row index with a guaranteed-unique key. Rank == position in the sorted list, always.
- **Descriptive titles** — `descriptiveAttackPathTitle` keeps a specific backend title but replaces the generic "Exposure path" fallback with concrete `entry → crown-jewel` endpoints.
- **Reconciled scores** — one clearly labeled **Path risk** in the card header (and command center); the duplicate unlabeled badge inside the chain is suppressed via a new `showRiskBadge` prop.
- **No truncation** — key entity names wrap with a `title` tooltip instead of hard-truncating; token-only styling, `zinc-*` removed.

## Verification

`npm ci` · `npm run typecheck` · `npm run build` · `vitest` — all green (495 tests, 98 files). New/updated unit coverage for the chain mapper, descriptive-title fallback, rank uniqueness under key collisions, full-chain rendering, the risk-badge toggle, and the no-truncation tooltip.

No backend routes touched — the API already returns the full chain, so no follow-up field is needed.

Part of the graph-UX epic #3931; fixes the ranked exposure-path cards.