### PR TITLE
fix(compliance-hub): guard Postgres PK migration so cold start no-ops at scale

### DIFF
--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -356,14 +356,37 @@ class PostgresComplianceHubStore:
 
     @staticmethod
     def _migrate_primary_key(conn: Any) -> None:
-        """Collapse the primary key to ``(tenant_id, finding_id)`` (idempotent).
+        """Collapse the primary key to ``(tenant_id, finding_id)`` (true no-op once done).
 
         Pre-idempotency deployments keyed on ``(tenant_id, finding_id, ordinal)``
         so every resend of the same finding appended a fresh row. Dedup existing
-        duplicates (keep the lowest ordinal), then swap the primary key. Guarded
-        so it is a no-op once the collapsed key is in place.
+        duplicates (keep the lowest ordinal), then swap the primary key.
+
+        The dedup DELETE is a full-table self-join — O(n^2)-class on a large
+        table — so we must never run it on an already-migrated store. Probe
+        ``pg_constraint`` first and return early when the collapsed key is
+        already in place: no DELETE, no DDL. Only a genuinely old-shape (or
+        missing) primary key triggers the dedup + constraint swap. Without this
+        guard the self-join ran on every store init and blew the default 15s
+        ``statement_timeout`` at scale, so init 500'd on every request (#3980).
         """
-        # Drop duplicates ahead of the unique key, keeping the original ingest.
+        pk_row = conn.execute(
+            """
+            SELECT string_agg(a.attname, ',' ORDER BY array_position(c.conkey, a.attnum))
+              FROM pg_constraint c
+              JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+             WHERE c.conrelid = 'compliance_hub_findings'::regclass
+               AND c.contype = 'p'
+            """
+        ).fetchone()
+        pk_cols = pk_row[0] if pk_row else None
+        if pk_cols == "tenant_id,finding_id":
+            # Already collapsed — skip the dedup DELETE + DDL entirely so an
+            # already-migrated (possibly very large) table pays nothing at
+            # init and cannot exceed statement_timeout (#3980).
+            return
+        # Old-shape or missing primary key: drop duplicates ahead of the unique
+        # key, keeping the original ingest, then swap the primary key.
         conn.execute(
             """
             DELETE FROM compliance_hub_findings a

