### PR TITLE
fix(scan): honest verdicts for empty scans, malicious packages, offline coverage gaps

### DIFF
--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -1704,6 +1704,26 @@ async def get_posture_scorecard(request: Request) -> dict:
             "score": 0,
             "summary": "No completed scans available",
             "dimensions": {},
+            "no_data": True,
+        }
+
+    # Did-we-scan guard: a completed scan that examined ZERO gradable artifacts
+    # must not report a passing grade. Mirror the honest no-data / N/A treatment
+    # rather than surfacing a fallback "B" from empty-default dimensions.
+    summary = latest_result.get("summary") or {}
+    examined_artifacts = (
+        int(summary.get("total_packages") or 0)
+        + int(summary.get("total_mcp_servers") or 0)
+        + int(summary.get("total_findings") or 0)
+        + int(summary.get("total_vulnerabilities") or 0)
+    )
+    if examined_artifacts == 0:
+        return {
+            "grade": "N/A",
+            "score": 0,
+            "summary": "No artifacts scanned — posture grade unavailable. Connect a surface or run a scan to grade posture.",
+            "dimensions": {},
+            "no_data": True,
         }
 
     scorecard = latest_result.get("posture_scorecard")
@@ -1715,6 +1735,7 @@ async def get_posture_scorecard(request: Request) -> dict:
         "score": 0,
         "summary": "Scorecard not computed for this scan",
         "dimensions": {},
+        "no_data": True,
     }
 
 

