### PR TITLE
fix(exec-score,spdx): diminishing-returns grade curve + canonical SPDX 3.0.1 JSON-LD

### DIFF
--- a/src/agent_bom/exec_score.py
+++ b/src/agent_bom/exec_score.py
@@ -11,13 +11,24 @@ non-zero penalty, so the estate can't read as a clean "A / no vulnerabilities"
 while findings are open.
 
 Model shape (all penalty POINTS per unit of the driver's count, not fractions —
-this keeps each contribution legible: "3 critical × 12 = 36 points off"):
+this keeps each contribution legible: "3 critical × 12 = 36 points of pressure"):
 
     critical    12   high        6    medium      2    low        0.5
     unrated      1   kev         8    exposure    5    compliance 6
 
-``score = clamp(0, 100, 100 - min(100, Σ weight[d] × count[d]))`` and the letter
-grade comes from configurable thresholds (default A≥90, B≥80, C≥70, D≥60).
+The per-driver points sum to an unbounded ``pressure = Σ weight[d] × count[d]``
+which is then mapped to a 0–100 score through a **diminishing-returns curve**
+so the grade discriminates across the full estate size instead of saturating::
+
+    score = 100 × scale / (scale + pressure)      (scale = 70)
+
+This is monotonic (more findings only ever lower the score, never raise it),
+scores a genuinely clean estate a perfect 100 (grade A), and — unlike a
+``100 − min(100, pressure)`` cap that floors at 0 once ~9 criticals accumulate —
+keeps assigning *distinct* failing scores to a 20-critical vs a 2000-critical
+estate (both F, but distinguishable). Adopters steepen or soften the curve by
+scaling the weights: doubling every weight halves the effective ``scale``. The
+letter grade comes from configurable thresholds (default A≥90, B≥80, C≥70, D≥60).
 
 Adopters are not locked onto the defaults. Weights, grade thresholds, and the
 display format (``grade`` / ``percent`` / ``points``) can be overridden per
@@ -90,9 +101,12 @@ DEFAULT_DISPLAY_FORMAT = "percent"
 # A single driver weight is clamped into this range so a hostile / fat-fingered
 # override can neither invert the score (negative) nor overflow it.
 _MAX_WEIGHT = 100.0
-# Total penalty is capped so the score floors cleanly at 0 (grade F) instead of
-# going negative.
-_MAX_PENALTY = 100.0
+# Diminishing-returns scale for the pressure→score curve
+# ``score = 100 × scale / (scale + pressure)``. At ``scale = 70`` the historical
+# anchor holds exactly (2 critical + 1 high = 30 pressure → score 70 → grade C),
+# a clean estate scores 100, and the score decays toward — but never reaches — 0
+# so ever-larger estates keep earning distinct (still-failing) scores.
+_PENALTY_SCALE = 70.0
 
 
 @dataclass(frozen=True)