--- a/tests/test_postgres_compliance_hub_migration.py
+++ b/tests/test_postgres_compliance_hub_migration.py
@@ -1,0 +1,86 @@
+"""Regression tests for the Postgres Compliance Hub primary-key migration.
+
+The dedup DELETE in ``_migrate_primary_key`` is a full-table self-join that,
+on a large already-migrated table, exceeded the default 15s statement_timeout
+and 500'd every store init (#3980). These tests pin the fix: the migration is a
+true no-op (no DELETE, no DDL) once the collapsed ``(tenant_id, finding_id)``
+primary key is in place, and still dedups + swaps the key on an old-shape or
+missing primary key. They use a connection spy so they run without a live
+Postgres (the store's own tests mock psycopg for the same reason).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from agent_bom.api.postgres_compliance_hub import PostgresComplianceHubStore
+
+
+@dataclass
+class _FakeCursor:
+    row: tuple[Any, ...] | None = None
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self.row
+
+
+@dataclass
+class _ConnSpy:
+    """Records executed SQL and answers the pkey-shape probe with ``pk_cols``."""
+
+    pk_cols: str | None
+    executed: list[str] = field(default_factory=list)
+
+    def execute(self, sql: str, params: tuple | None = None) -> _FakeCursor:
+        self.executed.append(sql)
+        normalized = " ".join(sql.split()).lower()
+        if "from pg_constraint" in normalized and "string_agg" in normalized:
+            return _FakeCursor(row=(self.pk_cols,))
+        return _FakeCursor()
+
+    def _statements(self) -> list[str]:
+        return [" ".join(s.split()).lower() for s in self.executed]
+
+    def _issued_delete(self) -> bool:
+        return any(s.startswith("delete from compliance_hub_findings a") for s in self._statements())
+
+    def _issued_pk_ddl(self) -> bool:
+        return any("add constraint compliance_hub_findings_pkey" in s for s in self._statements())
+
+    def _issued_probe(self) -> bool:
+        return any("from pg_constraint" in s and "string_agg" in s for s in self._statements())
+
+
+def test_migration_is_true_no_op_when_pk_already_collapsed():
+    """Already-migrated table: probe only, no dedup DELETE and no DDL (#3980)."""
+    conn = _ConnSpy(pk_cols="tenant_id,finding_id")
+
+    PostgresComplianceHubStore._migrate_primary_key(conn)
+
+    assert conn._issued_probe(), "expected the pkey-shape probe to run"
+    assert not conn._issued_delete(), "dedup self-join DELETE must not run when PK is already collapsed"
+    assert not conn._issued_pk_ddl(), "no constraint swap when PK is already collapsed"
+    # Probe is the only statement issued on the hot path.
+    assert len(conn.executed) == 1
+
+
+def test_migration_dedups_and_swaps_pk_on_old_shape():
+    """Legacy (tenant_id, finding_id, ordinal) key: dedup DELETE + constraint swap."""
+    conn = _ConnSpy(pk_cols="tenant_id,finding_id,ordinal")
+
+    PostgresComplianceHubStore._migrate_primary_key(conn)
+
+    assert conn._issued_probe()
+    assert conn._issued_delete(), "old-shape table must be deduped before the unique key"
+    assert conn._issued_pk_ddl(), "old-shape table must have the collapsed PK added"
+
+
+def test_migration_runs_when_primary_key_missing():
+    """No primary key at all: still dedup + add the collapsed key (safe fallback)."""
+    conn = _ConnSpy(pk_cols=None)
+
+    PostgresComplianceHubStore._migrate_primary_key(conn)
+
+    assert conn._issued_delete()
+    assert conn._issued_pk_ddl()


### PR DESCRIPTION
## Problem

`PostgresComplianceHubStore._migrate_primary_key(conn)` ran a full-table dedup **self-join `DELETE`** unconditionally on **every** store init:

```sql
DELETE FROM compliance_hub_findings a
USING compliance_hub_findings b
WHERE a.tenant_id = b.tenant_id AND a.finding_id = b.finding_id AND a.ordinal > b.ordinal
```

The PK-shape guard (the `DO $$ … IF NOT EXISTS(pg_constraint …) ADD CONSTRAINT`) ran **after** the delete, so the delete always executed even though the docstring claimed the migration was a guarded no-op. On a large, already-migrated table (~10M rows) the O(n^2)-class self-join exceeded the default 15s `statement_timeout`, so the store never initialised and every compliance-hub request 500'd (cold-start failure).

## Fix

Make the dedup conditional by probing the current primary-key shape **first**:

- Query `pg_constraint` for the table's primary-key columns.
- If the PK is already the collapsed `(tenant_id, finding_id)` shape → **return early: no `DELETE`, no DDL.** This is the hot path for every healthy/fresh table, so init pays only a cheap catalog lookup and can never blow the statement timeout.
- Only an **old-shape** (`tenant_id, finding_id, ordinal`) or **missing** primary key triggers the dedup `DELETE` + constraint swap, preserving the original migration for genuinely-unmigrated deployments. Safe on a fresh (empty) table, whose `CREATE TABLE` already declares the collapsed PK.

## Test (TDD, no live PG required)

`tests/test_postgres_compliance_hub_migration.py` uses a connection spy (same pattern as `test_postgres_rate_limit_store.py`) that records executed SQL and answers the pkey-shape probe:

- **`test_migration_is_true_no_op_when_pk_already_collapsed`** — asserts the migration issues **only the probe** (no `DELETE`, no `ADD CONSTRAINT`) when the PK is already `(tenant_id, finding_id)`. This fails against the pre-fix code, which always issued the `DELETE`.
- **`test_migration_dedups_and_swaps_pk_on_old_shape`** — legacy `(tenant_id, finding_id, ordinal)` key still gets deduped + the collapsed PK added.
- **`test_migration_runs_when_primary_key_missing`** — no PK at all still dedups + adds the key (safe fallback).

## Verification

- `pytest tests/test_postgres_compliance_hub_migration.py` → 3 passed
- `pytest tests/test_compliance_hub.py test_compliance_hub_store_pagination.py test_compliance_hub_ingest.py test_postgres_store.py` → 164 passed
- `ruff` + `mypy` clean on the touched module
- `make preflight` green
- No live Postgres available in this environment; robustness rests on the SQL-order connection-spy unit test.

Scope: only `src/agent_bom/api/postgres_compliance_hub.py` and its new test.

Closes #3980