### PR TITLE
UI: light-theme tokenization (zinc→tokens) (#3966 part)

### DIFF
--- a/ui/app/activity/page.tsx
+++ b/ui/app/activity/page.tsx
@@ -53,7 +53,7 @@ export default function ActivityPage() {
     return (
       <div className="space-y-6">
         <GatewayLiveFeedCard />
-        <div className="flex items-center justify-center py-20 text-zinc-400">
+        <div className="flex items-center justify-center py-20 text-[var(--text-secondary)]">
           <Loader2 className="h-6 w-6 animate-spin mr-2" />
           Loading activity timeline...
         </div>
@@ -121,18 +121,18 @@ export default function ActivityPage() {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-zinc-100 flex items-center gap-2">
+          <h1 className="text-2xl font-bold text-[var(--foreground)] flex items-center gap-2">
             <Clock className="w-6 h-6 text-emerald-400" />
             Agent Activity Timeline
           </h1>
-          <p className="text-sm text-zinc-500 mt-1">
+          <p className="text-sm text-[var(--text-tertiary)] mt-1">
             Account: {timeline.account} | Discovered: {formatDate(timeline.discovered_at)}
           </p>
         </div>
         <select
           value={days}
           onChange={(e) => setDays(Number(e.target.value))}
-          className="bg-zinc-900 border border-zinc-700 rounded-md px-3 py-1.5 text-sm text-zinc-300"
+          className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-md px-3 py-1.5 text-sm text-[var(--text-secondary)]"
         >
           <option value={7}>Last 7 days</option>
           <option value={30}>Last 30 days</option>
@@ -187,9 +187,9 @@ export default function ActivityPage() {
 
       {/* Activity bar chart */}
       {Object.keys(patternCounts).length > 0 && (
-        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
-          <h3 className="text-sm font-semibold text-zinc-300 mb-1">Agent Query Patterns</h3>
-          <p className="text-[10px] text-zinc-600 mb-4">Query count by detected agent pattern</p>
+        <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-5">
+          <h3 className="text-sm font-semibold text-[var(--text-secondary)] mb-1">Agent Query Patterns</h3>
+          <p className="text-[10px] text-[var(--text-tertiary)] mb-4">Query count by detected agent pattern</p>
           <div className="h-44">
             <ResponsiveContainer width="100%" height="100%">
               <BarChart
@@ -229,24 +229,24 @@ export default function ActivityPage() {
           />
         </div>
         <div className="relative flex-1 max-w-xs">
-          <Search className="w-3.5 h-3.5 absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500" />
+          <Search className="w-3.5 h-3.5 absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)]" />
           <input
             type="text"
             placeholder="Search..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="w-full bg-zinc-900 border border-zinc-700 rounded-md pl-9 pr-3 py-1.5 text-sm text-zinc-300 placeholder-zinc-600"
+            className="w-full bg-[var(--surface)] border border-[var(--border-subtle)] rounded-md pl-9 pr-3 py-1.5 text-sm text-[var(--text-secondary)] placeholder-[var(--text-tertiary)]"
           />
         </div>
       </div>
 
       {/* Query History Tab */}
       {tab === "queries" && (
-        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 overflow-hidden">
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full text-xs">
               <thead>
-                <tr className="text-zinc-500 border-b border-zinc-800 bg-zinc-900">
+                <tr className="text-[var(--text-tertiary)] border-b border-[var(--border-subtle)] bg-[var(--surface)]">
                   <th className="text-left py-2 px-3">Time</th>
                   <th className="text-left py-2 px-3">User</th>
                   <th className="text-left py-2 px-3">Role</th>
@@ -260,15 +260,15 @@ export default function ActivityPage() {
                 {filteredQueries.slice(0, 100).map((q) => (
                   <tr
                     key={q.query_id}
-                    className="border-b border-zinc-800/50 hover:bg-zinc-800/30"
+                    className="border-b border-[var(--border-subtle)]/50 hover:bg-[var(--surface-elevated)]/30"
                   >
-                    <td className="py-1.5 px-3 text-zinc-500 whitespace-nowrap">
+                    <td className="py-1.5 px-3 text-[var(--text-tertiary)] whitespace-nowrap">
                       {formatDate(q.start_time)}
                     </td>
-                    <td className="py-1.5 px-3 text-zinc-300 font-mono">
+                    <td className="py-1.5 px-3 text-[var(--text-secondary)] font-mono">
                       {q.user_name}
                     </td>
-                    <td className="py-1.5 px-3 text-zinc-400 font-mono">
+                    <td className="py-1.5 px-3 text-[var(--text-secondary)] font-mono">
                       {q.role_name}
                     </td>
                     <td className="py-1.5 px-3">
@@ -277,16 +277,16 @@ export default function ActivityPage() {
                           {q.agent_pattern}
                         </span>
                       ) : (
-                        <span className="text-zinc-600">-</span>
+                        <span className="text-[var(--text-tertiary)]">-</span>
                       )}
                     </td>
-                    <td className="py-1.5 px-3 text-zinc-400 font-mono truncate max-w-[300px]">
+                    <td className="py-1.5 px-3 text-[var(--text-secondary)] font-mono truncate max-w-[300px]">
                       {q.query_text}
                     </td>
                     <td className="py-1.5 px-3">
                       <StatusBadge status={q.execution_status} />
                     </td>
-                    <td className="py-1.5 px-3 text-right text-zinc-500 font-mono">
+                    <td className="py-1.5 px-3 text-right text-[var(--text-tertiary)] font-mono">
                       {q.execution_time_ms.toLocaleString()}
                     </td>
                   </tr>
@@ -294,7 +294,7 @@ export default function ActivityPage() {
               </tbody>
             </table>
             {filteredQueries.length === 0 && (
-              <div className="text-center py-8 text-zinc-500 text-sm">
+              <div className="text-center py-8 text-[var(--text-tertiary)] text-sm">
                 No queries match the search.
               </div>
             )}
@@ -304,11 +304,11 @@ export default function ActivityPage() {
 
       {/* Observability Events Tab */}
       {tab === "events" && (
-        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 overflow-hidden">
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full text-xs">
               <thead>
-                <tr className="text-zinc-500 border-b border-zinc-800 bg-zinc-900">
+                <tr className="text-[var(--text-tertiary)] border-b border-[var(--border-subtle)] bg-[var(--surface)]">
                   <th className="text-left py-2 px-3">Time</th>
                   <th className="text-left py-2 px-3">Agent</th>
                   <th className="text-left py-2 px-3">Event Type</th>
@@ -323,30 +323,30 @@ export default function ActivityPage() {
                 {filteredEvents.slice(0, 100).map((e) => (
                   <tr
                     key={e.event_id}
-                    className="border-b border-zinc-800/50 hover:bg-zinc-800/30"
+                    className="border-b border-[var(--border-subtle)]/50 hover:bg-[var(--surface-elevated)]/30"
                   >
-                    <td className="py-1.5 px-3 text-zinc-500 whitespace-nowrap">
+                    <td className="py-1.5 px-3 text-[var(--text-tertiary)] whitespace-nowrap">
                       {formatDate(e.timestamp)}
                     </td>
-                    <td className="py-1.5 px-3 text-zinc-300 font-mono">
+                    <td className="py-1.5 px-3 text-[var(--text-secondary)] font-mono">
                       {e.agent_name || "-"}
                     </td>
                     <td className="py-1.5 px-3">
                       <EventTypeBadge type={e.event_type} />
                     </td>
-                    <td className="py-1.5 px-3 text-zinc-400 font-mono">
+                    <td className="py-1.5 px-3 text-[var(--text-secondary)] font-mono">
                       {e.tool_name || "-"}
                     </td>
-                    <td className="py-1.5 px-3 text-zinc-500 font-mono text-xs">
+                    <td className="py-1.5 px-3 text-[var(--text-tertiary)] font-mono text-xs">
                       {e.model_name || "-"}
                     </td>
-                    <td className="py-1.5 px-3 text-zinc-600 font-mono truncate max-w-[100px]">
+                    <td className="py-1.5 px-3 text-[var(--text-tertiary)] font-mono truncate max-w-[100px]">
                       {e.trace_id || "-"}
                     </td>
-                    <td className="py-1.5 px-3 text-right text-zinc-500 font-mono">
+                    <td className="py-1.5 px-3 text-right text-[var(--text-tertiary)] font-mono">
                       {(e.input_tokens + e.output_tokens).toLocaleString()}
                     </td>
-                    <td className="py-1.5 px-3 text-right text-zinc-500 font-mono">
+                    <td className="py-1.5 px-3 text-right text-[var(--text-tertiary)] font-mono">
                       {e.duration_ms.toLocaleString()}ms
                     </td>
                   </tr>
@@ -354,7 +354,7 @@ export default function ActivityPage() {
               </tbody>
             </table>
             {filteredEvents.length === 0 && (
-              <div className="text-center py-8 text-zinc-500 text-sm">
+              <div className="text-center py-8 text-[var(--text-tertiary)] text-sm">
                 {timeline.observability_events.length === 0
                   ? "No AI observability events available. Enable AI observability in Snowflake."
                   : "No events match the search."}
@@ -379,12 +379,12 @@ function StatCard({
   color: string;
 }) {
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-4">
       <div className="flex items-center gap-2 mb-1">
         <Icon className={`w-4 h-4 ${color}`} />
-        <span className="text-xs text-zinc-500">{label}</span>
+        <span className="text-xs text-[var(--text-tertiary)]">{label}</span>
       </div>
-      <p className="text-2xl font-bold text-zinc-100">{value.toLocaleString()}</p>
+      <p className="text-2xl font-bold text-[var(--foreground)]">{value.toLocaleString()}</p>
     </div>
   );
 }
@@ -403,8 +403,8 @@ function TabButton({
       onClick={onClick}
       className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
         active
-          ? "bg-zinc-700 text-zinc-100"
-          : "bg-zinc-900 text-zinc-400 hover:bg-zinc-800"
+          ? "bg-[var(--surface-muted)] text-[var(--foreground)]"
+          : "bg-[var(--surface)] text-[var(--text-secondary)] hover:bg-[var(--surface-elevated)]"
       }`}
     >
       {label}
@@ -418,7 +418,7 @@ function StatusBadge({ status }: { status: string }) {
       ? "text-emerald-400 bg-emerald-950 border-emerald-800"
       : status === "FAIL" || status === "FAILED"
         ? "text-red-400 bg-red-950 border-red-800"
-        : "text-zinc-400 bg-zinc-800 border-zinc-700";
+        : "text-[var(--text-secondary)] bg-[var(--surface-elevated)] border-[var(--border-subtle)]";
 
   return (
     <span className={`px-2 py-0.5 rounded text-xs border ${color}`}>
@@ -438,7 +438,7 @@ function EventTypeBadge({ type }: { type: string }) {
   return (
     <span
       className={`px-2 py-0.5 rounded text-xs border ${
-        colorMap[type] || "text-zinc-400 bg-zinc-800 border-zinc-700"
+        colorMap[type] || "text-[var(--text-secondary)] bg-[var(--surface-elevated)] border-[var(--border-subtle)]"
       }`}
     >
       {type}

--- a/ui/app/audit/page.tsx
+++ b/ui/app/audit/page.tsx
@@ -34,7 +34,7 @@ const ACTION_COLORS: Record<string, string> = {
   fleet_change: "bg-purple-950 text-purple-300 border-purple-800",
   exception: "bg-yellow-950 text-yellow-300 border-yellow-800",
   alert: "bg-red-950 text-red-300 border-red-800",
-  config: "bg-zinc-800 text-zinc-300 border-zinc-700",
+  config: "bg-[var(--surface-elevated)] text-[var(--text-secondary)] border-[var(--border-subtle)]",
 };
 
 const ACTION_TYPES = ["scan", "policy_eval", "fleet_change", "exception", "alert", "config"];
@@ -154,7 +154,7 @@ export default function AuditLogPage() {
                 void loadAdmin();
               }
             }}
-            className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] border border-[var(--border-subtle)] rounded-lg text-xs text-[var(--text-secondary)] transition-colors"
           >
             <RefreshCw className="w-3.5 h-3.5" />
             Refresh
@@ -176,17 +176,17 @@ export default function AuditLogPage() {
       {/* Integrity banner + stats */}
       {integrity && (
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+          <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-4">
             <FileText className="w-4 h-4 mb-2 text-blue-400" />
             <div className="text-2xl font-bold font-mono">{total.toLocaleString()}</div>
-            <div className="text-xs text-zinc-500 mt-0.5">Total Entries</div>
+            <div className="text-xs text-[var(--text-tertiary)] mt-0.5">Total Entries</div>
           </div>
-          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+          <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-4">
             <CheckCircle2 className="w-4 h-4 mb-2 text-emerald-400" />
             <div className="text-2xl font-bold font-mono">{integrity.verified.toLocaleString()}</div>
-            <div className="text-xs text-zinc-500 mt-0.5">HMAC Verified</div>
+            <div className="text-xs text-[var(--text-tertiary)] mt-0.5">HMAC Verified</div>
           </div>
-          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+          <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-4">
             {integrity.tampered > 0 ? (
               <ShieldAlert className="w-4 h-4 mb-2 text-red-400" />
             ) : (
@@ -195,19 +195,19 @@ export default function AuditLogPage() {
             <div className={`text-2xl font-bold font-mono ${integrity.tampered > 0 ? "text-red-400" : ""}`}>
               {integrity.tampered}
             </div>
-            <div className="text-xs text-zinc-500 mt-0.5">Tampered</div>
+            <div className="text-xs text-[var(--text-tertiary)] mt-0.5">Tampered</div>
           </div>
-          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
-            <Search className="w-4 h-4 mb-2 text-zinc-400" />
+          <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-4">
+            <Search className="w-4 h-4 mb-2 text-[var(--text-secondary)]" />
             <div className="text-2xl font-bold font-mono">{integrity.checked.toLocaleString()}</div>
-            <div className="text-xs text-zinc-500 mt-0.5">Checked</div>
+            <div className="text-xs text-[var(--text-tertiary)] mt-0.5">Checked</div>
           </div>
         </div>
       )}
 
       {/* Filters */}
       <div className="flex flex-wrap items-center gap-3">
-        <div className="flex items-center gap-1.5 text-xs text-zinc-500">
+        <div className="flex items-center gap-1.5 text-xs text-[var(--text-tertiary)]">
           <Filter className="w-3.5 h-3.5" />
           Filter:
         </div>
@@ -215,7 +215,7 @@ export default function AuditLogPage() {
           <button
             onClick={() => { setActionFilter(""); setPage(0); }}
             className={`px-2.5 py-1 rounded text-[11px] font-medium transition-colors ${
-              !actionFilter ? "bg-zinc-700 text-zinc-100" : "text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800"
+              !actionFilter ? "bg-[var(--surface-muted)] text-[var(--foreground)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-elevated)]"
             }`}
           >
             All
@@ -225,7 +225,7 @@ export default function AuditLogPage() {
               key={a}
               onClick={() => { setActionFilter(a); setPage(0); }}
               className={`px-2.5 py-1 rounded text-[11px] font-medium transition-colors ${
-                actionFilter === a ? "bg-zinc-700 text-zinc-100" : "text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800"
+                actionFilter === a ? "bg-[var(--surface-muted)] text-[var(--foreground)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-elevated)]"
               }`}
             >
               {a}
@@ -236,14 +236,14 @@ export default function AuditLogPage() {
           value={resourceFilter}
           onChange={(e) => { setResourceFilter(e.target.value); setPage(0); }}
           placeholder="Filter by resource…"
-          className="w-full min-w-0 rounded border border-zinc-700 bg-zinc-800 px-2.5 py-1 text-xs text-zinc-100 placeholder-zinc-600 focus:outline-none focus:border-blue-600 sm:w-48"
+          className="w-full min-w-0 rounded border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-2.5 py-1 text-xs text-[var(--foreground)] placeholder-[var(--text-tertiary)] focus:outline-none focus:border-blue-600 sm:w-48"
         />
       </div>
 
       {/* Loading */}
       {loading && (
         <div className="flex items-center justify-center py-12">
-          <Loader2 className="w-6 h-6 animate-spin text-zinc-500" />
+          <Loader2 className="w-6 h-6 animate-spin text-[var(--text-tertiary)]" />
         </div>
       )}
 
@@ -252,10 +252,10 @@ export default function AuditLogPage() {
         <div className="text-center py-10 border border-dashed border-red-900/50 rounded-xl space-y-3">
           <AlertTriangle className="w-8 h-8 text-red-500 mx-auto" />
           <p className="text-red-400 text-sm">Failed to load audit log</p>
-          <p className="text-zinc-500 text-xs">{error}</p>
+          <p className="text-[var(--text-tertiary)] text-xs">{error}</p>
           <button
             onClick={load}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] border border-[var(--border-subtle)] rounded-lg text-xs text-[var(--text-secondary)] transition-colors"
           >
             <RefreshCw className="w-3.5 h-3.5" /> Retry
           </button>
@@ -266,12 +266,12 @@ export default function AuditLogPage() {
       {!loading && !error && (
         <>
           {entries.length === 0 ? (
-            <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
-              <FileText className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
-              <p className="text-zinc-500 text-sm">
+            <div className="text-center py-16 border border-dashed border-[var(--border-subtle)] rounded-xl">
+              <FileText className="w-8 h-8 text-[var(--text-tertiary)] mx-auto mb-3" />
+              <p className="text-[var(--text-tertiary)] text-sm">
                 {auditUnavailable ? "No runtime audit surfaces enabled" : "No audit log entries"}
               </p>
-              <p className="text-zinc-600 text-xs mt-1">
+              <p className="text-[var(--text-tertiary)] text-xs mt-1">
                 {auditUnavailable
                   ? "Enable proxy, gateway, or trace ingest to populate runtime audit history."
                   : "Entries will appear as scan, policy, and fleet actions are performed."}
@@ -284,11 +284,11 @@ export default function AuditLogPage() {
                 return (
                   <div
                     key={entry.entry_id}
-                    className="bg-zinc-900 border border-zinc-800 rounded-lg overflow-hidden"
+                    className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-lg overflow-hidden"
                   >
                     <button
                       onClick={() => toggleExpand(entry.entry_id)}
-                      className="w-full px-4 py-2.5 flex items-center justify-between hover:bg-zinc-800/50 transition-colors"
+                      className="w-full px-4 py-2.5 flex items-center justify-between hover:bg-[var(--surface-elevated)]/50 transition-colors"
                     >
                       <div className="flex items-center gap-3 min-w-0">
                         <span
@@ -298,51 +298,51 @@ export default function AuditLogPage() {
                         >
                           {entry.action}
                         </span>
-                        <span className="text-xs text-zinc-300 font-mono shrink-0">
+                        <span className="text-xs text-[var(--text-secondary)] font-mono shrink-0">
                           {entry.actor}
                         </span>
-                        <span className="text-xs text-zinc-500 truncate">
+                        <span className="text-xs text-[var(--text-tertiary)] truncate">
                           {entry.resource}
                         </span>
                       </div>
-                      <span className="text-[10px] text-zinc-600 shrink-0 ml-3">
+                      <span className="text-[10px] text-[var(--text-tertiary)] shrink-0 ml-3">
                         {formatDate(entry.timestamp)}
                       </span>
                     </button>
                     {isExpanded && (
-                      <div className="border-t border-zinc-800 px-4 py-3 space-y-2">
+                      <div className="border-t border-[var(--border-subtle)] px-4 py-3 space-y-2">
                         <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-xs">
                           <div>
-                            <span className="text-zinc-500">Entry ID</span>
-                            <div className="text-zinc-300 mt-0.5 font-mono text-[10px] break-all">
+                            <span className="text-[var(--text-tertiary)]">Entry ID</span>
+                            <div className="text-[var(--text-secondary)] mt-0.5 font-mono text-[10px] break-all">
                               {entry.entry_id}
                             </div>
                           </div>
                           <div>
-                            <span className="text-zinc-500">Timestamp</span>
-                            <div className="text-zinc-300 mt-0.5">
+                            <span className="text-[var(--text-tertiary)]">Timestamp</span>
+                            <div className="text-[var(--text-secondary)] mt-0.5">
                               {formatDate(entry.timestamp)}
                             </div>
                           </div>
                           <div>
-                            <span className="text-zinc-500">Actor</span>
-                            <div className="text-zinc-300 mt-0.5 font-mono">
+                            <span className="text-[var(--text-tertiary)]">Actor</span>
+                            <div className="text-[var(--text-secondary)] mt-0.5 font-mono">
                               {entry.actor}
                             </div>
                           </div>
                           <div>
-                            <span className="text-zinc-500">HMAC</span>
-                            <div className="text-zinc-300 mt-0.5 font-mono text-[10px] truncate">
+                            <span className="text-[var(--text-tertiary)]">HMAC</span>
+                            <div className="text-[var(--text-secondary)] mt-0.5 font-mono text-[10px] truncate">
                               {entry.hmac_signature.slice(0, 16)}…
                             </div>
                           </div>
                         </div>
                         {Object.keys(entry.details).length > 0 && (
                           <div>
-                            <span className="text-xs text-zinc-500 block mb-1">
+                            <span className="text-xs text-[var(--text-tertiary)] block mb-1">
                               Details
                             </span>
-                            <pre className="text-[11px] text-zinc-400 bg-zinc-800 border border-zinc-700 rounded-lg p-3 overflow-x-auto max-h-48">
+                            <pre className="text-[11px] text-[var(--text-secondary)] bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded-lg p-3 overflow-x-auto max-h-48">
                               {JSON.stringify(entry.details, null, 2)}
                             </pre>
                           </div>

--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -71,22 +71,22 @@ function ContextStats({ data, compact = false }: { data: ContextGraphData; compa
     ? [
         { label: "Agents", value: s.agent_count, color: "text-emerald-400" },
         { label: "Paths", value: s.lateral_path_count, color: "text-orange-400" },
-        { label: "Top risk", value: s.highest_path_risk.toFixed(1), color: s.highest_path_risk >= 7 ? "text-red-400" : "text-zinc-400" },
+        { label: "Top risk", value: s.highest_path_risk.toFixed(1), color: s.highest_path_risk >= 7 ? "text-red-400" : "text-[var(--text-secondary)]" },
       ]
     : [
         { label: "Agents", value: s.agent_count, color: "text-emerald-400" },
         { label: "Shared Servers", value: s.shared_server_count, color: "text-cyan-400" },
         { label: "Shared Credentials", value: s.shared_credential_count, color: "text-amber-400" },
         { label: "Lateral Paths", value: s.lateral_path_count, color: "text-orange-400" },
-        { label: "Highest Risk", value: s.highest_path_risk.toFixed(1), color: s.highest_path_risk >= 7 ? "text-red-400" : "text-zinc-400" },
+        { label: "Highest Risk", value: s.highest_path_risk.toFixed(1), color: s.highest_path_risk >= 7 ? "text-red-400" : "text-[var(--text-secondary)]" },
         { label: "Risk Patterns", value: s.interaction_risk_count, color: "text-purple-400" },
       ];
 
   return (
-    <div className={`flex flex-wrap items-center gap-3 border-b border-zinc-800 px-4 text-xs ${compact ? "py-1.5" : "py-2"}`}>
+    <div className={`flex flex-wrap items-center gap-3 border-b border-[var(--border-subtle)] px-4 text-xs ${compact ? "py-1.5" : "py-2"}`}>
       {items?.map((it) => (
         <div key={it.label} className="flex items-center gap-1.5">
-          <span className="text-zinc-500">{it.label}</span>
+          <span className="text-[var(--text-tertiary)]">{it.label}</span>
           <span className={`font-semibold ${it.color}`}>{it.value}</span>
         </div>
       ))}
@@ -160,18 +160,18 @@ function LateralPanel({
   const topPaths = distinctPaths.slice(0, pathFocusActive ? 3 : 5);
 
   return (
-    <div className="w-80 shrink-0 overflow-y-auto border-l border-zinc-800 bg-zinc-950">
-      <div className="p-3 border-b border-zinc-800">
-        <h3 className="text-xs font-semibold text-zinc-300 mb-1">
+    <div className="w-80 shrink-0 overflow-y-auto border-l border-[var(--border-subtle)] bg-[var(--background)]">
+      <div className="p-3 border-b border-[var(--border-subtle)]">
+        <h3 className="text-xs font-semibold text-[var(--text-secondary)] mb-1">
           {agentScopeHeading(selectedAgent, agents)}
         </h3>
-        <p className="text-[10px] text-zinc-600">
+        <p className="text-[10px] text-[var(--text-tertiary)]">
           {pathFocusActive
             ? "Canvas shows the top lateral path only. Other agents appear when they share reachability — not because they are the same workload."
             : "Ranked reachability chains from scan evidence."}
         </p>
         {topPaths.length === 0 ? (
-          <p className="mt-2 text-[10px] text-zinc-600">No lateral paths found</p>
+          <p className="mt-2 text-[10px] text-[var(--text-tertiary)]">No lateral paths found</p>
         ) : (
           <div className="mt-2 space-y-2">
             {topPaths?.map((p, i) => (
@@ -180,11 +180,11 @@ function LateralPanel({
                 className={`rounded-lg border p-2 ${
                   i === 0 && pathFocusActive
                     ? "border-orange-500/40 bg-orange-950/20"
-                    : "border-zinc-800 bg-zinc-900"
+                    : "border-[var(--border-subtle)] bg-[var(--surface)]"
                 }`}
               >
                 <div className="flex items-center justify-between mb-1">
-                  <span className="text-[10px] text-zinc-500">
+                  <span className="text-[10px] text-[var(--text-tertiary)]">
                     {p.hops.length - 1} hop{p.hops.length - 1 !== 1 ? "s" : ""}
                   </span>
                   <span
@@ -193,13 +193,13 @@ function LateralPanel({
                         ? "text-red-400"
                         : p.composite_risk >= 4
                         ? "text-amber-400"
-                        : "text-zinc-400"
+                        : "text-[var(--text-secondary)]"
                     }`}
                   >
                     Risk {p.composite_risk.toFixed(1)}
                   </span>
                 </div>
-                <p className="break-words text-[11px] leading-relaxed text-zinc-200">
+                <p className="break-words text-[11px] leading-relaxed text-[var(--foreground)]">
                   {pathDisplayTitle(lateralPathToExposure(p, selectedAgent ?? "agent"))}
                 </p>
                 {p.credential_exposure.length > 0 && (
@@ -227,7 +227,7 @@ function LateralPanel({
       <div className="p-3">
         <button
           onClick={() => setRisksOpen(!risksOpen)}
-          className="flex items-center gap-1 text-xs font-semibold text-zinc-300 mb-2"
+          className="flex items-center gap-1 text-xs font-semibold text-[var(--text-secondary)] mb-2"
         >
           {risksOpen ? (
             <ChevronDown className="w-3 h-3" />
@@ -241,10 +241,10 @@ function LateralPanel({
             {risks?.map((r, i) => (
               <div
                 key={i}
-                className="bg-zinc-900 border border-zinc-800 rounded-lg p-2"
+                className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-lg p-2"
               >
                 <div className="flex items-center justify-between mb-1">
-                  <span className="text-[10px] text-zinc-500 capitalize">
+                  <span className="text-[10px] text-[var(--text-tertiary)] capitalize">
                     {r.pattern.replace(/_/g, " ")}
                   </span>
                   <span
@@ -253,13 +253,13 @@ function LateralPanel({
                         ? "text-red-400"
                         : r.risk_score >= 5
                         ? "text-amber-400"
-                        : "text-zinc-400"
+                        : "text-[var(--text-secondary)]"
                     }`}
                   >
                     {r.risk_score.toFixed(1)}
                   </span>
                 </div>
-                <p className="break-words text-[10px] leading-relaxed text-zinc-400">
+                <p className="break-words text-[10px] leading-relaxed text-[var(--text-secondary)]">
                   {r.description}
                 </p>
                 {r.owasp_agentic_tag && (
@@ -569,14 +569,14 @@ export default function ContextPage() {
   return (
     <div className="h-[calc(100vh-3.5rem)] flex flex-col">
       {/* Header */}
-      <div className="flex flex-col gap-2 border-b border-zinc-800 px-4 py-2.5">
+      <div className="flex flex-col gap-2 border-b border-[var(--border-subtle)] px-4 py-2.5">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0">
-            <h1 className="text-base font-semibold text-zinc-100 flex items-center gap-2">
+            <h1 className="text-base font-semibold text-[var(--foreground)] flex items-center gap-2">
               <Waypoints className="w-4 h-4 text-orange-400" />
               Context Map
             </h1>
-            <p className="text-xs text-zinc-500">
+            <p className="text-xs text-[var(--text-tertiary)]">
               Static reachability for one agent at a time. Path focus shows the highest-risk lateral chain.
             </p>
           </div>
@@ -587,7 +587,7 @@ export default function ContextPage() {
             onChange={(e) =>
               setSelectedAgent(e.target.value || null)
             }
-            className="min-w-0 max-w-[12rem] truncate rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-1 text-xs text-zinc-300 focus:outline-none focus:border-orange-600"
+            className="min-w-0 max-w-[12rem] truncate rounded-md border border-[var(--border-subtle)] bg-[var(--surface)] px-2.5 py-1 text-xs text-[var(--text-secondary)] focus:outline-none focus:border-orange-600"
           >
             <option value="">All agents</option>
             {agentNames?.map((name) => (
@@ -601,7 +601,7 @@ export default function ContextPage() {
           <select
             value={selectedJobId}
             onChange={(e) => setSelectedJobId(e.target.value)}
-            className="min-w-0 max-w-[14rem] truncate rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-1 text-xs text-zinc-300 focus:outline-none focus:border-emerald-600"
+            className="min-w-0 max-w-[14rem] truncate rounded-md border border-[var(--border-subtle)] bg-[var(--surface)] px-2.5 py-1 text-xs text-[var(--text-secondary)] focus:outline-none focus:border-emerald-600"
           >
             {jobs?.map((j) => (
               <option key={j.job_id} value={j.job_id}>
@@ -613,13 +613,13 @@ export default function ContextPage() {
 
           {/* Search */}
           <div className="relative w-full min-w-0 sm:max-w-[14rem]">
-            <Search className="w-3.5 h-3.5 text-zinc-500 absolute left-2 top-1/2 -translate-y-1/2" />
+            <Search className="w-3.5 h-3.5 text-[var(--text-tertiary)] absolute left-2 top-1/2 -translate-y-1/2" />
             <input
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="Search agent, server, tool, CVE"
-              className="w-full bg-zinc-900 border border-zinc-700 rounded pl-7 pr-2 py-1 text-xs text-zinc-300 placeholder:text-zinc-600 focus:outline-none focus:border-emerald-600"
+              className="w-full bg-[var(--surface)] border border-[var(--border-subtle)] rounded pl-7 pr-2 py-1 text-xs text-[var(--text-secondary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-emerald-600"
             />
           </div>
 

--- a/ui/app/cost/page.tsx
+++ b/ui/app/cost/page.tsx
@@ -71,12 +71,12 @@ function StatCard({
   color: string;
 }) {
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-4">
       <div className="mb-1 flex items-center gap-2">
         <Icon className={`h-4 w-4 ${color}`} />
-        <span className="text-xs text-zinc-500">{label}</span>
+        <span className="text-xs text-[var(--text-tertiary)]">{label}</span>
       </div>
-      <p className="text-2xl font-bold text-zinc-100">{value}</p>
+      <p className="text-2xl font-bold text-[var(--foreground)]">{value}</p>
     </div>
   );
 }
@@ -84,9 +84,9 @@ function StatCard({
 function BudgetBanner({ budget }: { budget: CostReport["budget"] }) {
   if (!budget?.configured) {
     return (
-      <div className="rounded-xl border border-zinc-800 bg-zinc-900/40 p-4 text-sm text-zinc-400">
+      <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-4 text-sm text-[var(--text-secondary)]">
         No spend budget configured for this tenant. Set one via{" "}
-        <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+        <code className="rounded bg-[var(--surface-elevated)] px-1.5 py-0.5 text-xs text-[var(--text-secondary)]">
           POST /v1/observability/costs/budget
         </code>{" "}
         to enable pre-invocation enforcement at the gateway.
@@ -106,7 +106,7 @@ function BudgetBanner({ budget }: { budget: CostReport["budget"] }) {
       className={`rounded-xl border p-4 ${
         budget.exceeded
           ? "border-red-800/60 bg-red-950/20"
-          : "border-zinc-800 bg-zinc-900/40"
+          : "border-[var(--border-subtle)] bg-[var(--surface)]/40"
       }`}
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -114,14 +114,14 @@ function BudgetBanner({ budget }: { budget: CostReport["budget"] }) {
           <Gauge
             className={`h-4 w-4 ${budget.exceeded ? "text-red-400" : "text-emerald-400"}`}
           />
-          <span className="text-sm font-medium text-zinc-200">
+          <span className="text-sm font-medium text-[var(--foreground)]">
             Budget {budget.agent ? `· agent ${budget.agent}` : "· tenant-wide"}
           </span>
           <span
             className={`rounded-full px-2 py-0.5 text-xs font-medium ${
               enforce
                 ? "bg-emerald-900/60 text-emerald-300"
-                : "bg-zinc-800 text-zinc-400"
+                : "bg-[var(--surface-elevated)] text-[var(--text-secondary)]"
             }`}
           >
             {enforce ? "enforce" : "report-only"}
@@ -132,17 +132,17 @@ function BudgetBanner({ budget }: { budget: CostReport["budget"] }) {
             </span>
           )}
         </div>
-        <span className="text-sm text-zinc-400">
+        <span className="text-sm text-[var(--text-secondary)]">
           {fmtUsd(budget.spend_usd)}{" "}
           {budget.limit_usd != null && <>/ {fmtUsd(budget.limit_usd)}</>}
           {budget.remaining_usd != null && (
-            <span className="ml-2 text-zinc-500">
+            <span className="ml-2 text-[var(--text-tertiary)]">
               ({fmtUsd(Math.max(0, budget.remaining_usd))} left)
             </span>
           )}
         </span>
       </div>
-      <div className="mt-3 h-2.5 overflow-hidden rounded-full bg-zinc-800">
+      <div className="mt-3 h-2.5 overflow-hidden rounded-full bg-[var(--surface-elevated)]">
         <div
           className={`h-full ${barColor} transition-all duration-700`}
           style={{ width: `${pct}%` }}
@@ -161,14 +161,14 @@ function BreakdownTable({
 }) {
   const top = [...rows].sort((a, b) => b.cost_usd - a.cost_usd).slice(0, 12);
   return (
-    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
-      <h3 className="mb-3 text-sm font-semibold text-zinc-300">{title}</h3>
+    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
+      <h3 className="mb-3 text-sm font-semibold text-[var(--text-secondary)]">{title}</h3>
       {top.length === 0 ? (
-        <p className="text-sm text-zinc-500">No cost records yet.</p>
+        <p className="text-sm text-[var(--text-tertiary)]">No cost records yet.</p>
       ) : (
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-zinc-800 text-left text-xs text-zinc-500">
+            <tr className="border-b border-[var(--border-subtle)] text-left text-xs text-[var(--text-tertiary)]">
               <th className="pb-2 font-medium">Name</th>
               <th className="pb-2 text-right font-medium">Calls</th>
               <th className="pb-2 text-right font-medium">Tokens (in/out)</th>
@@ -179,18 +179,18 @@ function BreakdownTable({
             {top.map((r) => (
               <tr
                 key={r.key}
-                className="border-b border-zinc-900 last:border-0"
+                className="border-b border-[var(--border-subtle)] last:border-0"
               >
-                <td className="py-2 font-mono text-xs text-zinc-300">
+                <td className="py-2 font-mono text-xs text-[var(--text-secondary)]">
                   {r.key || "—"}
                 </td>
-                <td className="py-2 text-right text-zinc-400">
+                <td className="py-2 text-right text-[var(--text-secondary)]">
                   {fmtInt(r.calls)}
                 </td>
-                <td className="py-2 text-right text-zinc-500">
+                <td className="py-2 text-right text-[var(--text-tertiary)]">
                   {fmtInt(r.input_tokens)} / {fmtInt(r.output_tokens)}
                 </td>
-                <td className="py-2 text-right font-medium text-zinc-200">
+                <td className="py-2 text-right font-medium text-[var(--foreground)]">
                   {fmtUsd(r.cost_usd)}
                 </td>
               </tr>
@@ -229,7 +229,7 @@ function ForecastPanel({ forecast }: { forecast: CostForecast | null }) {
     ok: "bg-emerald-900/60 text-emerald-300",
     warn: "bg-amber-900/60 text-amber-300",
     danger: "bg-red-900/60 text-red-300",
-    muted: "bg-zinc-800 text-zinc-400",
+    muted: "bg-[var(--surface-elevated)] text-[var(--text-secondary)]",
   }[meta.tone];
 
   const hasRate = forecast?.burn_rate_usd_per_day != null;
@@ -241,10 +241,10 @@ function ForecastPanel({ forecast }: { forecast: CostForecast | null }) {
     forecast.days_remaining <= 14;
 
   return (
-    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
       <div className="mb-3 flex items-center gap-2">
         <CalendarClock className="h-4 w-4 text-sky-400" />
-        <h3 className="text-sm font-semibold text-zinc-300">
+        <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
           Forecast &amp; runway
         </h3>
         <span
@@ -254,7 +254,7 @@ function ForecastPanel({ forecast }: { forecast: CostForecast | null }) {
         </span>
       </div>
       {!hasRate && !hasRunway ? (
-        <p className="text-sm text-zinc-500">
+        <p className="text-sm text-[var(--text-tertiary)]">
           {status === "insufficient_history"
             ? "Not enough timestamped spend yet to project a burn rate. A forecast appears once at least two priced LLM calls are recorded."
             : status === "no_budget"
@@ -266,64 +266,64 @@ function ForecastPanel({ forecast }: { forecast: CostForecast | null }) {
       ) : (
         <>
           <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-            <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
               <div className="mb-1 flex items-center gap-1.5">
                 <Flame className="h-3.5 w-3.5 text-orange-400" />
-                <span className="text-xs text-zinc-500">Burn / day</span>
+                <span className="text-xs text-[var(--text-tertiary)]">Burn / day</span>
               </div>
-              <p className="text-lg font-bold text-zinc-100">
+              <p className="text-lg font-bold text-[var(--foreground)]">
                 {forecast?.burn_rate_usd_per_day != null
                   ? fmtUsd(forecast.burn_rate_usd_per_day)
                   : "—"}
               </p>
               {forecast?.burn_rate_basis && (
-                <p className="mt-0.5 text-[11px] text-zinc-600">
+                <p className="mt-0.5 text-[11px] text-[var(--text-tertiary)]">
                   {forecast.burn_rate_basis.replace(/_/g, " ")}
                 </p>
               )}
             </div>
-            <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
               <div className="mb-1 flex items-center gap-1.5">
-                <Gauge className="h-3.5 w-3.5 text-zinc-400" />
-                <span className="text-xs text-zinc-500">Runway</span>
+                <Gauge className="h-3.5 w-3.5 text-[var(--text-secondary)]" />
+                <span className="text-xs text-[var(--text-tertiary)]">Runway</span>
               </div>
               <p
-                className={`text-lg font-bold ${atRisk ? "text-amber-300" : "text-zinc-100"}`}
+                className={`text-lg font-bold ${atRisk ? "text-amber-300" : "text-[var(--foreground)]"}`}
               >
                 {forecast?.days_remaining != null
                   ? fmtDays(forecast.days_remaining)
                   : "—"}
               </p>
             </div>
-            <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
               <div className="mb-1 flex items-center gap-1.5">
-                <CalendarClock className="h-3.5 w-3.5 text-zinc-400" />
-                <span className="text-xs text-zinc-500">Exhaustion</span>
+                <CalendarClock className="h-3.5 w-3.5 text-[var(--text-secondary)]" />
+                <span className="text-xs text-[var(--text-tertiary)]">Exhaustion</span>
               </div>
-              <p className="text-sm font-medium text-zinc-200">
+              <p className="text-sm font-medium text-[var(--foreground)]">
                 {forecast?.projected_exhaustion_at
                   ? formatDate(forecast.projected_exhaustion_at)
                   : "—"}
               </p>
             </div>
-            <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
               <div className="mb-1 flex items-center gap-1.5">
-                <TrendingUp className="h-3.5 w-3.5 text-zinc-400" />
-                <span className="text-xs text-zinc-500">Projected period</span>
+                <TrendingUp className="h-3.5 w-3.5 text-[var(--text-secondary)]" />
+                <span className="text-xs text-[var(--text-tertiary)]">Projected period</span>
               </div>
-              <p className="text-sm font-medium text-zinc-200">
+              <p className="text-sm font-medium text-[var(--foreground)]">
                 {forecast?.projected_period_spend_usd != null
                   ? fmtUsd(forecast.projected_period_spend_usd)
                   : "—"}
               </p>
               {forecast?.budget_limit_usd != null && (
-                <p className="mt-0.5 text-[11px] text-zinc-600">
+                <p className="mt-0.5 text-[11px] text-[var(--text-tertiary)]">
                   of {fmtUsd(forecast.budget_limit_usd)} cap
                 </p>
               )}
             </div>
           </div>
-          <p className="mt-3 text-[11px] text-zinc-600">
+          <p className="mt-3 text-[11px] text-[var(--text-tertiary)]">
             Reference only — a forecast never blocks a call; enforcement stays at
             the gateway.
           </p>
@@ -337,26 +337,26 @@ function ChargebackPanel({ rows }: { rows: CostBreakdownRow[] }) {
   const top = [...rows].sort((a, b) => b.cost_usd - a.cost_usd).slice(0, 12);
   const total = rows.reduce((sum, r) => sum + r.cost_usd, 0);
   return (
-    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
       <div className="mb-3 flex items-center gap-2">
         <Building2 className="h-4 w-4 text-violet-400" />
-        <h3 className="text-sm font-semibold text-zinc-300">
+        <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
           Chargeback by cost-center
         </h3>
       </div>
       {top.length === 0 ? (
-        <p className="text-sm text-zinc-500">
+        <p className="text-sm text-[var(--text-tertiary)]">
           No chargeback allocation recorded. Tag GenAI spans with{" "}
-          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          <code className="rounded bg-[var(--surface-elevated)] px-1.5 py-0.5 text-xs text-[var(--text-secondary)]">
             agent.cost_center
           </code>{" "}
-          (or <code className="text-zinc-300">allocation.tag.*</code>) to attribute
+          (or <code className="text-[var(--text-secondary)]">allocation.tag.*</code>) to attribute
           spend to a budget unit.
         </p>
       ) : (
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-zinc-800 text-left text-xs text-zinc-500">
+            <tr className="border-b border-[var(--border-subtle)] text-left text-xs text-[var(--text-tertiary)]">
               <th className="pb-2 font-medium">Cost center</th>
               <th className="pb-2 text-right font-medium">Calls</th>
               <th className="pb-2 text-right font-medium">Share</th>
@@ -369,18 +369,18 @@ function ChargebackPanel({ rows }: { rows: CostBreakdownRow[] }) {
               return (
                 <tr
                   key={r.key}
-                  className="border-b border-zinc-900 last:border-0"
+                  className="border-b border-[var(--border-subtle)] last:border-0"
                 >
-                  <td className="py-2 font-mono text-xs text-zinc-300">
+                  <td className="py-2 font-mono text-xs text-[var(--text-secondary)]">
                     {r.key || "unallocated"}
                   </td>
-                  <td className="py-2 text-right text-zinc-400">
+                  <td className="py-2 text-right text-[var(--text-secondary)]">
                     {fmtInt(r.calls)}
                   </td>
-                  <td className="py-2 text-right text-zinc-500">
+                  <td className="py-2 text-right text-[var(--text-tertiary)]">
                     {(share * 100).toFixed(1)}%
                   </td>
-                  <td className="py-2 text-right font-medium text-zinc-200">
+                  <td className="py-2 text-right font-medium text-[var(--foreground)]">
                     {fmtUsd(r.cost_usd)}
                   </td>
                 </tr>
@@ -408,18 +408,18 @@ function AnomalyRow({ a }: { a: CostAnomaly }) {
           <ShieldAlert
             className={`h-4 w-4 ${high ? "text-red-400" : "text-amber-400"}`}
           />
-          <span className="text-sm font-medium text-zinc-200">
+          <span className="text-sm font-medium text-[var(--foreground)]">
             {a.type.replace(/_/g, " ")}
           </span>
-          <span className="font-mono text-xs text-zinc-500">
+          <span className="font-mono text-xs text-[var(--text-tertiary)]">
             {a.agent ?? a.session_id ?? ""}
           </span>
         </div>
-        <span className="font-mono text-xs text-zinc-400">
+        <span className="font-mono text-xs text-[var(--text-secondary)]">
           z={a.z_score.toFixed(1)}
         </span>
       </div>
-      <p className="mt-1 text-xs text-zinc-400">
+      <p className="mt-1 text-xs text-[var(--text-secondary)]">
         {a.metric} ={" "}
         {typeof a.value === "number" ? a.value.toLocaleString() : a.value} vs
         baseline {a.baseline_median.toLocaleString()} — {a.recommendation}
@@ -544,28 +544,28 @@ export default function CostPage() {
               icon={ArrowDownToLine}
               label="Input tokens"
               value={fmtInt(report.total_input_tokens)}
-              color="text-zinc-400"
+              color="text-[var(--text-secondary)]"
             />
             <StatCard
               icon={ArrowUpFromLine}
               label="Output tokens"
               value={fmtInt(report.total_output_tokens)}
-              color="text-zinc-400"
+              color="text-[var(--text-secondary)]"
             />
             <StatCard
               icon={AlertTriangle}
               label="Unpriced calls"
               value={fmtInt(report.unpriced_calls)}
               color={
-                report.unpriced_calls > 0 ? "text-amber-400" : "text-zinc-400"
+                report.unpriced_calls > 0 ? "text-amber-400" : "text-[var(--text-secondary)]"
               }
             />
           </div>
 
-          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+          <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
             <div className="mb-3 flex items-center gap-2">
               <TrendingUp className="h-4 w-4 text-emerald-400" />
-              <h3 className="text-sm font-semibold text-zinc-300">
+              <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
                 Spend by agent (top 10)
               </h3>
             </div>
@@ -607,10 +607,10 @@ export default function CostPage() {
         </>
       )}
 
-      <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+      <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
         <div className="mb-3 flex items-center gap-2">
           <ShieldAlert className="h-4 w-4 text-amber-400" />
-          <h3 className="text-sm font-semibold text-zinc-300">
+          <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
             Cost & behavior anomalies
           </h3>
           {anomalyCount > 0 && (
@@ -620,7 +620,7 @@ export default function CostPage() {
           )}
         </div>
         {anomalyCount === 0 ? (
-          <p className="text-sm text-zinc-500">
+          <p className="text-sm text-[var(--text-tertiary)]">
             No statistical anomalies detected across cost or call-rate
             baselines.
           </p>

--- a/ui/app/drift/page.tsx
+++ b/ui/app/drift/page.tsx
@@ -38,12 +38,12 @@ function StatCard({
   color: string;
 }) {
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-4">
       <div className="mb-1 flex items-center gap-2">
         <Icon className={`h-4 w-4 ${color}`} />
-        <span className="text-xs text-zinc-500">{label}</span>
+        <span className="text-xs text-[var(--text-tertiary)]">{label}</span>
       </div>
-      <p className="text-2xl font-bold text-zinc-100">{value}</p>
+      <p className="text-2xl font-bold text-[var(--foreground)]">{value}</p>
     </div>
   );
 }
@@ -70,15 +70,15 @@ function IncidentCard({
     <div
       className={`rounded-xl border p-4 ${
         incident.resolved
-          ? "border-zinc-800 bg-zinc-900/30 opacity-70"
-          : "border-zinc-800 bg-zinc-900/50"
+          ? "border-[var(--border-subtle)] bg-[var(--surface)]/30 opacity-70"
+          : "border-[var(--border-subtle)] bg-[var(--surface)]/50"
       }`}
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            <GitBranch className="h-4 w-4 text-zinc-500" />
-            <span className="font-mono text-sm font-semibold text-zinc-200">
+            <GitBranch className="h-4 w-4 text-[var(--text-tertiary)]" />
+            <span className="font-mono text-sm font-semibold text-[var(--foreground)]">
               {incident.blueprint_id}
             </span>
             <span
@@ -95,12 +95,12 @@ function IncidentCard({
                 : incident.status.replace(/_/g, " ")}
             </span>
             {incident.occurrences > 1 && (
-              <span className="rounded bg-zinc-800 px-2 py-0.5 text-xs text-zinc-400">
+              <span className="rounded bg-[var(--surface-elevated)] px-2 py-0.5 text-xs text-[var(--text-secondary)]">
                 ×{incident.occurrences}
               </span>
             )}
           </div>
-          <p className="mt-1 text-xs text-zinc-500">
+          <p className="mt-1 text-xs text-[var(--text-tertiary)]">
             {incident.violation_count} violation
             {incident.violation_count !== 1 ? "s" : ""} ·{" "}
             {incident.warning_count} warning
@@ -134,13 +134,13 @@ function IncidentCard({
       </div>
 
       <div className="mt-3 flex items-center gap-3">
-        <div className="h-2 flex-1 overflow-hidden rounded-full bg-zinc-800">
+        <div className="h-2 flex-1 overflow-hidden rounded-full bg-[var(--surface-elevated)]">
           <div
             className={`h-full ${scoreColor(incident.drift_score)} transition-all`}
             style={{ width: `${pct}%` }}
           />
         </div>
-        <span className="font-mono text-xs text-zinc-400">
+        <span className="font-mono text-xs text-[var(--text-secondary)]">
           drift {incident.drift_score.toFixed(2)}
         </span>
       </div>
@@ -150,7 +150,7 @@ function IncidentCard({
           {incident.top_violations.slice(0, 8).map((v, i) => (
             <span
               key={i}
-              className="rounded bg-zinc-800 px-2 py-0.5 font-mono text-xs text-zinc-300"
+              className="rounded bg-[var(--surface-elevated)] px-2 py-0.5 font-mono text-xs text-[var(--text-secondary)]"
             >
               {(v.tool_name as string) || (v.type as string) || "violation"}
             </span>
@@ -159,7 +159,7 @@ function IncidentCard({
       )}
 
       {incident.resolved && incident.resolved_by && (
-        <p className="mt-2 text-xs text-zinc-600">
+        <p className="mt-2 text-xs text-[var(--text-tertiary)]">
           Resolved by {incident.resolved_by}
           {incident.resolved_at ? ` · ${formatDate(incident.resolved_at)}` : ""}
           {incident.resolution_note ? ` · ${incident.resolution_note}` : ""}
@@ -236,14 +236,14 @@ export default function DriftPage() {
         <div className="flex items-center gap-2">
           <Radar className="h-6 w-6 text-rose-400" />
           <div>
-            <h1 className="text-2xl font-semibold text-zinc-100">Drift</h1>
-            <p className="text-sm text-zinc-500">
+            <h1 className="text-2xl font-semibold text-[var(--foreground)]">Drift</h1>
+            <p className="text-sm text-[var(--text-tertiary)]">
               Behavioral drift incidents where live agent activity diverged from
               its declared blueprint.
             </p>
           </div>
         </div>
-        <label className="flex cursor-pointer items-center gap-2 text-xs text-zinc-400">
+        <label className="flex cursor-pointer items-center gap-2 text-xs text-[var(--text-secondary)]">
           <input
             type="checkbox"
             checked={showResolved}

--- a/ui/app/error.tsx
+++ b/ui/app/error.tsx
@@ -26,8 +26,8 @@ export default function GlobalError({
   return (
     <div className="flex flex-col items-center justify-center h-[80vh] gap-4 text-center">
       <ShieldX className="w-12 h-12 text-red-500" />
-      <h2 className="text-lg font-semibold text-zinc-200">Something went wrong</h2>
-      <p className="text-sm text-zinc-400 max-w-md">{error.message}</p>
+      <h2 className="text-lg font-semibold text-[var(--foreground)]">Something went wrong</h2>
+      <p className="text-sm text-[var(--text-secondary)] max-w-md">{error.message}</p>
       <button
         onClick={reset}
         className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 rounded-md text-sm text-white transition-colors"

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -884,7 +884,7 @@ function FindingsPage() {
     {
       key: "all",
       label: `All (${useServerPaging ? findingsTotalLabel : vulns.length})`,
-      color: "text-zinc-300",
+      color: "text-[var(--text-secondary)]",
     },
     { key: "critical", label: `Critical${useServerPaging ? "" : ` (${counts.critical})`}`, color: "text-red-400" },
     { key: "high",     label: `High${useServerPaging ? "" : ` (${counts.high})`}`,         color: "text-orange-400" },
@@ -957,7 +957,7 @@ function FindingsPage() {
                 </button>
                 <button
                   onClick={() => downloadJson(displayed, `findings-${new Date().toISOString().slice(0, 10)}.json`)}
-                  className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 text-sm font-medium rounded-lg transition-colors"
+                  className="flex items-center gap-1.5 px-3 py-1.5 bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] border border-[var(--border-subtle)] text-[var(--text-secondary)] text-sm font-medium rounded-lg transition-colors"
                   title="Export filtered findings as JSON"
                 >
                   <Download className="w-3.5 h-3.5" />
@@ -1017,16 +1017,16 @@ function FindingsPage() {
         <>
           {/* Controls */}
           <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-2 rounded-xl border border-zinc-800 bg-zinc-950/70 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-col gap-2 rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/70 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
-                <h2 className="text-sm font-semibold text-zinc-200">{findingsQueueTitle(lens)}</h2>
-                <p className="mt-1 text-xs text-zinc-500">{findingsQueueDetail(lens)}</p>
+                <h2 className="text-sm font-semibold text-[var(--foreground)]">{findingsQueueTitle(lens)}</h2>
+                <p className="mt-1 text-xs text-[var(--text-tertiary)]">{findingsQueueDetail(lens)}</p>
               </div>
-              <div className="flex flex-wrap gap-2 text-xs text-zinc-500">
-                <span className="rounded-full border border-zinc-800 bg-zinc-900 px-2 py-1">{PAGE_SIZE} per page</span>
-                <span className="rounded-full border border-zinc-800 bg-zinc-900 px-2 py-1">{displayed.length} filtered</span>
+              <div className="flex flex-wrap gap-2 text-xs text-[var(--text-tertiary)]">
+                <span className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-1">{PAGE_SIZE} per page</span>
+                <span className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-1">{displayed.length} filtered</span>
                 <span
-                  className="rounded-full border border-zinc-800 bg-zinc-900 px-2 py-1"
+                  className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-1"
                   title="OpenVEX export is available after a finding is triaged as not_affected with justification"
                 >
                   {vexEligibleCount} OpenVEX-ready
@@ -1041,7 +1041,7 @@ function FindingsPage() {
                 ) : (
                   <a
                     href="/remediation"
-                    className="rounded-full border border-zinc-800 bg-zinc-900 px-2 py-1 hover:border-zinc-700 hover:text-zinc-300"
+                    className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-1 hover:border-[var(--border-subtle)] hover:text-[var(--text-secondary)]"
                   >
                     Remediation
                   </a>
@@ -1053,7 +1053,7 @@ function FindingsPage() {
             <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
               <div className="flex flex-col gap-2">
                 <div className="flex flex-wrap items-center gap-1">
-                  <span className="mr-1 text-[10px] font-medium uppercase tracking-[0.14em] text-zinc-500">Issue type</span>
+                  <span className="mr-1 text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-tertiary)]">Issue type</span>
                   {ISSUE_TYPE_FILTERS.map(({ key, label, hint }) => (
                     <button
                       key={key}
@@ -1063,7 +1063,7 @@ function FindingsPage() {
                       className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
                         issueTypeFilter === key
                           ? "border-cyan-700 bg-cyan-950/40 text-cyan-200"
-                          : "border-zinc-800 text-zinc-500 hover:border-zinc-700 hover:text-zinc-300"
+                          : "border-[var(--border-subtle)] text-[var(--text-tertiary)] hover:border-[var(--border-subtle)] hover:text-[var(--text-secondary)]"
                       }`}
                     >
                       {label}
@@ -1071,15 +1071,15 @@ function FindingsPage() {
                   ))}
                 </div>
                 <div className="flex flex-wrap items-center gap-1">
-                  <span className="mr-1 text-[10px] font-medium uppercase tracking-[0.14em] text-zinc-500">Severity</span>
+                  <span className="mr-1 text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-tertiary)]">Severity</span>
                   {FILTERS?.map(({ key, label, color }) => (
                     <button
                       key={key}
                       onClick={() => setFilter(key)}
                       className={`rounded-md border px-3 py-1 text-xs font-medium transition-colors ${
                         filter === key
-                          ? `${color} border-zinc-600 bg-zinc-800`
-                          : "text-zinc-500 border-zinc-800 hover:border-zinc-700 hover:text-zinc-300"
+                          ? `${color} border-[var(--border-strong)] bg-[var(--surface-elevated)]`
+                          : "text-[var(--text-tertiary)] border-[var(--border-subtle)] hover:border-[var(--border-subtle)] hover:text-[var(--text-secondary)]"
                       }`}
                     >
                       {label}
@@ -1092,23 +1092,23 @@ function FindingsPage() {
                 placeholder={findingsSearchPlaceholder(lens)}
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                className="w-full sm:w-64 bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500"
+                className="w-full sm:w-64 bg-[var(--surface)] border border-[var(--border-subtle)] rounded-lg px-3 py-1.5 text-sm text-[var(--foreground)] placeholder-[var(--text-tertiary)] focus:outline-none focus:border-[var(--border-strong)]"
               />
             </div>
 
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-2">
-                <span className="text-xs text-zinc-500 uppercase tracking-wide font-medium">Scope</span>
+                <span className="text-xs text-[var(--text-tertiary)] uppercase tracking-wide font-medium">Scope</span>
                 <select
                   value={scope}
                   onChange={(e) => setScope(e.target.value as ScanScope)}
-                  className="bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:border-zinc-500"
+                  className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-lg px-3 py-1.5 text-sm text-[var(--foreground)] focus:outline-none focus:border-[var(--border-strong)]"
                 >
                   <option value="latest">Latest completed scan</option>
                   <option value="all">All completed scans</option>
                 </select>
               </div>
-              <p className="text-xs text-zinc-600">
+              <p className="text-xs text-[var(--text-tertiary)]">
                 Default stays scoped for speed. Expand to all scans only when you need history-wide findings aggregation.
               </p>
             </div>
@@ -1189,7 +1189,7 @@ function FindingsPage() {
             </div>
 
             {detailLoading && vulns.length > 0 && (
-              <div className="flex items-center gap-2 text-xs text-zinc-500">
+              <div className="flex items-center gap-2 text-xs text-[var(--text-tertiary)]">
                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
                 {scope === "latest" ? "Refreshing latest scan..." : "Refreshing historical aggregation..."}
               </div>
@@ -1197,15 +1197,15 @@ function FindingsPage() {
 
             {/* Group by */}
             <div className="flex items-center gap-2">
-              <span className="text-xs text-zinc-500 uppercase tracking-wide font-medium">Group by</span>
+              <span className="text-xs text-[var(--text-tertiary)] uppercase tracking-wide font-medium">Group by</span>
               {GROUP_OPTIONS?.map(({ key, label, icon: Icon }) => (
                 <button
                   key={key}
                   onClick={() => setGroupBy(key)}
                   className={`flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md border transition-colors ${
                     groupBy === key
-                      ? "text-zinc-200 border-zinc-600 bg-zinc-800"
-                      : "text-zinc-500 border-zinc-800 hover:border-zinc-700 hover:text-zinc-300"
+                      ? "text-[var(--foreground)] border-[var(--border-strong)] bg-[var(--surface-elevated)]"
+                      : "text-[var(--text-tertiary)] border-[var(--border-subtle)] hover:border-[var(--border-subtle)] hover:text-[var(--text-secondary)]"
                   }`}
                 >
                   <Icon className="w-3 h-3" />
@@ -1238,12 +1238,12 @@ function FindingsPage() {
                       className="flex w-full items-center gap-2 mb-2 text-left transition-colors group"
                     >
                       {collapsed ? (
-                        <ChevronRight className="h-4 w-4 text-zinc-500 group-hover:text-zinc-300" />
+                        <ChevronRight className="h-4 w-4 text-[var(--text-tertiary)] group-hover:text-[var(--text-secondary)]" />
                       ) : (
-                        <ChevronDown className="h-4 w-4 text-zinc-500 group-hover:text-zinc-300" />
+                        <ChevronDown className="h-4 w-4 text-[var(--text-tertiary)] group-hover:text-[var(--text-secondary)]" />
                       )}
-                      <h3 className="text-sm font-semibold text-zinc-300">{groupLabel}</h3>
-                      <span className="text-xs font-mono text-zinc-600 bg-zinc-800 rounded px-1.5 py-0.5">
+                      <h3 className="text-sm font-semibold text-[var(--text-secondary)]">{groupLabel}</h3>
+                      <span className="text-xs font-mono text-[var(--text-tertiary)] bg-[var(--surface-elevated)] rounded px-1.5 py-0.5">
                         {groupVulns.length}
                       </span>
                     </button>
@@ -1262,7 +1262,7 @@ function FindingsPage() {
                           columns={visibleColumns}
                         />
                         {groupOverflow > 0 && (
-                          <p className="mt-2 text-xs text-zinc-600">
+                          <p className="mt-2 text-xs text-[var(--text-tertiary)]">
                             Showing first {PAGE_SIZE} of {groupVulns.length} —
                             narrow with the search box or switch to the flat
                             view (Group: none) for full pagination.
@@ -1301,7 +1301,7 @@ function FindingsPage() {
           )}
 
           {grouped && (
-            <p className="text-xs text-zinc-600 text-right">
+            <p className="text-xs text-[var(--text-tertiary)] text-right">
               Showing {displayed.length} of {vulns.length} findings
             </p>
           )}

--- a/ui/app/fleet/page.tsx
+++ b/ui/app/fleet/page.tsx
@@ -60,11 +60,11 @@ const STATE_LABELS: Record<FleetLifecycleState, string> = {
 };
 
 const STATE_COLORS: Record<FleetLifecycleState, string> = {
-  discovered: "bg-zinc-800 text-zinc-300 border-zinc-700",
+  discovered: "bg-[var(--surface-elevated)] text-[var(--text-secondary)] border-[var(--border-subtle)]",
   pending_review: "bg-yellow-950 text-yellow-300 border-yellow-800",
   approved: "bg-emerald-950 text-emerald-300 border-emerald-800",
   quarantined: "bg-red-950 text-red-300 border-red-800",
-  decommissioned: "bg-zinc-900 text-zinc-500 border-zinc-800",
+  decommissioned: "bg-[var(--surface)] text-[var(--text-tertiary)] border-[var(--border-subtle)]",
 };
 
 const TRANSITIONS: Record<FleetLifecycleState, FleetLifecycleState[]> = {
@@ -230,7 +230,7 @@ export default function FleetPage() {
             <Users className="w-6 h-6 text-emerald-400" />
             Fleet
           </h1>
-          <p className="text-zinc-400 text-sm mt-1">
+          <p className="text-[var(--text-secondary)] text-sm mt-1">
             Persisted agent inventory, review state, and trust score from the fleet store
           </p>
         </div>
@@ -238,7 +238,7 @@ export default function FleetPage() {
           {agents.length > 0 && (
             <button
               onClick={() => downloadJson(filtered, `fleet-${new Date().toISOString().slice(0, 10)}.json`)}
-              className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 text-sm font-medium rounded-lg transition-colors"
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] border border-[var(--border-subtle)] text-[var(--text-secondary)] text-sm font-medium rounded-lg transition-colors"
               title="Export fleet list as JSON"
             >
               <Download className="w-3.5 h-3.5" />
@@ -257,16 +257,16 @@ export default function FleetPage() {
       </div>
 
       {/* Trust Threshold Settings */}
-      <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+      <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-4">
         <div className="flex items-center gap-2 mb-3">
-          <Settings className="w-4 h-4 text-zinc-400" />
-          <h3 className="text-sm font-semibold text-zinc-300">Policy threshold</h3>
+          <Settings className="w-4 h-4 text-[var(--text-secondary)]" />
+          <h3 className="text-sm font-semibold text-[var(--text-secondary)]">Policy threshold</h3>
         </div>
         <div className="flex flex-col sm:flex-row sm:items-center gap-4">
           <div className="flex-1">
             <div className="flex items-center justify-between mb-1">
-              <span className="text-xs text-zinc-500">Minimum trust score</span>
-              <span className="text-xs font-mono text-zinc-200">{trustThreshold}</span>
+              <span className="text-xs text-[var(--text-tertiary)]">Minimum trust score</span>
+              <span className="text-xs font-mono text-[var(--foreground)]">{trustThreshold}</span>
             </div>
             <input
               type="range"
@@ -274,11 +274,11 @@ export default function FleetPage() {
               max={100}
               value={trustThreshold}
               onChange={(e) => setTrustThreshold(Number(e.target.value))}
-              className="w-full h-1.5 bg-zinc-800 rounded-full appearance-none cursor-pointer accent-emerald-500"
+              className="w-full h-1.5 bg-[var(--surface-elevated)] rounded-full appearance-none cursor-pointer accent-emerald-500"
             />
           </div>
           <div className="flex items-center gap-4">
-            <span className="text-xs text-zinc-400">
+            <span className="text-xs text-[var(--text-secondary)]">
               <span className="font-mono text-yellow-400">{belowThresholdCount}</span> agents below threshold
             </span>
           </div>
@@ -288,7 +288,7 @@ export default function FleetPage() {
       {/* Stats */}
       {stats && (
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-          <StatCard label="Total Agents" value={stats.total} icon={Users} color="text-zinc-400" />
+          <StatCard label="Total Agents" value={stats.total} icon={Users} color="text-[var(--text-secondary)]" />
           <StatCard label="Approved" value={stats.by_state.approved ?? 0} icon={ShieldCheck} color="text-emerald-400" />
           <StatCard label="Low Trust" value={stats.low_trust_count} icon={ShieldAlert} color="text-yellow-400" />
           <StatCard
@@ -314,9 +314,9 @@ export default function FleetPage() {
           .filter(([, v]) => v > 0)
           .map(([state, count]) => ({ state: STATE_LABELS[state as FleetLifecycleState] ?? state, count, fill: STATE_CHART_COLORS[state] ?? "#71717a" }));
         return (
-          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
-            <h3 className="text-sm font-semibold text-zinc-300 mb-1">Lifecycle Distribution</h3>
-            <p className="text-[10px] text-zinc-600 mb-4">Agent count by lifecycle state</p>
+          <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-5">
+            <h3 className="text-sm font-semibold text-[var(--text-secondary)] mb-1">Lifecycle Distribution</h3>
+            <p className="text-[10px] text-[var(--text-tertiary)] mb-4">Agent count by lifecycle state</p>
             <div className="h-36">
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={chartData} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
@@ -336,20 +336,20 @@ export default function FleetPage() {
       {/* Search + Filter tabs */}
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div className="relative w-full sm:w-96">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-zinc-600" />
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-[var(--text-tertiary)]" />
           <input
             type="text"
             placeholder="Search by name, owner, environment, or tag..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="w-full bg-zinc-900 border border-zinc-700 rounded-lg pl-8 pr-3 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500"
+            className="w-full bg-[var(--surface)] border border-[var(--border-subtle)] rounded-lg pl-8 pr-3 py-1.5 text-sm text-[var(--foreground)] placeholder-[var(--text-tertiary)] focus:outline-none focus:border-[var(--border-strong)]"
           />
         </div>
-        <div className="text-xs text-zinc-500">
+        <div className="text-xs text-[var(--text-tertiary)]">
           {fleetTotal > 0 ? (
             <span>
-              Showing <span className="font-mono text-zinc-300">{pageStart}-{pageEnd}</span> of{" "}
-              <span className="font-mono text-zinc-300">{fleetTotal}</span> agents
+              Showing <span className="font-mono text-[var(--text-secondary)]">{pageStart}-{pageEnd}</span> of{" "}
+              <span className="font-mono text-[var(--text-secondary)]">{fleetTotal}</span> agents
             </span>
           ) : (
             <span>No matching agents</span>
@@ -364,13 +364,13 @@ export default function FleetPage() {
             onClick={() => setStateFilter(s)}
             className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
               stateFilter === s
-                ? "bg-zinc-800 text-zinc-100"
-                : "text-zinc-500 hover:text-zinc-300 hover:bg-zinc-900"
+                ? "bg-[var(--surface-elevated)] text-[var(--foreground)]"
+                : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface)]"
             }`}
           >
             {s === "all" ? "All" : STATE_LABELS[s as FleetLifecycleState]}
             {s !== "all" && stats && (
-              <span className="ml-1 text-zinc-600">
+              <span className="ml-1 text-[var(--text-tertiary)]">
                 {stats.by_state[s] ?? 0}
               </span>
             )}
@@ -381,7 +381,7 @@ export default function FleetPage() {
       {/* Loading */}
       {loading && (
         <div className="flex items-center justify-center py-12">
-          <Loader2 className="w-6 h-6 animate-spin text-zinc-500" />
+          <Loader2 className="w-6 h-6 animate-spin text-[var(--text-tertiary)]" />
         </div>
       )}
 
@@ -390,7 +390,7 @@ export default function FleetPage() {
         <div className="text-center py-16 border border-dashed border-red-900/50 rounded-xl">
           <AlertTriangle className="w-8 h-8 text-red-500 mx-auto mb-3" />
           <p className="text-red-400 text-sm">Failed to load fleet data</p>
-          <p className="text-zinc-500 text-xs mt-1">{error}</p>
+          <p className="text-[var(--text-tertiary)] text-xs mt-1">{error}</p>
         </div>
       )}
 
@@ -418,10 +418,10 @@ export default function FleetPage() {
         (counts && !isDeploymentSurfaceAvailable("fleet", counts) ? (
           <DeploymentSurfaceRequiredState surface="fleet" counts={counts} detail={warning} />
         ) : (
-          <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
-            <Users className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
-            <p className="text-zinc-500 text-sm">No agents in fleet yet.</p>
-            <p className="text-zinc-600 text-xs mt-1">
+          <div className="text-center py-16 border border-dashed border-[var(--border-subtle)] rounded-xl">
+            <Users className="w-8 h-8 text-[var(--text-tertiary)] mx-auto mb-3" />
+            <p className="text-[var(--text-tertiary)] text-sm">No agents in fleet yet.</p>
+            <p className="text-[var(--text-tertiary)] text-xs mt-1">
               Click &quot;Sync Now&quot; to discover and register agents.
             </p>
           </div>
@@ -434,23 +434,23 @@ export default function FleetPage() {
             const isExpanded = expanded.has(agent.agent_id);
             const transitions = TRANSITIONS[agent.lifecycle_state] ?? [];
             return (
-              <div key={agent.agent_id} className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
+              <div key={agent.agent_id} className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl overflow-hidden">
                 <button
                   onClick={() => toggleExpand(agent.agent_id)}
-                  className="w-full px-4 py-3 flex flex-col gap-3 text-left transition-colors hover:bg-zinc-800/50 sm:flex-row sm:items-center sm:justify-between"
+                  className="w-full px-4 py-3 flex flex-col gap-3 text-left transition-colors hover:bg-[var(--surface-elevated)]/50 sm:flex-row sm:items-center sm:justify-between"
                 >
                   <div className="flex min-w-0 flex-wrap items-center gap-3">
-                    {isExpanded ? <ChevronDown className="w-4 h-4 shrink-0 text-zinc-500" /> : <ChevronRight className="w-4 h-4 shrink-0 text-zinc-500" />}
-                    <span className="min-w-0 break-words font-medium text-zinc-100">{agent.name}</span>
+                    {isExpanded ? <ChevronDown className="w-4 h-4 shrink-0 text-[var(--text-tertiary)]" /> : <ChevronRight className="w-4 h-4 shrink-0 text-[var(--text-tertiary)]" />}
+                    <span className="min-w-0 break-words font-medium text-[var(--foreground)]">{agent.name}</span>
                     <span className={`text-[10px] px-1.5 py-0.5 rounded border ${STATE_COLORS[agent.lifecycle_state]}`}>
                       {STATE_LABELS[agent.lifecycle_state]}
                     </span>
-                    <span className="break-words text-xs text-zinc-600">{agent.agent_type}</span>
+                    <span className="break-words text-xs text-[var(--text-tertiary)]">{agent.agent_type}</span>
                   </div>
                   <div className="flex flex-wrap items-center gap-4">
                     {/* Trust score bar */}
                     <div className="flex items-center gap-2 w-32">
-                      <div className="flex-1 h-1.5 bg-zinc-800 rounded-full overflow-hidden">
+                      <div className="flex-1 h-1.5 bg-[var(--surface-elevated)] rounded-full overflow-hidden">
                         <div
                           className={`h-full rounded-full ${trustColor(agent.trust_score)}`}
                           style={{ width: `${agent.trust_score}%` }}
@@ -461,7 +461,7 @@ export default function FleetPage() {
                       </span>
                     </div>
                     {/* Counts */}
-                    <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-500">
+                    <div className="flex flex-wrap items-center gap-3 text-xs text-[var(--text-tertiary)]">
                       <span className="flex items-center gap-1"><Server className="w-3 h-3" />{agent.server_count}</span>
                       <span className="flex items-center gap-1"><Package className="w-3 h-3" />{agent.package_count}</span>
                       {agent.credential_count > 0 && (
@@ -474,34 +474,34 @@ export default function FleetPage() {
                   </div>
                 </button>
                 {isExpanded && (
-                  <div className="border-t border-zinc-800 px-4 py-3 space-y-3">
+                  <div className="border-t border-[var(--border-subtle)] px-4 py-3 space-y-3">
                     {/* Detail grid */}
                     <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-xs">
                       <div>
-                        <span className="text-zinc-500">Owner</span>
-                        <div className="text-zinc-300 mt-0.5 break-words">{agent.owner || "—"}</div>
+                        <span className="text-[var(--text-tertiary)]">Owner</span>
+                        <div className="text-[var(--text-secondary)] mt-0.5 break-words">{agent.owner || "—"}</div>
                       </div>
                       <div>
-                        <span className="text-zinc-500">Environment</span>
-                        <div className="text-zinc-300 mt-0.5 break-words">{agent.environment || "—"}</div>
+                        <span className="text-[var(--text-tertiary)]">Environment</span>
+                        <div className="text-[var(--text-secondary)] mt-0.5 break-words">{agent.environment || "—"}</div>
                       </div>
                       <div>
-                        <span className="text-zinc-500">Last Discovery</span>
-                        <div className="text-zinc-300 mt-0.5">{agent.last_discovery ? formatDate(agent.last_discovery) : "—"}</div>
+                        <span className="text-[var(--text-tertiary)]">Last Discovery</span>
+                        <div className="text-[var(--text-secondary)] mt-0.5">{agent.last_discovery ? formatDate(agent.last_discovery) : "—"}</div>
                       </div>
                       <div>
-                        <span className="text-zinc-500">Config</span>
-                        <div className="text-zinc-300 mt-0.5 break-all font-mono">{agent.config_path || "—"}</div>
+                        <span className="text-[var(--text-tertiary)]">Config</span>
+                        <div className="text-[var(--text-secondary)] mt-0.5 break-all font-mono">{agent.config_path || "—"}</div>
                       </div>
                     </div>
                     {/* Trust factors */}
                     {Object.keys(agent.trust_factors).length > 0 && (
                       <div>
-                        <span className="text-xs text-zinc-500 block mb-1">Trust Factors</span>
+                        <span className="text-xs text-[var(--text-tertiary)] block mb-1">Trust Factors</span>
                         <div className="flex flex-wrap gap-2">
                           {Object.entries(agent.trust_factors).map(([k, v]) => (
-                            <span key={k} className="text-xs bg-zinc-800 border border-zinc-700 rounded px-2 py-0.5 text-zinc-400">
-                              {k.replace(/_/g, " ")}: <span className="break-all font-mono text-zinc-200">{v}</span>
+                            <span key={k} className="text-xs bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded px-2 py-0.5 text-[var(--text-secondary)]">
+                              {k.replace(/_/g, " ")}: <span className="break-all font-mono text-[var(--foreground)]">{v}</span>
                             </span>
                           ))}
                         </div>
@@ -510,7 +510,7 @@ export default function FleetPage() {
                     {/* State transitions */}
                     {transitions.length > 0 && (
                       <div className="flex flex-wrap items-center gap-2">
-                        <span className="text-xs text-zinc-500">Transition:</span>
+                        <span className="text-xs text-[var(--text-tertiary)]">Transition:</span>
                         {transitions?.map((t) => (
                           <button
                             key={t}
@@ -527,7 +527,7 @@ export default function FleetPage() {
                     )}
                     {/* One-click containment: quarantine + gateway deny */}
                     {agent.lifecycle_state !== "decommissioned" && (
-                      <div className="flex flex-col gap-2 border-t border-zinc-800 pt-3 sm:flex-row sm:items-center">
+                      <div className="flex flex-col gap-2 border-t border-[var(--border-subtle)] pt-3 sm:flex-row sm:items-center">
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
@@ -547,7 +547,7 @@ export default function FleetPage() {
                             ? "Re-enforce gateway deny"
                             : "Quarantine + gateway deny"}
                         </button>
-                        <span className="min-w-0 break-words text-[10px] text-zinc-600">
+                        <span className="min-w-0 break-words text-[10px] text-[var(--text-tertiary)]">
                           Blocks every tool call from this agent at the gateway.
                         </span>
                       </div>
@@ -568,7 +568,7 @@ export default function FleetPage() {
           onNext={() => setFleetOffset((current) => current + FLEET_PAGE_SIZE)}
           previousDisabled={fleetOffset === 0}
           nextDisabled={fleetOffset + agents.length >= fleetTotal}
-          className="rounded-xl border border-zinc-800 bg-zinc-900 px-4 py-3"
+          className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)] px-4 py-3"
         />
       )}
     </div>
@@ -591,12 +591,12 @@ function StatCard({
   suffix?: string;
 }) {
   return (
-    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+    <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-4">
       <Icon className={`w-4 h-4 mb-2 ${color}`} />
       <div className="text-2xl font-bold font-mono">
         {Math.round(value)}{suffix}
       </div>
-      <div className="text-xs text-zinc-500 mt-0.5">{label}</div>
+      <div className="text-xs text-[var(--text-tertiary)] mt-0.5">{label}</div>
     </div>
   );
 }

--- a/ui/app/gateway/GatewayDashboard.tsx
+++ b/ui/app/gateway/GatewayDashboard.tsx
@@ -48,7 +48,7 @@ const MODE_COLORS: Record<PolicyMode, string> = {
 };
 
 const RUNTIME_COLORS: Record<GatewayPolicyRuntimeSummary["rollout_mode"], string> = {
-  disabled: "bg-zinc-900 text-zinc-300 border-zinc-700",
+  disabled: "bg-[var(--surface)] text-[var(--text-secondary)] border-[var(--border-subtle)]",
   advisory_only: "bg-blue-950 text-blue-300 border-blue-800",
   mixed: "bg-amber-950 text-amber-300 border-amber-800",
   default_deny: "bg-red-950 text-red-300 border-red-800",
@@ -165,7 +165,7 @@ export default function GatewayPage() {
             <Lock className="w-6 h-6 text-blue-400" />
             Gateway Policies
           </h1>
-          <p className="text-zinc-400 text-sm mt-1">
+          <p className="text-[var(--text-secondary)] text-sm mt-1">
             Runtime MCP gateway rules with policy-as-code enforcement
           </p>
         </div>
@@ -189,7 +189,7 @@ export default function GatewayPage() {
             <FirewallRuntimeCard runtime={stats.firewall_runtime} />
           )}
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-            <StatCard label="Total Policies" value={stats.total_policies} icon={Lock} color="text-zinc-400" />
+            <StatCard label="Total Policies" value={stats.total_policies} icon={Lock} color="text-[var(--text-secondary)]" />
             <StatCard label="Enforce Mode" value={stats.enforce_count} icon={ShieldAlert} color="text-red-400" />
             <StatCard label="Audit Mode" value={stats.audit_count} icon={ShieldCheck} color="text-blue-400" />
             <StatCard label="Blocked" value={stats.blocked_count} icon={ShieldAlert} color="text-orange-400" />
@@ -205,8 +205,8 @@ export default function GatewayPage() {
             onClick={() => setTab(t)}
             className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors inline-flex items-center gap-1.5 ${
               tab === t
-                ? "bg-zinc-800 text-zinc-100"
-                : "text-zinc-500 hover:text-zinc-300 hover:bg-zinc-900"
+                ? "bg-[var(--surface-elevated)] text-[var(--foreground)]"
+                : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface)]"
             }`}
           >
             {t === "feed" && <Activity className="w-3.5 h-3.5" />}
@@ -229,7 +229,7 @@ export default function GatewayPage() {
       {/* Loading */}
       {loading && tab !== "feed" && (
         <div className="flex items-center justify-center py-12">
-          <Loader2 className="w-6 h-6 animate-spin text-zinc-500" />
+          <Loader2 className="w-6 h-6 animate-spin text-[var(--text-tertiary)]" />
         </div>
       )}
 
@@ -238,8 +238,8 @@ export default function GatewayPage() {
         <div className="text-center py-10 border border-dashed border-red-900/50 rounded-xl space-y-3">
           <AlertTriangle className="w-8 h-8 text-red-500 mx-auto" />
           <p className="text-red-400 text-sm">Failed to load gateway data</p>
-          <p className="text-zinc-500 text-xs">{error}</p>
-          <button onClick={load} className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors">
+          <p className="text-[var(--text-tertiary)] text-xs">{error}</p>
+          <button onClick={load} className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] border border-[var(--border-subtle)] rounded-lg text-xs text-[var(--text-secondary)] transition-colors">
             <RefreshCw className="w-3.5 h-3.5" /> Retry
           </button>
         </div>
@@ -247,24 +247,24 @@ export default function GatewayPage() {
 
       {/* Create modal */}
       {showCreate && (
-        <div className="bg-zinc-900 border border-zinc-700 rounded-xl p-5 space-y-4">
-          <h3 className="text-sm font-semibold text-zinc-100">New Gateway Policy</h3>
+        <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-5 space-y-4">
+          <h3 className="text-sm font-semibold text-[var(--foreground)]">New Gateway Policy</h3>
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="text-xs text-zinc-500 block mb-1">Name</label>
+              <label className="text-xs text-[var(--text-tertiary)] block mb-1">Name</label>
               <input
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
-                className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-100 focus:outline-none focus:border-blue-600"
+                className="w-full bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded px-3 py-1.5 text-sm text-[var(--foreground)] focus:outline-none focus:border-blue-600"
                 placeholder="block-exec-tools"
               />
             </div>
             <div>
-              <label className="text-xs text-zinc-500 block mb-1">Mode</label>
+              <label className="text-xs text-[var(--text-tertiary)] block mb-1">Mode</label>
               <select
                 value={newMode}
                 onChange={(e) => setNewMode(e.target.value as PolicyMode)}
-                className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-100 focus:outline-none focus:border-blue-600"
+                className="w-full bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded px-3 py-1.5 text-sm text-[var(--foreground)] focus:outline-none focus:border-blue-600"
               >
                 <option value="audit">Audit (log only)</option>
                 <option value="enforce">Enforce (block)</option>
@@ -272,27 +272,27 @@ export default function GatewayPage() {
             </div>
           </div>
           <div>
-            <label className="text-xs text-zinc-500 block mb-1">Block Tools (comma-separated)</label>
+            <label className="text-xs text-[var(--text-tertiary)] block mb-1">Block Tools (comma-separated)</label>
             <input
               value={newBlockTools}
               onChange={(e) => setNewBlockTools(e.target.value)}
-              className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-100 focus:outline-none focus:border-blue-600"
+              className="w-full bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded px-3 py-1.5 text-sm text-[var(--foreground)] focus:outline-none focus:border-blue-600"
               placeholder="execute_command, write_file, http_request"
             />
           </div>
           <div>
-            <label className="text-xs text-zinc-500 block mb-1">Description</label>
+            <label className="text-xs text-[var(--text-tertiary)] block mb-1">Description</label>
             <input
               value={newDescription}
               onChange={(e) => setNewDescription(e.target.value)}
-              className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-100 focus:outline-none focus:border-blue-600"
+              className="w-full bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded px-3 py-1.5 text-sm text-[var(--foreground)] focus:outline-none focus:border-blue-600"
               placeholder="Block dangerous command execution tools"
             />
           </div>
           <div className="flex gap-2 justify-end">
             <button
               onClick={() => setShowCreate(false)}
-              className="px-3 py-1.5 text-sm text-zinc-400 hover:text-zinc-200 transition-colors"
+              className="px-3 py-1.5 text-sm text-[var(--text-secondary)] hover:text-[var(--foreground)] transition-colors"
             >
               Cancel
             </button>
@@ -311,12 +311,12 @@ export default function GatewayPage() {
       {!loading && tab === "policies" && (
         <>
           {policies.length === 0 && (
-            <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
-              <Lock className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
-              <p className="text-zinc-500 text-sm">
+            <div className="text-center py-16 border border-dashed border-[var(--border-subtle)] rounded-xl">
+              <Lock className="w-8 h-8 text-[var(--text-tertiary)] mx-auto mb-3" />
+              <p className="text-[var(--text-tertiary)] text-sm">
                 {gatewayUnavailable ? "Gateway not enabled for this estate." : "No gateway policies yet."}
               </p>
-              <p className="text-zinc-600 text-xs mt-1">
+              <p className="text-[var(--text-tertiary)] text-xs mt-1">
                 {gatewayUnavailable
                   ? "Enable the runtime gateway to manage shared MCP policy enforcement."
                   : "Create a policy to define runtime MCP tool enforcement rules."}
@@ -327,24 +327,24 @@ export default function GatewayPage() {
             {policies?.map((policy) => {
               const isExpanded = expanded.has(policy.policy_id);
               return (
-                <div key={policy.policy_id} className="bg-zinc-900 border border-zinc-800 rounded-xl overflow-hidden">
+                <div key={policy.policy_id} className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl overflow-hidden">
                   <button
                     onClick={() => toggleExpand(policy.policy_id)}
-                    className="w-full px-4 py-3 flex items-center justify-between hover:bg-zinc-800/50 transition-colors"
+                    className="w-full px-4 py-3 flex items-center justify-between hover:bg-[var(--surface-elevated)]/50 transition-colors"
                   >
                     <div className="flex items-center gap-3">
-                      {isExpanded ? <ChevronDown className="w-4 h-4 text-zinc-500" /> : <ChevronRight className="w-4 h-4 text-zinc-500" />}
-                      <span className="font-medium text-zinc-100">{policy.name}</span>
+                      {isExpanded ? <ChevronDown className="w-4 h-4 text-[var(--text-tertiary)]" /> : <ChevronRight className="w-4 h-4 text-[var(--text-tertiary)]" />}
+                      <span className="font-medium text-[var(--foreground)]">{policy.name}</span>
                       <span className={`text-[10px] px-1.5 py-0.5 rounded border ${MODE_COLORS[policy.mode]}`}>
                         {policy.mode}
                       </span>
                       {!policy.enabled && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded border bg-zinc-900 text-zinc-500 border-zinc-800">
+                        <span className="text-[10px] px-1.5 py-0.5 rounded border bg-[var(--surface)] text-[var(--text-tertiary)] border-[var(--border-subtle)]">
                           disabled
                         </span>
                       )}
                     </div>
-                    <div className="flex items-center gap-3 text-xs text-zinc-500">
+                    <div className="flex items-center gap-3 text-xs text-[var(--text-tertiary)]">
                       <span>{policy.rules.length} rule{policy.rules.length !== 1 ? "s" : ""}</span>
                       {policy.bound_agents.length > 0 && (
                         <span>{policy.bound_agents.length} bound</span>
@@ -352,18 +352,18 @@ export default function GatewayPage() {
                     </div>
                   </button>
                   {isExpanded && (
-                    <div className="border-t border-zinc-800 px-4 py-3 space-y-3">
+                    <div className="border-t border-[var(--border-subtle)] px-4 py-3 space-y-3">
                       {policy.description && (
-                        <p className="text-xs text-zinc-400">{policy.description}</p>
+                        <p className="text-xs text-[var(--text-secondary)]">{policy.description}</p>
                       )}
                       {/* Rules */}
                       {policy.rules.length > 0 && (
                         <div>
-                          <span className="text-xs text-zinc-500 block mb-1">Rules</span>
+                          <span className="text-xs text-[var(--text-tertiary)] block mb-1">Rules</span>
                           <div className="space-y-1">
                             {policy.rules?.map((rule) => (
-                              <div key={rule.id} className="text-xs bg-zinc-800 border border-zinc-700 rounded px-2 py-1.5 text-zinc-400">
-                                <span className="text-zinc-200 font-mono">{rule.id}</span>
+                              <div key={rule.id} className="text-xs bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded px-2 py-1.5 text-[var(--text-secondary)]">
+                                <span className="text-[var(--foreground)] font-mono">{rule.id}</span>
                                 {rule.description && <span className="ml-2">{rule.description}</span>}
                                 {rule.block_tools.length > 0 && (
                                   <span className="ml-2 text-red-400">
@@ -383,27 +383,27 @@ export default function GatewayPage() {
                       {/* Detail grid */}
                       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-xs">
                         <div>
-                          <span className="text-zinc-500">Created</span>
-                          <div className="text-zinc-300 mt-0.5">{policy.created_at ? formatDate(policy.created_at) : "—"}</div>
+                          <span className="text-[var(--text-tertiary)]">Created</span>
+                          <div className="text-[var(--text-secondary)] mt-0.5">{policy.created_at ? formatDate(policy.created_at) : "—"}</div>
                         </div>
                         <div>
-                          <span className="text-zinc-500">Updated</span>
-                          <div className="text-zinc-300 mt-0.5">{policy.updated_at ? formatDate(policy.updated_at) : "—"}</div>
+                          <span className="text-[var(--text-tertiary)]">Updated</span>
+                          <div className="text-[var(--text-secondary)] mt-0.5">{policy.updated_at ? formatDate(policy.updated_at) : "—"}</div>
                         </div>
                         <div>
-                          <span className="text-zinc-500">Bound Agents</span>
-                          <div className="text-zinc-300 mt-0.5">{policy.bound_agents.length > 0 ? policy.bound_agents.join(", ") : "All"}</div>
+                          <span className="text-[var(--text-tertiary)]">Bound Agents</span>
+                          <div className="text-[var(--text-secondary)] mt-0.5">{policy.bound_agents.length > 0 ? policy.bound_agents.join(", ") : "All"}</div>
                         </div>
                         <div>
-                          <span className="text-zinc-500">Environments</span>
-                          <div className="text-zinc-300 mt-0.5">{policy.bound_environments.length > 0 ? policy.bound_environments.join(", ") : "All"}</div>
+                          <span className="text-[var(--text-tertiary)]">Environments</span>
+                          <div className="text-[var(--text-secondary)] mt-0.5">{policy.bound_environments.length > 0 ? policy.bound_environments.join(", ") : "All"}</div>
                         </div>
                       </div>
                       {/* Actions */}
                       <div className="flex items-center gap-2">
                         <button
                           onClick={(e) => { e.stopPropagation(); void handleToggleEnabled(policy); }}
-                          className="text-[10px] px-2 py-0.5 rounded border transition-colors hover:opacity-80 bg-zinc-800 text-zinc-300 border-zinc-700"
+                          className="text-[10px] px-2 py-0.5 rounded border transition-colors hover:opacity-80 bg-[var(--surface-elevated)] text-[var(--text-secondary)] border-[var(--border-subtle)]"
                         >
                           {policy.enabled ? "Disable" : "Enable"}
                         </button>
@@ -428,9 +428,9 @@ export default function GatewayPage() {
       {!loading && tab === "audit" && (
         <>
           {audit.length === 0 ? (
-            <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
-              <FileText className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
-              <p className="text-zinc-500 text-sm">No audit entries yet.</p>
+            <div className="text-center py-16 border border-dashed border-[var(--border-subtle)] rounded-xl">
+              <FileText className="w-8 h-8 text-[var(--text-tertiary)] mx-auto mb-3" />
+              <p className="text-[var(--text-tertiary)] text-sm">No audit entries yet.</p>
             </div>
           ) : (
             <>
@@ -451,9 +451,9 @@ export default function GatewayPage() {
                   .slice(0, 10)
                   .map(([tool, counts]) => ({ tool: tool.length > 16 ? tool.slice(0, 14) + "…" : tool, ...counts }));
                 return (
-                  <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
-                    <h3 className="text-sm font-semibold text-zinc-300 mb-1">Enforcement Actions by Tool</h3>
-                    <p className="text-[10px] text-zinc-600 mb-4">Top tools by blocked + alerted count</p>
+                  <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-5">
+                    <h3 className="text-sm font-semibold text-[var(--text-secondary)] mb-1">Enforcement Actions by Tool</h3>
+                    <p className="text-[10px] text-[var(--text-tertiary)] mb-4">Top tools by blocked + alerted count</p>
                     <div className="h-44">
                       <ResponsiveContainer width="100%" height="100%">
                         <BarChart data={chartData} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
@@ -472,7 +472,7 @@ export default function GatewayPage() {
               })()}
             <div className="space-y-1">
               {audit?.map((entry) => (
-                <div key={entry.entry_id} className="bg-zinc-900 border border-zinc-800 rounded-lg px-4 py-2 flex items-center justify-between">
+                <div key={entry.entry_id} className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-lg px-4 py-2 flex items-center justify-between">
                   <div className="flex items-center gap-3">
                     <span className={`text-[10px] px-1.5 py-0.5 rounded border ${
                       entry.action_taken === "blocked"
@@ -483,11 +483,11 @@ export default function GatewayPage() {
                     }`}>
                       {entry.action_taken}
                     </span>
-                    <span className="text-xs text-zinc-300 font-mono">{entry.tool_name}</span>
-                    <span className="text-xs text-zinc-500">{entry.agent_name || "—"}</span>
-                    <span className="text-xs text-zinc-600 truncate max-w-xs">{entry.reason}</span>
+                    <span className="text-xs text-[var(--text-secondary)] font-mono">{entry.tool_name}</span>
+                    <span className="text-xs text-[var(--text-tertiary)]">{entry.agent_name || "—"}</span>
+                    <span className="text-xs text-[var(--text-tertiary)] truncate max-w-xs">{entry.reason}</span>
                   </div>
-                  <span className="text-xs text-zinc-600">{entry.timestamp ? formatDate(entry.timestamp) : ""}</span>
+                  <span className="text-xs text-[var(--text-tertiary)]">{entry.timestamp ? formatDate(entry.timestamp) : ""}</span>
                 </div>
               ))}
             </div>
@@ -498,30 +498,30 @@ export default function GatewayPage() {
 
       {/* Evaluate tab */}
       {!loading && tab === "evaluate" && (
-        <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5 space-y-4">
-          <h3 className="text-sm font-semibold text-zinc-100 flex items-center gap-2">
+        <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-5 space-y-4">
+          <h3 className="text-sm font-semibold text-[var(--foreground)] flex items-center gap-2">
             <Play className="w-4 h-4 text-blue-400" />
             Dry-Run Evaluation
           </h3>
-          <p className="text-xs text-zinc-500">
+          <p className="text-xs text-[var(--text-tertiary)]">
             Test how gateway policies would evaluate a tool call without actually making one.
           </p>
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="text-xs text-zinc-500 block mb-1">Tool Name</label>
+              <label className="text-xs text-[var(--text-tertiary)] block mb-1">Tool Name</label>
               <input
                 value={evalTool}
                 onChange={(e) => setEvalTool(e.target.value)}
-                className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-100 font-mono focus:outline-none focus:border-blue-600"
+                className="w-full bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded px-3 py-1.5 text-sm text-[var(--foreground)] font-mono focus:outline-none focus:border-blue-600"
                 placeholder="execute_command"
               />
             </div>
             <div>
-              <label className="text-xs text-zinc-500 block mb-1">Arguments (JSON)</label>
+              <label className="text-xs text-[var(--text-tertiary)] block mb-1">Arguments (JSON)</label>
               <input
                 value={evalArgs}
                 onChange={(e) => setEvalArgs(e.target.value)}
-                className="w-full bg-zinc-800 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-100 font-mono focus:outline-none focus:border-blue-600"
+                className="w-full bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded px-3 py-1.5 text-sm text-[var(--foreground)] font-mono focus:outline-none focus:border-blue-600"
                 placeholder='{"command": "rm -rf /"}'
               />
             </div>
@@ -551,7 +551,7 @@ export default function GatewayPage() {
                 </span>
               </div>
               {evalResult.reason && (
-                <p className="text-xs text-zinc-400 mt-1">{evalResult.reason}</p>
+                <p className="text-xs text-[var(--text-secondary)] mt-1">{evalResult.reason}</p>
               )}
             </div>
           )}
@@ -575,10 +575,10 @@ function StatCard({
   color: string;
 }) {
   return (
-    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+    <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-4">
       <Icon className={`w-4 h-4 mb-2 ${color}`} />
       <div className="text-2xl font-bold font-mono">{value}</div>
-      <div className="text-xs text-zinc-500 mt-0.5">{label}</div>
+      <div className="text-xs text-[var(--text-tertiary)] mt-0.5">{label}</div>
     </div>
   );
 }
@@ -599,29 +599,29 @@ function RuntimePostureCard({ runtime }: { runtime: GatewayPolicyRuntimeSummary 
   }
 
   return (
-    <div className="rounded-2xl border border-zinc-800 bg-[linear-gradient(135deg,rgba(24,24,27,0.98),rgba(9,9,11,0.98))] p-5">
+    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[linear-gradient(135deg,rgba(24,24,27,0.98),rgba(9,9,11,0.98))] p-5">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="space-y-2">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-zinc-500">
+            <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
               Runtime posture
             </span>
             <span className={`rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] ${RUNTIME_COLORS[runtime.rollout_mode]}`}>
               {runtime.rollout_mode.replaceAll("_", " ")}
             </span>
           </div>
-          <p className="max-w-2xl text-sm text-zinc-300">{runtime.summary}</p>
+          <p className="max-w-2xl text-sm text-[var(--text-secondary)]">{runtime.summary}</p>
           {runtime.denied_tool_classes.length > 0 && (
-            <p className="text-xs text-zinc-500">
+            <p className="text-xs text-[var(--text-tertiary)]">
               Denied tool classes: {runtime.denied_tool_classes.join(", ")}
             </p>
           )}
         </div>
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
           {highlights.map((item) => (
-            <div key={item.label} className="rounded-xl border border-zinc-800 bg-zinc-950/80 px-3 py-2">
-              <div className="text-[10px] uppercase tracking-[0.16em] text-zinc-600">{item.label}</div>
-              <div className="mt-1 text-sm font-semibold text-zinc-100">{item.value}</div>
+            <div key={item.label} className="rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/80 px-3 py-2">
+              <div className="text-[10px] uppercase tracking-[0.16em] text-[var(--text-tertiary)]">{item.label}</div>
+              <div className="mt-1 text-sm font-semibold text-[var(--foreground)]">{item.value}</div>
             </div>
           ))}
         </div>
@@ -645,25 +645,25 @@ function FirewallRuntimeCard({ runtime }: { runtime: FirewallRuntimeStats }) {
   const enforcementMode = runtime.recent[0]?.enforcement_mode ?? null;
 
   return (
-    <div className="rounded-2xl border border-zinc-800 bg-[linear-gradient(135deg,rgba(24,24,27,0.98),rgba(9,9,11,0.98))] p-5 space-y-4">
+    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[linear-gradient(135deg,rgba(24,24,27,0.98),rgba(9,9,11,0.98))] p-5 space-y-4">
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
         <div className="space-y-2">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-zinc-500">
+            <span className="text-[11px] font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
               Inter-agent firewall
             </span>
             {enforcementMode && (
-              <span className="rounded-full border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-zinc-300">
+              <span className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-secondary)]">
                 {enforcementMode === "dry_run" ? "dry run" : enforcementMode}
               </span>
             )}
           </div>
-          <p className="max-w-2xl text-sm text-zinc-300">
+          <p className="max-w-2xl text-sm text-[var(--text-secondary)]">
             {runtime.total_decisions} agent → agent decision(s) seen across the runtime plane. Last seen {lastSeen}.
           </p>
         </div>
         <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
-          <FirewallStat label="Total" value={runtime.total_decisions} tone="text-zinc-100" />
+          <FirewallStat label="Total" value={runtime.total_decisions} tone="text-[var(--foreground)]" />
           <FirewallStat label="Allow" value={runtime.allow} tone="text-emerald-400" />
           <FirewallStat label="Warn" value={runtime.warn} tone="text-amber-400" />
           <FirewallStat label="Deny" value={runtime.deny} tone="text-rose-400" />
@@ -671,16 +671,16 @@ function FirewallRuntimeCard({ runtime }: { runtime: FirewallRuntimeStats }) {
       </div>
       {runtime.top_pairs.length > 0 && (
         <div>
-          <div className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 mb-2">Top pairs</div>
+          <div className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] mb-2">Top pairs</div>
           <div className="flex flex-wrap gap-2">
             {runtime.top_pairs.map((p) => (
               <div
                 key={`${p.source_agent}->${p.target_agent}`}
-                className="flex items-center gap-2 rounded-lg border border-zinc-800 bg-zinc-950/80 px-3 py-1.5 text-xs"
+                className="flex items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--background)]/80 px-3 py-1.5 text-xs"
               >
-                <span className="font-medium text-zinc-200">{p.source_agent}</span>
-                <span className="text-zinc-500">→</span>
-                <span className="font-medium text-zinc-200">{p.target_agent}</span>
+                <span className="font-medium text-[var(--foreground)]">{p.source_agent}</span>
+                <span className="text-[var(--text-tertiary)]">→</span>
+                <span className="font-medium text-[var(--foreground)]">{p.target_agent}</span>
                 {p.deny > 0 && <span className="text-rose-400">{p.deny}d</span>}
                 {p.warn > 0 && <span className="text-amber-400">{p.warn}w</span>}
                 {p.allow > 0 && <span className="text-emerald-400">{p.allow}a</span>}
@@ -691,12 +691,12 @@ function FirewallRuntimeCard({ runtime }: { runtime: FirewallRuntimeStats }) {
       )}
       {runtime.recent.length > 0 && (
         <div>
-          <div className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 mb-2">
+          <div className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] mb-2">
             Recent decisions
           </div>
-          <div className="overflow-hidden rounded-lg border border-zinc-800">
+          <div className="overflow-hidden rounded-lg border border-[var(--border-subtle)]">
             <table className="w-full text-xs">
-              <thead className="bg-zinc-900/60 text-zinc-500 uppercase tracking-[0.14em] text-[10px]">
+              <thead className="bg-[var(--surface)]/60 text-[var(--text-tertiary)] uppercase tracking-[0.14em] text-[10px]">
                 <tr>
                   <th className="text-left px-3 py-2 font-medium">When</th>
                   <th className="text-left px-3 py-2 font-medium">Source → Target</th>
@@ -704,26 +704,26 @@ function FirewallRuntimeCard({ runtime }: { runtime: FirewallRuntimeStats }) {
                   <th className="text-left px-3 py-2 font-medium">Rule</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-zinc-900">
+              <tbody className="divide-y divide-[var(--border-subtle)]">
                 {runtime.recent.slice(0, 10).map((r, idx) => (
-                  <tr key={`${r.timestamp}-${idx}`} className="bg-zinc-950/40">
-                    <td className="px-3 py-2 text-zinc-400">
+                  <tr key={`${r.timestamp}-${idx}`} className="bg-[var(--background)]/40">
+                    <td className="px-3 py-2 text-[var(--text-secondary)]">
                       {r.timestamp ? new Date(r.timestamp * 1000).toLocaleTimeString() : "—"}
                     </td>
-                    <td className="px-3 py-2 text-zinc-200">
+                    <td className="px-3 py-2 text-[var(--foreground)]">
                       <span>{r.source_agent}</span>
-                      <span className="text-zinc-500 mx-1">→</span>
+                      <span className="text-[var(--text-tertiary)] mx-1">→</span>
                       <span>{r.target_agent}</span>
                     </td>
                     <td className={`px-3 py-2 font-semibold ${FIREWALL_DECISION_COLORS[r.effective_decision]}`}>
                       {r.effective_decision.toUpperCase()}
                       {r.decision !== r.effective_decision && (
-                        <span className="text-zinc-500 ml-1">
+                        <span className="text-[var(--text-tertiary)] ml-1">
                           (was {r.decision})
                         </span>
                       )}
                     </td>
-                    <td className="px-3 py-2 text-zinc-400">
+                    <td className="px-3 py-2 text-[var(--text-secondary)]">
                       {r.matched_rule
                         ? r.matched_rule.description || `${r.matched_rule.source} → ${r.matched_rule.target}`
                         : "default"}
@@ -741,8 +741,8 @@ function FirewallRuntimeCard({ runtime }: { runtime: FirewallRuntimeStats }) {
 
 function FirewallStat({ label, value, tone }: { label: string; value: number; tone: string }) {
   return (
-    <div className="rounded-xl border border-zinc-800 bg-zinc-950/80 px-3 py-2">
-      <div className="text-[10px] uppercase tracking-[0.16em] text-zinc-600">{label}</div>
+    <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/80 px-3 py-2">
+      <div className="text-[10px] uppercase tracking-[0.16em] text-[var(--text-tertiary)]">{label}</div>
       <div className={`mt-1 text-sm font-semibold ${tone}`}>{value}</div>
     </div>
   );

--- a/ui/app/gateway/GatewayFeedPanel.tsx
+++ b/ui/app/gateway/GatewayFeedPanel.tsx
@@ -182,14 +182,14 @@ export function GatewayFeedPanel({ onActivity }: { onActivity?: () => void }) {
                 </>
               ) : (
                 <>
-                  <WifiOff className="w-3.5 h-3.5 text-zinc-500" />
-                  <span className="text-zinc-500">Disconnected</span>
+                  <WifiOff className="w-3.5 h-3.5 text-[var(--text-tertiary)]" />
+                  <span className="text-[var(--text-tertiary)]">Disconnected</span>
                 </>
               )}
             </div>
             <button
               onClick={load}
-              className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors"
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] border border-[var(--border-subtle)] rounded-lg text-xs text-[var(--text-secondary)] transition-colors"
             >
               <RefreshCw className="w-3.5 h-3.5" />
               Refresh
@@ -213,8 +213,8 @@ export function GatewayFeedPanel({ onActivity }: { onActivity?: () => void }) {
               onClick={() => setActionFilter(value as GatewayFeedActionType | "")}
               className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
                 actionFilter === value
-                  ? "bg-zinc-700 text-zinc-100"
-                  : "text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800"
+                  ? "bg-[var(--surface-muted)] text-[var(--foreground)]"
+                  : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-elevated)]"
               }`}
             >
               {label}
@@ -224,7 +224,7 @@ export function GatewayFeedPanel({ onActivity }: { onActivity?: () => void }) {
 
         {loading && (
           <div className="flex items-center justify-center py-10">
-            <Loader2 className="w-5 h-5 animate-spin text-zinc-500" />
+            <Loader2 className="w-5 h-5 animate-spin text-[var(--text-tertiary)]" />
           </div>
         )}
 
@@ -235,7 +235,7 @@ export function GatewayFeedPanel({ onActivity }: { onActivity?: () => void }) {
         {!loading && !error && filtered.length === 0 && (
           <div className="text-center py-10">
             <ShieldCheck className="w-6 h-6 text-emerald-600 mx-auto mb-2" />
-            <p className="text-zinc-600 text-xs">
+            <p className="text-[var(--text-tertiary)] text-xs">
               No gateway activity yet. Events appear as agents call tools through the gateway/proxy.
             </p>
           </div>
@@ -259,15 +259,15 @@ function FeedRow({ event }: { event: GatewayFeedEvent }) {
   const meta = ACTION_META[event.action_type];
   const Icon = meta.icon;
   return (
-    <div className="flex items-center justify-between px-3 py-2 bg-zinc-800/50 border border-zinc-800 rounded-lg">
+    <div className="flex items-center justify-between px-3 py-2 bg-[var(--surface-elevated)]/50 border border-[var(--border-subtle)] rounded-lg">
       <div className="flex items-center gap-3 min-w-0">
         <Icon className={`w-3.5 h-3.5 shrink-0 ${meta.tone}`} />
         {/* Per-agent attribution → target */}
-        <span className="text-xs text-zinc-200 font-mono shrink-0 max-w-[10rem] truncate" title={event.agent}>
+        <span className="text-xs text-[var(--foreground)] font-mono shrink-0 max-w-[10rem] truncate" title={event.agent}>
           {event.agent}
         </span>
-        <span className="text-zinc-600 shrink-0 text-xs">→</span>
-        <span className="text-xs text-zinc-400 font-mono shrink-0 max-w-[12rem] truncate" title={event.target}>
+        <span className="text-[var(--text-tertiary)] shrink-0 text-xs">→</span>
+        <span className="text-xs text-[var(--text-secondary)] font-mono shrink-0 max-w-[12rem] truncate" title={event.target}>
           {event.target}
         </span>
         <span className={`shrink-0 rounded border px-1.5 py-0.5 text-xs ${meta.badge}`}>
@@ -278,7 +278,7 @@ function FeedRow({ event }: { event: GatewayFeedEvent }) {
             shadow AI
           </span>
         )}
-        <span className="text-xs text-zinc-500 truncate" title={event.detail}>
+        <span className="text-xs text-[var(--text-tertiary)] truncate" title={event.detail}>
           {event.detail}
         </span>
       </div>

--- a/ui/app/gateway/page.tsx
+++ b/ui/app/gateway/page.tsx
@@ -16,7 +16,7 @@ export default function GatewayRedirect() {
   }, [router]);
   return (
     <div className="flex min-h-[40vh] items-center justify-center">
-      <Loader2 className="h-6 w-6 animate-spin text-zinc-500" />
+      <Loader2 className="h-6 w-6 animate-spin text-[var(--text-tertiary)]" />
     </div>
   );
 }

--- a/ui/app/global-error.tsx
+++ b/ui/app/global-error.tsx
@@ -25,11 +25,11 @@ export default function GlobalError({
 
   return (
     <html lang="en">
-      <body className="min-h-screen bg-zinc-950 text-zinc-100">
+      <body className="min-h-screen bg-[var(--background)] text-[var(--foreground)]">
         <main className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
           <ShieldX className="h-12 w-12 text-red-500" aria-hidden="true" />
           <h1 className="text-lg font-semibold">Something went wrong</h1>
-          <p className="max-w-md text-sm text-zinc-400">{error.message}</p>
+          <p className="max-w-md text-sm text-[var(--text-secondary)]">{error.message}</p>
           <button
             type="button"
             onClick={reset}

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -26,6 +26,11 @@
   /* Mint brand accent */
   --accent-mint: #34d399;
 
+  /* Text that sits on a bright accent fill (emerald/sky buttons). Near-black
+   * in both themes because the fill stays bright — replaces hardcoded
+   * text-zinc-950 so light theme keeps the same legible contrast (#3966). */
+  --on-accent: #0b0d10;
+
   /* Severity — badges, charts, dots (hex aligned with ui/lib/theme-colors.ts) */
   --severity-critical: #ff6b6b;
   --severity-critical-bg: rgba(255, 107, 107, 0.16);

--- a/ui/app/governance/page.tsx
+++ b/ui/app/governance/page.tsx
@@ -58,7 +58,7 @@ export default function GovernancePage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-20 text-zinc-400">
+      <div className="flex items-center justify-center py-20 text-[var(--text-secondary)]">
         <Loader2 className="h-6 w-6 animate-spin mr-2" />
         Loading governance report...
       </div>
@@ -96,18 +96,18 @@ export default function GovernancePage() {
       {/* Header */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="min-w-0">
-          <h1 className="text-2xl font-bold text-zinc-100 flex items-center gap-2">
+          <h1 className="text-2xl font-bold text-[var(--foreground)] flex items-center gap-2">
             <Eye className="w-6 h-6 text-emerald-400" />
             Governance Posture
           </h1>
-          <p className="mt-1 break-words text-sm text-zinc-500">
+          <p className="mt-1 break-words text-sm text-[var(--text-tertiary)]">
             Account: {report.account} | Discovered: {formatDate(report.discovered_at)}
           </p>
         </div>
         <select
           value={days}
           onChange={(e) => setDays(Number(e.target.value))}
-          className="bg-zinc-900 border border-zinc-700 rounded-md px-3 py-1.5 text-sm text-zinc-300"
+          className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-md px-3 py-1.5 text-sm text-[var(--text-secondary)]"
         >
           <option value={7}>Last 7 days</option>
           <option value={30}>Last 30 days</option>
@@ -166,9 +166,9 @@ export default function GovernancePage() {
         }).filter((d) => d.critical + d.high + d.medium + d.low > 0);
         if (chartData.length === 0) return null;
         return (
-          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
-            <h3 className="text-sm font-semibold text-zinc-300 mb-1">Findings by Category & Severity</h3>
-            <p className="text-[10px] text-zinc-600 mb-4">Stacked count of findings per governance category</p>
+          <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-5">
+            <h3 className="text-sm font-semibold text-[var(--text-secondary)] mb-1">Findings by Category & Severity</h3>
+            <p className="text-[10px] text-[var(--text-tertiary)] mb-4">Stacked count of findings per governance category</p>
             <div className="h-44">
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={chartData} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
@@ -217,7 +217,7 @@ export default function GovernancePage() {
             onClick={() => setCategoryFilter(cat)}
           />
         ))}
-        <span className="w-px bg-zinc-700 mx-1" />
+        <span className="w-px bg-[var(--surface-muted)] mx-1" />
         <FilterButton
           label="All Severities"
           active={severityFilter === null}
@@ -235,11 +235,11 @@ export default function GovernancePage() {
 
       {/* Findings */}
       <div className="space-y-3">
-        <h2 className="text-lg font-semibold text-zinc-200">
+        <h2 className="text-lg font-semibold text-[var(--foreground)]">
           Findings ({filteredFindings.length})
         </h2>
         {filteredFindings.length === 0 ? (
-          <p className="text-sm text-zinc-500">No findings match the current filters.</p>
+          <p className="text-sm text-[var(--text-tertiary)]">No findings match the current filters.</p>
         ) : (
           filteredFindings?.map((f, i) => <FindingCard key={i} finding={f} />)
         )}
@@ -249,15 +249,15 @@ export default function GovernancePage() {
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Elevated Privileges */}
         {report.privilege_grants.filter((g) => g.is_elevated).length > 0 && (
-          <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
-            <h3 className="text-sm font-semibold text-zinc-300 mb-3 flex items-center gap-2">
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-4">
+            <h3 className="text-sm font-semibold text-[var(--text-secondary)] mb-3 flex items-center gap-2">
               <Lock className="w-4 h-4 text-purple-400" />
               Elevated Privileges
             </h3>
             <div className="overflow-x-auto">
               <table className="w-full text-xs">
                 <thead>
-                  <tr className="text-zinc-500 border-b border-zinc-800">
+                  <tr className="text-[var(--text-tertiary)] border-b border-[var(--border-subtle)]">
                     <th className="text-left py-1.5 pr-3">Role</th>
                     <th className="text-left py-1.5 pr-3">Privilege</th>
                     <th className="text-left py-1.5">Object</th>
@@ -268,10 +268,10 @@ export default function GovernancePage() {
                     .filter((g) => g.is_elevated)
                     .slice(0, 20)
                     .map((g, i) => (
-                      <tr key={i} className="border-b border-zinc-800/50">
-                        <td className="py-1.5 pr-3 text-zinc-300 font-mono">{g.grantee}</td>
+                      <tr key={i} className="border-b border-[var(--border-subtle)]/50">
+                        <td className="py-1.5 pr-3 text-[var(--text-secondary)] font-mono">{g.grantee}</td>
                         <td className="py-1.5 pr-3 text-red-400">{g.privilege}</td>
-                        <td className="py-1.5 text-zinc-500 font-mono truncate max-w-[200px]">
+                        <td className="py-1.5 text-[var(--text-tertiary)] font-mono truncate max-w-[200px]">
                           {g.object_name}
                         </td>
                       </tr>
@@ -284,15 +284,15 @@ export default function GovernancePage() {
 
         {/* Data Classifications */}
         {report.data_classifications.length > 0 && (
-          <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
-            <h3 className="text-sm font-semibold text-zinc-300 mb-3 flex items-center gap-2">
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-4">
+            <h3 className="text-sm font-semibold text-[var(--text-secondary)] mb-3 flex items-center gap-2">
               <Database className="w-4 h-4 text-blue-400" />
               Data Classifications
             </h3>
             <div className="overflow-x-auto">
               <table className="w-full text-xs">
                 <thead>
-                  <tr className="text-zinc-500 border-b border-zinc-800">
+                  <tr className="text-[var(--text-tertiary)] border-b border-[var(--border-subtle)]">
                     <th className="text-left py-1.5 pr-3">Object</th>
                     <th className="text-left py-1.5 pr-3">Tag</th>
                     <th className="text-left py-1.5">Value</th>
@@ -300,15 +300,15 @@ export default function GovernancePage() {
                 </thead>
                 <tbody>
                   {report.data_classifications.slice(0, 20).map((d, i) => (
-                    <tr key={i} className="border-b border-zinc-800/50">
-                      <td className="py-1.5 pr-3 text-zinc-300 font-mono truncate max-w-[200px]">
+                    <tr key={i} className="border-b border-[var(--border-subtle)]/50">
+                      <td className="py-1.5 pr-3 text-[var(--text-secondary)] font-mono truncate max-w-[200px]">
                         {d.object_name}
                         {d.column_name && (
-                          <span className="text-zinc-500">.{d.column_name}</span>
+                          <span className="text-[var(--text-tertiary)]">.{d.column_name}</span>
                         )}
                       </td>
                       <td className="py-1.5 pr-3 text-amber-400">{d.tag_name}</td>
-                      <td className="py-1.5 text-zinc-500">{d.tag_value}</td>
+                      <td className="py-1.5 text-[var(--text-tertiary)]">{d.tag_value}</td>
                     </tr>
                   ))}
                 </tbody>
@@ -333,12 +333,12 @@ function StatCard({
   color: string;
 }) {
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-4">
       <div className="flex items-center gap-2 mb-1">
         <Icon className={`w-4 h-4 ${color}`} />
-        <span className="text-xs text-zinc-500">{label}</span>
+        <span className="text-xs text-[var(--text-tertiary)]">{label}</span>
       </div>
-      <p className="text-2xl font-bold text-zinc-100">{value.toLocaleString()}</p>
+      <p className="text-2xl font-bold text-[var(--foreground)]">{value.toLocaleString()}</p>
     </div>
   );
 }
@@ -357,8 +357,8 @@ function FilterButton({
       onClick={onClick}
       className={`px-3 py-1 rounded-md text-xs font-medium capitalize transition-colors ${
         active
-          ? "bg-zinc-700 text-zinc-100"
-          : "bg-zinc-900 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-300"
+          ? "bg-[var(--surface-muted)] text-[var(--foreground)]"
+          : "bg-[var(--surface)] text-[var(--text-secondary)] hover:bg-[var(--surface-elevated)] hover:text-[var(--text-secondary)]"
       }`}
     >
       {label}
@@ -378,17 +378,17 @@ function FindingCard({ finding }: { finding: GovernanceFinding }) {
         <div className="flex min-w-0 items-start gap-3">
           <span className={`mt-1.5 h-2 w-2 shrink-0 rounded-full ${severityDot(finding.severity)}`} />
           <div className="min-w-0">
-            <p className="break-words text-sm font-medium text-zinc-100">{finding.title}</p>
-            <p className="mt-0.5 break-words text-xs text-zinc-400">{finding.description}</p>
+            <p className="break-words text-sm font-medium text-[var(--foreground)]">{finding.title}</p>
+            <p className="mt-0.5 break-words text-xs text-[var(--text-secondary)]">{finding.description}</p>
             <div className="mt-2 flex flex-wrap gap-2">
-              <span className="px-2 py-0.5 rounded text-xs bg-zinc-800 text-zinc-400 capitalize">
+              <span className="px-2 py-0.5 rounded text-xs bg-[var(--surface-elevated)] text-[var(--text-secondary)] capitalize">
                 {finding.category.replace("_", " ")}
               </span>
-              <span className="px-2 py-0.5 rounded text-xs bg-zinc-800 text-zinc-400 capitalize">
+              <span className="px-2 py-0.5 rounded text-xs bg-[var(--surface-elevated)] text-[var(--text-secondary)] capitalize">
                 {finding.severity}
               </span>
               {finding.agent_or_role && (
-                <span className="max-w-full break-all rounded bg-zinc-800 px-2 py-0.5 font-mono text-xs text-zinc-400">
+                <span className="max-w-full break-all rounded bg-[var(--surface-elevated)] px-2 py-0.5 font-mono text-xs text-[var(--text-secondary)]">
                   {finding.agent_or_role}
                 </span>
               )}
@@ -396,14 +396,14 @@ function FindingCard({ finding }: { finding: GovernanceFinding }) {
           </div>
         </div>
         {expanded ? (
-          <ChevronUp className="w-4 h-4 text-zinc-500 flex-shrink-0" />
+          <ChevronUp className="w-4 h-4 text-[var(--text-tertiary)] flex-shrink-0" />
         ) : (
-          <ChevronDown className="w-4 h-4 text-zinc-500 flex-shrink-0" />
+          <ChevronDown className="w-4 h-4 text-[var(--text-tertiary)] flex-shrink-0" />
         )}
       </div>
       {expanded && Object.keys(finding.details).length > 0 && (
-        <div className="mt-3 pl-5 border-t border-zinc-800 pt-3">
-          <pre className="text-xs text-zinc-400 whitespace-pre-wrap break-words">
+        <div className="mt-3 pl-5 border-t border-[var(--border-subtle)] pt-3">
+          <pre className="text-xs text-[var(--text-secondary)] whitespace-pre-wrap break-words">
             {JSON.stringify(finding.details, null, 2)}
           </pre>
         </div>

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -2199,7 +2199,7 @@ function GraphPageInner() {
       : 1;
   if (loadingSnapshots) {
     return (
-      <div className="flex items-center justify-center h-[80vh] text-zinc-400">
+      <div className="flex items-center justify-center h-[80vh] text-[var(--text-secondary)]">
         <Loader2 className="w-5 h-5 animate-spin mr-2" />
         Loading persisted graph snapshots...
       </div>
@@ -2208,12 +2208,12 @@ function GraphPageInner() {
 
   if (error && snapshots.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-[80vh] text-zinc-400 gap-3">
+      <div className="flex flex-col items-center justify-center h-[80vh] text-[var(--text-secondary)] gap-3">
         <AlertTriangle className="w-8 h-8 text-amber-500" />
         {rateLimited ? (
           <>
             <p className="text-sm">Graph temporarily rate-limited</p>
-            <p className="text-xs text-zinc-500">
+            <p className="text-xs text-[var(--text-tertiary)]">
               The API is shedding load (HTTP 429). Wait a moment and retry — your
               snapshots are still there.
             </p>
@@ -2221,7 +2221,7 @@ function GraphPageInner() {
         ) : (
           <>
             <p className="text-sm">Could not load the unified graph</p>
-            <p className="text-xs text-zinc-500">
+            <p className="text-xs text-[var(--text-tertiary)]">
               Run a scan first so the API can persist graph snapshots.
             </p>
           </>
@@ -2232,10 +2232,10 @@ function GraphPageInner() {
 
   if (snapshots.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-[80vh] text-zinc-400 gap-3">
-        <ShieldAlert className="w-8 h-8 text-zinc-600" />
+      <div className="flex flex-col items-center justify-center h-[80vh] text-[var(--text-secondary)] gap-3">
+        <ShieldAlert className="w-8 h-8 text-[var(--text-tertiary)]" />
         <p className="text-sm">No graph snapshots found</p>
-        <p className="text-xs text-zinc-500">
+        <p className="text-xs text-[var(--text-tertiary)]">
           Run a scan to persist the unified inventory and security graph.
         </p>
       </div>
@@ -2252,16 +2252,16 @@ function GraphPageInner() {
     <div className="min-h-[calc(100vh-3.5rem)] flex flex-col">
       <PulseStyles />
 
-      <div className="border-b border-zinc-800 bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.10),transparent_24%),linear-gradient(180deg,rgba(24,24,27,0.96),rgba(9,9,11,0.96))] px-4 py-3">
+      <div className="border-b border-[var(--border-subtle)] bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.10),transparent_24%),linear-gradient(180deg,rgba(24,24,27,0.96),rgba(9,9,11,0.96))] px-4 py-3">
         <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
           <div>
             <p className="text-[10px] uppercase tracking-[0.24em] text-sky-400">
               Unified graph
             </p>
-            <h1 className="mt-1 text-lg font-semibold text-zinc-100">
+            <h1 className="mt-1 text-lg font-semibold text-[var(--foreground)]">
               Lineage Graph
             </h1>
-            <p className="text-xs text-zinc-500">
+            <p className="text-xs text-[var(--text-tertiary)]">
               Evidence-backed relationships across agents, servers, packages,
               credentials, tools, and findings.
             </p>
@@ -2293,7 +2293,7 @@ function GraphPageInner() {
             <select
               value={selectedScanId}
               onChange={(event) => setSelectedScanId(event.target.value)}
-              className="rounded-xl border border-zinc-700 bg-zinc-900/90 px-3 py-2 text-sm text-zinc-300 focus:border-sky-600 focus:outline-none"
+              className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/90 px-3 py-2 text-sm text-[var(--text-secondary)] focus:border-sky-600 focus:outline-none"
             >
               {snapshots.map((snapshot) => (
                 <option key={snapshot.scan_id} value={snapshot.scan_id}>
@@ -2325,18 +2325,18 @@ function GraphPageInner() {
               value={searchQuery}
               onChange={(event) => setSearchQuery(event.target.value)}
               placeholder="Search nodes, tags, severities, or attributes"
-              className="min-w-[260px] flex-1 rounded-xl border border-zinc-700 bg-zinc-900/90 px-3 py-2 text-sm text-zinc-300 placeholder:text-zinc-500 focus:border-sky-600 focus:outline-none"
+              className="min-w-[260px] flex-1 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/90 px-3 py-2 text-sm text-[var(--text-secondary)] placeholder:text-[var(--text-tertiary)] focus:border-sky-600 focus:outline-none"
             />
             <button
               type="submit"
               disabled={searching || !selectedScanId}
-              className="rounded-xl border border-zinc-700 bg-zinc-900/80 px-3 py-2 text-sm text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-40"
+              className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-2 text-sm text-[var(--text-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
             >
               {searching ? "Searching..." : "Search"}
             </button>
           </form>
 
-          <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-zinc-400">
+          <div className="mt-3 flex flex-wrap items-center gap-2 text-[11px] text-[var(--text-secondary)]">
             <ViewPill
               label="Scope"
               value={filters.agentName ? filters.agentName : "all agents"}
@@ -2349,7 +2349,7 @@ function GraphPageInner() {
             {sourceNodeCount > 0 && (
               <span
                 data-testid="graph-compression-summary"
-                className="rounded-lg border border-zinc-800 bg-zinc-900/80 px-2.5 py-1 text-zinc-400"
+                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-2.5 py-1 text-[var(--text-secondary)]"
               >
                 {compressedGroupCount > 0
                   ? `${compressedGroupCount} compressed groups`
@@ -2441,8 +2441,8 @@ function GraphPageInner() {
             )}
 
           {searchResults.length > 0 && (
-            <div className="mt-2 rounded-2xl border border-zinc-800 bg-zinc-950/90 p-2">
-              <div className="mb-2 px-1 text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+            <div className="mt-2 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/90 p-2">
+              <div className="mb-2 px-1 text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
                 Search respects current entity scope
                 {filters.severity ? ` and ${filters.severity}+ severity` : ""}
               </div>
@@ -2453,15 +2453,15 @@ function GraphPageInner() {
                     type="button"
                     data-testid={`graph-search-result-${result.id}`}
                     onClick={() => void focusSearchResult(result)}
-                    className="rounded-xl border border-zinc-800 bg-zinc-900/80 px-3 py-2 text-left transition hover:border-zinc-600 hover:bg-zinc-900"
+                    className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-2 text-left transition hover:border-[var(--border-strong)] hover:bg-[var(--surface)]"
                   >
-                    <p className="truncate text-sm font-medium text-zinc-100">
+                    <p className="truncate text-sm font-medium text-[var(--foreground)]">
                       {result.label}
                     </p>
-                    <p className="mt-1 text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+                    <p className="mt-1 text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
                       {String(result.entity_type)}
                     </p>
-                    <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-zinc-500">
+                    <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-[var(--text-tertiary)]">
                       {result.severity && <span>{result.severity}</span>}
                       <span>
                         risk{" "}
@@ -2478,7 +2478,7 @@ function GraphPageInner() {
           )}
         </div>
 
-        <div className="mt-3 flex flex-wrap items-center gap-4 text-[11px] text-zinc-500">
+        <div className="mt-3 flex flex-wrap items-center gap-4 text-[11px] text-[var(--text-tertiary)]">
           {activeSnapshot && (
             <>
               <span>{activeSnapshot.node_count} nodes</span>
@@ -2501,40 +2501,40 @@ function GraphPageInner() {
             View controls, operator evaluation/diff lenses, and the ranked
             attack-path queue — so the operator reaches them in one place
             without any of them stacking on the default page load. */}
-        <details className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 group">
+        <details className="mt-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 group">
           <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-3 px-3 py-2 [&::-webkit-details-marker]:hidden">
             <div>
-              <span className="text-[10px] uppercase tracking-[0.22em] text-zinc-500">
+              <span className="text-[10px] uppercase tracking-[0.22em] text-[var(--text-tertiary)]">
                 Advanced controls
               </span>
-              <p className="mt-1 text-xs text-zinc-400">
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">
                 View controls, operator evaluation and diff lenses, and the
                 ranked attack-path queue.
               </p>
             </div>
-            <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:hidden">
+            <span className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] group-open:hidden">
               show
             </span>
-            <span className="hidden text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:inline">
+            <span className="hidden text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] group-open:inline">
               hide
             </span>
           </summary>
-          <div className="space-y-3 border-t border-zinc-800/80 p-3">
-          <details className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3 group">
+          <div className="space-y-3 border-t border-[var(--border-subtle)]/80 p-3">
+          <details className="mt-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3 group">
             <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-3 [&::-webkit-details-marker]:hidden">
               <div>
-                <span className="text-[10px] uppercase tracking-[0.22em] text-zinc-500">
+                <span className="text-[10px] uppercase tracking-[0.22em] text-[var(--text-tertiary)]">
                   View controls
                 </span>
-                <p className="mt-1 text-xs text-zinc-400">
+                <p className="mt-1 text-xs text-[var(--text-secondary)]">
                   Change scope, layers, severity, traversal, and page size
                   without changing the persisted graph.
                 </p>
               </div>
-              <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:hidden">
+              <span className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] group-open:hidden">
                 show
               </span>
-              <span className="hidden text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:inline">
+              <span className="hidden text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] group-open:inline">
                 hide
               </span>
             </summary>
@@ -2616,16 +2616,16 @@ function GraphPageInner() {
             </div>
           </details>
 
-        <details className="mt-3 rounded-xl border border-zinc-800 bg-zinc-950/70">
-          <summary className="cursor-pointer list-none px-3 py-2 text-xs font-medium text-zinc-400 [&::-webkit-details-marker]:hidden">
+        <details className="mt-3 rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/70">
+          <summary className="cursor-pointer list-none px-3 py-2 text-xs font-medium text-[var(--text-secondary)] [&::-webkit-details-marker]:hidden">
             Operator details · evaluation, diff, lenses
           </summary>
-          <div className="space-y-3 border-t border-zinc-800/80 px-3 py-3">
-            <div className="rounded-xl border border-zinc-800/80 bg-zinc-950/50 px-3 py-2">
-              <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+          <div className="space-y-3 border-t border-[var(--border-subtle)]/80 px-3 py-3">
+            <div className="rounded-xl border border-[var(--border-subtle)]/80 bg-[var(--background)]/50 px-3 py-2">
+              <p className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
                 Graph evaluation
               </p>
-              <p className="mt-1 text-xs text-zinc-300">
+              <p className="mt-1 text-xs text-[var(--text-secondary)]">
                 Score {Math.round(graphEvaluation.score)} ({graphEvaluation.grade})
               </p>
               <GraphEvaluationSummary evaluation={graphEvaluation} />
@@ -2639,13 +2639,13 @@ function GraphPageInner() {
             stop them from owning a full screen of vertical space on every
             page-load. */}
         {activeSnapshot && (
-          <details className="rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3 group">
+          <details className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3 group">
             <summary className="flex flex-wrap items-center justify-between gap-3 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
               <div className="flex items-center gap-3">
                 <span className="text-[10px] uppercase tracking-[0.24em] text-sky-400">
                   Snapshot diff
                 </span>
-                <span className="text-xs text-zinc-500">
+                <span className="text-xs text-[var(--text-tertiary)]">
                   {graphDiff
                     ? `+${graphDiff.nodes_added.length} −${graphDiff.nodes_removed.length} nodes · +${graphDiff.edges_added.length} −${graphDiff.edges_removed.length} edges`
                     : previousSnapshot
@@ -2660,10 +2660,10 @@ function GraphPageInner() {
                     loading
                   </span>
                 )}
-                <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:hidden">
+                <span className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] group-open:hidden">
                   show
                 </span>
-                <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 hidden group-open:inline">
+                <span className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] hidden group-open:inline">
                   hide
                 </span>
               </div>
@@ -2723,8 +2723,8 @@ function GraphPageInner() {
         )}
 
         {graphDiff && (
-          <details className="rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3">
-            <summary className="cursor-pointer list-none text-xs font-medium text-zinc-300 [&::-webkit-details-marker]:hidden">
+          <details className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3">
+            <summary className="cursor-pointer list-none text-xs font-medium text-[var(--text-secondary)] [&::-webkit-details-marker]:hidden">
               Snapshot drift lens · {drift.critical} critical changes
             </summary>
             <div className="mt-3">
@@ -2754,8 +2754,8 @@ function GraphPageInner() {
           />
         ) : null}
 
-        <details className="rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3">
-          <summary className="cursor-pointer list-none text-xs font-medium text-zinc-300 [&::-webkit-details-marker]:hidden">
+        <details className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3">
+          <summary className="cursor-pointer list-none text-xs font-medium text-[var(--text-secondary)] [&::-webkit-details-marker]:hidden">
             Evidence lens · {evidenceCounts.all} nodes
           </summary>
           <div className="mt-3">
@@ -2772,15 +2772,15 @@ function GraphPageInner() {
           </div>
         </details>
 
-        <details className="rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3 text-xs text-zinc-400 group">
+        <details className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3 text-xs text-[var(--text-secondary)] group">
           <summary className="flex items-center justify-between cursor-pointer list-none [&::-webkit-details-marker]:hidden">
-            <span className="font-medium text-zinc-200">
+            <span className="font-medium text-[var(--foreground)]">
               How to read this graph
             </span>
-            <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:hidden">
+            <span className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] group-open:hidden">
               show
             </span>
-            <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 hidden group-open:inline">
+            <span className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] hidden group-open:inline">
               hide
             </span>
           </summary>
@@ -2823,28 +2823,28 @@ function GraphPageInner() {
         </details>
 
         {attackPaths.length > 0 && (
-          <details className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/60 p-3 group">
+          <details className="mt-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/60 p-3 group">
             <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-2 [&::-webkit-details-marker]:hidden">
               <div>
                 <p className="text-[10px] uppercase tracking-[0.24em] text-orange-400">
                   Attack paths
                 </p>
-                <p className="mt-1 text-xs text-zinc-500">
+                <p className="mt-1 text-xs text-[var(--text-tertiary)]">
                   {attackPaths.length} ranked path
                   {attackPaths.length === 1 ? "" : "s"} available for focused
                   investigation.
                 </p>
               </div>
-              <span className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:hidden">
+              <span className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] group-open:hidden">
                 show queue
               </span>
-              <span className="hidden text-[10px] uppercase tracking-[0.18em] text-zinc-500 group-open:inline">
+              <span className="hidden text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] group-open:inline">
                 hide queue
               </span>
             </summary>
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div>
-                <p className="mt-3 text-xs text-zinc-500">
+                <p className="mt-3 text-xs text-[var(--text-tertiary)]">
                   Focus the current graph on a precomputed exploit chain in this
                   filtered snapshot page.
                 </p>
@@ -2855,7 +2855,7 @@ function GraphPageInner() {
                   onClick={() => {
                     setSelectedAttackPathKey(null);
                   }}
-                  className="rounded-lg border border-zinc-700 bg-zinc-900/80 px-3 py-1.5 text-xs text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100"
+                  className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-1.5 text-xs text-[var(--text-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
                 >
                   Clear path focus
                 </button>
@@ -2871,7 +2871,7 @@ function GraphPageInner() {
                 return (
                   <div
                     key={key}
-                    className={`min-w-[360px] rounded-2xl transition ${isActive ? "ring-2 ring-orange-400/70 ring-offset-2 ring-offset-zinc-950" : ""}`}
+                    className={`min-w-[360px] rounded-2xl transition ${isActive ? "ring-2 ring-orange-400/70 ring-offset-2 ring-offset-[var(--background)]" : ""}`}
                   >
                     <AttackPathCard
                       nodes={pathNodes}
@@ -3080,7 +3080,7 @@ function GraphPageInner() {
           {loadingGraph && graphData && <GraphRefreshOverlay />}
 
           {graphData && graphData.pagination.total > filters.pageSize && (
-            <div className="mt-2 flex flex-wrap items-center gap-2 border-t border-zinc-800/80 px-1 pt-2 text-xs">
+            <div className="mt-2 flex flex-wrap items-center gap-2 border-t border-[var(--border-subtle)]/80 px-1 pt-2 text-xs">
               <button
                 type="button"
                 onClick={() =>
@@ -3089,7 +3089,7 @@ function GraphPageInner() {
                   )
                 }
                 disabled={loadingGraph || pageOffset === 0}
-                className="rounded-lg border border-zinc-700 bg-zinc-900/80 px-3 py-1.5 text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-40"
+                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-1.5 text-[var(--text-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
               >
                 Previous page
               </button>
@@ -3099,11 +3099,11 @@ function GraphPageInner() {
                   setPageOffset((current) => current + filters.pageSize)
                 }
                 disabled={loadingGraph || !graphData?.pagination.has_more}
-                className="rounded-lg border border-zinc-700 bg-zinc-900/80 px-3 py-1.5 text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-40"
+                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-1.5 text-[var(--text-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
               >
                 Next page
               </button>
-              <span className="text-zinc-500">
+              <span className="text-[var(--text-tertiary)]">
                 Page {pageNumber} of {totalPages} · showing {pageStart}-{pageEnd} of{" "}
                 {graphData.pagination.total} nodes
               </span>
@@ -3158,20 +3158,20 @@ function MetricCard({
         ? "border-orange-500/20 bg-orange-500/10 text-orange-200"
         : accent === "blue"
           ? "border-sky-500/20 bg-sky-500/10 text-sky-200"
-          : "border-zinc-800 bg-zinc-900/80 text-zinc-300";
+          : "border-[var(--border-subtle)] bg-[var(--surface)]/80 text-[var(--text-secondary)]";
 
   return (
     <div className={`rounded-xl border px-3 py-1.5 text-xs ${accentClass}`}>
-      <span className="font-mono text-zinc-100">{value}</span> {label}
+      <span className="font-mono text-[var(--foreground)]">{value}</span> {label}
     </div>
   );
 }
 
 function ViewPill({ label, value }: { label: string; value: string }) {
   return (
-    <span className="rounded-lg border border-zinc-800 bg-zinc-900/80 px-2.5 py-1">
-      <span className="text-zinc-500">{label}</span>
-      <span className="ml-1 text-zinc-300">{value}</span>
+    <span className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-2.5 py-1">
+      <span className="text-[var(--text-tertiary)]">{label}</span>
+      <span className="ml-1 text-[var(--text-secondary)]">{value}</span>
     </span>
   );
 }
@@ -3230,12 +3230,12 @@ function ReachabilityDrillInPanel({
 
       {summary && (
         <div className="mt-3 grid gap-3 xl:grid-cols-[minmax(0,0.8fr)_minmax(0,1.2fr)]">
-          <div className="rounded-xl border border-rose-400/20 bg-zinc-950/45 p-2">
+          <div className="rounded-xl border border-rose-400/20 bg-[var(--background)]/45 p-2">
             <p className="text-[10px] uppercase tracking-[0.2em] text-rose-300">
               Affected by type
             </p>
             {Object.keys(summary.countsByType).length === 0 ? (
-              <p className="mt-2 text-zinc-400">
+              <p className="mt-2 text-[var(--text-secondary)]">
                 No downstream nodes returned for this root.
               </p>
             ) : (
@@ -3254,12 +3254,12 @@ function ReachabilityDrillInPanel({
             )}
           </div>
 
-          <div className="rounded-xl border border-rose-400/20 bg-zinc-950/45 p-2">
+          <div className="rounded-xl border border-rose-400/20 bg-[var(--background)]/45 p-2">
             <p className="text-[10px] uppercase tracking-[0.2em] text-rose-300">
               Bounded paths
             </p>
             {summary.pathPreviews.length === 0 ? (
-              <p className="mt-2 text-zinc-400">
+              <p className="mt-2 text-[var(--text-secondary)]">
                 No path preview is available for this root.
               </p>
             ) : (
@@ -3267,18 +3267,18 @@ function ReachabilityDrillInPanel({
                 {summary.pathPreviews.map((path) => (
                   <div
                     key={`${path.targetId}:${path.hops.join(">")}`}
-                    className="rounded-lg bg-zinc-950/70 px-2 py-1.5"
+                    className="rounded-lg bg-[var(--background)]/70 px-2 py-1.5"
                   >
                     <div className="flex flex-wrap items-center justify-between gap-2">
                       <span className="font-medium text-rose-50">
                         {path.targetLabel}
                       </span>
-                      <span className="text-[10px] uppercase tracking-[0.16em] text-zinc-500">
+                      <span className="text-[10px] uppercase tracking-[0.16em] text-[var(--text-tertiary)]">
                         {prettifyReachabilityType(path.targetType)} ·{" "}
                         {path.depth} hop{path.depth === 1 ? "" : "s"}
                       </span>
                     </div>
-                    <p className="mt-1 truncate font-mono text-[10px] text-zinc-400">
+                    <p className="mt-1 truncate font-mono text-[10px] text-[var(--text-secondary)]">
                       {path.labels.join(" -> ")}
                     </p>
                   </div>
@@ -3344,7 +3344,7 @@ function BlastRadiusPanel({
       </div>
 
       {summary && Object.keys(summary.countsByType).length > 0 && (
-        <div className="mt-3 rounded-xl border border-violet-400/20 bg-zinc-950/45 p-2">
+        <div className="mt-3 rounded-xl border border-violet-400/20 bg-[var(--background)]/45 p-2">
           <p className="text-[10px] uppercase tracking-[0.2em] text-violet-300">
             Impacted by type
           </p>
@@ -3364,7 +3364,7 @@ function BlastRadiusPanel({
       )}
 
       {summary && summary.affectedCount === 0 && (
-        <p className="mt-2 text-zinc-400">
+        <p className="mt-2 text-[var(--text-secondary)]">
           Nothing downstream depends on this node in the current snapshot.
         </p>
       )}
@@ -3471,7 +3471,7 @@ function RollupNavigationPanel({
 function scopeButtonClass(active: boolean): string {
   return active
     ? "rounded-lg border border-sky-500/40 bg-sky-500/15 px-2.5 py-1 text-sky-100 transition hover:border-sky-400/70"
-    : "rounded-lg border border-zinc-700 bg-zinc-900/80 px-2.5 py-1 text-zinc-300 transition hover:border-zinc-500 hover:text-zinc-100";
+    : "rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-2.5 py-1 text-[var(--text-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)]";
 }
 
 function PathStat({
@@ -3490,14 +3490,14 @@ function PathStat({
         ? "border-amber-500/20 bg-amber-500/10 text-amber-200"
         : tone === "blue"
           ? "border-sky-500/20 bg-sky-500/10 text-sky-200"
-          : "border-zinc-800 bg-zinc-900/80 text-zinc-300";
+          : "border-[var(--border-subtle)] bg-[var(--surface)]/80 text-[var(--text-secondary)]";
 
   return (
     <div className={`rounded-xl border px-3 py-2 ${toneClass}`}>
-      <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+      <p className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
         {label}
       </p>
-      <p className="mt-1 font-mono text-sm text-zinc-100">{value}</p>
+      <p className="mt-1 font-mono text-sm text-[var(--foreground)]">{value}</p>
     </div>
   );
 }
@@ -3513,16 +3513,16 @@ function PathTagList({
 }) {
   return (
     <div
-      className={`rounded-xl border border-zinc-800 bg-zinc-900/70 p-3 ${wide ? "lg:col-span-4" : ""}`}
+      className={`rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/70 p-3 ${wide ? "lg:col-span-4" : ""}`}
     >
-      <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+      <p className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
         {label}
       </p>
       <div className="mt-2 flex flex-wrap gap-1.5">
         {tags.map((tag) => (
           <span
             key={`${label}-${tag}`}
-            className="rounded-lg border border-zinc-700 bg-zinc-800/80 px-2 py-1 text-[11px] text-zinc-300"
+            className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/80 px-2 py-1 text-[11px] text-[var(--text-secondary)]"
           >
             {tag}
           </span>
@@ -3550,10 +3550,10 @@ function DiffMetric({
 
   return (
     <div className={`rounded-xl border px-3 py-2 ${toneClass}`}>
-      <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+      <p className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
         {label}
       </p>
-      <p className="mt-1 font-mono text-lg text-zinc-100">{value}</p>
+      <p className="mt-1 font-mono text-lg text-[var(--foreground)]">{value}</p>
     </div>
   );
 }
@@ -3573,12 +3573,12 @@ function DiffLoadingGrid() {
       ].map((label) => (
         <div
           key={label}
-          className="rounded-xl border border-zinc-800 bg-zinc-900/70 px-3 py-2"
+          className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/70 px-3 py-2"
         >
-          <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
             {label}
           </p>
-          <div className="mt-2 h-6 w-12 animate-pulse rounded-full bg-zinc-800" />
+          <div className="mt-2 h-6 w-12 animate-pulse rounded-full bg-[var(--surface-elevated)]" />
         </div>
       ))}
     </div>
@@ -3605,12 +3605,12 @@ export function DiffPreview({
 }) {
   const visible = items.slice(0, 5);
   return (
-    <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-3">
+    <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/70 p-3">
       <div className="flex items-center justify-between gap-2">
-        <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
+        <p className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
           {label}
         </p>
-        <span className="font-mono text-[11px] text-zinc-500">
+        <span className="font-mono text-[11px] text-[var(--text-tertiary)]">
           {items.length}
         </span>
       </div>
@@ -3618,13 +3618,13 @@ export function DiffPreview({
         {visible.map((item) => (
           <p
             key={`${label}-${diffItemKey(item)}`}
-            className="truncate font-mono text-[11px] text-zinc-300"
+            className="truncate font-mono text-[11px] text-[var(--text-secondary)]"
           >
             {diffItemLabel(item)}
           </p>
         ))}
         {items.length > visible.length && (
-          <p className="text-[11px] text-zinc-500">
+          <p className="text-[11px] text-[var(--text-tertiary)]">
             +{items.length - visible.length} more
           </p>
         )}

--- a/ui/app/identity/page.tsx
+++ b/ui/app/identity/page.tsx
@@ -52,7 +52,7 @@ function Badge({
     blue: "bg-blue-900/60 text-blue-300",
     red: "bg-red-900/60 text-red-300",
     amber: "bg-amber-900/60 text-amber-300",
-    zinc: "bg-zinc-800 text-zinc-400",
+    zinc: "bg-[var(--surface-elevated)] text-[var(--text-secondary)]",
   } as const;
   return (
     <span
@@ -94,12 +94,12 @@ function StatCard({
   color: string;
 }) {
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-4">
       <div className="mb-1 flex items-center gap-2">
         <Icon className={`h-4 w-4 ${color}`} />
-        <span className="text-xs text-zinc-500">{label}</span>
+        <span className="text-xs text-[var(--text-tertiary)]">{label}</span>
       </div>
-      <p className="text-2xl font-bold text-zinc-100">
+      <p className="text-2xl font-bold text-[var(--foreground)]">
         {value.toLocaleString()}
       </p>
     </div>
@@ -175,55 +175,55 @@ function CredentialExpiryPanel({ report }: { report: CredentialExpiryReport }) {
         : "green";
 
   return (
-    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
       <div className="mb-3 flex items-center gap-2">
         <KeyRound className="h-4 w-4 text-amber-400" />
-        <h3 className="text-sm font-semibold text-zinc-300">
+        <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
           Credential expiry &amp; rotation
         </h3>
         <Badge tone={statusTone}>{report.status.replace(/_/g, " ")}</Badge>
-        <span className="ml-auto text-xs text-zinc-600">
+        <span className="ml-auto text-xs text-[var(--text-tertiary)]">
           {report.evaluated} evaluated · reference-only, no secret values
         </span>
       </div>
       <div className="mb-3 grid grid-cols-3 gap-3">
-        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
-          <span className="text-xs text-zinc-500">Expired / overdue</span>
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
+          <span className="text-xs text-[var(--text-tertiary)]">Expired / overdue</span>
           <p
-            className={`text-xl font-bold ${overdue > 0 ? "text-red-400" : "text-zinc-100"}`}
+            className={`text-xl font-bold ${overdue > 0 ? "text-red-400" : "text-[var(--foreground)]"}`}
           >
             {overdue.toLocaleString()}
           </p>
         </div>
-        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
-          <span className="text-xs text-zinc-500">Expiring / rotation due</span>
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
+          <span className="text-xs text-[var(--text-tertiary)]">Expiring / rotation due</span>
           <p
-            className={`text-xl font-bold ${expiring > 0 ? "text-amber-400" : "text-zinc-100"}`}
+            className={`text-xl font-bold ${expiring > 0 ? "text-amber-400" : "text-[var(--foreground)]"}`}
           >
             {expiring.toLocaleString()}
           </p>
         </div>
-        <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
-          <span className="text-xs text-zinc-500">Healthy</span>
-          <p className="text-xl font-bold text-zinc-100">
+        <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
+          <span className="text-xs text-[var(--text-tertiary)]">Healthy</span>
+          <p className="text-xl font-bold text-[var(--foreground)]">
             {(report.counts.ok ?? 0).toLocaleString()}
           </p>
         </div>
       </div>
       {report.evaluated === 0 ? (
-        <p className="text-sm text-zinc-500">
+        <p className="text-sm text-[var(--text-tertiary)]">
           No control-plane secrets or discovered NHI credentials carry an age or
           expiry signal yet.
         </p>
       ) : rows.length === 0 ? (
-        <p className="text-sm text-zinc-500">
+        <p className="text-sm text-[var(--text-tertiary)]">
           All evaluated credentials are within rotation and expiry bounds.
         </p>
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-zinc-800 text-left text-xs text-zinc-500">
+              <tr className="border-b border-[var(--border-subtle)] text-left text-xs text-[var(--text-tertiary)]">
                 <th className="pb-2 font-medium">Credential</th>
                 <th className="pb-2 font-medium">Provider</th>
                 <th className="pb-2 font-medium">State</th>
@@ -235,21 +235,21 @@ function CredentialExpiryPanel({ report }: { report: CredentialExpiryReport }) {
               {rows.map((c, i) => (
                 <tr
                   key={`${c.id ?? c.name ?? "cred"}-${i}`}
-                  className="border-b border-zinc-900 last:border-0"
+                  className="border-b border-[var(--border-subtle)] last:border-0"
                 >
-                  <td className="py-2 font-medium text-zinc-200">
+                  <td className="py-2 font-medium text-[var(--foreground)]">
                     {c.name ?? c.id ?? "—"}
                   </td>
-                  <td className="py-2 text-zinc-400">{c.provider ?? "—"}</td>
+                  <td className="py-2 text-[var(--text-secondary)]">{c.provider ?? "—"}</td>
                   <td className="py-2">
                     <Badge tone={credStateTone(c.state)}>
                       {c.state.replace(/_/g, " ")}
                     </Badge>
                   </td>
-                  <td className="py-2 text-right text-zinc-400">
+                  <td className="py-2 text-right text-[var(--text-secondary)]">
                     {c.age_days != null ? `${c.age_days}d` : "—"}
                   </td>
-                  <td className="py-2 text-right text-zinc-400">
+                  <td className="py-2 text-right text-[var(--text-secondary)]">
                     {c.days_until_expiry != null
                       ? `${c.days_until_expiry}d`
                       : "—"}
@@ -270,17 +270,17 @@ function AccessReviewPanel({
   campaigns: AccessReviewCampaign[];
 }) {
   return (
-    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
       <div className="mb-3 flex items-center gap-2">
         <CalendarCheck className="h-4 w-4 text-emerald-400" />
-        <h3 className="text-sm font-semibold text-zinc-300">
+        <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
           Access-review campaigns
         </h3>
       </div>
       {campaigns.length === 0 ? (
-        <p className="text-sm text-zinc-500">
+        <p className="text-sm text-[var(--text-tertiary)]">
           No recertification campaigns. Create one via{" "}
-          <code className="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-300">
+          <code className="rounded bg-[var(--surface-elevated)] px-1.5 py-0.5 text-xs text-[var(--text-secondary)]">
             POST /v1/identities/access-reviews
           </code>{" "}
           to schedule a review of non-human identities and their effective
@@ -290,7 +290,7 @@ function AccessReviewPanel({
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-zinc-800 text-left text-xs text-zinc-500">
+              <tr className="border-b border-[var(--border-subtle)] text-left text-xs text-[var(--text-tertiary)]">
                 <th className="pb-2 font-medium">Campaign</th>
                 <th className="pb-2 font-medium">Status</th>
                 <th className="pb-2 text-right font-medium">Reviewed</th>
@@ -301,18 +301,18 @@ function AccessReviewPanel({
               {campaigns.map((c) => (
                 <tr
                   key={c.campaign_id}
-                  className="border-b border-zinc-900 last:border-0"
+                  className="border-b border-[var(--border-subtle)] last:border-0"
                 >
-                  <td className="py-2 font-medium text-zinc-200">{c.name}</td>
+                  <td className="py-2 font-medium text-[var(--foreground)]">{c.name}</td>
                   <td className="py-2">
                     <Badge tone={campaignTone(c.status)}>
                       {c.status.replace(/_/g, " ")}
                     </Badge>
                   </td>
-                  <td className="py-2 text-right text-zinc-400">
+                  <td className="py-2 text-right text-[var(--text-secondary)]">
                     {c.decided_count} / {c.item_count}
                   </td>
-                  <td className="py-2 text-zinc-500">
+                  <td className="py-2 text-[var(--text-tertiary)]">
                     {c.due_at ? formatDate(c.due_at) : "—"}
                   </td>
                 </tr>
@@ -340,19 +340,19 @@ function NhiDiscoveryPanel({
     (discovery.count === 0 && enabledProviders.length === 0);
 
   return (
-    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
       <div className="mb-3 flex items-center gap-2">
         <Radar className="h-4 w-4 text-sky-400" />
-        <h3 className="text-sm font-semibold text-zinc-300">
+        <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
           Discovered non-human identities
         </h3>
       </div>
       {disabled ? (
-        <div className="flex items-start gap-2 rounded-lg border border-zinc-800 bg-zinc-900/50 p-3 text-sm text-zinc-400">
-          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-zinc-500" />
+        <div className="flex items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3 text-sm text-[var(--text-secondary)]">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-[var(--text-tertiary)]" />
           <span>
             NHI discovery is disabled. Enable an IdP connector (Okta / Entra) via
-            its <code className="text-zinc-300">*_DISCOVERY</code> environment
+            its <code className="text-[var(--text-secondary)]">*_DISCOVERY</code> environment
             flag and token to enumerate service accounts and service principals.
             Discovery is read-only and reference-only — it never reads secret
             material.
@@ -361,22 +361,22 @@ function NhiDiscoveryPanel({
       ) : (
         <>
           <div className="mb-3 grid grid-cols-2 gap-3 md:grid-cols-4">
-            <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3">
-              <span className="text-xs text-zinc-500">Identities</span>
-              <p className="text-xl font-bold text-zinc-100">
+            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
+              <span className="text-xs text-[var(--text-tertiary)]">Identities</span>
+              <p className="text-xl font-bold text-[var(--foreground)]">
                 {discovery.count.toLocaleString()}
               </p>
             </div>
             {discovery.providers.map((p) => (
               <div
                 key={p.provider ?? "provider"}
-                className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3"
+                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3"
               >
-                <span className="text-xs capitalize text-zinc-500">
+                <span className="text-xs capitalize text-[var(--text-tertiary)]">
                   {p.provider ?? "provider"}
                 </span>
                 <div className="flex items-baseline gap-2">
-                  <p className="text-xl font-bold text-zinc-100">
+                  <p className="text-xl font-bold text-[var(--foreground)]">
                     {p.count.toLocaleString()}
                   </p>
                   <Badge tone={p.status === "ok" ? "green" : "zinc"}>
@@ -387,7 +387,7 @@ function NhiDiscoveryPanel({
             ))}
           </div>
           {discovery.warnings.length > 0 && (
-            <ul className="space-y-1 text-xs text-zinc-500">
+            <ul className="space-y-1 text-xs text-[var(--text-tertiary)]">
               {discovery.warnings.map((w, i) => (
                 <li key={i}>· {w}</li>
               ))}
@@ -491,8 +491,8 @@ export default function IdentityPage() {
       <div className="flex items-center gap-2">
         <Fingerprint className="h-6 w-6 text-indigo-400" />
         <div>
-          <h1 className="text-2xl font-semibold text-zinc-100">Identity</h1>
-          <p className="text-sm text-zinc-500">
+          <h1 className="text-2xl font-semibold text-[var(--foreground)]">Identity</h1>
+          <p className="text-sm text-[var(--text-tertiary)]">
             Managed agent identities, just-in-time access, and context-aware
             conditional access.
           </p>
@@ -522,7 +522,7 @@ export default function IdentityPage() {
           icon={Ban}
           label="Revoked / expired"
           value={inactiveIdentities}
-          color="text-zinc-400"
+          color="text-[var(--text-secondary)]"
         />
       </div>
 
@@ -541,17 +541,17 @@ export default function IdentityPage() {
       <NhiDiscoveryPanel discovery={discovery} />
 
       {identities.length > 0 && (
-        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+        <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
           <div className="mb-3 flex items-center gap-2">
             <Fingerprint className="h-4 w-4 text-indigo-400" />
-            <h3 className="text-sm font-semibold text-zinc-300">
+            <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
               Managed identities
             </h3>
           </div>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-zinc-800 text-left text-xs text-zinc-500">
+                <tr className="border-b border-[var(--border-subtle)] text-left text-xs text-[var(--text-tertiary)]">
                   <th className="pb-2 font-medium">Agent</th>
                   <th className="pb-2 font-medium">Role</th>
                   <th className="pb-2 font-medium">Status</th>
@@ -564,28 +564,28 @@ export default function IdentityPage() {
                 {identities.map((i) => (
                   <tr
                     key={i.identity_id}
-                    className="border-b border-zinc-900 last:border-0"
+                    className="border-b border-[var(--border-subtle)] last:border-0"
                   >
-                    <td className="py-2 font-medium text-zinc-200">
+                    <td className="py-2 font-medium text-[var(--foreground)]">
                       {i.agent_id}
                     </td>
-                    <td className="py-2 text-zinc-400">{i.role}</td>
+                    <td className="py-2 text-[var(--text-secondary)]">{i.role}</td>
                     <td className="py-2">
                       <Badge tone={identityTone(i.status)}>{i.status}</Badge>
                     </td>
-                    <td className="py-2 text-zinc-400">
+                    <td className="py-2 text-[var(--text-secondary)]">
                       {i.allowed_tools.length === 0 ? (
-                        <span className="text-zinc-600">any tool</span>
+                        <span className="text-[var(--text-tertiary)]">any tool</span>
                       ) : (
                         <span className="font-mono text-xs">
                           {i.allowed_tools.join(", ")}
                         </span>
                       )}
                     </td>
-                    <td className="py-2 font-mono text-xs text-zinc-500">
+                    <td className="py-2 font-mono text-xs text-[var(--text-tertiary)]">
                       abi_{i.token_prefix}…
                     </td>
-                    <td className="py-2 text-zinc-500">
+                    <td className="py-2 text-[var(--text-tertiary)]">
                       {i.expires_at ? formatDate(i.expires_at) : "—"}
                     </td>
                   </tr>
@@ -597,17 +597,17 @@ export default function IdentityPage() {
       )}
 
       {grants.length > 0 && (
-        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+        <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
           <div className="mb-3 flex items-center gap-2">
             <KeyRound className="h-4 w-4 text-emerald-400" />
-            <h3 className="text-sm font-semibold text-zinc-300">
+            <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
               JIT access grants
             </h3>
           </div>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-zinc-800 text-left text-xs text-zinc-500">
+                <tr className="border-b border-[var(--border-subtle)] text-left text-xs text-[var(--text-tertiary)]">
                   <th className="pb-2 font-medium">Tool</th>
                   <th className="pb-2 font-medium">Agent</th>
                   <th className="pb-2 font-medium">Status</th>
@@ -620,22 +620,22 @@ export default function IdentityPage() {
                 {grants.map((g) => (
                   <tr
                     key={g.grant_id}
-                    className="border-b border-zinc-900 last:border-0"
+                    className="border-b border-[var(--border-subtle)] last:border-0"
                   >
-                    <td className="py-2 font-mono text-xs text-zinc-200">
+                    <td className="py-2 font-mono text-xs text-[var(--foreground)]">
                       {g.tool_name}
                     </td>
-                    <td className="py-2 text-zinc-400">{g.agent_id}</td>
+                    <td className="py-2 text-[var(--text-secondary)]">{g.agent_id}</td>
                     <td className="py-2">
                       <Badge tone={jitTone(g.status)}>{g.status}</Badge>
                     </td>
-                    <td className="py-2 font-mono text-xs text-zinc-500">
+                    <td className="py-2 font-mono text-xs text-[var(--text-tertiary)]">
                       {g.ticket_id || "—"}
                     </td>
-                    <td className="py-2 text-zinc-400">
+                    <td className="py-2 text-[var(--text-secondary)]">
                       {g.approved_by || "—"}
                     </td>
-                    <td className="py-2 text-zinc-500">
+                    <td className="py-2 text-[var(--text-tertiary)]">
                       {g.expires_at ? formatDate(g.expires_at) : "—"}
                     </td>
                   </tr>
@@ -647,10 +647,10 @@ export default function IdentityPage() {
       )}
 
       {policies.length > 0 && (
-        <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+        <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
           <div className="mb-3 flex items-center gap-2">
             <ShieldCheck className="h-4 w-4 text-blue-400" />
-            <h3 className="text-sm font-semibold text-zinc-300">
+            <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
               Conditional-access policies
             </h3>
           </div>
@@ -660,10 +660,10 @@ export default function IdentityPage() {
               .map((p) => (
                 <div
                   key={p.policy_id}
-                  className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3"
+                  className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3"
                 >
                   <div className="flex flex-wrap items-center gap-2">
-                    <span className="text-sm font-medium text-zinc-200">
+                    <span className="text-sm font-medium text-[var(--foreground)]">
                       {p.name}
                     </span>
                     <Badge tone={p.effect === "deny" ? "red" : "blue"}>
@@ -672,16 +672,16 @@ export default function IdentityPage() {
                     <Badge tone={p.status === "active" ? "green" : "zinc"}>
                       {p.status}
                     </Badge>
-                    <span className="text-xs text-zinc-600">
+                    <span className="text-xs text-[var(--text-tertiary)]">
                       priority {p.priority}
                     </span>
                   </div>
-                  <p className="mt-1.5 text-xs text-zinc-400">
-                    <span className="text-zinc-500">scope:</span>{" "}
+                  <p className="mt-1.5 text-xs text-[var(--text-secondary)]">
+                    <span className="text-[var(--text-tertiary)]">scope:</span>{" "}
                     {scopeSummary(p)}
                   </p>
-                  <p className="mt-0.5 text-xs text-zinc-400">
-                    <span className="text-zinc-500">when:</span>{" "}
+                  <p className="mt-0.5 text-xs text-[var(--text-secondary)]">
+                    <span className="text-[var(--text-tertiary)]">when:</span>{" "}
                     {conditionSummary(p)}
                   </p>
                 </div>

--- a/ui/app/jobs/page.tsx
+++ b/ui/app/jobs/page.tsx
@@ -37,9 +37,9 @@ function StatusIcon({ status }: { status: JobStatus }) {
     case "running":
       return <Loader2 className="w-4 h-4 text-blue-400 animate-spin" />;
     case "cancelled":
-      return <XCircle className="w-4 h-4 text-zinc-500" />;
+      return <XCircle className="w-4 h-4 text-[var(--text-tertiary)]" />;
     default:
-      return <Clock className="w-4 h-4 text-zinc-500" />;
+      return <Clock className="w-4 h-4 text-[var(--text-tertiary)]" />;
   }
 }
 
@@ -52,8 +52,8 @@ function statusColor(s: JobStatus) {
     case "done":      return "text-emerald-400";
     case "failed":    return "text-red-400";
     case "running":   return "text-blue-400";
-    case "cancelled": return "text-zinc-500";
-    default:          return "text-zinc-400";
+    case "cancelled": return "text-[var(--text-tertiary)]";
+    default:          return "text-[var(--text-secondary)]";
   }
 }
 
@@ -183,13 +183,13 @@ function JobsPageContent() {
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Scan jobs</h1>
-          <p className="text-zinc-400 text-sm mt-1">Completed and in-flight evidence runs</p>
+          <p className="text-[var(--text-secondary)] text-sm mt-1">Completed and in-flight evidence runs</p>
         </div>
         <div className="flex items-center gap-2">
           {jobs.length > 0 && (
             <button
               onClick={() => downloadJson(filteredJobs, `jobs-${new Date().toISOString().slice(0, 10)}.json`)}
-              className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 text-sm font-medium rounded-lg transition-colors"
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] border border-[var(--border-subtle)] text-[var(--text-secondary)] text-sm font-medium rounded-lg transition-colors"
               title="Export job list as JSON"
             >
               <Download className="w-3.5 h-3.5" />
@@ -206,19 +206,19 @@ function JobsPageContent() {
         </div>
       </div>
 
-      {loading && <p className="text-zinc-500 text-sm">Loading jobs…</p>}
+      {loading && <p className="text-[var(--text-tertiary)] text-sm">Loading jobs…</p>}
       {error && (
         <div className="flex items-center gap-3 p-3 bg-red-950/30 border border-red-800/40 rounded-lg">
           <p className="text-red-400 text-sm flex-1">{error}</p>
-          <button onClick={load} className="text-xs text-zinc-400 hover:text-zinc-200 px-2 py-1 border border-zinc-700 rounded">Retry</button>
+          <button onClick={load} className="text-xs text-[var(--text-secondary)] hover:text-[var(--foreground)] px-2 py-1 border border-[var(--border-subtle)] rounded">Retry</button>
         </div>
       )}
 
       {!loading && jobs.length === 0 && (
-        <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
-          <Clock className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
-          <p className="text-zinc-500 text-sm">No scan jobs yet.</p>
-          <p className="text-zinc-600 text-xs mt-1">
+        <div className="text-center py-16 border border-dashed border-[var(--border-subtle)] rounded-xl">
+          <Clock className="w-8 h-8 text-[var(--text-tertiary)] mx-auto mb-3" />
+          <p className="text-[var(--text-tertiary)] text-sm">No scan jobs yet.</p>
+          <p className="text-[var(--text-tertiary)] text-xs mt-1">
             <Link href="/scan" className="text-emerald-500 hover:text-emerald-400">Run your first scan</Link> to see results here.
           </p>
         </div>
@@ -227,28 +227,28 @@ function JobsPageContent() {
       {!loading && (jobs.length > 0 || sources.length > 0 || schedules.length > 0) && (
         <section
           data-testid="source-job-evidence-workflow"
-          className="space-y-4 rounded-xl border border-zinc-800 bg-zinc-950 p-5"
+          className="space-y-4 rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] p-5"
         >
           <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div>
               <p className="text-[10px] font-semibold uppercase tracking-[0.28em] text-emerald-400">
                 Source → job → evidence
               </p>
-              <h2 className="mt-1 text-base font-semibold text-zinc-100">Control-plane workflow</h2>
-              <p className="mt-1 max-w-3xl text-sm text-zinc-500">
+              <h2 className="mt-1 text-base font-semibold text-[var(--foreground)]">Control-plane workflow</h2>
+              <p className="mt-1 max-w-3xl text-sm text-[var(--text-tertiary)]">
                 Registered sources enqueue scan jobs. Each job runs the six-stage read-only pipeline below, then publishes findings, graph, and compliance evidence.
               </p>
-              <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-zinc-400">
-                <span className="rounded-full border border-zinc-800 px-2.5 py-1">
+              <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-[var(--text-secondary)]">
+                <span className="rounded-full border border-[var(--border-subtle)] px-2.5 py-1">
                   {sources.length} sources · {sources.filter((source) => source.enabled).length} enabled
                 </span>
-                <span className="rounded-full border border-zinc-800 px-2.5 py-1">
+                <span className="rounded-full border border-[var(--border-subtle)] px-2.5 py-1">
                   {jobs.filter((job) => job.status === "running").length} running · {jobs.length} total jobs
                 </span>
-                <span className="rounded-full border border-zinc-800 px-2.5 py-1">
+                <span className="rounded-full border border-[var(--border-subtle)] px-2.5 py-1">
                   {evidenceReadyJobs.length} evidence-ready
                 </span>
-                <span className="rounded-full border border-zinc-800 px-2.5 py-1">
+                <span className="rounded-full border border-[var(--border-subtle)] px-2.5 py-1">
                   {schedules.filter((schedule) => schedule.enabled).length} active schedules
                 </span>
               </div>
@@ -258,7 +258,7 @@ function JobsPageContent() {
                 type="button"
                 onClick={() => setWorkflowOpen((open) => !open)}
                 aria-expanded={workflowOpen}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:border-zinc-600 hover:text-zinc-100"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border-subtle)] px-3 py-1.5 text-xs font-medium text-[var(--text-secondary)] hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
               >
                 {workflowOpen ? (
                   <ChevronDown className="h-3.5 w-3.5" />
@@ -269,7 +269,7 @@ function JobsPageContent() {
               </button>
               <Link
                 href="/sources"
-                className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-300 hover:border-zinc-600 hover:text-zinc-100"
+                className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border-subtle)] px-3 py-1.5 text-xs font-medium text-[var(--text-secondary)] hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
               >
                 Manage sources
               </Link>
@@ -286,8 +286,8 @@ function JobsPageContent() {
                 summary={featuredJob.summary}
               />
             ) : (
-              <div className="rounded-xl border border-dashed border-zinc-800 bg-zinc-900/30 p-4">
-                <p className="text-sm text-zinc-400">
+              <div className="rounded-xl border border-dashed border-[var(--border-subtle)] bg-[var(--surface)]/30 p-4">
+                <p className="text-sm text-[var(--text-secondary)]">
                   Run a scan to see the live six-stage pipeline DAG with per-step timing and activity.
                 </p>
                 <div className="mt-4">
@@ -310,8 +310,8 @@ function JobsPageContent() {
                   onClick={() => { setStatusFilter(s); setPage(1); }}
                   className={`px-3 py-1 text-xs font-medium rounded-md border transition-colors ${
                     statusFilter === s
-                      ? "text-zinc-200 border-zinc-600 bg-zinc-800"
-                      : "text-zinc-500 border-zinc-800 hover:border-zinc-700 hover:text-zinc-300"
+                      ? "text-[var(--foreground)] border-[var(--border-strong)] bg-[var(--surface-elevated)]"
+                      : "text-[var(--text-tertiary)] border-[var(--border-subtle)] hover:border-[var(--border-subtle)] hover:text-[var(--text-secondary)]"
                   }`}
                 >
                   {s === "all"
@@ -321,32 +321,32 @@ function JobsPageContent() {
               ))}
             </div>
             <div className="relative w-full sm:w-56">
-              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-zinc-600" />
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-[var(--text-tertiary)]" />
               <input
                 type="text"
                 placeholder="Search jobs or sources…"
                 value={search}
                 onChange={(e) => { setSearch(e.target.value); setPage(1); }}
-                className="w-full bg-zinc-900 border border-zinc-700 rounded-lg pl-8 pr-3 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500"
+                className="w-full bg-[var(--surface)] border border-[var(--border-subtle)] rounded-lg pl-8 pr-3 py-1.5 text-sm text-[var(--foreground)] placeholder-[var(--text-tertiary)] focus:outline-none focus:border-[var(--border-strong)]"
               />
             </div>
           </div>
 
-          <div className="border border-zinc-800 rounded-xl overflow-hidden overflow-x-auto">
+          <div className="border border-[var(--border-subtle)] rounded-xl overflow-hidden overflow-x-auto">
             <table className="w-full text-sm">
-              <thead className="bg-zinc-900 border-b border-zinc-800">
+              <thead className="bg-[var(--surface)] border-b border-[var(--border-subtle)]">
                 <tr>
                   <th className="w-10 px-3 py-3" aria-label="Expand pipeline" />
-                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Job ID</th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Status</th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Source</th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Started</th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Completed</th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Evidence</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Job ID</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Status</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Source</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Started</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Completed</th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Evidence</th>
                   <th className="px-4 py-3" />
                 </tr>
               </thead>
-              <tbody className="divide-y divide-zinc-800 bg-zinc-950">
+              <tbody className="divide-y divide-[var(--border-subtle)] bg-[var(--background)]">
                 {pagedJobs?.map((job) => {
                   const linkedSource = sourceForJob(job, sourceById, sourceByLastJobId);
                   const sourceId = sourceIdForJob(job);
@@ -355,7 +355,7 @@ function JobsPageContent() {
                   return (
                     <Fragment key={job.job_id}>
                     <tr
-                      className="hover:bg-zinc-900 transition-colors cursor-pointer group"
+                      className="hover:bg-[var(--surface)] transition-colors cursor-pointer group"
                       onClick={() => setExpandedJobId((current) => (current === job.job_id ? null : job.job_id))}
                     >
                       <td className="px-3 py-3">
@@ -367,7 +367,7 @@ function JobsPageContent() {
                             event.stopPropagation();
                             setExpandedJobId((current) => (current === job.job_id ? null : job.job_id));
                           }}
-                          className="rounded p-1 text-zinc-500 hover:bg-zinc-800 hover:text-zinc-200"
+                          className="rounded p-1 text-[var(--text-tertiary)] hover:bg-[var(--surface-elevated)] hover:text-[var(--foreground)]"
                         >
                           {expanded ? (
                             <ChevronDown className="h-4 w-4" />
@@ -380,7 +380,7 @@ function JobsPageContent() {
                         <Link
                           href={`/scan?id=${encodeURIComponent(job.job_id)}`}
                           onClick={(event) => event.stopPropagation()}
-                          className="font-mono text-xs text-zinc-300 hover:text-emerald-300"
+                          className="font-mono text-xs text-[var(--text-secondary)] hover:text-emerald-300"
                         >
                           {job.job_id.slice(0, 8)}…
                         </Link>
@@ -393,24 +393,24 @@ function JobsPageContent() {
                       </td>
                       <td className="px-4 py-3">
                         <div className="max-w-56">
-                          <p className="truncate text-xs font-medium text-zinc-300">
+                          <p className="truncate text-xs font-medium text-[var(--text-secondary)]">
                             {linkedSource?.display_name ?? (sourceId || "Manual / pushed scan")}
                           </p>
-                          <p className="mt-0.5 truncate text-[11px] text-zinc-600">
+                          <p className="mt-0.5 truncate text-[11px] text-[var(--text-tertiary)]">
                             {linkedSource ? `${linkedSource.kind} · ${linkedSource.owner || "unowned"}` : sourceId || "No registered source"}
                           </p>
                         </div>
                       </td>
-                      <td className="px-4 py-3 text-xs text-zinc-500">
+                      <td className="px-4 py-3 text-xs text-[var(--text-tertiary)]">
                         {formatDate(job.created_at)}
                       </td>
-                      <td className="px-4 py-3 text-xs text-zinc-500">
+                      <td className="px-4 py-3 text-xs text-[var(--text-tertiary)]">
                         {job.completed_at ? formatDate(job.completed_at) : "—"}
                       </td>
                       <td className="px-4 py-3">
                         {evidenceReady ? (
                           <div className="space-y-2">
-                            <p className="text-[11px] text-zinc-500">{evidenceSummary(job)}</p>
+                            <p className="text-[11px] text-[var(--text-tertiary)]">{evidenceSummary(job)}</p>
                             <div className="flex flex-wrap gap-1.5">
                               {[
                                 { href: `/findings?scan=${encodeURIComponent(job.job_id)}`, label: "Findings" },
@@ -421,7 +421,7 @@ function JobsPageContent() {
                                   key={link.label}
                                   href={link.href}
                                   onClick={(event) => event.stopPropagation()}
-                                  className="rounded-md border border-zinc-800 px-2 py-1 text-[11px] font-medium text-zinc-400 hover:border-zinc-700 hover:text-zinc-100"
+                                  className="rounded-md border border-[var(--border-subtle)] px-2 py-1 text-[11px] font-medium text-[var(--text-secondary)] hover:border-[var(--border-subtle)] hover:text-[var(--foreground)]"
                                 >
                                   {link.label}
                                 </Link>
@@ -429,14 +429,14 @@ function JobsPageContent() {
                             </div>
                           </div>
                         ) : (
-                          <span className="text-xs text-zinc-600">Available when complete</span>
+                          <span className="text-xs text-[var(--text-tertiary)]">Available when complete</span>
                         )}
                       </td>
                       <td className="px-4 py-3 text-right">
                         <button
                           onClick={(e) => handleDelete(job.job_id, e)}
                           disabled={deleting === job.job_id}
-                          className="opacity-0 group-hover:opacity-100 p-1 text-zinc-600 hover:text-red-400 transition-all rounded"
+                          className="opacity-0 group-hover:opacity-100 p-1 text-[var(--text-tertiary)] hover:text-red-400 transition-all rounded"
                           title="Delete job"
                         >
                           {deleting === job.job_id
@@ -447,7 +447,7 @@ function JobsPageContent() {
                       </td>
                     </tr>
                     {expanded ? (
-                      <tr key={`${job.job_id}-pipeline`} className="bg-zinc-900/40">
+                      <tr key={`${job.job_id}-pipeline`} className="bg-[var(--surface)]/40">
                         <td colSpan={8} className="px-4 py-4">
                           <JobPipelinePanel
                             jobId={job.job_id}
@@ -464,7 +464,7 @@ function JobsPageContent() {
                 })}
                 {pagedJobs.length === 0 && (
                   <tr>
-                    <td colSpan={8} className="px-4 py-8 text-center text-zinc-600 text-sm">
+                    <td colSpan={8} className="px-4 py-8 text-center text-[var(--text-tertiary)] text-sm">
                       No jobs match your filters.
                     </td>
                   </tr>
@@ -490,7 +490,7 @@ export default function JobsPage() {
   return (
     <Suspense
       fallback={
-        <div className="flex items-center justify-center py-20 text-zinc-400">
+        <div className="flex items-center justify-center py-20 text-[var(--text-secondary)]">
           <Loader2 className="mr-2 h-6 w-6 animate-spin" />
           Loading jobs...
         </div>

--- a/ui/app/loading.tsx
+++ b/ui/app/loading.tsx
@@ -8,18 +8,18 @@ export default function Loading() {
           <ShieldCheck className="h-5 w-5 text-emerald-400" aria-hidden="true" />
         </div>
         <div>
-          <div className="h-4 w-36 rounded bg-zinc-800" />
-          <div className="mt-2 h-3 w-56 rounded bg-zinc-900" />
+          <div className="h-4 w-36 rounded bg-[var(--surface-elevated)]" />
+          <div className="mt-2 h-3 w-56 rounded bg-[var(--surface)]" />
         </div>
       </div>
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
         {["a", "b", "c", "d"].map((key) => (
-          <div key={key} className="h-28 rounded-lg border border-zinc-800 bg-zinc-950" />
+          <div key={key} className="h-28 rounded-lg border border-[var(--border-subtle)] bg-[var(--background)]" />
         ))}
       </div>
       <div className="mt-6 grid gap-4 lg:grid-cols-[1.7fr_1fr]">
-        <div className="h-80 rounded-lg border border-zinc-800 bg-zinc-950" />
-        <div className="h-80 rounded-lg border border-zinc-800 bg-zinc-950" />
+        <div className="h-80 rounded-lg border border-[var(--border-subtle)] bg-[var(--background)]" />
+        <div className="h-80 rounded-lg border border-[var(--border-subtle)] bg-[var(--background)]" />
       </div>
     </div>
   );

--- a/ui/app/login/page.tsx
+++ b/ui/app/login/page.tsx
@@ -28,7 +28,7 @@ export default function LoginPage() {
   return (
     <Suspense
       fallback={
-        <div className="flex min-h-screen items-center justify-center text-zinc-400">
+        <div className="flex min-h-screen items-center justify-center text-[var(--text-secondary)]">
           <Loader2 className="mr-2 h-5 w-5 animate-spin" />
           Loading sign-in...
         </div>

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -80,15 +80,15 @@ function MeshToolbar({
   toggleAgent: (name: string) => void;
 }) {
   const toggles: { key: keyof NodeTypeFilter; label: string; color: string }[] = [
-    { key: "packages", label: "Packages", color: "text-zinc-400" },
+    { key: "packages", label: "Packages", color: "text-[var(--text-secondary)]" },
     { key: "vulnerabilities", label: "Vulns", color: "text-red-400" },
     { key: "credentials", label: "Creds", color: "text-amber-400" },
     { key: "tools", label: "Tools", color: "text-purple-400" },
   ];
 
   return (
-    <div className="flex flex-wrap items-center gap-3 border-b border-zinc-800 px-4 py-2 text-xs">
-      <SlidersHorizontal className="w-3.5 h-3.5 text-zinc-500 shrink-0" />
+    <div className="flex flex-wrap items-center gap-3 border-b border-[var(--border-subtle)] px-4 py-2 text-xs">
+      <SlidersHorizontal className="w-3.5 h-3.5 text-[var(--text-tertiary)] shrink-0" />
 
       {/* Node type toggles */}
       {toggles?.map((t) => (
@@ -97,19 +97,19 @@ function MeshToolbar({
             type="checkbox"
             checked={nodeFilter[t.key]}
             onChange={() => setNodeFilter({ ...nodeFilter, [t.key]: !nodeFilter[t.key] })}
-            className="w-3 h-3 rounded border-zinc-600 bg-zinc-800 text-emerald-500 focus:ring-0 focus:ring-offset-0"
+            className="w-3 h-3 rounded border-[var(--border-strong)] bg-[var(--surface-elevated)] text-emerald-500 focus:ring-0 focus:ring-offset-0"
           />
-          <span className={nodeFilter[t.key] ? t.color : "text-zinc-600"}>{t.label}</span>
+          <span className={nodeFilter[t.key] ? t.color : "text-[var(--text-tertiary)]"}>{t.label}</span>
         </label>
       ))}
 
-      <div className="hidden h-4 w-px bg-zinc-700 sm:block" />
+      <div className="hidden h-4 w-px bg-[var(--surface-muted)] sm:block" />
 
       {/* Severity filter */}
       <select
         value={severityFilter}
         onChange={(e) => setSeverityFilter(e.target.value as SeverityFilter)}
-        className="bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-xs text-zinc-300 focus:outline-none focus:border-emerald-600"
+        className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded px-2 py-1 text-xs text-[var(--text-secondary)] focus:outline-none focus:border-emerald-600"
       >
         <option value="all">All Severities</option>
         <option value="critical">Critical Only</option>
@@ -118,32 +118,32 @@ function MeshToolbar({
         <option value="low">Low+</option>
       </select>
 
-      <label className="flex items-center gap-1.5 text-zinc-400">
+      <label className="flex items-center gap-1.5 text-[var(--text-secondary)]">
         <input
           type="checkbox"
           checked={vulnerableOnly}
           onChange={(event) => setVulnerableOnly(event.target.checked)}
-          className="w-3 h-3 rounded border-zinc-600 bg-zinc-800 text-emerald-500 focus:ring-0 focus:ring-offset-0"
+          className="w-3 h-3 rounded border-[var(--border-strong)] bg-[var(--surface-elevated)] text-emerald-500 focus:ring-0 focus:ring-offset-0"
         />
         Vulnerable only
       </label>
 
-      <div className="hidden h-4 w-px bg-zinc-700 sm:block" />
+      <div className="hidden h-4 w-px bg-[var(--surface-muted)] sm:block" />
 
       {/* Search */}
       <div className="relative min-w-[12rem] flex-1 sm:max-w-xs">
-        <Search className="w-3.5 h-3.5 text-zinc-500 absolute left-2 top-1/2 -translate-y-1/2" />
+        <Search className="w-3.5 h-3.5 text-[var(--text-tertiary)] absolute left-2 top-1/2 -translate-y-1/2" />
         <input
           type="text"
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder="Search nodes, CVEs, packages..."
-          className="w-full bg-zinc-900 border border-zinc-700 rounded pl-7 pr-2 py-1 text-xs text-zinc-300 placeholder:text-zinc-600 focus:outline-none focus:border-emerald-600"
+          className="w-full bg-[var(--surface)] border border-[var(--border-subtle)] rounded pl-7 pr-2 py-1 text-xs text-[var(--text-secondary)] placeholder:text-[var(--text-tertiary)] focus:outline-none focus:border-emerald-600"
         />
         {searchQuery && (
           <button
             onClick={() => setSearchQuery("")}
-            className="absolute right-2 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300"
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
           >
             ×
           </button>
@@ -152,7 +152,7 @@ function MeshToolbar({
 
       {agentOptions.length > 0 && (
         <>
-          <div className="hidden h-4 w-px bg-zinc-700 sm:block" />
+          <div className="hidden h-4 w-px bg-[var(--surface-muted)] sm:block" />
           <div className="flex max-w-full items-center gap-1.5 overflow-x-auto pb-1 sm:max-w-[28rem]">
             {agentOptions.map(({ key, label }) => {
               const active = selectedAgents.includes(key);
@@ -164,7 +164,7 @@ function MeshToolbar({
                   className={`max-w-[13rem] truncate rounded-full border px-2.5 py-1 text-[11px] transition ${
                     active
                       ? "border-emerald-500/50 bg-emerald-500/10 text-emerald-200"
-                      : "border-zinc-700 bg-zinc-900/70 text-zinc-500 hover:border-zinc-500 hover:text-zinc-300"
+                      : "border-[var(--border-subtle)] bg-[var(--surface)]/70 text-[var(--text-tertiary)] hover:border-[var(--border-strong)] hover:text-[var(--text-secondary)]"
                   }`}
                 >
                   {label}
@@ -513,7 +513,7 @@ export default function MeshPage() {
             </p>
           </div>
           <div className="flex min-w-0 flex-wrap items-center gap-2">
-            <div className="flex max-w-full items-center overflow-hidden rounded-lg border border-zinc-700 bg-zinc-800">
+            <div className="flex max-w-full items-center overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)]">
               {[
                 { key: "radial" as const, label: "Risk Map", icon: Orbit },
                 { key: "topology" as const, label: "Flow", icon: Network },
@@ -526,7 +526,7 @@ export default function MeshPage() {
                   className={`flex items-center gap-1 px-2.5 py-1 text-[11px] font-medium transition-colors ${
                     layoutMode === key
                       ? "bg-emerald-600 text-white"
-                      : "text-zinc-400 hover:text-zinc-200"
+                      : "text-[var(--text-secondary)] hover:text-[var(--foreground)]"
                   }`}
                 >
                   <Icon className="h-3.5 w-3.5" />
@@ -537,7 +537,7 @@ export default function MeshPage() {
             <select
               value={selectedJob}
               onChange={(e) => setSelectedJob(e.target.value)}
-              className="min-w-0 max-w-[14rem] truncate rounded-md border border-zinc-700 bg-zinc-900 px-2.5 py-1 text-xs text-zinc-300 focus:outline-none focus:border-emerald-600"
+              className="min-w-0 max-w-[14rem] truncate rounded-md border border-[var(--border-subtle)] bg-[var(--surface)] px-2.5 py-1 text-xs text-[var(--text-secondary)] focus:outline-none focus:border-emerald-600"
             >
               {jobs?.map((j) => (
                 <option key={j.job_id} value={j.job_id}>
@@ -563,8 +563,8 @@ export default function MeshPage() {
 
       {/* Filter toolbar */}
       {!captureMode && (
-      <details className="group border-b border-zinc-800" open={!pathFocusActive}>
-        <summary className="flex cursor-pointer list-none items-center justify-between px-4 py-1.5 text-[11px] text-zinc-500 [&::-webkit-details-marker]:hidden">
+      <details className="group border-b border-[var(--border-subtle)]" open={!pathFocusActive}>
+        <summary className="flex cursor-pointer list-none items-center justify-between px-4 py-1.5 text-[11px] text-[var(--text-tertiary)] [&::-webkit-details-marker]:hidden">
           <span className="font-medium uppercase tracking-[0.16em]">Scope & filters</span>
           <span className="text-[10px] uppercase tracking-[0.14em] group-open:hidden">show</span>
           <span className="hidden text-[10px] uppercase tracking-[0.14em] group-open:inline">hide</span>

--- a/ui/app/not-found.tsx
+++ b/ui/app/not-found.tsx
@@ -4,9 +4,9 @@ import Link from "next/link";
 export default function NotFound() {
   return (
     <div className="flex flex-col items-center justify-center h-[80vh] gap-4 text-center">
-      <ShieldAlert className="w-12 h-12 text-zinc-600" />
-      <h2 className="text-lg font-semibold text-zinc-200">Page not found</h2>
-      <p className="text-sm text-zinc-400">The page you are looking for does not exist.</p>
+      <ShieldAlert className="w-12 h-12 text-[var(--text-tertiary)]" />
+      <h2 className="text-lg font-semibold text-[var(--foreground)]">Page not found</h2>
+      <p className="text-sm text-[var(--text-secondary)]">The page you are looking for does not exist.</p>
       <Link
         href="/"
         className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 rounded-md text-sm text-white transition-colors"

--- a/ui/app/proxy/ProxyDashboard.tsx
+++ b/ui/app/proxy/ProxyDashboard.tsx
@@ -48,7 +48,7 @@ const SEVERITY_COLORS: Record<string, string> = {
   high: "bg-orange-950 text-orange-300 border-orange-800",
   medium: "bg-yellow-950 text-yellow-300 border-yellow-800",
   low: "bg-blue-950 text-blue-300 border-blue-800",
-  info: "bg-zinc-800 text-zinc-300 border-zinc-700",
+  info: "bg-[var(--surface-elevated)] text-[var(--text-secondary)] border-[var(--border-subtle)]",
 };
 
 const PIE_COLORS = ["#ef4444", "#f97316", "#eab308", "#3b82f6", "#71717a"];
@@ -208,7 +208,7 @@ export default function ProxyDashboard() {
             <Shield className="w-6 h-6 text-emerald-400" />
             Proxy Dashboard
           </h1>
-          <p className="text-zinc-400 text-sm mt-1">
+          <p className="text-[var(--text-secondary)] text-sm mt-1">
             Runtime MCP proxy metrics, detector activity, and security alerts
           </p>
         </div>
@@ -221,14 +221,14 @@ export default function ProxyDashboard() {
               </>
             ) : (
               <>
-                <WifiOff className="w-3.5 h-3.5 text-zinc-500" />
-                <span className="text-zinc-500">Disconnected</span>
+                <WifiOff className="w-3.5 h-3.5 text-[var(--text-tertiary)]" />
+                <span className="text-[var(--text-tertiary)]">Disconnected</span>
               </>
             )}
           </div>
           <button
             onClick={load}
-            className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] border border-[var(--border-subtle)] rounded-lg text-xs text-[var(--text-secondary)] transition-colors"
           >
             <RefreshCw className="w-3.5 h-3.5" />
             Refresh
@@ -240,7 +240,7 @@ export default function ProxyDashboard() {
       {/* Loading */}
       {loading && (
         <div className="flex items-center justify-center py-12">
-          <Loader2 className="w-6 h-6 animate-spin text-zinc-500" />
+          <Loader2 className="w-6 h-6 animate-spin text-[var(--text-tertiary)]" />
         </div>
       )}
 
@@ -249,10 +249,10 @@ export default function ProxyDashboard() {
         <div className="text-center py-10 border border-dashed border-red-900/50 rounded-xl space-y-3">
           <AlertTriangle className="w-8 h-8 text-red-500 mx-auto" />
           <p className="text-red-400 text-sm">Failed to load proxy data</p>
-          <p className="text-zinc-500 text-xs">{error}</p>
+          <p className="text-[var(--text-tertiary)] text-xs">{error}</p>
           <button
             onClick={load}
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 rounded-lg text-xs text-zinc-300 transition-colors"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] border border-[var(--border-subtle)] rounded-lg text-xs text-[var(--text-secondary)] transition-colors"
           >
             <RefreshCw className="w-3.5 h-3.5" /> Retry
           </button>
@@ -261,12 +261,12 @@ export default function ProxyDashboard() {
 
       {/* No proxy session */}
       {!loading && !error && !isActive && (
-        <div className="rounded-xl border border-dashed border-zinc-800 bg-zinc-950/70 p-8">
-          <Shield className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
-          <p className="text-zinc-300 text-sm text-center">
+        <div className="rounded-xl border border-dashed border-[var(--border-subtle)] bg-[var(--background)]/70 p-8">
+          <Shield className="w-8 h-8 text-[var(--text-tertiary)] mx-auto mb-3" />
+          <p className="text-[var(--text-secondary)] text-sm text-center">
             {proxyUnavailable ? "Proxy telemetry is not enabled for this estate" : "No runtime telemetry connected"}
           </p>
-          <p className="text-zinc-500 text-xs mt-2 max-w-2xl mx-auto text-center">
+          <p className="text-[var(--text-tertiary)] text-xs mt-2 max-w-2xl mx-auto text-center">
             {proxyUnavailable
               ? "Enable an inline proxy when you want live tool-call review, policy enforcement, and audit alerts."
               : "Proxy is an optional runtime feed for live tool-call review, policy enforcement, and audit alerts. Core scanning, graph analysis, and compliance workflows do not depend on it."}
@@ -323,18 +323,18 @@ export default function ProxyDashboard() {
               label="Uptime"
               value={uptime != null ? formatUptime(uptime) : "—"}
               icon={Activity}
-              color="text-zinc-400"
+              color="text-[var(--text-secondary)]"
             />
           </div>
 
           {/* Charts row */}
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
             {/* Tool call frequency */}
-            <div className="lg:col-span-2 bg-zinc-900 border border-zinc-800 rounded-xl p-5">
-              <h3 className="text-sm font-semibold text-zinc-300 mb-1">
+            <div className="lg:col-span-2 bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-5">
+              <h3 className="text-sm font-semibold text-[var(--text-secondary)] mb-1">
                 Tool Call Frequency
               </h3>
-              <p className="text-[10px] text-zinc-600 mb-4">
+              <p className="text-[10px] text-[var(--text-tertiary)] mb-4">
                 Top tools by invocation count
               </p>
               {toolChartData.length > 0 ? (
@@ -383,18 +383,18 @@ export default function ProxyDashboard() {
                   </ResponsiveContainer>
                 </div>
               ) : (
-                <div className="h-52 flex items-center justify-center text-zinc-600 text-xs">
+                <div className="h-52 flex items-center justify-center text-[var(--text-tertiary)] text-xs">
                   No tool calls recorded yet
                 </div>
               )}
             </div>
 
             {/* Blocked breakdown pie */}
-            <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
-              <h3 className="text-sm font-semibold text-zinc-300 mb-1">
+            <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-5">
+              <h3 className="text-sm font-semibold text-[var(--text-secondary)] mb-1">
                 Block Reasons
               </h3>
-              <p className="text-[10px] text-zinc-600 mb-4">
+              <p className="text-[10px] text-[var(--text-tertiary)] mb-4">
                 Why tool calls were blocked
               </p>
               {blockedPieData.length > 0 ? (
@@ -435,7 +435,7 @@ export default function ProxyDashboard() {
                     {blockedPieData?.map((d, i) => (
                       <div
                         key={d.name}
-                        className="flex items-center gap-1.5 text-[10px] text-zinc-400"
+                        className="flex items-center gap-1.5 text-[10px] text-[var(--text-secondary)]"
                       >
                         <span
                           className="w-2 h-2 rounded-full"
@@ -453,7 +453,7 @@ export default function ProxyDashboard() {
                 <div className="h-52 flex items-center justify-center">
                   <div className="text-center">
                     <ShieldCheck className="w-6 h-6 text-emerald-600 mx-auto mb-2" />
-                    <span className="text-zinc-600 text-xs">
+                    <span className="text-[var(--text-tertiary)] text-xs">
                       No blocked calls
                     </span>
                   </div>
@@ -464,8 +464,8 @@ export default function ProxyDashboard() {
 
           {/* Detectors */}
           {status?.detectors_active && status.detectors_active.length > 0 && (
-            <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
-              <h3 className="text-sm font-semibold text-zinc-300 mb-3">
+            <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-5">
+              <h3 className="text-sm font-semibold text-[var(--text-secondary)] mb-3">
                 Active Detectors
               </h3>
               <div className="flex flex-wrap gap-2">
@@ -482,13 +482,13 @@ export default function ProxyDashboard() {
           )}
 
           {/* Alerts */}
-          <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-5">
+          <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-5">
             <div className="flex items-center justify-between mb-4">
               <div>
-                <h3 className="text-sm font-semibold text-zinc-300">
+                <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
                   Recent Alerts
                 </h3>
-                <p className="text-[10px] text-zinc-600 mt-0.5">
+                <p className="text-[10px] text-[var(--text-tertiary)] mt-0.5">
                   Security alerts from proxy detectors
                 </p>
               </div>
@@ -499,8 +499,8 @@ export default function ProxyDashboard() {
                     onClick={() => setSeverityFilter(sev)}
                     className={`px-2 py-1 rounded text-[10px] font-medium transition-colors ${
                       severityFilter === sev
-                        ? "bg-zinc-700 text-zinc-100"
-                        : "text-zinc-500 hover:text-zinc-300 hover:bg-zinc-800"
+                        ? "bg-[var(--surface-muted)] text-[var(--foreground)]"
+                        : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] hover:bg-[var(--surface-elevated)]"
                     }`}
                   >
                     {sev || "All"}
@@ -512,7 +512,7 @@ export default function ProxyDashboard() {
             {filteredAlerts.length === 0 ? (
               <div className="text-center py-8">
                 <ShieldCheck className="w-6 h-6 text-emerald-600 mx-auto mb-2" />
-                <p className="text-zinc-600 text-xs">No alerts</p>
+                <p className="text-[var(--text-tertiary)] text-xs">No alerts</p>
               </div>
             ) : (
               <div className="space-y-1 max-h-96 overflow-y-auto">
@@ -521,7 +521,7 @@ export default function ProxyDashboard() {
                     key={proxyAlertKey(alert, i)}
                     type="button"
                     onClick={() => setSelectedAlert(alert)}
-                    className="flex w-full items-center justify-between rounded-lg border border-zinc-800 bg-zinc-800/50 px-3 py-2 text-left transition-colors hover:border-zinc-600 hover:bg-zinc-800"
+                    className="flex w-full items-center justify-between rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/50 px-3 py-2 text-left transition-colors hover:border-[var(--border-strong)] hover:bg-[var(--surface-elevated)]"
                   >
                     <div className="flex min-w-0 items-center gap-3">
                       <span
@@ -531,17 +531,17 @@ export default function ProxyDashboard() {
                       >
                         {alert.severity}
                       </span>
-                      <span className="shrink-0 font-mono text-xs text-zinc-400">
+                      <span className="shrink-0 font-mono text-xs text-[var(--text-secondary)]">
                         {alert.detector}
                       </span>
-                      <span className="shrink-0 font-mono text-xs text-zinc-300">
+                      <span className="shrink-0 font-mono text-xs text-[var(--text-secondary)]">
                         {alert.tool_name}
                       </span>
-                      <span className="truncate text-xs text-zinc-500">
+                      <span className="truncate text-xs text-[var(--text-tertiary)]">
                         {proxyAlertSummary(alert)}
                       </span>
                     </div>
-                    <span className="ml-3 shrink-0 text-[10px] text-zinc-600">
+                    <span className="ml-3 shrink-0 text-[10px] text-[var(--text-tertiary)]">
                       {alert.ts ? formatDate(alert.ts) : ""}
                     </span>
                   </button>
@@ -569,10 +569,10 @@ function SetupCard({
   command: string;
 }) {
   return (
-    <div className="rounded-xl border border-zinc-800 bg-zinc-900/70 p-4">
-      <p className="text-sm font-medium text-zinc-100">{title}</p>
-      <p className="mt-2 text-xs leading-5 text-zinc-500">{body}</p>
-      <code className="mt-3 block rounded-lg bg-zinc-950 px-3 py-2 text-[11px] text-zinc-300">
+    <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/70 p-4">
+      <p className="text-sm font-medium text-[var(--foreground)]">{title}</p>
+      <p className="mt-2 text-xs leading-5 text-[var(--text-tertiary)]">{body}</p>
+      <code className="mt-3 block rounded-lg bg-[var(--background)] px-3 py-2 text-[11px] text-[var(--text-secondary)]">
         {command}
       </code>
     </div>
@@ -601,10 +601,10 @@ function StatCard({
   color: string;
 }) {
   return (
-    <div className="bg-zinc-900 border border-zinc-800 rounded-xl p-4">
+    <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-4">
       <Icon className={`w-4 h-4 mb-2 ${color}`} />
       <div className="text-2xl font-bold font-mono">{value}</div>
-      <div className="text-xs text-zinc-500 mt-0.5">{label}</div>
+      <div className="text-xs text-[var(--text-tertiary)] mt-0.5">{label}</div>
     </div>
   );
 }

--- a/ui/app/proxy/page.tsx
+++ b/ui/app/proxy/page.tsx
@@ -16,7 +16,7 @@ export default function ProxyRedirect() {
   }, [router]);
   return (
     <div className="flex min-h-[40vh] items-center justify-center">
-      <Loader2 className="h-6 w-6 animate-spin text-zinc-500" />
+      <Loader2 className="h-6 w-6 animate-spin text-[var(--text-tertiary)]" />
     </div>
   );
 }

--- a/ui/app/remediation/page.tsx
+++ b/ui/app/remediation/page.tsx
@@ -80,7 +80,7 @@ function SortButton({
     <button
       onClick={() => onClick(field)}
       className={`flex items-center gap-0.5 text-xs font-medium uppercase tracking-wide transition-colors ${
-        active ? "text-zinc-200" : "text-zinc-500 hover:text-zinc-300"
+        active ? "text-[var(--foreground)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
       }`}
     >
       {label}
@@ -110,7 +110,7 @@ function NarrativeRow({
 
   return (
     <>
-      <tr className="hover:bg-zinc-900 transition-colors">
+      <tr className="hover:bg-[var(--surface)] transition-colors">
         {/* Package */}
         <td className="px-4 py-3">
           <div className="flex items-center gap-2">
@@ -120,11 +120,11 @@ function NarrativeRow({
               )}`}
             />
           <div>
-              <span className="font-mono text-xs text-zinc-200">
+              <span className="font-mono text-xs text-[var(--foreground)]">
                 {item.package}
               </span>
               <div className="mt-1 flex flex-wrap items-center gap-2 text-[11px]">
-                <span className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-400">
+                <span className="rounded border border-[var(--border-subtle)] bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[var(--text-secondary)]">
                   current {item.current_version}
                 </span>
               </div>
@@ -138,13 +138,13 @@ function NarrativeRow({
             {item.vulnerabilities.slice(0, 2).map((cve) => (
               <span
                 key={cve}
-                className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-[10px] text-zinc-300"
+                className="rounded border border-[var(--border-subtle)] bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--text-secondary)]"
               >
                 {cve}
               </span>
             ))}
             {item.vulnerabilities.length > 2 && (
-              <span className="text-[10px] text-zinc-500">+{item.vulnerabilities.length - 2}</span>
+              <span className="text-[10px] text-[var(--text-tertiary)]">+{item.vulnerabilities.length - 2}</span>
             )}
           </div>
         </td>
@@ -170,14 +170,14 @@ function NarrativeRow({
           {item.fixed_version ? (
             <span className="font-mono text-emerald-400">{item.fixed_version}</span>
           ) : (
-            <span className="text-zinc-600">N/A</span>
+            <span className="text-[var(--text-tertiary)]">N/A</span>
           )}
         </td>
 
         {/* Risk score */}
         <td className="px-4 py-3">
           <div className="flex items-center gap-2">
-            <div className="w-16 h-1.5 bg-zinc-800 rounded-full overflow-hidden">
+            <div className="w-16 h-1.5 bg-[var(--surface-elevated)] rounded-full overflow-hidden">
               <div
                 className={`h-full rounded-full ${
                   item.impact_score >= 8
@@ -191,16 +191,16 @@ function NarrativeRow({
                 style={{ width: `${(item.impact_score / 10) * 100}%` }}
               />
             </div>
-            <span className="text-xs font-mono text-zinc-300">
+            <span className="text-xs font-mono text-[var(--text-secondary)]">
               {item.impact_score.toFixed(1)}
             </span>
           </div>
         </td>
 
         {/* Reach */}
-        <td className="px-4 py-3 text-xs text-zinc-400">
+        <td className="px-4 py-3 text-xs text-[var(--text-secondary)]">
           <div>{item.affected_agents?.length ?? 0} agent{(item.affected_agents?.length ?? 0) !== 1 ? "s" : ""}</div>
-          <div className="text-zinc-600">{item.exposed_credentials?.length ?? 0} credential{(item.exposed_credentials?.length ?? 0) !== 1 ? "s" : ""}</div>
+          <div className="text-[var(--text-tertiary)]">{item.exposed_credentials?.length ?? 0} credential{(item.exposed_credentials?.length ?? 0) !== 1 ? "s" : ""}</div>
         </td>
 
         {/* Compliance tags */}
@@ -209,13 +209,13 @@ function NarrativeRow({
             {allTags.slice(0, 3).map((tag) => (
               <span
                 key={tag}
-                className="text-[10px] font-mono bg-zinc-800 border border-zinc-700 rounded px-1.5 py-0.5 text-zinc-400"
+                className="text-[10px] font-mono bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded px-1.5 py-0.5 text-[var(--text-secondary)]"
               >
                 {tag}
               </span>
             ))}
             {allTags.length > 3 && (
-              <span className="text-[10px] text-zinc-600">
+              <span className="text-[10px] text-[var(--text-tertiary)]">
                 +{allTags.length - 3}
               </span>
             )}
@@ -227,7 +227,7 @@ function NarrativeRow({
           {item.risk_narrative || item.command || item.verify_command ? (
             <button
               onClick={() => setExpanded((v) => !v)}
-              className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-zinc-800 hover:bg-zinc-700 text-zinc-400 hover:text-zinc-200 transition-colors"
+              className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] text-[var(--text-secondary)] hover:text-[var(--foreground)] transition-colors"
             >
               {expanded ? (
                 <ChevronUp className="w-3 h-3" />
@@ -237,7 +237,7 @@ function NarrativeRow({
               Details
             </button>
           ) : (
-            <span className="text-xs text-zinc-600">—</span>
+            <span className="text-xs text-[var(--text-tertiary)]">—</span>
           )}
         </td>
 
@@ -245,7 +245,7 @@ function NarrativeRow({
         <td className="px-4 py-3">
           <button
             onClick={() => onCreateJira(item)}
-            className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-zinc-800 hover:bg-zinc-700 text-zinc-300 hover:text-zinc-100 transition-colors"
+            className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] text-[var(--text-secondary)] hover:text-[var(--foreground)] transition-colors"
             title="Create Jira ticket"
           >
             <Ticket className="w-3 h-3" />
@@ -256,12 +256,12 @@ function NarrativeRow({
 
       {/* Expanded narrative */}
       {expanded && (item.risk_narrative || item.command || item.verify_command) && (
-        <tr className="bg-zinc-900/50">
+        <tr className="bg-[var(--surface)]/50">
           <td colSpan={9} className="px-6 py-4">
             <div className="grid gap-4 lg:grid-cols-[1.25fr_0.75fr]">
               <div className="space-y-3">
                 {item.risk_narrative ? (
-                  <div className="border-l-2 border-emerald-800 pl-3 text-xs leading-relaxed text-zinc-400">
+                  <div className="border-l-2 border-emerald-800 pl-3 text-xs leading-relaxed text-[var(--text-secondary)]">
                     {item.risk_narrative}
                   </div>
                 ) : null}
@@ -269,7 +269,7 @@ function NarrativeRow({
                   {item.vulnerabilities.map((cve) => (
                     <span
                       key={cve}
-                      className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-[10px] text-zinc-300"
+                      className="rounded border border-[var(--border-subtle)] bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--text-secondary)]"
                     >
                       {cve}
                     </span>
@@ -277,13 +277,13 @@ function NarrativeRow({
                 </div>
                 {(item.reachable_tools?.length ?? 0) > 0 && (
                   <div className="flex flex-wrap gap-1">
-                    <span className="mr-1 text-[10px] font-medium uppercase tracking-wide text-zinc-600">
+                    <span className="mr-1 text-[10px] font-medium uppercase tracking-wide text-[var(--text-tertiary)]">
                       Reachable tools
                     </span>
                     {item.reachable_tools.map((t) => (
                       <span
                         key={t}
-                        className="rounded border border-zinc-700 bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] text-zinc-500"
+                        className="rounded border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--text-tertiary)]"
                       >
                         {t}
                       </span>
@@ -293,17 +293,17 @@ function NarrativeRow({
               </div>
               <div className="space-y-3">
                 {item.command ? (
-                  <div className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-3">
-                    <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Recommended command</div>
+                  <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-3 py-3">
+                    <div className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Recommended command</div>
                     <code className="mt-2 block whitespace-pre-wrap font-mono text-xs leading-6 text-emerald-300">
                       {item.command}
                     </code>
                   </div>
                 ) : null}
                 {item.verify_command ? (
-                  <div className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-3">
-                    <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Verify</div>
-                    <code className="mt-2 block whitespace-pre-wrap font-mono text-xs leading-6 text-zinc-300">
+                  <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-3 py-3">
+                    <div className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Verify</div>
+                    <code className="mt-2 block whitespace-pre-wrap font-mono text-xs leading-6 text-[var(--text-secondary)]">
                       {item.verify_command}
                     </code>
                   </div>
@@ -371,12 +371,12 @@ function JiraModal({
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
         onClick={onClose}
       />
-      <div className="relative w-full max-w-md bg-zinc-900 border border-zinc-700/60 rounded-xl shadow-2xl overflow-hidden">
-        <div className="px-5 py-4 border-b border-zinc-800">
-          <h2 className="text-sm font-semibold text-zinc-100">
+      <div className="relative w-full max-w-md bg-[var(--surface)] border border-[var(--border-subtle)]/60 rounded-xl shadow-2xl overflow-hidden">
+        <div className="px-5 py-4 border-b border-[var(--border-subtle)]">
+          <h2 className="text-sm font-semibold text-[var(--foreground)]">
             Create Jira Ticket
           </h2>
-          <p className="text-xs text-zinc-500 mt-0.5">
+          <p className="text-xs text-[var(--text-tertiary)] mt-0.5">
             {item.package} {item.current_version}
           </p>
         </div>
@@ -388,7 +388,7 @@ function JiraModal({
             </p>
             <button
               onClick={onClose}
-              className="mt-4 px-4 py-2 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors"
+              className="mt-4 px-4 py-2 bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] border border-[var(--border-subtle)] text-[var(--text-secondary)] text-sm rounded-lg transition-colors"
             >
               Close
             </button>
@@ -430,7 +430,7 @@ function JiraModal({
               },
             ].map(({ id, label, val, set, type, placeholder }) => (
               <div key={id}>
-                <label className="block text-xs text-zinc-400 mb-1">
+                <label className="block text-xs text-[var(--text-secondary)] mb-1">
                   {label}
                 </label>
                 <input
@@ -439,7 +439,7 @@ function JiraModal({
                   onChange={(e) => set(e.target.value)}
                   placeholder={placeholder}
                   required
-                  className="w-full bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500"
+                  className="w-full bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded-lg px-3 py-1.5 text-sm text-[var(--foreground)] placeholder-[var(--text-tertiary)] focus:outline-none focus:border-[var(--border-strong)]"
                 />
               </div>
             ))}
@@ -450,7 +450,7 @@ function JiraModal({
               <button
                 type="button"
                 onClick={onClose}
-                className="px-3 py-1.5 text-xs text-zinc-400 hover:text-zinc-200 transition-colors"
+                className="px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--foreground)] transition-colors"
               >
                 Cancel
               </button>
@@ -476,7 +476,7 @@ export default function RemediationPageWrapper() {
   return (
     <Suspense
       fallback={
-        <div className="flex items-center justify-center py-20 text-zinc-400">
+        <div className="flex items-center justify-center py-20 text-[var(--text-secondary)]">
           <Loader2 className="h-6 w-6 animate-spin mr-2" />
           Loading remediation plan...
         </div>
@@ -605,7 +605,7 @@ function RemediationPage() {
     {
       key: "all",
       label: `All (${items.length})`,
-      color: "text-zinc-300",
+      color: "text-[var(--text-secondary)]",
     },
     {
       key: "critical",
@@ -642,7 +642,7 @@ function RemediationPage() {
           <h1 className="text-2xl font-semibold tracking-tight">
             Remediation
           </h1>
-          <p className="text-zinc-400 text-sm mt-1">
+          <p className="text-[var(--text-secondary)] text-sm mt-1">
             {items.length} packages prioritized by reach, severity, and available fixes
           </p>
         </div>
@@ -654,7 +654,7 @@ function RemediationPage() {
                 `remediation-plan-${new Date().toISOString().slice(0, 10)}.json`
               )
             }
-            className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 text-sm font-medium rounded-lg transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] border border-[var(--border-subtle)] text-[var(--text-secondary)] text-sm font-medium rounded-lg transition-colors"
             title="Export remediation plan as JSON"
           >
             <Download className="w-3.5 h-3.5" />
@@ -665,7 +665,7 @@ function RemediationPage() {
 
       {/* Loading */}
       {loading && (
-        <div className="flex items-center justify-center py-20 text-zinc-400">
+        <div className="flex items-center justify-center py-20 text-[var(--text-secondary)]">
           <Loader2 className="h-6 w-6 animate-spin mr-2" />
           Loading remediation plan...
         </div>
@@ -673,11 +673,11 @@ function RemediationPage() {
 
       {/* Error */}
       {!loading && error && (
-        <div className="text-center py-12 border border-dashed border-zinc-800 rounded-xl">
+        <div className="text-center py-12 border border-dashed border-[var(--border-subtle)] rounded-xl">
           <p className="text-red-400 text-sm mb-3">{error}</p>
           <button
             onClick={load}
-            className="px-3 py-1.5 bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 text-zinc-300 text-sm rounded-lg transition-colors"
+            className="px-3 py-1.5 bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] border border-[var(--border-subtle)] text-[var(--text-secondary)] text-sm rounded-lg transition-colors"
           >
             Retry
           </button>
@@ -686,12 +686,12 @@ function RemediationPage() {
 
       {/* Empty */}
       {!loading && !error && items.length === 0 && (
-        <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
-          <Wrench className="w-8 h-8 text-zinc-700 mx-auto mb-3" />
-          <p className="text-zinc-500 text-sm">
+        <div className="text-center py-16 border border-dashed border-[var(--border-subtle)] rounded-xl">
+          <Wrench className="w-8 h-8 text-[var(--text-tertiary)] mx-auto mb-3" />
+          <p className="text-[var(--text-tertiary)] text-sm">
             Run a scan to see remediation recommendations
           </p>
-          <p className="text-zinc-600 text-xs mt-1">
+          <p className="text-[var(--text-tertiary)] text-xs mt-1">
             Remediation plans are generated automatically after each completed
             scan.
           </p>
@@ -702,22 +702,22 @@ function RemediationPage() {
       {!loading && !error && items.length > 0 && (
         <>
           {/* Compliance impact summary */}
-          <div className="bg-zinc-900 border border-zinc-800 rounded-xl px-5 py-4">
-            <p className="text-sm text-zinc-300">
+          <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl px-5 py-4">
+            <p className="text-sm text-[var(--text-secondary)]">
               <span className="font-semibold text-emerald-400">
                 Fixing the top 5 packages
               </span>{" "}
               clears{" "}
-              <span className="font-semibold text-zinc-100">
+              <span className="font-semibold text-[var(--foreground)]">
                 {impact.controls} controls
               </span>{" "}
               across{" "}
-              <span className="font-semibold text-zinc-100">
+              <span className="font-semibold text-[var(--foreground)]">
                 {impact.frameworks} framework
                 {impact.frameworks !== 1 ? "s" : ""}
               </span>
             </p>
-            <p className="text-xs text-zinc-600 mt-1">
+            <p className="text-xs text-[var(--text-tertiary)] mt-1">
               Based on OWASP LLM Top 10 and MITRE ATLAS tags assigned to each
               remediation item.
             </p>
@@ -734,8 +734,8 @@ function RemediationPage() {
                     onClick={() => setSeverityFilter(key)}
                     className={`px-3 py-1 text-xs font-medium rounded-md border transition-colors ${
                       severityFilter === key
-                        ? `${color} border-zinc-600 bg-zinc-800`
-                        : "text-zinc-500 border-zinc-800 hover:border-zinc-700 hover:text-zinc-300"
+                        ? `${color} border-[var(--border-strong)] bg-[var(--surface-elevated)]`
+                        : "text-[var(--text-tertiary)] border-[var(--border-subtle)] hover:border-[var(--border-subtle)] hover:text-[var(--text-secondary)]"
                     }`}
                   >
                     {label}
@@ -751,8 +751,8 @@ function RemediationPage() {
                     onClick={() => setFrameworkFilter(key)}
                     className={`px-3 py-1 text-xs font-medium rounded-md border transition-colors ${
                       frameworkFilter === key
-                        ? "text-zinc-200 border-zinc-600 bg-zinc-800"
-                        : "text-zinc-500 border-zinc-800 hover:border-zinc-700 hover:text-zinc-300"
+                        ? "text-[var(--foreground)] border-[var(--border-strong)] bg-[var(--surface-elevated)]"
+                        : "text-[var(--text-tertiary)] border-[var(--border-subtle)] hover:border-[var(--border-subtle)] hover:text-[var(--text-secondary)]"
                     }`}
                   >
                     {label}
@@ -763,7 +763,7 @@ function RemediationPage() {
                   className={`px-3 py-1 text-xs font-medium rounded-md border transition-colors ${
                     fixableOnly
                       ? "text-emerald-400 border-emerald-800 bg-emerald-950/40"
-                      : "text-zinc-500 border-zinc-800 hover:border-zinc-700 hover:text-zinc-300"
+                      : "text-[var(--text-tertiary)] border-[var(--border-subtle)] hover:border-[var(--border-subtle)] hover:text-[var(--text-secondary)]"
                   }`}
                 >
                   Fixable only
@@ -773,14 +773,14 @@ function RemediationPage() {
           </div>
 
           {/* Table */}
-          <div className="border border-zinc-800 rounded-xl overflow-hidden overflow-x-auto">
+          <div className="border border-[var(--border-subtle)] rounded-xl overflow-hidden overflow-x-auto">
             <table className="w-full text-sm">
-              <thead className="bg-zinc-900 border-b border-zinc-800">
+              <thead className="bg-[var(--surface)] border-b border-[var(--border-subtle)]">
                 <tr>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">
                     Package
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">
                     CVEs
                   </th>
                   <th className="text-left px-4 py-3">
@@ -792,7 +792,7 @@ function RemediationPage() {
                       onClick={handleSort}
                     />
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">
                     Fix
                   </th>
                   <th className="text-left px-4 py-3">
@@ -804,21 +804,21 @@ function RemediationPage() {
                       onClick={handleSort}
                     />
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">
                     Reach
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">
                     Compliance
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">
                     Details
                   </th>
-                  <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">
                     Actions
                   </th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-zinc-800 bg-zinc-950">
+              <tbody className="divide-y divide-[var(--border-subtle)] bg-[var(--background)]">
                 {paged.map((item) => (
                   <NarrativeRow
                     key={`${item.package}-${item.current_version}`}
@@ -830,7 +830,7 @@ function RemediationPage() {
             </table>
 
             {paged.length === 0 && (
-              <div className="px-4 py-8 text-center text-zinc-600 text-sm">
+              <div className="px-4 py-8 text-center text-[var(--text-tertiary)] text-sm">
                 No items match your filters.
               </div>
             )}

--- a/ui/app/runtime/page.tsx
+++ b/ui/app/runtime/page.tsx
@@ -33,10 +33,10 @@ function RuntimeTabs() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-4 border-b border-zinc-800 pb-4 lg:flex-row lg:items-end lg:justify-between">
+      <div className="flex flex-col gap-4 border-b border-[var(--border-subtle)] pb-4 lg:flex-row lg:items-end lg:justify-between">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight text-zinc-100">Runtime</h1>
-          <p className="mt-1 max-w-3xl text-sm text-zinc-400">
+          <h1 className="text-2xl font-semibold tracking-tight text-[var(--foreground)]">Runtime</h1>
+          <p className="mt-1 max-w-3xl text-sm text-[var(--text-secondary)]">
             One enforcement surface for MCP proxy telemetry and gateway policy. Switch tabs to review live
             activity, alerts, rollout posture, and audit evidence without hopping between nav entries.
           </p>
@@ -53,7 +53,7 @@ function RuntimeTabs() {
                 className={`inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium transition-colors ${
                   selected
                     ? "border-emerald-700 bg-emerald-950/40 text-emerald-200"
-                    : "border-zinc-800 bg-zinc-950 text-zinc-400 hover:border-zinc-700 hover:text-zinc-200"
+                    : "border-[var(--border-subtle)] bg-[var(--background)] text-[var(--text-secondary)] hover:border-[var(--border-subtle)] hover:text-[var(--foreground)]"
                 }`}
               >
                 <Icon className="h-4 w-4" />
@@ -64,7 +64,7 @@ function RuntimeTabs() {
         </div>
       </div>
 
-      <p className="text-xs text-zinc-500">{active.description}</p>
+      <p className="text-xs text-[var(--text-tertiary)]">{active.description}</p>
 
       <RuntimeEmbedProvider>
         {tab === "proxy" ? <ProxyDashboard /> : <GatewayPage />}
@@ -78,7 +78,7 @@ export default function RuntimePage() {
     <Suspense
       fallback={
         <div className="flex min-h-[40vh] items-center justify-center">
-          <Loader2 className="h-6 w-6 animate-spin text-zinc-500" />
+          <Loader2 className="h-6 w-6 animate-spin text-[var(--text-tertiary)]" />
         </div>
       }
     >

--- a/ui/app/scan/page.tsx
+++ b/ui/app/scan/page.tsx
@@ -28,7 +28,7 @@ export default function ScanPage() {
   return (
     <Suspense
       fallback={
-        <div className="flex items-center justify-center h-[50vh] text-zinc-400">
+        <div className="flex items-center justify-center h-[50vh] text-[var(--text-secondary)]">
           <Loader2 className="w-5 h-5 animate-spin mr-2" />Loading...
         </div>
       }

--- a/ui/app/sources/page.tsx
+++ b/ui/app/sources/page.tsx
@@ -224,7 +224,7 @@ function toneForStatus(status: string): string {
     case "degraded":
       return "text-amber-400";
     case "disabled":
-      return "text-zinc-400";
+      return "text-[var(--text-secondary)]";
     default:
       return "text-sky-400";
   }
@@ -1123,7 +1123,7 @@ function ProviderContractCard({ provider }: { provider: DiscoveryProviderContrac
           className={`rounded-full border px-2.5 py-1 text-[11px] font-medium ${
             trust.supports_scope_zero
               ? "border-emerald-900 bg-emerald-950/40 text-emerald-300"
-              : "border-zinc-800 bg-zinc-950/60 text-zinc-400"
+              : "border-[var(--border-subtle)] bg-[var(--background)]/60 text-[var(--text-secondary)]"
           }`}
         >
           {trust.supports_scope_zero ? "scope-zero" : "direct pull"}
@@ -1158,7 +1158,7 @@ function ProviderContractCard({ provider }: { provider: DiscoveryProviderContrac
           <span className="text-[var(--text-tertiary)]">Permissions used: </span>
           <span className="text-[var(--foreground)]">{permissions.length}</span>
           {permissions.length > 0 ? (
-            <span className="ml-1 font-mono text-[11px] text-zinc-400">
+            <span className="ml-1 font-mono text-[11px] text-[var(--text-secondary)]">
               {permissions.slice(0, 3).join(", ")}
               {permissions.length > 3 ? ` +${permissions.length - 3}` : ""}
             </span>
@@ -1166,7 +1166,7 @@ function ProviderContractCard({ provider }: { provider: DiscoveryProviderContrac
         </div>
         <div>
           <span className="text-[var(--text-tertiary)]">Network: </span>
-          <span className="font-mono text-[11px] text-zinc-400">
+          <span className="font-mono text-[11px] text-[var(--text-secondary)]">
             {destinations.length ? destinations.slice(0, 3).join(", ") : "none"}
             {destinations.length > 3 ? ` +${destinations.length - 3}` : ""}
           </span>

--- a/ui/app/traces/page.tsx
+++ b/ui/app/traces/page.tsx
@@ -82,22 +82,22 @@ export default function TracesPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-4 rounded-3xl border border-zinc-800 bg-zinc-950/70 p-6 shadow-2xl shadow-black/20 lg:flex-row lg:items-start lg:justify-between">
+      <div className="flex flex-col gap-4 rounded-3xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-6 shadow-2xl shadow-black/20 lg:flex-row lg:items-start lg:justify-between">
         <div className="max-w-3xl">
           <p className="text-[11px] uppercase tracking-[0.22em] text-emerald-400">Trace review</p>
-          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-zinc-100">Runtime tool-call correlation</h1>
-          <p className="mt-3 text-sm leading-6 text-zinc-400">
+          <h1 className="mt-2 text-3xl font-semibold tracking-tight text-[var(--foreground)]">Runtime tool-call correlation</h1>
+          <p className="mt-3 text-sm leading-6 text-[var(--text-secondary)]">
             {tracesUnavailable
               ? "Trace ingest is not enabled for this estate yet. Use the explorer when gateway traffic exists, or paste OTLP JSON to validate correlation."
               : "Explore blocked and observed tool calls joined to the same findings and compliance controls surfaced in triage."}{" "}
-            Production collectors send OTLP JSON to <code className="rounded bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-200">POST /v1/traces</code>.
+            Production collectors send OTLP JSON to <code className="rounded bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[var(--foreground)]">POST /v1/traces</code>.
           </p>
-          <div className="mt-4 inline-flex rounded-xl border border-zinc-800 bg-zinc-900/70 p-1">
+          <div className="mt-4 inline-flex rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/70 p-1">
             <button
               type="button"
               onClick={() => setMode("explorer")}
               className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs ${
-                mode === "explorer" ? "bg-emerald-600 text-white" : "text-zinc-400 hover:text-zinc-200"
+                mode === "explorer" ? "bg-emerald-600 text-white" : "text-[var(--text-secondary)] hover:text-[var(--foreground)]"
               }`}
             >
               <GitBranch className="h-3.5 w-3.5" />
@@ -107,7 +107,7 @@ export default function TracesPage() {
               type="button"
               onClick={() => setMode("queue")}
               className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs ${
-                mode === "queue" ? "bg-emerald-600 text-white" : "text-zinc-400 hover:text-zinc-200"
+                mode === "queue" ? "bg-emerald-600 text-white" : "text-[var(--text-secondary)] hover:text-[var(--foreground)]"
               }`}
             >
               <ShieldAlert className="h-3.5 w-3.5" />
@@ -117,7 +117,7 @@ export default function TracesPage() {
               type="button"
               onClick={() => setMode("ingest")}
               className={`inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs ${
-                mode === "ingest" ? "bg-emerald-600 text-white" : "text-zinc-400 hover:text-zinc-200"
+                mode === "ingest" ? "bg-emerald-600 text-white" : "text-[var(--text-secondary)] hover:text-[var(--foreground)]"
               }`}
             >
               <FileUp className="h-3.5 w-3.5" />
@@ -125,16 +125,16 @@ export default function TracesPage() {
             </button>
           </div>
         </div>
-        <div className="grid gap-3 text-xs text-zinc-400 sm:grid-cols-2 lg:w-[360px]">
-          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4">
-            <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Input</div>
-            <div className="mt-2 text-sm text-zinc-200">OTLP JSON export</div>
-            <div className="mt-1 text-zinc-500">Paste, upload, or send directly from a collector.</div>
+        <div className="grid gap-3 text-xs text-[var(--text-secondary)] sm:grid-cols-2 lg:w-[360px]">
+          <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/60 p-4">
+            <div className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Input</div>
+            <div className="mt-2 text-sm text-[var(--foreground)]">OTLP JSON export</div>
+            <div className="mt-1 text-[var(--text-tertiary)]">Paste, upload, or send directly from a collector.</div>
           </div>
-          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4">
-            <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Output</div>
-            <div className="mt-2 text-sm text-zinc-200">Flagged tool calls</div>
-            <div className="mt-1 text-zinc-500">Server, package, CVE, and severity correlation.</div>
+          <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/60 p-4">
+            <div className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Output</div>
+            <div className="mt-2 text-sm text-[var(--foreground)]">Flagged tool calls</div>
+            <div className="mt-1 text-[var(--text-tertiary)]">Server, package, CVE, and severity correlation.</div>
           </div>
         </div>
       </div>
@@ -145,21 +145,21 @@ export default function TracesPage() {
         <HitlApprovalQueuePanel />
       ) : (
       <div className="grid grid-cols-1 gap-6 xl:grid-cols-[1.05fr_0.95fr]">
-        <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-5">
+        <section className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-5">
           <div className="flex items-center justify-between gap-3">
             <div>
-              <h2 className="text-sm font-semibold text-zinc-200">Trace intake</h2>
-              <p className="mt-1 text-xs text-zinc-500">Use a real OTLP export or the sample payload for a quick validation run.</p>
+              <h2 className="text-sm font-semibold text-[var(--foreground)]">Trace intake</h2>
+              <p className="mt-1 text-xs text-[var(--text-tertiary)]">Use a real OTLP export or the sample payload for a quick validation run.</p>
             </div>
             <div className="flex flex-wrap gap-2">
-              <label className="inline-flex cursor-pointer items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-200 transition-colors hover:bg-zinc-700">
+              <label className="inline-flex cursor-pointer items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-xs text-[var(--foreground)] transition-colors hover:bg-[var(--surface-muted)]">
                 <FileUp className="h-3.5 w-3.5" />
                 Upload JSON
                 <input type="file" accept=".json,application/json" className="hidden" onChange={handleFile} />
               </label>
               <button
                 onClick={() => setPayload(SAMPLE_PAYLOAD)}
-                className="inline-flex items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800 px-3 py-2 text-xs text-zinc-200 transition-colors hover:bg-zinc-700"
+                className="inline-flex items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-xs text-[var(--foreground)] transition-colors hover:bg-[var(--surface-muted)]"
               >
                 <PlayCircle className="h-3.5 w-3.5" />
                 Use sample
@@ -171,7 +171,7 @@ export default function TracesPage() {
             value={payload}
             onChange={(e) => setPayload(e.target.value)}
             rows={18}
-            className="mt-4 w-full resize-none rounded-2xl border border-zinc-800 bg-zinc-950 px-4 py-3 font-mono text-xs leading-6 text-zinc-300 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+            className="mt-4 w-full resize-none rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)] px-4 py-3 font-mono text-xs leading-6 text-[var(--text-secondary)] focus:outline-none focus:ring-1 focus:ring-emerald-500"
             spellCheck={false}
           />
 
@@ -184,25 +184,25 @@ export default function TracesPage() {
               {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
               Run correlation
             </button>
-            <p className="text-xs text-zinc-500">
-              Endpoint: <code className="rounded bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-300">POST /v1/traces</code>
+            <p className="text-xs text-[var(--text-tertiary)]">
+              Endpoint: <code className="rounded bg-[var(--background)] px-1.5 py-0.5 font-mono text-[var(--text-secondary)]">POST /v1/traces</code>
             </p>
           </div>
         </section>
 
-        <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-5">
+        <section className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-5">
           <div className="flex items-center justify-between gap-3">
             <div>
-              <h2 className="text-sm font-semibold text-zinc-200">Correlation result</h2>
-              <p className="mt-1 text-xs text-zinc-500">Review flagged calls with mapped server, package, and CVE context.</p>
+              <h2 className="text-sm font-semibold text-[var(--foreground)]">Correlation result</h2>
+              <p className="mt-1 text-xs text-[var(--text-tertiary)]">Review flagged calls with mapped server, package, and CVE context.</p>
             </div>
           </div>
 
           {!result && !error && (
-            <div className="mt-4 rounded-2xl border border-dashed border-zinc-800 py-16 text-center">
-              <Activity className="mx-auto mb-3 h-8 w-8 text-zinc-700" />
-              <p className="text-sm text-zinc-500">No trace run yet.</p>
-              <p className="mt-1 text-xs text-zinc-600">Submit a payload to validate correlation against known vulnerable assets.</p>
+            <div className="mt-4 rounded-2xl border border-dashed border-[var(--border-subtle)] py-16 text-center">
+              <Activity className="mx-auto mb-3 h-8 w-8 text-[var(--text-tertiary)]" />
+              <p className="text-sm text-[var(--text-tertiary)]">No trace run yet.</p>
+              <p className="mt-1 text-xs text-[var(--text-tertiary)]">Submit a payload to validate correlation against known vulnerable assets.</p>
             </div>
           )}
 
@@ -218,12 +218,12 @@ export default function TracesPage() {
           {result && (
             <div className="mt-4 space-y-4">
               <div className="grid grid-cols-2 gap-3">
-                <div className="rounded-2xl border border-zinc-800 bg-zinc-950 px-4 py-3">
-                  <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Traces parsed</div>
-                  <div className="mt-2 text-2xl font-semibold text-zinc-100">{result.traces}</div>
+                <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)] px-4 py-3">
+                  <div className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Traces parsed</div>
+                  <div className="mt-2 text-2xl font-semibold text-[var(--foreground)]">{result.traces}</div>
                 </div>
-                <div className="rounded-2xl border border-zinc-800 bg-zinc-950 px-4 py-3">
-                  <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Flagged calls</div>
+                <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)] px-4 py-3">
+                  <div className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Flagged calls</div>
                   <div className={`mt-2 text-2xl font-semibold ${result.flagged.length > 0 ? "text-red-400" : "text-emerald-400"}`}>
                     {result.flagged.length}
                   </div>
@@ -231,7 +231,7 @@ export default function TracesPage() {
               </div>
 
               {result.message ? (
-                <div className="rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-3 text-xs text-zinc-500">
+                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-4 py-3 text-xs text-[var(--text-tertiary)]">
                   {result.message}
                 </div>
               ) : null}
@@ -244,40 +244,40 @@ export default function TracesPage() {
                   </div>
                 </div>
               ) : (
-                <div className="overflow-hidden rounded-2xl border border-zinc-800">
+                <div className="overflow-hidden rounded-2xl border border-[var(--border-subtle)]">
                   <table className="w-full text-sm">
-                    <thead className="bg-zinc-900 border-b border-zinc-800">
+                    <thead className="bg-[var(--surface)] border-b border-[var(--border-subtle)]">
                       <tr>
-                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Tool</th>
-                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Server</th>
-                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Package</th>
-                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">CVEs</th>
-                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Risk</th>
+                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Tool</th>
+                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Server</th>
+                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Package</th>
+                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">CVEs</th>
+                        <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Risk</th>
                       </tr>
                     </thead>
-                    <tbody className="divide-y divide-zinc-800 bg-zinc-950">
+                    <tbody className="divide-y divide-[var(--border-subtle)] bg-[var(--background)]">
                       {result.flagged.map((flagged) => (
-                        <tr key={`${flagged.span_id}-${flagged.tool_name}`} className="align-top hover:bg-zinc-900/70">
+                        <tr key={`${flagged.span_id}-${flagged.tool_name}`} className="align-top hover:bg-[var(--surface)]/70">
                           <td className="px-4 py-3">
-                            <div className="font-mono text-xs text-zinc-200">{flagged.tool_name}</div>
-                            <div className="mt-1 text-xs text-zinc-500">{flagged.reason}</div>
+                            <div className="font-mono text-xs text-[var(--foreground)]">{flagged.tool_name}</div>
+                            <div className="mt-1 text-xs text-[var(--text-tertiary)]">{flagged.reason}</div>
                           </td>
-                          <td className="px-4 py-3 text-xs text-zinc-400">{flagged.server || "N/A"}</td>
-                          <td className="px-4 py-3 text-xs text-zinc-400">{flagged.package_name || "N/A"}</td>
+                          <td className="px-4 py-3 text-xs text-[var(--text-secondary)]">{flagged.server || "N/A"}</td>
+                          <td className="px-4 py-3 text-xs text-[var(--text-secondary)]">{flagged.package_name || "N/A"}</td>
                           <td className="px-4 py-3">
                             {flagged.cve_ids.length > 0 ? (
                               <div className="flex flex-wrap gap-1">
                                 {flagged.cve_ids.map((cve) => (
                                   <span
                                     key={cve}
-                                    className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-[10px] text-zinc-300"
+                                    className="rounded border border-[var(--border-subtle)] bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--text-secondary)]"
                                   >
                                     {cve}
                                   </span>
                                 ))}
                               </div>
                             ) : (
-                              <span className="text-xs text-zinc-600">N/A</span>
+                              <span className="text-xs text-[var(--text-tertiary)]">N/A</span>
                             )}
                           </td>
                           <td className="px-4 py-3">

--- a/ui/app/vulns/page.tsx
+++ b/ui/app/vulns/page.tsx
@@ -16,7 +16,7 @@ function VulnsRedirect() {
   }, [router, searchParams]);
   return (
     <div className="flex min-h-[40vh] items-center justify-center">
-      <Loader2 className="h-6 w-6 animate-spin text-zinc-500" />
+      <Loader2 className="h-6 w-6 animate-spin text-[var(--text-tertiary)]" />
     </div>
   );
 }
@@ -26,7 +26,7 @@ export default function VulnsRedirectPage() {
     <Suspense
       fallback={
         <div className="flex min-h-[40vh] items-center justify-center">
-          <Loader2 className="h-6 w-6 animate-spin text-zinc-500" />
+          <Loader2 className="h-6 w-6 animate-spin text-[var(--text-tertiary)]" />
         </div>
       }
     >

--- a/ui/components/activity-feed.tsx
+++ b/ui/components/activity-feed.tsx
@@ -152,15 +152,15 @@ export function ActivityFeed({
 
   return (
     <div
-      className={`bg-zinc-900 border border-zinc-800 rounded-xl ${className ?? ""}`}
+      className={`bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl ${className ?? ""}`}
     >
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
-        <h3 className="text-sm font-semibold text-zinc-300">Activity</h3>
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border-subtle)]">
+        <h3 className="text-sm font-semibold text-[var(--text-secondary)]">Activity</h3>
         <select
           value={filter}
           onChange={(e) => setFilter(e.target.value as ActivityType | "all")}
-          className="text-xs bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-zinc-400"
+          className="text-xs bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded px-2 py-1 text-[var(--text-secondary)]"
         >
           <option value="all">All</option>
           <option value="scan_started">Scans</option>
@@ -170,13 +170,13 @@ export function ActivityFeed({
       </div>
 
       {/* Event list */}
-      <div className="divide-y divide-zinc-800 max-h-[400px] overflow-y-auto">
+      <div className="divide-y divide-[var(--border-subtle)] max-h-[400px] overflow-y-auto">
         {loading ? (
-          <div className="p-4 text-center text-zinc-600 text-xs">
+          <div className="p-4 text-center text-[var(--text-tertiary)] text-xs">
             Loading...
           </div>
         ) : filtered.length === 0 ? (
-          <div className="p-4 text-center text-zinc-600 text-xs">
+          <div className="p-4 text-center text-[var(--text-tertiary)] text-xs">
             No activity yet
           </div>
         ) : (
@@ -186,16 +186,16 @@ export function ActivityFeed({
             return (
               <div
                 key={event.id}
-                className="flex items-start gap-3 px-4 py-3 hover:bg-zinc-800/50 transition-colors"
+                className="flex items-start gap-3 px-4 py-3 hover:bg-[var(--surface-elevated)]/50 transition-colors"
               >
                 <Icon
                   className={`w-3.5 h-3.5 mt-0.5 shrink-0 ${color}`}
                 />
                 <div className="flex-1 min-w-0">
-                  <p className="text-xs text-zinc-300 leading-tight truncate">
+                  <p className="text-xs text-[var(--text-secondary)] leading-tight truncate">
                     {event.message}
                   </p>
-                  <p className="text-[10px] text-zinc-600 mt-0.5">
+                  <p className="text-[10px] text-[var(--text-tertiary)] mt-0.5">
                     {timeAgo(event.timestamp)}
                   </p>
                 </div>

--- a/ui/components/api-offline-state.tsx
+++ b/ui/components/api-offline-state.tsx
@@ -71,35 +71,35 @@ export function ApiOfflineState({
 
   return (
     <div className="py-10">
-      <div className="mx-auto max-w-5xl rounded-3xl border border-zinc-800 bg-zinc-950/70 p-6 shadow-2xl shadow-black/20 md:p-8">
+      <div className="mx-auto max-w-5xl rounded-3xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-6 shadow-2xl shadow-black/20 md:p-8">
         <div className="mx-auto max-w-3xl text-center">
           <AlertTriangle className="mx-auto mb-4 h-11 w-11 text-orange-400" />
-          <h2 className="text-2xl font-semibold tracking-tight text-zinc-100">{resolvedTitle}</h2>
+          <h2 className="text-2xl font-semibold tracking-tight text-[var(--foreground)]">{resolvedTitle}</h2>
           {kind === "network" ? (
-            <p className="mt-3 text-sm leading-6 text-zinc-400">
+            <p className="mt-3 text-sm leading-6 text-[var(--text-secondary)]">
               Run the local stack at{" "}
-              <code className="rounded bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-200">
+              <code className="rounded bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[var(--foreground)]">
                 {apiUrl}
               </code>{" "}
               so the dashboard can load live scan data, graph views, and compliance surfaces.
             </p>
           ) : kind === "auth" ? (
-            <p className="mt-3 text-sm leading-6 text-zinc-400">
+            <p className="mt-3 text-sm leading-6 text-[var(--text-secondary)]">
               The API is reachable but rejected an unauthenticated request. Sign in via your IdP, set{" "}
-              <code className="rounded bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-200">AGENT_BOM_API_KEY</code>{" "}
-              when launching <code className="rounded bg-zinc-900 px-1.5 py-0.5 font-mono text-zinc-200">agent-bom serve</code>,
+              <code className="rounded bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[var(--foreground)]">AGENT_BOM_API_KEY</code>{" "}
+              when launching <code className="rounded bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[var(--foreground)]">agent-bom serve</code>,
               or request access from your administrator.
             </p>
           ) : (
-            <p className="mt-3 text-sm leading-6 text-zinc-400">
+            <p className="mt-3 text-sm leading-6 text-[var(--text-secondary)]">
               Authenticated, but your role doesn&apos;t carry the permissions this view needs.
               Ask your administrator to grant a role with the relevant scope, or browse a
               tab that fits your current role.
             </p>
           )}
           {resolvedDetail ? (
-            <p className="mt-3 text-xs text-zinc-500">
-              Current error: <span className="font-mono text-zinc-400">{resolvedDetail}</span>
+            <p className="mt-3 text-xs text-[var(--text-tertiary)]">
+              Current error: <span className="font-mono text-[var(--text-secondary)]">{resolvedDetail}</span>
             </p>
           ) : null}
         </div>
@@ -112,10 +112,10 @@ export function ApiOfflineState({
                   <PlayCircle className="h-4 w-4" />
                   Recommended: start the full product surface
                 </div>
-                <p className="mb-4 text-sm text-zinc-400">
+                <p className="mb-4 text-sm text-[var(--text-secondary)]">
                   This starts the API and serves the bundled dashboard from one command path.
                 </p>
-                <code className="block rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-3 font-mono text-sm leading-7 text-emerald-400">
+                <code className="block rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-4 py-3 font-mono text-sm leading-7 text-emerald-400">
                   pip install &apos;agent-bom[ui]&apos;
                   <br />
                   agent-bom serve
@@ -127,10 +127,10 @@ export function ApiOfflineState({
                   <Server className="h-4 w-4" />
                   API only
                 </div>
-                <p className="mb-4 text-sm text-zinc-400">
+                <p className="mb-4 text-sm text-[var(--text-secondary)]">
                   Use this if the dashboard is already running separately and only the backend is missing.
                 </p>
-                <code className="block rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-3 font-mono text-sm leading-7 text-blue-300">
+                <code className="block rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-4 py-3 font-mono text-sm leading-7 text-blue-300">
                   pip install &apos;agent-bom[api]&apos;
                   <br />
                   agent-bom api
@@ -138,23 +138,23 @@ export function ApiOfflineState({
               </div>
             </div>
 
-            <div className="mt-4 rounded-2xl border border-zinc-800 bg-zinc-900/60 p-4 text-sm text-zinc-400">
+            <div className="mt-4 rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/60 p-4 text-sm text-[var(--text-secondary)]">
               If the API is already running and you still see this page, check the browser console for CORS errors and confirm{" "}
-              <code className="rounded bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-200">NEXT_PUBLIC_API_URL</code>{" "}
+              <code className="rounded bg-[var(--background)] px-1.5 py-0.5 font-mono text-[var(--foreground)]">NEXT_PUBLIC_API_URL</code>{" "}
               points to{" "}
-              <code className="rounded bg-zinc-950 px-1.5 py-0.5 font-mono text-zinc-200">{apiUrl}</code>.
+              <code className="rounded bg-[var(--background)] px-1.5 py-0.5 font-mono text-[var(--foreground)]">{apiUrl}</code>.
             </div>
           </>
         ) : null}
 
         {onImport ? (
-          <div className="mt-6 rounded-2xl border border-dashed border-zinc-700 bg-zinc-900/40 p-6 text-center">
-            <FileText className="mx-auto mb-3 h-8 w-8 text-zinc-500" />
-            <h3 className="text-sm font-semibold text-zinc-200">Or stay offline and import a real report</h3>
-            <p className="mt-2 text-sm text-zinc-500">
+          <div className="mt-6 rounded-2xl border border-dashed border-[var(--border-subtle)] bg-[var(--surface)]/40 p-6 text-center">
+            <FileText className="mx-auto mb-3 h-8 w-8 text-[var(--text-tertiary)]" />
+            <h3 className="text-sm font-semibold text-[var(--foreground)]">Or stay offline and import a real report</h3>
+            <p className="mt-2 text-sm text-[var(--text-tertiary)]">
               Use the built-in demo for a reproducible sample, or export a real project scan and load it here.
             </p>
-            <code className="mt-4 block rounded-xl border border-zinc-800 bg-zinc-950 px-4 py-3 font-mono text-xs leading-7 text-zinc-300">
+            <code className="mt-4 block rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-4 py-3 font-mono text-xs leading-7 text-[var(--text-secondary)]">
               agent-bom agents --demo --offline -f json -o report.json
               <br />
               agent-bom agents -p . -f json -o report.json
@@ -164,7 +164,7 @@ export function ApiOfflineState({
                 <p className="break-words text-xs font-mono text-red-400">{importError}</p>
               </div>
             ) : null}
-            <label className="mt-5 inline-flex cursor-pointer items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm text-zinc-200 transition-colors hover:bg-zinc-700">
+            <label className="mt-5 inline-flex cursor-pointer items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-4 py-2 text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--surface-muted)]">
               <FileText className="h-4 w-4" />
               Choose report.json
               <input
@@ -174,13 +174,13 @@ export function ApiOfflineState({
                 onChange={handleFile}
               />
             </label>
-            <p className="mt-3 text-xs text-zinc-600">Max 10 MB. Schema-validated before import.</p>
+            <p className="mt-3 text-xs text-[var(--text-tertiary)]">Max 10 MB. Schema-validated before import.</p>
           </div>
         ) : (
           <div className="mt-6 text-center">
             <Link
               href="/"
-              className="inline-flex items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm text-zinc-200 transition-colors hover:bg-zinc-700"
+              className="inline-flex items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-4 py-2 text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--surface-muted)]"
             >
               <FileText className="h-4 w-4" />
               Import a local report from the home page

--- a/ui/components/attack-flow.tsx
+++ b/ui/components/attack-flow.tsx
@@ -31,7 +31,7 @@ const NODE_ICONS: Record<string, React.ElementType> = {
 
 const NODE_COLORS: Record<string, string> = {
   cve: "border-red-600 bg-red-950/80",
-  package: "border-zinc-600 bg-zinc-900/80",
+  package: "border-[var(--border-strong)] bg-[var(--surface)]/80",
   server: "border-blue-600 bg-blue-950/80",
   agent: "border-emerald-600 bg-emerald-950/80",
   credential: "border-yellow-600 bg-yellow-950/80",
@@ -58,10 +58,10 @@ function AttackFlowNode({ data }: { data: AttackFlowNodeData }) {
 
   return (
     <div className={`rounded-lg border-2 px-3 py-2 min-w-[140px] max-w-[220px] shadow-lg backdrop-blur ${colorClass}`}>
-      {showTarget && <Handle type="target" position={Position.Left} className="!bg-zinc-500 !w-2 !h-2 !border-zinc-400" />}
+      {showTarget && <Handle type="target" position={Position.Left} className="!bg-[var(--text-tertiary)] !w-2 !h-2 !border-[var(--border-strong)]" />}
       <div className="flex items-center gap-1.5 mb-0.5">
         <Icon className="w-3.5 h-3.5 shrink-0" />
-        <span className="text-xs font-semibold text-zinc-100 truncate">{data.label}</span>
+        <span className="text-xs font-semibold text-[var(--foreground)] truncate">{data.label}</span>
       </div>
       <div className="flex flex-wrap gap-1 mt-1">
         {nodeType === "cve" && data.severity && (
@@ -71,11 +71,11 @@ function AttackFlowNode({ data }: { data: AttackFlowNodeData }) {
           <span className="text-[10px] px-1 py-0.5 rounded border font-mono border-red-700 bg-red-950 text-red-400">KEV</span>
         )}
         {nodeType === "cve" && data.cvss_score != null && (
-          <span className="text-[10px] text-zinc-400 font-mono">CVSS {data.cvss_score.toFixed(1)}</span>
+          <span className="text-[10px] text-[var(--text-secondary)] font-mono">CVSS {data.cvss_score.toFixed(1)}</span>
         )}
-        {nodeType === "package" && data.version && <span className="text-[10px] text-zinc-400 font-mono">@{data.version}</span>}
-        {nodeType === "package" && data.ecosystem && <span className="text-[10px] text-zinc-500 font-mono">{data.ecosystem}</span>}
-        {nodeType === "agent" && data.agent_type && <span className="text-[10px] text-zinc-400 font-mono">{data.agent_type}</span>}
+        {nodeType === "package" && data.version && <span className="text-[10px] text-[var(--text-secondary)] font-mono">@{data.version}</span>}
+        {nodeType === "package" && data.ecosystem && <span className="text-[10px] text-[var(--text-tertiary)] font-mono">{data.ecosystem}</span>}
+        {nodeType === "agent" && data.agent_type && <span className="text-[10px] text-[var(--text-secondary)] font-mono">{data.agent_type}</span>}
       </div>
       {nodeType === "cve" && (data.owasp_tags?.length || data.atlas_tags?.length || data.owasp_mcp_tags?.length) ? (
         <div className="flex flex-wrap gap-0.5 mt-1">
@@ -90,7 +90,7 @@ function AttackFlowNode({ data }: { data: AttackFlowNodeData }) {
           ))}
         </div>
       ) : null}
-      {showSource && <Handle type="source" position={Position.Right} className="!bg-zinc-500 !w-2 !h-2 !border-zinc-400" />}
+      {showSource && <Handle type="source" position={Position.Right} className="!bg-[var(--text-tertiary)] !w-2 !h-2 !border-[var(--border-strong)]" />}
     </div>
   );
 }
@@ -101,32 +101,32 @@ const nodeTypes = { attackFlowNode: AttackFlowNode };
 
 function DetailPanel({ data, onClose }: { data: AttackFlowNodeData; onClose: () => void }) {
   const typeLabels: Record<string, string> = { cve: "Vulnerability", package: "Package", server: "MCP Server", agent: "Agent", credential: "Credential", tool: "Tool" };
-  const borderColors: Record<string, string> = { cve: "border-red-700", package: "border-zinc-700", server: "border-blue-700", agent: "border-emerald-700", credential: "border-yellow-700", tool: "border-purple-700" };
+  const borderColors: Record<string, string> = { cve: "border-red-700", package: "border-[var(--border-subtle)]", server: "border-blue-700", agent: "border-emerald-700", credential: "border-yellow-700", tool: "border-purple-700" };
   const osvUrl = data.nodeType === "cve" ? getOsvVulnerabilityUrl(data.label) : null;
 
   return (
-    <div className={`absolute right-0 top-0 bottom-0 w-80 bg-zinc-950/95 backdrop-blur-sm border-l ${borderColors[data.nodeType] ?? "border-zinc-700"} z-50 overflow-y-auto`}>
+    <div className={`absolute right-0 top-0 bottom-0 w-80 bg-[var(--background)]/95 backdrop-blur-sm border-l ${borderColors[data.nodeType] ?? "border-[var(--border-subtle)]"} z-50 overflow-y-auto`}>
       <div className="p-4 space-y-4">
         <div className="flex items-start justify-between">
           <div>
-            <span className="text-[10px] uppercase tracking-wider text-zinc-500">{typeLabels[data.nodeType] ?? data.nodeType}</span>
-            <h3 className="text-sm font-semibold text-zinc-100 mt-0.5 break-all">{data.label}</h3>
+            <span className="text-[10px] uppercase tracking-wider text-[var(--text-tertiary)]">{typeLabels[data.nodeType] ?? data.nodeType}</span>
+            <h3 className="text-sm font-semibold text-[var(--foreground)] mt-0.5 break-all">{data.label}</h3>
           </div>
-          <button onClick={onClose} className="p-1 text-zinc-500 hover:text-zinc-300 transition-colors"><X className="w-4 h-4" /></button>
+          <button onClick={onClose} className="p-1 text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"><X className="w-4 h-4" /></button>
         </div>
         {data.nodeType === "cve" && (
           <div className="space-y-3">
             {data.severity && <SeverityBadge severity={data.severity} />}
             <div className="grid grid-cols-2 gap-2">
-              {data.cvss_score != null && <div className="bg-zinc-900 rounded-lg p-2 text-center"><div className="text-lg font-bold font-mono text-zinc-100">{data.cvss_score.toFixed(1)}</div><div className="text-[10px] text-zinc-500">CVSS</div></div>}
-              {data.epss_score != null && <div className="bg-zinc-900 rounded-lg p-2 text-center"><div className="text-lg font-bold font-mono text-zinc-100">{(data.epss_score * 100).toFixed(1)}%</div><div className="text-[10px] text-zinc-500">EPSS</div></div>}
+              {data.cvss_score != null && <div className="bg-[var(--surface)] rounded-lg p-2 text-center"><div className="text-lg font-bold font-mono text-[var(--foreground)]">{data.cvss_score.toFixed(1)}</div><div className="text-[10px] text-[var(--text-tertiary)]">CVSS</div></div>}
+              {data.epss_score != null && <div className="bg-[var(--surface)] rounded-lg p-2 text-center"><div className="text-lg font-bold font-mono text-[var(--foreground)]">{(data.epss_score * 100).toFixed(1)}%</div><div className="text-[10px] text-[var(--text-tertiary)]">EPSS</div></div>}
             </div>
             {data.is_kev && <div className="text-xs font-mono bg-red-950 border border-red-800 text-red-400 rounded px-2 py-1.5 flex items-center gap-1.5"><AlertTriangle className="w-3 h-3" />CISA Known Exploited Vulnerability</div>}
-            {data.fixed_version && <div className="text-xs text-zinc-400">Fix available: <span className="text-emerald-400 font-mono font-semibold">{data.fixed_version}</span></div>}
+            {data.fixed_version && <div className="text-xs text-[var(--text-secondary)]">Fix available: <span className="text-emerald-400 font-mono font-semibold">{data.fixed_version}</span></div>}
             {data.owasp_tags && data.owasp_tags.length > 0 && <FrameworkTags title="OWASP LLM Top 10" tags={data.owasp_tags} catalog={OWASP_LLM_TOP10} color="purple" />}
             {data.owasp_mcp_tags && data.owasp_mcp_tags.length > 0 && <FrameworkTags title="OWASP MCP Top 10" tags={data.owasp_mcp_tags} catalog={OWASP_MCP_TOP10} color="amber" />}
             {data.atlas_tags && data.atlas_tags.length > 0 && <FrameworkTags title="MITRE ATLAS" tags={data.atlas_tags} catalog={MITRE_ATLAS} color="cyan" />}
-            {data.risk_score != null && <div className="text-xs text-zinc-400">Risk score: <span className="text-red-400 font-mono font-bold">{data.risk_score}</span></div>}
+            {data.risk_score != null && <div className="text-xs text-[var(--text-secondary)]">Risk score: <span className="text-red-400 font-mono font-bold">{data.risk_score}</span></div>}
             {osvUrl && (
               <a href={osvUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1.5 text-xs text-emerald-400 hover:text-emerald-300 transition-colors">
                 <ExternalLink className="w-3 h-3" />View on OSV
@@ -134,11 +134,11 @@ function DetailPanel({ data, onClose }: { data: AttackFlowNodeData; onClose: () 
             )}
           </div>
         )}
-        {data.nodeType === "package" && <div className="space-y-2">{data.version && <div className="text-xs text-zinc-400 font-mono">Version: {data.version}</div>}{data.ecosystem && <div className="text-xs text-zinc-400 font-mono">Ecosystem: {data.ecosystem}</div>}</div>}
-        {data.nodeType === "server" && <div className="text-xs text-zinc-400">MCP server in the supply chain</div>}
-        {data.nodeType === "agent" && <div className="space-y-2">{data.agent_type && <div className="text-xs text-zinc-400 font-mono">Type: {data.agent_type}</div>}{data.status && <div className={`text-xs px-2 py-1 rounded border font-mono ${data.status === "installed-not-configured" ? "border-yellow-800 bg-yellow-950 text-yellow-400" : "border-emerald-800 bg-emerald-950 text-emerald-400"}`}>{data.status === "installed-not-configured" ? "Not Configured" : "Configured"}</div>}</div>}
-        {data.nodeType === "credential" && <div className="space-y-2"><div className="flex items-center gap-1.5 text-xs text-amber-400"><KeyRound className="w-3 h-3" />Exposed credential env var</div><div className="text-xs text-zinc-400">This credential is accessible through a vulnerable MCP server in the supply chain.</div></div>}
-        {data.nodeType === "tool" && <div className="space-y-2"><div className="flex items-center gap-1.5 text-xs text-purple-400"><Wrench className="w-3 h-3" />Reachable MCP tool</div><div className="text-xs text-zinc-400">This tool is exposed through a vulnerable MCP server and could be invoked by an attacker.</div></div>}
+        {data.nodeType === "package" && <div className="space-y-2">{data.version && <div className="text-xs text-[var(--text-secondary)] font-mono">Version: {data.version}</div>}{data.ecosystem && <div className="text-xs text-[var(--text-secondary)] font-mono">Ecosystem: {data.ecosystem}</div>}</div>}
+        {data.nodeType === "server" && <div className="text-xs text-[var(--text-secondary)]">MCP server in the supply chain</div>}
+        {data.nodeType === "agent" && <div className="space-y-2">{data.agent_type && <div className="text-xs text-[var(--text-secondary)] font-mono">Type: {data.agent_type}</div>}{data.status && <div className={`text-xs px-2 py-1 rounded border font-mono ${data.status === "installed-not-configured" ? "border-yellow-800 bg-yellow-950 text-yellow-400" : "border-emerald-800 bg-emerald-950 text-emerald-400"}`}>{data.status === "installed-not-configured" ? "Not Configured" : "Configured"}</div>}</div>}
+        {data.nodeType === "credential" && <div className="space-y-2"><div className="flex items-center gap-1.5 text-xs text-amber-400"><KeyRound className="w-3 h-3" />Exposed credential env var</div><div className="text-xs text-[var(--text-secondary)]">This credential is accessible through a vulnerable MCP server in the supply chain.</div></div>}
+        {data.nodeType === "tool" && <div className="space-y-2"><div className="flex items-center gap-1.5 text-xs text-purple-400"><Wrench className="w-3 h-3" />Reachable MCP tool</div><div className="text-xs text-[var(--text-secondary)]">This tool is exposed through a vulnerable MCP server and could be invoked by an attacker.</div></div>}
       </div>
     </div>
   );
@@ -147,7 +147,7 @@ function DetailPanel({ data, onClose }: { data: AttackFlowNodeData; onClose: () 
 function FrameworkTags({ title, tags, catalog, color }: { title: string; tags: string[]; catalog: Record<string, string>; color: string }) {
   return (
     <div>
-      <div className="text-[10px] text-zinc-500 uppercase tracking-wider mb-1">{title}</div>
+      <div className="text-[10px] text-[var(--text-tertiary)] uppercase tracking-wider mb-1">{title}</div>
       <div className="space-y-1">
         {tags?.map((tag) => (
           <div key={tag} className={`text-xs font-mono bg-${color}-950/40 border border-${color}-800/50 text-${color}-400 rounded px-2 py-1`}>
@@ -173,7 +173,7 @@ function ExportButton() {
   }, [getNodes, getEdges]);
 
   return (
-    <button onClick={handleExport} className="flex items-center gap-1.5 px-3 py-1.5 bg-zinc-800 border border-zinc-700 rounded-lg text-xs text-zinc-300 hover:bg-zinc-700 transition-colors">
+    <button onClick={handleExport} className="flex items-center gap-1.5 px-3 py-1.5 bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded-lg text-xs text-[var(--text-secondary)] hover:bg-[var(--surface-muted)] transition-colors">
       <Download className="w-3 h-3" />Export JSON
     </button>
   );
@@ -201,30 +201,30 @@ function FilterBar({ filters, onChange, blastRadius }: { filters: AttackFlowFilt
 
   return (
     <div className="flex items-center gap-2 flex-wrap">
-      <Filter className="w-3.5 h-3.5 text-zinc-500" />
-      <select value={filters.cve} onChange={(e) => onChange({ ...filters, cve: e.target.value })} className="bg-zinc-900 border border-zinc-700 rounded-md px-2 py-1 text-xs text-zinc-300 focus:outline-none focus:border-emerald-600">
+      <Filter className="w-3.5 h-3.5 text-[var(--text-tertiary)]" />
+      <select value={filters.cve} onChange={(e) => onChange({ ...filters, cve: e.target.value })} className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-md px-2 py-1 text-xs text-[var(--text-secondary)] focus:outline-none focus:border-emerald-600">
         <option value="">All CVEs</option>
         {cveIds?.map((id) => <option key={id} value={id}>{id}</option>)}
       </select>
       <div className="flex gap-0.5">
         {severities?.map((sev) => (
-          <button key={sev} onClick={() => onChange({ ...filters, severity: activeSev === sev ? "" : sev })} className={`text-[10px] font-mono uppercase px-2 py-1 rounded border transition-colors ${activeSev === sev ? severityColor(sev) : "border-zinc-700 bg-zinc-900 text-zinc-500 hover:border-zinc-600"}`}>{sev}</button>
+          <button key={sev} onClick={() => onChange({ ...filters, severity: activeSev === sev ? "" : sev })} className={`text-[10px] font-mono uppercase px-2 py-1 rounded border transition-colors ${activeSev === sev ? severityColor(sev) : "border-[var(--border-subtle)] bg-[var(--surface)] text-[var(--text-tertiary)] hover:border-[var(--border-strong)]"}`}>{sev}</button>
         ))}
       </div>
       {frameworkTags.length > 0 && (
-        <select value={filters.framework} onChange={(e) => onChange({ ...filters, framework: e.target.value })} className="bg-zinc-900 border border-zinc-700 rounded-md px-2 py-1 text-xs text-zinc-300 focus:outline-none focus:border-emerald-600">
+        <select value={filters.framework} onChange={(e) => onChange({ ...filters, framework: e.target.value })} className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-md px-2 py-1 text-xs text-[var(--text-secondary)] focus:outline-none focus:border-emerald-600">
           <option value="">All Frameworks</option>
           {frameworkTags?.map((tag) => <option key={tag} value={tag}>{tag} {OWASP_LLM_TOP10[tag] ? `- ${OWASP_LLM_TOP10[tag]}` : OWASP_MCP_TOP10[tag] ? `- ${OWASP_MCP_TOP10[tag]}` : MITRE_ATLAS[tag] ? `- ${MITRE_ATLAS[tag]}` : ""}</option>)}
         </select>
       )}
       {agentNames.length > 0 && (
-        <select value={filters.agent} onChange={(e) => onChange({ ...filters, agent: e.target.value })} className="bg-zinc-900 border border-zinc-700 rounded-md px-2 py-1 text-xs text-zinc-300 focus:outline-none focus:border-emerald-600">
+        <select value={filters.agent} onChange={(e) => onChange({ ...filters, agent: e.target.value })} className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-md px-2 py-1 text-xs text-[var(--text-secondary)] focus:outline-none focus:border-emerald-600">
           <option value="">All Agents</option>
           {agentNames?.map((name) => <option key={name} value={name}>{name}</option>)}
         </select>
       )}
       {(filters.cve || filters.severity || filters.framework || filters.agent) && (
-        <button onClick={() => onChange({ cve: "", severity: "", framework: "", agent: "" })} className="text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors underline">Clear filters</button>
+        <button onClick={() => onChange({ cve: "", severity: "", framework: "", agent: "" })} className="text-[10px] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors underline">Clear filters</button>
       )}
     </div>
   );
@@ -235,7 +235,7 @@ function FilterBar({ filters, onChange, blastRadius }: { filters: AttackFlowFilt
 function StatsBar({ stats }: { stats: AttackFlowResponse["stats"] }) {
   const items = [
     { label: "CVEs", value: stats.total_cves, color: "text-red-400" },
-    { label: "Packages", value: stats.total_packages, color: "text-zinc-300" },
+    { label: "Packages", value: stats.total_packages, color: "text-[var(--text-secondary)]" },
     { label: "Servers", value: stats.total_servers, color: "text-blue-400" },
     { label: "Agents", value: stats.total_agents, color: "text-emerald-400" },
     { label: "Credentials", value: stats.total_credentials, color: "text-yellow-400" },
@@ -246,10 +246,10 @@ function StatsBar({ stats }: { stats: AttackFlowResponse["stats"] }) {
       {items.filter((i) => i.value > 0).map((item) => (
         <span key={item.label} className="flex items-center gap-1 text-xs">
           <span className={`font-mono font-bold ${item.color}`}>{item.value}</span>
-          <span className="text-zinc-500">{item.label}</span>
+          <span className="text-[var(--text-tertiary)]">{item.label}</span>
         </span>
       ))}
-      <span className="text-zinc-700">|</span>
+      <span className="text-[var(--text-tertiary)]">|</span>
       {Object.entries(stats.severity_counts).filter(([, v]) => v > 0).map(([sev, count]) => (
         <span key={sev} className={`text-[10px] font-mono uppercase px-1.5 py-0.5 rounded border ${severityColor(sev)}`}>{count} {sev}</span>
       ))}
@@ -268,13 +268,13 @@ function AttackFlowContent({ id, job, flowData, filters, onFiltersChange }: { id
 
   return (
     <div className="h-[calc(100vh-3.5rem)] flex flex-col">
-      <div className="px-4 py-3 border-b border-zinc-800 space-y-2">
+      <div className="px-4 py-3 border-b border-[var(--border-subtle)] space-y-2">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <Link href={`/scan?id=${id}`} className="text-zinc-500 hover:text-zinc-300 transition-colors"><ArrowLeft className="w-4 h-4" /></Link>
+            <Link href={`/scan?id=${id}`} className="text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"><ArrowLeft className="w-4 h-4" /></Link>
             <div>
-              <h1 className="text-lg font-semibold text-zinc-100">Attack Flow</h1>
-              <p className="text-xs text-zinc-500">CVE &rarr; Package &rarr; Server &rarr; Agent blast radius chain</p>
+              <h1 className="text-lg font-semibold text-[var(--foreground)]">Attack Flow</h1>
+              <p className="text-xs text-[var(--text-tertiary)]">CVE &rarr; Package &rarr; Server &rarr; Agent blast radius chain</p>
             </div>
           </div>
           <div className="flex items-center gap-3">
@@ -287,8 +287,8 @@ function AttackFlowContent({ id, job, flowData, filters, onFiltersChange }: { id
       </div>
       <div className="flex-1 relative">
         {flowData.nodes.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full text-zinc-400 gap-3">
-            <Filter className="w-8 h-8 text-zinc-600" />
+          <div className="flex flex-col items-center justify-center h-full text-[var(--text-secondary)] gap-3">
+            <Filter className="w-8 h-8 text-[var(--text-tertiary)]" />
             <p className="text-sm">No results match the current filters</p>
             <button onClick={() => onFiltersChange({ cve: "", severity: "", framework: "", agent: "" })} className="text-xs text-emerald-400 hover:text-emerald-300 underline">Clear all filters</button>
           </div>
@@ -301,9 +301,9 @@ function AttackFlowContent({ id, job, flowData, filters, onFiltersChange }: { id
         )}
         {selectedNode && <DetailPanel data={selectedNode} onClose={() => setSelectedNode(null)} />}
       </div>
-      <div className="px-4 py-2 border-t border-zinc-800 flex items-center gap-4 text-[10px] text-zinc-500">
+      <div className="px-4 py-2 border-t border-[var(--border-subtle)] flex items-center gap-4 text-[10px] text-[var(--text-tertiary)]">
         <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded border-2 border-red-600 bg-red-950" /> CVE</span>
-        <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded border-2 border-zinc-600 bg-zinc-900" /> Package</span>
+        <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded border-2 border-[var(--border-strong)] bg-[var(--surface)]" /> Package</span>
         <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded border-2 border-blue-600 bg-blue-950" /> Server</span>
         <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded border-2 border-emerald-600 bg-emerald-950" /> Agent</span>
         <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded border-2 border-yellow-600 bg-yellow-950" /> Credential</span>
@@ -337,8 +337,8 @@ export function AttackFlowView({ id }: { id: string }) {
     return () => window.clearTimeout(timer);
   }, [id, filters]);
 
-  if (loading && !flowData) return <div className="flex items-center justify-center h-[80vh] text-zinc-400"><Loader2 className="w-5 h-5 animate-spin mr-2" />Loading attack flow...</div>;
-  if (error) return <div className="flex flex-col items-center justify-center h-[80vh] text-zinc-400 gap-3"><AlertTriangle className="w-8 h-8 text-amber-500" /><p className="text-sm">Could not load attack flow</p><p className="text-xs text-zinc-500">{error}</p><Link href={`/scan?id=${id}`} className="text-xs text-emerald-400 hover:text-emerald-300 underline">Back to scan results</Link></div>;
+  if (loading && !flowData) return <div className="flex items-center justify-center h-[80vh] text-[var(--text-secondary)]"><Loader2 className="w-5 h-5 animate-spin mr-2" />Loading attack flow...</div>;
+  if (error) return <div className="flex flex-col items-center justify-center h-[80vh] text-[var(--text-secondary)] gap-3"><AlertTriangle className="w-8 h-8 text-amber-500" /><p className="text-sm">Could not load attack flow</p><p className="text-xs text-[var(--text-tertiary)]">{error}</p><Link href={`/scan?id=${id}`} className="text-xs text-emerald-400 hover:text-emerald-300 underline">Back to scan results</Link></div>;
   if (!job || !flowData) return null;
 
   return <ReactFlowProvider><AttackFlowContent id={id} job={job} flowData={flowData} filters={filters} onFiltersChange={setFilters} /></ReactFlowProvider>;

--- a/ui/components/auth-gate.tsx
+++ b/ui/components/auth-gate.tsx
@@ -45,7 +45,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   if (loading) {
     return (
       <div className="flex min-h-[calc(100vh-5rem)] items-center justify-center">
-        <Loader2 className="h-6 w-6 animate-spin text-zinc-500" />
+        <Loader2 className="h-6 w-6 animate-spin text-[var(--text-tertiary)]" />
       </div>
     );
   }
@@ -58,11 +58,11 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
     return (
       <div className="flex min-h-[calc(100vh-5rem)] items-center justify-center px-4 py-10">
         <div className="w-full max-w-xl rounded-3xl border border-amber-900/50 bg-amber-950/20 p-8 text-center shadow-2xl shadow-black/20">
-          <h1 className="text-xl font-semibold tracking-tight text-zinc-100">Control plane unreachable</h1>
-          <p className="mt-3 text-sm leading-6 text-zinc-400">
+          <h1 className="text-xl font-semibold tracking-tight text-[var(--foreground)]">Control plane unreachable</h1>
+          <p className="mt-3 text-sm leading-6 text-[var(--text-secondary)]">
             Authentication could not be verified because the API is offline or returned a server error.
           </p>
-          <p className="mt-2 text-xs text-zinc-500">{error}</p>
+          <p className="mt-2 text-xs text-[var(--text-tertiary)]">{error}</p>
         </div>
       </div>
     );
@@ -71,7 +71,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
   if (needsAuth) {
     return (
       <div className="flex min-h-[calc(100vh-5rem)] items-center justify-center">
-        <Loader2 className="h-6 w-6 animate-spin text-zinc-500" />
+        <Loader2 className="h-6 w-6 animate-spin text-[var(--text-tertiary)]" />
       </div>
     );
   }

--- a/ui/components/card.tsx
+++ b/ui/components/card.tsx
@@ -9,9 +9,9 @@ type CardProps = HTMLAttributes<HTMLDivElement> & {
 
 /**
  * Canonical card shell. The app duplicates this 50+× with two radius scales
- * (rounded-xl vs rounded-2xl) and two color systems (hardcoded zinc-* vs CSS
- * vars). This standardizes on a single radius (rounded-xl), the subtle border
- * + surface tokens, and p-5 padding so every card matches across themes.
+ * (rounded-xl vs rounded-2xl). This standardizes on a single radius
+ * (rounded-xl), the subtle border + surface tokens, and p-5 padding so every
+ * card reads correctly across both light and dark themes.
  */
 export function Card({ as, flush = false, className = "", children, ...rest }: CardProps) {
   const Tag = as ?? "div";

--- a/ui/components/findings-queue.tsx
+++ b/ui/components/findings-queue.tsx
@@ -42,7 +42,7 @@ function ReachabilityBadge({
     return (
       <span
         title="Package is in inventory but no agent traversal reaches it"
-        className="text-xs font-mono bg-zinc-900 border border-zinc-700 text-zinc-500 rounded px-1.5 py-0.5"
+        className="text-xs font-mono bg-[var(--surface)] border border-[var(--border-subtle)] text-[var(--text-tertiary)] rounded px-1.5 py-0.5"
       >
         Unreachable
       </span>
@@ -77,7 +77,7 @@ function SortButton({
     <button
       onClick={() => onClick(field)}
       className={`flex items-center gap-0.5 text-xs font-medium uppercase tracking-wide transition-colors ${
-        active ? "text-zinc-200" : "text-zinc-500 hover:text-zinc-300"
+        active ? "text-[var(--foreground)]" : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
       }`}
     >
       {label}
@@ -93,7 +93,7 @@ function renderScoreValue(value: number | undefined, missingLabel: string) {
     return value.toFixed(1);
   }
   return (
-    <span className="rounded bg-zinc-900 px-1.5 py-0.5 text-zinc-500" title={missingLabel}>
+    <span className="rounded bg-[var(--surface)] px-1.5 py-0.5 text-[var(--text-tertiary)]" title={missingLabel}>
       N/A
     </span>
   );
@@ -104,7 +104,7 @@ function renderPercentValue(value: number | undefined, missingLabel: string) {
     return `${(value * 100).toFixed(1)}%`;
   }
   return (
-    <span className="rounded bg-zinc-900 px-1.5 py-0.5 text-zinc-500" title={missingLabel}>
+    <span className="rounded bg-[var(--surface)] px-1.5 py-0.5 text-[var(--text-tertiary)]" title={missingLabel}>
       N/A
     </span>
   );
@@ -134,9 +134,9 @@ export function FindingsQueueTable({
   columns?: FindingColumnVisibility;
 }) {
   return (
-    <div className="border border-zinc-800 rounded-xl overflow-hidden overflow-x-auto">
+    <div className="border border-[var(--border-subtle)] rounded-xl overflow-hidden overflow-x-auto">
       <table className="w-full text-sm">
-        <thead className="bg-zinc-900 border-b border-zinc-800">
+        <thead className="bg-[var(--surface)] border-b border-[var(--border-subtle)]">
           <tr>
             <th className="text-left px-4 py-3">
               <SortButton label="CVE" field="id" current={sortKey} dir={sortDir} onClick={handleSort} />
@@ -146,8 +146,8 @@ export function FindingsQueueTable({
             </th>
             {showLifecycle ? (
               <>
-                <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Status</th>
-                <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Last seen</th>
+                <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Status</th>
+                <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Last seen</th>
               </>
             ) : null}
             {columns.cvss ? (
@@ -161,18 +161,18 @@ export function FindingsQueueTable({
               </th>
             ) : null}
             {columns.packages ? (
-              <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Packages</th>
+              <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Packages</th>
             ) : null}
             {columns.agents ? (
-              <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Agents</th>
+              <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Agents</th>
             ) : null}
             {columns.fix ? (
-              <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Fix</th>
+              <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Fix</th>
             ) : null}
-            <th className="text-left px-4 py-3 text-xs font-medium text-zinc-500 uppercase tracking-wide">Actions</th>
+            <th className="text-left px-4 py-3 text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wide">Actions</th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-zinc-800 bg-zinc-950">
+        <tbody className="divide-y divide-[var(--border-subtle)] bg-[var(--background)]">
           {vulns?.map((v) => {
             const rowKey = vulnRowKey(v);
             const isSelected = selectedId === rowKey || selectedId === v.id;
@@ -180,7 +180,7 @@ export function FindingsQueueTable({
             return (
               <tr
                 key={rowKey}
-                className={`cursor-pointer transition-colors ${isSelected ? "bg-zinc-900/90 ring-1 ring-inset ring-emerald-900/60" : "hover:bg-zinc-900"}`}
+                className={`cursor-pointer transition-colors ${isSelected ? "bg-[var(--surface)]/90 ring-1 ring-inset ring-emerald-900/60" : "hover:bg-[var(--surface)]"}`}
                 onClick={() => onSelect(rowKey)}
               >
                 <td className="px-4 py-3">
@@ -191,7 +191,7 @@ export function FindingsQueueTable({
                         event.stopPropagation();
                         onSelect(rowKey);
                       }}
-                      className="mt-0.5 rounded p-0.5 text-zinc-500 transition-colors hover:bg-zinc-800 hover:text-zinc-300"
+                      className="mt-0.5 rounded p-0.5 text-[var(--text-tertiary)] transition-colors hover:bg-[var(--surface-elevated)] hover:text-[var(--text-secondary)]"
                       aria-label={`Open details for ${v.id}`}
                     >
                       <ChevronRight className="h-3.5 w-3.5" />
@@ -205,7 +205,7 @@ export function FindingsQueueTable({
                               event.stopPropagation();
                               onSelect(rowKey);
                             }}
-                            className="font-mono text-xs text-zinc-200 transition-colors hover:text-emerald-400"
+                            className="font-mono text-xs text-[var(--foreground)] transition-colors hover:text-emerald-400"
                           >
                             {v.id}
                           </button>
@@ -214,7 +214,7 @@ export function FindingsQueueTable({
                             target="_blank"
                             rel="noopener noreferrer"
                             onClick={(event) => event.stopPropagation()}
-                            className="inline-flex items-center gap-1 rounded-full border border-zinc-700 px-2 py-0.5 text-[11px] font-medium text-zinc-400 transition-colors hover:border-zinc-600 hover:text-zinc-200"
+                            className="inline-flex items-center gap-1 rounded-full border border-[var(--border-subtle)] px-2 py-0.5 text-[11px] font-medium text-[var(--text-secondary)] transition-colors hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
                           >
                             OSV
                             <ExternalLink className="h-3 w-3" />
@@ -226,7 +226,7 @@ export function FindingsQueueTable({
                           />
                         </div>
                         {secondary && (
-                          <p className="text-xs text-zinc-600 mt-0.5 ml-3.5 line-clamp-1 max-w-xs">
+                          <p className="text-xs text-[var(--text-tertiary)] mt-0.5 ml-3.5 line-clamp-1 max-w-xs">
                             {secondary}
                           </p>
                         )}
@@ -247,18 +247,18 @@ export function FindingsQueueTable({
                           {findingStatusLabel(v.lifecycle_status)}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-xs font-mono text-zinc-400">
+                      <td className="px-4 py-3 text-xs font-mono text-[var(--text-secondary)]">
                         {formatFindingTimestamp(v.last_seen ?? v.first_seen)}
                       </td>
                     </>
                   ) : null}
                   {columns.cvss ? (
-                    <td className="px-4 py-3 text-xs font-mono text-zinc-400">
+                    <td className="px-4 py-3 text-xs font-mono text-[var(--text-secondary)]">
                       {renderScoreValue(v.cvss_score, "CVSS not published by the current advisory")}
                     </td>
                   ) : null}
                   {columns.epss ? (
-                    <td className="px-4 py-3 text-xs font-mono text-zinc-400">
+                    <td className="px-4 py-3 text-xs font-mono text-[var(--text-secondary)]">
                       {renderPercentValue(v.epss_score, "EPSS not available for this advisory")}
                     </td>
                   ) : null}
@@ -266,20 +266,20 @@ export function FindingsQueueTable({
                     <td className="px-4 py-3">
                       <div className="flex flex-wrap gap-1">
                         {v.packages.slice(0, 3).map((p) => (
-                          <span key={p} className="text-xs font-mono bg-zinc-800 border border-zinc-700 rounded px-1.5 py-0.5 text-zinc-400">
+                          <span key={p} className="text-xs font-mono bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded px-1.5 py-0.5 text-[var(--text-secondary)]">
                             {p}
                           </span>
                         ))}
                         {v.packages.length > 3 && (
-                          <span className="text-xs text-zinc-600">+{v.packages.length - 3}</span>
+                          <span className="text-xs text-[var(--text-tertiary)]">+{v.packages.length - 3}</span>
                         )}
                       </div>
                     </td>
                   ) : null}
                   {columns.agents ? (
-                    <td className="px-4 py-3 text-xs text-zinc-500">
+                    <td className="px-4 py-3 text-xs text-[var(--text-tertiary)]">
                       {v.agents.slice(0, 2).join(", ")}
-                      {v.agents.length > 2 && <span className="text-zinc-600"> +{v.agents.length - 2}</span>}
+                      {v.agents.length > 2 && <span className="text-[var(--text-tertiary)]"> +{v.agents.length - 2}</span>}
                     </td>
                   ) : null}
                   {columns.fix ? (
@@ -289,7 +289,7 @@ export function FindingsQueueTable({
                   ) : null}
                   <td className="px-4 py-3">
                     {suppressed.has(v.id) ? (
-                      <span className="text-xs font-medium px-2 py-0.5 rounded border bg-zinc-800 border-zinc-700 text-zinc-400">
+                      <span className="text-xs font-medium px-2 py-0.5 rounded border bg-[var(--surface-elevated)] border-[var(--border-subtle)] text-[var(--text-secondary)]">
                         Suppressed
                       </span>
                     ) : (
@@ -298,7 +298,7 @@ export function FindingsQueueTable({
                           event.stopPropagation();
                           onMarkFP(v.id, v.packages[0] ?? "");
                         }}
-                        className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-zinc-700 hover:bg-zinc-600 text-zinc-300 transition-colors"
+                        className="flex items-center gap-1 px-2 py-1 rounded text-xs font-medium bg-[var(--surface-muted)] hover:bg-[var(--surface-muted)] text-[var(--text-secondary)] transition-colors"
                       >
                         <ShieldOff className="w-3 h-3" />
                         Mark FP
@@ -312,7 +312,7 @@ export function FindingsQueueTable({
       </table>
 
       {vulns.length === 0 && (
-        <div className="px-4 py-8 text-center text-zinc-600 text-sm">
+        <div className="px-4 py-8 text-center text-[var(--text-tertiary)] text-sm">
           No vulnerabilities match your filters.
         </div>
       )}

--- a/ui/components/gateway-live-feed-card.tsx
+++ b/ui/components/gateway-live-feed-card.tsx
@@ -184,18 +184,18 @@ export function GatewayLiveFeedCard({
   return (
     <div
       data-testid="gateway-live-feed"
-      className={`flex flex-col overflow-hidden rounded-xl border border-zinc-800 bg-zinc-900 ${
+      className={`flex flex-col overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)] ${
         className ?? ""
       }`}
     >
       {/* Header */}
-      <div className="flex items-center justify-between gap-3 border-b border-zinc-800 px-4 py-3">
-        <h3 className="flex min-w-0 items-center gap-2 text-sm font-semibold text-zinc-200">
+      <div className="flex items-center justify-between gap-3 border-b border-[var(--border-subtle)] px-4 py-3">
+        <h3 className="flex min-w-0 items-center gap-2 text-sm font-semibold text-[var(--foreground)]">
           <span className="h-2 w-2 shrink-0 rounded-full bg-emerald-400" />
           <span className="truncate">Gateway Live Feed</span>
         </h3>
         {isSample ? (
-          <span className="shrink-0 rounded-full border border-zinc-700 bg-zinc-800 px-2 py-0.5 text-[10px] font-medium text-zinc-400">
+          <span className="shrink-0 rounded-full border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-secondary)]">
             sample data
           </span>
         ) : (
@@ -211,21 +211,21 @@ export function GatewayLiveFeedCard({
 
       {/* Rows */}
       {loading ? (
-        <div className="px-4 py-8 text-center text-xs text-zinc-600">
+        <div className="px-4 py-8 text-center text-xs text-[var(--text-tertiary)]">
           Loading gateway activity…
         </div>
       ) : rows.length === 0 ? (
-        <div className="px-4 py-8 text-center text-xs text-zinc-600">
+        <div className="px-4 py-8 text-center text-xs text-[var(--text-tertiary)]">
           No gateway activity yet.
         </div>
       ) : (
-        <ul className="divide-y divide-zinc-800">
+        <ul className="divide-y divide-[var(--border-subtle)]">
           {rows.map((event, i) => {
             const blocked = isBlocked(event);
             return (
               <li
                 key={`${event.ts}-${event.agent}-${i}`}
-                className="flex items-start gap-3 px-4 py-3 transition-colors hover:bg-zinc-800/40"
+                className="flex items-start gap-3 px-4 py-3 transition-colors hover:bg-[var(--surface-elevated)]/40"
               >
                 {/* Status dot */}
                 <span
@@ -238,20 +238,20 @@ export function GatewayLiveFeedCard({
                 {/* Text column — min-w-0 lets children truncate instead of overflow */}
                 <div className="min-w-0 flex-1">
                   <div className="flex items-baseline justify-between gap-2">
-                    <span className="truncate text-sm font-medium text-zinc-100">
+                    <span className="truncate text-sm font-medium text-[var(--foreground)]">
                       {decisionTitle(event)}
                     </span>
-                    <time className="shrink-0 text-[10px] tabular-nums text-zinc-600">
+                    <time className="shrink-0 text-[10px] tabular-nums text-[var(--text-tertiary)]">
                       {eventTime(event.ts)}
                     </time>
                   </div>
                   <code
-                    className="mt-0.5 block truncate font-mono text-xs text-zinc-400"
+                    className="mt-0.5 block truncate font-mono text-xs text-[var(--text-secondary)]"
                     title={`${event.agent} → ${event.target}`}
                   >
                     {event.agent} → {event.target}
                   </code>
-                  <p className="mt-0.5 truncate text-xs text-zinc-500">
+                  <p className="mt-0.5 truncate text-xs text-[var(--text-tertiary)]">
                     {subLabel(event)}
                   </p>
                 </div>
@@ -262,8 +262,8 @@ export function GatewayLiveFeedCard({
       )}
 
       {/* Aggregate footer */}
-      <div className="mt-auto border-t border-zinc-800 px-4 py-2.5">
-        <p className="truncate text-center text-[11px] tabular-nums text-zinc-500">
+      <div className="mt-auto border-t border-[var(--border-subtle)] px-4 py-2.5">
+        <p className="truncate text-center text-[11px] tabular-nums text-[var(--text-tertiary)]">
           {footerText(kpis)}
         </p>
       </div>

--- a/ui/components/graph-drift-legend.tsx
+++ b/ui/components/graph-drift-legend.tsx
@@ -71,7 +71,7 @@ export function GraphDriftLegend({
   return (
     <div
       data-testid="graph-drift-legend"
-      className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3"
+      className="mt-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3"
     >
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
@@ -80,7 +80,7 @@ export function GraphDriftLegend({
             Drift lens
           </span>
           {comparedLabel ? (
-            <span className="text-xs text-zinc-500">
+            <span className="text-xs text-[var(--text-tertiary)]">
               vs <span className="font-mono">{comparedLabel}</span>
             </span>
           ) : null}
@@ -94,7 +94,7 @@ export function GraphDriftLegend({
           className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
             active
               ? "border-sky-500/60 bg-sky-500/15 text-sky-200"
-              : "border-zinc-700 bg-zinc-900/60 text-zinc-400 hover:text-zinc-200"
+              : "border-[var(--border-subtle)] bg-[var(--surface)]/60 text-[var(--text-secondary)] hover:text-[var(--foreground)]"
           }`}
         >
           {active ? "Lens on" : "Lens off"}
@@ -122,11 +122,11 @@ export function GraphDriftLegend({
                   className={`rounded-full border px-3 py-1 text-xs transition-colors ${
                     selected
                       ? "border-sky-500/60 bg-sky-500/15 text-sky-100"
-                      : "border-zinc-700 bg-zinc-900/60 text-zinc-400 hover:text-zinc-200"
+                      : "border-[var(--border-subtle)] bg-[var(--surface)]/60 text-[var(--text-secondary)] hover:text-[var(--foreground)]"
                   }`}
                 >
                   {CHIP_LABELS[chip]}
-                  <span className="ml-1.5 font-mono text-[11px] text-zinc-500">
+                  <span className="ml-1.5 font-mono text-[11px] text-[var(--text-tertiary)]">
                     {count}
                   </span>
                 </button>
@@ -151,8 +151,8 @@ export function GraphDriftLegend({
                     className="inline-block h-2.5 w-2.5 rounded-full"
                     style={{ backgroundColor: meta.color }}
                   />
-                  <span className="text-[11px] text-zinc-300">{meta.label}</span>
-                  <span className="font-mono text-[11px] text-zinc-500">
+                  <span className="text-[11px] text-[var(--text-secondary)]">{meta.label}</span>
+                  <span className="font-mono text-[11px] text-[var(--text-tertiary)]">
                     {counts[kind]}
                   </span>
                 </div>
@@ -177,7 +177,7 @@ export function GraphDriftLegend({
           ) : null}
         </>
       ) : (
-        <p className="mt-2 text-xs text-zinc-500">
+        <p className="mt-2 text-xs text-[var(--text-tertiary)]">
           Turn the lens on to classify this snapshot against{" "}
           {comparedLabel ? (
             <span className="font-mono">{comparedLabel}</span>

--- a/ui/components/graph-edge-changes-panel.tsx
+++ b/ui/components/graph-edge-changes-panel.tsx
@@ -81,7 +81,7 @@ export function GraphEdgeChangesPanel({
   return (
     <div
       data-testid="graph-edge-changes-panel"
-      className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3"
+      className="mt-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3"
     >
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
@@ -90,7 +90,7 @@ export function GraphEdgeChangesPanel({
             Edge changes
           </span>
           {comparedLabel ? (
-            <span className="text-xs text-zinc-500">
+            <span className="text-xs text-[var(--text-tertiary)]">
               vs <span className="font-mono">{comparedLabel}</span>
             </span>
           ) : null}
@@ -101,7 +101,7 @@ export function GraphEdgeChangesPanel({
             loading
           </span>
         ) : summary ? (
-          <span className="font-mono text-[11px] text-zinc-500">
+          <span className="font-mono text-[11px] text-[var(--text-tertiary)]">
             +{summary.added} −{summary.removed} ~{summary.changed}
           </span>
         ) : null}
@@ -110,9 +110,9 @@ export function GraphEdgeChangesPanel({
       {error ? (
         <p className="mt-2 text-xs text-amber-200">{error}</p>
       ) : loading && !changes ? (
-        <p className="mt-2 text-xs text-zinc-500">Loading edge lifecycle diff…</p>
+        <p className="mt-2 text-xs text-[var(--text-tertiary)]">Loading edge lifecycle diff…</p>
       ) : !hasDrillDown ? (
-        <p className="mt-2 text-xs text-zinc-500">
+        <p className="mt-2 text-xs text-[var(--text-tertiary)]">
           No relationship additions, removals, or material changes between
           snapshots.
         </p>

--- a/ui/components/graph-evaluation-summary.tsx
+++ b/ui/components/graph-evaluation-summary.tsx
@@ -22,7 +22,7 @@ export function GraphEvaluationSummary({ evaluation }: GraphEvaluationSummaryPro
   return (
     <section
       aria-label="Graph evaluation"
-      className="mt-3 rounded-xl border border-zinc-800 bg-zinc-950/70 p-3"
+      className="mt-3 rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3"
       data-testid="graph-evaluation-summary"
     >
       <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
@@ -33,13 +33,13 @@ export function GraphEvaluationSummary({ evaluation }: GraphEvaluationSummaryPro
               {evaluation.grade}
             </span>
           </div>
-          <p className="mt-1 max-w-3xl text-xs leading-5 text-zinc-400">
+          <p className="mt-1 max-w-3xl text-xs leading-5 text-[var(--text-secondary)]">
             Scores whether this graph view has enough entity variety, relationships, path signal, evidence, and readable rendering for review.
           </p>
         </div>
-        <div className="flex shrink-0 items-baseline gap-2 rounded-lg border border-zinc-800 bg-zinc-900/70 px-3 py-2">
-          <span className="text-2xl font-semibold tabular-nums text-zinc-100">{Math.round(evaluation.score)}</span>
-          <span className="text-[10px] uppercase tracking-[0.16em] text-zinc-500">score</span>
+        <div className="flex shrink-0 items-baseline gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/70 px-3 py-2">
+          <span className="text-2xl font-semibold tabular-nums text-[var(--foreground)]">{Math.round(evaluation.score)}</span>
+          <span className="text-[10px] uppercase tracking-[0.16em] text-[var(--text-tertiary)]">score</span>
         </div>
       </div>
 
@@ -47,21 +47,21 @@ export function GraphEvaluationSummary({ evaluation }: GraphEvaluationSummaryPro
         {evaluation.dimensions.map((dimension) => {
           const Icon = dimensionIcon[dimension.id];
           return (
-            <div key={dimension.id} className="rounded-lg border border-zinc-800 bg-zinc-900/60 p-2.5">
+            <div key={dimension.id} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/60 p-2.5">
               <div className="flex items-center justify-between gap-2">
                 <div className="flex min-w-0 items-center gap-2">
-                  <Icon className="h-3.5 w-3.5 shrink-0 text-zinc-500" />
-                  <span className="truncate text-xs font-medium text-zinc-200">{dimension.label}</span>
+                  <Icon className="h-3.5 w-3.5 shrink-0 text-[var(--text-tertiary)]" />
+                  <span className="truncate text-xs font-medium text-[var(--foreground)]">{dimension.label}</span>
                 </div>
-                <span className="text-xs font-semibold tabular-nums text-zinc-100">{Math.round(dimension.score)}</span>
+                <span className="text-xs font-semibold tabular-nums text-[var(--foreground)]">{Math.round(dimension.score)}</span>
               </div>
-              <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-zinc-800">
+              <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[var(--surface-elevated)]">
                 <div
                   className={`h-full rounded-full ${barTone(dimension.score)}`}
                   style={{ width: `${Math.max(6, Math.min(100, dimension.score))}%` }}
                 />
               </div>
-              <p className="mt-2 break-words text-[11px] leading-4 text-zinc-500">{dimension.detail}</p>
+              <p className="mt-2 break-words text-[11px] leading-4 text-[var(--text-tertiary)]">{dimension.detail}</p>
             </div>
           );
         })}

--- a/ui/components/graph-evidence-legend.tsx
+++ b/ui/components/graph-evidence-legend.tsx
@@ -39,7 +39,7 @@ export function GraphEvidenceLegend({
   return (
     <div
       data-testid="graph-evidence-legend"
-      className="mt-3 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-3"
+      className="mt-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3"
     >
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
@@ -56,7 +56,7 @@ export function GraphEvidenceLegend({
           className={`rounded-full border px-3 py-1 text-xs transition-colors ${
             active
               ? "border-violet-500/60 bg-violet-500/15 text-violet-100"
-              : "border-zinc-700 bg-zinc-900/60 text-zinc-400 hover:text-zinc-200"
+              : "border-[var(--border-subtle)] bg-[var(--surface)]/60 text-[var(--text-secondary)] hover:text-[var(--foreground)]"
           }`}
         >
           {active ? "Lens on" : "Lens off"}
@@ -77,11 +77,11 @@ export function GraphEvidenceLegend({
                 className={`rounded-full border px-3 py-1 text-xs transition-colors ${
                   selected
                     ? "border-violet-500/60 bg-violet-500/15 text-violet-100"
-                    : "border-zinc-700 bg-zinc-900/60 text-zinc-400 hover:text-zinc-200"
+                    : "border-[var(--border-subtle)] bg-[var(--surface)]/60 text-[var(--text-secondary)] hover:text-[var(--foreground)]"
                 }`}
               >
                 {CHIP_LABELS[chip]}
-                <span className="ml-1.5 font-mono text-[11px] text-zinc-500">
+                <span className="ml-1.5 font-mono text-[11px] text-[var(--text-tertiary)]">
                   {counts[chip]}
                 </span>
               </button>
@@ -89,7 +89,7 @@ export function GraphEvidenceLegend({
           })}
         </div>
       ) : (
-        <p className="mt-2 text-xs text-zinc-500">
+        <p className="mt-2 text-xs text-[var(--text-tertiary)]">
           Turn the lens on to highlight nodes backed by runtime observed or blocked
           evidence instead of static scan inference alone.
         </p>

--- a/ui/components/graph-lens-switcher.tsx
+++ b/ui/components/graph-lens-switcher.tsx
@@ -93,9 +93,9 @@ export function GraphLensSwitcher({
     <div
       className={
         variant === "floating"
-          ? "pointer-events-auto flex min-w-0 flex-wrap items-center justify-between gap-2 rounded-2xl border border-zinc-700/80 bg-zinc-950/85 px-3 py-2 shadow-2xl shadow-black/40 backdrop-blur"
+          ? "pointer-events-auto flex min-w-0 flex-wrap items-center justify-between gap-2 rounded-2xl border border-[var(--border-subtle)]/80 bg-[var(--background)]/85 px-3 py-2 shadow-2xl shadow-black/40 backdrop-blur"
           : variant === "compact"
-            ? "flex flex-col gap-2 rounded-xl border border-zinc-800 bg-zinc-950/80 px-3 py-2"
+            ? "flex flex-col gap-2 rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/80 px-3 py-2"
             : "flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3"
       }
     >

--- a/ui/components/hitl-approval-queue-panel.tsx
+++ b/ui/components/hitl-approval-queue-panel.tsx
@@ -47,7 +47,7 @@ export function HitlApprovalQueuePanel() {
 
   if (loading) {
     return (
-      <div className="flex items-center gap-2 rounded-2xl border border-zinc-800 bg-zinc-900/50 px-4 py-10 text-sm text-zinc-400">
+      <div className="flex items-center gap-2 rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/50 px-4 py-10 text-sm text-[var(--text-secondary)]">
         <Loader2 className="h-4 w-4 animate-spin" />
         Loading approval queue…
       </div>
@@ -64,7 +64,7 @@ export function HitlApprovalQueuePanel() {
 
   if (items.length === 0) {
     return (
-      <div className="rounded-2xl border border-dashed border-zinc-800 bg-zinc-900/40 px-4 py-10 text-center text-sm text-zinc-500">
+      <div className="rounded-2xl border border-dashed border-[var(--border-subtle)] bg-[var(--surface)]/40 px-4 py-10 text-center text-sm text-[var(--text-tertiary)]">
         No blocked tool calls in the approval queue. Gateway/proxy blocks appear here for human review.
       </div>
     );
@@ -72,38 +72,38 @@ export function HitlApprovalQueuePanel() {
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-zinc-800 bg-zinc-900/50 px-4 py-3 text-sm text-zinc-300">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/50 px-4 py-3 text-sm text-[var(--text-secondary)]">
         <span>
-          <span className="font-semibold text-zinc-100">{pendingCount}</span> pending · {items.length} total blocked spans
+          <span className="font-semibold text-[var(--foreground)]">{pendingCount}</span> pending · {items.length} total blocked spans
         </span>
         <button
           type="button"
           onClick={() => void load()}
-          className="rounded-lg border border-zinc-700 px-3 py-1.5 text-xs text-zinc-300 hover:border-zinc-600 hover:text-zinc-100"
+          className="rounded-lg border border-[var(--border-subtle)] px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
         >
           Refresh
         </button>
       </div>
 
-      <div className="overflow-hidden rounded-2xl border border-zinc-800">
+      <div className="overflow-hidden rounded-2xl border border-[var(--border-subtle)]">
         <table className="w-full text-sm">
-          <thead className="border-b border-zinc-800 bg-zinc-900">
+          <thead className="border-b border-[var(--border-subtle)] bg-[var(--surface)]">
             <tr>
-              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Agent / tool</th>
-              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Findings</th>
-              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Controls</th>
-              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-zinc-500">Status</th>
-              <th className="px-4 py-2.5 text-right text-xs font-medium uppercase tracking-wide text-zinc-500">Action</th>
+              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Agent / tool</th>
+              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Findings</th>
+              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Controls</th>
+              <th className="px-4 py-2.5 text-left text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Status</th>
+              <th className="px-4 py-2.5 text-right text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Action</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-zinc-800 bg-zinc-950">
+          <tbody className="divide-y divide-[var(--border-subtle)] bg-[var(--background)]">
             {items.map((item) => (
-              <tr key={item.item_id} className="align-top hover:bg-zinc-900/60">
+              <tr key={item.item_id} className="align-top hover:bg-[var(--surface)]/60">
                 <td className="px-4 py-3">
-                  <div className="font-medium text-zinc-200">{item.agent || "unknown agent"}</div>
-                  <div className="mt-1 font-mono text-xs text-zinc-400">{item.tool}</div>
-                  {item.detail ? <p className="mt-2 text-xs text-zinc-500">{item.detail}</p> : null}
-                  <p className="mt-1 text-[11px] text-zinc-600">session {item.session_id}</p>
+                  <div className="font-medium text-[var(--foreground)]">{item.agent || "unknown agent"}</div>
+                  <div className="mt-1 font-mono text-xs text-[var(--text-secondary)]">{item.tool}</div>
+                  {item.detail ? <p className="mt-2 text-xs text-[var(--text-tertiary)]">{item.detail}</p> : null}
+                  <p className="mt-1 text-[11px] text-[var(--text-tertiary)]">session {item.session_id}</p>
                 </td>
                 <td className="px-4 py-3">
                   {item.linked_finding_ids.length > 0 ? (
@@ -112,20 +112,20 @@ export function HitlApprovalQueuePanel() {
                         <Link
                           key={fid}
                           href={`/findings?search=${encodeURIComponent(fid)}`}
-                          className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-[10px] text-emerald-300 hover:underline"
+                          className="rounded border border-[var(--border-subtle)] bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[10px] text-emerald-300 hover:underline"
                         >
                           {fid}
                         </Link>
                       ))}
                     </div>
                   ) : (
-                    <span className="text-xs text-zinc-600">—</span>
+                    <span className="text-xs text-[var(--text-tertiary)]">—</span>
                   )}
                 </td>
                 <td className="px-4 py-3">
                   <div className="flex flex-wrap gap-1">
                     {item.compliance_controls.slice(0, 4).map((tag) => (
-                      <span key={tag} className="rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 font-mono text-[10px] text-zinc-400">
+                      <span key={tag} className="rounded border border-[var(--border-subtle)] bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[10px] text-[var(--text-secondary)]">
                         {tag}
                       </span>
                     ))}
@@ -168,7 +168,7 @@ export function HitlApprovalQueuePanel() {
                       </button>
                     </div>
                   ) : (
-                    <span className="text-xs text-zinc-500">{item.decided_by || "—"}</span>
+                    <span className="text-xs text-[var(--text-tertiary)]">{item.decided_by || "—"}</span>
                   )}
                 </td>
               </tr>

--- a/ui/components/integration-required-state.tsx
+++ b/ui/components/integration-required-state.tsx
@@ -23,33 +23,33 @@ export function IntegrationRequiredState({
 }: IntegrationRequiredStateProps) {
   return (
     <div className="py-8">
-      <div className="mx-auto max-w-5xl rounded-3xl border border-zinc-800 bg-zinc-950/70 p-6 shadow-2xl shadow-black/20 md:p-8">
+      <div className="mx-auto max-w-5xl rounded-3xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-6 shadow-2xl shadow-black/20 md:p-8">
         <div className="grid gap-4 lg:grid-cols-[1.3fr_0.9fr]">
-          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
-            <div className="flex items-center gap-2 text-sm font-semibold text-zinc-200">
+          <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/60 p-5">
+            <div className="flex items-center gap-2 text-sm font-semibold text-[var(--foreground)]">
               <Database className="h-4 w-4 text-emerald-400" />
               {title}
             </div>
-            <p className="mt-3 text-sm leading-6 text-zinc-400">{summary}</p>
-            <div className="mt-4 rounded-2xl border border-zinc-800 bg-zinc-950 px-4 py-3">
-              <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">API requirement</div>
-              <div className="mt-2 font-mono text-sm text-zinc-200">{requirement}</div>
+            <p className="mt-3 text-sm leading-6 text-[var(--text-secondary)]">{summary}</p>
+            <div className="mt-4 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)] px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">API requirement</div>
+              <div className="mt-2 font-mono text-sm text-[var(--foreground)]">{requirement}</div>
             </div>
-            <div className="mt-4 rounded-2xl border border-zinc-800 bg-zinc-950 px-4 py-3">
-              <div className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Enable this surface</div>
+            <div className="mt-4 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)] px-4 py-3">
+              <div className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Enable this surface</div>
               <code className="mt-2 block whitespace-pre-wrap font-mono text-sm leading-7 text-emerald-300">
                 {command}
               </code>
             </div>
             {detail ? (
-              <p className="mt-4 text-xs text-zinc-500">
-                Current API response: <span className="font-mono text-zinc-400">{detail}</span>
+              <p className="mt-4 text-xs text-[var(--text-tertiary)]">
+                Current API response: <span className="font-mono text-[var(--text-secondary)]">{detail}</span>
               </p>
             ) : null}
           </div>
 
-          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-5">
-            <div className="flex items-center gap-2 text-sm font-semibold text-zinc-200">
+          <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/60 p-5">
+            <div className="flex items-center gap-2 text-sm font-semibold text-[var(--foreground)]">
               <Settings2 className="h-4 w-4 text-blue-400" />
               What this unlocks
             </div>
@@ -57,19 +57,19 @@ export function IntegrationRequiredState({
               {capabilities.map((capability) => (
                 <li
                   key={capability}
-                  className="rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-2 text-sm text-zinc-400"
+                  className="rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--text-secondary)]"
                 >
                   {capability}
                 </li>
               ))}
             </ul>
-            <p className="mt-4 text-xs leading-5 text-zinc-500">
+            <p className="mt-4 text-xs leading-5 text-[var(--text-tertiary)]">
               Core scan, graph, remediation, and compliance flows still work without this optional data source.
             </p>
             {onRetry ? (
               <button
                 onClick={onRetry}
-                className="mt-5 inline-flex items-center gap-2 rounded-lg border border-zinc-700 bg-zinc-800 px-4 py-2 text-sm text-zinc-200 transition-colors hover:bg-zinc-700"
+                className="mt-5 inline-flex items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-4 py-2 text-sm text-[var(--foreground)] transition-colors hover:bg-[var(--surface-muted)]"
               >
                 <RefreshCw className="h-4 w-4" />
                 Retry

--- a/ui/components/key-lifecycle-panel.tsx
+++ b/ui/components/key-lifecycle-panel.tsx
@@ -50,7 +50,7 @@ function keyStateTone(state: ApiKeyRecord["state"]): string {
       return "border-red-900/60 bg-red-950/30 text-red-300";
     case "expired":
     default:
-      return "border-zinc-800 bg-zinc-900 text-zinc-400";
+      return "border-[var(--border-subtle)] bg-[var(--surface)] text-[var(--text-secondary)]";
   }
 }
 
@@ -105,7 +105,7 @@ function modeTone(value: string): string {
       return "border-amber-900/60 bg-amber-950/30 text-amber-300";
     case "no_auth":
     default:
-      return "border-zinc-800 bg-zinc-900 text-zinc-400";
+      return "border-[var(--border-subtle)] bg-[var(--surface)] text-[var(--text-secondary)]";
   }
 }
 
@@ -123,7 +123,7 @@ function quotaStatusTone(status: string): string {
       return "border-red-900/60 bg-red-950/30 text-red-300";
     case "unlimited":
     default:
-      return "border-zinc-800 bg-zinc-900 text-zinc-400";
+      return "border-[var(--border-subtle)] bg-[var(--surface)] text-[var(--text-secondary)]";
   }
 }
 
@@ -372,14 +372,14 @@ export function KeyLifecyclePanel({
   }
 
   return (
-    <section className="space-y-4 rounded-2xl border border-zinc-800 bg-zinc-950/70 p-5">
+    <section className="space-y-4 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-5">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div>
-          <h2 className="flex items-center gap-2 text-lg font-semibold text-zinc-100">
+          <h2 className="flex items-center gap-2 text-lg font-semibold text-[var(--foreground)]">
             <KeyRound className="h-5 w-5 text-emerald-400" />
             Control-plane auth and API keys
           </h2>
-          <p className="mt-1 text-sm text-zinc-400">
+          <p className="mt-1 text-sm text-[var(--text-secondary)]">
             Rotate service keys with an overlap window, inspect auth policy, and revoke stale machine-to-machine access
             without leaving the control plane.
           </p>
@@ -398,7 +398,7 @@ export function KeyLifecyclePanel({
           </button>
           <button
             onClick={() => void onRefresh()}
-            className="inline-flex items-center gap-1.5 rounded-xl border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-300 transition hover:bg-zinc-800"
+            className="inline-flex items-center gap-1.5 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--text-secondary)] transition hover:bg-[var(--surface-elevated)]"
           >
             <RefreshCw className="h-4 w-4" />
             Refresh
@@ -411,18 +411,18 @@ export function KeyLifecyclePanel({
           <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
             <div>
               <p className="text-sm font-semibold text-emerald-300">{issuedSecret.title}</p>
-              <p className="mt-1 text-sm text-zinc-300">{issuedSecret.detail}</p>
-              <p className="mt-2 text-xs text-zinc-500">This raw key is shown once. Store it securely before you close this panel.</p>
+              <p className="mt-1 text-sm text-[var(--text-secondary)]">{issuedSecret.detail}</p>
+              <p className="mt-2 text-xs text-[var(--text-tertiary)]">This raw key is shown once. Store it securely before you close this panel.</p>
             </div>
             <button
               onClick={() => void copyIssuedSecret()}
-              className="inline-flex items-center gap-1.5 rounded-xl border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-300 transition hover:bg-zinc-800"
+              className="inline-flex items-center gap-1.5 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)] px-3 py-2 text-sm text-[var(--text-secondary)] transition hover:bg-[var(--surface-elevated)]"
             >
               {copied ? <CheckCircle2 className="h-4 w-4 text-emerald-400" /> : <Copy className="h-4 w-4" />}
               {copied ? "Copied" : "Copy raw key"}
             </button>
           </div>
-          <pre className="mt-3 max-w-full overflow-x-auto whitespace-pre-wrap break-all rounded-xl border border-zinc-800 bg-zinc-950 px-3 py-3 text-sm text-zinc-100">
+          <pre className="mt-3 max-w-full overflow-x-auto whitespace-pre-wrap break-all rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-3 py-3 text-sm text-[var(--foreground)]">
             {issuedSecret.rawKey}
           </pre>
         </div>
@@ -433,66 +433,66 @@ export function KeyLifecyclePanel({
       ) : null}
 
       {createOpen ? (
-        <form onSubmit={handleCreateSubmit} className="grid gap-4 rounded-2xl border border-zinc-800 bg-zinc-900/50 p-4 md:grid-cols-3">
-          <label className="space-y-2 text-sm text-zinc-300">
+        <form onSubmit={handleCreateSubmit} className="grid gap-4 rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-4 md:grid-cols-3">
+          <label className="space-y-2 text-sm text-[var(--text-secondary)]">
             <span>Name</span>
             <input
               required
               value={createForm.name}
               onChange={(event) => setCreateForm((current) => ({ ...current, name: event.target.value }))}
-              className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-emerald-500"
+              className="w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none focus:border-emerald-500"
               placeholder="ci-service"
             />
           </label>
-          <label className="space-y-2 text-sm text-zinc-300">
+          <label className="space-y-2 text-sm text-[var(--text-secondary)]">
             <span>Role</span>
             <select
               value={createForm.role}
               onChange={(event) => setCreateForm((current) => ({ ...current, role: event.target.value }))}
-              className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-emerald-500"
+              className="w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none focus:border-emerald-500"
             >
               <option value="viewer">viewer</option>
               <option value="analyst">analyst</option>
               <option value="admin">admin</option>
             </select>
           </label>
-          <label className="space-y-2 text-sm text-zinc-300">
+          <label className="space-y-2 text-sm text-[var(--text-secondary)]">
             <span>Expires at (optional)</span>
             <input
               type="datetime-local"
               value={createForm.expiresAt}
               onChange={(event) => setCreateForm((current) => ({ ...current, expiresAt: event.target.value }))}
-              className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-emerald-500"
+              className="w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none focus:border-emerald-500"
             />
           </label>
-          <label className="space-y-2 text-sm text-zinc-300 md:col-span-3">
+          <label className="space-y-2 text-sm text-[var(--text-secondary)] md:col-span-3">
             <span>Owner (optional)</span>
             <input
               value={createForm.owner}
               onChange={(event) => setCreateForm((current) => ({ ...current, owner: event.target.value }))}
-              className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-emerald-500"
+              className="w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none focus:border-emerald-500"
               placeholder="user@example.com or SCIM user id"
             />
-            <span className="block text-xs text-zinc-500">
+            <span className="block text-xs text-[var(--text-tertiary)]">
               Bind this key to a user so it is revoked when that user is deprovisioned.
             </span>
           </label>
           <div className="md:col-span-3 flex items-center justify-between gap-3">
-            <p className="text-xs text-zinc-500">
+            <p className="text-xs text-[var(--text-tertiary)]">
               Default TTL: {policy ? formatSeconds(policy.api_key.default_ttl_seconds) : "policy unavailable"}.
             </p>
             <div className="flex gap-2">
               <button
                 type="button"
                 onClick={() => setCreateOpen(false)}
-                className="rounded-xl border border-zinc-700 px-3 py-2 text-sm text-zinc-300 transition hover:bg-zinc-800"
+                className="rounded-xl border border-[var(--border-subtle)] px-3 py-2 text-sm text-[var(--text-secondary)] transition hover:bg-[var(--surface-elevated)]"
               >
                 Cancel
               </button>
               <button
                 type="submit"
                 disabled={busyAction === "create"}
-                className="inline-flex items-center gap-1.5 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-zinc-950 transition hover:bg-emerald-400 disabled:opacity-60"
+                className="inline-flex items-center gap-1.5 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-[var(--on-accent)] transition hover:bg-emerald-400 disabled:opacity-60"
               >
                 {busyAction === "create" ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
                 Create key
@@ -506,29 +506,29 @@ export function KeyLifecyclePanel({
         <form onSubmit={handleRotateSubmit} className="grid gap-4 rounded-2xl border border-sky-900/50 bg-sky-950/20 p-4 md:grid-cols-3">
           <div className="md:col-span-3">
             <p className="text-sm font-semibold text-sky-300">Rotate {rotationTarget.name}</p>
-            <p className="mt-1 text-sm text-zinc-300">
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">
               The current key stays valid during the overlap window so clients can roll without downtime.
             </p>
           </div>
-          <label className="space-y-2 text-sm text-zinc-300">
+          <label className="space-y-2 text-sm text-[var(--text-secondary)]">
             <span>Replacement name (optional)</span>
             <input
               value={rotateForm.name}
               onChange={(event) => setRotateForm((current) => ({ ...current, name: event.target.value }))}
-              className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-sky-500"
+              className="w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none focus:border-sky-500"
               placeholder={rotationTarget.name}
             />
           </label>
-          <label className="space-y-2 text-sm text-zinc-300">
+          <label className="space-y-2 text-sm text-[var(--text-secondary)]">
             <span>Replacement expiry (optional)</span>
             <input
               type="datetime-local"
               value={rotateForm.expiresAt}
               onChange={(event) => setRotateForm((current) => ({ ...current, expiresAt: event.target.value }))}
-              className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-sky-500"
+              className="w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none focus:border-sky-500"
             />
           </label>
-          <label className="space-y-2 text-sm text-zinc-300">
+          <label className="space-y-2 text-sm text-[var(--text-secondary)]">
             <span>Overlap seconds</span>
             <input
               type="number"
@@ -536,26 +536,26 @@ export function KeyLifecyclePanel({
               max={policy?.api_key.max_overlap_seconds ?? 86400}
               value={rotateForm.overlapSeconds}
               onChange={(event) => setRotateForm((current) => ({ ...current, overlapSeconds: event.target.value }))}
-              className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-sky-500"
+              className="w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none focus:border-sky-500"
               placeholder={String(policy?.api_key.default_overlap_seconds ?? 900)}
             />
           </label>
           <div className="md:col-span-3 flex items-center justify-between gap-3">
-            <p className="text-xs text-zinc-500">
+            <p className="text-xs text-[var(--text-tertiary)]">
               Allowed overlap: up to {policy ? formatSeconds(policy.api_key.max_overlap_seconds) : "policy unavailable"}.
             </p>
             <div className="flex gap-2">
               <button
                 type="button"
                 onClick={() => setRotationTarget(null)}
-                className="rounded-xl border border-zinc-700 px-3 py-2 text-sm text-zinc-300 transition hover:bg-zinc-800"
+                className="rounded-xl border border-[var(--border-subtle)] px-3 py-2 text-sm text-[var(--text-secondary)] transition hover:bg-[var(--surface-elevated)]"
               >
                 Cancel
               </button>
               <button
                 type="submit"
                 disabled={busyAction === "rotate"}
-                className="inline-flex items-center gap-1.5 rounded-xl bg-sky-500 px-4 py-2 text-sm font-medium text-zinc-950 transition hover:bg-sky-400 disabled:opacity-60"
+                className="inline-flex items-center gap-1.5 rounded-xl bg-sky-500 px-4 py-2 text-sm font-medium text-[var(--on-accent)] transition hover:bg-sky-400 disabled:opacity-60"
               >
                 {busyAction === "rotate" ? <Loader2 className="h-4 w-4 animate-spin" /> : <RotateCw className="h-4 w-4" />}
                 Rotate key
@@ -566,7 +566,7 @@ export function KeyLifecyclePanel({
       ) : null}
 
       {loading ? (
-        <div className="flex items-center justify-center rounded-2xl border border-zinc-800 bg-zinc-900/40 px-4 py-10 text-zinc-400">
+        <div className="flex items-center justify-center rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 px-4 py-10 text-[var(--text-secondary)]">
           <Loader2 className="mr-2 h-5 w-5 animate-spin" />
           Loading auth policy and keys...
         </div>
@@ -595,8 +595,8 @@ export function KeyLifecyclePanel({
           </div>
 
           <div className="grid gap-4 xl:grid-cols-[1.2fr_1fr]">
-            <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
-              <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Operator guidance</p>
+            <section className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-4">
+              <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Operator guidance</p>
               <div className="mt-3 flex flex-wrap gap-2">
                 <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs ${modeTone(policy.ui.recommended_mode)}`}>
                   Recommended: {formatModeLabel(policy.ui.recommended_mode)}
@@ -607,52 +607,52 @@ export function KeyLifecyclePanel({
                   </span>
                 ))}
               </div>
-              <p className="mt-3 text-sm text-zinc-300">{policy.ui.message}</p>
+              <p className="mt-3 text-sm text-[var(--text-secondary)]">{policy.ui.message}</p>
               <div className="mt-4 grid gap-3 md:grid-cols-2">
-                <div className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-3">
-                  <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Runtime rate-limit backend</p>
-                  <p className="mt-2 text-sm font-semibold text-zinc-100">
+                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3">
+                  <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Runtime rate-limit backend</p>
+                  <p className="mt-2 text-sm font-semibold text-[var(--foreground)]">
                     {policy.rate_limit_runtime.backend}
                     {policy.rate_limit_runtime.shared_across_replicas ? " · shared" : " · process-local"}
                   </p>
-                  <p className="mt-1 text-xs text-zinc-400">{policy.rate_limit_runtime.message}</p>
+                  <p className="mt-1 text-xs text-[var(--text-secondary)]">{policy.rate_limit_runtime.message}</p>
                 </div>
-                <div className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-3">
-                  <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Trusted browser path</p>
-                  <p className="mt-2 text-sm font-semibold text-zinc-100">{policy.ui.credentials_mode === "include" ? "Cookie-backed browser session" : policy.ui.credentials_mode}</p>
-                  <p className="mt-1 text-xs text-zinc-400">
+                <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3">
+                  <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Trusted browser path</p>
+                  <p className="mt-2 text-sm font-semibold text-[var(--foreground)]">{policy.ui.credentials_mode === "include" ? "Cookie-backed browser session" : policy.ui.credentials_mode}</p>
+                  <p className="mt-1 text-xs text-[var(--text-secondary)]">
                     Trusted headers: {policy.ui.trusted_proxy_headers.length ? policy.ui.trusted_proxy_headers.join(", ") : "none"}.
                   </p>
                 </div>
               </div>
             </section>
 
-            <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
-              <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Tenant guardrails</p>
-              <p className="mt-3 text-sm text-zinc-300">{policy.tenant_quota_runtime.message}</p>
-              <div className="mt-3 rounded-xl border border-zinc-800 bg-zinc-950/70 p-3">
-                <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Quota source</p>
-                <p className="mt-2 text-sm font-semibold text-zinc-100">
+            <section className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-4">
+              <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Tenant guardrails</p>
+              <p className="mt-3 text-sm text-[var(--text-secondary)]">{policy.tenant_quota_runtime.message}</p>
+              <div className="mt-3 rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3">
+                <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Quota source</p>
+                <p className="mt-2 text-sm font-semibold text-[var(--foreground)]">
                   {policy.tenant_quota_runtime.source}
                   {policy.tenant_quota_runtime.active_override ? " · tenant override active" : " · global defaults active"}
                 </p>
-                <p className="mt-1 break-words text-xs text-zinc-400 [overflow-wrap:anywhere]">Manage overrides at {policy.tenant_quota_runtime.override_endpoint}.</p>
+                <p className="mt-1 break-words text-xs text-[var(--text-secondary)] [overflow-wrap:anywhere]">Manage overrides at {policy.tenant_quota_runtime.override_endpoint}.</p>
               </div>
               <div className="mt-3 grid grid-cols-2 gap-3">
                 {quotaCards.map(({ field, label, value }) => (
-                  <div key={field} className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-3">
+                  <div key={field} className="rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3">
                     <div className="flex items-start justify-between gap-2">
-                      <p className="text-[11px] uppercase tracking-[0.16em] text-zinc-500">{label}</p>
+                      <p className="text-[11px] uppercase tracking-[0.16em] text-[var(--text-tertiary)]">{label}</p>
                       <span className={`rounded-md border px-1.5 py-0.5 text-[10px] uppercase tracking-[0.12em] ${quotaStatusTone(value.status)}`}>
                         {quotaStatusLabel(value.status)}
                       </span>
                     </div>
-                    <p className="mt-2 text-lg font-semibold text-zinc-100">{value.enforced ? value.limit : "Unlimited"}</p>
-                    <p className="mt-1 text-xs text-zinc-400">
+                    <p className="mt-2 text-lg font-semibold text-[var(--foreground)]">{value.enforced ? value.limit : "Unlimited"}</p>
+                    <p className="mt-1 text-xs text-[var(--text-secondary)]">
                       Current {value.current}
                       {value.remaining != null ? ` · Remaining ${value.remaining}` : " · Unlimited"}
                     </p>
-                    <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-zinc-800" aria-hidden="true">
+                    <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-[var(--surface-elevated)]" aria-hidden="true">
                       <div
                         className={`h-full rounded-full ${
                           value.status === "at_limit" ? "bg-red-500" : value.status === "near_limit" ? "bg-amber-400" : "bg-emerald-400"
@@ -660,35 +660,35 @@ export function KeyLifecyclePanel({
                         style={{ width: `${value.utilization_pct ?? 0}%` }}
                       />
                     </div>
-                    <p className="mt-2 text-xs text-zinc-500">{value.recommended_action}</p>
-                    <p className="mt-1 text-[11px] uppercase tracking-[0.14em] text-zinc-500">
+                    <p className="mt-2 text-xs text-[var(--text-tertiary)]">{value.recommended_action}</p>
+                    <p className="mt-1 text-[11px] uppercase tracking-[0.14em] text-[var(--text-tertiary)]">
                       {value.source === "tenant_override" ? "Tenant override" : "Global default"}
                     </p>
                   </div>
                 ))}
               </div>
-              <form onSubmit={handleQuotaSubmit} className="mt-3 rounded-xl border border-zinc-800 bg-zinc-950/70 p-3">
-                <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Override management</p>
-                <p className="mt-2 text-xs text-zinc-400">
+              <form onSubmit={handleQuotaSubmit} className="mt-3 rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3">
+                <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Override management</p>
+                <p className="mt-2 text-xs text-[var(--text-secondary)]">
                   Leave a field blank to inherit the global default. Set `0` only when you intentionally want an unlimited or disabled guardrail.
                 </p>
                 <div className="mt-3 grid grid-cols-2 gap-3">
                   {quotaCards.map(({ field, label, value }) => (
-                    <label key={field} className="space-y-2 text-sm text-zinc-300">
+                    <label key={field} className="space-y-2 text-sm text-[var(--text-secondary)]">
                       <span>{label}</span>
                       <input
                         type="number"
                         min={0}
                         value={quotaForm[field]}
                         onChange={(event) => setQuotaForm((current) => ({ ...current, [field]: event.target.value }))}
-                        className="w-full rounded-xl border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-emerald-500"
+                        className="w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none focus:border-emerald-500"
                         placeholder={`Default ${value.default_limit}`}
                       />
                     </label>
                   ))}
                 </div>
                 <div className="mt-3 flex items-center justify-between gap-3">
-                  <p className="text-xs text-zinc-500">
+                  <p className="text-xs text-[var(--text-tertiary)]">
                     {policy.tenant_quota_runtime.active_override ? "Tenant-specific overrides are active." : "No tenant-specific overrides are active."}
                   </p>
                   <div className="flex gap-2">
@@ -696,14 +696,14 @@ export function KeyLifecyclePanel({
                       type="button"
                       onClick={() => void handleQuotaReset()}
                       disabled={busyAction === "quota"}
-                      className="rounded-xl border border-zinc-700 px-3 py-2 text-sm text-zinc-300 transition hover:bg-zinc-800 disabled:opacity-60"
+                      className="rounded-xl border border-[var(--border-subtle)] px-3 py-2 text-sm text-[var(--text-secondary)] transition hover:bg-[var(--surface-elevated)] disabled:opacity-60"
                     >
                       Reset overrides
                     </button>
                     <button
                       type="submit"
                       disabled={busyAction === "quota"}
-                      className="inline-flex items-center gap-1.5 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-zinc-950 transition hover:bg-emerald-400 disabled:opacity-60"
+                      className="inline-flex items-center gap-1.5 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-[var(--on-accent)] transition hover:bg-emerald-400 disabled:opacity-60"
                     >
                       {busyAction === "quota" ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
                       Save overrides
@@ -714,8 +714,8 @@ export function KeyLifecyclePanel({
             </section>
           </div>
 
-          <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
-            <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Data access boundaries</p>
+          <section className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-4">
+            <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Data access boundaries</p>
             <div className="mt-3 grid gap-3 lg:grid-cols-3">
               <BoundaryCard
                 title="Default posture"
@@ -774,25 +774,25 @@ export function KeyLifecyclePanel({
             </div>
             <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
               {policy.data_access_boundaries.modes.map((mode) => (
-                <div key={mode.mode} className="rounded-xl border border-zinc-800 bg-zinc-950/70 p-3">
-                  <p className="text-sm font-semibold text-zinc-100">{formatStatusLabel(mode.mode)}</p>
-                  <p className="mt-1 text-xs leading-5 text-zinc-400">Reads: {formatBoundaryList(mode.reads)}</p>
+                <div key={mode.mode} className="rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3">
+                  <p className="text-sm font-semibold text-[var(--foreground)]">{formatStatusLabel(mode.mode)}</p>
+                  <p className="mt-1 text-xs leading-5 text-[var(--text-secondary)]">Reads: {formatBoundaryList(mode.reads)}</p>
                   {mode.does_not_read?.length ? (
-                    <p className="mt-1 text-xs leading-5 text-zinc-500">Does not read: {formatBoundaryList(mode.does_not_read)}</p>
+                    <p className="mt-1 text-xs leading-5 text-[var(--text-tertiary)]">Does not read: {formatBoundaryList(mode.does_not_read)}</p>
                   ) : null}
                   {mode.does_not_do?.length ? (
-                    <p className="mt-1 text-xs leading-5 text-zinc-500">Does not do: {formatBoundaryList(mode.does_not_do)}</p>
+                    <p className="mt-1 text-xs leading-5 text-[var(--text-tertiary)]">Does not do: {formatBoundaryList(mode.does_not_do)}</p>
                   ) : null}
                   {mode.does_not_store?.length ? (
-                    <p className="mt-1 text-xs leading-5 text-zinc-500">Does not store: {formatBoundaryList(mode.does_not_store)}</p>
+                    <p className="mt-1 text-xs leading-5 text-[var(--text-tertiary)]">Does not store: {formatBoundaryList(mode.does_not_store)}</p>
                   ) : null}
                 </div>
               ))}
             </div>
           </section>
 
-          <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
-            <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Secret and integrity posture</p>
+          <section className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-4">
+            <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Secret and integrity posture</p>
             <div className="mt-3 grid gap-3 lg:grid-cols-2">
               <BoundaryCard
                 title="Audit HMAC"
@@ -813,8 +813,8 @@ export function KeyLifecyclePanel({
             </div>
           </section>
 
-          <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
-            <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Rotation posture</p>
+          <section className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-4">
+            <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Rotation posture</p>
             <div className="mt-3 grid gap-3 lg:grid-cols-2 xl:grid-cols-4">
               <BoundaryCard
                 title="Service API keys"
@@ -839,8 +839,8 @@ export function KeyLifecyclePanel({
             </div>
           </section>
 
-          <section className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
-            <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">Identity lifecycle</p>
+          <section className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-4">
+            <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Identity lifecycle</p>
             <div className="mt-3 grid gap-3 lg:grid-cols-3">
               <BoundaryCard
                 title="OIDC browser / bearer"
@@ -898,15 +898,15 @@ export function KeyLifecyclePanel({
             </div>
           </section>
 
-          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
+          <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-4">
             <div className="flex flex-wrap items-center justify-between gap-2">
               <div>
-                <h3 className="text-sm font-semibold text-zinc-200">Key inventory</h3>
-                <p className="mt-1 text-xs text-zinc-500">
+                <h3 className="text-sm font-semibold text-[var(--foreground)]">Key inventory</h3>
+                <p className="mt-1 text-xs text-[var(--text-tertiary)]">
                   Rotation overlap lets old and new keys coexist briefly while clients roll.
                 </p>
               </div>
-              <div className="flex flex-wrap gap-2 text-xs text-zinc-500">
+              <div className="flex flex-wrap gap-2 text-xs text-[var(--text-tertiary)]">
                 <span>{stateCounts.rotation_overlap ?? 0} rotating</span>
                 <span>{stateCounts.rotated ?? 0} rotated</span>
                 <span>{stateCounts.revoked ?? 0} revoked</span>
@@ -915,7 +915,7 @@ export function KeyLifecyclePanel({
 
             <div className="mt-4 overflow-x-auto">
               <table className="w-full text-left text-sm">
-                <thead className="text-xs uppercase tracking-[0.18em] text-zinc-500">
+                <thead className="text-xs uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
                   <tr>
                     <th className="pb-2">Name</th>
                     <th className="pb-2">Role</th>
@@ -925,7 +925,7 @@ export function KeyLifecyclePanel({
                     <th className="pb-2 text-right">Actions</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-zinc-800">
+                <tbody className="divide-y divide-[var(--border-subtle)]">
                   {keys.map((key) => {
                     const sessionKey = isSessionKey(key);
                     const canRotate = key.state === "active" && !sessionKey;
@@ -933,20 +933,20 @@ export function KeyLifecyclePanel({
                     return (
                       <tr key={key.key_id}>
                         <td className="py-3">
-                          <div className="font-medium text-zinc-200">{key.name}</div>
-                          <div className="text-xs text-zinc-500">
+                          <div className="font-medium text-[var(--foreground)]">{key.name}</div>
+                          <div className="text-xs text-[var(--text-tertiary)]">
                             {key.key_prefix} · {sessionKey ? "session key" : "service key"}
                           </div>
-                          {key.owner ? <div className="text-xs text-zinc-500">owner: {key.owner}</div> : null}
+                          {key.owner ? <div className="text-xs text-[var(--text-tertiary)]">owner: {key.owner}</div> : null}
                         </td>
-                        <td className="py-3 text-zinc-300">{key.role}</td>
+                        <td className="py-3 text-[var(--text-secondary)]">{key.role}</td>
                         <td className="py-3">
                           <span className={`inline-flex rounded-full border px-2 py-1 text-xs ${keyStateTone(key.state)}`}>
                             {stateLabel(key.state)}
                           </span>
                         </td>
-                        <td className="py-3 text-zinc-400">{key.expires_at ? formatDate(key.expires_at) : "Never"}</td>
-                        <td className="py-3 text-zinc-400">
+                        <td className="py-3 text-[var(--text-secondary)]">{key.expires_at ? formatDate(key.expires_at) : "Never"}</td>
+                        <td className="py-3 text-[var(--text-secondary)]">
                           {key.rotation_overlap_until
                             ? `${formatDate(key.rotation_overlap_until)}${
                                 key.overlap_seconds_remaining != null ? ` · ${formatSeconds(key.overlap_seconds_remaining)} left` : ""
@@ -1005,10 +1005,10 @@ export function KeyLifecyclePanel({
 
 function MetricCard({ label, value, hint }: { label: string; value: string; hint: string }) {
   return (
-    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
-      <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">{label}</p>
-      <p className="mt-2 text-lg font-semibold text-zinc-100">{value}</p>
-      <p className="mt-1 text-xs text-zinc-500">{hint}</p>
+    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-4">
+      <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-tertiary)]">{label}</p>
+      <p className="mt-2 text-lg font-semibold text-[var(--foreground)]">{value}</p>
+      <p className="mt-1 text-xs text-[var(--text-tertiary)]">{hint}</p>
     </div>
   );
 }
@@ -1037,9 +1037,9 @@ function BoundaryCard({
           detail: "text-amber-200/70",
         };
   return (
-    <div className={`min-w-0 rounded-xl border bg-zinc-950/50 p-3 ${tone.border}`}>
+    <div className={`min-w-0 rounded-xl border bg-[var(--background)]/50 p-3 ${tone.border}`}>
       <p className={`text-sm font-semibold ${tone.title}`}>{title}</p>
-      <p className="mt-1 break-words text-xs leading-5 text-zinc-300 [overflow-wrap:anywhere]">{body}</p>
+      <p className="mt-1 break-words text-xs leading-5 text-[var(--text-secondary)] [overflow-wrap:anywhere]">{body}</p>
       {detail ? (
         <p className={`mt-2 break-words text-[11px] uppercase tracking-[0.14em] [overflow-wrap:anywhere] ${tone.detail}`}>{detail}</p>
       ) : null}

--- a/ui/components/large-graph-overview.tsx
+++ b/ui/components/large-graph-overview.tsx
@@ -41,7 +41,7 @@ function StatPill({
   tone?: "zinc" | "red" | "amber" | "cyan";
 }) {
   const toneClass = {
-    zinc: "border-zinc-800 bg-zinc-950/70 text-zinc-300",
+    zinc: "border-[var(--border-subtle)] bg-[var(--background)]/70 text-[var(--text-secondary)]",
     red: "border-red-500/30 bg-red-950/25 text-red-100",
     amber: "border-amber-500/30 bg-amber-950/25 text-amber-100",
     cyan: "border-cyan-500/30 bg-cyan-950/25 text-cyan-100",
@@ -50,7 +50,7 @@ function StatPill({
   return (
     <div className={`flex min-w-0 items-center gap-2 rounded-lg border px-2.5 py-2 ${toneClass}`}>
       <Icon className="h-4 w-4 shrink-0" />
-      <span className="min-w-0 truncate text-[11px] uppercase tracking-[0.14em] text-zinc-500">{label}</span>
+      <span className="min-w-0 truncate text-[11px] uppercase tracking-[0.14em] text-[var(--text-tertiary)]">{label}</span>
       <span className="ml-auto shrink-0 font-mono text-sm font-semibold">{value}</span>
     </div>
   );
@@ -63,12 +63,12 @@ function RelationshipRail({ items }: { items: Array<{ relationship: string; coun
       {items.map((item) => (
         <span
           key={item.relationship}
-          className="inline-flex items-center gap-1.5 rounded-full border border-zinc-800 bg-zinc-950/75 px-2.5 py-1 text-[11px] text-zinc-300"
+          className="inline-flex items-center gap-1.5 rounded-full border border-[var(--border-subtle)] bg-[var(--background)]/75 px-2.5 py-1 text-[11px] text-[var(--text-secondary)]"
         >
           <span className="max-w-36 truncate" title={item.relationship}>
             {item.relationship.replace(/_/g, " ")}
           </span>
-          <span className="font-mono text-zinc-500">{item.count}</span>
+          <span className="font-mono text-[var(--text-tertiary)]">{item.count}</span>
         </span>
       ))}
     </div>
@@ -202,18 +202,18 @@ export function LargeGraphOverview({
   }, [model, selectedNodeId, viewport]);
 
   return (
-    <div className="flex h-full min-h-[72vh] flex-col overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950 shadow-2xl shadow-black/30" data-testid="large-graph-overview">
-      <div className="border-b border-zinc-800 bg-zinc-950/95 p-3">
+    <div className="flex h-full min-h-[72vh] flex-col overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] shadow-2xl shadow-black/30" data-testid="large-graph-overview">
+      <div className="border-b border-[var(--border-subtle)] bg-[var(--background)]/95 p-3">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           <span className="inline-flex shrink-0 items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-950/25 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-200">
             <Network className="h-3.5 w-3.5" />
             Large graph overview
           </span>
-          <span className="min-w-0 text-xs text-zinc-500">
+          <span className="min-w-0 text-xs text-[var(--text-tertiary)]">
             2D canvas overview for broad estate scans; focused investigations still use React Flow.
           </span>
         </div>
-        <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-zinc-500">
+        <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-[var(--text-tertiary)]">
           <span>
             Draw budget: {model.nodes.length.toLocaleString()}/{model.sourceNodeCount.toLocaleString()} nodes,{" "}
             {model.edges.length.toLocaleString()}/{model.sourceEdgeCount.toLocaleString()} edges.

--- a/ui/components/lineage-detail.tsx
+++ b/ui/components/lineage-detail.tsx
@@ -111,7 +111,7 @@ const TYPE_LABELS: Record<LineageNodeData["nodeType"], string> = {
 };
 
 const TYPE_BORDER: Record<LineageNodeData["nodeType"], string> = {
-  provider: "border-zinc-700",
+  provider: "border-[var(--border-subtle)]",
   agent: "border-emerald-700",
   org: "border-teal-800",
   account: "border-teal-700",
@@ -127,7 +127,7 @@ const TYPE_BORDER: Record<LineageNodeData["nodeType"], string> = {
   cluster: "border-sky-700",
   server: "border-blue-700",
   sharedServer: "border-cyan-700",
-  package: "border-zinc-700",
+  package: "border-[var(--border-subtle)]",
   vulnerability: "border-red-700",
   misconfiguration: "border-orange-700",
   credential: "border-amber-700",
@@ -200,24 +200,24 @@ export function LineageDetailPanel({
 
   return (
     <div
-      className={`absolute right-0 top-0 bottom-0 w-80 bg-zinc-950/95 backdrop-blur-sm border-l ${TYPE_BORDER[data.nodeType]} z-50 overflow-y-auto`}
+      className={`absolute right-0 top-0 bottom-0 w-80 bg-[var(--background)]/95 backdrop-blur-sm border-l ${TYPE_BORDER[data.nodeType]} z-50 overflow-y-auto`}
     >
       <div className="p-4 space-y-4">
         <div className="flex items-start justify-between">
           <div>
-            <span className="text-[10px] uppercase tracking-wider text-zinc-500">
+            <span className="text-[10px] uppercase tracking-wider text-[var(--text-tertiary)]">
               {TYPE_LABELS[data.nodeType]}
             </span>
             <div className="flex items-center gap-2 mt-0.5">
-              <Icon className="w-4 h-4 text-zinc-400" />
-              <h3 className="text-sm font-semibold text-zinc-100">
+              <Icon className="w-4 h-4 text-[var(--text-secondary)]" />
+              <h3 className="text-sm font-semibold text-[var(--foreground)]">
                 {data.label}
               </h3>
             </div>
           </div>
           <button
             onClick={onClose}
-            className="p-1 text-zinc-500 hover:text-zinc-300 transition-colors"
+            className="p-1 text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"
           >
             <X className="w-4 h-4" />
           </button>
@@ -383,7 +383,7 @@ export function LineageDetailPanel({
                     {data.effectiveReach.band}
                   </span>
                 </div>
-                <div className="text-[10px] font-mono text-zinc-400 break-all">
+                <div className="text-[10px] font-mono text-[var(--text-secondary)] break-all">
                   {reachFormula(data.effectiveReach)}
                 </div>
                 {data.effectiveReach.reachable_tools &&
@@ -436,7 +436,7 @@ export function LineageDetailPanel({
               </span>
             )}
             {data.description && (
-              <div className="text-xs text-zinc-400">{data.description}</div>
+              <div className="text-xs text-[var(--text-secondary)]">{data.description}</div>
             )}
           </div>
         )}
@@ -454,7 +454,7 @@ export function LineageDetailPanel({
         )}
 
         {data.nodeType === "tool" && data.description && (
-          <div className="text-xs text-zinc-400">{data.description}</div>
+          <div className="text-xs text-[var(--text-secondary)]">{data.description}</div>
         )}
 
         {data.nodeType === "model" && (
@@ -645,7 +645,7 @@ function GenericAssetSection({
   return (
     <div className="space-y-3">
       {description && (
-        <div className="text-xs text-zinc-400">{description}</div>
+        <div className="text-xs text-[var(--text-secondary)]">{description}</div>
       )}
       {version && <Row label="Version / hash" value={version} />}
       {typeof attributes?.verified === "boolean" && (
@@ -669,7 +669,7 @@ function TagList({
   const toneClass =
     tone === "blue"
       ? "bg-blue-950 text-blue-300 border-blue-800"
-      : "bg-zinc-800 text-zinc-400 border-zinc-700";
+      : "bg-[var(--surface-elevated)] text-[var(--text-secondary)] border-[var(--border-subtle)]";
   return (
     <div>
       <Label>{label}</Label>
@@ -701,7 +701,7 @@ function CodeBlock({ label, value }: { label: string; value: string }) {
   return (
     <div>
       <Label>{label}</Label>
-      <div className="text-xs font-mono text-zinc-300 bg-zinc-900 rounded px-2 py-1 break-all">
+      <div className="text-xs font-mono text-[var(--text-secondary)] bg-[var(--surface)] rounded px-2 py-1 break-all">
         {value}
       </div>
     </div>
@@ -710,7 +710,7 @@ function CodeBlock({ label, value }: { label: string; value: string }) {
 
 function Label({ children }: { children: ReactNode }) {
   return (
-    <div className="text-[10px] uppercase tracking-wider text-zinc-500 mb-0.5">
+    <div className="text-[10px] uppercase tracking-wider text-[var(--text-tertiary)] mb-0.5">
       {children}
     </div>
   );
@@ -727,9 +727,9 @@ function Row({
 }) {
   return (
     <div className="flex items-center justify-between gap-4 text-xs">
-      <span className="text-zinc-500">{label}</span>
+      <span className="text-[var(--text-tertiary)]">{label}</span>
       <span
-        className={`text-zinc-300 font-mono text-right break-all ${className}`}
+        className={`text-[var(--text-secondary)] font-mono text-right break-all ${className}`}
       >
         {value}
       </span>
@@ -792,7 +792,7 @@ function EvidenceTierBadge({
   // replay_only
   if (!captureReplay) {
     return (
-      <div className="flex items-center gap-1.5 rounded border border-zinc-700 bg-zinc-900 px-2 py-1 text-[10px] font-mono text-zinc-400">
+      <div className="flex items-center gap-1.5 rounded border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-1 text-[10px] font-mono text-[var(--text-secondary)]">
         <ShieldOff className="w-3 h-3" />
         <span>Not persisted</span>
       </div>
@@ -833,7 +833,7 @@ function RuntimeEvidenceBadge({
   > = {
     static_scan: {
       text: "Static scan evidence",
-      className: "border-zinc-700 bg-zinc-900 text-zinc-300",
+      className: "border-[var(--border-subtle)] bg-[var(--surface)] text-[var(--text-secondary)]",
     },
     runtime_observed: {
       text: "Runtime observed path",

--- a/ui/components/lineage-filter.tsx
+++ b/ui/components/lineage-filter.tsx
@@ -333,10 +333,10 @@ const SEVERITY_RANK_MAP: Record<string, number> = {
 };
 
 const LAYER_LABELS: { key: LineageNodeType; label: string; color: string }[] = [
-  { key: "provider", label: "Providers", color: "bg-zinc-500" },
+  { key: "provider", label: "Providers", color: "bg-[var(--text-tertiary)]" },
   { key: "agent", label: "Agents", color: "bg-emerald-500" },
   { key: "server", label: "Servers", color: "bg-blue-500" },
-  { key: "package", label: "Packages", color: "bg-zinc-500" },
+  { key: "package", label: "Packages", color: "bg-[var(--text-tertiary)]" },
   { key: "model", label: "Models", color: "bg-violet-500" },
   { key: "dataset", label: "Datasets", color: "bg-cyan-500" },
   { key: "container", label: "Containers", color: "bg-indigo-500" },

--- a/ui/components/lineage-nodes.tsx
+++ b/ui/components/lineage-nodes.tsx
@@ -104,7 +104,7 @@ const RUNTIME_EVIDENCE_CHIP: Record<
   static_scan: {
     label: "Static",
     className:
-      "border-zinc-600/70 bg-zinc-900/80 text-zinc-300 dark:border-zinc-500 dark:bg-zinc-950",
+      "border-[var(--border-strong)] bg-[var(--surface-muted)] text-[var(--text-secondary)]",
   },
   runtime_observed: {
     label: "Observed",
@@ -164,10 +164,10 @@ function NodeCard({
       />
       <div className="flex items-center gap-2 mb-1">
         <Icon className={`w-[18px] h-[18px] shrink-0 ${iconClass}`} />
-        <span className="text-[15px] font-semibold leading-5 text-zinc-950 dark:text-zinc-50 truncate">
+        <span className="text-[15px] font-semibold leading-5 text-[var(--foreground)] truncate">
           {data.label}
         </span>
-        <span className="ml-auto rounded border border-black/10 bg-white/70 px-1.5 py-0.5 text-[10px] uppercase tracking-[0.1em] text-zinc-600 dark:border-white/15 dark:bg-black/25 dark:text-zinc-200">
+        <span className="ml-auto rounded border border-black/10 bg-white/70 px-1.5 py-0.5 text-[10px] uppercase tracking-[0.1em] text-[var(--text-secondary)] dark:border-white/15 dark:bg-black/25">
           {NODE_TYPE_BADGES[data.nodeType]}
         </span>
         {data.runtimeEvidenceTier && data.runtimeEvidenceTier !== "static_scan" ? (
@@ -175,7 +175,7 @@ function NodeCard({
         ) : null}
       </div>
       {subtitle && (
-        <div className="text-xs leading-4 text-zinc-700 dark:text-zinc-200/90 truncate">
+        <div className="text-xs leading-4 text-[var(--text-secondary)] truncate">
           {subtitle}
         </div>
       )}
@@ -241,7 +241,7 @@ function AgentNode({ data }: { data: LineageNodeData }) {
       target={false}
       subtitle={data.agentType}
       footer={
-        <div className="flex gap-2 mt-1 text-[10px] text-zinc-600 dark:text-zinc-500">
+        <div className="flex gap-2 mt-1 text-[10px] text-[var(--text-tertiary)]">
           {data.serverCount !== undefined && (
             <span>{data.serverCount} srv</span>
           )}
@@ -261,14 +261,14 @@ function ProviderNode({ data }: { data: LineageNodeData }) {
   return (
     <NodeCard
       data={data}
-      borderClass="border-zinc-300 dark:border-zinc-600"
-      bgClass="bg-white dark:bg-zinc-900/90"
-      ringClass="ring-zinc-400"
-      iconClass="text-zinc-600 dark:text-zinc-400"
+      borderClass="border-[var(--border-subtle)]"
+      bgClass="bg-[var(--surface)]"
+      ringClass="ring-[var(--border-strong)]"
+      iconClass="text-[var(--text-tertiary)]"
       target={false}
       footer={
         data.agentCount !== undefined ? (
-          <div className="mt-1 text-[10px] text-zinc-600 dark:text-zinc-500">
+          <div className="mt-1 text-[10px] text-[var(--text-tertiary)]">
             {data.agentCount} agents
           </div>
         ) : undefined
@@ -365,7 +365,7 @@ function StructureNode({
       iconClass={iconClass}
       subtitle={data.description}
       footer={
-        <div className="flex gap-2 mt-1 text-[10px] text-zinc-600 dark:text-zinc-500">
+        <div className="flex gap-2 mt-1 text-[10px] text-[var(--text-tertiary)]">
           {data.agentCount !== undefined && (
             <span>{data.agentCount} agents</span>
           )}
@@ -436,7 +436,7 @@ function ServerNode({ data }: { data: LineageNodeData }) {
             </span>
           )}
           {data.packageCount !== undefined && data.packageCount > 0 && (
-            <span className="flex items-center gap-0.5 text-[10px] text-zinc-400">
+            <span className="flex items-center gap-0.5 text-[10px] text-[var(--text-secondary)]">
               <Package className="w-2.5 h-2.5" /> {data.packageCount}
             </span>
           )}
@@ -457,15 +457,15 @@ function PackageNode({ data }: { data: LineageNodeData }) {
       borderClass={
         hasVulns
           ? "border-red-400 dark:border-red-600/60"
-          : "border-zinc-300 dark:border-zinc-600"
+          : "border-[var(--border-subtle)]"
       }
       bgClass={
         hasVulns
           ? "bg-red-50 dark:bg-red-950/40"
-          : "bg-white dark:bg-zinc-900/80"
+          : "bg-[var(--surface)]"
       }
-      ringClass="ring-zinc-400"
-      iconClass="text-zinc-600 dark:text-zinc-400"
+      ringClass="ring-[var(--border-strong)]"
+      iconClass="text-[var(--text-tertiary)]"
       subtitle={
         data.version
           ? `${data.version}${data.ecosystem ? ` · ${data.ecosystem}` : ""}${provenance ? ` · ${provenance}` : ""}`
@@ -517,7 +517,7 @@ function FindingNode({
           )}
           {typeof data.cvssScore === "number" &&
           Number.isFinite(data.cvssScore) ? (
-            <span className="text-[10px] text-zinc-400">
+            <span className="text-[10px] text-[var(--text-secondary)]">
               CVSS {data.cvssScore.toFixed(1)}
             </span>
           ) : null}
@@ -721,7 +721,7 @@ function SharedServerNode({ data }: { data: LineageNodeData }) {
             </span>
           )}
           {data.packageCount !== undefined && data.packageCount > 0 && (
-            <span className="flex items-center gap-0.5 text-[10px] text-zinc-600 dark:text-zinc-300">
+            <span className="flex items-center gap-0.5 text-[10px] text-[var(--text-secondary)]">
               <Package className="w-2.5 h-2.5" /> {data.packageCount}
             </span>
           )}
@@ -747,7 +747,7 @@ function SummaryNode({ data }: { data: LineageNodeData }) {
         ? "border-orange-500 bg-orange-100 text-orange-950 dark:bg-orange-950/60 dark:text-orange-200"
         : sev === "medium"
           ? "border-yellow-500 bg-yellow-100 text-yellow-950 dark:bg-yellow-950/55 dark:text-yellow-200"
-          : "border-zinc-300 bg-white text-zinc-900 dark:border-zinc-700 dark:bg-zinc-900/80 dark:text-zinc-200";
+          : "border-[var(--border-subtle)] bg-[var(--surface)] text-[var(--foreground)]";
   const vulnCount = data.vulnCount ?? 0;
   return (
     <div

--- a/ui/components/login-panel.tsx
+++ b/ui/components/login-panel.tsx
@@ -44,7 +44,7 @@ export function LoginPanel({
   if (loading) {
     return (
       <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center">
-        <Loader2 className="h-6 w-6 animate-spin text-zinc-500" />
+        <Loader2 className="h-6 w-6 animate-spin text-[var(--text-tertiary)]" />
       </div>
     );
   }
@@ -58,18 +58,18 @@ export function LoginPanel({
       <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-10">
         <div className="w-full max-w-xl rounded-3xl border border-amber-900/50 bg-amber-950/20 p-8 text-center shadow-2xl shadow-black/20">
           <ShieldCheck className="mx-auto mb-4 h-8 w-8 text-amber-300" />
-          <h1 className="text-xl font-semibold tracking-tight text-zinc-100">Control plane unreachable</h1>
-          <p className="mt-3 text-sm leading-6 text-zinc-400">
+          <h1 className="text-xl font-semibold tracking-tight text-[var(--foreground)]">Control plane unreachable</h1>
+          <p className="mt-3 text-sm leading-6 text-[var(--text-secondary)]">
             Authentication could not be verified because the API is offline or returned a server error. The dashboard
             stays locked until session discovery succeeds.
           </p>
-          <p className="mt-2 text-xs text-zinc-500">
+          <p className="mt-2 text-xs text-[var(--text-tertiary)]">
             {userFacingApiErrorMessage(error, "Failed to load auth session")}
           </p>
           <button
             type="button"
             onClick={() => void refresh()}
-            className="mt-6 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-zinc-950 transition hover:bg-emerald-400"
+            className="mt-6 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-[var(--on-accent)] transition hover:bg-emerald-400"
           >
             Retry connection
           </button>
@@ -90,13 +90,13 @@ export function LoginPanel({
 
     return (
       <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-10">
-        <div className="w-full max-w-md rounded-3xl border border-zinc-800 bg-zinc-950/80 p-8 shadow-2xl shadow-black/20">
+        <div className="w-full max-w-md rounded-3xl border border-[var(--border-subtle)] bg-[var(--background)]/80 p-8 shadow-2xl shadow-black/20">
           <div className="mb-6 text-center">
             <div className="mx-auto mb-4 flex justify-center">
               <BrandLogo />
             </div>
-            <h1 className="text-xl font-semibold tracking-tight text-zinc-100">{title}</h1>
-            <p className="mt-1 text-sm text-zinc-400">
+            <h1 className="text-xl font-semibold tracking-tight text-[var(--foreground)]">{title}</h1>
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">
               {browserOidcConfigured
                 ? "Sign in with SSO, or use an API key as a fallback."
                 : "Enter your API key to access the dashboard."}
@@ -107,15 +107,15 @@ export function LoginPanel({
             <div className="mb-6">
               <a
                 href={OIDC_BROWSER_LOGIN_PATH}
-                className="flex w-full items-center justify-center rounded-xl bg-emerald-500 px-4 py-2.5 text-sm font-medium text-zinc-950 transition hover:bg-emerald-400"
+                className="flex w-full items-center justify-center rounded-xl bg-emerald-500 px-4 py-2.5 text-sm font-medium text-[var(--on-accent)] transition hover:bg-emerald-400"
               >
                 Sign in with SSO
               </a>
               {showApiKeyDivider ? (
-                <div className="mt-6 flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-zinc-600">
-                  <span className="h-px flex-1 bg-zinc-800" />
+                <div className="mt-6 flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-[var(--text-tertiary)]">
+                  <span className="h-px flex-1 bg-[var(--surface-elevated)]" />
                   or use an API key
-                  <span className="h-px flex-1 bg-zinc-800" />
+                  <span className="h-px flex-1 bg-[var(--surface-elevated)]" />
                 </div>
               ) : null}
             </div>
@@ -123,15 +123,15 @@ export function LoginPanel({
 
           {proxyOrBearerHint ? (
             <div className="mb-6">
-              <p className="rounded-2xl border border-zinc-800 bg-zinc-900/60 px-4 py-3 text-center text-sm text-zinc-400">
+              <p className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/60 px-4 py-3 text-center text-sm text-[var(--text-secondary)]">
                 {trustedProxyConfigured
                   ? "Single sign-on is handled by your reverse proxy. Continue there, or use an API key below."
                   : "Single sign-on is handled by your identity provider or reverse proxy."}
               </p>
-              <div className="mt-6 flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-zinc-600">
-                <span className="h-px flex-1 bg-zinc-800" />
+              <div className="mt-6 flex items-center gap-3 text-[11px] uppercase tracking-[0.2em] text-[var(--text-tertiary)]">
+                <span className="h-px flex-1 bg-[var(--surface-elevated)]" />
                 or use an API key
-                <span className="h-px flex-1 bg-zinc-800" />
+                <span className="h-px flex-1 bg-[var(--surface-elevated)]" />
               </div>
             </div>
           ) : null}
@@ -163,28 +163,28 @@ export function LoginPanel({
           >
             <label
               htmlFor="agent-bom-browser-session-api-key"
-              className="mb-2 block text-xs uppercase tracking-[0.2em] text-zinc-500"
+              className="mb-2 block text-xs uppercase tracking-[0.2em] text-[var(--text-tertiary)]"
             >
               API key
             </label>
             <div className="relative">
-              <KeyRound className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-600" />
+              <KeyRound className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-tertiary)]" />
               <input
                 id="agent-bom-browser-session-api-key"
                 type="password"
                 value={apiKey}
                 onChange={(event) => setApiKey(event.target.value)}
-                className="w-full rounded-xl border border-zinc-700 bg-zinc-950 py-2.5 pl-9 pr-3 font-mono text-sm text-zinc-100 outline-none ring-0 placeholder:text-zinc-600 focus:border-emerald-500"
+                className="w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] py-2.5 pl-9 pr-3 font-mono text-sm text-[var(--foreground)] outline-none ring-0 placeholder:text-[var(--text-tertiary)] focus:border-emerald-500"
                 placeholder="Paste your API key"
                 autoComplete="off"
                 autoFocus={!browserOidcConfigured}
               />
             </div>
-            <p className="mt-2 text-xs leading-5 text-zinc-500">
+            <p className="mt-2 text-xs leading-5 text-[var(--text-tertiary)]">
               No key yet? Server operators set API keys via the{" "}
-              <code className="rounded bg-zinc-900 px-1 py-0.5 font-mono text-zinc-300">AGENT_BOM_API_KEYS</code> env var
+              <code className="rounded bg-[var(--surface)] px-1 py-0.5 font-mono text-[var(--text-secondary)]">AGENT_BOM_API_KEYS</code> env var
               (format{" "}
-              <code className="rounded bg-zinc-900 px-1 py-0.5 font-mono text-zinc-300">&lt;key&gt;:&lt;admin|analyst|viewer&gt;</code>).
+              <code className="rounded bg-[var(--surface)] px-1 py-0.5 font-mono text-[var(--text-secondary)]">&lt;key&gt;:&lt;admin|analyst|viewer&gt;</code>).
             </p>
 
             <button
@@ -192,8 +192,8 @@ export function LoginPanel({
               disabled={!apiKey.trim()}
               className={
                 browserOidcConfigured
-                  ? "mt-5 w-full rounded-xl border border-zinc-700 bg-zinc-900 px-4 py-2.5 text-sm font-medium text-zinc-100 transition hover:border-zinc-500 hover:bg-zinc-800 disabled:cursor-not-allowed disabled:border-zinc-800 disabled:bg-zinc-950 disabled:text-zinc-600"
-                  : "mt-5 w-full rounded-xl bg-emerald-500 px-4 py-2.5 text-sm font-medium text-zinc-950 transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-zinc-800 disabled:text-zinc-500"
+                  ? "mt-5 w-full rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)] px-4 py-2.5 text-sm font-medium text-[var(--foreground)] transition hover:border-[var(--border-strong)] hover:bg-[var(--surface-elevated)] disabled:cursor-not-allowed disabled:border-[var(--border-subtle)] disabled:bg-[var(--background)] disabled:text-[var(--text-tertiary)]"
+                  : "mt-5 w-full rounded-xl bg-emerald-500 px-4 py-2.5 text-sm font-medium text-[var(--on-accent)] transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:bg-[var(--surface-elevated)] disabled:text-[var(--text-tertiary)]"
               }
             >
               Sign in
@@ -219,7 +219,7 @@ export function LoginPanel({
                   setApiKey("");
                   await refresh();
                 }}
-                className="text-xs text-zinc-500 underline-offset-4 transition hover:text-zinc-300 hover:underline"
+                className="text-xs text-[var(--text-tertiary)] underline-offset-4 transition hover:text-[var(--text-secondary)] hover:underline"
               >
                 Clear
               </button>
@@ -227,7 +227,7 @@ export function LoginPanel({
           </form>
 
           {!browserOidcConfigured && !proxyOrBearerHint ? (
-            <p className="mt-6 border-t border-zinc-900 pt-4 text-center text-xs text-zinc-600">
+            <p className="mt-6 border-t border-[var(--border-subtle)] pt-4 text-center text-xs text-[var(--text-tertiary)]">
               Setting up single sign-on? Configure browser OIDC, a reverse proxy, or an OIDC issuer in your deployment.
             </p>
           ) : null}

--- a/ui/components/mesh-stats.tsx
+++ b/ui/components/mesh-stats.tsx
@@ -42,7 +42,7 @@ export function MeshStats({
         {compact ? (
           <>
             <Stat icon={ShieldAlert} label="Agents" value={stats.totalAgents} color="text-emerald-400" />
-            <Stat icon={Package} label="Pkgs" value={stats.totalPackages} color="text-zinc-400" />
+            <Stat icon={Package} label="Pkgs" value={stats.totalPackages} color="text-[var(--text-secondary)]" />
             <Stat icon={Bug} label="Vulns" value={stats.totalVulnerabilities} color="text-red-400" />
             {stats.sharedServers > 0 && (
               <Stat icon={Server} label="Shared" value={stats.sharedServers} color="text-cyan-400" />
@@ -52,7 +52,7 @@ export function MeshStats({
           <>
             <Stat icon={ShieldAlert} label="Agents" value={stats.totalAgents} color="text-emerald-400" />
             <Stat icon={Server} label="Shared Servers" value={stats.sharedServers} color="text-cyan-400" />
-            <Stat icon={Package} label="Packages" value={stats.totalPackages} color="text-zinc-400" />
+            <Stat icon={Package} label="Packages" value={stats.totalPackages} color="text-[var(--text-secondary)]" />
             <Stat icon={Bug} label="Vulns" value={stats.totalVulnerabilities} color="text-red-400" />
             <Stat icon={KeyRound} label="Credential refs" value={stats.uniqueCredentials} color="text-amber-400" />
             <Stat icon={Wrench} label="Tool Overlap" value={stats.toolOverlap} color="text-purple-400" />
@@ -63,7 +63,7 @@ export function MeshStats({
         {totalSev > 0 && (
           <div className="flex items-center gap-1.5 ml-2">
             <span className="text-[var(--text-secondary)]">Severity:</span>
-            <div className="flex h-2.5 rounded-full overflow-hidden w-24 bg-zinc-800">
+            <div className="flex h-2.5 rounded-full overflow-hidden w-24 bg-[var(--surface-elevated)]">
               {stats.criticalCount > 0 && (
                 <div
                   className="bg-red-500 h-full"

--- a/ui/components/pagination-bar.tsx
+++ b/ui/components/pagination-bar.tsx
@@ -32,13 +32,13 @@ export function PaginationBar({
 
   return (
     <div className={`flex flex-wrap items-center justify-between gap-3 ${className}`}>
-      <p className="text-xs text-zinc-500">{summary}</p>
+      <p className="text-xs text-[var(--text-tertiary)]">{summary}</p>
       <div className="flex items-center gap-1">
         <button
           type="button"
           onClick={onPrevious}
           disabled={previousDisabled}
-          className="flex items-center gap-1 rounded-md border border-zinc-800 px-2.5 py-1 text-xs font-medium text-zinc-400 transition-colors hover:border-zinc-700 hover:text-zinc-200 disabled:cursor-not-allowed disabled:opacity-40"
+          className="flex items-center gap-1 rounded-md border border-[var(--border-subtle)] px-2.5 py-1 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:border-[var(--border-subtle)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
         >
           <ChevronLeft className="h-3 w-3" />
           Prev
@@ -47,7 +47,7 @@ export function PaginationBar({
           type="button"
           onClick={onNext}
           disabled={nextDisabled}
-          className="flex items-center gap-1 rounded-md border border-zinc-800 px-2.5 py-1 text-xs font-medium text-zinc-400 transition-colors hover:border-zinc-700 hover:text-zinc-200 disabled:cursor-not-allowed disabled:opacity-40"
+          className="flex items-center gap-1 rounded-md border border-[var(--border-subtle)] px-2.5 py-1 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:border-[var(--border-subtle)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
         >
           Next
           <ChevronRight className="h-3 w-3" />

--- a/ui/components/posture-grade.tsx
+++ b/ui/components/posture-grade.tsx
@@ -225,13 +225,13 @@ function CompactDimensionCard({
   const content = (
     <>
       <div className="flex items-center justify-between gap-3">
-        <span className="truncate text-xs font-medium text-zinc-200">{dimension.label}</span>
+        <span className="truncate text-xs font-medium text-[var(--foreground)]">{dimension.label}</span>
         <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${tone.badge}`}>
           {tone.label}
         </span>
       </div>
       <div className="mt-2 flex items-baseline justify-between gap-3">
-        <span className="font-mono text-lg text-zinc-100">{dimension.score}/100</span>
+        <span className="font-mono text-lg text-[var(--foreground)]">{dimension.score}/100</span>
         <span className="text-[11px] text-[var(--text-tertiary)]">{postureDimensionHint(dimensionKey, dimension.label)}</span>
       </div>
       <div className="mt-2 h-1.5 rounded-full bg-[var(--surface-muted)]">
@@ -278,7 +278,7 @@ function DimensionRow({
   const content = (
     <div className="space-y-1">
       <div className="flex items-center justify-between gap-3">
-        <span className="text-xs font-medium text-zinc-300">{dimension.label}</span>
+        <span className="text-xs font-medium text-[var(--text-secondary)]">{dimension.label}</span>
         <span className={`rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${tone.badge}`}>
           {tone.label}
         </span>

--- a/ui/components/proxy-alert-drawer.tsx
+++ b/ui/components/proxy-alert-drawer.tsx
@@ -11,7 +11,7 @@ const SEVERITY_COLORS: Record<string, string> = {
   high: "bg-orange-950 text-orange-300 border-orange-800",
   medium: "bg-yellow-950 text-yellow-300 border-yellow-800",
   low: "bg-blue-950 text-blue-300 border-blue-800",
-  info: "bg-zinc-800 text-zinc-300 border-zinc-700",
+  info: "bg-[var(--surface-elevated)] text-[var(--text-secondary)] border-[var(--border-subtle)]",
 };
 
 export function ProxyAlertDrawer({
@@ -36,10 +36,10 @@ export function ProxyAlertDrawer({
         aria-label="Close proxy alert details"
         onClick={onClose}
       />
-      <aside className="relative h-full w-full max-w-lg overflow-y-auto border-l border-zinc-800 bg-zinc-950 p-5 shadow-2xl">
-        <div className="mb-4 flex items-start justify-between gap-4 border-b border-zinc-800 pb-4">
+      <aside className="relative h-full w-full max-w-lg overflow-y-auto border-l border-[var(--border-subtle)] bg-[var(--background)] p-5 shadow-2xl">
+        <div className="mb-4 flex items-start justify-between gap-4 border-b border-[var(--border-subtle)] pb-4">
           <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
               Runtime alert
             </p>
             <div className="mt-2 flex flex-wrap items-center gap-2">
@@ -50,20 +50,20 @@ export function ProxyAlertDrawer({
               >
                 {alert.severity}
               </span>
-              <span className="font-mono text-sm text-zinc-100">{alert.detector}</span>
+              <span className="font-mono text-sm text-[var(--foreground)]">{alert.detector}</span>
             </div>
-            <h2 className="mt-2 break-all font-mono text-lg font-semibold text-zinc-100">
+            <h2 className="mt-2 break-all font-mono text-lg font-semibold text-[var(--foreground)]">
               {alert.tool_name}
             </h2>
-            <p className="mt-1 text-sm text-zinc-400">{proxyAlertSummary(alert)}</p>
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">{proxyAlertSummary(alert)}</p>
             {alert.ts ? (
-              <p className="mt-2 text-xs text-zinc-600">{formatDate(alert.ts)}</p>
+              <p className="mt-2 text-xs text-[var(--text-tertiary)]">{formatDate(alert.ts)}</p>
             ) : null}
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg border border-zinc-800 bg-zinc-900 p-2 text-zinc-400 transition-colors hover:border-zinc-700 hover:text-zinc-100"
+            className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] p-2 text-[var(--text-secondary)] transition-colors hover:border-[var(--border-subtle)] hover:text-[var(--foreground)]"
             aria-label="Close proxy alert drawer"
           >
             <X className="h-4 w-4" />
@@ -74,12 +74,12 @@ export function ProxyAlertDrawer({
           {rows.map((row) => (
             <div
               key={`${row.label}:${row.value}`}
-              className="rounded-lg border border-zinc-800 bg-zinc-900/60 px-3 py-2"
+              className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/60 px-3 py-2"
             >
-              <dt className="text-[10px] uppercase tracking-[0.16em] text-zinc-500">
+              <dt className="text-[10px] uppercase tracking-[0.16em] text-[var(--text-tertiary)]">
                 {row.label}
               </dt>
-              <dd className="mt-1 break-words font-mono text-xs text-zinc-200">{row.value}</dd>
+              <dd className="mt-1 break-words font-mono text-xs text-[var(--foreground)]">{row.value}</dd>
             </div>
           ))}
         </dl>

--- a/ui/components/scan-mesh.tsx
+++ b/ui/components/scan-mesh.tsx
@@ -80,10 +80,10 @@ export function ScanMeshView({ id }: { id: string }) {
   const onNodeMouseEnter = useCallback((_event: React.MouseEvent, node: Node) => { setHoveredNodeId(node.id); }, []);
   const onNodeMouseLeave = useCallback(() => { setHoveredNodeId(null); }, []);
 
-  if (loading) return <div className="flex items-center justify-center h-[80vh] text-zinc-400"><Loader2 className="w-5 h-5 animate-spin mr-2" />Loading mesh...</div>;
+  if (loading) return <div className="flex items-center justify-center h-[80vh] text-[var(--text-secondary)]"><Loader2 className="w-5 h-5 animate-spin mr-2" />Loading mesh...</div>;
 
   if (error || !job?.result) return (
-    <div className="flex flex-col items-center justify-center h-[80vh] text-zinc-400 gap-3">
+    <div className="flex flex-col items-center justify-center h-[80vh] text-[var(--text-secondary)] gap-3">
       <AlertTriangle className="w-8 h-8 text-amber-500" />
       <p className="text-sm">{error ?? "No scan results found"}</p>
       <Link href={`/scan?id=${id}`} className="text-xs text-emerald-400 hover:text-emerald-300 underline">Back to scan results</Link>
@@ -92,13 +92,13 @@ export function ScanMeshView({ id }: { id: string }) {
 
   return (
     <div className="h-[calc(100vh-3.5rem)] flex flex-col">
-      <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--border-subtle)]">
         <div>
           <div className="flex items-center gap-2">
-            <Link href={`/scan?id=${id}`} className="text-zinc-500 hover:text-zinc-300"><ArrowLeft className="w-4 h-4" /></Link>
-            <h1 className="text-lg font-semibold text-zinc-100">Agent Mesh</h1>
+            <Link href={`/scan?id=${id}`} className="text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"><ArrowLeft className="w-4 h-4" /></Link>
+            <h1 className="text-lg font-semibold text-[var(--foreground)]">Agent Mesh</h1>
           </div>
-          <p className="text-xs text-zinc-500 ml-6">
+          <p className="text-xs text-[var(--text-tertiary)] ml-6">
             Agent-centered shared infrastructure for scan {id.slice(0, 8)} — {job.created_at ? new Date(job.created_at).toLocaleDateString() : ""}
           </p>
         </div>

--- a/ui/components/service-state-chip.tsx
+++ b/ui/components/service-state-chip.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/lib/service-registry";
 
 const STATE_STYLE: Record<ServiceEntry["state"], string> = {
-  locked: "border-zinc-700 bg-zinc-900/80 text-zinc-400",
+  locked: "border-[var(--border-subtle)] bg-[var(--surface)]/80 text-[var(--text-secondary)]",
   connected: "border-amber-500/30 bg-amber-500/10 text-amber-200",
   live: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200",
 };

--- a/ui/components/sigma-graph-overview.tsx
+++ b/ui/components/sigma-graph-overview.tsx
@@ -54,7 +54,7 @@ function StatPill({
   tone?: "zinc" | "red" | "amber" | "emerald";
 }) {
   const toneClass = {
-    zinc: "border-zinc-800 bg-zinc-950/70 text-zinc-300",
+    zinc: "border-[var(--border-subtle)] bg-[var(--background)]/70 text-[var(--text-secondary)]",
     red: "border-red-500/30 bg-red-950/25 text-red-100",
     amber: "border-amber-500/30 bg-amber-950/25 text-amber-100",
     emerald: "border-emerald-500/30 bg-emerald-950/25 text-emerald-100",
@@ -63,7 +63,7 @@ function StatPill({
   return (
     <div className={`flex min-w-0 items-center gap-2 rounded-lg border px-2.5 py-2 ${toneClass}`}>
       <Icon className="h-4 w-4 shrink-0" />
-      <span className="min-w-0 truncate text-[11px] uppercase tracking-[0.14em] text-zinc-500">{label}</span>
+      <span className="min-w-0 truncate text-[11px] uppercase tracking-[0.14em] text-[var(--text-tertiary)]">{label}</span>
       <span className="ml-auto shrink-0 font-mono text-sm font-semibold">{value}</span>
     </div>
   );
@@ -76,12 +76,12 @@ function RelationshipRail({ items }: { items: Array<{ relationship: string; coun
       {items.map((item) => (
         <span
           key={item.relationship}
-          className="inline-flex items-center gap-1.5 rounded-full border border-zinc-800 bg-zinc-950/75 px-2.5 py-1 text-[11px] text-zinc-300"
+          className="inline-flex items-center gap-1.5 rounded-full border border-[var(--border-subtle)] bg-[var(--background)]/75 px-2.5 py-1 text-[11px] text-[var(--text-secondary)]"
         >
           <span className="max-w-36 truncate" title={item.relationship}>
             {item.relationship.replace(/_/g, " ")}
           </span>
-          <span className="font-mono text-zinc-500">{item.count}</span>
+          <span className="font-mono text-[var(--text-tertiary)]">{item.count}</span>
         </span>
       ))}
     </div>
@@ -211,20 +211,20 @@ export function SigmaGraphOverview({
 
   return (
     <div
-      className="flex h-full min-h-[72vh] flex-col overflow-hidden rounded-xl border border-zinc-800 bg-zinc-950 shadow-2xl shadow-black/30"
+      className="flex h-full min-h-[72vh] flex-col overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] shadow-2xl shadow-black/30"
       data-testid="sigma-graph-overview"
     >
-      <div className="border-b border-zinc-800 bg-zinc-950/95 p-3">
+      <div className="border-b border-[var(--border-subtle)] bg-[var(--background)]/95 p-3">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           <span className="inline-flex shrink-0 items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-950/25 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-200">
             <Sparkles className="h-3.5 w-3.5" />
             WebGL graph overview
           </span>
-          <span className="min-w-0 text-xs text-zinc-500">
+          <span className="min-w-0 text-xs text-[var(--text-tertiary)]">
             Sigma.js renderer for broad estate scans; focused investigations still use React Flow.
           </span>
         </div>
-        <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-zinc-500">
+        <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-[var(--text-tertiary)]">
           <span>
             Switches on with renderer=webgl at {LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD.toLocaleString()} nodes or{" "}
             {LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD.toLocaleString()} edges.
@@ -264,8 +264,8 @@ export function SigmaGraphOverview({
           </div>
         )}
         <div className="pointer-events-auto absolute right-3 top-3 max-w-[min(30rem,calc(100vw-2rem))]">
-          <details className="rounded-xl border border-zinc-800 bg-zinc-950/85 p-2 backdrop-blur">
-            <summary className="cursor-pointer list-none text-[10px] uppercase tracking-[0.18em] text-zinc-400 [&::-webkit-details-marker]:hidden">
+          <details className="rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/85 p-2 backdrop-blur">
+            <summary className="cursor-pointer list-none text-[10px] uppercase tracking-[0.18em] text-[var(--text-secondary)] [&::-webkit-details-marker]:hidden">
               Legend
             </summary>
             <div className="mt-2">

--- a/ui/components/topology-detail-drawer.tsx
+++ b/ui/components/topology-detail-drawer.tsx
@@ -69,19 +69,19 @@ export function TopologyDetailDrawer({
       aria-label={`Topology details for ${title}`}
     >
       <button type="button" className="absolute inset-0 cursor-default" aria-label="Close topology details" onClick={onClose} />
-      <aside className="relative h-full w-full max-w-md overflow-y-auto border-l border-zinc-800 bg-zinc-950 p-5 shadow-2xl">
-        <div className="mb-4 flex items-start justify-between gap-4 border-b border-zinc-800 pb-4">
+      <aside className="relative h-full w-full max-w-md overflow-y-auto border-l border-[var(--border-subtle)] bg-[var(--background)] p-5 shadow-2xl">
+        <div className="mb-4 flex items-start justify-between gap-4 border-b border-[var(--border-subtle)] pb-4">
           <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-500">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
               {selection.kind === "agent" ? "Agent runtime" : "Shared MCP service"}
             </p>
-            <h2 className="mt-2 text-lg font-semibold text-zinc-100">{title}</h2>
-            <p className="mt-1 text-sm text-zinc-400">{subtitle}</p>
+            <h2 className="mt-2 text-lg font-semibold text-[var(--foreground)]">{title}</h2>
+            <p className="mt-1 text-sm text-[var(--text-secondary)]">{subtitle}</p>
           </div>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg border border-zinc-700 bg-zinc-900 p-2 text-zinc-400 transition hover:text-zinc-100"
+            className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] p-2 text-[var(--text-secondary)] transition hover:text-[var(--foreground)]"
             aria-label="Close topology drawer"
           >
             <X className="h-4 w-4" />
@@ -104,13 +104,13 @@ export function TopologyDetailDrawer({
 
         {selection.kind === "server" && connectedAgents.length > 1 ? (
           <div className="mb-4">
-            <p className="mb-2 flex items-center gap-1.5 text-xs text-zinc-500">
+            <p className="mb-2 flex items-center gap-1.5 text-xs text-[var(--text-tertiary)]">
               <Users className="h-3.5 w-3.5" />
               Shared blast radius
             </p>
             <div className="flex flex-wrap gap-1.5">
               {connectedAgents.map((entry) => (
-                <span key={entry.name} className="rounded bg-zinc-900 px-2 py-0.5 text-xs text-zinc-300">
+                <span key={entry.name} className="rounded bg-[var(--surface)] px-2 py-0.5 text-xs text-[var(--text-secondary)]">
                   {topologyAgentDisplayName(entry)}
                 </span>
               ))}
@@ -124,7 +124,7 @@ export function TopologyDetailDrawer({
           ))}
         </div>
 
-        <div className="mt-5 flex flex-wrap gap-2 border-t border-zinc-800 pt-4">
+        <div className="mt-5 flex flex-wrap gap-2 border-t border-[var(--border-subtle)] pt-4">
           {selection.kind === "agent" ? (
             <Link
               href={`/agents?name=${encodeURIComponent(selection.name)}`}
@@ -135,13 +135,13 @@ export function TopologyDetailDrawer({
           ) : null}
           <Link
             href="/mesh"
-            className="rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-xs font-medium text-zinc-300"
+            className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-3 py-1.5 text-xs font-medium text-[var(--text-secondary)]"
           >
             Agent mesh
           </Link>
           <Link
             href="/security-graph"
-            className="rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-xs font-medium text-zinc-300"
+            className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-3 py-1.5 text-xs font-medium text-[var(--text-secondary)]"
           >
             Security graph
           </Link>
@@ -163,12 +163,12 @@ function Metric({
   tone?: "neutral" | "danger";
 }) {
   return (
-    <div className="rounded-lg border border-zinc-800 bg-zinc-900/70 px-3 py-2">
-      <div className={`flex items-center gap-1.5 text-[10px] ${tone === "danger" ? "text-red-300" : "text-zinc-500"}`}>
+    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/70 px-3 py-2">
+      <div className={`flex items-center gap-1.5 text-[10px] ${tone === "danger" ? "text-red-300" : "text-[var(--text-tertiary)]"}`}>
         <Icon className="h-3.5 w-3.5" />
         {label}
       </div>
-      <div className={`mt-1 font-mono text-sm ${tone === "danger" ? "text-red-100" : "text-zinc-100"}`}>{value}</div>
+      <div className={`mt-1 font-mono text-sm ${tone === "danger" ? "text-red-100" : "text-[var(--foreground)]"}`}>{value}</div>
     </div>
   );
 }
@@ -176,13 +176,13 @@ function Metric({
 function ServerCard({ agentName, server }: { agentName: string; server: MCPServer }) {
   const vulns = serverVulnerabilityCount(server);
   return (
-    <div className="rounded-xl border border-zinc-800 bg-zinc-900/60 px-3 py-2.5">
+    <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/60 px-3 py-2.5">
       <div className="flex items-center justify-between gap-2">
-        <span className="text-sm font-medium text-zinc-100">{server.name}</span>
+        <span className="text-sm font-medium text-[var(--foreground)]">{server.name}</span>
         {serverHasCredentials(server) ? <Lock className="h-3.5 w-3.5 text-amber-300" /> : null}
       </div>
-      <p className="mt-1 truncate font-mono text-[10px] text-zinc-500">{agentName}</p>
-      <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-zinc-500">
+      <p className="mt-1 truncate font-mono text-[10px] text-[var(--text-tertiary)]">{agentName}</p>
+      <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-[var(--text-tertiary)]">
         <span>{server.packages?.length ?? 0} packages</span>
         <span>{server.tools?.length ?? 0} tools</span>
         {vulns > 0 ? <span className="text-red-300">{vulns} CVE{vulns === 1 ? "" : "s"}</span> : null}

--- a/ui/components/trace-explorer-panel.tsx
+++ b/ui/components/trace-explorer-panel.tsx
@@ -51,7 +51,7 @@ export function TraceExplorerPanel() {
 
   if (loading) {
     return (
-      <div className="flex items-center gap-2 rounded-2xl border border-zinc-800 bg-zinc-900/50 px-4 py-10 text-sm text-zinc-400">
+      <div className="flex items-center gap-2 rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/50 px-4 py-10 text-sm text-[var(--text-secondary)]">
         <Loader2 className="h-4 w-4 animate-spin" />
         Loading runtime trace explorer…
       </div>
@@ -68,7 +68,7 @@ export function TraceExplorerPanel() {
 
   if (!data || data.sessions.length === 0) {
     return (
-      <div className="rounded-2xl border border-dashed border-zinc-800 bg-zinc-900/40 px-4 py-10 text-center text-sm text-zinc-500">
+      <div className="rounded-2xl border border-dashed border-[var(--border-subtle)] bg-[var(--surface)]/40 px-4 py-10 text-center text-sm text-[var(--text-tertiary)]">
         No runtime sessions yet. Gateway/proxy blocks and authorized tool calls will appear here once enforcement traffic is flowing.
       </div>
     );
@@ -76,9 +76,9 @@ export function TraceExplorerPanel() {
 
   return (
     <div className="grid gap-4 xl:grid-cols-[280px_minmax(0,1fr)_320px]">
-      <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-4">
-        <h2 className="text-sm font-semibold text-zinc-200">Sessions</h2>
-        <p className="mt-1 text-xs text-zinc-500">{data.session_count} sessions · {data.blocked_count} blocked spans</p>
+      <section className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-4">
+        <h2 className="text-sm font-semibold text-[var(--foreground)]">Sessions</h2>
+        <p className="mt-1 text-xs text-[var(--text-tertiary)]">{data.session_count} sessions · {data.blocked_count} blocked spans</p>
         <div className="mt-4 space-y-2">
           {data.sessions.map((session) => (
             <button
@@ -91,11 +91,11 @@ export function TraceExplorerPanel() {
               className={`w-full rounded-xl border px-3 py-2 text-left transition-colors ${
                 selectedSessionId === session.session_id
                   ? "border-emerald-700/60 bg-emerald-950/30"
-                  : "border-zinc-800 bg-zinc-950/60 hover:border-zinc-700"
+                  : "border-[var(--border-subtle)] bg-[var(--background)]/60 hover:border-[var(--border-subtle)]"
               }`}
             >
-              <div className="text-sm font-medium text-zinc-100">{session.agent || session.session_id}</div>
-              <div className="mt-1 text-xs text-zinc-500">
+              <div className="text-sm font-medium text-[var(--foreground)]">{session.agent || session.session_id}</div>
+              <div className="mt-1 text-xs text-[var(--text-tertiary)]">
                 {session.spans.length} spans · {session.blocked_count} blocked
               </div>
             </button>
@@ -103,9 +103,9 @@ export function TraceExplorerPanel() {
         </div>
       </section>
 
-      <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-4">
-        <h2 className="text-sm font-semibold text-zinc-200">Flow</h2>
-        <p className="mt-1 text-xs text-zinc-500">Tool-call timeline for the selected session.</p>
+      <section className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-4">
+        <h2 className="text-sm font-semibold text-[var(--foreground)]">Flow</h2>
+        <p className="mt-1 text-xs text-[var(--text-tertiary)]">Tool-call timeline for the selected session.</p>
         <div className="mt-4 space-y-2">
           {(selectedSession?.spans ?? []).map((span) => (
             <button
@@ -115,7 +115,7 @@ export function TraceExplorerPanel() {
               className={`flex w-full items-center gap-3 rounded-xl border px-3 py-3 text-left transition-colors ${
                 selectedSpanId === span.span_id
                   ? "border-sky-700/60 bg-sky-950/20"
-                  : "border-zinc-800 bg-zinc-950/60 hover:border-zinc-700"
+                  : "border-[var(--border-subtle)] bg-[var(--background)]/60 hover:border-[var(--border-subtle)]"
               }`}
             >
               <span
@@ -128,24 +128,24 @@ export function TraceExplorerPanel() {
                 {span.verdict === "blocked" ? <ShieldAlert className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
               </span>
               <span className="min-w-0 flex-1">
-                <span className="block truncate font-mono text-xs text-zinc-200">{span.tool || span.action_type}</span>
-                <span className="mt-1 block text-[11px] text-zinc-500">{span.timestamp || "—"} · {span.verdict}</span>
+                <span className="block truncate font-mono text-xs text-[var(--foreground)]">{span.tool || span.action_type}</span>
+                <span className="mt-1 block text-[11px] text-[var(--text-tertiary)]">{span.timestamp || "—"} · {span.verdict}</span>
               </span>
             </button>
           ))}
         </div>
       </section>
 
-      <section className="rounded-2xl border border-zinc-800 bg-zinc-900/50 p-4">
-        <h2 className="text-sm font-semibold text-zinc-200">Detail</h2>
+      <section className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-4">
+        <h2 className="text-sm font-semibold text-[var(--foreground)]">Detail</h2>
         {!selectedSpan ? (
-          <p className="mt-4 text-sm text-zinc-500">Select a span to inspect policy and finding joins.</p>
+          <p className="mt-4 text-sm text-[var(--text-tertiary)]">Select a span to inspect policy and finding joins.</p>
         ) : (
           <div className="mt-4 space-y-4 text-sm">
             <div>
-              <div className="text-[11px] uppercase tracking-wide text-zinc-500">Tool call</div>
-              <div className="mt-1 font-mono text-zinc-100">{selectedSpan.tool || "unknown"}</div>
-              <div className="mt-2 text-xs text-zinc-400">{selectedSpan.detail}</div>
+              <div className="text-[11px] uppercase tracking-wide text-[var(--text-tertiary)]">Tool call</div>
+              <div className="mt-1 font-mono text-[var(--foreground)]">{selectedSpan.tool || "unknown"}</div>
+              <div className="mt-2 text-xs text-[var(--text-secondary)]">{selectedSpan.detail}</div>
             </div>
             <div className="flex flex-wrap gap-2">
               <span className={`rounded border px-2 py-0.5 text-xs uppercase ${
@@ -155,18 +155,18 @@ export function TraceExplorerPanel() {
               }`}>
                 {selectedSpan.verdict}
               </span>
-              <span className="rounded border border-zinc-700 bg-zinc-900 px-2 py-0.5 text-xs text-zinc-300">
+              <span className="rounded border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-0.5 text-xs text-[var(--text-secondary)]">
                 {selectedSpan.agent}
               </span>
             </div>
             <div>
-              <div className="text-[11px] uppercase tracking-wide text-zinc-500">Linked findings</div>
+              <div className="text-[11px] uppercase tracking-wide text-[var(--text-tertiary)]">Linked findings</div>
               {selectedSpan.linked_findings.length === 0 ? (
-                <p className="mt-2 text-xs text-zinc-500">No correlated CVE findings for this agent/tool path.</p>
+                <p className="mt-2 text-xs text-[var(--text-tertiary)]">No correlated CVE findings for this agent/tool path.</p>
               ) : (
                 <div className="mt-2 space-y-2">
                   {selectedSpan.linked_findings.map((finding) => (
-                    <div key={String(finding.finding_id)} className="rounded-lg border border-zinc-800 bg-zinc-950/70 p-3">
+                    <div key={String(finding.finding_id)} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3">
                       <div className="flex items-center justify-between gap-2">
                         <Link href={`/findings?cve=${encodeURIComponent(String(finding.vulnerability_id || ""))}`} className="font-mono text-xs text-emerald-300 hover:underline">
                           {finding.vulnerability_id}
@@ -188,10 +188,10 @@ export function TraceExplorerPanel() {
             </div>
             {selectedSpan.compliance_controls.length > 0 && (
               <div>
-                <div className="text-[11px] uppercase tracking-wide text-zinc-500">Compliance controls</div>
+                <div className="text-[11px] uppercase tracking-wide text-[var(--text-tertiary)]">Compliance controls</div>
                 <div className="mt-2 flex flex-wrap gap-1">
                   {selectedSpan.compliance_controls.map((tag) => (
-                    <span key={tag} className="rounded border border-zinc-700 bg-zinc-900 px-2 py-0.5 font-mono text-[10px] text-zinc-300">
+                    <span key={tag} className="rounded border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-0.5 font-mono text-[10px] text-[var(--text-secondary)]">
                       {tag}
                     </span>
                   ))}

--- a/ui/lib/findings-view.ts
+++ b/ui/lib/findings-view.ts
@@ -103,7 +103,7 @@ export function findingStatusClass(status: string | undefined): string {
   if (normalized === "reopened") {
     return "bg-orange-950 border-orange-800 text-orange-300";
   }
-  return "bg-zinc-900 border-zinc-700 text-zinc-500";
+  return "bg-[var(--surface)] border-[var(--border-subtle)] text-[var(--text-tertiary)]";
 }
 
 export function hasLifecycleMetadata(rows: EnrichedVuln[]): boolean {

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -19,10 +19,10 @@ import type { GraphChangeKind, GraphDiffResponse } from "@/lib/api-types";
 // ─── Shared Styling Constants ────────────────────────────────────────────────
 
 export const CONTROLS_CLASS =
-  "!bg-zinc-900/90 !border-zinc-700 !rounded-lg !backdrop-blur-sm [&>button]:!bg-zinc-800 [&>button]:!border-zinc-700 [&>button]:!text-zinc-300 [&>button:hover]:!bg-zinc-700";
+  "!bg-[var(--surface)]/90 !border-[var(--border-subtle)] !rounded-lg !backdrop-blur-sm [&>button]:!bg-[var(--surface-elevated)] [&>button]:!border-[var(--border-subtle)] [&>button]:!text-[var(--text-secondary)] [&>button:hover]:!bg-[var(--surface-muted)]";
 
 export const MINIMAP_CLASS =
-  "!bg-zinc-900/90 !border-zinc-700 !rounded-lg !backdrop-blur-sm";
+  "!bg-[var(--surface)]/90 !border-[var(--border-subtle)] !rounded-lg !backdrop-blur-sm";
 export const MINIMAP_BG = "#09090b";
 export const MINIMAP_MASK = "rgba(24,24,27,0.82)";
 

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -28,7 +28,10 @@ const BUDGETS = {
   // and graph investigation. Total counts every emitted route chunk, including lazy-loaded views.
   // Includes the New Scan scope explainer, connected-account picker, and
   // repository-surface coverage cockpit shipped with the operator workflow.
-  totalClientJsBytes: 3_300_000,
+  // Raised for the light-theme tokenization — semantic token class names
+  // (`text-[color:var(--text-tertiary)]`) are longer string literals than the raw
+  // `zinc-*` utilities they replace, so the compiled className strings grow a few KiB.
+  totalClientJsBytes: 3_379_200,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };

--- a/ui/tests/light-theme-token-guard.test.ts
+++ b/ui/tests/light-theme-token-guard.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -11,12 +11,57 @@ const GUARDED_GRAPH_SURFACES = [
 const DARK_ONLY_SURFACE_CLASS =
   /\b(?:bg|border)-zinc-(?:700|800|900|950)(?:\/\d+)?\b|\btext-zinc-(?:100|200|300|400|500|600)(?:\/\d+)?\b|\b(?:bg-black|text-white|shadow-black)(?:\/\d+)?\b/g;
 
+// Any Tailwind zinc-* color utility (bg/text/border/ring/divide/etc.), with an
+// optional variant chain, ! important, and /opacity suffix. Light theme is only
+// legible when every surface/label uses a semantic token from globals.css, so
+// the whole UI tree must be free of hardcoded zinc utilities (#3966).
+const ZINC_UTILITY =
+  /(?:^|[\s"'`([{])(?:[\w.&>[\]-]+:)*!?(?:bg|text|border|divide|ring-offset|ring|placeholder|outline|fill|stroke|from|via|to)-zinc-\d{2,3}(?:\/\d+)?/g;
+
+const UI_ROOT = process.cwd();
+const SCAN_DIRS = ["app", "components", "lib", "hooks"];
+
+function walk(dir: string): string[] {
+  let out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === ".next") continue;
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out = out.concat(walk(full));
+    } else if (/\.(tsx?|jsx?)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
 describe("light theme token guard", () => {
   it("keeps shared graph chrome and filters on theme tokens instead of dark-only panels", () => {
     const violations = GUARDED_GRAPH_SURFACES.flatMap((file) => {
-      const source = readFileSync(path.join(process.cwd(), file), "utf8");
+      const source = readFileSync(path.join(UI_ROOT, file), "utf8");
       return [...source.matchAll(DARK_ONLY_SURFACE_CLASS)].map((match) => `${file}: ${match[0]}`);
     });
+
+    expect(violations).toEqual([]);
+  });
+
+  it("has no hardcoded zinc-* Tailwind utilities anywhere in the UI source", () => {
+    const violations: string[] = [];
+    for (const dir of SCAN_DIRS) {
+      const base = path.join(UI_ROOT, dir);
+      let files: string[];
+      try {
+        files = walk(base);
+      } catch {
+        continue; // dir may not exist
+      }
+      for (const file of files) {
+        const source = readFileSync(file, "utf8");
+        for (const match of source.matchAll(ZINC_UTILITY)) {
+          violations.push(`${path.relative(UI_ROOT, file)}: ${match[0].trim()}`);
+        }
+      }
+    }
 
     expect(violations).toEqual([]);
   });


### PR DESCRIPTION
Light-theme tokenization pass (part of #3966): replaces hard-coded `zinc-*` utility colours across the dashboard with theme tokens so the UI renders correctly in light mode. ~61 UI files, 1994 → 0 raw `zinc` usages, guarded by `ui/tests/light-theme-token-guard.test.ts`.

UI-only change. Rebased onto current `main`.

## Bundle budget
The semantic token class names (e.g. `text-[color:var(--text-tertiary)]`) are longer string literals than the raw `zinc-*` utilities they replace, so the compiled `className` strings in the client JS grew ~3.4 KiB (measured 3226.1 KiB). This is expected content growth — no new dependency or import (package.json / lockfile untouched). `totalClientJsBytes` is intentionally raised to 3300 KiB (~2.3% honest headroom); the other budgets are unchanged and still pass.

**Follow-up (not done here):** registering these tokens as Tailwind theme color utilities — so we can write the short `text-text-tertiary` instead of the arbitrary-value `text-[color:var(--text-tertiary)]` — would shrink the class strings and reclaim most of that budget. Tracked as a separate cleanup.

## Verification (from `ui/`)
- `npm ci` → 590 packages, 0 vulnerabilities
- `npm run typecheck` (`tsc --noEmit`) → clean
- `npm run build` → **Compiled successfully**, all routes prerendered
- `npm run bundle:check` → **PASS** (3226.1 KiB / budget 3300.0 KiB)
- `npx vitest run` → **503 passed (99 files)**, including the light-theme token guard

Scope note: this is the token-migration part of #3966. The Recharts hex-colour charts still read raw hex and are tracked as a **separate follow-up** — not included here.

Refs #3966 (light-theme tokenization part).
