### PR TITLE
feat(api): unify finding-list envelope across every surface (#3666)

### DIFF
--- a/docs/design/API_ORPHAN_ROUTES.md
+++ b/docs/design/API_ORPHAN_ROUTES.md
@@ -36,12 +36,40 @@ product consumers.
   paths, and asserts OpenAPI marks those operations deprecated while leaving
   SAML relay-state and held graph routes unmarked.
 
+## Findings-list contract (item 1) — landed
+
+Every finding-list surface now returns one canonical envelope, built by
+`agent_bom.api.finding_list_envelope.finding_list_envelope()`
+(`FINDING_LIST_ENVELOPE_KEYS` pins the key set; the UI mirror is
+`FindingListEnvelope<T>` in `ui/lib/api-types.ts`):
+
+```
+{schema_version, findings, count, total, limit, offset, sort, scan_id,
+ cursor, next_cursor, has_more, warnings, [total_approximate]}
+```
+
+| Route | Pagination | Notes |
+|---|---|---|
+| `GET /v1/findings` | keyset `cursor`/`next_cursor` (never OFFSET at scale) + `limit`/`offset` | Reference contract; default sort `effective_reach`. |
+| `GET /v1/compliance/hub/findings` | `limit`/`offset`, ingest-order (`sort="ordinal"`) | External ingests + native scan projection. Scale keyset reads over the same durable store are available via `/v1/findings?cursor=`. |
+| `GET /v1/governance/findings` | `limit`/`offset` over the materialized list (`cursor` stays empty) | Computed on demand from Snowflake; no keyset store to walk. |
+
+Change is **additive** — legacy fields and legacy pagination are preserved
+(`test_sqlite_backend_preserves_ingest_order` stays green; governance filters
+unchanged). The three routes serve distinct data sources (scan+bulk / hub
+external+native / Snowflake governance), so none is a duplicate/alias of
+another — envelope unification, not route removal, is the consolidation.
+Guarded by `tests/api/test_findings_contract_envelope.py`.
+
 ## Out of scope (later #3666 phases)
 
 - Deleting soft-deprecated routes
-- Findings-list contract unification
-- List-envelope / pagination standardization
-- Changing response shapes
+- Hub-findings **keyset over ingest order** — needs an `ordinal`-keyset store
+  fix (SQLite `ORDER BY ledger_ordinal` does not line up with the
+  `(last_seen, canonical_id)` cursor predicate); ingest-order paging stays on
+  `limit`/`offset` until then.
+- Namespacing filtered views under `/v1/findings/...` (versioned migration)
+- Changing response shapes on non-findings list surfaces
 
 ## How to revisit
 

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -7642,7 +7642,7 @@
         ]
       },
       "get": {
-        "description": "List compliance-hub findings for the current tenant.\n\nIncludes durable external ingests plus native scan findings projected into\nthe same shape so the list endpoint matches `/hub/posture` totals.",
+        "description": "List compliance-hub findings for the current tenant.\n\nReturns the canonical finding-list envelope (#3666) shared with\n``/v1/findings`` so consumers learn one shape across every finding surface.\nIncludes durable external ingests plus native scan findings projected into\nthe same shape so the list endpoint matches `/hub/posture` totals.\n\nOrdering is ingest-order (``sort=\"ordinal\"``) so the list matches the way\nfindings were imported; pagination is ``limit`` / ``offset``. Keyset\npagination over the same durable hub store is available (keyset-safe sort)\nthrough ``/v1/findings?cursor=`` for scale reads.",
         "operationId": "list_hub_findings_v1_compliance_hub_findings_get",
         "parameters": [
           {
@@ -12832,7 +12832,7 @@
     },
     "/v1/governance/findings": {
       "get": {
-        "description": "Return only governance findings, optionally filtered.",
+        "description": "Return only governance findings, optionally filtered.\n\nReturns the canonical finding-list envelope (#3666) shared with\n``/v1/findings`` so consumers learn one shape across every finding surface.\nGovernance findings are computed on demand from Snowflake discovery rather\nthan served from a keyset store, so pagination is in-memory ``limit`` /\n``offset`` over the materialized list; ``cursor`` / ``next_cursor`` stay\nempty for this surface.",
         "operationId": "governance_findings_v1_governance_findings_get",
         "parameters": [
           {
@@ -12875,6 +12875,26 @@
                 }
               ],
               "title": "Category"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 500,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Offset",
+              "type": "integer"
             }
           }
         ],

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -5032,9 +5032,22 @@ paths:
       description: 'List compliance-hub findings for the current tenant.
 
 
+        Returns the canonical finding-list envelope (#3666) shared with
+
+        ``/v1/findings`` so consumers learn one shape across every finding surface.
+
         Includes durable external ingests plus native scan findings projected into
 
-        the same shape so the list endpoint matches `/hub/posture` totals.'
+        the same shape so the list endpoint matches `/hub/posture` totals.
+
+
+        Ordering is ingest-order (``sort="ordinal"``) so the list matches the way
+
+        findings were imported; pagination is ``limit`` / ``offset``. Keyset
+
+        pagination over the same durable hub store is available (keyset-safe sort)
+
+        through ``/v1/findings?cursor=`` for scale reads.'
       operationId: list_hub_findings_v1_compliance_hub_findings_get
       parameters:
       - in: query
@@ -8377,7 +8390,20 @@ paths:
       - governance
   /v1/governance/findings:
     get:
-      description: Return only governance findings, optionally filtered.
+      description: 'Return only governance findings, optionally filtered.
+
+
+        Returns the canonical finding-list envelope (#3666) shared with
+
+        ``/v1/findings`` so consumers learn one shape across every finding surface.
+
+        Governance findings are computed on demand from Snowflake discovery rather
+
+        than served from a keyset store, so pagination is in-memory ``limit`` /
+
+        ``offset`` over the materialized list; ``cursor`` / ``next_cursor`` stay
+
+        empty for this surface.'
       operationId: governance_findings_v1_governance_findings_get
       parameters:
       - in: query
@@ -8403,6 +8429,20 @@ paths:
           - type: string
           - type: 'null'
           title: Category
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 500
+          title: Limit
+          type: integer
+      - in: query
+        name: offset
+        required: false
+        schema:
+          default: 0
+          title: Offset
+          type: integer
       responses:
         '200':
           content:

--- a/src/agent_bom/api/finding_list_envelope.py
+++ b/src/agent_bom/api/finding_list_envelope.py
@@ -1,0 +1,77 @@
+"""Canonical finding-list envelope (#3666).
+
+Every finding-list surface returns this one shape so consumers learn a single
+contract instead of a per-route dialect:
+
+    ``/v1/findings``                 (scan.py, the reference contract)
+    ``/v1/compliance/hub/findings``  (compliance.py)
+    ``/v1/governance/findings``      (governance.py)
+
+The envelope keys and their order are fixed by :data:`FINDING_LIST_ENVELOPE_KEYS`.
+Keyset ``cursor``/``next_cursor`` is the forward-compatible pagination path
+(the store walks rows without a deep ``OFFSET`` scan); ``limit``/``offset``
+stay for backward compatibility and for computed lists that have no keyset
+store to walk. ``total_approximate`` is appended only when the total is a
+lower-bound estimate rather than an exact ``COUNT(*)``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+FINDING_LIST_SCHEMA_VERSION = "v1"
+
+# The canonical key set every finding-list envelope must expose. Contract tests
+# assert equality against this so a new divergent shape fails loudly.
+FINDING_LIST_ENVELOPE_KEYS: tuple[str, ...] = (
+    "schema_version",
+    "findings",
+    "count",
+    "total",
+    "limit",
+    "offset",
+    "sort",
+    "scan_id",
+    "cursor",
+    "next_cursor",
+    "has_more",
+    "warnings",
+)
+
+
+def finding_list_envelope(
+    *,
+    findings: list[dict[str, Any]],
+    total: int | None,
+    limit: int,
+    offset: int = 0,
+    sort: str | None = None,
+    scan_id: str | None = None,
+    cursor: str = "",
+    next_cursor: str = "",
+    warnings: list[str] | None = None,
+    total_approximate: bool = False,
+    schema_version: str = FINDING_LIST_SCHEMA_VERSION,
+) -> dict[str, Any]:
+    """Build the canonical finding-list envelope shared by every list surface.
+
+    ``count`` and ``has_more`` are derived so callers cannot drift them out of
+    sync with ``findings`` and ``next_cursor``.
+    """
+    envelope: dict[str, Any] = {
+        "schema_version": schema_version,
+        "findings": findings,
+        "count": len(findings),
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "sort": sort,
+        "scan_id": scan_id,
+        "cursor": cursor,
+        "next_cursor": next_cursor,
+        "has_more": bool(next_cursor),
+        "warnings": warnings if warnings is not None else [],
+    }
+    if total_approximate:
+        envelope["total_approximate"] = True
+    return envelope

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -2054,37 +2054,46 @@ def _unpack_hub_list_page(result: tuple[Any, ...]) -> tuple[list[dict[str, Any]]
 async def list_hub_findings(request: Request, limit: int = 200, offset: int = 0) -> dict:
     """List compliance-hub findings for the current tenant.
 
+    Returns the canonical finding-list envelope (#3666) shared with
+    ``/v1/findings`` so consumers learn one shape across every finding surface.
     Includes durable external ingests plus native scan findings projected into
     the same shape so the list endpoint matches `/hub/posture` totals.
+
+    Ordering is ingest-order (``sort="ordinal"``) so the list matches the way
+    findings were imported; pagination is ``limit`` / ``offset``. Keyset
+    pagination over the same durable hub store is available (keyset-safe sort)
+    through ``/v1/findings?cursor=`` for scale reads.
     """
     from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+    from agent_bom.api.finding_list_envelope import finding_list_envelope
 
     tenant_id = _tenant_id(request)
     safe_limit = max(1, min(limit, 1000))
     safe_offset = max(0, offset)
+    sort = "ordinal"
     native = _native_hub_findings(request)
     store = get_compliance_hub_store()
     list_page = getattr(store, "list_current_page", None) or getattr(store, "list_page", None)
     if callable(list_page):
         if native:
             window = safe_offset + safe_limit
-            hub_rows, hub_total = _unpack_hub_list_page(list_page(tenant_id, limit=window, offset=0, sort="ordinal"))
+            hub_rows, hub_total = _unpack_hub_list_page(list_page(tenant_id, limit=window, offset=0, sort=sort))
             combined = native + hub_rows
             page = combined[safe_offset : safe_offset + safe_limit]
             total = len(native) + hub_total
         else:
-            page, total = _unpack_hub_list_page(list_page(tenant_id, limit=safe_limit, offset=safe_offset, sort="ordinal"))
+            page, total = _unpack_hub_list_page(list_page(tenant_id, limit=safe_limit, offset=safe_offset, sort=sort))
     else:
         findings = store.list(tenant_id) + native
         page = findings[safe_offset : safe_offset + safe_limit]
         total = len(findings)
-    return {
-        "findings": page,
-        "count": len(page),
-        "total": total,
-        "limit": safe_limit,
-        "offset": safe_offset,
-    }
+    return finding_list_envelope(
+        findings=page,
+        total=total,
+        limit=safe_limit,
+        offset=safe_offset,
+        sort=sort,
+    )
 
 
 @router.get("/compliance/hub/posture", tags=["compliance"])

--- a/src/agent_bom/api/routes/governance.py
+++ b/src/agent_bom/api/routes/governance.py
@@ -54,11 +54,25 @@ async def governance_findings(
     days: int = 30,
     severity: str | None = None,
     category: str | None = None,
+    limit: int = 500,
+    offset: int = 0,
 ):
-    """Return only governance findings, optionally filtered."""
+    """Return only governance findings, optionally filtered.
+
+    Returns the canonical finding-list envelope (#3666) shared with
+    ``/v1/findings`` so consumers learn one shape across every finding surface.
+    Governance findings are computed on demand from Snowflake discovery rather
+    than served from a keyset store, so pagination is in-memory ``limit`` /
+    ``offset`` over the materialized list; ``cursor`` / ``next_cursor`` stay
+    empty for this surface.
+    """
     import os
 
+    from agent_bom.api.finding_list_envelope import finding_list_envelope
+
     days = max(1, min(days, 365))
+    safe_limit = max(1, min(limit, 1000))
+    safe_offset = max(0, offset)
 
     if not os.environ.get("SNOWFLAKE_ACCOUNT"):
         raise HTTPException(
@@ -77,11 +91,15 @@ async def governance_findings(
         if category:
             findings = [f for f in findings if f["category"] == category.lower()]
 
-        return {
-            "findings": findings,
-            "count": len(findings),
-            "warnings": report.warnings,
-        }
+        total = len(findings)
+        page = findings[safe_offset : safe_offset + safe_limit]
+        return finding_list_envelope(
+            findings=page,
+            total=total,
+            limit=safe_limit,
+            offset=safe_offset,
+            warnings=list(report.warnings),
+        )
     except Exception as exc:
         _logger.exception("Request failed")
         raise HTTPException(status_code=500, detail=sanitize_error(exc))

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -39,6 +39,7 @@ from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from werkzeug.security import safe_join
 
+from agent_bom.api.finding_list_envelope import finding_list_envelope
 from agent_bom.api.idempotency_store import IdempotencyConflictError, idempotency_request_fingerprint
 from agent_bom.api.models import (
     BrowserExtensionsRequest,
@@ -1920,23 +1921,18 @@ def _list_findings_impl(
         page_rows = combined[offset : offset + limit]
 
     page = _redact_finding_page(page_rows)
-    response: dict[str, Any] = {
-        "schema_version": "v1",
-        "findings": page,
-        "count": len(page),
-        "total": total,
-        "limit": limit,
-        "offset": 0 if cursor else offset,
-        "sort": sort_key,
-        "scan_id": scan_id,
-        "cursor": cursor or "",
-        "next_cursor": next_cursor or "",
-        "has_more": bool(next_cursor),
-        "warnings": warnings,
-    }
-    if total_approximate:
-        response["total_approximate"] = True
-    return response
+    return finding_list_envelope(
+        findings=page,
+        total=total,
+        limit=limit,
+        offset=0 if cursor else offset,
+        sort=sort_key,
+        scan_id=scan_id,
+        cursor=cursor or "",
+        next_cursor=next_cursor or "",
+        warnings=warnings,
+        total_approximate=total_approximate,
+    )
 
 
 @router.post("/findings/bulk", tags=["scan"], status_code=201)

--- a/tests/api/test_findings_contract_envelope.py
+++ b/tests/api/test_findings_contract_envelope.py
@@ -1,0 +1,180 @@
+"""Contract: every finding-list surface returns the one canonical envelope (#3666).
+
+The audit found three divergent finding-list endpoints:
+
+    ``GET /v1/findings``                 rich canonical envelope (the target)
+    ``GET /v1/compliance/hub/findings``  ``{findings, count, total, limit, offset}``
+    ``GET /v1/governance/findings``      ``{findings, count, warnings}`` (no paging)
+
+This locks all three onto :func:`finding_list_envelope` so consumers learn one
+shape, and pins that the migration stayed backward compatible (legacy fields
+still present) and that the hub keyset cursor walks rows 0-dup / 0-drop.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import reset_compliance_hub_store
+from agent_bom.api.finding_list_envelope import FINDING_LIST_ENVELOPE_KEYS
+from agent_bom.api.server import app, set_job_store
+from agent_bom.api.store import InMemoryJobStore
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+@pytest.fixture(autouse=True)
+def _reset_store():
+    reset_compliance_hub_store()
+    set_job_store(InMemoryJobStore())
+    yield
+    reset_compliance_hub_store()
+    set_job_store(InMemoryJobStore())
+
+
+def _client(tenant: str = "tenant-alpha", role: str = "admin") -> TestClient:
+    client = TestClient(app)
+    client.headers.update(proxy_headers(role=role, tenant=tenant))
+    return client
+
+
+def _assert_canonical_envelope(body: dict) -> None:
+    # ``total_approximate`` is the only optional key; everything else is fixed.
+    keys = set(body) - {"total_approximate"}
+    assert keys == set(FINDING_LIST_ENVELOPE_KEYS), sorted(keys ^ set(FINDING_LIST_ENVELOPE_KEYS))
+    assert isinstance(body["findings"], list)
+    assert body["count"] == len(body["findings"])
+    assert body["has_more"] == bool(body["next_cursor"])
+    assert isinstance(body["warnings"], list)
+    assert body["schema_version"] == "v1"
+
+
+def _ingest_csv(client: TestClient, rows: int) -> None:
+    csv_rows = "Title,Severity\n" + "\n".join(f"row-{i},low" for i in range(rows))
+    resp = client.post("/v1/compliance/ingest", json={"format": "csv", "content": csv_rows})
+    assert resp.status_code in (200, 201), resp.text
+
+
+def _ingest_bulk(client: TestClient, count: int) -> None:
+    resp = client.post(
+        "/v1/findings/bulk",
+        json={
+            "source": "external_scan",
+            "findings": [
+                {
+                    "id": f"f-{i}",
+                    "vulnerability_id": f"CVE-2026-{i:04d}",
+                    "severity": "high",
+                    "package": "pkg",
+                    "title": f"row-{i}",
+                }
+                for i in range(count)
+            ],
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+
+
+# ─── Canonical envelope across every surface ─────────────────────────────────
+
+
+def test_v1_findings_returns_canonical_envelope():
+    client = _client(role="analyst")
+    client.post(
+        "/v1/findings/bulk",
+        json={
+            "source": "external_scan",
+            "findings": [{"id": "f-1", "vulnerability_id": "CVE-2026-0001", "severity": "high", "title": "x"}],
+        },
+    )
+    body = client.get("/v1/findings").json()
+    _assert_canonical_envelope(body)
+
+
+def test_hub_findings_returns_canonical_envelope():
+    client = _client()
+    _ingest_csv(client, 3)
+    body = client.get("/v1/compliance/hub/findings").json()
+    _assert_canonical_envelope(body)
+    # Legacy consumers depend on these — must survive the migration.
+    assert body["total"] == 3
+    assert body["count"] == 3
+    assert body["offset"] == 0
+    assert body["sort"] == "ordinal"
+
+
+def test_governance_findings_returns_canonical_envelope(monkeypatch):
+    class _Finding:
+        def __init__(self, sev: str, cat: str) -> None:
+            self._d = {"id": f"gov-{sev}-{cat}", "severity": sev, "category": cat, "title": "gov"}
+
+        def to_dict(self) -> dict:
+            return dict(self._d)
+
+    class _Report:
+        findings = [_Finding("high", "access"), _Finding("low", "tagging")]
+        warnings = ["snowflake sample"]
+
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "acct-test")
+    import agent_bom.cloud as cloud_mod
+
+    monkeypatch.setattr(cloud_mod, "discover_governance", lambda **_: _Report())
+
+    body = _client().get("/v1/governance/findings").json()
+    _assert_canonical_envelope(body)
+    assert body["total"] == 2
+    assert body["warnings"] == ["snowflake sample"]
+    # Filter still applies within the canonical envelope.
+    filtered = _client().get("/v1/governance/findings?severity=high").json()
+    assert filtered["count"] == 1
+    assert filtered["findings"][0]["severity"] == "high"
+
+
+# ─── Canonical /v1/findings keyset cursor: 0-dup / 0-drop ────────────────────
+
+
+def test_v1_findings_keyset_cursor_no_dup_no_drop():
+    client = _client(role="analyst")
+    _ingest_bulk(client, 50)
+
+    # Ground truth: the full set of ingested findings (single deep page).
+    baseline = client.get("/v1/findings?limit=1000").json()
+    _assert_canonical_envelope(baseline)
+    expected = {f["vulnerability_id"] for f in baseline["findings"]}
+    assert len(expected) == 50
+
+    # Walk the same rows with keyset pagination (never OFFSET).
+    seen: list[str] = []
+    cursor = ""
+    pages = 0
+    while True:
+        qs = f"/v1/findings?limit=10{f'&cursor={cursor}' if cursor else ''}"
+        body = client.get(qs).json()
+        _assert_canonical_envelope(body)
+        seen.extend(f["vulnerability_id"] for f in body["findings"])
+        pages += 1
+        cursor = body["next_cursor"]
+        if not cursor:
+            break
+        assert pages < 20, "cursor walk did not terminate"
+
+    assert len(seen) == len(set(seen)), "cursor walk produced duplicates"
+    assert set(seen) == expected, "cursor walk dropped or added rows"
+
+
+def test_hub_findings_offset_pagination_stays_backward_compatible():
+    client = _client()
+    _ingest_csv(client, 50)
+    body = client.get("/v1/compliance/hub/findings?limit=10&offset=20").json()
+    _assert_canonical_envelope(body)
+    assert body["count"] == 10
+    assert body["total"] == 50
+    assert body["offset"] == 20

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -916,18 +916,30 @@ export interface UnifiedFinding {
   scan_count?: number | undefined;
 }
 
-export interface FindingsResponse {
+/**
+ * Canonical finding-list envelope (#3666). Every finding-list surface
+ * (`/v1/findings`, `/v1/compliance/hub/findings`, `/v1/governance/findings`)
+ * returns this shape, generic over the finding row type, so consumers learn
+ * one contract. Keyset `cursor` / `next_cursor` is the scale pagination path;
+ * `limit` / `offset` stay for backward compatibility.
+ */
+export interface FindingListEnvelope<T> {
   schema_version: string;
-  findings: UnifiedFinding[];
+  findings: T[];
   count: number;
   total: number;
   total_approximate?: boolean | undefined;
   limit: number;
   offset: number;
-  sort: string;
+  sort: string | null;
   scan_id?: string | null | undefined;
+  cursor: string;
+  next_cursor: string;
+  has_more: boolean;
   warnings: string[];
 }
+
+export type FindingsResponse = FindingListEnvelope<UnifiedFinding>;
 
 export interface BlastRadius {
   vulnerability_id: string;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -34,6 +34,7 @@ import type {
   ScoreConfigUpdate,
   RemediationItem,
   FindingsResponse,
+  FindingListEnvelope,
   FindingTriageRequest,
   FindingTriageDecisionRequest,
   FindingTriageResponse,
@@ -953,7 +954,7 @@ export const api = {
     const params = new URLSearchParams({ days: String(days) });
     if (severity) params.set("severity", severity);
     if (category) params.set("category", category);
-    return get<{ findings: GovernanceFinding[]; count: number; warnings: string[] }>(
+    return get<FindingListEnvelope<GovernanceFinding>>(
       `/v1/governance/findings?${params}`
     );
   },


### PR DESCRIPTION
Closes #3666 (item 1 — divergent findings-list contracts).

## What consolidated

The audit found three finding-list endpoints returning three envelopes. This unifies them onto one canonical shape so consumers learn a single contract.

| Endpoint | Before | After |
|---|---|---|
| `GET /v1/findings` | `{schema_version, findings, count, total, limit, offset, sort, scan_id, cursor, next_cursor, has_more, warnings}` (target) | same, built via shared helper (byte-identical) |
| `GET /v1/compliance/hub/findings` | `{findings, count, total, limit, offset}` | canonical envelope; ingest-order `limit`/`offset` preserved |
| `GET /v1/governance/findings` | `{findings, count, warnings}` (no paging) | canonical envelope + `limit`/`offset` over the materialized list |

New single source of truth: `agent_bom.api.finding_list_envelope.finding_list_envelope()` (`FINDING_LIST_ENVELOPE_KEYS` pins the keys).

## Backward compatibility / deprecations

- **Additive only** — every previously-present field is retained; legacy `limit`/`offset` paging still works. No consumer breaks.
- **No route removed / no alias needed.** The three routes serve *distinct data sources* (scan+bulk / hub external+native / Snowflake governance), so none is a duplicate or legacy of another — there is nothing to redirect. Envelope unification, not route removal, is the consolidation here.
- Hub-findings **keyset over ingest order** is the flagged remainder: it needs an `ordinal`-keyset store fix (SQLite `ORDER BY ledger_ordinal` doesn't line up with the `(last_seen, canonical_id)` cursor predicate). Ingest-order paging stays on `limit`/`offset`; scale keyset reads over the same durable hub store are already available via `/v1/findings?cursor=`.

## Full-stack layers touched

- **API**: `finding_list_envelope.py` (new) + `scan.py`, `compliance.py`, `governance.py`.
- **OpenAPI**: regenerated `docs/openapi/v1.{json,yaml}` (`make preflight` green — schemas/product-surface/SDK-patterns all match).
- **UI**: generic `FindingListEnvelope<T>` in `ui/lib/api-types.ts` (`FindingsResponse = FindingListEnvelope<UnifiedFinding>`, now also typing `cursor`/`next_cursor`/`has_more`); `getGovernanceFindings` consumes the envelope.
- **SDK**: `client.list_findings` already targets canonical `/v1/findings` — no change.
- **Docs**: `docs/design/API_ORPHAN_ROUTES.md` records the landed contract + remainder.
- **Tests**: `tests/api/test_findings_contract_envelope.py` (new).

## Verification

- Python: contract + hub + governance + scan/finding suites + `tests/api/` (814 passed); `ruff` + `mypy` clean on changed modules.
- Contract test asserts: every finding-list endpoint returns the canonical key set; `/v1/findings` keyset walk is 0-dup/0-drop; hub offset paging stays backward compatible; governance filter works within the envelope.
- `make preflight`: OpenAPI / v1 schemas / product-surface / SDK-patterns / release-consistency all green.
- UI: `npm run typecheck`, `npm run build`, `vitest` (findings-page + api = 36 passed), `bundle:check` all pass.