### PR TITLE
Combine: DSPM Luhn+secrets classification + SSO IdP presets

### DIFF
--- a/src/agent_bom/cloud/db_data_classifier.py
+++ b/src/agent_bom/cloud/db_data_classifier.py
@@ -42,7 +42,11 @@ class DatabaseContentClassification:
     def sensitivity_score(self) -> int:
         if not self.total_findings:
             return 0
-        high = sum(self.findings_by_type.get(kind, 0) for kind in {"ssn", "credit_card", "iban", "passport", "nhs_number"})
+        high = sum(
+            count
+            for kind, count in self.findings_by_type.items()
+            if kind in {"ssn", "credit_card", "iban", "passport", "nhs_number"} or kind.startswith("secret:")
+        )
         if high:
             return 90
         if any(kind in self.findings_by_type for kind in {"email", "phone", "date_of_birth", "drivers_license", "medical_record_keyword"}):

--- a/src/agent_bom/cloud/gcs_data_classifier.py
+++ b/src/agent_bom/cloud/gcs_data_classifier.py
@@ -96,7 +96,11 @@ class GCSBucketClassification:
     def sensitivity_score(self) -> int:
         if not self.total_findings:
             return 0
-        high = sum(self.findings_by_type.get(kind, 0) for kind in {"ssn", "credit_card", "iban", "passport", "nhs_number"})
+        high = sum(
+            count
+            for kind, count in self.findings_by_type.items()
+            if kind in {"ssn", "credit_card", "iban", "passport", "nhs_number"} or kind.startswith("secret:")
+        )
         if high:
             return 90
         if any(kind in self.findings_by_type for kind in {"email", "phone", "date_of_birth", "drivers_license", "medical_record_keyword"}):

--- a/src/agent_bom/cloud/s3_data_classifier.py
+++ b/src/agent_bom/cloud/s3_data_classifier.py
@@ -96,7 +96,11 @@ class S3BucketClassification:
     def sensitivity_score(self) -> int:
         if not self.total_findings:
             return 0
-        high = sum(self.findings_by_type.get(kind, 0) for kind in {"ssn", "credit_card", "iban", "passport", "nhs_number"})
+        high = sum(
+            count
+            for kind, count in self.findings_by_type.items()
+            if kind in {"ssn", "credit_card", "iban", "passport", "nhs_number"} or kind.startswith("secret:")
+        )
         if high:
             return 90
         if any(kind in self.findings_by_type for kind in {"email", "phone", "date_of_birth", "drivers_license", "medical_record_keyword"}):

--- a/src/agent_bom/parsers/dataset_pii_scanner.py
+++ b/src/agent_bom/parsers/dataset_pii_scanner.py
@@ -15,7 +15,23 @@ email, ssn, credit_card, phone, ip_address, passport (US/UK/EU),
 iban, date_of_birth, nhs_number, medicare_id, medical_record_keyword,
 drivers_license (US)
 
