### PR TITLE
fix(scan): honest verdicts — did-we-scan guard, malicious check, offline coverage symmetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **Honest scan verdicts** (#3965): the posture scorecard no longer reports a passing `B` / 87.5 for a scan that processed zero artifacts — an empty scan now returns grade `N/A` across CLI, JSON, and the `/posture` API. The pre-install `check` command now blocks known-malicious packages (typosquat / dependency-confusion carry no CVE rows, so they previously reported "no known vulnerabilities" / exit 0) with a `malicious` verdict and non-zero exit. Offline `check` of a package whose ecosystem has zero advisories in the local DB now exits 2 (untrustworthy clean), symmetric with the existing deb/apk/rpm incomplete-context guard.
+
 ## [0.95.0] - 2026-07-13
 
 Enterprise auth, cloud-connect, and interop release: browser OIDC SSO, actionable cloud connections, compliance honesty, refreshed dashboard/branding, and a large security-hardening batch on top of 0.94.2.

--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -352,6 +352,7 @@ def _check_result_payload(
     exit_zero: bool = False,
     fail_on_severity: str | None = None,
     fail_on_severity_count: int | None = None,
+    malicious_reason: str | None = None,
 ) -> dict:
     """Build machine-readable check output."""
     serialized_vulns = []
@@ -398,6 +399,8 @@ def _check_result_payload(
         "fail_on_severity": fail_on_severity,
         "fail_on_severity_count": fail_on_severity_count,
         "vulnerability_count": len(serialized_vulns),
+        "is_malicious": malicious_reason is not None,
+        "malicious_reason": malicious_reason,
         "scan_warnings": warnings or [],
         "vulnerabilities": serialized_vulns,
     }
@@ -715,7 +718,13 @@ def check(
         status_context = nullcontext()
 
     with status_context:
-        from agent_bom.scanners import IncompleteScanError, ScanOptions, consume_scan_warnings, scan_packages
+        from agent_bom.scanners import (
+            IncompleteScanError,
+            ScanOptions,
+            consume_scan_warnings,
+            offline_coverage_gap,
+            scan_packages,
+        )
 
         try:
             asyncio.run(scan_packages(pkgs, options=ScanOptions(offline=offline)))
@@ -766,6 +775,45 @@ def check(
             if not quiet and not structured_output:
                 console.print(f"  [yellow]⚠[/yellow] External enrichment skipped: {exc}")
 
+    # ── Malicious-package gate ──
+    # `scan_packages` flags typosquats, dependency-confusion, and MAL- advisories
+    # via `is_malicious` — but those signals (except MAL- rows) produce NO
+    # vulnerability rows, so a verdict derived only from `vulns` would report a
+    # known-malicious package as "clean" / exit 0. A pre-install gate must block
+    # it. Surface the malicious verdict before any clean/incomplete branch.
+    malicious_pkgs = [p for p in pkgs if getattr(p, "is_malicious", False)]
+    if malicious_pkgs:
+        reasons = sorted({p.malicious_reason for p in malicious_pkgs if p.malicious_reason})
+        reason_text = "; ".join(reasons) if reasons else "flagged as known-malicious"
+        message = f"{name}@{version} is flagged MALICIOUS: {reason_text}. Do not install."
+        mal_exit = 0 if exit_zero else 1
+        if structured_output:
+            _write_check_output(
+                _check_result_payload(
+                    name=name,
+                    version=version,
+                    ecosystems=ecosystems,
+                    verdict="malicious",
+                    message=message,
+                    exit_code=mal_exit,
+                    vulnerabilities=vulns,
+                    warnings=scan_warnings,
+                    exit_zero=exit_zero,
+                    malicious_reason=reason_text,
+                ),
+                output_path,
+                agent_mode=agent_mode,
+                exit_code=mal_exit,
+                output_format=output_format,
+            )
+            sys.exit(mal_exit)
+        if quiet:
+            click.echo(f"{name}@{version}: MALICIOUS — {reason_text}")
+        else:
+            console.print(f"  [red bold]✗ MALICIOUS: {name}@{version} — {reason_text}[/red bold]")
+            console.print("  Flagged as known-malicious (typosquat / dependency-confusion / advisory). Do not install.\n")
+        sys.exit(mal_exit)
+
     if not vulns and matched_pkg.ecosystem in {"deb", "apk", "rpm"} and not os_context_complete:
         message = (
             f"Incomplete OS package context for {name}@{version}. "
@@ -795,6 +843,45 @@ def check(
             console.print(
                 "  Best-effort matching found no vulnerabilities, but source/distro metadata was "
                 "insufficient for a trustworthy clean verdict.\n"
+            )
+        sys.exit(2)
+
+    # ── Offline coverage-gap gate ──
+    # Symmetric with the deb/apk/rpm incomplete-context guard above: in offline
+    # mode, if the local DB holds zero advisories for this package's ecosystem,
+    # a "no vulnerabilities" result is not trustworthy (the DB has no data for
+    # that ecosystem), so exit 2 instead of a false-clean. deb/apk/rpm gaps are
+    # already handled by the OS-context branch; this closes the pypi/npm/etc. leg.
+    if not vulns and offline and pkgs and all(offline_coverage_gap(p) for p in pkgs):
+        message = (
+            f"Offline coverage gap for {name}@{version}: the local vulnerability DB has no "
+            f"advisories for this ecosystem, so a clean verdict is not trustworthy. "
+            f"Run `agent-bom db update` for full offline coverage."
+        )
+        if structured_output:
+            _write_check_output(
+                _check_result_payload(
+                    name=name,
+                    version=version,
+                    ecosystems=ecosystems,
+                    verdict="incomplete",
+                    message=message,
+                    exit_code=2,
+                    warnings=scan_warnings,
+                ),
+                output_path,
+                agent_mode=agent_mode,
+                exit_code=2,
+                output_format=output_format,
+            )
+            sys.exit(2)
+        if quiet:
+            click.echo(f"{name}@{version}: incomplete offline coverage")
+        else:
+            console.print(f"  [yellow]⚠ Offline coverage gap for {name}@{version}[/yellow]")
+            console.print(
+                "  The local vulnerability DB has no advisories for this ecosystem; a clean "
+                "verdict is not trustworthy. Run `agent-bom db update` for full offline coverage.\n"
             )
         sys.exit(2)
 

--- a/src/agent_bom/output/compact.py
+++ b/src/agent_bom/output/compact.py
@@ -53,6 +53,9 @@ def _posture_grade_badge(grade: str) -> str:
         style = "black on yellow"
     elif grade == "D":
         style = "white on dark_orange3"
+    elif grade in ("N/A", "?"):
+        # Neutral — "not assessed" is not a failing grade; do not paint it red.
+        style = "white on grey37"
     else:
         style = "white on red"
     return f"[bold {style}] {grade} [/bold {style}]"

--- a/src/agent_bom/posture.py
+++ b/src/agent_bom/posture.py
@@ -465,6 +465,30 @@ def compute_posture_scorecard(
         details=config_detail,
     )
 
+    # ── Did-we-scan guard ──
+    # A scorecard is only meaningful if the scan actually processed artifacts
+    # this scorecard measures (agents, MCP servers, packages, vulnerabilities).
+    # An empty report (no completed scan target, or a job that scanned zero
+    # artifacts) would otherwise take every "nothing found" branch and land at
+    # 87.5 / 'B' — an honest-looking grade for a scan that assessed nothing.
+    # Report grade "N/A" (matching the route's no-completed-scan sentinel) so a
+    # zero-artifact scan can never masquerade as a passing posture.
+    scanned_nothing = (
+        report.total_agents == 0
+        and report.total_servers == 0
+        and report.total_packages == 0
+        and not report.blast_radii
+        and not report.findings
+    )
+    if scanned_nothing:
+        return PostureScorecard(
+            grade="N/A",
+            score=0.0,
+            dimensions=dimensions,
+            summary="No artifacts scanned — posture cannot be assessed. Run a scan against a real target before reading a grade.",
+            policy_source=resolved.source,
+        )
+
     # ── Final score ──
     total_score = sum(d.score * d.weight for d in dimensions.values())
     total_score = round(min(100.0, max(0.0, total_score)), 1)

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -334,6 +334,26 @@ def _db_covered_ecosystems() -> set[str]:
         return set()
 
 
+def offline_coverage_gap(pkg: Package) -> bool:
+    """Return True if an offline scan of *pkg* falls in a real DB coverage gap.
+
+    In offline mode the local advisory DB is the only source of truth. If the
+    DB holds zero advisories for the package's ecosystem, a "no vulnerabilities"
+    result is *not* trustworthy — the DB simply has no data for that ecosystem,
+    exactly as an incomplete OS-package context is untrustworthy for deb/apk/rpm.
+    Callers (e.g. the pre-install ``check`` gate) use this to exit non-zero on an
+    offline coverage gap instead of reporting a false-clean.
+
+    Returns False when the ecosystem *is* covered (a clean result is real) and
+    when the DB is entirely empty/missing (that case is surfaced separately as an
+    ``IncompleteScanError`` by the scan path, not as a per-ecosystem gap).
+    """
+    covered = _db_covered_ecosystems()
+    if not covered:
+        return False
+    return not any(eco in covered for eco in _db_ecosystems_for_package(pkg))
+
+
 # ── Scan cache (optional, lazy-initialised) ────────────────────────────────
 
 _scan_cache_instance: "ScanCache | object | None" = None

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -30,6 +30,79 @@ def test_check_clean_exits_zero(monkeypatch):
     assert "No known vulnerabilities" in result.output
 
 
+def _patch_malicious_scan(monkeypatch, reason):
+    async def _scan_packages(pkgs, **_kwargs):
+        for pkg in pkgs:
+            pkg.vulnerabilities = []
+            pkg.is_malicious = True
+            pkg.malicious_reason = reason
+
+    monkeypatch.setattr("agent_bom.scanners.scan_packages", _scan_packages)
+    monkeypatch.setattr("agent_bom.parsers.os_parsers.enrich_os_package_context", lambda pkg: True)
+
+
+def test_check_malicious_package_exits_nonzero(monkeypatch):
+    """A typosquat/dep-confusion package produces no vuln rows but is_malicious;
+    it must NOT report clean/exit 0 (a pre-install gate has to block it)."""
+    _patch_malicious_scan(monkeypatch, "Possible typosquat of 'requests'")
+
+    result = CliRunner().invoke(main, ["check", "reqeusts@1.0.0", "--ecosystem", "pypi"])
+
+    assert result.exit_code == 1
+    assert "MALICIOUS" in result.output
+    assert "typosquat" in result.output
+    assert "No known vulnerabilities" not in result.output
+
+
+def test_check_malicious_json_verdict(monkeypatch):
+    _patch_malicious_scan(monkeypatch, "Possible dependency confusion")
+
+    result = CliRunner().invoke(
+        main,
+        ["check", "internal-lib@1.0.0", "--ecosystem", "npm", "--format", "json", "--quiet"],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["verdict"] == "malicious"
+    assert payload["is_malicious"] is True
+    assert payload["malicious_reason"] == "Possible dependency confusion"
+
+
+def test_check_malicious_exit_zero_downgrades(monkeypatch):
+    """--exit-zero reports the malicious verdict without failing the gate."""
+    _patch_malicious_scan(monkeypatch, "Possible typosquat of 'flask'")
+
+    result = CliRunner().invoke(main, ["check", "falsk@1.0.0", "--ecosystem", "pypi", "--exit-zero"])
+
+    assert result.exit_code == 0
+    assert "MALICIOUS" in result.output
+
+
+def test_check_offline_coverage_gap_exits_incomplete(monkeypatch):
+    """Offline mode with no DB advisories for the ecosystem: a clean verdict is
+    untrustworthy, so exit 2 — symmetric with the deb/apk/rpm incomplete guard."""
+    _patch_check_scan(monkeypatch, [])
+    monkeypatch.setattr("agent_bom.scanners.offline_coverage_gap", lambda pkg: True)
+
+    result = CliRunner().invoke(main, ["check", "django@4.1.0", "--ecosystem", "pypi", "--offline"])
+
+    assert result.exit_code == 2
+    assert "Offline coverage gap" in result.output
+    assert "No known vulnerabilities" not in result.output
+
+
+def test_check_offline_with_coverage_still_clean(monkeypatch):
+    """Offline mode where the ecosystem IS covered: a clean result is real, exit 0."""
+    _patch_check_scan(monkeypatch, [])
+    monkeypatch.setattr("agent_bom.scanners.offline_coverage_gap", lambda pkg: False)
+
+    result = CliRunner().invoke(main, ["check", "django@4.1.0", "--ecosystem", "pypi", "--offline"])
+
+    assert result.exit_code == 0
+    assert "No known vulnerabilities" in result.output
+
+
 def test_check_vulns_exit_one_by_default(monkeypatch):
     _patch_check_scan(
         monkeypatch,

--- a/tests/test_enterprise_scenarios.py
+++ b/tests/test_enterprise_scenarios.py
@@ -108,13 +108,25 @@ def _make_report(agents=None, blast_radii=None):
 
 class TestPostureScorecard:
     def test_clean_report_good_grade(self):
-        """Clean report (no vulns) should get a good grade (A or B)."""
+        """A clean report that actually scanned an artifact (no vulns) should get
+        a good grade (A or B). An *empty* report — nothing scanned — must not; see
+        test_empty_report_not_assessed."""
         from agent_bom.posture import compute_posture_scorecard
 
-        report = _make_report()
+        # A real clean scan: one package processed, zero vulnerabilities.
+        server = _make_server(packages=[_make_package()])
+        report = _make_report(agents=[_make_agent(servers=[server])])
         sc = compute_posture_scorecard(report)
         assert sc.grade in ("A", "B")
         assert sc.score >= 75
+
+    def test_empty_report_not_assessed(self):
+        """A report that scanned zero artifacts must not read as a passing grade."""
+        from agent_bom.posture import compute_posture_scorecard
+
+        sc = compute_posture_scorecard(_make_report())
+        assert sc.grade == "N/A"
+        assert sc.score == 0.0
 
     def test_critical_vulns_lower_score(self):
         """Critical vulnerabilities should significantly reduce score."""

--- a/tests/test_posture_policy.py
+++ b/tests/test_posture_policy.py
@@ -4,12 +4,35 @@ from __future__ import annotations
 
 import json
 
-from agent_bom.models import AIBOMReport
+from agent_bom.models import Agent as AgentModel
+from agent_bom.models import AgentType, AIBOMReport, MCPServer, Package
 from agent_bom.posture import (
     DEFAULT_DIMENSION_WEIGHTS,
     compute_posture_scorecard,
     load_posture_policy,
 )
+
+
+def _report_with_one_package() -> AIBOMReport:
+    """A minimal report that actually scanned an artifact (one clean package)."""
+    server = MCPServer(name="srv", packages=[Package(name="django", version="4.1.0", ecosystem="pypi")])
+    agent = AgentModel(name="a", agent_type=AgentType.CUSTOM, config_path="/x", mcp_servers=[server])
+    return AIBOMReport(agents=[agent], blast_radii=[])
+
+
+def test_empty_scan_reports_na_grade_not_b() -> None:
+    """A scan that processed zero artifacts must not read as a passing 'B'."""
+    scorecard = compute_posture_scorecard(AIBOMReport(agents=[], blast_radii=[]))
+    assert scorecard.grade == "N/A"
+    assert scorecard.score == 0.0
+    assert "No artifacts scanned" in scorecard.summary
+
+
+def test_scanned_report_gets_letter_grade() -> None:
+    """A report that scanned a real (clean) package still gets a normal grade."""
+    scorecard = compute_posture_scorecard(_report_with_one_package())
+    assert scorecard.grade in {"A", "B", "C", "D", "F"}
+    assert scorecard.grade != "N/A"
 
 
 def test_default_policy_weights_sum_to_one() -> None:


### PR DESCRIPTION
## Summary
Closes three scan-honesty gaps where the tool reported a reassuring result for a scan that assessed nothing, or for a package that is actually dangerous:

- **Posture did-we-scan guard** — an empty report (no completed target / zero artifacts scanned) took every "nothing found" branch and landed at 87.5 / `B`. It now returns grade `N/A` / score 0 (the same sentinel the `/posture` route already uses for "no completed scan"). One fix in `compute_posture_scorecard` covers the CLI compact output, JSON output, and the API.
- **Malicious-package gate in `check`** — `scan_packages` flags typosquats and dependency-confusion via `is_malicious`, but those signals carry **no** vulnerability rows, so a verdict derived only from `vulns` reported a known-malicious package as "clean" / exit 0. Added a `malicious` verdict (exit 1, honors `--exit-zero`) before the clean/incomplete branches, with `malicious_reason` in the structured payload.
- **Offline coverage symmetry** — deb/apk/rpm packages with incomplete context exit 2, but pypi/npm packages in an ecosystem the local DB has zero advisories for exited 0 with only a warning. Added a public `offline_coverage_gap()` helper and a gate in `check` so an untrustworthy clean verdict exits 2, symmetric with the OS-package leg.

## Related Issues
Closes #3965

## Test plan
- [x] `ruff check` + `ruff format` clean on changed lines (pre-existing lines left in `main`'s style — CI ruff 0.15.21 vs local 0.15.8 differ on unrelated lines)
- [x] `mypy` clean on changed source files
- [ ] `pytest tests/ -x -q` — **could not run in this sandbox** (PyPI egress is blocked 403 and the app's runtime deps, e.g. `rich`/`pydantic`, are not in the local cache, so the venv can't be built). Tests were written following the existing `test_cli_check` / `test_posture_policy` / `test_enterprise_scenarios` patterns and the logic was reviewed by hand.

### Tests added/updated
- `test_cli_check.py`: malicious verdict (console + JSON + `--exit-zero` downgrade); offline coverage-gap → exit 2; offline-but-covered → still clean exit 0.
- `test_posture_policy.py`: empty scan → `N/A`; scanned clean package → real letter grade.
- `test_enterprise_scenarios.py`: `test_clean_report_good_grade` now uses a report that actually scanned an artifact (its previous empty fixture encoded the exact bug fixed here); added `test_empty_report_not_assessed`.

## Breaking changes
- [x] None to the API contract. Behavior change (intentional, the point of the fix): an empty-scan posture grade is now `N/A` instead of `B`; `check` on a malicious package or an offline coverage gap now exits non-zero. No routes or Pydantic models changed, so no OpenAPI/atlas regeneration needed.

## Checklist
- [x] No secrets, credentials, or PII in diff
- [x] Backend, CLI, outputs, and tests aligned
- [x] CHANGELOG entry added

## Exceptions
- None

---
_Generated by [Claude Code](https://claude.ai/code/session_013i7mYYrrizpz1DVJCiNGu3)_