### PR TITLE
UI: branching scan-DAG + charts light-theme tokenization

### DIFF
--- a/ui/app/activity/page.tsx
+++ b/ui/app/activity/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { api, formatDate } from "@/lib/api";
 import type { ActivityTimeline } from "@/lib/api";
+import { useChartTheme } from "@/lib/theme-colors";
 import { IntegrationRequiredState } from "@/components/integration-required-state";
 import { GatewayLiveFeedCard } from "@/components/gateway-live-feed-card";
 import {
@@ -25,6 +26,7 @@ import {
 } from "recharts";
 
 export default function ActivityPage() {
+  const chart = useChartTheme();
   const [timeline, setTimeline] = useState<ActivityTimeline | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -199,15 +201,15 @@ export default function ActivityPage() {
                   .map(([pattern, count]) => ({ pattern: pattern.length > 18 ? pattern.slice(0, 16) + "…" : pattern, count }))}
                 margin={{ top: 4, right: 8, bottom: 4, left: 0 }}
               >
-                <CartesianGrid strokeDasharray="3 3" stroke="#27272a" vertical={false} />
-                <XAxis dataKey="pattern" tick={{ fontSize: 9, fill: "#71717a" }} tickLine={false} axisLine={{ stroke: "#27272a" }} />
-                <YAxis tick={{ fontSize: 10, fill: "#71717a" }} tickLine={false} axisLine={false} allowDecimals={false} width={28} />
+                <CartesianGrid strokeDasharray="3 3" stroke={chart.grid} vertical={false} />
+                <XAxis dataKey="pattern" tick={{ fontSize: 9, fill: chart.text }} tickLine={false} axisLine={{ stroke: chart.border }} />
+                <YAxis tick={{ fontSize: 10, fill: chart.text }} tickLine={false} axisLine={false} allowDecimals={false} width={28} />
                 <Tooltip
-                  contentStyle={{ background: "#09090b", border: "1px solid #27272a", borderRadius: 8, fontSize: 12 }}
-                  itemStyle={{ color: "#e4e4e7" }}
-                  labelStyle={{ color: "#71717a", marginBottom: 4 }}
+                  contentStyle={{ background: chart.tooltip.bg, border: `1px solid ${chart.tooltip.border}`, borderRadius: 8, fontSize: 12 }}
+                  itemStyle={{ color: chart.tooltip.text }}
+                  labelStyle={{ color: chart.text, marginBottom: 4 }}
                 />
-                <Bar dataKey="count" name="queries" fill="#10b981" radius={[4, 4, 0, 0]} fillOpacity={0.75} />
+                <Bar dataKey="count" name="queries" fill={chart.accent} radius={[4, 4, 0, 0]} fillOpacity={0.75} />
               </BarChart>
             </ResponsiveContainer>
           </div>

--- a/ui/app/fleet/page.tsx
+++ b/ui/app/fleet/page.tsx
@@ -40,6 +40,7 @@ import {
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
+import { useChartTheme } from "@/lib/theme-colors";
 
 function downloadJson(data: unknown, filename: string) {
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
@@ -92,6 +93,7 @@ function trustTextColor(score: number): string {
 // ─── Page ───────────────────────────────────────────────────────────────────
 
 export default function FleetPage() {
+  const chart = useChartTheme();
   const [agents, setAgents] = useState<FleetAgent[]>([]);
   const [stats, setStats] = useState<FleetStatsResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -304,15 +306,15 @@ export default function FleetPage() {
       {/* Fleet state distribution chart */}
       {stats && stats.total > 0 && (() => {
         const STATE_CHART_COLORS: Record<string, string> = {
-          discovered: "#71717a",
-          pending_review: "#eab308",
-          approved: "#22c55e",
-          quarantined: "#ef4444",
-          decommissioned: "#3f3f46",
+          discovered: chart.severity.unrated,
+          pending_review: chart.status.warn,
+          approved: chart.status.success,
+          quarantined: chart.status.danger,
+          decommissioned: chart.text,
         };
         const chartData = Object.entries(stats.by_state)
           .filter(([, v]) => v > 0)
-          .map(([state, count]) => ({ state: STATE_LABELS[state as FleetLifecycleState] ?? state, count, fill: STATE_CHART_COLORS[state] ?? "#71717a" }));
+          .map(([state, count]) => ({ state: STATE_LABELS[state as FleetLifecycleState] ?? state, count, fill: STATE_CHART_COLORS[state] ?? chart.severity.unrated }));
         return (
           <div className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-xl p-5">
             <h3 className="text-sm font-semibold text-[var(--text-secondary)] mb-1">Lifecycle Distribution</h3>
@@ -320,9 +322,9 @@ export default function FleetPage() {
             <div className="h-36">
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={chartData} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
-                  <XAxis dataKey="state" tick={{ fontSize: 10, fill: "#71717a" }} tickLine={false} axisLine={{ stroke: "#27272a" }} />
-                  <YAxis tick={{ fontSize: 10, fill: "#71717a" }} tickLine={false} axisLine={false} allowDecimals={false} width={28} />
-                  <Tooltip contentStyle={{ background: "#09090b", border: "1px solid #27272a", borderRadius: 8, fontSize: 12 }} itemStyle={{ color: "#e4e4e7" }} labelStyle={{ color: "#71717a", marginBottom: 4 }} />
+                  <XAxis dataKey="state" tick={{ fontSize: 10, fill: chart.text }} tickLine={false} axisLine={{ stroke: chart.border }} />
+                  <YAxis tick={{ fontSize: 10, fill: chart.text }} tickLine={false} axisLine={false} allowDecimals={false} width={28} />
+                  <Tooltip contentStyle={{ background: chart.tooltip.bg, border: `1px solid ${chart.tooltip.border}`, borderRadius: 8, fontSize: 12 }} itemStyle={{ color: chart.tooltip.text }} labelStyle={{ color: chart.text, marginBottom: 4 }} />
                   <Bar dataKey="count" name="agents" radius={[4, 4, 0, 0]}>
                     {chartData?.map((entry, i) => <Cell key={i} fill={entry.fill} fillOpacity={0.8} />)}
                   </Bar>

--- a/ui/app/gateway/GatewayDashboard.tsx
+++ b/ui/app/gateway/GatewayDashboard.tsx
@@ -39,6 +39,7 @@ import { GatewayFeedPanel } from "./GatewayFeedPanel";
 import { GatewayFeedKpiBar } from "@/components/gateway-feed-kpi-bar";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { useRuntimeEmbedded } from "@/components/runtime-embed-context";
+import { useChartTheme } from "@/lib/theme-colors";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -58,6 +59,7 @@ const RUNTIME_COLORS: Record<GatewayPolicyRuntimeSummary["rollout_mode"], string
 // ─── Page ───────────────────────────────────────────────────────────────────
 
 export default function GatewayPage() {
+  const chart = useChartTheme();
   const embedded = useRuntimeEmbedded();
   const { counts } = useDeploymentContext();
   const [kpiRefreshKey, setKpiRefreshKey] = useState(0);
@@ -457,13 +459,13 @@ export default function GatewayPage() {
                     <div className="h-44">
                       <ResponsiveContainer width="100%" height="100%">
                         <BarChart data={chartData} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
-                          <CartesianGrid strokeDasharray="3 3" stroke="#27272a" vertical={false} />
-                          <XAxis dataKey="tool" tick={{ fontSize: 9, fill: "#71717a" }} tickLine={false} axisLine={{ stroke: "#27272a" }} />
-                          <YAxis tick={{ fontSize: 10, fill: "#71717a" }} tickLine={false} axisLine={false} allowDecimals={false} width={28} />
-                          <Tooltip contentStyle={{ background: "#09090b", border: "1px solid #27272a", borderRadius: 8, fontSize: 12 }} itemStyle={{ color: "#e4e4e7" }} labelStyle={{ color: "#71717a", marginBottom: 4 }} />
-                          <Bar dataKey="blocked" name="blocked" stackId="a" fill="#ef4444" fillOpacity={0.8} />
-                          <Bar dataKey="alerted" name="alerted" stackId="a" fill="#f97316" fillOpacity={0.8} />
-                          <Bar dataKey="allowed" name="allowed" stackId="a" fill="#22c55e" fillOpacity={0.5} radius={[4, 4, 0, 0]} />
+                          <CartesianGrid strokeDasharray="3 3" stroke={chart.grid} vertical={false} />
+                          <XAxis dataKey="tool" tick={{ fontSize: 9, fill: chart.text }} tickLine={false} axisLine={{ stroke: chart.border }} />
+                          <YAxis tick={{ fontSize: 10, fill: chart.text }} tickLine={false} axisLine={false} allowDecimals={false} width={28} />
+                          <Tooltip contentStyle={{ background: chart.tooltip.bg, border: `1px solid ${chart.tooltip.border}`, borderRadius: 8, fontSize: 12 }} itemStyle={{ color: chart.tooltip.text }} labelStyle={{ color: chart.text, marginBottom: 4 }} />
+                          <Bar dataKey="blocked" name="blocked" stackId="a" fill={chart.severity.critical} fillOpacity={0.8} />
+                          <Bar dataKey="alerted" name="alerted" stackId="a" fill={chart.severity.high} fillOpacity={0.8} />
+                          <Bar dataKey="allowed" name="allowed" stackId="a" fill={chart.status.success} fillOpacity={0.5} radius={[4, 4, 0, 0]} />
                         </BarChart>
                       </ResponsiveContainer>
                     </div>

--- a/ui/app/governance/page.tsx
+++ b/ui/app/governance/page.tsx
@@ -19,6 +19,7 @@ import {
   formatDate,
 } from "@/lib/api";
 import type { GovernanceReport, GovernanceFinding } from "@/lib/api";
+import { useChartTheme } from "@/lib/theme-colors";
 import { IntegrationRequiredState } from "@/components/integration-required-state";
 import {
   ResponsiveContainer,
@@ -32,6 +33,7 @@ import {
 } from "recharts";
 
 export default function GovernancePage() {
+  const chart = useChartTheme();
   const [report, setReport] = useState<GovernanceReport | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -152,7 +154,7 @@ export default function GovernancePage() {
 
       {/* Findings severity bar chart */}
       {report.findings.length > 0 && (() => {
-        const sevColors: Record<string, string> = { critical: "#ef4444", high: "#f97316", medium: "#eab308", low: "#3b82f6" };
+        const sevColors: Record<string, string> = { critical: chart.severity.critical, high: chart.severity.high, medium: chart.severity.medium, low: chart.severity.low };
         const cats = ["access", "privilege", "data_classification", "agent_usage"];
         const chartData = cats?.map((cat) => {
           const fs = report.findings.filter((f) => f.category === cat);
@@ -172,13 +174,13 @@ export default function GovernancePage() {
             <div className="h-44">
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={chartData} margin={{ top: 4, right: 8, bottom: 4, left: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#27272a" vertical={false} />
-                  <XAxis dataKey="category" tick={{ fontSize: 10, fill: "#71717a" }} tickLine={false} axisLine={{ stroke: "#27272a" }} />
-                  <YAxis tick={{ fontSize: 10, fill: "#71717a" }} tickLine={false} axisLine={false} allowDecimals={false} width={28} />
+                  <CartesianGrid strokeDasharray="3 3" stroke={chart.grid} vertical={false} />
+                  <XAxis dataKey="category" tick={{ fontSize: 10, fill: chart.text }} tickLine={false} axisLine={{ stroke: chart.border }} />
+                  <YAxis tick={{ fontSize: 10, fill: chart.text }} tickLine={false} axisLine={false} allowDecimals={false} width={28} />
                   <Tooltip
-                    contentStyle={{ background: "#09090b", border: "1px solid #27272a", borderRadius: 8, fontSize: 12 }}
-                    itemStyle={{ color: "#e4e4e7" }}
-                    labelStyle={{ color: "#71717a", marginBottom: 4 }}
+                    contentStyle={{ background: chart.tooltip.bg, border: `1px solid ${chart.tooltip.border}`, borderRadius: 8, fontSize: 12 }}
+                    itemStyle={{ color: chart.tooltip.text }}
+                    labelStyle={{ color: chart.text, marginBottom: 4 }}
                   />
                   {(["critical", "high", "medium", "low"] as const).map((sev) => (
                     <Bar key={sev} dataKey={sev} stackId="a" fill={sevColors[sev]} fillOpacity={0.8} radius={sev === "critical" ? [4, 4, 0, 0] : [0, 0, 0, 0]}>

--- a/ui/app/jobs/page.tsx
+++ b/ui/app/jobs/page.tsx
@@ -291,7 +291,7 @@ function JobsPageContent() {
                   Run a scan to see the live six-stage pipeline DAG with per-step timing and activity.
                 </p>
                 <div className="mt-4">
-                  <ScanPipeline steps={new Map()} className="h-[180px]" />
+                  <ScanPipeline steps={new Map()} className="h-[260px]" />
                 </div>
               </div>
             )

--- a/ui/app/proxy/ProxyDashboard.tsx
+++ b/ui/app/proxy/ProxyDashboard.tsx
@@ -40,6 +40,7 @@ import {
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { ProxyAlertDrawer } from "@/components/proxy-alert-drawer";
 import { proxyAlertKey, proxyAlertSummary } from "@/lib/proxy-alerts";
+import { useChartTheme } from "@/lib/theme-colors";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -50,8 +51,6 @@ const SEVERITY_COLORS: Record<string, string> = {
   low: "bg-blue-950 text-blue-300 border-blue-800",
   info: "bg-[var(--surface-elevated)] text-[var(--text-secondary)] border-[var(--border-subtle)]",
 };
-
-const PIE_COLORS = ["#ef4444", "#f97316", "#eab308", "#3b82f6", "#71717a"];
 
 // ─── WebSocket metrics type ──────────────────────────────────────────────────
 
@@ -69,6 +68,14 @@ interface LiveMetrics {
 // ─── Page ────────────────────────────────────────────────────────────────────
 
 export default function ProxyDashboard() {
+  const chart = useChartTheme();
+  const pieColors = [
+    chart.severity.critical,
+    chart.severity.high,
+    chart.severity.medium,
+    chart.severity.low,
+    chart.severity.unrated,
+  ];
   const embedded = useRuntimeEmbedded();
   const { counts } = useDeploymentContext();
   const [status, setStatus] = useState<ProxyStatusResponse | null>(null);
@@ -346,17 +353,17 @@ export default function ProxyDashboard() {
                     >
                       <CartesianGrid
                         strokeDasharray="3 3"
-                        stroke="#27272a"
+                        stroke={chart.grid}
                         vertical={false}
                       />
                       <XAxis
                         dataKey="tool"
-                        tick={{ fontSize: 9, fill: "#71717a" }}
+                        tick={{ fontSize: 9, fill: chart.text }}
                         tickLine={false}
-                        axisLine={{ stroke: "#27272a" }}
+                        axisLine={{ stroke: chart.border }}
                       />
                       <YAxis
-                        tick={{ fontSize: 10, fill: "#71717a" }}
+                        tick={{ fontSize: 10, fill: chart.text }}
                         tickLine={false}
                         axisLine={false}
                         allowDecimals={false}
@@ -364,18 +371,18 @@ export default function ProxyDashboard() {
                       />
                       <Tooltip
                         contentStyle={{
-                          background: "#09090b",
-                          border: "1px solid #27272a",
+                          background: chart.tooltip.bg,
+                          border: `1px solid ${chart.tooltip.border}`,
                           borderRadius: 8,
                           fontSize: 12,
                         }}
-                        itemStyle={{ color: "#e4e4e7" }}
-                        labelStyle={{ color: "#71717a", marginBottom: 4 }}
+                        itemStyle={{ color: chart.tooltip.text }}
+                        labelStyle={{ color: chart.text, marginBottom: 4 }}
                       />
                       <Bar
                         dataKey="count"
                         name="Calls"
-                        fill="#34d399"
+                        fill={chart.accent}
                         fillOpacity={0.8}
                         radius={[4, 4, 0, 0]}
                       />
@@ -409,25 +416,25 @@ export default function ProxyDashboard() {
                         outerRadius={70}
                         dataKey="value"
                         nameKey="name"
-                        stroke="#09090b"
+                        stroke={chart.bg}
                         strokeWidth={2}
                       >
                         {blockedPieData?.map((_, i) => (
                           <Cell
                             key={i}
-                            fill={PIE_COLORS[i % PIE_COLORS.length] ?? "#71717a"}
+                            fill={pieColors[i % pieColors.length] ?? chart.severity.unrated}
                             fillOpacity={0.85}
                           />
                         ))}
                       </Pie>
                       <Tooltip
                         contentStyle={{
-                          background: "#09090b",
-                          border: "1px solid #27272a",
+                          background: chart.tooltip.bg,
+                          border: `1px solid ${chart.tooltip.border}`,
                           borderRadius: 8,
                           fontSize: 12,
                         }}
-                        itemStyle={{ color: "#e4e4e7" }}
+                        itemStyle={{ color: chart.tooltip.text }}
                       />
                     </PieChart>
                   </ResponsiveContainer>
@@ -441,7 +448,7 @@ export default function ProxyDashboard() {
                           className="w-2 h-2 rounded-full"
                           style={{
                             backgroundColor:
-                              PIE_COLORS[i % PIE_COLORS.length],
+                              pieColors[i % pieColors.length],
                           }}
                         />
                         {d.name}: {d.value}

--- a/ui/components/job-pipeline-panel.tsx
+++ b/ui/components/job-pipeline-panel.tsx
@@ -21,22 +21,27 @@ import {
 } from "@/lib/api";
 import { useScanStream } from "@/lib/use-scan-stream";
 import {
+  describeWallClock,
   formatDurationMs,
+  formatStageDuration,
   mergePipelineSteps,
   parsePipelineStepsFromProgress,
   summarizePipeline,
   synthesizePipelineSteps,
 } from "@/lib/scan-pipeline-progress";
+import {
+  PIPELINE_GRAPH,
+  backendStepForNode,
+  type DomainLaneData,
+  type ScannerDomain,
+} from "@/lib/scan-pipeline-graph";
+import {
+  cloudIdentityCount,
+  cloudResourceCount,
+  domainFindingsForScan,
+} from "@/lib/scan-domain-findings";
 
-// ── Result-stat extraction (defensive; cloud fields arrive as `unknown`) ─────
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function asNumber(value: unknown): number | null {
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
+// ── Result-stat extraction ───────────────────────────────────────────────────
 
 interface ResultStat {
   key: string;
@@ -44,80 +49,37 @@ interface ResultStat {
   value: string;
 }
 
-function cloudResourceCount(inventory: unknown): number | null {
-  if (Array.isArray(inventory)) {
-    let total = 0;
-    let seen = false;
-    for (const item of inventory) {
-      if (!isRecord(item)) continue;
-      const n = asNumber(item.resource_count);
-      if (n != null) {
-        total += n;
-        seen = true;
-      }
-    }
-    return seen ? total : null;
-  }
-  if (isRecord(inventory)) return asNumber(inventory.resource_count);
-  return null;
+interface ResultView {
+  lanes: Record<ScannerDomain, DomainLaneData> | undefined;
+  stats: ResultStat[];
 }
 
-function cloudIdentityCount(inventory: unknown): number | null {
-  if (Array.isArray(inventory)) {
-    let total = 0;
-    let seen = false;
-    for (const item of inventory) {
-      if (!isRecord(item)) continue;
-      const n = asNumber(item.identity_count);
-      if (n != null) {
-        total += n;
-        seen = true;
-      }
-    }
-    return seen ? total : null;
-  }
-  if (isRecord(inventory)) return asNumber(inventory.identity_count);
-  return null;
-}
-
-function cisPassRate(benchmark: unknown): number | null {
-  if (!isRecord(benchmark)) return null;
-  const raw = asNumber(benchmark.pass_rate);
-  if (raw == null) return null;
-  // Backends emit either 0–1 or 0–100; normalize to a percentage.
-  return raw <= 1 ? raw * 100 : raw;
-}
-
-function deriveResultStats(
+/**
+ * Build the reconciled result chips + scanner-lane data. The headline
+ * "findings" count sums every domain that ran (CIS failures included), so it
+ * agrees with the domain lanes instead of the old "0 findings / 32% CIS pass"
+ * contradiction.
+ */
+function deriveResultView(
   job: ScanJob | null,
   fallback: Summary | undefined,
-): ResultStat[] {
-  const summary = job?.result?.summary ?? fallback;
-  const stats: ResultStat[] = [];
+  summarized: boolean,
+): ResultView {
+  const result = job?.result;
+  const summary = result?.summary ?? fallback;
+  const { lanes, reconciled, cis } = domainFindingsForScan({ result, summary, summarized });
 
-  if (summary) {
-    stats.push({
-      key: "findings",
-      label: "findings",
-      value: String(summary.total_vulnerabilities ?? 0),
-    });
-    if ((summary.critical_findings ?? 0) > 0) {
-      stats.push({
-        key: "critical",
-        label: "critical",
-        value: String(summary.critical_findings),
-      });
-    }
-    if ((summary.total_packages ?? 0) > 0) {
-      stats.push({
-        key: "packages",
-        label: "packages",
-        value: String(summary.total_packages),
-      });
-    }
+  const stats: ResultStat[] = [];
+  if (reconciled.domainsRun > 0) {
+    stats.push({ key: "findings", label: "findings", value: String(reconciled.total) });
+  }
+  if ((summary?.critical_findings ?? 0) > 0) {
+    stats.push({ key: "critical", label: "critical", value: String(summary!.critical_findings) });
+  }
+  if ((summary?.total_packages ?? 0) > 0) {
+    stats.push({ key: "packages", label: "packages", value: String(summary!.total_packages) });
   }
 
-  const result = job?.result;
   if (result) {
     const resources = cloudResourceCount(result.cloud_inventory);
     if (resources != null) {
@@ -127,18 +89,18 @@ function deriveResultStats(
     if (identities != null) {
       stats.push({ key: "identities", label: "identities", value: String(identities) });
     }
-    const passRate =
-      cisPassRate(result.cis_benchmark) ??
-      cisPassRate(result.azure_cis_benchmark) ??
-      cisPassRate(result.gcp_cis_benchmark) ??
-      cisPassRate(result.snowflake_cis_benchmark) ??
-      cisPassRate(result.databricks_cis_benchmark);
-    if (passRate != null) {
-      stats.push({ key: "cis", label: "CIS pass", value: `${passRate.toFixed(0)}%` });
+  }
+  if (cis) {
+    const failed = reconciled.byDomain.cis;
+    if (failed != null) {
+      stats.push({ key: "cis-fail", label: "CIS fail", value: String(failed) });
+    }
+    if (cis.passRate != null) {
+      stats.push({ key: "cis-pass", label: "CIS pass", value: `${cis.passRate.toFixed(0)}%` });
     }
   }
 
-  return stats;
+  return { lanes, stats };
 }
 
 // Which evidence surfaces are most relevant to drill into from a given stage.
@@ -284,9 +246,12 @@ export function JobPipelinePanel({
     [steps, createdAt, completedAt, job, status],
   );
 
-  const resultStats = useMemo(
-    () => (status === "done" ? deriveResultStats(job, listSummary) : []),
-    [status, job, listSummary],
+  const { lanes, stats: resultStats } = useMemo<ResultView>(
+    () =>
+      status === "done"
+        ? deriveResultView(job, listSummary, synthesized)
+        : { lanes: undefined, stats: [] },
+    [status, job, listSummary, synthesized],
   );
 
   const recentMessages = useMemo(() => {
@@ -304,9 +269,10 @@ export function JobPipelinePanel({
     return merged.slice(-4);
   }, [job?.progress, messages]);
 
-  const selectedStep = selectedStepId ? steps.get(selectedStepId) : undefined;
+  const selectedBackendStep = selectedStepId ? backendStepForNode(selectedStepId) : undefined;
+  const selectedStep = selectedBackendStep ? steps.get(selectedBackendStep) : undefined;
   const selectedMeta = selectedStepId
-    ? PIPELINE_STEPS.find((step) => step.id === selectedStepId)
+    ? PIPELINE_GRAPH.find((node) => node.id === selectedStepId)
     : undefined;
 
   return (
@@ -349,7 +315,10 @@ export function JobPipelinePanel({
           <span>
             Wall clock{" "}
             <span className="font-mono text-[var(--text-secondary)]">
-              {formatDurationMs(summary.wallClockMs)}
+              {describeWallClock(summary.wallClockMs, {
+                synthesized,
+                running: status === "running" || status === "pending",
+              })}
             </span>
           </span>
           <Link
@@ -374,10 +343,11 @@ export function JobPipelinePanel({
       <div className="mt-4 flex flex-col gap-3 lg:flex-row">
         <ScanPipeline
           steps={steps}
-          className="h-[220px] flex-1 rounded-lg border border-[var(--border-subtle)]"
+          lanes={lanes}
+          className="h-[300px] flex-1 rounded-lg border border-[var(--border-subtle)]"
           selectedStepId={selectedStepId}
-          onStepClick={(stepId) =>
-            setSelectedStepId((current) => (current === stepId ? null : stepId))
+          onStepClick={(nodeId) =>
+            setSelectedStepId((current) => (current === nodeId ? null : nodeId))
           }
         />
         {selectedStepId ? (
@@ -408,9 +378,9 @@ export function JobPipelinePanel({
                 {selectedStep.message}
               </p>
             ) : null}
-            {selectedStepId && summary.stepDurationsMs[selectedStepId] != null ? (
+            {selectedBackendStep && summary.stepDurationsMs[selectedBackendStep] != null ? (
               <p className="mt-1 font-mono text-[11px] text-[var(--text-tertiary)]">
-                {formatDurationMs(summary.stepDurationsMs[selectedStepId])}
+                {formatDurationMs(summary.stepDurationsMs[selectedBackendStep])}
               </p>
             ) : null}
             {selectedStep?.stats && Object.keys(selectedStep.stats).length > 0 ? (
@@ -425,9 +395,9 @@ export function JobPipelinePanel({
                 ))}
               </div>
             ) : null}
-            {stageLinks(selectedStepId, jobId).length > 0 ? (
+            {selectedBackendStep && stageLinks(selectedBackendStep, jobId).length > 0 ? (
               <div className="mt-3 flex flex-wrap gap-1.5">
-                {stageLinks(selectedStepId, jobId).map((link) => (
+                {stageLinks(selectedBackendStep, jobId).map((link) => (
                   <Link
                     key={link.label}
                     href={link.href}
@@ -475,13 +445,7 @@ export function JobPipelinePanel({
                     >
                       <dt className="text-[var(--text-secondary)]">{step.label}</dt>
                       <dd className="font-mono text-[var(--text-secondary)]">
-                        {duration != null
-                          ? formatDurationMs(duration)
-                          : stepStatus === "running"
-                            ? "running…"
-                            : stepStatus === "done"
-                              ? "done"
-                              : "—"}
+                        {formatStageDuration(duration, stepStatus, synthesized)}
                       </dd>
                     </div>
                   );

--- a/ui/components/scan-pipeline.tsx
+++ b/ui/components/scan-pipeline.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 /**
- * Scan Pipeline DAG — shows scan execution stages as a React Flow graph
- * with live status updates from SSE step events. Interactive: pan / zoom /
- * drag / select, with click-to-drill-in on any stage.
+ * Scan Pipeline DAG — shows scan execution as a branching React Flow graph.
+ *
+ * Discovery → Extraction fans out into parallel scanner lanes (SCA / secrets /
+ * IaC / CIS / cloud) that converge back into Enrichment → Analysis → Report.
+ * The branching shape and node ranks are derived from `lib/scan-pipeline-graph`
+ * (dependency edges only) and laid out by the Sankey helper — no hand-placed
+ * coordinates. Interactive: pan / zoom / drag / select, with click-to-drill-in
+ * on any node.
  */
 
 import { useCallback, useMemo } from "react";
@@ -15,7 +20,6 @@ import {
   Position,
   ReactFlowProvider,
   type Node,
-  type Edge,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import {
@@ -24,7 +28,11 @@ import {
   Bug,
   Zap,
   Shield,
+  ShieldCheck,
   FileText,
+  FileCode,
+  KeyRound,
+  Cloud,
   Loader2,
   CheckCircle,
   XCircle,
@@ -32,44 +40,57 @@ import {
   SkipForward,
 } from "lucide-react";
 import { useGraphLayout } from "@/lib/use-graph-layout";
-import type { StepEvent, StepStatus } from "@/lib/api";
-import { PIPELINE_STEPS } from "@/lib/api";
+import type { StepStatus, StepEvent } from "@/lib/api";
+import {
+  buildPipelineGraph,
+  type DomainLaneData,
+  type PipelineNodeKind,
+  type ScannerDomain,
+} from "@/lib/scan-pipeline-graph";
 
 // ── Step node component ─────────────────────────────────────────────────────
 
 interface PipelineNodeData {
   [key: string]: unknown;
+  nodeId: string;
+  stepId: string;
   label: string;
   description: string;
-  stepId: string;
+  kind: PipelineNodeKind;
+  domain?: ScannerDomain | undefined;
   status: StepStatus;
   message?: string | undefined;
   stats?: Record<string, number> | undefined;
   startedAt?: string | undefined;
   completedAt?: string | undefined;
   progressPct?: number | undefined;
+  findings?: number | null | undefined;
+  ran?: boolean | undefined;
+  detail?: string | undefined;
+  summarized?: boolean | undefined;
   selected?: boolean | undefined;
 }
 
-const STEP_ICONS: Record<string, React.ElementType> = {
+// Icons keyed by DAG node id, falling back to the backend stage id.
+const NODE_ICONS: Record<string, React.ElementType> = {
   discovery: Search,
   extraction: Package,
   scanning: Bug,
   enrichment: Zap,
   analysis: Shield,
   output: FileText,
+  sca: Bug,
+  secrets: KeyRound,
+  iac: FileCode,
+  cis: ShieldCheck,
+  cloud: Cloud,
 };
 
 // Neutral (non-severity) surfaces use design tokens so the DAG tracks the
 // active theme; running/done/failed keep their semantic emerald/red hues.
 const STATUS_STYLES: Record<
   StepStatus,
-  {
-    border: string;
-    bg: string;
-    icon: React.ElementType;
-    iconColor: string;
-  }
+  { border: string; bg: string; icon: React.ElementType; iconColor: string }
 > = {
   pending: {
     border: "border-[var(--border-subtle)]",
@@ -96,47 +117,63 @@ const STATUS_STYLES: Record<
     iconColor: "text-red-400",
   },
   skipped: {
-    border: "border-[var(--border-subtle)]",
+    border: "border-dashed border-[var(--border-subtle)]",
     bg: "bg-[var(--surface-muted)]",
     icon: SkipForward,
     iconColor: "text-[var(--text-tertiary)]",
   },
 };
 
-const STEP_DESCRIPTIONS: Record<string, string> = {
-  discovery: "Find MCP agents and configs",
-  extraction: "Extract packages from servers",
-  scanning: "Query vulnerability databases",
-  enrichment: "NVD CVSS, EPSS, CISA KEV",
-  analysis: "Compute blast radius",
-  output: "Generate final report",
-};
+function LaneFindings({ data }: { data: PipelineNodeData }) {
+  if (data.status === "skipped" || data.ran === false) {
+    return <p className="text-[10px] text-[var(--text-tertiary)]">not run</p>;
+  }
+  if (data.findings == null) {
+    return (
+      <p className="text-[10px] text-[var(--text-tertiary)]">
+        {data.status === "running" ? "scanning…" : data.detail ?? "—"}
+      </p>
+    );
+  }
+  const hasFindings = data.findings > 0;
+  return (
+    <div className="flex items-center gap-1.5">
+      <span
+        className={`inline-flex items-center rounded-md border px-1.5 py-0.5 font-mono text-[10px] ${
+          hasFindings
+            ? "border-[var(--severity-high-border)] bg-[var(--severity-high-bg)] text-[color:var(--severity-high)]"
+            : "border-[var(--status-success-border)] bg-[var(--status-success-bg)] text-[color:var(--status-success)]"
+        }`}
+      >
+        {data.detail ?? (hasFindings ? `${data.findings} findings` : "clean")}
+      </span>
+    </div>
+  );
+}
 
 function PipelineNode({ data }: { data: PipelineNodeData }) {
   const style = STATUS_STYLES[data.status];
   const StatusIcon = style.icon;
-  const StepIcon = STEP_ICONS[data.stepId] ?? Shield;
+  const StepIcon = NODE_ICONS[data.nodeId] ?? NODE_ICONS[data.stepId] ?? Shield;
+  const isScanner = data.kind === "scanner";
 
   const duration =
     data.completedAt && data.startedAt
       ? (
-          (new Date(data.completedAt).getTime() -
-            new Date(data.startedAt).getTime()) /
+          (new Date(data.completedAt).getTime() - new Date(data.startedAt).getTime()) /
           1000
         ).toFixed(1)
       : null;
 
   return (
     <div
-      className={`rounded-2xl border-2 ${style.border} ${style.bg} min-w-[176px] max-w-[208px] cursor-pointer overflow-hidden shadow-lg shadow-[var(--shadow-color)] transition-shadow ${
+      className={`rounded-2xl border-2 ${style.border} ${style.bg} ${
+        isScanner ? "min-w-[150px] max-w-[178px]" : "min-w-[176px] max-w-[208px]"
+      } cursor-pointer overflow-hidden shadow-lg shadow-[var(--shadow-color)] transition-shadow ${
         data.selected ? "ring-2 ring-emerald-400/70 ring-offset-1 ring-offset-transparent" : ""
       }`}
     >
-      <Handle
-        type="target"
-        position={Position.Left}
-        className="!bg-[var(--border-strong)]"
-      />
+      <Handle type="target" position={Position.Left} className="!bg-[var(--border-strong)]" />
 
       <div className="border-b border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-2">
         <div className="flex items-center gap-2">
@@ -145,7 +182,7 @@ function PipelineNode({ data }: { data: PipelineNodeData }) {
           </div>
           <div className="min-w-0">
             <div className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
-              {data.stepId}
+              {isScanner ? "scanner" : data.nodeId}
             </div>
             <span className="block truncate text-sm font-semibold text-[var(--foreground)]">
               {data.label}
@@ -156,46 +193,44 @@ function PipelineNode({ data }: { data: PipelineNodeData }) {
       </div>
 
       <div className="px-3 py-2.5">
-        <p className="text-[10px] leading-tight text-[var(--text-tertiary)]">
-          {data.status !== "pending"
-            ? data.message
-            : STEP_DESCRIPTIONS[data.stepId] ?? data.description}
-        </p>
+        {isScanner ? (
+          <LaneFindings data={data} />
+        ) : (
+          <>
+            <p className="text-[10px] leading-tight text-[var(--text-tertiary)]">
+              {data.status !== "pending" && data.message ? data.message : data.description}
+            </p>
 
-        {data.stats && Object.keys(data.stats).length > 0 && (
-          <div className="mt-2 flex flex-wrap gap-1">
-            {Object.entries(data.stats).map(([k, v]) => (
-              <span
-                key={k}
-                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[9px] text-[var(--text-secondary)]"
-              >
-                {v} {k}
-              </span>
-            ))}
-          </div>
-        )}
+            {data.stats && Object.keys(data.stats).length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1">
+                {Object.entries(data.stats).map(([k, v]) => (
+                  <span
+                    key={k}
+                    className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-1.5 py-0.5 font-mono text-[9px] text-[var(--text-secondary)]"
+                  >
+                    {v} {k}
+                  </span>
+                ))}
+              </div>
+            )}
 
-        {data.progressPct != null && data.status === "running" && (
-          <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[var(--surface-muted)]">
-            <div
-              className="h-full bg-emerald-500 transition-all duration-300"
-              style={{ width: `${data.progressPct}%` }}
-            />
-          </div>
-        )}
+            {data.progressPct != null && data.status === "running" && (
+              <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[var(--surface-muted)]">
+                <div
+                  className="h-full bg-emerald-500 transition-all duration-300"
+                  style={{ width: `${data.progressPct}%` }}
+                />
+              </div>
+            )}
 
-        {duration && (
-          <p className="mt-1 font-mono text-[9px] text-[var(--text-tertiary)]">
-            {duration}s
-          </p>
+            {duration && (
+              <p className="mt-1 font-mono text-[9px] text-[var(--text-tertiary)]">{duration}s</p>
+            )}
+          </>
         )}
       </div>
 
-      <Handle
-        type="source"
-        position={Position.Right}
-        className="!bg-[var(--border-strong)]"
-      />
+      <Handle type="source" position={Position.Right} className="!bg-[var(--border-strong)]" />
     </div>
   );
 }
@@ -206,74 +241,36 @@ const nodeTypes = { pipelineStep: PipelineNode };
 
 interface ScanPipelineProps {
   steps: Map<string, StepEvent>;
+  /** Per-domain finding counts driving the scanner lanes. */
+  lanes?: Record<ScannerDomain, DomainLaneData> | undefined;
   className?: string | undefined;
-  /** Currently drilled-in step (adds a selection ring). */
+  /** Currently drilled-in node (adds a selection ring). */
   selectedStepId?: string | null | undefined;
-  /** Fired when a stage node is clicked, for drill-in panels. */
-  onStepClick?: ((stepId: string) => void) | undefined;
+  /** Fired when a node is clicked, for drill-in panels. Receives the DAG node id. */
+  onStepClick?: ((nodeId: string) => void) | undefined;
   /** Enable pan/zoom/drag/select + on-canvas controls. Defaults to true. */
   interactive?: boolean | undefined;
 }
 
 function ScanPipelineInner({
   steps,
+  lanes,
   className,
   selectedStepId,
   onStepClick,
   interactive = true,
 }: ScanPipelineProps) {
   const { rawNodes, rawEdges } = useMemo(() => {
-    const rawNodes: Node[] = PIPELINE_STEPS?.map((step) => ({
-      id: step.id,
-      type: "pipelineStep",
-      position: { x: 0, y: 0 },
-      data: {
-        label: step.label,
-        description: STEP_DESCRIPTIONS[step.id] ?? "",
-        stepId: step.id,
-        status: (steps.get(step.id)?.status ?? "pending") as StepStatus,
-        message: steps.get(step.id)?.message,
-        stats: steps.get(step.id)?.stats,
-        startedAt: steps.get(step.id)?.started_at,
-        completedAt: steps.get(step.id)?.completed_at,
-        progressPct: steps.get(step.id)?.progress_pct,
-        selected: selectedStepId === step.id,
-      } satisfies PipelineNodeData,
-    }));
-
-    const rawEdges: Edge[] = PIPELINE_STEPS.slice(1).map((step, i) => {
-      const prevId = PIPELINE_STEPS[i]!.id;
-      const prevStatus = steps.get(prevId)?.status;
-      const curStatus = steps.get(step.id)?.status;
-
-      return {
-        id: `e-${prevId}-${step.id}`,
-        source: prevId,
-        target: step.id,
-        type: "default",
-        // Motion only while something is actively running.
-        animated: prevStatus === "running" || curStatus === "running",
-        style: {
-          stroke:
-            curStatus === "done"
-              ? "#10b981"
-              : curStatus === "failed"
-                ? "#ef4444"
-                : "var(--border-strong)",
-          strokeWidth: 2,
-        },
-      };
-    });
-
-    return { rawNodes, rawEdges };
-  }, [steps, selectedStepId]);
+    const built = buildPipelineGraph({ steps, lanes, selectedNodeId: selectedStepId });
+    return { rawNodes: built.nodes, rawEdges: built.edges };
+  }, [steps, lanes, selectedStepId]);
 
   const { nodes, edges } = useGraphLayout("sankey", rawNodes, rawEdges, {
     sankey: {
-      nodeWidth: 190,
-      nodeHeight: 90,
-      columnGap: 50,
-      rowGap: 20,
+      nodeWidth: 180,
+      nodeHeight: 78,
+      columnGap: 64,
+      rowGap: 16,
     },
   });
 
@@ -291,8 +288,8 @@ function ScanPipelineInner({
         edges={edges}
         nodeTypes={nodeTypes}
         fitView
-        fitViewOptions={{ padding: 0.2 }}
-        minZoom={0.4}
+        fitViewOptions={{ padding: 0.16 }}
+        minZoom={0.25}
         maxZoom={1.5}
         panOnDrag={interactive}
         zoomOnScroll={interactive}

--- a/ui/components/scan-result.tsx
+++ b/ui/components/scan-result.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { api, type ScanJob, type ScanJobStatus, type ScanResult, type BlastRadius, type RemediationItem, type GraphExportFormat, formatDate, OWASP_LLM_TOP10, MITRE_ATLAS, severityColor } from "@/lib/api";
 import { useScanStream } from "@/lib/use-scan-stream";
 import { mergePipelineSteps, parsePipelineStepsFromProgress } from "@/lib/scan-pipeline-progress";
+import { domainFindingsForScan } from "@/lib/scan-domain-findings";
 import { ScanPipeline } from "@/components/scan-pipeline";
 import { RepoScanOverviewPanel } from "@/components/repo-scan-overview-panel";
 import { SeverityBadge } from "@/components/severity-badge";
@@ -101,6 +102,13 @@ export function ScanResultView({ id }: { id: string }) {
 
   const result = job?.result as ScanResult | undefined;
   const summary = result?.summary;
+  const pipelineLanes = useMemo(
+    () =>
+      job?.status === "done"
+        ? domainFindingsForScan({ result, summary }).lanes
+        : undefined,
+    [job?.status, result, summary],
+  );
   const blastRadius = result?.blast_radius ?? [];
   const cloudEvidence = result ? summarizeCloudEvidence(result) : null;
   const repoUrl =
@@ -177,7 +185,7 @@ export function ScanResultView({ id }: { id: string }) {
             </span>
           </div>
           {replayedSteps.size > 0 ? (
-            <ScanPipeline steps={replayedSteps} />
+            <ScanPipeline steps={replayedSteps} lanes={pipelineLanes} className="h-[300px]" />
           ) : (
             <p className="text-xs font-mono text-[color:var(--text-tertiary)] animate-pulse">Waiting for scan to start...</p>
           )}

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -23,7 +23,11 @@ export const CONTROLS_CLASS =
 
 export const MINIMAP_CLASS =
   "!bg-[var(--surface)]/90 !border-[var(--border-subtle)] !rounded-lg !backdrop-blur-sm";
-export const MINIMAP_BG = "#09090b";
+// React Flow forwards `bgColor` into an inline CSS custom property that its
+// stylesheet resolves with `var()`, so a token reference here follows the
+// light/dark toggle without any runtime JS (was a hardcoded near-black #09090b
+// that rendered as a black panel on the light canvas).
+export const MINIMAP_BG = "var(--surface)";
 export const MINIMAP_MASK = "rgba(24,24,27,0.82)";
 
 // Dot-grid tint. #1c1c1e sat one step off the page background, so the canvas

--- a/ui/lib/scan-domain-findings.ts
+++ b/ui/lib/scan-domain-findings.ts
@@ -1,0 +1,156 @@
+/**
+ * Derive per-domain scanner findings from a scan result.
+ *
+ * Shared by the jobs pipeline panel and the full scan view so both render the
+ * same branching DAG lanes and the same reconciled finding count. Cloud CIS
+ * fields arrive as `unknown`, so every accessor is defensive.
+ */
+
+import type { ScanResult, Summary } from "@/lib/api";
+import {
+  deriveDomainLanes,
+  reconcileFindings,
+  type CisSummary,
+  type DomainLaneData,
+  type ReconciledFindings,
+  type ScannerDomain,
+} from "@/lib/scan-pipeline-graph";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function cloudResourceCount(inventory: unknown): number | null {
+  if (Array.isArray(inventory)) {
+    let total = 0;
+    let seen = false;
+    for (const item of inventory) {
+      if (!isRecord(item)) continue;
+      const n = asNumber(item.resource_count);
+      if (n != null) {
+        total += n;
+        seen = true;
+      }
+    }
+    return seen ? total : null;
+  }
+  if (isRecord(inventory)) return asNumber(inventory.resource_count);
+  return null;
+}
+
+export function cloudIdentityCount(inventory: unknown): number | null {
+  if (Array.isArray(inventory)) {
+    let total = 0;
+    let seen = false;
+    for (const item of inventory) {
+      if (!isRecord(item)) continue;
+      const n = asNumber(item.identity_count);
+      if (n != null) {
+        total += n;
+        seen = true;
+      }
+    }
+    return seen ? total : null;
+  }
+  if (isRecord(inventory)) return asNumber(inventory.identity_count);
+  return null;
+}
+
+/** Pass/fail/total for a single CIS benchmark, from explicit counts or a checks array. */
+function cisCounts(benchmark: unknown): { passed: number; failed: number; total: number } | null {
+  if (!isRecord(benchmark)) return null;
+  const passed = asNumber(benchmark.passed);
+  const failed = asNumber(benchmark.failed);
+  const total = asNumber(benchmark.total);
+  if (passed != null || failed != null || total != null) {
+    const p = passed ?? 0;
+    const f = failed ?? 0;
+    return { passed: p, failed: f, total: total ?? p + f };
+  }
+  const checks = benchmark.checks;
+  if (Array.isArray(checks)) {
+    let p = 0;
+    let f = 0;
+    for (const raw of checks) {
+      if (!isRecord(raw)) continue;
+      const status = String(raw.status ?? raw.result ?? "").toLowerCase();
+      if (["pass", "passed", "ok", "success"].includes(status)) p += 1;
+      if (["fail", "failed", "error"].includes(status)) f += 1;
+    }
+    return { passed: p, failed: f, total: checks.length };
+  }
+  return null;
+}
+
+function passRateOnly(benchmark: unknown): number | null {
+  if (!isRecord(benchmark)) return null;
+  const raw = asNumber(benchmark.pass_rate);
+  if (raw == null) return null;
+  // Backends emit either 0–1 or 0–100; normalize to a percentage.
+  return raw <= 1 ? raw * 100 : raw;
+}
+
+/**
+ * Aggregate every CIS benchmark on the result into one honest posture summary.
+ * `failed` is "controls not passing" (total − passed) so it reconciles with
+ * the pass-rate narrative — a 32%-pass run reports 68% as CSPM findings.
+ */
+export function cisSummaryFromResult(result: ScanResult | null | undefined): CisSummary | null {
+  if (!result) return null;
+  const benches = [
+    result.cis_benchmark,
+    result.azure_cis_benchmark,
+    result.gcp_cis_benchmark,
+    result.snowflake_cis_benchmark,
+    result.databricks_cis_benchmark,
+  ];
+  let passed = 0;
+  let total = 0;
+  let seen = false;
+  for (const bench of benches) {
+    const counts = cisCounts(bench);
+    if (!counts) continue;
+    seen = true;
+    passed += counts.passed;
+    total += counts.total;
+  }
+  if (seen && total > 0) {
+    return { passed, failed: Math.max(0, total - passed), total, passRate: (passed / total) * 100 };
+  }
+  const passRate =
+    passRateOnly(result.cis_benchmark) ??
+    passRateOnly(result.azure_cis_benchmark) ??
+    passRateOnly(result.gcp_cis_benchmark) ??
+    passRateOnly(result.snowflake_cis_benchmark) ??
+    passRateOnly(result.databricks_cis_benchmark);
+  if (passRate != null) return { passed: null, failed: null, total: null, passRate };
+  return null;
+}
+
+export interface DomainFindingsView {
+  lanes: Record<ScannerDomain, DomainLaneData>;
+  reconciled: ReconciledFindings;
+  cis: CisSummary | null;
+}
+
+/**
+ * Build the scanner-lane table + reconciled totals for a completed scan.
+ * A domain only counts as "ran" when the scan produced data for it, so a
+ * repo SCA scan leaves the CIS/cloud lanes as "not run".
+ */
+export function domainFindingsForScan(input: {
+  result?: ScanResult | null | undefined;
+  summary?: Summary | null | undefined;
+  summarized?: boolean;
+}): DomainFindingsView {
+  const summary = input.result?.summary ?? input.summary ?? undefined;
+  const cis = cisSummaryFromResult(input.result);
+  const scannedPackages = (summary?.total_packages ?? 0) > 0;
+  const vulnerabilities = scannedPackages ? summary?.total_vulnerabilities ?? 0 : null;
+  const lanes = deriveDomainLanes({ vulnerabilities, cis, summarized: input.summarized ?? false });
+  return { lanes, reconciled: reconcileFindings(lanes), cis };
+}

--- a/ui/lib/scan-pipeline-graph.ts
+++ b/ui/lib/scan-pipeline-graph.ts
@@ -1,0 +1,365 @@
+/**
+ * Scan-pipeline branching DAG model + honesty reconciliation.
+ *
+ * The backend streams six linear stages (discovery → extraction → scanning →
+ * enrichment → analysis → output). Rendered as a single row that reads as a
+ * flat line, it hides the real shape of a scan: after extraction the work
+ * fans out into parallel scanner domains (SCA / secrets / IaC / CIS / cloud)
+ * that converge back into enrichment. This module turns the streamed steps
+ * into that branching graph and derives per-domain finding counts so the
+ * result chips reconcile with the domain lanes — a CIS run that is "32% pass"
+ * is "68% fail", and those failures ARE findings, not "0 findings".
+ *
+ * Pure + framework-neutral (node.data is a plain record) so the branching
+ * layout and reconciliation math are unit-testable without React Flow.
+ */
+
+import type { Edge, Node } from "@xyflow/react";
+import type { StepEvent, StepStatus } from "@/lib/api";
+
+export type PipelineNodeKind = "stage" | "scanner";
+
+export type ScannerDomain = "sca" | "secrets" | "iac" | "cis" | "cloud";
+
+export const SCANNER_DOMAINS: readonly ScannerDomain[] = ["sca", "secrets", "iac", "cis", "cloud"];
+
+export interface PipelineGraphNodeSpec {
+  id: string;
+  label: string;
+  kind: PipelineNodeKind;
+  /** Backend step whose streamed status/timing this node reflects. */
+  stepId: string;
+  domain?: ScannerDomain;
+  dependsOn: string[];
+  description: string;
+}
+
+/**
+ * The branching pipeline topology. Rank is implied by the dependency edges,
+ * so the Sankey layout fans the scanner lanes out of `extraction` and back
+ * into `enrichment` automatically — no hand-placed coordinates.
+ */
+export const PIPELINE_GRAPH: readonly PipelineGraphNodeSpec[] = [
+  {
+    id: "discovery",
+    label: "Discovery",
+    kind: "stage",
+    stepId: "discovery",
+    dependsOn: [],
+    description: "Find agents, configs, and cloud accounts",
+  },
+  {
+    id: "extraction",
+    label: "Extraction",
+    kind: "stage",
+    stepId: "extraction",
+    dependsOn: ["discovery"],
+    description: "Resolve packages and assets to scan",
+  },
+  {
+    id: "sca",
+    label: "SCA · CVEs",
+    kind: "scanner",
+    domain: "sca",
+    stepId: "scanning",
+    dependsOn: ["extraction"],
+    description: "Query vulnerability databases",
+  },
+  {
+    id: "secrets",
+    label: "Secrets",
+    kind: "scanner",
+    domain: "secrets",
+    stepId: "scanning",
+    dependsOn: ["extraction"],
+    description: "Scan for exposed credentials",
+  },
+  {
+    id: "iac",
+    label: "IaC",
+    kind: "scanner",
+    domain: "iac",
+    stepId: "scanning",
+    dependsOn: ["extraction"],
+    description: "Terraform / K8s misconfig checks",
+  },
+  {
+    id: "cis",
+    label: "CIS · CSPM",
+    kind: "scanner",
+    domain: "cis",
+    stepId: "scanning",
+    dependsOn: ["extraction"],
+    description: "Benchmark cloud posture controls",
+  },
+  {
+    id: "cloud",
+    label: "Cloud posture",
+    kind: "scanner",
+    domain: "cloud",
+    stepId: "scanning",
+    dependsOn: ["extraction"],
+    description: "Inventory + exposure evidence",
+  },
+  {
+    id: "enrichment",
+    label: "Enrichment",
+    kind: "stage",
+    stepId: "enrichment",
+    dependsOn: [...SCANNER_DOMAINS],
+    description: "NVD CVSS, EPSS, CISA KEV",
+  },
+  {
+    id: "analysis",
+    label: "Analysis",
+    kind: "stage",
+    stepId: "analysis",
+    dependsOn: ["enrichment"],
+    description: "Compute blast radius + reachability",
+  },
+  {
+    id: "output",
+    label: "Report",
+    kind: "stage",
+    stepId: "output",
+    dependsOn: ["analysis"],
+    description: "Publish findings, graph, compliance",
+  },
+];
+
+const NODE_BY_ID = new Map(PIPELINE_GRAPH.map((spec) => [spec.id, spec]));
+
+/** Backend step id a DAG node reflects (scanner lanes all map to `scanning`). */
+export function backendStepForNode(nodeId: string): string {
+  return NODE_BY_ID.get(nodeId)?.stepId ?? nodeId;
+}
+
+// ── Per-domain findings ──────────────────────────────────────────────────────
+
+export interface CisSummary {
+  passed: number | null;
+  failed: number | null;
+  total: number | null;
+  passRate: number | null;
+}
+
+export interface DomainLaneData {
+  /** Whether this scan actually exercised the domain. */
+  ran: boolean;
+  /** Findings this domain contributes to the reconciled total. */
+  findings: number | null;
+  /** Short label for the lane chip (e.g. "68 fail · 100 checks"). */
+  detail?: string;
+  /** True when the domain reports a summarised (synchronous) result with no streamed timing. */
+  summarized?: boolean;
+}
+
+const EMPTY_LANE: DomainLaneData = { ran: false, findings: null };
+
+/** Failed CIS checks — the honest "findings" count behind a pass rate. */
+export function cisFailedCount(cis: CisSummary | null | undefined): number | null {
+  if (!cis) return null;
+  if (cis.failed != null && cis.failed >= 0) return cis.failed;
+  if (cis.total != null && cis.passed != null) return Math.max(0, cis.total - cis.passed);
+  if (cis.total != null && cis.passRate != null) {
+    const rate = cis.passRate <= 1 ? cis.passRate : cis.passRate / 100;
+    return Math.max(0, Math.round(cis.total * (1 - rate)));
+  }
+  return null;
+}
+
+function cisDetail(cis: CisSummary): string | undefined {
+  const failed = cisFailedCount(cis);
+  if (cis.total != null && failed != null) return `${failed} fail · ${cis.total} checks`;
+  if (failed != null) return `${failed} fail`;
+  return undefined;
+}
+
+export interface DeriveDomainLanesInput {
+  /** SCA / CVE findings (e.g. scanning-step `vulnerabilities` stat or summary total). */
+  vulnerabilities?: number | null;
+  secrets?: number | null;
+  iac?: number | null;
+  cloudFindings?: number | null;
+  cis?: CisSummary | null;
+  /** True when the scan ran synchronously and carries no per-stage timing. */
+  summarized?: boolean;
+}
+
+/**
+ * Build the per-domain lane table. A domain only counts as "ran" when the
+ * scan actually produced data for it — a repo SCA scan leaves the CIS/cloud
+ * lanes as "not run" rather than fabricating a clean pass.
+ */
+export function deriveDomainLanes(
+  input: DeriveDomainLanesInput,
+): Record<ScannerDomain, DomainLaneData> {
+  const summarized = input.summarized ?? false;
+  const scalarLane = (value: number | null | undefined, noun: string): DomainLaneData => {
+    if (value == null) return { ...EMPTY_LANE };
+    return {
+      ran: true,
+      findings: value,
+      detail: value === 0 ? "clean" : `${value} ${noun}`,
+      summarized,
+    };
+  };
+
+  const cisLane: DomainLaneData = (() => {
+    if (!input.cis) return { ...EMPTY_LANE };
+    const failed = cisFailedCount(input.cis);
+    const lane: DomainLaneData = { ran: true, findings: failed, summarized };
+    const detail = cisDetail(input.cis);
+    if (detail !== undefined) lane.detail = detail;
+    else if (failed === 0) lane.detail = "clean";
+    return lane;
+  })();
+
+  return {
+    sca: scalarLane(input.vulnerabilities, input.vulnerabilities === 1 ? "CVE" : "CVEs"),
+    secrets: scalarLane(input.secrets, input.secrets === 1 ? "secret" : "secrets"),
+    iac: scalarLane(input.iac, "misconfig"),
+    cis: cisLane,
+    cloud: scalarLane(input.cloudFindings, "exposure"),
+  };
+}
+
+export interface ReconciledFindings {
+  /** Total findings across every domain that ran (CIS fails included). */
+  total: number;
+  /** Number of scanner domains that actually ran. */
+  domainsRun: number;
+  byDomain: Record<ScannerDomain, number | null>;
+}
+
+/**
+ * Reconcile the headline finding count with the domain lanes: CIS failures
+ * count as findings, so a "0 vulnerabilities / 32% CIS pass" run reports the
+ * 68 failing controls instead of a contradictory "0 findings".
+ */
+export function reconcileFindings(
+  lanes: Record<ScannerDomain, DomainLaneData>,
+): ReconciledFindings {
+  let total = 0;
+  let domainsRun = 0;
+  const byDomain = {} as Record<ScannerDomain, number | null>;
+  for (const domain of SCANNER_DOMAINS) {
+    const lane = lanes[domain];
+    byDomain[domain] = lane.ran ? lane.findings : null;
+    if (lane.ran) {
+      domainsRun += 1;
+      if (lane.findings != null) total += lane.findings;
+    }
+  }
+  return { total, domainsRun, byDomain };
+}
+
+// ── React Flow graph assembly ────────────────────────────────────────────────
+
+/**
+ * A scanner lane mirrors the single streamed `scanning` step, but a domain
+ * the scan never touched should read as "skipped", not stuck "pending" or
+ * falsely "done". Once scanning reaches a terminal state, lanes without data
+ * collapse to skipped.
+ */
+export function laneStatus(scanStatus: StepStatus, ran: boolean): StepStatus {
+  const terminal = scanStatus === "done" || scanStatus === "failed" || scanStatus === "skipped";
+  if (terminal && !ran) return "skipped";
+  return scanStatus;
+}
+
+const TERMINAL: ReadonlySet<StepStatus> = new Set<StepStatus>(["done", "failed", "skipped"]);
+
+export interface BuildPipelineGraphInput {
+  steps: Map<string, StepEvent>;
+  lanes?: Record<ScannerDomain, DomainLaneData> | undefined;
+  selectedNodeId?: string | null | undefined;
+}
+
+export interface BuildPipelineGraphResult {
+  nodes: Node[];
+  edges: Edge[];
+}
+
+function statusOf(
+  spec: PipelineGraphNodeSpec,
+  steps: Map<string, StepEvent>,
+  lanes: Record<ScannerDomain, DomainLaneData> | undefined,
+): StepStatus {
+  const raw = (steps.get(spec.stepId)?.status ?? "pending") as StepStatus;
+  if (spec.kind === "scanner" && spec.domain) {
+    return laneStatus(raw, lanes?.[spec.domain]?.ran ?? false);
+  }
+  return raw;
+}
+
+/**
+ * Assemble React Flow nodes + edges for the branching DAG. Positions are left
+ * at the origin; the Sankey layout ranks nodes by the dependency edges, so
+ * the fan-out/fan-in shape is fully derived from `dependsOn`.
+ */
+export function buildPipelineGraph(input: BuildPipelineGraphInput): BuildPipelineGraphResult {
+  const { steps, lanes, selectedNodeId } = input;
+  const statusById = new Map<string, StepStatus>();
+  for (const spec of PIPELINE_GRAPH) statusById.set(spec.id, statusOf(spec, steps, lanes));
+
+  const nodes: Node[] = PIPELINE_GRAPH.map((spec) => {
+    const event = steps.get(spec.stepId);
+    const status = statusById.get(spec.id) ?? "pending";
+    const lane = spec.domain ? lanes?.[spec.domain] : undefined;
+    return {
+      id: spec.id,
+      type: "pipelineStep",
+      position: { x: 0, y: 0 },
+      data: {
+        nodeId: spec.id,
+        stepId: spec.stepId,
+        label: spec.label,
+        description: spec.description,
+        kind: spec.kind,
+        domain: spec.domain,
+        status,
+        message: event?.message,
+        // Only stages carry the streamed stat chips; scanner lanes show findings.
+        stats: spec.kind === "stage" ? event?.stats : undefined,
+        startedAt: event?.started_at,
+        completedAt: event?.completed_at,
+        progressPct: event?.progress_pct,
+        findings: lane?.findings ?? null,
+        ran: lane?.ran ?? spec.kind === "stage",
+        detail: lane?.detail,
+        summarized: lane?.summarized ?? false,
+        selected: selectedNodeId === spec.id,
+      },
+    } satisfies Node;
+  });
+
+  const edges: Edge[] = [];
+  for (const spec of PIPELINE_GRAPH) {
+    for (const source of spec.dependsOn) {
+      const sourceStatus = statusById.get(source);
+      const targetStatus = statusById.get(spec.id);
+      const active = sourceStatus === "running" || targetStatus === "running";
+      const flowed = targetStatus === "done" && TERMINAL.has(sourceStatus ?? "pending");
+      edges.push({
+        id: `e-${source}-${spec.id}`,
+        source,
+        target: spec.id,
+        type: "default",
+        animated: active,
+        style: {
+          stroke:
+            targetStatus === "failed"
+              ? "var(--severity-critical)"
+              : flowed
+                ? "var(--status-success)"
+                : "var(--border-strong)",
+          strokeWidth: 1.75,
+          opacity: targetStatus === "skipped" ? 0.4 : 1,
+        },
+      });
+    }
+  }
+
+  return { nodes, edges };
+}

--- a/ui/lib/scan-pipeline-progress.ts
+++ b/ui/lib/scan-pipeline-progress.ts
@@ -70,6 +70,40 @@ export function formatDurationMs(ms: number | null | undefined): string {
   return `${minutes}m ${remainder}s`;
 }
 
+/**
+ * Honest wall-clock label. A synchronous scan (cloud-connection runs, dry
+ * runs) finishes with no streamed timing, so its elapsed time collapses to
+ * ~0ms — reporting "0ms" is misleading. Show "summarized" instead of faking a
+ * duration, and "running…" while a live scan has no end yet.
+ */
+export function describeWallClock(
+  wallClockMs: number | null | undefined,
+  opts: { synthesized?: boolean; running?: boolean } = {},
+): string {
+  if (opts.synthesized) return "summarized";
+  if (wallClockMs == null) return opts.running ? "running…" : "—";
+  if (wallClockMs <= 0) return "summarized";
+  return formatDurationMs(wallClockMs);
+}
+
+/**
+ * Honest per-stage timing cell. Real streamed stages show their measured
+ * duration; a summarized (synthesized) stage says so rather than claiming a
+ * crisp "done" with no numbers behind it.
+ */
+export function formatStageDuration(
+  duration: number | null | undefined,
+  status: StepStatus | undefined,
+  synthesized = false,
+): string {
+  if (duration != null) return formatDurationMs(duration);
+  if (status === "running") return "running…";
+  if (synthesized && (status === "done" || status === "skipped")) return "summarized";
+  if (status === "done") return "done";
+  if (status === "skipped") return "skipped";
+  return "—";
+}
+
 export function jobWallClockMs(input: {
   created_at: string;
   started_at?: string | null;

--- a/ui/lib/theme-colors.ts
+++ b/ui/lib/theme-colors.ts
@@ -4,6 +4,8 @@
  * `ui/app/globals.css` severity and surface variables.
  */
 
+import { useThemeMode } from "./theme-mode";
+
 export const SEVERITY_HEX = {
   critical: "#ff6b6b",
   high: "#ff9f4a",
@@ -25,17 +27,48 @@ export function readThemeColor(varName: string, fallback: string): string {
   return value || fallback;
 }
 
-/** Recharts/SVG chrome — reads live CSS vars so light/dark stay aligned. */
+/**
+ * Recharts/SVG chrome + data colors — reads live CSS vars so light/dark stay
+ * aligned. `bg`/`border`/`grid`/`text`/`tooltip` style the chart chrome; the
+ * `severity`/`status`/`accent` maps drive series fills off the same tokens so
+ * bars, pies, and areas track the theme instead of a hardcoded dark palette.
+ */
 export function getChartTheme() {
   return {
     bg: readThemeColor("--surface", "#22262f"),
     border: readThemeColor("--border-subtle", "rgba(110, 118, 138, 0.78)"),
     grid: readThemeColor("--border-subtle", "rgba(110, 118, 138, 0.78)"),
     text: readThemeColor("--text-tertiary", "#a8aebc"),
+    accent: readThemeColor("--accent-mint", "#34d399"),
+    severity: {
+      critical: readThemeColor("--severity-critical", SEVERITY_HEX.critical),
+      high: readThemeColor("--severity-high", SEVERITY_HEX.high),
+      medium: readThemeColor("--severity-medium", SEVERITY_HEX.medium),
+      low: readThemeColor("--severity-low", SEVERITY_HEX.low),
+      unrated: readThemeColor("--severity-unrated", SEVERITY_HEX.none),
+    },
+    status: {
+      success: readThemeColor("--status-success", "#34d399"),
+      warn: readThemeColor("--status-warn", "#fbbf24"),
+      danger: readThemeColor("--status-danger", SEVERITY_HEX.critical),
+    },
     tooltip: {
       bg: readThemeColor("--surface-elevated", "#2c3140"),
       border: readThemeColor("--border-strong", "rgba(140, 148, 168, 0.92)"),
       text: readThemeColor("--foreground", "#f4f5f8"),
     },
   };
+}
+
+export type ChartTheme = ReturnType<typeof getChartTheme>;
+
+/**
+ * Hook variant of {@link getChartTheme}. Subscribes to the theme mode so any
+ * chart reading these colors re-renders (and re-reads the CSS vars) the moment
+ * the user flips light/dark — a bare `getChartTheme()` call would otherwise
+ * keep stale chrome until the next data-driven render.
+ */
+export function useChartTheme(): ChartTheme {
+  useThemeMode();
+  return getChartTheme();
 }

--- a/ui/tests/chart-theme-colors.test.tsx
+++ b/ui/tests/chart-theme-colors.test.tsx
@@ -1,0 +1,119 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getChartTheme, useChartTheme } from "@/lib/theme-colors";
+
+// Chart chrome (tooltips/axes/grids) and series fills are JS style props, so
+// the class-based light-theme sweep could not reach them. They must instead be
+// driven off the CSS tokens in globals.css so they render legibly in BOTH
+// themes and follow the light/dark toggle. These tests lock that contract in.
+
+const UI_ROOT = process.cwd();
+
+// Chart surfaces whose Recharts style props must be fully tokenized — no raw
+// hex chrome or series colors may creep back in.
+const TOKENIZED_CHART_FILES = [
+  "app/fleet/page.tsx",
+  "app/gateway/GatewayDashboard.tsx",
+  "app/activity/page.tsx",
+  "app/governance/page.tsx",
+  "app/proxy/ProxyDashboard.tsx",
+] as const;
+
+const HEX_LITERAL = /#[0-9a-fA-F]{6}\b/g;
+
+function resetRoot() {
+  const root = document.documentElement;
+  root.removeAttribute("data-theme");
+  root.removeAttribute("style");
+  try {
+    window.localStorage.clear();
+  } catch {
+    // ignore
+  }
+}
+
+afterEach(resetRoot);
+
+describe("getChartTheme", () => {
+  it("exposes chrome, severity, status and accent color maps", () => {
+    const theme = getChartTheme();
+    expect(theme).toMatchObject({
+      bg: expect.any(String),
+      border: expect.any(String),
+      grid: expect.any(String),
+      text: expect.any(String),
+      accent: expect.any(String),
+      severity: {
+        critical: expect.any(String),
+        high: expect.any(String),
+        medium: expect.any(String),
+        low: expect.any(String),
+        unrated: expect.any(String),
+      },
+      status: {
+        success: expect.any(String),
+        warn: expect.any(String),
+        danger: expect.any(String),
+      },
+      tooltip: {
+        bg: expect.any(String),
+        border: expect.any(String),
+        text: expect.any(String),
+      },
+    });
+  });
+
+  it("reads live CSS token values instead of a baked palette", () => {
+    const root = document.documentElement;
+    root.style.setProperty("--surface", "rgb(255, 255, 255)");
+    root.style.setProperty("--severity-critical", "rgb(220, 38, 38)");
+    root.style.setProperty("--accent-mint", "rgb(5, 150, 105)");
+
+    const theme = getChartTheme();
+    expect(theme.bg).toBe("rgb(255, 255, 255)");
+    expect(theme.severity.critical).toBe("rgb(220, 38, 38)");
+    expect(theme.accent).toBe("rgb(5, 150, 105)");
+  });
+});
+
+describe("useChartTheme", () => {
+  it("re-reads token values when the theme mode toggles", () => {
+    const root = document.documentElement;
+    root.style.setProperty("--surface", "rgb(34, 38, 47)");
+
+    const { result } = renderHook(() => useChartTheme());
+    expect(result.current.bg).toBe("rgb(34, 38, 47)");
+
+    act(() => {
+      // Mirror ThemeToggle.applyTheme: flip the mode + swap the token, then
+      // notify subscribers. The hook must re-render and read the new value.
+      root.dataset.theme = "light";
+      root.style.setProperty("--surface", "rgb(255, 255, 255)");
+      window.dispatchEvent(new Event("agent-bom-theme-change"));
+    });
+
+    expect(result.current.bg).toBe("rgb(255, 255, 255)");
+  });
+});
+
+describe("chart hex regression guard", () => {
+  it("keeps tokenized chart surfaces free of raw hex style props", () => {
+    const violations: string[] = [];
+    for (const rel of TOKENIZED_CHART_FILES) {
+      const source = readFileSync(path.join(UI_ROOT, rel), "utf8");
+      for (const match of source.matchAll(HEX_LITERAL)) {
+        violations.push(`${rel}: ${match[0]}`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it("keeps the graph minimap background on a theme token", () => {
+    const source = readFileSync(path.join(UI_ROOT, "lib/graph-utils.ts"), "utf8");
+    expect(source).toMatch(/export const MINIMAP_BG = "var\(--[\w-]+\)";/);
+  });
+});

--- a/ui/tests/scan-pipeline-graph.test.ts
+++ b/ui/tests/scan-pipeline-graph.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import type { StepEvent } from "@/lib/api";
+import {
+  PIPELINE_GRAPH,
+  SCANNER_DOMAINS,
+  backendStepForNode,
+  buildPipelineGraph,
+  cisFailedCount,
+  deriveDomainLanes,
+  laneStatus,
+  reconcileFindings,
+} from "@/lib/scan-pipeline-graph";
+
+function step(partial: Partial<StepEvent> & { step_id: string; status: StepEvent["status"] }): StepEvent {
+  return { type: "step", message: "", ...partial };
+}
+
+function stepsMap(events: StepEvent[]): Map<string, StepEvent> {
+  return new Map(events.map((e) => [e.step_id, e]));
+}
+
+describe("scan-pipeline-graph topology", () => {
+  it("fans extraction out to five scanner lanes that converge into enrichment", () => {
+    const scannerIds = PIPELINE_GRAPH.filter((n) => n.kind === "scanner").map((n) => n.id);
+    expect(scannerIds).toEqual([...SCANNER_DOMAINS]);
+
+    for (const id of scannerIds) {
+      const node = PIPELINE_GRAPH.find((n) => n.id === id)!;
+      expect(node.dependsOn).toEqual(["extraction"]);
+      expect(backendStepForNode(id)).toBe("scanning");
+    }
+
+    const enrichment = PIPELINE_GRAPH.find((n) => n.id === "enrichment")!;
+    expect(enrichment.dependsOn).toEqual([...SCANNER_DOMAINS]);
+  });
+
+  it("builds a branching (not linear) edge set", () => {
+    const { nodes, edges } = buildPipelineGraph({ steps: new Map() });
+    expect(nodes).toHaveLength(PIPELINE_GRAPH.length);
+
+    // extraction fans out to all five lanes
+    const fanOut = edges.filter((e) => e.source === "extraction");
+    expect(fanOut.map((e) => e.target).sort()).toEqual([...SCANNER_DOMAINS].sort());
+
+    // all five lanes fan in to enrichment
+    const fanIn = edges.filter((e) => e.target === "enrichment");
+    expect(fanIn.map((e) => e.source).sort()).toEqual([...SCANNER_DOMAINS].sort());
+
+    // it is genuinely a fork: more than one node shares extraction as a source
+    expect(fanOut.length).toBeGreaterThan(1);
+  });
+
+  it("carries backend stepId + node id so scanner lanes drill into scanning", () => {
+    const { nodes } = buildPipelineGraph({ steps: new Map() });
+    const sca = nodes.find((n) => n.id === "sca")!;
+    expect(sca.data.stepId).toBe("scanning");
+    expect(sca.data.kind).toBe("scanner");
+    expect(sca.data.domain).toBe("sca");
+  });
+});
+
+describe("scan-pipeline-graph lane status", () => {
+  it("collapses lanes with no domain data to skipped once scanning is terminal", () => {
+    expect(laneStatus("done", false)).toBe("skipped");
+    expect(laneStatus("done", true)).toBe("done");
+    expect(laneStatus("running", false)).toBe("running");
+    expect(laneStatus("pending", false)).toBe("pending");
+  });
+
+  it("marks scanner nodes without data as skipped after a completed scan", () => {
+    const steps = stepsMap([
+      step({ step_id: "scanning", status: "done", message: "Found 3 vulnerabilities" }),
+    ]);
+    const lanes = deriveDomainLanes({ vulnerabilities: 3 });
+    const { nodes } = buildPipelineGraph({ steps, lanes });
+    const byId = new Map(nodes.map((n) => [n.id, n.data.status]));
+    expect(byId.get("sca")).toBe("done");
+    expect(byId.get("secrets")).toBe("skipped");
+    expect(byId.get("cis")).toBe("skipped");
+  });
+});
+
+describe("scan-pipeline-graph honesty reconciliation", () => {
+  it("counts CIS failures as findings (0 vulns / 32% pass is 68 findings, not 0)", () => {
+    const cis = { passed: 32, failed: null, total: 100, passRate: 0.32 };
+    expect(cisFailedCount(cis)).toBe(68);
+
+    const lanes = deriveDomainLanes({ vulnerabilities: 0, cis });
+    const reconciled = reconcileFindings(lanes);
+    expect(reconciled.total).toBe(68);
+    expect(reconciled.byDomain.sca).toBe(0);
+    expect(reconciled.byDomain.cis).toBe(68);
+    expect(lanes.cis.detail).toBe("68 fail · 100 checks");
+  });
+
+  it("derives CIS failures from an explicit failed count or a pass rate", () => {
+    expect(cisFailedCount({ passed: null, failed: 12, total: 50, passRate: null })).toBe(12);
+    expect(cisFailedCount({ passed: null, failed: null, total: 200, passRate: 90 })).toBe(20);
+    expect(cisFailedCount(null)).toBeNull();
+  });
+
+  it("leaves untouched domains out of the total and marks them not-run", () => {
+    const lanes = deriveDomainLanes({ vulnerabilities: 5 });
+    const reconciled = reconcileFindings(lanes);
+    expect(reconciled.total).toBe(5);
+    expect(reconciled.domainsRun).toBe(1);
+    expect(reconciled.byDomain.secrets).toBeNull();
+    expect(lanes.secrets.ran).toBe(false);
+    expect(lanes.sca.detail).toBe("5 CVEs");
+  });
+
+  it("labels a clean scanned domain as clean, not absent", () => {
+    const lanes = deriveDomainLanes({ vulnerabilities: 0 });
+    expect(lanes.sca.ran).toBe(true);
+    expect(lanes.sca.findings).toBe(0);
+    expect(lanes.sca.detail).toBe("clean");
+  });
+});

--- a/ui/tests/scan-pipeline-progress.test.ts
+++ b/ui/tests/scan-pipeline-progress.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  describeWallClock,
   formatDurationMs,
+  formatStageDuration,
   jobWallClockMs,
   mergePipelineSteps,
   parsePipelineStepsFromProgress,
@@ -116,6 +118,26 @@ describe("scan-pipeline-progress", () => {
     });
     expect(summary.completedSteps).toBe(6);
     expect(summary.currentStepLabel).toBeNull();
+  });
+
+  it("reports summarized instead of a misleading 0ms wall clock", () => {
+    // Synchronous cloud scan: created_at === completed_at → 0ms elapsed.
+    expect(
+      describeWallClock(0, { synthesized: true }),
+    ).toBe("summarized");
+    expect(describeWallClock(0)).toBe("summarized");
+    expect(describeWallClock(null, { running: true })).toBe("running…");
+    expect(describeWallClock(null)).toBe("—");
+    expect(describeWallClock(2_000)).toBe("2.0s");
+  });
+
+  it("labels summarized stage timing honestly rather than a bare done", () => {
+    expect(formatStageDuration(2_000, "done")).toBe("2.0s");
+    expect(formatStageDuration(null, "running")).toBe("running…");
+    expect(formatStageDuration(null, "done", true)).toBe("summarized");
+    expect(formatStageDuration(null, "done", false)).toBe("done");
+    expect(formatStageDuration(null, "skipped", false)).toBe("skipped");
+    expect(formatStageDuration(null, "pending")).toBe("—");
   });
 
   it("leaves real step events untouched and does not synthesize while running", () => {


### PR DESCRIPTION
## Summary

Combines two independently-verified UI branches into one PR (disjoint files, merged clean with no conflicts).

### 1. Scan pipeline → branching DAG + honesty + timing
Reworks the scan pipeline view from a linear list into a branching DAG that reflects how domains actually fan out, surfaces an honest CIS-fails count (no more silent zero), and adds per-stage timing.
- `ui/components/scan-pipeline.tsx`, `job-pipeline-panel.tsx`, `scan-result.tsx`, `app/jobs/page.tsx`
- new `ui/lib/scan-pipeline-graph.ts`, `ui/lib/scan-domain-findings.ts`, `ui/lib/scan-pipeline-progress.ts` + unit tests

### 2. Charts light-theme tokenization (#3966 follow-up)
Moves the remaining Recharts hardcoded hex colors onto design tokens via a `useChartTheme()` hook so charts render correctly in both light and dark themes.
- `ui/lib/theme-colors.ts`, `ui/lib/graph-utils.ts`
- `app/fleet`, `app/activity`, `app/governance`, `gateway/GatewayDashboard`, `proxy/ProxyDashboard` + test

## Verification (combined branch)
- `npm ci` — clean
- `npm run typecheck` — pass
- `npm run build` — pass
- `npx vitest run` — 519 passed / 101 files, green
- `npm run lint` — 0 errors (1 pre-existing nav.tsx warning, unrelated)
- `npm run bundle:check` — PASS, total client JS 3241.8 KiB / 3300.0 KiB budget (no budget bump needed)

Design tokens only; both themes covered.

## References
- Dashboard-UX epic #3931
- Charts follow-up #3966
