### PR TITLE
fix(cloud): Snowflake CIS benchmark over REST + guard in-memory hub sort ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **Snowflake CIS benchmark reachable over REST** (#3967): `GET /v1/cloud/snowflake/cis-benchmark` no longer 404s — it runs the real `snowflake_cis_benchmark` and, when the connector/credentials are absent, degrades to the shared HTTP-200 `unavailable` envelope like AWS/Azure/GCP, bringing the REST surface to parity with the CLI/MCP `cis-benchmark --provider snowflake`.
+- **In-memory compliance-hub sort ceiling guarded** (#3967): the process-local demo backend re-sorts a tenant's whole row list per paged read; past a documented ceiling it now warns once per tenant (steering operators to the SQLite/Postgres backend) instead of degrading silently. No behavior change to results.
+
 ## [0.95.0] - 2026-07-13
 
 Enterprise auth, cloud-connect, and interop release: browser OIDC SSO, actionable cloud connections, compliance honesty, refreshed dashboard/branding, and a large security-hardening batch on top of 0.94.2.

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -21,6 +21,7 @@ with ``ingested_at`` so future expiry / TTL work has a key.
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 import threading
 from collections.abc import Callable, Iterable, Sequence
@@ -50,8 +51,18 @@ from agent_bom.api.hub_reference_store import (
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.graph.severity import severity_policy_rank
 
+_logger = logging.getLogger(__name__)
+
 # Chunk size for reconcile UPDATE … IN (…) to stay under SQLite/Postgres bind limits.
 RECONCILE_ABSENT_CHUNK = 500
+
+# Row-count ceiling for the process-local InMemoryComplianceHubStore. Its paged
+# read copies + re-sorts a tenant's entire row list on every request (O(n log n)
+# per read, independent of page size) — fine for the demo/single-node backend it
+# is scoped to, but it degrades on a large tenant. Above this ceiling we emit a
+# one-time-per-tenant warning steering operators to a SQL backend (SQLite /
+# Postgres), which sort in the query plan instead of in Python.
+IN_MEMORY_SORT_CEILING = 50_000
 
 # Defined here (module scope) so ``list`` resolves to the builtin: the store
 # classes below define a ``list`` method that would otherwise shadow it in
@@ -640,10 +651,20 @@ def _migrate_lifecycle_observations_l2_sqlite(conn: sqlite3.Connection) -> None:
 
 
 class InMemoryComplianceHubStore:
-    """Process-local store. Ephemeral; tests + single-node demos only."""
+    """Process-local store. Ephemeral; tests + single-node demos only.
+
+    Scale ceiling: reads copy + re-sort a tenant's whole row list per request
+    (see ``IN_MEMORY_SORT_CEILING``). This backend is intentionally the demo /
+    single-node path; production deployments use the SQLite or Postgres backend,
+    which sort in the query plan. A tenant that grows past the ceiling logs a
+    one-time warning rather than silently degrading.
+    """
 
     def __init__(self) -> None:
         self._by_tenant: dict[str, list[dict[str, Any]]] = {}
+        # Tenants already warned about crossing IN_MEMORY_SORT_CEILING, so the
+        # guard logs once per tenant instead of on every paged read.
+        self._sort_ceiling_warned: set[str] = set()
         # Maps finding_id -> ingest-order slot so a resend of the same
         # (tenant_id, finding_id) refreshes its row in place instead of
         # appending a duplicate (idempotent ingest, mirrors the SQL backends).
@@ -681,6 +702,25 @@ class InMemoryComplianceHubStore:
             rows = list(self._by_tenant.get(tenant_id, []))
         return hydrate_finding_payloads_memory(tenant_id, rows)
 
+    def _guard_sort_ceiling(self, tenant_id: str, row_count: int) -> None:
+        """Warn once per tenant when the whole-tenant re-sort ceiling is crossed.
+
+        The in-memory backend re-sorts a tenant's entire row list on every paged
+        read. Past ``IN_MEMORY_SORT_CEILING`` that is a real per-request cost;
+        surface it (once per tenant) instead of degrading silently — a SQL
+        backend sorts in the query plan and should be used at that scale.
+        """
+        if row_count <= IN_MEMORY_SORT_CEILING or tenant_id in self._sort_ceiling_warned:
+            return
+        self._sort_ceiling_warned.add(tenant_id)
+        _logger.warning(
+            "InMemoryComplianceHubStore is sorting %d rows per read (ceiling %d); "
+            "this demo/single-node backend re-sorts the whole tenant per request — "
+            "use the SQLite or Postgres backend at this scale.",
+            row_count,
+            IN_MEMORY_SORT_CEILING,
+        )
+
     def list_page(
         self,
         tenant_id: str,
@@ -695,6 +735,7 @@ class InMemoryComplianceHubStore:
     ) -> FindingPage:
         with self._lock:
             rows = list(self._by_tenant.get(tenant_id, []))
+        self._guard_sort_ceiling(tenant_id, len(rows))
         rows = _filter_hub_rows(rows, severity=severity, scan_id=scan_id, origin=origin)
         total = len(rows) if include_total else None
         if sort != "ordinal":

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -71,7 +71,7 @@ _CIS_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
 )
 
 _INVENTORY_PROVIDERS = ("aws", "azure", "gcp")
-_CIS_PROVIDERS = ("aws", "azure", "gcp")
+_CIS_PROVIDERS = ("aws", "azure", "gcp", "snowflake")
 _REGION_RE = re.compile(r"[a-z]{2}(-gov)?-[a-z]+-\d{1,2}")
 _PROFILE_RE = re.compile(r"[a-zA-Z0-9._-]{1,100}")
 # Audit-field allowlists. IAM action identifiers (AWS ``svc:Action``, GCP
@@ -280,6 +280,17 @@ async def cloud_cis_benchmark(
                 from agent_bom.cloud.azure_cis_benchmark import run_benchmark as run_azure_cis
 
                 report = run_azure_cis(subscription_id=subscription_id.strip() or None, checks=check_list)
+            elif requested == "snowflake":
+                from agent_bom.cloud.snowflake_cis_benchmark import run_benchmark as run_snowflake_cis
+
+                # Snowflake has no region/profile/subscription/project scoping; its
+                # account/user/authenticator come from the standard read-only env
+                # credentials (SNOWFLAKE_ACCOUNT/USER + key-pair/SSO), mirroring how
+                # the CLI/MCP snowflake CIS path resolves them. When the connector or
+                # credentials are absent, run_benchmark raises CloudDiscoveryError and
+                # the handler below degrades to the same HTTP-200 "unavailable" shape
+                # as the other providers — never a 500.
+                report = run_snowflake_cis(checks=check_list)
             else:  # gcp
                 from agent_bom.cloud.gcp_cis_benchmark import run_benchmark as run_gcp_cis
 
@@ -297,6 +308,8 @@ async def cloud_cis_benchmark(
                 provider_label = "azure"
             elif requested == "gcp":
                 provider_label = "gcp"
+            elif requested == "snowflake":
+                provider_label = "snowflake"
             else:
                 provider_label = "unknown"
             _logger.warning("Cloud CIS benchmark unavailable for %s", provider_label)

--- a/tests/api/test_api_cloud_surface_parity.py
+++ b/tests/api/test_api_cloud_surface_parity.py
@@ -136,6 +136,29 @@ def test_cloud_cis_unknown_provider_404() -> None:
     assert resp.status_code == 404
 
 
+def test_cloud_cis_snowflake_is_wired_not_404() -> None:
+    # Snowflake CIS is a real benchmark (snowflake_cis_benchmark.run_benchmark);
+    # it must not 404 like an unknown provider. Without the snowflake connector /
+    # credentials in the test env it degrades to the shared "unavailable"
+    # envelope (HTTP 200), exactly like the other providers — never 404, never 500.
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/snowflake/cis-benchmark", headers=_proxy_headers())
+    assert resp.status_code == 200
+    body = resp.json()
+    if "error" in body:
+        assert body["status"] == "unavailable"
+        assert body["provider"] == "snowflake"
+    else:
+        assert body["audit_metadata"]["read_only"] is True
+        assert "checks" in body or "summary" in body
+
+
+def test_cloud_cis_snowflake_rejects_underprivileged_role() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/snowflake/cis-benchmark", headers=_proxy_headers(role="viewer"))
+    assert resp.status_code == 403
+
+
 def test_cloud_cis_bad_region_400() -> None:
     client = TestClient(app)
     resp = client.get("/v1/cloud/aws/cis-benchmark?region=BAD", headers=_proxy_headers())

--- a/tests/test_compliance_hub_store_pagination.py
+++ b/tests/test_compliance_hub_store_pagination.py
@@ -362,3 +362,38 @@ def test_sqlite_list_page_limit1_stays_fast_at_1m(tmp_path) -> None:
     # Generous ceiling — this guards against a catastrophic regression (filesort /
     # full-scan), not a tight latency SLA, so it stays green under CI load.
     assert elapsed < 2.0, f"limit=1 index read took {elapsed:.3f}s at {target} rows"
+
+
+def test_in_memory_sort_ceiling_warns_once_per_tenant(monkeypatch, caplog) -> None:
+    """The in-memory backend re-sorts the whole tenant per read; above the ceiling
+    it warns (once per tenant) instead of degrading silently. Results are unchanged."""
+    from agent_bom.api import compliance_hub_store as hub
+
+    monkeypatch.setattr(hub, "IN_MEMORY_SORT_CEILING", 3)
+    store = InMemoryComplianceHubStore()
+    tenant = "tenant-ceiling"
+    store.add(tenant, [_finding(i) for i in range(5)])  # 5 rows > ceiling 3
+
+    with caplog.at_level("WARNING", logger="agent_bom.api.compliance_hub_store"):
+        rows1, total = store.list_page(tenant, limit=2, sort="effective_reach")
+        store.list_page(tenant, limit=2, sort="effective_reach")  # second read
+
+    # Behaviour is unchanged — still a correctly bounded page.
+    assert len(rows1) == 2
+    assert total == 5
+    warnings = [r for r in caplog.records if r.levelname == "WARNING" and "sorting" in r.getMessage()]
+    assert len(warnings) == 1  # once per tenant, not once per read
+
+
+def test_in_memory_sort_ceiling_silent_below_ceiling(monkeypatch, caplog) -> None:
+    from agent_bom.api import compliance_hub_store as hub
+
+    monkeypatch.setattr(hub, "IN_MEMORY_SORT_CEILING", 100)
+    store = InMemoryComplianceHubStore()
+    tenant = "tenant-small"
+    store.add(tenant, [_finding(i) for i in range(5)])
+
+    with caplog.at_level("WARNING", logger="agent_bom.api.compliance_hub_store"):
+        store.list_page(tenant, limit=2, sort="effective_reach")
+
+    assert not [r for r in caplog.records if "sorting" in r.getMessage()]


### PR DESCRIPTION
## Summary
Two safe, self-contained items from the audit backlog #3967:

- **Snowflake CIS benchmark over REST** — `GET /v1/cloud/snowflake/cis-benchmark` returned **404** even though `snowflake_cis_benchmark.run_benchmark` is a real backend and the CLI/MCP already expose `cis-benchmark --provider snowflake`. Added `snowflake` to the REST CIS provider set with its own dispatch branch (env-resolved account/user, no region/profile scoping) and provider label. When the connector/credentials are absent, `run_benchmark` raises `CloudDiscoveryError` and the route degrades to the same **HTTP-200 `unavailable`** envelope AWS/Azure/GCP use — never 404, never 500. Brings REST to parity with CLI/MCP.
- **Guard the in-memory compliance-hub sort ceiling** — `InMemoryComplianceHubStore` copies and re-sorts a tenant's entire row list on every paged read (O(n log n) per request, independent of page size). Fine for the demo/single-node backend it's scoped to; it degrades on a large tenant. Above a documented `IN_MEMORY_SORT_CEILING` it now logs a **one-time-per-tenant** warning steering operators to the SQLite/Postgres backend (which sort in the query plan) instead of degrading silently. No change to results.

## Related Issues
Addresses #3967 (Snowflake CIS 404 + in-memory sort ceiling). The two remaining items in that grouped backlog are **not** in this PR and are tracked in a comment on the issue: the Snowflake **inventory** half needs a net-new discovery backend, and the exec-score saturation item is a scoring-model change that overlaps the in-flight exec/overview work in #3974 — so this PR does not auto-close #3967.

## Test plan
- [x] `ruff check` clean; `ruff format` clean on all changed lines (only unrelated pre-existing lines differ under local ruff 0.15.8 vs CI 0.15.21)
- [x] `mypy` clean on changed source files
- [x] No API route/Pydantic-model change: `{provider}` stays a plain path string with no new query params, so the generated OpenAPI spec is byte-identical — no regeneration needed
- [ ] `pytest tests/ -x -q` — **could not run in this sandbox** (PyPI egress is blocked 403 and the app's runtime deps, e.g. `rich`/`pydantic`, are not in the local cache, so the venv can't be built). Tests were written against the existing `test_api_cloud_surface_parity` and `test_compliance_hub_store_pagination` patterns and reviewed by hand.

### Tests added
- `test_api_cloud_surface_parity.py`: `/v1/cloud/snowflake/cis-benchmark` is wired (200 + `unavailable` envelope when the connector is absent), not 404; still enforces the read role (403 for `viewer`).
- `test_compliance_hub_store_pagination.py`: sort-ceiling guard warns once per tenant above the ceiling and stays silent below it, with paged results unchanged.

## Breaking changes
- [x] None. Snowflake CIS moves from 404 → a real/unavailable response; the sort-ceiling change is a log-only guard with no result change.

## Checklist
- [x] No secrets, credentials, or PII in diff (Snowflake creds are env/reference-only, never stored or logged)
- [x] Backend, API, docs (CHANGELOG), and tests aligned
- [x] Security review: read-only benchmark, role-gated route unchanged, degrade-to-`unavailable` avoids exception/stack exposure

## Exceptions
- None

---
_Generated by [Claude Code](https://claude.ai/code/session_013i7mYYrrizpz1DVJCiNGu3)_