### PR TITLE
fix(ui): auto-fit + node-size cap on selected exposure-path graph

### DIFF
--- a/ui/components/exposure-path-command-center.tsx
+++ b/ui/components/exposure-path-command-center.tsx
@@ -15,6 +15,8 @@ import {
   Wrench,
 } from "lucide-react";
 import { pathDisplayTitle, pathFixLabel, type ExposureEntityRole, type ExposurePath } from "@/lib/exposure-path";
+import { GRAPH_ROLE_STYLE } from "@/lib/exposure-path-graph-style";
+import { buildPathGraphLayout, wrapGraphText, truncateGraphText } from "@/lib/exposure-path-graph-layout";
 import { ExposurePathNeighborExplorer } from "@/components/exposure-path-neighbor-explorer";
 
 export interface ExposurePathCommandAction {
@@ -33,18 +35,6 @@ const ROLE_META: Record<ExposureEntityRole, { label: string; icon: LucideIcon; t
   environment: { label: "Environment", icon: Database, tint: "border-cyan-500/30 bg-cyan-500/10 text-cyan-200" },
   cluster: { label: "Cluster", icon: Database, tint: "border-indigo-500/30 bg-indigo-500/10 text-indigo-200" },
   unknown: { label: "Entity", icon: ShieldAlert, tint: "border-slate-500/30 bg-slate-500/10 text-slate-200" },
-};
-
-const GRAPH_ROLE_STYLE: Record<ExposureEntityRole, { fill: string; stroke: string; text: string; accent: string }> = {
-  agent: { fill: "#052e24", stroke: "#10b981", text: "#d1fae5", accent: "#34d399" },
-  server: { fill: "#082f49", stroke: "#0ea5e9", text: "#e0f2fe", accent: "#38bdf8" },
-  package: { fill: "#422006", stroke: "#f59e0b", text: "#fef3c7", accent: "#fbbf24" },
-  finding: { fill: "#450a0a", stroke: "#ef4444", text: "#fee2e2", accent: "#f87171" },
-  credential: { fill: "#3b0764", stroke: "#d946ef", text: "#fae8ff", accent: "#e879f9" },
-  tool: { fill: "#2e1065", stroke: "#a855f7", text: "#f3e8ff", accent: "#c084fc" },
-  environment: { fill: "#164e63", stroke: "#06b6d4", text: "#cffafe", accent: "#22d3ee" },
-  cluster: { fill: "#312e81", stroke: "#6366f1", text: "#e0e7ff", accent: "#818cf8" },
-  unknown: { fill: "#1e293b", stroke: "#64748b", text: "#f1f5f9", accent: "#94a3b8" },
 };
 
 export function ExposurePathCommandCenter({
@@ -201,12 +191,14 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
   const layout = buildPathGraphLayout(path);
 
   return (
-    <div className="overflow-x-auto p-2">
+    <div className="flex justify-center overflow-x-auto p-2">
       <svg
         viewBox={`0 0 ${layout.width} ${layout.height}`}
+        preserveAspectRatio="xMidYMid meet"
         role="img"
         aria-label={`Selected exposure path graph for ${pathDisplayTitle(path)}`}
-        className="block h-auto min-w-[720px] w-full md:min-w-0"
+        style={{ maxWidth: `${layout.fitWidth}px` }}
+        className="mx-auto block h-auto w-full"
       >
         <defs>
           <marker id="exposure-arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
@@ -252,7 +244,7 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
         {layout.nodes.map((node, index) => {
           const style = GRAPH_ROLE_STYLE[node.role] ?? GRAPH_ROLE_STYLE.unknown;
           const meta = ROLE_META[node.role] ?? ROLE_META.unknown;
-          const titleLines = wrapGraphText(node.label, 18, 2);
+          const titleLines = wrapGraphText(node.label, layout.labelChars, 2);
           return (
             <g key={`${node.id}-${index}`} transform={`translate(${node.x} ${node.y})`}>
               <rect
@@ -286,112 +278,6 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
       </svg>
     </div>
   );
-}
-
-function buildPathGraphLayout(path: ExposurePath) {
-  // Geometry note: nodes are spaced with a generous horizontal gap so the
-  // relationship pill sits centred in the clear channel between two node boxes
-  // — never overlapping a node or getting clipped at the container edge. The
-  // SVG scales to its container via viewBox, so a wider board just renders a
-  // little smaller; it never crowds the labels.
-  const nodeWidth = 188;
-  const nodeHeight = 76;
-  const marginX = 28;
-  const marginY = 30;
-  const columnGap = 132;
-  const rowGap = 116;
-  const columns = Math.min(4, Math.max(1, path.hops.length));
-  const rows = Math.max(1, Math.ceil(path.hops.length / columns));
-  const pitchX = nodeWidth + columnGap;
-  const width = marginX * 2 + columns * nodeWidth + (columns - 1) * columnGap;
-  const height = marginY * 2 + rows * nodeHeight + (rows - 1) * (rowGap - nodeHeight);
-  const nodes = path.hops.map((hop, index) => {
-    const row = Math.floor(index / columns);
-    const col = index % columns;
-    const visualCol = row % 2 === 0 ? col : columns - 1 - col;
-    return {
-      ...hop,
-      x: marginX + visualCol * pitchX,
-      y: marginY + row * rowGap,
-    };
-  });
-  const edges = nodes.slice(0, -1).map((source, index) => {
-    const target = nodes[index + 1]!;
-    const relationship = relationshipForPathStep(path, source.id, target.id, index);
-    const startX = source.x + nodeWidth;
-    const startY = source.y + nodeHeight / 2;
-    const endX = target.x;
-    const endY = target.y + nodeHeight / 2;
-    const sameRow = Math.abs(startY - endY) < 10;
-    const control = sameRow ? Math.max(40, Math.abs(endX - startX) / 2) : 56;
-    const pathD = sameRow
-      ? `M ${startX} ${startY} C ${startX + control} ${startY}, ${endX - control} ${endY}, ${endX} ${endY}`
-      : `M ${source.x + nodeWidth / 2} ${source.y + nodeHeight} C ${source.x + nodeWidth / 2} ${source.y + nodeHeight + control}, ${target.x + nodeWidth / 2} ${target.y - control}, ${target.x + nodeWidth / 2} ${target.y}`;
-    const style = GRAPH_ROLE_STYLE[target.role] ?? GRAPH_ROLE_STYLE.unknown;
-    return {
-      id: `${source.id}->${target.id}`,
-      path: pathD,
-      stroke: style.stroke,
-      label: truncateGraphText(relationship, 16),
-      // Centre the pill on the edge line, mid-channel between the two nodes.
-      labelX: sameRow ? (startX + endX) / 2 : source.x + nodeWidth / 2,
-      labelY: sameRow ? startY : (source.y + nodeHeight + target.y) / 2,
-    };
-  });
-  const relationshipLabels = edges.map((edge) => ({
-    id: `${edge.id}:label`,
-    text: edge.label,
-    x: edge.labelX,
-    y: edge.labelY,
-    width: Math.max(50, Math.round(edge.label.length * 6.6 + 22)),
-  }));
-
-  return { width, height, nodeWidth, nodeHeight, nodes, edges, relationshipLabels };
-}
-
-function relationshipForPathStep(path: ExposurePath, source: string, target: string, index: number): string {
-  const byEndpoints = path.relationships.find((relationship) => relationship.source === source && relationship.target === target);
-  const raw = byEndpoints?.relationship ?? path.relationships[index]?.relationship ?? "reaches";
-  return humanizeRelationship(raw);
-}
-
-function humanizeRelationship(value: string): string {
-  return value
-    .replace(/[_:]+/g, " ")
-    .trim()
-    .replace(/\b\w/g, (char) => char.toUpperCase());
-}
-
-function truncateGraphText(value: string, maxLength: number): string {
-  return value.length > maxLength ? `${value.slice(0, Math.max(1, maxLength - 1))}…` : value;
-}
-
-function wrapGraphText(value: string, maxLineLength: number, maxLines: number): string[] {
-  const normalized = value.replace(/\s+/g, " ").trim();
-  if (normalized.length <= maxLineLength) return [normalized];
-
-  const lines: string[] = [];
-  let remaining = normalized;
-  while (remaining.length > 0 && lines.length < maxLines) {
-    const isLastLine = lines.length === maxLines - 1;
-    if (remaining.length <= maxLineLength) {
-      lines.push(remaining);
-      break;
-    }
-    if (isLastLine) {
-      lines.push(truncateGraphText(remaining, maxLineLength));
-      break;
-    }
-
-    const window = remaining.slice(0, maxLineLength + 1);
-    const breakpoints = [" ", "-", "_", "/", ":", "@", "."].map((character) => window.lastIndexOf(character));
-    const breakpoint = Math.max(...breakpoints);
-    const cut = breakpoint >= Math.floor(maxLineLength * 0.45) ? breakpoint + 1 : maxLineLength;
-    lines.push(remaining.slice(0, cut).trim());
-    remaining = remaining.slice(cut).trim();
-  }
-
-  return lines.length > 0 ? lines : [truncateGraphText(normalized, maxLineLength)];
 }
 
 function EvidenceRow({

--- a/ui/lib/exposure-path-graph-layout.ts
+++ b/ui/lib/exposure-path-graph-layout.ts
@@ -1,0 +1,188 @@
+import type { ExposurePath } from "@/lib/exposure-path";
+import { GRAPH_ROLE_STYLE } from "@/lib/exposure-path-graph-style";
+
+// Node sizing. Few nodes render at the full design size (never larger — a
+// 2-node path must not balloon into two canvas-filling boxes). As the path
+// grows the boxes shrink toward a readable floor so the whole board stays
+// compact and no single node dominates the viewport.
+export const MAX_NODE_WIDTH = 188;
+export const MIN_NODE_WIDTH = 148;
+export const MAX_NODE_HEIGHT = 76;
+export const MIN_NODE_HEIGHT = 62;
+
+const MARGIN_X = 28;
+const MARGIN_Y = 30;
+const COLUMN_GAP = 132;
+const ROW_GAP_EXTRA = 40; // vertical clear channel between wrapped rows
+const MAX_COLUMNS = 4;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Node box size for a path of `count` hops. Interpolates from the full design
+ * size (<= 3 nodes) down to a readable floor (>= 9 nodes) so denser paths scale
+ * down instead of overflowing. Monotonically non-increasing in `count`.
+ */
+export function nodeSizeForCount(count: number): { width: number; height: number } {
+  const t = clamp((count - 3) / 6, 0, 1);
+  return {
+    width: Math.round(MAX_NODE_WIDTH - t * (MAX_NODE_WIDTH - MIN_NODE_WIDTH)),
+    height: Math.round(MAX_NODE_HEIGHT - t * (MAX_NODE_HEIGHT - MIN_NODE_HEIGHT)),
+  };
+}
+
+/** Characters per label line, scaled so text stays readable as nodes shrink. */
+export function labelCharsForWidth(nodeWidth: number): number {
+  return Math.max(12, Math.floor((nodeWidth - 28) / 8));
+}
+
+export type PathGraphNode = ExposurePath["hops"][number] & {
+  x: number;
+  y: number;
+};
+
+export interface PathGraphEdge {
+  id: string;
+  path: string;
+  stroke: string;
+  label: string;
+  labelX: number;
+  labelY: number;
+}
+
+export interface PathGraphLayout {
+  width: number;
+  height: number;
+  /**
+   * Natural (1x) CSS pixel width of the board. The SVG is capped at this width
+   * so a small graph renders compact and centred rather than being stretched to
+   * fill the canvas; larger boards still shrink-to-fit via `width: 100%`.
+   */
+  fitWidth: number;
+  nodeWidth: number;
+  nodeHeight: number;
+  labelChars: number;
+  nodes: PathGraphNode[];
+  edges: PathGraphEdge[];
+  relationshipLabels: { id: string; text: string; x: number; y: number; width: number }[];
+}
+
+export function buildPathGraphLayout(path: ExposurePath): PathGraphLayout {
+  const count = path.hops.length;
+  const { width: nodeWidth, height: nodeHeight } = nodeSizeForCount(count);
+  const columns = Math.min(MAX_COLUMNS, Math.max(1, count));
+  const pitchX = nodeWidth + COLUMN_GAP;
+  const rowGap = nodeHeight + ROW_GAP_EXTRA;
+
+  const nodes: PathGraphNode[] = path.hops.map((hop, index) => {
+    const row = Math.floor(index / columns);
+    const col = index % columns;
+    // Boustrophedon rows so a wrapped path reads left-to-right, then back.
+    const visualCol = row % 2 === 0 ? col : columns - 1 - col;
+    return {
+      ...hop,
+      x: MARGIN_X + visualCol * pitchX,
+      y: MARGIN_Y + row * rowGap,
+    };
+  });
+
+  // Auto-fit: the viewBox is the tight bounding box of every node plus a uniform
+  // margin, so the rendered graph always frames its own content — a 1-hop path
+  // is compact, a many-hop path scales down to fit, nothing overflows.
+  const maxX = nodes.reduce((acc, node) => Math.max(acc, node.x + nodeWidth), nodeWidth);
+  const maxY = nodes.reduce((acc, node) => Math.max(acc, node.y + nodeHeight), nodeHeight);
+  const width = maxX + MARGIN_X;
+  const height = maxY + MARGIN_Y;
+
+  const edges: PathGraphEdge[] = nodes.slice(0, -1).map((source, index) => {
+    const target = nodes[index + 1]!;
+    const relationship = relationshipForPathStep(path, source.id, target.id, index);
+    const startX = source.x + nodeWidth;
+    const startY = source.y + nodeHeight / 2;
+    const endX = target.x;
+    const endY = target.y + nodeHeight / 2;
+    const sameRow = Math.abs(startY - endY) < 10;
+    const control = sameRow ? Math.max(40, Math.abs(endX - startX) / 2) : 56;
+    const pathD = sameRow
+      ? `M ${startX} ${startY} C ${startX + control} ${startY}, ${endX - control} ${endY}, ${endX} ${endY}`
+      : `M ${source.x + nodeWidth / 2} ${source.y + nodeHeight} C ${source.x + nodeWidth / 2} ${source.y + nodeHeight + control}, ${target.x + nodeWidth / 2} ${target.y - control}, ${target.x + nodeWidth / 2} ${target.y}`;
+    const style = GRAPH_ROLE_STYLE[target.role] ?? GRAPH_ROLE_STYLE.unknown;
+    return {
+      id: `${source.id}->${target.id}`,
+      path: pathD,
+      stroke: style.stroke,
+      label: truncateGraphText(relationship, 16),
+      labelX: sameRow ? (startX + endX) / 2 : source.x + nodeWidth / 2,
+      labelY: sameRow ? startY : (source.y + nodeHeight + target.y) / 2,
+    };
+  });
+
+  const relationshipLabels = edges.map((edge) => ({
+    id: `${edge.id}:label`,
+    text: edge.label,
+    x: edge.labelX,
+    y: edge.labelY,
+    width: Math.max(50, Math.round(edge.label.length * 6.6 + 22)),
+  }));
+
+  return {
+    width,
+    height,
+    fitWidth: width,
+    nodeWidth,
+    nodeHeight,
+    labelChars: labelCharsForWidth(nodeWidth),
+    nodes,
+    edges,
+    relationshipLabels,
+  };
+}
+
+function relationshipForPathStep(path: ExposurePath, source: string, target: string, index: number): string {
+  const byEndpoints = path.relationships.find(
+    (relationship) => relationship.source === source && relationship.target === target,
+  );
+  const raw = byEndpoints?.relationship ?? path.relationships[index]?.relationship ?? "reaches";
+  return humanizeRelationship(raw);
+}
+
+export function humanizeRelationship(value: string): string {
+  return value
+    .replace(/[_:]+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function truncateGraphText(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, Math.max(1, maxLength - 1))}…` : value;
+}
+
+export function wrapGraphText(value: string, maxLineLength: number, maxLines: number): string[] {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLineLength) return [normalized];
+
+  const lines: string[] = [];
+  let remaining = normalized;
+  while (remaining.length > 0 && lines.length < maxLines) {
+    const isLastLine = lines.length === maxLines - 1;
+    if (remaining.length <= maxLineLength) {
+      lines.push(remaining);
+      break;
+    }
+    if (isLastLine) {
+      lines.push(truncateGraphText(remaining, maxLineLength));
+      break;
+    }
+
+    const window = remaining.slice(0, maxLineLength + 1);
+    const breakpoints = [" ", "-", "_", "/", ":", "@", "."].map((character) => window.lastIndexOf(character));
+    const breakpoint = Math.max(...breakpoints);
+    const cut = breakpoint >= Math.floor(maxLineLength * 0.45) ? breakpoint + 1 : maxLineLength;
+    lines.push(remaining.slice(0, cut).trim());
+    remaining = remaining.slice(cut).trim();
+  }
+
+  return lines.length > 0 ? lines : [truncateGraphText(normalized, maxLineLength)];
+}

--- a/ui/lib/exposure-path-graph-style.ts
+++ b/ui/lib/exposure-path-graph-style.ts
@@ -1,0 +1,20 @@
+import type { ExposureEntityRole } from "@/lib/exposure-path";
+
+export interface GraphRoleStyle {
+  fill: string;
+  stroke: string;
+  text: string;
+  accent: string;
+}
+
+export const GRAPH_ROLE_STYLE: Record<ExposureEntityRole, GraphRoleStyle> = {
+  agent: { fill: "#052e24", stroke: "#10b981", text: "#d1fae5", accent: "#34d399" },
+  server: { fill: "#082f49", stroke: "#0ea5e9", text: "#e0f2fe", accent: "#38bdf8" },
+  package: { fill: "#422006", stroke: "#f59e0b", text: "#fef3c7", accent: "#fbbf24" },
+  finding: { fill: "#450a0a", stroke: "#ef4444", text: "#fee2e2", accent: "#f87171" },
+  credential: { fill: "#3b0764", stroke: "#d946ef", text: "#fae8ff", accent: "#e879f9" },
+  tool: { fill: "#2e1065", stroke: "#a855f7", text: "#f3e8ff", accent: "#c084fc" },
+  environment: { fill: "#164e63", stroke: "#06b6d4", text: "#cffafe", accent: "#22d3ee" },
+  cluster: { fill: "#312e81", stroke: "#6366f1", text: "#e0e7ff", accent: "#818cf8" },
+  unknown: { fill: "#1e293b", stroke: "#64748b", text: "#f1f5f9", accent: "#94a3b8" },
+};

--- a/ui/tests/exposure-path-graph-layout.test.ts
+++ b/ui/tests/exposure-path-graph-layout.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExposureEntityRef, ExposurePath } from "@/lib/exposure-path";
+import {
+  MAX_NODE_HEIGHT,
+  MAX_NODE_WIDTH,
+  MIN_NODE_HEIGHT,
+  MIN_NODE_WIDTH,
+  buildPathGraphLayout,
+  labelCharsForWidth,
+  nodeSizeForCount,
+} from "@/lib/exposure-path-graph-layout";
+
+function makePath(nodeCount: number): ExposurePath {
+  const hops: ExposureEntityRef[] = Array.from({ length: nodeCount }, (_, index) => ({
+    id: `node:${index}`,
+    label: `entity-with-a-fairly-long-name-${index}`,
+    role: index === 0 ? "agent" : "package",
+  }));
+  return {
+    id: "path-test",
+    label: hops.map((hop) => hop.label).join(" -> "),
+    summary: "",
+    riskScore: 5,
+    severity: "high",
+    source: hops[0]!,
+    target: hops[hops.length - 1]!,
+    hops,
+    relationships: [],
+    nodeIds: hops.map((hop) => hop.id),
+    edgeIds: [],
+    findings: [],
+    affectedAgents: [],
+    affectedServers: [],
+    reachableTools: [],
+    exposedCredentials: [],
+  };
+}
+
+describe("nodeSizeForCount", () => {
+  it("renders few-node paths at full design size and never larger", () => {
+    for (const count of [1, 2, 3]) {
+      const size = nodeSizeForCount(count);
+      expect(size.width).toBe(MAX_NODE_WIDTH);
+      expect(size.height).toBe(MAX_NODE_HEIGHT);
+    }
+  });
+
+  it("shrinks node size monotonically as the path grows, down to a readable floor", () => {
+    const sizes = [2, 4, 6, 8, 10, 20].map((count) => nodeSizeForCount(count).width);
+    for (let i = 1; i < sizes.length; i += 1) {
+      expect(sizes[i]!).toBeLessThanOrEqual(sizes[i - 1]!);
+    }
+    const dense = nodeSizeForCount(20);
+    expect(dense.width).toBeGreaterThanOrEqual(MIN_NODE_WIDTH);
+    expect(dense.height).toBeGreaterThanOrEqual(MIN_NODE_HEIGHT);
+    // A large path must be strictly smaller than a tiny one.
+    expect(dense.width).toBeLessThan(MAX_NODE_WIDTH);
+  });
+});
+
+describe("labelCharsForWidth", () => {
+  it("keeps a readable minimum of characters even at the smallest node", () => {
+    expect(labelCharsForWidth(MIN_NODE_WIDTH)).toBeGreaterThanOrEqual(12);
+    expect(labelCharsForWidth(MAX_NODE_WIDTH)).toBeGreaterThan(labelCharsForWidth(MIN_NODE_WIDTH) - 1);
+  });
+});
+
+describe("buildPathGraphLayout auto-fit", () => {
+  it("frames a 2-node path compactly so nodes cannot fill the whole canvas", () => {
+    const layout = buildPathGraphLayout(makePath(2));
+    // Single row: viewBox height is just one node band plus margins.
+    expect(layout.height).toBeLessThan(layout.nodeHeight * 2);
+    // The board is capped at its natural width so it renders 1:1, not stretched.
+    expect(layout.fitWidth).toBe(layout.width);
+    // Each node is a minority of the board width — never half-a-canvas boxes.
+    expect(layout.nodeWidth / layout.width).toBeLessThan(0.4);
+  });
+
+  it("tightly bounds every node inside the viewBox with no overflow", () => {
+    for (const count of [1, 2, 3, 6, 10]) {
+      const layout = buildPathGraphLayout(makePath(count));
+      for (const node of layout.nodes) {
+        expect(node.x).toBeGreaterThanOrEqual(0);
+        expect(node.y).toBeGreaterThanOrEqual(0);
+        expect(node.x + layout.nodeWidth).toBeLessThanOrEqual(layout.width);
+        expect(node.y + layout.nodeHeight).toBeLessThanOrEqual(layout.height);
+      }
+      expect(layout.nodes).toHaveLength(count);
+    }
+  });
+
+  it("wraps a 10-node path into rows that fit instead of one giant row", () => {
+    const layout = buildPathGraphLayout(makePath(10));
+    // At most 4 columns, so the board never grows unbounded horizontally.
+    const distinctX = new Set(layout.nodes.map((node) => Math.round(node.x)));
+    expect(distinctX.size).toBeLessThanOrEqual(4);
+    // Multiple rows means it grew vertically to fit, not off the right edge.
+    const distinctY = new Set(layout.nodes.map((node) => Math.round(node.y)));
+    expect(distinctY.size).toBeGreaterThan(1);
+    // Dense path uses smaller nodes than a 2-node path.
+    expect(layout.nodeWidth).toBeLessThan(buildPathGraphLayout(makePath(2)).nodeWidth);
+  });
+
+  it("produces one edge per hop transition", () => {
+    const layout = buildPathGraphLayout(makePath(5));
+    expect(layout.edges).toHaveLength(4);
+    expect(layout.relationshipLabels).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
## Problem

The Security-Graph **selected exposure-path** SVG framed its `viewBox` to a
tiny content box and then stretched it to fill the canvas, so a trivial
2-node / 1-hop path rendered as **two enormous boxes filling the whole
canvas**. Larger paths could also overflow. There was no fit-to-content
scaling and node boxes were a fixed oversized dimension.

## Fix

Extracted the graph layout into a small, testable helper
(`ui/lib/exposure-path-graph-layout.ts`) and added:

- **Auto-fit**: the `viewBox` is the tight bounding box of every node
  position plus a uniform margin, so any path frames its own content — a
  1-hop path is compact, a many-hop path scales down to fit, nothing
  overflows.
- **Render-size cap**: the SVG is capped at its natural (1x) pixel width and
  centred (`max-width` + `mx-auto` + `preserveAspectRatio="xMidYMid meet"`),
  so a small graph renders compact instead of being stretched up into giant
  boxes; larger boards still shrink-to-fit via `width: 100%`.
- **Node-size scaling**: box size interpolates from the full design size
  (<= 3 nodes) down to a readable floor (>= 9 nodes), with the label wrap
  width scaled to match so the key entity is never truncated.

Preserves the drill-to-drawer behaviour, works in light + dark, uses design
tokens only. Shared node role-style palette extracted to
`exposure-path-graph-style.ts`.

## Tests

New `tests/exposure-path-graph-layout.test.ts` covers the fit math:
few-node paths stay at full size and never larger; node size shrinks
monotonically to a floor as the path grows; a 2-node path can't fill the
canvas; every node is bounded inside the `viewBox` (no overflow) for
1/2/3/6/10/20-node paths; a 10-node path wraps into rows.

## Verify

From `ui/`: `npm ci` · `npm run typecheck` · `npm run build` · `vitest`
(exposure-path layout + command-center + neighbor-explorer) all green;
eslint clean on touched files.

## Notes

The scan-pipeline graph rendering as a flat line rather than a real
branching DAG (feedback item V) is a separate, larger change and is **not**
in this PR.

Refs #3931 (graph-UX epic) · feedback items M/W (auto-fit + node sizing).