### PR TITLE
fix(release): combine Snowflake CIS guard and compact navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **Snowflake CIS benchmark reachable over REST** (#3967): `GET /v1/cloud/snowflake/cis-benchmark` no longer 404s — it runs the real `snowflake_cis_benchmark` and, when the connector/credentials are absent, degrades to the shared HTTP-200 `unavailable` envelope like AWS/Azure/GCP, bringing the REST surface to parity with the CLI/MCP `cis-benchmark --provider snowflake`.
+- **In-memory compliance-hub sort ceiling guarded** (#3967): the process-local demo backend re-sorts a tenant's whole row list per paged read; past a documented ceiling it now warns once per tenant (steering operators to the SQLite/Postgres backend) instead of degrading silently. No behavior change to results.
+
 ## [0.95.0] - 2026-07-13
 
 Enterprise auth, cloud-connect, and interop release: browser OIDC SSO, actionable cloud connections, compliance honesty, refreshed dashboard/branding, and a large security-hardening batch on top of 0.94.2.

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -21,6 +21,7 @@ with ``ingested_at`` so future expiry / TTL work has a key.
 
 from __future__ import annotations
 
+import logging
 import sqlite3
 import threading
 from collections.abc import Callable, Iterable, Sequence
@@ -50,8 +51,18 @@ from agent_bom.api.hub_reference_store import (
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.graph.severity import severity_policy_rank
 
+_logger = logging.getLogger(__name__)
+
 # Chunk size for reconcile UPDATE … IN (…) to stay under SQLite/Postgres bind limits.
 RECONCILE_ABSENT_CHUNK = 500
+
+# Row-count ceiling for the process-local InMemoryComplianceHubStore. Its paged
+# read copies + re-sorts a tenant's entire row list on every request (O(n log n)
+# per read, independent of page size) — fine for the demo/single-node backend it
+# is scoped to, but it degrades on a large tenant. Above this ceiling we emit a
+# one-time-per-tenant warning steering operators to a SQL backend (SQLite /
+# Postgres), which sort in the query plan instead of in Python.
+IN_MEMORY_SORT_CEILING = 50_000
 
 # Defined here (module scope) so ``list`` resolves to the builtin: the store
 # classes below define a ``list`` method that would otherwise shadow it in
@@ -640,10 +651,20 @@ def _migrate_lifecycle_observations_l2_sqlite(conn: sqlite3.Connection) -> None:
 
 
 class InMemoryComplianceHubStore:
-    """Process-local store. Ephemeral; tests + single-node demos only."""
+    """Process-local store. Ephemeral; tests + single-node demos only.
+
+    Scale ceiling: reads copy + re-sort a tenant's whole row list per request
+    (see ``IN_MEMORY_SORT_CEILING``). This backend is intentionally the demo /
+    single-node path; production deployments use the SQLite or Postgres backend,
+    which sort in the query plan. A tenant that grows past the ceiling logs a
+    one-time warning rather than silently degrading.
+    """
 
     def __init__(self) -> None:
         self._by_tenant: dict[str, list[dict[str, Any]]] = {}
+        # Tenants already warned about crossing IN_MEMORY_SORT_CEILING, so the
+        # guard logs once per tenant instead of on every paged read.
+        self._sort_ceiling_warned: set[str] = set()
         # Maps finding_id -> ingest-order slot so a resend of the same
         # (tenant_id, finding_id) refreshes its row in place instead of
         # appending a duplicate (idempotent ingest, mirrors the SQL backends).
@@ -681,6 +702,25 @@ class InMemoryComplianceHubStore:
             rows = list(self._by_tenant.get(tenant_id, []))
         return hydrate_finding_payloads_memory(tenant_id, rows)
 
+    def _guard_sort_ceiling(self, tenant_id: str, row_count: int) -> None:
+        """Warn once per tenant when the whole-tenant re-sort ceiling is crossed.
+
+        The in-memory backend re-sorts a tenant's entire row list on every paged
+        read. Past ``IN_MEMORY_SORT_CEILING`` that is a real per-request cost;
+        surface it (once per tenant) instead of degrading silently — a SQL
+        backend sorts in the query plan and should be used at that scale.
+        """
+        if row_count <= IN_MEMORY_SORT_CEILING or tenant_id in self._sort_ceiling_warned:
+            return
+        self._sort_ceiling_warned.add(tenant_id)
+        _logger.warning(
+            "InMemoryComplianceHubStore is sorting %d rows per read (ceiling %d); "
+            "this demo/single-node backend re-sorts the whole tenant per request — "
+            "use the SQLite or Postgres backend at this scale.",
+            row_count,
+            IN_MEMORY_SORT_CEILING,
+        )
+
     def list_page(
         self,
         tenant_id: str,
@@ -695,6 +735,7 @@ class InMemoryComplianceHubStore:
     ) -> FindingPage:
         with self._lock:
             rows = list(self._by_tenant.get(tenant_id, []))
+        self._guard_sort_ceiling(tenant_id, len(rows))
         rows = _filter_hub_rows(rows, severity=severity, scan_id=scan_id, origin=origin)
         total = len(rows) if include_total else None
         if sort != "ordinal":

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -71,7 +71,7 @@ _CIS_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
 )
 
 _INVENTORY_PROVIDERS = ("aws", "azure", "gcp")
-_CIS_PROVIDERS = ("aws", "azure", "gcp")
+_CIS_PROVIDERS = ("aws", "azure", "gcp", "snowflake")
 _REGION_RE = re.compile(r"[a-z]{2}(-gov)?-[a-z]+-\d{1,2}")
 _PROFILE_RE = re.compile(r"[a-zA-Z0-9._-]{1,100}")
 # Audit-field allowlists. IAM action identifiers (AWS ``svc:Action``, GCP
@@ -280,6 +280,17 @@ async def cloud_cis_benchmark(
                 from agent_bom.cloud.azure_cis_benchmark import run_benchmark as run_azure_cis
 
                 report = run_azure_cis(subscription_id=subscription_id.strip() or None, checks=check_list)
+            elif requested == "snowflake":
+                from agent_bom.cloud.snowflake_cis_benchmark import run_benchmark as run_snowflake_cis
+
+                # Snowflake has no region/profile/subscription/project scoping; its
+                # account/user/authenticator come from the standard read-only env
+                # credentials (SNOWFLAKE_ACCOUNT/USER + key-pair/SSO), mirroring how
+                # the CLI/MCP snowflake CIS path resolves them. When the connector or
+                # credentials are absent, run_benchmark raises CloudDiscoveryError and
+                # the handler below degrades to the same HTTP-200 "unavailable" shape
+                # as the other providers — never a 500.
+                report = run_snowflake_cis(checks=check_list)
             else:  # gcp
                 from agent_bom.cloud.gcp_cis_benchmark import run_benchmark as run_gcp_cis
 
@@ -297,6 +308,8 @@ async def cloud_cis_benchmark(
                 provider_label = "azure"
             elif requested == "gcp":
                 provider_label = "gcp"
+            elif requested == "snowflake":
+                provider_label = "snowflake"
             else:
                 provider_label = "unknown"
             _logger.warning("Cloud CIS benchmark unavailable for %s", provider_label)

--- a/tests/api/test_api_cloud_surface_parity.py
+++ b/tests/api/test_api_cloud_surface_parity.py
@@ -136,6 +136,29 @@ def test_cloud_cis_unknown_provider_404() -> None:
     assert resp.status_code == 404
 
 
+def test_cloud_cis_snowflake_is_wired_not_404() -> None:
+    # Snowflake CIS is a real benchmark (snowflake_cis_benchmark.run_benchmark);
+    # it must not 404 like an unknown provider. Without the snowflake connector /
+    # credentials in the test env it degrades to the shared "unavailable"
+    # envelope (HTTP 200), exactly like the other providers — never 404, never 500.
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/snowflake/cis-benchmark", headers=_proxy_headers())
+    assert resp.status_code == 200
+    body = resp.json()
+    if "error" in body:
+        assert body["status"] == "unavailable"
+        assert body["provider"] == "snowflake"
+    else:
+        assert body["audit_metadata"]["read_only"] is True
+        assert "checks" in body or "summary" in body
+
+
+def test_cloud_cis_snowflake_rejects_underprivileged_role() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/snowflake/cis-benchmark", headers=_proxy_headers(role="viewer"))
+    assert resp.status_code == 403
+
+
 def test_cloud_cis_bad_region_400() -> None:
     client = TestClient(app)
     resp = client.get("/v1/cloud/aws/cis-benchmark?region=BAD", headers=_proxy_headers())

--- a/tests/test_compliance_hub_store_pagination.py
+++ b/tests/test_compliance_hub_store_pagination.py
@@ -391,3 +391,38 @@ def test_sqlite_severity_breakdown_counts_empty_as_unknown(tmp_path: Any) -> Non
     counts = store.severity_breakdown("t1")
     assert counts["high"] == 1
     assert counts["unknown"] == 1
+
+
+def test_in_memory_sort_ceiling_warns_once_per_tenant(monkeypatch, caplog) -> None:
+    """The in-memory backend re-sorts the whole tenant per read; above the ceiling
+    it warns (once per tenant) instead of degrading silently. Results are unchanged."""
+    from agent_bom.api import compliance_hub_store as hub
+
+    monkeypatch.setattr(hub, "IN_MEMORY_SORT_CEILING", 3)
+    store = InMemoryComplianceHubStore()
+    tenant = "tenant-ceiling"
+    store.add(tenant, [_finding(i) for i in range(5)])  # 5 rows > ceiling 3
+
+    with caplog.at_level("WARNING", logger="agent_bom.api.compliance_hub_store"):
+        rows1, total = store.list_page(tenant, limit=2, sort="effective_reach")
+        store.list_page(tenant, limit=2, sort="effective_reach")  # second read
+
+    # Behaviour is unchanged — still a correctly bounded page.
+    assert len(rows1) == 2
+    assert total == 5
+    warnings = [r for r in caplog.records if r.levelname == "WARNING" and "sorting" in r.getMessage()]
+    assert len(warnings) == 1  # once per tenant, not once per read
+
+
+def test_in_memory_sort_ceiling_silent_below_ceiling(monkeypatch, caplog) -> None:
+    from agent_bom.api import compliance_hub_store as hub
+
+    monkeypatch.setattr(hub, "IN_MEMORY_SORT_CEILING", 100)
+    store = InMemoryComplianceHubStore()
+    tenant = "tenant-small"
+    store.add(tenant, [_finding(i) for i in range(5)])
+
+    with caplog.at_level("WARNING", logger="agent_bom.api.compliance_hub_store"):
+        store.list_page(tenant, limit=2, sort="effective_reach")
+
+    assert not [r for r in caplog.records if "sorting" in r.getMessage()]

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -24,6 +24,7 @@ import {
   PanelLeft,
   Search,
   LayoutGrid,
+  LayoutDashboard,
   Wrench,
   RefreshCw,
   Focus,
@@ -38,6 +39,12 @@ import {
   ClipboardList,
   FileCheck,
   Layers,
+  Gauge,
+  Cpu,
+  Scale,
+  Library,
+  Cog,
+  ListChecks,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { useAuthState } from "@/components/auth-provider";
@@ -107,9 +114,9 @@ function activeGroupForPath(path: string | null): string {
 const NAV_GROUPS: NavGroup[] = [
   {
     label: "Posture",
-    icon: LayoutGrid,
+    icon: Gauge,
     links: [
-      { href: "/", label: "Overview", icon: LayoutGrid },
+      { href: "/", label: "Overview", icon: LayoutDashboard },
       { href: "/findings", label: "Findings", icon: Bug },
       { href: "/security-graph", label: "Security Graph", icon: Network },
       { href: "/remediation", label: "Remediation", icon: Wrench },
@@ -122,7 +129,7 @@ const NAV_GROUPS: NavGroup[] = [
   },
   {
     label: "AI inventory",
-    icon: Bot,
+    icon: LayoutGrid,
     links: [
       { href: "/agents", label: "Agents", icon: Bot },
       { href: "/manifest", label: "AI BOM", icon: ClipboardList },
@@ -142,7 +149,7 @@ const NAV_GROUPS: NavGroup[] = [
   },
   {
     label: "Runtime",
-    icon: Shield,
+    icon: Cpu,
     links: [
       { href: "/runtime", label: "Runtime", icon: Shield },
       { href: "/traces", label: "Traces", icon: Radio },
@@ -150,22 +157,22 @@ const NAV_GROUPS: NavGroup[] = [
   },
   {
     label: "Governance",
-    icon: Eye,
+    icon: Scale,
     links: [
       { href: "/compliance", label: "Compliance", icon: FileCheck },
-      { href: "/findings?lens=trust", label: "Findings triage", icon: Bug },
+      { href: "/findings?lens=trust", label: "Findings triage", icon: ListChecks },
       { href: "/governance", label: "Governance", icon: Eye, capability: "policy.manage" },
       { href: "/audit", label: "Audit Log", icon: FileText },
     ],
   },
   {
     label: "Reference",
-    icon: Boxes,
+    icon: Library,
     links: [{ href: "/registry", label: "MCP Catalog", icon: Boxes }],
   },
   {
     label: "Operations",
-    icon: Activity,
+    icon: Cog,
     links: [
       { href: "/cost", label: "AI Spend", icon: DollarSign },
       { href: "/jobs", label: "Scan Jobs", icon: Clock },
@@ -493,7 +500,7 @@ export function Nav() {
       )}
 
       {/* Navigation Groups */}
-      <nav className={`${isCollapsed ? "overflow-visible" : "overflow-y-auto scrollbar-thin"} flex-1 px-2 py-2 space-y-2`}>
+      <nav className={`${isCollapsed ? "overflow-visible px-1.5" : "overflow-y-auto scrollbar-thin px-2"} flex-1 py-2 space-y-1.5`}>
         {navGroups.map((group) => {
           const isExpanded = expandedGroups.has(group.label);
           const GroupIcon = group.icon;
@@ -524,8 +531,8 @@ export function Nav() {
                 onMouseLeave={isCollapsed ? scheduleCollapsedFlyoutClose : undefined}
                 onFocus={isCollapsed ? (event) => openCollapsedFlyout(group.label, event.currentTarget) : undefined}
                 onBlur={isCollapsed ? scheduleCollapsedFlyoutClose : undefined}
-                className={`w-full flex items-center gap-2 px-2.5 py-2 rounded-xl text-xs font-medium transition-colors border-l-2 ${
-                  isCollapsed ? "justify-center px-2 py-3" : ""
+                className={`w-full flex items-center gap-2 px-2.5 py-2 rounded-lg text-xs font-medium transition-colors border-l-2 ${
+                  isCollapsed ? "justify-center px-0 py-2" : ""
                 } ${
                   hasActiveChild
                     ? "border-[color:var(--border-strong)] text-[color:var(--foreground)] bg-[color:var(--surface-elevated)]"
@@ -535,7 +542,7 @@ export function Nav() {
                 aria-label={isCollapsed ? group.label : undefined}
               >
                 <GroupIcon
-                  className={`${isCollapsed ? "h-5 w-5" : "h-4 w-4"} shrink-0 ${navGroupIconClass(group.label, hasActiveChild)}`}
+                  className={`${isCollapsed ? "h-[18px] w-[18px]" : "h-4 w-4"} shrink-0 ${navGroupIconClass(group.label, hasActiveChild)}`}
                 />
                 {!isCollapsed && (
                   <>
@@ -658,25 +665,25 @@ export function Nav() {
 
               {isCollapsed && collapsedFlyoutGroup === group.label && (
                 <div
-                  className="fixed left-[52px] z-[70] w-[340px] pl-4"
+                  className="fixed left-[52px] z-[70] w-[288px] pl-3"
                   style={{ top: collapsedFlyoutTop }}
                   onMouseEnter={cancelCollapsedFlyoutClose}
                   onMouseLeave={scheduleCollapsedFlyoutClose}
                   onFocus={cancelCollapsedFlyoutClose}
                   onBlur={scheduleCollapsedFlyoutClose}
                 >
-                  <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3 shadow-2xl shadow-black/45">
-                    <div className="mb-3 flex items-start gap-3">
-                      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)]">
-                        <GroupIcon className={`h-5 w-5 ${navGroupIconClass(group.label, hasActiveChild)}`} />
+                  <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-2.5 shadow-2xl shadow-black/45">
+                    <div className="mb-2 flex items-center gap-2.5">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)]">
+                        <GroupIcon className={`h-[18px] w-[18px] ${navGroupIconClass(group.label, hasActiveChild)}`} />
                       </div>
                       <div className="min-w-0">
-                        <p className="text-[11px] font-semibold uppercase tracking-[0.28em] text-[color:var(--foreground)]">
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-[color:var(--foreground)]">
                           {group.label}
                         </p>
                       </div>
                     </div>
-                    <div className="space-y-1">
+                    <div className="space-y-0.5">
                       {group.visibleLinks.map(({ href, label, icon: Icon }) => {
                         const hrefPath = href.split("?")[0] ?? href;
                         const active =
@@ -689,7 +696,7 @@ export function Nav() {
                           <Link
                             key={href}
                             href={href}
-                            className={`group/link flex items-start gap-3 rounded-xl px-3 py-2.5 transition-colors ${
+                            className={`group/link flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 transition-colors ${
                               active
                                 ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
                                 : "text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--foreground)]"
@@ -697,16 +704,16 @@ export function Nav() {
                             onClick={() => setCollapsedFlyoutGroup(null)}
                           >
                             <Icon
-                              className={`mt-0.5 h-4 w-4 shrink-0 ${navLinkIconClass(hrefPath, active, "group/link")}`}
+                              className={`h-4 w-4 shrink-0 ${navLinkIconClass(hrefPath, active, "group/link")}`}
                             />
                             <span className="min-w-0">
-                              <span className="block text-sm font-medium">{label}</span>
+                              <span className="block text-[13px] font-medium">{label}</span>
                             </span>
                           </Link>
                         );
                       })}
                       {group.secondaryLinks.length > 0 && (
-                        <p className="mt-3 px-3 text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                        <p className="mt-2 px-2.5 pb-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
                           Graph lenses
                         </p>
                       )}
@@ -716,7 +723,7 @@ export function Nav() {
                           <Link
                             key={href}
                             href={href}
-                            className={`group/link flex items-start gap-3 rounded-xl px-3 py-2 transition-colors ${
+                            className={`group/link flex items-center gap-2.5 rounded-lg px-2.5 py-1.5 transition-colors ${
                               active
                                 ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
                                 : "text-[color:var(--text-tertiary)] hover:bg-[color:var(--surface-muted)] hover:text-[color:var(--foreground)]"
@@ -724,7 +731,7 @@ export function Nav() {
                             onClick={() => setCollapsedFlyoutGroup(null)}
                           >
                             <Icon
-                              className={`mt-0.5 h-4 w-4 shrink-0 ${navLinkIconClass(href, active, "group/link")}`}
+                              className={`h-4 w-4 shrink-0 ${navLinkIconClass(href, active, "group/link")}`}
                             />
                             <span className="min-w-0">
                               <span className="block text-[13px]">{label}</span>
@@ -734,7 +741,7 @@ export function Nav() {
                       })}
                     </div>
                     {group.hiddenLinks.length > 0 && (
-                      <p className="mt-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-[11px] text-[color:var(--text-tertiary)]">
+                      <p className="mt-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1.5 text-[11px] text-[color:var(--text-tertiary)]">
                         {group.hiddenLinks.length} page{group.hiddenLinks.length === 1 ? "" : "s"} hidden for{" "}
                         {deploymentModeLabel(counts?.deployment_mode)} mode.
                       </p>
@@ -811,7 +818,7 @@ export function Nav() {
       {/* Desktop Sidebar */}
       <aside
         className={`hidden lg:flex flex-col fixed left-0 top-16 bottom-0 z-40 bg-[color:var(--surface)] border-r border-[color:var(--border-subtle)] transition-[width] duration-200 ${
-          collapsed ? "w-[60px]" : "w-[240px]"
+          collapsed ? "w-[52px]" : "w-[240px]"
         }`}
       >
         {renderSidebarContent(collapsed, true)}
@@ -911,7 +918,7 @@ function SessionStatus({
 }) {
   if (collapsed) {
     if (loading) {
-      return <div className="mx-auto h-2 w-2 rounded-full bg-zinc-500 animate-pulse" title="Checking session" />;
+      return <div className="mx-auto h-2 w-2 rounded-full bg-[color:var(--text-tertiary)] animate-pulse" title="Checking session" />;
     }
     if (session?.authenticated) {
       return (
@@ -988,7 +995,7 @@ function ApiStatus({ collapsed }: { collapsed: boolean }) {
       ? "bg-emerald-500"
       : status === "offline"
       ? "bg-red-500"
-      : "bg-zinc-500 animate-pulse";
+      : "bg-[color:var(--text-tertiary)] animate-pulse";
 
   if (collapsed) {
     return (

--- a/ui/components/sidebar-layout.tsx
+++ b/ui/components/sidebar-layout.tsx
@@ -36,5 +36,5 @@ export function useSidebarLayout(): SidebarLayoutValue {
 
 /** Desktop sidebar is fixed; padding reserves the same width so content never sits underneath. */
 export function mainContentPaddingClass(collapsed: boolean): string {
-  return collapsed ? "lg:pl-[60px]" : "lg:pl-[240px]";
+  return collapsed ? "lg:pl-[52px]" : "lg:pl-[240px]";
 }

--- a/ui/tests/sidebar-layout.test.tsx
+++ b/ui/tests/sidebar-layout.test.tsx
@@ -4,7 +4,7 @@ import { mainContentPaddingClass } from "@/components/sidebar-layout";
 
 describe("mainContentPaddingClass", () => {
   it("reserves the rail width when collapsed and the full sidebar when expanded", () => {
-    expect(mainContentPaddingClass(true)).toBe("lg:pl-[60px]");
+    expect(mainContentPaddingClass(true)).toBe("lg:pl-[52px]");
     expect(mainContentPaddingClass(false)).toBe("lg:pl-[240px]");
   });
 });


### PR DESCRIPTION
## Summary

- expose the existing Snowflake CIS benchmark through the role-gated REST cloud route with the standard unavailable envelope
- warn once per tenant when the demo in-memory compliance store exceeds its documented sort ceiling
- compact the dashboard navigation rail and flyouts while keeping section icons distinct and semantic
- supersede #3979 and #3977 while retaining their changes as separate commits

## Verification

- `make preflight`
- `uv run ruff check src/agent_bom/api/compliance_hub_store.py src/agent_bom/api/routes/cloud.py tests/api/test_api_cloud_surface_parity.py tests/test_compliance_hub_store_pagination.py`
- `uv run pytest -q tests/api/test_api_cloud_surface_parity.py tests/test_compliance_hub_store_pagination.py` (61 passed)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run verify:toolchain`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm ci` (0 vulnerabilities)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm run typecheck`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm test -- --run tests/sidebar-layout.test.tsx` (1 passed)
- `git diff --check origin/main...HEAD`

## Notes

The test-file conflict with current main was resolved by retaining both the existing severity-breakdown coverage and the new in-memory sort-ceiling regressions. The cloud/API and UI changes remain separate signed commits for auditability.