--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -581,8 +581,10 @@ def check(
     \b
     Exit codes:
       0  Clean — no known vulnerabilities
-      1  Unsafe — vulnerabilities found
-      2  Incomplete — OS package context insufficient for a trustworthy verdict
+      1  Unsafe — vulnerabilities found, or package flagged as malicious
+      2  Incomplete — insufficient context for a trustworthy clean verdict
+         (missing version, OS package metadata, or offline scan of an
+         ecosystem the local DB carries no advisories for)
 
     \b
     Notes:
@@ -715,7 +717,13 @@ def check(
         status_context = nullcontext()
 
     with status_context:
-        from agent_bom.scanners import IncompleteScanError, ScanOptions, consume_scan_warnings, scan_packages
+        from agent_bom.scanners import (
+            IncompleteScanError,
+            ScanOptions,
+            consume_coverage_warnings,
+            consume_scan_warnings,
+            scan_packages,
+        )
 
         try:
             asyncio.run(scan_packages(pkgs, options=ScanOptions(offline=offline)))
@@ -740,12 +748,51 @@ def check(
             sys.exit(2)
 
     scan_warnings = consume_scan_warnings()
+    coverage_warnings = consume_coverage_warnings()
+    offline_coverage_gap = offline and any(
+        w.get("kind") == "offline_ecosystem_gap" for w in coverage_warnings
+    )
     if scan_warnings and not quiet and not structured_output:
         console.print(f"  [yellow]⚠[/yellow] Scan completed with {len(scan_warnings)} warning(s); results may be incomplete.")
 
     matched_pkg = next((p for p in pkgs if p.vulnerabilities), pkgs[0])
     vulns = matched_pkg.vulnerabilities
     fail_threshold = fail_on_severity.lower() if fail_on_severity else None
+
+    # ── Malicious-package gate (fail closed) ─────────────────────────────────
+    # A package flagged as malicious (typosquat, dependency-confusion, or a
+    # known-malicious MAL- advisory) is a BLOCK regardless of CVE rows. Reading
+    # only vuln rows let such a package report "No known vulnerabilities" and
+    # exit 0 — a pre-install gate must never install a malicious package, and
+    # this decision is independent of --exit-zero / --fail-on-severity, which
+    # only govern vulnerability triage.
+    malicious_pkg = next((p for p in pkgs if getattr(p, "is_malicious", False)), None)
+    if malicious_pkg is not None:
+        reason = malicious_pkg.malicious_reason or "flagged as malicious (typosquat / dependency confusion / known-malicious advisory)"
+        message = f"MALICIOUS package {malicious_pkg.name}@{malicious_pkg.version} — {reason}. Do not install."
+        if structured_output:
+            _write_check_output(
+                _check_result_payload(
+                    name=name,
+                    version=version,
+                    ecosystems=ecosystems,
+                    verdict="malicious",
+                    message=message,
+                    exit_code=1,
+                    vulnerabilities=vulns,
+                    warnings=scan_warnings,
+                ),
+                output_path,
+                agent_mode=agent_mode,
+                exit_code=1,
+                output_format=output_format,
+            )
+            sys.exit(1)
+        if quiet:
+            click.echo(f"{name}@{version}: MALICIOUS — {reason}")
+        else:
+            console.print(f"  [red]✗ MALICIOUS: {message}[/red]\n")
+        sys.exit(1)
 
     if enrich and any(pkg.vulnerabilities for pkg in pkgs):
         from agent_bom.enrichment import enrich_vulnerabilities
@@ -765,6 +812,41 @@ def check(
             scan_warnings.append(f"External enrichment skipped: {exc}")
             if not quiet and not structured_output:
                 console.print(f"  [yellow]⚠[/yellow] External enrichment skipped: {exc}")
+
+    if not vulns and offline_coverage_gap:
+        # Symmetric with the deb/apk/rpm incomplete path below: an offline scan
+        # of an ecosystem the local DB carries no advisories for produced no
+        # vulns because nothing could be matched — NOT because the package is
+        # clean. Fail closed (rc=2) so a pre-install gate isn't silently green.
+        # Re-run online, `agent-bom db update` for coverage, or --exit-zero to
+        # force a non-failing exploratory result.
+        message = (
+            f"Incomplete offline coverage for {name}@{version} ({eco_display}). "
+            "The local vulnerability DB carries no advisories for this ecosystem, so a clean result "
+            "cannot be trusted. Run `agent-bom db update` (online) for full coverage."
+        )
+        if structured_output:
+            _write_check_output(
+                _check_result_payload(
+                    name=name,
+                    version=version,
+                    ecosystems=ecosystems,
+                    verdict="incomplete",
+                    message=message,
+                    exit_code=2,
+                    warnings=scan_warnings,
+                ),
+                output_path,
+                agent_mode=agent_mode,
+                exit_code=2,
+                output_format=output_format,
+            )
+            sys.exit(2)
+        if quiet:
+            click.echo(f"{name}@{version}: incomplete offline coverage ({eco_display})")
+        else:
+            console.print(f"  [yellow]⚠ {message}[/yellow]\n")
+        sys.exit(2)
 
     if not vulns and matched_pkg.ecosystem in {"deb", "apk", "rpm"} and not os_context_complete:
         message = (

--- a/src/agent_bom/posture.py
+++ b/src/agent_bom/posture.py
@@ -171,11 +171,12 @@ def _is_number(value: object) -> bool:
 class PostureScorecard:
     """Enterprise posture scorecard result."""
 
-    grade: str  # A, B, C, D, F
+    grade: str  # A, B, C, D, F, or N/A
     score: float  # 0-100
     dimensions: dict[str, DimensionScore] = field(default_factory=dict)
     summary: str = ""
     policy_source: str = "default"
+    no_data: bool = False  # True when the scan examined no gradable artifacts
 
     def to_dict(self) -> dict:
         return {
@@ -183,6 +184,7 @@ class PostureScorecard:
             "score": self.score,
             "summary": self.summary,
             "policy_source": self.policy_source,
+            "no_data": self.no_data,
             "dimensions": {k: v.to_dict() for k, v in self.dimensions.items()},
         }
 
@@ -464,6 +466,25 @@ def compute_posture_scorecard(
         weight=float(w["configuration_quality"]),
         details=config_detail,
     )
+
+    # ── Did-we-scan guard ──
+    # A grade requires real evaluated inputs. When a scan examined ZERO gradable
+    # artifacts (no packages, no MCP servers, no active findings), every
+    # dimension above falls back to its empty default (100/50) and would produce
+    # a passing "B" — an honest-looking pass for a scan that evaluated nothing.
+    # Return an explicit no-data / N/A posture instead, mirroring the honest N/A
+    # treatment used elsewhere (overview tile, exec score). Dimensions and policy
+    # source are preserved for downstream plumbing; only the headline is honest.
+    examined_artifacts = total_vulns + total_servers + len(all_packages)
+    if examined_artifacts == 0:
+        return PostureScorecard(
+            grade="N/A",
+            score=0.0,
+            dimensions=dimensions,
+            summary="No artifacts scanned — posture grade unavailable. Connect a surface or run a scan to grade posture.",
+            policy_source=resolved.source,
+            no_data=True,
+        )
 
     # ── Final score ──
     total_score = sum(d.score * d.weight for d in dimensions.values())

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -1207,6 +1207,18 @@ async def scan_packages(
                     f"offline coverage gap: {len(uncovered)} package(s) in ecosystem(s) "
                     f"{', '.join(gap_ecos)} have no advisories in the local vulnerability DB"
                 )
+                # Structured signal so consumers (e.g. `check`) can fail closed
+                # deterministically instead of string-matching the warning above.
+                # A zero-vuln result for an ecosystem the local DB carries no
+                # advisories for is NOT a clean bill of health.
+                record_coverage_warning(
+                    {
+                        "kind": "offline_ecosystem_gap",
+                        "release": f"offline:{','.join(gap_ecos)}",
+                        "ecosystems": gap_ecos,
+                        "package_count": len(uncovered),
+                    }
+                )
         results = {}
     elif scan_prefer_local_db and osv_targets:
         # DB is fresh — only query OSV for packages genuinely missing from DB

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -546,3 +546,100 @@ def test_check_without_version_json_reports_nonzero(monkeypatch):
     payload = json.loads(result.output)
     assert payload["verdict"] == "skipped"
     assert payload["exit_code"] == 2
+
+
+def _patch_check_scan_malicious(monkeypatch, reason="Possible typosquat of 'requests'"):
+    async def _scan_packages(pkgs, **_kwargs):
+        for pkg in pkgs:
+            pkg.vulnerabilities = []
+            pkg.is_malicious = True
+            pkg.malicious_reason = reason
+
+    monkeypatch.setattr("agent_bom.scanners.scan_packages", _scan_packages)
+    monkeypatch.setattr("agent_bom.parsers.os_parsers.enrich_os_package_context", lambda pkg: True)
+
+
+def test_check_malicious_package_blocks_without_cve(monkeypatch):
+    """A typosquat / dependency-confusion package with no CVE rows must BLOCK.
+
+    Reading only vuln rows let a malicious package report "No known
+    vulnerabilities" and exit 0 — a pre-install gate must fail closed."""
+    _patch_check_scan_malicious(monkeypatch)
+
+    result = CliRunner().invoke(main, ["check", "reqeusts@1.0.0", "--ecosystem", "pypi"])
+
+    assert result.exit_code == 1
+    assert "No known vulnerabilities" not in result.output
+    assert "malicious" in result.output.lower() or "typosquat" in result.output.lower()
+
+
+def test_check_malicious_package_json_verdict(monkeypatch):
+    _patch_check_scan_malicious(monkeypatch, reason="Dependency confusion risk")
+
+    result = CliRunner().invoke(
+        main, ["check", "internal-lib@1.0.0", "--ecosystem", "pypi", "--format", "json"]
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["verdict"] == "malicious"
+    assert payload["exit_code"] == 1
+    assert "Dependency confusion risk" in payload["message"]
+
+
+def test_check_malicious_beats_exit_zero(monkeypatch):
+    """--exit-zero is for vulnerability triage; it must not let a malicious
+    package through the pre-install gate."""
+    _patch_check_scan_malicious(monkeypatch)
+
+    result = CliRunner().invoke(
+        main, ["check", "reqeusts@1.0.0", "--ecosystem", "pypi", "--exit-zero"]
+    )
+
+    assert result.exit_code == 1
+
+
+def _patch_check_scan_offline_gap(monkeypatch):
+    async def _scan_packages(pkgs, **_kwargs):
+        from agent_bom.scanners import record_coverage_warning
+
+        for pkg in pkgs:
+            pkg.vulnerabilities = []
+        record_coverage_warning(
+            {
+                "kind": "offline_ecosystem_gap",
+                "release": "offline:pypi",
+                "ecosystems": ["pypi"],
+                "package_count": len(pkgs),
+            }
+        )
+
+    monkeypatch.setattr("agent_bom.scanners.scan_packages", _scan_packages)
+    monkeypatch.setattr("agent_bom.parsers.os_parsers.enrich_os_package_context", lambda pkg: True)
+
+
+def test_check_offline_coverage_gap_exits_incomplete(monkeypatch):
+    """Offline scan of an ecosystem the local DB has no advisories for is NOT a
+    clean pass — it must exit 2 (incomplete), symmetric with deb/apk/rpm."""
+    _patch_check_scan_offline_gap(monkeypatch)
+
+    result = CliRunner().invoke(
+        main, ["check", "somepypipkg@1.0.0", "--ecosystem", "pypi", "--offline"]
+    )
+
+    assert result.exit_code == 2
+    assert "No known vulnerabilities" not in result.output
+
+
+def test_check_offline_coverage_gap_json_incomplete(monkeypatch):
+    _patch_check_scan_offline_gap(monkeypatch)
+
+    result = CliRunner().invoke(
+        main,
+        ["check", "somepypipkg@1.0.0", "--ecosystem", "pypi", "--offline", "--format", "json"],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["verdict"] == "incomplete"
+    assert payload["exit_code"] == 2

--- a/tests/test_enterprise_scenarios.py
+++ b/tests/test_enterprise_scenarios.py
@@ -108,13 +108,24 @@ def _make_report(agents=None, blast_radii=None):
 
 class TestPostureScorecard:
     def test_clean_report_good_grade(self):
-        """Clean report (no vulns) should get a good grade (A or B)."""
+        """A report that actually scanned a clean package gets a good grade (A/B)."""
         from agent_bom.posture import compute_posture_scorecard
 
-        report = _make_report()
+        server = _make_server(packages=[_make_package()], registry_verified=True)
+        agent = _make_agent(servers=[server])
+        report = _make_report(agents=[agent])
         sc = compute_posture_scorecard(report)
         assert sc.grade in ("A", "B")
         assert sc.score >= 75
+        assert sc.no_data is False
+
+    def test_empty_scan_is_no_data_not_passing(self):
+        """A scan that examined zero artifacts is N/A, never a passing grade."""
+        from agent_bom.posture import compute_posture_scorecard
+
+        sc = compute_posture_scorecard(_make_report())
+        assert sc.grade == "N/A"
+        assert sc.no_data is True
 
     def test_critical_vulns_lower_score(self):
         """Critical vulnerabilities should significantly reduce score."""

--- a/tests/test_posture_policy.py
+++ b/tests/test_posture_policy.py
@@ -4,12 +4,52 @@ from __future__ import annotations
 
 import json
 
-from agent_bom.models import AIBOMReport
+from agent_bom.models import Agent, AgentType, AIBOMReport, MCPServer, Package
 from agent_bom.posture import (
     DEFAULT_DIMENSION_WEIGHTS,
     compute_posture_scorecard,
     load_posture_policy,
 )
+
+
+def test_no_artifact_scan_returns_na_not_passing_grade() -> None:
+    """A scan that examined zero artifacts must not report a passing grade.
+
+    Previously an empty report defaulted every dimension to 100/50 and produced
+    a "B" (87.5) — an honest-looking pass for a scan that evaluated nothing.
+    """
+    scorecard = compute_posture_scorecard(AIBOMReport(agents=[], blast_radii=[]))
+    assert scorecard.grade == "N/A"
+    assert scorecard.score == 0
+    assert scorecard.no_data is True
+    # Policy plumbing is still preserved for downstream consumers.
+    assert scorecard.policy_source == "default"
+    d = scorecard.to_dict()
+    assert d["grade"] == "N/A"
+    assert d["no_data"] is True
+
+
+def test_scan_with_real_artifacts_gets_a_real_grade() -> None:
+    """A scan that actually examined a package still gets a real letter grade."""
+    report = AIBOMReport(
+        agents=[
+            Agent(
+                name="cursor",
+                agent_type=AgentType.CUSTOM,
+                config_path="/tmp/mcp.json",
+                mcp_servers=[
+                    MCPServer(
+                        name="fs",
+                        packages=[Package(name="requests", version="2.31.0", ecosystem="pypi")],
+                    )
+                ],
+            )
+        ],
+        blast_radii=[],
+    )
+    scorecard = compute_posture_scorecard(report)
+    assert scorecard.grade in {"A", "B", "C", "D", "F"}
+    assert scorecard.no_data is False
 
 
 def test_default_policy_weights_sum_to_one() -> None:


### PR DESCRIPTION
Closes #3965

Three scan-honesty gaps let a scan that evaluated nothing — or nothing trustworthy — read as a pass. Each is fixed test-first.

## 1. Did-we-scan posture guard
`compute_posture_scorecard` defaulted every dimension to 100/50 for a scan that examined **zero gradable artifacts**, producing a passing `B` (87.5) for a scan that evaluated nothing. It now returns an explicit **N/A / `no_data`** posture unless real inputs were evaluated (packages, MCP servers, or active findings). Dimensions and policy source are preserved for downstream plumbing; only the headline is honest. The `/compliance/posture` route gains a matching did-we-scan guard keyed off the scan summary counts (defense-in-depth).

- `src/agent_bom/posture.py`, `src/agent_bom/api/routes/compliance.py`
- Tests: `test_no_artifact_scan_returns_na_not_passing_grade`, `test_scan_with_real_artifacts_gets_a_real_grade`, `test_empty_scan_is_no_data_not_passing`

## 2. `check` fails closed on malicious packages
The pre-install verdict read only vulnerability rows, so a typosquat / dependency-confusion package with no CVE reported "No known vulnerabilities" and **exited 0**. A package flagged `is_malicious` is now a **BLOCK** (`verdict=malicious`, exit 1), independent of vuln rows and of `--exit-zero` / `--fail-on-severity` (which only govern vulnerability triage).

- `src/agent_bom/cli/_check.py`
- Tests: `test_check_malicious_package_blocks_without_cve`, `test_check_malicious_package_json_verdict`, `test_check_malicious_beats_exit_zero`
- Verified end-to-end: `agent-bom check reqeusts@1.0.0 -e pypi` now exits 1 with a MALICIOUS verdict.

## 3. Offline coverage-gap exit symmetry
An offline scan of an ecosystem the local DB has no advisories for exited 0 clean (warning only) — asymmetric with deb/apk/rpm, which exit 2. The scanner now emits a structured `offline_ecosystem_gap` coverage warning, and `check` exits **2 (incomplete)** for such a no-vuln result. `--exit-zero` remains the documented opt-out.

- `src/agent_bom/scanners/__init__.py`, `src/agent_bom/cli/_check.py`
- Tests: `test_check_offline_coverage_gap_exits_incomplete`, `test_check_offline_coverage_gap_json_incomplete`

## Verification
- New + existing suites: `test_cli_check`, `test_posture_policy`, `test_enterprise_scenarios`, `test_scanners`, `test_scanners_offline_enrichment`, `test_compliance`, `test_compliance_hub_api`, `test_mcp_posture_tools`, `test_core`, `test_scan_contract` — all green (407 in the focused sweep).
- `mypy` + `ruff` clean on all changed files.
- One existing test (`test_clean_report_good_grade`) asserted the old dishonest behavior (empty report -> passing grade); updated to scan a real clean package and added an explicit empty-scan N/A assertion.