### PR TITLE
Combine: live IAM evaluation + MITRE ATT&CK coverage endpoint

### DIFF
--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -17,7 +17,7 @@ attack paths, compliance tags, and runtime audit chain.
 | Area | Shipped today |
 |---|---|
 | MCP security tools | 73 tools, 6 resources, 8 workflow prompts |
-| REST API | 306 operations across 35 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| REST API | 307 operations across 36 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,7 +155,7 @@ flowchart TB
         M4["Max body size"]
     end
     subgraph BE["Backend - FastAPI"]
-        R["306 REST operations across 35 route modules\nplus 2 WebSocket routes"]
+        R["307 REST operations across 36 route modules\nplus 2 WebSocket routes"]
     end
     subgraph ST["Stores - start on SQLite, scale to a cluster without rewrites"]
         S1["SQLite (default / single node)"]

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 260 |
+| `docs/openapi/v1.json` | paths | 261 |
 | `docs/openapi/v1.json` | component schemas | 68 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (260 paths / 306 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (261 paths / 307 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,7 +47,7 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 
 - Deployment chooser (Docker / Helm / EKS / Postgres):
   [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
-- API contract (306 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- API contract (307 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
 - Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
   [`PERMISSIONS.md`](PERMISSIONS.md)
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -17978,6 +17978,90 @@
         ]
       }
     },
+    "/v1/mitre/coverage": {
+      "get": {
+        "description": "Per-framework MITRE technique coverage for the current tenant.\n\nAggregates hub-ingested plus native scan findings and reports, for each of\nMITRE ATT&CK, MITRE ATLAS, and MAESTRO: the covered technique count and\nlist (techniques with >=1 finding of evidence), the total catalogue count,\nthe coverage percentage, and the covered techniques' finding references.\n\nHonest by construction: uncovered techniques mean \"no evidence\", not\n\"safe\". The store read runs off the event loop.",
+        "operationId": "mitre_coverage_v1_mitre_coverage_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Mitre Coverage V1 Mitre Coverage Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mitre Coverage",
+        "tags": [
+          "mitre"
+        ]
+      }
+    },
     "/v1/observability/anomalies": {
       "get": {
         "description": "Detect cost and behavior anomalies (per-agent spend + per-session call-rate\nz-scores) for the active tenant. Proactive surfacing of runaway agents.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -11728,6 +11728,67 @@ paths:
       summary: Check Malicious
       tags:
       - security
+  /v1/mitre/coverage:
+    get:
+      description: 'Per-framework MITRE technique coverage for the current tenant.
+
+
+        Aggregates hub-ingested plus native scan findings and reports, for each of
+
+        MITRE ATT&CK, MITRE ATLAS, and MAESTRO: the covered technique count and
+
+        list (techniques with >=1 finding of evidence), the total catalogue count,
+
+        the coverage percentage, and the covered techniques'' finding references.
+
+
+        Honest by construction: uncovered techniques mean "no evidence", not
+
+        "safe". The store read runs off the event loop.'
+      operationId: mitre_coverage_v1_mitre_coverage_get
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Mitre Coverage V1 Mitre Coverage Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Mitre Coverage
+      tags:
+      - mitre
   /v1/observability/anomalies:
     get:
       description: 'Detect cost and behavior anomalies (per-agent spend + per-session

--- a/src/agent_bom/api/hub_reference_payload.py
+++ b/src/agent_bom/api/hub_reference_payload.py
@@ -38,6 +38,7 @@ _CVE_INTEL_KEYS: tuple[str, ...] = (
 _FRAMEWORK_TAG_KEYS: tuple[str, ...] = (
     "owasp_tags",
     "atlas_tags",
+    "attack_tags",
     "nist_ai_rmf_tags",
     "owasp_mcp_tags",
     "owasp_agentic_tags",

--- a/src/agent_bom/api/routes/mitre.py
+++ b/src/agent_bom/api/routes/mitre.py
@@ -1,0 +1,113 @@
+"""MITRE technique-coverage API routes (#3892).
+
+Endpoint:
+    GET /v1/mitre/coverage   per-framework technique coverage for the tenant
+
+Coverage is the honest read of *which adversary techniques the estate's
+findings actually provide evidence for* versus the full technique catalogue,
+unified across MITRE ATT&CK, MITRE ATLAS, and MAESTRO. "Covered" means a
+finding maps to the technique; "uncovered" means no evidence yet — never an
+assertion that the technique is mitigated. See :mod:`agent_bom.mitre_coverage`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+import anyio.to_thread
+from fastapi import APIRouter, Request
+
+from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.rbac import require_authenticated_permission
+
+
+def _dep(permission: str) -> Any:
+    return cast(Any, require_authenticated_permission(permission))
+
+
+router = APIRouter(dependencies=[_dep("read")])
+_logger = logging.getLogger(__name__)
+
+# Finding-payload fields the coverage aggregation reads. Kept small so native
+# scan rows can be projected cheaply without the full finding-view pipeline.
+_TAG_FIELDS: tuple[str, ...] = (
+    "attack_tags",
+    "attack_techniques",
+    "mitre_attack_tags",
+    "atlas_tags",
+    "mitre_atlas_tags",
+)
+
+
+def _native_coverage_findings(jobs: list[Any]) -> list[dict[str, Any]]:
+    """Project completed native scans into slim coverage findings.
+
+    Only technique tags, a stable id, and the finding source are needed, so we
+    read ``blast_radius`` directly instead of the heavier finding-view path.
+    """
+    from agent_bom.api.models import JobStatus
+
+    rows: list[dict[str, Any]] = []
+    for job in jobs:
+        if getattr(job, "status", None) != JobStatus.DONE or not getattr(job, "result", None):
+            continue
+        result = job.result or {}
+        job_id = str(getattr(job, "job_id", "") or "")
+        for idx, item in enumerate(result.get("blast_radius", []) or []):
+            if not isinstance(item, dict):
+                continue
+            vuln = str(item.get("vulnerability_id") or item.get("id") or "")
+            pkg = str(item.get("package") or item.get("package_name") or "")
+            row: dict[str, Any] = {
+                "id": item.get("finding_id") or item.get("id") or f"{job_id}:{vuln}:{pkg}:{idx}",
+                "source": item.get("source") or "blast_radius",
+            }
+            for field in _TAG_FIELDS:
+                value = item.get(field)
+                if value:
+                    row[field] = value
+            rows.append(row)
+    return rows
+
+
+def _build_coverage(tenant_id: str, jobs: list[Any]) -> dict[str, Any]:
+    """Collect the tenant's findings and compute coverage (runs off-loop)."""
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+    from agent_bom.mitre_coverage import build_mitre_coverage
+
+    findings: list[dict[str, Any]] = []
+    store = get_compliance_hub_store()
+    try:
+        hub_findings = store.list(tenant_id)
+    except Exception:  # pragma: no cover - defensive: never fail coverage on a store hiccup
+        _logger.warning("hub store list failed for tenant coverage", exc_info=True)
+        hub_findings = []
+    findings.extend(f for f in hub_findings if isinstance(f, dict))
+    findings.extend(_native_coverage_findings(jobs))
+
+    coverage = build_mitre_coverage(findings)
+    coverage["sources"] = {
+        "hub_findings": len(hub_findings),
+        "native_findings": len(findings) - len(hub_findings),
+    }
+    return coverage
+
+
+@router.get("/mitre/coverage", tags=["mitre"])
+async def mitre_coverage(request: Request) -> dict[str, Any]:
+    """Per-framework MITRE technique coverage for the current tenant.
+
+    Aggregates hub-ingested plus native scan findings and reports, for each of
+    MITRE ATT&CK, MITRE ATLAS, and MAESTRO: the covered technique count and
+    list (techniques with >=1 finding of evidence), the total catalogue count,
+    the coverage percentage, and the covered techniques' finding references.
+
+    Honest by construction: uncovered techniques mean "no evidence", not
+    "safe". The store read runs off the event loop.
+    """
+    tenant_id = require_request_tenant_id(request)
+    from agent_bom.api.stores import _get_store
+
+    jobs = _get_store().list_all(tenant_id=tenant_id)
+    return await anyio.to_thread.run_sync(_build_coverage, tenant_id, jobs)

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -873,8 +873,8 @@ from agent_bom.api.routes.governance import router as _governance_router  # noqa
 from agent_bom.api.routes.graph import router as _graph_router  # noqa: E402
 from agent_bom.api.routes.identities import router as _identities_router  # noqa: E402
 from agent_bom.api.routes.intel import router as _intel_router  # noqa: E402
-from agent_bom.api.routes.mitre import router as _mitre_router  # noqa: E402
 from agent_bom.api.routes.inventory_assets import router as _inventory_assets_router  # noqa: E402
+from agent_bom.api.routes.mitre import router as _mitre_router  # noqa: E402
 from agent_bom.api.routes.observability import infra_router as _observability_infra_router  # noqa: E402
 from agent_bom.api.routes.observability import router as _observability_router  # noqa: E402
 from agent_bom.api.routes.overview import router as _overview_router  # noqa: E402

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -873,6 +873,7 @@ from agent_bom.api.routes.governance import router as _governance_router  # noqa
 from agent_bom.api.routes.graph import router as _graph_router  # noqa: E402
 from agent_bom.api.routes.identities import router as _identities_router  # noqa: E402
 from agent_bom.api.routes.intel import router as _intel_router  # noqa: E402
+from agent_bom.api.routes.mitre import router as _mitre_router  # noqa: E402
 from agent_bom.api.routes.inventory_assets import router as _inventory_assets_router  # noqa: E402
 from agent_bom.api.routes.observability import infra_router as _observability_infra_router  # noqa: E402
 from agent_bom.api.routes.observability import router as _observability_router  # noqa: E402
@@ -916,6 +917,7 @@ for _router in (
     _identities_router,
     _intel_router,
     _inventory_assets_router,
+    _mitre_router,
     _observability_router,
     _overview_router,
     _plugins_router,

--- a/src/agent_bom/cloud/aws.py
+++ b/src/agent_bom/cloud/aws.py
@@ -565,30 +565,32 @@ def _policy_actions_from_document(document: Any) -> list[str]:
     return actions
 
 
-def _policy_privilege(iam: Any, policy_arn: str, policy_name: str, *, warnings: list[str]) -> tuple[str, list[str]]:
-    """Return (privilege_level, sampled_actions) for an attached policy.
+def _policy_privilege(iam: Any, policy_arn: str, policy_name: str, *, warnings: list[str]) -> tuple[str, list[str], dict[str, Any] | None]:
+    """Return (privilege_level, sampled_actions, raw_document) for an attached policy.
 
-    AWS-managed policies are classified by their canonical name (no API call).
-    Customer-managed policies are fetched and classified by their actions.
-    Degrades to ('unknown', []) on any error — never blocks discovery.
+    AWS-managed policies are classified by their canonical name (no API call) and
+    carry no document. Customer-managed policies are fetched and classified by
+    their actions, and the raw document is returned so the effective-permissions
+    overlay can run real policy evaluation.
+    Degrades to ('unknown', [], None) on any error — never blocks discovery.
     """
     name_key = (policy_name or policy_arn).rsplit("/", 1)[-1].lower()
     if ":aws:policy/" in policy_arn and name_key in _AWS_MANAGED_PRIVILEGE:
-        return _AWS_MANAGED_PRIVILEGE[name_key], []
+        return _AWS_MANAGED_PRIVILEGE[name_key], [], None
     if ":aws:policy/" in policy_arn:
         # Unknown AWS-managed policy — name still hints at privilege.
         if "fullaccess" in name_key or "admin" in name_key:
-            return "admin", []
+            return "admin", [], None
         if "readonly" in name_key or "viewonly" in name_key:
-            return "read", []
+            return "read", [], None
     try:
         version_id = iam.get_policy(PolicyArn=policy_arn)["Policy"]["DefaultVersionId"]
         document = iam.get_policy_version(PolicyArn=policy_arn, VersionId=version_id)["PolicyVersion"]["Document"]
         actions = _policy_actions_from_document(document)
-        return _classify_policy_actions(actions), sorted(set(actions))[:25]
+        return _classify_policy_actions(actions), sorted(set(actions))[:25], document if isinstance(document, dict) else None
     except Exception as exc:  # noqa: BLE001
         warnings.append(f"IAM policy action lookup skipped for {policy_name or policy_arn}: {sanitize_discovery_warning(exc)}")
-        return "unknown", []
+        return "unknown", [], None
 
 
 def _enrich_agents_with_iam(session: Any, agents: list[Agent], *, account_id: str | None, warnings: list[str]) -> None:
@@ -624,17 +626,20 @@ def _enrich_agents_with_iam(session: Any, agents: list[Agent], *, account_id: st
                     policy_name = str(policy.get("PolicyName") or policy_arn or "")
                     if not (policy_arn or policy_name):
                         continue
-                    privilege_level, actions = _policy_privilege(iam, policy_arn, policy_name, warnings=warnings)
-                    policies.append(
-                        {
-                            "policy_id": policy_arn,
-                            "policy_name": policy_name,
-                            "attachment_type": "managed",
-                            "privilege_level": privilege_level,
-                            "actions": actions,
-                            "source_field": "ListAttachedRolePolicies.AttachedPolicies",
-                        }
-                    )
+                    privilege_level, actions, document = _policy_privilege(iam, policy_arn, policy_name, warnings=warnings)
+                    policy_entry: dict[str, Any] = {
+                        "policy_id": policy_arn,
+                        "policy_name": policy_name,
+                        "attachment_type": "managed",
+                        "privilege_level": privilege_level,
+                        "actions": actions,
+                        "source_field": "ListAttachedRolePolicies.AttachedPolicies",
+                    }
+                    # Retain the raw document (customer-managed only) so the graph
+                    # can run real effective-permission evaluation.
+                    if isinstance(document, dict):
+                        policy_entry["policy_document"] = document
+                    policies.append(policy_entry)
         except Exception as exc:
             warnings.append(f"IAM role enrichment skipped for {role_name}: {sanitize_discovery_warning(exc)}")
             continue

--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -1401,15 +1401,20 @@ def _attached_policies(iam: Any, principal_kind: str, principal_name: str, *, wa
                 policy_name = str(policy.get("PolicyName", "") or policy_arn)
                 if not (policy_arn or policy_name):
                     continue
-                policies.append(
-                    {
-                        "policy_id": policy_arn,
-                        "policy_name": policy_name,
-                        "attachment_type": "managed",
-                        "privilege_level": _policy_privilege(iam, policy_arn, policy_name, warnings=warnings),
-                        "source_field": f"ListAttached{principal_kind.capitalize()}Policies.AttachedPolicies",
-                    }
-                )
+                privilege_level, document = _policy_privilege_and_document(iam, policy_arn, policy_name, warnings=warnings)
+                entry: dict[str, Any] = {
+                    "policy_id": policy_arn,
+                    "policy_name": policy_name,
+                    "attachment_type": "managed",
+                    "privilege_level": privilege_level,
+                    "source_field": f"ListAttached{principal_kind.capitalize()}Policies.AttachedPolicies",
+                }
+                # Carry the raw document so the effective-permissions overlay can run
+                # REAL policy evaluation (customer-managed only; AWS-managed policies
+                # are name-classified without a fetch and have no document to attach).
+                if isinstance(document, dict):
+                    entry["policy_document"] = document
+                policies.append(entry)
     except Exception as exc:  # noqa: BLE001
         warnings.append(f"IAM policy enumeration skipped for {principal_kind} {principal_name}: {sanitize_discovery_warning(exc)}")
     return policies
@@ -1436,21 +1441,26 @@ def _inline_policies(iam: Any, principal_kind: str, principal_name: str, *, warn
                 if not name:
                     continue
                 privilege = "unknown"
+                document: Any = None
                 try:
                     document = get_doc(**{kwarg: principal_name, "PolicyName": name}).get("PolicyDocument")
                     privilege = _classify_policy_actions(_policy_actions_from_document(document))
                 except Exception as exc:  # noqa: BLE001
                     short = sanitize_discovery_warning(exc)
                     warnings.append(f"IAM inline policy doc skipped for {principal_kind} {principal_name}/{name}: {short}")
-                policies.append(
-                    {
-                        "policy_id": f"{principal_name}/{name}",
-                        "policy_name": str(name),
-                        "attachment_type": "inline",
-                        "privilege_level": privilege,
-                        "source_field": f"List{principal_kind.capitalize()}Policies.PolicyNames",
-                    }
-                )
+                entry: dict[str, Any] = {
+                    "policy_id": f"{principal_name}/{name}",
+                    "policy_name": str(name),
+                    "attachment_type": "inline",
+                    "privilege_level": privilege,
+                    "source_field": f"List{principal_kind.capitalize()}Policies.PolicyNames",
+                }
+                # Inline documents are already read for classification; retain the raw
+                # document so the overlay can evaluate it (an inline "*:*" is a common
+                # benignly-named admin path the name heuristic cannot see).
+                if isinstance(document, dict):
+                    entry["policy_document"] = document
+                policies.append(entry)
     except Exception as exc:  # noqa: BLE001
         warnings.append(f"IAM inline policy enumeration skipped for {principal_kind} {principal_name}: {sanitize_discovery_warning(exc)}")
     return policies
@@ -1468,28 +1478,32 @@ _AWS_MANAGED_PRIVILEGE: dict[str, str] = {
 }
 
 
-def _policy_privilege(iam: Any, policy_arn: str, policy_name: str, *, warnings: list[str]) -> str:
-    """Classify an attached policy as admin / write / read / unknown.
+def _policy_privilege_and_document(
+    iam: Any, policy_arn: str, policy_name: str, *, warnings: list[str]
+) -> tuple[str, dict[str, Any] | None]:
+    """Classify an attached policy and return its raw document when fetched.
 
-    AWS-managed policies are classified by canonical name (no API call).
-    Customer-managed policies are fetched and classified by their Allow actions.
-    Degrades to ``"unknown"`` on any error — never blocks enumeration.
+    AWS-managed policies are classified by canonical name (no API call), so no
+    document is returned for them (``None``). Customer-managed policies are
+    fetched and classified by their Allow actions, and the raw document is
+    returned so the effective-permissions overlay can evaluate it.
+    Degrades to ``("unknown", None)`` on any error — never blocks enumeration.
     """
     name_key = (policy_name or policy_arn).rsplit("/", 1)[-1].lower()
     if ":aws:policy/" in policy_arn and name_key in _AWS_MANAGED_PRIVILEGE:
-        return _AWS_MANAGED_PRIVILEGE[name_key]
+        return _AWS_MANAGED_PRIVILEGE[name_key], None
     if ":aws:policy/" in policy_arn:
         if "fullaccess" in name_key or "admin" in name_key:
-            return "admin"
+            return "admin", None
         if "readonly" in name_key or "viewonly" in name_key:
-            return "read"
+            return "read", None
     try:
         version_id = iam.get_policy(PolicyArn=policy_arn)["Policy"]["DefaultVersionId"]
         document = iam.get_policy_version(PolicyArn=policy_arn, VersionId=version_id)["PolicyVersion"]["Document"]
-        return _classify_policy_actions(_policy_actions_from_document(document))
+        return _classify_policy_actions(_policy_actions_from_document(document)), document if isinstance(document, dict) else None
     except Exception as exc:  # noqa: BLE001
         warnings.append(f"IAM policy action lookup skipped for {policy_name or policy_arn}: {sanitize_discovery_warning(exc)}")
-        return "unknown"
+        return "unknown", None
 
 
 _PRIVILEGE_RANK = {"admin": 3, "write": 2, "read": 1, "unknown": 0}

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -16,6 +16,7 @@ from typing import Any
 from agent_bom.api.tracing import get_tracer
 from agent_bom.asset_provenance import package_version_provenance, sanitize_discovery_provenance
 from agent_bom.canonical_ids import canonical_agent_id, canonical_graph_node_id, source_ids
+from agent_bom.cloud.aws_iam_evidence import EvidenceCompleteness, normalize_iam_policy_document
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import NodeDimensions, UnifiedNode, stable_node_id
@@ -1927,26 +1928,52 @@ def _first_cloud_scope_value(scope: dict[str, Any], *keys: str) -> tuple[str, st
     return "", ""
 
 
-def _policy_entries(principal: dict[str, Any]) -> list[dict[str, str]]:
+def _policy_entries(principal: dict[str, Any]) -> list[dict[str, Any]]:
     raw_policies = principal.get("policies") or principal.get("attached_policies") or principal.get("policy_ids") or []
     if isinstance(raw_policies, (str, bytes)):
         raw_policies = [raw_policies]
     if not isinstance(raw_policies, list):
         return []
 
-    policies: list[dict[str, str]] = []
+    policies: list[dict[str, Any]] = []
     for raw_policy in raw_policies:
         privilege_level = "unknown"
+        document: Any = None
         if isinstance(raw_policy, dict):
             policy_id = _clean_graph_part(raw_policy.get("policy_id")) or _clean_graph_part(raw_policy.get("arn"))
             policy_name = _clean_graph_part(raw_policy.get("policy_name")) or _clean_graph_part(raw_policy.get("name")) or policy_id
             privilege_level = str(raw_policy.get("privilege_level") or "unknown")
+            # Discovery may carry the raw IAM policy document (``policy_document``,
+            # or the AWS API ``PolicyDocument``); pass it through so the POLICY node
+            # can carry it and the effective-permissions overlay can evaluate it.
+            document = raw_policy.get("policy_document")
+            if document is None:
+                document = raw_policy.get("PolicyDocument")
         else:
             policy_id = _clean_graph_part(raw_policy)
             policy_name = policy_id
         if policy_id:
-            policies.append({"id": policy_id, "name": policy_name or policy_id, "privilege_level": privilege_level})
+            entry: dict[str, Any] = {"id": policy_id, "name": policy_name or policy_id, "privilege_level": privilege_level}
+            if isinstance(document, dict) and document:
+                entry["policy_document"] = document
+            policies.append(entry)
     return policies
+
+
+def _policy_document_attrs(policy: Mapping[str, Any]) -> dict[str, Any]:
+    """Return ``{"policy_document": <doc>}`` for a parseable IAM policy, else ``{}``.
+
+    The raw document is what the effective-permissions overlay expects on the
+    POLICY node — it re-normalizes at evaluation time. We validate here with
+    ``normalize_iam_policy_document`` and only attach documents that parse to at
+    least one statement, so unparseable/empty payloads never bloat the graph.
+    """
+    document = policy.get("policy_document")
+    if not isinstance(document, Mapping) or not document:
+        return {}
+    if normalize_iam_policy_document(document).completeness is EvidenceCompleteness.UNAVAILABLE:
+        return {}
+    return {"policy_document": dict(document)}
 
 
 def _trust_entries(principal: dict[str, Any]) -> list[dict[str, str]]:
@@ -2269,6 +2296,7 @@ def _add_agent_cloud_lineage(
             policy_name=policy["name"],
             privilege_level=policy.get("privilege_level", "unknown"),
             cloud_provider=provider,
+            **_policy_document_attrs(policy),
         )
         _add_rel_edge(
             graph,
@@ -5577,6 +5605,7 @@ def _add_inventory_principal(
                     "policy_name": policy["name"],
                     "privilege_level": policy.get("privilege_level", "unknown"),
                     "cloud_provider": provider,
+                    **_policy_document_attrs(policy),
                 },
                 data_sources=data_sources,
                 dimensions=NodeDimensions(cloud_provider=provider, surface="identity"),
@@ -5706,6 +5735,7 @@ def _add_inventory_group(
             policy_name=policy["name"],
             privilege_level=policy.get("privilege_level", "unknown"),
             cloud_provider=provider,
+            **_policy_document_attrs(policy),
         )
         _add_rel_edge(
             graph, group_node_id, policy_node_id, RelationshipType.ATTACHED, {"source": "cloud-inventory", "principal_type": "group"}

--- a/src/agent_bom/mitre_coverage.py
+++ b/src/agent_bom/mitre_coverage.py
@@ -1,0 +1,255 @@
+"""MITRE technique-coverage surface (#3892).
+
+Aggregates a tenant's findings into an honest *coverage* view per adversary
+framework: which techniques the estate's findings actually provide evidence
+for, versus the full technique catalogue.
+
+Honesty contract:
+
+* **Covered** = a technique carries at least one finding with mapped evidence
+  (an ATT&CK / ATLAS technique tag, or a MAESTRO layer derived from an
+  explicitly mapped finding source).
+* **Uncovered** = *no evidence yet*. It is **not** an assertion that the
+  technique is mitigated or that the estate is safe against it. A big estate
+  with few tagged findings honestly shows low coverage rather than a fabricated
+  high number.
+
+Denominators come straight from the active catalogues (ATT&CK / ATLAS) or the
+fixed MAESTRO layer set, so ``coverage_pct`` reflects the real framework size.
+
+This module is pure and side-effect free: callers pass in already-loaded
+finding payloads (see :mod:`agent_bom.api.routes` for the tenant-scoped, off
+the event loop wiring). It does no database or network I/O of its own.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+# Cap finding references per technique so the payload stays bounded even when a
+# single technique is tagged by hundreds of thousands of findings at scale.
+_MAX_REFS_PER_TECHNIQUE = 25
+
+COVERED_DEFINITION = "technique has >=1 finding with mapped evidence"
+UNCOVERED_DEFINITION = (
+    "no finding evidence yet; this is 'no evidence', NOT an assertion that the "
+    "technique is mitigated or that the estate is safe against it"
+)
+
+# Candidate finding fields that may carry ATT&CK technique tags, in priority
+# order. Native scans emit ``attack_tags``; some ingest paths use
+# ``attack_techniques``.
+_ATTACK_TAG_FIELDS: tuple[str, ...] = ("attack_tags", "attack_techniques", "mitre_attack_tags")
+_ATLAS_TAG_FIELDS: tuple[str, ...] = ("atlas_tags", "mitre_atlas_tags")
+
+
+def _canonical_technique_id(raw: Any) -> str:
+    """Normalize a raw technique tag to its canonical catalogue form."""
+    text = str(raw or "").strip().upper()
+    # Tags are sometimes rendered as "T1190 Exploit Public-Facing App"; keep the
+    # leading identifier token only.
+    return text.split()[0] if text else ""
+
+
+def _finding_ref(finding: Mapping[str, Any]) -> str:
+    for key in ("id", "finding_id", "canonical_id"):
+        value = finding.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def _iter_tags(finding: Mapping[str, Any], fields: tuple[str, ...]) -> Iterable[str]:
+    for field in fields:
+        raw = finding.get(field)
+        if not raw:
+            continue
+        if isinstance(raw, str):
+            yield raw
+            continue
+        if isinstance(raw, Iterable):
+            for item in raw:
+                if item:
+                    yield str(item)
+
+
+def _collect_technique_refs(
+    findings: Iterable[Mapping[str, Any]],
+    *,
+    tag_fields: tuple[str, ...],
+    valid_ids: Mapping[str, str],
+) -> dict[str, list[str]]:
+    """Map ``technique_id -> ordered, de-duplicated finding refs``.
+
+    Only technique ids present in ``valid_ids`` are counted, so an unknown or
+    malformed tag never inflates coverage.
+    """
+    refs: dict[str, list[str]] = {}
+    seen: dict[str, set[str]] = {}
+    for finding in findings:
+        if not isinstance(finding, Mapping):
+            continue
+        ref = _finding_ref(finding)
+        for raw in _iter_tags(finding, tag_fields):
+            tid = _canonical_technique_id(raw)
+            if not tid or tid not in valid_ids:
+                continue
+            bucket = refs.setdefault(tid, [])
+            seen_refs = seen.setdefault(tid, set())
+            if ref and ref not in seen_refs:
+                seen_refs.add(ref)
+                bucket.append(ref)
+    return refs
+
+
+def _covered_techniques(
+    refs: Mapping[str, list[str]],
+    *,
+    labels: Mapping[str, str],
+    label_fn: Any = None,
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for tid in sorted(refs):
+        ordered = refs[tid]
+        label = label_fn(tid) if label_fn is not None else labels.get(tid, tid)
+        out.append(
+            {
+                "id": tid,
+                "label": label,
+                "finding_count": len(ordered),
+                "finding_refs": ordered[:_MAX_REFS_PER_TECHNIQUE],
+                "finding_refs_truncated": len(ordered) > _MAX_REFS_PER_TECHNIQUE,
+            }
+        )
+    return out
+
+
+def _coverage_pct(covered: int, total: int) -> float:
+    if total <= 0:
+        return 0.0
+    return round(covered / total * 100, 2)
+
+
+def build_attack_coverage(findings: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    """Coverage of MITRE ATT&CK Enterprise techniques by finding evidence."""
+    from agent_bom.mitre_attack import get_attack_techniques
+    from agent_bom.mitre_fetch import get_attack_version
+
+    catalogue = get_attack_techniques()
+    findings = list(findings)
+    refs = _collect_technique_refs(findings, tag_fields=_ATTACK_TAG_FIELDS, valid_ids=catalogue)
+    covered = _covered_techniques(refs, labels=catalogue)
+    total = len(catalogue)
+    return {
+        "framework": "mitre_attack",
+        "name": "MITRE ATT&CK Enterprise",
+        "evidence_source": "finding.attack_tags",
+        "catalogue_total": total,
+        "catalogue_version": get_attack_version(),
+        "covered_count": len(covered),
+        "coverage_pct": _coverage_pct(len(covered), total),
+        "covered_techniques": covered,
+    }
+
+
+def build_atlas_coverage(findings: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    """Coverage of MITRE ATLAS techniques by finding evidence.
+
+    ``catalogue_total`` is the curated tag surface (the techniques findings can
+    actually be mapped to); ``catalogue_upstream_total`` discloses the full
+    upstream ATLAS catalogue so the number is not read as total ATLAS coverage.
+    """
+    from agent_bom import atlas
+
+    catalogue = dict(atlas.ATLAS_TECHNIQUES)
+    findings = list(findings)
+    refs = _collect_technique_refs(findings, tag_fields=_ATLAS_TAG_FIELDS, valid_ids=catalogue)
+    covered = _covered_techniques(refs, labels=catalogue, label_fn=atlas.atlas_label)
+    total = atlas.curated_total()
+    return {
+        "framework": "mitre_atlas",
+        "name": "MITRE ATLAS",
+        "evidence_source": "finding.atlas_tags",
+        "catalogue_total": total,
+        "catalogue_upstream_total": atlas.upstream_total(),
+        "covered_count": len(covered),
+        "coverage_pct": _coverage_pct(len(covered), total),
+        "covered_techniques": covered,
+    }
+
+
+def build_maestro_coverage(findings: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    """Coverage of MAESTRO layers by finding evidence.
+
+    A layer is credited only when a finding's ``source`` maps *explicitly* to
+    it. The default ``KC6`` fallback used elsewhere is deliberately not applied
+    here, so an unmapped source never fabricates infrastructure-layer coverage.
+    """
+    from agent_bom.maestro import _SOURCE_TO_LAYER, LAYER_DESCRIPTIONS, MaestroLayer, layer_label
+
+    findings = list(findings)
+    # Layer id ("KC1") -> ordered, de-duplicated finding refs.
+    refs: dict[str, list[str]] = {}
+    seen: dict[str, set[str]] = {}
+    for finding in findings:
+        if not isinstance(finding, Mapping):
+            continue
+        source = str(finding.get("source") or "").strip().lower()
+        if not source:
+            continue
+        layer = _SOURCE_TO_LAYER.get(source)
+        if layer is None:
+            continue
+        layer_id = layer.value.split(":", 1)[0].strip()
+        ref = _finding_ref(finding)
+        bucket = refs.setdefault(layer_id, [])
+        seen_refs = seen.setdefault(layer_id, set())
+        if ref and ref not in seen_refs:
+            seen_refs.add(ref)
+            bucket.append(ref)
+
+    covered: list[dict[str, Any]] = []
+    for layer_id in sorted(refs):
+        ordered = refs[layer_id]
+        layer = next((la for la in MaestroLayer if la.value.startswith(f"{layer_id}:")), None)
+        label = layer_label(layer) if layer is not None else layer_id
+        covered.append(
+            {
+                "id": layer_id,
+                "label": label,
+                "finding_count": len(ordered),
+                "finding_refs": ordered[:_MAX_REFS_PER_TECHNIQUE],
+                "finding_refs_truncated": len(ordered) > _MAX_REFS_PER_TECHNIQUE,
+            }
+        )
+
+    total = len(LAYER_DESCRIPTIONS)
+    return {
+        "framework": "mitre_maestro",
+        "name": "MAESTRO",
+        "evidence_source": "finding.source -> MAESTRO layer",
+        "catalogue_total": total,
+        "covered_count": len(covered),
+        "coverage_pct": _coverage_pct(len(covered), total),
+        "covered_techniques": covered,
+    }
+
+
+def build_mitre_coverage(findings: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    """Unified coverage across ATT&CK, ATLAS, and MAESTRO.
+
+    ``findings`` is materialized once and shared across all three builders so
+    the caller pays a single pass over the tenant's findings.
+    """
+    materialized = list(findings)
+    return {
+        "covered_definition": COVERED_DEFINITION,
+        "uncovered_definition": UNCOVERED_DEFINITION,
+        "finding_count": len(materialized),
+        "frameworks": [
+            build_attack_coverage(materialized),
+            build_atlas_coverage(materialized),
+            build_maestro_coverage(materialized),
+        ],
+    }

--- a/tests/test_aws_iam_privilege.py
+++ b/tests/test_aws_iam_privilege.py
@@ -30,8 +30,8 @@ def test_policy_actions_from_document_allow_only():
 
 def test_aws_managed_policy_classified_by_name_without_fetch():
     iam = MagicMock()
-    level, actions = _policy_privilege(iam, "arn:aws:iam::aws:policy/AdministratorAccess", "AdministratorAccess", warnings=[])
-    assert level == "admin" and actions == []
+    level, actions, document = _policy_privilege(iam, "arn:aws:iam::aws:policy/AdministratorAccess", "AdministratorAccess", warnings=[])
+    assert level == "admin" and actions == [] and document is None
     iam.get_policy.assert_not_called()  # AWS-managed → no API call
 
 
@@ -41,17 +41,19 @@ def test_customer_managed_policy_fetched_and_classified():
     iam.get_policy_version.return_value = {
         "PolicyVersion": {"Document": {"Statement": [{"Effect": "Allow", "Action": ["dynamodb:DeleteTable"]}]}}
     }
-    level, actions = _policy_privilege(iam, "arn:aws:iam::123:policy/team-custom", "team-custom", warnings=[])
+    level, actions, document = _policy_privilege(iam, "arn:aws:iam::123:policy/team-custom", "team-custom", warnings=[])
     assert level == "write"
     assert "dynamodb:DeleteTable" in actions
+    # Customer-managed documents are retained for real policy evaluation.
+    assert document == {"Statement": [{"Effect": "Allow", "Action": ["dynamodb:DeleteTable"]}]}
 
 
 def test_policy_lookup_failure_degrades_gracefully():
     iam = MagicMock()
     iam.get_policy.side_effect = RuntimeError("AccessDenied")
     warnings: list[str] = []
-    level, actions = _policy_privilege(iam, "arn:aws:iam::123:policy/x", "x", warnings=warnings)
-    assert level == "unknown" and actions == []
+    level, actions, document = _policy_privilege(iam, "arn:aws:iam::123:policy/x", "x", warnings=warnings)
+    assert level == "unknown" and actions == [] and document is None
     assert warnings  # warning recorded, no raise
 
 

--- a/tests/test_iam_policy_document_population.py
+++ b/tests/test_iam_policy_document_population.py
@@ -1,0 +1,152 @@
+"""Populate raw IAM policy documents onto graph POLICY nodes so the
+effective-permissions overlay runs REAL policy evaluation on real scans.
+
+Before this wiring the inventory->graph boundary only carried a scanner-derived
+``privilege_level``; the raw policy document was fetched during discovery and
+then dropped, leaving ``effective_permissions`` unable to evaluate and forcing
+it onto the name/keyword heuristic. These tests pin the full path:
+
+    inventory discovery (retains document)
+        -> builder ``_policy_entries`` (carries document)
+        -> POLICY node ``policy_document`` attribute
+        -> effective-permissions REAL evaluation (``policy_evaluation`` basis)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_bom.graph.builder import _policy_entries, build_unified_graph_from_report
+from agent_bom.graph.types import EntityType
+
+_ALLOW_STAR = {"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*"}]}
+_READ_ONLY = {"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"}]}
+
+
+class _Paginator:
+    def __init__(self, pages: list[dict[str, Any]]):
+        self._pages = pages
+
+    def paginate(self, **_kw: Any) -> list[dict[str, Any]]:
+        return self._pages
+
+
+# ── inventory discovery retains the raw policy document ──────────────────────
+class _InventoryIam:
+    """Minimal IAM client for attached + inline customer-managed policies."""
+
+    def get_paginator(self, op: str) -> _Paginator:
+        if op == "list_attached_role_policies":
+            return _Paginator([{"AttachedPolicies": [{"PolicyArn": "arn:aws:iam::123:policy/team-custom", "PolicyName": "team-custom"}]}])
+        if op == "list_role_policies":
+            return _Paginator([{"PolicyNames": ["inline-utility"]}])
+        return _Paginator([])
+
+    def get_policy(self, PolicyArn: str) -> dict[str, Any]:  # noqa: N803 — boto3 param name
+        return {"Policy": {"DefaultVersionId": "v1"}}
+
+    def get_policy_version(self, PolicyArn: str, VersionId: str) -> dict[str, Any]:  # noqa: N803
+        return {"PolicyVersion": {"Document": _ALLOW_STAR}}
+
+    def get_role_policy(self, RoleName: str, PolicyName: str) -> dict[str, Any]:  # noqa: N803
+        return {"PolicyDocument": _READ_ONLY}
+
+
+def test_attached_customer_managed_policy_retains_document() -> None:
+    from agent_bom.cloud import aws_inventory as inv
+
+    policies = inv._attached_policies(_InventoryIam(), "role", "batch-helper-role", warnings=[])
+    assert policies, "expected the attached customer-managed policy"
+    assert policies[0]["policy_document"] == _ALLOW_STAR
+    assert policies[0]["privilege_level"] == "admin"
+
+
+def test_attached_aws_managed_policy_has_no_document() -> None:
+    from agent_bom.cloud import aws_inventory as inv
+
+    class _AwsManagedIam(_InventoryIam):
+        def get_paginator(self, op: str) -> _Paginator:
+            if op == "list_attached_role_policies":
+                arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+                return _Paginator([{"AttachedPolicies": [{"PolicyArn": arn, "PolicyName": "AdministratorAccess"}]}])
+            return _Paginator([])
+
+    policies = inv._attached_policies(_AwsManagedIam(), "role", "r", warnings=[])
+    # AWS-managed policies are classified by name without a fetch; no document to carry.
+    assert policies[0]["privilege_level"] == "admin"
+    assert policies[0].get("policy_document") is None
+
+
+def test_inline_policy_retains_document() -> None:
+    from agent_bom.cloud import aws_inventory as inv
+
+    policies = inv._inline_policies(_InventoryIam(), "role", "batch-helper-role", warnings=[])
+    assert policies, "expected the inline policy"
+    assert policies[0]["policy_document"] == _READ_ONLY
+    assert policies[0]["attachment_type"] == "inline"
+
+
+# ── builder carries the document from principal dict onto the POLICY node ─────
+def test_policy_entries_carries_document() -> None:
+    principal = {
+        "policies": [
+            {"policy_id": "p/inline", "policy_name": "team-utility", "privilege_level": "unknown", "policy_document": _ALLOW_STAR},
+            {"policy_id": "p/none", "policy_name": "no-doc", "privilege_level": "unknown"},
+        ]
+    }
+    entries = _policy_entries(principal)
+    assert entries[0]["policy_document"] == _ALLOW_STAR
+    assert "policy_document" not in entries[1]
+
+
+# ── end-to-end: scanned inline wildcard policy -> admin via EVALUATION ────────
+def _inventory_report(policy_document: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "scan_sources": ["aws-inventory"],
+        "cloud_inventory": {
+            "status": "ok",
+            "provider": "aws",
+            "account_id": "111122223333",
+            "roles": [
+                {
+                    "name": "batch-helper-role",
+                    "arn": "arn:aws:iam::111122223333:role/batch-helper-role",
+                    "principal_type": "role",
+                    "privilege_level": "unknown",  # benign: scanner did NOT flag admin
+                    "policies": [
+                        {
+                            "policy_id": "batch-helper-role/inline-utility",
+                            "policy_name": "team-utility-policy",  # benign name, no admin keyword
+                            "attachment_type": "inline",
+                            "privilege_level": "unknown",
+                            "policy_document": policy_document,
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+
+
+def test_scanned_wildcard_policy_flagged_admin_via_evaluation_end_to_end() -> None:
+    graph = build_unified_graph_from_report(_inventory_report(_ALLOW_STAR))
+
+    policy_nodes = [n for n in graph.nodes.values() if n.entity_type == EntityType.POLICY]
+    assert policy_nodes, "expected a POLICY node built from inventory"
+    assert any(n.attributes.get("policy_document") == _ALLOW_STAR for n in policy_nodes), "raw document must reach the POLICY node"
+
+    role = next(n for n in graph.nodes.values() if n.entity_type == EntityType.ROLE)
+    # The benignly-named policy is caught ONLY because the overlay evaluated the
+    # real document — the name/keyword heuristic (#3888 could only catch in theory)
+    # would have missed it.
+    assert role.attributes.get("admin_equivalent") is True
+    assert role.attributes.get("admin_equivalence_basis") == "policy_evaluation"
+
+
+def test_scanned_benign_read_only_policy_not_flagged_admin_end_to_end() -> None:
+    # Control: same benign name, but a read-only document -> a real evaluation
+    # verdict of NOT admin (recorded basis is still policy_evaluation, not a guess).
+    graph = build_unified_graph_from_report(_inventory_report(_READ_ONLY))
+    role = next(n for n in graph.nodes.values() if n.entity_type == EntityType.ROLE)
+    assert role.attributes.get("admin_equivalent") is not True
+    assert role.attributes.get("admin_equivalence_basis") == "policy_evaluation"

--- a/tests/test_mitre_coverage.py
+++ b/tests/test_mitre_coverage.py
@@ -1,0 +1,184 @@
+"""Unit tests for the MITRE technique-coverage aggregation (#3892).
+
+Coverage is honest: a technique is "covered" only when at least one finding
+carries real mapped evidence for it. Uncovered means "no evidence", never
+"safe". These tests pin that contract across ATT&CK, ATLAS, and MAESTRO.
+"""
+
+from __future__ import annotations
+
+from agent_bom import atlas
+from agent_bom.mitre_attack import get_attack_techniques
+from agent_bom.mitre_coverage import (
+    COVERED_DEFINITION,
+    UNCOVERED_DEFINITION,
+    build_atlas_coverage,
+    build_attack_coverage,
+    build_maestro_coverage,
+    build_mitre_coverage,
+)
+
+
+def _valid_attack_id() -> str:
+    return next(iter(get_attack_techniques()))
+
+
+def _valid_atlas_id() -> str:
+    return next(iter(atlas.ATLAS_TECHNIQUES))
+
+
+# ─── Empty estate: honest zeros, never fabricated coverage ───────────────────
+
+
+def test_empty_estate_is_zero_covered_not_fake() -> None:
+    result = build_mitre_coverage([])
+    assert result["finding_count"] == 0
+    frameworks = {f["framework"]: f for f in result["frameworks"]}
+    for fw in frameworks.values():
+        assert fw["covered_count"] == 0
+        assert fw["coverage_pct"] == 0.0
+        assert fw["covered_techniques"] == []
+        # Catalogue total is a real, non-zero denominator even with no findings.
+        assert fw["catalogue_total"] > 0
+
+
+def test_definitions_label_uncovered_as_no_evidence() -> None:
+    result = build_mitre_coverage([])
+    assert result["covered_definition"] == COVERED_DEFINITION
+    assert result["uncovered_definition"] == UNCOVERED_DEFINITION
+    # Honesty guard: uncovered must not be presented as "safe".
+    assert "safe" in UNCOVERED_DEFINITION.lower()
+    assert "not" in UNCOVERED_DEFINITION.lower()
+
+
+# ─── ATT&CK ──────────────────────────────────────────────────────────────────
+
+
+def test_attack_coverage_reflects_finding_tags() -> None:
+    tid = _valid_attack_id()
+    findings = [
+        {"id": "f1", "attack_tags": [tid]},
+        {"id": "f2", "attack_tags": [tid]},
+        {"id": "f3", "attack_tags": []},
+    ]
+    cov = build_attack_coverage(findings)
+    assert cov["framework"] == "mitre_attack"
+    assert cov["covered_count"] == 1
+    assert cov["catalogue_total"] == len(get_attack_techniques())
+    covered = {t["id"]: t for t in cov["covered_techniques"]}
+    assert tid in covered
+    assert covered[tid]["finding_count"] == 2
+    assert set(covered[tid]["finding_refs"]) == {"f1", "f2"}
+    expected_pct = round(1 / len(get_attack_techniques()) * 100, 2)
+    assert cov["coverage_pct"] == expected_pct
+
+
+def test_attack_coverage_ignores_unknown_technique_ids() -> None:
+    findings = [{"id": "f1", "attack_tags": ["T9999999", "not-a-technique", ""]}]
+    cov = build_attack_coverage(findings)
+    assert cov["covered_count"] == 0
+    assert cov["covered_techniques"] == []
+
+
+def test_attack_coverage_canonicalizes_and_dedupes() -> None:
+    tid = _valid_attack_id()
+    findings = [
+        {"id": "f1", "attack_tags": [f"  {tid.lower()} "]},
+        {"id": "f1", "attack_tags": [tid]},  # same finding id -> deduped ref
+    ]
+    cov = build_attack_coverage(findings)
+    assert cov["covered_count"] == 1
+    covered = cov["covered_techniques"][0]
+    assert covered["id"] == tid
+    assert covered["finding_refs"] == ["f1"]
+    assert covered["finding_count"] == 1
+
+
+def test_attack_coverage_accepts_alternate_tag_field() -> None:
+    tid = _valid_attack_id()
+    cov = build_attack_coverage([{"id": "f1", "attack_techniques": [tid]}])
+    assert cov["covered_count"] == 1
+
+
+# ─── ATLAS ───────────────────────────────────────────────────────────────────
+
+
+def test_atlas_coverage_reflects_finding_tags() -> None:
+    aid = _valid_atlas_id()
+    cov = build_atlas_coverage([{"id": "f1", "atlas_tags": [aid]}])
+    assert cov["framework"] == "mitre_atlas"
+    assert cov["covered_count"] == 1
+    assert cov["catalogue_total"] == atlas.curated_total()
+    assert cov["catalogue_upstream_total"] == atlas.upstream_total()
+    assert cov["covered_techniques"][0]["id"] == aid
+
+
+def test_atlas_empty_is_zero() -> None:
+    cov = build_atlas_coverage([{"id": "f1", "atlas_tags": []}])
+    assert cov["covered_count"] == 0
+    assert cov["coverage_pct"] == 0.0
+
+
+# ─── MAESTRO (source -> layer, explicit evidence only) ───────────────────────
+
+
+def test_maestro_coverage_from_explicit_source() -> None:
+    findings = [
+        {"id": "f1", "source": "huggingface"},  # KC1
+        {"id": "f2", "source": "mcp_server"},  # KC5
+    ]
+    cov = build_maestro_coverage(findings)
+    assert cov["framework"] == "mitre_maestro"
+    assert cov["catalogue_total"] == 6
+    covered_ids = {t["id"] for t in cov["covered_techniques"]}
+    assert "KC1" in covered_ids
+    assert "KC5" in covered_ids
+    assert cov["covered_count"] == 2
+
+
+def test_maestro_unknown_source_is_not_credited() -> None:
+    # Honesty: an unmapped source must NOT silently count as KC6 coverage.
+    cov = build_maestro_coverage([{"id": "f1", "source": "totally-unknown-source"}])
+    assert cov["covered_count"] == 0
+    assert cov["covered_techniques"] == []
+
+
+def test_maestro_layer_references_findings() -> None:
+    cov = build_maestro_coverage(
+        [
+            {"id": "f1", "source": "ollama"},
+            {"id": "f2", "source": "ollama"},
+        ]
+    )
+    kc1 = next(t for t in cov["covered_techniques"] if t["id"] == "KC1")
+    assert kc1["finding_count"] == 2
+    assert set(kc1["finding_refs"]) == {"f1", "f2"}
+
+
+# ─── Unified surface ─────────────────────────────────────────────────────────
+
+
+def test_build_mitre_coverage_unifies_three_frameworks() -> None:
+    tid = _valid_attack_id()
+    aid = _valid_atlas_id()
+    findings = [
+        {"id": "f1", "attack_tags": [tid], "atlas_tags": [aid], "source": "vector_db"},
+    ]
+    result = build_mitre_coverage(findings)
+    assert result["finding_count"] == 1
+    ids = {f["framework"] for f in result["frameworks"]}
+    assert ids == {"mitre_attack", "mitre_atlas", "mitre_maestro"}
+    by_id = {f["framework"]: f for f in result["frameworks"]}
+    assert by_id["mitre_attack"]["covered_count"] == 1
+    assert by_id["mitre_atlas"]["covered_count"] == 1
+    assert by_id["mitre_maestro"]["covered_count"] == 1  # KC4 from vector_db
+
+
+def test_finding_refs_are_capped_for_scale() -> None:
+    tid = _valid_attack_id()
+    findings = [{"id": f"f{i}", "attack_tags": [tid]} for i in range(500)]
+    cov = build_attack_coverage(findings)
+    covered = cov["covered_techniques"][0]
+    assert covered["finding_count"] == 500
+    assert len(covered["finding_refs"]) <= 25
+    assert covered["finding_refs_truncated"] is True

--- a/tests/test_mitre_coverage_route.py
+++ b/tests/test_mitre_coverage_route.py
@@ -1,0 +1,128 @@
+"""API tests for GET /v1/mitre/coverage (#3892).
+
+Coverage reflects the technique tags actually carried by the tenant's
+findings. An empty estate returns honest zeros with real catalogue
+denominators, and tenants are isolated from each other.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom import atlas
+from agent_bom.api.compliance_hub_store import get_compliance_hub_store, reset_compliance_hub_store
+from agent_bom.api.server import app
+from agent_bom.mitre_attack import get_attack_techniques
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+@pytest.fixture(autouse=True)
+def _reset_store():
+    from agent_bom.api.server import set_job_store
+    from agent_bom.api.store import InMemoryJobStore
+
+    reset_compliance_hub_store()
+    set_job_store(InMemoryJobStore())
+    yield
+    reset_compliance_hub_store()
+    set_job_store(InMemoryJobStore())
+
+
+def _client(tenant: str = "tenant-alpha", role: str = "admin") -> TestClient:
+    client = TestClient(app)
+    client.headers.update(proxy_headers(role=role, tenant=tenant))
+    return client
+
+
+def _attack_id() -> str:
+    return next(iter(get_attack_techniques()))
+
+
+def _atlas_id() -> str:
+    return next(iter(atlas.ATLAS_TECHNIQUES))
+
+
+def _frameworks(payload: dict) -> dict:
+    return {f["framework"]: f for f in payload["frameworks"]}
+
+
+def test_empty_estate_returns_honest_zeros() -> None:
+    resp = _client().get("/v1/mitre/coverage")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["finding_count"] == 0
+    frameworks = _frameworks(body)
+    assert set(frameworks) == {"mitre_attack", "mitre_atlas", "mitre_maestro"}
+    for fw in frameworks.values():
+        assert fw["covered_count"] == 0
+        assert fw["coverage_pct"] == 0.0
+        assert fw["covered_techniques"] == []
+        assert fw["catalogue_total"] > 0
+    assert "safe" in body["uncovered_definition"].lower()
+
+
+def test_coverage_reflects_hub_finding_tags() -> None:
+    tid = _attack_id()
+    aid = _atlas_id()
+    get_compliance_hub_store().add(
+        "tenant-alpha",
+        [
+            {"id": "hub-1", "severity": "high", "attack_tags": [tid], "atlas_tags": [aid], "source": "huggingface"},
+            {"id": "hub-2", "severity": "low", "attack_tags": [tid]},
+        ],
+    )
+    body = _client().get("/v1/mitre/coverage").json()
+    frameworks = _frameworks(body)
+
+    attack = frameworks["mitre_attack"]
+    assert attack["covered_count"] == 1
+    covered = attack["covered_techniques"][0]
+    assert covered["id"] == tid
+    assert covered["finding_count"] == 2
+    assert set(covered["finding_refs"]) == {"hub-1", "hub-2"}
+
+    atlas_fw = frameworks["mitre_atlas"]
+    assert atlas_fw["covered_count"] == 1
+    assert atlas_fw["covered_techniques"][0]["id"] == aid
+
+    maestro = frameworks["mitre_maestro"]
+    kc1 = [t for t in maestro["covered_techniques"] if t["id"] == "KC1"]
+    assert kc1 and kc1[0]["finding_count"] == 1
+
+
+def test_tenant_isolation() -> None:
+    tid = _attack_id()
+    get_compliance_hub_store().add("tenant-alpha", [{"id": "a1", "attack_tags": [tid]}])
+
+    beta = _client(tenant="tenant-beta").get("/v1/mitre/coverage").json()
+    assert _frameworks(beta)["mitre_attack"]["covered_count"] == 0
+
+    alpha = _client(tenant="tenant-alpha").get("/v1/mitre/coverage").json()
+    assert _frameworks(alpha)["mitre_attack"]["covered_count"] == 1
+
+
+def test_unknown_technique_tags_do_not_inflate_coverage() -> None:
+    get_compliance_hub_store().add(
+        "tenant-alpha",
+        [{"id": "a1", "attack_tags": ["T0000000", "bogus"], "atlas_tags": ["AML.T9999"]}],
+    )
+    body = _client().get("/v1/mitre/coverage").json()
+    frameworks = _frameworks(body)
+    assert frameworks["mitre_attack"]["covered_count"] == 0
+    assert frameworks["mitre_atlas"]["covered_count"] == 0
+
+
+def test_read_gated_endpoint_serves_read_roles() -> None:
+    # The endpoint is gated on the "read" permission. viewer/analyst/admin all
+    # hold it; a viewer must be able to read coverage (read-only surface).
+    body = _client(role="viewer").get("/v1/mitre/coverage").json()
+    assert set(_frameworks(body)) == {"mitre_attack", "mitre_atlas", "mitre_maestro"}


### PR DESCRIPTION
## Summary

Combines two independently-verified backend branches into one PR and re-verifies the merged result.

**1. Live IAM evaluation (follow-up to #3888)**
Populates real IAM policy documents onto graph nodes so the effective-permissions / IAM evaluator runs against actual policy data instead of placeholders. Touches `cloud/aws_inventory.py`, `cloud/aws.py`, `graph/builder.py`, plus IAM privilege / policy-document-population tests.

**2. MITRE ATT&CK coverage endpoint (#3892)**
Adds `GET /v1/mitre/coverage` (`mitre_coverage.py`, `routes/mitre.py`, wired in `server.py`) and fixes `attack_tags` hub-persistence via `hub_reference_payload.py`. Includes OpenAPI regeneration (`docs/openapi/*`) and coverage + route tests.

## Combined verification (from merged branch, PYTHONPATH-pinned)

| Check | Command | Result |
| --- | --- | --- |
| Touched suites | `PYTHONPATH=$PWD/src pytest` (graph builder, effective-permissions, iam-evaluator/evidence/privilege, policy-doc population, inventory, mitre-coverage, mitre-route, mitre-attack, compliance-hub, hub-reference-normalization) | 263 passed |
| Types | `PYTHONPATH=$PWD/src mypy src/agent_bom` | Success, no issues (693 files) |
| Lint | `PYTHONPATH=$PWD/src ruff check src tests` | All checks passed |
| Contract | `make preflight` (`--check`) | passed; OpenAPI matches app, `/v1/mitre/coverage` present, atlas path count 261 |

## Combine-only drift fixed on this branch

Neither branch failed alone, but the combine surfaced two generated/lint drifts, fixed here (not papered over):
- `api/server.py`: the mitre router import sorted out of order once `inventory_assets` was present alongside it (`ruff` I001) — re-sorted.
- `docs/DATA_MODEL.md`: the new mitre REST path bumped the OpenAPI path count 260 → 261 — atlas regenerated via `scripts/regenerate_data_model_atlas.py`.

Closes #3892
Makes #3888's IAM evaluation live (follow-up; #3888 already merged in #3988).
