### PR TITLE
fix(release): combine database, scoring/SPDX, and graph-layout corrections

### DIFF
--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -356,14 +356,37 @@ class PostgresComplianceHubStore:
 
     @staticmethod
     def _migrate_primary_key(conn: Any) -> None:
-        """Collapse the primary key to ``(tenant_id, finding_id)`` (idempotent).
+        """Collapse the primary key to ``(tenant_id, finding_id)`` (true no-op once done).
 
         Pre-idempotency deployments keyed on ``(tenant_id, finding_id, ordinal)``
         so every resend of the same finding appended a fresh row. Dedup existing
-        duplicates (keep the lowest ordinal), then swap the primary key. Guarded
-        so it is a no-op once the collapsed key is in place.
+        duplicates (keep the lowest ordinal), then swap the primary key.
+
+        The dedup DELETE is a full-table self-join — O(n^2)-class on a large
+        table — so we must never run it on an already-migrated store. Probe
+        ``pg_constraint`` first and return early when the collapsed key is
+        already in place: no DELETE, no DDL. Only a genuinely old-shape (or
+        missing) primary key triggers the dedup + constraint swap. Without this
+        guard the self-join ran on every store init and blew the default 15s
+        ``statement_timeout`` at scale, so init 500'd on every request (#3980).
         """
-        # Drop duplicates ahead of the unique key, keeping the original ingest.
+        pk_row = conn.execute(
+            """
+            SELECT string_agg(a.attname, ',' ORDER BY array_position(c.conkey, a.attnum))
+              FROM pg_constraint c
+              JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+             WHERE c.conrelid = 'compliance_hub_findings'::regclass
+               AND c.contype = 'p'
+            """
+        ).fetchone()
+        pk_cols = pk_row[0] if pk_row else None
+        if pk_cols == "tenant_id,finding_id":
+            # Already collapsed — skip the dedup DELETE + DDL entirely so an
+            # already-migrated (possibly very large) table pays nothing at
+            # init and cannot exceed statement_timeout (#3980).
+            return
+        # Old-shape or missing primary key: drop duplicates ahead of the unique
+        # key, keeping the original ingest, then swap the primary key.
         conn.execute(
             """
             DELETE FROM compliance_hub_findings a

--- a/src/agent_bom/exec_score.py
+++ b/src/agent_bom/exec_score.py
@@ -11,13 +11,24 @@ non-zero penalty, so the estate can't read as a clean "A / no vulnerabilities"
 while findings are open.
 
 Model shape (all penalty POINTS per unit of the driver's count, not fractions —
-this keeps each contribution legible: "3 critical × 12 = 36 points off"):
+this keeps each contribution legible: "3 critical × 12 = 36 points of pressure"):
 
     critical    12   high        6    medium      2    low        0.5
     unrated      1   kev         8    exposure    5    compliance 6
 
-``score = clamp(0, 100, 100 - min(100, Σ weight[d] × count[d]))`` and the letter
-grade comes from configurable thresholds (default A≥90, B≥80, C≥70, D≥60).
+The per-driver points sum to an unbounded ``pressure = Σ weight[d] × count[d]``
+which is then mapped to a 0–100 score through a **diminishing-returns curve**
+so the grade discriminates across the full estate size instead of saturating::
+
+    score = 100 × scale / (scale + pressure)      (scale = 70)
+
+This is monotonic (more findings only ever lower the score, never raise it),
+scores a genuinely clean estate a perfect 100 (grade A), and — unlike a
+``100 − min(100, pressure)`` cap that floors at 0 once ~9 criticals accumulate —
+keeps assigning *distinct* failing scores to a 20-critical vs a 2000-critical
+estate (both F, but distinguishable). Adopters steepen or soften the curve by
+scaling the weights: doubling every weight halves the effective ``scale``. The
+letter grade comes from configurable thresholds (default A≥90, B≥80, C≥70, D≥60).
 
 Adopters are not locked onto the defaults. Weights, grade thresholds, and the
 display format (``grade`` / ``percent`` / ``points``) can be overridden per
@@ -90,9 +101,12 @@ DEFAULT_DISPLAY_FORMAT = "percent"
 # A single driver weight is clamped into this range so a hostile / fat-fingered
 # override can neither invert the score (negative) nor overflow it.
 _MAX_WEIGHT = 100.0
-# Total penalty is capped so the score floors cleanly at 0 (grade F) instead of
-# going negative.
-_MAX_PENALTY = 100.0
+# Diminishing-returns scale for the pressure→score curve
+# ``score = 100 × scale / (scale + pressure)``. At ``scale = 70`` the historical
+# anchor holds exactly (2 critical + 1 high = 30 pressure → score 70 → grade C),
+# a clean estate scores 100, and the score decays toward — but never reaches — 0
+# so ever-larger estates keep earning distinct (still-failing) scores.
+_PENALTY_SCALE = 70.0
 
 
 @dataclass(frozen=True)