-Issue: #984
+Deep classification (beyond tag/regex)
+--------------------------------------
+- ``credit_card`` — candidate PANs are **Luhn-checksum + IIN/length
+  validated** (Visa/Mastercard/Amex/Discover) so a bare ``\\d{16}`` sequence
+  that fails the checksum does not classify. This kills the dominant false
+  positive of naive card regexes.
+- ``secret:*`` — a curated set of high-signal credential detectors (AWS keys,
+  GitHub/GitLab/Slack tokens, JWTs, PEM private-key blocks, provider API keys)
+  reused from the runtime credential pattern library, surfaced as a data-class
+  so DSPM reports the same secrets the runtime proxy detects.
+
+Every finding carries a ``confidence`` tier: regex-only matches are ``low`` /
+``medium``; Luhn- or structurally-validated matches are ``high``. Matched card
+and secret values are never logged or echoed — findings carry a redacted
+marker only.
+
+Issues: #984, #3880
 """
 
 from __future__ import annotations
@@ -27,6 +43,8 @@ import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
+
+from agent_bom.runtime.patterns import CREDENTIAL_PATTERNS
 
 logger = logging.getLogger(__name__)
 
@@ -46,15 +64,9 @@ _PII_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
         "ssn",
         "high",
     ),
-    # Credit / debit card numbers (Visa, Mastercard, Amex, Discover)
-    (
-        re.compile(
-            r"\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|"
-            r"3[47][0-9]{13}|6(?:011|5[0-9]{2})[0-9]{12})\b"
-        ),
-        "credit_card",
-        "high",
-    ),
+    # NOTE: credit / debit card numbers are handled by the Luhn-validated
+    # detector (_detect_payment_cards), NOT a bare regex — a raw IIN/length
+    # regex over-fires on any 16-digit sequence (order ids, timestamps).
     # US/Canada phone
     (
         re.compile(r"\b(?:\+1[-.\s]?)?\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}\b"),
@@ -130,14 +142,17 @@ _MAX_FILE_SIZE = 10 * 1024 * 1024
 
 @dataclass
 class PiiFinding:
-    """A single PII match found in a dataset row."""
+    """A single PII / secret match found in a dataset row."""
 
     file_path: str
     row_index: int
     column: str
     pii_type: str
     severity: str
-    sample: str  # redacted snippet — never the raw value
+    sample: str  # redacted marker — never the raw value
+    # Detection confidence: "low"/"medium" for regex-only matches, "high" for
+    # Luhn-checksum (cards) or structurally-validated (prefixed secrets) hits.
+    confidence: str = "medium"
 
 
 @dataclass
@@ -164,6 +179,7 @@ class DatasetPiiResult:
                     "column": f.column,
                     "pii_type": f.pii_type,
                     "severity": f.severity,
+                    "confidence": f.confidence,
                     "sample": f.sample,
                 }
                 for f in self.top_findings
@@ -188,7 +204,11 @@ class DirectoryPiiResult:
     @property
     def high_severity_count(self) -> int:
         pii_types_high = {"ssn", "credit_card", "iban", "passport", "nhs_number"}
-        return sum(v for k, v in self.findings_by_type.items() if k in pii_types_high)
+        return sum(
+            v
+            for k, v in self.findings_by_type.items()
+            if k in pii_types_high or k.startswith("secret:")
+        )
 
     def to_dict(self) -> dict:
         return {
@@ -220,8 +240,154 @@ def _redact(value: str, pii_type: str) -> str:
     return f"[{pii_type}:REDACTED]"
 
 
+# ─── Luhn-validated payment-card detection ────────────────────────────────────
+#
+# A bare ``\d{16}`` (or IIN-anchored) regex over-fires: order ids, epoch
+# timestamps, and phone/account digit runs all match. We instead extract
+# candidate digit runs, then require BOTH a recognized IIN/length pairing
+# (Visa/Mastercard/Amex/Discover) AND a valid Luhn checksum. Only a real card
+# number survives — the dominant false positive is eliminated.
+
+# Candidate PAN: 13–19 digits, optionally split by single spaces or hyphens.
+_PAN_CANDIDATE_RE = re.compile(r"(?<![0-9])(?:\d[ -]?){12,18}\d(?![0-9])")
+
+
+def _luhn_valid(digits: str) -> bool:
+    """Return True if ``digits`` (all-digit string) passes the Luhn checksum."""
+    if not digits.isdigit():
+        return False
+    total = 0
+    parity = len(digits) % 2
+    for i, ch in enumerate(digits):
+        d = int(ch)
+        if i % 2 == parity:
+            d *= 2
+            if d > 9:
+                d -= 9
+        total += d
+    return total % 10 == 0
+
+
+def _card_brand(digits: str) -> str | None:
+    """Return the card network if ``digits`` matches a known IIN/length pairing.
+
+    Basic issuer-identification-number + length sanity so a valid-Luhn string
+    that isn't a real card format (e.g. a random 16-digit id that happens to
+    checksum) does not classify as a payment card.
+    """
+    if not digits.isdigit():
+        return None
+    n = len(digits)
+    # Visa: IIN 4, length 13/16/19.
+    if digits[0] == "4" and n in (13, 16, 19):
+        return "visa"
+    # Mastercard: IIN 51-55 or 2221-2720, length 16.
+    if n == 16:
+        two = int(digits[:2])
+        four = int(digits[:4])
+        if 51 <= two <= 55 or 2221 <= four <= 2720:
+            return "mastercard"
+    # Amex: IIN 34/37, length 15.
+    if n == 15 and digits[:2] in ("34", "37"):
+        return "amex"
+    # Discover: IIN 6011, 65, 644-649, 622126-622925, length 16.
+    if n == 16:
+        four = int(digits[:4])
+        six = int(digits[:6])
+        if (
+            digits.startswith("6011")
+            or digits[:2] == "65"
+            or 644 <= int(digits[:3]) <= 649
+            or 622126 <= six <= 622925
+        ):
+            return "discover"
+    return None
+
+
+def _detect_payment_cards(value: str, row_idx: int, col: str, file_path: str) -> list[PiiFinding]:
+    """Find Luhn- + IIN/length-validated payment card numbers in ``value``."""
+    findings: list[PiiFinding] = []
+    for match in _PAN_CANDIDATE_RE.finditer(value):
+        digits = match.group().replace(" ", "").replace("-", "")
+        if not (13 <= len(digits) <= 19):
+            continue
+        if _card_brand(digits) is None or not _luhn_valid(digits):
+            continue
+        findings.append(
+            PiiFinding(
+                file_path=file_path,
+                row_index=row_idx,
+                column=col,
+                pii_type="credit_card",
+                severity="high",
+                sample=_redact("", "credit_card"),
+                confidence="high",  # checksum + issuer validated
+            )
+        )
+        break  # one card finding per cell is enough
+    return findings
+
+
+# ─── Secret / credential detection (data-class) ───────────────────────────────
+#
+# DSPM surfaces the SAME credential detectors the runtime proxy uses — reused
+# from CREDENTIAL_PATTERNS rather than duplicated — as a ``secret:<type>``
+# data-class. Structurally distinctive detectors (fixed prefix + charset/length,
+# e.g. AKIA…, ghp_…, JWT, PEM blocks) are high confidence; context/generic
+# detectors (generic api-key/bearer, bare connection strings) are lower.
+
+# Credential names whose pattern is context- or shape-generic → lower confidence.
+_LOWER_CONFIDENCE_SECRETS: frozenset[str] = frozenset(
+    {
+        "AWS Secret Key",
+        "AWS Session Token",
+        "Generic Bearer Token",
+        "Generic API Key",
+        "Connection String",
+        "Mailgun API Key",
+        "Heroku API Key",
+        "Telegram Bot Token",
+        "Datadog API Key",
+        "Snowflake JWT",
+        "PagerDuty API Key",
+    }
+)
+
+
+def _secret_slug(name: str) -> str:
+    """Normalize a credential detector name to a ``secret:<slug>`` data-class."""
+    slug = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+    return f"secret:{slug}"
+
+
+def _detect_secrets(value: str, row_idx: int, col: str, file_path: str) -> list[PiiFinding]:
+    """Detect hardcoded secrets/credentials in ``value`` (redacted output)."""
+    findings: list[PiiFinding] = []
+    seen: set[str] = set()
+    for name, pattern in CREDENTIAL_PATTERNS:
+        if not pattern.search(value):
+            continue
+        data_class = _secret_slug(name)
+        if data_class in seen:
+            continue
+        seen.add(data_class)
+        low = name in _LOWER_CONFIDENCE_SECRETS
+        findings.append(
+            PiiFinding(
+                file_path=file_path,
+                row_index=row_idx,
+                column=col,
+                pii_type=data_class,
+                severity="high" if not low else "medium",
+                sample=_redact("", data_class),
+                confidence="low" if low else "high",
+            )
+        )
+    return findings
+
+
 def _scan_cell(value: str, row_idx: int, col: str, file_path: str) -> list[PiiFinding]:
-    """Scan a single cell value against all PII patterns."""
+    """Scan a single cell value for PII, payment cards, and secrets."""
     findings: list[PiiFinding] = []
     seen_types: set[str] = set()
     for pattern, pii_type, severity in _PII_PATTERNS:
@@ -237,8 +403,15 @@ def _scan_cell(value: str, row_idx: int, col: str, file_path: str) -> list[PiiFi
                     pii_type=pii_type,
                     severity=severity,
                     sample=_redact(value, pii_type),
+                    confidence="medium",  # regex-only structural match
                 )
             )
+    for detector in (_detect_payment_cards, _detect_secrets):
+        for finding in detector(value, row_idx, col, file_path):
+            if finding.pii_type in seen_types:
+                continue
+            seen_types.add(finding.pii_type)
+            findings.append(finding)
     return findings
 
 

--- a/tests/test_dspm_luhn_secrets.py
+++ b/tests/test_dspm_luhn_secrets.py
@@ -1,0 +1,195 @@
+"""Tests for Luhn-validated PAN + secret/credential DSPM detection (#3880).
+
+Deepens dataset data classification beyond bare tag/regex:
+- Payment cards are Luhn-checksum + IIN/length validated so an invalid
+  16-digit sequence does NOT classify (kills the ``\\d{16}`` false positives).
+- Curated high-signal secret/credential detectors are surfaced as a
+  ``secret:`` data-class, reusing the runtime credential pattern library.
+- Every detection carries a confidence tier (regex-only = lower,
+  Luhn/structural-validated = higher).
+- Matched card / secret values are NEVER echoed in the output.
+"""
+
+from __future__ import annotations
+
+from agent_bom.parsers.dataset_pii_scanner import (
+    _card_brand,
+    _detect_payment_cards,
+    _detect_secrets,
+    _luhn_valid,
+    _scan_cell,
+)
+
+# ─── Luhn checksum ────────────────────────────────────────────────────────────
+
+
+def test_luhn_valid_true_for_known_test_pans():
+    # Classic brand test PANs — all valid Luhn.
+    assert _luhn_valid("4111111111111111")  # Visa
+    assert _luhn_valid("5555555555554444")  # Mastercard
+    assert _luhn_valid("378282246310005")  # Amex
+    assert _luhn_valid("6011111111111117")  # Discover
+
+
+def test_luhn_invalid_for_off_by_one():
+    # Same IIN/length, checksum broken -> must be rejected.
+    assert not _luhn_valid("4111111111111112")
+    assert not _luhn_valid("5555555555554445")
+
+
+def test_luhn_rejects_non_digits():
+    assert not _luhn_valid("41111111111111x1")
+
+
+# ─── IIN / length brand sanity ───────────────────────────────────────────────
+
+
+def test_card_brand_recognizes_major_networks():
+    assert _card_brand("4111111111111111") == "visa"
+    assert _card_brand("5555555555554444") == "mastercard"
+    assert _card_brand("378282246310005") == "amex"
+    assert _card_brand("6011111111111117") == "discover"
+
+
+def test_card_brand_rejects_unknown_iin_or_length():
+    # Valid Luhn but no recognized IIN/length pairing.
+    assert _card_brand("1234567812345670") is None
+    # Visa IIN but wrong length.
+    assert _card_brand("411111111111") is None
+
+
+# ─── Luhn-validated PAN detection (the FP-reduction win) ──────────────────────
+
+
+def test_detect_payment_cards_accepts_valid_pan():
+    findings = _detect_payment_cards("card 4111111111111111 on file", 0, "c", "f.csv")
+    assert len(findings) == 1
+    assert findings[0].pii_type == "credit_card"
+    assert findings[0].confidence == "high"
+    assert findings[0].severity == "high"
+
+
+def test_detect_payment_cards_rejects_invalid_16_digit():
+    # Bare 16-digit number that fails Luhn must NOT classify — this is exactly
+    # the false positive a naive \d{16} regex produces.
+    findings = _detect_payment_cards("order id 4111111111111112 shipped", 0, "c", "f.csv")
+    assert findings == []
+
+
+def test_detect_payment_cards_rejects_random_16_digits():
+    findings = _detect_payment_cards("1234567812345678", 0, "c", "f.csv")
+    assert findings == []
+
+
+def test_detect_payment_cards_accepts_separated_pan():
+    findings = _detect_payment_cards("4111 1111 1111 1111", 0, "c", "f.csv")
+    assert len(findings) == 1
+    assert findings[0].pii_type == "credit_card"
+
+
+def test_detect_payment_cards_redacts_value():
+    pan = "4111111111111111"
+    findings = _detect_payment_cards(pan, 0, "c", "f.csv")
+    assert findings[0].sample == "[credit_card:REDACTED]"
+    for digit in pan:
+        assert digit not in findings[0].sample
+
+
+# ─── Secret / credential detection ───────────────────────────────────────────
+
+
+def test_detect_secrets_aws_access_key():
+    findings = _detect_secrets("AKIAIOSFODNN7EXAMPLE", 0, "c", "f.csv")
+    types = {f.pii_type for f in findings}
+    assert "secret:aws_access_key" in types
+    hit = next(f for f in findings if f.pii_type == "secret:aws_access_key")
+    assert hit.confidence == "high"
+
+
+def test_detect_secrets_github_token():
+    tok = "ghp_" + "a" * 36
+    findings = _detect_secrets(tok, 0, "c", "f.csv")
+    assert "secret:github_token" in {f.pii_type for f in findings}
+
+
+def test_detect_secrets_slack_token():
+    findings = _detect_secrets("xoxb-1234567890-abcdefghijkl", 0, "c", "f.csv")
+    assert "secret:slack_token" in {f.pii_type for f in findings}
+
+
+def test_detect_secrets_private_key_pem():
+    findings = _detect_secrets("-----BEGIN RSA PRIVATE KEY-----", 0, "c", "f.csv")
+    assert "secret:private_key_block" in {f.pii_type for f in findings}
+
+
+def test_detect_secrets_jwt():
+    jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abcDEF123_-xyz"
+    findings = _detect_secrets(jwt, 0, "c", "f.csv")
+    assert "secret:jwt_token" in {f.pii_type for f in findings}
+
+
+def test_detect_secrets_generic_api_key_lower_confidence():
+    findings = _detect_secrets("api_key=abcdefghijklmnopqrstuvwx", 0, "c", "f.csv")
+    hit = next(f for f in findings if f.pii_type == "secret:generic_api_key")
+    assert hit.confidence == "low"
+
+
+def test_detect_secrets_rejects_near_miss_aws():
+    # AKIA prefix but too short to be a real access key id.
+    findings = _detect_secrets("AKIA123", 0, "c", "f.csv")
+    assert findings == []
+
+
+def test_detect_secrets_rejects_near_miss_github():
+    # ghp_ prefix but far too short.
+    findings = _detect_secrets("ghp_short", 0, "c", "f.csv")
+    assert findings == []
+
+
+def test_detect_secrets_rejects_plain_prose():
+    findings = _detect_secrets("this is just a normal sentence with no secrets", 0, "c", "f.csv")
+    assert findings == []
+
+
+def test_detect_secrets_redacts_value():
+    key = "AKIAIOSFODNN7EXAMPLE"
+    findings = _detect_secrets(key, 0, "c", "f.csv")
+    hit = next(f for f in findings if f.pii_type == "secret:aws_access_key")
+    assert hit.sample == "[secret:aws_access_key:REDACTED]"
+    assert "AKIA" not in hit.sample
+    assert key not in hit.sample
+
+
+# ─── _scan_cell integration ──────────────────────────────────────────────────
+
+
+def test_scan_cell_valid_card_classifies():
+    findings = _scan_cell("4111111111111111", 0, "card", "f.csv")
+    assert "credit_card" in {f.pii_type for f in findings}
+
+
+def test_scan_cell_invalid_card_does_not_classify_as_card():
+    findings = _scan_cell("4111111111111112", 0, "card", "f.csv")
+    assert "credit_card" not in {f.pii_type for f in findings}
+
+
+def test_scan_cell_surfaces_secret():
+    findings = _scan_cell("AKIAIOSFODNN7EXAMPLE", 0, "creds", "f.csv")
+    assert "secret:aws_access_key" in {f.pii_type for f in findings}
+
+
+def test_scan_cell_all_findings_carry_confidence():
+    findings = _scan_cell("alice@example.com 4111111111111111 AKIAIOSFODNN7EXAMPLE", 0, "mix", "f.csv")
+    assert findings
+    for f in findings:
+        assert f.confidence in {"low", "medium", "high"}
+
+
+def test_scan_cell_never_leaks_matched_values():
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    pan = "4111111111111111"
+    findings = _scan_cell(f"{secret} {pan}", 0, "mix", "f.csv")
+    for f in findings:
+        assert secret not in f.sample
+        assert pan not in f.sample
+        assert "REDACTED" in f.sample

--- a/ui/components/key-lifecycle-panel.tsx
+++ b/ui/components/key-lifecycle-panel.tsx
@@ -21,6 +21,7 @@ import {
   ShieldAlert,
   ShieldOff,
 } from "lucide-react";
+import { SsoSetupPresets } from "@/components/sso-setup-presets";
 
 function formatSeconds(value: number): string {
   if (value < 60) return `${value}s`;
@@ -879,6 +880,8 @@ export function KeyLifecyclePanel({
               />
             </div>
           </section>
+
+          <SsoSetupPresets />
 
           <section className="rounded-2xl border border-amber-900/40 bg-amber-950/10 p-4">
             <p className="text-xs uppercase tracking-[0.18em] text-amber-200/70">Revocation boundaries</p>

--- a/ui/components/sso-setup-presets.tsx
+++ b/ui/components/sso-setup-presets.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+import {
+  applySsoPreset,
+  buildSsoEnvSnippet,
+  ssoPresetsForProtocol,
+  type SsoProtocol,
+  type SsoProviderPreset,
+} from "@/lib/sso-provider-presets";
+
+function fieldTone(kind: SsoProviderPreset["fields"][number]["kind"]): string {
+  switch (kind) {
+    case "secret":
+      return "border-amber-900/50 bg-amber-950/20 text-amber-200";
+    case "tenant":
+      return "border-sky-900/50 bg-sky-950/20 text-sky-200";
+    case "config":
+    default:
+      return "border-[var(--border-subtle)] bg-[var(--surface)] text-[var(--text-secondary)]";
+  }
+}
+
+function kindLabel(kind: SsoProviderPreset["fields"][number]["kind"]): string {
+  switch (kind) {
+    case "secret":
+      return "You supply · secret";
+    case "tenant":
+      return "You supply";
+    case "config":
+    default:
+      return "Prefilled";
+  }
+}
+
+/**
+ * Operator helper: pick an IdP preset and get the provider-specific OIDC/SAML
+ * fields pre-filled with the issuer / discovery / endpoint shapes. Tenant and
+ * secret values are never prefilled. Read-only guidance — SSO config is applied
+ * via the AGENT_BOM_* environment (copy the generated block).
+ */
+export function SsoSetupPresets() {
+  const [protocol, setProtocol] = useState<SsoProtocol>("oidc");
+  const presets = ssoPresetsForProtocol(protocol);
+  const [presetId, setPresetId] = useState<string>(presets[0]!.id);
+  const [copied, setCopied] = useState(false);
+
+  const preset = useMemo<SsoProviderPreset>(() => {
+    return presets.find((p) => p.id === presetId) ?? presets[0]!;
+  }, [presets, presetId]);
+
+  const filled = useMemo(() => applySsoPreset(preset), [preset]);
+
+  function selectProtocol(next: SsoProtocol) {
+    setProtocol(next);
+    setPresetId(ssoPresetsForProtocol(next)[0]!.id);
+    setCopied(false);
+  }
+
+  async function copyEnv() {
+    try {
+      await navigator.clipboard.writeText(buildSsoEnvSnippet(preset));
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  }
+
+  return (
+    <section className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.18em] text-[var(--text-tertiary)]">SSO provider presets</p>
+          <p className="mt-1 text-sm text-[var(--text-secondary)]">
+            Pick your identity provider to pre-fill the issuer, discovery and endpoint shapes. You still supply your
+            domain, client id and secret — secrets are never prefilled.
+          </p>
+        </div>
+        <div className="inline-flex rounded-lg border border-[var(--border-subtle)] p-0.5" role="tablist" aria-label="SSO protocol">
+          {(["oidc", "saml"] as const).map((value) => (
+            <button
+              key={value}
+              type="button"
+              role="tab"
+              aria-selected={protocol === value}
+              onClick={() => selectProtocol(value)}
+              className={`rounded-md px-3 py-1 text-xs font-semibold uppercase tracking-wide transition ${
+                protocol === value
+                  ? "bg-[var(--surface)] text-[var(--foreground)]"
+                  : "text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]"
+              }`}
+            >
+              {value}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        {presets.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            aria-pressed={option.id === preset.id}
+            onClick={() => {
+              setPresetId(option.id);
+              setCopied(false);
+            }}
+            className={`rounded-lg border px-3 py-1.5 text-sm transition ${
+              option.id === preset.id
+                ? "border-sky-500/70 bg-[var(--surface)] text-[var(--foreground)]"
+                : "border-[var(--border-subtle)] bg-transparent text-[var(--text-secondary)] hover:text-[var(--foreground)]"
+            }`}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+
+      <p className="mt-3 text-xs text-[var(--text-tertiary)]">{preset.tagline}</p>
+
+      <div className="mt-3 overflow-x-auto">
+        <div className="min-w-[36rem] space-y-1.5">
+          {preset.fields.map((field) => (
+            <div
+              key={field.key}
+              className={`flex items-start justify-between gap-3 rounded-lg border px-3 py-2 text-xs ${fieldTone(field.kind)}`}
+            >
+              <div className="min-w-0">
+                <p className="font-mono text-[11px] text-[var(--text-tertiary)]">{field.envVar}</p>
+                <p className="mt-0.5 font-mono text-[13px] break-all text-[var(--foreground)]">
+                  {filled[field.key] ? filled[field.key] : <span className="text-[var(--text-tertiary)]">{field.placeholder}</span>}
+                </p>
+                {field.hint ? <p className="mt-0.5 text-[11px] text-[var(--text-tertiary)]">{field.hint}</p> : null}
+              </div>
+              <span className="shrink-0 rounded-full border border-[var(--border-subtle)] px-2 py-0.5 text-[10px] uppercase tracking-wide">
+                {kindLabel(field.kind)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <p className="text-[11px] text-[var(--text-tertiary)]">{preset.docsHint}</p>
+        <button
+          type="button"
+          onClick={copyEnv}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--border-subtle)] px-3 py-1.5 text-xs font-semibold text-[var(--text-secondary)] transition hover:text-[var(--foreground)]"
+        >
+          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+          {copied ? "Copied" : "Copy env config"}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/ui/lib/sso-provider-presets.ts
+++ b/ui/lib/sso-provider-presets.ts
@@ -1,0 +1,697 @@
+/**
+ * IdP SSO provider presets for the enterprise auth setup surface.
+ *
+ * Mirrors the cloud connect wizard (`cloud-connect-wizard.ts`): a pure,
+ * unit-tested catalog of provider metadata plus a small set of helpers that a
+ * setup form consumes. Selecting a preset pre-fills the provider-specific
+ * OIDC/SAML fields with the IdP's discovery-URL / issuer / endpoint shapes,
+ * leaving `{placeholder}` tokens for the tenant-specific parts the customer
+ * still supplies (their Okta domain, Entra tenant id, client id, …).
+ *
+ * Field keys and env vars map 1:1 onto the backend config dataclasses:
+ *   - OIDC:  `OIDCConfig` / `OIDCBrowserConfig` (src/agent_bom/api/oidc.py,
+ *            oidc_browser.py) — AGENT_BOM_OIDC_*
+ *   - SAML:  `SAMLConfig` (src/agent_bom/api/saml.py) — AGENT_BOM_SAML_*
+ *
+ * Hard invariants (enforced by sso-provider-presets.test.ts):
+ *   - A `secret`-kind field is NEVER prefilled — its `value` is always "".
+ *   - "Generic" presets stay fully manual — every `value` is "".
+ *   - Provider discovery-URL shapes track the current IdP docs (verified
+ *     2026-07-14): Okta org vs `/oauth2/default`, Entra
+ *     `login.microsoftonline.com/{tenantId}/v2.0`, Google `accounts.google.com`.
+ */
+
+export type SsoProtocol = "oidc" | "saml";
+
+export type SsoProviderId =
+  | "okta-oidc"
+  | "entra-oidc"
+  | "google-oidc"
+  | "generic-oidc"
+  | "okta-saml"
+  | "entra-saml"
+  | "google-saml"
+  | "generic-saml";
+
+/**
+ * How a field is treated when a preset is applied:
+ * - `config`  — provider-specific value the preset pre-fills (may contain
+ *               `{placeholder}` tokens for the tenant-specific part).
+ * - `tenant`  — the customer must supply it; the preset leaves `value` blank.
+ * - `secret`  — sensitive; the customer must supply it; `value` is ALWAYS "".
+ */
+export type SsoFieldKind = "config" | "tenant" | "secret";
+
+export interface SsoPresetField {
+  /** Config attribute key (matches the backend dataclass field). */
+  key: string;
+  /** Environment variable the control plane reads. */
+  envVar: string;
+  label: string;
+  kind: SsoFieldKind;
+  /** Pre-filled value. Empty for `tenant`/`secret` and every generic field. */
+  value: string;
+  /** Guidance shown in the empty form input. */
+  placeholder: string;
+  hint?: string;
+}
+
+export interface SsoProviderPreset {
+  id: SsoProviderId;
+  /** Vendor name shown in the selector (e.g. "Okta"). */
+  label: string;
+  protocol: SsoProtocol;
+  tagline: string;
+  /** True for the manual, no-prefill Generic OIDC / Generic SAML presets. */
+  generic: boolean;
+  fields: SsoPresetField[];
+  /** Ordered onboarding steps, mirroring the cloud wizard `setupSteps`. */
+  setupSteps: string[];
+  /** Doc reference for the provider setup. */
+  docsHint: string;
+}
+
+// ── Shared field templates ──────────────────────────────────────────────────
+
+/** Non-secret OIDC client fields the customer always supplies themselves. */
+function oidcTenantClientFields(clientIdPlaceholder: string, audiencePlaceholder: string): SsoPresetField[] {
+  return [
+    {
+      key: "audience",
+      envVar: "AGENT_BOM_OIDC_AUDIENCE",
+      label: "Audience (aud)",
+      kind: "tenant",
+      value: "",
+      placeholder: audiencePlaceholder,
+      hint: "Must equal the aud claim your IdP stamps on tokens for this app.",
+    },
+    {
+      key: "client_id",
+      envVar: "AGENT_BOM_OIDC_CLIENT_ID",
+      label: "Client ID",
+      kind: "tenant",
+      value: "",
+      placeholder: clientIdPlaceholder,
+      hint: "The Application (client) ID from the IdP app registration.",
+    },
+    {
+      key: "redirect_uri",
+      envVar: "AGENT_BOM_OIDC_REDIRECT_URI",
+      label: "Redirect URI",
+      kind: "tenant",
+      value: "",
+      placeholder: "https://agent-bom.your-org.example/v1/auth/oidc/callback",
+      hint: "Register this exact URL as an allowed redirect on the IdP app.",
+    },
+    {
+      key: "client_secret",
+      envVar: "AGENT_BOM_OIDC_CLIENT_SECRET",
+      label: "Client secret",
+      kind: "secret",
+      value: "",
+      placeholder: "Paste after creating the app — never committed, encrypted at rest",
+      hint: "Confidential clients only. Stored server-side; never prefilled or logged.",
+    },
+  ];
+}
+
+/** SP-side SAML fields (agent-bom's own metadata) — same across every IdP. */
+function samlServiceProviderFields(): SsoPresetField[] {
+  return [
+    {
+      key: "sp_entity_id",
+      envVar: "AGENT_BOM_SAML_SP_ENTITY_ID",
+      label: "SP entity ID",
+      kind: "config",
+      value: "https://agent-bom.your-org.example/v1/auth/saml/metadata",
+      placeholder: "https://agent-bom.your-org.example/v1/auth/saml/metadata",
+      hint: "This deployment's SP entity ID — swap in your agent-bom host.",
+    },
+    {
+      key: "sp_acs_url",
+      envVar: "AGENT_BOM_SAML_SP_ACS_URL",
+      label: "SP ACS URL",
+      kind: "config",
+      value: "https://agent-bom.your-org.example/v1/auth/saml/login",
+      placeholder: "https://agent-bom.your-org.example/v1/auth/saml/login",
+      hint: "Assertion Consumer Service URL the IdP posts the assertion to.",
+    },
+  ];
+}
+
+/** Role/tenant attribute mapping fields for SAML, defaulting to backend names. */
+function samlAttributeFields(): SsoPresetField[] {
+  return [
+    {
+      key: "role_attribute",
+      envVar: "AGENT_BOM_SAML_ROLE_ATTRIBUTE",
+      label: "Role attribute",
+      kind: "config",
+      value: "agent_bom_role",
+      placeholder: "agent_bom_role",
+      hint: "Configure the IdP to release an attribute of this name (admin/analyst/viewer).",
+    },
+    {
+      key: "tenant_attribute",
+      envVar: "AGENT_BOM_SAML_TENANT_ATTRIBUTE",
+      label: "Tenant attribute",
+      kind: "config",
+      value: "tenant_id",
+      placeholder: "tenant_id",
+      hint: "Attribute carrying the tenant id for multi-tenant deployments.",
+    },
+  ];
+}
+
+function samlIdpCertField(): SsoPresetField {
+  return {
+    key: "idp_x509_cert",
+    envVar: "AGENT_BOM_SAML_IDP_X509_CERT",
+    label: "IdP signing certificate (X.509)",
+    kind: "tenant",
+    value: "",
+    placeholder: "-----BEGIN CERTIFICATE-----\n… paste the IdP's public signing cert …",
+    hint: "Public signing certificate downloaded from the IdP — not a secret, but you supply it.",
+  };
+}
+
+// ── OIDC presets ────────────────────────────────────────────────────────────
+
+const OKTA_OIDC: SsoProviderPreset = {
+  id: "okta-oidc",
+  label: "Okta",
+  protocol: "oidc",
+  tagline: "Okta OIDC via the default custom authorization server.",
+  generic: false,
+  docsHint: "Okta admin → Applications → Create App Integration → OIDC · Web.",
+  fields: [
+    {
+      key: "issuer",
+      envVar: "AGENT_BOM_OIDC_ISSUER",
+      label: "Issuer",
+      kind: "config",
+      value: "https://{yourOktaDomain}/oauth2/default",
+      placeholder: "https://your-org.okta.com/oauth2/default",
+      hint: "Default custom auth server. Use https://{yourOktaDomain} alone for the org server.",
+    },
+    {
+      key: "jwks_uri",
+      envVar: "AGENT_BOM_OIDC_JWKS_URI",
+      label: "JWKS URI",
+      kind: "config",
+      value: "https://{yourOktaDomain}/oauth2/default/v1/keys",
+      placeholder: "https://your-org.okta.com/oauth2/default/v1/keys",
+      hint: "Pin the JWKS URI (or allowlist the discovered value) for fail-closed discovery.",
+    },
+    {
+      key: "scopes",
+      envVar: "AGENT_BOM_OIDC_SCOPES",
+      label: "Scopes",
+      kind: "config",
+      value: "openid profile email groups",
+      placeholder: "openid profile email groups",
+    },
+    {
+      key: "role_claim",
+      envVar: "AGENT_BOM_OIDC_ROLE_CLAIM",
+      label: "Role claim",
+      kind: "config",
+      value: "groups",
+      placeholder: "groups",
+      hint: "Add a groups claim to the Okta app and map group names to admin/analyst/viewer.",
+    },
+    {
+      key: "tenant_claim",
+      envVar: "AGENT_BOM_OIDC_TENANT_CLAIM",
+      label: "Tenant claim",
+      kind: "config",
+      value: "tenant_id",
+      placeholder: "tenant_id",
+    },
+    ...oidcTenantClientFields("0oabc1234DEF5678gh7", "api://default"),
+  ],
+  setupSteps: [
+    "In Okta, create an OIDC Web app integration and note the client id + secret.",
+    "Add https://<agent-bom-host>/v1/auth/oidc/callback as a sign-in redirect URI.",
+    "Add a groups claim to the app so agent-bom can map roles from group membership.",
+    "Set AGENT_BOM_OIDC_AUDIENCE to the token audience (api://default on the default server).",
+  ],
+};
+
+const ENTRA_OIDC: SsoProviderPreset = {
+  id: "entra-oidc",
+  label: "Microsoft Entra ID",
+  protocol: "oidc",
+  tagline: "Entra ID (Azure AD) tenant-scoped v2.0 authority.",
+  generic: false,
+  docsHint: "Entra admin center → App registrations → New registration.",
+  fields: [
+    {
+      key: "issuer",
+      envVar: "AGENT_BOM_OIDC_ISSUER",
+      label: "Issuer",
+      kind: "config",
+      value: "https://login.microsoftonline.com/{tenantId}/v2.0",
+      placeholder: "https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0",
+      hint: "Use your Directory (tenant) ID. `organizations` disables single-tenant pinning.",
+    },
+    {
+      key: "jwks_uri",
+      envVar: "AGENT_BOM_OIDC_JWKS_URI",
+      label: "JWKS URI",
+      kind: "config",
+      value: "https://login.microsoftonline.com/{tenantId}/discovery/v2.0/keys",
+      placeholder: "https://login.microsoftonline.com/<tenant-id>/discovery/v2.0/keys",
+    },
+    {
+      key: "scopes",
+      envVar: "AGENT_BOM_OIDC_SCOPES",
+      label: "Scopes",
+      kind: "config",
+      value: "openid profile email",
+      placeholder: "openid profile email",
+    },
+    {
+      key: "role_claim",
+      envVar: "AGENT_BOM_OIDC_ROLE_CLAIM",
+      label: "Role claim",
+      kind: "config",
+      value: "roles",
+      placeholder: "roles",
+      hint: "Define app roles in the Entra app registration; they surface in the roles claim.",
+    },
+    {
+      key: "tenant_claim",
+      envVar: "AGENT_BOM_OIDC_TENANT_CLAIM",
+      label: "Tenant claim",
+      kind: "config",
+      value: "tid",
+      placeholder: "tid",
+      hint: "Entra stamps the directory id in the tid claim.",
+    },
+    ...oidcTenantClientFields("00001111-aaaa-2222-bbbb-3333cccc4444", "api://<application-client-id>"),
+  ],
+  setupSteps: [
+    "Register an application in Microsoft Entra ID and record the Application (client) ID.",
+    "Add https://<agent-bom-host>/v1/auth/oidc/callback under Authentication → Web redirect URIs.",
+    "Under Certificates & secrets, create a client secret and paste it into the secret field.",
+    "Define app roles (admin/analyst/viewer) so the roles claim drives agent-bom RBAC.",
+  ],
+};
+
+const GOOGLE_OIDC: SsoProviderPreset = {
+  id: "google-oidc",
+  label: "Google Workspace",
+  protocol: "oidc",
+  tagline: "Google Workspace via accounts.google.com OpenID Connect.",
+  generic: false,
+  docsHint: "Google Cloud console → APIs & Services → Credentials → OAuth client ID.",
+  fields: [
+    {
+      key: "issuer",
+      envVar: "AGENT_BOM_OIDC_ISSUER",
+      label: "Issuer",
+      kind: "config",
+      value: "https://accounts.google.com",
+      placeholder: "https://accounts.google.com",
+      hint: "Fixed issuer for all Google Workspace tenants.",
+    },
+    {
+      key: "jwks_uri",
+      envVar: "AGENT_BOM_OIDC_JWKS_URI",
+      label: "JWKS URI",
+      kind: "config",
+      value: "https://www.googleapis.com/oauth2/v3/certs",
+      placeholder: "https://www.googleapis.com/oauth2/v3/certs",
+    },
+    {
+      key: "scopes",
+      envVar: "AGENT_BOM_OIDC_SCOPES",
+      label: "Scopes",
+      kind: "config",
+      value: "openid profile email",
+      placeholder: "openid profile email",
+    },
+    {
+      key: "role_claim",
+      envVar: "AGENT_BOM_OIDC_ROLE_CLAIM",
+      label: "Role claim",
+      kind: "config",
+      value: "groups",
+      placeholder: "groups",
+      hint: "Google does not emit groups by default — add them via a mapping / directory sync.",
+    },
+    {
+      key: "tenant_claim",
+      envVar: "AGENT_BOM_OIDC_TENANT_CLAIM",
+      label: "Tenant claim",
+      kind: "config",
+      value: "hd",
+      placeholder: "hd",
+      hint: "The hd (hosted domain) claim identifies the Workspace domain.",
+    },
+    ...oidcTenantClientFields("1234567890-abc123.apps.googleusercontent.com", "1234567890-abc123.apps.googleusercontent.com"),
+  ],
+  setupSteps: [
+    "In Google Cloud console, create an OAuth 2.0 Web application client id + secret.",
+    "Add https://<agent-bom-host>/v1/auth/oidc/callback as an authorized redirect URI.",
+    "Restrict sign-in to your Workspace domain and verify the hd claim.",
+    "Map Workspace groups to agent-bom roles (admin/analyst/viewer).",
+  ],
+};
+
+const GENERIC_OIDC: SsoProviderPreset = {
+  id: "generic-oidc",
+  label: "Generic OIDC",
+  protocol: "oidc",
+  tagline: "Any standards-compliant OIDC issuer — fill in every field manually.",
+  generic: true,
+  docsHint: "Provide the issuer's /.well-known/openid-configuration values.",
+  fields: [
+    {
+      key: "issuer",
+      envVar: "AGENT_BOM_OIDC_ISSUER",
+      label: "Issuer",
+      kind: "config",
+      value: "",
+      placeholder: "https://idp.your-org.example",
+      hint: "Discovery is fetched from <issuer>/.well-known/openid-configuration.",
+    },
+    {
+      key: "jwks_uri",
+      envVar: "AGENT_BOM_OIDC_JWKS_URI",
+      label: "JWKS URI",
+      kind: "config",
+      value: "",
+      placeholder: "https://idp.your-org.example/.well-known/jwks.json",
+    },
+    {
+      key: "scopes",
+      envVar: "AGENT_BOM_OIDC_SCOPES",
+      label: "Scopes",
+      kind: "config",
+      value: "",
+      placeholder: "openid profile email",
+    },
+    {
+      key: "role_claim",
+      envVar: "AGENT_BOM_OIDC_ROLE_CLAIM",
+      label: "Role claim",
+      kind: "config",
+      value: "",
+      placeholder: "agent_bom_role",
+    },
+    {
+      key: "tenant_claim",
+      envVar: "AGENT_BOM_OIDC_TENANT_CLAIM",
+      label: "Tenant claim",
+      kind: "config",
+      value: "",
+      placeholder: "tenant_id",
+    },
+    {
+      key: "audience",
+      envVar: "AGENT_BOM_OIDC_AUDIENCE",
+      label: "Audience (aud)",
+      kind: "tenant",
+      value: "",
+      placeholder: "agent-bom",
+    },
+    {
+      key: "client_id",
+      envVar: "AGENT_BOM_OIDC_CLIENT_ID",
+      label: "Client ID",
+      kind: "tenant",
+      value: "",
+      placeholder: "your-client-id",
+    },
+    {
+      key: "redirect_uri",
+      envVar: "AGENT_BOM_OIDC_REDIRECT_URI",
+      label: "Redirect URI",
+      kind: "tenant",
+      value: "",
+      placeholder: "https://agent-bom.your-org.example/v1/auth/oidc/callback",
+    },
+    {
+      key: "client_secret",
+      envVar: "AGENT_BOM_OIDC_CLIENT_SECRET",
+      label: "Client secret",
+      kind: "secret",
+      value: "",
+      placeholder: "Paste after creating the app — encrypted at rest, never prefilled",
+    },
+  ],
+  setupSteps: [
+    "Read the issuer's discovery document at /.well-known/openid-configuration.",
+    "Register agent-bom as a confidential client and add the callback redirect URI.",
+    "Map an audience and a role claim, then supply the client id + secret.",
+  ],
+};
+
+// ── SAML presets ────────────────────────────────────────────────────────────
+
+const OKTA_SAML: SsoProviderPreset = {
+  id: "okta-saml",
+  label: "Okta",
+  protocol: "saml",
+  tagline: "Okta SAML 2.0 app integration.",
+  generic: false,
+  docsHint: "Okta admin → Applications → Create App Integration → SAML 2.0.",
+  fields: [
+    {
+      key: "idp_entity_id",
+      envVar: "AGENT_BOM_SAML_IDP_ENTITY_ID",
+      label: "IdP entity ID (issuer)",
+      kind: "config",
+      value: "http://www.okta.com/{appId}",
+      placeholder: "http://www.okta.com/exk1a2b3c4D5E6F7g8",
+      hint: "Shown on the Okta app's Sign On tab as the Identity Provider Issuer.",
+    },
+    {
+      key: "idp_sso_url",
+      envVar: "AGENT_BOM_SAML_IDP_SSO_URL",
+      label: "IdP SSO URL",
+      kind: "config",
+      value: "https://{yourOktaDomain}/app/{appName}/{appId}/sso/saml",
+      placeholder: "https://your-org.okta.com/app/agent-bom/exk.../sso/saml",
+    },
+    samlIdpCertField(),
+    ...samlAttributeFields(),
+    ...samlServiceProviderFields(),
+  ],
+  setupSteps: [
+    "Create an Okta SAML 2.0 app and set the SSO URL / ACS to the SP ACS URL above.",
+    "Set the Audience URI to the SP entity ID above.",
+    "Add attribute statements named agent_bom_role and tenant_id.",
+    "Download the IdP signing certificate from the Sign On tab and paste it in.",
+  ],
+};
+
+const ENTRA_SAML: SsoProviderPreset = {
+  id: "entra-saml",
+  label: "Microsoft Entra ID",
+  protocol: "saml",
+  tagline: "Entra ID (Azure AD) SAML 2.0 enterprise application.",
+  generic: false,
+  docsHint: "Entra admin center → Enterprise applications → New → single sign-on (SAML).",
+  fields: [
+    {
+      key: "idp_entity_id",
+      envVar: "AGENT_BOM_SAML_IDP_ENTITY_ID",
+      label: "IdP entity ID (issuer)",
+      kind: "config",
+      value: "https://sts.windows.net/{tenantId}/",
+      placeholder: "https://sts.windows.net/00000000-0000-0000-0000-000000000000/",
+      hint: "The Microsoft Entra Identifier from the SAML SSO blade.",
+    },
+    {
+      key: "idp_sso_url",
+      envVar: "AGENT_BOM_SAML_IDP_SSO_URL",
+      label: "IdP SSO URL",
+      kind: "config",
+      value: "https://login.microsoftonline.com/{tenantId}/saml2",
+      placeholder: "https://login.microsoftonline.com/<tenant-id>/saml2",
+    },
+    samlIdpCertField(),
+    ...samlAttributeFields(),
+    ...samlServiceProviderFields(),
+  ],
+  setupSteps: [
+    "Create an Entra enterprise application and choose SAML single sign-on.",
+    "Set the Identifier (Entity ID) to the SP entity ID and Reply URL to the SP ACS URL above.",
+    "Add claims for agent_bom_role and tenant_id.",
+    "Download the Certificate (Base64) and paste it into the IdP certificate field.",
+  ],
+};
+
+const GOOGLE_SAML: SsoProviderPreset = {
+  id: "google-saml",
+  label: "Google Workspace",
+  protocol: "saml",
+  tagline: "Google Workspace custom SAML app.",
+  generic: false,
+  docsHint: "Google Admin console → Apps → Web and mobile apps → Add custom SAML app.",
+  fields: [
+    {
+      key: "idp_entity_id",
+      envVar: "AGENT_BOM_SAML_IDP_ENTITY_ID",
+      label: "IdP entity ID (issuer)",
+      kind: "config",
+      value: "https://accounts.google.com/o/saml2?idpid={idpId}",
+      placeholder: "https://accounts.google.com/o/saml2?idpid=C01abc234",
+      hint: "The Entity ID from the Google SAML app's IdP metadata.",
+    },
+    {
+      key: "idp_sso_url",
+      envVar: "AGENT_BOM_SAML_IDP_SSO_URL",
+      label: "IdP SSO URL",
+      kind: "config",
+      value: "https://accounts.google.com/o/saml2/idp?idpid={idpId}",
+      placeholder: "https://accounts.google.com/o/saml2/idp?idpid=C01abc234",
+    },
+    samlIdpCertField(),
+    ...samlAttributeFields(),
+    ...samlServiceProviderFields(),
+  ],
+  setupSteps: [
+    "In the Google Admin console, add a custom SAML app for agent-bom.",
+    "Set the ACS URL to the SP ACS URL and Entity ID to the SP entity ID above.",
+    "Add attribute mappings for agent_bom_role and tenant_id.",
+    "Download the IdP certificate from the Google metadata and paste it in.",
+  ],
+};
+
+const GENERIC_SAML: SsoProviderPreset = {
+  id: "generic-saml",
+  label: "Generic SAML",
+  protocol: "saml",
+  tagline: "Any SAML 2.0 IdP — fill in every field manually.",
+  generic: true,
+  docsHint: "Provide the IdP's entity ID, SSO URL and signing certificate.",
+  fields: [
+    {
+      key: "idp_entity_id",
+      envVar: "AGENT_BOM_SAML_IDP_ENTITY_ID",
+      label: "IdP entity ID (issuer)",
+      kind: "config",
+      value: "",
+      placeholder: "https://idp.your-org.example/metadata",
+    },
+    {
+      key: "idp_sso_url",
+      envVar: "AGENT_BOM_SAML_IDP_SSO_URL",
+      label: "IdP SSO URL",
+      kind: "config",
+      value: "",
+      placeholder: "https://idp.your-org.example/sso",
+    },
+    {
+      key: "idp_x509_cert",
+      envVar: "AGENT_BOM_SAML_IDP_X509_CERT",
+      label: "IdP signing certificate (X.509)",
+      kind: "tenant",
+      value: "",
+      placeholder: "-----BEGIN CERTIFICATE-----\n…",
+    },
+    {
+      key: "role_attribute",
+      envVar: "AGENT_BOM_SAML_ROLE_ATTRIBUTE",
+      label: "Role attribute",
+      kind: "config",
+      value: "",
+      placeholder: "agent_bom_role",
+    },
+    {
+      key: "tenant_attribute",
+      envVar: "AGENT_BOM_SAML_TENANT_ATTRIBUTE",
+      label: "Tenant attribute",
+      kind: "config",
+      value: "",
+      placeholder: "tenant_id",
+    },
+    {
+      key: "sp_entity_id",
+      envVar: "AGENT_BOM_SAML_SP_ENTITY_ID",
+      label: "SP entity ID",
+      kind: "config",
+      value: "",
+      placeholder: "https://agent-bom.your-org.example/v1/auth/saml/metadata",
+    },
+    {
+      key: "sp_acs_url",
+      envVar: "AGENT_BOM_SAML_SP_ACS_URL",
+      label: "SP ACS URL",
+      kind: "config",
+      value: "",
+      placeholder: "https://agent-bom.your-org.example/v1/auth/saml/login",
+    },
+  ],
+  setupSteps: [
+    "Register agent-bom as a SAML SP using the SP entity ID + ACS URL.",
+    "Copy the IdP entity ID, SSO URL and signing certificate from the IdP.",
+    "Map role and tenant attributes onto agent_bom_role / tenant_id.",
+  ],
+};
+
+// ── Catalog + lookups ───────────────────────────────────────────────────────
+
+export const SSO_OIDC_PRESETS: SsoProviderPreset[] = [OKTA_OIDC, ENTRA_OIDC, GOOGLE_OIDC, GENERIC_OIDC];
+export const SSO_SAML_PRESETS: SsoProviderPreset[] = [OKTA_SAML, ENTRA_SAML, GOOGLE_SAML, GENERIC_SAML];
+
+export const SSO_PROVIDER_PRESETS: Record<SsoProviderId, SsoProviderPreset> = {
+  "okta-oidc": OKTA_OIDC,
+  "entra-oidc": ENTRA_OIDC,
+  "google-oidc": GOOGLE_OIDC,
+  "generic-oidc": GENERIC_OIDC,
+  "okta-saml": OKTA_SAML,
+  "entra-saml": ENTRA_SAML,
+  "google-saml": GOOGLE_SAML,
+  "generic-saml": GENERIC_SAML,
+};
+
+export function ssoProviderPreset(id: string): SsoProviderPreset | null {
+  if (id in SSO_PROVIDER_PRESETS) {
+    return SSO_PROVIDER_PRESETS[id as SsoProviderId];
+  }
+  return null;
+}
+
+export function ssoPresetsForProtocol(protocol: SsoProtocol): SsoProviderPreset[] {
+  return protocol === "oidc" ? SSO_OIDC_PRESETS : SSO_SAML_PRESETS;
+}
+
+/**
+ * Apply a preset to produce the initial form values keyed by field key.
+ * Config fields carry their pre-filled template; `tenant`/`secret` fields and
+ * every generic field stay blank so the operator supplies them. Secrets are
+ * never populated.
+ */
+export function applySsoPreset(preset: SsoProviderPreset): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const field of preset.fields) {
+    values[field.key] = field.kind === "secret" ? "" : field.value;
+  }
+  return values;
+}
+
+/** Placeholder emitted for any field the operator must supply. */
+function envPlaceholder(field: SsoPresetField): string {
+  const token = field.key.toUpperCase();
+  return `<${token}>`;
+}
+
+/**
+ * Build a copy-pasteable env-var block for a preset, mirroring the cloud
+ * wizard's grant-script builder. Config fields render their template value;
+ * `tenant`/`secret` fields render a `<PLACEHOLDER>` — a real secret is never
+ * emitted.
+ */
+export function buildSsoEnvSnippet(preset: SsoProviderPreset): string {
+  const header = `# agent-bom ${preset.label} ${preset.protocol.toUpperCase()} SSO — replace {placeholders} with your values`;
+  const lines = preset.fields.map((field) => {
+    const rendered = field.kind === "config" && field.value ? field.value : envPlaceholder(field);
+    return `${field.envVar}=${rendered}`;
+  });
+  return [header, ...lines].join("\n");
+}

--- a/ui/tests/sso-provider-presets.test.ts
+++ b/ui/tests/sso-provider-presets.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SSO_OIDC_PRESETS,
+  SSO_PROVIDER_PRESETS,
+  SSO_SAML_PRESETS,
+  applySsoPreset,
+  buildSsoEnvSnippet,
+  ssoPresetsForProtocol,
+  ssoProviderPreset,
+  type SsoProviderPreset,
+} from "@/lib/sso-provider-presets";
+
+const ALL_PRESETS: SsoProviderPreset[] = Object.values(SSO_PROVIDER_PRESETS);
+
+describe("sso provider preset catalog", () => {
+  it("ships Okta, Entra, Google and Generic for both OIDC and SAML", () => {
+    expect(ssoPresetsForProtocol("oidc").map((p) => p.id)).toEqual([
+      "okta-oidc",
+      "entra-oidc",
+      "google-oidc",
+      "generic-oidc",
+    ]);
+    expect(ssoPresetsForProtocol("saml").map((p) => p.id)).toEqual([
+      "okta-saml",
+      "entra-saml",
+      "google-saml",
+      "generic-saml",
+    ]);
+    // The exported arrays are the same objects the lookup resolves.
+    expect(SSO_OIDC_PRESETS).toBe(ssoPresetsForProtocol("oidc"));
+    expect(SSO_SAML_PRESETS).toBe(ssoPresetsForProtocol("saml"));
+  });
+
+  it("resolves presets by id and returns null for unknown ids", () => {
+    expect(ssoProviderPreset("okta-oidc")?.label).toBe("Okta");
+    expect(ssoProviderPreset("nope")).toBeNull();
+  });
+
+  it("maps every prefilled field to a real AGENT_BOM_* env var", () => {
+    for (const preset of ALL_PRESETS) {
+      expect(preset.fields.length).toBeGreaterThan(0);
+      for (const field of preset.fields) {
+        expect(field.envVar.startsWith("AGENT_BOM_")).toBe(true);
+        expect(field.key).toBeTruthy();
+        expect(field.label).toBeTruthy();
+      }
+    }
+  });
+});
+
+describe("selecting an OIDC provider preset fills the issuer template", () => {
+  it("Okta prefills the /oauth2/default issuer + JWKS with a domain placeholder", () => {
+    const filled = applySsoPreset(ssoProviderPreset("okta-oidc")!);
+    expect(filled.issuer).toBe("https://{yourOktaDomain}/oauth2/default");
+    expect(filled.issuer?.startsWith("https://")).toBe(true);
+    expect(filled.issuer).toContain("{yourOktaDomain}");
+    expect(filled.jwks_uri).toBe("https://{yourOktaDomain}/oauth2/default/v1/keys");
+  });
+
+  it("Entra prefills the tenant-scoped v2.0 authority + keys endpoint", () => {
+    const filled = applySsoPreset(ssoProviderPreset("entra-oidc")!);
+    expect(filled.issuer).toBe("https://login.microsoftonline.com/{tenantId}/v2.0");
+    expect(filled.issuer).toContain("{tenantId}");
+    expect(filled.jwks_uri).toBe("https://login.microsoftonline.com/{tenantId}/discovery/v2.0/keys");
+  });
+
+  it("Google prefills the fixed accounts.google.com issuer + certs endpoint", () => {
+    const filled = applySsoPreset(ssoProviderPreset("google-oidc")!);
+    expect(filled.issuer).toBe("https://accounts.google.com");
+    expect(filled.jwks_uri).toBe("https://www.googleapis.com/oauth2/v3/certs");
+  });
+});
+
+describe("selecting a SAML provider preset fills the IdP endpoints", () => {
+  it("Okta prefills the IdP entity id + SSO url templates", () => {
+    const filled = applySsoPreset(ssoProviderPreset("okta-saml")!);
+    expect(filled.idp_entity_id).toContain("okta.com");
+    expect(filled.idp_sso_url).toContain("{yourOktaDomain}");
+  });
+
+  it("Entra prefills the tenant-scoped saml2 endpoints", () => {
+    const filled = applySsoPreset(ssoProviderPreset("entra-saml")!);
+    expect(filled.idp_sso_url).toBe("https://login.microsoftonline.com/{tenantId}/saml2");
+    expect(filled.idp_entity_id).toContain("{tenantId}");
+  });
+});
+
+describe("Generic stays fully manual", () => {
+  it("leaves every generic field blank so the operator supplies all values", () => {
+    for (const id of ["generic-oidc", "generic-saml"] as const) {
+      const preset = ssoProviderPreset(id)!;
+      expect(preset.generic).toBe(true);
+      const filled = applySsoPreset(preset);
+      for (const value of Object.values(filled)) {
+        expect(value).toBe("");
+      }
+    }
+  });
+});
+
+describe("secrets are never prefilled or emitted", () => {
+  it("no secret-kind field on any preset carries a value", () => {
+    for (const preset of ALL_PRESETS) {
+      for (const field of preset.fields) {
+        if (field.kind === "secret") {
+          expect(field.value).toBe("");
+        }
+      }
+    }
+  });
+
+  it("only OIDC presets carry a client-secret field and it is always empty", () => {
+    const oktaSecret = ssoProviderPreset("okta-oidc")!.fields.find((f) => f.key === "client_secret");
+    expect(oktaSecret?.kind).toBe("secret");
+    expect(oktaSecret?.value).toBe("");
+    // applied form never contains a non-empty client secret.
+    expect(applySsoPreset(ssoProviderPreset("okta-oidc")!).client_secret).toBe("");
+    // SAML has no secret (the IdP cert is a public signing certificate).
+    expect(ssoProviderPreset("okta-saml")!.fields.some((f) => f.kind === "secret")).toBe(false);
+  });
+
+  it("the generated env snippet placeholders a secret, never a real value", () => {
+    const snippet = buildSsoEnvSnippet(ssoProviderPreset("entra-oidc")!);
+    expect(snippet).toContain("AGENT_BOM_OIDC_ISSUER=");
+    expect(snippet).toContain("https://login.microsoftonline.com/{tenantId}/v2.0");
+    // client secret line exists but only as a paste-me placeholder in angle brackets.
+    const secretLine = snippet.split("\n").find((line) => line.startsWith("AGENT_BOM_OIDC_CLIENT_SECRET="));
+    expect(secretLine).toBeDefined();
+    expect(secretLine).toMatch(/=<.*>$/);
+  });
+});

--- a/ui/tests/sso-setup-presets.test.tsx
+++ b/ui/tests/sso-setup-presets.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { SsoSetupPresets } from "@/components/sso-setup-presets";
+
+describe("SsoSetupPresets", () => {
+  it("defaults to Okta OIDC and shows the issuer template, never a secret value", async () => {
+    render(<SsoSetupPresets />);
+    expect(screen.getByText("SSO provider presets")).toBeInTheDocument();
+    expect(screen.getByText("https://{yourOktaDomain}/oauth2/default")).toBeInTheDocument();
+
+    // The client-secret row is present but shows guidance, not a value.
+    const secretEnv = screen.getByText("AGENT_BOM_OIDC_CLIENT_SECRET");
+    const secretRow = secretEnv.closest("div")?.parentElement as HTMLElement;
+    expect(within(secretRow).getByText(/never prefilled/i)).toBeInTheDocument();
+  });
+
+  it("switching to Google OIDC swaps in the fixed accounts.google.com issuer", async () => {
+    const user = userEvent.setup();
+    render(<SsoSetupPresets />);
+    await user.click(screen.getByRole("button", { name: "Google Workspace" }));
+    expect(screen.getByText("https://accounts.google.com")).toBeInTheDocument();
+    expect(screen.getByText("https://www.googleapis.com/oauth2/v3/certs")).toBeInTheDocument();
+  });
+
+  it("Generic OIDC leaves the issuer blank (placeholder only)", async () => {
+    const user = userEvent.setup();
+    render(<SsoSetupPresets />);
+    await user.click(screen.getByRole("button", { name: "Generic OIDC" }));
+    // No prefilled issuer template is rendered for the generic preset.
+    expect(screen.queryByText("https://{yourOktaDomain}/oauth2/default")).not.toBeInTheDocument();
+    expect(screen.getByText("https://idp.your-org.example")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Combines two independently verified branches into one PR. The trees are disjoint (backend `src/` vs `ui/`), so the merges applied cleanly with no conflicts.

## Changes

### 1. DSPM: Luhn card validation + secret data-class (#3880)
Backend data-classification hardening. Adds Luhn checksum validation for candidate credit-card numbers (cutting false positives from arbitrary digit runs) and a dedicated `secret` data-class for detected credentials.
- `src/agent_bom/parsers/dataset_pii_scanner.py`
- `src/agent_bom/cloud/{s3,gcs,db}_data_classifier.py`
- `tests/test_dspm_luhn_secrets.py`

### 2. SSO IdP presets (UI, presets part of #3736)
Guided SSO setup presets for common identity providers, wiring provider metadata into the setup flow and key-lifecycle panel.
- `ui/lib/sso-provider-presets.ts`
- `ui/components/sso-setup-presets.tsx`
- `ui/components/key-lifecycle-panel.tsx`
- `ui/tests/sso-provider-presets.test.ts`, `ui/tests/sso-setup-presets.test.tsx`

## Combined verification (both gates re-run on the merged result)

**Backend**
- `pytest` DSPM + cloud-classifier suites — 68 passed
- `mypy src/agent_bom` — no issues (693 files)
- `ruff check src tests` — all checks passed
- `make preflight` — passed

**UI** (from `ui/`)
- `npm ci` — clean, 0 vulnerabilities
- `npm run typecheck` — clean
- `npm run build` — success
- `npx vitest run` — 518 passed (101 files)
- `npm run lint` — 0 errors (1 pre-existing warning in `nav.tsx`, unrelated)
- `npm run bundle:check` — PASS (client JS 3243.7 / 3300 KiB budget; no bump needed)

Closes #3880
Closes the SSO-provider-presets part of #3736 (the guided wizard already shipped).