@@ -311,12 +325,12 @@ def compute_exec_score(
     finding_total = counts["critical"] + counts["high"] + counts["medium"] + counts["low"] + counts["unrated"]
 
     breakdown: list[dict[str, Any]] = []
-    raw_penalty = 0.0
+    pressure = 0.0
     for driver in DRIVER_ORDER:
         weight = float(weights.get(driver, 0.0))
         count = counts[driver]
         contribution = round(weight * count, 2)
-        raw_penalty += weight * count
+        pressure += weight * count
         breakdown.append(
             {
                 "driver": driver,
@@ -327,8 +341,12 @@ def compute_exec_score(
             }
         )
 
-    penalty = min(_MAX_PENALTY, raw_penalty)
-    count_score = max(0.0, round(100.0 - penalty, 1))
+    # Diminishing-returns curve: unbounded pressure maps to a (0, 100] score that
+    # never floors at 0, so a 20-critical and a 2000-critical estate stay
+    # distinguishable instead of both saturating to F/0. score(0) == 100.
+    count_score = max(0.0, round(100.0 * _PENALTY_SCALE / (_PENALTY_SCALE + pressure), 1))
+    # Effective points removed to reach the count score (score + penalty == 100).
+    penalty = round(100.0 - count_score, 1)
 
     has_evidence = floor_score is not None or finding_total > 0 or counts["kev"] > 0 or counts["exposure"] > 0 or counts["compliance"] > 0
 

--- a/src/agent_bom/output/spdx_fmt.py
+++ b/src/agent_bom/output/spdx_fmt.py
@@ -13,17 +13,32 @@ from agent_bom.compliance_utils import framework_qualified_finding_tags
 from agent_bom.models import AIBOMReport
 from agent_bom.output.finding_views import cve_findings, package_ecosystem, package_name, package_version
 
-SPDX_3_CONTEXT = "https://spdx.org/rdf/3.0.0/spdx-context.jsonl"
+# Canonical SPDX 3.0.1 JSON-LD context (media type application/spdx+json-ld,
+# ``.spdx.json`` / ``.jsonld`` extension). Every SPDX 3.0.1 document references
+# this global context at the top level.
+SPDX_3_CONTEXT = "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+# Core/CreationInfo/specVersion is a SemVer token in 3.0 (the ``SPDX-<x.y>``
+# form was dropped after 2.x); ``3.0.1`` is the current canonical value.
+SPDX_3_SPEC_VERSION = "3.0.1"
+# Blank-node id shared by every element's ``creationInfo`` back-reference.
+_CREATION_INFO_ID = "_:creationinfo"
+# Profiles this document draws vocabulary from (namespaced ``software_``/
+# ``security_``/``ai_`` terms below).
+SPDX_3_PROFILE_CONFORMANCE = ("core", "software", "security", "ai")
 
 
 def to_spdx(report: AIBOMReport) -> dict:
-    """Build an SPDX 3.0 (JSON-LD) dict from report.
+    """Build a canonical SPDX 3.0.1 JSON-LD dict from report.
 
-    Follows the SPDX 3.0 AI BOM profile where applicable:
-    - Each agent becomes an /AI element
-    - Each package becomes a /Package element
-    - Vulnerabilities become security_VulnAssessmentRelationship elements
-    - Dependency edges become dependsOn relationships
+    Emits the canonical ``{"@context": ..., "@graph": [...]}`` serialization:
+    a ``CreationInfo`` blank node, a ``SpdxDocument`` root, and every element and
+    relationship as a flat node in ``@graph`` (each carrying a ``creationInfo``
+    back-reference). Follows the SPDX 3.0 AI BOM profile where applicable:
+    - Each agent / MCP server becomes a ``software_Package`` element
+    - Each dependency becomes a ``software_Package`` element
+    - Vulnerabilities become ``security_Vulnerability`` elements with
+      ``security_*VulnAssessmentRelationship`` edges
+    - Dependency edges become ``dependsOn`` relationships
     """
     spdx_id_counter = [0]
 
@@ -33,32 +48,43 @@ def to_spdx(report: AIBOMReport) -> dict:
 
     elements: list[dict[str, Any]] = []
     relationships: list[dict[str, Any]] = []
+    root_element_ids: list[str] = []
     document_id = _next_id("SPDXRef-DOCUMENT")
+    tool_id = "SPDXRef-Tool-agent-bom"
 
-    creation_info = {
-        "specVersion": "3.0.0",
-        "created": report.generated_at.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    created = (
+        report.generated_at.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         if report.generated_at.tzinfo
-        else report.generated_at.strftime("%Y-%m-%dT%H:%M:%SZ") + "Z",
-        "createdBy": [
+        else report.generated_at.strftime("%Y-%m-%dT%H:%M:%SZ") + "Z"
+    )
+    creation_info = {
+        "@id": _CREATION_INFO_ID,
+        "type": "CreationInfo",
+        "specVersion": SPDX_3_SPEC_VERSION,
+        "created": created,
+        "createdBy": [tool_id],
+    }
+    tool_element: dict[str, Any] = {
+        "type": "Tool",
+        "spdxId": tool_id,
+        "creationInfo": _CREATION_INFO_ID,
+        "name": f"agent-bom {report.tool_version}",
+        "externalIdentifier": [
             {
-                "type": "Tool",
-                "name": f"agent-bom {report.tool_version}",
-                "externalIdentifier": [
-                    {
-                        "type": "PackageURL",
-                        "identifier": f"pkg:pypi/agent-bom@{report.tool_version}",
-                    }
-                ],
+                "type": "ExternalIdentifier",
+                "externalIdentifierType": "packageUrl",
+                "identifier": f"pkg:pypi/agent-bom@{report.tool_version}",
             }
         ],
     }
+    elements.append(tool_element)
 
     pkg_ref_map: dict[str, str] = {}
     vuln_compliance_tags = _finding_compliance_tags(report)
 
     for agent in report.agents:
         agent_id = _next_id("SPDXRef-Agent")
+        root_element_ids.append(agent_id)
 
         agent_element: dict[str, Any] = {
             "type": "software_Package",
@@ -165,7 +191,9 @@ def to_spdx(report: AIBOMReport) -> dict:
                     if verified_using:
                         pkg_element["verifiedUsing"] = verified_using
                     if pkg.purl:
-                        pkg_element["externalIdentifier"] = [{"type": "PackageURL", "identifier": pkg.purl}]
+                        pkg_element["externalIdentifier"] = [
+                            {"type": "ExternalIdentifier", "externalIdentifierType": "packageUrl", "identifier": pkg.purl}
+                        ]
                     if pkg.license_expression or pkg.license:
                         pkg_element["declaredLicense"] = pkg.license_expression or pkg.license
                     if pkg.supplier:
@@ -198,7 +226,11 @@ def to_spdx(report: AIBOMReport) -> dict:
                         "spdxId": vuln_element_id,
                         "name": vuln.id,
                         "description": vuln.summary or "",
-                        "externalIdentifier": [{"type": "cve", "identifier": vuln.id}] if vuln.id.startswith("CVE-") else [],
+                        "externalIdentifier": (
+                            [{"type": "ExternalIdentifier", "externalIdentifierType": "cve", "identifier": vuln.id}]
+                            if vuln.id.startswith("CVE-")
+                            else []
+                        ),
                     }
                     vuln_annotations = _vulnerability_annotations(
                         vuln,
@@ -238,15 +270,19 @@ def to_spdx(report: AIBOMReport) -> dict:
                         assessment["comment"] = "CISA KEV: actively exploited in the wild"
                     relationships.append(assessment)
 
-    return {
-        "@context": SPDX_3_CONTEXT,
-        "spdxVersion": "SPDX-3.0",
-        "dataLicense": "CC0-1.0",
-        "SPDXID": document_id,
+    # Stamp the shared CreationInfo back-reference on every element / relationship
+    # node (Relationships are Elements in SPDX 3.0 and require creationInfo too).
+    for node in (*elements, *relationships):
+        node.setdefault("creationInfo", _CREATION_INFO_ID)
+
+    spdx_document: dict[str, Any] = {
+        "type": "SpdxDocument",
+        "spdxId": document_id,
+        "creationInfo": _CREATION_INFO_ID,
         "name": f"agent-bom-{report.generated_at.strftime('%Y%m%d-%H%M%S')}",
-        "creationInfo": creation_info,
-        "elements": elements,
-        "relationships": relationships,
+        "dataLicense": "CC0-1.0",
+        "profileConformance": list(SPDX_3_PROFILE_CONFORMANCE),
+        "rootElement": root_element_ids,
         "comment": (
             f"Security scan generated by agent-bom {report.tool_version}. "
             f"Covers {report.total_agents} agent(s), {report.total_servers} MCP server(s), "
@@ -254,9 +290,17 @@ def to_spdx(report: AIBOMReport) -> dict:
         ),
     }
 
+    # Canonical JSON-LD: a single flat @graph holding the CreationInfo blank node,
+    # the SpdxDocument root, and every element + relationship.
+    graph: list[dict[str, Any]] = [creation_info, spdx_document, *elements, *relationships]
+    return {
+        "@context": SPDX_3_CONTEXT,
+        "@graph": graph,
+    }
+
 
 def export_spdx(report: AIBOMReport, output_path: str) -> None:
-    """Export report as SPDX 3.0 JSON-LD file."""
+    """Export report as a canonical SPDX 3.0.1 JSON-LD file."""
     data = to_spdx(report)
     Path(output_path).write_text(json.dumps(data, indent=2))
 

--- a/src/agent_bom/sbom.py
+++ b/src/agent_bom/sbom.py
@@ -313,7 +313,8 @@ def _spdx3_purl(elem: dict) -> str:
         if not identifier:
             continue
         id_type = str(entry.get("type") or "").lower()
-        if id_type in ("packageurl", "purl") or identifier.startswith("pkg:"):
+        ext_id_type = str(entry.get("externalIdentifierType") or "").lower()
+        if id_type in ("packageurl", "purl") or ext_id_type in ("packageurl", "purl") or identifier.startswith("pkg:"):
             return identifier
         if not fallback:
             fallback = identifier
@@ -445,13 +446,65 @@ def _spdx3_vulnerabilities(data: dict, pkg_by_id: dict[str, Package]) -> None:
             )
 
 
+def _spdx3_graph(data: dict) -> list | None:
+    """Return the JSON-LD ``@graph`` node list if ``data`` is a canonical
+    SPDX 3.0 document, else ``None``."""
+    graph = data.get("@graph")
+    if not isinstance(graph, list):
+        return None
+    ctx = data.get("@context")
+    if isinstance(ctx, str) and "spdx.org/rdf/3." in ctx:
+        return graph
+    if isinstance(ctx, list) and any(isinstance(c, str) and "spdx.org/rdf/3." in c for c in ctx):
+        return graph
+    for node in graph:
+        if isinstance(node, dict) and node.get("type") == "CreationInfo" and str(node.get("specVersion") or "").startswith("3."):
+            return graph
+    return None
+
+
+def _normalize_spdx3_graph(data: dict) -> dict:
+    """Project a canonical ``@graph`` SPDX 3.0.1 document onto the flat
+    ``elements``/``relationships``/``spdxVersion`` shape the parser consumes.
+
+    Legacy flat SPDX 3.0 documents and non-SPDX-3 documents pass through
+    unchanged, so both serializations round-trip through the same reader.
+    """
+    graph = _spdx3_graph(data)
+    if graph is None:
+        return data
+    spec = ""
+    doc_id = ""
+    doc_name = ""
+    for node in graph:
+        if not isinstance(node, dict):
+            continue
+        ntype = node.get("type")
+        if ntype == "CreationInfo" and not spec:
+            spec = str(node.get("specVersion") or "")
+        elif ntype == "SpdxDocument":
+            doc_id = node.get("spdxId") or node.get("SPDXID") or doc_id
+            doc_name = node.get("name") or doc_name
+    relationships = [n for n in graph if isinstance(n, dict) and str(n.get("type") or "").endswith("Relationship")]
+    projected = dict(data)
+    projected["spdxVersion"] = f"SPDX-{spec}" if spec else "SPDX-3.0"
+    projected["elements"] = graph
+    projected["relationships"] = relationships
+    if doc_id:
+        projected["SPDXID"] = doc_id
+    if doc_name and not projected.get("name"):
+        projected["name"] = doc_name
+    return projected
+
+
 def parse_spdx(data: dict) -> list[Package]:
     """Parse an SPDX 2.x or 3.0 JSON document into Package objects.
 
     Handles both:
     - SPDX 2.x: top-level "packages" array with "name", "versionInfo", "externalRefs"
-    - SPDX 3.0: "elements" array with type "software/Package"
+    - SPDX 3.0: canonical ``@graph`` JSON-LD or a flat "elements" array
     """
+    data = _normalize_spdx3_graph(data)
     packages: list[Package] = []
 
     # SPDX 3.0: build direct dependency set from DEPENDS_ON relationships. These
@@ -596,6 +649,7 @@ def detect_sbom_resource_name(data: dict) -> str | None:
 
     Returns None if no meaningful name is found.
     """
+    data = _normalize_spdx3_graph(data)
     # CycloneDX
     if data.get("bomFormat") == "CycloneDX":
         comp = data.get("metadata", {}).get("component", {})
@@ -625,6 +679,7 @@ def parse_sbom_document(data: dict, source_name: str = "<memory>") -> tuple[list
     Returns ``(packages, format_name, resource_name)`` where ``resource_name``
     is auto-detected from SBOM metadata when available.
     """
+    data = _normalize_spdx3_graph(data)
     resource_name = detect_sbom_resource_name(data)
 
     if "bomFormat" in data and data["bomFormat"] == "CycloneDX":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -936,19 +936,22 @@ def test_spdx_output_structure(sample_report):
     from agent_bom.output import to_spdx
 
     data = to_spdx(sample_report)
-    assert data["spdxVersion"] == "SPDX-3.0"
-    assert data["dataLicense"] == "CC0-1.0"
-    assert "elements" in data
-    assert "relationships" in data
-    assert "creationInfo" in data
-    assert len(data["elements"]) > 0
+    # Canonical SPDX 3.0.1 JSON-LD: @context + @graph, no legacy top-level keys.
+    assert set(data) == {"@context", "@graph"}
+    assert data["@context"] == "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+    graph = data["@graph"]
+    doc = next(n for n in graph if n["type"] == "SpdxDocument")
+    assert doc["dataLicense"] == "CC0-1.0"
+    ci = next(n for n in graph if n["type"] == "CreationInfo")
+    assert ci["specVersion"] == "3.0.1"
+    assert len(graph) > 0
 
 
 def test_spdx_has_vulnerability_elements(sample_report):
     from agent_bom.output import to_spdx
 
     data = to_spdx(sample_report)
-    vuln_elements = [e for e in data["elements"] if e.get("type") == "security_Vulnerability"]
+    vuln_elements = [e for e in data["@graph"] if e.get("type") == "security_Vulnerability"]
     assert len(vuln_elements) >= 1
     assert vuln_elements[0]["name"] == "CVE-2024-1234"
 
@@ -959,7 +962,8 @@ def test_spdx_export_file(sample_report, tmp_path):
     out = tmp_path / "test.spdx.json"
     export_spdx(sample_report, str(out))
     data = json.loads(out.read_text())
-    assert data["spdxVersion"] == "SPDX-3.0"
+    assert data["@context"] == "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+    assert next(n for n in data["@graph"] if n["type"] == "CreationInfo")["specVersion"] == "3.0.1"
 
 
 def test_cli_scan_has_spdx_format():
@@ -4239,7 +4243,7 @@ def test_spdx_includes_declared_license():
     agent = Agent(name="a", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/tmp/c.json", mcp_servers=[server])
     report = AIBOMReport(agents=[agent], blast_radii=[])
     spdx = to_spdx(report)
-    pkg_elements = [e for e in spdx["elements"] if e.get("declaredLicense")]
+    pkg_elements = [e for e in spdx["@graph"] if e.get("declaredLicense")]
     assert len(pkg_elements) >= 1
     assert pkg_elements[0]["declaredLicense"] == "BSD-3-Clause"
 

--- a/tests/test_exec_score.py
+++ b/tests/test_exec_score.py
@@ -45,11 +45,46 @@ def test_summary_never_claims_no_vulns_when_counted() -> None:
     assert "3 high" in result["summary"]
 
 
-def test_penalty_caps_score_floor_at_zero() -> None:
+def test_large_estate_grades_f_without_flooring_at_zero() -> None:
+    """A big critical estate is grade F with a very low — but non-zero — score.
+
+    The diminishing-returns curve approaches 0 asymptotically; it must never
+    round to a hard 0 for a finite estate (that is the saturation bug: 0 leaves
+    no room to distinguish a bad estate from a catastrophic one)."""
     result = compute_exec_score(severity=_sev(critical=50))
-    assert result["score"] == 0.0
     assert result["grade"] == "F"
-    assert result["penalty_total"] == 100.0
+    assert 0.0 < result["score"] < 15.0
+    # score + penalty_total reconcile to a full 100 points.
+    assert round(result["score"] + result["penalty_total"], 1) == 100.0
+
+
+def test_score_discriminates_across_estate_scale() -> None:
+    """The core #3967 fix: two estates with very different critical counts get
+    *different* failing scores — both bad, but distinguishable, not both F/0."""
+    small = compute_exec_score(severity=_sev(critical=20))
+    mid = compute_exec_score(severity=_sev(critical=200))
+    large = compute_exec_score(severity=_sev(critical=2000))
+    # All fail, but each is strictly worse than the last — no saturation.
+    assert small["grade"] == mid["grade"] == large["grade"] == "F"
+    assert small["score"] > mid["score"] > large["score"] > 0.0
+    # The 20-vs-2000 gap the audit called out is materially resolvable.
+    assert small["score"] - large["score"] > 5.0
+
+
+def test_more_criticals_never_raise_the_score() -> None:
+    """Monotonic invariant (#3949): adding findings only lowers the score."""
+    prev = compute_exec_score(severity=_sev(critical=1))["score"]
+    for n in range(2, 40):
+        cur = compute_exec_score(severity=_sev(critical=n))["score"]
+        assert cur < prev, f"critical={n} did not lower the score"
+        prev = cur
+
+
+def test_clean_estate_still_scores_a() -> None:
+    """A scanned estate with zero findings (floor present) still grades A."""
+    result = compute_exec_score(severity=_sev(), floor_score=100.0)
+    assert result["score"] == 100.0
+    assert result["grade"] == "A"
 
 
 def test_floor_never_launders_a_failing_scorecard_up() -> None:
@@ -63,8 +98,11 @@ def test_floor_never_launders_a_failing_scorecard_up() -> None:
 def test_floor_does_not_raise_a_worse_count() -> None:
     """When counts are worse than the floor, the worse count wins."""
     result = compute_exec_score(severity=_sev(critical=10), floor_score=95.0)
-    assert result["score"] == 0.0
+    # Count-derived score (10 critical) is well below the benign 95 floor, so the
+    # count wins and the floor is not applied.
     assert result["grade"] == "F"
+    assert result["score"] < 60.0
+    assert result["floored"] is False
 
 
 def test_kev_and_exposure_amplify() -> None:

--- a/tests/test_interop_schema_conformance.py
+++ b/tests/test_interop_schema_conformance.py
@@ -9,9 +9,9 @@ generates each format from one multi-entity report (agent -> MCP server -> tool
 
 * SARIF 2.1.0 / CycloneDX 1.6 / SPDX 2.3 validate against their vendored
   official JSON schemas (``jsonschema``);
-* SPDX 3.0 carries the 3.0 JSON-LD vocabulary (the 3.0.0 serialization agent-bom
-  emits predates the strict 3.0.1 ``@graph`` schema, so it is checked
-  structurally — see ``test_spdx_3_0_carries_spdx3_vocabulary``);
+* SPDX 3.0 is emitted as canonical SPDX 3.0.1 JSON-LD (``@context`` + ``@graph``
+  with a ``CreationInfo`` blank node and ``SpdxDocument`` root) and is checked
+  structurally + round-tripped — see ``test_spdx_3_0_is_canonical_jsonld``;
 * JSON package serializers surface ``is_malicious`` / ``malicious_reason``; and
 * two consecutive runs on identical input yield byte-identical bytes.
 
@@ -182,32 +182,57 @@ def test_spdx2_conforms_to_2_3_schema(report: AIBOMReport) -> None:
     _assert_schema_valid("SPDX 2.3", "spdx-2.3.schema.json", Draft201909Validator, to_spdx2(report))
 
 
-def test_spdx_3_0_carries_spdx3_vocabulary(report: AIBOMReport) -> None:
-    """SPDX 3.0 output uses the 3.0.0 JSON-LD serialization (fixed in #3779). The
-    strict 3.0.1 ``@graph`` schema does not model this shape, so conformance is
-    asserted against the required 3.0 vocabulary rather than rewriting the doc."""
+def test_spdx_3_0_is_canonical_jsonld(report: AIBOMReport) -> None:
+    """SPDX 3.0 output is canonical SPDX 3.0.1 JSON-LD (#3967): a top-level
+    ``@context`` + ``@graph``, a ``CreationInfo`` blank node with the semver
+    ``specVersion``, an ``SpdxDocument`` root, and namespaced 3.0 vocabulary."""
     doc = to_spdx(report)
-    assert doc["spdxVersion"] == "SPDX-3.0"
-    assert doc["@context"].startswith("https://spdx.org/rdf/3.0")
-    assert doc["creationInfo"]["specVersion"] == "3.0.0"
-    assert doc["SPDXID"].startswith("SPDXRef-")
+    # Canonical top level — exactly @context + @graph, no legacy flat keys.
+    assert set(doc) == {"@context", "@graph"}
+    assert doc["@context"] == "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+    # Parses as JSON-LD (deserializes cleanly, @graph is a node list).
+    graph = json.loads(json.dumps(doc))["@graph"]
+    assert isinstance(graph, list) and graph
 
-    elements = doc["elements"]
-    assert elements, "expected at least one SPDX 3.0 element"
-    element_types = {e["type"] for e in elements}
+    creation_info = next(n for n in graph if n["type"] == "CreationInfo")
+    assert creation_info["@id"].startswith("_:")
+    assert creation_info["specVersion"] == "3.0.1"
+
+    spdx_document = next(n for n in graph if n["type"] == "SpdxDocument")
+    assert spdx_document["spdxId"].startswith("SPDXRef-")
+    assert spdx_document["creationInfo"] == creation_info["@id"]
+    assert "core" in spdx_document["profileConformance"]
+    assert spdx_document["rootElement"], "SpdxDocument must reference a root element"
+
+    element_types = {n["type"] for n in graph}
     # 3.0 profile-namespaced vocabulary — a 2.x-style bare "Package" is a regression.
     assert "software_Package" in element_types
     assert "security_Vulnerability" in element_types
-    for element in elements:
-        assert element.get("spdxId", "").startswith("SPDXRef-"), element
+
+    # Every graph node (bar the CreationInfo blank node itself) is a real Element:
+    # it carries a spdxId and a back-reference to the shared CreationInfo.
+    for node in graph:
+        if node["type"] == "CreationInfo":
+            continue
+        assert node.get("spdxId", "").startswith("SPDXRef-"), node
+        assert node.get("creationInfo") == creation_info["@id"], node
 
     valid_rel_types = {"contains", "dependsOn", "hasAssessmentFor", "affects", "describes", "generates"}
-    for rel in doc["relationships"]:
-        # Either the base Relationship or a 3.0 profile subtype (e.g.
+    relationships = [n for n in graph if str(n.get("type") or "").endswith("Relationship")]
+    assert relationships
+    for rel in relationships:
+        # Base Relationship or a 3.0 profile subtype (e.g.
         # security_CvssV3VulnAssessmentRelationship) — all end in "Relationship".
         assert rel["type"].endswith("Relationship"), rel
         assert rel["relationshipType"] in valid_rel_types, rel
         assert rel.get("from") and rel.get("to"), rel
+
+    # Round-trips back through the SBOM reader with packages + vuln intact.
+    from agent_bom.sbom import parse_sbom_document
+
+    packages, fmt, _name = parse_sbom_document(doc)
+    assert fmt == "spdx-3"
+    assert {p.name for p in packages}, "expected packages recovered from @graph"
 
 
 def test_json_packages_carry_is_malicious(report: AIBOMReport) -> None:

--- a/tests/test_output_cov.py
+++ b/tests/test_output_cov.py
@@ -489,7 +489,7 @@ class TestToSpdx:
     def test_empty_report(self):
         report = _make_report()
         spdx = to_spdx(report)
-        assert spdx["spdxVersion"] == "SPDX-3.0"
+        assert next(n for n in spdx["@graph"] if n["type"] == "CreationInfo")["specVersion"] == "3.0.1"
 
 
 def test_spdx_package_preserves_version_provenance_annotations():
@@ -500,7 +500,7 @@ def test_spdx_package_preserves_version_provenance_annotations():
     report = _make_report(agents=[agent])
 
     spdx = to_spdx(report)
-    pkg_element = next(element for element in spdx["elements"] if element.get("name") == pkg.name)
+    pkg_element = next(element for element in spdx["@graph"] if element.get("name") == pkg.name)
     statements = {annotation["statement"] for annotation in pkg_element["annotation"]}
 
     assert "agent-bom:version-provenance-source=lockfile" in statements
@@ -531,7 +531,7 @@ def test_json_output_redacts_server_launch_fields():
         br = _make_blast_radius(pkg=pkg, agents=[agent])
         report = _make_report(agents=[agent], blast_radii=[br])
         spdx = to_spdx(report)
-        assert len(spdx["elements"]) >= 1
+        assert len(spdx["@graph"]) >= 1
 
 
 class TestToJson:
@@ -1287,7 +1287,7 @@ def test_to_spdx_with_agent():
     agent = _make_agent_cov2(servers=[srv])
     report = _make_report_cov2(agents=[agent])
     result = to_spdx(report)
-    assert len(result.get("packages", result.get("elements", []))) >= 1
+    assert len(result["@graph"]) >= 1
 
 
 # ── to_sarif extras (from cov2) ─────────────────────────────────────────────

--- a/tests/test_output_fidelity_correctness.py
+++ b/tests/test_output_fidelity_correctness.py
@@ -74,11 +74,11 @@ def test_spdx3_flags_malicious_package():
     from agent_bom.output.spdx_fmt import to_spdx
 
     doc = to_spdx(_mal_report())
-    evil = next(e for e in doc["elements"] if e.get("name") == "evil-lib")
+    evil = next(e for e in doc["@graph"] if e.get("name") == "evil-lib")
     statements = {a["statement"] for a in evil.get("annotation", [])}
     assert any(s.startswith("agent-bom:malicious=true") for s in statements)
 
-    benign = next(e for e in doc["elements"] if e.get("name") == "requests")
+    benign = next(e for e in doc["@graph"] if e.get("name") == "requests")
     benign_statements = {a["statement"] for a in benign.get("annotation", [])}
     assert not any(s.startswith("agent-bom:malicious=true") for s in benign_statements)
 
@@ -102,26 +102,29 @@ def test_spdx3_uses_spdx3_vocabulary():
     from agent_bom.output.spdx_fmt import to_spdx
 
     doc = to_spdx(_mal_report())
-    assert doc["spdxVersion"] == "SPDX-3.0"
+    graph = doc["@graph"]
+    creation_info = next(n for n in graph if n["type"] == "CreationInfo")
+    assert creation_info["specVersion"] == "3.0.1"
 
-    element_types = {e.get("type") for e in doc["elements"]}
+    element_types = {e.get("type") for e in graph}
     assert "software_Package" in element_types
     assert "security_Vulnerability" in element_types
     # No SPDX-2.x element vocabulary leaked into a 3.0 document.
     assert not set(_SPDX2_TOKENS) & element_types
 
-    for elem in doc["elements"]:
+    for elem in graph:
         # 2.x used "primaryPurpose"; 3.0 namespaces it as "software_primaryPurpose".
         assert "primaryPurpose" not in elem
         # No ad-hoc CVSS score object on the vulnerability element.
         assert "score" not in elem
 
-    rel_types = {r.get("relationshipType") for r in doc["relationships"]}
+    relationships = [r for r in graph if str(r.get("type") or "").endswith("Relationship")]
+    rel_types = {r.get("relationshipType") for r in relationships}
     assert {"contains", "dependsOn", "affects"} <= rel_types
     assert not set(_SPDX2_REL_TYPES) & rel_types
 
     # CVSS is expressed as a security-profile assessment relationship.
-    cvss_rels = [r for r in doc["relationships"] if r.get("type") == "security_CvssV3VulnAssessmentRelationship"]
+    cvss_rels = [r for r in relationships if r.get("type") == "security_CvssV3VulnAssessmentRelationship"]
     assert cvss_rels
     assert cvss_rels[0]["security_score"] == 7.5
     assert cvss_rels[0]["relationshipType"] == "hasAssessmentFor"

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -837,8 +837,8 @@ def test_spdx_vulnerability_annotations_preserve_enrichment_and_compliance_metad
     report = _make_report(agents=[_make_agent(servers=[_make_server(packages=[pkg])])], blast_radii=[br])
 
     spdx = to_spdx(report)
-    assert spdx["@context"] == "https://spdx.org/rdf/3.0.0/spdx-context.jsonl"
-    vuln_element = next(element for element in spdx["elements"] if element.get("type") == "security_Vulnerability")
+    assert spdx["@context"] == "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+    vuln_element = next(element for element in spdx["@graph"] if element.get("type") == "security_Vulnerability")
     statements = {annotation["statement"] for annotation in vuln_element["annotation"]}
 
     assert "agent-bom:severity-source=nvd:cvss_v3" in statements
@@ -861,7 +861,7 @@ def test_spdx_vulnerability_annotations_use_unified_findings_without_blast_radii
     report.findings = [_make_unified_cve_finding()]
 
     spdx = to_spdx(report)
-    vuln_element = next(element for element in spdx["elements"] if element.get("type") == "security_Vulnerability")
+    vuln_element = next(element for element in spdx["@graph"] if element.get("type") == "security_Vulnerability")
     statements = {annotation["statement"] for annotation in vuln_element["annotation"]}
 
     assert "agent-bom:compliance-tag=owasp_llm:LLM05" in statements

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -175,9 +175,10 @@ def test_overview_reads_compacted_scan_summary() -> None:
 
     # The configurable exec-score engine (#3940) recomputes the grade from the
     # honest estate counts and takes the *worst* of that and the scan scorecard
-    # floor (42.0). 3 critical + 12 high + 72 unrated caps the penalty, so the
-    # honest score is 0.0 — still an F, and the CVE/severity tiles are populated
-    # (the compaction-must-not-zero-tiles intent this test guards).
+    # floor (42.0). 3 critical + 12 high + 72 unrated is heavy pressure, so the
+    # diminishing-returns score lands well below the floor — still an F, and the
+    # CVE/severity tiles are populated (the compaction-must-not-zero-tiles intent
+    # this test guards).
     assert data["posture"]["grade"] == "F"
     assert data["posture"]["score"] <= 42.0
     assert data["headline"]["critical"] == 3

--- a/tests/test_spdx2_and_checksums.py
+++ b/tests/test_spdx2_and_checksums.py
@@ -150,7 +150,7 @@ def test_spdx2_tagvalue_emits_checksum_and_relationships():
 def test_spdx3_surfaces_verified_using_checksum():
     report, expected_hex = _report_with_checksummed_pkg()
     doc = to_spdx(report)
-    pkg_elements = [e for e in doc["elements"] if e.get("software_primaryPurpose") == "library"]
+    pkg_elements = [e for e in doc["@graph"] if e.get("software_primaryPurpose") == "library"]
     assert pkg_elements
     verified = pkg_elements[0]["verifiedUsing"]
     assert {"type": "Hash", "algorithm": "sha512", "hashValue": expected_hex} in verified


### PR DESCRIPTION
Closes the **exec-score saturation** and **SPDX 3.0 non-canonical** parts of #3967. The Snowflake-404 and in-memory-sort parts of #3967 are handled separately in #3979 / #3981 and are not touched here.

## 1. Exec-score saturation (audit P2-9c)

`exec_score.py` scored posture as `score = 100 − min(100, Σ weight×count)`. That penalty caps at 100, so the score floors at **0 / "F" once ~9 criticals accumulate** — a 20-critical estate and a 2000-critical estate both read F with no discrimination at scale.

**Fix:** replace the capped-linear penalty with a **diminishing-returns curve**:

```
pressure = Σ weight[d] × count[d]          (unbounded, per-driver points unchanged)
score    = 100 × scale / (scale + pressure)   (scale = 70)
```

How it discriminates and preserves the #3949 invariants:

| estate | pressure | score | grade |
|--------|---------:|------:|:-----:|
| clean (0 findings, floor present) | 0 | 100.0 | A |
| 2 critical + 1 high | 30 | 70.0 | C |
| 20 critical | 240 | 22.6 | F |
| 200 critical | 2400 | 2.8 | F |
| 2000 critical | 24000 | 0.3 | F |

- **Discriminates across the full range** — 20 vs 2000 criticals now score 22.6 vs 0.3 (both F, distinguishable) instead of both 0.
- **Monotonic** — more findings only ever lower the score (test walks critical 1→39).
- **Clean estate still A** — `score(0) == 100`.
- **Floor still a hard min-cap** — an authoritative failing scorecard can't be laundered upward by a benign count.
- `scale = 70` keeps the historical anchor (2 critical + 1 high → 70 → C) exact, so existing consumers/thresholds are unchanged. Configurability is preserved: scaling all weights steepens/softens the curve (doubling weights halves the effective scale). No new config/API surface, so no OpenAPI/schema drift.

## 2. SPDX 3.0 non-canonical (audit P2-9a)

`spdx_fmt.py` emitted non-canonical JSON-LD: `.jsonl` context extension, `3.0.0` specVersion, and a flat `elements`/`relationships` layout with ad-hoc `externalIdentifier` types.

**Fix — canonical SPDX 3.0.1 JSON-LD** (validated against the official SPDX 3.0.1 AI-BOM example shape):
- `@context` = `https://spdx.org/rdf/3.0.1/spdx-context.jsonld` (correct `.jsonld` extension + version token)
- single flat **`@graph`** holding a `CreationInfo` **blank node** (`_:creationinfo`, `specVersion: "3.0.1"` — the SemVer token; the `SPDX-<x.y>` form was dropped after 2.x), an `SpdxDocument` root with `profileConformance` + `rootElement`, and every element/relationship carrying a `creationInfo` back-reference
- canonical `externalIdentifier` shape (`{type: ExternalIdentifier, externalIdentifierType: packageUrl|cve, identifier: …}`)

The SBOM reader (`sbom.py`) learns the canonical `@graph` layout (with legacy-flat and third-party fallbacks), so `to_spdx` → `parse_spdx` **round-trips** with packages + vulnerability metadata intact. A new conformance test asserts the canonical structure and round-trips through `parse_sbom_document`.

## Verification
- `pytest` exec-score, SPDX, output, ingestion, interop, core suites — all green (new discrimination/invariant tests + canonical-JSON-LD conformance test added)
- `ruff` + `mypy` clean on changed source
- `make preflight` drift gates (OpenAPI / v1 schemas / env-var reference) pass — no drift