@@ -311,12 +325,12 @@ def compute_exec_score(
     finding_total = counts["critical"] + counts["high"] + counts["medium"] + counts["low"] + counts["unrated"]
 
     breakdown: list[dict[str, Any]] = []
-    raw_penalty = 0.0
+    pressure = 0.0
     for driver in DRIVER_ORDER:
         weight = float(weights.get(driver, 0.0))
         count = counts[driver]
         contribution = round(weight * count, 2)
-        raw_penalty += weight * count
+        pressure += weight * count
         breakdown.append(
             {
                 "driver": driver,
@@ -327,8 +341,12 @@ def compute_exec_score(
             }
         )
 
-    penalty = min(_MAX_PENALTY, raw_penalty)
-    count_score = max(0.0, round(100.0 - penalty, 1))
+    # Diminishing-returns curve: unbounded pressure maps to a (0, 100] score that
+    # never floors at 0, so a 20-critical and a 2000-critical estate stay
+    # distinguishable instead of both saturating to F/0. score(0) == 100.
+    count_score = max(0.0, round(100.0 * _PENALTY_SCALE / (_PENALTY_SCALE + pressure), 1))
+    # Effective points removed to reach the count score (score + penalty == 100).
+    penalty = round(100.0 - count_score, 1)
 
     has_evidence = floor_score is not None or finding_total > 0 or counts["kev"] > 0 or counts["exposure"] > 0 or counts["compliance"] > 0
 

--- a/src/agent_bom/output/spdx_fmt.py
+++ b/src/agent_bom/output/spdx_fmt.py
@@ -13,17 +13,32 @@ from agent_bom.compliance_utils import framework_qualified_finding_tags
 from agent_bom.models import AIBOMReport
 from agent_bom.output.finding_views import cve_findings, package_ecosystem, package_name, package_version
 
-SPDX_3_CONTEXT = "https://spdx.org/rdf/3.0.0/spdx-context.jsonl"
+# Canonical SPDX 3.0.1 JSON-LD context (media type application/spdx+json-ld,
+# ``.spdx.json`` / ``.jsonld`` extension). Every SPDX 3.0.1 document references
+# this global context at the top level.
+SPDX_3_CONTEXT = "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+# Core/CreationInfo/specVersion is a SemVer token in 3.0 (the ``SPDX-<x.y>``
+# form was dropped after 2.x); ``3.0.1`` is the current canonical value.
+SPDX_3_SPEC_VERSION = "3.0.1"
+# Blank-node id shared by every element's ``creationInfo`` back-reference.
+_CREATION_INFO_ID = "_:creationinfo"
+# Profiles this document draws vocabulary from (namespaced ``software_``/
+# ``security_``/``ai_`` terms below).
+SPDX_3_PROFILE_CONFORMANCE = ("core", "software", "security", "ai")
 
 
 def to_spdx(report: AIBOMReport) -> dict:
-    """Build an SPDX 3.0 (JSON-LD) dict from report.
+    """Build a canonical SPDX 3.0.1 JSON-LD dict from report.
 
-    Follows the SPDX 3.0 AI BOM profile where applicable:
-    - Each agent becomes an /AI element
-    - Each package becomes a /Package element
-    - Vulnerabilities become security_VulnAssessmentRelationship elements
-    - Dependency edges become dependsOn relationships
+    Emits the canonical ``{"@context": ..., "@graph": [...]}`` serialization:
+    a ``CreationInfo`` blank node, a ``SpdxDocument`` root, and every element and
+    relationship as a flat node in ``@graph`` (each carrying a ``creationInfo``
+    back-reference). Follows the SPDX 3.0 AI BOM profile where applicable:
+    - Each agent / MCP server becomes a ``software_Package`` element
+    - Each dependency becomes a ``software_Package`` element
+    - Vulnerabilities become ``security_Vulnerability`` elements with
+      ``security_*VulnAssessmentRelationship`` edges
+    - Dependency edges become ``dependsOn`` relationships
     """
     spdx_id_counter = [0]
 
@@ -33,32 +48,43 @@ def to_spdx(report: AIBOMReport) -> dict:
 
     elements: list[dict[str, Any]] = []
     relationships: list[dict[str, Any]] = []
+    root_element_ids: list[str] = []
     document_id = _next_id("SPDXRef-DOCUMENT")
+    tool_id = "SPDXRef-Tool-agent-bom"
 
-    creation_info = {
-        "specVersion": "3.0.0",
-        "created": report.generated_at.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    created = (
+        report.generated_at.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         if report.generated_at.tzinfo
-        else report.generated_at.strftime("%Y-%m-%dT%H:%M:%SZ") + "Z",
-        "createdBy": [
+        else report.generated_at.strftime("%Y-%m-%dT%H:%M:%SZ") + "Z"
+    )
+    creation_info = {
+        "@id": _CREATION_INFO_ID,
+        "type": "CreationInfo",
+        "specVersion": SPDX_3_SPEC_VERSION,
+        "created": created,
+        "createdBy": [tool_id],
+    }
+    tool_element: dict[str, Any] = {
+        "type": "Tool",
+        "spdxId": tool_id,
+        "creationInfo": _CREATION_INFO_ID,
+        "name": f"agent-bom {report.tool_version}",
+        "externalIdentifier": [
             {
-                "type": "Tool",
-                "name": f"agent-bom {report.tool_version}",
-                "externalIdentifier": [
-                    {
-                        "type": "PackageURL",
-                        "identifier": f"pkg:pypi/agent-bom@{report.tool_version}",
-                    }
-                ],
+                "type": "ExternalIdentifier",
+                "externalIdentifierType": "packageUrl",
+                "identifier": f"pkg:pypi/agent-bom@{report.tool_version}",
             }
         ],
     }
+    elements.append(tool_element)
 
     pkg_ref_map: dict[str, str] = {}
     vuln_compliance_tags = _finding_compliance_tags(report)
 
     for agent in report.agents:
         agent_id = _next_id("SPDXRef-Agent")
+        root_element_ids.append(agent_id)
 
         agent_element: dict[str, Any] = {
             "type": "software_Package",
@@ -165,7 +191,9 @@ def to_spdx(report: AIBOMReport) -> dict:
                     if verified_using:
                         pkg_element["verifiedUsing"] = verified_using
                     if pkg.purl:
-                        pkg_element["externalIdentifier"] = [{"type": "PackageURL", "identifier": pkg.purl}]
+                        pkg_element["externalIdentifier"] = [
+                            {"type": "ExternalIdentifier", "externalIdentifierType": "packageUrl", "identifier": pkg.purl}
+                        ]
                     if pkg.license_expression or pkg.license:
                         pkg_element["declaredLicense"] = pkg.license_expression or pkg.license
                     if pkg.supplier:
@@ -198,7 +226,11 @@ def to_spdx(report: AIBOMReport) -> dict:
                         "spdxId": vuln_element_id,
                         "name": vuln.id,
                         "description": vuln.summary or "",
-                        "externalIdentifier": [{"type": "cve", "identifier": vuln.id}] if vuln.id.startswith("CVE-") else [],
+                        "externalIdentifier": (
+                            [{"type": "ExternalIdentifier", "externalIdentifierType": "cve", "identifier": vuln.id}]
+                            if vuln.id.startswith("CVE-")
+                            else []
+                        ),
                     }
                     vuln_annotations = _vulnerability_annotations(
                         vuln,
@@ -238,15 +270,19 @@ def to_spdx(report: AIBOMReport) -> dict:
                         assessment["comment"] = "CISA KEV: actively exploited in the wild"
                     relationships.append(assessment)
 
-    return {
-        "@context": SPDX_3_CONTEXT,
-        "spdxVersion": "SPDX-3.0",
-        "dataLicense": "CC0-1.0",
-        "SPDXID": document_id,
+    # Stamp the shared CreationInfo back-reference on every element / relationship
+    # node (Relationships are Elements in SPDX 3.0 and require creationInfo too).
+    for node in (*elements, *relationships):
+        node.setdefault("creationInfo", _CREATION_INFO_ID)
+
+    spdx_document: dict[str, Any] = {
+        "type": "SpdxDocument",
+        "spdxId": document_id,
+        "creationInfo": _CREATION_INFO_ID,
         "name": f"agent-bom-{report.generated_at.strftime('%Y%m%d-%H%M%S')}",
-        "creationInfo": creation_info,
-        "elements": elements,
-        "relationships": relationships,
+        "dataLicense": "CC0-1.0",
+        "profileConformance": list(SPDX_3_PROFILE_CONFORMANCE),
+        "rootElement": root_element_ids,
         "comment": (
             f"Security scan generated by agent-bom {report.tool_version}. "
             f"Covers {report.total_agents} agent(s), {report.total_servers} MCP server(s), "
@@ -254,9 +290,17 @@ def to_spdx(report: AIBOMReport) -> dict:
         ),
     }
 
+    # Canonical JSON-LD: a single flat @graph holding the CreationInfo blank node,
+    # the SpdxDocument root, and every element + relationship.
+    graph: list[dict[str, Any]] = [creation_info, spdx_document, *elements, *relationships]
+    return {
+        "@context": SPDX_3_CONTEXT,
+        "@graph": graph,
+    }
+
 
 def export_spdx(report: AIBOMReport, output_path: str) -> None:
-    """Export report as SPDX 3.0 JSON-LD file."""
+    """Export report as a canonical SPDX 3.0.1 JSON-LD file."""
     data = to_spdx(report)
     Path(output_path).write_text(json.dumps(data, indent=2))
 

--- a/src/agent_bom/sbom.py
+++ b/src/agent_bom/sbom.py
@@ -313,7 +313,8 @@ def _spdx3_purl(elem: dict) -> str:
         if not identifier:
             continue
         id_type = str(entry.get("type") or "").lower()
-        if id_type in ("packageurl", "purl") or identifier.startswith("pkg:"):
+        ext_id_type = str(entry.get("externalIdentifierType") or "").lower()
+        if id_type in ("packageurl", "purl") or ext_id_type in ("packageurl", "purl") or identifier.startswith("pkg:"):
             return identifier
         if not fallback:
             fallback = identifier
@@ -445,13 +446,65 @@ def _spdx3_vulnerabilities(data: dict, pkg_by_id: dict[str, Package]) -> None:
             )
 
 
+def _spdx3_graph(data: dict) -> list | None:
+    """Return the JSON-LD ``@graph`` node list if ``data`` is a canonical
+    SPDX 3.0 document, else ``None``."""
+    graph = data.get("@graph")
+    if not isinstance(graph, list):
+        return None
+    ctx = data.get("@context")
+    if isinstance(ctx, str) and "spdx.org/rdf/3." in ctx:
+        return graph
+    if isinstance(ctx, list) and any(isinstance(c, str) and "spdx.org/rdf/3." in c for c in ctx):
+        return graph
+    for node in graph:
+        if isinstance(node, dict) and node.get("type") == "CreationInfo" and str(node.get("specVersion") or "").startswith("3."):
+            return graph
+    return None
+
+
+def _normalize_spdx3_graph(data: dict) -> dict:
+    """Project a canonical ``@graph`` SPDX 3.0.1 document onto the flat
+    ``elements``/``relationships``/``spdxVersion`` shape the parser consumes.
+
+    Legacy flat SPDX 3.0 documents and non-SPDX-3 documents pass through
+    unchanged, so both serializations round-trip through the same reader.
+    """
+    graph = _spdx3_graph(data)
+    if graph is None:
+        return data
+    spec = ""
+    doc_id = ""
+    doc_name = ""
+    for node in graph:
+        if not isinstance(node, dict):
+            continue
+        ntype = node.get("type")
+        if ntype == "CreationInfo" and not spec:
+            spec = str(node.get("specVersion") or "")
+        elif ntype == "SpdxDocument":
+            doc_id = node.get("spdxId") or node.get("SPDXID") or doc_id
+            doc_name = node.get("name") or doc_name
+    relationships = [n for n in graph if isinstance(n, dict) and str(n.get("type") or "").endswith("Relationship")]
+    projected = dict(data)
+    projected["spdxVersion"] = f"SPDX-{spec}" if spec else "SPDX-3.0"
+    projected["elements"] = graph
+    projected["relationships"] = relationships
+    if doc_id:
+        projected["SPDXID"] = doc_id
+    if doc_name and not projected.get("name"):
+        projected["name"] = doc_name
+    return projected
+
+
 def parse_spdx(data: dict) -> list[Package]:
     """Parse an SPDX 2.x or 3.0 JSON document into Package objects.
 
     Handles both:
     - SPDX 2.x: top-level "packages" array with "name", "versionInfo", "externalRefs"
-    - SPDX 3.0: "elements" array with type "software/Package"
+    - SPDX 3.0: canonical ``@graph`` JSON-LD or a flat "elements" array
     """
+    data = _normalize_spdx3_graph(data)
     packages: list[Package] = []
 
     # SPDX 3.0: build direct dependency set from DEPENDS_ON relationships. These
@@ -596,6 +649,7 @@ def detect_sbom_resource_name(data: dict) -> str | None:
 
     Returns None if no meaningful name is found.
     """
+    data = _normalize_spdx3_graph(data)
     # CycloneDX
     if data.get("bomFormat") == "CycloneDX":
         comp = data.get("metadata", {}).get("component", {})
@@ -625,6 +679,7 @@ def parse_sbom_document(data: dict, source_name: str = "<memory>") -> tuple[list
     Returns ``(packages, format_name, resource_name)`` where ``resource_name``
     is auto-detected from SBOM metadata when available.
     """
+    data = _normalize_spdx3_graph(data)
     resource_name = detect_sbom_resource_name(data)
 
     if "bomFormat" in data and data["bomFormat"] == "CycloneDX":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -936,19 +936,22 @@ def test_spdx_output_structure(sample_report):
     from agent_bom.output import to_spdx
 
     data = to_spdx(sample_report)
-    assert data["spdxVersion"] == "SPDX-3.0"
-    assert data["dataLicense"] == "CC0-1.0"
-    assert "elements" in data
-    assert "relationships" in data
-    assert "creationInfo" in data
-    assert len(data["elements"]) > 0
+    # Canonical SPDX 3.0.1 JSON-LD: @context + @graph, no legacy top-level keys.
+    assert set(data) == {"@context", "@graph"}
+    assert data["@context"] == "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+    graph = data["@graph"]
+    doc = next(n for n in graph if n["type"] == "SpdxDocument")
+    assert doc["dataLicense"] == "CC0-1.0"
+    ci = next(n for n in graph if n["type"] == "CreationInfo")
+    assert ci["specVersion"] == "3.0.1"
+    assert len(graph) > 0
 
 
 def test_spdx_has_vulnerability_elements(sample_report):
     from agent_bom.output import to_spdx
 
     data = to_spdx(sample_report)
-    vuln_elements = [e for e in data["elements"] if e.get("type") == "security_Vulnerability"]
+    vuln_elements = [e for e in data["@graph"] if e.get("type") == "security_Vulnerability"]
     assert len(vuln_elements) >= 1
     assert vuln_elements[0]["name"] == "CVE-2024-1234"
 
@@ -959,7 +962,8 @@ def test_spdx_export_file(sample_report, tmp_path):
     out = tmp_path / "test.spdx.json"
     export_spdx(sample_report, str(out))
     data = json.loads(out.read_text())
-    assert data["spdxVersion"] == "SPDX-3.0"
+    assert data["@context"] == "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+    assert next(n for n in data["@graph"] if n["type"] == "CreationInfo")["specVersion"] == "3.0.1"
 
 
 def test_cli_scan_has_spdx_format():
@@ -4239,7 +4243,7 @@ def test_spdx_includes_declared_license():
     agent = Agent(name="a", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/tmp/c.json", mcp_servers=[server])
     report = AIBOMReport(agents=[agent], blast_radii=[])
     spdx = to_spdx(report)
-    pkg_elements = [e for e in spdx["elements"] if e.get("declaredLicense")]
+    pkg_elements = [e for e in spdx["@graph"] if e.get("declaredLicense")]
     assert len(pkg_elements) >= 1
     assert pkg_elements[0]["declaredLicense"] == "BSD-3-Clause"
 

--- a/tests/test_exec_score.py
+++ b/tests/test_exec_score.py
@@ -45,11 +45,46 @@ def test_summary_never_claims_no_vulns_when_counted() -> None:
     assert "3 high" in result["summary"]
 
 
-def test_penalty_caps_score_floor_at_zero() -> None:
+def test_large_estate_grades_f_without_flooring_at_zero() -> None:
+    """A big critical estate is grade F with a very low — but non-zero — score.
+
+    The diminishing-returns curve approaches 0 asymptotically; it must never
+    round to a hard 0 for a finite estate (that is the saturation bug: 0 leaves
+    no room to distinguish a bad estate from a catastrophic one)."""
     result = compute_exec_score(severity=_sev(critical=50))
-    assert result["score"] == 0.0
     assert result["grade"] == "F"
-    assert result["penalty_total"] == 100.0
+    assert 0.0 < result["score"] < 15.0
+    # score + penalty_total reconcile to a full 100 points.
+    assert round(result["score"] + result["penalty_total"], 1) == 100.0
+
+
+def test_score_discriminates_across_estate_scale() -> None:
+    """The core #3967 fix: two estates with very different critical counts get
+    *different* failing scores — both bad, but distinguishable, not both F/0."""
+    small = compute_exec_score(severity=_sev(critical=20))
+    mid = compute_exec_score(severity=_sev(critical=200))
+    large = compute_exec_score(severity=_sev(critical=2000))
+    # All fail, but each is strictly worse than the last — no saturation.
+    assert small["grade"] == mid["grade"] == large["grade"] == "F"
+    assert small["score"] > mid["score"] > large["score"] > 0.0
+    # The 20-vs-2000 gap the audit called out is materially resolvable.
+    assert small["score"] - large["score"] > 5.0
+
+
+def test_more_criticals_never_raise_the_score() -> None:
+    """Monotonic invariant (#3949): adding findings only lowers the score."""
+    prev = compute_exec_score(severity=_sev(critical=1))["score"]
+    for n in range(2, 40):
+        cur = compute_exec_score(severity=_sev(critical=n))["score"]
+        assert cur < prev, f"critical={n} did not lower the score"
+        prev = cur
+
+
+def test_clean_estate_still_scores_a() -> None:
+    """A scanned estate with zero findings (floor present) still grades A."""
+    result = compute_exec_score(severity=_sev(), floor_score=100.0)
+    assert result["score"] == 100.0
+    assert result["grade"] == "A"
 
 
 def test_floor_never_launders_a_failing_scorecard_up() -> None:
@@ -63,8 +98,11 @@ def test_floor_never_launders_a_failing_scorecard_up() -> None:
 def test_floor_does_not_raise_a_worse_count() -> None:
     """When counts are worse than the floor, the worse count wins."""
     result = compute_exec_score(severity=_sev(critical=10), floor_score=95.0)
-    assert result["score"] == 0.0
+    # Count-derived score (10 critical) is well below the benign 95 floor, so the
+    # count wins and the floor is not applied.
     assert result["grade"] == "F"
+    assert result["score"] < 60.0
+    assert result["floored"] is False
 
 
 def test_kev_and_exposure_amplify() -> None:

--- a/tests/test_interop_schema_conformance.py
+++ b/tests/test_interop_schema_conformance.py
@@ -9,9 +9,9 @@ generates each format from one multi-entity report (agent -> MCP server -> tool
 
 * SARIF 2.1.0 / CycloneDX 1.6 / SPDX 2.3 validate against their vendored
   official JSON schemas (``jsonschema``);
-* SPDX 3.0 carries the 3.0 JSON-LD vocabulary (the 3.0.0 serialization agent-bom
-  emits predates the strict 3.0.1 ``@graph`` schema, so it is checked
-  structurally — see ``test_spdx_3_0_carries_spdx3_vocabulary``);
+* SPDX 3.0 is emitted as canonical SPDX 3.0.1 JSON-LD (``@context`` + ``@graph``
+  with a ``CreationInfo`` blank node and ``SpdxDocument`` root) and is checked
+  structurally + round-tripped — see ``test_spdx_3_0_is_canonical_jsonld``;
 * JSON package serializers surface ``is_malicious`` / ``malicious_reason``; and
 * two consecutive runs on identical input yield byte-identical bytes.
 
@@ -182,32 +182,57 @@ def test_spdx2_conforms_to_2_3_schema(report: AIBOMReport) -> None:
     _assert_schema_valid("SPDX 2.3", "spdx-2.3.schema.json", Draft201909Validator, to_spdx2(report))
 
 
-def test_spdx_3_0_carries_spdx3_vocabulary(report: AIBOMReport) -> None:
-    """SPDX 3.0 output uses the 3.0.0 JSON-LD serialization (fixed in #3779). The
-    strict 3.0.1 ``@graph`` schema does not model this shape, so conformance is
-    asserted against the required 3.0 vocabulary rather than rewriting the doc."""
+def test_spdx_3_0_is_canonical_jsonld(report: AIBOMReport) -> None:
+    """SPDX 3.0 output is canonical SPDX 3.0.1 JSON-LD (#3967): a top-level
+    ``@context`` + ``@graph``, a ``CreationInfo`` blank node with the semver
+    ``specVersion``, an ``SpdxDocument`` root, and namespaced 3.0 vocabulary."""
     doc = to_spdx(report)
-    assert doc["spdxVersion"] == "SPDX-3.0"
-    assert doc["@context"].startswith("https://spdx.org/rdf/3.0")
-    assert doc["creationInfo"]["specVersion"] == "3.0.0"
-    assert doc["SPDXID"].startswith("SPDXRef-")
+    # Canonical top level — exactly @context + @graph, no legacy flat keys.
+    assert set(doc) == {"@context", "@graph"}
+    assert doc["@context"] == "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+    # Parses as JSON-LD (deserializes cleanly, @graph is a node list).
+    graph = json.loads(json.dumps(doc))["@graph"]
+    assert isinstance(graph, list) and graph
 
-    elements = doc["elements"]
-    assert elements, "expected at least one SPDX 3.0 element"
-    element_types = {e["type"] for e in elements}
+    creation_info = next(n for n in graph if n["type"] == "CreationInfo")
+    assert creation_info["@id"].startswith("_:")
+    assert creation_info["specVersion"] == "3.0.1"
+
+    spdx_document = next(n for n in graph if n["type"] == "SpdxDocument")
+    assert spdx_document["spdxId"].startswith("SPDXRef-")
+    assert spdx_document["creationInfo"] == creation_info["@id"]
+    assert "core" in spdx_document["profileConformance"]
+    assert spdx_document["rootElement"], "SpdxDocument must reference a root element"
+
+    element_types = {n["type"] for n in graph}
     # 3.0 profile-namespaced vocabulary — a 2.x-style bare "Package" is a regression.
     assert "software_Package" in element_types
     assert "security_Vulnerability" in element_types
-    for element in elements:
-        assert element.get("spdxId", "").startswith("SPDXRef-"), element
+
+    # Every graph node (bar the CreationInfo blank node itself) is a real Element:
+    # it carries a spdxId and a back-reference to the shared CreationInfo.
+    for node in graph:
+        if node["type"] == "CreationInfo":
+            continue
+        assert node.get("spdxId", "").startswith("SPDXRef-"), node
+        assert node.get("creationInfo") == creation_info["@id"], node
 
     valid_rel_types = {"contains", "dependsOn", "hasAssessmentFor", "affects", "describes", "generates"}
-    for rel in doc["relationships"]:
-        # Either the base Relationship or a 3.0 profile subtype (e.g.
+    relationships = [n for n in graph if str(n.get("type") or "").endswith("Relationship")]
+    assert relationships
+    for rel in relationships:
+        # Base Relationship or a 3.0 profile subtype (e.g.
         # security_CvssV3VulnAssessmentRelationship) — all end in "Relationship".
         assert rel["type"].endswith("Relationship"), rel
         assert rel["relationshipType"] in valid_rel_types, rel
         assert rel.get("from") and rel.get("to"), rel
+
+    # Round-trips back through the SBOM reader with packages + vuln intact.
+    from agent_bom.sbom import parse_sbom_document
+
+    packages, fmt, _name = parse_sbom_document(doc)
+    assert fmt == "spdx-3"
+    assert {p.name for p in packages}, "expected packages recovered from @graph"
 
 
 def test_json_packages_carry_is_malicious(report: AIBOMReport) -> None:

--- a/tests/test_output_cov.py
+++ b/tests/test_output_cov.py
@@ -489,7 +489,7 @@ class TestToSpdx:
     def test_empty_report(self):
         report = _make_report()
         spdx = to_spdx(report)
-        assert spdx["spdxVersion"] == "SPDX-3.0"
+        assert next(n for n in spdx["@graph"] if n["type"] == "CreationInfo")["specVersion"] == "3.0.1"
 
 
 def test_spdx_package_preserves_version_provenance_annotations():
@@ -500,7 +500,7 @@ def test_spdx_package_preserves_version_provenance_annotations():
     report = _make_report(agents=[agent])
 
     spdx = to_spdx(report)
-    pkg_element = next(element for element in spdx["elements"] if element.get("name") == pkg.name)
+    pkg_element = next(element for element in spdx["@graph"] if element.get("name") == pkg.name)
     statements = {annotation["statement"] for annotation in pkg_element["annotation"]}
 
     assert "agent-bom:version-provenance-source=lockfile" in statements
@@ -531,7 +531,7 @@ def test_json_output_redacts_server_launch_fields():
         br = _make_blast_radius(pkg=pkg, agents=[agent])
         report = _make_report(agents=[agent], blast_radii=[br])
         spdx = to_spdx(report)
-        assert len(spdx["elements"]) >= 1
+        assert len(spdx["@graph"]) >= 1
 
 
 class TestToJson:
@@ -1287,7 +1287,7 @@ def test_to_spdx_with_agent():
     agent = _make_agent_cov2(servers=[srv])
     report = _make_report_cov2(agents=[agent])
     result = to_spdx(report)
-    assert len(result.get("packages", result.get("elements", []))) >= 1
+    assert len(result["@graph"]) >= 1
 
 
 # ── to_sarif extras (from cov2) ─────────────────────────────────────────────

--- a/tests/test_output_fidelity_correctness.py
+++ b/tests/test_output_fidelity_correctness.py
@@ -74,11 +74,11 @@ def test_spdx3_flags_malicious_package():
     from agent_bom.output.spdx_fmt import to_spdx
 
     doc = to_spdx(_mal_report())
-    evil = next(e for e in doc["elements"] if e.get("name") == "evil-lib")
+    evil = next(e for e in doc["@graph"] if e.get("name") == "evil-lib")
     statements = {a["statement"] for a in evil.get("annotation", [])}
     assert any(s.startswith("agent-bom:malicious=true") for s in statements)
 
-    benign = next(e for e in doc["elements"] if e.get("name") == "requests")
+    benign = next(e for e in doc["@graph"] if e.get("name") == "requests")
     benign_statements = {a["statement"] for a in benign.get("annotation", [])}
     assert not any(s.startswith("agent-bom:malicious=true") for s in benign_statements)
 
@@ -102,26 +102,29 @@ def test_spdx3_uses_spdx3_vocabulary():
     from agent_bom.output.spdx_fmt import to_spdx
 
     doc = to_spdx(_mal_report())
-    assert doc["spdxVersion"] == "SPDX-3.0"
+    graph = doc["@graph"]
+    creation_info = next(n for n in graph if n["type"] == "CreationInfo")
+    assert creation_info["specVersion"] == "3.0.1"
 
-    element_types = {e.get("type") for e in doc["elements"]}
+    element_types = {e.get("type") for e in graph}
     assert "software_Package" in element_types
     assert "security_Vulnerability" in element_types
     # No SPDX-2.x element vocabulary leaked into a 3.0 document.
     assert not set(_SPDX2_TOKENS) & element_types
 
-    for elem in doc["elements"]:
+    for elem in graph:
         # 2.x used "primaryPurpose"; 3.0 namespaces it as "software_primaryPurpose".
         assert "primaryPurpose" not in elem
         # No ad-hoc CVSS score object on the vulnerability element.
         assert "score" not in elem
 
-    rel_types = {r.get("relationshipType") for r in doc["relationships"]}
+    relationships = [r for r in graph if str(r.get("type") or "").endswith("Relationship")]
+    rel_types = {r.get("relationshipType") for r in relationships}
     assert {"contains", "dependsOn", "affects"} <= rel_types
     assert not set(_SPDX2_REL_TYPES) & rel_types
 
     # CVSS is expressed as a security-profile assessment relationship.
-    cvss_rels = [r for r in doc["relationships"] if r.get("type") == "security_CvssV3VulnAssessmentRelationship"]
+    cvss_rels = [r for r in relationships if r.get("type") == "security_CvssV3VulnAssessmentRelationship"]
     assert cvss_rels
     assert cvss_rels[0]["security_score"] == 7.5
     assert cvss_rels[0]["relationshipType"] == "hasAssessmentFor"

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -837,8 +837,8 @@ def test_spdx_vulnerability_annotations_preserve_enrichment_and_compliance_metad
     report = _make_report(agents=[_make_agent(servers=[_make_server(packages=[pkg])])], blast_radii=[br])
 
     spdx = to_spdx(report)
-    assert spdx["@context"] == "https://spdx.org/rdf/3.0.0/spdx-context.jsonl"
-    vuln_element = next(element for element in spdx["elements"] if element.get("type") == "security_Vulnerability")
+    assert spdx["@context"] == "https://spdx.org/rdf/3.0.1/spdx-context.jsonld"
+    vuln_element = next(element for element in spdx["@graph"] if element.get("type") == "security_Vulnerability")
     statements = {annotation["statement"] for annotation in vuln_element["annotation"]}
 
     assert "agent-bom:severity-source=nvd:cvss_v3" in statements
@@ -861,7 +861,7 @@ def test_spdx_vulnerability_annotations_use_unified_findings_without_blast_radii
     report.findings = [_make_unified_cve_finding()]
 
     spdx = to_spdx(report)
-    vuln_element = next(element for element in spdx["elements"] if element.get("type") == "security_Vulnerability")
+    vuln_element = next(element for element in spdx["@graph"] if element.get("type") == "security_Vulnerability")
     statements = {annotation["statement"] for annotation in vuln_element["annotation"]}
 
     assert "agent-bom:compliance-tag=owasp_llm:LLM05" in statements

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -175,9 +175,10 @@ def test_overview_reads_compacted_scan_summary() -> None:
 
     # The configurable exec-score engine (#3940) recomputes the grade from the
     # honest estate counts and takes the *worst* of that and the scan scorecard
-    # floor (42.0). 3 critical + 12 high + 72 unrated caps the penalty, so the
-    # honest score is 0.0 — still an F, and the CVE/severity tiles are populated
-    # (the compaction-must-not-zero-tiles intent this test guards).
+    # floor (42.0). 3 critical + 12 high + 72 unrated is heavy pressure, so the
+    # diminishing-returns score lands well below the floor — still an F, and the
+    # CVE/severity tiles are populated (the compaction-must-not-zero-tiles intent
+    # this test guards).
     assert data["posture"]["grade"] == "F"
     assert data["posture"]["score"] <= 42.0
     assert data["headline"]["critical"] == 3

--- a/tests/test_postgres_compliance_hub_migration.py
+++ b/tests/test_postgres_compliance_hub_migration.py
@@ -1,0 +1,86 @@
+"""Regression tests for the Postgres Compliance Hub primary-key migration.
+
+The dedup DELETE in ``_migrate_primary_key`` is a full-table self-join that,
+on a large already-migrated table, exceeded the default 15s statement_timeout
+and 500'd every store init (#3980). These tests pin the fix: the migration is a
+true no-op (no DELETE, no DDL) once the collapsed ``(tenant_id, finding_id)``
+primary key is in place, and still dedups + swaps the key on an old-shape or
+missing primary key. They use a connection spy so they run without a live
+Postgres (the store's own tests mock psycopg for the same reason).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from agent_bom.api.postgres_compliance_hub import PostgresComplianceHubStore
+
+
+@dataclass
+class _FakeCursor:
+    row: tuple[Any, ...] | None = None
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self.row
+
+
+@dataclass
+class _ConnSpy:
+    """Records executed SQL and answers the pkey-shape probe with ``pk_cols``."""
+
+    pk_cols: str | None
+    executed: list[str] = field(default_factory=list)
+
+    def execute(self, sql: str, params: tuple | None = None) -> _FakeCursor:
+        self.executed.append(sql)
+        normalized = " ".join(sql.split()).lower()
+        if "from pg_constraint" in normalized and "string_agg" in normalized:
+            return _FakeCursor(row=(self.pk_cols,))
+        return _FakeCursor()
+
+    def _statements(self) -> list[str]:
+        return [" ".join(s.split()).lower() for s in self.executed]
+
+    def _issued_delete(self) -> bool:
+        return any(s.startswith("delete from compliance_hub_findings a") for s in self._statements())
+
+    def _issued_pk_ddl(self) -> bool:
+        return any("add constraint compliance_hub_findings_pkey" in s for s in self._statements())
+
+    def _issued_probe(self) -> bool:
+        return any("from pg_constraint" in s and "string_agg" in s for s in self._statements())
+
+
+def test_migration_is_true_no_op_when_pk_already_collapsed():
+    """Already-migrated table: probe only, no dedup DELETE and no DDL (#3980)."""
+    conn = _ConnSpy(pk_cols="tenant_id,finding_id")
+
+    PostgresComplianceHubStore._migrate_primary_key(conn)
+
+    assert conn._issued_probe(), "expected the pkey-shape probe to run"
+    assert not conn._issued_delete(), "dedup self-join DELETE must not run when PK is already collapsed"
+    assert not conn._issued_pk_ddl(), "no constraint swap when PK is already collapsed"
+    # Probe is the only statement issued on the hot path.
+    assert len(conn.executed) == 1
+
+
+def test_migration_dedups_and_swaps_pk_on_old_shape():
+    """Legacy (tenant_id, finding_id, ordinal) key: dedup DELETE + constraint swap."""
+    conn = _ConnSpy(pk_cols="tenant_id,finding_id,ordinal")
+
+    PostgresComplianceHubStore._migrate_primary_key(conn)
+
+    assert conn._issued_probe()
+    assert conn._issued_delete(), "old-shape table must be deduped before the unique key"
+    assert conn._issued_pk_ddl(), "old-shape table must have the collapsed PK added"
+
+
+def test_migration_runs_when_primary_key_missing():
+    """No primary key at all: still dedup + add the collapsed key (safe fallback)."""
+    conn = _ConnSpy(pk_cols=None)
+
+    PostgresComplianceHubStore._migrate_primary_key(conn)
+
+    assert conn._issued_delete()
+    assert conn._issued_pk_ddl()

--- a/tests/test_spdx2_and_checksums.py
+++ b/tests/test_spdx2_and_checksums.py
@@ -150,7 +150,7 @@ def test_spdx2_tagvalue_emits_checksum_and_relationships():
 def test_spdx3_surfaces_verified_using_checksum():
     report, expected_hex = _report_with_checksummed_pkg()
     doc = to_spdx(report)
-    pkg_elements = [e for e in doc["elements"] if e.get("software_primaryPurpose") == "library"]
+    pkg_elements = [e for e in doc["@graph"] if e.get("software_primaryPurpose") == "library"]
     assert pkg_elements
     verified = pkg_elements[0]["verifiedUsing"]
     assert {"type": "Hash", "algorithm": "sha512", "hashValue": expected_hex} in verified

--- a/ui/components/exposure-path-command-center.tsx
+++ b/ui/components/exposure-path-command-center.tsx
@@ -15,6 +15,8 @@ import {
   Wrench,
 } from "lucide-react";
 import { pathDisplayTitle, pathFixLabel, type ExposureEntityRole, type ExposurePath } from "@/lib/exposure-path";
+import { GRAPH_ROLE_STYLE } from "@/lib/exposure-path-graph-style";
+import { buildPathGraphLayout, wrapGraphText, truncateGraphText } from "@/lib/exposure-path-graph-layout";
 import { ExposurePathNeighborExplorer } from "@/components/exposure-path-neighbor-explorer";
 
 export interface ExposurePathCommandAction {
@@ -33,18 +35,6 @@ const ROLE_META: Record<ExposureEntityRole, { label: string; icon: LucideIcon; t
   environment: { label: "Environment", icon: Database, tint: "border-cyan-500/30 bg-cyan-500/10 text-cyan-200" },
   cluster: { label: "Cluster", icon: Database, tint: "border-indigo-500/30 bg-indigo-500/10 text-indigo-200" },
   unknown: { label: "Entity", icon: ShieldAlert, tint: "border-slate-500/30 bg-slate-500/10 text-slate-200" },
-};
-
-const GRAPH_ROLE_STYLE: Record<ExposureEntityRole, { fill: string; stroke: string; text: string; accent: string }> = {
-  agent: { fill: "#052e24", stroke: "#10b981", text: "#d1fae5", accent: "#34d399" },
-  server: { fill: "#082f49", stroke: "#0ea5e9", text: "#e0f2fe", accent: "#38bdf8" },
-  package: { fill: "#422006", stroke: "#f59e0b", text: "#fef3c7", accent: "#fbbf24" },
-  finding: { fill: "#450a0a", stroke: "#ef4444", text: "#fee2e2", accent: "#f87171" },
-  credential: { fill: "#3b0764", stroke: "#d946ef", text: "#fae8ff", accent: "#e879f9" },
-  tool: { fill: "#2e1065", stroke: "#a855f7", text: "#f3e8ff", accent: "#c084fc" },
-  environment: { fill: "#164e63", stroke: "#06b6d4", text: "#cffafe", accent: "#22d3ee" },
-  cluster: { fill: "#312e81", stroke: "#6366f1", text: "#e0e7ff", accent: "#818cf8" },
-  unknown: { fill: "#1e293b", stroke: "#64748b", text: "#f1f5f9", accent: "#94a3b8" },
 };
 
 export function ExposurePathCommandCenter({
@@ -201,12 +191,14 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
   const layout = buildPathGraphLayout(path);
 
   return (
-    <div className="overflow-x-auto p-2">
+    <div className="flex justify-center overflow-x-auto p-2">
       <svg
         viewBox={`0 0 ${layout.width} ${layout.height}`}
+        preserveAspectRatio="xMidYMid meet"
         role="img"
         aria-label={`Selected exposure path graph for ${pathDisplayTitle(path)}`}
-        className="block h-auto min-w-[720px] w-full md:min-w-0"
+        style={{ maxWidth: `${layout.fitWidth}px` }}
+        className="mx-auto block h-auto w-full"
       >
         <defs>
           <marker id="exposure-arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
@@ -252,7 +244,7 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
         {layout.nodes.map((node, index) => {
           const style = GRAPH_ROLE_STYLE[node.role] ?? GRAPH_ROLE_STYLE.unknown;
           const meta = ROLE_META[node.role] ?? ROLE_META.unknown;
-          const titleLines = wrapGraphText(node.label, 18, 2);
+          const titleLines = wrapGraphText(node.label, layout.labelChars, 2);
           return (
             <g key={`${node.id}-${index}`} transform={`translate(${node.x} ${node.y})`}>
               <rect
@@ -286,112 +278,6 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
       </svg>
     </div>
   );
-}
-
-function buildPathGraphLayout(path: ExposurePath) {
-  // Geometry note: nodes are spaced with a generous horizontal gap so the
-  // relationship pill sits centred in the clear channel between two node boxes
-  // — never overlapping a node or getting clipped at the container edge. The
-  // SVG scales to its container via viewBox, so a wider board just renders a
-  // little smaller; it never crowds the labels.
-  const nodeWidth = 188;
-  const nodeHeight = 76;
-  const marginX = 28;
-  const marginY = 30;
-  const columnGap = 132;
-  const rowGap = 116;
-  const columns = Math.min(4, Math.max(1, path.hops.length));
-  const rows = Math.max(1, Math.ceil(path.hops.length / columns));
-  const pitchX = nodeWidth + columnGap;
-  const width = marginX * 2 + columns * nodeWidth + (columns - 1) * columnGap;
-  const height = marginY * 2 + rows * nodeHeight + (rows - 1) * (rowGap - nodeHeight);
-  const nodes = path.hops.map((hop, index) => {
-    const row = Math.floor(index / columns);
-    const col = index % columns;
-    const visualCol = row % 2 === 0 ? col : columns - 1 - col;
-    return {
-      ...hop,
-      x: marginX + visualCol * pitchX,
-      y: marginY + row * rowGap,
-    };
-  });
-  const edges = nodes.slice(0, -1).map((source, index) => {
-    const target = nodes[index + 1]!;
-    const relationship = relationshipForPathStep(path, source.id, target.id, index);
-    const startX = source.x + nodeWidth;
-    const startY = source.y + nodeHeight / 2;
-    const endX = target.x;
-    const endY = target.y + nodeHeight / 2;
-    const sameRow = Math.abs(startY - endY) < 10;
-    const control = sameRow ? Math.max(40, Math.abs(endX - startX) / 2) : 56;
-    const pathD = sameRow
-      ? `M ${startX} ${startY} C ${startX + control} ${startY}, ${endX - control} ${endY}, ${endX} ${endY}`
-      : `M ${source.x + nodeWidth / 2} ${source.y + nodeHeight} C ${source.x + nodeWidth / 2} ${source.y + nodeHeight + control}, ${target.x + nodeWidth / 2} ${target.y - control}, ${target.x + nodeWidth / 2} ${target.y}`;
-    const style = GRAPH_ROLE_STYLE[target.role] ?? GRAPH_ROLE_STYLE.unknown;
-    return {
-      id: `${source.id}->${target.id}`,
-      path: pathD,
-      stroke: style.stroke,
-      label: truncateGraphText(relationship, 16),
-      // Centre the pill on the edge line, mid-channel between the two nodes.
-      labelX: sameRow ? (startX + endX) / 2 : source.x + nodeWidth / 2,
-      labelY: sameRow ? startY : (source.y + nodeHeight + target.y) / 2,
-    };
-  });
-  const relationshipLabels = edges.map((edge) => ({
-    id: `${edge.id}:label`,
-    text: edge.label,
-    x: edge.labelX,
-    y: edge.labelY,
-    width: Math.max(50, Math.round(edge.label.length * 6.6 + 22)),
-  }));
-
-  return { width, height, nodeWidth, nodeHeight, nodes, edges, relationshipLabels };
-}
-
-function relationshipForPathStep(path: ExposurePath, source: string, target: string, index: number): string {
-  const byEndpoints = path.relationships.find((relationship) => relationship.source === source && relationship.target === target);
-  const raw = byEndpoints?.relationship ?? path.relationships[index]?.relationship ?? "reaches";
-  return humanizeRelationship(raw);
-}
-
-function humanizeRelationship(value: string): string {
-  return value
-    .replace(/[_:]+/g, " ")
-    .trim()
-    .replace(/\b\w/g, (char) => char.toUpperCase());
-}
-
-function truncateGraphText(value: string, maxLength: number): string {
-  return value.length > maxLength ? `${value.slice(0, Math.max(1, maxLength - 1))}…` : value;
-}
-
-function wrapGraphText(value: string, maxLineLength: number, maxLines: number): string[] {
-  const normalized = value.replace(/\s+/g, " ").trim();
-  if (normalized.length <= maxLineLength) return [normalized];
-
-  const lines: string[] = [];
-  let remaining = normalized;
-  while (remaining.length > 0 && lines.length < maxLines) {
-    const isLastLine = lines.length === maxLines - 1;
-    if (remaining.length <= maxLineLength) {
-      lines.push(remaining);
-      break;
-    }
-    if (isLastLine) {
-      lines.push(truncateGraphText(remaining, maxLineLength));
-      break;
-    }
-
-    const window = remaining.slice(0, maxLineLength + 1);
-    const breakpoints = [" ", "-", "_", "/", ":", "@", "."].map((character) => window.lastIndexOf(character));
-    const breakpoint = Math.max(...breakpoints);
-    const cut = breakpoint >= Math.floor(maxLineLength * 0.45) ? breakpoint + 1 : maxLineLength;
-    lines.push(remaining.slice(0, cut).trim());
-    remaining = remaining.slice(cut).trim();
-  }
-
-  return lines.length > 0 ? lines : [truncateGraphText(normalized, maxLineLength)];
 }
 
 function EvidenceRow({

--- a/ui/lib/exposure-path-graph-layout.ts
+++ b/ui/lib/exposure-path-graph-layout.ts
@@ -1,0 +1,188 @@
+import type { ExposurePath } from "@/lib/exposure-path";
+import { GRAPH_ROLE_STYLE } from "@/lib/exposure-path-graph-style";
+
+// Node sizing. Few nodes render at the full design size (never larger — a
+// 2-node path must not balloon into two canvas-filling boxes). As the path
+// grows the boxes shrink toward a readable floor so the whole board stays
+// compact and no single node dominates the viewport.
+export const MAX_NODE_WIDTH = 188;
+export const MIN_NODE_WIDTH = 148;
+export const MAX_NODE_HEIGHT = 76;
+export const MIN_NODE_HEIGHT = 62;
+
+const MARGIN_X = 28;
+const MARGIN_Y = 30;
+const COLUMN_GAP = 132;
+const ROW_GAP_EXTRA = 40; // vertical clear channel between wrapped rows
+const MAX_COLUMNS = 4;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * Node box size for a path of `count` hops. Interpolates from the full design
+ * size (<= 3 nodes) down to a readable floor (>= 9 nodes) so denser paths scale
+ * down instead of overflowing. Monotonically non-increasing in `count`.
+ */
+export function nodeSizeForCount(count: number): { width: number; height: number } {
+  const t = clamp((count - 3) / 6, 0, 1);
+  return {
+    width: Math.round(MAX_NODE_WIDTH - t * (MAX_NODE_WIDTH - MIN_NODE_WIDTH)),
+    height: Math.round(MAX_NODE_HEIGHT - t * (MAX_NODE_HEIGHT - MIN_NODE_HEIGHT)),
+  };
+}
+
+/** Characters per label line, scaled so text stays readable as nodes shrink. */
+export function labelCharsForWidth(nodeWidth: number): number {
+  return Math.max(12, Math.floor((nodeWidth - 28) / 8));
+}
+
+export type PathGraphNode = ExposurePath["hops"][number] & {
+  x: number;
+  y: number;
+};
+
+export interface PathGraphEdge {
+  id: string;
+  path: string;
+  stroke: string;
+  label: string;
+  labelX: number;
+  labelY: number;
+}
+
+export interface PathGraphLayout {
+  width: number;
+  height: number;
+  /**
+   * Natural (1x) CSS pixel width of the board. The SVG is capped at this width
+   * so a small graph renders compact and centred rather than being stretched to
+   * fill the canvas; larger boards still shrink-to-fit via `width: 100%`.
+   */
+  fitWidth: number;
+  nodeWidth: number;
+  nodeHeight: number;
+  labelChars: number;
+  nodes: PathGraphNode[];
+  edges: PathGraphEdge[];
+  relationshipLabels: { id: string; text: string; x: number; y: number; width: number }[];
+}
+
+export function buildPathGraphLayout(path: ExposurePath): PathGraphLayout {
+  const count = path.hops.length;
+  const { width: nodeWidth, height: nodeHeight } = nodeSizeForCount(count);
+  const columns = Math.min(MAX_COLUMNS, Math.max(1, count));
+  const pitchX = nodeWidth + COLUMN_GAP;
+  const rowGap = nodeHeight + ROW_GAP_EXTRA;
+
+  const nodes: PathGraphNode[] = path.hops.map((hop, index) => {
+    const row = Math.floor(index / columns);
+    const col = index % columns;
+    // Boustrophedon rows so a wrapped path reads left-to-right, then back.
+    const visualCol = row % 2 === 0 ? col : columns - 1 - col;
+    return {
+      ...hop,
+      x: MARGIN_X + visualCol * pitchX,
+      y: MARGIN_Y + row * rowGap,
+    };
+  });
+
+  // Auto-fit: the viewBox is the tight bounding box of every node plus a uniform
+  // margin, so the rendered graph always frames its own content — a 1-hop path
+  // is compact, a many-hop path scales down to fit, nothing overflows.
+  const maxX = nodes.reduce((acc, node) => Math.max(acc, node.x + nodeWidth), nodeWidth);
+  const maxY = nodes.reduce((acc, node) => Math.max(acc, node.y + nodeHeight), nodeHeight);
+  const width = maxX + MARGIN_X;
+  const height = maxY + MARGIN_Y;
+
+  const edges: PathGraphEdge[] = nodes.slice(0, -1).map((source, index) => {
+    const target = nodes[index + 1]!;
+    const relationship = relationshipForPathStep(path, source.id, target.id, index);
+    const startX = source.x + nodeWidth;
+    const startY = source.y + nodeHeight / 2;
+    const endX = target.x;
+    const endY = target.y + nodeHeight / 2;
+    const sameRow = Math.abs(startY - endY) < 10;
+    const control = sameRow ? Math.max(40, Math.abs(endX - startX) / 2) : 56;
+    const pathD = sameRow
+      ? `M ${startX} ${startY} C ${startX + control} ${startY}, ${endX - control} ${endY}, ${endX} ${endY}`
+      : `M ${source.x + nodeWidth / 2} ${source.y + nodeHeight} C ${source.x + nodeWidth / 2} ${source.y + nodeHeight + control}, ${target.x + nodeWidth / 2} ${target.y - control}, ${target.x + nodeWidth / 2} ${target.y}`;
+    const style = GRAPH_ROLE_STYLE[target.role] ?? GRAPH_ROLE_STYLE.unknown;
+    return {
+      id: `${source.id}->${target.id}`,
+      path: pathD,
+      stroke: style.stroke,
+      label: truncateGraphText(relationship, 16),
+      labelX: sameRow ? (startX + endX) / 2 : source.x + nodeWidth / 2,
+      labelY: sameRow ? startY : (source.y + nodeHeight + target.y) / 2,
+    };
+  });
+
+  const relationshipLabels = edges.map((edge) => ({
+    id: `${edge.id}:label`,
+    text: edge.label,
+    x: edge.labelX,
+    y: edge.labelY,
+    width: Math.max(50, Math.round(edge.label.length * 6.6 + 22)),
+  }));
+
+  return {
+    width,
+    height,
+    fitWidth: width,
+    nodeWidth,
+    nodeHeight,
+    labelChars: labelCharsForWidth(nodeWidth),
+    nodes,
+    edges,
+    relationshipLabels,
+  };
+}
+
+function relationshipForPathStep(path: ExposurePath, source: string, target: string, index: number): string {
+  const byEndpoints = path.relationships.find(
+    (relationship) => relationship.source === source && relationship.target === target,
+  );
+  const raw = byEndpoints?.relationship ?? path.relationships[index]?.relationship ?? "reaches";
+  return humanizeRelationship(raw);
+}
+
+export function humanizeRelationship(value: string): string {
+  return value
+    .replace(/[_:]+/g, " ")
+    .trim()
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+export function truncateGraphText(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, Math.max(1, maxLength - 1))}…` : value;
+}
+
+export function wrapGraphText(value: string, maxLineLength: number, maxLines: number): string[] {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLineLength) return [normalized];
+
+  const lines: string[] = [];
+  let remaining = normalized;
+  while (remaining.length > 0 && lines.length < maxLines) {
+    const isLastLine = lines.length === maxLines - 1;
+    if (remaining.length <= maxLineLength) {
+      lines.push(remaining);
+      break;
+    }
+    if (isLastLine) {
+      lines.push(truncateGraphText(remaining, maxLineLength));
+      break;
+    }
+
+    const window = remaining.slice(0, maxLineLength + 1);
+    const breakpoints = [" ", "-", "_", "/", ":", "@", "."].map((character) => window.lastIndexOf(character));
+    const breakpoint = Math.max(...breakpoints);
+    const cut = breakpoint >= Math.floor(maxLineLength * 0.45) ? breakpoint + 1 : maxLineLength;
+    lines.push(remaining.slice(0, cut).trim());
+    remaining = remaining.slice(cut).trim();
+  }
+
+  return lines.length > 0 ? lines : [truncateGraphText(normalized, maxLineLength)];
+}

--- a/ui/lib/exposure-path-graph-style.ts
+++ b/ui/lib/exposure-path-graph-style.ts
@@ -1,0 +1,20 @@
+import type { ExposureEntityRole } from "@/lib/exposure-path";
+
+export interface GraphRoleStyle {
+  fill: string;
+  stroke: string;
+  text: string;
+  accent: string;
+}
+
+export const GRAPH_ROLE_STYLE: Record<ExposureEntityRole, GraphRoleStyle> = {
+  agent: { fill: "#052e24", stroke: "#10b981", text: "#d1fae5", accent: "#34d399" },
+  server: { fill: "#082f49", stroke: "#0ea5e9", text: "#e0f2fe", accent: "#38bdf8" },
+  package: { fill: "#422006", stroke: "#f59e0b", text: "#fef3c7", accent: "#fbbf24" },
+  finding: { fill: "#450a0a", stroke: "#ef4444", text: "#fee2e2", accent: "#f87171" },
+  credential: { fill: "#3b0764", stroke: "#d946ef", text: "#fae8ff", accent: "#e879f9" },
+  tool: { fill: "#2e1065", stroke: "#a855f7", text: "#f3e8ff", accent: "#c084fc" },
+  environment: { fill: "#164e63", stroke: "#06b6d4", text: "#cffafe", accent: "#22d3ee" },
+  cluster: { fill: "#312e81", stroke: "#6366f1", text: "#e0e7ff", accent: "#818cf8" },
+  unknown: { fill: "#1e293b", stroke: "#64748b", text: "#f1f5f9", accent: "#94a3b8" },
+};

--- a/ui/tests/exposure-path-graph-layout.test.ts
+++ b/ui/tests/exposure-path-graph-layout.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import type { ExposureEntityRef, ExposurePath } from "@/lib/exposure-path";
+import {
+  MAX_NODE_HEIGHT,
+  MAX_NODE_WIDTH,
+  MIN_NODE_HEIGHT,
+  MIN_NODE_WIDTH,
+  buildPathGraphLayout,
+  labelCharsForWidth,
+  nodeSizeForCount,
+} from "@/lib/exposure-path-graph-layout";
+
+function makePath(nodeCount: number): ExposurePath {
+  const hops: ExposureEntityRef[] = Array.from({ length: nodeCount }, (_, index) => ({
+    id: `node:${index}`,
+    label: `entity-with-a-fairly-long-name-${index}`,
+    role: index === 0 ? "agent" : "package",
+  }));
+  return {
+    id: "path-test",
+    label: hops.map((hop) => hop.label).join(" -> "),
+    summary: "",
+    riskScore: 5,
+    severity: "high",
+    source: hops[0]!,
+    target: hops[hops.length - 1]!,
+    hops,
+    relationships: [],
+    nodeIds: hops.map((hop) => hop.id),
+    edgeIds: [],
+    findings: [],
+    affectedAgents: [],
+    affectedServers: [],
+    reachableTools: [],
+    exposedCredentials: [],
+  };
+}
+
+describe("nodeSizeForCount", () => {
+  it("renders few-node paths at full design size and never larger", () => {
+    for (const count of [1, 2, 3]) {
+      const size = nodeSizeForCount(count);
+      expect(size.width).toBe(MAX_NODE_WIDTH);
+      expect(size.height).toBe(MAX_NODE_HEIGHT);
+    }
+  });
+
+  it("shrinks node size monotonically as the path grows, down to a readable floor", () => {
+    const sizes = [2, 4, 6, 8, 10, 20].map((count) => nodeSizeForCount(count).width);
+    for (let i = 1; i < sizes.length; i += 1) {
+      expect(sizes[i]!).toBeLessThanOrEqual(sizes[i - 1]!);
+    }
+    const dense = nodeSizeForCount(20);
+    expect(dense.width).toBeGreaterThanOrEqual(MIN_NODE_WIDTH);
+    expect(dense.height).toBeGreaterThanOrEqual(MIN_NODE_HEIGHT);
+    // A large path must be strictly smaller than a tiny one.
+    expect(dense.width).toBeLessThan(MAX_NODE_WIDTH);
+  });
+});
+
+describe("labelCharsForWidth", () => {
+  it("keeps a readable minimum of characters even at the smallest node", () => {
+    expect(labelCharsForWidth(MIN_NODE_WIDTH)).toBeGreaterThanOrEqual(12);
+    expect(labelCharsForWidth(MAX_NODE_WIDTH)).toBeGreaterThan(labelCharsForWidth(MIN_NODE_WIDTH) - 1);
+  });
+});
+
+describe("buildPathGraphLayout auto-fit", () => {
+  it("frames a 2-node path compactly so nodes cannot fill the whole canvas", () => {
+    const layout = buildPathGraphLayout(makePath(2));
+    // Single row: viewBox height is just one node band plus margins.
+    expect(layout.height).toBeLessThan(layout.nodeHeight * 2);
+    // The board is capped at its natural width so it renders 1:1, not stretched.
+    expect(layout.fitWidth).toBe(layout.width);
+    // Each node is a minority of the board width — never half-a-canvas boxes.
+    expect(layout.nodeWidth / layout.width).toBeLessThan(0.4);
+  });
+
+  it("tightly bounds every node inside the viewBox with no overflow", () => {
+    for (const count of [1, 2, 3, 6, 10]) {
+      const layout = buildPathGraphLayout(makePath(count));
+      for (const node of layout.nodes) {
+        expect(node.x).toBeGreaterThanOrEqual(0);
+        expect(node.y).toBeGreaterThanOrEqual(0);
+        expect(node.x + layout.nodeWidth).toBeLessThanOrEqual(layout.width);
+        expect(node.y + layout.nodeHeight).toBeLessThanOrEqual(layout.height);
+      }
+      expect(layout.nodes).toHaveLength(count);
+    }
+  });
+
+  it("wraps a 10-node path into rows that fit instead of one giant row", () => {
+    const layout = buildPathGraphLayout(makePath(10));
+    // At most 4 columns, so the board never grows unbounded horizontally.
+    const distinctX = new Set(layout.nodes.map((node) => Math.round(node.x)));
+    expect(distinctX.size).toBeLessThanOrEqual(4);
+    // Multiple rows means it grew vertically to fit, not off the right edge.
+    const distinctY = new Set(layout.nodes.map((node) => Math.round(node.y)));
+    expect(distinctY.size).toBeGreaterThan(1);
+    // Dense path uses smaller nodes than a 2-node path.
+    expect(layout.nodeWidth).toBeLessThan(buildPathGraphLayout(makePath(2)).nodeWidth);
+  });
+
+  it("produces one edge per hop transition", () => {
+    const layout = buildPathGraphLayout(makePath(5));
+    expect(layout.edges).toHaveLength(4);
+    expect(layout.relationshipLabels).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
## Summary

- make the Postgres compliance-hub primary-key migration a catalog-probed no-op once the collapsed key is installed
- replace saturated executive scoring with a monotonic diminishing-returns curve and emit canonical SPDX 3.0.1 JSON-LD
- auto-fit selected exposure-path graphs and cap node rendering so small paths stay compact and large paths remain bounded
- supersede #3982, #3986, and #3983 while retaining each fix as a separate signed commit

## Verification

- `make preflight`
- targeted `ruff check` on changed Python source and tests
- targeted migration, executive-score, SPDX, output, interop, and core suites (446 passed)
- supported Node 22 / npm 10 toolchain with clean `npm ci` (0 vulnerabilities)
- `npm run typecheck`
- focused exposure-path graph tests (8 passed)
- `npm run build` (35 routes)
- `git diff --check origin/main...HEAD`

## Notes

No live Postgres instance was available locally; the migration ordering and no-op behavior are covered by the connection-spy regression tests. All three changes remain isolated in signed commits for review and rollback.